### PR TITLE
Fix memory leak in FFI usage from multiple runtimes

### DIFF
--- a/src/org/jruby/ext/ffi/AbstractInvoker.java
+++ b/src/org/jruby/ext/ffi/AbstractInvoker.java
@@ -28,9 +28,6 @@
 
 package org.jruby.ext.ffi;
 
-import java.util.Collections;
-import java.util.Map;
-import java.util.WeakHashMap;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
@@ -48,13 +45,6 @@ import org.jruby.runtime.builtin.IRubyObject;
 @JRubyClass(name = "FFI::" + AbstractInvoker.CLASS_NAME, parent = "Object")
 public abstract class AbstractInvoker extends Pointer {
     static final String CLASS_NAME = "AbstractInvoker";
-
-    /**
-     * Reference map to keep libraries open for as long as there is a method mapped
-     * to that library.
-     */
-    private static final Map<DynamicMethod, AbstractInvoker> refmap
-            = Collections.synchronizedMap(new WeakHashMap<DynamicMethod, AbstractInvoker>());
     
     /**
      * The arity of this function.
@@ -94,7 +84,7 @@ public abstract class AbstractInvoker extends Pointer {
         if (obj instanceof RubyModule) {
             ((RubyModule) obj).addMethod(methodName.asJavaString(), m);
         }
-        refmap.put(m, this);
+        getRuntime().getFFI().registerAttachedMethod(m, this);
         
         return this;
     }

--- a/src/org/jruby/ext/ffi/FFI.java
+++ b/src/org/jruby/ext/ffi/FFI.java
@@ -1,10 +1,12 @@
 package org.jruby.ext.ffi;
 
 import org.jruby.*;
+import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.WeakHashMap;
 
 /**
  * The holder of all per-ruby-runtime FFI data
@@ -17,6 +19,13 @@ public class FFI {
     public final RubyHash typedefs;
     private final NullMemoryIO nullMemoryIO;
     private final TypeSizeMapper sizeMapper;
+    
+    /**
+     * Reference map to keep libraries open for as long as there is a method mapped
+     * to that library.
+     */
+    private final Map<DynamicMethod, AbstractInvoker> refmap
+            = Collections.synchronizedMap(new WeakHashMap<DynamicMethod, AbstractInvoker>());
 
 
     public FFI(RubyModule ffiModule) {
@@ -40,5 +49,9 @@ public class FFI {
 
     public NullMemoryIO getNullMemoryIO() {
         return nullMemoryIO;
+    }
+
+    public void registerAttachedMethod(DynamicMethod method, AbstractInvoker invoker) {
+        refmap.put(method, invoker);
     }
 }


### PR DESCRIPTION
This fixes JRUBY-5053 and GitHub issue #203. Instead of storing the
AbstractInvoker refmap in a static Map, the same data is now stored on
an instance of the FFI class which holds all other per-runtime
FFI-related data.
