### PR TITLE
Don't override default_exec_format method for rubygems

### DIFF
--- a/lib/ruby/shared/rubygems/defaults/jruby.rb
+++ b/lib/ruby/shared/rubygems/defaults/jruby.rb
@@ -53,11 +53,6 @@ module Gem
     @@win_platform
   end
 
-  # We do not want prefixes on installed binaries.
-  def self.default_exec_format
-    "%s"
-  end
-
   # Allow specifying jar and classpath type gem path entries
   def self.path_separator
     return File::PATH_SEPARATOR unless File::PATH_SEPARATOR == ':'


### PR DESCRIPTION
It isn't necessary to override this, since it is only used if the --format-executable flag is given.  The --format-executable flag defaults to off, so executables from a gem wont' be prefixed unless the user explicitly asks for it.
