### PR TITLE
-X... and -X? options to search for properties.

### DIFF
--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -232,6 +232,9 @@ do
             java_args=("${java_args[@]}" "${1:2}")
         fi
         ;;
+     # Pass -X... and -X? search options through
+     -X*\.\.\.|-X*\?)
+        ruby_args=("${ruby_args[@]}" "$1") ;;
      # Match -Xa.b.c=d to translate to -Da.b.c=d as a java option
      -X*)
         val=${1:2}

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -191,6 +191,9 @@ do
             java_args="${java_args} ${1:2}"
         fi
         ;;
+     # Pass -X... and -X? search options through
+     -X*\.\.\.|-X*\?)
+        ruby_args="${ruby_args} $1" ;;
      # Match -Xa.b.c=d to translate to -Da.b.c=d as a java option
      -X*)
      val=${1:2}

--- a/core/src/main/java/org/jruby/util/cli/ArgumentProcessor.java
+++ b/core/src/main/java/org/jruby/util/cli/ArgumentProcessor.java
@@ -353,6 +353,12 @@ public class ArgumentProcessor {
                         checkGraalVersion();
                         config.setCompileMode(RubyInstanceConfig.CompileMode.TRUFFLE);
                         config.setDisableGems(true);
+                    } else if (extendedOption.endsWith("...")) {
+                        Options.listPrefix(extendedOption.substring(0, extendedOption.length() - "...".length()));
+                        config.setShouldRunInterpreter(false);
+                    } else if (extendedOption.endsWith("?")) {
+                        Options.listContains(extendedOption.substring(0, extendedOption.length() - 1));
+                        config.setShouldRunInterpreter(false);
                     } else {
                         MainExitException mee = new MainExitException(1, "jruby: invalid extended option " + extendedOption + " (-X will list valid options)\n");
                         mee.setUsageError(true);

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -305,4 +305,37 @@ public class Options {
         // We were defaulting on for Java 8 and might again later if JEP 210 helps reduce warmup time.
         return false;
     }
+
+    private static enum SearchMode {
+        PREFIX,
+        CONTAINS
+    }
+
+    public static void listPrefix(String prefix) {
+        list(SearchMode.PREFIX, prefix);
+    }
+
+    public static void listContains(String substring) {
+        list(SearchMode.CONTAINS, substring);
+    }
+
+    private static void list(SearchMode mode, String string) {
+        for (Option option : PROPERTIES) {
+            boolean include = false;
+
+            switch (mode) {
+                case PREFIX:
+                    include = option.shortName().startsWith(string);
+                    break;
+                case CONTAINS:
+                    include = option.shortName().contains(string);
+                    break;
+            }
+
+            if (include) {
+                System.out.printf("%s=%s\n", option.shortName(), option.load());
+            }
+        }
+    }
+
 }

--- a/core/src/main/java/org/jruby/util/cli/OutputStrings.java
+++ b/core/src/main/java/org/jruby/util/cli/OutputStrings.java
@@ -79,14 +79,16 @@ public class OutputStrings {
         StringBuilder sb = new StringBuilder();
         sb
                 .append("Extended options:\n")
-                .append("  -X-O        run with ObjectSpace disabled (default; improves performance)\n")
-                .append("  -X+O        run with ObjectSpace enabled (reduces performance)\n")
-                .append("  -X-C        disable all compilation\n")
+                .append("  -X-O          run with ObjectSpace disabled (default; improves performance)\n")
+                .append("  -X+O          run with ObjectSpace enabled (reduces performance)\n")
+                .append("  -X-C          disable all compilation\n")
                 .append("  -X-CIR        disable all compilation and use IR runtime\n")
-                .append("  -X+C        force compilation of all scripts before they are run (except eval)\n")
-                .append("  -X+CIR      force compilation and use IR runtime\n")
-                .append("  -X+JIR      JIT compilation and use IR runtime\n")
-                .append("  -X+T        use Truffle\n");
+                .append("  -X+C          force compilation of all scripts before they are run (except eval)\n")
+                .append("  -X+CIR        force compilation and use IR runtime\n")
+                .append("  -X+JIR        JIT compilation and use IR runtime\n")
+                .append("  -X+T          use Truffle\n")
+                .append("  -Xsubstring?  list options that contain substring in their name\n")
+                .append("  -Xprefix...   list options that are prefixed wtih prefix\n");
 
         return sb.toString();
     }


### PR DESCRIPTION
I can never remember the names of various JRuby options - even my own! This allows you to search for them, either by prefix or substring. Are we interested in having this functionality?

Examples:

```
$ bin/jruby -Xdump?
compile.dump=false
jit.dumping=false
ffi.compile.dump=false
thread.dump.signal=USR2
dump.variables=false
```

```
$ bin/jruby -Xir...
ir.debug=false
ir.profile=false
ir.compiler.debug=false
ir.visualizer=false
ir.unboxing=false
ir.passes=null
ir.jit.passes=null
ir.reading=false
ir.reading.debug=false
ir.writing=false
ir.writing.debug=false
ir.inline_passes=null
```

I've modified the `.sh` and `.bash` launchers. Is there anything else I need to modify to pass these arguments through?
