### PR TITLE
Clarify documentation for isTrue, isFalse

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -407,7 +407,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     }
 
     /**
-     * Is this value a falsy value or not? Based on the {@link #FALSE_F} flag.
+     * Is this value a falsey value or not? Based on the {@link #FALSE_F} flag.
      */
     public final boolean isFalse() {
         return (flags & FALSE_F) != 0;


### PR DESCRIPTION
`BasicRubyObject.isTrue` and `.isFalse` correspond to whether the RubyObject is truthy or falsy, not just whether or not it is an instance of TrueClass or FalseClass. This documentation change makes that clear.

I confirmed this by calling `isTrue` on a RubyString, which returned true.
