### PR TITLE
Static JavaProxy#getJavaClass needs to clear $!

### DIFF
--- a/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
@@ -181,11 +181,14 @@ public class JavaProxy extends RubyObject {
 
     private static Class<?> getJavaClass(ThreadContext context, RubyModule module) {
         try {
-        IRubyObject jClass = Helpers.invoke(context, module, "java_class");
+            IRubyObject jClass = Helpers.invoke(context, module, "java_class");
 
-
-        return !(jClass instanceof JavaClass) ? null : ((JavaClass) jClass).javaClass();
-        } catch (Exception e) { return null; }
+            return !(jClass instanceof JavaClass) ? null : ((JavaClass) jClass).javaClass();
+        } catch (Exception e) {
+            // clear $! since our "java_class" invoke above may have failed and set it
+            context.setErrorInfo(context.nil);
+            return null;
+        }
     }
     
     /**

--- a/spec/regression/java_proxy_clear_last_exception.rb
+++ b/spec/regression/java_proxy_clear_last_exception.rb
@@ -1,0 +1,9 @@
+describe "JavaProxy" do
+  it "should clear $! if there is not exception" do
+    class JavaTester < org.jruby.RubyString
+      field_reader :value
+    end
+
+    $!.should == nil
+  end
+end


### PR DESCRIPTION
Calls from Ruby which go through the static `JavaProxy.getJavaClass` (ie. `field_writer`, `field_reader`, and `field_accessor`) can result in `$!` incorrectly containing a `NoMethodError` from its attempt to invoke `java_class`.  Ensure we clear it in the catch block.

(I stumbled on this because Minitest was loading all tests up but then executing none of them [because `'$!` wasn't clear](https://github.com/seattlerb/minitest/blob/master/lib/minitest.rb#L46))
