### PR TITLE
UTF-8 symbols should be encoded as such

### DIFF
--- a/spec/regression/symbol_encoding_spec.rb
+++ b/spec/regression/symbol_encoding_spec.rb
@@ -1,13 +1,27 @@
+# encoding: utf-8
 require 'rspec'
 
 if RUBY_VERSION >= "1.9.2"
   describe "symbol encoding" do
-    it "should be US-ASCII" do
-      :foo.encoding.name.should == "US-ASCII"
+    context "for ASCII symbols" do
+      it "should be US-ASCII" do
+        :foo.encoding.name.should == "US-ASCII"
+      end
+
+      it "should be US-ASCII after converting to string" do
+        :foo.to_s.encoding.name.should == "US-ASCII"
+      end
     end
 
-    it "should be US-ASCII after converting to string" do
-      :foo.to_s.encoding.name.should == "US-ASCII"
+    context "for UTF-8 symbols" do
+      it "should be UTF-8" do
+        :åäö.encoding.name.should == "UTF-8"
+      end
+
+      it "should be UTF-8 after converting to string" do
+        :åäö.to_s.encoding.name.should == "UTF-8"
+      end
     end
   end
 end
+


### PR DESCRIPTION
This is (currently) a failing spec pull request only. 

```
$ rvm use 1.9.3
Using /Users/carl/.rvm/gems/ruby-1.9.3-p194
$ ruby -e "puts :aaa.encoding"
US-ASCII
$ ruby -e "puts :åäö.encoding"
UTF-8
```

```
$ rvm use jruby-1.7.0.preview1
Using /Users/carl/.rvm/gems/jruby-1.7.0.preview1
$ ruby -e "puts :aaa.encoding"
US-ASCII
$ ruby -e "puts :åäö.encoding"
US-ASCII
```
