### PR TITLE
have an ExtendedFileResource which keeps the URL of a FileResource 

### DIFF
--- a/core/src/main/java/org/jruby/runtime/load/ExtendedFileResource.java
+++ b/core/src/main/java/org/jruby/runtime/load/ExtendedFileResource.java
@@ -1,0 +1,9 @@
+package org.jruby.runtime.load;
+
+import java.net.URL;
+
+import org.jruby.util.FileResource;
+
+public interface ExtendedFileResource extends FileResource {
+    URL getURL();
+}

--- a/core/src/main/java/org/jruby/util/ClasspathResource.java
+++ b/core/src/main/java/org/jruby/util/ClasspathResource.java
@@ -2,6 +2,8 @@ package org.jruby.util;
 
 import java.net.URL;
 
+import org.jruby.runtime.load.ExtendedFileResource;
+
 class ClasspathResource extends URLResource {
 
     private static final String CLASSPATH = "classpath:/";
@@ -12,7 +14,7 @@ class ClasspathResource extends URLResource {
         super(url);
     }
 
-    public static FileResource create(String pathname)
+    public static ExtendedFileResource create(String pathname)
     {
         if (!pathname.startsWith(CLASSPATH)) {
             return null;

--- a/core/src/main/java/org/jruby/util/EmptyFileResource.java
+++ b/core/src/main/java/org/jruby/util/EmptyFileResource.java
@@ -1,13 +1,16 @@
 package org.jruby.util;
 
+import java.io.InputStream;
+import java.net.URL;
+
 import jnr.posix.FileStat;
 import jnr.posix.POSIX;
-import org.jruby.runtime.ThreadContext;
+
+import org.jruby.runtime.load.ExtendedFileResource;
 import org.jruby.util.io.ChannelDescriptor;
 import org.jruby.util.io.ModeFlags;
-import java.io.InputStream;
 
-class EmptyFileResource implements FileResource {
+class EmptyFileResource implements ExtendedFileResource {
     // All empty resources are the same and immutable, so may as well
     // cache the instance
     private static final EmptyFileResource INSTANCE = new EmptyFileResource();
@@ -93,5 +96,11 @@ class EmptyFileResource implements FileResource {
     @Override
     public ChannelDescriptor openDescriptor(ModeFlags flags, POSIX posix, int perm) throws ResourceException {
         throw new ResourceException.NotFound(absolutePath());
+    }
+
+    @Override
+    public URL getURL()
+    {
+        return null;
     }
 }

--- a/core/src/main/java/org/jruby/util/FileResource.java
+++ b/core/src/main/java/org/jruby/util/FileResource.java
@@ -1,10 +1,12 @@
 package org.jruby.util;
 
+import java.io.InputStream;
+
 import jnr.posix.FileStat;
 import jnr.posix.POSIX;
+
 import org.jruby.util.io.ChannelDescriptor;
 import org.jruby.util.io.ModeFlags;
-import java.io.InputStream;
 
 /**
  * This is a shared interface for files loaded as {@link java.io.File} and {@link java.util.zip.ZipEntry}.

--- a/core/src/main/java/org/jruby/util/FileResourceFactory.java
+++ b/core/src/main/java/org/jruby/util/FileResourceFactory.java
@@ -1,0 +1,46 @@
+package org.jruby.util;
+
+import org.jruby.Ruby;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.load.ExtendedFileResource;
+
+public class FileResourceFactory {
+    public static ExtendedFileResource createResource(ThreadContext context, String pathname) {
+        return createResource(context.runtime, pathname);
+      }
+
+      public static ExtendedFileResource createResource(Ruby runtime, String pathname) {
+        return createResource(runtime.getCurrentDirectory(), pathname);
+      }
+
+      public static ExtendedFileResource createResource(String cwd, String pathname) {
+          ExtendedFileResource emptyResource = EmptyFileResource.create(pathname);
+          if (emptyResource != null) {
+              return emptyResource;
+          }
+
+          ExtendedFileResource jarResource = JarResource.create(pathname);
+          if (jarResource != null) {
+              return jarResource;
+          }
+
+          // HACK turn the pathname into something meaningful in case of being an URI
+          ExtendedFileResource cpResource = ClasspathResource.create(pathname.replace(cwd == null ? "" : cwd, "" ));
+          if (cpResource != null) {
+              return cpResource;
+          }
+
+          // HACK this codes get triggers by LoadService via findOnClasspath, so remove the prefix to get the uri
+          ExtendedFileResource urlResource = URLResource.create(pathname.replace("classpath:/", ""));
+          if (urlResource != null) {
+              return urlResource;
+          }
+
+          if (pathname.startsWith("file:")) {
+              pathname = pathname.substring(5);
+          }
+
+          // If any other special resource types fail, count it as a filesystem backed resource.
+          return new RegularFileResource(JRubyFile.create(cwd, pathname));
+      }
+}

--- a/core/src/main/java/org/jruby/util/JRubyFile.java
+++ b/core/src/main/java/org/jruby/util/JRubyFile.java
@@ -53,48 +53,21 @@ import java.io.IOException;
  */
 public class JRubyFile extends JavaSecuredFile {
     private static final long serialVersionUID = 435364547567567L;
-
+    
     public static JRubyFile create(String cwd, String pathname) {
         return createNoUnicodeConversion(cwd, pathname);
     }
 
     public static FileResource createResource(ThreadContext context, String pathname) {
-      return createResource(context.runtime, pathname);
+      return FileResourceFactory.createResource(context.runtime, pathname);
     }
 
     public static FileResource createResource(Ruby runtime, String pathname) {
-      return createResource(runtime.getCurrentDirectory(), pathname);
+      return FileResourceFactory.createResource(runtime.getCurrentDirectory(), pathname);
     }
 
     public static FileResource createResource(String cwd, String pathname) {
-        FileResource emptyResource = EmptyFileResource.create(pathname);
-        if (emptyResource != null) {
-            return emptyResource;
-        }
-
-        FileResource jarResource = JarResource.create(pathname);
-        if (jarResource != null) {
-            return jarResource;
-        }
-
-        // HACK turn the pathname into something meaningful in case of being an URI
-        FileResource cpResource = ClasspathResource.create(pathname.replace(cwd == null ? "" : cwd, "" ));
-        if (cpResource != null) {
-            return cpResource;
-        }
-
-        // HACK this codes get triggers by LoadService via findOnClasspath, so remove the prefix to get the uri
-        FileResource urlResource = URLResource.create(pathname.replace("classpath:/", ""));
-        if (urlResource != null) {
-            return urlResource;
-        }
-
-        if (pathname.startsWith("file:")) {
-            pathname = pathname.substring(5);
-        }
-
-        // If any other special resource types fail, count it as a filesystem backed resource.
-        return new RegularFileResource(create(cwd, pathname));
+        return FileResourceFactory.createResource(cwd, pathname);
     }
 
     public static String normalizeSeps(String path) {

--- a/core/src/main/java/org/jruby/util/JarResource.java
+++ b/core/src/main/java/org/jruby/util/JarResource.java
@@ -1,16 +1,20 @@
 package org.jruby.util;
 
-import jnr.posix.FileStat;
-import jnr.posix.POSIX;
-
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.net.URLDecoder;
 import java.util.jar.JarEntry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-abstract class JarResource implements FileResource {
+import jnr.posix.FileStat;
+import jnr.posix.POSIX;
+
+import org.jruby.runtime.load.ExtendedFileResource;
+
+abstract class JarResource implements ExtendedFileResource {
     private static Pattern PREFIX_MATCH = Pattern.compile("^(?:jar:)?(?:file:)?(.*)$");
 
     private static final JarCache jarCache = new JarCache();
@@ -83,6 +87,19 @@ abstract class JarResource implements FileResource {
     @Override
     public String absolutePath() {
         return jarPrefix + entryName();
+    }
+
+    @Override
+    public URL getURL()
+    {
+        try
+        {
+            return new URL( "jar:" + absolutePath() );
+        }
+        catch (MalformedURLException e)
+        {
+            return null;
+        }
     }
 
     @Override

--- a/core/src/main/java/org/jruby/util/RegularFileResource.java
+++ b/core/src/main/java/org/jruby/util/RegularFileResource.java
@@ -1,25 +1,29 @@
 package org.jruby.util;
 
-import jnr.posix.FileStat;
-import jnr.posix.POSIX;
-import jnr.posix.POSIXFactory;
 import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.RandomAccessFile;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.channels.FileChannel;
 
+import jnr.posix.FileStat;
+import jnr.posix.POSIX;
+import jnr.posix.POSIXFactory;
+
+import org.jruby.runtime.load.ExtendedFileResource;
 import org.jruby.util.io.ChannelDescriptor;
 import org.jruby.util.io.ModeFlags;
 
 /**
  * Represents a "regular" file, backed by regular file system.
  */
-class RegularFileResource implements FileResource {
+class RegularFileResource implements ExtendedFileResource {
     private final JRubyFile file;
     private final POSIX symlinkPosix = POSIXFactory.getPOSIX();
 
@@ -233,5 +237,18 @@ class RegularFileResource implements FileResource {
         //if (modes.isAppendable()) seek(0, Stream.SEEK_END);
 
         return new ChannelDescriptor(fileChannel, flags, fileDescriptor, isInAppendMode);
+    }
+
+    @Override
+    public URL getURL()
+    {
+        try
+        {
+            return new File(absolutePath()).toURI().toURL();
+        }
+        catch (MalformedURLException e)
+        {
+            return null;
+        }
     }
 }

--- a/core/src/main/java/org/jruby/util/URLResource.java
+++ b/core/src/main/java/org/jruby/util/URLResource.java
@@ -8,10 +8,11 @@ import java.net.URL;
 import jnr.posix.FileStat;
 import jnr.posix.POSIX;
 
+import org.jruby.runtime.load.ExtendedFileResource;
 import org.jruby.util.io.ChannelDescriptor;
 import org.jruby.util.io.ModeFlags;
 
-class URLResource implements FileResource {
+class URLResource implements ExtendedFileResource {
 
     private final URL url;
     
@@ -119,7 +120,7 @@ class URLResource implements FileResource {
         return null;
     }
 
-    public static FileResource create(String pathname)
+    public static ExtendedFileResource create(String pathname)
     {
         URL url;
         try
@@ -135,6 +136,12 @@ class URLResource implements FileResource {
         {
             return null;
         }
+    }
+
+    @Override
+    public URL getURL()
+    {
+        return url;
     }
     
 }


### PR DESCRIPTION
have an ExtendedFileResource which keeps the URL of a FileResource to load jar files. the JRubyFile "factory" API and FileResource API remain as they were before.
