### PR TITLE
Fixnum#to_sym is not defined in Ruby 1.9

### DIFF
--- a/src/org/jruby/RubyFixnum.java
+++ b/src/org/jruby/RubyFixnum.java
@@ -318,7 +318,7 @@ public class RubyFixnum extends RubyInteger {
     /** fix_to_sym
      * 
      */
-    @JRubyMethod
+    @JRubyMethod(compat = RUBY1_8)
     public IRubyObject to_sym() {
         RubySymbol symbol = RubySymbol.getSymbolLong(getRuntime(), value);
         


### PR DESCRIPTION
In MRI 1.9, `Fixnum` does not respond to `to_sym`.

```
1.9.3-p194 :001 > 1.to_sym
NoMethodError: undefined method `to_sym' for 1:Fixnum
    from (irb):1
    from /Users/alindeman/.rvm/rubies/ruby-1.9.3-p194/bin/irb:16:in `<main>'
```

I got pretty confused when trying to write an automated test for this: I don't know if it should be a rubyspec (I haven't had good luck with getting my pull requests merged there) or a JRuby spec (Java or Ruby?). If anyone wants to hold my hand, let me know and I'll gladly try.
