### PR TITLE
BUILDING.md: Added info about incremental compiling, cleaning after switching branches

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -93,6 +93,14 @@ mvn -Pbootstrap
 This only needs to be run once to install these gems or if you update
 one of the gems to a newer version or clean out all installed gems.
 
+### Incremental compiling
+
+After changing Java code, you can recompile quickly by running:
+
+```
+mvn compile
+```
+
 ### Day to Day Testing
 
 For normal day-to-day testing, we recommend running the Ruby 1.9 tests
@@ -141,6 +149,10 @@ mvn clean install -Pjruby-jars
 ```
 
 this first cleans everything and then starts the new build in one go !
+
+Cleaning the build may be necessary after switching to a different
+version of JRuby (for example, after switching git branches) to ensure
+that everything is rebuilt properly.
 
 NOTE: ```mvn clean``` just cleans the **jruby-core** artifact and the **./lib/jruby.jar** !
 


### PR DESCRIPTION
When I started developing with JRuby I didn't know how to do a quick incremental compilation.  I ran "mvn package" after every change to any Java code.  Thankfully, @mkristian told me how to do it in this comment:

https://github.com/jruby/jruby/issues/1470#issuecomment-33900740

@mkristian also said it would be necessary to clean the build after switching branches (i.e. from master to jruby-1_7) and I have confirmed that it is necessary with an experiment, as discussed in issue #1470.

I think it would be helpful to other new JRuby developers if this information was in BUILDING.md, so I made this pull request to add it.  I really don't know much about Maven or Java compilation but hopefully I got this right.

This pull request goes to the jruby-1_7 branch, which I think is the right way to do it.  It should be merged into master too so people can see it easily on github.  Thanks!
