### PR TITLE
Fix italics syntax in BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -46,7 +46,7 @@ Running JRuby
 rvm use system
 ```
 
-*to make sure you do not use another Ruby's gems or execute another Ruby implementation.
+*to make sure you do not use another Ruby's gems or execute another Ruby implementation.*
 
 Once bootstrapped, JRuby can be run with the `build/jruby` executable. If
 the `jruby-launcher` gem installed successfully, this will be a native


### PR DESCRIPTION
Really tiny fix, but a closing asterisk was missed in a part of BUILDING.md which should be in italics.
