### PR TITLE
Update psych to edf05c9f40e0c566e391f7e04b4a30327c31a828

### DIFF
--- a/lib/ruby/1.9/psych.rb
+++ b/lib/ruby/1.9/psych.rb
@@ -18,8 +18,8 @@ require 'psych/handlers/document_stream'
 ###
 # = Overview
 #
-# Psych is a YAML parser and emitter. 
-# Psych leverages libyaml [Home page: http://pyyaml.org/wiki/LibYAML] 
+# Psych is a YAML parser and emitter.
+# Psych leverages libyaml [Home page: http://pyyaml.org/wiki/LibYAML]
 # or [Git repo: https://github.com/zerotao/libyaml] for its YAML parsing
 # and emitting capabilities. In addition to wrapping libyaml, Psych also
 # knows how to serialize and de-serialize most Ruby objects to and from
@@ -43,27 +43,6 @@ require 'psych/handlers/document_stream'
 # level, is an event based parser.  Mid level is access to the raw YAML AST,
 # and at the highest level is the ability to unmarshal YAML to ruby objects.
 #
-# === Low level parsing
-#
-# The lowest level parser should be used when the YAML input is already known,
-# and the developer does not want to pay the price of building an AST or
-# automatic detection and conversion to ruby objects.  See Psych::Parser for
-# more information on using the event based parser.
-#
-# === Mid level parsing
-#
-# Psych provides access to an AST produced from parsing a YAML document.  This
-# tree is built using the Psych::Parser and Psych::TreeBuilder.  The AST can
-# be examined and manipulated freely.  Please see Psych::parse_stream,
-# Psych::Nodes, and Psych::Nodes::Node for more information on dealing with
-# YAML syntax trees.
-#
-# === High level parsing
-#
-# The high level YAML parser provided by Psych simply takes YAML as input and
-# returns a Ruby data structure.  For information on using the high level parser
-# see Psych.load
-#
 # == YAML Emitting
 #
 # Psych provides a range of interfaces ranging from low to high level for
@@ -72,14 +51,98 @@ require 'psych/handlers/document_stream'
 # a YAML AST, and the highest level is converting a Ruby object straight to
 # a YAML document.
 #
-# === Low level emitting
+# == High-level API
 #
-# The lowest level emitter is an event based system.  Events are sent to a
-# Psych::Emitter object.  That object knows how to convert the events to a YAML
-# document.  This interface should be used when document format is known in
-# advance or speed is a concern.  See Psych::Emitter for more information.
+# === Parsing
 #
-# === Mid level emitting
+# The high level YAML parser provided by Psych simply takes YAML as input and
+# returns a Ruby data structure.  For information on using the high level parser
+# see Psych.load
+#
+# ==== Reading from a string
+#
+#   Psych.load("--- a")             # => 'a'
+#   Psych.load("---\n - a\n - b")   # => ['a', 'b']
+#
+# ==== Reading from a file
+#
+#   Psych.load_file("database.yml")
+#
+# ==== Exception handling
+#
+#   begin
+#     # The second argument chnages only the exception contents
+#     Psych.parse("--- `", "file.txt")
+#   rescue Psych::SyntaxError => ex
+#     ex.file    # => 'file.txt'
+#     ex.message # => "(file.txt): found character that cannot start any token"
+#   end
+#
+# === Emitting
+#
+# The high level emitter has the easiest interface.  Psych simply takes a Ruby
+# data structure and converts it to a YAML document.  See Psych.dump for more
+# information on dumping a Ruby data structure.
+#
+# ==== Writing to a string
+#
+#   # Dump an array, get back a YAML string
+#   Psych.dump(['a', 'b'])  # => "---\n- a\n- b\n"
+#
+#   # Dump an array to an IO object
+#   Psych.dump(['a', 'b'], StringIO.new)  # => #<StringIO:0x000001009d0890>
+#
+#   # Dump an array with indentation set
+#   Psych.dump(['a', ['b']], :indentation => 3) # => "---\n- a\n-  - b\n"
+#
+#   # Dump an array to an IO with indentation set
+#   Psych.dump(['a', ['b']], StringIO.new, :indentation => 3)
+#
+# ==== Writing to a file
+#
+# Currently there is no direct API for dumping Ruby structure to file:
+#
+#   File.open('database.yml', 'w') do |file|
+#     file.write(Psych.dump(['a', 'b']))
+#   end
+#
+# == Mid-level API
+#
+# === Parsing
+#
+# Psych provides access to an AST produced from parsing a YAML document.  This
+# tree is built using the Psych::Parser and Psych::TreeBuilder.  The AST can
+# be examined and manipulated freely.  Please see Psych::parse_stream,
+# Psych::Nodes, and Psych::Nodes::Node for more information on dealing with
+# YAML syntax trees.
+#
+# ==== Reading from a string
+#
+#   # Returns Psych::Nodes::Stream
+#   Psych.parse_stream("---\n - a\n - b")
+#
+#   # Returns Psych::Nodes::Document
+#   Psych.parse("---\n - a\n - b")
+#
+# ==== Reading from a file
+#
+#   # Returns Psych::Nodes::Stream
+#   Psych.parse_stream(File.read('database.yml'))
+#
+#   # Returns Psych::Nodes::Document
+#   Psych.parse_file('database.yml')
+#
+# ==== Exception handling
+#
+#   begin
+#     # The second argument chnages only the exception contents
+#     Psych.parse("--- `", "file.txt")
+#   rescue Psych::SyntaxError => ex
+#     ex.file    # => 'file.txt'
+#     ex.message # => "(file.txt): found character that cannot start any token"
+#   end
+#
+# === Emitting
 #
 # At the mid level is building an AST.  This AST is exactly the same as the AST
 # used when parsing a YAML document.  Users can build an AST by hand and the
