### PR TITLE
fix encoding of substrings when the original string contains binary (i.e. > 0x7f) bytes.

### DIFF
--- a/src/org/jruby/RubyString.java
+++ b/src/org/jruby/RubyString.java
@@ -7546,7 +7546,8 @@ public class RubyString extends RubyObject implements EncodingCapable {
 
         // MRI does not allow ASCII-8BIT chars > 127 to transcode to multibyte encodings
         if (fromName.equals("ASCII-8BIT") && encoder.maxBytesPerChar() > 1.0) {
-            for (byte b : fromBytes.array()) {
+            for (int byteidx = value.begin(); byteidx < value.begin() + value.length(); byteidx++) {
+                byte b = fromBytes.get(byteidx);
                 if ((b & 0xFF) > 0x7F) {
                     throw runtime.newUndefinedConversionError(
                             "\"\\x" + Integer.toHexString(b & 0xFF).toUpperCase() +


### PR DESCRIPTION
A new rubyspec was added that demonstrates the issue (https://github.com/rubyspec/rubyspec/pull/146).
