### PR TITLE
Add fails tag to failing Kernel.spawn spec

### DIFF
--- a/spec/tags/1.9/ruby/core/kernel/spawn_tags.txt
+++ b/spec/tags/1.9/ruby/core/kernel/spawn_tags.txt
@@ -51,6 +51,7 @@ fails:Kernel#spawn with a single argument raises a TypeError if the argument doe
 fails:Kernel#spawn with multiple arguments raises an ArgumentError if an argument includes a null byte
 fails:Kernel#spawn with multiple arguments raises a TypeError if an argument does not respond to #to_str
 fails:Kernel#spawn with a command array uses the first element as the command name and the second as the argv[0] value
+fails:Kernel.spawn with a command array does not subject the arguments to shell expansion
 fails:Kernel#spawn with a command array calls #to_ary to convert the argument to an Array
 fails:Kernel#spawn with a command array raises an ArgumentError if the Strings in the Array include a null byte
 fails:Kernel#spawn with a command array raises a TypeError if an element in the Array does not respond to #to_str


### PR DESCRIPTION
I think if you accept:

https://github.com/jruby/jruby/pull/715
https://github.com/jruby/jruby/pull/716

and this pull request then the 1.9 mode rubyspecs will start passing on travis and we can remove them from the "allow_failures"
