### PR TITLE
Fix unseekable stream implementation of IO.copy_stream in RubyIO.java

### DIFF
--- a/src/org/jruby/RubyIO.java
+++ b/src/org/jruby/RubyIO.java
@@ -4296,7 +4296,8 @@ public class RubyIO extends RubyObject implements IOEncodable {
     private static long transfer(ReadableByteChannel from, FileChannel to) throws IOException {
         long transferred = 0;
         long bytes;
-        while ((bytes = to.transferFrom(from, to.position(), 4196)) > 0) {
+        long startPosition = to.position();
+        while ((bytes = to.transferFrom(from, startPosition+transferred, 4196)) > 0) {
             transferred += bytes;
         }
 


### PR DESCRIPTION
Fixes JRUBY-7157
Fixed the transfer method to properly handle the fact that Java's FileChannel transferFrom method doesn't update the position of the destination channel.  This version of the transfer method is only called if the source stream is unseekable (i.e. a socket or, in my case ServletUpload's FileItemStream).  The bug occurs if the size of the source is greater than 4196 bytes.
