### PR TITLE
Fixed https://github.com/jruby/jruby/issues/1486

### DIFF
--- a/core/src/main/java/org/jruby/ast/WhenOneArgNode.java
+++ b/core/src/main/java/org/jruby/ast/WhenOneArgNode.java
@@ -43,12 +43,6 @@ public class WhenOneArgNode extends WhenNode {
     public IRubyObject when(IRubyObject test, ThreadContext context, Ruby runtime, IRubyObject self, Block aBlock) {
         // No actual test, so do 'when' if when expression is not nil
         if (test == null) return whenNoTest(context, runtime, self, aBlock);
-        if (!(expressionNodes instanceof IEqlNode)) return whenSlowTest(test, context, runtime, self, aBlock);
-
-        if (((IEqlNode) expressionNodes).eql(test, context, runtime, self, aBlock)) {
-            return bodyNode.interpret(runtime, context, self, aBlock);
-        }
-
-        return null;
+        return whenSlowTest(test, context, runtime, self, aBlock);
     }
 }

--- a/spec/ruby/core/fixnum/case_compare_spec.rb
+++ b/spec/ruby/core/fixnum/case_compare_spec.rb
@@ -4,5 +4,23 @@ require File.expand_path('../shared/equal', __FILE__)
 ruby_version_is "1.9" do
   describe "Fixnum#===" do
     it_behaves_like :fixnum_equal, :===
+
+    it "should pickuo overriden stuff" do
+      class Fixnum
+        def ===(other)
+          true
+        end
+      end
+
+      ret = case 4
+        when 3
+          "YES"
+        else
+          "NO"
+        end
+
+      ret.should == "YES"
+      Fixnum.send(:remove_method, :===)
+    end
   end
 end


### PR DESCRIPTION
Unfortunately, seems like now comparing two fixnums will incur a regular
ruby object comparison overhead. But that seems unavoidable when we want
to allow to override behavior of even core classes.
