### PR TITLE
remove useless initial load path entries of the ScriptingContainer

### DIFF
--- a/core/src/main/java/org/jruby/embed/ScriptingContainer.java
+++ b/core/src/main/java/org/jruby/embed/ScriptingContainer.java
@@ -252,8 +252,6 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
     }
 
     private void initConfig() throws URISyntaxException, UnsupportedEncodingException {
-        List<String> paths = SystemPropertyCatcher.findLoadPaths();
-        provider.getRubyInstanceConfig().setLoadPaths(paths);
         String home = SystemPropertyCatcher.findJRubyHome(this);
         if (home != null) {
         	provider.getRubyInstanceConfig().setJRubyHome(home);

--- a/core/src/test/java/org/jruby/embed/ScriptingContainerTest.java
+++ b/core/src/test/java/org/jruby/embed/ScriptingContainerTest.java
@@ -1550,9 +1550,9 @@ public class ScriptingContainerTest {
         instance.setOutput(pstream);
         instance.setWriter(writer);
         instance.setErrorWriter(writer);
-        List result = instance.getLoadPaths();
+        List<String> result = instance.getLoadPaths();
         assertTrue(result != null);
-        assertTrue(result.size() > 0);
+        assertTrue(result.size() == 0);
         
         instance = null;
     }
@@ -2629,5 +2629,15 @@ public class ScriptingContainerTest {
         ScriptingContainer instance = new ScriptingContainer(LocalContextScope.SINGLETHREAD);
         Object result = instance.runScriptlet("exit 1234");
         assertEquals(1234L, result);
+    }
+
+    @Test
+    public void testLoadPathOfScriptingContainer() {
+        ScriptingContainer instance = new ScriptingContainer(LocalContextScope.SINGLETHREAD);
+        // note that instance.getLoadPath is not the load-path of the runtime !!!
+        String[] results = instance.runScriptlet("$LOAD_PATH").toString().split(", ");
+        for(String result : results){
+            assertTrue(result + " containt lib/ruby/", result.contains("lib/ruby/"));
+        }
     }
 }


### PR DESCRIPTION
the ScriptingContainer propopulate the LOAD_PATH with all the jars from java.class.path and other system properties. they are following issues with this "feature"
- those LOAD_PATH entries are file entries and no directory entries and have NO effect on LOAD_PATH since the file entries are treated as directory and just adds failings attempts to find a file on the LOAD_PATH
- the feature is superseeded by the LoadService.findResourceOnClasspath since there all the files part of the classloader will be found
- in some frameworks like j2ee or osgi those entries are NOT at all related to the "ruby" application since they are usually there to bootstrap the framework and jruby runs in an isolated manner inside this framework.

when using org.jruby:jruby maven artifact then the a typical LOAD_PATH like this:

```
/home/christian/projects/active/maven/jruby/core/target/test-classes
/home/christian/projects/active/maven/jruby/core/target/classes
/usr/local/repository/org/ow2/asm/asm/5.0.3/asm-5.0.3.jar
/usr/local/repository/org/ow2/asm/asm-commons/5.0.3/asm-commons-5.0.3.jar
/usr/local/repository/org/ow2/asm/asm-tree/5.0.3/asm-tree-5.0.3.jar
/usr/local/repository/org/ow2/asm/asm-analysis/5.0.3/asm-analysis-5.0.3.jar
/usr/local/repository/org/ow2/asm/asm-util/5.0.3/asm-util-5.0.3.jar
/usr/local/repository/com/github/jnr/jnr-netdb/1.1.2/jnr-netdb-1.1.2.jar
/usr/local/repository/com/github/jnr/jnr-enxio/0.4/jnr-enxio-0.4.jar
/usr/local/repository/com/github/jnr/jnr-x86asm/1.0.2/jnr-x86asm-1.0.2.jar
/usr/local/repository/com/github/jnr/jnr-unixsocket/0.3/jnr-unixsocket-0.3.jar
/usr/local/repository/com/github/jnr/jnr-posix/3.0.2/jnr-posix-3.0.2.jar
/usr/local/repository/com/github/jnr/jnr-constants/0.8.6-SNAPSHOT/jnr-constants-0.8.6-SNAPSHOT.jar
/usr/local/repository/com/github/jnr/jnr-ffi/2.0.0-SNAPSHOT/jnr-ffi-2.0.0-SNAPSHOT.jar
/usr/local/repository/com/github/jnr/jffi/1.2.7/jffi-1.2.7.jar
/usr/local/repository/com/github/jnr/jffi/1.2.7/jffi-1.2.7-native.jar
/usr/local/repository/org/jruby/joni/joni/2.1.3/joni-2.1.3.jar
/usr/local/repository/org/jruby/extras/bytelist/1.0.12-SNAPSHOT/bytelist-1.0.12-SNAPSHOT.jar
/usr/local/repository/org/jruby/jcodings/jcodings/1.0.12-SNAPSHOT/jcodings-1.0.12-SNAPSHOT.jar
/usr/local/repository/org/jruby/yecht/1.0/yecht-1.0.jar
/usr/local/repository/com/headius/invokebinder/1.4-SNAPSHOT/invokebinder-1.4-SNAPSHOT.jar
/usr/local/repository/com/headius/options/1.1/options-1.1.jar
/usr/local/repository/com/headius/coro-mock/1.0/coro-mock-1.0.jar
/usr/local/repository/com/headius/unsafe-mock/8.0/unsafe-mock-8.0.jar
/usr/local/repository/com/headius/jsr292-mock/1.1/jsr292-mock-1.1.jar
/usr/local/repository/org/ow2/asm/asm-debug-all/5.0_BETA/asm-debug-all-5.0_BETA.jar
/usr/local/repository/bsf/bsf/2.4.0/bsf-2.4.0.jar
/usr/local/repository/commons-logging/commons-logging/1.0.4/commons-logging-1.0.4.jar
/usr/local/repository/com/jcraft/jzlib/1.1.2/jzlib-1.1.2.jar
/usr/local/repository/com/martiansoftware/nailgun-server/0.9.1/nailgun-server-0.9.1.jar
/usr/local/repository/com/oracle/truffle/0.5/truffle-0.5.jar
/usr/local/repository/com/oracle/truffle-dsl-processor/0.5/truffle-dsl-processor-0.5.jar
/usr/local/repository/junit/junit/4.11/junit-4.11.jar
/usr/local/repository/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar
/usr/local/repository/org/apache/ant/ant/1.9.2/ant-1.9.2.jar
/usr/local/repository/org/apache/ant/ant-launcher/1.9.2/ant-launcher-1.9.2.jar
/usr/local/repository/org/osgi/org.osgi.core/5.0.0/org.osgi.core-5.0.0.jar
/usr/local/repository/org/yaml/snakeyaml/1.13/snakeyaml-1.13.jar
/usr/local/repository/org/jruby/joda-timezones/2013d/joda-timezones-2013d.jar
/usr/local/repository/joda-time/joda-time/2.3/joda-time-2.3.jar
/home/christian/projects/active/maven/jruby/core/src/test/ruby
/home/christian/projects/active/maven/jruby/core/../lib/ruby/2.1/site_ruby
/home/christian/projects/active/maven/jruby/core/../lib/ruby/shared
/home/christian/projects/active/maven/jruby/core/../lib/ruby/2.1
```

where only the last three entries are derived from jruby.home and the rest comes the "java.class.path" system property. the example here is taken from a test case under core/src/test/java where there are also some test framework jar added to classpath ....

@enebo @ratnikov
