### PR TITLE
Backport assertion fixes to 1.7 branch

### DIFF
--- a/spec/compiler/general_spec.rb
+++ b/spec/compiler/general_spec.rb
@@ -41,15 +41,6 @@ end
 
 describe "JRuby's compiler" do
   include CompilerTestUtils
-  let(:base){"'0123456789A' =~ /(1)(2)(3)(4)(5)(6)(7)(8)(9)/; "}
-  let(:expected){[[1, 2, 3, 4, 5, 6, 7, 8],
-          [9, 10, 11, 12, 13, 14, 15, 16],
-          [17, 18, 19, 20, 21, 22, 23, 24],
-          [25, 26, 27, 28, 29, 30, 31, 32],
-          [33, 34, 35, 36, 37, 38, 39, 40],
-          [41, 42, 43, 44, 45, 46, 47, 48],
-          [49, 50, 51, 52, 53, 54, 55, 56],
-          [57, 58, 59, 60, 61, 62, 63, 64]]}
 
   StandardASMCompiler = org.jruby.compiler.impl.StandardASMCompiler
   ASTCompiler = is19 ? org.jruby.compiler.ASTCompiler19 : org.jruby.compiler.ASTCompiler
@@ -138,6 +129,7 @@ describe "JRuby's compiler" do
   end
   
   it "compiles backrefs" do
+    base = "'0123456789A' =~ /(1)(2)(3)(4)(5)(6)(7)(8)(9)/; "
     expect(compile_and_run(base + "$~")).to  be_a_kind_of MatchData
     expect(compile_and_run(base + "$`")).to eq '0'
     expect(compile_and_run(base + "$'")).to eq 'A'
@@ -402,6 +394,14 @@ describe "JRuby's compiler" do
         ary
     end
     EOS
+    expected = [[1, 2, 3, 4, 5, 6, 7, 8],
+                [9, 10, 11, 12, 13, 14, 15, 16],
+                [17, 18, 19, 20, 21, 22, 23, 24],
+                [25, 26, 27, 28, 29, 30, 31, 32],
+                [33, 34, 35, 36, 37, 38, 39, 40],
+                [41, 42, 43, 44, 45, 46, 47, 48],
+                [49, 50, 51, 52, 53, 54, 55, 56],
+                [57, 58, 59, 60, 61, 62, 63, 64]]
     expect(compile_and_run(big_triple_flip)).to  eq(expected)
   end
 


### PR DESCRIPTION
Backports the fixes from #1120 to the 1.7 maintenance branch.

cc @atambo
