### PR TITLE
BasicSocket#shutdown should accept strings or symbols

### DIFF
--- a/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
@@ -376,7 +376,24 @@ public class RubyBasicSocket extends RubyIO {
         int how = 2;
 
         if (args.length > 0) {
-            how = RubyNumeric.fix2int(args[0]);
+            String howString = null;
+            if (args[0] instanceof RubyString) {
+                howString = ((RubyString) args[0]).asJavaString();
+            } else if (args[0] instanceof RubySymbol) {
+                howString = ((RubySymbol) args[0]).asJavaString();
+            }
+
+            if (howString != null) {
+                if (howString.equals("RD") || howString.equals("SHUT_RD")) {
+                    how = 0;
+                } else if (howString.equals("WR") || howString.equals("SHUT_WR")) {
+                    how = 1;
+                } else if (howString.equals("RDWR") || howString.equals("SHUT_RDWR")) {
+                    how = 2;
+                }
+            } else {
+                how = RubyNumeric.fix2int(args[0]);
+            }
         }
 
         try {
@@ -616,7 +633,7 @@ public class RubyBasicSocket extends RubyIO {
             return RubyFixnum.zero(runtime);
 
             default:
-            throw runtime.newArgumentError("`how' should be either 0, 1, 2");
+            throw runtime.newArgumentError("`how' should be either :SHUT_RD, :SHUT_WR, :SHUT_RDWR");
         }
     }
 

--- a/spec/regression/GH-1579_basicsocket_shutdown_with_string_or_symbol_spec.rb
+++ b/spec/regression/GH-1579_basicsocket_shutdown_with_string_or_symbol_spec.rb
@@ -1,0 +1,37 @@
+require 'socket'
+
+describe "BasicSocket#shutdown" do
+  before(:each) do
+    @server = TCPServer.new('127.0.0.1', 0)
+    port = @server.addr[1]
+    @client = TCPSocket.new('127.0.0.1', port)
+  end
+
+  it "accepts no arguments" do
+    expect(@client.shutdown).to eql(0)
+  end
+
+  it "accepts number arguments" do
+    expect(@client.shutdown(0)).to eql(0)
+    expect(@client.shutdown(1)).to eql(0)
+    expect(@client.shutdown(2)).to eql(0)
+  end
+
+  it "accepts string arguments" do
+    expect(@client.shutdown("RD")).to eql(0)
+    expect(@client.shutdown("SHUT_RD")).to eql(0)
+    expect(@client.shutdown("WR")).to eql(0)
+    expect(@client.shutdown("SHUT_WR")).to eql(0)
+    expect(@client.shutdown("RDWR")).to eql(0)
+    expect(@client.shutdown("SHUT_RDWR")).to eql(0)
+  end
+
+  it "accepts symbol arguments" do
+    expect(@client.shutdown(:RD)).to eql(0)
+    expect(@client.shutdown(:SHUT_RD)).to eql(0)
+    expect(@client.shutdown(:WR)).to eql(0)
+    expect(@client.shutdown(:SHUT_WR)).to eql(0)
+    expect(@client.shutdown(:RDWR)).to eql(0)
+    expect(@client.shutdown(:SHUT_RDWR)).to eql(0)
+  end
+end


### PR DESCRIPTION
Fixes #1579
