### PR TITLE
Fix so require_relative can handle an absolute path.

### DIFF
--- a/src/jruby/kernel19/kernel.rb
+++ b/src/jruby/kernel19/kernel.rb
@@ -10,12 +10,12 @@ module Kernel
     relative_feature = JRuby::Type.convert_to_str(relative_feature)
     
     c = caller.first
-    e = c.rindex(/:\d+:in /)
-    file = $`
+    e = c.rindex(/:\d+:in /) 
+    file = $` # just the filename
     if /\A\((.*)\)/ =~ file # eval, etc.
       raise LoadError, "cannot infer basepath"
     end
-    absolute_feature = File.join(File.dirname(File.realpath(file)), relative_feature)
+    absolute_feature = File.expand_path(relative_feature, File.dirname(file))
     require absolute_feature
   end
 


### PR DESCRIPTION
`require_relative` was failing for me when passed an absolute path to a file. I've updated the specs on rubyspecs because they weren't checking for an absolute path being passed (commit [#95e39ad659](https://github.com/rubyspec/rubyspec/commit/95e39ad6596249aede89f77edda71b6dc2f9f4da)).

The code I've changed here was concatenating an absolute path to either another absolute path (where it failed), or it still left dots in the path (which seemed strange), before passing it to `require`. I've updated it, but I can't run a high enough version of ant on my machine to run the specs against it (the curse of Apple). Hopefully it works, apologies if not.

Regards,
Iain
