### PR TITLE
Fix each_with_index argument handling

### DIFF
--- a/spec/regression/GH-744_each_with_index_using_call.rb
+++ b/spec/regression/GH-744_each_with_index_using_call.rb
@@ -1,0 +1,89 @@
+require 'rspec'
+
+describe "Enumerable#each_with_index with Enumerable#each implemented with a call rather than a yield" do
+  it "passes nil to the block if each passes no args" do
+    no_args_each = Class.new do
+      include Enumerable
+      def each(&block)
+        block.call
+      end
+    end
+
+    no_args_each.new.each_with_index do |args, index|
+      args.should == nil
+      index.should == 0
+    end
+  end
+
+  it "passes the arg directly to the block if each passes one arg" do
+    one_arg_each = Class.new do
+      include Enumerable
+      def each(&block)
+        block.call("one")
+      end
+    end
+
+    one_arg_each.new.each_with_index do |args, index|
+      args.should == "one"
+      index.should == 0
+    end
+  end
+
+  it "passes an array of arguments to the block if Enumerable#each passes multiple values" do
+    many_args_each = Class.new do
+      include Enumerable
+      def each(&block)
+        block.call(0, 1, 2, 3)
+      end
+    end
+
+    many_args_each.new.each_with_index do |args, index|
+      args.should == [0, 1, 2, 3]
+      index.should == 0
+    end
+  end
+end
+
+describe "Enumerator#each_with_index for a method implemented with a call rather than a yield" do
+  it "passes nil to the block if the method passes no args" do
+    no_args_method = Class.new do
+      include Enumerable
+      def my_method(&block)
+        block.call
+      end
+    end
+
+    no_args_method.new.enum_for(:my_method).each_with_index do |args, index|
+      args.should == nil
+      index.should == 0
+    end
+  end
+
+  it "passes the arg directly to the block if the method passes one arg" do
+    one_arg_each = Class.new do
+      include Enumerable
+      def my_method(&block)
+        block.call("one")
+      end
+    end
+
+    one_arg_each.new.enum_for(:my_method) do |args, index|
+      args.should == "one"
+      index.should == 0
+    end
+  end
+
+  it "passes an array of arguments to the block if the method passes multiple values" do
+    many_args_method = Class.new do
+      include Enumerable
+      def my_method(&block)
+        block.call(0, 1, 2, 3)
+      end
+    end
+
+    many_args_method.new.enum_for(:my_method).each_with_index do |args, index|
+      args.should == [0, 1, 2, 3]
+      index.should == 0
+    end
+  end
+end


### PR DESCRIPTION
This fixes #744 and cleans up a couple of related things discovered while down that rabbit hole.

The block `RubyEnumerable` creates to handle `each_with_index` was incorrectly assigned a fixed arity of two.  When the `each` we passed this block to is implemented with a `call` rather than a `yield`, this arity was enforced. This resulted in wrapping zero or one arguments in an array (which is what leads to #744) or, in the case of more than two arguments, lopping off the extra arguments.

This pull updates the `each_with_index` block to have `Arity.OPTIONAL`, and fixes the `EachWithIndex.call` logic around packaging up the arguments to handle all arities properly.

Also noticed that `RubyEnumerator$EachWithIndex` needed precisely the same logic around argument packaging, and refactored it to use the fixed `RubyEnumerable$EachWithIndex`.  In particular, this fixes an issue where `RubyEnumerator$EachWithIndex` handled multiple arguments incorrectly (it always truncated down to the first arg).
