### PR TITLE
Allow qualified constant names to be used in Module#const_get

### DIFF
--- a/test/test_qualified_const_get.rb
+++ b/test/test_qualified_const_get.rb
@@ -1,0 +1,42 @@
+# FIXME: remove this file when the Ruby 2.0 tests are pulled into the JRuby source tree
+
+if RUBY_VERSION >= "2.0"
+  require "test/unit"
+
+  class TestQualifiedConstGet < Test::Unit::TestCase
+    module X
+      module Y
+      end
+
+      Z = 123
+    end
+
+    def test_nested_get
+      assert_equal Test::Unit::TestCase, Object.const_get("Test::Unit::TestCase")
+      assert_equal X::Y, self.class.const_get("X::Y")
+    end
+
+    def test_nested_get_symbol
+      assert_equal Test::Unit::TestCase, Object.const_get(:"Test::Unit::TestCase")
+      assert_equal X::Y, self.class.const_get(:"X::Y")
+    end
+
+    def test_nested_get_const_missing
+      classes = []
+      klass = Class.new {
+        define_singleton_method(:const_missing) { |name|
+          classes << name
+          klass
+        }
+      }
+      klass.const_get("Foo::Bar::Baz")
+      assert_equal [:Foo, :Bar, :Baz], classes
+    end
+
+    def test_nested_bad_class
+      assert_raises(TypeError) do
+        self.class.const_get([X, 'Z', 'Foo'].join('::'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request implements the new `Module#const_get` functionality recently added to MRI: http://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=37335&view=revision
