### PR TITLE
Import specs from rubysl-zlib

### DIFF
--- a/spec/ruby/library/zlib/adler32_spec.rb
+++ b/spec/ruby/library/zlib/adler32_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../spec_helper', __FILE__)
 require 'zlib'
 
 describe "Zlib.adler32" do

--- a/spec/ruby/library/zlib/crc32_spec.rb
+++ b/spec/ruby/library/zlib/crc32_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../spec_helper', __FILE__)
 require 'zlib'
 
 describe "Zlib.crc32" do

--- a/spec/ruby/library/zlib/crc_table_spec.rb
+++ b/spec/ruby/library/zlib/crc_table_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../spec_helper', __FILE__)
 require "zlib"
 
 describe "Zlib.crc_table" do

--- a/spec/ruby/library/zlib/deflate/append_spec.rb
+++ b/spec/ruby/library/zlib/deflate/append_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/deflate/flush_spec.rb
+++ b/spec/ruby/library/zlib/deflate/flush_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/deflate/initialize_copy_spec.rb
+++ b/spec/ruby/library/zlib/deflate/initialize_copy_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/deflate/new_spec.rb
+++ b/spec/ruby/library/zlib/deflate/new_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/deflate/params_spec.rb
+++ b/spec/ruby/library/zlib/deflate/params_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'zlib'
 
 describe "Zlib::Deflate#params" do

--- a/spec/ruby/library/zlib/deflate/set_dictionary_spec.rb
+++ b/spec/ruby/library/zlib/deflate/set_dictionary_spec.rb
@@ -1,5 +1,4 @@
 # -*- encoding: US-ASCII -*-
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'zlib'
 
 describe "Zlib::Deflate#set_dictionary" do

--- a/spec/ruby/library/zlib/gzipfile/close_spec.rb
+++ b/spec/ruby/library/zlib/gzipfile/close_spec.rb
@@ -1,5 +1,4 @@
 # -*- encoding: ascii-8bit -*-
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'stringio'
 require 'zlib'
 

--- a/spec/ruby/library/zlib/gzipfile/closed_spec.rb
+++ b/spec/ruby/library/zlib/gzipfile/closed_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'stringio'
 require 'zlib'
 

--- a/spec/ruby/library/zlib/gzipfile/comment_spec.rb
+++ b/spec/ruby/library/zlib/gzipfile/comment_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'stringio'
 require 'zlib'
 

--- a/spec/ruby/library/zlib/gzipfile/crc_spec.rb
+++ b/spec/ruby/library/zlib/gzipfile/crc_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipfile/finish_spec.rb
+++ b/spec/ruby/library/zlib/gzipfile/finish_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipfile/level_spec.rb
+++ b/spec/ruby/library/zlib/gzipfile/level_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipfile/mtime_spec.rb
+++ b/spec/ruby/library/zlib/gzipfile/mtime_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipfile/orig_name_spec.rb
+++ b/spec/ruby/library/zlib/gzipfile/orig_name_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'stringio'
 require 'zlib'
 

--- a/spec/ruby/library/zlib/gzipfile/os_code_spec.rb
+++ b/spec/ruby/library/zlib/gzipfile/os_code_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipfile/sync_spec.rb
+++ b/spec/ruby/library/zlib/gzipfile/sync_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipfile/to_io_spec.rb
+++ b/spec/ruby/library/zlib/gzipfile/to_io_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipfile/wrap_spec.rb
+++ b/spec/ruby/library/zlib/gzipfile/wrap_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipreader/each_byte_spec.rb
+++ b/spec/ruby/library/zlib/gzipreader/each_byte_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'stringio'
 require 'zlib'
 

--- a/spec/ruby/library/zlib/gzipreader/each_line_spec.rb
+++ b/spec/ruby/library/zlib/gzipreader/each_line_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipreader/each_spec.rb
+++ b/spec/ruby/library/zlib/gzipreader/each_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipreader/eof_spec.rb
+++ b/spec/ruby/library/zlib/gzipreader/eof_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'stringio'
 require 'zlib'
 

--- a/spec/ruby/library/zlib/gzipreader/getc_spec.rb
+++ b/spec/ruby/library/zlib/gzipreader/getc_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'stringio'
 require 'zlib'
 

--- a/spec/ruby/library/zlib/gzipreader/gets_spec.rb
+++ b/spec/ruby/library/zlib/gzipreader/gets_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipreader/lineno_spec.rb
+++ b/spec/ruby/library/zlib/gzipreader/lineno_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipreader/new_spec.rb
+++ b/spec/ruby/library/zlib/gzipreader/new_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipreader/open_spec.rb
+++ b/spec/ruby/library/zlib/gzipreader/open_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipreader/pos_spec.rb
+++ b/spec/ruby/library/zlib/gzipreader/pos_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'stringio'
 require 'zlib'
 

--- a/spec/ruby/library/zlib/gzipreader/read_spec.rb
+++ b/spec/ruby/library/zlib/gzipreader/read_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'stringio'
 require 'zlib'
 

