### PR TITLE
JRUBY-4446

### DIFF
--- a/src/org/jruby/RubyFileTest.java
+++ b/src/org/jruby/RubyFileTest.java
@@ -173,6 +173,11 @@ public class RubyFileTest {
         Ruby runtime = recv.getRuntime();
         JRubyFile file = file(filename);
 
+        // JRUBY-4446, grpowned? always returns false on Windows
+        if (Platform.IS_WINDOWS) {
+            return runtime.getFalse();
+        }
+        
         return runtime.newBoolean(file.exists() && runtime.getPosix().stat(file.getAbsolutePath()).isGroupOwned());
     }
 


### PR DESCRIPTION
It's stupid to have such a simple-to-patch bug like this on Windows, let's close this.

```
C:\Develop\rubyspec>mspec -t j core\filetest\grpowned_spec.rb
jruby 1.6.0.RC2 (ruby 1.8.7 patchlevel 330) (2011-02-25 cf8d961) (Java HotSpot(TM) Client VM 1.6.0_16) [Windows XP-x86-java]
..

Finished in 0.062000 seconds

1 file, 2 examples, 2 expectations, 0 failures, 0 errors
```