@@ -87,18 +150,76 @@ require 'psych/handlers/document_stream'
 # Psych::Nodes::Node, and Psych::TreeBuilder for more information on building
 # a YAML AST.
 #
-# === High level emitting
+# ==== Writing to a string
 #
-# The high level emitter has the easiest interface.  Psych simply takes a Ruby
-# data structure and converts it to a YAML document.  See Psych.dump for more
-# information on dumping a Ruby data structure.
+#   # We need Psych::Nodes::Stream (not Psych::Nodes::Document)
+#   stream = Psych.parse_stream("---\n - a\n - b")
+#
+#   stream.to_yaml # => "---\n- a\n- b\n"
+#
+# ==== Writing to a file
+#
+#   # We need Psych::Nodes::Stream (not Psych::Nodes::Document)
+#   stream = Psych.parse_stream(File.read('database.yml'))
+#
+#   File.open('database.yml', 'w') do |file|
+#     file.write(stream.to_yaml)
+#   end
+#
+# == Low-level API
+#
+# === Parsing
+#
+# The lowest level parser should be used when the YAML input is already known,
+# and the developer does not want to pay the price of building an AST or
+# automatic detection and conversion to ruby objects.  See Psych::Parser for
+# more information on using the event based parser.
+#
+# ==== Reading to Psych::Nodes::Stream structure
+#
+#   parser = Psych::Parser.new(TreeBuilder.new) # => #<Psych::Parser>
+#   parser = Psych.parser                       # it's an alias for the above
+#
+#   parser.parse("---\n - a\n - b")             # => #<Psych::Parser>
+#   parser.handler                              # => #<Psych::TreeBuilder>
+#   parser.handler.root                         # => #<Psych::Nodes::Stream>
+#
+# ==== Receiving an events stream
+#
+#   parser = Psych::Parser.new(Psych::Handlers::Recorder.new)
+#
+#   parser.parse("---\n - a\n - b")
+#   parser.events # => [list of [event, args] lists]
+#                 # event is one of: Psych::Handler::EVENTS
+#                 # args are the arguments passed to the event
+#
+# === Emitting
+#
+# The lowest level emitter is an event based system.  Events are sent to a
+# Psych::Emitter object.  That object knows how to convert the events to a YAML
+# document.  This interface should be used when document format is known in
+# advance or speed is a concern.  See Psych::Emitter for more information.
+#
+# ==== Writing to a ruby structure
+#
+#   Psych.parser.parse("--- a")       # => #<Psych::Parser>
+#
+#   parser.handler.first              # => #<Psych::Nodes::Stream>
+#   parser.handler.first.to_ruby      # => ["a"]
+#
+#   parser.handler.root.first         # => #<Psych::Nodes::Document>
+#   parser.handler.root.first.to_ruby # => "a"
+#
+#   # You can instantiate an Emitter manually
+#   Psych::Visitors::ToRuby.new.accept(parser.handler.root.first)
+#   # => "a"
 
 module Psych
   # The version is Psych you're using
-  VERSION         = '1.3.4'
+  VERSION         = '2.0.0'
 
   # The version of libyaml Psych is using
