### PR TITLE
align file name with content encoding

### DIFF
--- a/test/JRUBY_6606/dir-j.rb
+++ b/test/JRUBY_6606/dir-j.rb
@@ -1,6 +1,6 @@
-# encoding: Shift_JIS
+# encoding: EUC-JP
 
 Dir.chdir(File.dirname __FILE__) do
-  Dir.entries('res/‚ ‚¢').each{|n| p n unless n == '.' || n == '..'}
-  Dir.foreach('res/‚ ‚¢') {|n| p n unless n == '.' || n == '..'}
+  Dir.entries('res/¤¢¤¤').each{|n| p n unless n == '.' || n == '..'}
+  Dir.foreach('res/¤¢¤¤') {|n| p n unless n == '.' || n == '..'}
 end

--- a/test/JRUBY_6606/dir-js.rb
+++ b/test/JRUBY_6606/dir-js.rb
@@ -1,6 +1,6 @@
-# encoding: EUC-JP
+# encoding: Shift_JIS
 
 Dir.chdir(File.dirname __FILE__) do
-  Dir.entries('res/¤¢¤¤').each{|n| p n unless n == '.' || n == '..'}
-  Dir.foreach('res/¤¢¤¤') {|n| p n unless n == '.' || n == '..'}
+  Dir.entries('res/‚ ‚¢').each{|n| p n unless n == '.' || n == '..'}
+  Dir.foreach('res/‚ ‚¢') {|n| p n unless n == '.' || n == '..'}
 end


### PR DESCRIPTION
This is a follow up for pull request [159](https://github.com/jruby/jruby/pull/159).

`dir-j.rb` and `dir-js.rb` each incorrectly took the other's name, now swapped.
