### PR TITLE
binwrite should pass write only when options are not empty but don't have a "mode"

### DIFF
--- a/src/org/jruby/RubyIO.java
+++ b/src/org/jruby/RubyIO.java
@@ -3709,8 +3709,8 @@ public class RubyIO extends RubyObject implements IOEncodable {
 
         RubyIO file = null;
 
+        long mode = ModeFlags.CREAT | ModeFlags.BINARY;
         if (options == null || (options != null && options.isEmpty())) {
-            long mode = ModeFlags.CREAT | ModeFlags.BINARY;
 
             if (offset == null) {
                 mode |= ModeFlags.WRONLY;
@@ -3719,6 +3719,9 @@ public class RubyIO extends RubyObject implements IOEncodable {
             }
 
             file = (RubyIO) Helpers.invoke(context, runtime.getFile(), "new", path, RubyFixnum.newFixnum(runtime, mode));
+        } else if (!options.containsKey(runtime.newSymbol("mode"))) {
+            mode |= ModeFlags.WRONLY;
+            file = (RubyIO) Helpers.invoke(context, runtime.getFile(), "new", path, RubyFixnum.newFixnum(runtime, mode), options);
         } else {
             file = (RubyIO) Helpers.invoke(context, runtime.getFile(), "new", path, options);
         }


### PR DESCRIPTION
This fixes problem when passing "encoding" as an option but don't pass a "mode". 
I added this spec to rubyspec on this commit:

https://github.com/rubyspec/rubyspec/commit/f32725141a63a621b771755dc50ec107db0324d6
