### PR TITLE
Calls modify() in select_bang to make sure shared memory is not overwrit...

### DIFF
--- a/src/org/jruby/RubyArray.java
+++ b/src/org/jruby/RubyArray.java
@@ -2396,7 +2396,9 @@ public class RubyArray extends RubyObject implements List, RandomAccess {
     public IRubyObject select_bang(ThreadContext context, Block block) {
         Ruby runtime = context.getRuntime();
         if (!block.isGiven()) return enumeratorize(runtime, this, "select!");
-
+        
+        modify();
+        
         int newLength = 0;
         IRubyObject[] aux = new IRubyObject[values.length];
 


### PR DESCRIPTION
...ten.

This happens in jruby 1.6.5.1 when an array is copied and the copy is modified using select!:

irb(main):007:0> a = [1, 2, 3]
=> [1, 2, 3]
irb(main):008:0> b = Array.new(a)
=> [1, 2, 3]
irb(main):009:0> b.select! &:odd?
=> [1, 3]
irb(main):010:0> a
=> [1, 3, 3]
