### PR TITLE
Fix string representation of an Edge object

### DIFF
--- a/core/src/main/java/org/jruby/ir/util/Edge.java
+++ b/core/src/main/java/org/jruby/ir/util/Edge.java
@@ -25,10 +25,10 @@ public class Edge<T> {
     public Object getType() {
         return type;
     }
-    
+
     @Override
     public String toString() {
-        return "<" + source.getID() + " --> " + 
-                destination.getID() + (type == null ? "" : "> (" + type + ")");
+        return "<" + source.getID() + " --> " +
+                destination.getID() + ">" + (type == null ? "" : " (" + type + ")");
     }
 }

--- a/spec/ir/directed_graph/edge_spec.rb
+++ b/spec/ir/directed_graph/edge_spec.rb
@@ -1,0 +1,26 @@
+import 'org.jruby.ir.util.Edge'
+import 'org.jruby.ir.util.Vertex'
+import 'org.jruby.ir.util.DirectedGraph'
+
+describe "Edge" do
+
+  before do
+    @graph = DirectedGraph.new
+  end
+
+  describe "toString" do
+    context "When edge type is not null" do
+      it "represents edge with type" do
+        edge  = Edge.new(Vertex.new(@graph, "foo", 1), Vertex.new(@graph, "bar", 2), "baz")
+        expect(edge.toString).to eq "<1 --> 2> (baz)"
+      end
+    end
+
+    context "When edge type is null" do
+      it "represents edge without type" do
+        edge  = Edge.new(Vertex.new(@graph, "foo", 1), Vertex.new(@graph, "bar", 2), nil)
+        expect(edge.toString).to eq "<1 --> 2>"
+      end
+    end
+  end
+end


### PR DESCRIPTION
- If edge has a non-null type, then string representation is
  '<1 --> 2> (baz)', where 1 and 2 are vertices and baz is edge type
- With null edge type, it is '<1 --> 2'
- After this commit, with null type, '<1 --> 2>'
- Specs added
