### PR TITLE
Array#repeated_permutation should have arity 1

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -3708,11 +3708,6 @@ public class RubyArray extends RubyObject implements List, RandomAccess {
         return block.isGiven() ? permutationCommon(context, RubyNumeric.num2int(num), true, block) : enumeratorize(context.runtime, this, "repeated_permutation", num);
     }
 
-    @JRubyMethod(name = "repeated_permutation", compat = RUBY1_9)
-    public IRubyObject repeated_permutation(ThreadContext context, Block block) {
-        return block.isGiven() ? permutationCommon(context, realLength, true, block) : enumeratorize(context.runtime, this, "repeated_permutation");
-    }
-
     private IRubyObject permutationCommon(ThreadContext context, int r, boolean repeat, Block block) {
         if (r == 0) {
             block.yield(context, newEmptyArray(context.runtime));

--- a/spec/regression/array_repeated_permutation_requires_arg_spec.rb
+++ b/spec/regression/array_repeated_permutation_requires_arg_spec.rb
@@ -1,0 +1,7 @@
+require 'rspec'
+
+describe "Array#repeated_permutation" do
+  it "has arity one" do
+    [].method(:repeated_permutation).arity.should == 1
+  end
+end if RUBY_VERSION >= "1.9"


### PR DESCRIPTION
Remove arg-less Array#repeated_permutation to match MRI behavior.  (Noticed this implementing `Array#repeated_permutation.size`: it relies on `#repeated_permutation` having an arg)

``` bash
$ ruby -e "p [].repeated_permutation"
-e:1:in `repeated_permutation': wrong number of arguments (0 for 1) (ArgumentError)
    from -e:1:in `<main>'
```

vs.

``` bash
$ jruby -e "p [].repeated_permutation"
#<Enumerator: []:repeated_permutation>
```
