### PR TITLE
Ensure Enumerator#size reflects changes to its underlying object

### DIFF
--- a/core/src/main/java/org/jruby/RubyFixnum.java
+++ b/core/src/main/java/org/jruby/RubyFixnum.java
@@ -276,7 +276,7 @@ public class RubyFixnum extends RubyInteger {
             }
             return this;
         } else {
-            return RubyEnumerator.enumeratorizeWithSize(context, this, "times", timesSize(context.runtime));
+            return RubyEnumerator.enumeratorizeWithSize(context, this, "times", timesSizeFn(context.runtime));
         }
     }
 

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -71,6 +71,7 @@ import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
 import static org.jruby.runtime.Helpers.invokedynamic;
 import static org.jruby.runtime.Visibility.PRIVATE;
 import static org.jruby.runtime.invokedynamic.MethodNames.HASH;
+import static org.jruby.RubyEnumerator.SizeFn;
 
 // Design overview:
 //
@@ -847,6 +848,16 @@ public class RubyHash extends RubyObject implements Map {
         return getRuntime().newFixnum(size);
     }
 
+    private SizeFn enumSizeFn() {
+        final RubyHash self = this;
+        return new RubyEnumerator.SizeFn() {
+            @Override
+            public IRubyObject size(IRubyObject[] args) {
+                return self.rb_size();
+            }
+        };
+    }
+
     /** rb_hash_empty_p
      *
      */
