### PR TITLE
Resolve symlinks when using Find.find.

### DIFF
--- a/lib/ruby/1.9/find.rb
+++ b/lib/ruby/1.9/find.rb
@@ -46,11 +46,7 @@ module Find
         end
         if s.directory? || s.symlink? then
           begin
-            fs = if s.symlink?
-              Dir.entries(File.readlink(file))
-            else
-              Dir.entries(file)
-            end
+            fs = s.symlink? ? Dir.entries(File.readlink(file)) : Dir.entries(file)
           rescue Errno::ENOENT, Errno::EACCES, Errno::ENOTDIR, Errno::ELOOP, Errno::ENAMETOOLONG
             next
           end

--- a/spec/regression/GH-1647_find_does_not_follow_symlinks_spec.rb
+++ b/spec/regression/GH-1647_find_does_not_follow_symlinks_spec.rb
@@ -3,13 +3,13 @@ require 'find'
 require 'set'
 require 'rspec'
 
-describe "Find.find" do
+describe 'Find.find' do
   it 'finds files in symlinks' do
     Dir.mktmpdir('jruby-file-find-test') do |fn|
       FileUtils.cd(fn) do
         # Create real dir with file.
         FileUtils.mkdir_p('dir')
-        File.write('dir/foo.txt', 'Hello world!')
+        File.open('dir/foo.txt', 'w') { |f| f.write('Hello world!') }
 
         # Create symlink.
         File.symlink('dir', 'dir-link')


### PR DESCRIPTION
Find.find doesn't follow symlinks, as reported in issue #1647.
This is a fix with the test case provided by @ddfreyne.
