### PR TITLE
Update jnr-ffi dependency version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -98,7 +98,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-ffi</artifactId>
-      <version>1.0.7</version>
+      <version>1.0.10</version>
       <type>jar</type>
     </dependency>
     <dependency>


### PR DESCRIPTION
A recent commit seems to have bumped the version number of the
jnr-posix dependency, which has a transitive dependency on
jnr-ffi 1.0.10.  However, the jruby-core pom still specifies
an explicit dependency on 1.0.7.  This updates it to 1.0.10.
