### PR TITLE
speed up packagemaker in mac installer task

### DIFF
--- a/rakelib/installer.rake
+++ b/rakelib/installer.rake
@@ -40,10 +40,10 @@ task :macos_installer do
     replace_variables_in UNINSTALLER_SCRIPT
     replace_variables_in UNINSTALLER_WELCOME
 
-    puts "- Building package, it takes a while, be patient my friend"
+    puts "- Building package"
     mkdir_p PKG_DIR
-    sh "time /Developer/Applications/Utilities/PackageMaker.app/Contents/MacOS/PackageMaker -v --doc JRuby-installer.pmdoc --out #{PKG_DIR}/JRuby-#{VERSION_JRUBY}.pkg --version #{VERSION_JRUBY}"
-    sh "time /Developer/Applications/Utilities/PackageMaker.app/Contents/MacOS/PackageMaker -v --doc JRuby-uninstaller.pmdoc --out #{PKG_DIR}/JRuby-uninstaller-#{VERSION_JRUBY}.pkg --version #{VERSION_JRUBY}"
+    sh "time /usr/bin/xcrun packagemaker --no-recommend -v --doc JRuby-installer.pmdoc --out #{PKG_DIR}/JRuby-#{VERSION_JRUBY}.pkg --version #{VERSION_JRUBY}"
+    sh "time /usr/bin/xcrun packagemaker --no-recommend -v --doc JRuby-uninstaller.pmdoc --out #{PKG_DIR}/JRuby-uninstaller-#{VERSION_JRUBY}.pkg --version #{VERSION_JRUBY}"
 
     rm DMG if File.exist? DMG = File.join(BASE_DIR, DIST_DIR, "JRuby-#{VERSION_JRUBY}.dmg")
     sh "time hdiutil create #{DMG} -volname JRuby-#{VERSION_JRUBY} -fs HFS+ -srcfolder #{PKG_DIR}"


### PR DESCRIPTION
speed up packagemaker run on macos by telling it not to apply
"recommended permissions" heuristics. it will also not overwrite
permissions with those it finds in previously installed versions of the
package without warning as part of said heuristics. in short, this
brings the build time down from 16 minutes to 2 simply by declaring our own
competency.
