### PR TITLE
Include runtime version in site dir

### DIFF
--- a/src/org/jruby/ext/rbconfig/RbConfigLibrary.java
+++ b/src/org/jruby/ext/rbconfig/RbConfigLibrary.java
@@ -185,7 +185,7 @@ public class RbConfigLibrary implements Library {
     }
 
     public static String getSiteDir(Ruby runtime) {
-        return new NormalizedFile(getSiteDirGeneral(runtime), "ruby/site_ruby").getPath();
+        return new NormalizedFile(getSiteDirGeneral(runtime), String.format("ruby/%s/site_ruby", getRuntimeVerStr(runtime))).getPath();
     }
 
     public static String getSiteLibDir(Ruby runtime) {


### PR DESCRIPTION
I forgot this during doing the path rework, I think it's not used by anyone except me for Fedora packaging, so it can safely be merged into 1.7 tree.
