### PR TITLE
Allow disabling ENV write-through to the real environment [JRUBY-5934]

### DIFF
--- a/src/org/jruby/RubyGlobal.java
+++ b/src/org/jruby/RubyGlobal.java
@@ -73,8 +73,8 @@ public class RubyGlobal {
      */
     public static class CaseInsensitiveStringOnlyRubyHash extends StringOnlyRubyHash {
         
-        public CaseInsensitiveStringOnlyRubyHash(Ruby runtime, Map valueMap, IRubyObject defaultValue) {
-            super(runtime, valueMap, defaultValue, true);
+        public CaseInsensitiveStringOnlyRubyHash(Ruby runtime, Map valueMap, IRubyObject defaultValue, boolean updateRealENV) {
+            super(runtime, valueMap, defaultValue, updateRealENV);
         }
 
         @Override
@@ -382,11 +382,14 @@ public class RubyGlobal {
     		environmentVariableMap = new HashMap();
     	}
 
-        CaseInsensitiveStringOnlyRubyHash h1 = new CaseInsensitiveStringOnlyRubyHash(runtime,
-                                                       environmentVariableMap, runtime.getNil());
-        h1.getSingletonClass().defineAnnotatedMethods(CaseInsensitiveStringOnlyRubyHash.class);
-        runtime.defineGlobalConstant("ENV", h1);
-        runtime.setENV(h1);
+    	CaseInsensitiveStringOnlyRubyHash env = new CaseInsensitiveStringOnlyRubyHash(runtime,
+                                                       environmentVariableMap, 
+                                                       runtime.getNil(),
+                                                       RubyInstanceConfig.nativeEnabled && 
+                                                           runtime.getInstanceConfig().isUpdateNativeENVEnabled() );
+        env.getSingletonClass().defineAnnotatedMethods(CaseInsensitiveStringOnlyRubyHash.class);
+        runtime.defineGlobalConstant("ENV", env);
+        runtime.setENV(env);
 
         // Define System.getProperties() in ENV_JAVA
         Map systemProps = environment.getSystemPropertiesMap(runtime);

--- a/src/org/jruby/RubyInstanceConfig.java
+++ b/src/org/jruby/RubyInstanceConfig.java
@@ -251,7 +251,8 @@ public class RubyInstanceConfig {
     private String threadDumpSignal = null;
     private boolean hardExit = false;
     private boolean disableGems = false;
-
+    private boolean updateNativeENVEnabled = true;
+    
     private int safeLevel = 0;
 
     private String jrubyHome;
@@ -427,6 +428,7 @@ public class RubyInstanceConfig {
         runRubyInProcess = parentConfig.runRubyInProcess;
         excludedMethods = parentConfig.excludedMethods;
         threadDumpSignal = parentConfig.threadDumpSignal;
+        updateNativeENVEnabled = parentConfig.updateNativeENVEnabled;
         
         classCache = new ClassCache<Script>(loader, jitMax);
 
@@ -1028,6 +1030,16 @@ public class RubyInstanceConfig {
         }
         return home;
     }
+
+    
+    public boolean isUpdateNativeENVEnabled() {
+        return updateNativeENVEnabled;
+    }
+
+    public void setUpdateNativeENVEnabled(boolean updateNativeENVEnabled) {
+        this.updateNativeENVEnabled = updateNativeENVEnabled;
+    }
+
 
     private final class Argument {
         public final String originalValue;

--- a/test/org/jruby/test/TestRubyInstanceConfig.java
+++ b/test/org/jruby/test/TestRubyInstanceConfig.java
@@ -56,6 +56,7 @@ public class TestRubyInstanceConfig extends TestRubyBase {
         assertNull(config.getScriptFileName());
         assertTrue(config.loadPaths().isEmpty());
         assertTrue(config.requiredLibraries().isEmpty());
+        assertTrue(config.isUpdateNativeENVEnabled());
     }
 
     protected final static class NullLoadService extends LoadService {


### PR DESCRIPTION
This adds updateNativeENVEnabled to RubyInstanceConfig with a default of true.
If it is true and jruby.native.enabled is also true, any modifications to
the runtime's ruby ENV will be reflected in the system env via POSIX. Otherwise,
the modifications are not written through.

This setting has not yet been pushed out to the embedding API's (ScriptingContainer
& JRubyEngine), nor has it been documented.

See http://jira.codehaus.org/browse/JRUBY-5934 for details.
