### PR TITLE
Quick change to add support for jruby on msys/mingw

### DIFF
--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -17,6 +17,7 @@ cygwin=false
 case "`uname`" in
   CYGWIN*) cygwin=true;;
   Darwin) darwin=true;;
+  MINGW*) jruby.exe "$@"; exit $?;;
 esac
 
 # ----- Verify and Set Required Environment Variables -------------------------


### PR DESCRIPTION
This change simply executes the jruby.exe (passing along any arguments) when 'jruby' is called from mingw. It then exits with the returned code from jruby.exe.
