### PR TITLE
Tag unreliable specs unstable rather than fails

### DIFF
--- a/spec/tags/1.8/ruby/core/io/close_tags.txt
+++ b/spec/tags/1.8/ruby/core/io/close_tags.txt
@@ -1,1 +1,1 @@
-fails(JRUBY-4110,linux,intermittent failure):IO#close on an IO.popen stream sets $?
+unstable(JRUBY-4110,linux,intermittent failure):IO#close on an IO.popen stream sets $?

--- a/spec/tags/1.8/ruby/core/process/kill_tags.txt
+++ b/spec/tags/1.8/ruby/core/process/kill_tags.txt
@@ -1,3 +1,3 @@
 windows(JRUBY-4317):Process.kill raises an ArgumentError for unknown signals
 fails:Process.kill raises a TypeError if the PID is not a Fixnum
-fails(travis,intermittent):Process.kill accepts a signal name without the 'SIG' prefix
+unstable(travis,intermittent):Process.kill accepts a signal name without the 'SIG' prefix

--- a/spec/tags/1.9/ruby/core/io/close_tags.txt
+++ b/spec/tags/1.9/ruby/core/io/close_tags.txt
@@ -1,1 +1,1 @@
-fails(JRUBY-4110,linux,intermittent failure):IO#close on an IO.popen stream sets $?
+unstable(JRUBY-4110,linux,intermittent failure):IO#close on an IO.popen stream sets $?

--- a/spec/tags/1.9/ruby/core/kernel/spawn_tags.txt
+++ b/spec/tags/1.9/ruby/core/kernel/spawn_tags.txt
@@ -88,40 +88,40 @@ fails:Kernel.spawn does NOT redirect both STDERR and STDOUT at the time to the g
 fails:Kernel#spawn with multiple arguments preserves whitespace in passed arguments
 fails(only in full runs):Kernel#spawn with multiple arguments calls #to_str to convert the arguments to Strings
 fails(only in full runs):Kernel.spawn with multiple arguments does not subject the arguments to shell expansion
