### PR TITLE
[JRUBY-5791] ant uses JRuby's gem home

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -5,6 +5,8 @@
 
   <property name="base.dir" location="${basedir}"/>
 
+  <property name="jruby.gem.home.1.8" location="${basedir}/lib/ruby/gems/1.8"/>
+
   <!-- First try to load machine-specific properties. -->
   <property file="build.properties"/>
 
@@ -773,7 +775,7 @@
       <srcfiles dir="${basedir}" includes="${dev.gems}"/>
       <chainedmapper>
         <flattenmapper/>
-        <globmapper from="*.gem" to="${basedir}/lib/ruby/gems/1.8/specifications/*.gemspec"/>
+        <globmapper from="*.gem" to="${jruby.gem.home.1.8}/specifications/*.gemspec"/>
       </chainedmapper>
     </uptodate>
   </condition>
@@ -784,6 +786,15 @@
       <classpath path="${jruby.classes.dir}"/>
       <sysproperty key="jruby.home" value="${basedir}"/>
       <env key="GEM_PATH" value=""/> <!-- to ignore any gems installed in ~/.gem -->
+      <env key="GEM_HOME" value="${jruby.gem.home.1.8}"/> <!-- to make sure we are working with JRuby and not RVM's gems -->
+      <arg line="-e 'require %q/rubygems/; require %q/yaml/; puts %Q/Gem.ruby #{Gem.ruby}/; puts %Q/Gem.bindir #{Gem.bindir}/'"/>
+    </java>
+    <java classname="org.jruby.Main" fork="true" maxmemory="${jruby.launch.memory}" failonerror="false">
+      <classpath refid="build.classpath"/>
+      <classpath path="${jruby.classes.dir}"/>
+      <sysproperty key="jruby.home" value="${basedir}"/>
+      <env key="GEM_PATH" value=""/> <!-- to ignore any gems installed in ~/.gem -->
+      <env key="GEM_HOME" value="${jruby.gem.home.1.8}"/> <!-- to make sure we are working with JRuby and not RVM's gems -->
       <arg line="-S gem uninstall --all ${dev.gem.names}"/>
     </java>
     <java classname="org.jruby.Main" fork="true" maxmemory="${jruby.launch.memory}" failonerror="true">
@@ -791,6 +802,7 @@
       <classpath path="${jruby.classes.dir}"/>
       <sysproperty key="jruby.home" value="${basedir}"/>
       <env key="GEM_PATH" value=""/> <!-- to ignore any gems installed in ~/.gem -->
+      <env key="GEM_HOME" value="${jruby.gem.home.1.8}"/> <!-- to make sure we are working with JRuby and not RVM's gems -->
       <arg line="-S gem install ${dev.gems}"/>
     </java>
   </target>
@@ -802,7 +814,7 @@
         <srcfiles dir="${basedir}" includes="${jruby.launcher.gem}"/>
         <chainedmapper>
           <flattenmapper/>
-          <globmapper from="*.gem" to="${basedir}/lib/ruby/gems/1.8/specifications/*.gemspec"/>
+          <globmapper from="*.gem" to="${jruby.gem.home.1.8}/specifications/*.gemspec"/>
         </chainedmapper>
       </uptodate>
     </or>


### PR DESCRIPTION
RVM defines GEM_HOME and JRuby installs it's development
gems in the wrong place. 

The install-dev-gems ant task now proactively defines
GEM_HOME to reference JRuby's gem home for 1.8 gems.

Having GEM_HOME reference another Ruby is still a problem for 
JRuby, this patch just fixes the ant task.
