### PR TITLE
Bash launcher refactor

### DIFF
--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -342,59 +342,59 @@ if [ "$nailgun_client" != "" ]; then
     exit 1
   fi
 else
-if [ "$VERIFY_JRUBY" != "" ]; then
-  if [ "$PROFILE_ARGS" != "" ]; then
-      echo "Running with instrumented profiler"
-  fi
+  if [ "$VERIFY_JRUBY" != "" ]; then
+    if [ "$PROFILE_ARGS" != "" ]; then
+        echo "Running with instrumented profiler"
+    fi
 
-  if [[ "${java_class:-}" == "${JAVA_CLASS_NGSERVER:-}" && -n "${JRUBY_OPTS:-}" ]]; then
-    echo "warning: starting a nailgun server; discarding JRUBY_OPTS: ${JRUBY_OPTS}"
-    JRUBY_OPTS=''
-  fi
+    if [[ "${java_class:-}" == "${JAVA_CLASS_NGSERVER:-}" && -n "${JRUBY_OPTS:-}" ]]; then
+      echo "warning: starting a nailgun server; discarding JRUBY_OPTS: ${JRUBY_OPTS}"
+      JRUBY_OPTS=''
+    fi
 
-  "$JAVACMD" $PROFILE_ARGS $JAVA_OPTS "$JFFI_OPTS" "${java_args[@]}" -classpath "$JRUBY_CP$CP_DELIMITER$CP$CP_DELIMITER$CLASSPATH" \
-    "-Djruby.home=$JRUBY_HOME" \
-    "-Djruby.lib=$JRUBY_HOME/lib" -Djruby.script=jruby \
-    "-Djruby.shell=$JRUBY_SHELL" \
-    $java_class $JRUBY_OPTS "$@"
-
-  # Record the exit status immediately, or it will be overridden.
-  JRUBY_STATUS=$?
-
-  if [ "$PROFILE_ARGS" != "" ]; then
-      echo "Profiling results:"
-      cat profile.txt
-      rm profile.txt
-  fi
-
-  if $cygwin; then
-    stty icanon echo > /dev/null 2>&1
-  fi
-
-  exit $JRUBY_STATUS
-else
-  if $cygwin; then
-    # exec doed not work correctly with cygwin bash
-    "$JAVACMD" $JAVA_OPTS "$JFFI_OPTS" "${java_args[@]}" -Xbootclasspath/a:"$JRUBY_CP" -classpath "$CP$CP_DELIMITER$CLASSPATH" \
+    "$JAVACMD" $PROFILE_ARGS $JAVA_OPTS "$JFFI_OPTS" "${java_args[@]}" -classpath "$JRUBY_CP$CP_DELIMITER$CP$CP_DELIMITER$CLASSPATH" \
       "-Djruby.home=$JRUBY_HOME" \
       "-Djruby.lib=$JRUBY_HOME/lib" -Djruby.script=jruby \
       "-Djruby.shell=$JRUBY_SHELL" \
-      $java_class $mode "$@"
+      $java_class $JRUBY_OPTS "$@"
 
     # Record the exit status immediately, or it will be overridden.
     JRUBY_STATUS=$?
 
-    stty icanon echo > /dev/null 2>&1
+    if [ "$PROFILE_ARGS" != "" ]; then
+        echo "Profiling results:"
+        cat profile.txt
+        rm profile.txt
+    fi
+
+    if $cygwin; then
+      stty icanon echo > /dev/null 2>&1
+    fi
 
     exit $JRUBY_STATUS
   else
-    exec "$JAVACMD" $JAVA_OPTS "$JFFI_OPTS" "${java_args[@]}" -Xbootclasspath/a:"$JRUBY_CP" -classpath "$CP$CP_DELIMITER$CLASSPATH" \
-      "-Djruby.home=$JRUBY_HOME" \
-      "-Djruby.lib=$JRUBY_HOME/lib" -Djruby.script=jruby \
-      "-Djruby.shell=$JRUBY_SHELL" \
-      $java_class $mode "$@"
+    if $cygwin; then
+      # exec doed not work correctly with cygwin bash
+      "$JAVACMD" $JAVA_OPTS "$JFFI_OPTS" "${java_args[@]}" -Xbootclasspath/a:"$JRUBY_CP" -classpath "$CP$CP_DELIMITER$CLASSPATH" \
+        "-Djruby.home=$JRUBY_HOME" \
+        "-Djruby.lib=$JRUBY_HOME/lib" -Djruby.script=jruby \
+        "-Djruby.shell=$JRUBY_SHELL" \
+        $java_class $mode "$@"
+
+      # Record the exit status immediately, or it will be overridden.
+      JRUBY_STATUS=$?
+
+      stty icanon echo > /dev/null 2>&1
+
+      exit $JRUBY_STATUS
+    else
+      exec "$JAVACMD" $JAVA_OPTS "$JFFI_OPTS" "${java_args[@]}" -Xbootclasspath/a:"$JRUBY_CP" -classpath "$CP$CP_DELIMITER$CLASSPATH" \
+        "-Djruby.home=$JRUBY_HOME" \
+        "-Djruby.lib=$JRUBY_HOME/lib" -Djruby.script=jruby \
+        "-Djruby.shell=$JRUBY_SHELL" \
+        $java_class $mode "$@"
+    fi
   fi
-fi
 fi
 
 # Be careful adding code down here, you might override the exit

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -393,9 +393,10 @@ else
         "-Djruby.lib=$JRUBY_HOME/lib" -Djruby.script=jruby \
         "-Djruby.shell=$JRUBY_SHELL" \
         $java_class $mode "$@"
+
+      JRUBY_STATUS=$?
+
+      exit $JRUBY_STATUS
     fi
   fi
 fi
-
-# Be careful adding code down here, you might override the exit
-# status of the jruby invocation.

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -58,9 +58,10 @@ unset JRUBY_OPTS_TEMP
 function process_special_opts {
     case $1 in
         --ng) nailgun_client=true;;
