### PR TITLE
no need to report memory/stack as properties

### DIFF
--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -248,16 +248,13 @@ if [[ -z "$JAVA_ENCODING" ]]; then
   java_args="${java_args} -Dfile.encoding=UTF-8"
 fi
 
-# Add a property to report memory max
-JAVA_OPTS="$JAVA_OPTS $JAVA_VM -Djruby.memory.max=${JAVA_MEM} -Djruby.stack.max=${JAVA_STACK}"
-
 # Append the rest of the arguments
 ruby_args="${ruby_args} $@"
 
 # Put the ruby_args back into the position arguments $1, $2 etc
 set -- "${ruby_args}"
 
-JAVA_OPTS="$JAVA_OPTS $JAVA_MEM $JAVA_STACK"
+JAVA_OPTS="$JAVA_OPTS $JAVA_VM $JAVA_MEM $JAVA_STACK"
 
 JFFI_BOOT=""
 if [ -d "$JRUBY_HOME/lib/native/" ]; then


### PR DESCRIPTION
as they are resolved from RuntimeMXBean (see 5d86783e2db0879a13feb6037af0891eb24785e5)
