### PR TITLE
Actually use Java7ClassValue when using Java 7+.

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/JavaSupport.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupport.java
@@ -95,7 +95,7 @@ public class JavaSupport {
                 // try to load the ClassValue class. If it succeeds, we can use our
                 // ClassValue-based cache.
                 Class.forName("java.lang.ClassValue");
-                constructor = (Constructor<ClassValue>)Class.forName("org.jruby.java.proxies.ClassValueProxyCache").getConstructor(ClassValueCalculator.class);
+                constructor = (Constructor<ClassValue>)Class.forName("org.jruby.util.collections.Java7ClassValue").getConstructor(ClassValueCalculator.class);
             }
             catch (Exception ex) {
                 // fall through to Map version


### PR DESCRIPTION
When f5850a515adadc6589cc286d4d38c2fecc79f2bf was created, the `org.jruby.java.proxies.ClassValueProxyCache` class was renamed as `org.jruby.util.collections.Java7ClassValue`. But that class was only referenced via reflection, and so IDE-based refactoring did not catch it, and `Java7ClassValue` ended up being totally unused.
