### PR TITLE
Ignore AccessControlException while setting network stack system property

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -131,6 +131,7 @@ import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.net.BindException;
 import java.nio.channels.ClosedChannelException;
+import java.security.AccessControlException;
 import java.security.SecureRandom;
 import java.util.*;
 import java.util.concurrent.Callable;
@@ -4493,10 +4494,18 @@ public final class Ruby {
     }
     
     private void setNetworkStack() {
-        if (config.getIPv4Preferred()) {
-            System.setProperty("java.net.preferIPv4Stack", "true");
-        } else {
-            System.setProperty("java.net.preferIPv4Stack", "false");
+        try {
+            if (config.getIPv4Preferred()) {
+                System.setProperty("java.net.preferIPv4Stack", "true");
+            } else {
+                System.setProperty("java.net.preferIPv4Stack", "false");
+            }
+        } catch (AccessControlException ace) {
+            if (isVerbose()) {
+                LOG.warn("warning: unable to set network stack system property due "
+                        + "to security restrictions, please set it manually as JVM "
+                        + "parameter (-Djava.net.preferIPv4Stack=true|false)");
+            }
         }
     }
 


### PR DESCRIPTION
Fixes Issue #1116. An instance of `org.jruby.Ruby` can now be created even if a security policy prevents setting the network stack system property. Instead of ignoring the exception if opted to log it on warn level if `verbose` is set to `true`.
