### PR TITLE
Fully unregister the instance mbean [JRUBY-6019]

### DIFF
--- a/src/org/jruby/Ruby.java
+++ b/src/org/jruby/Ruby.java
@@ -2822,6 +2822,7 @@ public final class Ruby {
         getBeanManager().unregisterParserStats();
         getBeanManager().unregisterClassCache();
         getBeanManager().unregisterMethodCache();
+        getBeanManager().unregisterRuntime();
 
         getSelectorPool().cleanup();
 


### PR DESCRIPTION
This is a patch for http://jira.codehaus.org/browse/JRUBY-6019.
