### PR TITLE
Restore ant dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
-      <version>1.7.1.dev</version>
+      <version>1.7.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Fix ant dependency version, as it was erroneously changed when upgrading jruby version.
