### PR TITLE
Windows Process.kill 'KILL'

### DIFF
--- a/src/org/jruby/RubyProcess.java
+++ b/src/org/jruby/RubyProcess.java
@@ -934,7 +934,7 @@ public class RubyProcess {
 					          throw runtime.newErrnoEPERMError("unable to call GetExitCodeProcess " + pid);
 					       } else {
 					           if(status.getInt(0) != STILL_ACTIVE) {
-							       throw runtime.newErrnoEPERMError("Process does not exist " + pid);
+							       throw runtime.newErrnoEPERMError("Process exists but is not alive anymore " + pid);
                                }
 					       }
 					   } finally {


### PR DESCRIPTION
Implements Process.kill 'KILL', pid
for windows. Kind of based off this other pull request being merged first: 
https://github.com/jruby/jruby/pull/319
see http://jira.codehaus.org/browse/JRUBY-4317
