### PR TITLE
Bignum#/ should not raise ZeroDivisionError if other is zero and is a Float

### DIFF
--- a/src/org/jruby/RubyBignum.java
+++ b/src/org/jruby/RubyBignum.java
@@ -412,7 +412,7 @@ public class RubyBignum extends RubyInteger {
             otherValue = ((RubyBignum) other).value;
         } else if (other instanceof RubyFloat) {
             double otherFloatValue = ((RubyFloat) other).getDoubleValue();
-            if (runtime.is1_9()) {
+            if (runtime.is1_9() && !slash) {
                 if (otherFloatValue == 0.0) throw runtime.newZeroDivisionError();
             }
             double div = big2dbl(this) / otherFloatValue;


### PR DESCRIPTION
There is a failing rubyspec for this that was never tagged that you can see failing in the allowed failures on travis here:

https://s3.amazonaws.com/archive.travis-ci.org/jobs/6976679/log.txt
