### PR TITLE
normalize JRubyHome for windows.

### DIFF
--- a/core/src/main/java/org/jruby/RubyInstanceConfig.java
+++ b/core/src/main/java/org/jruby/RubyInstanceConfig.java
@@ -320,7 +320,7 @@ public class RubyInstanceConfig {
             }
         }
         
-        return newJRubyHome;
+        return new NormalizedFile(newJRubyHome).getPath();
     }
 
     // We require the home directory to be absolute


### PR DESCRIPTION
there code returns backslash cotained strings on windows. cruby is not.
```ruby
RbConfig::CONFIG['prefix']
RbConfig::CONFIG['exec_prefix']
```