### PR TITLE
String#{to_r,to_c} should not use backref when calling gsub internally

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -3132,7 +3132,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
                 } else {            // block given
                     match = RubyRegexp.createMatchData19(context, this, matcher, pattern);
                     match.regexp = regexp;
-                    context.setBackRef(match);
+                    if (useBackref) context.setBackRef(match);
                     val = objAsString(context, block.yield(context, substr));
                 }
                 modifyCheck(bytes, slen, enc);
@@ -3163,7 +3163,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         } else {
             match = RubyRegexp.createMatchData19(context, this, matcher, pattern);
             match.regexp = regexp;
-            context.setBackRef(match);
+            if (useBackref) context.setBackRef(match);
         }
 
         if (bang) {
@@ -7473,10 +7473,9 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     public IRubyObject to_c(ThreadContext context) {
         Ruby runtime = context.runtime;
 
-        IRubyObject s = Helpers.invoke(
-                context, this, "gsub",
-                RubyRegexp.newDummyRegexp(runtime, Numeric.ComplexPatterns.underscores_pat),
-                runtime.newString(new ByteList(new byte[]{'_'})));
+        RubyString underscore = runtime.newString(new ByteList(new byte[]{'_'}));
+        RubyRegexp underscore_pattern = RubyRegexp.newDummyRegexp(runtime, Numeric.ComplexPatterns.underscores_pat);
+        IRubyObject s = this.gsubCommon19(context, null, underscore, null, underscore_pattern, false, 0, false);
 
         RubyArray a = RubyComplex.str_to_c_internal(context, s);
 
@@ -7494,10 +7493,9 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     public IRubyObject to_r(ThreadContext context) {
         Ruby runtime = context.runtime;
 
-        IRubyObject s = Helpers.invoke(
-                context, this, "gsub",
-                RubyRegexp.newDummyRegexp(runtime, Numeric.ComplexPatterns.underscores_pat),
-                runtime.newString(new ByteList(new byte[]{'_'})));
+        RubyString underscore = runtime.newString(new ByteList(new byte[]{'_'}));
+        RubyRegexp underscore_pattern = RubyRegexp.newDummyRegexp(runtime, Numeric.ComplexPatterns.underscores_pat);
+        IRubyObject s = this.gsubCommon19(context, null, underscore, null, underscore_pattern, false, 0, false);
 
         RubyArray a = RubyRational.str_to_r_internal(context, s);
 


### PR DESCRIPTION
Fixes #1563 
