### PR TITLE
Fix for JRUBY-5095

### DIFF
--- a/lib/ruby/1.8/pathname.rb
+++ b/lib/ruby/1.8/pathname.rb
@@ -260,7 +260,7 @@ class Pathname
         ensure
           Thread.current[:pathname_sub_matchdata] = old
         end
-        yield *args
+        yield(*args)
       }
     else
       path = @path.sub(pattern, *rest)


### PR DESCRIPTION
Darn safe change, add ()'s to avoid warning output on running tests, etc.

(Resubmitted with proper commit range, targeting jruby-1_5. The change should also be applied to master.)
