### PR TITLE
Verifying if character is corrupted, meaning that one more char is needed.

### DIFF
--- a/spec/tags/1.9/ruby/core/io/foreach_tags.txt
+++ b/spec/tags/1.9/ruby/core/io/foreach_tags.txt
@@ -1,2 +1,1 @@
 fails:IO.foreach when the filename starts with | gets data from a fork when passed -
-fails:IO.foreach when passed name, object when the object is a Fixnum uses the object as a limit if it is a Fixnum

--- a/spec/tags/1.9/ruby/core/io/readlines_tags.txt
+++ b/spec/tags/1.9/ruby/core/io/readlines_tags.txt
@@ -1,2 +1,1 @@
 fails:IO#readlines when passed a string that starts with a | gets data from a fork when passed -
-fails:IO.readlines when passed name, object when the object is a Fixnum uses the object as a limit if it is a Fixnum

--- a/src/org/jruby/RubyIO.java
+++ b/src/org/jruby/RubyIO.java
@@ -106,6 +106,7 @@ import org.jruby.runtime.encoding.EncodingService;
 import org.jruby.util.CharsetTranscoder;
 import org.jruby.util.ShellLauncher.POpenProcess;
 import org.jruby.util.io.IOEncodable;
+import static org.jruby.util.StringSupport.isIncompleteChar;
 
 /**
  * 
@@ -664,6 +665,11 @@ public class RubyIO extends RubyObject implements IOEncodable {
                                     n = readStream.getline(buf, (byte) newline);
                                 } else {
                                     n = readStream.getline(buf, (byte) newline, limit);
+
+                                    if (buf.length() > 0 && isIncompleteChar(buf.get(buf.length() - 1))) {
+                                        buf.append((byte)readStream.fgetc());
+                                    }
+
                                     limit -= n;
                                     if (limit <= 0) {
                                         update = limitReached = true;

--- a/src/org/jruby/util/StringSupport.java
+++ b/src/org/jruby/util/StringSupport.java
@@ -524,4 +524,9 @@ public final class StringSupport {
         return format;
     }
 
+    // mri: ONIGENC_MBCLEN_NEEDMORE_P - onigurama.h
+    public static boolean isIncompleteChar(int b) {
+        return b < -1;
+    }
+
 }


### PR DESCRIPTION
@headius and @enebo this patch fixes the problem we discussed on irc today, specs for readlines and foreach pass, and the File.new('a.txt').gets(5) that Charles did also works.
I came to that comparison "<-1" after debugging the MRI code and seeing that it is exactly what they do there. What do you think about it?
