### PR TITLE
Avoid creating a throwaway raise exception

### DIFF
--- a/core/src/main/java/org/jruby/exceptions/RaiseException.java
+++ b/core/src/main/java/org/jruby/exceptions/RaiseException.java
@@ -144,7 +144,7 @@ public class RaiseException extends JumpException {
         providedMessage = buildMessage(cause);
         setException(nativeException, true);
         preRaise(nativeException.getRuntime().getCurrentContext(), nativeException.getCause().getStackTrace());
-        setStackTrace(javaTraceFromRubyTrace(exception.getBacktraceElements()));
+        setStackTrace(RaiseException.javaTraceFromRubyTrace(exception.getBacktraceElements()));
     }
 
     /**
@@ -222,7 +222,7 @@ public class RaiseException extends JumpException {
         if (exception instanceof NativeException) {
             setStackTrace(((NativeException)exception).getCause().getStackTrace());
         } else {
-            setStackTrace(javaTraceFromRubyTrace(exception.getBacktraceElements()));
+            setStackTrace(RaiseException.javaTraceFromRubyTrace(exception.getBacktraceElements()));
         }
 
         if (RubyInstanceConfig.LOG_EXCEPTIONS) TraceType.dumpException(exception);
@@ -247,7 +247,7 @@ public class RaiseException extends JumpException {
         this.nativeException = nativeException;
     }
 
-    private StackTraceElement[] javaTraceFromRubyTrace(RubyStackTraceElement[] trace) {
+    public static StackTraceElement[] javaTraceFromRubyTrace(RubyStackTraceElement[] trace) {
         StackTraceElement[] newTrace = new StackTraceElement[trace.length];
         for (int i = 0; i < newTrace.length; i++) {
             newTrace[i] = trace[i].getElement();

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -33,6 +33,7 @@ import org.jruby.javasupport.JavaUtil;
 import org.jruby.lexer.yacc.ISourcePosition;
 import org.jruby.lexer.yacc.SimpleSourcePosition;
 import org.jruby.parser.StaticScope;
+import org.jruby.runtime.backtrace.BacktraceData;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.invokedynamic.MethodNames;
 import org.jruby.util.ByteList;
@@ -3103,8 +3104,9 @@ public class Helpers {
     }
 
     public static IRubyObject rewriteStackTraceAndThrow(Throwable t, Ruby runtime) {
-        RaiseException rewriteStackTrace = RaiseException.createNativeRaiseException(runtime, t);
-        t.setStackTrace(rewriteStackTrace.getStackTrace());
+        StackTraceElement[] javaTrace = t.getStackTrace();
+        BacktraceData backtraceData = runtime.getInstanceConfig().getTraceType().getIntegratedBacktrace(runtime.getCurrentContext(), javaTrace);
+        t.setStackTrace(RaiseException.javaTraceFromRubyTrace(backtraceData.getBacktrace(runtime)));
         throwException(t);
 
         // not reached


### PR DESCRIPTION
In particular, a long error message including the java stack trace was being built and then discarded.

In general, it is unclear to me why `createNativeRaiseException` calls `buildMessage` (twice), but for the case where we rewrite an existing stack trace, the message is obviously discarded, so I took the safe route and just specialized the rewrite stack trace case.

Overall, it is unclear to me why exception backtraces are being rewritten from `JavaCallable` and `invokedynamic.InvocationLinker`, whereas in places like `Reflected{Java,Compiled}Method` the exceptions are wrapped in `RaiseException`s.
