### PR TITLE
Fixes JRUBY-6677

### DIFF
--- a/src/org/jruby/RubyKernel.java
+++ b/src/org/jruby/RubyKernel.java
@@ -277,9 +277,17 @@ public class RubyKernel {
         Ruby runtime = context.getRuntime();
 
         if (arg.startsWith("|")) {
-            String command = arg.substring(1);
+            IRubyObject command = runtime.newString(arg.substring(1));
+
+            final IRubyObject[] popenArgs;
+            if (args.length >= 2) {
+                popenArgs = new IRubyObject[] { command, args[1] };
+            } else {
+                popenArgs = new IRubyObject[] { command };
+            }
+
             // exec process, create IO with process
-            return RubyIO.popen(context, runtime.getIO(), new IRubyObject[] {runtime.newString(command)}, block);
+            return RubyIO.popen(context, runtime.getIO(), popenArgs, block);
         } 
 
         return RubyFile.open(context, runtime.getFile(), args, block);


### PR DESCRIPTION
Corrects failing rubyspec/rubyspec#139
- Passes the `mode` argument correctly from Kernel#open to IO#popen, so
  if a non-default mode is specified (e.g., "w"), it is honored
