### PR TITLE
Have test_openssl.rb be explicit about security checks it adds

### DIFF
--- a/test/org/jruby/security/SecurityManager.java
+++ b/test/org/jruby/security/SecurityManager.java
@@ -1,0 +1,82 @@
+package org.jruby.security;
+
+import org.jruby.Ruby;
+import org.jruby.RubyString;
+import org.jruby.runtime.builtin.IRubyObject;
+import java.security.Permission;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SecurityManager extends java.lang.SecurityManager {
+  public static class RubyPermission {
+    private final IRubyObject lambda;
+
+    public RubyPermission(IRubyObject lambda) {
+      this.lambda = lambda;
+    }
+
+    public boolean matches(java.security.Permission perm) {
+      Ruby runtime = lambda.getRuntime();
+
+      return lambda.callMethod(runtime.getCurrentContext(),
+          "call",
+          new IRubyObject[] {
+            RubyString.newString(runtime, perm.getClass().getSimpleName()),
+            RubyString.newString(runtime, perm.getName()),
+            RubyString.newString(runtime, perm.getActions())
+      }).isTrue();
+    }
+  }
+
+  public static SecurityManager install() {
+    SecurityManager manager = new SecurityManager();
+
+    System.setSecurityManager(manager);
+
+    return manager;
+  }
+
+  private boolean verbose = false;
+  private boolean strict = false;
+  private final List<RubyPermission> temporaryPermissions = new ArrayList<RubyPermission>();
+
+  @Override
+  public void checkPermission(java.security.Permission perm) {
+    for (RubyPermission permission: temporaryPermissions) {
+      if (permission.matches(perm)) {
+        return;
+      }
+    }
+
+    if (strict) {
+      logTrace(perm.toString() + " denied");
+      super.checkPermission(perm);
+    }
+  }
+
+  public SecurityManager setIsStrict(boolean strict) {
+    this.strict = strict;
+    return this;
+  }
+
+  public SecurityManager permit(RubyPermission permission) {
+    temporaryPermissions.add(permission);
+    return this;
+  }
+
+  public SecurityManager revoke(RubyPermission permission) {
+    temporaryPermissions.remove(permission);
+    return this;
+  }
+
+  public SecurityManager setVerbosity(boolean verbose) {
+    this.verbose = verbose;
+    return this;
+  }
+
+  private void logTrace(String message) {
+    if (verbose) {
+      new Exception(message).printStackTrace();
+    }
+  }
+}

--- a/test/security_helper.rb
+++ b/test/security_helper.rb
@@ -1,0 +1,127 @@
+class Wrapper
+  java_import 'org.jruby.security.SecurityManager'
+
+  attr_reader :java_manager
+
+  def initialize(java_manager)
+    @java_manager = java_manager
+  end
+
+  def allow(permissions_hash = nil, &block)
+    if permissions_hash
+      permissions = parse_hash_value(permissions_hash).uniq.map { |v| v.flatten }
+
+      return allow do |expected_type, expected_name, expected_actions|
+        permissions.any? do |parr|
+          (type, name, actions) = *parr
+          (type == expected_type &&
+            (name.nil? || name == expected_name) &&
+            (actions.nil? || actions == expected_actions))
+        end
+      end
+    end
+
+    SecurityManager::RubyPermission.new(block).tap { |p| java_manager.permit p }
+  end
+
+  def with_permissions(hash)
+    p = allow(hash)
+    begin
+      yield
+    ensure
+      java_manager.revoke p
+    end
+  end
+
+  def permissive!
+    java_manager.setIsStrict(false)
+    self
+  end
+
+  def strict!
+    java_manager.setIsStrict(true)
+    self
+  end
+
+  def verbose!
+    java_manager.setVerbosity true
+    self
+  end
+
+  def silent!
+    java_manager.setVerbosity false
+    self
+  end
+
+  private
+
+  def parse_hash_value(value)
+    if value.respond_to?(:each_pair)
+      values = []
+      value.each_pair { |k, v| values += [ k ].product(parse_hash_value(v)) }
+      values
+    else
+      value.to_a.compact
+    end
+  end
+end
+
+::SecurityManager = Wrapper.new org.jruby.security.SecurityManager.install
+
+SecurityManager.allow do |type, name, actions|
+  case type
+  when "FilePermission"
+    # Allow to read anything within the jruby directory
+    (name.start_with?(File.expand_path("../../", __FILE__)) && actions == "read") ||
+
+    # Allow to load jdk classes
+    name =~ /jdk/
+  when 'LoggingPermission'
+    # Allow any logging access
+    false
+  when 'PropertyPermission'
+    (actions == "read") && [
+      "java.protocol.handler.pkgs",
+      "sun.misc.ProxyGenerator.saveGeneratedFiles",
+
+      # FFI needs to be able to read its properties
+      /^jnr\.ffi\..*/,
+
+      # Allow reading any jruby properties
+      /^jruby/,
+
+      # Allow knowledge about environment
+      /^os\..*/,
+      /^user\..*/,
+      "sun.arch.data.model",
+      "java.home",
+
+      # Allow proxies
+      /^sun.reflect.proxy.*/
+    ].any? { |read_permission| read_permission === name }
+  when 'RuntimePermission'
+    # Allow loading of native libraries
+    (name =~ /^loadLibrary\..*\.so$/) ||
+    (name == "loadLibrary.nio") ||
+
+    # jnr.posix needs this
+    (name == "accessDeclaredMembers") ||
+    (name == "createClassLoader") ||
+
+    # Let Main do System.exit
+    (name == "exitVM.1") ||
+
+    (name =~ /^accessClassInPackage\.sun.*$/) ||
+
+    # Not sure what this is about
+    (name == "getProtectionDomain") ||
+    (name == "fileSystemProvider")
+  when 'ReflectPermission'
+    # JRuby makes heavy usage of reflection for dynamic invocation, etc
+    name == "suppressAccessChecks"
+  else
+    false
+  end
+end
+
+::SecurityManager.permissive!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ require 'rbconfig'
 require 'jruby' if defined?(JRUBY_VERSION)
 require 'tempfile'
 
+
 module TestHelper
   # TODO: Consider how this should work if we have --windows or similiar
   WINDOWS = RbConfig::CONFIG['host_os'] =~ /Windows|mswin/
@@ -74,3 +75,5 @@ module TestHelper
     assert run_in_sub_runtime(script)
   end
 end
+
+org.jruby.security.SecurityManager.install


### PR DESCRIPTION
Hey all,

With this commit I'm trying to get JRuby more explicit about the security checks it requires to run. There are three parts to this commit:

1) General framework of being able to set allowed security checks for tests.
2) General security checks that are assumed to be required to get JRuby running (in test/security_helper.rb)
3) Specific security checks required for test_openssl.rb to work.

Please let me know what you think. Assuming this gets merged in, I'd like to tackle test_load.rb next to provide some motivation to get rid of CompoundJar loader. ;)