@@ -1297,7 +1308,7 @@ public class RubyHash extends RubyObject implements Map {
 
     @JRubyMethod(name = "each")
     public IRubyObject each19(final ThreadContext context, final Block block) {
-        return block.isGiven() ? each_pairCommon(context, block, true) : enumeratorizeWithSize(context, this, "each", rb_size());
+        return block.isGiven() ? each_pairCommon(context, block, true) : enumeratorizeWithSize(context, this, "each", enumSizeFn());
     }
 
     /** rb_hash_each_pair
@@ -1323,7 +1334,7 @@ public class RubyHash extends RubyObject implements Map {
 
     @JRubyMethod
     public IRubyObject each_pair(final ThreadContext context, final Block block) {
-        return block.isGiven() ? each_pairCommon(context, block, true) : enumeratorizeWithSize(context, this, "each_pair", rb_size());
+        return block.isGiven() ? each_pairCommon(context, block, true) : enumeratorizeWithSize(context, this, "each_pair", enumSizeFn());
     }
 
     /** rb_hash_each_value
@@ -1342,7 +1353,7 @@ public class RubyHash extends RubyObject implements Map {
 
     @JRubyMethod
     public IRubyObject each_value(final ThreadContext context, final Block block) {
-        return block.isGiven() ? each_valueCommon(context, block) : enumeratorizeWithSize(context, this, "each_value", rb_size());
+        return block.isGiven() ? each_valueCommon(context, block) : enumeratorizeWithSize(context, this, "each_value", enumSizeFn());
     }
 
     /** rb_hash_each_key
@@ -1361,14 +1372,14 @@ public class RubyHash extends RubyObject implements Map {
 
     @JRubyMethod
     public IRubyObject each_key(final ThreadContext context, final Block block) {
-        return block.isGiven() ? each_keyCommon(context, block) : enumeratorizeWithSize(context, this, "each_key", rb_size());
+        return block.isGiven() ? each_keyCommon(context, block) : enumeratorizeWithSize(context, this, "each_key", enumSizeFn());
     }
 
     @JRubyMethod(name = "select!")
     public IRubyObject select_bang(final ThreadContext context, final Block block) {
         if (block.isGiven()) return keep_ifCommon(context, block) ? this : context.runtime.getNil();
 
-        return enumeratorizeWithSize(context, this, "select!", rb_size());
+        return enumeratorizeWithSize(context, this, "select!", enumSizeFn());
     }
 
     @JRubyMethod
@@ -1378,7 +1389,7 @@ public class RubyHash extends RubyObject implements Map {
             return this;
         } 
 
-        return enumeratorizeWithSize(context, this, "keep_if", rb_size());
+        return enumeratorizeWithSize(context, this, "keep_if", enumSizeFn());
     }
     
     public boolean keep_ifCommon(final ThreadContext context, final Block block) {
@@ -1546,7 +1557,7 @@ public class RubyHash extends RubyObject implements Map {
     @JRubyMethod(name = "select")
     public IRubyObject select19(final ThreadContext context, final Block block) {
         final Ruby runtime = context.runtime;
-        if (!block.isGiven()) return enumeratorizeWithSize(context, this, "select", rb_size());
+        if (!block.isGiven()) return enumeratorizeWithSize(context, this, "select", enumSizeFn());
 
         final RubyHash result = newHash(runtime);
 
@@ -1584,7 +1595,7 @@ public class RubyHash extends RubyObject implements Map {
 
     @JRubyMethod
     public IRubyObject delete_if(final ThreadContext context, final Block block) {
-        return block.isGiven() ? delete_ifInternal(context, block) : enumeratorizeWithSize(context, this, "delete_if", rb_size());
+        return block.isGiven() ? delete_ifInternal(context, block) : enumeratorizeWithSize(context, this, "delete_if", enumSizeFn());
     }
 
     /** rb_hash_reject
@@ -1596,7 +1607,7 @@ public class RubyHash extends RubyObject implements Map {
 
     @JRubyMethod
     public IRubyObject reject(final ThreadContext context, final Block block) {
-        return block.isGiven() ? rejectInternal(context, block) : enumeratorizeWithSize(context, this, "reject", rb_size());
+        return block.isGiven() ? rejectInternal(context, block) : enumeratorizeWithSize(context, this, "reject", enumSizeFn());
     }
 
     /** rb_hash_reject_bang
@@ -1611,7 +1622,7 @@ public class RubyHash extends RubyObject implements Map {
 
     @JRubyMethod(name = "reject!")
     public IRubyObject reject_bang(final ThreadContext context, final Block block) {
-        return block.isGiven() ? reject_bangInternal(context, block) : enumeratorizeWithSize(context, this, "reject!", rb_size());
+        return block.isGiven() ? reject_bangInternal(context, block) : enumeratorizeWithSize(context, this, "reject!", enumSizeFn());
     }
 
     /** rb_hash_clear

--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -54,6 +54,7 @@ import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
 import static org.jruby.util.Numeric.checkInteger;
 import static org.jruby.util.Numeric.f_gcd;
 import static org.jruby.util.Numeric.f_lcm;
+import static org.jruby.RubyEnumerator.SizeFn;
 
 /** Implementation of the Integer class.
  *
@@ -242,18 +243,24 @@ public abstract class RubyInteger extends RubyNumeric {
             }
             return this;
         } else {
-            return enumeratorizeWithSize(context, this, "times", timesSize(context.runtime));
+            return enumeratorizeWithSize(context, this, "times", timesSizeFn(context.runtime));
         }
     }
 
-    protected RubyInteger timesSize(Ruby runtime) {
-        RubyFixnum zero = RubyFixnum.zero(runtime);
-        if ((this instanceof RubyFixnum && getLongValue() < 0)
-                || this.callMethod("<", zero).isTrue()) {
-            return zero;
-        }
+    protected SizeFn timesSizeFn(final Ruby runtime) {
+        final RubyInteger self = this;
+        return new SizeFn() {
+            @Override
+            public IRubyObject size(IRubyObject[] args) {
+                RubyFixnum zero = RubyFixnum.zero(runtime);
+                if ((self instanceof RubyFixnum && getLongValue() < 0)
+                        || self.callMethod("<", zero).isTrue()) {
+                    return zero;
+                }
 
-        return this;
+                return self;
+            }
+        };
     }
 
     /** int_succ

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -52,6 +52,7 @@ import org.jruby.util.ConvertDouble;
 
 import java.math.BigInteger;
 
+import static org.jruby.RubyEnumerator.SizeFn;
 import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
 import static org.jruby.runtime.Helpers.invokedynamic;
 import static org.jruby.util.Numeric.f_abs;
@@ -775,7 +776,7 @@ public class RubyNumeric extends RubyObject {
         if (block.isGiven()) {
             return stepCommon(context, arg0, RubyFixnum.one(context.runtime), block);
         } else {
-            return enumeratorizeWithSize(context, this, "step", new IRubyObject[] { arg0 }, stepSize(context, this, arg0, RubyFixnum.one(context.runtime)));
+            return enumeratorizeWithSize(context, this, "step", new IRubyObject[] { arg0 }, stepSizeFn(context, this, arg0, RubyFixnum.one(context.runtime)));
         }
     }
 
@@ -784,7 +785,7 @@ public class RubyNumeric extends RubyObject {
         if (block.isGiven()) {
             return stepCommon(context, to, step, block);
         } else {
-            return enumeratorizeWithSize(context, this, "step", new IRubyObject[]{to, step}, stepSize(context, this, to, step));
+            return enumeratorizeWithSize(context, this, "step", new IRubyObject[]{to, step}, stepSizeFn(context, this, to, step));
         }
     }
 
@@ -918,8 +919,13 @@ public class RubyNumeric extends RubyObject {
         }
     }
 
-    public static RubyNumeric stepSize(ThreadContext context, IRubyObject from, IRubyObject to, IRubyObject step) {
-        return intervalStepSize(context, from, to, step, false);
+    private SizeFn stepSizeFn(final ThreadContext context, final IRubyObject from, final IRubyObject to, final IRubyObject step) {
+        return new SizeFn() {
+            @Override
+            public IRubyObject size(IRubyObject[] args) {
+                return intervalStepSize(context, from, to, step, false);
+            }
+        };
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -101,6 +101,7 @@ import static org.jruby.util.StringSupport.toLower;
 import static org.jruby.util.StringSupport.toUpper;
 import static org.jruby.util.StringSupport.unpackArg;
 import static org.jruby.util.StringSupport.unpackResult;
+import static org.jruby.RubyEnumerator.SizeFn;
 
 /**
  * Implementation of Ruby String class
@@ -2300,6 +2301,17 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     public RubyFixnum bytesize() {
         return getRuntime().newFixnum(value.getRealSize());
     }
+
+    private SizeFn eachByteSizeFn() {
+        final RubyString self = this;
+        return new SizeFn() {
+            @Override
+            public IRubyObject size(IRubyObject[] args) {
+                return self.bytesize();
+            }
+        };
+    }
+
     /** rb_str_empty
      *
      */
@@ -5730,7 +5742,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
 
     @JRubyMethod(name = "each_byte")
     public IRubyObject each_byte19(ThreadContext context, Block block) {
-        return block.isGiven() ? each_byte(context, block) : enumeratorizeWithSize(context, this, "each_byte", bytesize());
+        return block.isGiven() ? each_byte(context, block) : enumeratorizeWithSize(context, this, "each_byte", eachByteSizeFn());
     }
 
     @JRubyMethod
@@ -5740,12 +5752,22 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
 
     @JRubyMethod(name = "each_char")
     public IRubyObject each_char19(ThreadContext context, Block block) {
-        return block.isGiven() ? each_charCommon19(context, block) : enumeratorizeWithSize(context, this, "each_char", length());
+        return block.isGiven() ? each_charCommon19(context, block) : enumeratorizeWithSize(context, this, "each_char", eachCharSizeFn());
     }
 
     @JRubyMethod(name = "chars")
     public IRubyObject chars19(ThreadContext context, Block block) {
-        return block.isGiven() ? each_charCommon19(context, block) : enumeratorizeWithSize(context, this, "chars", length());
+        return block.isGiven() ? each_charCommon19(context, block) : enumeratorizeWithSize(context, this, "chars", eachCharSizeFn());
+    }
+
+    private SizeFn eachCharSizeFn() {
+        final RubyString self = this;
+        return new SizeFn() {
+            @Override
+            public IRubyObject size(IRubyObject[] args) {
+                return self.length();
+            }
+        };
     }
 
     private IRubyObject each_charCommon19(ThreadContext context, Block block) {
@@ -5780,14 +5802,24 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
      */
     @JRubyMethod
     public IRubyObject each_codepoint(ThreadContext context, Block block) {
-        if (!block.isGiven()) return enumeratorizeWithSize(context, this, "each_codepoint", length());
+        if (!block.isGiven()) return enumeratorizeWithSize(context, this, "each_codepoint", eachCodepointSizeFn());
         return singleByteOptimizable() ? each_byte(context, block) : each_codepointCommon(context, block);
     }
 
     @JRubyMethod
     public IRubyObject codepoints(ThreadContext context, Block block) {
-        if (!block.isGiven()) return enumeratorizeWithSize(context, this, "codepoints", length());
+        if (!block.isGiven()) return enumeratorizeWithSize(context, this, "codepoints", eachCodepointSizeFn());
         return singleByteOptimizable() ? each_byte(context, block) : each_codepointCommon(context, block);
+    }
+
+    private SizeFn eachCodepointSizeFn() {
+        final RubyString self = this;
+        return new SizeFn() {
+            @Override
+            public IRubyObject size(IRubyObject[] args) {
+                return self.length();
+            }
+        };
     }
 
     private IRubyObject each_codepointCommon(ThreadContext context, Block block) {


### PR DESCRIPTION
Realized I was missing this important aspect in my implementations for #980: internally created enumerators need to lazily evaluate their size so that they stay consistent with the underlying object.  For example:

``` ruby
a = [1,2]
e = a.each
p e.size # should be 2
a << 3
p e.size # should be 3
```

I'm planning to put a RubySpec in to cover this, but in the meantime I used this [quick and dirty script](https://gist.github.com/dmarcotte/7826748) to exercise the new code.  (Side note: MRI fails one case in that script.  [Issue here](https://bugs.ruby-lang.org/issues/9223))
