### PR TITLE
Fix Encoding::Converter#inspect output

### DIFF
--- a/core/src/main/java/org/jruby/RubyConverter.java
+++ b/core/src/main/java/org/jruby/RubyConverter.java
@@ -187,7 +187,7 @@ public class RubyConverter extends RubyObject {
 
     @JRubyMethod
     public IRubyObject inspect(ThreadContext context) {
-        return RubyString.newString(context.runtime, "#<Encoding::Converter: " + transcoder.inEncoding + " to " + transcoder.outEncoding);
+        return RubyString.newString(context.runtime, "#<Encoding::Converter: " + transcoder.inEncoding + " to " + transcoder.outEncoding + ">");
     }
 
     @JRubyMethod


### PR DESCRIPTION
Hello,

This pull request simply adds a missing closing chevron in the computed string of the `Encoding::Converter#inspect` method.

A RubySpec has been added for this in rubinius/rubinius#3083.

Have a nice day.
