### PR TITLE
Remove now-unneeded "aValue" param from yields

### DIFF
--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -389,7 +389,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding {
 
             @Override
             public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self,
-                    RubyModule klass, boolean aValue, Binding binding, Block.Type type, Block block) {
+                    RubyModule klass, Binding binding, Block.Type type, Block block) {
                 RubyProc.prepareArgs(context, type, block.arity(), args);
                 return yieldInner(context, context.runtime.newArrayNoCopyLight(args), block);
             }
@@ -406,7 +406,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding {
             }
 
             @Override
-            protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Type type) {
+            protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, Binding binding, Type type) {
                 return yieldInner(context, context.runtime.newArrayNoCopyLight(args), Block.NULL_BLOCK);
             }
 

--- a/core/src/main/java/org/jruby/runtime/Block.java
+++ b/core/src/main/java/org/jruby/runtime/Block.java
@@ -145,7 +145,7 @@ public final class Block {
 
     public IRubyObject yieldNonArray(ThreadContext context, IRubyObject value, IRubyObject self,
             RubyModule klass) {
-        return body.yield(context, new IRubyObject[] { value }, self, klass, true, binding, type);
+        return body.yield(context, new IRubyObject[] { value }, self, klass, binding, type);
     }
 
     public IRubyObject yieldArray(ThreadContext context, IRubyObject value, IRubyObject self,
@@ -156,7 +156,7 @@ public final class Block {
         } else {
             args = value.convertToArray().toJavaArray();
         }
-        return body.yield(context, args, self, klass, true, binding, type);
+        return body.yield(context, args, self, klass, binding, type);
     }
 
     public Block cloneBlock() {

--- a/core/src/main/java/org/jruby/runtime/BlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/BlockBody.java
@@ -64,14 +64,14 @@ public abstract class BlockBody {
     public IRubyObject call(ThreadContext context, IRubyObject[] args, Binding binding, Block.Type type) {
         args = prepareArgumentsForCall(context, args, type);
 
-        return yield(context, args, null, null, true, binding, type);
+        return yield(context, args, null, null, binding, type);
     }
 
     public IRubyObject call(ThreadContext context, IRubyObject[] args, Binding binding,
             Block.Type type, Block block) {
         args = prepareArgumentsForCall(context, args, type);
 
-        return yield(context, args, null, null, true, binding, type, block);
+        return yield(context, args, null, null, binding, type, block);
     }
 
     public final IRubyObject yield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type) {
@@ -79,9 +79,9 @@ public abstract class BlockBody {
     }
 
     public final IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self,
-                                   RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
+                                   RubyModule klass, Binding binding, Block.Type type) {
         IRubyObject[] preppedValue = RubyProc.prepareArgs(context, type, arity(), args);
-        return doYield(context, preppedValue, self, klass, aValue, binding, type);
+        return doYield(context, preppedValue, self, klass, binding, type);
     }
 
     /**
@@ -95,17 +95,17 @@ public abstract class BlockBody {
     /**
      * Subclass specific yield implementation.
      * <p>
-     * Should not be called directly. Gets called by {@link #yield(ThreadContext, IRubyObject[], IRubyObject, RubyModule, boolean, Binding, Block.Type)}
+     * Should not be called directly. Gets called by {@link #yield(ThreadContext, IRubyObject[], IRubyObject, RubyModule, Binding, Block.Type)}
      * after ensuring that all common yield logic is taken care of.
      */
     protected abstract IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self,
-                                           RubyModule klass, boolean aValue, Binding binding, Block.Type type);
+                                           RubyModule klass, Binding binding, Block.Type type);
 
     // FIXME: This should be unified with the final versions above
     // Here to allow incremental replacement. Overriden by subclasses which support it.
     public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self,
-            RubyModule klass, boolean aValue, Binding binding, Block.Type type, Block block) {
-        return yield(context, args, self, klass, aValue, binding, type);
+            RubyModule klass, Binding binding, Block.Type type, Block block) {
+        return yield(context, args, self, klass, binding, type);
     }
 
     // FIXME: This should be unified with the final versions above
