### PR TITLE
Check if all throwables are Java exceptions in interpreted mode (JRUBY-6641)

### DIFF
--- a/src/org/jruby/javasupport/util/RuntimeHelpers.java
+++ b/src/org/jruby/javasupport/util/RuntimeHelpers.java
@@ -1056,7 +1056,7 @@ public class RuntimeHelpers {
             return isExceptionHandled(((RaiseException)currentThrowable).getException(), throwables, context);
         } else {
             for (int i = 0; i < throwables.length; i++) {
-                if (checkJavaException(currentThrowable, throwables[0], context)) {
+                if (checkJavaException(currentThrowable, throwables[i], context)) {
                     return context.getRuntime().getTrue();
                 }
             }


### PR DESCRIPTION
This fixes a simple typo in the RuntimeHelpers.isJavaExceptionHandled logic.
