### PR TITLE
replace "/bin/bash" with "/usr/bin/env bash" in shebangs

### DIFF
--- a/bin/generate_parser
+++ b/bin/generate_parser
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Run from your JRuby home directory....More smarts needed here.
 #

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -----------------------------------------------------------------------------
 # jruby.bash - Start Script for the JRuby interpreter
 #

--- a/test/org/jruby/util/shell_launcher_test
+++ b/test/org/jruby/util/shell_launcher_test
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 true

--- a/tool/git_bisect_run_general.sh
+++ b/tool/git_bisect_run_general.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # simple script for use with 'git bisect run'
 # e.g., git bisect run tool/git_bisect_run.sh -T--1.9 spec/ruby/language/defined_spec.rb


### PR DESCRIPTION
bash doesn't necessarily live in /bin.  Update shebangs to invoke
"/usr/bin/env bash" and make life a bit easier for all us
non-GNU+Linux folk.
