### PR TITLE
Array#pack(cC) should not raise RangeError when argument is bignum

### DIFF
--- a/core/src/main/java/org/jruby/util/Pack.java
+++ b/core/src/main/java/org/jruby/util/Pack.java
@@ -377,6 +377,10 @@ public class Pack {
                 byte c = (byte) (RubyNumeric.num2long(o) & 0xff);
                 result.append(c);
             }
+            public void encode19(Ruby runtime, IRubyObject o, ByteList result) {
+                byte c = (byte) (num2quad19(o) & 0xff);
+                result.append(c);
+            }
         };
         // unsigned char
         converters['C'] = new Converter(1, "Integer") {
@@ -385,6 +389,10 @@ public class Pack {
             }
             public void encode(Ruby runtime, IRubyObject o, ByteList result){
                 byte c = o == runtime.getNil() ? 0 : (byte) (RubyNumeric.num2long(o) & 0xff);
+                result.append(c);
+            }
+            public void encode19(Ruby runtime, IRubyObject o, ByteList result){
+                byte c = o == runtime.getNil() ? 0 : (byte) (num2quad19(o) & 0xff);
                 result.append(c);
             }
         };

--- a/spec/regression/GH-1478_pack_c_bignum_spec.rb
+++ b/spec/regression/GH-1478_pack_c_bignum_spec.rb
@@ -1,0 +1,11 @@
+describe "Array#pack('c')" do
+  it 'does not raise RangeError when argument is bignum' do
+    [0xfffffffffffffffff].pack("c").should == "\xFF"
+  end
+end unless RUBY_VERSION < '1.9'
+
+describe "Array#pack('C')" do
+  it 'does not raise RangeError when argument is bignum' do
+    [0xfffffffffffffffff].pack("C").should == "\xFF"
+  end
+end unless RUBY_VERSION < '1.9'


### PR DESCRIPTION
Fixes #1478
