### PR TITLE
A simple fix for JRUBY-6070

### DIFF
--- a/src/org/jruby/ext/socket/RubyTCPSocket.java
+++ b/src/org/jruby/ext/socket/RubyTCPSocket.java
@@ -96,10 +96,10 @@ public class RubyTCPSocket extends RubyIPSocket {
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
         Arity.checkArgumentCount(context.getRuntime(), args, 2, 4);
 
-        String remoteHost = args[0].isNil()? "localhost" : args[0].convertToString().toString();
-        int remotePort = getPortFrom(context.getRuntime(), args[1]);
-        String localHost = args.length >= 3 && !args[2].isNil() ? args[2].convertToString().toString() : null;
-        int localPort = args.length == 4 ? getPortFrom(context.getRuntime(), args[3]) : 0;
+        String remoteHost = args[0].isNil() ? "localhost" : args[0].convertToString().toString();
+        int remotePort    = getPortFrom(context.getRuntime(), args[1]);
+        String localHost  = args.length >= 3 && !args[2].isNil() ? args[2].convertToString().toString() : null;
+        int localPort     = args.length == 4 && !args[3].isNil() ? getPortFrom(context.getRuntime(), args[3]) : 0;
 
         try {
             // This is a bit convoluted because (1) SocketChannel.bind is only in jdk 7 and


### PR DESCRIPTION
Headius and Rakaur said there might be a spec (?) that tests this already, but I don't know how that works.

This is the output I get from my local build:

jruby-1.6.4 :003 > TCPSocket.new('someplace', 1234, nil, nil)
SocketError: initialize: name or service not known
    from org/jruby/ext/socket/RubyTCPSocket.java:128:in `initialize'

It matches the output from Ruby 1.9.2

ruby-1.9.2-p290 :002 > TCPSocket.new('someplace', 1234, nil, nil)
SocketError: getaddrinfo: nodename nor servname provided, or not known
    from (irb):2:in `initialize'
