### PR TITLE
Use pwd -P to work on systemlinked locations.

### DIFF
--- a/test/test_kernel.rb
+++ b/test/test_kernel.rb
@@ -572,7 +572,7 @@ class TestKernel < Test::Unit::TestCase
     if (WINDOWS)
       result = `"#{TESTAPP_NONORM}" #{Dir.pwd}`.strip
     else
-      result = `"pwd" .`.strip
+      result = `""pwd -P"" .`.strip
     end
     expected = Dir.pwd
     assert_equal(expected, result)
@@ -583,7 +583,7 @@ class TestKernel < Test::Unit::TestCase
       result = `cmd /c cd`.strip.gsub('\\', '/').downcase
       expected = Dir.pwd.downcase
     else
-      result = `sh -c pwd`.strip
+      result = `sh -c "pwd -P"`.strip
       expected = Dir.pwd
     end
     assert_equal(expected, result)
@@ -594,7 +594,7 @@ class TestKernel < Test::Unit::TestCase
       result = `cmd.exe /c cd`.strip.gsub('\\', '/').downcase
       expected = Dir.pwd.downcase
     else
-      result = `pwd`.strip
+      result = `pwd -P`.strip
       expected = Dir.pwd
     end
     assert_equal(expected, result)


### PR DESCRIPTION
Since I have my jruby.git directory in a symlinked directory, I get a failure:

 1) Failure:
test_backquote1(TestKernel) [test/test_kernel.rb:589]:
<"/ssd/ratnikov/jruby.git"> expected but was
<"/usr/local/XXX/ratnikov/ssd/jruby.git">.

since Dir.pwd resolves system links and pwd apparently doesn't. Using pwd -P solves this issue.
