### PR TITLE
[GH-1726] - File.read should raise an Errno::ENOENT when the file is an empty String

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -3823,7 +3823,11 @@ public class RubyIO extends RubyObject implements IOEncodable {
         IRubyObject cmd;
         
         IRubyObject[] pm = {vperm, vmode};
-        
+
+        if (filename instanceof RubyString && ((RubyString) filename).isEmpty()){
+            throw context.getRuntime().newErrnoENOENTError();
+        }
+
         RubyFile file = (RubyFile)context.runtime.getFile().allocate();
         EncodingUtils.extractModeEncoding(context, file, pm, opt, oflags_p, fmode_p);
         perm = (pm[EncodingUtils.PERM] == null || pm[EncodingUtils.PERM].isNil()) ? 0666 : RubyNumeric.num2int(pm[EncodingUtils.PERM]);

--- a/spec/regression/GH-1726_File_read_raises_an_enoent.rb
+++ b/spec/regression/GH-1726_File_read_raises_an_enoent.rb
@@ -1,0 +1,6 @@
+#https://github.com/jruby/jruby/issues/1726
+describe 'File#read' do
+  it 'raises an Errno::ENOENT when the filepath is an empty string' do
+    lambda { File.read("") }.should raise_error(Errno::ENOENT)
+  end
+end


### PR DESCRIPTION
Fixing #1726
