### PR TITLE
Some rubyspec additions

### DIFF
--- a/spec/jruby.1.8.mspec
+++ b/spec/jruby.1.8.mspec
@@ -49,7 +49,6 @@ class MSpecScript
     '^' + SPEC_DIR + '/library/drb',
     '^' + SPEC_DIR + '/library/net',
     '^' + SPEC_DIR + '/library/openssl',
-    '^' + SPEC_DIR + '/library/ping',
 
     # unstable
     '^' + SPEC_DIR + '/library/syslog',

--- a/spec/jruby.1.9.mspec
+++ b/spec/jruby.1.9.mspec
@@ -51,7 +51,6 @@ class MSpecScript
     '^' + SPEC_DIR + '/library/drb',
     '^' + SPEC_DIR + '/library/net',
     '^' + SPEC_DIR + '/library/openssl',
-    '^' + SPEC_DIR + '/library/ping',
 
     # unstable
     '^' + SPEC_DIR + '/library/syslog',


### PR DESCRIPTION
Stopped excluding etc and ping rubyspecs and also added back the 1.9 library files to the ci_files. Not sure if mspec ci is ever run but if it is then at least it will run the library specs now.
