### PR TITLE
JRUBY-3944: process :binmode option

### DIFF
--- a/src/org/jruby/RubyIO.java
+++ b/src/org/jruby/RubyIO.java
@@ -4006,6 +4006,21 @@ public class RubyIO extends RubyObject {
             modes = parseModes19(context, rubyOptions.fastARef(runtime.newSymbol("mode")).asString());
         }
 
+	// This duplicates the non-error behavior of MRI 1.9: the
+	// :binmode option is ORed in with other options. It does
+	// not obliterate what came before.
+
+	if (rubyOptions.containsKey(runtime.newSymbol("binmode")) &&
+	    rubyOptions.fastARef(runtime.newSymbol("binmode")).isTrue()) {
+	    try {
+		modes = new ModeFlags(modes.getFlags() | ModeFlags.BINARY);
+	    } catch (InvalidValueException e) {
+		throw getRuntime().newErrnoEINVALError(); // n.b., this should be unreachable
+							  // because we are changing neither read-only
+							  // nor append.
+	    }
+	}
+
 //      FIXME: check how ruby 1.9 handles this
 
 //        if (rubyOptions.containsKey(runtime.newSymbol("textmode")) &&

--- a/src/org/jruby/util/io/ModeFlags.java
+++ b/src/org/jruby/util/io/ModeFlags.java
@@ -206,7 +206,17 @@ public class ModeFlags implements Cloneable {
         // TODO: Make this more intelligible value
         return ""+flags;
     }
-    
+
+    /**
+     * Return a value that, when passed to our constructor,
+     * would create a copy of this instance.
+     *
+     * @return an int of the private flags variable.
+     */
+    public int getFlags() {
+	return flags;
+    }
+
     /**
      * Convert the flags in this object to a set of flags appropriate for the
      * OpenFile structure and logic therein.


### PR DESCRIPTION
The :binmode option, when set to TRUE, is ORed in with flags from the mode string or
:mode option, as it is in MRI 1.9.2. Tested in rubyspec; both MRI and this code pass
new tests for :binmode, and the existing jruby 1.6.5 code fails as expected.
