### PR TITLE
removed snapshot in versions

### DIFF
--- a/maven/jruby-core/pom.xml
+++ b/maven/jruby-core/pom.xml
@@ -36,12 +36,12 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-unixsocket</artifactId>
-      <version>0.1-SNAPSHOT</version>
+      <version>0.1</version>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
-      <version>2.2.1-SNAPSHOT</version>
+      <version>2.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.jruby.extras</groupId>


### PR DESCRIPTION
after jnr-posix, jnr-enxio and jnr-unix-sockets are released and on maven-central we need to remove the SNAPSHOT from those versions.
