### PR TITLE
#enum_slice and #enum_cons are 1.8-only

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -1034,8 +1034,8 @@ public class RubyEnumerable {
         return block.isGiven() ? each_slice(context, self, arg, block) : enumeratorize(context.runtime, self, "each_slice", arg);
     }
 
-    @JRubyMethod(name = "enum_slice")
-    public static IRubyObject enum_slice19(ThreadContext context, IRubyObject self, IRubyObject arg, final Block block) {
+    @JRubyMethod(name = "enum_slice", compat = RUBY1_8)
+    public static IRubyObject enum_slice(ThreadContext context, IRubyObject self, IRubyObject arg, final Block block) {
         return block.isGiven() ? each_slice(context, self, arg, block) : enumeratorize(context.runtime, self, "enum_slice", arg);
     }
 
@@ -1063,8 +1063,8 @@ public class RubyEnumerable {
         return block.isGiven() ? each_cons(context, self, arg, block) : enumeratorize(context.runtime, self, "each_cons", arg);
     }
 
-    @JRubyMethod(name = "enum_cons")
-    public static IRubyObject enum_cons19(ThreadContext context, IRubyObject self, IRubyObject arg, final Block block) {
+    @JRubyMethod(name = "enum_cons", compat = RUBY1_8)
+    public static IRubyObject enum_cons(ThreadContext context, IRubyObject self, IRubyObject arg, final Block block) {
         return block.isGiven() ? each_cons(context, self, arg, block) : enumeratorize(context.runtime, self, "enum_cons", arg);
     }
 

--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -366,8 +366,8 @@ public class RubyEnumerator extends RubyObject {
         return block.isGiven() ? RubyEnumerable.each_slice(context, this, arg, block) : enumeratorize(context.runtime, getType(), this, "each_slice", arg);
     }
 
-    @JRubyMethod(name = "enum_slice")
-    public IRubyObject enum_slice19(ThreadContext context, IRubyObject arg, final Block block) {
+    @JRubyMethod(name = "enum_slice", compat = RUBY1_8)
+    public IRubyObject enum_slice(ThreadContext context, IRubyObject arg, final Block block) {
         return block.isGiven() ? RubyEnumerable.each_slice(context, this, arg, block) : enumeratorize(context.runtime, getType(), this, "enum_slice", arg);
     }
 
@@ -376,8 +376,8 @@ public class RubyEnumerator extends RubyObject {
         return block.isGiven() ? RubyEnumerable.each_cons(context, this, arg, block) : enumeratorize(context.runtime, getType(), this, "each_cons", arg);
     }
 
-    @JRubyMethod(name = "enum_cons")
-    public IRubyObject enum_cons19(ThreadContext context, IRubyObject arg, final Block block) {
+    @JRubyMethod(name = "enum_cons", compat = RUBY1_8)
+    public IRubyObject enum_cons(ThreadContext context, IRubyObject arg, final Block block) {
         return block.isGiven() ? RubyEnumerable.each_cons(context, this, arg, block) : enumeratorize(context.runtime, getType(), this, "enum_cons", arg);
     }
     

--- a/spec/regression/enum_cons_and_enum_slice_only_in_1.8_spec.rb
+++ b/spec/regression/enum_cons_and_enum_slice_only_in_1.8_spec.rb
@@ -1,0 +1,39 @@
+require 'rspec'
+
+shared_examples :enum do
+  describe "#enum_slice" do
+    it "is only defined in 1.8 mode" do
+      if RUBY_VERSION =~ /1\.8/
+        subject.respond_to?(:enum_slice).should == true
+      else
+        subject.respond_to?(:enum_slice).should == false
+      end
+    end
+  end
+
+  describe "#enum_cons" do
+    it "is only defined in 1.8 mode" do
+      if RUBY_VERSION =~ /1\.8/
+        subject.respond_to?(:enum_cons).should == true
+      else
+        subject.respond_to?(:enum_cons).should == false
+      end
+    end
+  end
+end
+
+describe "Enumerable" do
+  subject {
+    Class.new do
+      include Enumerable
+    end.new
+  }
+  it_behaves_like :enum
+end
+
+describe "Enumerator" do
+  subject {
+    [].each
+  }
+  it_behaves_like :enum
+end


### PR DESCRIPTION
`#enum_slice` and `#enum_cons` were removed removed from MRI for 1.9+
