### PR TITLE
Fiber finalizer fix

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -2605,6 +2605,10 @@ public final class Ruby {
         return threadService;
     }
 
+    public boolean hasCurrentContext() {
+        return threadService.hasCurrentContext();
+    }
+
     public ThreadContext getCurrentContext() {
         return threadService.getCurrentContext();
     }

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -1078,20 +1078,21 @@ public class RubyThread extends RubyObject implements ExecutionContext {
 
     @JRubyMethod(name = {"kill", "exit", "terminate"})
     public IRubyObject kill() {
-        // need to reexamine this
-        RubyThread currentThread = getRuntime().getCurrentContext().getThread();
+        if (getRuntime().hasCurrentContext()) {
+            // need to reexamine this
+            RubyThread currentThread = getRuntime().getCurrentContext().getThread();
         
-        // If the killee thread is the same as the killer thread, just die
-        if (currentThread == this) throwThreadKill();
+            // If the killee thread is the same as the killer thread, just die
+            if (currentThread == this) throwThreadKill();
 
-        debug(this, "trying to kill");
+            debug(this, "trying to kill");
 
-        currentThread.pollThreadEvents();
+            currentThread.pollThreadEvents();
 
-        getRuntime().getThreadService().deliverEvent(new ThreadService.Event(currentThread, this, ThreadService.Event.Type.KILL));
+            getRuntime().getThreadService().deliverEvent(new ThreadService.Event(currentThread, this, ThreadService.Event.Type.KILL));
 
-        debug(this, "succeeded with kill");
-        
+            debug(this, "succeeded with kill");        
+        }
         return this;
     }
 

--- a/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
+++ b/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
@@ -208,6 +208,16 @@ public class ThreadService {
         return context;
     }
 
+    /**
+     * The getCurrentContext() method always returns a context, but sometimes
+     * we need to know if a context already exists without creating one.
+     *
+     * @return true if a context is set for the current thread, false otherwise
+     */
+    public boolean hasCurrentContext() {
+        return localContext.get() != null;
+    }
+
     /*
      * Used only for Fiber context management
      */
@@ -290,8 +300,10 @@ public class ThreadService {
     
     public synchronized void unregisterThread(RubyThread thread) {
         rubyThreadMap.remove(Thread.currentThread());
-        getCurrentContext().setThread(null);
-        localContext.set(null);
+        if (hasCurrentContext()) {
+            getCurrentContext().setThread(null);
+            localContext.set(null);
+        }
     }
     
     public void setCritical(boolean critical) {


### PR DESCRIPTION
ThreadFiber's finalizer was triggering the creation of a new ThreadFiber instance. So, for every ThreadFiber instance that got garbage collected another one was created.

This behavior can lead to the finalizer queue filling up as quickly as it's emptied under heavy memory pressure and the JVM grinding to a halt.

This fixes the issue with TorqueBox integration tests under JRuby 1.7.5 hanging when they didn't under 1.7.4.
