### PR TITLE
ArrayJavaProxy#to_a now returns nested arrays where applicable

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtil.java
@@ -104,6 +104,8 @@ public class JavaUtil {
             Object element = Array.get(array, i);
             if (element instanceof ArrayJavaProxy) {
                 outer.append(convertJavaArrayToRubyWithNesting(context, ((ArrayJavaProxy)element).getObject()));
+            } else if (element.getClass().isArray()) {
+                outer.append(convertJavaArrayToRubyWithNesting(context, element));
             } else {
                 outer.append(JavaUtil.convertJavaToUsableRubyObject(context.runtime, element));
             }


### PR DESCRIPTION
`[[1],[2]].to_java(Java::byte[]).to_a`
