### PR TITLE
Do not wrap arg arrays in RubyArrays prematurely

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -137,14 +137,15 @@ public class RubyEnumerable {
         
         if (block.isGiven()) {
             each(context, self, new JavaInternalBlockBody(runtime, context, "Enumerable#count", Arity.OPTIONAL) {
-                public IRubyObject yield(ThreadContext context, IRubyObject arg) {
-                    if (block.yield(context, arg).isTrue()) result[0]++; 
+                public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
+                    IRubyObject packedArg = packEnumValues(context.runtime, args);
+                    if (block.yield(context, packedArg).isTrue()) result[0]++;
                     return runtime.getNil();
                 }
             });
         } else {
             each(context, self, new JavaInternalBlockBody(runtime, context, "Enumerable#count", Arity.NO_ARGUMENTS) {
-                public IRubyObject yield(ThreadContext context, IRubyObject unusedValue) {
+                public IRubyObject yield(ThreadContext context, IRubyObject[] unusedValue) {
                     result[0]++;
                     return runtime.getNil();
                 }
@@ -166,8 +167,9 @@ public class RubyEnumerable {
         if (block.isGiven()) runtime.getWarnings().warn(ID.BLOCK_UNUSED , "given block not used");
         
         each(context, self, new JavaInternalBlockBody(runtime, context, "Enumerable#count", Arity.ONE_REQUIRED) {
-            public IRubyObject yield(ThreadContext context, IRubyObject blockArg) {
-                if (blockArg.equals(methodArg)) result[0]++;
+            public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
+                IRubyObject packedArg = packEnumValues(context.runtime, args);
+                if (packedArg.equals(methodArg)) result[0]++;
                 
                 return runtime.getNil();
             }
@@ -208,9 +210,10 @@ public class RubyEnumerable {
         final RubyArray result = runtime.newArray();
 
         each(context, self, new JavaInternalBlockBody(runtime, Arity.OPTIONAL) {
-            public IRubyObject yield(ThreadContext context, IRubyObject arg) {
-                synchronized (result) { result.append(arg); }
-                block.yield(context, arg);
+            public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
+                IRubyObject packedArg = packEnumValues(context.runtime, args);
+                synchronized (result) { result.append(packedArg); }
+                block.yield(context, packedArg);
                 return runtime.getNil();            
             }
         });
@@ -240,9 +243,10 @@ public class RubyEnumerable {
         try {
             each(context, self, new JavaInternalBlockBody(runtime, Arity.ONE_REQUIRED) {
                 long i = len; // Atomic ?
-                public IRubyObject yield(ThreadContext context, IRubyObject arg) {
+                public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
                     synchronized (result) {
-                        result.append(arg);
+                        IRubyObject packedArg = packEnumValues(context.runtime, args);
+                        result.append(packedArg);
                         if (--i == 0) throw JumpException.SPECIAL_JUMP; 
                     }
                     
@@ -265,9 +269,10 @@ public class RubyEnumerable {
 
         try {
             each(context, self, new JavaInternalBlockBody(runtime, Arity.OPTIONAL) {
-                public IRubyObject yield(ThreadContext context, IRubyObject arg) {
-                    if (!block.yield(context, arg).isTrue()) throw JumpException.SPECIAL_JUMP;
-                    synchronized (result) { result.append(arg); }
+                public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
+                    IRubyObject packedArg = packEnumValues(context.runtime, args);
+                    if (!block.yield(context, packedArg).isTrue()) throw JumpException.SPECIAL_JUMP;
+                    synchronized (result) { result.append(packedArg); }
                     return runtime.getNil();
                 }
             });
@@ -287,13 +292,14 @@ public class RubyEnumerable {
         try {
             each(context, self, new JavaInternalBlockBody(runtime, Arity.NO_ARGUMENTS) {
                 long i = len; // Atomic ?
-                public IRubyObject yield(ThreadContext context, IRubyObject arg) {
+                public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
+                    IRubyObject packedArg = packEnumValues(context.runtime, args);
                     synchronized (result) {
                         if (i == 0) {
                             // While iterating over an RubyEnumerator, "arg"
                             // gets overwritten by the new value, leading to JRUBY-6892.
                             // So call .dup() whenever appropriate.
-                            result.append(arg.isImmediate() ? arg : arg.dup());
+                            result.append(packedArg.isImmediate() ? packedArg : packedArg.dup());
                         } else {
                             --i;
                         }
@@ -318,9 +324,10 @@ public class RubyEnumerable {
         try {
             each(context, self, new JavaInternalBlockBody(runtime, context, "Enumerable#drop_while", Arity.OPTIONAL) {
                 boolean memo = false;
-                public IRubyObject yield(ThreadContext context, IRubyObject arg) {
-                    if (!memo && !block.yield(context, arg).isTrue()) memo = true;
-                    if (memo) synchronized (result) { result.append(arg); }
+                public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
+                    IRubyObject packedArg = packEnumValues(context.runtime, args);
+                    if (!memo && !block.yield(context, packedArg).isTrue()) memo = true;
+                    if (memo) synchronized (result) { result.append(packedArg); }
                     return runtime.getNil();
                 }
             });
@@ -335,8 +342,9 @@ public class RubyEnumerable {
 
         try {
             each(context, self, new JavaInternalBlockBody(context.runtime, context, null, Arity.ONE_REQUIRED) {
-                public IRubyObject yield(ThreadContext context, IRubyObject arg) {
-                    holder[0] = arg;
+                public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
+                    IRubyObject packedArg = packEnumValues(context.runtime, args);
+                    holder[0] = packedArg;
                     throw JumpException.SPECIAL_JUMP;
                 }
             });
@@ -357,8 +365,9 @@ public class RubyEnumerable {
         try {
             each(context, self, new JavaInternalBlockBody(runtime, context, null, Arity.ONE_REQUIRED) {
                 private int iter = RubyNumeric.fix2int(num);                
-                public IRubyObject yield(ThreadContext context, IRubyObject arg) {
-                    result.append(arg);
+                public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
+                    IRubyObject packedArg = packEnumValues(context.runtime, args);
+                    result.append(packedArg);
                     if (iter-- == 1) throw JumpException.SPECIAL_JUMP;
                     return runtime.getNil();                
                 }
@@ -426,10 +435,11 @@ public class RubyEnumerable {
 
             each(context, self, new JavaInternalBlockBody(runtime, Arity.OPTIONAL) {
                 AtomicInteger i = new AtomicInteger(0);
-                public IRubyObject yield(ThreadContext context, IRubyObject arg) {
+                public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
+                    IRubyObject packedArg = packEnumValues(context.runtime, args);
                     IRubyObject[] myVandC = valuesAndCriteriaArray[i.getAndIncrement()];
-                    myVandC[0] = arg;
-                    myVandC[1] = block.yield(context, arg);
+                    myVandC[0] = packedArg;
+                    myVandC[1] = block.yield(context, packedArg);
                     return runtime.getNil();
                 }
             });
@@ -930,7 +940,7 @@ public class RubyEnumerable {
         final Ruby runtime = context.runtime;
         RubyEnumerable.callEach(runtime, context, self, Arity.OPTIONAL, new BlockCallback() {
             public IRubyObject call(ThreadContext ctx, IRubyObject[] largs, Block blk) {
-                block.call(ctx, new IRubyObject[]{runtime.newArray(packEnumValues(runtime, largs), arg)});
+                block.call(ctx, new IRubyObject[]{ packEnumValues(runtime, largs), arg });
                 return runtime.getNil();
             }
         });
@@ -985,7 +995,7 @@ public class RubyEnumerable {
 
         RubyEnumerable.callEach(runtime, context, self, Arity.OPTIONAL, new BlockCallback() {
             public IRubyObject call(ThreadContext ctx, IRubyObject[] largs, Block blk) {
-                result[0].append(packEnumValues(runtime,largs));
+                result[0].append(packEnumValues(runtime, largs));
                 if (result[0].size() == size) {
                     block.yield(ctx, result[0]);
                     result[0] = runtime.newArray(size);
@@ -1309,9 +1319,9 @@ public class RubyEnumerable {
                     public IRubyObject call(ThreadContext ctx, IRubyObject[] largs, Block blk) {
                         checkContext(localContext, ctx, "none?");
                         IRubyObject larg = packEnumValues(runtime, largs);
-                        if (block.yield(ctx, larg).isTrue()) throw JumpException.SPECIAL_JUMP; 
+                        if (block.yield(ctx, larg).isTrue()) throw JumpException.SPECIAL_JUMP;
                         return runtime.getNil();
-                        
+
                     }
                 });
             } else {
@@ -1443,15 +1453,17 @@ public class RubyEnumerable {
         try {
             if (block.isGiven()) {
                 each(context, self, new JavaInternalBlockBody(runtime, context, "Enumerable#any?", block.arity()) {
-                    public IRubyObject yield(ThreadContext context, IRubyObject arg) {
-                        if (block.yield(context, arg).isTrue()) throw JumpException.SPECIAL_JUMP;
+                    public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
+                        IRubyObject packedArg = packEnumValues(context.runtime, args);
+                        if (block.yield(context, packedArg).isTrue()) throw JumpException.SPECIAL_JUMP;
                         return runtime.getNil();
                     }
                 });
             } else {
                 each(context, self, new JavaInternalBlockBody(runtime, context, "Enumerable#any?", Arity.ONE_REQUIRED) {
-                    public IRubyObject yield(ThreadContext context, IRubyObject arg) {
-                        if (arg.isTrue()) throw JumpException.SPECIAL_JUMP;
+                    public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
+                        IRubyObject packedArg = packEnumValues(context.runtime, args);
+                        if (packedArg.isTrue()) throw JumpException.SPECIAL_JUMP;
                         return runtime.getNil();
                     }
                 });
@@ -1779,9 +1791,9 @@ public class RubyEnumerable {
                         if(arg.state.isNil()) {
                             v = arg.categorize.callMethod(ctx, "call", i);
                         } else {
-                            v = arg.categorize.callMethod(ctx, "call", new IRubyObject[]{i, arg.state});  
+                            v = arg.categorize.callMethod(ctx, "call", new IRubyObject[]{i, arg.state});
                         }
-                        
+
                         if(v == alone) {
                             if(!arg.prev_value.isNil()) {
                                 arg.yielder.callMethod(ctx, "<<", runtime.newArray(arg.prev_value, arg.prev_elts));

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -36,24 +36,17 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby;
 
-import org.jruby.parser.StaticScope;
-import org.jruby.runtime.Binding;
-import org.jruby.runtime.Block.Type;
-import static org.jruby.util.StringSupport.codeLength;
-import static org.jruby.util.StringSupport.codePoint;
-
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.ReentrantLock;
-
 import org.jcodings.Encoding;
-import org.jcodings.specific.ISO8859_1Encoding;
 import org.jcodings.specific.USASCIIEncoding;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.common.IRubyWarnings.ID;
+import org.jruby.parser.StaticScope;
 import org.jruby.runtime.Arity;
+import org.jruby.runtime.Binding;
 import org.jruby.runtime.Block;
+import org.jruby.runtime.Block.Type;
 import org.jruby.runtime.BlockBody;
 import org.jruby.runtime.CallSite;
 import org.jruby.runtime.ClassIndex;
@@ -67,6 +60,12 @@ import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.util.ByteList;
 import org.jruby.util.PerlHash;
 import org.jruby.util.SipHashInline;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.jruby.util.StringSupport.codeLength;
+import static org.jruby.util.StringSupport.codePoint;
 
 /**
  * Represents a Ruby symbol (e.g. :bar)
@@ -442,12 +441,9 @@ public class RubySymbol extends RubyObject implements MarshalEncoding {
             }
 
             @Override
-            public IRubyObject yield(ThreadContext context, IRubyObject value, IRubyObject self,
+            public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self,
                     RubyModule klass, boolean aValue, Binding binding, Block.Type type, Block block) {
-                RubyArray array = aValue && value instanceof RubyArray ?
-                        (RubyArray) value : ArgsUtil.convertToRubyArray(context.runtime, value, false);
-
-                return yieldInner(context, array, block);
+                return yieldInner(context, context.runtime.newArrayNoCopyLight(args), block);
             }
 
             @Override
@@ -462,11 +458,8 @@ public class RubySymbol extends RubyObject implements MarshalEncoding {
             }
 
             @Override
-            public IRubyObject yield(ThreadContext context, IRubyObject value, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Type type) {
-                RubyArray array = aValue && value instanceof RubyArray ?
-                        (RubyArray) value : ArgsUtil.convertToRubyArray(context.runtime, value, false);
-
-                return yieldInner(context, array, Block.NULL_BLOCK);
+            public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Type type) {
+                return yieldInner(context, context.runtime.newArrayNoCopyLight(args), Block.NULL_BLOCK);
             }
 
             @Override

--- a/core/src/main/java/org/jruby/runtime/Block.java
+++ b/core/src/main/java/org/jruby/runtime/Block.java
@@ -41,6 +41,7 @@
 
 package org.jruby.runtime;
 
+import org.jruby.RubyArray;
 import org.jruby.RubyModule;
 import org.jruby.RubyProc;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -142,32 +143,22 @@ public final class Block {
         return body.yield(context, value, binding, type);
     }
 
-    @Deprecated
-    public IRubyObject yield(ThreadContext context, IRubyObject value, IRubyObject self, 
-            RubyModule klass, boolean aValue) {
-        return body.yield(context, value, self, klass, aValue, binding, type);
-    }
-
     public IRubyObject yieldNonArray(ThreadContext context, IRubyObject value, IRubyObject self,
             RubyModule klass) {
-        return body.yield(context, value, self, klass, false, binding, type);
+        return body.yield(context, new IRubyObject[] { value }, self, klass, true, binding, type);
     }
 
     public IRubyObject yieldArray(ThreadContext context, IRubyObject value, IRubyObject self,
             RubyModule klass) {
-        return body.yield(context, value, self, klass, true, binding, type);
+        IRubyObject[] args;
+        if (!(value instanceof RubyArray)) {
+            args = new IRubyObject[] { value };
+        } else {
+            args = value.convertToArray().toJavaArray();
+        }
+        return body.yield(context, args, self, klass, true, binding, type);
     }
 
-    @Deprecated
-    public IRubyObject yield(ThreadContext context, IRubyObject value, boolean aValue) {
-        return body.yield(context, value, null, null, aValue, binding, type);
-    }
-
-    @Deprecated
-    public IRubyObject yield(ThreadContext context, boolean aValue) {
-        return body.yield(context, null, null, null, aValue, binding, type);
-    }
-    
     public Block cloneBlock() {
         Block newBlock = new Block(body, binding);
         

--- a/core/src/main/java/org/jruby/runtime/BlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/BlockBody.java
@@ -63,26 +63,26 @@ public abstract class BlockBody {
     public IRubyObject call(ThreadContext context, IRubyObject[] args, Binding binding, Block.Type type) {
         args = prepareArgumentsForCall(context, args, type);
 
-        return yield(context, RubyArray.newArrayNoCopy(context.runtime, args), null, null, true, binding, type);
+        return yield(context, args, null, null, true, binding, type);
     }
 
     public IRubyObject call(ThreadContext context, IRubyObject[] args, Binding binding,
             Block.Type type, Block block) {
         args = prepareArgumentsForCall(context, args, type);
 
-        return yield(context, RubyArray.newArrayNoCopy(context.runtime, args), null, null, true, binding, type, block);
+        return yield(context, args, null, null, true, binding, type, block);
     }
 
     public abstract IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type);
 
-    public abstract IRubyObject yield(ThreadContext context, IRubyObject value, IRubyObject self,
-            RubyModule klass, boolean aValue, Binding binding, Block.Type type);
+    public abstract IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self,
+                                      RubyModule klass, boolean aValue, Binding binding, Block.Type type);
 
     // FIXME: This should replace blockless abstract versions of yield above and become abstract.
     // Here to allow incremental replacement. Overriden by subclasses which support it.
-    public IRubyObject yield(ThreadContext context, IRubyObject value, IRubyObject self,
+    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self,
             RubyModule klass, boolean aValue, Binding binding, Block.Type type, Block block) {
-        return yield(context, value, self, klass, aValue, binding, type);
+        return yield(context, args, self, klass, aValue, binding, type);
     }
 
     // FIXME: This should replace blockless abstract versions of yield above and become abstract.
@@ -100,7 +100,7 @@ public abstract class BlockBody {
         IRubyObject[] args = IRubyObject.NULL_ARRAY;
         args = prepareArgumentsForCall(context, args, type);
 
-        return yield(context, RubyArray.newArrayNoCopy(context.runtime, args), null, null, true, binding, type);
+        return yield(context, args, null, null, true, binding, type);
     }
     public IRubyObject call(ThreadContext context, Binding binding,
             Block.Type type, Block unusedBlock) {
@@ -108,13 +108,13 @@ public abstract class BlockBody {
     }
 
     public IRubyObject yieldSpecific(ThreadContext context, Binding binding, Block.Type type) {
-        return yield(context, null, null, null, true, binding, type);
+        return yield(context, null, binding, type);
     }
     public IRubyObject call(ThreadContext context, IRubyObject arg0, Binding binding, Block.Type type) {
         IRubyObject[] args = new IRubyObject[] {arg0};
         args = prepareArgumentsForCall(context, args, type);
 
-        return yield(context, RubyArray.newArrayNoCopy(context.runtime, args), null, null, true, binding, type);
+        return yield(context, args, null, null, true, binding, type);
     }
     public IRubyObject call(ThreadContext context, IRubyObject arg0, Binding binding,
             Block.Type type, Block unusedBlock) {
@@ -122,13 +122,13 @@ public abstract class BlockBody {
     }
 
     public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, Binding binding, Block.Type type) {
-        return yield(context, arg0, null, null, true, binding, type);
+        return yield(context, arg0, binding, type);
     }
     public IRubyObject call(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Binding binding, Block.Type type) {
         IRubyObject[] args = new IRubyObject[] {arg0, arg1};
         args = prepareArgumentsForCall(context, args, type);
 
-        return yield(context, RubyArray.newArrayNoCopy(context.runtime, args), null, null, true, binding, type);
+        return yield(context, args, null, null, true, binding, type);
     }
     public IRubyObject call(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Binding binding,
             Block.Type type, Block unusedBlock) {
@@ -136,13 +136,13 @@ public abstract class BlockBody {
     }
 
     public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Binding binding, Block.Type type) {
-        return yield(context, context.runtime.newArrayNoCopyLight(arg0, arg1), null, null, true, binding, type);
+        return yield(context, new IRubyObject[] { arg0, arg1 }, null, null, true, binding, type);
     }
     public IRubyObject call(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Binding binding, Block.Type type) {
         IRubyObject[] args = new IRubyObject[] {arg0, arg1, arg2};
         args = prepareArgumentsForCall(context, args, type);
 
-        return yield(context, RubyArray.newArrayNoCopy(context.runtime, args), null, null, true, binding, type);
+        return yield(context, args, null, null, true, binding, type);
     }
     public IRubyObject call(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Binding binding,
             Block.Type type, Block unusedBlock) {
@@ -150,7 +150,7 @@ public abstract class BlockBody {
     }
 
     public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Binding binding, Block.Type type) {
-        return yield(context, context.runtime.newArrayNoCopyLight(arg0, arg1, arg2), null, null, true, binding, type);
+        return yield(context, new IRubyObject[] { arg0, arg1, arg2 }, null, null, true, binding, type);
     }
 
 
@@ -260,28 +260,4 @@ public abstract class BlockBody {
     }
 
     public static final BlockBody NULL_BODY = new NullBlockBody();
-
-    public IRubyObject newArgsArrayFromArgsWithUnbox(IRubyObject[] args, ThreadContext context) {
-        IRubyObject value;
-        if (args.length == 0) {
-            value = context.runtime.getEmptyFrozenArray();
-        } else {
-            if (args.length == 1) {
-                value = args[0];
-            } else {
-                value = context.runtime.newArrayNoCopyLight(args);
-            }
-        }
-        return value;
-    }
-
-    public IRubyObject newArgsArrayFromArgsWithoutUnbox(IRubyObject[] args, ThreadContext context) {
-        IRubyObject value;
-        if (args.length == 0) {
-            value = context.runtime.getEmptyFrozenArray();
-        } else {
-            value = context.runtime.newArrayNoCopyLight(args);
-        }
-        return value;
-    }
 }

--- a/core/src/main/java/org/jruby/runtime/CallBlock.java
+++ b/core/src/main/java/org/jruby/runtime/CallBlock.java
@@ -73,40 +73,17 @@ public class CallBlock extends BlockBody {
 
     @Override
     public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, Binding binding, Block.Type type) {
-        return callback.call(context, new IRubyObject[] {arg0}, Block.NULL_BLOCK);
+        return callback.call(context, new IRubyObject[]{arg0}, Block.NULL_BLOCK);
     }
 
     @Override
-    public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Binding binding, Block.Type type) {
-        return yield(context, new IRubyObject[] {arg0, arg1}, Block.NULL_BLOCK);
-    }
-
-    @Override
-    public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Binding binding, Block.Type type) {
-        return yield(context, new IRubyObject[] {arg0, arg1, arg2}, Block.NULL_BLOCK);
-    }
-    
     public IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type) {
-        return callback.call(context, new IRubyObject[] {value}, Block.NULL_BLOCK);
+        return callback.call(context, new IRubyObject[]{value}, Block.NULL_BLOCK);
     }
 
-    /**
-     * Yield to this block, usually passed to the current call.
-     * 
-     * @param context represents the current thread-specific data
-     * @param value The value to yield, either a single value or an array of values
-     * @param self The current self
-     * @param klass
-     * @param aValue Should value be arrayified or not?
-     * @return
-     */
-    public IRubyObject yield(ThreadContext context, IRubyObject value, IRubyObject self, 
+    @Override
+    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self,
             RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
-        IRubyObject[] args = value.respondsTo("to_a") ? value.convertToArray().toJavaArray() : new IRubyObject[] {value};
-        return yield(context, args, Block.NULL_BLOCK);
-    }
-
-    private IRubyObject yield(ThreadContext context, IRubyObject[] args, Block block) {
         IRubyObject[] preppedArgs = RubyProc.prepareProcArgs(context, arity(), args);
         return callback.call(context, preppedArgs, Block.NULL_BLOCK);
     }

--- a/core/src/main/java/org/jruby/runtime/CallBlock19.java
+++ b/core/src/main/java/org/jruby/runtime/CallBlock19.java
@@ -27,7 +27,6 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby.runtime;
 
-import org.jruby.RubyArray;
 import org.jruby.RubyModule;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -94,20 +93,15 @@ public class CallBlock19 extends BlockBody {
      * Yield to this block, usually passed to the current call.
      * 
      * @param context represents the current thread-specific data
-     * @param value The value to yield, either a single value or an array of values
+     * @param args The args to yield
      * @param self The current self
      * @param klass
      * @param aValue Should value be arrayified or not?
      * @return
      */
-    public IRubyObject yield(ThreadContext context, IRubyObject value, IRubyObject self, 
+    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self,
             RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
-        if (aValue) {
-            // expand args
-            return callback.call(context, ((RubyArray)value).toJavaArray(), Block.NULL_BLOCK);
-        }
-        
-        return callback.call(context, new IRubyObject[] {value}, Block.NULL_BLOCK);
+        return callback.call(context, args, Block.NULL_BLOCK);
     }
     
     public StaticScope getStaticScope() {

--- a/core/src/main/java/org/jruby/runtime/CompiledBlock.java
+++ b/core/src/main/java/org/jruby/runtime/CompiledBlock.java
@@ -82,20 +82,21 @@ public class CompiledBlock extends ContextAwareBlockBody {
 
     @Override
     public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Binding binding, Block.Type type) {
-        return yield(context, context.runtime.newArrayNoCopyLight(arg0, arg1), null, null, true, binding, type);
+        return yield(context, new IRubyObject[] { arg0, arg1 }, null, null, true, binding, type);
     }
 
     @Override
     public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Binding binding, Block.Type type) {
-        return yield(context, context.runtime.newArrayNoCopyLight(arg0, arg1, arg2), null, null, true, binding, type);
+        return yield(context, new IRubyObject[] { arg0, arg1, arg2 }, null, null, true, binding, type);
     }
 
     @Override
     public IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type) {
         return yield(context, value, binding, type, Block.NULL_BLOCK);
     }
-    
-    public IRubyObject yield(ThreadContext context, IRubyObject args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
+
+    @Override
+    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
         return yield(context, args, self, klass, aValue, binding, type, Block.NULL_BLOCK);
     }
 
@@ -119,13 +120,14 @@ public class CompiledBlock extends ContextAwareBlockBody {
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Block.Type type, Block block) {
+    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Block.Type type, Block block) {
         if (klass == null) {
             self = prepareSelf(binding);
         }
 
+        RubyArray value = context.runtime.newArrayNoCopyLight(args);
         IRubyObject realArg = aValue ?
-                setupBlockArgs(context, args, self) : setupBlockArg(context.runtime, args, self);
+                setupBlockArgs(context, value, self) : setupBlockArg(context.runtime, value, self);
         Visibility oldVis = binding.getFrame().getVisibility();
         Frame lastFrame = pre(context, klass, binding);
 

--- a/core/src/main/java/org/jruby/runtime/CompiledBlock19.java
+++ b/core/src/main/java/org/jruby/runtime/CompiledBlock19.java
@@ -79,12 +79,12 @@ public class CompiledBlock19 extends ContextAwareBlockBody {
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject[] args, Binding binding, Block.Type type) {
-        return yield(context, newArgsArrayFromArgsWithUnbox(args, context), null, null, true, binding, type, Block.NULL_BLOCK);
+        return yield(context, args, null, null, true, binding, type, Block.NULL_BLOCK);
     }
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject[] args, Binding binding, Block.Type type, Block block) {
-        return yield(context, newArgsArrayFromArgsWithoutUnbox(args, context), null, null, true, binding, type, block);
+        return yield(context, args, null, null, true, binding, type, block);
     }
 
     @Override
@@ -141,12 +141,13 @@ public class CompiledBlock19 extends ContextAwareBlockBody {
         }
     }
 
-    public IRubyObject yield(ThreadContext context, IRubyObject args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
+    @Override
+    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
         return yield(context, args, self, klass, aValue, binding, type, Block.NULL_BLOCK);
     }
     
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Block.Type type, Block block) {
+    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Block.Type type, Block block) {
         if (klass == null) {
             self = prepareSelf(binding);
         }
@@ -155,7 +156,7 @@ public class CompiledBlock19 extends ContextAwareBlockBody {
         Frame lastFrame = pre(context, klass, binding);
         
         try {
-            IRubyObject[] realArgs = setupBlockArgs(args, type, aValue);
+            IRubyObject[] realArgs = setupBlockArgs(context.runtime.newArrayNoCopyLight(args), type, aValue);
             return callback.call(context, self, realArgs, block);
         } catch (JumpException.NextJump nj) {
             // A 'next' is like a local return from the block, ending this call or yield.

--- a/core/src/main/java/org/jruby/runtime/InterpretedIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/InterpretedIRBlockBody.java
@@ -49,22 +49,11 @@ public class InterpretedIRBlockBody extends ContextAwareBlockBody {
 
     @Override
     public IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Type type) {
-        return yield(context, value, null, null, false, binding, type);
+        return yield(context, value, binding, type);
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject value, IRubyObject self, RubyModule klass, boolean isArray, Binding binding, Type type) {
-        IRubyObject[] args;
-        if (isArray) {
-            if (arity().getValue() > 1) {
-                args = value == null ? IRubyObject.NULL_ARRAY : prepareArgumentsForYield(context, ((RubyArray)value).toJavaArray(), type);
-            } else {
-                args = assignArrayToBlockArgs(context.runtime, value);
-            }
-        } else {
-            args = prepareArgumentsForYield(context, value == null ? IRubyObject.NULL_ARRAY : new IRubyObject[] { value }, type);
-        }
-
+    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean isArray, Binding binding, Type type) {
         return commonYieldPath(context, args, self, klass, binding, type, Block.NULL_BLOCK);
     }
 

--- a/core/src/main/java/org/jruby/runtime/InterpretedIRBlockBody19.java
+++ b/core/src/main/java/org/jruby/runtime/InterpretedIRBlockBody19.java
@@ -113,16 +113,16 @@ public class InterpretedIRBlockBody19 extends InterpretedIRBlockBody {
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject value, IRubyObject self, RubyModule klass, boolean argIsArray, Binding binding, Type type) {
+    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean argIsArray, Binding binding, Type type) {
 		// Unwrap the array arg
-        IRubyObject[] args;
+        IRubyObject[] newArgs;
         if (type == Block.Type.LAMBDA) {
-            args = (value == null) ? IRubyObject.NULL_ARRAY : (argIsArray ? ((RubyArray)value).toJavaArray() : new IRubyObject[] { value });
+            newArgs = (args == null) ? IRubyObject.NULL_ARRAY : args;
             arity().checkArity(context.runtime, args);
         } else {
-            args = (value == null) ? IRubyObject.NULL_ARRAY : convertValueIntoArgArray(context, value, false, argIsArray);
+            newArgs = (args == null) ? IRubyObject.NULL_ARRAY : args;
         }
-        return commonYieldPath(context, args, self, klass, binding, type, Block.NULL_BLOCK);
+        return commonYieldPath(context, newArgs, self, klass, binding, type, Block.NULL_BLOCK);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/runtime/JavaInternalBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/JavaInternalBlockBody.java
@@ -5,7 +5,6 @@
 package org.jruby.runtime;
 
 import org.jruby.Ruby;
-import org.jruby.RubyArray;
 import org.jruby.RubyModule;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.Block.Type;
@@ -50,43 +49,31 @@ public abstract class JavaInternalBlockBody extends BlockBody {
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject[] args, Binding binding, Block.Type type) {
-        IRubyObject value;
-        if (args.length == 1) {
-            value = args[0];
-        } else {
-            value = RubyArray.newArrayNoCopy(context.runtime, args);
-        }
-        return yield(context, value, null, null, true, binding, type);
+        return yield(context, args, null, null, true, binding, type);
     }
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject[] args, Binding binding,
                             Block.Type type, Block block) {
-        IRubyObject value;
-        if (args.length == 1) {
-            value = args[0];
-        } else {
-            value = RubyArray.newArrayNoCopy(context.runtime, args);
-        }
-        return yield(context, value, null, null, true, binding, type, block);
+        return yield(context, args, null, null, true, binding, type, block);
     }
 
     @Override
     public IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Type type) {
         threadCheck(context);
         
-        return yield(context, value);        
+        return yield(context, new IRubyObject[] { value });
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject value, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Type type) {
+    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Type type) {
         threadCheck(context);
         
         
-        return yield(context, value);
+        return yield(context, args);
     }
     
-    public abstract IRubyObject yield(ThreadContext context, IRubyObject value);
+    public abstract IRubyObject yield(ThreadContext context, IRubyObject[] args);
 
     @Override
     public StaticScope getStaticScope() {

--- a/core/src/main/java/org/jruby/runtime/MethodBlock.java
+++ b/core/src/main/java/org/jruby/runtime/MethodBlock.java
@@ -31,11 +31,11 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby.runtime;
 
-import org.jruby.runtime.backtrace.BacktraceElement;
 import org.jruby.RubyMethod;
 import org.jruby.RubyModule;
 import org.jruby.exceptions.JumpException;
 import org.jruby.parser.StaticScope;
+import org.jruby.runtime.backtrace.BacktraceElement;
 import org.jruby.runtime.builtin.IRubyObject;
 
 /**
@@ -79,12 +79,12 @@ public abstract class MethodBlock extends ContextAwareBlockBody {
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject[] args, Binding binding, Block.Type type) {
-        return yield(context, newArgsArrayFromArgsWithoutUnbox(args, context), null, null, true, binding, type, Block.NULL_BLOCK);
+        return yield(context, args, null, null, true, binding, type, Block.NULL_BLOCK);
     }
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject[] args, Binding binding, Block.Type type, Block block) {
-        return yield(context, newArgsArrayFromArgsWithoutUnbox(args, context), null, null, true, binding, type, block);
+        return yield(context, args, null, null, true, binding, type, block);
     }
     
     @Override
@@ -109,42 +109,42 @@ public abstract class MethodBlock extends ContextAwareBlockBody {
 
     @Override
     public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Binding binding, Block.Type type) {
-        return yield(context, context.runtime.newArrayNoCopyLight(arg0, arg1), null, null, true, binding, type);
+        return yield(context, new IRubyObject[] { arg0, arg1 }, null, null, true, binding, type);
     }
 
     @Override
     public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Binding binding, Block.Type type) {
-        return yield(context, context.runtime.newArrayNoCopyLight(arg0, arg1, arg2), null, null, true, binding, type);
+        return yield(context, new IRubyObject[] { arg0, arg1, arg2 }, null, null, true, binding, type);
     }
     
     @Override
     public IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type) {
-        return yield(context, value, null, null, false, binding, type);
+        return yield(context, value, binding, type);
     }
 
     @Override
     public IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type, Block block) {
-        return yield(context, value, null, null, false, binding, type, block);
+        return yield(context, value, binding, type);
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject value, IRubyObject self,
+    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self,
                              RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
-        return yield(context, value, self, klass, aValue, binding, type, Block.NULL_BLOCK);
+        return yield(context, args, self, klass, aValue, binding, type, Block.NULL_BLOCK);
     }
 
     /**
      * Yield to this block, usually passed to the current call.
      * 
      * @param context represents the current thread-specific data
-     * @param value The value to yield, either a single value or an array of values
+     * @param args The args for yield
      * @param self The current self
      * @param klass
      * @param aValue Should value be arrayified or not?
      * @return
      */
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject value, IRubyObject self, 
+    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self,
             RubyModule klass, boolean aValue, Binding binding, Block.Type type, Block block) {
         if (klass == null) {
             self = binding.getSelf();
@@ -157,7 +157,7 @@ public abstract class MethodBlock extends ContextAwareBlockBody {
             // This while loop is for restarting the block call in case a 'redo' fires.
             while (true) {
                 try {
-                    return callback(value, method, self, block);
+                    return callback(context.runtime.newArrayNoCopyLight(args), method, self, block);
                 } catch (JumpException.RedoJump rj) {
                     context.pollThreadEvents();
                     // do nothing, allow loop to redo

--- a/core/src/main/java/org/jruby/runtime/NullBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/NullBlockBody.java
@@ -55,8 +55,8 @@ public class NullBlockBody extends BlockBody {
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject value, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Type type) {
-        throw context.runtime.newLocalJumpError(RubyLocalJumpError.Reason.NOREASON, value, "yield called out of block");
+    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Type type) {
+        throw context.runtime.newLocalJumpError(RubyLocalJumpError.Reason.NOREASON, args[0], "yield called out of block");
     }
 
     @Override

--- a/core/src/main/java/org/jruby/runtime/SharedScopeBlock.java
+++ b/core/src/main/java/org/jruby/runtime/SharedScopeBlock.java
@@ -56,7 +56,7 @@ public class SharedScopeBlock extends InterpretedBlock {
     }
     
     public IRubyObject call(ThreadContext context, IRubyObject[] args, IRubyObject replacementSelf, Binding binding, Block.Type type) {
-        return yield(context, newArgsArrayFromArgsWithoutUnbox(args, context), null, null, true, binding, type);
+        return yield(context, args, null, null, true, binding, type);
     }
     
     @Override


### PR DESCRIPTION
Hey @enebo, here's the first bite-sized chunk of #1143.

This is pretty much a straight refactor which makes it easier for deeper calls to determine exactly what their args look like (when transformed into a RubyArray too soon, it was hard for yielders to tell if you have multiple args, or one array arg).  Also has the added benefit of removing some allocations and redundant code.

(I also re-targeted this at the 1_7 branch since I saw in other comments that it's going to be around for a while and should be kept as merge-friendly as possible.  Let me know if that was the wrong call and you'd rather master)

As always, let me know if you have any questions.
