### PR TITLE
String#rindex should handle matchdata strings

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -3478,13 +3478,12 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         int p = value.getBegin();
         int end = p + value.getRealSize();
 
-        byte[]sbytes = sub.value.getUnsafeBytes();
-        int sp = sub.value.getBegin();
+        byte[]sbytes = sub.value.bytes();
         slen = sub.value.getRealSize();
 
         int s = StringSupport.nth(enc, bytes, p, end, pos);
         while (s >= 0) {
-            if (ByteList.memcmp(bytes, s, sbytes, sp, slen) == 0) return pos;
+            if (ByteList.memcmp(bytes, s, sbytes, 0, slen) == 0) return pos;
 
             if (pos == 0) break;
             pos--;

--- a/spec/regression/GH-1688_rindex_with_matchdata_spec.rb
+++ b/spec/regression/GH-1688_rindex_with_matchdata_spec.rb
@@ -1,0 +1,7 @@
+describe "String#rindex" do
+  it "works with matchdata" do
+    message = "I love this new status update..."
+    matched_string = message.match(/status update/)[0]
+    expect(message.rindex(matched_string)).to eql 16
+  end
+end


### PR DESCRIPTION
A string extracted from a matchdata object shares the same
byte array as the string it was matched against. When doing a
rindex between a string from a matchdata and the string the matchdata
was matched against the same byte array is passed into `ByteList.memcmp`
which will always return 0 as `ByteList.memcmp` just checks for equality
of the byte arrays.

I fix this by passing `bytes()` instead `getUnsafeBytes()` into the
`ByteList.memcmp` method so that the byte arrays are different.

Fixes #1688
