### PR TITLE
remove rspec should also use let for input stream

### DIFF
--- a/spec/java_integration/addons/io_spec.rb
+++ b/spec/java_integration/addons/io_spec.rb
@@ -2,13 +2,14 @@ require File.dirname(__FILE__) + "/../spec_helper"
 require 'tempfile'
 
 describe "Ruby IO" do
-  it "should be able to get an IO from a java.io.InputStream" do
-    io = java.io.ByteArrayInputStream.new("1234567890".to_java_bytes).to_io
+  let(:input_number){"1234567890"}
+  it "gets an IO from a java.io.InputStream" do
+    io = java.io.ByteArrayInputStream.new(input_number.to_java_bytes).to_io
     io.class.should == IO
     io.read(5).should == "12345"
   end
   
-  it "should be able to get an IO from a java.io.OutputStream" do
+  it "gets an IO from a java.io.OutputStream" do
     output = java.io.ByteArrayOutputStream.new
     io = output.to_io
     io.class.should == IO
@@ -17,7 +18,7 @@ describe "Ruby IO" do
     String.from_java_bytes(output.to_byte_array).should == "12345"
   end
 
-  it "should be coercible to java.io.InputStream with IO#to_inputstream" do
+  it "coercible to java.io.InputStream with IO#to_inputstream" do
     file = File.open(__FILE__)
     first_ten = file.read(10)
     file.seek(0)
@@ -29,12 +30,12 @@ describe "Ruby IO" do
     String.from_java_bytes(bytes).should == first_ten
   end
 
-  it "should be coercible to java.io.OutputStream with IO#to_outputstream" do
+  it "coercible to java.io.OutputStream with IO#to_outputstream" do
     file = Tempfile.new("io_spec")
     stream = file.to_outputstream
     java.io.OutputStream.should === stream 
     
-    bytes = "1234567890".to_java_bytes
+    bytes = input_number.to_java_bytes
     stream.write(bytes)
     stream.flush
     file.seek(0)
@@ -42,8 +43,8 @@ describe "Ruby IO" do
     str.should == String.from_java_bytes(bytes)
   end
 
-  it "should be able to get an IO from a java.nio.channels.Channel" do
-    input = java.io.ByteArrayInputStream.new("1234567890".to_java_bytes)
+  it "gets an IO from a java.nio.channels.Channel" do
+    input = java.io.ByteArrayInputStream.new(input_number.to_java_bytes)
     channel = java.nio.channels.Channels.newChannel(input)
     io = channel.to_io
     io.class.should == IO
@@ -58,12 +59,12 @@ describe "Ruby IO" do
     String.from_java_bytes(output.to_byte_array).should == "12345"
   end
 
-  it "should be coercible to java.nio.channels.Channel with IO#to_channel" do
+  it "coercible to java.nio.channels.Channel with IO#to_channel" do
     file = Tempfile.new("io_spec")
     channel = file.to_channel
     java.nio.channels.Channel.should === channel 
     
-    bytes = java.nio.ByteBuffer.wrap("1234567890".to_java_bytes)
+    bytes = java.nio.ByteBuffer.wrap(input_number.to_java_bytes)
     channel.write(bytes)
     file.seek(0)
     str = file.read(10)


### PR DESCRIPTION
We can skip not use of "should" in rspec  `it{}` message. also use let now it will replace all the input number by just one predeclaration.
