### PR TITLE
Fix edge case where rescued Exceptions may be nil

### DIFF
--- a/spec/regression/GH-311_rescue_nil_exception.rb
+++ b/spec/regression/GH-311_rescue_nil_exception.rb
@@ -1,0 +1,18 @@
+require 'rspec'
+
+describe 'nested rescue of java exception' do
+  it 'should not have a nil exception' do
+    caught = false
+    begin
+      begin
+        raise 'success'
+      rescue javax.naming.NameNotFoundException
+      end
+    rescue Exception => ex
+      ex.should_not be_nil
+      ex.message.should == 'success'
+      caught = true
+    end
+    caught.should be_true
+  end
+end

--- a/src/org/jruby/javasupport/Java.java
+++ b/src/org/jruby/javasupport/Java.java
@@ -919,12 +919,13 @@ public class Java implements Library {
             // this covers the rare case of lower-case class names (and thus will
             // fail 99.999% of the time). fortunately, we'll only do this once per
             // package name. (and seriously, folks, look into best practices...)
+            IRubyObject previousErrorInfo = RuntimeHelpers.getErrorInfo(runtime);
             try {
                 return getProxyClass(runtime, JavaClass.forNameQuiet(runtime, fullName));
             } catch (RaiseException re) { /* expected */
                 RubyException rubyEx = re.getException();
                 if (rubyEx.kind_of_p(context, runtime.getStandardError()).isTrue()) {
-                    RuntimeHelpers.setErrorInfo(runtime, runtime.getNil());
+                    RuntimeHelpers.setErrorInfo(runtime, previousErrorInfo);
                 }
             } catch (Exception e) { /* expected */ }
 


### PR DESCRIPTION
If an inner rescue block causes a Java proxy or package to be looked
up then an outer rescue block was receiving a nil Exception object,
only when running in interpretered, non-IR mode. Running the test with
"-X+C" or "-X-CIR" did not reproduce the behavior.

This behavior was introduced by the commits 20632af6 and 7c3f6426,
which were cleaning up a hack around the way $! got set. The mentioned
hack was covering up this bug.
