### PR TITLE
Fix Enumerable#slice_before arg handling

### DIFF
--- a/core/src/main/ruby/jruby/kernel19/enumerable.rb
+++ b/core/src/main/ruby/jruby/kernel19/enumerable.rb
@@ -17,7 +17,11 @@ module Enumerable
 
     Enumerator.new do |yielder|
       ary = nil
-      self.each do |elt|
+      self.each do |*elt|
+        if elt.size < 2
+          elt = elt.size == 0 ? nil : elt[0]
+        end
+
         if block
           if no_filter
             state = block.call elt

--- a/spec/regression/GH-744_GH-264_enum_args_using_call_spec.rb
+++ b/spec/regression/GH-744_GH-264_enum_args_using_call_spec.rb
@@ -325,6 +325,14 @@ describe "Enumerables whose #each method passes multiple values to a block.call 
       it_behaves_like "an Enumerable method which takes a block", :array
     end
 
+    describe "Enumerable#slice_before" do
+      it "passes all #each args to its block" do
+        @test_enum.slice_before do |obj|
+          obj.should == [1, 2, 3]
+        end.each{}
+      end
+    end
+
     describe "Enumerable#flat_map" do
       subject { :flat_map }
       it_behaves_like "an Enumerable method which takes a block", :first_arg


### PR DESCRIPTION
Emulate packEnumArgs in the slice_before definition in enumerable.rb to ensure its arg handling behavior matches MRI.

Addresses the slice_before part of #901.
