### PR TITLE
Add encoding annotation to test_unicode_path

### DIFF
--- a/test/test_unicode_paths.rb
+++ b/test/test_unicode_paths.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'test/unit'
 
 class TestUnicodePaths < Test::Unit::TestCase


### PR DESCRIPTION
The test fails in Ruby 1.9 mode when environment encoding is set to something different than utf-8.
