### PR TITLE
Fix #276. For good.

### DIFF
--- a/src/org/jruby/ast/Yield19Node.java
+++ b/src/org/jruby/ast/Yield19Node.java
@@ -30,7 +30,7 @@ public class Yield19Node extends YieldNode {
             case ARGSPUSHNODE:
             case ARGSCATNODE:
             case SPLATNODE: 
-                RuntimeHelpers.unsplatValue19IfArityOne(argsResult, yieldToBlock);
+                argsResult = RuntimeHelpers.unsplatValue19IfArityOne(argsResult, yieldToBlock);
                 break;
             case ARRAYNODE:
                 // Pass-thru


### PR DESCRIPTION
`RuntimeHelpers.unsplatValue19IfArityOne` must be assigned back to `argsResult` for the refactor to work.

This fixes related tests:

```
➈❸ greystones:~/dev/jruby (gh276)$ ./bin/jruby -I"lib:test" test/externals/ruby1.9/test_pp.rb -n "test_hash_with_boolean_value"
Run options: -n test_hash_with_boolean_value

# Running tests:

.

Finished tests in 0.086000s, 11.6279 tests/s, 11.6279 assertions/s.

1 tests, 1 assertions, 0 failures, 0 errors, 0 skips
➈❸ greystones:~/dev/jruby (gh276)$ ./bin/jruby -S rspec spec/regression/GH-276_yield_splat_behaviour_causes_pp_to_break.rb 
.....

Finished in 0.022 seconds
5 examples, 0 failures

```