-  LIBYAML_VERSION = Psych.libyaml_version.join '.' unless RUBY_ENGINE == 'jruby'
+  LIBYAML_VERSION = Psych.libyaml_version.join '.'
 
   class Exception < RuntimeError
   end
@@ -123,7 +244,7 @@ module Psych
   #     Psych.load("--- `", "file.txt")
   #   rescue Psych::SyntaxError => ex
   #     ex.file    # => 'file.txt'
-  #     ex.message # => "(foo.txt): found character that cannot start any token"
+  #     ex.message # => "(file.txt): found character that cannot start any token"
   #   end
   def self.load yaml, filename = nil
     result = parse(yaml, filename)
@@ -131,7 +252,7 @@ module Psych
   end
 
   ###
-  # Parse a YAML string in +yaml+.  Returns the first object of a YAML AST.
+  # Parse a YAML string in +yaml+.  Returns the Psych::Nodes::Document.
   # +filename+ is used in the exception message if a Psych::SyntaxError is
   # raised.
   #
@@ -139,13 +260,13 @@ module Psych
   #
   # Example:
   #
-  #   Psych.parse("---\n - a\n - b") # => #<Psych::Nodes::Sequence:0x00>
+  #   Psych.parse("---\n - a\n - b") # => #<Psych::Nodes::Document:0x00>
   #
   #   begin
   #     Psych.parse("--- `", "file.txt")
   #   rescue Psych::SyntaxError => ex
   #     ex.file    # => 'file.txt'
-  #     ex.message # => "(foo.txt): found character that cannot start any token"
+  #     ex.message # => "(file.txt): found character that cannot start any token"
   #   end
   #
   # See Psych::Nodes for more information about YAML AST.
@@ -157,7 +278,7 @@ module Psych
   end
 
   ###
-  # Parse a file at +filename+. Returns the YAML AST.
+  # Parse a file at +filename+. Returns the Psych::Nodes::Document.
   #
   # Raises a Psych::SyntaxError when a YAML syntax error is detected.
   def self.parse_file filename
@@ -173,7 +294,7 @@ module Psych
   end
 
   ###
-  # Parse a YAML string in +yaml+.  Returns the full AST for the YAML document.
+  # Parse a YAML string in +yaml+.  Returns the Psych::Nodes::Stream.
   # This method can handle multiple YAML documents contained in +yaml+.
   # +filename+ is used in the exception message if a Psych::SyntaxError is
   # raised.
@@ -195,7 +316,7 @@ module Psych
   #     Psych.parse_stream("--- `", "file.txt")
   #   rescue Psych::SyntaxError => ex
   #     ex.file    # => 'file.txt'
-  #     ex.message # => "(foo.txt): found character that cannot start any token"
+  #     ex.message # => "(file.txt): found character that cannot start any token"
   #   end
   #
   # See Psych::Nodes for more information about YAML AST.

--- a/lib/ruby/1.9/psych/scalar_scanner.rb
+++ b/lib/ruby/1.9/psych/scalar_scanner.rb
@@ -68,11 +68,11 @@ module Psych
           string
         end
       when /^\.inf$/i
-        1 / 0.0
+        Float::INFINITY
       when /^-\.inf$/i
-        -1 / 0.0
+        -Float::INFINITY
       when /^\.nan$/i
