### PR TITLE
JRUBY-6510 fix String.encode!

### DIFF
--- a/spec/regression/JRUBY-6510_hash_treat_as_encoding_spec.rb
+++ b/spec/regression/JRUBY-6510_hash_treat_as_encoding_spec.rb
@@ -1,0 +1,16 @@
+# encoding: UTF-8
+require 'rspec'
+
+describe 'JRUBY-6510: String.encode!' do
+  it 'should also accept a hash as the only argument' do
+    enc_dft_in = Encoding.default_internal
+    begin
+      Encoding.default_internal = 'ISO-8859-1'
+      s = "äöü"
+      s.encode!({:invalid => :replace, :undef => :replace})
+      s.encoding.name.should == 'ISO-8859-1'
+    ensure
+      Encoding.default_internal = enc_dft_in unless enc_dft_in.nil?
+    end
+  end
+end

--- a/src/org/jruby/RubyString.java
+++ b/src/org/jruby/RubyString.java
@@ -7372,11 +7372,22 @@ public class RubyString extends RubyObject implements EncodingCapable {
     }
 
     @JRubyMethod(name = "encode!", compat = RUBY1_9)
-    public IRubyObject encode_bang(ThreadContext context, IRubyObject enc) {
+    public IRubyObject encode_bang(ThreadContext context, IRubyObject arg) {
         Ruby runtime = context.runtime;
         modify19();
+        Encoding toEncoding;
+        IRubyObject options;
 
-        value = transcode(context, value, null, getEncoding(runtime, enc), runtime.getNil());
+        if (arg instanceof RubyHash) {
+            toEncoding = runtime.getDefaultInternalEncoding();
+            if (toEncoding == null) toEncoding = runtime.getEncodingService().getLocaleEncoding();
+            options = arg;
+        } else {
+            toEncoding = getEncoding(runtime, arg);
+            options = runtime.getNil();
+        }
+
+        value = transcode(context, value, null, toEncoding, options);
 
         return this;
     }
@@ -7425,20 +7436,20 @@ public class RubyString extends RubyObject implements EncodingCapable {
     @JRubyMethod(name = "encode", compat = RUBY1_9)
     public IRubyObject encode(ThreadContext context, IRubyObject arg) {
         Ruby runtime = context.runtime;
-        Encoding forceEncoding;
+        Encoding toEncoding;
         IRubyObject options;
 
         if (arg instanceof RubyHash) {
-            forceEncoding = runtime.getDefaultInternalEncoding();
-            if (forceEncoding == null) forceEncoding = runtime.getEncodingService().getLocaleEncoding();
-            if (forceEncoding == null) return dup();
+            toEncoding = runtime.getDefaultInternalEncoding();
+            if (toEncoding == null) toEncoding = runtime.getEncodingService().getLocaleEncoding();
+            if (toEncoding == null) return dup();
             options = arg;
         } else {
-            forceEncoding = getEncoding(runtime, arg);
+            toEncoding = getEncoding(runtime, arg);
             options = runtime.getNil();
         }
 
-        return runtime.newString(transcode(context, value, null, forceEncoding, options));
+        return runtime.newString(transcode(context, value, null, toEncoding, options));
     }
 
     @JRubyMethod(name = "encode", compat = RUBY1_9)


### PR DESCRIPTION
This is to fix issue [JRUBY-6510](https://jira.codehaus.org/browse/JRUBY-6510)

In the past, when there's only 1 argument to `String#encode!`, the argument was always treated as the target encoding to `transcode` to.

This is wrong, because, when the only argument is a hash, it should be treated as the option for `transcode`, not the target encoding.

btw, I renamed the variable name in the other unbang encode method to align with the argument name in transcode.
