### PR TITLE
Fixed issue 1441. Forced check that value was of an appropriate type.

### DIFF
--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -798,7 +798,7 @@ public class RubyBigDecimal extends RubyNumeric {
 
     @JRubyMethod(name = "-", required = 1)
     public IRubyObject op_minus19(ThreadContext context, IRubyObject b) {
-        return subInternal(context, getVpValue19(context, b, false), b);
+        return subInternal(context, getVpValue19(context, b, true), b);
     }
 
     public IRubyObject sub2(ThreadContext context, IRubyObject b, IRubyObject n) {


### PR DESCRIPTION
I verified that the issue reported was a difference between MRI and JRuby. Looking at the RubyBigDecimal class it seems to be a fairly simple fix, changing a false to true. After making this change to the "-" method code, I rebuilt JRuby and tried the example again. 

Before change:

```
Stevens-MacBook-Pro:jruby sjc$ ./bin/jruby -S irb
2.1.0 :001 > require 'bigdecimal'
 => true 
2.1.0 :002 > BigDecimal.new("0") - nil
TypeError: nil can't be coerced into BigDecimal
    from org/jruby/ext/bigdecimal/RubyBigDecimal.java:801:in `-'
    from (irb):2:in `evaluate'
    from org/jruby/RubyKernel.java:901:in `eval'
    from org/jruby/RubyKernel.java:1220:in `loop'
    from org/jruby/RubyKernel.java:1031:in `catch'
    from org/jruby/RubyKernel.java:1031:in `catch'
    from /Users/sjc/projects/ruby/jruby/bin/jirb:13:in `(root)'
```

After change:

```
Stevens-MacBook-Pro:jruby sjc$ ./bin/jruby -S irb
2.1.0 :001 > require 'bigdecimal'
 => true 
2.1.0 :002 > BigDecimal.new("0") - nil
TypeError: nil can't be coerced into BigDecimal
    from org/jruby/ext/bigdecimal/RubyBigDecimal.java:801:in `-'
    from (irb):2:in `evaluate'
    from org/jruby/RubyKernel.java:901:in `eval'
    from org/jruby/RubyKernel.java:1220:in `loop'
    from org/jruby/RubyKernel.java:1031:in `catch'
    from org/jruby/RubyKernel.java:1031:in `catch'
    from /Users/sjc/projects/ruby/jruby/bin/jirb:13:in `(root)'
2.1.0 :003 > 
```

This change seems to address the issue. Please let me know if there is something else that I have missed.
