### PR TITLE
Stop the JITCompiler's executor during Ruby tearDown

### DIFF
--- a/src/org/jruby/Ruby.java
+++ b/src/org/jruby/Ruby.java
@@ -2954,6 +2954,8 @@ public final class Ruby {
 
         getSelectorPool().cleanup();
 
+        getJITCompiler().tearDown();
+
         if (getJRubyClassLoader() != null) {
             getJRubyClassLoader().tearDown(isDebug());
         }

--- a/src/org/jruby/compiler/JITCompiler.java
+++ b/src/org/jruby/compiler/JITCompiler.java
@@ -106,6 +106,12 @@ public class JITCompiler implements JITCompilerMBean {
         }
     }
 
+    public void tearDown() {
+        if (executor != null) {
+            executor.shutdown();
+        }
+    }
+
     private void jitIsEnabled(DefaultMethod method, ThreadContext context, String className, String methodName) {
         RubyInstanceConfig instanceConfig = context.getRuntime().getInstanceConfig();
         


### PR DESCRIPTION
This stops the JITCompiler's executor when tearing down a Ruby runtime
so that JITCompiler threads don't continue running
indefinitely. Before this change JITCompiler was leaking two threads
for every Ruby that gets created and subsequently torn down,
eventually causing problems in applications that have the potential to
create and destroy a lot of Ruby runtimes - like when running inside
TorqueBox or other web servers.
