### PR TITLE
Fix compatibility wiht Bouncy Castle 1.49.

### DIFF
--- a/ext/openssl/src/main/java/org/jruby/ext/openssl/x509store/PEMInputOutput.java
+++ b/ext/openssl/src/main/java/org/jruby/ext/openssl/x509store/PEMInputOutput.java
@@ -366,19 +366,19 @@ public class PEMInputOutput {
 
     private static PrivateKey derivePrivateKeyPBES2(EncryptedPrivateKeyInfo eIn, AlgorithmIdentifier algId, char[] password)
             throws GeneralSecurityException, InvalidCipherTextException {
-        PBES2Parameters pbeParams = new PBES2Parameters((ASN1Sequence) algId.getParameters());
+        PBES2Parameters pbeParams = PBES2Parameters.getInstance((ASN1Sequence) algId.getParameters());
         CipherParameters cipherParams = extractPBES2CipherParams(password, pbeParams);
 
         EncryptionScheme scheme = pbeParams.getEncryptionScheme();
         BufferedBlockCipher cipher;
         if (scheme.getAlgorithm().equals(PKCSObjectIdentifiers.RC2_CBC)) {
-            RC2CBCParameter rc2Params = RC2CBCParameter.getInstance((ASN1Sequence) scheme.getObject());
+            RC2CBCParameter rc2Params = RC2CBCParameter.getInstance(scheme);
             byte[] iv = rc2Params.getIV();
             CipherParameters param = new ParametersWithIV(cipherParams, iv);
             cipher = new PaddedBufferedBlockCipher(new CBCBlockCipher(new RC2Engine()));
             cipher.init(false, param);
         } else {
-            byte[] iv = ((ASN1OctetString) scheme.getObject()).getOctets();
+            byte[] iv = ASN1OctetString.getInstance(scheme).getOctets();
             CipherParameters param = new ParametersWithIV(cipherParams, iv);
             cipher = new PaddedBufferedBlockCipher(new CBCBlockCipher(new DESedeEngine()));
             cipher.init(false, param);


### PR DESCRIPTION
Hi,

I am trying to update JRuby packages in Fedora and it seems that JRuby is not compatible with Bouncy Castle 1.49:

```
[ERROR] /builddir/build/BUILD/jruby-1.7.5/ext/openssl/src/main/java/org/jruby/ext/openssl/x509store/PEMInputOutput.java:[369,36] error: PBES2Parameters(ASN1Sequence) has private access in PBES2Parameters
[ERROR] /builddir/build/BUILD/jruby-1.7.5/ext/openssl/src/main/java/org/jruby/ext/openssl/x509store/PEMInputOutput.java:[375,89] error: cannot find symbol
[ERROR] /builddir/build/BUILD/jruby-1.7.5/ext/openssl/src/main/java/org/jruby/ext/openssl/x509store/PEMInputOutput.java:[381,49] error: cannot find symbol
```

I come with this patch to fix the compatibility. I would appreciate if you can accept
