### PR TITLE
Fix count_spec (1.7.x)

### DIFF
--- a/spec/tags/1.9/ruby/core/enumerable/count_tags.txt
+++ b/spec/tags/1.9/ruby/core/enumerable/count_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#count gathers initial args as elements when each yields multiple


### PR DESCRIPTION
Use the appropriate arity to get Enumerable#count to handle its args correctly.  Note that we need to switch from JavaInternalBlockBody to a BlockCallback since JavaInternalBlockBody does not currently get its arguments prepared correctly for the given arity (this is fixed in master).

This does not need to be merged into master since #1230 takes care of it.
