### PR TITLE
fix ld scripts on FreeBSD

### DIFF
--- a/lib/ruby/shared/ffi/library.rb
+++ b/lib/ruby/shared/ffi/library.rb
@@ -76,7 +76,7 @@ module FFI
               break if lib
             rescue Exception => ex
               ldscript = false
-              if ex.message =~ /(([^ \t()])+\.so([^ \t:()])*):([ \t])*invalid ELF header/
+              if ex.message =~ /(([^ \t()])+\.so([^ \t:()])*):([ \t])*(invalid ELF header|file too short|invalid file format)/
                 if File.read($1) =~ /GROUP *\( *([^ \)]+) *\)/
                   libname = $1
                   ldscript = true


### PR DESCRIPTION
another part of the regex used in MRI ffi was also missing
