### PR TITLE
Fix the timezone string parser so it won't choke on TZ=JST-9, etc.

### DIFF
--- a/src/org/jruby/RubyTime.java
+++ b/src/org/jruby/RubyTime.java
@@ -196,7 +196,8 @@ public class RubyTime extends RubyObject {
             String hours = tzMatcher.group(3);
             String minutes = tzMatcher.group(4);
             
-            if (Integer.parseInt(hours) > 23 || Integer.parseInt(minutes) > 59) {
+            if (Integer.parseInt(hours) > 23 ||
+                    (minutes != null && Integer.parseInt(minutes) > 59)) {
                 throw runtime.newArgumentError("utc_offset out of range");
             }
             

--- a/test/test_time_tz.rb
+++ b/test/test_time_tz.rb
@@ -1,0 +1,27 @@
+require 'test/unit'
+
+class TestTimeTZ < Test::Unit::TestCase
+  def test_tz_without_minutes
+    begin
+      old_tz, ENV['TZ'] = ENV['TZ'], 'JST-9'
+      assert_nothing_raised {
+        time = Time.at(86400)
+        assert_equal '1970-01-02T09:00:00+0900', time.strftime('%FT%T%z')
+      }
+    ensure
+      ENV['TZ'] = old_tz
+    end
+  end
+
+  def test_tz_with_minutes
+    begin
+      old_tz, ENV['TZ'] = ENV['TZ'], 'UTC+5:45'
+      assert_nothing_raised {
+        time = Time.at(86400)
+        assert_equal '1970-01-01T18:15:00-0545', time.strftime('%FT%T%z')
+      }
+    ensure
+      ENV['TZ'] = old_tz
+    end
+  end
+end


### PR DESCRIPTION
The previous change in TZ_PATTERN may render the minutes part to be
null, so a null check is required before passing a captured value to
Integer.parseInt().