-        *) break;;
+        *) return;;
     esac
 }
+
 for opt in ${JRUBY_OPTS[@]}; do
     for special in ${JRUBY_OPTS_SPECIAL[@]}; do
         if [ $opt != $special ]; then

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -14,7 +14,7 @@
 cygwin=false
 
 # ----- Identify OS we are running under --------------------------------------
-case "`uname`" in
+case "$(uname)" in
   CYGWIN*) cygwin=true;;
   Darwin) darwin=true;;
   MINGW*) jruby.exe "$@"; exit $?;;
@@ -41,12 +41,12 @@ done
 
 PRG=$SELF_PATH
 
-JRUBY_HOME_1=`dirname "$PRG"`           # the ./bin dir
+JRUBY_HOME_1=$(dirname "$PRG")           # the ./bin dir
 if [ "$JRUBY_HOME_1" = '.' ] ; then
-  cwd=`pwd`
-  JRUBY_HOME=`dirname "$cwd"` # JRUBY-2699
+  cwd=$(pwd)
+  JRUBY_HOME=$(dirname "$cwd") # JRUBY-2699
 else
-  JRUBY_HOME=`dirname "$JRUBY_HOME_1"`  # the . dir
+  JRUBY_HOME=$(dirname "$JRUBY_HOME_1")  # the . dir
 fi
 
 if [ -z "$JRUBY_OPTS" ] ; then
@@ -84,7 +84,7 @@ if [ -z "$JAVACMD" ] ; then
     JAVACMD='java'
   else
     if $cygwin; then
-      JAVACMD="`cygpath -u "$JAVA_HOME"`/bin/java"
+      JAVACMD="$(cygpath -u "$JAVA_HOME")/bin/java"
     else
       JAVACMD="$JAVA_HOME/bin/java"
     fi
@@ -147,7 +147,7 @@ for j in "$JRUBY_HOME"/lib/jruby.jar "$JRUBY_HOME"/lib/jruby-complete.jar; do
 done
 
 if $cygwin; then
-    JRUBY_CP=`cygpath -p -w "$JRUBY_CP"`
+    JRUBY_CP=$(cygpath -p -w "$JRUBY_CP")
 fi
 
 # ----- Set Up The System Classpath -------------------------------------------
@@ -172,7 +172,7 @@ else
     done
 
     if [ "$CP" != "" ] && $cygwin; then
-        CP=`cygpath -p -w "$CP"`
+        CP=$(cygpath -p -w "$CP")
     fi
 fi
 
@@ -258,7 +258,7 @@ do
           JAVACMD='jdb'
         else
           if $cygwin; then
-            JAVACMD="`cygpath -u "$JAVA_HOME"`/bin/jdb"
+            JAVACMD="$(cygpath -u "$JAVA_HOME")/bin/jdb"
           else
             JAVACMD="$JAVA_HOME/bin/jdb"
           fi
@@ -315,11 +315,11 @@ JAVA_OPTS="$JAVA_OPTS $JAVA_MEM $JAVA_MEM_MIN $JAVA_STACK"
 JFFI_OPTS="-Djffi.boot.library.path=$JRUBY_HOME/lib/jni"
 
 if $cygwin; then
-  JRUBY_HOME=`cygpath --mixed "$JRUBY_HOME"`
-  JRUBY_SHELL=`cygpath --mixed "$JRUBY_SHELL"`
+  JRUBY_HOME=$(cygpath --mixed "$JRUBY_HOME")
+  JRUBY_SHELL=$(cygpath --mixed "$JRUBY_SHELL")
 
   if [[ ( "${1:0:1}" = "/" ) && ( ( -f "$1" ) || ( -d "$1" )) ]]; then
-    win_arg=`cygpath -w "$1"`
+    win_arg=$(cygpath -w "$1")
     shift
     win_args=("$win_arg" "$@")
     set -- "${win_args[@]}"

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -36,7 +36,7 @@ while [ -h "$SELF_PATH" ]; do
     # 4) append the basename
     DIR=$(dirname -- "$SELF_PATH")
     SYM=$(readlink "$SELF_PATH")
-    SELF_PATH=$(cd "$DIR" && cd $(dirname -- "$SYM") && pwd)/$(basename -- "$SYM")
+    SELF_PATH="$(cd "$DIR" && cd "$(dirname -- "$SYM")" && pwd)/$(basename -- "$SYM")"
 done
 
 PRG=$SELF_PATH
@@ -44,7 +44,7 @@ PRG=$SELF_PATH
 JRUBY_HOME_1=`dirname "$PRG"`           # the ./bin dir
 if [ "$JRUBY_HOME_1" = '.' ] ; then
   cwd=`pwd`
-  JRUBY_HOME=`dirname $cwd` # JRUBY-2699
+  JRUBY_HOME=`dirname "$cwd"` # JRUBY-2699
 else
   JRUBY_HOME=`dirname "$JRUBY_HOME_1"`  # the . dir
 fi
@@ -140,7 +140,7 @@ for j in "$JRUBY_HOME"/lib/jruby.jar "$JRUBY_HOME"/lib/jruby-complete.jar; do
         else
         JRUBY_CP="$j"
     fi
-    if [ $JRUBY_ALREADY_ADDED ]; then
+    if [ "$JRUBY_ALREADY_ADDED" ]; then
         echo "WARNING: more than one JRuby JAR found in lib directory"
     fi
     JRUBY_ALREADY_ADDED=true
@@ -334,8 +334,8 @@ if $cygwin; then
 fi
 
 if [ "$nailgun_client" != "" ]; then
