### PR TITLE
Restore $! when catching exception.

### DIFF
--- a/src/org/jruby/RubyDir.java
+++ b/src/org/jruby/RubyDir.java
@@ -728,9 +728,13 @@ public class RubyDir extends RubyObject {
 
     @JRubyMethod(name = {"exists?", "exist?"}, meta = true, compat = RUBY1_9)
     public static IRubyObject exist(ThreadContext context, IRubyObject recv, IRubyObject arg) {
+        // Capture previous exception if any.
+        IRubyObject exception = context.runtime.getGlobalVariables().get("$!");
         try {
             return context.runtime.newFileStat(RubyFile.get_path(context, arg).asJavaString(), false).directory_p();
         } catch (Exception e) {
+            // Restore $!
+            context.runtime.getGlobalVariables().set("$!", exception);
             return context.runtime.newBoolean(false);
         }
     }


### PR DESCRIPTION
Hack-ish workaround for [JRUBY-7134](https://jira.codehaus.org/browse/JRUBY-7134) that restores `$!` when an exception is thrown when checking whether the dir exists.

Added also pull request for [rubyspec](https://github.com/rubyspec/rubyspec/pull/191).
