### PR TITLE
do not change jruby commandline context classloader

### DIFF
--- a/core/src/main/java/org/jruby/Main.java
+++ b/core/src/main/java/org/jruby/Main.java
@@ -283,8 +283,6 @@ public class Main {
         }
 
         try {
-            doSetContextClassLoader(runtime);
-
             if (in == null) {
                 // no script to run, return success
                 return new Status();
@@ -449,18 +447,6 @@ public class Main {
                 throw re;
             }
             return false;
-        }
-    }
-
-    private void doSetContextClassLoader(Ruby runtime) {
-        // set thread context JRuby classloader here, for the main thread
-        try {
-            Thread.currentThread().setContextClassLoader(runtime.getJRubyClassLoader());
-        } catch (SecurityException se) {
-            // can't set TC classloader
-            if (runtime.getInstanceConfig().isVerbose()) {
-                config.getError().println("WARNING: Security restrictions disallowed setting context classloader for main thread.");
-            }
         }
     }
 


### PR DESCRIPTION
putting the jruby-classloader as context classloader means that all attached "jars" can be found via
the Thread.currentThread.contextClassLoader. running jruby from other environments like servlets just
leave the context classloader as is. so this was a commandline only feature.

finally it keeps the classloader semantic uniform wether executed from commandline or inside a j2ee container
or osgi framework or embedded jruby in a java application.

maybe there is reason for this but this reason is not there with running any tests and any code depending on this feature of the commandline execution will cease to work when running in an environment where there runtime.getJRubyClassLoader is not the thread.contextClassLoader.

one more thing: image some jruby code loads some java which again uses the embedded JRuby via ScriptingContainer then you will chain instance of JRubyClassLoaders via the parent classloader, which is just asked for classloader problems. you all might have used ruby-maven which does exactly such JRuby -> Java -> JRuby thingy.

@enebo @ratnikov maybe one of you have a solid usecase why jruby commandline does such classloader tricks - please tell me !
