### PR TITLE
Missing require 'weakref' in 1.9's drb.rb

### DIFF
--- a/lib/ruby/1.9/drb/drb.rb
+++ b/lib/ruby/1.9/drb/drb.rb
@@ -54,6 +54,7 @@
 require 'socket'
 require 'thread'
 require 'fcntl'
+require 'weakref'
 require 'drb/eq'
 
 #


### PR DESCRIPTION
Commit 248d5e9c1e79565f7d412326a9a60d379deb498c brought 1.8's
non-ObjectSpace implementation of DRbIdConv to 1.9 but it forgot to
add the weakref require. As a result, "uninitialized constant
DRb::DRbIdConv::WeakRef" gets thrown when using DRb under 1.9.
