### PR TITLE
More arg-handling improvements for Enumerables

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -71,7 +71,7 @@ public class RubyEnumerator extends RubyObject {
         RubyModule enm = runtime.getClassFromPath("Enumerable");
         
         final RubyClass enmr;
-        if (runtime.is1_9()) {
+        if (runtime.is1_9() || runtime.is2_0()) {
             enmr = runtime.defineClass("Enumerator", runtime.getObject(), ENUMERATOR_ALLOCATOR);
         } else {
             enmr = enm.defineClassUnder("Enumerator", runtime.getObject(), ENUMERATOR_ALLOCATOR);

--- a/core/src/main/java/org/jruby/RubyProc.java
+++ b/core/src/main/java/org/jruby/RubyProc.java
@@ -34,12 +34,9 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby;
 
-import java.util.Arrays;
-
-import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.JumpException;
-import org.jruby.runtime.Helpers;
 import org.jruby.lexer.yacc.ISourcePosition;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.Arity;
@@ -47,14 +44,17 @@ import org.jruby.runtime.Binding;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.BlockBody;
 import org.jruby.runtime.ClassIndex;
+import org.jruby.runtime.Helpers;
 import org.jruby.runtime.MethodBlock;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
-import static org.jruby.CompatVersion.*;
-import org.jruby.runtime.Visibility;
-import org.jruby.runtime.backtrace.BacktraceElement;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.marshal.DataType;
+
+import java.util.Arrays;
+
+import static org.jruby.CompatVersion.RUBY1_8;
+import static org.jruby.CompatVersion.RUBY1_9;
 
 /**
  * @author  jpetersen
@@ -227,9 +227,12 @@ public class RubyProc extends RubyObject implements DataType {
     public IRubyObject call(ThreadContext context, IRubyObject[] args) {
         return call(context, args, null, Block.NULL_BLOCK);
     }
-    
-    private IRubyObject[] prepareProcArgs(ThreadContext context, IRubyObject[] args) {
-        Arity arity = block.arity();
+
+    /**
+     * Transforms the given arguments appropriately for the given arity (i.e. trimming to one arg for fixed
+     * arity of one, etc.)
+     */
+    public static IRubyObject[] prepareProcArgs(ThreadContext context, Arity arity, IRubyObject[] args) {
         boolean isFixed = arity.isFixed();
         int required = arity.required();
         int actual = args.length;
@@ -263,7 +266,7 @@ public class RubyProc extends RubyObject implements DataType {
         if (isLambda()) {
             block.arity().checkArity(context.runtime, args.length);
         }
-        if (isProc()) args = prepareProcArgs(context, args);
+        if (isProc()) args = prepareProcArgs(context, block.arity(), args);
 
         return call(context, args, null, blockCallArg);
     }

--- a/core/src/main/java/org/jruby/runtime/CallBlock.java
+++ b/core/src/main/java/org/jruby/runtime/CallBlock.java
@@ -27,8 +27,8 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby.runtime;
 
-import org.jruby.RubyArray;
 import org.jruby.RubyModule;
+import org.jruby.RubyProc;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -78,12 +78,12 @@ public class CallBlock extends BlockBody {
 
     @Override
     public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Binding binding, Block.Type type) {
-        return callback.call(context, new IRubyObject[] {RubyArray.newArrayLight(context.runtime, arg0, arg1)}, Block.NULL_BLOCK);
+        return yield(context, new IRubyObject[] {arg0, arg1}, Block.NULL_BLOCK);
     }
 
     @Override
     public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Binding binding, Block.Type type) {
-        return callback.call(context, new IRubyObject[] {RubyArray.newArrayLight(context.runtime, arg0, arg1, arg2)}, Block.NULL_BLOCK);
+        return yield(context, new IRubyObject[] {arg0, arg1, arg2}, Block.NULL_BLOCK);
     }
     
     public IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type) {
@@ -102,7 +102,13 @@ public class CallBlock extends BlockBody {
      */
     public IRubyObject yield(ThreadContext context, IRubyObject value, IRubyObject self, 
             RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
-        return callback.call(context, new IRubyObject[] {value}, Block.NULL_BLOCK);
+        IRubyObject[] args = value.respondsTo("to_a") ? value.convertToArray().toJavaArray() : new IRubyObject[] {value};
+        return yield(context, args, Block.NULL_BLOCK);
+    }
+
+    private IRubyObject yield(ThreadContext context, IRubyObject[] args, Block block) {
+        IRubyObject[] preppedArgs = RubyProc.prepareProcArgs(context, arity(), args);
+        return callback.call(context, preppedArgs, Block.NULL_BLOCK);
     }
     
     public StaticScope getStaticScope() {

--- a/spec/tags/1.9/ruby/core/enumerable/all_tags.txt
+++ b/spec/tags/1.9/ruby/core/enumerable/all_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#all? with block gathers initial args as elements when each yields multiple

--- a/spec/tags/1.9/ruby/core/enumerable/find_index_tags.txt
+++ b/spec/tags/1.9/ruby/core/enumerable/find_index_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#find_index gathers initial args as elements when each yields multiple

--- a/spec/tags/1.9/ruby/core/enumerable/none_tags.txt
+++ b/spec/tags/1.9/ruby/core/enumerable/none_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#none? with a block gathers initial args as elements when each yields multiple

--- a/spec/tags/1.9/ruby/core/enumerable/one_tags.txt
+++ b/spec/tags/1.9/ruby/core/enumerable/one_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#one? when passed a block gathers initial args as elements when each yields multiple

--- a/spec/tags/1.9/ruby/core/enumerable/zip_tags.txt
+++ b/spec/tags/1.9/ruby/core/enumerable/zip_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#zip gathers whole arrays as elements when each yields multiple


### PR DESCRIPTION
Here's the first follow-up (of probably a few) to #898, getting things even closer to full compatibility for `Enumerable`.

This makes `Enumerable#all`, `#none`, `#one`, and `#find_index` behave to
spec in the case of `#each` yielding multiple values (also untags `#zip_tags` since it's passing).

Note that this fix smells a touch too localized at the moment (what's so special about `CallBlock`'s `yield` that we prep the args there?  Isn't it likely that there's other places that need the same treatment?), but as I fix the rest of the Enumerable arg issues, I'm hoping that a good, holistic approach will reveal itself.

(Side note: I see Travis is red at the moment, but you can see a clean run on this branch [here](https://travis-ci.org/dmarcotte/jruby/builds/9630886))
