### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,13 @@ language: java
 before_script:
   - unset GEM_PATH GEM_HOME IRBRC
   - "export PATH=`pwd`/bin:$PATH"
-  - "export JRUBY_OPTS=-Xcompile.invokedynamic=false"
+jdk: oraclejdk7
+matrix:
+  include:
+    - jdk: openjdk6
+      env: JRUBY_OPTS="--server -Xcext.enabled=false -Xcompile.invokedynamic=false"
+    - jdk: openjdk7
+      env: JRUBY_OPTS="--server -Xcext.enabled=false -Xcompile.invokedynamic=false"
 script: "ant test-extended && rake test19"
 install: /bin/true
 notifications:


### PR DESCRIPTION
This adds the following matrix rows:

 \* Oracle JDK 7u5 w/ indy
 \* OpenJDK 6 w/o indy
 \* OpenJDK 7 (old-ish) w/o indy

If needed, we can extend that to testing against each in 1.8 and 1.9 mode (but maybe JRuby test suite already covers that?)

Our default `JRUBY_OPTS` will change today or tomorrow to disable indy, so I will possibly submit another PR tomorrow to make sure we test on Oracle JDK 7 with it.
