### PR TITLE
Pathname doesn't have to_path in 1.8

### DIFF
--- a/spec/regression/GH-1460_pathname_ivar_spec.rb
+++ b/spec/regression/GH-1460_pathname_ivar_spec.rb
@@ -5,7 +5,7 @@ describe "Pathname @path ivar should be transparent to Ruby land" do
     path = Pathname.new('test')
     path.instance_variable_get(:@path).should == 'test'
     path.instance_variable_set(:@path, 'foo')
-    path.to_path.should == 'foo'
+    path.to_s.should == 'foo'
   end
 
   specify "YAML deserialization" do
@@ -13,6 +13,6 @@ describe "Pathname @path ivar should be transparent to Ruby land" do
     path = Pathname.new('foo')
     yaml = path.to_yaml
     deserialized = YAML.load(yaml)
-    deserialized.to_path.should == 'foo'
+    deserialized.to_s.should == 'foo'
   end
 end


### PR DESCRIPTION
This should fix the jruby-1_7 build. Or at least partially fix it.

See https://github.com/jruby/jruby/issues/1460
