### PR TITLE
Fixed implicitly creating a vertex if it is absent while removing a edge or vertex

### DIFF
--- a/spec/ir/directed_graph/directed_graph_spec.rb
+++ b/spec/ir/directed_graph/directed_graph_spec.rb
@@ -9,56 +9,65 @@ describe "Directed Graph Utility" do
 
   before do
     @graph = DirectedGraph.new
-    @graph.addEdge(1,2,'simple')
-    @graph.addEdge(2,3,'simple')
-    @graph.addEdge(3,4,'simple')
-    @graph.addEdge(4,1,'simple')
   end
 
   it "should add an edge to newly created graph" do
-    @graph.edges.size.should == 4
-    @graph.addEdge(4,5,'simple')
-    @graph.edges.size.should == 5
+    @graph.edges.size.should be 0
+    @graph.addEdge(1,2,'foo')
+    @graph.addEdge(4,5,'bar')
+    @graph.edges.size.should be 2
   end
 
   it "should remove an existing edge from a graph" do
-    @graph.edges.size.should == 4
+    @graph.edges.size.should be 0
     @graph.removeEdge(1,2)
-    @graph.edges.size.should == 3
+    @graph.edges.size.should be 0
+    @graph.addEdge(1,2,'foo')
+    @graph.addEdge(4,5,'bar')
+    @graph.removeEdge(4,5)
+    @graph.edges.size.should be 1
   end
 
   it "should not delete a non-existent edge from the graph" do
-    @graph.edges.size.should == 4
+    @graph.edges.size.should be 0
     @graph.removeEdge(2,1)
-    @graph.edges.size.should == 4
+    @graph.edges.size.should be 0
   end
 
   it "should remove a vertex and its associated edges" do
     @graph.removeVertexFor(3)
-    @graph.edges.size.should == 2
-    @graph.vertices.size.should == 3
+    @graph.edges.size.should be 0
+    @graph.vertices.size.should be 0
+    @graph.addEdge(1,2,'foo')
+    @graph.addEdge(4,5,'bar')
     @graph.removeVertexFor(2)
-    @graph.vertices.size.should == 2
+    @graph.vertices.size.should be 3
+    @graph.edges.size.should be 1
   end
 
   it "should give vertex for given data" do
-    @graph.vertexFor(2).getData().should == 2
+    @graph.addEdge(1,2,'foo')
+    @graph.vertexFor(2).getData().should be 2
   end
 
   it "should create a new vertex if it is not present" do
-    @graph.vertexFor(100).getData().should == 100
+    @graph.vertexFor(100).getData().should be 100
   end
 
   it "should find already existing vertex" do
-    @graph.findVertexFor(2).getData().should == 2
-    @graph.findVertexFor(100).should == nil
+    @graph.findVertexFor(100).should be_nil
+    @graph.addEdge(1,2,'foo')
+    @graph.findVertexFor(1).getData().should be 1
+    @graph.findVertexFor(1).data.should be 1
   end
 
   it "should give correct size of graph" do
     @graph.removeEdge(1,2)
-    @graph.size.should == 4
-    @graph.addEdge(5,6,'simple')
-    @graph.size.should == 6
+    @graph.size.should be 0
+    @graph.addEdge(5,6,'baz')
+    @graph.size.should be 2
+    @graph.addEdge('foo','bar','baz')
+    @graph.size.should be 4
   end
 
 end

--- a/src/org/jruby/ir/util/DirectedGraph.java
+++ b/src/org/jruby/ir/util/DirectedGraph.java
@@ -16,71 +16,76 @@ public class DirectedGraph<T> {
     private Set<Edge<T>> edges = new HashSet<Edge<T>>();
     private ArrayList inOrderVerticeData = new ArrayList();
     int vertexIDCounter = 0;
-    
+
     public Collection<Vertex<T>> vertices() {
         return vertices.values();
     }
-    
+
     public Collection<Edge<T>> edges() {
         return edges;
     }
-    
+
     public Iterable<Edge<T>> edgesOfType(Object type) {
         return new EdgeTypeIterable<T>(edges, type);
     }
-    
+
     public Collection<T> allData() {
         return vertices.keySet();
     }
-    
+
     /**
      * @return data in the order it was added to this graph.
      */
     public Collection<T> getInorderData() {
         return inOrderVerticeData;
     }
-    
+
     public void addEdge(T source, T destination, Object type) {
         vertexFor(source).addEdgeTo(destination, type);
     }
-    
+
     public void removeEdge(Edge edge) {
         edge.getSource().removeEdgeTo(edge.getDestination());
     }
-    
+
     public void removeEdge(T source, T destination) {
-        for (Edge edge: vertexFor(source).getOutgoingEdges()) {
-            if (edge.getDestination().getData() == destination) {
-                vertexFor(source).removeEdgeTo(edge.getDestination());
-                return;
+        if (findVertexFor(source) != null) {
+            for (Edge edge: vertexFor(source).getOutgoingEdges()) {
+                if (edge.getDestination().getData() == destination) {
+                    vertexFor(source).removeEdgeTo(edge.getDestination());
+                    return;
+                }
             }
         }
+        return;
     }
-    
+
     public Vertex<T> findVertexFor(T data) {
         return vertices.get(data);
     }
-    
+
     public Vertex<T> vertexFor(T data) {
         Vertex vertex = vertices.get(data);
-        
+
         if (vertex != null) return vertex;
-        
+
         vertex = new Vertex(this, data, vertexIDCounter++);
         inOrderVerticeData.add(data);
-        
+
         vertices.put(data, vertex);
-        
+
         return vertex;
     }
-    
+
     public void removeVertexFor(T data) {
-        Vertex vertex = vertexFor(data);
-        vertices.remove(data);
-        inOrderVerticeData.remove(data);
-        vertex.removeAllEdges();
+        if (findVertexFor(data) != null) {
+            Vertex vertex = vertexFor(data);
+            vertices.remove(data);
+            inOrderVerticeData.remove(data);
+            vertex.removeAllEdges();
+        }
     }
-    
+
     /**
      * @return the number of vertices in the graph.
      */
@@ -91,13 +96,13 @@ public class DirectedGraph<T> {
     @Override
     public String toString() {
         StringBuilder buf = new StringBuilder();
-        
+
         ArrayList<Vertex<T>> verts = new ArrayList<Vertex<T>>(vertices.values());
         Collections.sort(verts);
         for (Vertex<T> vertex: verts) {
             buf.append(vertex);
         }
-        
+
         return buf.toString();
     }
 }


### PR DESCRIPTION
`vertexFor` method in `src/org/jruby/ir/util/DirectedGraph.java` creates a vertex implicitly.
While removing a edge or vertex there is no need to create this vertex implicitly by `vertexFor` method.
