### PR TITLE
Need to unwrap exception before checking for security exception

### DIFF
--- a/src/org/jruby/util/log/LoggerFactory.java
+++ b/src/org/jruby/util/log/LoggerFactory.java
@@ -65,10 +65,19 @@ public class LoggerFactory {
         try {
             Logger logger = (Logger) CTOR.newInstance(loggerName);
             return logger;
-        } catch (SecurityException e) {
-            return new StandardErrorLogger(loggerName);
         } catch (Exception e) {
-            throw new IllegalStateException("unable to instantiate logger", e);
+          Throwable rootCause = e;
+
+          // Unwrap reflection exception wrappers
+          while (rootCause.getCause() != null) {
+            rootCause = rootCause.getCause();
+          }
+
+          if (rootCause instanceof SecurityException) {
+            return new StandardErrorLogger(loggerName);
+          }
+
+          throw new IllegalStateException("unable to instantiate logger", e);
         }
     }
 }


### PR DESCRIPTION
As is the instanceof SecurityException is useless since reflection invocation will likely be wrapped in InvocationTargetException
