### PR TITLE
setup .gitattributes to always normalize eols

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*      text=auto
+*.bat  eol=crlf
+*.sh   eol=lf


### PR DESCRIPTION
this is to avoid warnings like

```
warning: CRLF will be replaced by LF in foo.bar
```
