### PR TITLE
Fix block form of 1.9 Open3::popen

### DIFF
--- a/lib/ruby/1.9/open3.rb
+++ b/lib/ruby/1.9/open3.rb
@@ -71,7 +71,7 @@ module Open3
   # Closing stdin, stdout and stderr does not wait the process.
   #
   def popen3(*cmd, &block)
-    IO::popen3(*cmd, &p)
+    IO::popen3(*cmd, &block)
     # if Hash === cmd.last
     #   opts = cmd.pop.dup
     # else


### PR DESCRIPTION
The call to IO::popen3 was copied from the 1.8 open3.rb, but there the block parameter is called differently. Because of this, the block was always ignored.
