### PR TITLE
Tag intermittent spec failures

### DIFF
--- a/spec/tags/1.8/ruby/core/process/kill_tags.txt
+++ b/spec/tags/1.8/ruby/core/process/kill_tags.txt
@@ -1,2 +1,3 @@
 windows(JRUBY-4317):Process.kill raises an ArgumentError for unknown signals
 fails:Process.kill raises a TypeError if the PID is not a Fixnum
+fails(travis,intermittent):Process.kill accepts a signal name without the 'SIG' prefix

--- a/spec/tags/1.9/ruby/core/io/close_spec.txt
+++ b/spec/tags/1.9/ruby/core/io/close_spec.txt
@@ -1,1 +1,0 @@
-failed:IO#close on an IO.popen stream sets $?

--- a/spec/tags/1.9/ruby/core/io/close_tags.txt
+++ b/spec/tags/1.9/ruby/core/io/close_tags.txt
@@ -1,0 +1,1 @@
+fails(JRUBY-4110,linux,intermittent failure):IO#close on an IO.popen stream sets $?

--- a/spec/tags/1.9/ruby/core/kernel/spawn_tags.txt
+++ b/spec/tags/1.9/ruby/core/kernel/spawn_tags.txt
@@ -88,3 +88,40 @@ fails:Kernel.spawn does NOT redirect both STDERR and STDOUT at the time to the g
 fails:Kernel#spawn with multiple arguments preserves whitespace in passed arguments
 fails(only in full runs):Kernel#spawn with multiple arguments calls #to_str to convert the arguments to Strings
 fails(only in full runs):Kernel.spawn with multiple arguments does not subject the arguments to shell expansion
+fails(intermittent, gh-779):Kernel#spawn with multiple arguments does not subject the arguments to shell expansion
+fails(intermittent, gh-779):Kernel.spawn with a single argument creates an argument array with shell parsing semantics for whitespace
+fails(intermittent, gh-779):Kernel.spawn with a command array preserves whitespace in passed arguments
+fails(intermittent, gh-779):Kernel#spawn with a single argument subjects the specified command to shell expansion
+fails(intermittent, gh-779):Kernel#spawn with a single argument creates an argument array with shell parsing semantics for whitespace
+fails(intermittent, gh-779):Kernel#spawn with a single argument calls #to_str to convert the argument to a String
+fails(intermittent, gh-779):Kernel#spawn with a command array does not subject the arguments to shell expansion
+fails(intermittent, gh-779):Kernel#spawn with a command array preserves whitespace in passed arguments
+fails(intermittent, gh-779):Kernel#spawn with a command array calls #to_str to convert the first element to a String
+fails(intermittent, gh-779):Kernel.spawn with a single argument subjects the specified command to shell expansion
+fails(intermittent, gh-779):Kernel.spawn with a single argument calls #to_str to convert the argument to a String
+fails(intermittent, gh-779):Kernel.spawn with multiple arguments preserves whitespace in passed arguments
+fails(intermittent, gh-779):Kernel.spawn with multiple arguments calls #to_str to convert the arguments to Strings
+fails(intermittent, gh-779):Kernel.spawn with a command array calls #to_str to convert the first element to a String
+fails(intermittent, gh-779):Kernel.spawn with a command array calls #to_str to convert the second element to a String
+fails(intermittent, gh-779):Kernel#spawn sets environment variables in the child environment
+fails(intermittent, gh-779):Kernel#spawn calls #to_hash to convert the environment
+fails(intermittent, gh-779):Kernel#spawn does not unset other environment variables when given a false :unsetenv_others option
+fails(intermittent, gh-779):Kernel#spawn does not unset other environment variables when given a nil :unsetenv_others option
+fails(intermittent, gh-779):Kernel#spawn does not unset environment variables included in the environment hash
+fails(intermittent, gh-779):Kernel#spawn joins the current process group by default
+fails(intermittent, gh-779):Kernel#spawn joins the current process if :pgroup => false
+fails(intermittent, gh-779):Kernel#spawn joins the current process if :pgroup => nil
+fails(intermittent, gh-779):Kernel#spawn joins the specified process group if :pgroup => pgid
+fails(intermittent, gh-779):Kernel#spawn uses the current working directory as its working directory
+fails(intermittent, gh-779):Kernel#spawn uses the current umask by default
+fails(intermittent, gh-779):Kernel.spawn sets environment variables in the child environment
+fails(intermittent, gh-779):Kernel.spawn calls #to_hash to convert the environment
+fails(intermittent, gh-779):Kernel.spawn does not unset other environment variables when given a false :unsetenv_others option
+fails(intermittent, gh-779):Kernel.spawn does not unset other environment variables when given a nil :unsetenv_others option
+fails(intermittent, gh-779):Kernel.spawn does not unset environment variables included in the environment hash
+fails(intermittent, gh-779):Kernel.spawn joins the current process group by default
+fails(intermittent, gh-779):Kernel.spawn joins the current process if :pgroup => false
+fails(intermittent, gh-779):Kernel.spawn joins the current process if :pgroup => nil
+fails(intermittent, gh-779):Kernel.spawn joins the specified process group if :pgroup => pgid
+fails(intermittent, gh-779):Kernel.spawn uses the current umask by default
+fails(intermittent, gh-779):Kernel#spawn with a command array calls #to_str to convert the second element to a String

