### PR TITLE
Added HTTP Patch to Net::HTTP

### DIFF
--- a/lib/ruby/1.8/net/http.rb
+++ b/lib/ruby/1.8/net/http.rb
@@ -194,6 +194,7 @@ module Net   #:nodoc:
   #       Net::HTTP::Head
   #       Net::HTTP::Post
   #       Net::HTTP::Put
+  #       Net::HTTP::Patch
   #       Net::HTTP::Proppatch
   #       Net::HTTP::Lock
   #       Net::HTTP::Unlock
@@ -855,6 +856,12 @@ module Net   #:nodoc:
 
     def put(path, data, initheader = nil)   #:nodoc:
       res = request(Put.new(path, initheader), data)
+      res.value unless @newimpl
+      res
+    end
+
+    def patch(path, data, initheader = nil)   #:nodoc:
+      res = request(Patch.new(path, initheader), data)
       res.value unless @newimpl
       res
     end
@@ -1624,6 +1631,12 @@ module Net   #:nodoc:
 
     class Put < HTTPRequest
       METHOD = 'PUT'
+      REQUEST_HAS_BODY = true
+      RESPONSE_HAS_BODY = true
+    end
+
+    class Patch < HTTPRequest
+      METHOD = 'PATCH'
       REQUEST_HAS_BODY = true
       RESPONSE_HAS_BODY = true
     end

--- a/lib/ruby/1.9/net/http.rb
+++ b/lib/ruby/1.9/net/http.rb
@@ -292,6 +292,7 @@ module Net   #:nodoc:
   #   * Net::HTTP::Head
   #   * Net::HTTP::Post
   #   * Net::HTTP::Put
+  #   * Net::HTTP::Patch
   #   * Net::HTTP::Proppatch
   #   * Net::HTTP::Lock
   #   * Net::HTTP::Unlock


### PR DESCRIPTION
This is to add the HTTP method PATCH. I did not do testing, but followed the convention outlined by other method implementations. Also, added a line of documentation that that 1.9 side did not have, as PATCH was already implemented in that side of the house.
