### PR TITLE
`CompatVersion.getVersionFromString` does not cover RUBY2_1

### DIFF
--- a/core/src/main/java/org/jruby/CompatVersion.java
+++ b/core/src/main/java/org/jruby/CompatVersion.java
@@ -29,6 +29,10 @@ public enum CompatVersion {
             return CompatVersion.RUBY2_0;
         } else if (compatString.equalsIgnoreCase("2.0")) {
             return CompatVersion.RUBY2_0;
+        } else if (compatString.equalsIgnoreCase("RUBY2_1")) {
+            return CompatVersion.RUBY2_1;
+        } else if (compatString.equalsIgnoreCase("2.1")) {
+            return CompatVersion.RUBY2_1;
         } else {
             return null;
         }


### PR DESCRIPTION
... it's deprecated but still should work as intended/expected.
