### PR TITLE
no duplicated yaml in jar files

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -219,6 +219,8 @@ project 'JRuby Core' do
                    :phase => 'package',
                    'relocations' => [ { 'pattern' => 'org.objectweb',
                                         'shadedPattern' => 'org.jruby.org.objectweb' } ],
+                   :filters => [ { :artifact => 'org.jruby:yecht',
+                                   :excludes => [ 'yaml/**', 'okay/**', '*.rb' ] } ],
                    'outputFile' => '${jruby.basedir}/lib/jruby.jar',
                    'transformers' => [ { '@implementation' => 'org.apache.maven.plugins.shade.resource.ManifestResourceTransformer',
                                          'mainClass' => 'org.jruby.Main' } ] )
@@ -280,6 +282,8 @@ project 'JRuby Core' do
                        'shadedClassifierName' =>  'complete',
                        'relocations' => [ { 'pattern' =>  'org.objectweb',
                                             'shadedPattern' =>  'org.jruby.org.objectweb' } ],
+                       :filters => [ { :artifact => 'org.jruby:yecht',
+                                       :excludes => [ 'yaml/**', 'okay/**', '*.rb' ] } ],
                        'transformers' => [ { '@implementation' => 'org.apache.maven.plugins.shade.resource.ManifestResourceTransformer',
                                              'mainClass' => 'org.jruby.Main' } ] )
       end

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -522,6 +522,16 @@
                   <shadedPattern>org.jruby.org.objectweb</shadedPattern>
                 </relocation>
               </relocations>
+              <filters>
+                <filter>
+                  <artifact>org.jruby:yecht</artifact>
+                  <excludes>
+                    <exclude>yaml/**</exclude>
+                    <exclude>okay/**</exclude>
+                    <exclude>*.rb</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <outputFile>${jruby.basedir}/lib/jruby.jar</outputFile>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
@@ -600,6 +610,16 @@
                       <shadedPattern>org.jruby.org.objectweb</shadedPattern>
                     </relocation>
                   </relocations>
+                  <filters>
+                    <filter>
+                      <artifact>org.jruby:yecht</artifact>
+                      <excludes>
+                        <exclude>yaml/**</exclude>
+                        <exclude>okay/**</exclude>
+                        <exclude>*.rb</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
                   <transformers>
                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                       <mainClass>org.jruby.Main</mainClass>
@@ -657,6 +677,16 @@
                       <shadedPattern>org.jruby.org.objectweb</shadedPattern>
                     </relocation>
                   </relocations>
+                  <filters>
+                    <filter>
+                      <artifact>org.jruby:yecht</artifact>
+                      <excludes>
+                        <exclude>yaml/**</exclude>
+                        <exclude>okay/**</exclude>
+                        <exclude>*.rb</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
                   <transformers>
                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                       <mainClass>org.jruby.Main</mainClass>
@@ -714,6 +744,16 @@
                       <shadedPattern>org.jruby.org.objectweb</shadedPattern>
                     </relocation>
                   </relocations>
+                  <filters>
+                    <filter>
+                      <artifact>org.jruby:yecht</artifact>
+                      <excludes>
+                        <exclude>yaml/**</exclude>
+                        <exclude>okay/**</exclude>
+                        <exclude>*.rb</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
                   <transformers>
                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                       <mainClass>org.jruby.Main</mainClass>
@@ -771,6 +811,16 @@
                       <shadedPattern>org.jruby.org.objectweb</shadedPattern>
                     </relocation>
                   </relocations>
+                  <filters>
+                    <filter>
+                      <artifact>org.jruby:yecht</artifact>
+                      <excludes>
+                        <exclude>yaml/**</exclude>
+                        <exclude>okay/**</exclude>
+                        <exclude>*.rb</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
                   <transformers>
                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                       <mainClass>org.jruby.Main</mainClass>
@@ -828,6 +878,16 @@
                       <shadedPattern>org.jruby.org.objectweb</shadedPattern>
                     </relocation>
                   </relocations>
+                  <filters>
+                    <filter>
+                      <artifact>org.jruby:yecht</artifact>
+                      <excludes>
+                        <exclude>yaml/**</exclude>
+                        <exclude>okay/**</exclude>
+                        <exclude>*.rb</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
                   <transformers>
                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                       <mainClass>org.jruby.Main</mainClass>
@@ -885,6 +945,16 @@
                       <shadedPattern>org.jruby.org.objectweb</shadedPattern>
                     </relocation>
                   </relocations>
+                  <filters>
+                    <filter>
+                      <artifact>org.jruby:yecht</artifact>
+                      <excludes>
+                        <exclude>yaml/**</exclude>
+                        <exclude>okay/**</exclude>
+                        <exclude>*.rb</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
                   <transformers>
                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                       <mainClass>org.jruby.Main</mainClass>
@@ -942,6 +1012,16 @@
                       <shadedPattern>org.jruby.org.objectweb</shadedPattern>
                     </relocation>
                   </relocations>
+                  <filters>
+                    <filter>
+                      <artifact>org.jruby:yecht</artifact>
+                      <excludes>
+                        <exclude>yaml/**</exclude>
+                        <exclude>okay/**</exclude>
+                        <exclude>*.rb</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
                   <transformers>
                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                       <mainClass>org.jruby.Main</mainClass>


### PR DESCRIPTION
jruby-core.jar or lib/jruby.jar has yaml/*\* ruby scripts almost the same as jruby-stdlib.jar

there are differences ! and it is just a bad to have different version of the same files
in the system (load-path or classpath etc)

I consider this a bug since once you `classpath:` or `uri:classloader:` to $LOAD_PATH you might switch to another version of yaml :(
this actually happens when you use IsolatedScriptingContainer !

@enebo @ratnikov
