### PR TITLE
Fix recursiveKey usage across multiple threads (JRUBY-6621)

### DIFF
--- a/src/org/jruby/Ruby.java
+++ b/src/org/jruby/Ruby.java
@@ -1481,7 +1481,6 @@ public final class Ruby {
             keyError = defineClassIfAllowed("KeyError", indexError);
 
             mathDomainError = defineClassUnder("DomainError", argumentError, argumentError.getAllocator(), mathModule);
-            recursiveKey.set(newSymbol("__recursive_key__"));
             inRecursiveListOperation.set(false);
         }
 
@@ -4449,7 +4448,11 @@ public final class Ruby {
 
     // structures and such for recursive operations
     private ThreadLocal<Map<String, RubyHash>> recursive = new ThreadLocal<Map<String, RubyHash>>();
-    private ThreadLocal<RubySymbol> recursiveKey = new ThreadLocal<RubySymbol>();
+    private ThreadLocal<RubySymbol> recursiveKey = new ThreadLocal<RubySymbol>() {
+        protected RubySymbol initialValue() {
+            return newSymbol("__recursive_key__");
+        }
+    };
     private ThreadLocal<Boolean> inRecursiveListOperation = new ThreadLocal<Boolean>();
 
     private FFI ffi;

--- a/test/org/jruby/test/TestRecursiveCheck.java
+++ b/test/org/jruby/test/TestRecursiveCheck.java
@@ -1,0 +1,33 @@
+package org.jruby.test;
+
+import junit.framework.TestCase;
+import org.jruby.CompatVersion;
+
+import org.jruby.Ruby;
+import org.jruby.RubyInstanceConfig;
+
+public class TestRecursiveCheck extends TestCase {
+    private Ruby runtime;
+
+    public TestRecursiveCheck(String name) {
+        super(name);
+    }
+
+    public void setUp() {
+        runtime = Ruby.newInstance(new RubyInstanceConfig() {
+            {
+                setCompatVersion(CompatVersion.RUBY1_9);
+            }
+        });
+    }
+
+    public void testWorksFromMultipleThreads() throws Exception {
+        Thread thread = new Thread(new Runnable() {
+            public void run() {
+                assertNotNull(runtime.evalScriptlet("[].hash").convertToInteger());
+            }
+        });
+        thread.start();
+        thread.join();
+    }
+}


### PR DESCRIPTION
Instead of calling recursiveKey.set when the runtime is initialized,
we implement getInitialValue of ThreadLocal to supply the default
value when recursiveKey.get() is called for the first time on a given
thread.

This avoids an NPE when a runtime is initialized on one thread and
subsequently used on another thread under 1.9.
