### PR TITLE
Catching RaiseException resolves the issue with Mirah macros. [JRUBY-6043]

### DIFF
--- a/src/org/jruby/javasupport/JavaClass.java
+++ b/src/org/jruby/javasupport/JavaClass.java
@@ -195,6 +195,7 @@ public class JavaClass extends JavaObject {
         } catch (ClassNotFoundException e) {
         } catch (NoSuchFieldException e) {
         } catch (IllegalAccessException e) {
+        } catch (RaiseException e) {
         }
     }
     


### PR DESCRIPTION
Catching RaiseException resolves the issue with Mirah macros. [JRUBY-6043]

Should also go into jruby-1_6.
