### PR TITLE
fix regexp.to_s string encoding (1.9 mode)

### DIFF
--- a/src/org/jruby/RubyRegexp.java
+++ b/src/org/jruby/RubyRegexp.java
@@ -1684,7 +1684,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
             result.append((byte)':');
             appendRegexpString(getRuntime(), result, bytes, p, len, getEncoding(runtime, str));
             result.append((byte)')');
-            return RubyString.newString(getRuntime(), result).infectBy(this);
+            return RubyString.newString(getRuntime(), result, getEncoding()).infectBy(this);
         } while (true);
     }
 


### PR DESCRIPTION
The encoding of string returned by regexp.to_s should take regexp's encoding into consideration:
#### ruby 1.9.2p180 (2011-02-18 revision 30909) [x86_64-linux]

``` shell
ruby -e "s=//;puts s.to_s.encoding" #=> US-ASCII
ruby -e "s=//u;puts s.to_s.encoding" #=> UTF-8
```
#### jruby 1.7.0.dev (ruby-1.9.2-p136) (2011-08-01 d7ff5b9) (Java HotSpot(TM) 64-Bit Server VM 1.7.0) [linux-amd64-java]

``` shell
jruby --1.9 -e "s=//;puts s.to_s.encoding" #=> ASCII-8BIT
jruby --1.9 -e "s=//u;puts s.to_s.encoding" #=> ASCII-8BIT
```
#### with this patch, jruby 1.7.0.dev (ruby-1.9.2-p136) (2011-08-02 c5ae261) (Java HotSpot(TM) 64-Bit Server VM 1.7.0) [linux-amd64-java]

``` shell
java -jar lib/jruby.jar --1.9 -e "s=//; puts s.to_s.encoding" #=> US-ASCII
java -jar lib/jruby.jar --1.9 -e "s=//u; puts s.to_s.encoding" #=> UTF-8
```
