### PR TITLE
Bump macosx-version-min from 10.4 to 10.5.

### DIFF
--- a/src/org/jruby/ext/rbconfig/RbConfigLibrary.java
+++ b/src/org/jruby/ext/rbconfig/RbConfigLibrary.java
@@ -292,7 +292,7 @@ public class RbConfigLibrary implements Library {
         } else if (Platform.IS_MAC) {
             ldsharedflags = " -dynamic -bundle -undefined dynamic_lookup ";
             cflags = " -fPIC -DTARGET_RT_MAC_CFM=0 " + cflags;
-            ldflags += " -bundle -framework JavaVM -Wl,-syslibroot,$(SDKROOT) -mmacosx-version-min=10.4 ";
+            ldflags += " -bundle -framework JavaVM -Wl,-syslibroot,$(SDKROOT) -mmacosx-version-min=10.5 ";
             archflags = " -arch " + Platform.ARCH;
             cppflags = " -D_XOPEN_SOURCE -D_DARWIN_C_SOURCE " + cppflags;
             setConfig(mkmfHash, "DLEXT", "bundle");


### PR DESCRIPTION
With this set at 10.4 the MacOS X compiler complains about '-rpath' only
being applicable to 10.5 and above (noticed during 'gem install
mysql2').  Bump it to 10.5 and the error is gone.
