### PR TITLE
Fix shell syntax compatibility for 'jruby' shell script.

### DIFF
--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -52,7 +52,7 @@ fi
 
 JRUBY_OPTS_SPECIAL="--ng" # space-separated list of special flags
 unset JRUBY_OPTS_TEMP
-function process_special_opts {
+process_special_opts() {
     case $1 in
         --ng) nailgun_client=true;;
         *) break;;


### PR DESCRIPTION
(If you want me to file a bug in Jira about this, or bring up discussion on another medium than github pull requests, I am happy to do so, just let me know)

Many /bin/sh's don't support function declarations in the form:

```
function somename {
  ...
}
```

but some only support the old bourne style functions:

```
somename() {
  ...
}
```

On systems like Ubuntu that use 'dash' for /bin/sh, this commit fixes
the following error:

```
bin/jruby: 55: function: not found
bin/jruby: 60: Syntax error: "}" unexpected
```
