### PR TITLE
Make Time#to_date compliant with MRI 1.9-2

### DIFF
--- a/lib/ruby/1.9/date.rb
+++ b/lib/ruby/1.9/date.rb
@@ -1783,8 +1783,7 @@ class Time
   def to_time() getlocal end
 
   def to_date
-    jd = Date.__send__(:civil_to_jd, year, mon, mday, Date::ITALY)
-    Date.new!(Date.__send__(:jd_to_ajd, jd, 0, 0), 0, Date::ITALY)
+    Date.jd(Date.__send__(:civil_to_jd, year, mon, mday, Date::GREGORIAN))
   end
 
   def to_datetime


### PR DESCRIPTION
Time#to_date should use the proleptic Gregorian calendar to construct a Date,
but should return a Date object with the default calendar reform day. This is
unlike the behavior of Ruby 1.8 Time#to_date, which was private and seems to
have served as the basis for the current implementation. A specification
for this method has been added to rubyspec.
