### PR TITLE
Add fails tags for Process.{get,set}rlimit

### DIFF
--- a/spec/tags/1.9/ruby/core/process/getrlimit_tags.txt
+++ b/spec/tags/1.9/ruby/core/process/getrlimit_tags.txt
@@ -11,6 +11,11 @@ fails:Process.getrlimit when passed a Symbol coerces :STACK into RLIMIT_STACK
 fails:Process.getrlimit when passed a Symbol coerces :MEMLOCK into RLIMIT_MEMLOCK
 fails:Process.getrlimit when passed a Symbol coerces :NPROC into RLIMIT_NPROC
 fails:Process.getrlimit when passed a Symbol coerces :RSS into RLIMIT_RSS
+fails:Process.getrlimit when passed a Symbol coerces :RTPRIO into RLIMIT_RTPRIO
+fails:Process.getrlimit when passed a Symbol coerces :RTTIME into RLIMIT_RTTIME
+fails:Process.getrlimit when passed a Symbol coerces :SIGPENDING into RLIMIT_SIGPENDING
+fails:Process.getrlimit when passed a Symbol coerces :MSGQUEUE into RLIMIT_MSGQUEUE
+fails:Process.getrlimit when passed a Symbol coerces :NICE into RLIMIT_NICE
 fails:Process.getrlimit when passed a Symbol raises ArgumentError when passed an unknown resource
 fails:Process.getrlimit when passed a String coerces 'AS' into RLIMIT_AS
 fails:Process.getrlimit when passed a String coerces 'CORE' into RLIMIT_CORE
@@ -22,6 +27,11 @@ fails:Process.getrlimit when passed a String coerces 'STACK' into RLIMIT_STACK
 fails:Process.getrlimit when passed a String coerces 'MEMLOCK' into RLIMIT_MEMLOCK
 fails:Process.getrlimit when passed a String coerces 'NPROC' into RLIMIT_NPROC
 fails:Process.getrlimit when passed a String coerces 'RSS' into RLIMIT_RSS
+fails:Process.getrlimit when passed a String coerces 'RTPRIO' into RLIMIT_RTPRIO
+fails:Process.getrlimit when passed a String coerces 'RTTIME' into RLIMIT_RTTIME
+fails:Process.getrlimit when passed a String coerces 'SIGPENDING' into RLIMIT_SIGPENDING
+fails:Process.getrlimit when passed a String coerces 'MSGQUEUE' into RLIMIT_MSGQUEUE
+fails:Process.getrlimit when passed a String coerces 'NICE' into RLIMIT_NICE
 fails:Process.getrlimit when passed a String raises ArgumentError when passed an unknown resource
 fails:Process.getrlimit when passed on Object calls #to_str to convert to a String
 fails:Process.getrlimit when passed on Object calls #to_int if #to_str does not return a String

--- a/spec/tags/1.9/ruby/core/process/setrlimit_tags.txt
+++ b/spec/tags/1.9/ruby/core/process/setrlimit_tags.txt
@@ -12,6 +12,11 @@ fails:Process.setrlimit when passed a Symbol coerces :STACK into RLIMIT_STACK
 fails:Process.setrlimit when passed a Symbol coerces :MEMLOCK into RLIMIT_MEMLOCK
 fails:Process.setrlimit when passed a Symbol coerces :NPROC into RLIMIT_NPROC
 fails:Process.setrlimit when passed a Symbol coerces :RSS into RLIMIT_RSS
+fails:Process.setrlimit when passed a Symbol coerces :RTPRIO into RLIMIT_RTPRIO
+fails:Process.setrlimit when passed a Symbol coerces :RTTIME into RLIMIT_RTTIME
+fails:Process.setrlimit when passed a Symbol coerces :SIGPENDING into RLIMIT_SIGPENDING
+fails:Process.setrlimit when passed a Symbol coerces :MSGQUEUE into RLIMIT_MSGQUEUE
+fails:Process.setrlimit when passed a Symbol coerces :NICE into RLIMIT_NICE
 fails:Process.setrlimit when passed a Symbol raises ArgumentError when passed an unknown resource
 fails:Process.setrlimit when passed a String coerces 'AS' into RLIMIT_AS
 fails:Process.setrlimit when passed a String coerces 'CORE' into RLIMIT_CORE
@@ -23,6 +28,11 @@ fails:Process.setrlimit when passed a String coerces 'STACK' into RLIMIT_STACK
 fails:Process.setrlimit when passed a String coerces 'MEMLOCK' into RLIMIT_MEMLOCK
 fails:Process.setrlimit when passed a String coerces 'NPROC' into RLIMIT_NPROC
 fails:Process.setrlimit when passed a String coerces 'RSS' into RLIMIT_RSS
+fails:Process.setrlimit when passed a String coerces 'RTPRIO' into RLIMIT_RTPRIO
+fails:Process.setrlimit when passed a String coerces 'RTTIME' into RLIMIT_RTTIME
+fails:Process.setrlimit when passed a String coerces 'SIGPENDING' into RLIMIT_SIGPENDING
+fails:Process.setrlimit when passed a String coerces 'MSGQUEUE' into RLIMIT_MSGQUEUE
+fails:Process.setrlimit when passed a String coerces 'NICE' into RLIMIT_NICE
 fails:Process.setrlimit when passed a String raises ArgumentError when passed an unknown resource
 fails:Process.setrlimit when passed on Object calls #to_str to convert to a String
 fails:Process.setrlimit when passed on Object calls #to_int if #to_str does not return a String


### PR DESCRIPTION
Travis runs on linux and the linux tags were missing. My guess is whoever generated the tags is using osx.

With these tags added there should only be like 1 or 2 failures left on the 1.9 mode rubyspecs on travis.
