### PR TITLE
Don't select bridge method for invocation.

### DIFF
--- a/src/org/jruby/javasupport/JavaClass.java
+++ b/src/org/jruby/javasupport/JavaClass.java
@@ -2049,6 +2049,11 @@ public class JavaClass extends JavaObject {
             // Skip private methods, since they may mess with dispatch
             if (Modifier.isPrivate(m.getModifiers())) continue;
 
+            // ignore bridge methods because we'd rather directly call methods that this method
+            // is bridging (and such methods are by definition always available.)
+            if ((m.getModifiers()&ACC_BRIDGE)!=0)
+                continue;
+
             if (!includeStatic && Modifier.isStatic(m.getModifiers())) {
                 // Skip static methods if we're not suppose to include them.
                 // Generally for superclasses; we only bind statics from the actual
@@ -2132,4 +2137,6 @@ public class JavaClass extends JavaObject {
         
         return finalList.toArray(new Method[finalList.size()]);
     }
+
+    private static final int ACC_BRIDGE    = 0x00000040;
 }


### PR DESCRIPTION
When selecting methods to expose to Ruby, there's no need to select bridge methods. 

This eliminates redundant method calls, although that isn't why I need it.

My primary reason for this change is bit unusual; I've got a little byte code post processor to inject synthetic bridge methods to help me evolve code without breaking existing binaries, (http://bridge-method-injector.infradna.com/), and as a part of this I generate a bridge method whose return type is narrower, instead of wider.

That is, whereas normally bridge methods are as follows:

<pre>
interface Base {
    Object foo();
}

class Impl implements Base {
    String foo() {...}

    // the above definition causes javac to insert the following
    // bridge method
    @Synthetic @Bridge
    Object foo() { return <String>foo(); }
}
</pre>


my byte code post processing would produce this:

```
class Impl /* no interface needed */ {
    Object foo() {...}

    @Synthetic @Bridge
    String foo() { return (String)<Object>foo(); }
}
```

This works with javac, in the sense that it'll invoke "Object foo()", by preferring non-bridge methods for resolution.

Unfortunately, JRuby doesn't discreminate against bridge methods, so it can end up calling "String foo()" depending on the exact implementation detail of the search.

This fix eliminates this issue by making JRuby ignore all bridge methods. Would you please please include this?

(In the past I've made [a similar patch to Groovy](http://jira.codehaus.org/browse/GROOVY-5003))
