### PR TITLE
Remove fileno map entries when closing a RubyIO (JRUBY-6137)

### DIFF
--- a/src/org/jruby/Ruby.java
+++ b/src/org/jruby/Ruby.java
@@ -3468,6 +3468,14 @@ public final class Ruby {
         return internal;
     }
 
+    public int getFilenoIntMapSize() {
+        return filenoIntExtMap.size();
+    }
+
+    public void removeFilenoIntMap(int internal) {
+        filenoIntExtMap.remove(internal);
+    }
+
     /**
      * Get the "external" fileno for a given ChannelDescriptor. Primarily for
      * the shared 0, 1, and 2 filenos, which we can't actually share across

--- a/src/org/jruby/util/io/OpenFile.java
+++ b/src/org/jruby/util/io/OpenFile.java
@@ -329,6 +329,7 @@ public class OpenFile {
                 if (ms != null) {
                     // TODO: Ruby logic is somewhat more complicated here, see comments after
                     main = ms.getDescriptor();
+                    runtime.removeFilenoIntMap(main.getFileno());
                     try {
                         // check for closed channel due to child exit
                         if (isProcess && ms.getChannel().isOpen()

--- a/test/test_io.rb
+++ b/test/test_io.rb
@@ -540,4 +540,15 @@ class TestIO < Test::Unit::TestCase
   def test_stringio_gets_separator
     assert_equal 'abc', @stringio.gets('c')
   end
+
+  # JRUBY-6137
+  def test_rubyio_fileno_mapping_leak
+    starting_count = JRuby.runtime.fileno_int_map_size
+    io = org.jruby.RubyIO.new(JRuby.runtime, org.jruby.util.io.STDIO::ERR)
+    open_io_count = JRuby.runtime.fileno_int_map_size
+    assert_equal(starting_count + 1, open_io_count)
+    io.close
+    closed_io_count = JRuby.runtime.fileno_int_map_size
+    assert_equal(starting_count, closed_io_count)
+  end
 end


### PR DESCRIPTION
We only remove the entry from filenoIntExtMap since that's the only one
that grows indefinitely as new RubyIOs are created for STDIO streams.
