### PR TITLE
RubyFileStat::cmp shouldn't throw ClassCastException

### DIFF
--- a/src/org/jruby/RubyFileStat.java
+++ b/src/org/jruby/RubyFileStat.java
@@ -368,7 +368,7 @@ public class RubyFileStat extends RubyObject {
 
     @JRubyMethod(name = "<=>", required = 1)
     public IRubyObject cmp(IRubyObject other) {
-        if (!(other instanceof RubyFileStat)) getRuntime().getNil();
+        if (!(other instanceof RubyFileStat)) return getRuntime().getNil();
         
         long time1 = stat.mtime();
         long time2 = ((RubyFileStat) other).stat.mtime();


### PR DESCRIPTION
Comparing a RubyFileStat object with an object which is not a RubyFileStat should return 'nil'.

Otherwise, we get a ClassCastException when we attempt to cast "other" to a RubyFileStat.
