### PR TITLE
Fix Dir.tmpdir exploding with unexisting TMPDIR regression

### DIFF
--- a/lib/ruby/1.9/tmpdir.rb
+++ b/lib/ruby/1.9/tmpdir.rb
@@ -28,7 +28,7 @@ class Dir
       # Opening directory is not allowed in Java.
       dirs = [ENV['TMPDIR'], ENV['TMP'], ENV['TEMP'], @@systmpdir, '/tmp', tmp]
       for dir in dirs
-        if dir and stat = File.stat(dir) and stat.directory? and stat.writable? and !stat.world_writable?
+        if dir and (stat = File.stat(dir) rescue nil) and stat.directory? and stat.writable? and !stat.world_writable?
           return File.expand_path(dir)
         end
       end


### PR DESCRIPTION
This pull fixes regression in 1.7, which makes following code explode:

TMPDIR=/foo bin/jruby -r tmpdir -e 'puts Dir.tmpdir'

What's a good test to reproduce this issue in? Is test//externals/ruby1.9/test_tempfile.rb the best place?
