### PR TITLE
Fix #1777: ServerSocket#accept_nonblock to return a correct Sockaddr

### DIFF
--- a/core/src/main/java/org/jruby/ext/socket/RubyServerSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyServerSocket.java
@@ -155,7 +155,7 @@ public class RubyServerSocket extends RubySocket {
 
                         RubySocket socket = doAccept(context, channel);
                         SocketChannel socketChannel = (SocketChannel)socket.getChannel();
-                        InetSocketAddress addr = (InetSocketAddress)socketChannel.socket().getLocalSocketAddress();
+                        InetSocketAddress addr = (InetSocketAddress)socketChannel.socket().getRemoteSocketAddress();
 
                         return context.runtime.newArray(
                                 socket,

--- a/spec/regression/GH-1777_ServerSocket_accept_nonblock_returns_server_port_spec.rb
+++ b/spec/regression/GH-1777_ServerSocket_accept_nonblock_returns_server_port_spec.rb
@@ -1,0 +1,24 @@
+require 'socket'
+
+#https://github.com/jruby/jruby/issues/1777
+describe 'ServerSocket#accept_nonblock' do
+  it 'returns the client address' do
+    server_port = 2**15 + rand(2**15)
+    puts 'server running on %d' % server_port
+    addrinfos = Socket.getaddrinfo('localhost', server_port, nil, Socket::SOCK_STREAM)
+    _, port, _, ip, address_family, socket_type = addrinfos.shift
+    sockaddr = Socket.sockaddr_in(port, ip)
+    client_socket = Socket.new(address_family, socket_type, 0)
+    server_socket = ServerSocket.new(address_family, socket_type, 0)
+    server_socket.bind(sockaddr, 5)
+    begin
+      client_socket.connect_nonblock(sockaddr)
+    rescue Errno::EINPROGRESS, Errno::EALREADY
+    end
+    IO.select([server_socket])
+    client_socket, client_sockaddr = server_socket.accept_nonblock
+    port = Socket.unpack_sockaddr_in(client_sockaddr).first
+    port.should eq(client_socket.remote_address.ip_port)
+    port.should_not eq(server_port)
+  end
+end


### PR DESCRIPTION
This is a fix for #1777

ServerSocket#accept_nonblock should return a Sockaddr with the remote port, not the local port.
