### PR TITLE
Fix BigDecimal#round behavior with NAN and INFINITY

### DIFF
--- a/test/externals/ruby1.9/bigdecimal/test_bigdecimal.rb
+++ b/test/externals/ruby1.9/bigdecimal/test_bigdecimal.rb
@@ -802,6 +802,18 @@ class TestBigDecimal < Test::Unit::TestCase
     end
   end
 
+  def test_round_with_nan_and_infinity
+    [BigDecimal::NAN, BigDecimal::INFINITY, -BigDecimal::INFINITY].each do |number|
+      assert_raise(FloatDomainError) { number.round }
+    end
+  end
+
+  def test_round_with_precision_on_nan_and_infinity
+    assert_equal(true, BigDecimal::NAN.round(1).nan?)
+    assert_equal(BigDecimal::INFINITY, BigDecimal::INFINITY.round(1))
+    assert_equal(-BigDecimal::INFINITY, -BigDecimal::INFINITY.round(1))
+  end
+
   def test_truncate
     assert_equal(3, BigDecimal.new("3.14159").truncate)
     assert_equal(8, BigDecimal.new("8.7").truncate)


### PR DESCRIPTION
Hello,

JRuby's behavior of `BigDecimal#round` with `BigDecimal::NAN` and `BigDecimal::INFINITY` is kind of weird as it computes a value of 0.0. Currently, the problem is that under the hood, JRuby defines the constant according to [`BigDecimal.ZERO`](https://github.com/jruby/jruby/blob/f089aaf97bd742b4f9840df4308033363ebe2c38/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java#L556) and [`round`](https://github.com/jruby/jruby/blob/f089aaf97bd742b4f9840df4308033363ebe2c38/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java#L1186) uses the value to compute the "rounding" but it should simply return the constant itself.

Moreover, when we call `#round` without any argument on these constants, a `FloatDomainError` should be raised.

This area of code on this branch is a bit different from `master` so here's [a diff](https://gist.github.com/robin850/f318aecdbcdac76ebcc5) that you can `git apply` to simplify the merge process between branches. 

Have a nice day.
