### PR TITLE
My stab at fixing JRUBY-7122

### DIFF
--- a/src/org/jruby/RubyFile.java
+++ b/src/org/jruby/RubyFile.java
@@ -1524,6 +1524,11 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         }
 
         if (uriParts != null) {
+            //If the path was an absolute classpath path, return it as-is.
+            if (uriParts[0].equals("classpath:")) {
+                return runtime.newString(relativePath);
+            }
+
             relativePath = uriParts[1];
         }
 


### PR DESCRIPTION
This fixes the issue for classpath:/ "relative" paths which by their very nature are always absolute. The same issue could be happening for some other URI schemes so I'm not sure if a special case for "classpath" is the right fix.
