### PR TITLE
Fix uniq/uniq! with block for array slices

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -3175,8 +3175,7 @@ public class RubyArray extends RubyObject implements List, RandomAccess {
     }
 
     private RubyHash makeHash(ThreadContext context, RubyHash hash, Block block) {
-        int myBegin = this.begin;
-        for (int i = myBegin; i < myBegin + realLength; i++) {
+        for (int i = 0; i < realLength; i++) {
             IRubyObject v = elt(i);
             IRubyObject k = block.yield(context, v);
             if (hash.fastARef(k) == null) hash.fastASet(k, v);

--- a/test/test_array.rb
+++ b/test/test_array.rb
@@ -25,6 +25,11 @@ class TestArray < Test::Unit::TestCase
     end
   end
 
+  def test_uniq_with_block_after_slice
+    assert_equal [1], [1, 1, 1][1,2].uniq { |x| x }
+    assert_equal [1], [1, 1, 1][1,2].uniq! { |x| x }
+  end
+
   # JRUBY-4157
   def test_shared_ary_slice
     assert_equal [4,5,6], [1,2,3,4,5,6].slice(1,5).slice!(2,3)


### PR DESCRIPTION
Avoid adjusting for slice offset twice.

Probably fixes #1434
