### PR TITLE
Improve performance of the Equals operator in the RubyComparable class for objects of different types

### DIFF
--- a/src/org/jruby/RubyComparable.java
+++ b/src/org/jruby/RubyComparable.java
@@ -116,6 +116,11 @@ public class RubyComparable {
         try {
             IRubyObject result = invokedynamic(context, recv, OP_CMP, other);
 
+			// This is only to prevent throwing exceptions by cmperr - it has poor performance
+			if (result.isNil()) {
+				return returnValueOnError;
+			}
+
             return RubyBoolean.newBoolean(runtime, cmpint(context, result, recv, other) == 0);
         } catch (RaiseException e) {
             if (e.getException().kind_of_p(context, runtime.getStandardError()).isTrue()) {


### PR DESCRIPTION
Please see the following ticket for all the details:
http://jira.codehaus.org/browse/JRUBY-6915
