### PR TITLE
Centrally prep args for calls/yields

### DIFF
--- a/core/src/main/java/org/jruby/RubyProc.java
+++ b/core/src/main/java/org/jruby/RubyProc.java
@@ -222,32 +222,47 @@ public class RubyProc extends RubyObject implements DataType {
     }
 
     /**
-     * Transforms the given arguments appropriately for the given arity (i.e. trimming to one arg for fixed
+     * For Type.LAMBDA, ensures that the args have the correct arity.
+     *
+     * For others, transforms the given arguments appropriately for the given arity (i.e. trimming to one arg for fixed
      * arity of one, etc.)
      */
-    public static IRubyObject[] prepareProcArgs(ThreadContext context, Arity arity, IRubyObject[] args) {
+    public static IRubyObject[] prepareArgs(ThreadContext context, Block.Type type, Arity arity, IRubyObject[] args) {
+        if (arity == null) {
+            return args;
+        }
+
+        if (args == null) {
+            return IRubyObject.NULL_ARRAY;
+        }
+
+        if (type == Block.Type.LAMBDA) {
+            arity.checkArity(context.runtime, args.length);
+            return args;
+        }
+
         boolean isFixed = arity.isFixed();
         int required = arity.required();
         int actual = args.length;
-        
+
         // for procs and blocks, single array passed to multi-arg must be spread
-        if (arity != Arity.ONE_ARGUMENT &&  required != 0 && 
+        if (arity != Arity.ONE_ARGUMENT &&  required != 0 &&
                 (isFixed || arity != Arity.OPTIONAL) &&
                 actual == 1 && args[0].respondsTo("to_ary")) {
             args = args[0].convertToArray().toJavaArray();
             actual = args.length;
         }
-        
+
         // fixed arity > 0 with mismatch needs a new args array
         if (isFixed && required > 0 && required != actual) {
-            
+
             IRubyObject[] newArgs = Arrays.copyOf(args, required);
-            
+
             // pad with nil
             if (required > actual) {
                 Helpers.fillNil(newArgs, actual, required, context.runtime);
             }
-            
+
             args = newArgs;
         }
 
@@ -256,12 +271,9 @@ public class RubyProc extends RubyObject implements DataType {
 
     @JRubyMethod(name = {"call", "[]", "yield", "==="}, rest = true)
     public IRubyObject call19(ThreadContext context, IRubyObject[] args, Block blockCallArg) {
-        if (isLambda()) {
-            block.arity().checkArity(context.runtime, args.length);
-        }
-        if (isProc()) args = prepareProcArgs(context, block.arity(), args);
+        IRubyObject[] preppedArgs = prepareArgs(context, type, block.arity(), args);
 
-        return call(context, args, null, blockCallArg);
+        return call(context, preppedArgs, null, blockCallArg);
     }
 
     public IRubyObject call(ThreadContext context, IRubyObject[] args, IRubyObject self, Block passedBlock) {

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -390,6 +390,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding {
             @Override
             public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self,
                     RubyModule klass, boolean aValue, Binding binding, Block.Type type, Block block) {
+                RubyProc.prepareArgs(context, type, block.arity(), args);
                 return yieldInner(context, context.runtime.newArrayNoCopyLight(args), block);
             }
 
@@ -400,12 +401,12 @@ public class RubySymbol extends RubyObject implements MarshalEncoding {
             }
             
             @Override
-            public IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Type type) {
+            protected IRubyObject doYield(ThreadContext context, IRubyObject value, Binding binding, Type type) {
                 return yieldInner(context, ArgsUtil.convertToRubyArray(context.runtime, value, false), Block.NULL_BLOCK);
             }
 
             @Override
-            public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Type type) {
+            protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Type type) {
                 return yieldInner(context, context.runtime.newArrayNoCopyLight(args), Block.NULL_BLOCK);
             }
 

--- a/core/src/main/java/org/jruby/runtime/CallBlock.java
+++ b/core/src/main/java/org/jruby/runtime/CallBlock.java
@@ -28,7 +28,6 @@
 package org.jruby.runtime;
 
 import org.jruby.RubyModule;
-import org.jruby.RubyProc;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -77,15 +76,14 @@ public class CallBlock extends BlockBody {
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type) {
+    protected IRubyObject doYield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type) {
         return callback.call(context, new IRubyObject[]{value}, Block.NULL_BLOCK);
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self,
+    protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self,
             RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
-        IRubyObject[] preppedArgs = RubyProc.prepareProcArgs(context, arity(), args);
-        return callback.call(context, preppedArgs, Block.NULL_BLOCK);
+        return callback.call(context, args, Block.NULL_BLOCK);
     }
     
     public StaticScope getStaticScope() {

--- a/core/src/main/java/org/jruby/runtime/CallBlock19.java
+++ b/core/src/main/java/org/jruby/runtime/CallBlock19.java
@@ -84,8 +84,8 @@ public class CallBlock19 extends BlockBody {
     public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Binding binding, Block.Type type) {
         return callback.call(context, new IRubyObject[] {arg0, arg1, arg2}, Block.NULL_BLOCK);
     }
-    
-    public IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type) {
+
+    protected IRubyObject doYield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type) {
         return callback.call(context, new IRubyObject[] {value}, Block.NULL_BLOCK);
     }
 
@@ -99,7 +99,7 @@ public class CallBlock19 extends BlockBody {
      * @param aValue Should value be arrayified or not?
      * @return
      */
-    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self,
+    protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self,
             RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
         return callback.call(context, args, Block.NULL_BLOCK);
     }

--- a/core/src/main/java/org/jruby/runtime/CompiledBlock.java
+++ b/core/src/main/java/org/jruby/runtime/CompiledBlock.java
@@ -30,6 +30,7 @@ package org.jruby.runtime;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyModule;
+import org.jruby.RubyProc;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.common.IRubyWarnings.ID;
 import org.jruby.exceptions.JumpException;
@@ -91,12 +92,12 @@ public class CompiledBlock extends ContextAwareBlockBody {
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type) {
+    protected IRubyObject doYield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type) {
         return yield(context, value, binding, type, Block.NULL_BLOCK);
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
+    protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
         return yield(context, args, self, klass, aValue, binding, type, Block.NULL_BLOCK);
     }
 
@@ -125,7 +126,8 @@ public class CompiledBlock extends ContextAwareBlockBody {
             self = prepareSelf(binding);
         }
 
-        RubyArray value = context.runtime.newArrayNoCopyLight(args);
+        IRubyObject[] preppedArgs = RubyProc.prepareArgs(context, type, arity, args);
+        RubyArray value = context.runtime.newArrayNoCopyLight(preppedArgs);
         IRubyObject realArg = aValue ?
                 setupBlockArgs(context, value, self) : setupBlockArg(context.runtime, value, self);
         Visibility oldVis = binding.getFrame().getVisibility();

--- a/core/src/main/java/org/jruby/runtime/CompiledBlock19.java
+++ b/core/src/main/java/org/jruby/runtime/CompiledBlock19.java
@@ -29,6 +29,7 @@ package org.jruby.runtime;
 
 import org.jruby.Ruby;
 import org.jruby.RubyModule;
+import org.jruby.RubyProc;
 import org.jruby.exceptions.JumpException;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -124,7 +125,7 @@ public class CompiledBlock19 extends ContextAwareBlockBody {
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type) {
+    protected IRubyObject doYield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type) {
         IRubyObject self = prepareSelf(binding);
 
         Visibility oldVis = binding.getFrame().getVisibility();
@@ -142,7 +143,7 @@ public class CompiledBlock19 extends ContextAwareBlockBody {
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
+    protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
         return yield(context, args, self, klass, aValue, binding, type, Block.NULL_BLOCK);
     }
     
@@ -156,7 +157,8 @@ public class CompiledBlock19 extends ContextAwareBlockBody {
         Frame lastFrame = pre(context, klass, binding);
         
         try {
-            IRubyObject[] realArgs = setupBlockArgs(context.runtime.newArrayNoCopyLight(args), type, aValue);
+            IRubyObject[] preppedArgs = RubyProc.prepareArgs(context, type, arity, args);
+            IRubyObject[] realArgs = setupBlockArgs(context.runtime.newArrayNoCopyLight(preppedArgs), type, aValue);
             return callback.call(context, self, realArgs, block);
         } catch (JumpException.NextJump nj) {
             // A 'next' is like a local return from the block, ending this call or yield.

--- a/core/src/main/java/org/jruby/runtime/CompiledIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/CompiledIRBlockBody.java
@@ -106,7 +106,7 @@ public class CompiledIRBlockBody extends ContextAwareBlockBody {
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Type type) {
+    public IRubyObject doYield(ThreadContext context, IRubyObject value, Binding binding, Type type) {
         IRubyObject[] args;
         if (type == Block.Type.LAMBDA) {
             args = new IRubyObject[] { value };
@@ -127,15 +127,7 @@ public class CompiledIRBlockBody extends ContextAwareBlockBody {
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean argIsArray, Binding binding, Type type) {
-        if (args == null) {
-            args = IRubyObject.NULL_ARRAY;
-        }
-
-        if (type == Block.Type.LAMBDA) {
-            arity().checkArity(context.runtime, args);
-        }
-
+    protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean argIsArray, Binding binding, Type type) {
         return commonYieldPath(context, args, self, klass, binding, type, Block.NULL_BLOCK);
     }
 

--- a/core/src/main/java/org/jruby/runtime/Interpreted19Block.java
+++ b/core/src/main/java/org/jruby/runtime/Interpreted19Block.java
@@ -29,6 +29,7 @@ package org.jruby.runtime;
 
 import org.jruby.Ruby;
 import org.jruby.RubyModule;
+import org.jruby.RubyProc;
 import org.jruby.ast.ArgsNoArgNode;
 import org.jruby.ast.ArgsNode;
 import org.jruby.ast.IterNode;
@@ -146,7 +147,7 @@ public class Interpreted19Block  extends ContextAwareBlockBody {
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type) {
+    protected IRubyObject doYield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type) {
         IRubyObject self = prepareSelf(binding);
 
         Visibility oldVis = binding.getFrame().getVisibility();
@@ -174,7 +175,7 @@ public class Interpreted19Block  extends ContextAwareBlockBody {
      * @return
      */
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self,
+    protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self,
             RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
         return yield(context, args, self, klass, aValue, binding, type, Block.NULL_BLOCK);
 
@@ -191,7 +192,8 @@ public class Interpreted19Block  extends ContextAwareBlockBody {
         Frame lastFrame = pre(context, klass, binding);
 
         try {
-            setupBlockArgs(context, context.runtime.newArrayNoCopyLight(args), self, block, type, aValue);
+            IRubyObject[] preppedArgs = RubyProc.prepareArgs(context, type, arity, args);
+            setupBlockArgs(context, context.runtime.newArrayNoCopyLight(preppedArgs), self, block, type, aValue);
 
             // This while loop is for restarting the block call in case a 'redo' fires.
             return evalBlockBody(context, binding, self);

--- a/core/src/main/java/org/jruby/runtime/InterpretedBlock.java
+++ b/core/src/main/java/org/jruby/runtime/InterpretedBlock.java
@@ -35,6 +35,7 @@ package org.jruby.runtime;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyModule;
+import org.jruby.RubyProc;
 import org.jruby.ast.IterNode;
 import org.jruby.ast.ListNode;
 import org.jruby.ast.MultipleAsgnNode;
@@ -310,7 +311,7 @@ public class InterpretedBlock extends ContextAwareBlockBody {
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type) {
+    protected IRubyObject doYield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type) {
         return yield(context, value, binding, type, Block.NULL_BLOCK);
 
     }
@@ -328,7 +329,8 @@ public class InterpretedBlock extends ContextAwareBlockBody {
 
         try {
             if (!noargblock) {
-                RubyArray argArray = context.runtime.newArrayNoCopyLight(args);
+                IRubyObject[] preppedArgs = RubyProc.prepareArgs(context, type, arity, args);
+                RubyArray argArray = context.runtime.newArrayNoCopyLight(preppedArgs);
                 IRubyObject values = alreadyArray ? assigner.convertIfAlreadyArray(runtime, argArray) :
                     assigner.convertToArray(runtime, argArray);
 
@@ -376,7 +378,7 @@ public class InterpretedBlock extends ContextAwareBlockBody {
      * @return result of block invocation
      */
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self,
+    protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self,
             RubyModule klass, boolean alreadyArray, Binding binding, Block.Type type) {
         return yield(context, args, self, klass, alreadyArray, binding, type, Block.NULL_BLOCK);
     }

--- a/core/src/main/java/org/jruby/runtime/InterpretedIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/InterpretedIRBlockBody.java
@@ -138,7 +138,7 @@ public class InterpretedIRBlockBody extends ContextAwareBlockBody {
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Type type) {
+    public IRubyObject doYield(ThreadContext context, IRubyObject value, Binding binding, Type type) {
         IRubyObject[] args;
         if (type == Block.Type.LAMBDA) {
             args = new IRubyObject[] { value };
@@ -159,7 +159,7 @@ public class InterpretedIRBlockBody extends ContextAwareBlockBody {
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean argIsArray, Binding binding, Type type) {
+    public IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean argIsArray, Binding binding, Type type) {
         args = (args == null) ? IRubyObject.NULL_ARRAY : args;
         if (type == Block.Type.LAMBDA) {
             arity().checkArity(context.runtime, args);

--- a/core/src/main/java/org/jruby/runtime/JavaInternalBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/JavaInternalBlockBody.java
@@ -59,16 +59,15 @@ public abstract class JavaInternalBlockBody extends BlockBody {
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Type type) {
+    protected IRubyObject doYield(ThreadContext context, IRubyObject value, Binding binding, Type type) {
         threadCheck(context);
         
         return yield(context, new IRubyObject[] { value });
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Type type) {
+    protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Type type) {
         threadCheck(context);
-        
         
         return yield(context, args);
     }

--- a/core/src/main/java/org/jruby/runtime/MethodBlock.java
+++ b/core/src/main/java/org/jruby/runtime/MethodBlock.java
@@ -33,6 +33,7 @@ package org.jruby.runtime;
 
 import org.jruby.RubyMethod;
 import org.jruby.RubyModule;
+import org.jruby.RubyProc;
 import org.jruby.exceptions.JumpException;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.backtrace.BacktraceElement;
@@ -118,7 +119,7 @@ public abstract class MethodBlock extends ContextAwareBlockBody {
     }
     
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type) {
+    protected IRubyObject doYield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type) {
         return yield(context, value, binding, type);
     }
 
@@ -128,7 +129,7 @@ public abstract class MethodBlock extends ContextAwareBlockBody {
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self,
+    protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self,
                              RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
         return yield(context, args, self, klass, aValue, binding, type, Block.NULL_BLOCK);
     }
@@ -157,7 +158,8 @@ public abstract class MethodBlock extends ContextAwareBlockBody {
             // This while loop is for restarting the block call in case a 'redo' fires.
             while (true) {
                 try {
-                    return callback(context.runtime.newArrayNoCopyLight(args), method, self, block);
+                    IRubyObject[] preppedArgs = RubyProc.prepareArgs(context, type, arity, args);
+                    return callback(context.runtime.newArrayNoCopyLight(preppedArgs), method, self, block);
                 } catch (JumpException.RedoJump rj) {
                     context.pollThreadEvents();
                     // do nothing, allow loop to redo

--- a/core/src/main/java/org/jruby/runtime/NullBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/NullBlockBody.java
@@ -50,12 +50,12 @@ public class NullBlockBody extends BlockBody {
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Type type) {
+    protected IRubyObject doYield(ThreadContext context, IRubyObject value, Binding binding, Type type) {
         throw context.runtime.newLocalJumpError(RubyLocalJumpError.Reason.NOREASON, value, "yield called out of block");
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Type type) {
+    protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Type type) {
         throw context.runtime.newLocalJumpError(RubyLocalJumpError.Reason.NOREASON, args[0], "yield called out of block");
     }
 

--- a/spec/tags/ruby/core/enumerable/any_tags.txt
+++ b/spec/tags/ruby/core/enumerable/any_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#any? with block gathers initial args as elements when each yields multiple


### PR DESCRIPTION
Next slice of #1143 @enebo...

Refactor to ensure at the BlockBody level that args are properly prepped for calls and yields (arity checking for lambdas, arity trimming for other blocks).  This doesn't guarantee all calling codepaths are covered (an irresponsible override of some of BlockBody's methods can get around it), but definitely moves in the right direction.

This lets us delete some ad-hoc prepping we were doing, and fills some gaps where args should have been prepped but were not (so, for instance, we can untag the Enumerable#any test now that its block args are being treated correctly).

I'll have a look at continuing to shore this up (checking on the no-array yield, discouraging the bad overrides mentioned above, unifying more places where args are prepped, etc.), but hopefully you agree this is a good place to commit for now.