-  if [ -f $JRUBY_HOME/tool/nailgun/ng ]; then
-    exec $JRUBY_HOME/tool/nailgun/ng org.jruby.util.NailMain $mode "$@"
+  if [ -f "$JRUBY_HOME/tool/nailgun/ng" ]; then
+    exec "$JRUBY_HOME/tool/nailgun/ng" org.jruby.util.NailMain $mode "$@"
   else
     echo "error: ng executable not found; run 'make' in ${JRUBY_HOME}/tool/nailgun"
     exit 1

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -11,50 +11,6 @@
 #
 # -----------------------------------------------------------------------------
 
-cygwin=false
-
-# ----- Identify OS we are running under --------------------------------------
-case "$(uname)" in
-  CYGWIN*) cygwin=true;;
-  Darwin) darwin=true;;
-  MINGW*) jruby.exe "$@"; exit $?;;
-esac
-
-# ----- Verify and Set Required Environment Variables -------------------------
-if [ -z "$JAVA_VM" ]; then
-  JAVA_VM=-client
-fi
-
-# get the absolute path of the executable
-SELF_PATH=$(builtin cd -P -- "$(dirname -- "$0")" >/dev/null && pwd -P) && SELF_PATH=$SELF_PATH/$(basename -- "$0")
-
-# resolve symlinks
-while [ -h "$SELF_PATH" ]; do
-    # 1) cd to directory of the symlink
-    # 2) cd to the directory of where the symlink points
-    # 3) get the pwd
-    # 4) append the basename
-    DIR=$(dirname -- "$SELF_PATH")
-    SYM=$(readlink "$SELF_PATH")
-    SELF_PATH="$(cd "$DIR" && cd "$(dirname -- "$SYM")" && pwd)/$(basename -- "$SYM")"
-done
-
-PRG=$SELF_PATH
-
-JRUBY_HOME_1=$(dirname "$PRG")           # the ./bin dir
-if [ "$JRUBY_HOME_1" = '.' ] ; then
-  cwd=$(pwd)
-  JRUBY_HOME=$(dirname "$cwd") # JRUBY-2699
-else
-  JRUBY_HOME=$(dirname "$JRUBY_HOME_1")  # the . dir
-fi
-
-if [ -z "$JRUBY_OPTS" ] ; then
-  JRUBY_OPTS=""
-fi
-
-JRUBY_OPTS_SPECIAL="--ng" # space-separated list of special flags
-unset JRUBY_OPTS_TEMP
 function process_special_opts {
     case $1 in
         --ng) nailgun_client=true;;
@@ -62,341 +18,390 @@ function process_special_opts {
     esac
 }
 
-for opt in ${JRUBY_OPTS[@]}; do
-    for special in ${JRUBY_OPTS_SPECIAL[@]}; do
-        if [ $opt != $special ]; then
-            JRUBY_OPTS_TEMP="${JRUBY_OPTS_TEMP} $opt"
-        else
-            # make sure flags listed in JRUBY_OPTS_SPECIAL are processed
-            case "$opt" in
-            --ng)
-                process_special_opts $opt;;
-            esac
-        fi
-    done
-    if [ $opt == "-server" ]; then # JRUBY-4204
-        JAVA_VM="-server"
-    fi
-done
-JRUBY_OPTS=${JRUBY_OPTS_TEMP}
+function main {
+  cygwin=false
 
-if [ -z "$JAVACMD" ] ; then
-  if [ -z "$JAVA_HOME" ] ; then
-    JAVACMD='java'
-  else
-    if $cygwin; then
-      JAVACMD="$(cygpath -u "$JAVA_HOME")/bin/java"
-    else
-      JAVACMD="$JAVA_HOME/bin/java"
-    fi
-  fi
-fi
-
-if [ -z "$JAVA_MEM" ] ; then
-  JAVA_MEM=-Xmx500m
-fi
-
-if [ -z "$JAVA_STACK" ] ; then
-  JAVA_STACK=-Xss2048k
-fi
-
-# process JAVA_OPTS
-unset JAVA_OPTS_TEMP
-JAVA_OPTS_TEMP=""
-for opt in ${JAVA_OPTS[@]}; do
-  case $opt in
-    -server)
-      JAVA_VM="-server";;
-    -Xmx*)
-      JAVA_MEM=$opt;;
-    -Xms*)
-      JAVA_MEM_MIN=$opt;;
-    -Xss*)
-      JAVA_STACK=$opt;;
-    *)
-      JAVA_OPTS_TEMP="${JAVA_OPTS_TEMP} $opt";;
+  # ----- Identify OS we are running under --------------------------------------
+  case "$(uname)" in
+    CYGWIN*) cygwin=true;;
+    Darwin) darwin=true;;
+    MINGW*) jruby.exe "$@"; exit $?;;
   esac
-done
 
-JAVA_OPTS=$JAVA_OPTS_TEMP
+  # ----- Verify and Set Required Environment Variables -------------------------
+  if [ -z "$JAVA_VM" ]; then
+    JAVA_VM=-client
+  fi
 
+  # get the absolute path of the executable
+  SELF_PATH=$(builtin cd -P -- "$(dirname -- "$0")" >/dev/null && pwd -P) && SELF_PATH=$SELF_PATH/$(basename -- "$0")
 
-# If you're seeing odd exceptions, you may have a bad JVM install.
-# Uncomment this and report the version to the JRuby team along with error.
-#$JAVACMD -version
+  # resolve symlinks
+  while [ -h "$SELF_PATH" ]; do
+      # 1) cd to directory of the symlink
+      # 2) cd to the directory of where the symlink points
+      # 3) get the pwd
+      # 4) append the basename
+      DIR=$(dirname -- "$SELF_PATH")
+      SYM=$(readlink "$SELF_PATH")
+      SELF_PATH="$(cd "$DIR" && cd "$(dirname -- "$SYM")" && pwd)/$(basename -- "$SYM")"
+  done
 
-JRUBY_SHELL=/bin/sh
+  PRG=$SELF_PATH
 
