### PR TITLE
Don't include imports from previously processed ruby files in every generated java file.

### DIFF
--- a/lib/ruby/shared/jruby/compiler/java_class.rb
+++ b/lib/ruby/shared/jruby/compiler/java_class.rb
@@ -288,7 +288,7 @@ module JRuby::Compiler
     def initialize(script_name, imports = BASE_IMPORTS)
       @classes = []
       @script_name = script_name
-      @imports = imports
+      @imports = imports.dup
       @requires = []
       @package = ""
     end

--- a/spec/compiler/rubyscript_spec.rb
+++ b/spec/compiler/rubyscript_spec.rb
@@ -1,0 +1,13 @@
+require 'jruby/compiler/java_class'
+
+describe JRuby::Compiler::RubyScript do
+
+  it "resets import list for each instance" do
+    script1 = JRuby::Compiler::RubyScript.new("script1")
+    script1.add_import('my.java.import')
+
+    script2 = JRuby::Compiler::RubyScript.new("script2")
+    script2.imports.should_not include('my.java.import')
+  end
+
+end


### PR DESCRIPTION
Using the --java option with jrubyc when compiling multiple ruby files resulted in each generated file containing all the imports from all the previously processed scripts.
