### PR TITLE
Fix the memory leak and actually close the resources.

### DIFF
--- a/core/src/main/java/org/jruby/util/ClasspathResource.java
+++ b/core/src/main/java/org/jruby/util/ClasspathResource.java
@@ -16,8 +16,6 @@ public class ClasspathResource implements FileResource {
 
     private final String uri;
 
-    private final InputStream is;
-    
     private String[] list = null;
     
     private final JarFileStat fileStat;
@@ -25,7 +23,6 @@ public class ClasspathResource implements FileResource {
     ClasspathResource(String uri) throws IOException
     {
         this.uri = uri;
-        this.is = getResourceURL(uri).openStream();
         this.fileStat = new JarFileStat(this);
     }
 
@@ -146,9 +143,13 @@ public class ClasspathResource implements FileResource {
     }
 
     @Override
-    public InputStream getInputStream()
+    public InputStream openInputStream()
     {
-        return is;
+        try {
+            return getResourceURL(uri).openStream();
+        } catch (IOException ioE) {
+            return null;
+        }
     }
 
     @Override

--- a/core/src/main/java/org/jruby/util/EmptyFileResource.java
+++ b/core/src/main/java/org/jruby/util/EmptyFileResource.java
@@ -86,7 +86,7 @@ class EmptyFileResource implements FileResource {
     }
 
     @Override
-    public InputStream getInputStream() {
+    public InputStream openInputStream() {
       return null;
     }
 

--- a/core/src/main/java/org/jruby/util/FileResource.java
+++ b/core/src/main/java/org/jruby/util/FileResource.java
@@ -37,6 +37,9 @@ public interface FileResource {
     // otherwise.
     JRubyFile hackyGetJRubyFile();
 
-    InputStream getInputStream();
+    // Opens a new input stream to read the contents of a resource and returns it.
+    // Note that implementations may be allocating native memory for the stream, so
+    // callers need to close this when they are done with it.
+    InputStream openInputStream();
     ChannelDescriptor openDescriptor(ModeFlags flags, POSIX posix, int perm) throws ResourceException;
 }

--- a/core/src/main/java/org/jruby/util/JarDirectoryResource.java
+++ b/core/src/main/java/org/jruby/util/JarDirectoryResource.java
@@ -61,7 +61,7 @@ class JarDirectoryResource extends JarResource {
     }
 
     @Override
-    public InputStream getInputStream() {
+    public InputStream openInputStream() {
       return null;
     }
 

--- a/core/src/main/java/org/jruby/util/JarFileResource.java
+++ b/core/src/main/java/org/jruby/util/JarFileResource.java
@@ -19,13 +19,13 @@ import java.util.jar.JarEntry;
  * </p>
  */
 class JarFileResource extends JarResource {
+  private final JarCache.JarIndex index;
   private final JarEntry entry;
-  private final InputStream entryStream;
 
-  JarFileResource(String jarPath, boolean rootSlashPrefix, JarEntry entry, InputStream entryStream) {
+  JarFileResource(String jarPath, boolean rootSlashPrefix, JarCache.JarIndex index, JarEntry entry) {
     super(jarPath, rootSlashPrefix);
+    this.index = index;
     this.entry = entry;
-    this.entryStream = entryStream;
   }
 
   @Override
@@ -60,12 +60,12 @@ class JarFileResource extends JarResource {
   }
 
   @Override
-  public InputStream getInputStream() {
-    return entryStream;
+  public InputStream openInputStream() {
+    return index.getInputStream(entry);
   }
 
   @Override
   public ChannelDescriptor openDescriptor(ModeFlags flags, POSIX posix, int perm) throws ResourceException {
-    return new ChannelDescriptor(Channels.newChannel(entryStream), flags);
+    return new ChannelDescriptor(Channels.newChannel(openInputStream()), flags);
   }
 }

--- a/core/src/main/java/org/jruby/util/JarResource.java
+++ b/core/src/main/java/org/jruby/util/JarResource.java
@@ -3,7 +3,6 @@ package org.jruby.util;
 import jnr.posix.FileStat;
 import jnr.posix.POSIX;
 
-import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.jar.JarEntry;
@@ -60,8 +59,7 @@ abstract class JarResource implements FileResource {
 
         JarEntry jarEntry = index.getJarEntry(entryPath);
         if (jarEntry != null) {
-            InputStream jarEntryStream = index.getInputStream(jarEntry);
-            return new JarFileResource(jarPath, rootSlashPrefix, jarEntry, jarEntryStream);
+            return new JarFileResource(jarPath, rootSlashPrefix, index, jarEntry);
         }
 
         return null;

--- a/core/src/main/java/org/jruby/util/RegularFileResource.java
+++ b/core/src/main/java/org/jruby/util/RegularFileResource.java
@@ -128,7 +128,7 @@ class RegularFileResource implements FileResource {
     }
 
     @Override
-    public InputStream getInputStream() {
+    public InputStream openInputStream() {
         try {
             return new java.io.BufferedInputStream(new FileInputStream(file), 32768);
         } catch (FileNotFoundException fnfe) {

--- a/core/src/main/java/org/jruby/util/URLResource.java
+++ b/core/src/main/java/org/jruby/util/URLResource.java
@@ -101,7 +101,7 @@ class URLResource implements FileResource {
     }
 
     @Override
-    public InputStream getInputStream()
+    public InputStream openInputStream()
     {
         try
         {


### PR DESCRIPTION
This should fix https://github.com/jruby/jruby/issues/1888

I've opted for direct rename of getInputStream => openInputStream which technically can break people depending on it in 1.7.13 but in reality I doubt anyone started using that interface.

But I guess I can add a deprecated getInputStream back.
