### PR TITLE
IO#readbyte should be available in 1.8 too

### DIFF
--- a/src/org/jruby/RubyIO.java
+++ b/src/org/jruby/RubyIO.java
@@ -2378,7 +2378,7 @@ public class RubyIO extends RubyObject {
         return getc(); // Yes 1.8 getc is 1.9 getbyte
     }
     
-    @JRubyMethod(compat = RUBY1_9)
+    @JRubyMethod
     public IRubyObject readbyte(ThreadContext context) {
         int c = getcCommon();
         if (c == -1) {


### PR DESCRIPTION
JRuby presents itself as "jruby 1.6.5 (ruby-1.8.7-p330)" and MRI 1.8.7 does support `IO#readbyte`.

This was also mentioned in [JRUBY-5888](http://jira.codehaus.org/browse/JRUBY-5888), but the implementation was specific to 1.9 compatibility mode.
