### PR TITLE
Fix #645 by calling Java Math.cbrt directly.

### DIFF
--- a/src/org/jruby/RubyMath.java
+++ b/src/org/jruby/RubyMath.java
@@ -503,14 +503,9 @@ public class RubyMath {
     
     @JRubyMethod(name = "cbrt", required = 1, module = true, visibility = Visibility.PRIVATE, compat = CompatVersion.RUBY1_9)
     public static RubyFloat cbrt(IRubyObject recv, IRubyObject x) {
-        double value = ((RubyFloat)RubyKernel.new_float(recv,x)).getDoubleValue();
-        double result;
+        double value = needFloat(x).getDoubleValue();
 
-        if (value < 0) {
-            result = -Math.pow(-value, 1/3.0);
-        } else{
-            result = Math.pow(value, 1/3.0);
-        }
+        double result = Math.cbrt(value);
 
         domainCheck(recv, result, "cbrt");
         return RubyFloat.newFloat(recv.getRuntime(), result);


### PR DESCRIPTION
This fixed jruby#645 by calling `java.lang.Math.cbrt` directly. `Math.cbrt` was introduced in [Java 5](http://docs.oracle.com/javase/7/docs/api/java/lang/Math.html#cbrt%28double%29), so it is safe to use in the JRuby codebase.  Also, `cbrt` now throws a `TypeError` if the argument cannot be coerced to Float.

Related rubyspec change: https://github.com/rubyspec/rubyspec/pull/206
