### PR TITLE
Remove the special invokedynamic default case for IBM J9

### DIFF
--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -244,8 +244,8 @@ public class Options {
         _loadedOptions.add(option);
         return option;
     }
+
     private static boolean calculateInvokedynamicDefault() {
-        String vmName = SafePropertyAccessor.getProperty("java.vm.name", "").toLowerCase();
         String javaVersion = SafePropertyAccessor.getProperty("java.specification.version", "");
         if (!javaVersion.equals("") && new BigDecimal(javaVersion).compareTo(new BigDecimal("1.8")) >= 0) {
             return true;


### PR DESCRIPTION
Much like Oracle's JVM, IBM's J9 VM doesn't support invokedynamic very well until 1.8.

This commit removes the special case that enabled invokedynamic for some J9 version 1.7 releases.
