### PR TITLE
Fix Readline.get_screen_size before Readline.readline

### DIFF
--- a/src/org/jruby/ext/Readline.java
+++ b/src/org/jruby/ext/Readline.java
@@ -136,6 +136,14 @@ public class Readline {
         return (ConsoleHolder) (runtime.getModule("Readline").dataGetStruct());
     }
 
+    public static ConsoleHolder getHolderWithReadline(Ruby runtime) {
+        ConsoleHolder holder = getHolder(runtime);
+        if (holder.readline == null) {
+            initReadline(runtime, holder);
+        }
+        return holder;
+    }
+
     public static void setCompletor(ConsoleHolder holder, Completer completor) {
         if (holder.readline != null) {
             holder.readline.removeCompleter(holder.currentCompletor);
@@ -157,10 +165,7 @@ public class Readline {
     @JRubyMethod(name = "readline", module = true, visibility = PRIVATE)
     public static IRubyObject s_readline(ThreadContext context, IRubyObject recv, IRubyObject prompt, IRubyObject add_to_hist) {
         Ruby runtime = context.runtime;
-        ConsoleHolder holder = getHolder(runtime);
-        if (holder.readline == null) {
-            initReadline(runtime, holder); // not overridden, let's go
-        }
+        ConsoleHolder holder = getHolderWithReadline(runtime);
         holder.readline.setExpandEvents(false);
         
         IRubyObject line = runtime.getNil();
@@ -299,7 +304,7 @@ public class Readline {
     @JRubyMethod(name = "get_screen_size", module = true, visibility = PRIVATE, compat = RUBY1_9)
     public static IRubyObject s_get_screen_size(ThreadContext context, IRubyObject recv) {
         Ruby runtime = context.runtime;
-        ConsoleHolder holder = getHolder(runtime);
+        ConsoleHolder holder = getHolderWithReadline(runtime);
         IRubyObject[] ary = new IRubyObject[2];
         ary[0] = runtime.newFixnum(holder.readline.getTerminal().getHeight());
         ary[1] = runtime.newFixnum(holder.readline.getTerminal().getWidth());
@@ -310,10 +315,7 @@ public class Readline {
     @JRubyMethod(name = "line_buffer", module = true, visibility = PRIVATE, compat = RUBY1_9)
     public static IRubyObject s_get_line_buffer(ThreadContext context, IRubyObject recv) {
         Ruby runtime = context.runtime;
-        ConsoleHolder holder = getHolder(runtime);
-        if (holder.readline == null) {
-            initReadline(runtime, holder);
-        }
+        ConsoleHolder holder = getHolderWithReadline(runtime);
         CursorBuffer cb = holder.readline.getCursorBuffer();
         return runtime.newString(cb.toString()).taint(context);
     }
@@ -321,10 +323,7 @@ public class Readline {
     @JRubyMethod(name = "point", module = true, visibility = PRIVATE, compat = RUBY1_9)
     public static IRubyObject s_get_point(ThreadContext context, IRubyObject recv) {
         Ruby runtime = context.runtime;
-        ConsoleHolder holder = getHolder(runtime);
-        if (holder.readline == null) {
-            initReadline(runtime, holder);
-        }
+        ConsoleHolder holder = getHolderWithReadline(runtime);
         CursorBuffer cb = holder.readline.getCursorBuffer();
         return runtime.newFixnum(cb.cursor);
     }
@@ -332,7 +331,7 @@ public class Readline {
     @JRubyMethod(name = "refresh_line", module = true, visibility = PRIVATE, compat = RUBY1_9)
     public static IRubyObject s_refresh_line(ThreadContext context, IRubyObject recv) {
         Ruby runtime = context.runtime;
-        ConsoleHolder holder = getHolder(runtime);
+        ConsoleHolder holder = getHolderWithReadline(runtime);
         try {
             holder.readline.redrawLine(); // not quite the same as rl_refresh_line()
         } catch (IOException ioe) {


### PR DESCRIPTION
It was missing a check for the lazily initialized holder.readline. I also added one in Readline.refresh_line which also accessed holder.readline without the check.

Without this, calling Readline.get_screen_size before calling Readline.readline raises a NullPointerException:

```
Java::JavaLang::NullPointerException: 
    org.jruby.ext.Readline.s_get_screen_size(Readline.java:304): on java objects - should include java-esque aliases if requested
    org.jruby.ext.Readline$INVOKER$s$0$0$s_get_screen_size.call(Readline$INVOKER$s$0$0$s_get_screen_size.gen)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:134)
    org.jruby.ast.CallNoArgNode.interpret(CallNoArgNode.java:64)
    org.jruby.ast.AndNode.interpret(AndNode.java:97)
    org.jruby.ast.ArrayNode.interpretPrimitive(ArrayNode.java:94)
    org.jruby.ast.ArrayNode.interpret(ArrayNode.java:84)
    org.jruby.ast.CallNoArgBlockNode.interpret(CallNoArgBlockNode.java:60)
    org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
    org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:75)
    org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:139)
    org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:172)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:134)
    org.jruby.ast.VCallNode.interpret(VCallNode.java:88)
    org.jruby.ast.MultipleAsgn19Node.interpret(MultipleAsgn19Node.java:104)
    org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
    org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
    org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:75)
    org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:139)
    org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:172)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:134)
    org.jruby.ast.CallNoArgNode.interpret(CallNoArgNode.java:64)
    org.jruby.ast.CallNoArgNode.interpret(CallNoArgNode.java:64)
    org.jruby.ast.IfNode.interpret(IfNode.java:110)
    org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
    org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
    org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:75)
    org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:182)
    org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:188)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:168)
    org.jruby.ast.FCallOneArgNode.interpret(FCallOneArgNode.java:36)
    org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
    org.jruby.ast.DNode.appendToString(DNode.java:74)
    org.jruby.ast.DNode.buildDynamicString(DNode.java:92)
    org.jruby.ast.DNode.interpret(DNode.java:40)
    org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
    org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
    org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:75)
    org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:225)
    org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:204)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:202)
    org.jruby.ast.FCallTwoArgNode.interpret(FCallTwoArgNode.java:38)
    org.jruby.ast.CallOneArgNode.interpret(CallOneArgNode.java:57)
    org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
    org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
    org.jruby.evaluator.ASTInterpreter.INTERPRET_BLOCK(ASTInterpreter.java:112)
    org.jruby.runtime.Interpreted19Block.evalBlockBody(Interpreted19Block.java:209)
    org.jruby.runtime.Interpreted19Block.yield(Interpreted19Block.java:160)
    org.jruby.runtime.Block.yield(Block.java:130)
    org.jruby.RubyArray.eachCommon(RubyArray.java:1605)
    org.jruby.RubyArray.each(RubyArray.java:1612)
    org.jruby.RubyArray$INVOKER$i$0$0$each.call(RubyArray$INVOKER$i$0$0$each.gen)
    org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:143)
    org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:154)
    org.jruby.ast.CallNoArgBlockNode.interpret(CallNoArgBlockNode.java:64)
    org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
    org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
    org.jruby.ast.IfNode.interpret(IfNode.java:116)
    org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
    org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
    org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:75)
    org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:139)
    org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:172)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:134)
    org.jruby.runtime.callsite.CachingCallSite.callVarargs(CachingCallSite.java:102)
    rubyjit.Pry::ClassCommand$$call_51E3E9685987B7A78DC960B56E3EC7D9BF353931.__file__(/0/ruby/pry/lib/pry/command.rb:643)
    rubyjit.Pry::ClassCommand$$call_51E3E9685987B7A78DC960B56E3EC7D9BF353931.__file__(/0/ruby/pry/lib/pry/command.rb)
    org.jruby.ast.executable.AbstractScript.__file__(AbstractScript.java:46)
    org.jruby.internal.runtime.methods.JittedMethod.call(JittedMethod.java:221)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:202)
    org.jruby.runtime.callsite.CachingCallSite.callVarargs(CachingCallSite.java:104)
    rubyjit.Pry::Command$$call_with_hooks_8B05D56652E0EA5B43F5AADC6F57DC94C76CF740.__file__(/0/ruby/pry/lib/pry/command.rb:430)
    rubyjit.Pry::Command$$call_with_hooks_8B05D56652E0EA5B43F5AADC6F57DC94C76CF740.__file__(/0/ruby/pry/lib/pry/command.rb)
    org.jruby.ast.executable.AbstractScript.__file__(AbstractScript.java:46)
    org.jruby.internal.runtime.methods.JittedMethod.call(JittedMethod.java:221)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:202)
    org.jruby.runtime.callsite.CachingCallSite.callVarargs(CachingCallSite.java:104)
    rubyjit.Pry::Command$$call_safely_EFD864497D475397564E99BF6254D26746E42F21.__file__(/0/ruby/pry/lib/pry/command.rb:403)
    rubyjit.Pry::Command$$call_safely_EFD864497D475397564E99BF6254D26746E42F21.__file__(/0/ruby/pry/lib/pry/command.rb)
    org.jruby.ast.executable.AbstractScript.__file__(AbstractScript.java:46)
    org.jruby.internal.runtime.methods.JittedMethod.call(JittedMethod.java:221)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:202)
    org.jruby.runtime.callsite.CachingCallSite.callVarargs(CachingCallSite.java:104)
    rubyjit.Pry::Command$$process_line_5D797228A1D97DCC91D7CE736B0F32763B228470.__file__(/0/ruby/pry/lib/pry/command.rb:345)
    rubyjit.Pry::Command$$process_line_5D797228A1D97DCC91D7CE736B0F32763B228470.__file__(/0/ruby/pry/lib/pry/command.rb)
    org.jruby.internal.runtime.methods.JittedMethod.call(JittedMethod.java:181)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:168)
    rubyjit.Pry::CommandSet$$process_line_34CAF2BBE1D7DC9FC9902B2581A702F332B460A5.__file__(/0/ruby/pry/lib/pry/command_set.rb:345)
    rubyjit.Pry::CommandSet$$process_line_34CAF2BBE1D7DC9FC9902B2581A702F332B460A5.__file__(/0/ruby/pry/lib/pry/command_set.rb)
    org.jruby.ast.executable.AbstractScript.__file__(AbstractScript.java:46)
    org.jruby.internal.runtime.methods.JittedMethod.call(JittedMethod.java:221)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:202)
    rubyjit.Pry$$process_command_1D9476D3C7BF8BB6A794E3309E0347A57016B4AF.__file__(/0/ruby/pry/lib/pry/pry_instance.rb:443)
    rubyjit.Pry$$process_command_1D9476D3C7BF8BB6A794E3309E0347A57016B4AF.__file__(/0/ruby/pry/lib/pry/pry_instance.rb)
    org.jruby.ast.executable.AbstractScript.__file__(AbstractScript.java:42)
    org.jruby.internal.runtime.methods.JittedMethod.call(JittedMethod.java:181)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:168)
    rubyjit.PryTester$$eval_985DAC1BB241F0893160CAECBAE9F57D83FC872E.block_0$RUBY$__file__(/0/ruby/pry/lib/pry/test/helper.rb:125)
    rubyjit$PryTester$$eval_985DAC1BB241F0893160CAECBAE9F57D83FC872E$block_0$RUBY$__file__.call(rubyjit$PryTester$$eval_985DAC1BB241F0893160CAECBAE9F57D83FC872E$block_0$RUBY$__file__)
    org.jruby.runtime.CompiledBlock19.yield(CompiledBlock19.java:139)
    org.jruby.runtime.Block.yield(Block.java:130)
    org.jruby.RubyArray.eachCommon(RubyArray.java:1605)
    org.jruby.RubyArray.each(RubyArray.java:1612)
    org.jruby.RubyArray$INVOKER$i$0$0$each.call(RubyArray$INVOKER$i$0$0$each.gen)
    org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:143)
    org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:154)
    rubyjit.PryTester$$eval_985DAC1BB241F0893160CAECBAE9F57D83FC872E.__file__(/0/ruby/pry/lib/pry/test/helper.rb:123)
    rubyjit.PryTester$$eval_985DAC1BB241F0893160CAECBAE9F57D83FC872E.__file__(/0/ruby/pry/lib/pry/test/helper.rb)
    org.jruby.ast.executable.AbstractScript.__file__(AbstractScript.java:42)
    org.jruby.internal.runtime.methods.JittedMethod.call(JittedMethod.java:181)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:168)
    org.jruby.runtime.callsite.CachingCallSite.callVarargs(CachingCallSite.java:103)
    rubyjit.Object$$pry_eval_CB1ABE1EBB9A3A51A74647E938D08EB9CD4E628F.__file__(/0/ruby/pry/lib/pry/test/helper.rb:100)
    rubyjit.Object$$pry_eval_CB1ABE1EBB9A3A51A74647E938D08EB9CD4E628F.__file__(/0/ruby/pry/lib/pry/test/helper.rb)
    org.jruby.ast.executable.AbstractScript.__file__(AbstractScript.java:42)
    org.jruby.internal.runtime.methods.JittedMethod.call(JittedMethod.java:181)
    org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:326)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
    org.jruby.ast.FCallOneArgNode.interpret(FCallOneArgNode.java:36)
    org.jruby.ast.CallNoArgNode.interpret(CallNoArgNode.java:64)
    org.jruby.ast.Match3Node.interpret(Match3Node.java:99)
    org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
    org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
    org.jruby.evaluator.ASTInterpreter.INTERPRET_BLOCK(ASTInterpreter.java:112)
    org.jruby.runtime.Interpreted19Block.evalBlockBody(Interpreted19Block.java:209)
    org.jruby.runtime.Interpreted19Block.yield(Interpreted19Block.java:197)
    org.jruby.runtime.Interpreted19Block.call(Interpreted19Block.java:128)
    org.jruby.runtime.Block.call(Block.java:89)
    org.jruby.RubyProc.call(RubyProc.java:261)
    org.jruby.RubyProc.call19(RubyProc.java:249)
    org.jruby.RubyProc$INVOKER$i$0$0$call19.call(RubyProc$INVOKER$i$0$0$call19.gen)
    org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:200)
    org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:196)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:134)
    rubyjit.Bacon::Context$$it_with_mocha_E90E8E88A88F9BEB754A85BAFA888BB0E158578F.chained_0_ensure_1$RUBY$__ensure__(/0/ruby/pry/spec/helpers/bacon.rb)
    rubyjit$Bacon::Context$$it_with_mocha_E90E8E88A88F9BEB754A85BAFA888BB0E158578F$block_0$RUBY$__file__.call(rubyjit$Bacon::Context$$it_with_mocha_E90E8E88A88F9BEB754A85BAFA888BB0E158578F$block_0$RUBY$__file__)
    org.jruby.runtime.CompiledBlock19.yield(CompiledBlock19.java:163)
    org.jruby.runtime.CompiledBlock19.yield(CompiledBlock19.java:149)
    org.jruby.runtime.Block.yieldNonArray(Block.java:141)
    org.jruby.RubyBasicObject.yieldUnder(RubyBasicObject.java:1781)
    org.jruby.RubyBasicObject.specificEval(RubyBasicObject.java:1805)
    org.jruby.RubyBasicObject.instance_eval19(RubyBasicObject.java:1691)
    org.jruby.RubyBasicObject$INVOKER$i$instance_eval19.call(RubyBasicObject$INVOKER$i$instance_eval19.gen)
    org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:143)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:149)
    rubyjit.Bacon::Context$$run_requirement_F2A91AFBD7C00282F057F724358B7E05D6A412CF.chained_2_ensure_2$RUBY$__ensure__(/home/conrad/.rvm/gems/jruby-head/gems/bacon-1.1.0/bin/../lib//bacon.rb)
    rubyjit.Bacon::Context$$run_requirement_F2A91AFBD7C00282F057F724358B7E05D6A412CF.chained_0_ensure_1$RUBY$__ensure__(/home/conrad/.rvm/gems/jruby-head/gems/bacon-1.1.0/bin/../lib//bacon.rb)
    rubyjit$Bacon::Context$$run_requirement_F2A91AFBD7C00282F057F724358B7E05D6A412CF$block_0$RUBY$__file__.call(rubyjit$Bacon::Context$$run_requirement_F2A91AFBD7C00282F057F724358B7E05D6A412CF$block_0$RUBY$__file__)
    org.jruby.runtime.CompiledBlock19.yieldSpecificInternal(CompiledBlock19.java:121)
    org.jruby.runtime.CompiledBlock19.yieldSpecific(CompiledBlock19.java:96)
    org.jruby.runtime.Block.yieldSpecific(Block.java:99)
    rubyjit.Bacon::TestUnitOutput$$handle_requirement_27DD182FA2B8F1CCDAB1C3C0F330905C131561B3.__file__(/0/ruby/pry/spec/helpers/bacon.rb)
    org.jruby.internal.runtime.methods.JittedMethod.call(JittedMethod.java:201)
    org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:177)
    org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:188)
    rubyjit.Bacon::Context$$run_requirement_F2A91AFBD7C00282F057F724358B7E05D6A412CF.__file__(/home/conrad/.rvm/gems/jruby-head/gems/bacon-1.1.0/bin/../lib//bacon.rb)
    org.jruby.internal.runtime.methods.JittedMethod.call(JittedMethod.java:221)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:202)
    rubyjit.Bacon::Context$$it_53BB58F48E9E1F6A967E77B1C940277ED6A032F7.__file__(/home/conrad/.rvm/gems/jruby-head/gems/bacon-1.1.0/bin/../lib//bacon.rb)
    org.jruby.internal.runtime.methods.JittedMethod.call(JittedMethod.java:201)
    org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:199)
    org.jruby.internal.runtime.methods.AliasMethod.call(AliasMethod.java:86)
    org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:177)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:183)
    rubyjit.Bacon::Context$$it_with_reset_binding_9B1347696A955DE1181B6C42F7E4E6A4BC809FC6.__file__(/0/ruby/pry/spec/helpers/bacon.rb)
    org.jruby.internal.runtime.methods.JittedMethod.call(JittedMethod.java:201)
    org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:199)
    org.jruby.internal.runtime.methods.AliasMethod.call(AliasMethod.java:86)
    org.jruby.internal.runtime.methods.AliasMethod.call(AliasMethod.java:86)
    org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:177)
    org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:188)
    rubyjit.Bacon::Context$$it_with_mocha_E90E8E88A88F9BEB754A85BAFA888BB0E158578F.__file__(/0/ruby/pry/spec/helpers/bacon.rb)
    org.jruby.internal.runtime.methods.JittedMethod.call(JittedMethod.java:201)
    org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:199)
    org.jruby.internal.runtime.methods.AliasMethod.call(AliasMethod.java:86)
    org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:336)
    org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:179)
    org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:188)
    org.jruby.ast.FCallOneArgBlockNode.interpret(FCallOneArgBlockNode.java:34)
    org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
    org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
    org.jruby.evaluator.ASTInterpreter.INTERPRET_BLOCK(ASTInterpreter.java:112)
    org.jruby.runtime.Interpreted19Block.evalBlockBody(Interpreted19Block.java:209)
    org.jruby.runtime.Interpreted19Block.yield(Interpreted19Block.java:197)
    org.jruby.runtime.Interpreted19Block.yield(Interpreted19Block.java:180)
    org.jruby.runtime.Block.yieldNonArray(Block.java:141)
    org.jruby.RubyBasicObject.yieldUnder(RubyBasicObject.java:1781)
    org.jruby.RubyBasicObject.specificEval(RubyBasicObject.java:1805)
    org.jruby.RubyBasicObject.instance_eval19(RubyBasicObject.java:1691)
    org.jruby.RubyBasicObject$INVOKER$i$instance_eval19.call(RubyBasicObject$INVOKER$i$instance_eval19.gen)
    org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:143)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:149)
    rubyjit$Bacon::Context$$run_3480DB9EF3486F25A0355BE477E07F8BD9CAA459$block_0$RUBY$__file__.call(rubyjit$Bacon::Context$$run_3480DB9EF3486F25A0355BE477E07F8BD9CAA459$block_0$RUBY$__file__)
    org.jruby.runtime.CompiledBlock19.yieldSpecificInternal(CompiledBlock19.java:121)
    org.jruby.runtime.CompiledBlock19.yieldSpecific(CompiledBlock19.java:96)
    org.jruby.runtime.Block.yieldSpecific(Block.java:99)
    rubyjit.Bacon::TestUnitOutput$$handle_specification_801F6A482F1291325BE7EBB00ED74E3A5C509A26.__file__(/home/conrad/.rvm/gems/jruby-head/gems/bacon-1.1.0/bin/../lib//bacon.rb)
    org.jruby.internal.runtime.methods.JittedMethod.call(JittedMethod.java:201)
    org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:177)
    org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:188)
    rubyjit.Bacon::Context$$run_3480DB9EF3486F25A0355BE477E07F8BD9CAA459.__file__(/home/conrad/.rvm/gems/jruby-head/gems/bacon-1.1.0/bin/../lib//bacon.rb)
    org.jruby.internal.runtime.methods.JittedMethod.call(JittedMethod.java:141)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:134)
    rubyjit.Bacon::Context$$describe_2D05ECD3B590BB221905DE1E5DD52B60D21E854B.__file__(/home/conrad/.rvm/gems/jruby-head/gems/bacon-1.1.0/bin/../lib//bacon.rb)
    org.jruby.ast.executable.AbstractScript.__file__(AbstractScript.java:42)
    org.jruby.internal.runtime.methods.JittedMethod.call(JittedMethod.java:201)
    org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:336)
    org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:179)
    org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:188)
    org.jruby.ast.FCallOneArgBlockNode.interpret(FCallOneArgBlockNode.java:34)
    org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
    org.jruby.ast.IfNode.interpret(IfNode.java:116)
    org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
    org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
    org.jruby.evaluator.ASTInterpreter.INTERPRET_BLOCK(ASTInterpreter.java:112)
    org.jruby.runtime.Interpreted19Block.evalBlockBody(Interpreted19Block.java:209)
    org.jruby.runtime.Interpreted19Block.yield(Interpreted19Block.java:197)
    org.jruby.runtime.Interpreted19Block.yield(Interpreted19Block.java:180)
    org.jruby.runtime.Block.yieldNonArray(Block.java:141)
    org.jruby.RubyBasicObject.yieldUnder(RubyBasicObject.java:1781)
    org.jruby.RubyBasicObject.specificEval(RubyBasicObject.java:1805)
    org.jruby.RubyBasicObject.instance_eval19(RubyBasicObject.java:1691)
    org.jruby.RubyBasicObject$INVOKER$i$instance_eval19.call(RubyBasicObject$INVOKER$i$instance_eval19.gen)
    org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:143)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:149)
    rubyjit$Bacon::Context$$run_3480DB9EF3486F25A0355BE477E07F8BD9CAA459$block_0$RUBY$__file__.call(rubyjit$Bacon::Context$$run_3480DB9EF3486F25A0355BE477E07F8BD9CAA459$block_0$RUBY$__file__)
    org.jruby.runtime.CompiledBlock19.yieldSpecificInternal(CompiledBlock19.java:121)
    org.jruby.runtime.CompiledBlock19.yieldSpecific(CompiledBlock19.java:96)
    org.jruby.runtime.Block.yieldSpecific(Block.java:99)
    rubyjit.Bacon::TestUnitOutput$$handle_specification_801F6A482F1291325BE7EBB00ED74E3A5C509A26.__file__(/home/conrad/.rvm/gems/jruby-head/gems/bacon-1.1.0/bin/../lib//bacon.rb)
    org.jruby.internal.runtime.methods.JittedMethod.call(JittedMethod.java:201)
    org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:177)
    org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:188)
    rubyjit.Bacon::Context$$run_3480DB9EF3486F25A0355BE477E07F8BD9CAA459.__file__(/home/conrad/.rvm/gems/jruby-head/gems/bacon-1.1.0/bin/../lib//bacon.rb)
    org.jruby.internal.runtime.methods.JittedMethod.call(JittedMethod.java:141)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:134)
    org.jruby.ast.CallNoArgNode.interpret(CallNoArgNode.java:64)
    org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
    org.jruby.evaluator.ASTInterpreter.INTERPRET_METHOD(ASTInterpreter.java:75)
    org.jruby.internal.runtime.methods.InterpretedMethod.call(InterpretedMethod.java:204)
    org.jruby.internal.runtime.methods.DefaultMethod.call(DefaultMethod.java:196)
    org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:336)
    org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:179)
    org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:188)
    org.jruby.ast.FCallOneArgBlockNode.interpret(FCallOneArgBlockNode.java:34)
    org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
    org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
    org.jruby.ast.RootNode.interpret(RootNode.java:129)
    org.jruby.evaluator.ASTInterpreter.INTERPRET_ROOT(ASTInterpreter.java:120)
    org.jruby.Ruby.runInterpreter(Ruby.java:833)
    org.jruby.Ruby.loadFile(Ruby.java:2626)
    org.jruby.runtime.load.ExternalScript.load(ExternalScript.java:66)
    org.jruby.runtime.load.LoadService.load(LoadService.java:331)
    org.jruby.RubyKernel.loadCommon(RubyKernel.java:1054)
    org.jruby.RubyKernel.load19(RubyKernel.java:1046)
    org.jruby.RubyKernel$INVOKER$s$0$1$load19.call(RubyKernel$INVOKER$s$0$1$load19.gen)
    org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:208)
    org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:204)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:168)
    org.jruby.ast.FCallOneArgNode.interpret(FCallOneArgNode.java:36)
    org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
    org.jruby.evaluator.ASTInterpreter.INTERPRET_BLOCK(ASTInterpreter.java:112)
    org.jruby.runtime.Interpreted19Block.evalBlockBody(Interpreted19Block.java:209)
    org.jruby.runtime.Interpreted19Block.yield(Interpreted19Block.java:160)
    org.jruby.runtime.Block.yield(Block.java:130)
    org.jruby.RubyArray.eachCommon(RubyArray.java:1605)
    org.jruby.RubyArray.each(RubyArray.java:1612)
    org.jruby.RubyArray$INVOKER$i$0$0$each.call(RubyArray$INVOKER$i$0$0$each.gen)
    org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:316)
    org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:145)
    org.jruby.runtime.callsite.CachingCallSite.callIter(CachingCallSite.java:154)
    org.jruby.ast.CallNoArgBlockNode.interpret(CallNoArgBlockNode.java:64)
    org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
    org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
    org.jruby.ast.RootNode.interpret(RootNode.java:129)
    org.jruby.evaluator.ASTInterpreter.INTERPRET_ROOT(ASTInterpreter.java:120)
    org.jruby.Ruby.runInterpreter(Ruby.java:833)
    org.jruby.Ruby.loadFile(Ruby.java:2626)
    org.jruby.runtime.load.ExternalScript.load(ExternalScript.java:66)
    org.jruby.runtime.load.LoadService.load(LoadService.java:331)
    org.jruby.RubyKernel.loadCommon(RubyKernel.java:1054)
    org.jruby.RubyKernel.load19(RubyKernel.java:1046)
    org.jruby.RubyKernel$INVOKER$s$0$1$load19.call(RubyKernel$INVOKER$s$0$1$load19.gen)
    org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:208)
    org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:204)
    org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:326)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:170)
    org.jruby.ast.FCallOneArgNode.interpret(FCallOneArgNode.java:36)
    org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
    org.jruby.ast.BlockNode.interpret(BlockNode.java:71)
    org.jruby.ast.RootNode.interpret(RootNode.java:129)
    org.jruby.evaluator.ASTInterpreter.INTERPRET_EVAL(ASTInterpreter.java:96)
    org.jruby.evaluator.ASTInterpreter.evalWithBinding(ASTInterpreter.java:175)
    org.jruby.RubyKernel.evalCommon(RubyKernel.java:1103)
    org.jruby.RubyKernel.eval19(RubyKernel.java:1066)
    org.jruby.RubyKernel$INVOKER$s$0$3$eval19.call(RubyKernel$INVOKER$s$0$3$eval19.gen)
    org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:224)
    org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:220)
    org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:366)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:238)
    home.conrad.$_dot_rvm.gems.jruby_minus_head.bin.ruby_noexec_wrapper.__file__(/home/conrad/.rvm/gems/jruby-head/bin/ruby_noexec_wrapper:14)
    home.conrad.$_dot_rvm.gems.jruby_minus_head.bin.ruby_noexec_wrapper.load(/home/conrad/.rvm/gems/jruby-head/bin/ruby_noexec_wrapper)
    org.jruby.Ruby.runScript(Ruby.java:806)
    org.jruby.Ruby.runScript(Ruby.java:799)
    org.jruby.Ruby.runNormally(Ruby.java:673)
    org.jruby.Ruby.runFromMain(Ruby.java:522)
    org.jruby.Main.doRunFromMain(Main.java:390)
    org.jruby.Main.internalRun(Main.java:279)
    org.jruby.Main.run(Main.java:221)
    org.jruby.Main.main(Main.java:201)
```
