### PR TITLE
Fix #1222, StringIO.gets w/ utf8

### DIFF
--- a/core/src/main/java/org/jruby/ext/stringio/StringIO.java
+++ b/core/src/main/java/org/jruby/ext/stringio/StringIO.java
@@ -433,7 +433,7 @@ public class StringIO extends RubyObject implements EncodingCapable {
                 j--;
             }
             if (j < 0) return k + 1;
-            i += skip[big[i + bstart]];
+            i += skip[big[i + bstart] & 0xFF];
         }
         return -1;
     }

--- a/test/test_io.rb
+++ b/test/test_io.rb
@@ -540,4 +540,11 @@ class TestIO < Test::Unit::TestCase
     closed_io_count = JRuby.runtime.fileno_int_map_size
     assert_equal(starting_count, closed_io_count)
   end
+
+  # JRUBY-1222
+  def test_stringio_gets_utf8
+    @stringio = StringIO.new("®\r\n®\r\n")
+    assert_equal "®\r\n", @stringio.gets("\r\n")
+    assert_equal "®\r\n", @stringio.gets("\r\n")
+  end
 end


### PR DESCRIPTION
https://github.com/jruby/jruby/issues/1222
