### PR TITLE
Show method names and local variables in Truffle backtrace

### DIFF
--- a/core/src/main/java/org/jruby/truffle/nodes/RubyNode.java
+++ b/core/src/main/java/org/jruby/truffle/nodes/RubyNode.java
@@ -205,15 +205,11 @@ public abstract class RubyNode extends Node {
         CompilerAsserts.neverPartOfCompilation();
     }
 
-    public void panic(Object... info) {
-        panic(this, info);
+    public void panic(RubyContext context, Object... info) {
+        panic(context, this, info);
     }
 
-    public static void panic2(Object... info) {
-        panic(null, info);
-    }
-
-    private static void panic(RubyNode node, Object... info) {
+    private static void panic(RubyContext context, RubyNode node, Object... info) {
         CompilerDirectives.transferToInterpreter();
 
         System.err.println("panic -----------------------");
@@ -231,7 +227,7 @@ public abstract class RubyNode extends Node {
         }
 
         System.err.println();
-        RubyCallStack.dump(node);
+        RubyCallStack.dump(context, node);
         System.err.println();
         new Exception().printStackTrace(System.err);
         System.err.println();

--- a/core/src/main/java/org/jruby/truffle/nodes/core/ArrayNodes.java
+++ b/core/src/main/java/org/jruby/truffle/nodes/core/ArrayNodes.java
@@ -864,7 +864,7 @@ public abstract class ArrayNodes {
                 if (normalisedBegin == 0 && normalisedEnd == array.getSize() - 1) {
                     array.setStore(Arrays.copyOf((int[]) other.getStore(), other.getSize()), other.getSize());
                 } else {
-                    panic();
+                    panic(getContext());
                     throw new RuntimeException();
                 }
             }

--- a/core/src/main/java/org/jruby/truffle/nodes/core/TruffleDebugNodes.java
+++ b/core/src/main/java/org/jruby/truffle/nodes/core/TruffleDebugNodes.java
@@ -137,7 +137,7 @@ public abstract class TruffleDebugNodes {
         @Specialization
         public NilPlaceholder dumpCallStack() {
             notDesignedForCompilation();
-            RubyCallStack.dump(this);
+            RubyCallStack.dump(getContext(), this);
             return NilPlaceholder.INSTANCE;
         }
 

--- a/core/src/main/java/org/jruby/truffle/runtime/RubyCallStack.java
+++ b/core/src/main/java/org/jruby/truffle/runtime/RubyCallStack.java
@@ -13,20 +13,21 @@ import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.Truffle;
-import com.oracle.truffle.api.frame.Frame;
-import com.oracle.truffle.api.frame.FrameInstance;
+import com.oracle.truffle.api.frame.*;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeUtil;
 import com.oracle.truffle.api.nodes.RootNode;
 import org.jruby.truffle.nodes.RubyRootNode;
+import org.jruby.truffle.runtime.core.RubyBasicObject;
 import org.jruby.truffle.runtime.core.RubyModule;
+import org.jruby.truffle.runtime.core.RubyObject;
 import org.jruby.truffle.runtime.methods.RubyMethod;
 
 import java.util.Iterator;
 
 public abstract class RubyCallStack {
 
-    public static void dump(Node currentNode) {
+    public static void dump(RubyContext context, Node currentNode) {
         CompilerAsserts.neverPartOfCompilation();
 
         System.err.println("call stack ----------");
@@ -38,16 +39,54 @@ public abstract class RubyCallStack {
         System.err.println("    in " + Truffle.getRuntime().getCurrentFrame().getCallTarget());
 
         for (FrameInstance frame : Truffle.getRuntime().getStackTrace()) {
-            String methodName = "<main>";
-            RubyMethod method = getMethod(frame);
-            if (method != null) {
-                methodName = method.getName();
-            }
-            String methodInfo = ":in `" + methodName + "'";
-            System.err.println("\tfrom " + frame.getCallNode().getEncapsulatingSourceSection() + methodInfo);
+            dumpFrame(context, frame);
         }
 
         System.err.println("---------------------");
+    }
+
+    private static void dumpFrame(RubyContext context, FrameInstance frame) {
+        String sourceInfo = frame.getCallNode().getEncapsulatingSourceSection().toString();
+        System.err.print("\tfrom " + sourceInfo + " in " + formatMethodName(frame));
+
+        MaterializedFrame f = frame.getFrame(FrameInstance.FrameAccess.MATERIALIZE, false).materialize();
+        FrameDescriptor fd = f.getFrameDescriptor();
+        boolean first = true;
+        for (Object ident : fd.getIdentifiers()) {
+            if (ident instanceof String) {
+                RubyBasicObject value = context.getCoreLibrary().box(f.getValue(fd.findFrameSlot(ident)));
+                // TODO(CS): slow path send
+                String repr = value.send("inspect", null).toString();
+                if (first) {
+                    first = false;
+                    System.err.print(" with ");
+                } else {
+                    System.err.print(", ");
+                }
+                int maxLength = 12;
+                if (repr.length() > maxLength) {
+                    repr = repr.substring(0, maxLength) + "... (" + value.getRubyClass().getName() + ")";
+                }
+                System.err.print(ident + " = " + repr);
+            }
+        }
+        System.err.println();
+    }
+
+    public static String formatMethodName(FrameInstance frame) {
+        String methodName;
+        RubyMethod method = getMethod(frame);
+        if (method == null) {
+            methodName = "<main>";
+        } else {
+            RubyModule module = method.getDeclaringModule();
+            if (module == null) {
+                methodName = "?#" + method.getName();
+            } else {
+                methodName = module.getName() + "#" + method.getName();
+            }
+        }
+        return methodName;
     }
 
     public static FrameInstance getCallerFrame() {


### PR DESCRIPTION
@chrisseaton That should be a start!

Say we have `test.rb` with:

``` ruby
def bar(b, c = 3.14)
  local = 42
  TruffleDebug.dump_call_stack
end

def foo(a)
  hidden = :hidden
  bar(2)
end

main = self
top = "level"*10
foo(1)
```

This outputs:

```
call stack ----------
    at TruffleDebug#dump_call_stack
    in TruffleDebug#dump_call_stack(core):TruffleDebug#dump_call_stack
    from test.rb:3 in #<Class:#<Object:0x71>>#bar with b = 2, c = 3.14, local = 42
    from test.rb:8 in #<Class:#<Object:0x71>>#foo with a = 1, hidden = :hidden
    from test.rb:13 in <main> with top = "levellevell... (String), main = #<Object:0x7... (Object)
---------------------
```

Not pretty yet, but it shows the possibilities.
BTW, the `#<Class:#<Object:0x71>>` reveals a bug in Truffle: methods defined at top-level should be defined on Object (and not main's singleton class) as private methods.
