### PR TITLE
replacing a hash with itself returns an empty hash in ruby 1.9 compatibility mode

### DIFF
--- a/src/org/jruby/RubyHash.java
+++ b/src/org/jruby/RubyHash.java
@@ -1747,9 +1747,9 @@ public class RubyHash extends RubyObject implements Map {
     private RubyHash replaceCommon19(final ThreadContext context, IRubyObject other, Visitor visitor) {
         final RubyHash otherHash = other.convertToHash();
 
-        rb_clear();
-
         if (this == otherHash) return this;
+
+        rb_clear();
 
         if (!isComparedByIdentity() && otherHash.isComparedByIdentity()) {
             setComparedByIdentity(true);


### PR DESCRIPTION
jruby (ruby 1.9 mode):

> h = {:one => 1}
> => { :one => 1 }
> h.replace h
> => {}

mri (1.8.7 through 2.0.0-rc2) and jruby (ruby 1.8 mode):

> h = {:one => 1}
> => { :one => 1 }
> h.replace h
> => { :one => 1 }
