### PR TITLE
Become java statics

### DIFF
--- a/src/org/jruby/RubyClass.java
+++ b/src/org/jruby/RubyClass.java
@@ -1293,7 +1293,7 @@ public class RubyClass extends RubyModule {
                     generateMethodAnnotations(methodAnnos, m, parameterAnnos);
 
                     m.getstatic(javaPath, "rubyClass", ci(RubyClass.class));
-                    m.invokevirtual("org/jruby/RubyClass", "getMetaClass", sig(RubyClass.class) );
+                    //m.invokevirtual("org/jruby/RubyClass", "getMetaClass", sig(RubyClass.class) );
                     m.ldc(methodName); // Method name
                     m.invokevirtual("org/jruby/RubyClass", "callMethod", sig(IRubyObject.class, String.class) );
                     break;
@@ -1303,7 +1303,6 @@ public class RubyClass extends RubyModule {
                     generateMethodAnnotations(methodAnnos, m, parameterAnnos);
 
                     m.getstatic(javaPath, "rubyClass", ci(RubyClass.class));
-                    m.invokevirtual("org/jruby/RubyClass", "getMetaClass", sig(RubyClass.class) );
                     m.ldc(methodName); // Method name
                     m.aload(0);
                     m.invokevirtual("org/jruby/RubyClass", "callMethod", sig(IRubyObject.class, String.class, IRubyObject[].class) );
@@ -1333,7 +1332,6 @@ public class RubyClass extends RubyModule {
                 m.astore(rubyIndex);
 
                 m.getstatic(javaPath, "rubyClass", ci(RubyClass.class));
-                m.invokevirtual("org/jruby/RubyClass", "getMetaClass", sig(RubyClass.class) );
                 
                 m.ldc(methodName); // method name
                 RealClassGenerator.coerceArgumentsToRuby(m, params, rubyIndex);


### PR DESCRIPTION
Patch to 1.5.3 branch to reify Ruby class methods to Java statics.

Does not rebase against master/HEAD due to some changes in visiting methods and the SkinnyMethodAdapter, I think.  I can float it up to master, perhaps, if you prefer.