-fails(intermittent, gh-779):Kernel#spawn with multiple arguments does not subject the arguments to shell expansion
-fails(intermittent, gh-779):Kernel.spawn with a single argument creates an argument array with shell parsing semantics for whitespace
-fails(intermittent, gh-779):Kernel.spawn with a command array preserves whitespace in passed arguments
-fails(intermittent, gh-779):Kernel#spawn with a single argument subjects the specified command to shell expansion
-fails(intermittent, gh-779):Kernel#spawn with a single argument creates an argument array with shell parsing semantics for whitespace
-fails(intermittent, gh-779):Kernel#spawn with a single argument calls #to_str to convert the argument to a String
-fails(intermittent, gh-779):Kernel#spawn with a command array does not subject the arguments to shell expansion
-fails(intermittent, gh-779):Kernel#spawn with a command array preserves whitespace in passed arguments
-fails(intermittent, gh-779):Kernel#spawn with a command array calls #to_str to convert the first element to a String
-fails(intermittent, gh-779):Kernel.spawn with a single argument subjects the specified command to shell expansion
-fails(intermittent, gh-779):Kernel.spawn with a single argument calls #to_str to convert the argument to a String
-fails(intermittent, gh-779):Kernel.spawn with multiple arguments preserves whitespace in passed arguments
-fails(intermittent, gh-779):Kernel.spawn with multiple arguments calls #to_str to convert the arguments to Strings
-fails(intermittent, gh-779):Kernel.spawn with a command array calls #to_str to convert the first element to a String
-fails(intermittent, gh-779):Kernel.spawn with a command array calls #to_str to convert the second element to a String
-fails(intermittent, gh-779):Kernel#spawn sets environment variables in the child environment
-fails(intermittent, gh-779):Kernel#spawn calls #to_hash to convert the environment
-fails(intermittent, gh-779):Kernel#spawn does not unset other environment variables when given a false :unsetenv_others option
-fails(intermittent, gh-779):Kernel#spawn does not unset other environment variables when given a nil :unsetenv_others option
-fails(intermittent, gh-779):Kernel#spawn does not unset environment variables included in the environment hash
-fails(intermittent, gh-779):Kernel#spawn joins the current process group by default
-fails(intermittent, gh-779):Kernel#spawn joins the current process if :pgroup => false
-fails(intermittent, gh-779):Kernel#spawn joins the current process if :pgroup => nil
-fails(intermittent, gh-779):Kernel#spawn joins the specified process group if :pgroup => pgid
-fails(intermittent, gh-779):Kernel#spawn uses the current working directory as its working directory
-fails(intermittent, gh-779):Kernel#spawn uses the current umask by default
-fails(intermittent, gh-779):Kernel.spawn sets environment variables in the child environment
-fails(intermittent, gh-779):Kernel.spawn calls #to_hash to convert the environment
-fails(intermittent, gh-779):Kernel.spawn does not unset other environment variables when given a false :unsetenv_others option
-fails(intermittent, gh-779):Kernel.spawn does not unset other environment variables when given a nil :unsetenv_others option
-fails(intermittent, gh-779):Kernel.spawn does not unset environment variables included in the environment hash
-fails(intermittent, gh-779):Kernel.spawn joins the current process group by default
-fails(intermittent, gh-779):Kernel.spawn joins the current process if :pgroup => false
-fails(intermittent, gh-779):Kernel.spawn joins the current process if :pgroup => nil
-fails(intermittent, gh-779):Kernel.spawn joins the specified process group if :pgroup => pgid
-fails(intermittent, gh-779):Kernel.spawn uses the current umask by default
-fails(intermittent, gh-779):Kernel#spawn with a command array calls #to_str to convert the second element to a String
+unstable(intermittent, gh-779):Kernel#spawn with multiple arguments does not subject the arguments to shell expansion
+unstable(intermittent, gh-779):Kernel.spawn with a single argument creates an argument array with shell parsing semantics for whitespace
+unstable(intermittent, gh-779):Kernel.spawn with a command array preserves whitespace in passed arguments
+unstable(intermittent, gh-779):Kernel#spawn with a single argument subjects the specified command to shell expansion
+unstable(intermittent, gh-779):Kernel#spawn with a single argument creates an argument array with shell parsing semantics for whitespace
+unstable(intermittent, gh-779):Kernel#spawn with a single argument calls #to_str to convert the argument to a String
+unstable(intermittent, gh-779):Kernel#spawn with a command array does not subject the arguments to shell expansion
+unstable(intermittent, gh-779):Kernel#spawn with a command array preserves whitespace in passed arguments
+unstable(intermittent, gh-779):Kernel#spawn with a command array calls #to_str to convert the first element to a String
+unstable(intermittent, gh-779):Kernel.spawn with a single argument subjects the specified command to shell expansion
+unstable(intermittent, gh-779):Kernel.spawn with a single argument calls #to_str to convert the argument to a String
+unstable(intermittent, gh-779):Kernel.spawn with multiple arguments preserves whitespace in passed arguments
+unstable(intermittent, gh-779):Kernel.spawn with multiple arguments calls #to_str to convert the arguments to Strings
+unstable(intermittent, gh-779):Kernel.spawn with a command array calls #to_str to convert the first element to a String
+unstable(intermittent, gh-779):Kernel.spawn with a command array calls #to_str to convert the second element to a String
+unstable(intermittent, gh-779):Kernel#spawn sets environment variables in the child environment
+unstable(intermittent, gh-779):Kernel#spawn calls #to_hash to convert the environment
+unstable(intermittent, gh-779):Kernel#spawn does not unset other environment variables when given a false :unsetenv_others option
+unstable(intermittent, gh-779):Kernel#spawn does not unset other environment variables when given a nil :unsetenv_others option
+unstable(intermittent, gh-779):Kernel#spawn does not unset environment variables included in the environment hash
+unstable(intermittent, gh-779):Kernel#spawn joins the current process group by default
+unstable(intermittent, gh-779):Kernel#spawn joins the current process if :pgroup => false
+unstable(intermittent, gh-779):Kernel#spawn joins the current process if :pgroup => nil
+unstable(intermittent, gh-779):Kernel#spawn joins the specified process group if :pgroup => pgid
+unstable(intermittent, gh-779):Kernel#spawn uses the current working directory as its working directory
+unstable(intermittent, gh-779):Kernel#spawn uses the current umask by default
+unstable(intermittent, gh-779):Kernel.spawn sets environment variables in the child environment
+unstable(intermittent, gh-779):Kernel.spawn calls #to_hash to convert the environment
+unstable(intermittent, gh-779):Kernel.spawn does not unset other environment variables when given a false :unsetenv_others option
+unstable(intermittent, gh-779):Kernel.spawn does not unset other environment variables when given a nil :unsetenv_others option
+unstable(intermittent, gh-779):Kernel.spawn does not unset environment variables included in the environment hash
+unstable(intermittent, gh-779):Kernel.spawn joins the current process group by default
+unstable(intermittent, gh-779):Kernel.spawn joins the current process if :pgroup => false
+unstable(intermittent, gh-779):Kernel.spawn joins the current process if :pgroup => nil
+unstable(intermittent, gh-779):Kernel.spawn joins the specified process group if :pgroup => pgid
+unstable(intermittent, gh-779):Kernel.spawn uses the current umask by default
+unstable(intermittent, gh-779):Kernel#spawn with a command array calls #to_str to convert the second element to a String

--- a/spec/tags/1.9/ruby/core/process/kill_tags.txt
+++ b/spec/tags/1.9/ruby/core/process/kill_tags.txt
@@ -1,2 +1,2 @@
 windows(JRUBY-4317):Process.kill raises an ArgumentError for unknown signals
-fails(travis,intermittent):Process.kill accepts a signal name without the 'SIG' prefix
+unstable(travis,intermittent):Process.kill accepts a signal name without the 'SIG' prefix

