### PR TITLE
Finish deversioning RubyKernel.java

### DIFF
--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -75,7 +75,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 
-import static org.jruby.CompatVersion.RUBY2_0;
 import org.jruby.anno.FrameField;
 import static org.jruby.anno.FrameField.BACKREF;
 import static org.jruby.anno.FrameField.BLOCK;


### PR DESCRIPTION
As discussed with @enebo on IRC, I've finished up deversioning RubyKernel.java. Where there are two versions of a method, I've left the old one intact but just calling through to the newer one (which I was told would keep merging with the jruby-1_7 branch easier on IRC).
