### PR TITLE
Add support for Floats as the first argument in Time.at.

### DIFF
--- a/src/org/jruby/RubyTime.java
+++ b/src/org/jruby/RubyTime.java
@@ -1023,43 +1023,34 @@ public class RubyTime extends RubyObject {
     public static IRubyObject at(ThreadContext context, IRubyObject recv, IRubyObject arg1, IRubyObject arg2) {
         Ruby runtime = context.runtime;
 
-        RubyTime time;
-        long seconds;
-        
-        if (arg1 instanceof RubyTime && runtime.is1_9()) {
-            time = new RubyTime(runtime, (RubyClass) recv, ((RubyTime) arg1).getDateTime());
-            seconds = time.getDateTime().getMillis() / 1000;
-        } else {
-            time = new RubyTime(runtime, (RubyClass) recv,
-                    new DateTime(0L, getLocalTimeZone(runtime)));
-            seconds = RubyNumeric.num2long(arg1);            
-        }
-
+        RubyTime time = new RubyTime(runtime, (RubyClass) recv, new DateTime(0L, getLocalTimeZone(runtime)));
         long millisecs;
-        long nanosecs;
+        long nanosecs = 0;
+
+        if (arg1 instanceof RubyFloat || arg1 instanceof RubyRational) {
+            double dbl = RubyNumeric.num2dbl(arg1);
+            millisecs = (long) (dbl * 1000);
+            nanosecs = ((long) (dbl * 1000000000)) % 1000000;
+        } else {
+            millisecs = RubyNumeric.num2long(arg1) * 1000;
+        }
 
         if (arg2 instanceof RubyFloat || arg2 instanceof RubyRational) {
             double micros = RubyNumeric.num2dbl(arg2);
             double nanos = micros * 1000;
-            millisecs = (long) (nanos / 1000000);
-            nanosecs = (long) (nanos % 1000000);
-        } else if (arg2 instanceof RubyTime && runtime.is1_9()) {
-            RubyTime t = (RubyTime) arg2;
-            // MRI treats the second argument as nanoseconds since the epoch
-            // However, RubyTime contains *seconds* since epoch, which is
-            // returned by .getMillis().
-            long nanos = t.getDateTime().getMillis();
-            millisecs = nanos / 1000000;
-            nanosecs = nanos % 1000000;
+            millisecs += (long) (nanos / 1000000);
+            nanosecs += (long) (nanos % 1000000);
         } else {
             long micros = RubyNumeric.num2long(arg2);
             long nanos = micros * 1000;
-            millisecs = nanos / 1000000;
-            nanosecs = nanos % 1000000;
+            millisecs += nanos / 1000000;
+            nanosecs += nanos % 1000000;
         }
 
-        time.setNSec(nanosecs);
-        time.dt = time.dt.withMillis(seconds * 1000 + millisecs);
+        long nanosecOverflow = (nanosecs / 1000000);
+
+        time.setNSec(nanosecs % 1000000);
+        time.dt = time.dt.withMillis(millisecs + nanosecOverflow);
 
         time.getMetaClass().getBaseCallSite(RubyClass.CS_IDX_INITIALIZE).call(context, recv, time);
 


### PR DESCRIPTION
While investigating #565, I noticed that JRuby converts a `Float` argument given to `Time.at` to a Java `long`, thus losing some precision. 

This commit fixes that, plus keeps track of nanoseconds overflowing to the next millisecond, which is possible when the first argument is not a `Fixnum`.
