### PR TITLE
Make Time#to_r consistent with MRI

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -709,13 +709,6 @@ public class RubyTime extends RubyObject {
     @JRubyMethod
     public IRubyObject to_r(ThreadContext context) {
         IRubyObject rational = to_f().to_r(context);
-        if (rational instanceof RubyRational) {
-            IRubyObject denominator = ((RubyRational)rational).denominator(context);
-            if (RubyNumeric.num2long(denominator) == 1) {
-                return ((RubyRational)rational).numerator(context);
-            }
-        }
-
         return rational;
     }
 


### PR DESCRIPTION
Hello,

There is an inconsistency between MRI and JRuby when dealing with a `Time` object then calling `to_r` on it. JRuby returns simply the numerator of the `Rational` if the latter has 1 as its denominator.

The commit introducing this feature is jruby/jruby@e748f0d6365615ecbf031fe59ed2a99d098aa6f5 ; this `if` call was there to make [this spec](https://github.com/rubyspec/rubyspec/commit/f9a06a0965d0aff608888dc8587083b08e9e128d#diff-ea4b73a64b30581a18eba2259c22c4b5R10) to pass but it has been [updated](https://github.com/rubyspec/rubyspec/commit/0a299b1717f2166fb506d788d531427a7e72062d#diff-ea4b73a64b30581a18eba2259c22c4b5) later (thanks Ben Browning for the investigation work here).

This makes the [following assertion](https://github.com/jruby/jruby/blob/cd3390067c9184e9239cd245c4f1f07b9f775d51/spec/ruby/core/time/to_r_spec.rb#L9) to pass now.

Have a nice day.
