### PR TITLE
Cleanup leftover bits from previous changes to Maven POMs (JRuby-6145)

### DIFF
--- a/maven/jruby-complete/pom.xml
+++ b/maven/jruby-complete/pom.xml
@@ -30,7 +30,7 @@
       <scope>${jar.scope}</scope>
     </dependency>
     <dependency>
-      <groupId>jnr.posix</groupId>
+      <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
       <scope>${jar.scope}</scope>
     </dependency>
@@ -52,11 +52,6 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jffi</artifactId>
-      <scope>${jar.scope}</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jruby.extras</groupId>
-      <artifactId>jaffl</artifactId>
       <scope>${jar.scope}</scope>
     </dependency>
     <dependency>

--- a/maven/jruby-core/pom.xml
+++ b/maven/jruby-core/pom.xml
@@ -30,7 +30,7 @@
       <scope>${jar.scope}</scope>
     </dependency>
     <dependency>
-      <groupId>jnr.posix</groupId>
+      <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
       <scope>${jar.scope}</scope>
     </dependency>
@@ -52,11 +52,6 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jffi</artifactId>
-      <scope>${jar.scope}</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jruby.extras</groupId>
-      <artifactId>jaffl</artifactId>
       <scope>${jar.scope}</scope>
     </dependency>
     <dependency>

--- a/maven/jruby/pom.xml
+++ b/maven/jruby/pom.xml
@@ -30,7 +30,7 @@
       <scope>${jar.scope}</scope>
     </dependency>
     <dependency>
-      <groupId>jnr.posix</groupId>
+      <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
       <scope>${jar.scope}</scope>
     </dependency>
@@ -52,11 +52,6 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jffi</artifactId>
-      <scope>${jar.scope}</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jruby.extras</groupId>
-      <artifactId>jaffl</artifactId>
       <scope>${jar.scope}</scope>
     </dependency>
     <dependency>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
-      <version>2.1<version>
+      <version>2.1</version>
       <scope>${jar.scope}</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This gets 'mvn install' working again on master.
