### PR TITLE
rspec test cases for mutex 'sleep'

### DIFF
--- a/spec/ruby/shared/mutex/sleep.rb
+++ b/spec/ruby/shared/mutex/sleep.rb
@@ -1,0 +1,19 @@
+describe :mutex_sleep, :shared => true do
+  it "sleeps timeout seconds" do
+    m = Mutex.new
+    m.lock
+    expect(m.sleep(1)).to eq(1)
+  end
+
+  it "raises ThreadError if mutex was not locked by the current thread" do
+    m = Mutex.new
+    expect{m.sleep}.to raise_error(ThreadError)
+  end
+
+  it "checkes when the thread is next woken up, it will attempt to reacquire the lock." do
+    m = Mutex.new
+    m.lock
+    m.sleep(1)
+    expect {m.locked?}.to be_true
+  end	
+end	


### PR DESCRIPTION
I saw that there was test cases for synchronize,lock,unlock but not for sleep
I have implemented some rspec test cases for the 'sleep' method of Mutex.

Also use <b>expect</b> rather than <b>should</b>
Thanks 
