### PR TITLE
jrubyc commandline flag to build for JDK5

### DIFF
--- a/lib/ruby/site_ruby/shared/jruby/compiler.rb
+++ b/lib/ruby/site_ruby/shared/jruby/compiler.rb
@@ -51,6 +51,10 @@ module JRuby::Compiler
         options[:javac_options] << tgt
       end
 
+      opts.on("-5"," --jdk5", "Generate JDK 5 classes (version 49)") do |x|
+        options[:jdk5] = true
+      end
+
       opts.on("--java", "Generate .java classes to accompany the script") do
         options[:java] = true
       end
@@ -146,6 +150,10 @@ module JRuby::Compiler
           inspector.inspect(node)
 
           asmCompiler = BytecodeCompiler.new(pathname.gsub(".", "/"), filename)
+          if options[:jdk5]
+            asmCompiler.java_version= 49
+          end
+
           compiler = ASTCompiler.new
           compiler.compile_root(node, asmCompiler, inspector)
 

--- a/src/org/jruby/compiler/impl/StandardASMCompiler.java
+++ b/src/org/jruby/compiler/impl/StandardASMCompiler.java
@@ -146,6 +146,8 @@ public class StandardASMCompiler implements ScriptCompiler, Opcodes {
     private String classname;
     private String sourcename;
 
+    private Integer javaVersion;
+
     private ClassWriter classWriter;
     private SkinnyMethodAdapter initMethod;
     private SkinnyMethodAdapter clinitMethod;
@@ -189,6 +191,10 @@ public class StandardASMCompiler implements ScriptCompiler, Opcodes {
     public StandardASMCompiler(String classname, String sourcename) {
         this.classname = classname;
         this.sourcename = sourcename;
+    }
+
+    public void setJavaVersion(Integer javaVersion) {
+        this.javaVersion = javaVersion;
     }
 
     public byte[] getClassByteArray() {
@@ -393,7 +399,8 @@ public class StandardASMCompiler implements ScriptCompiler, Opcodes {
         classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
 
         // Create the class with the appropriate class name and source file
-        classWriter.visit(RubyInstanceConfig.JAVA_VERSION, ACC_PUBLIC + ACC_SUPER,getClassname(), null, p(AbstractScript.class), null);
+        classWriter.visit(javaVersion == null ? RubyInstanceConfig.JAVA_VERSION : javaVersion,
+                ACC_PUBLIC + ACC_SUPER,getClassname(), null, p(AbstractScript.class), null);
 
         // add setPosition impl, which stores filename as constant to speed updates
         SkinnyMethodAdapter method = new SkinnyMethodAdapter(getClassVisitor().visitMethod(ACC_PRIVATE | ACC_STATIC | ACC_SYNTHETIC, "setPosition", sig(Void.TYPE, params(ThreadContext.class, int.class)), null, null));


### PR DESCRIPTION
This change adds a setter to the `StandardASMCompiler` that lets `jrubyc` change the target class file version based on a flag (`-5` or `--jdk5`).  The alternative would have been to modify `RubyInstanceConfig` to make `JAVA_VERSION` non-final and accessible, but that seemed a bit more awkward.

Works nicely:

<pre>$ java -version
java -version
java version "1.6.0_20"
Java(TM) SE Runtime Environment (build 1.6.0_20-b02-279-10M3065)
Java HotSpot(TM) 64-Bit Server VM (build 16.3-b01-279, mixed mode)
$ jrubyc -5 account_controller.rb
Compiling account_controller.rb to class account_controller
$ head -n 1 account_controller.class | cut -b 8 | xargs -IX printf '%d\n' "'X"
49
$ jrubyc account_controller.rb
Compiling account_controller.rb to class account_controller
$ head -n 1 account_controller.class | cut -b 8 | xargs -IX printf '%d\n' "'X"
50</pre>
