### PR TITLE
Remove [@] syntax to add IBM i compatibility

### DIFF
--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -58,8 +58,8 @@ process_special_opts() {
         *) break;;
     esac
 }
-for opt in ${JRUBY_OPTS[@]}; do
-    for special in ${JRUBY_OPTS_SPECIAL[@]}; do
+for opt in ${JRUBY_OPTS}; do
+    for special in ${JRUBY_OPTS_SPECIAL}; do
         if [ $opt != $special ]; then
             JRUBY_OPTS_TEMP="${JRUBY_OPTS_TEMP} $opt"
         else
@@ -280,7 +280,7 @@ if [ "$VERIFY_JRUBY" != "" ]; then
   fi
 
 
-  "$JAVACMD" $PROFILE_ARGS $JAVA_OPTS "$JFFI_OPTS" ${java_args[@]} -classpath "$JRUBY_CP$CP_DELIMITER$CP$CP_DELIMITER$CLASSPATH" \
+  "$JAVACMD" $PROFILE_ARGS $JAVA_OPTS "$JFFI_OPTS" ${java_args} -classpath "$JRUBY_CP$CP_DELIMITER$CP$CP_DELIMITER$CLASSPATH" \
     "-Djruby.home=$JRUBY_HOME" \
     "-Djruby.lib=$JRUBY_HOME/lib" -Djruby.script=jruby \
     "-Djruby.shell=$JRUBY_SHELL" \


### PR DESCRIPTION
Hello,

I try to use JRuby on IBM i. I can't use the jruby.sh script with the [@] syntax which is not compatible with the system.

In the case of this script I think the [@] can be removed safely. 

Thank.
