### PR TITLE
Fix Unmarshaling of Date objects marshaled with MRI 1.9+

### DIFF
--- a/lib/ruby/1.9/date.rb
+++ b/lib/ruby/1.9/date.rb
@@ -1499,8 +1499,14 @@ class Date
 
   # Load from Marshal format.
   def marshal_load(a)
-    @ajd, @of, @sg, = a
-    @__ca__ = {}
+    if a.length == 3
+      # old format
+      @ajd, @of, @sg, = a
+    elsif a.length == 6
+      _, jd, _, _, @of, @sg = a
+      @ajd = jd_to_ajd(jd, 0, @of)
+    end
+     @__ca__ = {}
   end
 
 end


### PR DESCRIPTION
A Date object marshaled with MRI 1.9+ is not unmarshaled correctly in JRuby at the moment. If you don't look to close it seems to be OK but comparing a Date object instantiated in JRuby and a Date object unmarshaled from a MRI marshaled object fails as the @ajd variable is not set correctly. The new format is a six element array and the old one was a three element array.   

To see how the marshaling code has changed have a look at https://github.com/ruby/ruby/blob/ruby_1_9_3/ext/date/date_core.c#L7242-L7264 

Example:

``` ruby
# MRI irb
require 'date'
Date.today
# => #<Date: 2013-07-11 ((2456485j,0s,0n),+0s,2299161j)>
str = Marshal.dump(Date.today)
# => "\x04\bU:\tDate[\vi\x00i\x03\xA5{%i\x00i\x00i\x00f\f2299161"
Marshal.load(str) == Date.today
# => true

# JRuby irb
require 'date'
str = "\x04\bU:\tDate[\vi\x00i\x03\xA5{%i\x00i\x00i\x00f\f2299161"
date = Marshal.load(str)
# => #<Date: 2013-07-11 (0,2456485,0)>
date == Date.today
# => false
date.to_s
# => "2013-07-11"
Date.today.to_s
# => "2013-07-11"
```

This patch might not be 100% correct but fixes the problem.   
