### PR TITLE
Fix arrays with overridden each

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -4025,6 +4025,7 @@ public class RubyArray extends RubyObject implements List, RandomAccess {
     }
 
     public IRubyObject any_p(ThreadContext context, Block block) {
+        if (!isBuiltin("each")) return RubyEnumerable.any_pCommon(context, this, block, Arity.OPTIONAL);
         if (!block.isGiven()) return any_pBlockless(context);
 
         for (int i = 0; i < realLength; i++) {

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -1416,17 +1416,19 @@ public class RubyEnumerable {
 
     @JRubyMethod(name = "all?", compat = RUBY1_8)
     public static IRubyObject all_p(ThreadContext context, IRubyObject self, final Block block) {
+        if (self instanceof RubyArray) return ((RubyArray) self).all_p(context, block);
+
         return all_pCommon(context, self, block, Arity.OPTIONAL);
     }
 
     @JRubyMethod(name = "all?", compat = RUBY1_9)
     public static IRubyObject all_p19(ThreadContext context, IRubyObject self, final Block block) {
+        if (self instanceof RubyArray) return ((RubyArray) self).all_p(context, block);
+
         return all_pCommon(context, self, block, block.arity());
     }
 
     public static IRubyObject all_pCommon(ThreadContext context, IRubyObject self, final Block block, Arity callbackArity) {
-        if (self instanceof RubyArray) return ((RubyArray) self).all_p(context, block);
-
         final Ruby runtime = context.runtime;
         final ThreadContext localContext = context;
 

--- a/spec/jruby/array_spec.rb
+++ b/spec/jruby/array_spec.rb
@@ -1,0 +1,25 @@
+# JRuby adds optimized versions of #any?, #all? and #find to Array which only delegate to Enumerable if Array#each has
+# been overridden.  This spec ensures we don't regress on any of the customizations.
+
+class ArrayExtender < Array
+  def each
+    yield "eachElem"
+  end
+end
+
+array_extender = ArrayExtender.new
+array_extender << "arrayElem"
+
+describe "Array" do
+  it "uses the #each method's override for #any? if one exists" do
+    array_extender.any? { |elem| elem.should == "eachElem" }
+  end
+
+  it "uses the #each method's override for #all? if one exists" do
+    array_extender.all? { |elem| elem.should == "eachElem" }
+  end
+
+  it "uses the #each method's override for #find? if one exists" do
+    array_extender.find { |elem| elem.should == "eachElem" }
+  end
+end


### PR DESCRIPTION
Fix a stack overflow in Array#all (https://github.com/jruby/jruby/issues/1265) and restore the correct behavior for Array#any (the needed isBuiltin check was incorrectly removed in https://github.com/jruby/jruby/pull/1234)

Also add a spec to ensure this remains stable going forward.
