### PR TITLE
ObjectInputStream issues

### DIFF
--- a/src/org/jruby/java/proxies/JavaProxy.java
+++ b/src/org/jruby/java/proxies/JavaProxy.java
@@ -37,6 +37,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 import org.jruby.util.CodegenUtils;
+import org.jruby.util.JRubyObjectInputStream;
 
 public class JavaProxy extends RubyObject {
     private static final boolean DEBUG = false;
@@ -364,7 +365,7 @@ public class JavaProxy extends RubyObject {
         try {
             ByteList byteList = str.convertToString().getByteList();
             ByteArrayInputStream bais = new ByteArrayInputStream(byteList.getUnsafeBytes(), byteList.getBegin(), byteList.getRealSize());
-            ObjectInputStream ois = new ObjectInputStream(bais);
+            ObjectInputStream ois = new JRubyObjectInputStream(context.getRuntime(), bais);
 
             object = ois.readObject();
 

--- a/src/org/jruby/javasupport/JavaObject.java
+++ b/src/org/jruby/javasupport/JavaObject.java
@@ -53,6 +53,7 @@ import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
+import org.jruby.util.JRubyObjectInputStream;
 
 /**
  *
@@ -309,7 +310,7 @@ public class JavaObject extends RubyObject {
         try {
             ByteList byteList = str.convertToString().getByteList();
             ByteArrayInputStream bais = new ByteArrayInputStream(byteList.getUnsafeBytes(), byteList.getBegin(), byteList.getRealSize());
-            ObjectInputStream ois = new ObjectInputStream(bais);
+            ObjectInputStream ois = new JRubyObjectInputStream(context.getRuntime(), bais);
 
             dataWrapStruct(ois.readObject());
 

--- a/src/org/jruby/util/JRubyObjectInputStream.java
+++ b/src/org/jruby/util/JRubyObjectInputStream.java
@@ -1,0 +1,27 @@
+package org.jruby.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+import org.jruby.Ruby;
+
+public class JRubyObjectInputStream extends ObjectInputStream {
+    private final Ruby runtime;
+
+    public JRubyObjectInputStream(Ruby runtime, InputStream input) throws IOException {
+        super(input);
+        this.runtime = runtime;
+    }
+
+    protected Class<?> resolveClass(ObjectStreamClass desc)
+        throws IOException, ClassNotFoundException
+    {
+        String name = desc.getName();
+        try {
+            return Class.forName(name, false, runtime.getJRubyClassLoader());
+        } catch (ClassNotFoundException ex) {
+            return super.resolveClass(desc);
+        }
+    }
+}


### PR DESCRIPTION
We use ObjectInputStream for unmarshaling java objects.  ObjectInputStream uses latestUserDefinedLoader() to load classes:
    /**
     \* Returns the first non-null class loader (not counting class loaders of
     \* generated reflection implementation classes) up the execution stack, or
     \* null if only code from the null class loader is on the stack.  This
     \* method is also called via reflection by the following RMI-IIOP class:
     *
     \*     com.sun.corba.se.internal.util.JDKClassLoader
     *
     \* This method should not be removed or its signature changed without
     \* corresponding modifications to the above class.
     */
    // REMIND: change name to something more accurate?
    private static native ClassLoader latestUserDefinedLoader();

Usually this ends up being the JRubyClassLoader and everything is happy.  However sometimes we get a OneShotClassLoader and things blow up.  This change tries to load from the JRubyClassLoader before using latestUserDefinedLoader();
