### PR TITLE
Blockless Struct#select should return an enumerator

### DIFF
--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -32,13 +32,15 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby;
 
-import static org.jruby.RubyEnumerator.enumeratorize;
-
-
-import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.common.IRubyWarnings.ID;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.internal.runtime.methods.CallConfiguration;
+import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
+import org.jruby.runtime.ClassIndex;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
@@ -48,15 +50,10 @@ import org.jruby.runtime.marshal.MarshalStream;
 import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.util.ByteList;
 import org.jruby.util.IdUtil;
-import org.jruby.common.IRubyWarnings.ID;
-import org.jruby.exceptions.RaiseException;
-import org.jruby.internal.runtime.methods.CallConfiguration;
-import org.jruby.internal.runtime.methods.DynamicMethod;
-import org.jruby.runtime.ClassIndex;
 
-import static org.jruby.runtime.Visibility.*;
-
+import static org.jruby.RubyEnumerator.enumeratorize;
 import static org.jruby.runtime.Helpers.invokedynamic;
+import static org.jruby.runtime.Visibility.PRIVATE;
 import static org.jruby.runtime.invokedynamic.MethodNames.HASH;
 
 /**
@@ -448,9 +445,18 @@ public class RubyStruct extends RubyObject {
     public RubyArray members19() {
         return members19(classOf(), Block.NULL_BLOCK);
     }
-    
-    @JRubyMethod
-    public RubyArray select(ThreadContext context, Block block) {
+
+    @JRubyMethod(name = "select", compat = CompatVersion.RUBY1_8)
+    public RubyArray select18(ThreadContext context, Block block) {
+        return selectCommon(context, block);
+    }
+
+    @JRubyMethod(name = "select", compat = CompatVersion.RUBY1_9)
+    public IRubyObject select(ThreadContext context, Block block) {
+        return block.isGiven() ? selectCommon(context, block) : enumeratorize(context.runtime, this, "select");
+    }
+
+    public RubyArray selectCommon(ThreadContext context, Block block) {
         RubyArray array = RubyArray.newArray(context.runtime);
         
         for (int i = 0; i < values.length; i++) {


### PR DESCRIPTION
Discovered this gap trying to get 'test_enumerator#test_size_for_enum_created_from_struct` passing for #980

For 1.9+ blockless `Struct#select` returns an enumerator.  Note that the latest RubySpect contains a [test covering this](https://github.com/rubyspec/rubyspec/blob/93d0ec63e14f6e88214c6c9b0f6cbf52e6d6379e/core/struct/select_spec.rb#L29).
