### PR TITLE
Fix Fiber#alive? regression.

### DIFF
--- a/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
+++ b/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
@@ -185,7 +185,7 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
     
     @JRubyMethod
     public IRubyObject __alive__(ThreadContext context) {
-        return context.runtime.newBoolean(thread != null && thread.isAlive());
+        return context.runtime.newBoolean(alive());
     }
     
     @JRubyMethod(meta = true)


### PR DESCRIPTION
In JRuby 1.7.10:

``` ruby
require 'fiber'

fiber = Fiber.new {}

fiber.alive? #=> true
fiber.resume
fiber.alive? #=> false
```

In JRuby 1.7.11 through 1.7.15:

``` ruby
require 'fiber'

fiber = Fiber.new {}

fiber.alive? #=> true
fiber.resume
fiber.alive? #=> true
```

It looks like this is [already fixed on master](https://github.com/jruby/jruby/blob/master/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java#L224).

Closes #1789.
