### PR TITLE
version array should be an empty list in the case there is no YAML version

### DIFF
--- a/src/org/jruby/ext/psych/PsychParser.java
+++ b/src/org/jruby/ext/psych/PsychParser.java
@@ -134,7 +134,7 @@ public class PsychParser extends RubyObject {
 
                     Integer[] versionInts = dse.getVersion();
                     IRubyObject version = versionInts == null ?
-                        runtime.getNil() :
+                        RubyArray.newArray(runtime) :
                         RubyArray.newArray(runtime, runtime.newFixnum(versionInts[0]), runtime.newFixnum(versionInts[1]));
                     
                     Map<String, String> tagsMap = dse.getTags();


### PR DESCRIPTION
The YAML AST generated by the java version of psych will not roundtrip and differs from the AST produced by the CRuby version of psych.  Here is some example code to show the problem:

``` ruby
require 'psych'

parser = Psych.parser
parser.parse 'null'
p parser.handler.root.to_yaml
```

I don't think a test needs to be added to psych on JRuby because I've added [added the test on trunk ruby](https://github.com/ruby/ruby/commit/75cff1d7d079ebcd7688341cf80bba6d647fd331).  That test should get imported next time you sync up with stdlib (I think).

Thanks!
