### PR TITLE
Fix enum arg handling in Enumerator Nexter

### DIFF
--- a/spec/regression/GH-744_GH-264_enum_args_using_call_spec.rb
+++ b/spec/regression/GH-744_GH-264_enum_args_using_call_spec.rb
@@ -57,6 +57,8 @@ describe "Enumerator#each_with_index for a method implemented with a call rather
       args.should == nil
       index.should == 0
     end
+
+    no_args_method.new.enum_for(:my_method).next.should == nil
   end
 
   it "passes the arg directly to the block if the method passes one arg" do
@@ -71,6 +73,8 @@ describe "Enumerator#each_with_index for a method implemented with a call rather
       args.should == "one"
       index.should == 0
     end
+
+    one_arg_each.new.enum_for(:my_method).next.should == "one"
   end
 
   it "passes an array of arguments to the block if the method passes multiple values" do
@@ -85,5 +89,7 @@ describe "Enumerator#each_with_index for a method implemented with a call rather
       args.should == [0, 1, 2, 3]
       index.should == 0
     end
+
+    many_args_method.new.enum_for(:my_method).next.should == [0, 1, 2, 3]
   end
 end

--- a/src/org/jruby/RubyEnumerable.java
+++ b/src/org/jruby/RubyEnumerable.java
@@ -885,15 +885,21 @@ public class RubyEnumerable {
         }
 
         public IRubyObject call(ThreadContext context, IRubyObject[] iargs, Block block) {
-            // Package the arguments appropriately depending on how many there are
-            // Corresponds to rb_enum_values_pack in MRI
-            if (iargs.length < 2) {
-                // For 0 or 1 arguments, we want the checkArgs behavior
-                return this.block.call(context, checkArgs(runtime, iargs), runtime.newFixnum(index++));
-            } else {
-                // For more than 1 arg, we pass them to our block as an arrays
-                return this.block.call(context, runtime.newArrayNoCopy(iargs), runtime.newFixnum(index++));
-            }
+            return this.block.call(context, packEnumValues(runtime, iargs), runtime.newFixnum(index++));
+        }
+    }
+
+    /**
+     * Package the arguments appropriately depending on how many there are
+     * Corresponds to rb_enum_values_pack in MRI
+     */
+    static IRubyObject packEnumValues(Ruby runtime, IRubyObject[] args) {
+        if (args.length < 2) {
+            // For 0 or 1 arguments, we want the checkArgs behavior
+            return checkArgs(runtime, args);
+        } else {
+            // For more than 1 arg, we pack them as an arrays
+            return runtime.newArrayNoCopy(args);
         }
     }
 

--- a/src/org/jruby/RubyEnumerator.java
+++ b/src/org/jruby/RubyEnumerator.java
@@ -675,7 +675,7 @@ public class RubyEnumerator extends RubyObject {
                             try {
                                 if (DEBUG) System.out.println(Thread.currentThread().getName() + ": exchanging: " + args[0]);
                                 if (die) throw new JumpException.BreakJump(-1, NEVER);
-                                out.put(args[0]);
+                                out.put(RubyEnumerable.packEnumValues(runtime, args));
                                 if (die) throw new JumpException.BreakJump(-1, NEVER);
                             } catch (InterruptedException ie) {
                                 if (DEBUG) System.out.println(Thread.currentThread().getName() + ": interrupted");


### PR DESCRIPTION
This fixes #264.  I noticed that issue had the same symptoms that #807 addressed for `each_with_index`.  This pull extends the #807 fix to cover the `next` case.

Note also that the regression test `no_args_method.new.enum_for(:my_method).next.should == nil` added here actually hangs prior to this fix (the nexter queue blocked forever waiting for a value that's not coming; now we explicitly feed it the `nil`), so avoiding that is a nice bonus.

Between the updated arg handing and avoiding that hang, it seems like there's a chance some specs can be untagged now... I'll have a look soon.
