### PR TITLE
Always compute Enumerable#count through enumeration for 1.9+

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -121,7 +121,16 @@ public class RubyEnumerable {
         }
     }
 
-    @JRubyMethod
+    @JRubyMethod(name = "count", compat = CompatVersion.RUBY1_8)
+    public static IRubyObject count18(ThreadContext context, IRubyObject self, final Block block) {
+        if (!block.isGiven() && self.respondsTo("size")) {
+            return self.callMethod(context, "size");
+        }
+
+        return count(context, self, block);
+    }
+
+    @JRubyMethod(name = "count", compat = CompatVersion.RUBY1_9)
     public static IRubyObject count(ThreadContext context, IRubyObject self, final Block block) {
         final Ruby runtime = context.runtime;
         final int result[] = new int[] { 0 };
@@ -134,8 +143,6 @@ public class RubyEnumerable {
                 }
             });
         } else {
-            if (self.respondsTo("size")) return self.callMethod(context, "size");
-            
             each(context, self, new JavaInternalBlockBody(runtime, context, "Enumerable#count", Arity.NO_ARGUMENTS) {
                 public IRubyObject yield(ThreadContext context, IRubyObject unusedValue) {
                     result[0]++;
@@ -145,8 +152,13 @@ public class RubyEnumerable {
         }
         return RubyFixnum.newFixnum(runtime, result[0]);
     }
-    
-    @JRubyMethod
+
+    @JRubyMethod(name = "count", compat = CompatVersion.RUBY1_8)
+    public static IRubyObject count18(ThreadContext context, IRubyObject self, final IRubyObject methodArg, final Block block) {
+        return count(context, self, methodArg, block);
+    }
+
+    @JRubyMethod(name = "count", compat = CompatVersion.RUBY1_9)
     public static IRubyObject count(ThreadContext context, IRubyObject self, final IRubyObject methodArg, final Block block) {
         final Ruby runtime = context.runtime;
         final int result[] = new int[] { 0 };


### PR DESCRIPTION
Looks like MRI [dropped the `#size` optimization in `#count`](https://github.com/ruby/ruby/commit/c0a0aa0c47f2cd5c97a35effb8b073eeb84b7d2d) in 1.9.2.  Comparing the [1.8 doc](http://ruby-doc.org/core-1.8.7/Enumerable.html#method-i-count) to the [2.0 doc](http://ruby-doc.org/core-2.0.0/Enumerable.html#method-i-count) also shows this is the intended behavior (interestingly, the [1.9 doc](http://ruby-doc.org/core-1.9.3/Enumerable.html#method-i-count) seems to be out of date)

Update to match that behavior (also fixes #922).
