### PR TITLE
Windows won't move the `.jar.bak` file back to the `.jar` as there's a f...

### DIFF
--- a/test/test_dir_with_jar_without_dir_entry.rb
+++ b/test/test_dir_with_jar_without_dir_entry.rb
@@ -13,7 +13,7 @@ class TestDirWithJarWithoutDirEntry < TestDir # < Test::Unit::TestCase
 
   def teardown
     super
-    FileUtils.mv JAR_BAK, JAR if File.exists? JAR_BAK
+    FileUtils.mv JAR_BAK, JAR, :force => true if File.exists? JAR_BAK
   end
 
 end


### PR DESCRIPTION
...ile there, so forcing it works when tearing down.
