### PR TITLE
Fix dash_s_spec

### DIFF
--- a/spec/tags/1.8/ruby/command_line/dash_s_tags.txt
+++ b/spec/tags/1.8/ruby/command_line/dash_s_tags.txt
@@ -1,4 +1,0 @@
-fails:The -s command line option when using -- to stop parsing parses long args into globals
-fails:The -s command line option when using -- to stop parsing converts extra dashes into underscorse
-fails:The -s command line option when running a script parses long args into globals
-fails:The -s command line option when running a script converts extra dashes into underscorse

--- a/spec/tags/1.9/ruby/command_line/dash_s_tags.txt
+++ b/spec/tags/1.9/ruby/command_line/dash_s_tags.txt
@@ -1,8 +1,0 @@
-fails:The -s command line option when using -- to stop parsing parses long args into globals
-fails:The -s command line option when using -- to stop parsing converts extra dashes into underscorse
-fails:The -s command line option when running a script parses long args into globals
-fails:The -s command line option when running a script converts extra dashes into underscorse
-fails(compiler):The -s command line option when using -- to stop parsing parses long args into globals
-fails(compiler):The -s command line option when using -- to stop parsing converts extra dashes into underscorse
-fails(compiler):The -s command line option when running a script parses long args into globals
-fails(compiler):The -s command line option when running a script converts extra dashes into underscorse

--- a/src/org/jruby/util/cli/ArgumentProcessor.java
+++ b/src/org/jruby/util/cli/ArgumentProcessor.java
@@ -118,7 +118,10 @@ public class ArgumentProcessor {
                 arg = arg.substring(1);
                 if (arg.indexOf('=') > 0) {
                     String[] keyvalue = arg.split("=", 2);
-                    config.getOptionGlobals().put(keyvalue[0], keyvalue[1]);
+
+                    // argv globals get their dashes replaced with underscores
+                    String globalName = keyvalue[0].replaceAll("-", "_");
+                    config.getOptionGlobals().put(globalName, keyvalue[1]);
                 } else {
                     config.getOptionGlobals().put(arg, null);
                 }


### PR DESCRIPTION
Replace any dashes in a global defined in `--` arguments with underscores to satisfy dash_s_spec.  (Side note: this will naturally also be compliant with the [updated dash_s_spec](https://github.com/rubyspec/rubyspec/pull/216) if it gets merged)

Also untag the other passing dash_s specs.
