### PR TITLE
BasicObject.constants should return [:BasicObject].

### DIFF
--- a/spec/tags/1.9/ruby/core/basicobject/basicobject_tags.txt
+++ b/spec/tags/1.9/ruby/core/basicobject/basicobject_tags.txt
@@ -1,1 +1,0 @@
-fails:BasicObject includes itself in its list of constants

--- a/src/org/jruby/RubyBasicObject.java
+++ b/src/org/jruby/RubyBasicObject.java
@@ -3083,6 +3083,14 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
             metaClass.getVariableAccessorForWrite(name).set(this, value);
         }
     }
+    
+    @JRubyMethod(name = "constants", module = true, compat = RUBY1_9)
+    public static RubyArray constants(ThreadContext context, IRubyObject recv) {
+        Ruby runtime = context.getRuntime();
+        RubyArray array = runtime.newArray();
+        array.add(runtime.newSymbol("BasicObject"));
+        return array;
+    }
 
     // Deprecated methods below this line
 


### PR DESCRIPTION
This fixes a RubySpec:

```
BasicObject.constants # => [:BasicObject]
```

`Module#constants` starts searching with `Object`, down to the current module itself for constants, so `BasicObject.constants` never gets a chance to inject `:BasicObject` to that list.

This hard codes `"BasicObject"`, which doesn't seem right to me. However, this invocation needs to be static, and I could not find an elegant way to obtain the class name.

Of course, there may be a entirely different and more elegant solution to this problem.
