### PR TITLE
Allow whitespace between -> and () in lambdas in 2.0

### DIFF
--- a/core/src/main/java/org/jruby/lexer/yacc/RubyYaccLexer.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/RubyYaccLexer.java
@@ -1833,6 +1833,10 @@ public class RubyYaccLexer {
                     result = Tokens.tLPAREN_ARG;
                 }
             }
+
+            if (isTwoZero && token == Tokens.tLAMBDA) {
+                result = Tokens.tLPAREN2;
+            }
         }
 
         parenNest++;


### PR DESCRIPTION
In Ruby 2.0, you can have a space between -> and () in lambdas (this was not allowed in 1.9 and earlier). This patch modifies the lexer to allow this in --2.0 mode.

I've added specs to RubySpec to test this in rubyspec/rubyspec#251