-# ----- Set Up The Boot Classpath -------------------------------------------
+  JRUBY_HOME_1=$(dirname "$PRG")           # the ./bin dir
+  if [ "$JRUBY_HOME_1" = '.' ] ; then
+    cwd=$(pwd)
+    JRUBY_HOME=$(dirname "$cwd") # JRUBY-2699
+  else
+    JRUBY_HOME=$(dirname "$JRUBY_HOME_1")  # the . dir
+  fi
 
-CP_DELIMITER=":"
+  if [ -z "$JRUBY_OPTS" ] ; then
+    JRUBY_OPTS=""
+  fi
 
-# add main jruby jar to the bootclasspath
-for j in "$JRUBY_HOME"/lib/jruby.jar "$JRUBY_HOME"/lib/jruby-complete.jar; do
-    if [ ! -e "$j" ]; then
-      continue
-    fi
-    if [ "$JRUBY_CP" ]; then
-        JRUBY_CP="$JRUBY_CP$CP_DELIMITER$j"
-        else
-        JRUBY_CP="$j"
-    fi
-    if [ "$JRUBY_ALREADY_ADDED" ]; then
-        echo "WARNING: more than one JRuby JAR found in lib directory"
-    fi
-    JRUBY_ALREADY_ADDED=true
-done
+  JRUBY_OPTS_SPECIAL="--ng" # space-separated list of special flags
+  unset JRUBY_OPTS_TEMP
 
