### PR TITLE
Fix typo in '`' method of process_manager.rb

### DIFF
--- a/src/jruby/kernel/jruby/process_manager.rb
+++ b/src/jruby/kernel/jruby/process_manager.rb
@@ -21,7 +21,7 @@ module JRuby
       if config.should_run_in_shell?
         config.verify_executable_for_shell
       else
-        config.verifiy_executable_for_direct
+        config.verify_executable_for_direct
       end
 
       pb = ProcessBuilder.new(config.exec_args)


### PR DESCRIPTION
Just a simple typo I noticed in the new process_manager.rb stuff
