### PR TITLE
Fix occasionally failing spec.

### DIFF
--- a/spec/regression/JRUBY-6896_thread_join_with_nil_waits_forever_spec.rb
+++ b/spec/regression/JRUBY-6896_thread_join_with_nil_waits_forever_spec.rb
@@ -4,6 +4,6 @@ describe 'Thread#join' do
   it 'waits forever if passed nil for timeout' do
     start = Time.now
     Thread.new {sleep 0.5}.join(nil)
-    (Time.now - start).should > 0.5
+    (Time.now - start).should >= 0.5
   end
 end


### PR DESCRIPTION
Time.now measures time with millisecond precision, so the spec will 
fail if Time.now - start is less than 0.501 seconds.
