### PR TITLE
Apply '-' behaviour to blank padded format directives.

### DIFF
--- a/src/org/jruby/util/TimeOutputFormatter.java
+++ b/src/org/jruby/util/TimeOutputFormatter.java
@@ -121,7 +121,7 @@ public class TimeOutputFormatter {
                         paddedWith = '0';
                         break;
                     case '-':
-                        sequence = sequence.replaceAll("^[0]", "");
+                        sequence = sequence.replaceAll("^[0 ]", "");
                         break;
                 }
             }

--- a/test/org/jruby/util/TimeOutputFormatterTest.java
+++ b/test/org/jruby/util/TimeOutputFormatterTest.java
@@ -88,4 +88,14 @@ public class TimeOutputFormatterTest extends TestCase {
         TimeOutputFormatter formatter = TimeOutputFormatter.getFormatter("%^5H");
         assertEquals("   UP", formatter.format("up"));
     }
+
+    public void testFormatNoPaddingForBlankPaddedValues() {
+       TimeOutputFormatter formatter = TimeOutputFormatter.getFormatter("%-3H");
+        assertEquals("up", formatter.format(" up"));
+    }
+
+   public void testFormatNoPaddingForZeroPaddedValues() {
+       TimeOutputFormatter formatter = TimeOutputFormatter.getFormatter("%-3H");
+        assertEquals("up", formatter.format("0up"));
+    }
 }


### PR DESCRIPTION
This commit addresses jruby issue #289.  The expected behaviour is documented in this rubyspec pull request: https://github.com/rubyspec/rubyspec/pull/153
