### PR TITLE
Fix: Added support for the Java cacerts trust anchors 

### DIFF
--- a/src/org/jruby/ext/openssl/X509Store.java
+++ b/src/org/jruby/ext/openssl/X509Store.java
@@ -156,11 +156,7 @@ public class X509Store extends RubyObject {
     @JRubyMethod
     public IRubyObject set_default_paths() {
         try {
-            RubyHash env = (RubyHash)getRuntime().getObject().fastGetConstant("ENV");
-            String file = (String)env.get(getRuntime().newString(X509Utils.getDefaultCertificateFileEnvironment()));
-            store.loadLocations(file, null);
-            String path = (String)env.get(getRuntime().newString(X509Utils.getDefaultCertificateDirectoryEnvironment()));
-            store.loadLocations(null, path);
+            store.setDefaultPaths();
         }
         catch(Exception e) {
             raise("setting default path failed: " + e.getMessage());

--- a/src/org/jruby/ext/openssl/x509store/Store.java
+++ b/src/org/jruby/ext/openssl/x509store/Store.java
@@ -325,9 +325,7 @@ public class Store implements X509TrustManager {
 
     /**
      * c: X509_STORE_set_default_paths
-     * not used for now: invoking this method causes refering System.getenv("SSL_CERT_DIR") etc.
-     * We need to get the dir via evaluating "ENV['SSL_CERT_DIR']" instead of it.
-     */
+     */     
     public int setDefaultPaths() throws Exception { 
         Lookup lookup;
 


### PR DESCRIPTION
This patch adds support for reading the Java cacerts keystore
to import the default trust anchors using the set_default_paths
API.  This patch addresses the problem discussed here:
http://jira.codehaus.org/browse/JRUBY-6140