@@ -123,7 +123,7 @@ public abstract class BlockBody {
         IRubyObject[] args = IRubyObject.NULL_ARRAY;
         args = prepareArgumentsForCall(context, args, type);
 
-        return yield(context, args, null, null, true, binding, type);
+        return yield(context, args, null, null, binding, type);
     }
     public IRubyObject call(ThreadContext context, Binding binding,
             Block.Type type, Block unusedBlock) {
@@ -137,7 +137,7 @@ public abstract class BlockBody {
         IRubyObject[] args = new IRubyObject[] {arg0};
         args = prepareArgumentsForCall(context, args, type);
 
-        return yield(context, args, null, null, true, binding, type);
+        return yield(context, args, null, null, binding, type);
     }
     public IRubyObject call(ThreadContext context, IRubyObject arg0, Binding binding,
             Block.Type type, Block unusedBlock) {
@@ -151,7 +151,7 @@ public abstract class BlockBody {
         IRubyObject[] args = new IRubyObject[] {arg0, arg1};
         args = prepareArgumentsForCall(context, args, type);
 
-        return yield(context, args, null, null, true, binding, type);
+        return yield(context, args, null, null, binding, type);
     }
     public IRubyObject call(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Binding binding,
             Block.Type type, Block unusedBlock) {
@@ -159,13 +159,13 @@ public abstract class BlockBody {
     }
 
     public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Binding binding, Block.Type type) {
-        return yield(context, new IRubyObject[] { arg0, arg1 }, null, null, true, binding, type);
+        return yield(context, new IRubyObject[] { arg0, arg1 }, null, null, binding, type);
     }
     public IRubyObject call(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Binding binding, Block.Type type) {
         IRubyObject[] args = new IRubyObject[] {arg0, arg1, arg2};
         args = prepareArgumentsForCall(context, args, type);
 
-        return yield(context, args, null, null, true, binding, type);
+        return yield(context, args, null, null, binding, type);
     }
     public IRubyObject call(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Binding binding,
             Block.Type type, Block unusedBlock) {
@@ -173,7 +173,7 @@ public abstract class BlockBody {
     }
 
     public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Binding binding, Block.Type type) {
-        return yield(context, new IRubyObject[] { arg0, arg1, arg2 }, null, null, true, binding, type);
+        return yield(context, new IRubyObject[] { arg0, arg1, arg2 }, null, null, binding, type);
     }
 
 

--- a/core/src/main/java/org/jruby/runtime/CallBlock.java
+++ b/core/src/main/java/org/jruby/runtime/CallBlock.java
@@ -82,7 +82,7 @@ public class CallBlock extends BlockBody {
 
     @Override
     protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self,
-            RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
+            RubyModule klass, Binding binding, Block.Type type) {
         return callback.call(context, args, Block.NULL_BLOCK);
     }
     

--- a/core/src/main/java/org/jruby/runtime/CallBlock19.java
+++ b/core/src/main/java/org/jruby/runtime/CallBlock19.java
@@ -85,6 +85,7 @@ public class CallBlock19 extends BlockBody {
         return callback.call(context, new IRubyObject[] {arg0, arg1, arg2}, Block.NULL_BLOCK);
     }
 
+    @Override
     protected IRubyObject doYield(ThreadContext context, IRubyObject value, Binding binding, Block.Type type) {
         return callback.call(context, new IRubyObject[] {value}, Block.NULL_BLOCK);
     }
@@ -96,11 +97,11 @@ public class CallBlock19 extends BlockBody {
      * @param args The args to yield
      * @param self The current self
      * @param klass
-     * @param aValue Should value be arrayified or not?
      * @return
      */
+    @Override
     protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self,
-            RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
+            RubyModule klass, Binding binding, Block.Type type) {
         return callback.call(context, args, Block.NULL_BLOCK);
     }
     

--- a/core/src/main/java/org/jruby/runtime/CompiledBlock.java
+++ b/core/src/main/java/org/jruby/runtime/CompiledBlock.java
@@ -83,12 +83,12 @@ public class CompiledBlock extends ContextAwareBlockBody {
 
     @Override
     public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Binding binding, Block.Type type) {
-        return yield(context, new IRubyObject[] { arg0, arg1 }, null, null, true, binding, type);
+        return yield(context, new IRubyObject[] { arg0, arg1 }, null, null, binding, type);
     }
 
     @Override
     public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Binding binding, Block.Type type) {
-        return yield(context, new IRubyObject[] { arg0, arg1, arg2 }, null, null, true, binding, type);
+        return yield(context, new IRubyObject[] { arg0, arg1, arg2 }, null, null, binding, type);
     }
 
     @Override
@@ -97,8 +97,8 @@ public class CompiledBlock extends ContextAwareBlockBody {
     }
 
     @Override
-    protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
-        return yield(context, args, self, klass, aValue, binding, type, Block.NULL_BLOCK);
+    protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, Binding binding, Block.Type type) {
+        return yield(context, args, self, klass, binding, type, Block.NULL_BLOCK);
     }
 
     // FIXME: These two duplicate overrides should go away
