### PR TITLE
Accept Encoding object for Encoding.compatible?

### DIFF
--- a/src/org/jruby/RubyEncoding.java
+++ b/src/org/jruby/RubyEncoding.java
@@ -116,10 +116,22 @@ public class RubyEncoding extends RubyObject {
     }
 
     public static Encoding areCompatible(IRubyObject obj1, IRubyObject obj2) {
-        if (obj1 instanceof EncodingCapable && obj2 instanceof EncodingCapable) {
-            Encoding enc1 = ((EncodingCapable)obj1).getEncoding();
-            Encoding enc2 = ((EncodingCapable)obj2).getEncoding();
+        Encoding enc1 = null;
+        Encoding enc2 = null;
 
+        if (obj1 instanceof RubyEncoding) {
+          enc1 = ((RubyEncoding)obj1).getEncoding();
+        } else if (obj1 instanceof EncodingCapable) {
+          enc1 = ((EncodingCapable)obj1).getEncoding();
+        }
+
+        if (obj2 instanceof RubyEncoding) {
+          enc2 = ((RubyEncoding)obj2).getEncoding();
+        } else if (obj2 instanceof EncodingCapable) {
+          enc2 = ((EncodingCapable)obj2).getEncoding();
+        }
+
+        if (enc1 != null && enc2 != null) {
             if (enc1 == enc2) return enc1;
 
             if (obj2 instanceof RubyString && ((RubyString) obj2).getByteList().getRealSize() == 0) return enc1;


### PR DESCRIPTION
With this change, the following calls are supported:

```
Encoding.compatible?(Encoding.find("UTF-8"),
                     "US-ASCII")
# => #<Encoding:UTF-8>

Encoding.compatible?("UTF-8",
                     Encoding.find("US-ASCII"))
# => #<Encoding:UTF-8>

Encoding.compatible?(Encoding.find("UTF-8"),
                     Encoding.find("US-ASCII"))
# => #<Encoding:UTF-8>
```

The following calls are supported before this changes:

```
Encoding.compatible?("UTF-8",
                     "US-ASCII")
# => #<Encoding:UTF-8>
```
