### PR TITLE
Implement Ruby 1.9 behavior for Time#<=>

### DIFF
--- a/spec/tags/1.9/ruby/core/time/comparison_tags.txt
+++ b/spec/tags/1.9/ruby/core/time/comparison_tags.txt
@@ -1,4 +1,0 @@
-fails:Time#<=> given a non-Time argument returns nil if argument <=> self returns nil
-fails:Time#<=> given a non-Time argument returns -1 if argument <=> self is greater than 0
-fails:Time#<=> given a non-Time argument returns 1 if argument <=> self is not greater than 0 and is less than 0
-fails:Time#<=> given a non-Time argument returns 0 if argument <=> self is neither greater than 0 nor less than 0

--- a/src/org/jruby/RubyTime.java
+++ b/src/org/jruby/RubyTime.java
@@ -541,15 +541,31 @@ public class RubyTime extends RubyObject {
         return (RubyNumeric.fix2int(invokedynamic(context, this, OP_CMP, other)) == 0) ? getRuntime().getTrue() : getRuntime().getFalse();
     }
 
-    @JRubyMethod(name = "<=>", required = 1)
+    @JRubyMethod(name = "<=>", required = 1, compat = CompatVersion.RUBY1_8)
     public IRubyObject op_cmp(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyTime) {
             return context.runtime.newFixnum(cmp((RubyTime) other));
         }
-
         return context.runtime.getNil();
     }
-    
+
+    @JRubyMethod(name = "<=>", required = 1, compat = CompatVersion.RUBY1_9)
+    public IRubyObject op_cmp19(ThreadContext context, IRubyObject other) {
+        if (other instanceof RubyTime) {
+            return context.runtime.newFixnum(cmp((RubyTime) other));
+        }
+
+        IRubyObject tmp = invokedynamic(context, other, OP_CMP, this);
+        if (tmp.isNil()) {
+            return context.runtime.getNil();
+        } else {
+            int n = -RubyComparable.cmpint(context, tmp, this, other);
+            if (n == 0) return context.runtime.newFixnum(0);
+            if (n > 0) return context.runtime.newFixnum(1);
+            return context.runtime.newFixnum(-1);
+        }
+    }
+
     @JRubyMethod(name = "eql?", required = 1)
     @Override
     public IRubyObject eql_p(IRubyObject other) {


### PR DESCRIPTION
It seems that ActiveSupport::TimeWithZone and TZInfo rely on this
behavior for comparisons. For example:

``` ruby
require 'active_support/time'
require 'active_support/time_with_zone'

time_zone = ActiveSupport::TimeZone.new('Eastern Time (US & Canada )')'
time_seed = Time.new(2012,11,10).in_time_zone(time_zone)
datetime_seed = DateTime.new(2012,11,10).in_time_zone(time_zone)

datetime_seed < time_seed #=> false
time_seed < datetime_seed #=> ArgumentError: comparison of ActiveSupport::TimeWithZone with ActiveSupport::TimeWithZone failed
```

This fix enables the comparison to be made in either direction.
