### PR TITLE
fix some error message in Struct#[]

### DIFF
--- a/src/org/jruby/RubyStruct.java
+++ b/src/org/jruby/RubyStruct.java
@@ -471,7 +471,7 @@ public class RubyStruct extends RubyObject {
     }
 
     private RaiseException notStructMemberError(String name) {
-        return getRuntime().newNameError(name + " is not struct member", name);
+        return getRuntime().newNameError("no member '" + name + "' in struct", name);
     }
 
     public IRubyObject get(int index) {
@@ -624,9 +624,9 @@ public class RubyStruct extends RubyObject {
         idx = idx < 0 ? values.length + idx : idx;
 
         if (idx < 0) {
-            throw getRuntime().newIndexError("offset " + idx + " too large for struct (size:" + values.length + ")");
+            throw getRuntime().newIndexError("offset " + idx + " too small for struct(size:" + values.length + ")");
         } else if (idx >= values.length) {
-            throw getRuntime().newIndexError("offset " + idx + " too large for struct (size:" + values.length + ")");
+            throw getRuntime().newIndexError("offset " + idx + " too large for struct(size:" + values.length + ")");
         }
 
         return values[idx];
@@ -643,9 +643,9 @@ public class RubyStruct extends RubyObject {
         idx = idx < 0 ? values.length + idx : idx;
 
         if (idx < 0) {
-            throw getRuntime().newIndexError("offset " + idx + " too large for struct (size:" + values.length + ")");
+            throw getRuntime().newIndexError("offset " + idx + " too small for struct(size:" + values.length + ")");
         } else if (idx >= values.length) {
-            throw getRuntime().newIndexError("offset " + idx + " too large for struct (size:" + values.length + ")");
+            throw getRuntime().newIndexError("offset " + idx + " too large for struct(size:" + values.length + ")");
         }
 
         modify();


### PR DESCRIPTION
For below case.

``` ruby
Foo = Struct.new :foo
foo = Foo.new true
```
### MRI/YARV

ruby 1.9.3p194 (2012-04-20 revision 35410) [x86_64-darwin11.4.0]

``` ruby
foo[-2]   #=> offset -1 too small for struct(size:1) (IndexError)
foo[:bar] #=> no member 'bar' in struct (NameError)
```
### JRuby

jruby 1.7.0.preview2 (1.9.3p203) 2012-08-31 aeef1b8 on Java HotSpot(TM) 64-Bit Server VM 1.6.0_33-b03-424-11M3720 [darwin-x86_64]

``` ruby
foo[-2]   #=> IndexError: offset -1 too large for struct (size:1)
foo[:bar] #=> NameError: bar is not struct member
```