--- a/spec/ruby/library/zlib/gzipreader/readchar_spec.rb
+++ b/spec/ruby/library/zlib/gzipreader/readchar_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipreader/readline_spec.rb
+++ b/spec/ruby/library/zlib/gzipreader/readline_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipreader/readlines_spec.rb
+++ b/spec/ruby/library/zlib/gzipreader/readlines_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipreader/rewind_spec.rb
+++ b/spec/ruby/library/zlib/gzipreader/rewind_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'stringio'
 require 'zlib'
 

--- a/spec/ruby/library/zlib/gzipreader/tell_spec.rb
+++ b/spec/ruby/library/zlib/gzipreader/tell_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipreader/ungetc_spec.rb
+++ b/spec/ruby/library/zlib/gzipreader/ungetc_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipreader/unused_spec.rb
+++ b/spec/ruby/library/zlib/gzipreader/unused_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipwriter/append_spec.rb
+++ b/spec/ruby/library/zlib/gzipwriter/append_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'stringio'
 require 'zlib'
 

--- a/spec/ruby/library/zlib/gzipwriter/comment_spec.rb
+++ b/spec/ruby/library/zlib/gzipwriter/comment_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipwriter/flush_spec.rb
+++ b/spec/ruby/library/zlib/gzipwriter/flush_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipwriter/mtime_spec.rb
+++ b/spec/ruby/library/zlib/gzipwriter/mtime_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'stringio'
 require 'zlib'
 

--- a/spec/ruby/library/zlib/gzipwriter/new_spec.rb
+++ b/spec/ruby/library/zlib/gzipwriter/new_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipwriter/open_spec.rb
+++ b/spec/ruby/library/zlib/gzipwriter/open_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipwriter/orig_name_spec.rb
+++ b/spec/ruby/library/zlib/gzipwriter/orig_name_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipwriter/pos_spec.rb
+++ b/spec/ruby/library/zlib/gzipwriter/pos_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipwriter/print_spec.rb
+++ b/spec/ruby/library/zlib/gzipwriter/print_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipwriter/printf_spec.rb
+++ b/spec/ruby/library/zlib/gzipwriter/printf_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipwriter/putc_spec.rb
+++ b/spec/ruby/library/zlib/gzipwriter/putc_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipwriter/puts_spec.rb
+++ b/spec/ruby/library/zlib/gzipwriter/puts_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipwriter/tell_spec.rb
+++ b/spec/ruby/library/zlib/gzipwriter/tell_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/gzipwriter/write_spec.rb
+++ b/spec/ruby/library/zlib/gzipwriter/write_spec.rb
@@ -1,5 +1,4 @@
 # -*- encoding: ascii-8bit -*-
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'stringio'
 require 'zlib'
 

--- a/spec/ruby/library/zlib/inflate/append_spec.rb
+++ b/spec/ruby/library/zlib/inflate/append_spec.rb
@@ -1,5 +1,4 @@
 # -*- encoding: US-ASCII -*-
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'zlib'
 
 describe "Zlib::Inflate#<<" do

--- a/spec/ruby/library/zlib/inflate/finish_spec.rb
+++ b/spec/ruby/library/zlib/inflate/finish_spec.rb
@@ -1,0 +1,29 @@
+# -*- encoding: US-ASCII -*-
+require 'zlib'
+
+describe "Zlib::Inflate#finish" do
+
+  before do
+    @zeros    = Zlib::Deflate.deflate("0" * 100_000)
+    @inflator = Zlib::Inflate.new
+    @chunks   = []
+
+    @inflator.inflate(@zeros) do |chunk|
+      @chunks << chunk
+      break
+    end
+
+    @inflator.finish do |chunk|
+      @chunks << chunk
+    end
+  end
+
+  it "inflates chunked data" do
+    @chunks.map { |chunk| chunk.length }.should == [16384, 16384, 16384, 16384, 16384, 16384, 1696]
+  end
+
+  it "each chunk should have the same prefix" do
+    @chunks.all? { |chunk| chunk =~ /\A0+\z/ }.should be_true
+  end
+
+end

--- a/spec/ruby/library/zlib/inflate/inflate_spec.rb
+++ b/spec/ruby/library/zlib/inflate/inflate_spec.rb
@@ -1,6 +1,5 @@
 # -*- encoding: US-ASCII -*-
 require 'zlib'
-require File.expand_path('../../../../spec_helper', __FILE__)
 
 describe "Zlib::Inflate#inflate" do
 
@@ -106,5 +105,48 @@ describe "Zlib::Inflate::inflate" do
     # the first chunk is inflated to its completion,
     # the second chunk is just passed through.
     result.should == "foo" + main_data
+  end
+end
+
+describe "Zlib::Inflate#inflate" do
+
+  before do
+    @zeros    = Zlib::Deflate.deflate("0" * 100_000)
+    @inflator = Zlib::Inflate.new
+    @chunks   = []
+  end
+
+  describe "without break" do
+
+    before do
+      @inflator.inflate(@zeros) do |chunk|
+        @chunks << chunk
+      end
+    end
+
+    it "inflates chunked data" do
+      @chunks.map { |chunk| chunk.size }.should == [16384, 16384, 16384, 16384, 16384, 16384, 1696]
+    end
+
+    it "properly handles chunked data" do
+      @chunks.all? { |chunk| chunk =~ /\A0+\z/ }.should be_true
+    end
+
+  end
+
+  describe "with break" do
+
+    before do
+      @inflator.inflate(@zeros) do |chunk|
+        @chunks << chunk
+        break
+      end
+    end
+
+    it "inflates chunked break" do
+      output = @inflator.inflate nil
+      (100_000 - @chunks.first.length).should == output.length
+    end
+
   end
 end

