### PR TITLE
--fast is mostly a no-op

### DIFF
--- a/src/org/jruby/RubyInstanceConfig.java
+++ b/src/org/jruby/RubyInstanceConfig.java
@@ -1403,14 +1403,6 @@ public class RubyInstanceConfig {
     public static boolean LAZYHANDLES_COMPILE = Options.COMPILE_LAZYHANDLES.load();
 
     /**
-     * Inline dynamic calls.
-     *
-     * Set with the <tt>jruby.compile.inlineDyncalls</tt> system property.
-     */
-    public static boolean INLINE_DYNCALL_ENABLED
-            = FASTEST_COMPILE_ENABLED || Options.COMPILE_INLINEDYNCALLS.load();
-
-    /**
      * Enable fast multiple assignment optimization.
      *
      * Set with the <tt>jruby.compile.fastMasgn</tt> system property.

--- a/src/org/jruby/compiler/impl/StandardInvocationCompiler.java
+++ b/src/org/jruby/compiler/impl/StandardInvocationCompiler.java
@@ -653,25 +653,6 @@ public class StandardInvocationCompiler implements InvocationCompiler {
     }
     
     public void invokeDynamic(String name, CompilerCallback receiverCallback, ArgumentsCallback argsCallback, CallType callType, CompilerCallback closureArg, boolean iterator) {
-        if (RubyInstanceConfig.INLINE_DYNCALL_ENABLED && closureArg == null) {
-            if (callType == CallType.FUNCTIONAL || callType == CallType.VARIABLE) {
-                if (argsCallback == null) {
-                    invokeDynamicSelfNoBlockZero(name);
-                    return;
-                } else if (argsCallback.getArity() >= 1 && argsCallback.getArity() <= 3) {
-                    invokeDynamicSelfNoBlockSpecificArity(name, argsCallback);
-                    return;
-                }
-//            } else if (callType == CallType.NORMAL) {
-//                if (argsCallback == null) {
-//                    invokeDynamicNoBlockZero(name, receiverCallback);
-//                    return;
-//                } else if (argsCallback.getArity() >= 1 && argsCallback.getArity() <= 3) {
-//                    invokeDynamicNoBlockSpecificArity(name, receiverCallback, argsCallback);
-//                    return;
-//                }
-            }
-        }
         methodCompiler.getScriptCompiler().getCacheCompiler().cacheCallSite(methodCompiler, name, callType);
 
         methodCompiler.loadThreadContext(); // [adapter, tc]

--- a/src/org/jruby/util/cli/ArgumentProcessor.java
+++ b/src/org/jruby/util/cli/ArgumentProcessor.java
@@ -394,9 +394,6 @@ public class ArgumentProcessor {
                         break FOR;
                     } else if (argument.equals("--fast")) {
                         config.setCompileMode(RubyInstanceConfig.CompileMode.FORCE);
-                        RubyInstanceConfig.FASTOPS_COMPILE_ENABLED = true;
-                        RubyInstanceConfig.FASTSEND_COMPILE_ENABLED = true;
-                        RubyInstanceConfig.INLINE_DYNCALL_ENABLED = true;
                         break FOR;
                     } else if (argument.equals("--profile.api")) {
                         config.setProfilingMode(RubyInstanceConfig.ProfilingMode.API);

--- a/src/org/jruby/util/cli/Options.java
+++ b/src/org/jruby/util/cli/Options.java
@@ -73,7 +73,6 @@ public class Options {
     public static final Option<Boolean> COMPILE_NOGUARDS = bool(COMPILER, "compile.noguards", false, "Compile calls without guards, for experimentation.");
     public static final Option<Boolean> COMPILE_FASTEST = bool(COMPILER, "compile.fastest", false, "Compile with all \"mostly harmless\" compiler optimizations.");
     public static final Option<Boolean> COMPILE_FASTSEND = bool(COMPILER, "compile.fastsend", false, "Compile obj.__send__(<literal>, ...) as obj.<literal>(...).");
-    public static final Option<Boolean> COMPILE_INLINEDYNCALLS = bool(COMPILER, "compile.inlineDyncalls", false, "Emit method lookup + invoke inline in bytecode.");
     public static final Option<Boolean> COMPILE_FASTMASGN = bool(COMPILER, "compile.fastMasgn", false, "Return true from multiple assignment instead of a new array.");
     public static final Option<Boolean> COMPILE_INVOKEDYNAMIC = bool(COMPILER, "compile.invokedynamic", true, "Use invokedynamic on Java 7+.");
     


### PR DESCRIPTION
Per the [discussion on Twitter](https://twitter.com/headius/status/209034181181837312), `--fast` should mostly go away.
- --fast is now basically synonymous with -X+C (force compilation)
- The other features that --fast enabled added complexity and often
  caused strange bugs (e.g., JRUBY-6698).
- I _think_ that much of these performance gains can be garnered by
  simply using JRuby 1.7 with Java 7 and invokedynamic.
