### PR TITLE
Restore hex and random_bytes to SecureRandom 1.8 (fixes Travis)

### DIFF
--- a/core/src/main/java/org/jruby/ext/securerandom/SecureRandomLibrary.java
+++ b/core/src/main/java/org/jruby/ext/securerandom/SecureRandomLibrary.java
@@ -1,5 +1,6 @@
 package org.jruby.ext.securerandom;
 
+import org.jruby.CompatVersion;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
@@ -30,7 +31,7 @@ public class SecureRandomLibrary {
         return RubyString.newStringNoCopy(context.runtime, ConvertBytes.twosComplementToHexBytes(nextBytes(context, n), false));
     }
 
-    @JRubyMethod(meta = true)
+    @JRubyMethod(meta = true, compat = CompatVersion.RUBY1_9)
     public static IRubyObject uuid(ThreadContext context, IRubyObject self) {
         return RubyString.newStringNoCopy(context.runtime, ConvertBytes.bytesToUUIDBytes(nextBytes(context, 16), false));
     }

--- a/lib/ruby/shared/securerandom.rb
+++ b/lib/ruby/shared/securerandom.rb
@@ -195,10 +195,10 @@ if RUBY_VERSION >= "1.9.0"
     len = format_message.call(format_message_ignore_inserts + format_message_from_system, 0, code, 0, msg, 1024, nil, nil, nil, nil, nil, nil, nil, nil)
     msg[0, len].tr("\r", '').chomp
   end
+end
 
   # Load the JRuby native ext
   JRuby.reference(self).define_annotated_methods(org.jruby.ext.securerandom.SecureRandomLibrary)
-end
 
   class << self
   private


### PR DESCRIPTION
The refactor which replaced hex and random_bytes with native code in SecureRandom accidentally left them broken for 1.8 (the [commit which native-ed uuid](https://github.com/jruby/jruby/commit/14f7c4780217f939adc6314201eca909773eb1fb) moved the native extension loading behind a Ruby 1.9-only check).  Restored!

This gets `jruby-1_7` Travis green.
