### PR TITLE
Improve GzipReader#gets performance.

### DIFF
--- a/src/org/jruby/ext/zlib/JZlibRubyGzipReader.java
+++ b/src/org/jruby/ext/zlib/JZlibRubyGzipReader.java
@@ -226,14 +226,15 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         // StringIO.new("あいう").gets(5) => "あい"
         // StringIO.new("あいう").gets(6) => "あい"
         // StringIO.new("あいう").gets(7) => "あいう"
-        while (result.indexOf(sep) == -1) {
+        while (limit <= 0 || result.length() < limit) {
+            int sepOffset = result.length() - sep.getRealSize();
+            if (sepOffset >= 0 && result.startsWith(sep, sepOffset)) break;
+
             ce = bufferedStream.read();
 
             if (ce == -1) break;
 
             result.append(ce);
-            
-            if (limit > 0 && result.length() >= limit) break;
         }
         
         // io.available() only returns 0 after EOF is encountered


### PR DESCRIPTION
Previously checked the whole line for the separator after each character
read. The new version instead just checks whether the line read so far
ends with the separator.

Note that the current version of ByteList#startsWith/endsWith assumes
the index and byte list arguments are valid, which means we must not
call the method before the line is long enough.
