### PR TITLE
Maven site can now be published to github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ See [README.test](docs/README.test.md) for more information.
 
 Visit http://jruby.org for more information.
 
+Visit http://jruby.github.io/jruby for the Maven Site documentation.
+
 ## License
 
 Read the [COPYING](COPYING) file.

--- a/pom.xml
+++ b/pom.xml
@@ -31,13 +31,22 @@
     <json.version>1.7.3</json.version>
     <base.java.version>1.6</base.java.version>
     <main.basedir>${project.basedir}</main.basedir>
+    <github.global.server>github</github.global.server>
   </properties>
 
   <scm>
     <connection>scm:git:git://github.com/jruby/jruby.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jruby/jruby.git</developerConnection>
-    <url>http://github.com/jruby/jruby</url>
+    <url>https://github.com/jruby/jruby</url>
   </scm>
+
+  <distributionManagement>
+    <site>
+      <id>gh-pages</id>
+      <name>JRuby Site</name>
+      <url>https://github.com/jruby/jruby</url>
+    </site>
+  </distributionManagement>
 
   <build>
     <defaultGoal>package</defaultGoal>
@@ -116,6 +125,13 @@
           <artifactId>lifecycle-mapping</artifactId>
           <version>1.0.0</version>
         </plugin>
+
+        <plugin>
+           <groupId>org.apache.maven.plugins</groupId>
+           <artifactId>maven-scm-publish-plugin</artifactId>
+           <version>1.0-beta-2</version>
+        </plugin>
+
       </plugins>
     </pluginManagement>
 
@@ -127,6 +143,41 @@
           <port>9000</port>
           <tempWebappDirectory>${basedir}/target/site/tempdir</tempWebappDirectory>
         </configuration>
+        <executions>
+          <execution>
+            <id>stage-for-scm-publish</id>
+            <phase>post-site</phase>
+            <goals>
+              <goal>stage</goal>
+            </goals>
+            <configuration>
+              <skipDeploy>false</skipDeploy>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <!-- To publish website to jruby.github.io/jruby execute:
+        mvn clean site site:stage site:stage-deploy scm-publish:publish-scm
+        -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-scm-publish-plugin</artifactId>
+        <version>1.0-beta-2</version>
+        <configuration>
+          <scmBranch>gh-pages</scmBranch>
+          <pubScmUrl>scm:git:git@github.com:jruby/jruby.git</pubScmUrl>
+          <tryUpdate>true</tryUpdate>
+        </configuration>
+        <executions>
+          <execution>
+            <id>scm-publish</id>
+            <phase>site-deploy</phase>
+            <goals>
+              <goal>publish-scm</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
@@ -205,14 +256,14 @@
             </propertyExpansion>
           </configuration>
         </plugin>
-        <plugin>
+      <!--  <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>cobertura-maven-plugin</artifactId>
           <version>2.5.1</version>
             <configuration>
                 <aggregate>true</aggregate>
             </configuration>
-        </plugin>
+        </plugin>  -->
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
           <version>2.8</version>
@@ -266,7 +317,7 @@
             <targetJdk>1.6</targetJdk>
           </configuration>
         </plugin>
-        <plugin>
+      <!--  <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jxr-plugin</artifactId>
           <version>2.3</version>
@@ -274,7 +325,7 @@
             <linkJavadoc>true</linkJavadoc>
               <aggregate>true</aggregate>
           </configuration>
-        </plugin>
+        </plugin> -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-report-plugin</artifactId>


### PR DESCRIPTION
The Maven site can now be published to Github pages using this command:
    mvn clean site site:stage site:stage-deploy scm-publish:publish-scm

You can see a test run of the site and upload at http://jendave.github.io/jruby/
