### PR TITLE
Net::HTTP ignores HTTP_PROXY and http.proxyHost

### DIFF
--- a/lib/ruby/1.9/net/http.rb
+++ b/lib/ruby/1.9/net/http.rb
@@ -877,6 +877,10 @@ module Net   #:nodoc:
     # If you want to use a proxy, you must set it explicitly.
     #
     def HTTP.Proxy(p_addr, p_port = nil, p_user = nil, p_pass = nil)
+      j_addr = java.lang.System.get_property('http.proxyHost')
+      j_port = java.lang.System.get_property('http.proxyPort')
+      p_addr = p_addr || j_addr
+      p_port = p_port || j_port
       return self unless p_addr
       delta = ProxyDelta
       proxyclass = Class.new(self)


### PR DESCRIPTION
Addresses open issue [#134](https://github.com/jruby/jruby/issues/194), [JRUBY-6701](https://jira.codehaus.org/browse/JRUBY-6701). Allowing the JVM arguments 'http.proxyHost' and 'http.proxyPort' to be set and used by Net::HTTP.
