### PR TITLE
JRuby 1.7 Bundles Invalid Bouncy Castle Security Provider

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -390,13 +390,6 @@
             <fileset dir="${jruby.classes.dir}"/>
             <zipgroupfileset dir="${build.lib.dir}" includes="${jruby.jar.zip.includes}"/>
 
-            <zipfileset src="${build.lib.dir}/bcmail-jdk15-146.jar">
-                <exclude name="META-INF/BCKEY.*"/>
-            </zipfileset>
-            <zipfileset src="${build.lib.dir}/bcprov-jdk15-146.jar">
-                <exclude name="META-INF/BCKEY.*"/>
-            </zipfileset>
-
             <metainf dir="spi">
                 <include name="services/**"/>
             </metainf>
@@ -452,13 +445,6 @@ other than ASM, which is rewritten to avoid conflicts. -->
         <jarjar destfile="${lib.dir}/jruby.jar" compress="true">
             <fileset dir="${jruby.classes.dir}"/>
             <zipgroupfileset dir="${build.lib.dir}" includes="${jruby.jar.zip.includes}"/>
-
-            <zipfileset src="${build.lib.dir}/bcmail-jdk15-146.jar">
-                <exclude name="META-INF/BCKEY.*"/>
-            </zipfileset>
-            <zipfileset src="${build.lib.dir}/bcprov-jdk15-146.jar">
-                <exclude name="META-INF/BCKEY.*"/>
-            </zipfileset>
 
             <metainf dir="spi">
                 <include name="services/**"/>
@@ -580,13 +566,6 @@ other than ASM, which is rewritten to avoid conflicts. -->
             <fileset dir="${jruby.classes.dir}"/>
             <fileset dir="${build.dir}/jar-complete"/>
             <zipgroupfileset dir="${build.lib.dir}" includes="${jruby.jar.zip.includes}"/>
-
-            <zipfileset src="${build.lib.dir}/bcmail-jdk15-146.jar">
-                <exclude name="META-INF/BCKEY.*"/>
-            </zipfileset>
-            <zipfileset src="${build.lib.dir}/bcprov-jdk15-146.jar">
-                <exclude name="META-INF/BCKEY.*"/>
-            </zipfileset>
 
             <metainf dir="spi">
                 <include name="services/**"/>


### PR DESCRIPTION
This does not pertain to Invoked Dynamic.  This relates to a PGP decryption / encryption wrapper I've written, around the Bouncy Castle PGP library.

The following example works on JRuby 1.6 / OpenJDK 1.6, but fails on JRuby 1.7 / OpenJDK 1.6.

ruby -v's:

```
jruby 1.7.0.preview2.dev (ruby-1.9.3-p203) (2012-06-13 cfbb64d) (Java HotSpot(TM) 64-Bit Server VM 1.6.0_31) [darwin-x86_64-java]
jruby 1.6.7.2 (ruby-1.8.7-p357) (2012-05-01 26e08ba) (Java HotSpot(TM) 64-Bit Server VM 1.6.0_31) [darwin-x86_64-java]
jruby 1.6.7.2 (ruby-1.9.2-p312) (2012-05-01 26e08ba) (Java HotSpot(TM) 64-Bit Server VM 1.6.0_31) [darwin-x86_64-java]
```

To reproduce, follow the instructions at the below repo:
https://github.com/sgonyea/bc_pgp_jruby1.7_bug

Let me know if you have any questions.  Thank you!
