### PR TITLE
Remove README.md notes on junit.jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,6 @@ See [BUILDING](BUILDING.md) for more information.
 
 ## Testing
 
-In order to run the unit tests, copy the `build_lib/junit.jar` file to either
-`$ANT_HOME/lib/junit.jar` or `~/.ant/lib/junit.jar`.
-
 See [README.test](docs/README.test.md) for more information.
 
 ## More Information


### PR DESCRIPTION
As per f5466e61306cc6a5f020f9fa201260479dc47e73, this JAR is no longer present in the repo and is now handled by Maven.
