### PR TITLE
Include vm.version in --version string

### DIFF
--- a/core/src/main/java/org/jruby/util/cli/OutputStrings.java
+++ b/core/src/main/java/org/jruby/util/cli/OutputStrings.java
@@ -115,12 +115,13 @@ public class OutputStrings {
         versionString = String.format("%s", ver);
 
         String fullVersion = String.format(
-                "jruby %s (%s) %s %s on %s %s%s [%s-%s]",
+                "jruby %s (%s) %s %s %s %s on %s%s [%s-%s]",
                 Constants.VERSION,
                 versionString,
                 Constants.COMPILE_DATE,
                 Constants.REVISION,
                 SafePropertyAccessor.getProperty("java.vm.name", "Unknown JVM"),
+                SafePropertyAccessor.getProperty("java.vm.version", "Unknown JVM version"),
                 SafePropertyAccessor.getProperty("java.runtime.version", SafePropertyAccessor.getProperty("java.version", "Unknown version")),
                 RubyInstanceConfig.USE_INVOKEDYNAMIC ? " +indy" : "",
                 Platform.getOSName(),


### PR DESCRIPTION
This patch modifies the --version string to include the property java.vm.version.

This seems like generally useful information, but I admit that my personal motivation is that it includes the information about whether or not the VM includes the Graal compiler.

I've done this as a PR because I guess the --version string might be something that people are depending on.
