### PR TITLE
Fix for issue 1695 : BigDecimal and Rational multiplication

### DIFF
--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -458,11 +458,14 @@ public class RubyBigDecimal extends RubyNumeric {
     }
     
     private static IRubyObject getVpRubyObjectWithPrec19Inner(ThreadContext context, RubyRational r, long precision, boolean must) {
-        long numerator = RubyNumeric.num2long(r.numerator(context));
-        long denominator = RubyNumeric.num2long(r.denominator(context));
-            
-        return new RubyBigDecimal(context.runtime, 
-                BigDecimal.valueOf(numerator).divide(BigDecimal.valueOf(denominator), getRoundingMode(context.runtime)));
+        BigDecimal numerator = BigDecimal.valueOf(RubyNumeric.num2long(r.numerator(context)));
+        BigDecimal denominator = BigDecimal.valueOf(RubyNumeric.num2long(r.denominator(context)));
+        
+        int len = numerator.precision() + denominator.precision();
+        int pow = len / 4;
+        MathContext mathContext = new MathContext((pow + 1) * 4, getRoundingMode(context.runtime));
+        
+        return new RubyBigDecimal(context.runtime, numerator.divide(denominator, mathContext));
     }
     
     private static RubyBigDecimal getVpValueWithPrec19(ThreadContext context, IRubyObject value, long precision, boolean must) {

--- a/spec/regression/GH-1695_bigdecimal_and_rational_multiplication_rounds_the_rational_number.rb
+++ b/spec/regression/GH-1695_bigdecimal_and_rational_multiplication_rounds_the_rational_number.rb
@@ -1,0 +1,12 @@
+require 'rational'
+require 'bigdecimal'
+
+# https://github.com/jruby/jruby/issues/1695
+describe 'BigDecimal#*' do
+  it 'returns correct value' do
+    (BigDecimal.new('100') * Rational(1, 100)).to_i.should == 1
+    (BigDecimal.new('100') * Rational(49, 100)).to_i.should == 49
+    (BigDecimal.new('100') * Rational(50, 100)).to_i.should == 50
+  end
+end
+


### PR DESCRIPTION
This commit fixes issue #1695.

When converting to Ruby BigDecimal from Ruby Rational, 
Java BigDecimal divide method runs by specifying the precision of the multiple of 4.
