### PR TITLE
use `java_import' ... message

### DIFF
--- a/src/org/jruby/runtime/load/CompiledScriptLoader.java
+++ b/src/org/jruby/runtime/load/CompiledScriptLoader.java
@@ -43,7 +43,7 @@ public class CompiledScriptLoader {
             if (Script.class.isAssignableFrom(clazz)) {
                 return (Script)clazz.newInstance();
             } else {
-                throw runtime.newLoadError("use `java_import' to load normal Java classes");
+                throw runtime.newLoadError("use `java_import' to load normal Java classes: "+className);
             }
         } catch (IOException e) {
             throw runtime.newIOErrorFromException(e);


### PR DESCRIPTION
I'm weaving Ruby and Java stuff together in some rather subtle (and scary) ways. It'd help if the "use ..." message told me which class it was having trouble with.
