### PR TITLE
Supporting IO.ungetbyte

### DIFF
--- a/spec/tags/1.9/ruby/core/io/ungetbyte_tags.txt
+++ b/spec/tags/1.9/ruby/core/io/ungetbyte_tags.txt
@@ -1,5 +1,1 @@
-fails:IO#ungetbyte does nothing when passed nil
-fails:IO#ungetbyte puts back each byte in a String argument
-fails:IO#ungetbyte calls #to_str to convert the argument
 fails:IO#ungetbyte puts back one byte for an Integer argument
-fails:IO#ungetbyte raises an IOError if the IO is closed

--- a/src/org/jruby/RubyIO.java
+++ b/src/org/jruby/RubyIO.java
@@ -2618,7 +2618,7 @@ public class RubyIO extends RubyObject implements IOEncodable {
         return getRuntime().getNil();
     }
 
-    @JRubyMethod(name = "ungetc", required = 1, compat = CompatVersion.RUBY1_9)
+    @JRubyMethod(name = {"ungetc", "ungetbyte"}, required = 1, compat = CompatVersion.RUBY1_9)
     public IRubyObject ungetc19(IRubyObject character) {
         Ruby runtime = getRuntime();
 


### PR DESCRIPTION
We can use ungetc to support ungetbyte, that will left only 1 spec failing which is an edge case. What happens is that when trying to push the number 4095, like the specs do on the ChanelStream class that int will be convert to a byte (-1) and inside jruby internals -1 is considered EOF, so for we to support this we would have to change a lot of things. The method willl work for every number but 4095 because of this case. 
