### PR TITLE
Fix "gem count" integrity test

### DIFF
--- a/maven/jruby-complete/src/it/integrity/verify.bsh
+++ b/maven/jruby-complete/src/it/integrity/verify.bsh
@@ -28,7 +28,7 @@ if ( !log.contains( expected ) )
 {
     throw new RuntimeException( "log file does not contain '" + expected + "'" );
 }
-expected = "gems count 8";
+expected = "gems count 7";
 if ( !log.contains( expected ) )
 {
     throw new RuntimeException( "log file does not contain '" + expected + "'" );

--- a/maven/jruby-dist/src/it/integrity/verify.bsh
+++ b/maven/jruby-dist/src/it/integrity/verify.bsh
@@ -28,7 +28,7 @@ if ( !log.contains( expected ) )
 {
     throw new RuntimeException( "log file does not contain '" + expected + "'" );
 }
-expected = "gems count 8";
+expected = "gems count 7";
 if ( !log.contains( expected ) )
 {
     throw new RuntimeException( "log file does not contain '" + expected + "'" );

--- a/maven/jruby-jars/src/it/integrity/verify.bsh
+++ b/maven/jruby-jars/src/it/integrity/verify.bsh
@@ -28,7 +28,7 @@ if ( !log.contains( expected ) )
 {
     throw new RuntimeException( "log file does not contain '" + expected + "'" );
 }
-expected = "gems count 8";
+expected = "gems count 7";
 if ( !log.contains( expected ) )
 {
     throw new RuntimeException( "log file does not contain '" + expected + "'" );

--- a/maven/jruby-noasm/src/it/integrity/verify.bsh
+++ b/maven/jruby-noasm/src/it/integrity/verify.bsh
@@ -28,7 +28,7 @@ if ( !log.contains( expected ) )
 {
     throw new RuntimeException( "log file does not contain '" + expected + "'" );
 }
-expected = "gems count 8";
+expected = "gems count 7";
 if ( !log.contains( expected ) )
 {
     throw new RuntimeException( "log file does not contain '" + expected + "'" );

--- a/maven/jruby/src/it/integrity/verify.bsh
+++ b/maven/jruby/src/it/integrity/verify.bsh
@@ -28,7 +28,7 @@ if ( !log.contains( expected ) )
 {
     throw new RuntimeException( "log file does not contain '" + expected + "'" );
 }
-expected = "gems count 8";
+expected = "gems count 7";
 if ( !log.contains( expected ) )
 {
     throw new RuntimeException( "log file does not contain '" + expected + "'" );


### PR DESCRIPTION
The bouncy-castle-java gem is no longer bundled, but the integrity tests are still counting it.  Update the test to expect the now-correct count of 7 bundled gems.

This moves `oraclejdk8 TARGET='-Pdist'`, `oraclejdk7 TARGET='-Pjruby-jars'`, `oraclejdk7 TARGET='-Pmain'`, and `oraclejdk8 TARGET='-Pcomplete'` from red to green on Travis (see [here](https://travis-ci.org/dmarcotte/jruby/builds/27794864))

Note: after this change, these tests will fail locally until you `mvn clean` at the root and also in `maven/jruby-dist` and `maven/jruby-stdlib`
