### PR TITLE
Use FileChannel instead of SeekableByteChannel to enable running on Ruboto

### DIFF
--- a/core/src/main/java/org/jruby/util/io/ChannelFD.java
+++ b/core/src/main/java/org/jruby/util/io/ChannelFD.java
@@ -13,7 +13,6 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.ReadableByteChannel;
-import java.nio.channels.SeekableByteChannel;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.channels.WritableByteChannel;
@@ -129,7 +128,7 @@ public class ChannelFD implements Closeable {
         else chRead = null;
         if (ch instanceof WritableByteChannel) chWrite = (WritableByteChannel)ch;
         else chWrite = null;
-        if (ch instanceof SeekableByteChannel) chSeek = (SeekableByteChannel)ch;
+        if (ch instanceof FileChannel) chSeek = (FileChannel)ch;
         else chSeek = null;
         if (ch instanceof SelectableChannel) chSelect = (SelectableChannel)ch;
         else chSelect = null;
@@ -153,7 +152,7 @@ public class ChannelFD implements Closeable {
     public Channel ch;
     public ReadableByteChannel chRead;
     public WritableByteChannel chWrite;
-    public SeekableByteChannel chSeek;
+    public FileChannel chSeek;
     public SelectableChannel chSelect;
     public FileChannel chFile;
     public SocketChannel chSock;

--- a/core/src/main/java/org/jruby/util/io/OpenFile.java
+++ b/core/src/main/java/org/jruby/util/io/OpenFile.java
@@ -38,7 +38,7 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.ReadableByteChannel;
-import java.nio.channels.SeekableByteChannel;
+import java.nio.channels.FileChannel;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
@@ -1325,7 +1325,7 @@ public class OpenFile implements Finalizable {
 
         // kinda-hacky way to see if there's more data to read from a seekable channel
         if (fd.chSeek != null) {
-            SeekableByteChannel fdSeek = fd.chSeek;
+            FileChannel fdSeek = fd.chSeek;
             try {
                 // not a real file, can't get size...we'll have to just read and block
                 if (fdSeek.size() < 0) return true;
@@ -2101,7 +2101,7 @@ public class OpenFile implements Finalizable {
         return fd.chWrite;
     }
 
-    public SeekableByteChannel seekChannel() {
+    public FileChannel seekChannel() {
         return fd.chSeek;
     }
 


### PR DESCRIPTION
SeekableByteChannel was introduced in Java 7, and is not present on Android.

We can use FileChannel instead of SeekableByteChannel and get the same behaviour.  FileChannel has been around since Java 1.4.  It is not ideal, since SeekableByteChannel explains better what is intended, but FileChannel is currently the only implementation of SeekableByteChannel in the Java standard library, so the effect is the same.
