### PR TITLE
Reduced the number of String allocations for the NONE parameterList case.

### DIFF
--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -2703,7 +2703,9 @@ public class Helpers {
             builder.append("b").append(argsNode.getBlock().getName());
         }
 
-        if (!added) builder.append("NONE");
+        if (!added) {
+          return "NONE";
+        }
 
         return builder.toString();
     }


### PR DESCRIPTION
Please double-check me on this, but I think previously "NONE" would only be appended if the builder was empty.  Rather than append to the builder and convert to a String, which will allocate a new copy of the String, I just return the String literal directly.  In a sample of a production app that was up for < 15 min., I had 6,346 copies of this String.
