### PR TITLE
Implemented multi args 'system' method on Windows fix #1074

### DIFF
--- a/core/src/main/java/org/jruby/util/ShellLauncher.java
+++ b/core/src/main/java/org/jruby/util/ShellLauncher.java
@@ -1168,12 +1168,20 @@ public class ShellLauncher {
         }
 
         public void verifyExecutableForDirect() {
-            verifyExecutable();
-            execArgs = args;
-            try {
-                execArgs[0] = executableFile.getCanonicalPath();
-            } catch (IOException ioe) {
-                // can't get the canonical path, will use as-is
+            if (isCmdBuiltin(args[0].trim())) {
+                execArgs = new String[args.length + 2];
+                execArgs[0] = shell;
+                execArgs[1] = "/c";
+                execArgs[2] = args[0].trim();
+                System.arraycopy(args, 1, execArgs, 3, args.length - 1);
+            } else {
+                verifyExecutable();
+                execArgs = args;
+                try {
+                    execArgs[0] = executableFile.getCanonicalPath();
+                } catch (IOException ioe) {
+                    // can't get the canonical path, will use as-is
+                }
             }
         }
 


### PR DESCRIPTION
'system' method of multi args was not able to support Windows internal commands.
(ex) echo, cd, etc
fix #1074

jruby 1.7.16

``` ruby
# example.rb
p system("echo", "hoge")
p "----------"
p system("jruby", "-v")
```

```
c:\workspace\jruby1074>jruby example.rb
nil
"----------"
jruby 1.7.16 (1.9.3p392) 2014-09-25 575b395 on Java HotSpot(TM) 64-Bit Server VM 1.7.0_07-b11 +jit [Windows 7-amd64]
true
```
