### PR TITLE
Fixes JRUBY-6658

### DIFF
--- a/src/org/jruby/RubyModule.java
+++ b/src/org/jruby/RubyModule.java
@@ -3530,8 +3530,11 @@ public class RubyModule extends RubyObject {
      * Define an autoload. ConstantMap holds UNDEF for the name as an autoload marker.
      */
     protected void defineAutoload(String name, IAutoloadMethod loadMethod) {
-        storeConstant(name, RubyObject.UNDEF);
-        getAutoloadMapForWrite().put(name, new Autoload(loadMethod));
+        Autoload existingAutoload = getAutoloadMap().get(name);
+        if (existingAutoload == null || existingAutoload.getValue() == null) {
+            storeConstant(name, RubyObject.UNDEF);
+            getAutoloadMapForWrite().put(name, new Autoload(loadMethod));
+        }
     }
     
     /**


### PR DESCRIPTION
This is my first attempt at a JRuby contribution, so make sure to sanity check me.
- If an autoload is defined, yet the constant is defined by other means,
  another autoload for the same constant does not reset the process.
- Fixes rubyspec/rubyspec#136 under JRuby
