### PR TITLE
Fix indentation in: e2c3728.

### DIFF
--- a/src/org/jruby/RubyComparable.java
+++ b/src/org/jruby/RubyComparable.java
@@ -116,10 +116,10 @@ public class RubyComparable {
         try {
             IRubyObject result = invokedynamic(context, recv, OP_CMP, other);
 
-			// This is only to prevent throwing exceptions by cmperr - it has poor performance
-			if (result.isNil()) {
-				return returnValueOnError;
-			}
+            // This is only to prevent throwing exceptions by cmperr - it has poor performance
+            if (result.isNil()) {
+                return returnValueOnError;
+            }
 
             return RubyBoolean.newBoolean(runtime, cmpint(context, result, recv, other) == 0);
         } catch (RaiseException e) {


### PR DESCRIPTION
In my previous pull request (https://github.com/jruby/jruby/pull/330) I used tabs instead of spaces.

Nothing very important, but here's a pull request to fix it. I'm sorry about that.
