### PR TITLE
Ruby 2.0 parser doesn't intern symbol strings in literal symbol array

### DIFF
--- a/core/src/main/java/org/jruby/parser/ParserSupport.java
+++ b/core/src/main/java/org/jruby/parser/ParserSupport.java
@@ -1147,7 +1147,7 @@ public class ParserSupport {
     
     public Node asSymbol(ISourcePosition position, Node value) {
         // FIXME: This might have an encoding issue since toString generally uses iso-8859-1
-        if (value instanceof StrNode) return new SymbolNode(position, ((StrNode) value).getValue().toString());
+        if (value instanceof StrNode) return new SymbolNode(position, ((StrNode) value).getValue().toString().intern());
         
         return new DSymbolNode(position, (DStrNode) value);
     }


### PR DESCRIPTION
Symbols created using a literal symbol array don't have the same identities as the same symbols created outside of a literal symbol array:

```
$ JRUBY_OPTS="--2.0" jirb
2.0.0-p247 :001 > [JRUBY_VERSION, RUBY_VERSION]
 => ["1.7.5.dev", "2.0.0"]
2.0.0-p247 :002 > %i(foo).include?(:foo)
 => false
```

org.jruby.parser.ParserSupport#asSymbol is not interning. This pull request adds the intern() call.