-if $cygwin; then
-    JRUBY_CP=$(cygpath -p -w "$JRUBY_CP")
-fi
-
-# ----- Set Up The System Classpath -------------------------------------------
-
-if [ "$JRUBY_PARENT_CLASSPATH" != "" ]; then
-    # Use same classpath propagated from parent jruby
-    CP=$JRUBY_PARENT_CLASSPATH
-else
-    # add other jars in lib to CP for command-line execution
-    for j in "$JRUBY_HOME"/lib/*.jar; do
-        if [ "$j" == "$JRUBY_HOME"/lib/jruby.jar ]; then
-          continue
-        fi
-        if [ "$j" == "$JRUBY_HOME"/lib/jruby-complete.jar ]; then
-          continue
-        fi
-        if [ "$CP" ]; then
-            CP="$CP$CP_DELIMITER$j"
-            else
-            CP="$j"
-        fi
-    done
-
-    if [ "$CP" != "" ] && $cygwin; then
-        CP=$(cygpath -p -w "$CP")
-    fi
-fi
-
-if $cygwin; then
-    # switch delimiter only after building Unix style classpaths
-    CP_DELIMITER=";"
-fi
-
-# ----- Execute The Requested Command -----------------------------------------
-JAVA_ENCODING=""
-
-declare -a java_args
-declare -a ruby_args
-mode=""
-
-JAVA_CLASS_JRUBY_MAIN=org.jruby.Main
-java_class=$JAVA_CLASS_JRUBY_MAIN
-JAVA_CLASS_NGSERVER=org.jruby.main.NailServerMain
-
-# Split out any -J argument for passing to the JVM.
-# Scanning for args is aborted by '--'.
-set -- $JRUBY_OPTS "$@"
-while [ $# -gt 0 ]
-do
-    case "$1" in
-    # Stuff after '-J' in this argument goes to JVM
-    -J*)
-        val=${1:2}
-        if [ "${val:0:4}" = "-Xmx" ]; then
-            JAVA_MEM=$val
-        elif [ "${val:0:4}" = "-Xms" ]; then
-            JAVA_MEM_MIN=$val
-        elif [ "${val:0:4}" = "-Xss" ]; then
-            JAVA_STACK=$val
-        elif [ "${val}" = "" ]; then
-            $JAVACMD -help
-            echo "(Prepend -J in front of these options when using 'jruby' command)"
-            exit
-        elif [ "${val}" = "-X" ]; then
-            $JAVACMD -X
-            echo "(Prepend -J in front of these options when using 'jruby' command)"
-            exit
-        elif [ "${val}" = "-classpath" ]; then
-            CP="$CP$CP_DELIMITER$2"
-            CLASSPATH=""
-            shift
-        elif [ "${val}" = "-cp" ]; then
-            CP="$CP$CP_DELIMITER$2"
-            CLASSPATH=""
-            shift
-        else
-            if [ "${val:0:3}" = "-ea" ]; then
-                VERIFY_JRUBY="yes"
-            elif [ "${val:0:16}" = "-Dfile.encoding=" ]; then
-                JAVA_ENCODING=$val
-            fi
-            java_args=("${java_args[@]}" "${1:2}")
-        fi
-        ;;
-     # Match -Xa.b.c=d to translate to -Da.b.c=d as a java option
-     -X*)
-        val=${1:2}
-        if expr "$val" : '.*[.]' > /dev/null; then
-          java_args=("${java_args[@]}" "-Djruby.${val}")
-        else
-          ruby_args=("${ruby_args[@]}" "-X${val}")
-        fi
-        ;;
-     # Match switches that take an argument
-     -C|-e|-I|-S) ruby_args=("${ruby_args[@]}" "$1" "$2"); shift ;;
-     # Match same switches with argument stuck together
-     -e*|-I*|-S*) ruby_args=("${ruby_args[@]}" "$1" ) ;;
-     # Run with JMX management enabled
-     --manage)
-        java_args=("${java_args[@]}" "-Dcom.sun.management.jmxremote")
-        java_args=("${java_args[@]}" "-Djruby.management.enabled=true") ;;
-     # Don't launch a GUI window, no matter what
-     --headless)
-        java_args=("${java_args[@]}" "-Djava.awt.headless=true") ;;
-     # Run under JDB
-     --jdb)
-        if [ -z "$JAVA_HOME" ] ; then
-          JAVACMD='jdb'
-        else
-          if $cygwin; then
-            JAVACMD="$(cygpath -u "$JAVA_HOME")/bin/jdb"
+  for opt in ${JRUBY_OPTS[@]}; do
+      for special in ${JRUBY_OPTS_SPECIAL[@]}; do
+          if [ $opt != $special ]; then
+              JRUBY_OPTS_TEMP="${JRUBY_OPTS_TEMP} $opt"
           else
-            JAVACMD="$JAVA_HOME/bin/jdb"
+              # make sure flags listed in JRUBY_OPTS_SPECIAL are processed
+              case "$opt" in
+              --ng)
+                  process_special_opts $opt;;
+              esac
           fi
-        fi
-        java_args=("${java_args[@]}" "-sourcepath" "$JRUBY_HOME/lib/ruby/1.9:.")
-        JRUBY_OPTS=("${JRUBY_OPTS[@]}" "-X+C") ;;
-     --client)
-        JAVA_VM=-client ;;
-     --server)
-        JAVA_VM=-server ;;
-     --dev)
-        JAVA_VM=-client
-        JAVA_OPTS="$JAVA_OPTS -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Djruby.compile.mode=OFF -Djruby.compile.invokedynamic=false" ;;
-     --noclient)         # JRUBY-4296
-        unset JAVA_VM ;; # For IBM JVM, neither '-client' nor '-server' is applicable
-     --sample)
-        java_args=("${java_args[@]}" "-Xprof") ;;
-     --ng-server)
-        # Start up as Nailgun server
-        java_class=$JAVA_CLASS_NGSERVER
-        VERIFY_JRUBY=true ;;
-     --ng)
-        # Use native Nailgun client to toss commands to server
-        process_special_opts "--ng" ;;
-     # warn but ignore
-     --1.8) echo "warning: --1.8 ignored" ;;
-     # warn but ignore
-     --1.9) echo "warning: --1.9 ignored" ;;
-     # warn but ignore
-     --2.0) echo "warning: --1.9 ignored" ;;
-     # Abort processing on the double dash
-     --) break ;;
-     # Other opts go to ruby
-     -*) ruby_args=("${ruby_args[@]}" "$1") ;;
-     # Abort processing on first non-opt arg
-     *) break ;;
+      done
+      if [ $opt == "-server" ]; then # JRUBY-4204
+          JAVA_VM="-server"
+      fi
+  done
+  JRUBY_OPTS=${JRUBY_OPTS_TEMP}
+
+  if [ -z "$JAVACMD" ] ; then
+    if [ -z "$JAVA_HOME" ] ; then
+      JAVACMD='java'
+    else
+      if $cygwin; then
+        JAVACMD="$(cygpath -u "$JAVA_HOME")/bin/java"
+      else
+        JAVACMD="$JAVA_HOME/bin/java"
+      fi
+    fi
+  fi
+
+  if [ -z "$JAVA_MEM" ] ; then
+    JAVA_MEM=-Xmx500m
+  fi
+
+  if [ -z "$JAVA_STACK" ] ; then
+    JAVA_STACK=-Xss2048k
+  fi
+
+  # process JAVA_OPTS
+  unset JAVA_OPTS_TEMP
+  JAVA_OPTS_TEMP=""
+  for opt in ${JAVA_OPTS[@]}; do
+    case $opt in
+      -server)
+        JAVA_VM="-server";;
+      -Xmx*)
+        JAVA_MEM=$opt;;
+      -Xms*)
+        JAVA_MEM_MIN=$opt;;
+      -Xss*)
+        JAVA_STACK=$opt;;
+      *)
+        JAVA_OPTS_TEMP="${JAVA_OPTS_TEMP} $opt";;
     esac
-    shift
-done
+  done
 
-# Force file.encoding to UTF-8 when on Mac, since Apple JDK defaults to MacRoman (JRUBY-3576)
-if [[ $darwin && -z "$JAVA_ENCODING" ]]; then
-  java_args=("${java_args[@]}" "-Dfile.encoding=UTF-8")
-fi
+  JAVA_OPTS=$JAVA_OPTS_TEMP
 
-# Append the rest of the arguments
-ruby_args=("${ruby_args[@]}" "$@")
 
-# Put the ruby_args back into the position arguments $1, $2 etc
-set -- "${ruby_args[@]}"
+  # If you're seeing odd exceptions, you may have a bad JVM install.
+  # Uncomment this and report the version to the JRuby team along with error.
+  #$JAVACMD -version
 
-JAVA_OPTS="$JAVA_OPTS $JAVA_MEM $JAVA_MEM_MIN $JAVA_STACK"
+  JRUBY_SHELL=/bin/sh
 
-JFFI_OPTS="-Djffi.boot.library.path=$JRUBY_HOME/lib/jni"
+  # ----- Set Up The Boot Classpath -------------------------------------------
 
-if $cygwin; then
-  JRUBY_HOME=$(cygpath --mixed "$JRUBY_HOME")
-  JRUBY_SHELL=$(cygpath --mixed "$JRUBY_SHELL")
+  CP_DELIMITER=":"
 
-  if [[ ( "${1:0:1}" = "/" ) && ( ( -f "$1" ) || ( -d "$1" )) ]]; then
-    win_arg=$(cygpath -w "$1")
-    shift
-    win_args=("$win_arg" "$@")
-    set -- "${win_args[@]}"
+  # add main jruby jar to the bootclasspath
+  for j in "$JRUBY_HOME"/lib/jruby.jar "$JRUBY_HOME"/lib/jruby-complete.jar; do
+      if [ ! -e "$j" ]; then
+        continue
+      fi
+      if [ "$JRUBY_CP" ]; then
+          JRUBY_CP="$JRUBY_CP$CP_DELIMITER$j"
+          else
+          JRUBY_CP="$j"
+      fi
+      if [ "$JRUBY_ALREADY_ADDED" ]; then
+          echo "WARNING: more than one JRuby JAR found in lib directory"
+      fi
+      JRUBY_ALREADY_ADDED=true
+  done
+
+  if $cygwin; then
+      JRUBY_CP=$(cygpath -p -w "$JRUBY_CP")
   fi
 
-  # fix JLine to use UnixTerminal
-  stty -icanon min 1 -echo > /dev/null 2>&1
-  if [ $? = 0 ]; then
-    JAVA_OPTS="$JAVA_OPTS -Djline.terminal=jline.UnixTerminal"
-  fi
+  # ----- Set Up The System Classpath -------------------------------------------
 
-fi
-
-if [ "$nailgun_client" != "" ]; then
-  if [ -f "$JRUBY_HOME/tool/nailgun/ng" ]; then
-    exec "$JRUBY_HOME/tool/nailgun/ng" org.jruby.util.NailMain $mode "$@"
+  if [ "$JRUBY_PARENT_CLASSPATH" != "" ]; then
+      # Use same classpath propagated from parent jruby
+      CP=$JRUBY_PARENT_CLASSPATH
   else
-    echo "error: ng executable not found; run 'make' in ${JRUBY_HOME}/tool/nailgun"
-    exit 1
+      # add other jars in lib to CP for command-line execution
+      for j in "$JRUBY_HOME"/lib/*.jar; do
+          if [ "$j" == "$JRUBY_HOME"/lib/jruby.jar ]; then
+            continue
+          fi
+          if [ "$j" == "$JRUBY_HOME"/lib/jruby-complete.jar ]; then
+            continue
+          fi
+          if [ "$CP" ]; then
+              CP="$CP$CP_DELIMITER$j"
+              else
+              CP="$j"
+          fi
+      done
+
+      if [ "$CP" != "" ] && $cygwin; then
+          CP=$(cygpath -p -w "$CP")
+      fi
   fi
-else
-  if [ "$VERIFY_JRUBY" != "" ]; then
-    if [ "$PROFILE_ARGS" != "" ]; then
-        echo "Running with instrumented profiler"
+
+  if $cygwin; then
+      # switch delimiter only after building Unix style classpaths
+      CP_DELIMITER=";"
+  fi
+
+  # ----- Execute The Requested Command -----------------------------------------
+  JAVA_ENCODING=""
+
+  declare -a java_args
+  declare -a ruby_args
+  mode=""
+
+  JAVA_CLASS_JRUBY_MAIN=org.jruby.Main
+  java_class=$JAVA_CLASS_JRUBY_MAIN
+  JAVA_CLASS_NGSERVER=org.jruby.main.NailServerMain
+
+  # Split out any -J argument for passing to the JVM.
+  # Scanning for args is aborted by '--'.
+  set -- $JRUBY_OPTS "$@"
+  while [ $# -gt 0 ]
+  do
+      case "$1" in
+      # Stuff after '-J' in this argument goes to JVM
+      -J*)
+          val=${1:2}
+          if [ "${val:0:4}" = "-Xmx" ]; then
+              JAVA_MEM=$val
+          elif [ "${val:0:4}" = "-Xms" ]; then
+              JAVA_MEM_MIN=$val
+          elif [ "${val:0:4}" = "-Xss" ]; then
+              JAVA_STACK=$val
+          elif [ "${val}" = "" ]; then
+              $JAVACMD -help
+              echo "(Prepend -J in front of these options when using 'jruby' command)"
+              exit
+          elif [ "${val}" = "-X" ]; then
+              $JAVACMD -X
+              echo "(Prepend -J in front of these options when using 'jruby' command)"
+              exit
+          elif [ "${val}" = "-classpath" ]; then
+              CP="$CP$CP_DELIMITER$2"
+              CLASSPATH=""
+              shift
+          elif [ "${val}" = "-cp" ]; then
+              CP="$CP$CP_DELIMITER$2"
+              CLASSPATH=""
+              shift
+          else
+              if [ "${val:0:3}" = "-ea" ]; then
+                  VERIFY_JRUBY="yes"
+              elif [ "${val:0:16}" = "-Dfile.encoding=" ]; then
+                  JAVA_ENCODING=$val
+              fi
+              java_args=("${java_args[@]}" "${1:2}")
+          fi
+          ;;
+       # Match -Xa.b.c=d to translate to -Da.b.c=d as a java option
+       -X*)
+          val=${1:2}
+          if expr "$val" : '.*[.]' > /dev/null; then
+            java_args=("${java_args[@]}" "-Djruby.${val}")
+          else
+            ruby_args=("${ruby_args[@]}" "-X${val}")
+          fi
+          ;;
+       # Match switches that take an argument
+       -C|-e|-I|-S) ruby_args=("${ruby_args[@]}" "$1" "$2"); shift ;;
+       # Match same switches with argument stuck together
+       -e*|-I*|-S*) ruby_args=("${ruby_args[@]}" "$1" ) ;;
+       # Run with JMX management enabled
+       --manage)
+          java_args=("${java_args[@]}" "-Dcom.sun.management.jmxremote")
+          java_args=("${java_args[@]}" "-Djruby.management.enabled=true") ;;
+       # Don't launch a GUI window, no matter what
+       --headless)
+          java_args=("${java_args[@]}" "-Djava.awt.headless=true") ;;
+       # Run under JDB
+       --jdb)
+          if [ -z "$JAVA_HOME" ] ; then
+            JAVACMD='jdb'
+          else
+            if $cygwin; then
+              JAVACMD="$(cygpath -u "$JAVA_HOME")/bin/jdb"
+            else
+              JAVACMD="$JAVA_HOME/bin/jdb"
+            fi
+          fi
+          java_args=("${java_args[@]}" "-sourcepath" "$JRUBY_HOME/lib/ruby/1.9:.")
+          JRUBY_OPTS=("${JRUBY_OPTS[@]}" "-X+C") ;;
+       --client)
+          JAVA_VM=-client ;;
+       --server)
+          JAVA_VM=-server ;;
+       --dev)
+          JAVA_VM=-client
+          JAVA_OPTS="$JAVA_OPTS -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Djruby.compile.mode=OFF -Djruby.compile.invokedynamic=false" ;;
+       --noclient)         # JRUBY-4296
+          unset JAVA_VM ;; # For IBM JVM, neither '-client' nor '-server' is applicable
+       --sample)
+          java_args=("${java_args[@]}" "-Xprof") ;;
+       --ng-server)
+          # Start up as Nailgun server
+          java_class=$JAVA_CLASS_NGSERVER
+          VERIFY_JRUBY=true ;;
+       --ng)
+          # Use native Nailgun client to toss commands to server
+          process_special_opts "--ng" ;;
+       # warn but ignore
+       --1.8) echo "warning: --1.8 ignored" ;;
+       # warn but ignore
+       --1.9) echo "warning: --1.9 ignored" ;;
+       # warn but ignore
+       --2.0) echo "warning: --1.9 ignored" ;;
+       # Abort processing on the double dash
+       --) break ;;
+       # Other opts go to ruby
+       -*) ruby_args=("${ruby_args[@]}" "$1") ;;
+       # Abort processing on first non-opt arg
+       *) break ;;
+      esac
+      shift
+  done
+
+  # Force file.encoding to UTF-8 when on Mac, since Apple JDK defaults to MacRoman (JRUBY-3576)
+  if [[ $darwin && -z "$JAVA_ENCODING" ]]; then
+    java_args=("${java_args[@]}" "-Dfile.encoding=UTF-8")
+  fi
+
+  # Append the rest of the arguments
+  ruby_args=("${ruby_args[@]}" "$@")
+
+  # Put the ruby_args back into the position arguments $1, $2 etc
+  set -- "${ruby_args[@]}"
+
+  JAVA_OPTS="$JAVA_OPTS $JAVA_MEM $JAVA_MEM_MIN $JAVA_STACK"
+
+  JFFI_OPTS="-Djffi.boot.library.path=$JRUBY_HOME/lib/jni"
+
+  if $cygwin; then
+    JRUBY_HOME=$(cygpath --mixed "$JRUBY_HOME")
+    JRUBY_SHELL=$(cygpath --mixed "$JRUBY_SHELL")
+
+    if [[ ( "${1:0:1}" = "/" ) && ( ( -f "$1" ) || ( -d "$1" )) ]]; then
+      win_arg=$(cygpath -w "$1")
+      shift
+      win_args=("$win_arg" "$@")
+      set -- "${win_args[@]}"
     fi
 
-    if [[ "${java_class:-}" == "${JAVA_CLASS_NGSERVER:-}" && -n "${JRUBY_OPTS:-}" ]]; then
-      echo "warning: starting a nailgun server; discarding JRUBY_OPTS: ${JRUBY_OPTS}"
-      JRUBY_OPTS=''
+    # fix JLine to use UnixTerminal
+    stty -icanon min 1 -echo > /dev/null 2>&1
+    if [ $? = 0 ]; then
+      JAVA_OPTS="$JAVA_OPTS -Djline.terminal=jline.UnixTerminal"
     fi
 
-    "$JAVACMD" $PROFILE_ARGS $JAVA_OPTS "$JFFI_OPTS" "${java_args[@]}" -classpath "$JRUBY_CP$CP_DELIMITER$CP$CP_DELIMITER$CLASSPATH" \
-      "-Djruby.home=$JRUBY_HOME" \
-      "-Djruby.lib=$JRUBY_HOME/lib" -Djruby.script=jruby \
-      "-Djruby.shell=$JRUBY_SHELL" \
-      $java_class $JRUBY_OPTS "$@"
+  fi
 
-    # Record the exit status immediately, or it will be overridden.
-    JRUBY_STATUS=$?
-
-    if [ "$PROFILE_ARGS" != "" ]; then
-        echo "Profiling results:"
-        cat profile.txt
-        rm profile.txt
+  if [ "$nailgun_client" != "" ]; then
+    if [ -f "$JRUBY_HOME/tool/nailgun/ng" ]; then
+      exec "$JRUBY_HOME/tool/nailgun/ng" org.jruby.util.NailMain $mode "$@"
+    else
+      echo "error: ng executable not found; run 'make' in ${JRUBY_HOME}/tool/nailgun"
+      exit 1
     fi
-
-    if $cygwin; then
-      stty icanon echo > /dev/null 2>&1
-    fi
-
-    exit $JRUBY_STATUS
   else
-    if $cygwin; then
-      # exec doed not work correctly with cygwin bash
-      "$JAVACMD" $JAVA_OPTS "$JFFI_OPTS" "${java_args[@]}" -Xbootclasspath/a:"$JRUBY_CP" -classpath "$CP$CP_DELIMITER$CLASSPATH" \
+    if [ "$VERIFY_JRUBY" != "" ]; then
+      if [ "$PROFILE_ARGS" != "" ]; then
+          echo "Running with instrumented profiler"
+      fi
+
+      if [[ "${java_class:-}" == "${JAVA_CLASS_NGSERVER:-}" && -n "${JRUBY_OPTS:-}" ]]; then
+        echo "warning: starting a nailgun server; discarding JRUBY_OPTS: ${JRUBY_OPTS}"
+        JRUBY_OPTS=''
+      fi
+
+      "$JAVACMD" $PROFILE_ARGS $JAVA_OPTS "$JFFI_OPTS" "${java_args[@]}" -classpath "$JRUBY_CP$CP_DELIMITER$CP$CP_DELIMITER$CLASSPATH" \
         "-Djruby.home=$JRUBY_HOME" \
         "-Djruby.lib=$JRUBY_HOME/lib" -Djruby.script=jruby \
         "-Djruby.shell=$JRUBY_SHELL" \
-        $java_class $mode "$@"
+        $java_class $JRUBY_OPTS "$@"
 
       # Record the exit status immediately, or it will be overridden.
       JRUBY_STATUS=$?
 
-      stty icanon echo > /dev/null 2>&1
+      if [ "$PROFILE_ARGS" != "" ]; then
+          echo "Profiling results:"
+          cat profile.txt
+          rm profile.txt
+      fi
+
+      if $cygwin; then
+        stty icanon echo > /dev/null 2>&1
+      fi
 
       exit $JRUBY_STATUS
     else
-      exec "$JAVACMD" $JAVA_OPTS "$JFFI_OPTS" "${java_args[@]}" -Xbootclasspath/a:"$JRUBY_CP" -classpath "$CP$CP_DELIMITER$CLASSPATH" \
-        "-Djruby.home=$JRUBY_HOME" \
-        "-Djruby.lib=$JRUBY_HOME/lib" -Djruby.script=jruby \
-        "-Djruby.shell=$JRUBY_SHELL" \
-        $java_class $mode "$@"
+      if $cygwin; then
+        # exec doed not work correctly with cygwin bash
+        "$JAVACMD" $JAVA_OPTS "$JFFI_OPTS" "${java_args[@]}" -Xbootclasspath/a:"$JRUBY_CP" -classpath "$CP$CP_DELIMITER$CLASSPATH" \
+          "-Djruby.home=$JRUBY_HOME" \
+          "-Djruby.lib=$JRUBY_HOME/lib" -Djruby.script=jruby \
+          "-Djruby.shell=$JRUBY_SHELL" \
+          $java_class $mode "$@"
 
-      JRUBY_STATUS=$?
+        # Record the exit status immediately, or it will be overridden.
+        JRUBY_STATUS=$?
 
-      exit $JRUBY_STATUS
+        stty icanon echo > /dev/null 2>&1
+
+        exit $JRUBY_STATUS
+      else
+        exec "$JAVACMD" $JAVA_OPTS "$JFFI_OPTS" "${java_args[@]}" -Xbootclasspath/a:"$JRUBY_CP" -classpath "$CP$CP_DELIMITER$CLASSPATH" \
+          "-Djruby.home=$JRUBY_HOME" \
+          "-Djruby.lib=$JRUBY_HOME/lib" -Djruby.script=jruby \
+          "-Djruby.shell=$JRUBY_SHELL" \
+          $java_class $mode "$@"
+
+        JRUBY_STATUS=$?
+
+        exit $JRUBY_STATUS
+      fi
     fi
   fi
-fi
+}
+
+main "$@"

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -18,15 +18,22 @@ function process_special_opts {
     esac
 }
 
-function main {
+# ----- Identify OS we are running under --------------------------------------
+function identify_platform {
   cygwin=false
-
-  # ----- Identify OS we are running under --------------------------------------
+  darwin=false
   case "$(uname)" in
     CYGWIN*) cygwin=true;;
     Darwin) darwin=true;;
     MINGW*) jruby.exe "$@"; exit $?;;
   esac
+}
+
+function main {
+
+  cygwin=false
+  darwin=false
+  identify_platform "$@"
 
   # ----- Verify and Set Required Environment Variables -------------------------
   if [ -z "$JAVA_VM" ]; then

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -209,11 +209,11 @@ do
             JAVA_STACK=$val
         elif [ "${val}" = "" ]; then
             $JAVACMD -help
-            echo "(Prepend -J in front of these options when using 'jruby' command)" 
+            echo "(Prepend -J in front of these options when using 'jruby' command)"
             exit
         elif [ "${val}" = "-X" ]; then
             $JAVACMD -X
-            echo "(Prepend -J in front of these options when using 'jruby' command)" 
+            echo "(Prepend -J in front of these options when using 'jruby' command)"
             exit
         elif [ "${val}" = "-classpath" ]; then
             CP="$CP$CP_DELIMITER$2"
@@ -234,13 +234,13 @@ do
         ;;
      # Match -Xa.b.c=d to translate to -Da.b.c=d as a java option
      -X*)
-	val=${1:2}
-	if expr "$val" : '.*[.]' > /dev/null; then
-	  java_args=("${java_args[@]}" "-Djruby.${val}")
-	else
-	  ruby_args=("${ruby_args[@]}" "-X${val}")
-	fi
-	;;
+        val=${1:2}
+        if expr "$val" : '.*[.]' > /dev/null; then
+          java_args=("${java_args[@]}" "-Djruby.${val}")
+        else
+          ruby_args=("${ruby_args[@]}" "-X${val}")
+        fi
+        ;;
      # Match switches that take an argument
      -C|-e|-I|-S) ruby_args=("${ruby_args[@]}" "$1" "$2"); shift ;;
      # Match same switches with argument stuck together
@@ -262,7 +262,7 @@ do
           else
             JAVACMD="$JAVA_HOME/bin/jdb"
           fi
-        fi 
+        fi
         java_args=("${java_args[@]}" "-sourcepath" "$JRUBY_HOME/lib/ruby/1.9:.")
         JRUBY_OPTS=("${JRUBY_OPTS[@]}" "-X+C") ;;
      --client)


### PR DESCRIPTION
This is the beginnings of a refactoring for the bash launcher.  I intend to modernize it and fix the following bug.

Currently the JRUBY_OPTS and option parsing code requires options that affect some kinds of code to be earlier in the option list than other kinds.  For example:

```
JRUBY_OPTS="--profile.html --profile.out test.html --sample" bin/jruby test.rb
```
this returns: jruby: unknown option --sample

```
bin/jruby --profile.html --profile.out test.html --sample test.rb
```
as does this.

This means that some options cannot currently be specified in JRUBY_OPTS if it is at all possible that anything launched with JRUBY_OPTS set may use some other options.

This rewrite is still in progress, I'm sending the pull request in case I end up not having time to finish it.