### PR TITLE
Phs/issue 1388 leaky thread locals

### DIFF
--- a/core/src/main/java/org/jruby/embed/internal/ConcurrentLocalContextProvider.java
+++ b/core/src/main/java/org/jruby/embed/internal/ConcurrentLocalContextProvider.java
@@ -30,6 +30,8 @@
 package org.jruby.embed.internal;
 
 import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicReference;
 import org.jruby.Ruby;
 import org.jruby.RubyInstanceConfig;
 import org.jruby.embed.LocalVariableBehavior;
@@ -38,21 +40,35 @@ import org.jruby.embed.LocalVariableBehavior;
  * Concurrent type local context provider.
  * Ruby runtime returned from the getRuntime() method is a classloader-global runtime.
  * While variables (except global variables) and constants are thread local.
- * 
+ *
  * @author Yoko Harada <yokolet@gmail.com>
  */
 public class ConcurrentLocalContextProvider extends AbstractLocalContextProvider {
-    private ThreadLocal<LocalContext> contextHolder =
-            new ThreadLocal<LocalContext>() {
+    private volatile ConcurrentLinkedQueue<AtomicReference<LocalContext>> contextRefs =
+        new ConcurrentLinkedQueue<AtomicReference<LocalContext>>();
+
+    private ThreadLocal<AtomicReference<LocalContext>> contextHolder =
+            new ThreadLocal<AtomicReference<LocalContext>>() {
                 @Override
-                public LocalContext initialValue() {
-                    return getInstance();
-                }
-                
-                @Override
-                public void remove() {
-                    LocalContext localContext = get();
-                    localContext.remove();
+                public AtomicReference<LocalContext> initialValue() {
+                    AtomicReference<LocalContext> contextRef = null;
+
+                    try {
+                        contextRef = new AtomicReference<LocalContext>(getInstance());
+                        contextRefs.add(contextRef);
+                        return contextRef;
+                    } catch (NullPointerException npe) {
+                        if (contextRefs == null) {
+                            // contextRefs became null, we've been terminated
+                            if (contextRef != null) {
+                                contextRef.get().remove();
+                            }
+
+                            return null;
+                        } else {
+                            throw npe;
+                        }
+                    }
                 }
             };
 
@@ -64,7 +80,7 @@ public class ConcurrentLocalContextProvider extends AbstractLocalContextProvider
         this.behavior = behavior;
         this.lazy = lazy;
     }
-    
+
     public Ruby getRuntime() {
         if (!Ruby.isGlobalRuntimeReady()) {
             return Ruby.newInstance(config);
@@ -79,18 +95,30 @@ public class ConcurrentLocalContextProvider extends AbstractLocalContextProvider
     }
 
     public BiVariableMap getVarMap() {
-        return contextHolder.get().getVarMap(this);
+        return contextHolder.get().get().getVarMap(this);
     }
 
     public Map getAttributeMap() {
-        return contextHolder.get().getAttributeMap();
+        return contextHolder.get().get().getAttributeMap();
     }
 
     public boolean isRuntimeInitialized() {
         return Ruby.isGlobalRuntimeReady();
     }
-    
+
     public void terminate() {
+        ConcurrentLinkedQueue<AtomicReference<LocalContext>> terminated = contextRefs;
+        contextRefs = null;
+
+        if (terminated != null) {
+            for (AtomicReference<LocalContext> contextRef : terminated) {
+                contextRef.get().remove();
+                contextRef.lazySet(null);
+            }
+
+            terminated.clear();
+        }
+
         contextHolder.remove();
         contextHolder.set(null);
     }


### PR DESCRIPTION
Thread-local and concurrent contexts can nearly reclaim thread locals. Java unfortunately offers no official way to clean up thread locals without having each thread that owns a copy execute `remove()`.  When JRuby is embedded in an application as a plugin in a larger system, this can be hard or impossible to arrange.  In this scenario `ConcurrentLocalContextProvider` and `ThreadSafeLocalContextProvider` are basically forced to leak their thread locals.

However, this does not mean they must leak the referenced `LocalContext` objects.  If those could be reclaimed, then the lion's share of resources would be garbage-collectable, even if the thread locals themselves leak.  Importantly, this would also allow the relevant jruby classloader to be collected to enable hot-unloading in embedding/plugin scenarios.

By wrapping each `LocalContext` in an explicit, mutable reference and tracking those references, the providers can still make the contexts unreachable without the help of other threads.  This is what we do here.

In each provider:
- `ThreadLocal<LocalContext>` becomes `ThreadLocal<AtomicReference<LocalContext>>`
- A `volatile` `ConcurrentLinkedQueue<WeakReference<AtomicReference<LocalContext>>>` is added to accumulate new `AtomicReference<LocalContext>` instances as they are created
- `terminate()` walks this collection, cleaning up each context and setting its owning `AtomicReference` value to `null`.

The `volatile`, combined with setting the container to null, takes care of a race condition between `initialValue()` and `terminate()`.  Weak references are used to prevent the collection from accumulating `LocalContext`s after the owning threads die.

`ConcurrentLocalContextProvider` has also become a subclass of `ThreadSafeLocalContextProvider`.

See #1388
