### PR TITLE
Fix for JRUBY-6666, Open3.popen3 handling for arrays in arg list

### DIFF
--- a/src/org/jruby/util/ShellLauncher.java
+++ b/src/org/jruby/util/ShellLauncher.java
@@ -1463,14 +1463,9 @@ public class ShellLauncher {
     private static String[] parseCommandLine(ThreadContext context, Ruby runtime, IRubyObject[] rawArgs) {
         String[] args;
         if (rawArgs.length == 1) {
-            if ((rawArgs[0] instanceof RubyArray)
-                && (((RubyArray) rawArgs[0]).getLength() == 2)) {
-                // a two-element array containing path and argv[0]
-                // but we can't pass argv[0] to ProcessBuilder
-                // so discard it
-                RubyArray initArray = (RubyArray) rawArgs[0];
-                args = new String[1];
-                args[0] = initArray.entry(0).toString();
+            if (hasLeadingArgvArray(rawArgs)) {
+                // can't make use of it, discard the argv[0] entry
+                args = new String[] { getPathEntry((RubyArray) rawArgs[0]) };
             } else {
                 synchronized (runtime.getLoadService()) {
                     runtime.getLoadService().require("jruby/path_helper");
@@ -1485,11 +1480,33 @@ public class ShellLauncher {
             }
         } else {
             args = new String[rawArgs.length];
-            for (int i = 0; i < rawArgs.length; i++) {
+            int start = 0;
+            if (hasLeadingArgvArray(rawArgs)) {
+                start = 1;
+                args[0] = getPathEntry((RubyArray) rawArgs[0]);
+            }
+            for (int i = start; i < rawArgs.length; i++) {
                 args[i] = rawArgs[i].toString();
             }
         }
         return args;
+    }
+
+    /** Takes an argument array suitable for Kernel#exec or similar,
+     * and indicates whether it has a leading two-element array giving
+     * the path and argv[0] entries separately.
+     *
+     * We can't use the argv[0] entry through ProcessBuilder, so
+     * we discard it.
+     */
+    private static boolean hasLeadingArgvArray(IRubyObject[] rawArgs) {
+        return (rawArgs.length >= 1
+                && (rawArgs[0] instanceof RubyArray)
+                && (((RubyArray) rawArgs[0]).getLength() == 2));
+    }
+
+    private static String getPathEntry(RubyArray initArray) {
+        return initArray.entry(0).toString();
     }
 
     private static String getShell(Ruby runtime) {


### PR DESCRIPTION
This is the same as #173 but applied to `master` instead of 1.6.7. I didn't realize we were at the end of the line for 1.6 already.

This patch adds a fix for [JRUBY-6666](http://jira.codehaus.org/browse/JRUBY-6666), a bug in the handling of Open3.popen3(). This method should accept a two-element array giving path and argv[0] as the first item in the argument list, as on MRI.

I have submitted a corresponding [test case](https://github.com/rubyspec/rubyspec/pull/137) to RubySpec. With the patch, JRuby passes this test. It also passes `ant test` and `ant spec:ci_interpreted_19`.
