### PR TITLE
Fixing RubyBasicObject#compareTo bug.

### DIFF
--- a/test/org/jruby/test/TestRubyHash.java
+++ b/test/org/jruby/test/TestRubyHash.java
@@ -30,10 +30,11 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby.test;
 
-import org.jruby.CompatVersion;
 import org.jruby.Ruby;
+import org.jruby.RubyFixnum;
 import org.jruby.RubyHash;
-import org.jruby.RubyInstanceConfig;
+import org.jruby.RubySymbol;
+import org.jruby.exceptions.RaiseException;
 
 /**
  * @author chadfowler
@@ -188,5 +189,21 @@ public class TestRubyHash extends TestRubyBase {
     public void testGet() {
         RubyHash rubyHash = new RubyHash(Ruby.getGlobalRuntime());
         assertEquals(null, rubyHash.get("Non matching key"));
+    }
+    
+    public void testJavaComparison() {
+        RubyHash rubyHash1 = new RubyHash(runtime);
+        RubyHash rubyHash2 = new RubyHash(runtime);
+        rubyHash1.put(
+                RubySymbol.newSymbol(runtime, "one"),
+                RubyFixnum.newFixnum(runtime, 1));
+        try {
+            int result = rubyHash1.compareTo(rubyHash2);
+            fail("compareTo did not throw IllegalArgumentException");
+        } catch (IllegalArgumentException ex) {
+            // this is correct
+        } catch (RaiseException ex) {
+            fail("Java call to compareTo raised a ruby exception");
+        }
     }
 }


### PR DESCRIPTION
All IRubyObjects implement Comparable and the default compareTo implementation
delegates to <=>. When the ruby object doesn't implement <=>, ruby raises a
NoMethodError. Because compareTo is called from java but the exception raised
is in ruby, the exception makes no sense: it has the ruby stack when ruby
called into java. For example, this happened on an Iterator that kept min and
max references. This iterator was implemented in java, but called by ruby so
the exception's stack ended with the call to next in java::lang::Iterator#each,
but was a NoMethodError for <=>.

This fix catches the NoMethodError and throws an IllegalArgumentException
wrapping it. This isn't a great solution because java callers expect compareTo
to succeed when objects implement Comparable. There may be a better java
exception to throw. This also updates the javadoc to avoid confusion.

In older versions, specifically 1.6.7, the op_cmp java method is called and
returns nil. Then nil is assumed to be an Integer and coerced, which produces a
TypeError. To be safe, this fix also checks the return value for nil when <=>
succeeds and throws another IllegalArgumentException.

Test update included for RubyHash.
