### PR TITLE
Throw error when chain certs are *not* OpenSSL::X509::Certificate

### DIFF
--- a/ext/openssl/src/main/java/org/jruby/ext/openssl/SSLContext.java
+++ b/ext/openssl/src/main/java/org/jruby/ext/openssl/SSLContext.java
@@ -570,7 +570,7 @@ public class SSLContext extends RubyObject {
 
                 public IRubyObject call(ThreadContext context, IRubyObject[] args, Block block) {
                     final IRubyObject cert = args[0];
-                    if ( _Certificate.isInstance(cert) ) {
+                    if ( ! ( _Certificate.isInstance(cert) ) ) {
                         throw context.runtime.newTypeError("wrong argument : " + cert.inspect() + " is not a " + _Certificate.getName());
                     }
                     result.add((X509Cert) cert);


### PR DESCRIPTION
In a recent refactor (f270d266b6435739cad7e4818dd1918535d97539) it looks like the logic to check for cert types was inverted.