--- a/spec/tags/1.9/ruby/core/process/spawn_tags.txt
+++ b/spec/tags/1.9/ruby/core/process/spawn_tags.txt
@@ -40,23 +40,23 @@ fails(only in rake run?):Kernel#spawn returns the process ID of the new process 
 fails:Process.spawn returns the process ID of the new process as a Fixnum
 fails(gh-631):Process.spawn with a single argument creates an argument array with shell parsing semantics for whitespace
 fails(gh-631):Process.spawn with multiple arguments preserves whitespace in passed arguments
-fails(intermittent, gh-779):Process.spawn with a command array does not subject the arguments to shell expansion
-fails(intermittent, gh-779):Process.spawn with a single argument calls #to_str to convert the argument to a String
-fails(intermittent, gh-779):Process.spawn with a single argument subjects the specified command to shell expansion
-fails(intermittent, gh-779):Process.spawn with multiple arguments does not subject the arguments to shell expansion
-fails(intermittent, gh-779):Process.spawn with multiple arguments calls #to_str to convert the arguments to Strings
-fails(intermittent, gh-779):Process.spawn with a command array preserves whitespace in passed arguments
-fails(intermittent, gh-779):Process.spawn with a command array calls #to_str to convert the first element to a String
-fails(intermittent, gh-779):Process.spawn with a command array calls #to_str to convert the second element to a String
-fails(intermittent, gh-779):Process.spawn executes the given command
-fails(intermittent, gh-779):Process.spawn sets environment variables in the child environment
-fails(intermittent, gh-779):Process.spawn calls #to_hash to convert the environment
-fails(intermittent, gh-779):Process.spawn does not unset other environment variables when given a false :unsetenv_others option
-fails(intermittent, gh-779):Process.spawn does not unset other environment variables when given a nil :unsetenv_others option
-fails(intermittent, gh-779):Process.spawn does not unset environment variables included in the environment hash
-fails(intermittent, gh-779):Process.spawn joins the current process group by default
-fails(intermittent, gh-779):Process.spawn joins the current process if :pgroup => false
-fails(intermittent, gh-779):Process.spawn joins the current process if :pgroup => nil
-fails(intermittent, gh-779):Process.spawn joins the specified process group if :pgroup => pgid
-fails(intermittent, gh-779):Process.spawn uses the current working directory as its working directory
-fails(intermittent, gh-779):Process.spawn uses the current umask by default
+unstable(intermittent, gh-779):Process.spawn with a command array does not subject the arguments to shell expansion
+unstable(intermittent, gh-779):Process.spawn with a single argument calls #to_str to convert the argument to a String
+unstable(intermittent, gh-779):Process.spawn with a single argument subjects the specified command to shell expansion
+unstable(intermittent, gh-779):Process.spawn with multiple arguments does not subject the arguments to shell expansion
+unstable(intermittent, gh-779):Process.spawn with multiple arguments calls #to_str to convert the arguments to Strings
+unstable(intermittent, gh-779):Process.spawn with a command array preserves whitespace in passed arguments
+unstable(intermittent, gh-779):Process.spawn with a command array calls #to_str to convert the first element to a String
+unstable(intermittent, gh-779):Process.spawn with a command array calls #to_str to convert the second element to a String
+unstable(intermittent, gh-779):Process.spawn executes the given command
+unstable(intermittent, gh-779):Process.spawn sets environment variables in the child environment
+unstable(intermittent, gh-779):Process.spawn calls #to_hash to convert the environment
+unstable(intermittent, gh-779):Process.spawn does not unset other environment variables when given a false :unsetenv_others option
+unstable(intermittent, gh-779):Process.spawn does not unset other environment variables when given a nil :unsetenv_others option
+unstable(intermittent, gh-779):Process.spawn does not unset environment variables included in the environment hash
+unstable(intermittent, gh-779):Process.spawn joins the current process group by default
+unstable(intermittent, gh-779):Process.spawn joins the current process if :pgroup => false
+unstable(intermittent, gh-779):Process.spawn joins the current process if :pgroup => nil
+unstable(intermittent, gh-779):Process.spawn joins the specified process group if :pgroup => pgid
+unstable(intermittent, gh-779):Process.spawn uses the current working directory as its working directory
+unstable(intermittent, gh-779):Process.spawn uses the current umask by default

--- a/spec/tags/1.9/ruby/library/fiber/transfer_tags.txt
+++ b/spec/tags/1.9/ruby/library/fiber/transfer_tags.txt
@@ -7,4 +7,4 @@ critical(hangs):Fiber#transfer can be invoked from the same Fiber it transfers c
 critical(hangs):Fiber#transfer raises a FiberError when transferring to a Fiber which resumes itself
 fails:Fiber#transfer can transfer control to a Fiber that has transfered to another Fiber
 fails:Fiber#transfer accepts any number of arguments
-fails(intermittent):Fiber#transfer raises a LocalJumpError if the block includes a return statement
+unstable(intermittent):Fiber#transfer raises a LocalJumpError if the block includes a return statement


### PR DESCRIPTION
Improve the tags added in #780.

Note: there were a couple of other "fails" tags not from #780 which claimed to be intermittent; this updates those too.
