### PR TITLE
fix slice_before on empty enumerable

### DIFF
--- a/src/jruby/kernel19/enumerable.rb
+++ b/src/jruby/kernel19/enumerable.rb
@@ -39,7 +39,7 @@ module Enumerable
           ary = [elt]
         end
       end
-      yielder.yield ary
+      yielder.yield ary unless ary.nil?
     end
   end
 end


### PR DESCRIPTION
This fixes an issue where calling slice_before on an empty enumerable
would return an enumerable containing one element of nil

``` rb
#before
[].slice_before(1).to_a #=> [nil]
#after
[].slice_before(1).to_a #=> []
```

Would you also like a test added to rubyspec around this?
