### PR TITLE
add a regression test for Open3.popen3, because it's also affected by "Stream closed" issue

### DIFF
--- a/spec/regression/JRUBY-6291_popen_close_streams_spec.rb
+++ b/spec/regression/JRUBY-6291_popen_close_streams_spec.rb
@@ -1,3 +1,5 @@
+require 'rbconfig'
+
 describe 'JRUBY-6291: Closing Stream in IO.popen4 and Open3.popen3' do
   it 'should not error when reading from other streams using IO.popen4' do
     if RbConfig::CONFIG['host_os'] =~ /mingw|mswin/


### PR DESCRIPTION
Imitating Ben Browning's test for IO.popen4, here's a test for Open3.popen3.
