### PR TITLE
Use <dependencyManagement> for junit. Updated other deps.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -36,8 +36,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jruby.joni</groupId>
@@ -90,7 +88,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jffi</artifactId>
-      <version>1.2.5</version>
+      <version>1.2.7</version>
       <type>jar</type>
     </dependency>
     <dependency>
@@ -102,7 +100,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.11</version>
+      <version>1.12</version>
       <type>jar</type>
     </dependency>
     <dependency>
@@ -120,14 +118,14 @@
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.core</artifactId>
-      <version>4.3.1</version>
+      <version>5.0.0</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
-      <version>1.8.4</version>
+      <version>1.9.1</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>

--- a/ext/openssl/pom.xml
+++ b/ext/openssl/pom.xml
@@ -24,20 +24,18 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.1</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.47</version>
+      <version>1.48</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.47</version>
+      <version>1.48</version>
       <type>jar</type>
       <scope>provided</scope>
     </dependency>

--- a/ext/readline/pom.xml
+++ b/ext/readline/pom.xml
@@ -22,8 +22,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.1</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jruby</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,17 @@
     </plugins>
   </build>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.11</version>
+        <scope>test</scope>
+       </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <profiles>
     <profile>
       <id>docs</id>


### PR DESCRIPTION
 Note that the bouncycastle deps are slightly stale because the latest version causes compilation failures.
