### PR TITLE
toURI would cause exception when there is special char in the absolute path

### DIFF
--- a/src/org/jruby/embed/osgi/utils/OSGiFileLocator.java
+++ b/src/org/jruby/embed/osgi/utils/OSGiFileLocator.java
@@ -67,7 +67,7 @@ public class OSGiFileLocator {
 		URL url = null;
 		try {
 			url = getFileURL(bundle.getEntry(path));
-			return new File(url.toURI());
+			return new File(url.getFile());
 		} catch (NullPointerException ne) {
 			throw new IOException("Unable to find the " + path + " folder in the bundle '" 
 					+ bundle.getSymbolicName() + "'; is the org.jruby.jruby bundle unzipped? ");


### PR DESCRIPTION
such as SPACE. 

better use getFile() as it is going to construct a File object.
