### PR TITLE
Document --2.0 flag.

### DIFF
--- a/core/src/main/java/org/jruby/util/cli/OutputStrings.java
+++ b/core/src/main/java/org/jruby/util/cli/OutputStrings.java
@@ -69,6 +69,7 @@ public class OutputStrings {
                 .append("  --headless      do not launch a GUI window, no matter what\n")
                 .append("  --1.8           specify Ruby 1.8.x compatibility\n")
                 .append("  --1.9           specify Ruby 1.9.x compatibility (default)\n")
+                .append("  --2.0           specify Ruby 2.0 compatibility\n")
                 .append("  --bytecode      show the JVM bytecode produced by compiling specified code\n")
                 .append("  --version       print the version\n")
                 .append("  --disable-gems  do not load RubyGems on startup\n");


### PR DESCRIPTION
Document the ability to run JRuby under Ruby 2.0 mode.

If 2.0 mode isn't ready for production, then an "(experimental)" note at the end of the line is ok, but 2.0 mode should be documented in some form, for the benefit of those unfamiliar with JRuby.
