### PR TITLE
Fix a naming conflict jrubyc can introduce in generated java.

### DIFF
--- a/lib/ruby/shared/jruby/compiler/java_class.rb
+++ b/lib/ruby/shared/jruby/compiler/java_class.rb
@@ -274,7 +274,7 @@ module JRuby::Compiler
       # ignore other nodes
     end
   end
-  
+
   class RubyScript
     BASE_IMPORTS = [
       "org.jruby.Ruby",
@@ -438,7 +438,7 @@ JAVA
 
       unless @has_constructor
         str << <<JAVA
-        
+
     /**
      * Default constructor. Invokes this(Ruby, RubyClass) with the classloader-static
      * Ruby and RubyClass instances assocated with this class, and then invokes the
@@ -529,7 +529,7 @@ JAVA
 
     def conversion_string(var_names)
       if arity <= MAX_UNBOXED_ARITY_LENGTH
-        var_names.map { |a| "        IRubyObject ruby_#{a} = JavaUtil.convertJavaToRuby(__ruby__, #{a});"}.join("\n")
+        var_names.map { |a| "        IRubyObject ruby_arg_#{a} = JavaUtil.convertJavaToRuby(__ruby__, #{a});"}.join("\n")
       else
         str =  "        IRubyObject ruby_args[] = new IRubyObject[#{arity}];\n"
         var_names.each_with_index { |a, i| str += "        ruby_args[#{i}] = JavaUtil.convertJavaToRuby(__ruby__, #{a});\n" }
@@ -559,7 +559,7 @@ JAVA
       end
 
       annotations = java_signature.modifiers.select(&:annotation?).map(&:to_s).join(" ")
-      
+
       "#{annotations}#{visibility_str}#{static_str}#{final_str}#{abstract_str}#{strictfp_str}#{native_str}#{synchronized_str}"
     end
 
@@ -600,7 +600,7 @@ JAVA
       return @passed_args if @passed_args
 
       if arity <= MAX_UNBOXED_ARITY_LENGTH
-        @passed_args = var_names.map {|a| "ruby_#{a}"}.join(', ')
+        @passed_args = var_names.map {|a| "ruby_arg_#{a}"}.join(', ')
         @passed_args = ', ' + @passed_args if args.size > 0
       else
         @passed_args = ", ruby_args";

--- a/test/compiler/test_jrubyc.rb
+++ b/test/compiler/test_jrubyc.rb
@@ -7,27 +7,33 @@ require 'jruby/jrubyc'
 
 class TestJrubyc < Test::Unit::TestCase
   def setup
-    @tempfile = Tempfile.open("test_jrubyc")
+    @tempfile_stdout = Tempfile.open("test_jrubyc_stdout")
     @old_stdout = $stdout.dup
-    $stdout.reopen @tempfile
+    $stdout.reopen @tempfile_stdout
     $stdout.sync = true
+
+    @tempfile_stderr = Tempfile.open("test_jrubyc_stderr")
+    @old_stderr = $stderr.dup
+    $stderr.reopen @tempfile_stderr
+    $stderr.sync = true
   end
 
   def teardown
     FileUtils.rm_rf(["foo", "ruby"])
     $stdout.reopen(@old_stdout)
+    $stderr.reopen(@old_stderr)
   end
 
 =begin Neither of these tests seem to work running under rake. FIXME
   def test_basic
     begin
       JRuby::Compiler::compile_argv(["--verbose", __FILE__])
-      output = File.read(@tempfile.path)
+      output = File.read(@tempfile_stdout.path)
 
       assert_equal(
         "Compiling #{__FILE__}\n",
         output)
-      
+
       class_file = __FILE__.gsub('.rb', '.class')
 
       assert(File.exist?(class_file))
@@ -37,9 +43,9 @@ class TestJrubyc < Test::Unit::TestCase
   end
 
   def test_target
-    tempdir = File.dirname(@tempfile.path)
+    tempdir = File.dirname(@tempfile_stdout.path)
     JRuby::Compiler::compile_argv(["--verbose", "-t", tempdir, __FILE__])
-    output = File.read(@tempfile.path)
+    output = File.read(@tempfile_stdout.path)
 
     assert_equal(
       "Compiling #{__FILE__}\n",
@@ -61,13 +67,13 @@ class TestJrubyc < Test::Unit::TestCase
       "Target dir not found: does_not_exist",
       e.message)
   end
-  
+
   def test_require
     $compile_test = false
     File.open("test_file1.rb", "w") {|file| file.write("$compile_test = true")}
-    
+
     JRuby::Compiler::compile_argv(["--verbose", "test_file1.rb"])
-    output = File.read(@tempfile.path)
+    output = File.read(@tempfile_stdout.path)
 
     assert_equal(
       "Compiling test_file1.rb\n",
@@ -78,5 +84,32 @@ class TestJrubyc < Test::Unit::TestCase
   ensure
     File.delete("test_file1.rb") rescue nil
     File.delete("test_file1.class") rescue nil
+  end
+
+  def test_signature_with_arg_named_result
+    $compile_test = false
+    File.open("test_file2.rb", "w") {|file| file.write(<<-RUBY
+      class C
+        java_signature 'public int f(int result)'
+        def f(arg)
+          $compile_test = true
+        end
+      end
+
+      C.new.f(0)
+    RUBY
+    )}
+
+    JRuby::Compiler::compile_argv(["--verbose", "--java", "--javac", "test_file2.rb"])
+    output = File.read(@tempfile_stderr.path)
+
+    assert_equal("", output)
+
+    assert_nothing_raised { require 'test_file2' }
+    assert($compile_test)
+  ensure
+    File.delete("test_file2.rb") rescue nil
+    File.delete("C.java") rescue nil
+    File.delete("C.class") rescue nil
   end
 end


### PR DESCRIPTION
A ruby argument named `result` will conflict with the stack local used for the return value: both will become `ruby_result` in java.

Namespace arguments away from this by prefixing them with `ruby_arg_` instead of merely `ruby_`.

See #812
