### PR TITLE
Fix for issue #1745 : DateTime#jd should return chronological Julian day number

### DIFF
--- a/lib/ruby/1.9/date.rb
+++ b/lib/ruby/1.9/date.rb
@@ -1160,7 +1160,7 @@ class Date
 
   # Get the date as a Julian Day Number.
   def jd
-    JODA::DateTimeUtils.toJulianDayNumber(@dt.getMillis)
+    ajd_to_jd(ajd, @of)[0]
   end
 
   # Get any fractional day part of the date.

--- a/spec/regression/GH-1745_datetime_jd_spec.rb
+++ b/spec/regression/GH-1745_datetime_jd_spec.rb
@@ -1,0 +1,17 @@
+require 'rspec'
+require 'date'
+
+# https://github.com/jruby/jruby/issues/1745
+if RUBY_VERSION > '1.9'
+  describe 'DateTime#jd' do
+    it 'returns chronological Julian day number' do
+      d1 = DateTime.parse('2014-04-05T23:59:59-07:00')
+      d1.jd.should == 2456753
+      
+      # see example below
+      # http://www.ruby-doc.org/stdlib-1.9.3/libdoc/date/rdoc/Date.html#method-i-jd
+      DateTime.new(2001,2,3,4,5,6,'+7').jd.should == 2451944
+      DateTime.new(2001,2,3,4,5,6,'-7').jd.should == 2451944
+    end
+  end
+end


### PR DESCRIPTION
DateTime#jd’ should return chronological Julian day number.
But org.joda.time.DateTimeUtils.toJulianDayNumber returns astronomical Julian day number.
This change uses DateTime#ajd_to_jd in DateTime#jd.
