### PR TITLE
fix ArrayJavaProxy#to_a failure on arrays containing null

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtil.java
@@ -104,7 +104,7 @@ public class JavaUtil {
             Object element = Array.get(array, i);
             if (element instanceof ArrayJavaProxy) {
                 outer.append(convertJavaArrayToRubyWithNesting(context, ((ArrayJavaProxy)element).getObject()));
-            } else if (element.getClass().isArray()) {
+            } else if (element != null && element.getClass().isArray()) {
                 outer.append(convertJavaArrayToRubyWithNesting(context, element));
             } else {
                 outer.append(JavaUtil.convertJavaToUsableRubyObject(context.runtime, element));

--- a/spec/regression/convert_null_containing_java_array_spec.rb
+++ b/spec/regression/convert_null_containing_java_array_spec.rb
@@ -1,0 +1,7 @@
+require 'rspec'
+
+describe "ArrayJavaProxy#to_a" do
+  it "succesfully converts arrays containing nil" do
+    [nil].to_java.to_a.should == [nil]
+  end
+end


### PR DESCRIPTION
https://github.com/jruby/jruby/commit/b96b2219f9df6622883a88eda0ae1dbbcb5c2267 added an unprotected method call in a place where the
target could be null. This adds a null check to that expression.
