### PR TITLE
Don't rely on FileStat#isIdentical on Windows, since it does not work [JRUBY-5726]

### DIFF
--- a/src/org/jruby/RubyFileTest.java
+++ b/src/org/jruby/RubyFileTest.java
@@ -186,9 +186,21 @@ public class RubyFileTest {
         Ruby runtime = recv.getRuntime();
         JRubyFile file1 = file(filename1);
         JRubyFile file2 = file(filename2);
-        
+
+        if (Platform.IS_WINDOWS) {
+            // posix stat uses inodes to determine indentity, and windows has no inodes
+            // (they are always zero), so we use canonical paths instead. (JRUBY-5726)
+            try {
+                return runtime.newBoolean(file1.exists() && file2.exists() &&
+                                          file1.getCanonicalPath().equals(file2.getCanonicalPath()));
+            } catch (IOException e) {
+                // this is indicative of something really wrong, but for now...
+                return runtime.getFalse();
+            }
+        }
+
         return runtime.newBoolean(file1.exists() && file2.exists() &&
-                runtime.getPosix().stat(file1.getAbsolutePath()).isIdentical(runtime.getPosix().stat(file2.getAbsolutePath())));        
+                runtime.getPosix().stat(file1.getAbsolutePath()).isIdentical(runtime.getPosix().stat(file2.getAbsolutePath())));   
     }
 
     @JRubyMethod(name = "owned?", required = 1, module = true)


### PR DESCRIPTION
Don't rely on FileStat#isIdentical on Windows, since it does not work [JRUBY-5726]

FileStat#isIndentical uses inodes for identity, but Windows doesn't
support inodes, and always returns zero, making all files appear identical.

The commit message has the incorrect jira # (5725 instead of 5726)
