### PR TITLE
call Kernel.require ruby method from autoload callback instead of callin...

### DIFF
--- a/src/org/jruby/RubyKernel.java
+++ b/src/org/jruby/RubyKernel.java
@@ -208,8 +208,9 @@ public class RubyKernel {
             }
 
             public void load(Ruby runtime) {
-                if (runtime.getLoadService().autoloadRequire(file())) {
-                    // Do not finish autoloading by cyclic autoload 
+                final ThreadContext context = runtime.getCurrentContext();
+                if (runtime.getKernel().callMethod(context, "require", file).isTrue()) {
+                    // Do not finish autoloading by cyclic autoload
                     module.finishAutoload(baseName);
                 }
             }


### PR DESCRIPTION
In jruby, the autoload mechanism doesn't actually call Kernel.require like the rubydocs claims it will.  This change attempts to fix that.

From http://www.ruby-doc.org/core-1.9.3/Module.html#method-i-autoload:

```
autoload(module, filename) → nil click to toggle source

Registers filename to be loaded (using Kernel::require) the first time that module (which may be a String or a symbol) is accessed in the namespace of mod.
```

Note that this change uses the context when require happens rather than when the autoload method is called.  I wasn't sure what the right thing to do is, or whether it really matters.

The purpose of this change is to allow the user to override Kernel.require even with autoloading.  I assume it rubygems is the most well-known overrider of Kernel.require.  It presumably ends up pulling in enough stuff into LOAD_PATH via direct requires that any autoloading it does still works, but I suspect it could be problematic if it tried to add paths for autoloaded files.

Thanks for your consideration,

Andrew
