### PR TITLE
Add missing throw to default_internal=.

### DIFF
--- a/src/org/jruby/RubyEncoding.java
+++ b/src/org/jruby/RubyEncoding.java
@@ -474,7 +474,7 @@ public class RubyEncoding extends RubyObject {
         Ruby runtime = recv.getRuntime();
         EncodingService service = runtime.getEncodingService();
         if (encoding.isNil()) {
-            recv.getRuntime().newArgumentError("default_internal can not be nil");
+            throw recv.getRuntime().newArgumentError("default_internal can not be nil");
         }
         recv.getRuntime().setDefaultInternalEncoding(service.getEncodingFromObject(encoding));
         return encoding;


### PR DESCRIPTION
The exception is created but not thrown in setDefaultInternal; the same issue used to exist for setDefaultExternal, but was previously fixed.
