### PR TITLE
BigDecimal#{round,truncate,floor,ceil} with no args returns to_i

### DIFF
--- a/spec/regression/GH-1578_bigdecimal_to_i_with_no_args.rb
+++ b/spec/regression/GH-1578_bigdecimal_to_i_with_no_args.rb
@@ -1,0 +1,25 @@
+require 'bigdecimal'
+
+describe "BigDecimal#round" do
+  it "returns fixnum if no args are passed" do
+    expect(BigDecimal.new('1').round).to be_a(Fixnum)
+  end
+end
+
+describe "BigDecimal#truncate" do
+  it "returns fixnum if no args are passed" do
+    expect(BigDecimal.new('1').truncate).to be_a(Fixnum)
+  end
+end
+
+describe "BigDecimal#floor" do
+  it "returns fixnum if no args are passed" do
+    expect(BigDecimal.new('1').floor).to be_a(Fixnum)
+  end
+end
+
+describe "BigDecimal#ceil" do
+  it "returns fixnum if no args are passed" do
+    expect(BigDecimal.new('1').ceil).to be_a(Fixnum)
+  end
+end


### PR DESCRIPTION
Fixes #1578
