### PR TITLE
Prevents "cygpath: can't convert empty path" on cygwin when no other jar...

### DIFF
--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -173,7 +173,7 @@ else
         fi
     done
 
-    if $cygwin; then
+    if [ "$CP" != "" ] && $cygwin; then
         CP=`cygpath -p -w "$CP"`
     fi
 fi


### PR DESCRIPTION
...s besides jruby.jar are present in $JRUBY_HOME/lib (as is the case with a fresh install).
