### PR TITLE
Flip the Array's isShared last flag last

### DIFF
--- a/src/org/jruby/RubyArray.java
+++ b/src/org/jruby/RubyArray.java
@@ -472,10 +472,10 @@ public class RubyArray extends RubyObject implements List, RandomAccess {
         modifyCheck();
         if (isShared) {
             IRubyObject[] vals = new IRubyObject[realLength];
-            isShared = false;
             safeArrayCopy(values, begin, vals, 0, realLength);
             begin = 0;            
             values = vals;
+            isShared = false;
         }
     }
 


### PR DESCRIPTION
Flip the isShared flag only after the array's values have been copied over.

Doing things in reverse order risks exposing an `Array` object with `isShared = false`, while `values` still pointing to a shared array.
