### PR TITLE
ArrayProxy#count returns number of elements and ArrayProxy#size returns logical size of all elements

### DIFF
--- a/false
+++ b/false
@@ -1,0 +1,5 @@
+More than one class or module matched your request. You can refine
+your search by asking for information on one of:
+
+     NonString, String, StringIO, StringScanner, NonString, String,
+     StringIO, StringScanner

--- a/spec/ffi/struct_spec.rb
+++ b/spec/ffi/struct_spec.rb
@@ -234,4 +234,17 @@ describe "Struct tests" do
     TestStruct.offset_of(:b).should == 4
     TestStruct.offset_of(:c).should == 8
   end
+  it "ArrayProxy#size should return total size in bytes" do
+    class Thing < FFI::Struct
+      layout :s => [:short, 3]
+    end
+    Thing.new.size.should == 6    
+  end
+  it "ArrayProxy#count should return number of elements" do
+    class Thing < FFI::Struct
+      layout :s => [:short, 3]
+    end
+    Thing.new.count.should == 3
+  end
+  
 end

--- a/src/org/jruby/ext/ffi/StructLayout.java
+++ b/src/org/jruby/ext/ffi/StructLayout.java
@@ -960,9 +960,14 @@ public final class StructLayout extends Type {
 
         @JRubyMethod(name = { "size" })
         public IRubyObject size(ThreadContext context) {
-            return arrayType.length(context);
+            return arrayType.size(context);
         }
 
+        @JRubyMethod(name = { "count"})
+        public IRubyObject length(ThreadContext context) {
+            return arrayType.length(context);
+        }
+        
         /**
          * Needed for Enumerable implementation
          */

--- a/src/org/jruby/ext/ffi/Type.java
+++ b/src/org/jruby/ext/ffi/Type.java
@@ -270,7 +270,7 @@ public abstract class Type extends RubyObject {
             return new Array(context.getRuntime(), (RubyClass) klass, (Type) componentType, RubyNumeric.fix2int(length));
         }
 
-        @JRubyMethod
+        @JRubyMethod(name = { "count"})
         public final IRubyObject length(ThreadContext context) {
             return context.getRuntime().newFixnum(length);
         }


### PR DESCRIPTION
ArrayProxy#count returns number of elements and ArrayProxy#size returns logical size of all elements

consider: 

require 'rubygems'
require 'ffi'

class Thing < FFI::Struct
  layout :s => [:int, 4]
end

t = Thing.new

puts t[:s].count
puts t[:s].size
#### 

in MRI 1.9.2 this prints:

4
16

jruby 1.6.1 prints:

16
16

jruby HEAD prints:

4
4

after this patch it should match MRI with 
4
16
