### PR TITLE
Fix DNS resolution randomly failing

### DIFF
--- a/lib/ruby/1.8/resolv.rb
+++ b/lib/ruby/1.8/resolv.rb
@@ -595,12 +595,7 @@ class Resolv
     end
 
     def self.bind_random_port(udpsock, bind_host="0.0.0.0") # :nodoc:
-      begin
-        port = rangerand(1024..65535)
-        udpsock.bind(bind_host, port)
-      rescue Errno::EADDRINUSE
-        retry
-      end
+      udpsock.bind(bind_host, 0)
     end
 
     class Requester # :nodoc:

--- a/lib/ruby/1.9/resolv.rb
+++ b/lib/ruby/1.9/resolv.rb
@@ -611,12 +611,7 @@ class Resolv
     end
 
     def self.bind_random_port(udpsock, bind_host="0.0.0.0") # :nodoc:
-      begin
-        port = rangerand(1024..65535)
-        udpsock.bind(bind_host, port)
-      rescue Errno::EADDRINUSE
-        retry
-      end
+      udpsock.bind(bind_host, 0)
     end
 
     class Requester # :nodoc:


### PR DESCRIPTION
When resolving DNS, the current code picks a random udp port and tries to bind to it to use for the DNS request. If the port it chooses is already in use, a SocketError is raised (Unlike in regular Ruby where Errno::EADDRINUSE is raised, and a new random port is chosen). Fix by letting the OS choose a random port that is not in use for us.
