### PR TITLE
increase MAX_PROFILE_METHODS to 500000

### DIFF
--- a/src/org/jruby/Ruby.java
+++ b/src/org/jruby/Ruby.java
@@ -4244,7 +4244,7 @@ public final class Ruby {
     private final RuntimeCache runtimeCache;
 
     // The maximum number of methods we will track for profiling purposes
-    private static final int MAX_PROFILE_METHODS = 100000;
+    private static final int MAX_PROFILE_METHODS = 500000;
 
     // The list of method names associated with method serial numbers
     public String[] profiledNames = new String[0];


### PR DESCRIPTION
This increases MAX_PROFILE_METHODS from 100,000 to 500,000, allowing larger code bases to be profiled.  See http://jira.codehaus.org/browse/JRUBY-6859
