### PR TITLE
Avoid warning: statement not reached SecureRandom

### DIFF
--- a/lib/ruby/site_ruby/shared/securerandom.rb
+++ b/lib/ruby/site_ruby/shared/securerandom.rb
@@ -55,74 +55,7 @@ module SecureRandom
     raise ArgumentError, "negative argument: #{n}" if n < 0
     bytes = Java::byte[n].new
     java.security.SecureRandom.new.nextBytes(bytes)
-    return String.from_java_bytes(bytes)
-
-    # original implementation
-    n ||= 16
-
-    if defined? OpenSSL::Random
-      @pid = $$ if !defined?(@pid)
-      pid = $$
-      if @pid != pid
-        now = Time.now
-        ary = [now.to_i, now.nsec, @pid, pid]
-        OpenSSL::Random.seed(ary.to_s)
-        @pid = pid
-      end
-      return OpenSSL::Random.random_bytes(n)
-    end
-
-    if !defined?(@has_urandom) || @has_urandom
-      flags = File::RDONLY
-      flags |= File::NONBLOCK if defined? File::NONBLOCK
-      flags |= File::NOCTTY if defined? File::NOCTTY
-      begin
-        File.open("/dev/urandom", flags) {|f|
-          unless f.stat.chardev?
-            raise Errno::ENOENT
-          end
-          @has_urandom = true
-          ret = f.readpartial(n)
-          if ret.length != n
-            raise NotImplementedError, "Unexpected partial read from random device"
-          end
-          return ret
-        }
-      rescue Errno::ENOENT
-        @has_urandom = false
-      end
-    end
-
-    if !defined?(@has_win32)
-      begin
-        require 'Win32API'
-
-        crypt_acquire_context = Win32API.new("advapi32", "CryptAcquireContext", 'PPPII', 'L')
-        @crypt_gen_random = Win32API.new("advapi32", "CryptGenRandom", 'LIP', 'L')
-
-        hProvStr = " " * 4
-        prov_rsa_full = 1
-        crypt_verifycontext = 0xF0000000
-
-        if crypt_acquire_context.call(hProvStr, nil, nil, prov_rsa_full, crypt_verifycontext) == 0
-          raise SystemCallError, "CryptAcquireContext failed: #{lastWin32ErrorMessage}"
-        end
-        @hProv, = hProvStr.unpack('L')
-
-        @has_win32 = true
-      rescue LoadError
-        @has_win32 = false
-      end
-    end
-    if @has_win32
-      bytes = " ".force_encoding("ASCII-8BIT") * n
-      if @crypt_gen_random.call(@hProv, bytes.size, bytes) == 0
-        raise SystemCallError, "CryptGenRandom failed: #{lastWin32ErrorMessage}"
-      end
-      return bytes
-    end
-
-    raise NotImplementedError, "No random device"
+    String.from_java_bytes(bytes)
   end
 
   # SecureRandom.hex generates a random hex string.


### PR DESCRIPTION
The runtime warning here was:

.../ruby/site_ruby/shared/securerandom.rb:61 warning: Statement not reached

and indeed there was a large block of unreachable code.
