### PR TITLE
arity of Psych::Parser#parse has changed in CRuby psych

### DIFF
--- a/src/org/jruby/ext/psych/PsychParser.java
+++ b/src/org/jruby/ext/psych/PsychParser.java
@@ -103,6 +103,13 @@ public class PsychParser extends RubyObject {
     @JRubyMethod
     public IRubyObject parse(ThreadContext context, IRubyObject yaml) {
         Ruby runtime = context.runtime;
+
+        return parse(context, yaml, RubyString.newString(runtime, "<unknown>"));
+    }
+
+    @JRubyMethod
+    public IRubyObject parse(ThreadContext context, IRubyObject yaml, IRubyObject path) {
+        Ruby runtime = context.runtime;
         boolean tainted = yaml.isTaint();
         
         // FIXME? only supports Unicode, since we have to produces strings...


### PR DESCRIPTION
The `parse` method now takes an optional filename.  I haven't fixed the java code to _do_ anything with the filename, but at least the arity matches.
