### PR TITLE
Implement Module#singleton_class? predicate method

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -867,6 +867,11 @@ public class RubyModule extends RubyObject {
         return context.runtime.getFalse();
     }
 
+    @JRubyMethod(name = "singleton_class?")
+    public IRubyObject singleton_class_p(ThreadContext context) {
+        return context.runtime.newBoolean(isSingleton());
+    }
+
     // TODO: Consider a better way of synchronizing 
     public void addMethod(String name, DynamicMethod method) {
         testFrozen("class/module");


### PR DESCRIPTION
Hello,

This pull request simply adds the `Module#singleton_class?` method to JRuby. This method has been introduced in Ruby 2.1 and is a convenient way to check whether a class is a singleton one or not (see https://bugs.ruby-lang.org/issues/7609 for further information).

A RubySpec has been added for that in rubyspec/rubyspec#279.

Have a nice day.
