### PR TITLE
test_zlib.rb should not be failed with  "uninitialized constant TestZlib::Tempfile"

### DIFF
--- a/test/test_zlib.rb
+++ b/test/test_zlib.rb
@@ -1,6 +1,7 @@
 require 'test/unit'
 require 'zlib'
 require 'stringio'
+require 'tempfile'
 
 class TestZlib < Test::Unit::TestCase
   def teardown;  File.unlink @filename if @filename; end


### PR DESCRIPTION
It seems "test_zlib.rb"  has one error like "uninitialized constant TestZlib::Tempfile",
and the proposed change will fix it.
