### PR TITLE
Warn if the user sets a property that we don't recognise.

### DIFF
--- a/core/src/main/java/org/jruby/util/cli/ArgumentProcessor.java
+++ b/core/src/main/java/org/jruby/util/cli/ArgumentProcessor.java
@@ -39,7 +39,11 @@ import org.jruby.util.SafePropertyAccessor;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
 
 /**
  * Encapsulated logic for processing JRuby's command-line arguments.

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -28,7 +28,12 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby.util.cli;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
 
 import com.headius.options.Option;
 import org.jruby.TruffleBridge;


### PR DESCRIPTION
I often think I've set a property via `-X`, but I haven't because I got the name wrong. Do we want to warn if we don't recognise a property that looks like it should be aimed at us (it starts with `jruby.`)?