--- a/spec/ruby/library/zlib/inflate/new_spec.rb
+++ b/spec/ruby/library/zlib/inflate/new_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/inflate/set_dictionary_spec.rb
+++ b/spec/ruby/library/zlib/inflate/set_dictionary_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'zlib'
 
 describe "Zlib::Inflate#set_dictionary" do

--- a/spec/ruby/library/zlib/inflate/sync_point_spec.rb
+++ b/spec/ruby/library/zlib/inflate/sync_point_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/inflate/sync_spec.rb
+++ b/spec/ruby/library/zlib/inflate/sync_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/zlib_version_spec.rb
+++ b/spec/ruby/library/zlib/zlib_version_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/zstream/adler_spec.rb
+++ b/spec/ruby/library/zlib/zstream/adler_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'zlib'
 
 describe "Zlib::ZStream#adler" do

--- a/spec/ruby/library/zlib/zstream/avail_in_spec.rb
+++ b/spec/ruby/library/zlib/zstream/avail_in_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'zlib'
 
 describe "Zlib::ZStream#avail_in" do

--- a/spec/ruby/library/zlib/zstream/avail_out_spec.rb
+++ b/spec/ruby/library/zlib/zstream/avail_out_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'zlib'
 
 describe "Zlib::ZStream#avail_out" do

--- a/spec/ruby/library/zlib/zstream/close_spec.rb
+++ b/spec/ruby/library/zlib/zstream/close_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/zstream/closed_spec.rb
+++ b/spec/ruby/library/zlib/zstream/closed_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/zstream/data_type_spec.rb
+++ b/spec/ruby/library/zlib/zstream/data_type_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'zlib'
 
 describe "Zlib::ZStream#data_type" do

--- a/spec/ruby/library/zlib/zstream/end_spec.rb
+++ b/spec/ruby/library/zlib/zstream/end_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/zstream/ended_spec.rb
+++ b/spec/ruby/library/zlib/zstream/ended_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/zstream/finish_spec.rb
+++ b/spec/ruby/library/zlib/zstream/finish_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/zstream/finished_spec.rb
+++ b/spec/ruby/library/zlib/zstream/finished_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/zstream/flush_next_in_spec.rb
+++ b/spec/ruby/library/zlib/zstream/flush_next_in_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/zstream/flush_next_out_spec.rb
+++ b/spec/ruby/library/zlib/zstream/flush_next_out_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../../spec_helper', __FILE__)
 require 'zlib'
 
 describe "Zlib::ZStream#flush_next_out" do

--- a/spec/ruby/library/zlib/zstream/reset_spec.rb
+++ b/spec/ruby/library/zlib/zstream/reset_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/zstream/stream_end_spec.rb
+++ b/spec/ruby/library/zlib/zstream/stream_end_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/zstream/total_in_spec.rb
+++ b/spec/ruby/library/zlib/zstream/total_in_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/ruby/library/zlib/zstream/total_out_spec.rb
+++ b/spec/ruby/library/zlib/zstream/total_out_spec.rb
@@ -1,1 +1,0 @@
-require File.expand_path('../../../../spec_helper', __FILE__)

--- a/spec/tags/ruby/library/zlib/deflate/deflate_tags.txt
+++ b/spec/tags/ruby/library/zlib/deflate/deflate_tags.txt
@@ -1,0 +1,7 @@
+fails:Zlib::Deflate#deflate without break deflates chunked data
+fails:Zlib::Deflate#deflate without break deflates chunked data with final chunk
+fails:Zlib::Deflate#deflate without break deflates chunked data without errors
+fails:Zlib::Deflate#deflate with break deflates only first chunk
+fails:Zlib::Deflate#deflate with break deflates chunked data with final chunk
+fails:Zlib::Deflate#deflate with break deflates chunked data without errors
+fails:Zlib.deflate deflates chunked data

--- a/spec/tags/ruby/library/zlib/inflate/finish_tags.txt
+++ b/spec/tags/ruby/library/zlib/inflate/finish_tags.txt
@@ -1,0 +1,1 @@
+fails:Zlib::Inflate#finish inflates chunked data

--- a/spec/tags/ruby/library/zlib/inflate/inflate_tags.txt
+++ b/spec/tags/ruby/library/zlib/inflate/inflate_tags.txt
@@ -1,0 +1,1 @@
+fails:Zlib::Inflate#inflate without break inflates chunked data


### PR DESCRIPTION
New zlib from ruby allows streams to be processed without huge
memory growth. There is specs for new API of #inflate and #deflate
methods.  Each of these methods may take a block which can process
one chunk of the stream.

Related to https://github.com/jruby/jruby/issues/1216