### PR TITLE
Allow Travis on select branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ branches:
   only:
     - master
     - jruby-1_7
+    - /^test-.*$/
 
 script: "ant $TARGET"
 install: /bin/true


### PR DESCRIPTION
I like to run Travis on my branches before sending pulls to keep things running smoothly.  A recent change restricting Travis runs to master and jruby-1_7 makes that awkward...

This change enables running Travis on any branch prefixed "test-", so we continue to avoid thrashing Travis on every single commit, but it's very easy to validate a branch by pushing it with a "test-" prefix.
