### PR TITLE
Don't set java.net.preferIPv4Stack in shell scripts #1286

### DIFF
--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -299,9 +299,6 @@ if [[ $darwin && -z "$JAVA_ENCODING" ]]; then
   java_args=("${java_args[@]}" "-Dfile.encoding=UTF-8")
 fi
 
-# prefer IPv4 to IPv6; see https://github.com/jruby/jruby/issues/775
-java_args=("${java_args[@]}" "-Djava.net.preferIPv4Stack=true")
-
 # Append the rest of the arguments
 ruby_args=("${ruby_args[@]}" "$@")
 

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -250,9 +250,6 @@ if [[ -z "$JAVA_ENCODING" ]]; then
   java_args="${java_args} -Dfile.encoding=UTF-8"
 fi
 
-# prefer IPv4 to IPv6; see https://github.com/jruby/jruby/issues/775
-java_args=("${java_args[@]}" "-Djava.net.preferIPv4Stack=true")
-
 # Append the rest of the arguments
 ruby_args="${ruby_args} $@"
 


### PR DESCRIPTION
The setting of java.net.preferIPv4Stack is handled in Java code. Setting it in the shell scripts prevents the use of IPv6 when JRuby is launched via those shell scripts.

(My earlier pull request mistakenly targeted the master branch. This correct targets the jruby-1_7 branch).
