### PR TITLE
Consolidate various JAR parsing areas into using FileResources.

### DIFF
--- a/core/src/main/java/org/jruby/util/FileResource.java
+++ b/core/src/main/java/org/jruby/util/FileResource.java
@@ -3,12 +3,23 @@ package org.jruby.util;
 /**
  * This is a shared interface for files loaded as {@link java.io.File} and {@link java.util.zip.ZipEntry}.
  */
-public interface FileResource { 
-  boolean exists();
+public interface FileResource {
+    String absolutePath();
 
-  boolean isDirectory();
-  boolean isFile();
+    boolean exists();
+    boolean isDirectory();
+    boolean isFile();
 
-  long lastModified();
-  long length();
+    long lastModified();
+    long length();
+
+    boolean canRead();
+    boolean canWrite();
+
+    /**
+     * @see java.io.File.list
+     */
+    String[] list();
+
+    boolean isSymLink();
 }

--- a/core/src/main/java/org/jruby/util/JRubyFile.java
+++ b/core/src/main/java/org/jruby/util/JRubyFile.java
@@ -36,16 +36,21 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 
 import org.jruby.Ruby;
+import org.jruby.RubyFile;
 
 import jnr.posix.JavaSecuredFile;
 import org.jruby.platform.Platform;
+import java.util.jar.JarFile;
+import java.util.jar.JarEntry;
+import java.util.zip.ZipEntry;
+import java.io.IOException;
 
 /**
  * <p>This file acts as an alternative to NormalizedFile, due to the problems with current working 
  * directory.</p>
  *
  */
-public class JRubyFile extends JavaSecuredFile implements FileResource {
+public class JRubyFile extends JavaSecuredFile {
     private static final long serialVersionUID = 435364547567567L;
 
     public static JRubyFile create(String cwd, String pathname) {
@@ -53,12 +58,13 @@ public class JRubyFile extends JavaSecuredFile implements FileResource {
     }
 
     public static FileResource createResource(String cwd, String pathname) {
-      if (pathname.indexOf('!') > 0) {
-        return JarFileResource.load(pathname);
-      } else {
-        // Regular file is fine
-        return create(cwd, pathname);
-      }
+        // Try as a jar resource first
+        FileResource jarResource = JarResource.create(pathname);
+        if (jarResource != null) {
+            return jarResource;
+        }
+
+        return new RegularFileResource(create(cwd, pathname));
     }
 
     public static String normalizeSeps(String path) {
@@ -96,27 +102,6 @@ public class JRubyFile extends JavaSecuredFile implements FileResource {
     }
 
     @Override
-    public String getAbsolutePath() {
-        return normalizeSeps(new File(super.getPath()).getAbsolutePath());
-    }
-
-    @Override
-    public String getCanonicalPath() throws IOException {
-        try {
-            return normalizeSeps(super.getCanonicalPath());
-        } catch (IOException e) {
-            // usually IOExceptions don't tell us anything about the path,
-            // so add an extra wrapper to give more debugging help.
-            throw (IOException) new IOException("Unable to canonicalize path: " + getAbsolutePath()).initCause(e);
-        }
-    }
-
-    @Override
-    public String getPath() {
-        return normalizeSeps(super.getPath());
-    }
-
-    @Override
     public String toString() {
         return normalizeSeps(super.toString());
     }
@@ -149,7 +134,7 @@ public class JRubyFile extends JavaSecuredFile implements FileResource {
             return new JRubyFile(par);
         }
     }
-    
+
     public static File[] listRoots() {
         File[] roots = File.listRoots();
         JRubyFile[] smartRoots = new JRubyFile[roots.length];
@@ -158,11 +143,11 @@ public class JRubyFile extends JavaSecuredFile implements FileResource {
         }
         return smartRoots;
     }
-    
+
     public static File createTempFile(String prefix, String suffix, File directory) throws IOException {
         return new JRubyFile(File.createTempFile(prefix, suffix,directory));
     }
-    
+
     public static File createTempFile(String prefix, String suffix) throws IOException {
         return new JRubyFile(File.createTempFile(prefix, suffix));
     }
@@ -173,7 +158,7 @@ public class JRubyFile extends JavaSecuredFile implements FileResource {
         if (files == null) {
             return null;
         }
-        
+
         String[] smartFiles = new String[files.length];
         for (int i = 0; i < files.length; i++) {
             smartFiles[i] = normalizeSeps(files[i]);

--- a/core/src/main/java/org/jruby/util/JarDirectoryResource.java
+++ b/core/src/main/java/org/jruby/util/JarDirectoryResource.java
@@ -1,0 +1,100 @@
+package org.jruby.util;
+
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.jar.JarFile;
+import java.util.jar.JarEntry;
+
+/**
+ * Represents a directory in a jar.
+ *
+ * <p>Jars do not necessarily have to contain entries for a directory. However, from ruby's point of
+ * view, if a jar contains entry /foo/bar, it already contains /foo directory. This resource permits
+ * just that.</p>
+ */
+class JarDirectoryResource extends JarResource {
+    public static JarDirectoryResource create(JarFile jar, String path) {
+        String dirPath = path.endsWith("/") ? path : path + "/";
+
+        // We always should have something in the jar, so "/" always corresponds to a directory
+        if ("/".equals(dirPath)) {
+            return new JarDirectoryResource(jar, dirPath);
+        }
+
+        Enumeration<JarEntry> entries = jar.entries();
+        while (entries.hasMoreElements()) {
+            if (entries.nextElement().getName().startsWith(dirPath)) {
+                return new JarDirectoryResource(jar, dirPath);
+            }
+        }
+        return null;
+    }
+
+    private final String path;
+
+    private JarDirectoryResource(JarFile jar, String path) {
+        super(jar);
+        this.path = path;
+    }
+
+    @Override
+    public String entryName() {
+        return path;
+    }
+
+    @Override
+    public boolean isDirectory() {
+        return true;
+    }
+
+    @Override
+    public boolean isFile() {
+        return false;
+    }
+
+    @Override
+    public long lastModified() {
+        // Iterating over matching entries is expensive, so let's return that we've never been
+        // modified
+        return 0L;
+    }
+
+    @Override
+    public long length() {
+        // this pseudo-directory doesn't take up any space
+        return 0L;
+    }
+
+    @Override
+    public String[] list() {
+        HashSet<String> dirs = new HashSet<String>();
+
+        Enumeration<JarEntry> entries = jar.entries();
+        while (entries.hasMoreElements()) {
+            String entryPath = entries.nextElement().getName();
+
+            String subPath;
+            if (isRoot()) {
+                subPath = entryPath;
+            } else if (entryPath.startsWith(path)) {
+                subPath = entryPath.substring(path.length());
+            } else {
+                // entry's path doesn't match the directory
+                continue;
+            }
+
+            // trim '/' from jar entry directories
+            if (subPath.endsWith("/") && subPath.length() > 1) {
+                subPath = subPath.substring(0, subPath.length() - 1);
+            }
+
+            dirs.add(subPath);
+        }
+
+        return dirs.toArray(new String[0]);
+    }
+
+    public boolean isRoot() {
+        return "/".equals(path);
+    }
+}

--- a/core/src/main/java/org/jruby/util/JarFileResource.java
+++ b/core/src/main/java/org/jruby/util/JarFileResource.java
@@ -1,56 +1,66 @@
 package org.jruby.util;
 
 import org.jruby.RubyFile;
+import org.jruby.Ruby;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.*;
 import java.util.zip.ZipEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarEntry;
 
 /**
- * A file resource that is contained within a jar.
+ * Represents a file in a jar.
+ *
+ * <p>
+ * Note: while directories can be contained within a jar, they're still represented by
+ * JarDirectoryResource, since Ruby expects a directory to exist as long as any files in that
+ * directory do, or Dir.glob would break.
+ * </p>
  */
-public class JarFileResource extends ZipEntry implements FileResource {
-  public static JarFileResource load(String path) {
-    String sanitized = path.startsWith("file:") ? path.substring(5) : path;
-
-    int bang = sanitized.indexOf('!');
-
-    if (bang == -1) {
-      throw new IllegalArgumentException("Expecting a jar containing path, but got: " + sanitized);
-    }
-
-    String jar = sanitized.substring(0, bang);
-    String after = sanitized.substring(bang + 2);
-
-    try {
-      return new JarFileResource(RubyFile.getDirOrFileEntry(jar, after));
-    } catch (IOException ioError) {
-      // Failed to get the file, so returning null, similar to like ZipFile#getEntry does
-      return null;
-    }
+class JarFileResource extends JarResource {
+  public static JarFileResource create(JarFile jar, String path) {
+    JarEntry entry = jar.getJarEntry(path);
+    return ((entry != null) && !entry.isDirectory()) ? new JarFileResource(jar, entry) : null;
   }
 
-  private JarFileResource(ZipEntry entry) {
-    super(entry);
+  private final ZipEntry entry;
+
+  private JarFileResource(JarFile jar, ZipEntry entry) {
+    super(jar);
+    this.entry = entry;
   }
 
   @Override
-  public boolean exists() {
-    // ZipEntry always exists
-    return true;
+  public String entryName() {
+    return entry.getName();
+  }
+
+  @Override
+  public boolean isDirectory() {
+    return false;
   }
 
   @Override
   public boolean isFile() {
-    return !isDirectory();
+    return true;
   }
 
   @Override
   public long length() {
-    return getSize();
+    return entry.getSize();
   }
 
   @Override
   public long lastModified() {
-    return getTime();
+    return entry.getTime();
+  }
+
+  @Override
+  public String[] list() {
+    // Files cannot be listed
+    return null;
   }
 }

--- a/core/src/main/java/org/jruby/util/JarResource.java
+++ b/core/src/main/java/org/jruby/util/JarResource.java
@@ -1,0 +1,96 @@
+package org.jruby.util;
+
+import org.jruby.Ruby;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.jar.JarFile;
+import java.util.jar.JarEntry;
+import java.util.zip.ZipEntry;
+
+public abstract class JarResource implements FileResource {
+    private static Pattern PREFIX_MATCH = Pattern.compile("^(?:jar:)?(?:file:)?(.*)$");
+
+    public static JarResource create(String pathname) {
+        Matcher matcher = PREFIX_MATCH.matcher(pathname);
+        String sanitized = matcher.matches() ? matcher.group(1) : pathname;
+
+        int bang = sanitized.indexOf('!');
+        if (bang < 0) {
+            return null;
+        }
+
+        String jarName = sanitized.substring(0, bang);
+        JarFile jar = Ruby.getGlobalRuntime().getCurrentContext().runtime.getLoadService().getJarFile(jarName);
+        if (jar == null) return null;
+
+        String slashPath = sanitized.substring(bang + 1);
+        if (!slashPath.startsWith("/")) {
+            slashPath = "/" + slashPath;
+        }
+
+        // TODO: Do we really need to support both test.jar!foo/bar.rb and test.jar!/foo/bar.rb cases?
+        JarResource resource = createJarResource(jar, slashPath);
+
+        if (resource == null) {
+            resource = createJarResource(jar, slashPath.substring(1));
+        }
+
+        return resource;
+    }
+
+    private static JarResource createJarResource(JarFile jar, String path) {
+        // Try as directory first, file second, because if test.jar contains:
+        //
+        // test/
+        // test/foo.rb
+        //
+        // file:test.jar!test should be a directory and not a file.
+        JarResource resource = JarDirectoryResource.create(jar, path);
+        if (resource == null) {
+            resource = JarFileResource.create(jar, path);
+        }
+        return resource;
+    }
+
+    protected final JarFile jar;
+
+    protected JarResource(JarFile jar) {
+        this.jar = jar;
+    }
+
+    @Override
+    public String absolutePath() {
+        return jar.getName() + "!" + entryName();
+    }
+
+    @Override
+    public boolean exists() {
+        // If a jar resource got created, then it always corresponds to some kind of resource
+        return true;
+    }
+
+    @Override
+    public boolean canRead() {
+        // Can always read from a jar
+        return true;
+    }
+
+    @Override
+    public boolean canWrite() {
+        return false;
+    }
+
+    @Override
+    public boolean isSymLink() {
+        // Jar archives shouldn't contain symbolic links, or it would break portability. `jar`
+        // command behavior seems to comform to that (it unwraps syumbolic links when creating a jar
+        // and replaces symbolic links with regular file when extracting from a zip that contains
+        // symbolic links). Also see:
+        // http://www.linuxquestions.org/questions/linux-general-1/how-to-create-jar-files-with-symbolic-links-639381/
+        return false;
+    }
+
+    abstract protected String entryName();
+}

--- a/core/src/main/java/org/jruby/util/RegularFileResource.java
+++ b/core/src/main/java/org/jruby/util/RegularFileResource.java
@@ -1,0 +1,103 @@
+package org.jruby.util;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FilenameFilter;
+import java.io.IOException;
+
+import org.jruby.Ruby;
+import org.jruby.RubyFile;
+
+import jnr.posix.JavaSecuredFile;
+import org.jruby.platform.Platform;
+import java.util.jar.JarFile;
+import java.util.jar.JarEntry;
+import java.util.zip.ZipEntry;
+import java.io.IOException;
+
+/**
+ * Represents a "regular" file, backed by regular file system.
+ */
+class RegularFileResource implements FileResource {
+    private final JRubyFile file;
+    private static final long serialVersionUID = 435364547567567L;
+
+    RegularFileResource(File file) {
+        this(file.getAbsolutePath());
+    }
+
+    protected RegularFileResource(String filename) {
+        this.file = new JRubyFile(filename);
+    }
+
+    @Override
+    public String absolutePath() {
+        return file.getAbsolutePath();
+    }
+
+    @Override
+    public long length() {
+        return file.length();
+    }
+
+    @Override
+    public long lastModified() {
+        return file.lastModified();
+    }
+
+    @Override
+    public boolean exists() {
+        return file.exists();
+    }
+
+    @Override
+    public boolean isFile() {
+        return file.isFile();
+    }
+
+    @Override
+    public boolean isDirectory() {
+        return file.isDirectory();
+    }
+
+    @Override
+    public boolean isSymLink() {
+        // java.io.File doesn't readily tells whether a file is a symlink,
+        // so rely on getCanonicalFile to expand symbolic links behavior to judge
+        try {
+            File canon;
+            if (file.getParent() == null) {
+                canon = file;
+            } else {
+                File canonDir;
+                canonDir = file.getParentFile().getCanonicalFile();
+
+                canon = new File(canonDir, file.getName());
+            }
+            return !canon.getCanonicalFile().equals(canon.getAbsoluteFile());
+        } catch (IOException e) {
+            return false;
+        }
+
+    }
+
+    @Override
+    public boolean canRead() {
+        return file.canRead();
+    }
+
+    @Override
+    public boolean canWrite() {
+        return file.canWrite();
+    }
+
+    @Override
+    public String[] list() {
+        return file.list();
+    }
+
+    @Override
+    public String toString() {
+        return file.toString();
+    }
+}


### PR DESCRIPTION
There are quite a lot of places in current JRuby code where jar:test.jar!foo/bar support is explicitly handled, which leads to plenty of code duplication.

This pull requests does following:

1) Update FileResource interface to replace JRubyFile functionality in most places.
2) Add JarFileResource and JarDirectoryResource resource types, which handle a jar directory entry and jar file entry respectively.
3) Move most of file resource logic from JRubyFile into RegularFileResource, leaving JRubyFile with methods for dealing with real files.
4) Replaces most places where {Jar,Zip}File are used to use resources instead.

TODO (which are not part of this PR):
1) LoadService should be able to use file resources as well, but the logic there is quite hairy, so leaving it for another refactoring day.
2) RubyFile tends to mix resources and JRubyFile which isn't really great.
