### PR TITLE
YAML file fails to load if JVM character set is MS932 (common on Windows)

### DIFF
--- a/core/src/main/java/org/jruby/ext/psych/PsychParser.java
+++ b/core/src/main/java/org/jruby/ext/psych/PsychParser.java
@@ -76,7 +76,7 @@ import org.jruby.util.ByteList;
 public class PsychParser extends RubyObject {
 
     private static final Logger LOG = LoggerFactory.getLogger("PsychParser");
-
+    
     public static void initPsychParser(Ruby runtime, RubyModule psych) {
         RubyClass psychParser = runtime.defineClassUnder("Parser", runtime.getObject(), new ObjectAllocator() {
             public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
@@ -110,7 +110,7 @@ public class PsychParser extends RubyObject {
 
         return stringFor(runtime, value, tainted);
     }
-
+    
     private RubyString stringFor(Ruby runtime, String value, boolean tainted) {
         Encoding encoding = runtime.getDefaultInternalEncoding();
         if (encoding == null) {
@@ -124,12 +124,12 @@ public class PsychParser extends RubyObject {
 
         ByteList bytes = new ByteList(value.getBytes(charset), encoding);
         RubyString string = RubyString.newString(runtime, bytes);
-
+        
         string.setTaint(tainted);
-
+        
         return string;
     }
-
+    
     private StreamReader readerFor(ThreadContext context, IRubyObject yaml) {
         Ruby runtime = context.runtime;
 
@@ -180,7 +180,7 @@ public class PsychParser extends RubyObject {
                     handleDocumentStart(context, (DocumentStartEvent) event, tainted, handler);
                 } else if (event.is(ID.DocumentEnd)) {
                     IRubyObject notExplicit = runtime.newBoolean(!((DocumentEndEvent) event).getExplicit());
-
+                    
                     invoke(context, handler, "end_document", notExplicit);
                 } else if (event.is(ID.Alias)) {
                     IRubyObject alias = stringOrNilFor(runtime, ((AliasEvent)event).getAnchor(), tainted);
@@ -198,7 +198,7 @@ public class PsychParser extends RubyObject {
                     invoke(context, handler, "end_mapping");
                 } else if (event.is(ID.StreamEnd)) {
                     invoke(context, handler, "end_stream");
-
+                    
                     break;
                 }
             }
@@ -225,7 +225,7 @@ public class PsychParser extends RubyObject {
 
         return this;
     }
-
+    
     private void handleDocumentStart(ThreadContext context, DocumentStartEvent dse, boolean tainted, IRubyObject handler) {
         Ruby runtime = context.runtime;
         DumperOptions.Version _version = dse.getVersion();
@@ -233,7 +233,7 @@ public class PsychParser extends RubyObject {
         IRubyObject version = versionInts == null ?
             RubyArray.newArray(runtime) :
             RubyArray.newArray(runtime, runtime.newFixnum(versionInts[0]), runtime.newFixnum(versionInts[1]));
-
+        
         Map<String, String> tagsMap = dse.getTags();
         RubyArray tags = RubyArray.newArray(runtime);
         if (tagsMap != null && tagsMap.size() > 0) {
@@ -248,7 +248,7 @@ public class PsychParser extends RubyObject {
 
         invoke(context, handler, "start_document", version, tags, notExplicit);
     }
-
+    
     private void handleMappingStart(ThreadContext context, MappingStartEvent mse, boolean tainted, IRubyObject handler) {
         Ruby runtime = context.runtime;
         IRubyObject anchor = stringOrNilFor(runtime, mse.getAnchor(), tainted);
@@ -258,7 +258,7 @@ public class PsychParser extends RubyObject {
 
         invoke(context, handler, "start_mapping", anchor, tag, implicit, style);
     }
-
+        
     private void handleScalar(ThreadContext context, ScalarEvent se, boolean tainted, IRubyObject handler) {
         Ruby runtime = context.runtime;
         IRubyObject anchor = stringOrNilFor(runtime, se.getAnchor(), tainted);
@@ -271,7 +271,7 @@ public class PsychParser extends RubyObject {
         invoke(context, handler, "scalar", val, anchor, tag, plain_implicit,
                 quoted_implicit, style);
     }
-
+    
     private void handleSequenceStart(ThreadContext context, SequenceStartEvent sse, boolean tainted, IRubyObject handler) {
         Ruby runtime = context.runtime;
         IRubyObject anchor = stringOrNilFor(runtime, sse.getAnchor(), tainted);
@@ -341,7 +341,7 @@ public class PsychParser extends RubyObject {
             default: return 0; // any
         }
     }
-
+    
     private static int translateFlowStyle(Boolean flowStyle) {
         if (flowStyle == null) return 0; // any
 


### PR DESCRIPTION
I fail to load yaml file in windows7.

"InputStreamReader" is using "Charset.defaultCharset"
https://github.com/jruby/jruby/blob/master/core/src/main/java/org/jruby/ext/psych/PsychParser.java#L150
I expect that  this is causing the problem.
#### env

```
c:\workspace\yaml171>jruby -v
jruby 1.7.5.dev (1.9.3p392) 2013-09-09 f87088b on Java HotSpot(TM) Client VM 1.7.0_17-b02 [Windows 7-x86]
c:\workspace\yaml171>jruby -e "import java.nio.charset.Charset; p Charset.defaultCharset()"
#<Java::SunNioCsExt::MS932:0x181af25>
```
#### case

``` ruby
#sample.rb

# -*- coding: utf-8 -*-
require 'yaml'
path = File.expand_path "../sample.yaml", __FILE__
p YAML.load_file(path)
```

``` yml
# sample.yaml
ja:
  hoge: "テストほげ"
```

```
c:\workspace\yaml171>jruby sample.rb
Psych::SyntaxError: (c:/workspace/yaml171/sample.yaml): found unexpected end of stream while scanning a quoted scalar at line 3 column 1
         parse at org/jruby/ext/psych/PsychParser.java:212
  parse_stream at C:/workspace/sandbox/jruby/lib/ruby/shared/psych.rb:205
         parse at C:/workspace/sandbox/jruby/lib/ruby/shared/psych.rb:153
          load at C:/workspace/sandbox/jruby/lib/ruby/shared/psych.rb:129
     load_file at C:/workspace/sandbox/jruby/lib/ruby/shared/psych.rb:299
          open at org/jruby/RubyIO.java:1185
     load_file at C:/workspace/sandbox/jruby/lib/ruby/shared/psych.rb:299
        (root) at sample.rb:4
```
