### PR TITLE
Fix compare_to for to_java'ed Ruby objects

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -1085,7 +1085,6 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
             
             // if RubyBasicObject#op_cmp is used, the result may be nil
             if (!cmp.isNil()) {
-            } else {
                 return (int) cmp.convertToInteger().getLongValue();
             }
         } catch (RaiseException ex) {

--- a/spec/regression/GH-1520_java_compare_to_spec.rb
+++ b/spec/regression/GH-1520_java_compare_to_spec.rb
@@ -1,0 +1,11 @@
+require 'date'
+
+describe "java.lang.Object#compareTo" do
+  it "returns the appropriate value when invoked on a to_java'd object" do
+    # note: this bug only appeared for objects which were not represented internally with
+    # RubyBignum, RubyFixnum, RubyFloat or RubyString since they override the compareTo in RubyBasicObject
+    expect(Date.today.to_java.compareTo((Date.today - 1).to_java)).to eql(1)
+    expect(Date.today.to_java.compareTo((Date.today).to_java)).to eql(0)
+    expect(Date.today.to_java.compareTo((Date.today + 1).to_java)).to eql(-1)
+  end
+end


### PR DESCRIPTION
Flip incorrect nil check which was resulting in #compare_to always returning 0 for many to_java'ed Ruby objects (anything not internally represented by a class which overrides RubyBasicObject#compareTo)

Fixes #1520
