### PR TITLE
tweak include order

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2429,14 +2429,17 @@ public class RubyModule extends RubyObject {
 
             // scan class hierarchy for module
             for (RubyClass nextClass = this.getSuperClass(); nextClass != null; nextClass = nextClass.getSuperClass()) {
-                if (doesTheClassWrapTheModule(nextClass, nextModule)) {
-                    // next in hierarchy is an included version of the module we're attempting,
-                    // so we skip including it
-                    
-                    // if we haven't encountered a real superclass, use the found module as the new inclusion point
-                    if (!superclassSeen) currentInclusionPoint = nextClass;
-                    
-                    continue ModuleLoop;
+                if (nextClass.isIncluded()) {
+                    // does the class equal the module
+                    if (nextClass.getNonIncludedClass() == nextModule.getNonIncludedClass()) {
+                        // next in hierarchy is an included version of the module we're attempting,
+                        // so we skip including it
+
+                        // if we haven't encountered a real superclass, use the found module as the new inclusion point
+                        if (!superclassSeen) currentInclusionPoint = nextClass;
+
+                        continue ModuleLoop;
+                    }
                 } else {
                     superclassSeen = true;
                 }

--- a/test/test_include_order.rb
+++ b/test/test_include_order.rb
@@ -1,0 +1,47 @@
+#GH-1938
+require "test/unit"
+
+class TestIncludeOrder < Test::Unit::TestCase
+  module X
+  end
+
+  class Q
+    def foo arg = []
+      arg << :Q
+    end
+  end
+
+  class Y < Q
+    include X
+  end
+
+  module A
+    def foo arg = []
+      arg << :A
+      super
+    end
+  end
+
+  module X
+    include A
+  end
+
+  module Z
+    def foo arg = []
+      arg << :Z
+      super
+    end
+  end
+
+  class Y
+    include Z
+  end
+
+  class Y
+    include X
+  end
+
+  def test_include_order
+    assert_equal Y.new.foo, [:Z, :A, :Q]
+  end
+end


### PR DESCRIPTION
resolves #1938 

MRI doesn't set superclassseen if the next class up is an included module.

https://github.com/ruby/ruby/blob/trunk/class.c#L868