@@ -121,15 +121,14 @@ public class CompiledBlock extends ContextAwareBlockBody {
     }
 
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Block.Type type, Block block) {
+    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, Binding binding, Block.Type type, Block block) {
         if (klass == null) {
             self = prepareSelf(binding);
         }
 
         IRubyObject[] preppedArgs = RubyProc.prepareArgs(context, type, arity, args);
         RubyArray value = context.runtime.newArrayNoCopyLight(preppedArgs);
-        IRubyObject realArg = aValue ?
-                setupBlockArgs(context, value, self) : setupBlockArg(context.runtime, value, self);
+        IRubyObject realArg = setupBlockArgs(context, value, self);
         Visibility oldVis = binding.getFrame().getVisibility();
         Frame lastFrame = pre(context, klass, binding);
 

--- a/core/src/main/java/org/jruby/runtime/CompiledBlock19.java
+++ b/core/src/main/java/org/jruby/runtime/CompiledBlock19.java
@@ -80,12 +80,12 @@ public class CompiledBlock19 extends ContextAwareBlockBody {
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject[] args, Binding binding, Block.Type type) {
-        return yield(context, args, null, null, true, binding, type, Block.NULL_BLOCK);
+        return yield(context, args, null, null, binding, type, Block.NULL_BLOCK);
     }
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject[] args, Binding binding, Block.Type type, Block block) {
-        return yield(context, args, null, null, true, binding, type, block);
+        return yield(context, args, null, null, binding, type, block);
     }
 
     @Override
@@ -143,12 +143,12 @@ public class CompiledBlock19 extends ContextAwareBlockBody {
     }
 
     @Override
-    protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
-        return yield(context, args, self, klass, aValue, binding, type, Block.NULL_BLOCK);
+    protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, Binding binding, Block.Type type) {
+        return yield(context, args, self, klass, binding, type, Block.NULL_BLOCK);
     }
     
     @Override
