### PR TITLE
Unbox 1-argument method calls with a block in IR Interpreter

### DIFF
--- a/core/src/main/java/org/jruby/ir/Operation.java
+++ b/core/src/main/java/org/jruby/ir/Operation.java
@@ -69,6 +69,7 @@ public enum Operation {
     /* specialized calls */
     CALL_1F(OpFlags.f_has_side_effect | OpFlags.f_is_call | OpFlags.f_can_raise_exception),
     CALL_1O(OpFlags.f_has_side_effect | OpFlags.f_is_call | OpFlags.f_can_raise_exception),
+    CALL_1OB(OpFlags.f_has_side_effect | OpFlags.f_is_call | OpFlags.f_can_raise_exception),
     CALL_0O(OpFlags.f_has_side_effect | OpFlags.f_is_call | OpFlags.f_can_raise_exception),
     NORESULT_CALL_1O(OpFlags.f_has_side_effect | OpFlags.f_is_call | OpFlags.f_can_raise_exception),
 

--- a/core/src/main/java/org/jruby/ir/instructions/CallBase.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CallBase.java
@@ -428,7 +428,7 @@ public abstract class CallBase extends Instr implements Specializeable, ClosureA
         return argList.toArray(new IRubyObject[argList.size()]);
     }
 
-    protected Block prepareBlock(ThreadContext context, IRubyObject self, DynamicScope currDynScope, Object[] temp) {
+    public Block prepareBlock(ThreadContext context, IRubyObject self, DynamicScope currDynScope, Object[] temp) {
         if (closure == null) return Block.NULL_BLOCK;
 
         return IRRuntimeHelpers.getBlockFromObject(context, closure.retrieve(context, self, currDynScope, temp));

--- a/core/src/main/java/org/jruby/ir/instructions/CallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CallInstr.java
@@ -4,6 +4,7 @@ import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
 import org.jruby.ir.instructions.specialized.OneFixnumArgNoBlockCallInstr;
 import org.jruby.ir.instructions.specialized.OneOperandArgNoBlockCallInstr;
+import org.jruby.ir.instructions.specialized.OneOperandArgBlockCallInstr;
 import org.jruby.ir.instructions.specialized.ZeroOperandArgNoBlockCallInstr;
 import org.jruby.ir.operands.MethAddr;
 import org.jruby.ir.operands.Operand;
@@ -55,15 +56,15 @@ public class CallInstr extends CallBase implements ResultInstr {
     @Override
     public CallBase specializeForInterpretation() {
         Operand[] callArgs = getCallArgs();
-        if (hasClosure() || containsArgSplat(callArgs)) return this;
+        if (containsArgSplat(callArgs)) return this;
 
         switch (callArgs.length) {
             case 0:
-                return new ZeroOperandArgNoBlockCallInstr(this);
+                return hasClosure() ? this : new ZeroOperandArgNoBlockCallInstr(this);
             case 1:
-                if (isAllFixnums()) return new OneFixnumArgNoBlockCallInstr(this);
+                if (isAllFixnums() && !hasClosure()) return new OneFixnumArgNoBlockCallInstr(this);
 
-                return new OneOperandArgNoBlockCallInstr(this);
+                return hasClosure() ? new OneOperandArgBlockCallInstr(this) : new OneOperandArgNoBlockCallInstr(this);
         }
         return this;
     }

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgBlockCallInstr.java
@@ -1,0 +1,36 @@
+package org.jruby.ir.instructions.specialized;
+
+import org.jruby.ir.instructions.CallInstr;
+import org.jruby.ir.Operation;
+import org.jruby.ir.operands.Operand;
+import org.jruby.runtime.Block;
+import org.jruby.runtime.DynamicScope;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+public class OneOperandArgBlockCallInstr extends CallInstr {
+    public OneOperandArgBlockCallInstr(CallInstr call) {
+        super(Operation.CALL_1OB, call);
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + "{1OB}";
+    }
+
+    public Operand getReceiver() {
+        return receiver;
+    }
+
+    public Operand getArg1() {
+        return getCallArgs()[0];
+    }
+
+    @Override
+    public Object interpret(ThreadContext context, DynamicScope dynamicScope, IRubyObject self, Object[] temp) {
+        IRubyObject object = (IRubyObject) receiver.retrieve(context, self, dynamicScope, temp);
+        IRubyObject arg1 = (IRubyObject) getCallArgs()[0].retrieve(context, self, dynamicScope, temp);
+        Block preparedBlock = prepareBlock(context, self, dynamicScope, temp);
+        return getCallSite().call(context, self, object, arg1, preparedBlock);
+    }
+}

--- a/core/src/main/java/org/jruby/ir/interpreter/Interpreter.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/Interpreter.java
@@ -49,6 +49,7 @@ import org.jruby.ir.instructions.SearchConstInstr;
 import org.jruby.ir.instructions.ReceivePostReqdArgInstr;
 import org.jruby.ir.instructions.specialized.OneFixnumArgNoBlockCallInstr;
 import org.jruby.ir.instructions.specialized.OneOperandArgNoBlockCallInstr;
+import org.jruby.ir.instructions.specialized.OneOperandArgBlockCallInstr;
 import org.jruby.ir.instructions.specialized.OneOperandArgNoBlockNoResultCallInstr;
 import org.jruby.ir.instructions.specialized.ZeroOperandArgNoBlockCallInstr;
 import org.jruby.ir.operands.Bignum;
@@ -359,6 +360,15 @@ public class Interpreter extends IRTranslator<IRubyObject, IRubyObject> {
             IRubyObject r = (IRubyObject)retrieveOp(call.getReceiver(), context, self, currDynScope, temp);
             IRubyObject o = (IRubyObject)call.getArg1().retrieve(context, self, currDynScope, temp);
             result = call.getCallSite().call(context, self, r, o);
+            setResult(temp, currDynScope, call.getResult(), result);
+            break;
+        }
+        case CALL_1OB: {
+            OneOperandArgBlockCallInstr call = (OneOperandArgBlockCallInstr)instr;
+            IRubyObject r = (IRubyObject)retrieveOp(call.getReceiver(), context, self, currDynScope, temp);
+            IRubyObject o = (IRubyObject)call.getArg1().retrieve(context, self, currDynScope, temp);
+            Block preparedBlock = call.prepareBlock(context, self, currDynScope, temp);
+            result = call.getCallSite().call(context, self, r, o, preparedBlock);
             setResult(temp, currDynScope, call.getResult(), result);
             break;
         }


### PR DESCRIPTION
Previously with method signatures like:

```
 @JRubyMethod(name = "execute_query_raw", required = 1) // optional block
    public IRubyObject execute_query_raw(final ThreadContext context,
        final IRubyObject sql, final Block block) throws SQLException {
```

and

```
  @JRubyMethod(name = "execute_query_raw", required = 2, optional = 1)
    public IRubyObject execute_query_raw(final ThreadContext context,
        final IRubyObject[] args, final Block block) throws SQLException {
```

passing one argument with a block would result in incorrectly selecting
the 2-argument method.  This would result in an ArgumentError.

To solve this we added a specialized operation for this kind of Call.

Example is from https://github.com/jruby/activerecord-jdbc-adapter/blob/v1.3.8/src/java/arjdbc/jdbc/RubyJdbcConnection.java#L712-L767.
