### PR TITLE
Don't assume every class has a ClassLoader [JRUBY-5965]

### DIFF
--- a/src/org/jruby/javasupport/JavaClass.java
+++ b/src/org/jruby/javasupport/JavaClass.java
@@ -131,7 +131,13 @@ public class JavaClass extends JavaObject {
     private void handleScalaSingletons(Class<?> javaClass, InitializerState state) {
         // check for Scala companion object
         try {
-            Class<?> companionClass = javaClass.getClassLoader().loadClass(javaClass.getName() + "$");
+            ClassLoader cl = javaClass.getClassLoader();
+            if (cl == null) {
+                //this is a core class, bail
+                return;
+            }
+            
+            Class<?> companionClass = cl.loadClass(javaClass.getName() + "$");
             Field field = companionClass.getField("MODULE$");
             Object singleton = field.get(null);
             if (singleton != null) {
@@ -184,8 +190,11 @@ public class JavaClass extends JavaObject {
                     }
                 }
             }
-        } catch (Exception e) {
-            // ignore... there's no companion object
+            
+        // ignore... there's no companion object
+        } catch (ClassNotFoundException e) {
+        } catch (NoSuchFieldException e) {
+        } catch (IllegalAccessException e) {
         }
     }
     


### PR DESCRIPTION
This also replaces the blanket catch with the proper exception classes.

This fixes http://jira.codehaus.org/browse/JRUBY-5965
