### PR TITLE
Module#ancestors now includes singletons themselves

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1332,13 +1332,13 @@ public final class Ruby {
         classClass = RubyClass.createBootstrapClass(this, "Class", moduleClass, RubyClass.CLASS_ALLOCATOR);
 
         basicObjectClass.setMetaClass(classClass);
-        objectClass.setMetaClass(classClass);
+        objectClass.setMetaClass(basicObjectClass);
         moduleClass.setMetaClass(classClass);
         classClass.setMetaClass(classClass);
 
         RubyClass metaClass;
         metaClass = basicObjectClass.makeMetaClass(classClass);
-        metaClass = objectClass.makeMetaClass(classClass);
+        metaClass = objectClass.makeMetaClass(metaClass);
         metaClass = moduleClass.makeMetaClass(metaClass);
         metaClass = classClass.makeMetaClass(metaClass);
 

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1739,7 +1739,7 @@ public class RubyModule extends RubyObject {
         ArrayList<IRubyObject> list = new ArrayList<IRubyObject>();
 
         for (RubyModule module = this; module != null; module = module.getSuperClass()) {
-            if(!(module.isSingleton() || module.methodLocation != module)) list.add(module.getNonIncludedClass());
+            if (module.methodLocation == module) list.add(module.getNonIncludedClass());
         }
 
         return list;

--- a/spec/tags/ruby/core/module/ancestors_tags.txt
+++ b/spec/tags/ruby/core/module/ancestors_tags.txt
@@ -1,1 +1,0 @@
-fails:Module#ancestors when called on a singleton class includes the singleton classes of ancestors


### PR DESCRIPTION
Hello,

Since Ruby 2.1, calling #ancestors on a singleton class should now include the class itself in the chain.

Since BasicObject is at the very base of the ancestors, we also need to change the meta class of Object so that BasicObject's singleton class correctly get included in the chain.

This patch has been written by @bbrowning!

Have a nice day!
