### PR TITLE
Add RVM step to build instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -38,6 +38,14 @@ updated gems.
 Running JRuby
 -------------
 
+*Note: For RVM users, you must first run:*
+
+```
+rvm use system
+```
+
+*to use the version of JRuby and the gems you just built*
+
 Once bootstrapped, JRuby can be run with the `build/jruby` executable. If
 the `jruby-launcher` gem installed successfully, this will be a native
 executable for your platform; otherwise, it will be a copy of the


### PR DESCRIPTION
Adds a reminder for RVM users to switch to system Ruby to the instructions in BUILDING.md

It was something silly that caught me out, so I figured it might be worth mentioning it (given how commonly used RVM is).
