### PR TITLE
Add missing space to Regexp exception message

### DIFF
--- a/src/org/jruby/RubyRegexp.java
+++ b/src/org/jruby/RubyRegexp.java
@@ -2307,7 +2307,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
     private static RubyString operandCheck(Ruby runtime, IRubyObject str) {
         if (str instanceof RubySymbol) return (RubyString)((RubySymbol)str).to_s();
         IRubyObject tmp = str.checkStringType();
-        if (tmp.isNil()) throw runtime.newTypeError("can't convert " + str.getMetaClass() + "to String");
+        if (tmp.isNil()) throw runtime.newTypeError("can't convert " + str.getMetaClass() + " into String");
         return (RubyString)tmp;
     }
 


### PR DESCRIPTION
When checking the argument type, if an argument to the Regexp is not a
String the exception message is missing a space between the class name
of the argument and the word "to".

``` ruby
p 'test' if /test/ =~ {}  # => TypeError: can't convert Hashto String
```
