### PR TITLE
fix test/test_file#test_file_uri_stat on WinXP

### DIFF
--- a/src/org/jruby/RubyFileStat.java
+++ b/src/org/jruby/RubyFileStat.java
@@ -112,40 +112,44 @@ public class RubyFileStat extends RubyObject {
             filename += "/";
         }
 
-        if (filename.startsWith("file:") && filename.indexOf('!') != -1) {
-            // file: URL handling
-            String zipFileEntry = filename.substring(filename.indexOf("!") + 1);
-            if (zipFileEntry.length() > 0) {
-                if (zipFileEntry.charAt(0) == '/') {
-                    if (zipFileEntry.length() > 1) {
-                        zipFileEntry = zipFileEntry.substring(1);
-                    } else {
+        if (filename.startsWith("file:") ) {
+            if (filename.indexOf('!') != -1) {
+                // file: URL handling
+                String zipFileEntry = filename.substring(filename.indexOf("!") + 1);
+                if (zipFileEntry.length() > 0) {
+                    if (zipFileEntry.charAt(0) == '/') {
+                        if (zipFileEntry.length() > 1) {
+                            zipFileEntry = zipFileEntry.substring(1);
+                        } else {
+                            throw getRuntime().newErrnoENOENTError("invalid jar/file URL: " + filename);
+                        }
+                    }
+                } else {
+                    throw getRuntime().newErrnoENOENTError("invalid jar/file URL: " + filename);
+                }
+                String zipfilename = filename.substring(5, filename.indexOf("!"));
+
+                try {
+                    ZipFile zipFile = new ZipFile(zipfilename);
+                    ZipEntry zipEntry = RubyFile.getFileEntry(zipFile, zipFileEntry);
+
+                    if (zipEntry == null) {
                         throw getRuntime().newErrnoENOENTError("invalid jar/file URL: " + filename);
                     }
+                    stat = new ZipFileStat(zipEntry);
+                    return;
+                } catch (IOException ioe) {
+                    // fall through and use the zip file as the file to stat
                 }
+
+                filename = zipfilename;
             } else {
                 throw getRuntime().newErrnoENOENTError("invalid jar/file URL: " + filename);
             }
-            String zipfilename = filename.substring(5, filename.indexOf("!"));
-            
-            try {
-                ZipFile zipFile = new ZipFile(zipfilename);
-                ZipEntry zipEntry = RubyFile.getFileEntry(zipFile, zipFileEntry);
-
-                if (zipEntry == null) {
-                    throw getRuntime().newErrnoENOENTError("invalid jar/file URL: " + filename);
-                }
-                stat = new ZipFileStat(zipEntry);
-                return;
-            } catch (IOException ioe) {
-                // fall through and use the zip file as the file to stat
-            }
-
-            filename = zipfilename;
         }
-            
+
         file = JRubyFile.create(getRuntime().getCurrentDirectory(), filename);
-        
+
         if (file instanceof JRubyNonExistentFile) {
             throw getRuntime().newErrnoENOENTError("No such file or directory - " + filename);
         }


### PR DESCRIPTION
The if statement should be broken down into two parts so an else clause
can throw an exception for file not found errors as it does throughout the
rest of the method.

Fixes the following test failures on WinXP when running `bin\jruby.bat test\test_file.rb`:

```
  2) Failure:
test_file_stat_uri_prefixes(TestFile) [.\test\test_file.rb:556]:
[Errno::ENOENT] exception expected, not
Class: <SystemCallError>
Message: <"Unknown error - Unknown Error (20047) - C:/klauer-jruby/file:">
---Backtrace---
org/jruby/RubyFile.java:1516:in `lstat'
.\test\test_file.rb:557:in `test_file_stat_uri_prefixes'
---------------

  3) Failure:
test_file_time_uri_prefixes(TestFile) [.\test\test_file.rb:573]:
[Errno::ENOENT] exception expected, not
Class: <SystemCallError>
Message: <"Unknown error - Unknown Error (20047) - C:/klauer-jruby/file:">
---Backtrace---
org/jruby/RubyFile.java:1528:in `atime'
.\test\test_file.rb:574:in `test_file_time_uri_prefixes'
---------------
```
