### PR TITLE
Fixes issue #549 (OpenSSL sockets spin indefinitely on timeout in handshake)

### DIFF
--- a/src/org/jruby/ext/openssl/SSLSocket.java
+++ b/src/org/jruby/ext/openssl/SSLSocket.java
@@ -448,9 +448,9 @@ public class SSLSocket extends RubyObject {
             throw ioe;
         }
         if (netData.hasRemaining()) {
-            return false;
-        }  else {
             return true;
+        }  else {
+            return false;
         }
     }
 


### PR DESCRIPTION
This pull request fixes Issue #549 (OpenSSL sockets spin indefinitely on timeout in handshake)

The only place that uses the return value of flushData can go into an infinite loop, and does so in production.

Just swapping the return values from flushData fixes the problem, and doesn't have any knock on effects we can find.
