### PR TITLE
JRubyClassloader seems to have a problem with file urls pointing to jar ...

### DIFF
--- a/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
+++ b/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
@@ -247,6 +247,9 @@ class LibrarySearcher {
         private void loadJar(Ruby runtime, boolean wrap) {
             try {
                 URL url = new File(location).toURI().toURL();
+                if ( location.contains( "!") ) {
+                    url = new URL( "jar:" + url );
+                }
                 runtime.getJRubyClassLoader().addURL(url);
             } catch (MalformedURLException badUrl) {
                 runtime.newIOErrorFromException(badUrl);


### PR DESCRIPTION
...within a jar. converting them into jar:file: do work - fixes #1850
