### PR TITLE
Added new option jruby.timeout.thread.pool.max to control the max number...

### DIFF
--- a/src/org/jruby/RubyInstanceConfig.java
+++ b/src/org/jruby/RubyInstanceConfig.java
@@ -1495,6 +1495,13 @@ public class RubyInstanceConfig {
     public static final int POOL_TTL = Options.THREADPOOL_TTL.load();
 
     /**
+     * Maximum timeout thread pool size (integer, default # of cores).
+     *
+     * Set with the <tt>jruby.timeout.thread.pool.max</tt> system property.
+     */
+    public static final int TIMEOUT_POOL_MAX = Options.TIMEOUT_THREADPOOL_MAX.load();
+
+    /**
      * Enable use of the native Java version of the 'net/protocol' library.
      *
      * Set with the <tt>jruby.thread.pool.max</tt> system property.

--- a/src/org/jruby/ext/timeout/Timeout.java
+++ b/src/org/jruby/ext/timeout/Timeout.java
@@ -36,6 +36,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyFixnum;
+import org.jruby.RubyInstanceConfig;
 import org.jruby.RubyKernel;
 import org.jruby.RubyModule;
 import org.jruby.RubyObject;
@@ -78,7 +79,7 @@ public class Timeout implements Library {
         runtime.getObject().defineAnnotatedMethods(TimeoutToplevel.class);
     }
 
-    private static ScheduledExecutorService timeoutExecutor = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors(), new DaemonThreadFactory());
+    private static ScheduledExecutorService timeoutExecutor = Executors.newScheduledThreadPool(RubyInstanceConfig.TIMEOUT_POOL_MAX, new DaemonThreadFactory("JRubyTimeoutWorker"));
 
     public static class TimeoutToplevel {
         @JRubyMethod(required = 1, optional = 1, visibility = PRIVATE)

--- a/src/org/jruby/util/cli/Options.java
+++ b/src/org/jruby/util/cli/Options.java
@@ -189,6 +189,8 @@ public class Options {
     public static final Option<Boolean> FFI_COMPILE_INVOKEDYNAMIC = bool(NATIVE, "ffi.compile.invokedynamic", false, "Use invokedynamic to bind FFI invocations.");
     public static final Option<Boolean> FFI_COMPILE_REIFY = bool(NATIVE, "ffi.compile.reify", false, "Reify FFI compiled classes.");
     
+    public static final Option<Integer> TIMEOUT_THREADPOOL_MAX = integer(THREADPOOL, "timeout.thread.pool.max", Runtime.getRuntime().availableProcessors(), "The maximum number of threads to allow in the timeout pool.");
+
     public static final Option<Boolean> THREADPOOL_ENABLED = bool(THREADPOOL, "thread.pool.enabled", false, "Enable reuse of native threads via a thread pool.");
     public static final Option<Integer> THREADPOOL_MIN = integer(THREADPOOL, "thread.pool.min", 0, "The minimum number of threads to keep alive in the pool.");
     public static final Option<Integer> THREADPOOL_MAX = integer(THREADPOOL, "thread.pool.max", Integer.MAX_VALUE, "The maximum number of threads to allow in the pool.");


### PR DESCRIPTION
Added new option, jruby.timeout.thread.pool.max, to enable the ability to override the max timeout worker threadpool size. The default still remains the # of cores available.
