### PR TITLE
Fix for JRUBY-6031

### DIFF
--- a/src/org/jruby/RubyEncoding.java
+++ b/src/org/jruby/RubyEncoding.java
@@ -30,6 +30,8 @@ import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CodingErrorAction;
+
 import org.jcodings.Encoding;
 import org.jcodings.EncodingDB.Entry;
 import org.jcodings.specific.ASCIIEncoding;
@@ -210,6 +212,10 @@ public class RubyEncoding extends RubyObject {
         private static final int BUF_SIZE = CHAR_THRESHOLD * 4;
         private final ByteBuffer byteBuffer = ByteBuffer.allocate(BUF_SIZE);
         private final CharBuffer charBuffer = CharBuffer.allocate(BUF_SIZE);
+
+        public UTF8Coder() {
+            decoder.onMalformedInput(CodingErrorAction.REPLACE);
+        }
 
         public byte[] encode(CharSequence cs) {
             ByteBuffer buffer;


### PR DESCRIPTION
When sending non-UTF-8 character strings into RubyString#getUnicodeValue,
the decoder was bailing out upon MalformedInput, but not communicating
that failure further up the stack.  Therefore, character strings were
getting silently truncated when going through ARJDBC.  This fix simply
sets CodingErrorAction.REPLACE instead, which means the entire string
will be returned, though with replacements for the malformed input.
