### PR TITLE
 java.util.Collection#each should respect to_ary that objects defined

### DIFF
--- a/spec/java_integration/extensions/list_spec.rb
+++ b/spec/java_integration/extensions/list_spec.rb
@@ -54,4 +54,22 @@ describe "List Ruby extensions" do
    it "should support slicing with exclusive ranges" do
     @list[0...2].to_a.should == @data[0...2]
   end
+
+  it "should respect to_ary objects defined on iteration" do
+    class Pair
+      def initialize(a, b)
+        @a = a
+        @b = b
+      end
+
+      def to_ary
+        [@a, @b]
+      end
+    end
+
+    ArrayList.new([Pair.new(:x, :y)]).each do |car, cdr|
+      car.should == :x
+      cdr.should == :y
+    end
+  end
 end

--- a/src/jruby/java/java_ext/java.util.rb
+++ b/src/jruby/java/java_ext/java.util.rb
@@ -4,7 +4,7 @@ module java::util::Collection
   def each(&block)
     iter = iterator
     while iter.hasNext
-      block.call(iter.next)
+      yield(iter.next)
     end
   end
   def <<(a); add(a); self; end


### PR DESCRIPTION
If you have a collection of objects that defined to_ary method, with normal ruby array you get sort of argument pattern matching when you iterate them:

``` ruby
class Pair 
  def initialize(a, b) 
    @a = a 
    @b = b 
  end

  def to_ary 
    [@a, @b] 
  end 
end
```

``` ruby
>> [Pair.new('first', 'second')].each {|a, b| p a; p b}
  "first"
  "second"
```

But with a java collection you do not get this behavior

``` ruby
>>java.util.ArrayList.new([Pair.new('first', 'second')]).each { |a, b| p a; p b }
  ##<Pair:0x54be8c3e @b="second", @a="first">
  nil
```

This seems like only a little bit inconsistency. But it do give me inconvenience currently. I have java methods returns a List of Pair defines in java which has to_ary defined on them. I need call to_a on the list each time I want to map through it.