-    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Block.Type type, Block block) {
+    public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, Binding binding, Block.Type type, Block block) {
         if (klass == null) {
             self = prepareSelf(binding);
         }
@@ -158,7 +158,7 @@ public class CompiledBlock19 extends ContextAwareBlockBody {
         
         try {
             IRubyObject[] preppedArgs = RubyProc.prepareArgs(context, type, arity, args);
-            IRubyObject[] realArgs = setupBlockArgs(context.runtime.newArrayNoCopyLight(preppedArgs), type, aValue);
+            IRubyObject[] realArgs = setupBlockArgs(context.runtime.newArrayNoCopyLight(preppedArgs), type, true);
             return callback.call(context, self, realArgs, block);
         } catch (JumpException.NextJump nj) {
             // A 'next' is like a local return from the block, ending this call or yield.

--- a/core/src/main/java/org/jruby/runtime/CompiledIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/CompiledIRBlockBody.java
@@ -127,7 +127,7 @@ public class CompiledIRBlockBody extends ContextAwareBlockBody {
     }
 
     @Override
-    protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean argIsArray, Binding binding, Type type) {
+    protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, Binding binding, Type type) {
         return commonYieldPath(context, args, self, klass, binding, type, Block.NULL_BLOCK);
     }
 

--- a/core/src/main/java/org/jruby/runtime/Interpreted19Block.java
+++ b/core/src/main/java/org/jruby/runtime/Interpreted19Block.java
@@ -45,7 +45,6 @@ import org.jruby.runtime.builtin.IRubyObject;
  * @author enebo
  */
 public class Interpreted19Block  extends ContextAwareBlockBody {
-    private static final boolean ALREADY_ARRAY = true;
 
     /** The position for the block */
     private final ISourcePosition position;
@@ -118,12 +117,12 @@ public class Interpreted19Block  extends ContextAwareBlockBody {
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject[] args, Binding binding, Block.Type type) {
-        return yield(context, args, null, null, ALREADY_ARRAY, binding, type, Block.NULL_BLOCK);
+        return yield(context, args, null, null, binding, type, Block.NULL_BLOCK);
     }
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject[] args, Binding binding, Block.Type type, Block block) {
-        return yield(context, args, null, null, ALREADY_ARRAY, binding, type, block);
+        return yield(context, args, null, null, binding, type, block);
     }
 
     @Override
@@ -138,12 +137,12 @@ public class Interpreted19Block  extends ContextAwareBlockBody {
 
     @Override
     public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Binding binding, Block.Type type) {
-        return yield(context, new IRubyObject[] { arg0, arg1 }, null, null, ALREADY_ARRAY, binding, type);
+        return yield(context, new IRubyObject[] { arg0, arg1 }, null, null, binding, type);
     }
 
     @Override
     public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Binding binding, Block.Type type) {
-        return yield(context, new IRubyObject[] { arg0, arg1, arg2 }, null, null, ALREADY_ARRAY, binding, type);
+        return yield(context, new IRubyObject[] { arg0, arg1, arg2 }, null, null, binding, type);
     }
 
     @Override
@@ -171,19 +170,18 @@ public class Interpreted19Block  extends ContextAwareBlockBody {
      * @param args The args for yield
      * @param self The current self
      * @param klass
-     * @param aValue Should value be arrayified or not?
      * @return
      */
     @Override
     protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self,
-            RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
-        return yield(context, args, self, klass, aValue, binding, type, Block.NULL_BLOCK);
+            RubyModule klass, Binding binding, Block.Type type) {
+        return yield(context, args, self, klass, binding, type, Block.NULL_BLOCK);
 
     }
 
     @Override
     public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self,
-            RubyModule klass, boolean aValue, Binding binding, Block.Type type, Block block) {
+            RubyModule klass, Binding binding, Block.Type type, Block block) {
         if (klass == null) {
             self = prepareSelf(binding);
         }
@@ -193,7 +191,7 @@ public class Interpreted19Block  extends ContextAwareBlockBody {
 
         try {
             IRubyObject[] preppedArgs = RubyProc.prepareArgs(context, type, arity, args);
-            setupBlockArgs(context, context.runtime.newArrayNoCopyLight(preppedArgs), self, block, type, aValue);
+            setupBlockArgs(context, context.runtime.newArrayNoCopyLight(preppedArgs), self, block, type, true);
 
             // This while loop is for restarting the block call in case a 'redo' fires.
             return evalBlockBody(context, binding, self);

--- a/core/src/main/java/org/jruby/runtime/InterpretedBlock.java
+++ b/core/src/main/java/org/jruby/runtime/InterpretedBlock.java
@@ -318,7 +318,7 @@ public class InterpretedBlock extends ContextAwareBlockBody {
 
     @Override
     public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self,
-            RubyModule klass, boolean alreadyArray, Binding binding, Block.Type type, Block block) {
+            RubyModule klass, Binding binding, Block.Type type, Block block) {
         if (klass == null) {
             self = prepareSelf(binding);
         }
@@ -331,10 +331,9 @@ public class InterpretedBlock extends ContextAwareBlockBody {
             if (!noargblock) {
                 IRubyObject[] preppedArgs = RubyProc.prepareArgs(context, type, arity, args);
                 RubyArray argArray = context.runtime.newArrayNoCopyLight(preppedArgs);
-                IRubyObject values = alreadyArray ? assigner.convertIfAlreadyArray(runtime, argArray) :
-                    assigner.convertToArray(runtime, argArray);
+                IRubyObject value = assigner.convertIfAlreadyArray(runtime, argArray);
 
-                assigner.assignArray(runtime, context, self, values, block);
+                assigner.assignArray(runtime, context, self, value, block);
             }
 
             // This while loop is for restarting the block call in case a 'redo' fires.
@@ -374,13 +373,12 @@ public class InterpretedBlock extends ContextAwareBlockBody {
      * @param args The args for yield
      * @param self The current self
      * @param klass
-     * @param alreadyArray do we need an array or should we assume it already is one?
      * @return result of block invocation
      */
     @Override
     protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self,
-            RubyModule klass, boolean alreadyArray, Binding binding, Block.Type type) {
-        return yield(context, args, self, klass, alreadyArray, binding, type, Block.NULL_BLOCK);
+            RubyModule klass, Binding binding, Block.Type type) {
+        return yield(context, args, self, klass, binding, type, Block.NULL_BLOCK);
     }
     
     private IRubyObject evalBlockBody(ThreadContext context, Binding binding, IRubyObject self) {

--- a/core/src/main/java/org/jruby/runtime/InterpretedIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/InterpretedIRBlockBody.java
@@ -159,7 +159,7 @@ public class InterpretedIRBlockBody extends ContextAwareBlockBody {
     }
 
     @Override
-    public IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean argIsArray, Binding binding, Type type) {
+    public IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, Binding binding, Type type) {
         args = (args == null) ? IRubyObject.NULL_ARRAY : args;
         if (type == Block.Type.LAMBDA) {
             arity().checkArity(context.runtime, args);

--- a/core/src/main/java/org/jruby/runtime/JavaInternalBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/JavaInternalBlockBody.java
@@ -49,13 +49,13 @@ public abstract class JavaInternalBlockBody extends BlockBody {
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject[] args, Binding binding, Block.Type type) {
-        return yield(context, args, null, null, true, binding, type);
+        return yield(context, args, null, null, binding, type);
     }
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject[] args, Binding binding,
                             Block.Type type, Block block) {
-        return yield(context, args, null, null, true, binding, type, block);
+        return yield(context, args, null, null, binding, type, block);
     }
 
     @Override
@@ -66,7 +66,7 @@ public abstract class JavaInternalBlockBody extends BlockBody {
     }
 
     @Override
-    protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Type type) {
+    protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, Binding binding, Type type) {
         threadCheck(context);
         
         return yield(context, args);

--- a/core/src/main/java/org/jruby/runtime/MethodBlock.java
+++ b/core/src/main/java/org/jruby/runtime/MethodBlock.java
@@ -80,12 +80,12 @@ public abstract class MethodBlock extends ContextAwareBlockBody {
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject[] args, Binding binding, Block.Type type) {
-        return yield(context, args, null, null, true, binding, type, Block.NULL_BLOCK);
+        return yield(context, args, null, null, binding, type, Block.NULL_BLOCK);
     }
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject[] args, Binding binding, Block.Type type, Block block) {
-        return yield(context, args, null, null, true, binding, type, block);
+        return yield(context, args, null, null, binding, type, block);
     }
     
     @Override
@@ -110,12 +110,12 @@ public abstract class MethodBlock extends ContextAwareBlockBody {
 
     @Override
     public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Binding binding, Block.Type type) {
-        return yield(context, new IRubyObject[] { arg0, arg1 }, null, null, true, binding, type);
+        return yield(context, new IRubyObject[] { arg0, arg1 }, null, null, binding, type);
     }
 
     @Override
     public IRubyObject yieldSpecific(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Binding binding, Block.Type type) {
-        return yield(context, new IRubyObject[] { arg0, arg1, arg2 }, null, null, true, binding, type);
+        return yield(context, new IRubyObject[] { arg0, arg1, arg2 }, null, null, binding, type);
     }
     
     @Override
@@ -130,8 +130,8 @@ public abstract class MethodBlock extends ContextAwareBlockBody {
 
     @Override
     protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self,
-                             RubyModule klass, boolean aValue, Binding binding, Block.Type type) {
-        return yield(context, args, self, klass, aValue, binding, type, Block.NULL_BLOCK);
+                             RubyModule klass, Binding binding, Block.Type type) {
+        return yield(context, args, self, klass, binding, type, Block.NULL_BLOCK);
     }
 
     /**
@@ -141,12 +141,11 @@ public abstract class MethodBlock extends ContextAwareBlockBody {
      * @param args The args for yield
      * @param self The current self
      * @param klass
-     * @param aValue Should value be arrayified or not?
      * @return
      */
     @Override
     public IRubyObject yield(ThreadContext context, IRubyObject[] args, IRubyObject self,
-            RubyModule klass, boolean aValue, Binding binding, Block.Type type, Block block) {
+            RubyModule klass, Binding binding, Block.Type type, Block block) {
         if (klass == null) {
             self = binding.getSelf();
             binding.getFrame().setSelf(self);

--- a/core/src/main/java/org/jruby/runtime/NullBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/NullBlockBody.java
@@ -55,7 +55,7 @@ public class NullBlockBody extends BlockBody {
     }
 
     @Override
-    protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, boolean aValue, Binding binding, Type type) {
+    protected IRubyObject doYield(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule klass, Binding binding, Type type) {
         throw context.runtime.newLocalJumpError(RubyLocalJumpError.Reason.NOREASON, args[0], "yield called out of block");
     }
 

--- a/core/src/main/java/org/jruby/runtime/SharedScopeBlock.java
+++ b/core/src/main/java/org/jruby/runtime/SharedScopeBlock.java
@@ -56,7 +56,7 @@ public class SharedScopeBlock extends InterpretedBlock {
     }
     
     public IRubyObject call(ThreadContext context, IRubyObject[] args, IRubyObject replacementSelf, Binding binding, Block.Type type) {
-        return yield(context, args, null, null, true, binding, type);
+        return yield(context, args, null, null, binding, type);
     }
     
     @Override


### PR DESCRIPTION
Since it's now always clear when we have an array of args (because #1200 refactored to use IRubyObject[] rather than an ambiguous IRubyObject), we can delete the flag that was being used to track whether given arguments should be treated as an array or not.
