### PR TITLE
Processdottimesfix

### DIFF
--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -54,6 +54,9 @@ import static org.jruby.runtime.invokedynamic.MethodNames.OP_EQUAL;
 import static org.jruby.util.WindowsFFI.kernel32;
 import static org.jruby.util.WindowsFFI.Kernel32.*;
 
+import java.lang.management.ThreadMXBean;
+import java.lang.management.ManagementFactory;
+
 /**
  */
 
@@ -1013,21 +1016,31 @@ public class RubyProcess {
 
     public static IRubyObject times(Ruby runtime) {
         Times tms = runtime.getPosix().times();
+        double utime = 0.0d, stime = 0.0d, cutime = 0.0d, cstime = 0.0d;
         if (tms == null) {
-            throw runtime.newErrnoFromLastPOSIXErrno();
+            ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+            if(bean.isCurrentThreadCpuTimeSupported()) {
+                cutime = utime = bean.getCurrentThreadUserTime();
+                cstime = stime = bean.getCurrentThreadCpuTime() - bean.getCurrentThreadUserTime();
+            }
+        } else {
+            utime = (double)tms.utime();
+            stime = (double)tms.stime();
+            cutime = (double)tms.cutime();
+            cstime = (double)tms.cstime();
         }
 
         long hz = runtime.getPosix().sysconf(Sysconf._SC_CLK_TCK);
         if (hz == -1) {
-            throw runtime.newErrnoFromLastPOSIXErrno();
+            hz = 60; //https://github.com/ruby/ruby/blob/trunk/process.c#L6616
         }
 
         return RubyStruct.newStruct(runtime.getTmsStruct(),
                 new IRubyObject[] {
-                        runtime.newFloat((double) tms.utime() / (double) hz),
-                        runtime.newFloat((double) tms.stime() / (double) hz),
-                        runtime.newFloat((double) tms.cutime() / (double) hz),
-                        runtime.newFloat((double) tms.cstime() / (double) hz)
+                        runtime.newFloat(utime / (double) hz),
+                        runtime.newFloat(stime / (double) hz),
+                        runtime.newFloat(cutime / (double) hz),
+                        runtime.newFloat(cstime / (double) hz)
                 },
                 Block.NULL_BLOCK);
     }


### PR DESCRIPTION
I have a feeling the real fix here is somewhere in jnr.posix since under C rubies, times(2) isn't returning -1 on overflow, this PR is meant to start discussion of a potential fix.

The bug this addresses is here http://linux.die.net/man/2/times, specifically the "Bugs" section. "A limitation of the Linux system call conventions on some architectures (notably i386) means that on Linux 2.6 there is a small time window (41 seconds) soon after boot when times() can return -1, falsely indicating that an error occurred. The same problem can occur when the return value wraps passed the maximum value that can be stored in clock_t."

In C Ruby, the return value of times(2) is never checked(though it probably should be).  https://github.com/ruby/ruby/blob/trunk/process.c#L6515

Also, without this patch, the error thrown is ENOENT, or something equally random since there isn't actually an error occurring and being set in kernel space on this call.  So, when the old throw occurred from tms being null, it was throwing whatever the last global error value was set to.

I'll stress again that while this keeps 32 bit stuff from crashing, the error is likely in jnr.posix and that our calling conventions from there do not match how Ruby is calling which is causing this issue to manifest.

I consent to having my contributions licensed under EPL, GPLv2, and LGPLv2.
