### PR TITLE
Fixes JRuby #1047 - incorrect test for whether a kw arg was provided.

### DIFF
--- a/core/src/main/java/org/jruby/ast/ArgsNode.java
+++ b/core/src/main/java/org/jruby/ast/ArgsNode.java
@@ -485,7 +485,7 @@ public class ArgsNode extends Node {
                         String name = ((INameNode) kasgn).getName();
                         RubySymbol sym = runtime.newSymbol(name);
 
-                        if (keyValues.op_aref(context, sym).isNil()) {
+                        if (keyValues.has_key_p(sym).isFalse()) {
                             kasgn.interpret(runtime, context, self, Block.NULL_BLOCK);
                         } else {
                             IRubyObject value = keyValues.delete(context, sym, Block.NULL_BLOCK);


### PR DESCRIPTION
Formerly, the code attempted to extract the argument value from the
hash of provided values and test it against nil. This fails in the
case of an explicitly passed nil. The new version instead tests
whether the hash contains the desired key.

Fixes #1047
