### PR TITLE
Return if we can’t get proper native handle.

### DIFF
--- a/core/src/main/java/org/jruby/runtime/ivars/VariableTableManager.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/VariableTableManager.java
@@ -333,6 +333,9 @@ public class VariableTableManager {
      */
     public final void setNativeHandle(RubyBasicObject self, Object value) {
         int index = getNativeHandleAccessorForRead().getIndex();
+        if(index == -1) {
+            return;
+        }
         setVariableInternal(realClass, self, index, value);
     }
 


### PR DESCRIPTION
This avoids a ArrayIndexOutOfBoundsException in case we got invalid
native handle. The program will still die, but it will now instead
return

  java.lang.RuntimeException: C extension initialized against invalid ruby
  runtime

as error.

..

I found this while debugging cext things. I guess I should throw changes related to cext (I managed to allow it to load extensions, still haven’t tested whether it works) to jruby-cext instead of this repository(I’ll do it after I manage to convert commits to that repo; I did my work using cext in this repo, as I didn’t know of that new repo before starting to fiddle with this). If so, maybe you should remove cext files and instead have something like README.cext which points to new repository. The copy in jruby repo does not work anyway.

If you don’t want this check and just let it fail when if fails, I won’t get mad :) 
