### PR TITLE
Fix BigDecimal tests on master

### DIFF
--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -329,7 +329,7 @@ public class RubyBigDecimal extends RubyNumeric {
         long _EXCEPTION_ALL =  bigDecimalConst(context.runtime, "EXCEPTION_ALL");
         if ((longMode & _EXCEPTION_ALL) != 0) {     
             if (value.isNil()) return c.searchInternalModuleVariable("vpExceptionMode");
-            if (!(value instanceof RubyBoolean)) throw context.runtime.newTypeError("second argument must be true or false");
+            if (!(value instanceof RubyBoolean)) throw context.runtime.newArgumentError("second argument must be true or false");
 
             RubyFixnum currentExceptionMode = (RubyFixnum)c.searchInternalModuleVariable("vpExceptionMode");
             RubyFixnum newExceptionMode = new RubyFixnum(context.runtime, currentExceptionMode.getLongValue());
@@ -410,7 +410,7 @@ public class RubyBigDecimal extends RubyNumeric {
 
         String err = v.isImmediate() ? RubyObject.inspect(context, v).toString() : v.getMetaClass().getBaseName();
             
-        throw context.runtime.newTypeError(err + " can't be coerced into BigDecimal");
+        throw context.runtime.newArgumentError(err + " can't be coerced into BigDecimal");
     }
     
     private static RubyBigDecimal unableToCoerceWithoutPrec(ThreadContext context, IRubyObject v, boolean must) {


### PR DESCRIPTION
@atambo looks like not all of 284eddc9d440f2968d9bd4b6989c24ab4c4e8555 made it over to master intact when merged, which left BigDecimal in a bad state.  

In particular, tests `TestBigDecimal#test_math_extension` and `TestBigDecimal#test_big_decimal_mode` were broken.  This fixes them up.

Note: those aren't the only tests having a rough time on master right now, so this won't quite get Travis green... will try to have a look at the other problems soon too.
