### PR TITLE
Fix structural problem with CSR request extension decoding.

### DIFF
--- a/src/org/jruby/ext/openssl/Request.java
+++ b/src/org/jruby/ext/openssl/Request.java
@@ -136,17 +136,16 @@ public class Request extends RubyObject {
             Object t = getRuntime().newFixnum(ASN1.idForClass(internal.getObjectAt(1).getClass()));
             ((X509Name)subject).addEntry(oid,v,t);
         }
+        // Attributes ::= SET OF Attribute
         ASN1Set in_attrs = req.getCertificationRequestInfo().getAttributes();
         for(Enumeration enm = in_attrs.getObjects();enm.hasMoreElements();) {
-            DERSet obj = (DERSet)enm.nextElement();
-            for(Enumeration enm2 = obj.getObjects();enm2.hasMoreElements();) {
-                DERSequence val = (DERSequence)enm2.nextElement();
-                DERObjectIdentifier v0 = (DERObjectIdentifier)val.getObjectAt(0);
-                DERObject v1 = (DERObject)val.getObjectAt(1);
-                IRubyObject a1 = getRuntime().newString(ASN1.getSymLookup(getRuntime()).get(v0));
-                IRubyObject a2 = ASN1.decode(getRuntime().getClassFromPath("OpenSSL::ASN1"), RubyString.newString(getRuntime(), v1.getDEREncoded()));
-                add_attribute(Utils.newRubyInstance(getRuntime(), "OpenSSL::X509::Attribute", new IRubyObject[] { a1, a2 }));
-            }
+            // Attribute ::= SEQUENCE { type, values SET SIZE(1..MAX) }
+            DERSequence val = (DERSequence)enm.nextElement();
+            DERObjectIdentifier v0 = (DERObjectIdentifier)val.getObjectAt(0);
+            DERObject v1 = (DERObject)val.getObjectAt(1);
+            IRubyObject a1 = getRuntime().newString(ASN1.getSymLookup(getRuntime()).get(v0));
+            IRubyObject a2 = ASN1.decode(getRuntime().getClassFromPath("OpenSSL::ASN1"), RubyString.newString(getRuntime(), v1.getDEREncoded()));
+            add_attribute(Utils.newRubyInstance(getRuntime(), "OpenSSL::X509::Attribute", new IRubyObject[] { a1, a2 }));
         }
         this.valid = true;
         return this;

--- a/test/test_openssl.rb
+++ b/test/test_openssl.rb
@@ -1,0 +1,28 @@
+require 'test/unit'
+require 'openssl'
+
+class TestOpenssl < Test::Unit::TestCase
+  def test_csr_request_extensions
+    key = OpenSSL::PKey::RSA.new(512)
+    csr = OpenSSL::X509::Request.new
+
+    csr.version = 0
+    csr.subject = OpenSSL::X509::Name.new([["CN", 'example.com']])
+    csr.public_key = key.public_key
+
+    names = OpenSSL::X509::ExtensionFactory.new.
+      create_extension("subjectAltName", 'DNS:example.com', false)
+
+    extReq = OpenSSL::ASN1::Set([OpenSSL::ASN1::Sequence([names])])
+    csr.add_attribute(OpenSSL::X509::Attribute.new("extReq", extReq))
+
+    csr.sign(key, OpenSSL::Digest::SHA256.new)
+
+    # The combination of the extreq and the stringification / revivification
+    # is what triggers the bad behaviour in the extension. (Any extended
+    # request type should do, but this matches my observed problems)
+    csr = OpenSSL::X509::Request.new(csr.to_s)
+
+    assert_equal '/CN=example.com', csr.subject.to_s
+  end
+end


### PR DESCRIPTION
The BounceCastle documented structure for PKCS10 request extensions is:

```
Attributes ::= SET OF Attribute

Attribute ::= SEQUENCE {
  type    ATTRIBUTE,
  values  SET SIZE(1..MAX) OF ATTRIBUTE.Type
}
```

The code for extracting the ASN1 structures assumed Set, Set, Sequence - an
additional ASN1 Set implementation between the Attributes and the
Attribute itself.

This corrects that, by extracting only one level deep, resulting in the
correct behaviour.  It includes a test to avoid regressions.

Signed-off-by: Daniel Pittman daniel@rimspace.net
