### PR TITLE
fix [JRUBY-5765]: cext build fails if 10.4 sdk installed

### DIFF
--- a/cext/src/Makefile
+++ b/cext/src/Makefile
@@ -154,7 +154,7 @@ endif
 
 ifeq ($(OS), darwin)
   PLATFORM = Darwin
-  MACSDK = $(firstword $(wildcard /Developer/SDKs/MacOSX*.sdk))
+  MACSDK = $(firstword $(wildcard /Developer/SDKs/MacOSX10.[56].sdk))
   JDK_INCLUDES = -I$(MACSDK)/System/Library/Frameworks/JavaVM.framework/Headers
   ARCHES = ppc
   ifneq ($(findstring $(CPU), i386 x86_64),)


### PR DESCRIPTION
If anybody has MacOS 10.7 installed and can confirm that 
the cext build succeeds with with what I assume will be a new
developer sdk named: MacOSX10.7.sdk then update the wildcard
in the make file like this:

  $(wildcard /Developer/SDKs/MacOSX10.[567].sdk)
