### PR TITLE
enhanced the java_class compiler so it can handle multiple constructors

### DIFF
--- a/lib/ruby/shared/jruby/compiler/java_class.rb
+++ b/lib/ruby/shared/jruby/compiler/java_class.rb
@@ -338,7 +338,8 @@ module JRuby::Compiler
     end
 
     def new_method(name, java_signature = nil, annotations = [])
-      is_constructor = name == "initialize"
+      is_constructor = name == "initialize" ||
+          java_signature.is_a?(Java::OrgJrubyAstJava_signature::ConstructorSignatureNode)
       @has_constructor ||= is_constructor
 
       if is_constructor

--- a/spec/java_integration/jrubyc/java/constructor_spec.rb
+++ b/spec/java_integration/jrubyc/java/constructor_spec.rb
@@ -27,6 +27,32 @@ describe "A Ruby class generating a Java stub" do
   end
 
   describe "with an initialize method" do
+    describe "and a constructor java_signature on a another method" do
+      it "generates a default constructor" do
+        cls = generate("class Foo; def initialize(a); end; java_signature 'Foo()'; def default_cnstr(); end; end").classes[0]
+        cls.constructor?.should be true
+
+        init = cls.methods[0]
+        init.should_not be nil
+        init.name.should == "initialize"
+        init.constructor?.should == true
+        init.java_signature.to_s.should == "Object initialize(Object a)"
+        init.args.length.should == 1
+
+        java = init.to_s
+        java.should match OBJECT_INITIALIZE_PATTERN
+
+        def_cnstr = cls.methods[1]
+        def_cnstr.should_not be nil
+        def_cnstr.constructor?.should == true
+        def_cnstr.java_signature.to_s.should == "Foo()"
+        def_cnstr.args.length.should == 0
+
+        java = def_cnstr.to_s
+        java.should match EMPTY_INITIALIZE_PATTERN
+      end
+    end
+
     describe "with no arguments" do
       it "generates a default constructor" do
         cls = generate("class Foo; def initialize; end; end").classes[0]
@@ -91,8 +117,8 @@ describe "A Ruby class generating a Java stub" do
         cls = generate("class Foo; java_signature 'Foo() throws FooBarException,QuxBazException'; def initialize(); end; end").classes[0]
 
         method = cls.methods[0]
-        method.java_signature.to_s.should == 'Foo() throws FooBarException, QuxBazException'   
-      end        
+        method.java_signature.to_s.should == 'Foo() throws FooBarException, QuxBazException'
+      end
     end
 
   end


### PR DESCRIPTION
This change would allow you to create multiple Java constructors for a Ruby class like so:

```
class Foo
  def initialize(a=nil)
    # ...
  end

  java_signature 'Foo()'
  def default_cnstr()
    # ...
  end
end
```

Such a capability is required for Java frameworks that require a no-arg constructor, even if your application code doesn't use it.

The call to `java_signature.is_a?(Java::OrgJrubyAstJava_signature::ConstructorSignatureNode)` in the java_class compiler is a little unfortunate. I'd prefer to add an `isConstructor` method to SignatureNode and override it to return true in ConstructorSignatureNode. I will update this PR with that change if it's desired.

Also, I can reopen this PR against master if needed.
