### PR TITLE
Removes Logger customizations in JavaUtilLoggingLogger

### DIFF
--- a/core/src/main/java/org/jruby/util/log/JavaUtilLoggingLogger.java
+++ b/core/src/main/java/org/jruby/util/log/JavaUtilLoggingLogger.java
@@ -41,23 +41,6 @@ public class JavaUtilLoggingLogger implements Logger {
 
     public JavaUtilLoggingLogger(String loggerName) {
         logger = java.util.logging.Logger.getLogger(loggerName);
-        logger.setUseParentHandlers(false);
-        ConsoleHandler handler = new ConsoleHandler();
-        handler.setFormatter(new Formatter() {
-            @Override
-            public String format(LogRecord lr) {
-                StringBuilder sb = new StringBuilder();
-                sb
-                        .append(new DateTime(lr.getMillis()).toString())
-                        .append(": ")
-                        .append(lr.getLoggerName())
-                        .append(": ")
-                        .append(lr.getMessage())
-                        .append("\n");
-                return sb.toString();
-            }
-        });
-        logger.addHandler(handler);
     }
 
     public String getName() {


### PR DESCRIPTION
This commit removes logger customizations in JavaUtilLoggingLogger to
prevent memory leaks when JavaUtilLoggingLogger is loaded via another
ClassLoader that will eventually need to be disposed of. This is common
in application servers which create a new ClassLoader for each application.

Fixes #1266
