### PR TITLE
add os400 support

### DIFF
--- a/core/src/main/java/org/jruby/ext/ffi/Platform.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Platform.java
@@ -98,6 +98,8 @@ public class Platform {
             return OS_TYPE.DARWIN;
         } else if (startsWithIgnoreCase(osName, "sunos") || startsWithIgnoreCase(osName, "solaris")) {
             return OS_TYPE.SOLARIS;
+        } else if (startsWithIgnoreCase(osName, "os/400")) {
+            return OS_TYPE.AIX;
         }
         for (OS_TYPE os : OS_TYPE.values()) {
             if (startsWithIgnoreCase(osName, os.toString())) {


### PR DESCRIPTION
Hello,

This PR try to add OS/400 compatibility for JRuby. 

The Unix part of OS/400 (PASE) is really close to AIX. This fix replaces "unknown os" by AIX.

Related discution :
https://www.ruby-forum.com/topic/4626015
