### PR TITLE
Fix for issue #1695

### DIFF
--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -462,7 +462,7 @@ public class RubyBigDecimal extends RubyNumeric {
         long denominator = RubyNumeric.num2long(r.denominator(context));
             
         return new RubyBigDecimal(context.runtime, 
-                BigDecimal.valueOf(numerator).divide(BigDecimal.valueOf(denominator), getRoundingMode(context.runtime)));
+                BigDecimal.valueOf(numerator).divide(BigDecimal.valueOf(denominator), MathContext.UNLIMITED));
     }
     
     private static RubyBigDecimal getVpValueWithPrec19(ThreadContext context, IRubyObject value, long precision, boolean must) {

--- a/spec/regression/GH-1695_bigdecimal_and_rational_multiplication_rounds_the_rational_number.rb
+++ b/spec/regression/GH-1695_bigdecimal_and_rational_multiplication_rounds_the_rational_number.rb
@@ -1,0 +1,11 @@
+require 'rational'
+require 'bigdecimal'
+
+# https://github.com/jruby/jruby/issues/1695
+describe 'BigDecimal#*' do
+  it 'returns correct value' do
+    (BigDecimal.new('100') * Rational(1, 100)).to_i.should == 1
+    (BigDecimal.new('100') * Rational(49, 100)).to_i.should == 49
+    (BigDecimal.new('100') * Rational(50, 100)).to_i.should == 50
+  end
+end


### PR DESCRIPTION
This commit fixes issue #1695.

The cause of this issue is RubyBigDecimal#getVpRubyObjectWithPrec19Inner rounds the RubyRational number.
