### PR TITLE
* JRUBY-6077 Allow loading a Ruby source file from the class path using the fully qualified name

### DIFF
--- a/src/org/jruby/runtime/load/LoadService.java
+++ b/src/org/jruby/runtime/load/LoadService.java
@@ -1258,6 +1258,10 @@ public class LoadService {
                 entry = entry.substring("classpath:".length());
             }
 
+            if (name.startsWith(entry)) {
+                name = name.substring(entry.length());
+            }
+
             // otherwise, try to load from classpath (Note: Jar resources always uses '/')
             LoadServiceResource foundResource = getClassPathResource(classLoader, entry + "/" + name);
             if (foundResource != null) {
@@ -1303,6 +1307,8 @@ public class LoadService {
         } else if (name.startsWith("classpath:")) {
             isClasspathScheme = true;
             name = name.substring("classpath:".length());
+        } else if(name.startsWith("file:") && name.indexOf("!/") != -1) {
+            name = name.substring(name.indexOf("!/") + 2);
         }
 
         debugLogTry("fileInClasspath", name);


### PR DESCRIPTION
This allows ActiveSupport autoloading source files from jars.
