### PR TITLE
added a java_field method for use in the jrubyc command. 

### DIFF
--- a/core/src/main/java/org/jruby/java/addons/KernelJavaAddons.java
+++ b/core/src/main/java/org/jruby/java/addons/KernelJavaAddons.java
@@ -32,7 +32,7 @@ public class KernelJavaAddons {
         if (exception != null) {
             // looks like someone's trying to raise a Java exception. Let them.
             Object maybeThrowable = exception.getObject();
-            
+
             if (maybeThrowable instanceof Throwable) {
                 // yes, we're cheating here.
                 Helpers.throwException((Throwable)maybeThrowable);
@@ -53,7 +53,7 @@ public class KernelJavaAddons {
             return Java.getInstance(context.runtime, fromObject.toJava(Object.class));
         }
     }
-    
+
     @JRubyMethod
     public static IRubyObject to_java(ThreadContext context, IRubyObject fromObject, IRubyObject type) {
         if (type.isNil()) {
@@ -102,6 +102,12 @@ public class KernelJavaAddons {
 
     @JRubyMethod(rest = true)
     public static IRubyObject java_package(IRubyObject recv, IRubyObject[] args) {
+        // empty stub for now
+        return recv.getRuntime().getNil();
+    }
+
+    @JRubyMethod(rest = true)
+    public static IRubyObject java_field(IRubyObject recv, IRubyObject[] args) {
         // empty stub for now
         return recv.getRuntime().getNil();
     }

--- a/spec/java_integration/jrubyc/java/field_spec.rb
+++ b/spec/java_integration/jrubyc/java/field_spec.rb
@@ -1,0 +1,58 @@
+require File.dirname(__FILE__) + "/../../spec_helper"
+require 'jruby'
+require 'jruby/compiler'
+
+describe "A Ruby class generating a Java stub" do
+  def generate(script)
+    node = JRuby.parse(script)
+    # we use __FILE__ so there's something for it to read
+    JRuby::Compiler::JavaGenerator.generate_java node, __FILE__
+  end
+
+  describe "with additional java_import lines" do
+    it "generates a field into the java source" do
+      script = generate("class Foo; java_field 'String abc'; end")
+
+      cls = script.classes[0]
+      cls.fields.length.should == 1
+      cls.fields.first.first.should == "String abc"
+      cls.fields.first.last.should be_empty
+
+      java = script.to_s
+      java.should match /String abc;/
+    end
+
+    it "generates fields into the java source" do
+      script = generate("class Foo; java_field 'String abc'; java_field 'Integer xyz'; end")
+
+      cls = script.classes[0]
+      cls.fields.length.should == 2
+      cls.fields.first.first.should == "String abc"
+      cls.fields.first.last.should be_empty
+      cls.fields.last.first.should == "Integer xyz"
+      cls.fields.last.last.should be_empty
+
+      java = script.to_s
+      java.should match /String abc;/
+      java.should match /Integer xyz;/
+    end
+
+    it "generates fields with annotations into the java source" do
+      script = generate("class Foo; java_annotation 'Deprecated'; java_field 'String abc'; java_field 'String xyx'; end")
+
+      cls = script.classes[0]
+      cls.fields.length.should == 2
+      cls.fields.first.first.should == "String abc"
+      cls.fields.first.last.should include "Deprecated"
+
+      java = script.to_s
+      java.should match /@Deprecated\s+String abc;/
+
+      cls = script.classes[0]
+      cls.fields.last.last.should be_empty
+
+      java = script.to_s
+      java.should_not match /String abc;\s+@Deprecated\s+String xyz;/
+    end
+  end
+end


### PR DESCRIPTION
This change enables something like the following:

```
class Foo
  java_annotation 'Deprecated'
  java_field 'private String bar'
end
```

Let me know if this needs to go against master instead of 1_7