--- a/spec/tags/1.9/ruby/core/process/kill_tags.txt
+++ b/spec/tags/1.9/ruby/core/process/kill_tags.txt
@@ -1,1 +1,2 @@
 windows(JRUBY-4317):Process.kill raises an ArgumentError for unknown signals
+fails(travis,intermittent):Process.kill accepts a signal name without the 'SIG' prefix

--- a/spec/tags/1.9/ruby/core/process/spawn_tags.txt
+++ b/spec/tags/1.9/ruby/core/process/spawn_tags.txt
@@ -40,3 +40,23 @@ fails(only in rake run?):Kernel#spawn returns the process ID of the new process 
 fails:Process.spawn returns the process ID of the new process as a Fixnum
 fails(gh-631):Process.spawn with a single argument creates an argument array with shell parsing semantics for whitespace
 fails(gh-631):Process.spawn with multiple arguments preserves whitespace in passed arguments
+fails(intermittent, gh-779):Process.spawn with a command array does not subject the arguments to shell expansion
+fails(intermittent, gh-779):Process.spawn with a single argument calls #to_str to convert the argument to a String
+fails(intermittent, gh-779):Process.spawn with a single argument subjects the specified command to shell expansion
+fails(intermittent, gh-779):Process.spawn with multiple arguments does not subject the arguments to shell expansion
+fails(intermittent, gh-779):Process.spawn with multiple arguments calls #to_str to convert the arguments to Strings
+fails(intermittent, gh-779):Process.spawn with a command array preserves whitespace in passed arguments
+fails(intermittent, gh-779):Process.spawn with a command array calls #to_str to convert the first element to a String
+fails(intermittent, gh-779):Process.spawn with a command array calls #to_str to convert the second element to a String
+fails(intermittent, gh-779):Process.spawn executes the given command
+fails(intermittent, gh-779):Process.spawn sets environment variables in the child environment
+fails(intermittent, gh-779):Process.spawn calls #to_hash to convert the environment
+fails(intermittent, gh-779):Process.spawn does not unset other environment variables when given a false :unsetenv_others option
+fails(intermittent, gh-779):Process.spawn does not unset other environment variables when given a nil :unsetenv_others option
+fails(intermittent, gh-779):Process.spawn does not unset environment variables included in the environment hash
+fails(intermittent, gh-779):Process.spawn joins the current process group by default
+fails(intermittent, gh-779):Process.spawn joins the current process if :pgroup => false
+fails(intermittent, gh-779):Process.spawn joins the current process if :pgroup => nil
+fails(intermittent, gh-779):Process.spawn joins the specified process group if :pgroup => pgid
+fails(intermittent, gh-779):Process.spawn uses the current working directory as its working directory
+fails(intermittent, gh-779):Process.spawn uses the current umask by default


### PR DESCRIPTION
This should improve the stability of the Travis build. Most of these failures are explained in #779 (and marked as such).  For the other two:
- `IO#close on an IO.popen stream sets $?` can been seen failing for no good reason [here](https://s3.amazonaws.com/archive.travis-ci.org/jobs/7496279/log.txt) (Note also that this is not a new tag; it simply fixes the tag so that it gets picked up by the build.  Copied from the [existing tag for 1.8](https://github.com/jruby/jruby/blob/dc3af39805c14195f3503e4d10861c6695f00ab5/spec/tags/1.8/ruby/core/io/close_tags.txt))
- `Process.kill accepts a signal name without the 'SIG' prefix` can be seen failing for no good reason [here](https://s3.amazonaws.com/archive.travis-ci.org/jobs/7570946/log.txt)
