### PR TITLE
DirectedGraph Specs : Removing a vertex doesn't remove edges from the graph

### DIFF
--- a/spec/ir/directed_graph/directed_graph_spec.rb
+++ b/spec/ir/directed_graph/directed_graph_spec.rb
@@ -32,4 +32,12 @@ describe "Directed Graph Utility" do
     @graph.edges.size.should == 4
   end
 
+  it "should remove a vertex and its associated edges" do
+    @graph.removeVertexFor(3)
+    @graph.edges.size.should == 2
+    @graph.vertices.size.should == 3
+    @graph.removeVertexFor(2)
+    @graph.vertices.size.should == 2
+  end
+
 end

--- a/src/org/jruby/ir/util/Vertex.java
+++ b/src/org/jruby/ir/util/Vertex.java
@@ -57,6 +57,7 @@ public class Vertex<T> implements Comparable<Vertex<T>> {
     public void removeAllIncomingEdges() {
         for (Edge edge: getIncomingEdges()) {
             edge.getSource().getOutgoingEdges().remove(edge);
+            graph.edges().remove(edge);
         }
         incoming = null;
     }
@@ -64,6 +65,7 @@ public class Vertex<T> implements Comparable<Vertex<T>> {
     public void removeAllOutgoingEdges() {
         for (Edge edge: getOutgoingEdges()) {
             edge.getDestination().getIncomingEdges().remove(edge);
+            graph.edges().remove(edge);
         }
         outgoing = null;
     }


### PR DESCRIPTION
Removing a vertex from a graph doesn't remove the edges from the graph itself. So after removing edges associated with vertex, i deleted it from the associated graph also.
