### PR TITLE
Readline.java: `Readline::HISTORY << str` and push should return HISTORY

### DIFF
--- a/src/org/jruby/ext/Readline.java
+++ b/src/org/jruby/ext/Readline.java
@@ -431,7 +431,7 @@ public class Readline {
                 RubyString line = lines[i].convertToString();
                 holder.history.addToHistory(line.getUnicodeValue());
             }
-            return recv.getRuntime().getNil();
+            return recv;
         }
 
         @JRubyMethod(name = "pop")


### PR DESCRIPTION
As other rubies:

$ ruby -vrreadline -e 'p(Readline::HISTORY<<"a")'
ruby 1.9.2p290 (2011-07-09 revision 32553) [x86_64-darwin10.8.0]
HISTORY

$ /usr/bin/ruby -vrreadline -e 'p(Readline::HISTORY<<"a")'
ruby 1.8.7 (2009-06-12 patchlevel 174) [universal-darwin10.0]
HISTORY

$ rbx -vrreadline -e 'p(Readline::HISTORY<<"a")'
rubinius 1.2.4 (1.8.7 release 2011-07-05 JI) [x86_64-apple-darwin10.8.0]
HISTORY

Thanks!
