### PR TITLE
Resolves Major Bug in Win32OLE in 1.9 mode (JRUBY-5216)

### DIFF
--- a/lib/ruby/1.9/win32/registry.rb
+++ b/lib/ruby/1.9/win32/registry.rb
@@ -215,11 +215,11 @@ For detail, see the MSDN[http://msdn.microsoft.com/library/en-us/sysinfo/base/pr
         "long RegEnumKeyExA(void *, long, void *, void *, void *, void *, void *, void *)",
         "long RegQueryValueExA(void *, void *, void *, void *, void *, void *)",
         "long RegSetValueExA(void *, void *, long, long, void *, long)",
-        "long RegDeleteValue(void *, void *)",
-        "long RegDeleteKey(void *, void *)",
+        "long RegDeleteValueA(void *, void *)",
+        "long RegDeleteKeyA(void *, void *)",
         "long RegFlushKey(void *)",
         "long RegCloseKey(void *)",
-        "long RegQueryInfoKey(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *)",
+        "long RegQueryInfoKeyA(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *)",
       ].each do |fn|
         cfunc = extern fn, :stdcall
         const_set cfunc.name.intern, cfunc


### PR DESCRIPTION
Win32OLE does not load at all in Ruby1.9 mode, though it works in Ruby1.8 mode.
See http://jira.codehaus.org/browse/JRUBY-5216 for more details.

According to the Windows API docs, these functions come in ANSI and Unicode flavors, so I chose the ANSI flavor to match the others called out in the existing code.

See the following WinAPI docs:
- RegDeleteValue: http://msdn.microsoft.com/en-us/library/ms724851(v=vs.85).aspx
- RegDeleteKey: http://msdn.microsoft.com/en-us/library/ms724845(v=vs.85).aspx
- RegQueryInfoKey: http://msdn.microsoft.com/en-us/library/ms724902(v=vs.85).aspx
