### PR TITLE
Deprecate overloaded `setProfile`, prefer `setProfilingMode`

### DIFF
--- a/core/src/main/java/org/jruby/embed/ScriptingContainer.java
+++ b/core/src/main/java/org/jruby/embed/ScriptingContainer.java
@@ -734,9 +734,32 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      *
      * @since JRuby 1.6.6.
      *
+     * @deprecated Use setProfilingMode instead
+     *
      * @param mode a new profiling mode to be set.
      */
+    @Deprecated
     public void setProfile(ProfilingMode mode) {
+        provider.getRubyInstanceConfig().setProfilingMode(mode);
+    }
+
+    /**
+     * Changes a ProfilingMode to a given one. The default value is Profiling.OFF.
+     * Call this method before you use put/get, runScriptlet, and parse methods so that
+     * initial configurations will work.
+     *
+     * ProfilingMode allows you to change profiling style.
+     *
+     * Profiling.OFF - default. profiling off.
+     * Profiling.API - activates Ruby profiler API. equivalent to --profile.api command line option
+     * Profiling.FLAT - synonym for --profile command line option equivalent to --profile.flat command line option
+     * Profiling.GRAPH - runs with instrumented (timed) profiling, graph format. equivalent to --profile.graph command line option.
+     *
+     * @since JRuby 1.7.15
+     *
+     * @param mode a new profiling mode to be set.
+     */
+    public void setProfilingMode(ProfilingMode mode) {
         provider.getRubyInstanceConfig().setProfilingMode(mode);
     }
 


### PR DESCRIPTION
The ScriptingContainer class contains two methods named `setProfile`,
which differ only by their single argument type and do very different
things from one another.  One of the two signatures accepts
an argument of type `ProfilingMode`, which, in other places in the
code, is exposed via more explicitly named accessor methods such as
`getProfilingMode` and `setProfilingMode`.  I'm wondering if maybe
the method in `ScriptingContainer` was simply accidentally mis-named.

This commit deprecates the `setProfile(ProfilingMode)` method, and
introduces a replacement method `setProfilingMode(ProfilingMode)`,
which is more consistent with the rest of the code.
