### PR TITLE
Patch for issue JRUBY-6389

### DIFF
--- a/src/org/jruby/runtime/load/LoadService.java
+++ b/src/org/jruby/runtime/load/LoadService.java
@@ -1045,8 +1045,7 @@ public class LoadService {
         Outer: for (int i = 0; i < loadPath.size(); i++) {
             // TODO this is really inefficient, and potentially a problem everytime anyone require's something.
             // we should try to make LoadPath a special array object.
-            RubyString entryString = loadPath.eltInternal(i).convertToString();
-            String loadPathEntry = entryString.asJavaString();
+            String loadPathEntry = getLoadPathEntry(loadPath.eltInternal(i));
 
             if (loadPathEntry.equals(".") || loadPathEntry.equals("")) {
                 foundResource = tryResourceFromCWD(state, baseName, suffixType);
@@ -1088,6 +1087,11 @@ public class LoadService {
         return foundResource;
     }
     
+    protected String getLoadPathEntry(IRubyObject entry) {
+        RubyString entryString = entry.convertToString();
+        return entryString.asJavaString();
+    }
+
     protected LoadServiceResource tryResourceFromJarURLWithLoadPath(String namePlusSuffix, String loadPathEntry) {
         LoadServiceResource foundResource = null;
         
@@ -1244,8 +1248,7 @@ public class LoadService {
         for (int i = 0; i < loadPath.size(); i++) {
             // TODO this is really inefficient, and potentially a problem everytime anyone require's something.
             // we should try to make LoadPath a special array object.
-            RubyString entryString = loadPath.eltInternal(i).convertToString();
-            String entry = entryString.asJavaString();
+            String entry = getLoadPathEntry(loadPath.eltInternal(i));
 
             // if entry is an empty string, skip it
             if (entry.length() == 0) continue;

--- a/src/org/jruby/runtime/load/LoadService19.java
+++ b/src/org/jruby/runtime/load/LoadService19.java
@@ -28,7 +28,10 @@
 package org.jruby.runtime.load;
 
 import org.jruby.Ruby;
+import org.jruby.RubyString;
 import org.jruby.platform.Platform;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.ThreadContext;
 import org.jruby.util.JRubyFile;
 
 import java.security.AccessControlException;
@@ -62,4 +65,19 @@ public class LoadService19 extends LoadService {
     protected String getFileName(JRubyFile file, String nameWithSuffix) {
         return file.getAbsolutePath();
     }
+
+    @Override
+    protected String getLoadPathEntry(IRubyObject entry) {
+        RubyString entryString;
+        ThreadContext context = entry.getRuntime().getCurrentContext();
+
+        if (entry.respondsTo("to_path")) {
+            entryString = entry.callMethod(context, "to_path").convertToString();
+        } else {
+            entryString = entry.convertToString();
+        }
+
+        return entryString.asJavaString();
+    }
 }
+


### PR DESCRIPTION
Fixes issue: http://jira.codehaus.org/browse/JRUBY-6389

MRI allows to use an object with `to_path` method in `$LOAD_PATH`. 
This patch makes JRuby behaviour compatible with MRI.
