### PR TITLE
Fix IOInputStream single-byte read

### DIFF
--- a/spec/java_integration/addons/stringio_addons.rb
+++ b/spec/java_integration/addons/stringio_addons.rb
@@ -4,10 +4,13 @@ require 'stringio'
 
 describe "Ruby StringIO" do
   it "should be coercible to java.io.InputStream with StringIO#to_inputstream" do
-    file = StringIO.new('abcdefghij')
+    file = StringIO.new("\xC3\x80abcdefghij")
     stream = file.to_inputstream
     java.io.InputStream.should === stream
-    
+
+    stream.read.should == 0xc3
+    stream.read.should == 0x80
+
     bytes = "0000000000".to_java_bytes
     stream.read(bytes).should == 10
     String.from_java_bytes(bytes).should == 'abcdefghij'
@@ -15,6 +18,7 @@ describe "Ruby StringIO" do
 
   it "should be coercible to java.io.OutputStream with StringIO#to_outputstream" do
     file = StringIO.new
+    stream = file.to_outputstream
     java.io.OutputStream.should === stream 
     
     bytes = "1234567890".to_java_bytes

--- a/src/org/jruby/util/IOInputStream.java
+++ b/src/org/jruby/util/IOInputStream.java
@@ -95,7 +95,7 @@ public class IOInputStream extends InputStream {
         IRubyObject readValue = readAdapter.call(io.getRuntime().getCurrentContext(), io, io, numOne);
         int returnValue = -1;
         if (!readValue.isNil()) {
-            returnValue = readValue.convertToString().getByteList().get(0);
+            returnValue = readValue.convertToString().getByteList().get(0) & 0xff;
         }
         return returnValue;
     }


### PR DESCRIPTION
Java does signed type conversions by default. Thus, any bytes above 127 resulted in negative return values, which where either illegal return values or signifying end of file.
