### PR TITLE
Implement String#to_sym special cases.

### DIFF
--- a/spec/tags/1.8/ruby/core/string/to_sym_tags.txt
+++ b/spec/tags/1.8/ruby/core/string/to_sym_tags.txt
@@ -1,4 +1,0 @@
-fails:String#to_sym special cases +(binary) and -(binary)
-fails:String#to_sym special cases !@ and ~@
-fails:String#to_sym special cases !(unary) and ~(unary)
-fails:String#to_sym special cases +(unary) and -(unary)

--- a/spec/tags/1.9/ruby/core/string/to_sym_tags.txt
+++ b/spec/tags/1.9/ruby/core/string/to_sym_tags.txt
@@ -1,1 +1,0 @@
-fails:String#to_sym special cases +(binary) and -(binary)


### PR DESCRIPTION
This fixes 5 failing `core/string/to_sym_spec` rubyspecs.
