### PR TITLE
Make behavior of Array#eql? more closely match MRI

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -1865,7 +1865,7 @@ public class RubyArray extends RubyObject implements List, RandomAccess {
     @JRubyMethod(name = "eql?", required = 1)
     public IRubyObject eql(ThreadContext context, IRubyObject obj) {
         if(!(obj instanceof RubyArray)) {
-            return runtime.getFalse();
+            return context.runtime.getFalse();
         }
         return RecursiveComparator.compare(context, MethodNames.EQL, this, obj);
     }


### PR DESCRIPTION
MRI's rb_ary_eql looks like this:

```
rb_ary_eql(VALUE ary1, VALUE ary2)
{
    if (ary1 == ary2) return Qtrue;
    if (!RB_TYPE_P(ary2, T_ARRAY)) return Qfalse;
    if (RARRAY_LEN(ary1) != RARRAY_LEN(ary2)) return Qfalse;
    return rb_exec_recursive_paired(recursive_eql, ary1, ary2, ary2);
}
```

Notice the `RB_TYPE_P` check. This will be true for instances of `Array` or a subclass of `Array`.

However, JRuby's `Array#eql?` returns true for objects which are _not_ Arrays, as long as they implement `#to_ary` and as long as all their members are `eql?` to the corresponding members in the receiver Array.

This is contrary to the intent of `#eql?` -- it is supposed to be a stricter version of `==` which checks not just value but also type.

This patch should bring the behavior of JRuby a little bit closer in line with MRI.
