### PR TITLE
Better messaging with NameErrors

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -982,7 +982,7 @@ public class Java implements Library {
                     // we'll try as a package
                     return getJavaPackageModule(runtime, fullName);
                 } else {
-                    throw runtime.newNameError("missing class or uppercase package name (`" + fullName + "')", fullName);
+                    throw runtime.newNameError("missing class or uppercase package name (`" + fullName + "'), caused by " + e.getMessage(), fullName);
                 }
             }
 


### PR DESCRIPTION
provide a pass through of the java error for easier debugging when jars actually exist but a name error manifests anyways

Makes something like this https://gist.github.com/adamstegman/5077010 far easier to debug.  I also ran into on my own project attempting to load jars that had a JVM Security Policy violation.

This if my first pull request, so if I did something wrong, let me know.

I consent to having my contributions licensed under EPL, GPLv2, and LGPLv2.
