### PR TITLE
In Ruby 2.0, String#lines returns an Array, rather than an Enumerator

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -82,6 +82,7 @@ import java.util.Locale;
 
 import static org.jruby.CompatVersion.RUBY1_8;
 import static org.jruby.CompatVersion.RUBY1_9;
+import static org.jruby.CompatVersion.RUBY2_0;
 import static org.jruby.RubyEnumerator.enumeratorize;
 import static org.jruby.anno.FrameField.BACKREF;
 import static org.jruby.runtime.Helpers.invokedynamic;
@@ -7177,6 +7178,18 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     public IRubyObject lines(ThreadContext context, IRubyObject arg, Block block) {
         return block.isGiven() ? each_lineCommon19(context, arg, block) : 
             enumeratorize(context.runtime, this, "lines", arg);
+    }
+
+    @JRubyMethod(name = "lines", compat = RUBY2_0)
+    public IRubyObject lines20(ThreadContext context, Block block) {
+        return block.isGiven() ? each_lineCommon19(context, block) :
+            enumeratorize(context.runtime, this, "lines").callMethod(context, "to_a");
+    }
+
+    @JRubyMethod(name = "lines", compat = RUBY2_0)
+    public IRubyObject lines20(ThreadContext context, IRubyObject arg, Block block) {
+        return block.isGiven() ? each_lineCommon19(context, arg, block) :
+            enumeratorize(context.runtime, this, "lines", arg).callMethod(context, "to_a");
     }
 
     private IRubyObject each_lineCommon19(ThreadContext context, Block block) {


### PR DESCRIPTION
Ruby 2.0 has changed the return type of String#lines to Array, from Enumerator. The difference in behaviour between MRI 2.0.0 and JRuby 1.7.4 with the --2.0 argument supplied is:

```
In MRI 2.0.0-p247:
sinjo@widdershins:~/projects/jruby-file-encoding$ rvm use 2.0.0
Using /home/sinjo/.rvm/gems/ruby-2.0.0-p247

sinjo@widdershins:~/projects/jruby-file-encoding$ ./demo input_file.txt 
["first line\r\n", "second line\r\n", "third line"]
"first line\r\n"

-----

In JRuby 1.7.4 with JRUBY_OPTS=--2.0:
sinjo@widdershins:~/projects/jruby-file-encoding$ rvm use jruby
Using /home/sinjo/.rvm/gems/jruby-1.7.4

sinjo@widdershins:~/projects/jruby-file-encoding$ ./demo input_file.txt 
[#<Enumerator: "first line\r\nsecond line\r\nthird line":lines>]
#<Enumerator: "first line\r\nsecond line\r\nthird line":lines>
```

Output taken from [this gist](https://gist.github.com/Sinjo/6125035)
