### PR TITLE
Fix for JRUBY-6043, JRUBY-6058.

### DIFF
--- a/src/org/jruby/javasupport/JavaClass.java
+++ b/src/org/jruby/javasupport/JavaClass.java
@@ -191,10 +191,8 @@ public class JavaClass extends JavaObject {
                 }
             }
             
-        // ignore... there's no companion object
-        } catch (ClassNotFoundException e) {
-        } catch (NoSuchFieldException e) {
-        } catch (IllegalAccessException e) {
+        } catch (Exception e) {
+            // ignore... there's no companion object
         }
     }
     


### PR DESCRIPTION
This reverts back to blanket exception catching (which JRUBY-5965 removed), since
at least two different exception types slipped through on the last patch, breaking
Mirah and GAE. This should get us back to a working state for both.

It's better to have it working than 'correct' with regards to all of the possible exceptions to catch.
