### PR TITLE
apply minor enebo's comments

### DIFF
--- a/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
+++ b/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
@@ -17,7 +17,6 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 class LibrarySearcher {
     static class Ruby18 extends LibrarySearcher {
@@ -50,8 +49,6 @@ class LibrarySearcher {
         }
     }
 
-    private static final Pattern ABSOLUTE_PATH_PATTERN = Pattern.compile("([^:]+:)*/.*");
-
     private final LoadService loadService;
     private final Ruby runtime;
     private final Map<String, Library> builtinLibraries;
@@ -74,8 +71,7 @@ class LibrarySearcher {
 
     public FoundLibrary findLibrary(String baseName, SuffixType suffixType) {
         for (String suffix : suffixType.getSuffixes()) {
-            FoundLibrary library = null;
-            if (library == null) library = findBuiltinLibrary(baseName, suffix);
+            FoundLibrary library = findBuiltinLibrary(baseName, suffix);
             if (library == null) library = findResourceLibrary(baseName, suffix);
             if (library == null) library = findServiceLibrary(baseName, suffix);
 
@@ -134,7 +130,7 @@ class LibrarySearcher {
         }
 
         // If path is absolute, try loading it directly
-        if (ABSOLUTE_PATH_PATTERN.matcher(baseName).matches()) {
+        if (new File(baseName).isAbsolute()) {
             return findFileResource(baseName, suffix);
         }
 


### PR DESCRIPTION
Changes:

1) Use new File(...).isAbsolute to detect whether path is absolute, rather than using a custom [probably faulty] regex.
2) Kill unnecessary if on null.

Concerning returning buffered stream to optimize file loads. I have looked into it, but behavior on my SSD seems pretty identical, whether to wrap BuffereInputStream with 8096 buffer or not. To test I've added a system properties to switch between the two strategies and used rails 4 and following command:

bin/jruby -e 'require "benchmark"; puts Benchmark.measure { require "rails/all" }'

Whether I turn buffering or not, the result is usually around 25seconds CPU time (sometimes bumping up to 34 for either case). But maybe that's because seek time is not a factor for SSDs, so I will try it on a regular hard drive on Monday.
