### PR TITLE
Present the same Thread object for all fibers within a thread

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -532,7 +532,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
 
     @JRubyMethod(meta = true)
     public static RubyThread current(IRubyObject recv) {
-        return recv.getRuntime().getCurrentContext().getThread();
+        return recv.getRuntime().getCurrentContext().getRootThread();
     }
 
     @JRubyMethod(meta = true)

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -333,6 +333,10 @@ public final class ThreadContext {
         this.rootFiber = rootFiber;
     }
     
+    public RubyThread getRootThread() {
+        return rootThread;
+    }
+
     public void setRootThread(RubyThread rootThread) {
         this.rootThread = rootThread;
     }


### PR DESCRIPTION
There is a [bug](http://jira.codehaus.org/browse/JRUBY-7081) which I am solving here. 
I haven't added a rubyspec. Is this conceptually correct?
