### PR TITLE
RubyNil.java: convert inspect() to correspond wanted symbol

### DIFF
--- a/core/src/main/java/org/jruby/RubyNil.java
+++ b/core/src/main/java/org/jruby/RubyNil.java
@@ -148,8 +148,8 @@ public class RubyNil extends RubyObject {
      *
      */
     @JRubyMethod
-    public static RubyString inspect(ThreadContext context, IRubyObject recv) {
-        return RubyString.newUSASCIIString(context.runtime, "nil");
+    public static  RubyString inspect(IRubyObject recv) {
+        return RubyString.newUSASCIIString(recv.getRuntime(), "nil");
     }
     
     /** nil_and


### PR DESCRIPTION
This removes errors like
java.lang.NoSuchMethodError: org.jruby.RubyNil.inspect
(Lorg/jruby/runtime/builtin/IRubyObject;)Lorg/jruby/RubyString;
## 

I have no idea what this in reality is about, but rake is throwing errors related to inspect() method (IIRC there was something else too what whined about this but can’t remember).

Thought I could inform you about this :) 

Actual error is as following:

```

smar@aaeru ~/P/r/antifraud (master) [1]> rake db:drop
rake aborted!
load error: active_support/core_ext/logger -- java.lang.NoSuchMethodError: org.jruby.RubyNil.inspect(Lorg/jruby/runtime/builtin/IRubyObject;)Lorg/jruby/RubyString;
org/jruby/RubyKernel.java:867:in `require'
org/jruby/RubyKernel.java:867:in `require'
org/jruby/RubyKernel.java:867:in `require'
org/jruby/RubyKernel.java:885:in `load'
/home/smar/Projektit/ruby/antifraud/Rakefile:1:in `(root)'
/home/smar/Projektit/ruby/antifraud/Rakefile:2:in `(root)'
org/jruby/RubyKernel.java:885:in `load'
(See full trace by running task with --trace)

smar@aaeru ~/P/r/antifraud (master) [1]> rake db:drop --trace
rake aborted!
load error: active_support/core_ext/logger -- java.lang.NoSuchMethodError: org.jruby.RubyNil.inspect(Lorg/jruby/runtime/builtin/IRubyObject;)Lorg/jruby/RubyString;
org/jruby/RubyKernel.java:867:in `require'
/home/smar/Paketit/scm/jruby/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:73:in `require'
/home/smar/Paketit/scm/jruby/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:71:in `require'
/home/smar/Paketit/scm/jruby/lib/ruby/gems/shared/gems/railties-3.2.15/lib/rails.rb:8:in `(root)'
org/jruby/RubyKernel.java:867:in `require'
/home/smar/Paketit/scm/jruby/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:73:in `require'
/home/smar/Paketit/scm/jruby/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:71:in `require'
/home/smar/Paketit/scm/jruby/lib/ruby/gems/shared/gems/standalone_migrations-2.1.1/lib/standalone_migrations.rb:1:in `(root)'
org/jruby/RubyKernel.java:867:in `require'
/home/smar/Paketit/scm/jruby/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:135:in `require'
/home/smar/Paketit/scm/jruby/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:133:in `require'
/home/smar/Paketit/scm/jruby/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:124:in `require'
/home/smar/Paketit/scm/jruby/lib/ruby/gems/shared/gems/standalone_migrations-2.1.1/lib/standalone_migrations.rb:5:in `(root)'
org/jruby/RubyKernel.java:885:in `load'
/home/smar/Projektit/ruby/antifraud/Rakefile:1:in `(root)'
/home/smar/Projektit/ruby/antifraud/Rakefile:2:in `(root)'
/home/smar/Paketit/scm/jruby/lib/ruby/shared/rake/rake_module.rb:1:in `(root)'
/home/smar/Paketit/scm/jruby/lib/ruby/shared/rake/rake_module.rb:25:in `load_rakefile'
/home/smar/Paketit/scm/jruby/lib/ruby/shared/rake/application.rb:637:in `raw_load_rakefile'
/home/smar/Paketit/scm/jruby/lib/ruby/shared/rake/application.rb:94:in `load_rakefile'
/home/smar/Paketit/scm/jruby/lib/ruby/shared/rake/application.rb:165:in `standard_exception_handling'
/home/smar/Paketit/scm/jruby/lib/ruby/shared/rake/application.rb:93:in `load_rakefile'
/home/smar/Paketit/scm/jruby/lib/ruby/shared/rake/application.rb:77:in `run'
org/jruby/RubyKernel.java:885:in `load'
/home/smar/Paketit/scm/jruby/bin/rake:23:in `(root)'
```