-        0.0 / 0.0
+        Float::NAN
       when /^:./
         if string =~ /^:(["'])(.*)\1/
           @symbol_cache[string] = $2.sub(/^:/, '').to_sym
@@ -96,7 +96,7 @@ module Psych
           @string_cache[string] = true
           string
         else
-          Float(string.gsub(/[,_]/, ''))
+          Float(string.gsub(/[,_]|\.$/, ''))
         end
       else
         int = parse_int string.gsub(/[,_]/, '')

--- a/lib/ruby/1.9/psych/visitors/to_ruby.rb
+++ b/lib/ruby/1.9/psych/visitors/to_ruby.rb
@@ -141,28 +141,6 @@ module Psych
         return revive_hash({}, o) unless o.tag
 
         case o.tag
-        when /^!(?:str|ruby\/string)(?::(.*))?/, 'tag:yaml.org,2002:str'
-          klass = resolve_class($1)
-          members = Hash[*o.children.map { |c| accept c }]
-          string = members.delete 'str'
-
-          if klass
-            string = klass.allocate.replace string
-            register(o, string)
-          end
-
-          init_with(string, members.map { |k,v| [k.to_s.sub(/^@/, ''),v] }, o)
-        when /^!ruby\/array:(.*)$/
-          klass = resolve_class($1)
-          list  = register(o, klass.allocate)
-
-          members = Hash[o.children.map { |c| accept c }.each_slice(2).to_a]
-          list.replace members['internal']
-
-          members['ivars'].each do |ivar, v|
-            list.instance_variable_set ivar, v
-          end
-          list
         when /^!ruby\/struct:?(.*)?$/
           klass = resolve_class($1)
 
@@ -187,6 +165,43 @@ module Psych
             Struct.new(*h.map { |k,v| k.to_sym }).new(*h.map { |k,v| v })
           end
 
+        when /^!ruby\/object:?(.*)?$/
+          name = $1 || 'Object'
+
+          if name == 'Complex'
+            h = Hash[*o.children.map { |c| accept c }]
+            register o, Complex(h['real'], h['image'])
+          elsif name == 'Rational'
+            h = Hash[*o.children.map { |c| accept c }]
+            register o, Rational(h['numerator'], h['denominator'])
+          else
+            obj = revive((resolve_class(name) || Object), o)
+            obj
+          end
+
+        when /^!(?:str|ruby\/string)(?::(.*))?/, 'tag:yaml.org,2002:str'
+          klass = resolve_class($1)
+          members = Hash[*o.children.map { |c| accept c }]
+          string = members.delete 'str'
+
+          if klass
+            string = klass.allocate.replace string
+            register(o, string)
+          end
+
+          init_with(string, members.map { |k,v| [k.to_s.sub(/^@/, ''),v] }, o)
+        when /^!ruby\/array:(.*)$/
+          klass = resolve_class($1)
+          list  = register(o, klass.allocate)
+
+          members = Hash[o.children.map { |c| accept c }.each_slice(2).to_a]
+          list.replace members['internal']
+
+          members['ivars'].each do |ivar, v|
+            list.instance_variable_set ivar, v
+          end
+          list
+
         when '!ruby/range'
           h = Hash[*o.children.map { |c| accept c }]
           register o, Range.new(h['begin'], h['end'], h['excl'])
@@ -205,19 +220,6 @@ module Psych
             set[accept(k)] = accept(v)
           end
           set
-
-        when '!ruby/object:Complex'
-          h = Hash[*o.children.map { |c| accept c }]
-          register o, Complex(h['real'], h['image'])
-
-        when '!ruby/object:Rational'
-          h = Hash[*o.children.map { |c| accept c }]
-          register o, Rational(h['numerator'], h['denominator'])
-
-        when /^!ruby\/object:?(.*)?$/
-          name = $1 || 'Object'
-          obj = revive((resolve_class(name) || Object), o)
-          obj
 
         when /^!map:(.*)$/, /^!ruby\/hash:(.*)$/
           revive_hash resolve_class($1).new, o
@@ -261,26 +263,40 @@ module Psych
       def revive_hash hash, o
         @st[o.anchor] = hash if o.anchor
 
-          o.children.each_slice(2) { |k,v|
+        o.children.each_slice(2) { |k,v|
           key = accept(k)
+          val = accept(v)
 
           if key == '<<'
             case v
             when Nodes::Alias
-              hash.merge! accept(v)
+              begin
+                hash.merge! val
+              rescue TypeError
+                hash[key] = val
+              end
             when Nodes::Sequence
-              accept(v).reverse_each do |value|
-                hash.merge! value
+              begin
+                h = {}
+                val.reverse_each do |value|
+                  h.merge! value
+                end
+                hash.merge! h
+              rescue TypeError
+                hash[key] = val
               end
             else
-              hash[key] = accept(v)
+              hash[key] = val
             end
           else
-            hash[key] = accept(v)
+            hash[key] = val
           end
 
         }
         hash
+      end
+
+      def merge_key hash, key, val
       end
 
       def revive klass, node

--- a/lib/ruby/1.9/psych/y.rb
+++ b/lib/ruby/1.9/psych/y.rb
@@ -1,4 +1,6 @@
 module Kernel
+  ###
+  # An alias for Psych.dump_stream meant to be used with IRB.
   def y *objects
     puts Psych.dump_stream(*objects)
   end


### PR DESCRIPTION
There's tons of string quotation fixes that I would :heart: to see in jruby 1.7.4. In order to generate this diff I ran the following commands:

`cp -R <psych checkout>/psych/lib/psych <jruby checkout>/lib/ruby/1.9`
`cp <psych checkout>/psych/lib/psych.rb <jruby checkout>/lib/ruby/1.9/psych.rb`
