### PR TITLE
remove obsolete yecht dependency from jruby.jar

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -44,7 +44,6 @@ project 'JRuby Core' do
   jar 'org.jruby.joni:joni:2.1.3'
   jar 'org.jruby.extras:bytelist:1.0.12-SNAPSHOT'
   jar 'org.jruby.jcodings:jcodings:1.0.12-SNAPSHOT'
-  jar 'org.jruby:yecht:1.0'
 
   jar 'com.headius:invokebinder:1.4-SNAPSHOT'
   jar 'com.headius:options:1.1'

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -110,11 +110,6 @@
       <version>1.0.12-SNAPSHOT</version>
     </dependency>
     <dependency>
-      <groupId>org.jruby</groupId>
-      <artifactId>yecht</artifactId>
-      <version>1.0</version>
-    </dependency>
-    <dependency>
       <groupId>com.headius</groupId>
       <artifactId>invokebinder</artifactId>
       <version>1.4-SNAPSHOT</version>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -252,7 +252,7 @@
                 </goals>
                 <configuration>
                   <target>
-                    <exec failonerror="true" dir="${jruby.home}" executable="${jruby.home}/bin/jruby">
+                    <exec dir="${jruby.home}" executable="${jruby.home}/bin/jruby" failonerror="true">
                       <arg value="-S" />
                       <arg value="rake" />
                       <arg value="${task}" />
@@ -280,7 +280,7 @@
                 </goals>
                 <configuration>
                   <target>
-                    <exec failonerror="true" dir="${jruby.home}" executable="${jruby.home}/bin/jruby">
+                    <exec dir="${jruby.home}" executable="${jruby.home}/bin/jruby" failonerror="true">
                       <arg value="-X+T" />
                       <arg value="-Xparser.warn.useless_use_of=false" />
                       <arg value="-Xparser.warn.not_reached=false" />
@@ -323,7 +323,7 @@
                 </goals>
                 <configuration>
                   <target>
-                    <exec failonerror="true" dir="${jruby.home}" executable="${jruby.home}/bin/jruby">
+                    <exec dir="${jruby.home}" executable="${jruby.home}/bin/jruby" failonerror="true">
                       <arg value="-X+T" />
                       <arg value="-Xparser.warn.useless_use_of=false" />
                       <arg value="-Xparser.warn.not_reached=false" />
@@ -366,7 +366,7 @@
                 </goals>
                 <configuration>
                   <target>
-                    <exec failonerror="true" dir="${jruby.home}" executable="${jruby.home}/bin/jruby">
+                    <exec dir="${jruby.home}" executable="${jruby.home}/bin/jruby" failonerror="true">
                       <arg value="-J-server" />
                       <arg value="-J-G:-TruffleBackgroundCompilation" />
                       <arg value="-J-G:+TruffleCompilationExceptionsAreFatal" />


### PR DESCRIPTION
this will remove the need for https://github.com/jruby/jruby/pull/2026
and allow to use the latest maven-felix-plugin to build osgi bundles from the jruby artifact and also for out build: https://github.com/jruby/jruby/issues/1845
