### PR TITLE
DocumentStartEvent expects "explicit" but we are passing implicit, so invert the flag

### DIFF
--- a/src/org/jruby/ext/psych/PsychEmitter.java
+++ b/src/org/jruby/ext/psych/PsychEmitter.java
@@ -135,7 +135,7 @@ public class PsychEmitter extends RubyObject {
             }
         }
 
-        DocumentStartEvent event = new DocumentStartEvent(NULL_MARK, NULL_MARK, implicitBool, versionInts, tagsMap);
+        DocumentStartEvent event = new DocumentStartEvent(NULL_MARK, NULL_MARK, !implicitBool, versionInts, tagsMap);
         emit(context, event);
         return this;
     }


### PR DESCRIPTION
The [DocumentStartEvent](http://snakeyamlrepo.appspot.com/releases/1.10/site/apidocs/org/yaml/snakeyaml/events/DocumentStartEvent.html) expects the flag to indicate if the document is _explicit_, yet the flag we're passing indicates _implicit_.  We should not the flag before passing to the constructor.
