### PR TITLE
Implement jar directory snapshot caching.

### DIFF
--- a/core/src/main/java/org/jruby/util/JarDirectoryResource.java
+++ b/core/src/main/java/org/jruby/util/JarDirectoryResource.java
@@ -1,7 +1,5 @@
 package org.jruby.util;
 
-import java.util.jar.JarFile;
-
 /**
  * Represents a directory in a jar.
  *
@@ -13,8 +11,8 @@ class JarDirectoryResource extends JarResource {
     private final String path;
     private final String[] contents;
 
-    JarDirectoryResource(JarFile jar, String path, String[] contents) {
-        super(jar);
+    JarDirectoryResource(String jarPath, String path, String[] contents) {
+        super(jarPath);
         this.path = path;
         this.contents = contents;
     }

--- a/core/src/main/java/org/jruby/util/JarFileResource.java
+++ b/core/src/main/java/org/jruby/util/JarFileResource.java
@@ -15,8 +15,8 @@ import java.util.jar.JarEntry;
 class JarFileResource extends JarResource {
   private final JarEntry entry;
 
-  JarFileResource(JarFile jar, JarEntry entry) {
-    super(jar);
+  JarFileResource(String jarPath, JarEntry entry) {
+    super(jarPath);
     this.entry = entry;
   }
 


### PR DESCRIPTION
Currently, when we try to load a jar resource, we go through all the jar entries to figure out if there are any that match the directory information. When doing globbing or Dir.entries it also currently scans the jar again.

This PR optimizes this by creating a static JarCache reference that caches information about loaded jars, including representation of the directory structure. The inform1.7.10: user 1m24.332s
HEAD: user 0m19.604sation is stored in a WeakHashMap which should allow it to be garbage collected. Benchmarking on a jar containing files from jruby.git/core (just over 9000 files) shows about 4x improvement:

```
time bin/jruby -e '5.times { Dir.glob("file:/home/ratnikov/jruby.git/stuff.jar!core/**/*") }'
```

Results for 1.7.10: 1m24.332s
Results for HEAD: 0m19.604s

I have considered doing a per Ruby runtime cache, but that would require resources to have a reference to a Runtime and caching cross-runtime jar contents is also probably okay.
