### PR TITLE
Fix any_spec

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -4025,7 +4025,6 @@ public class RubyArray extends RubyObject implements List, RandomAccess {
     }
 
     public IRubyObject any_p(ThreadContext context, Block block) {
-        if (!isBuiltin("each")) return RubyEnumerable.any_pCommon(context, this, block);
         if (!block.isGiven()) return any_pBlockless(context);
 
         for (int i = 0; i < realLength; i++) {

--- a/spec/tags/1.9/ruby/core/enumerable/any_tags.txt
+++ b/spec/tags/1.9/ruby/core/enumerable/any_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#any? with block gathers initial args as elements when each yields multiple


### PR DESCRIPTION
Use the appropriate arity to get Enumerable#any to handle its args correctly.  Note that we need to switch from JavaInternalBlockBody to a BlockCallback since JavaInternalBlockBody does not properly respect its arity in 1_7.

Note: this does not need to be merged into master.  `any_spec` was fixed for master in #1202
