### PR TITLE
StringIO.set_encoding may change shared ByteList encoding

### DIFF
--- a/core/src/main/java/org/jruby/ext/stringio/StringIO.java
+++ b/core/src/main/java/org/jruby/ext/stringio/StringIO.java
@@ -1164,7 +1164,10 @@ public class StringIO extends RubyObject implements EncodingCapable {
         } else {
             enc = EncodingUtils.rbToEncoding(context, ext_enc);
         }
-        ptr.string.setEncoding(enc);
+        if(ptr.string.getEncoding() != enc) {
+            ptr.string.modify();
+            ptr.string.setEncoding(enc);
+        }
         return this;
     }
     

--- a/spec/regression/stringio_set_encoding_changes_shared_bytelist_spec.rb
+++ b/spec/regression/stringio_set_encoding_changes_shared_bytelist_spec.rb
@@ -1,0 +1,11 @@
+require 'rspec'
+require 'stringio'
+
+describe 'StringIO.set_encoding' do
+  it 'does not change the encoding of shared empty bytelist' do
+    StringIO.new.set_encoding('UTF-16LE')
+    empty_utf8 = ''
+    utf8_matches = empty_utf8.scan(/(.*)/)[0]
+    utf8_matches[0].encoding.to_s.should_not == 'UTF-16LE'
+  end
+end


### PR DESCRIPTION
When creating a StringIO instance with no arguments, ptr.string references the shared EMPTY_BYTELISTS instance for that encoding.

It is possible to then call set_encoding to change the encoding on the shared instance.

This fix is to duplicate the value before changing the encoding.
