### PR TITLE
improve handling of non ascii character after backslash

### DIFF
--- a/core/src/main/java/org/jruby/lexer/yacc/StringTerm.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/StringTerm.java
@@ -259,6 +259,13 @@ public class StringTerm extends StrTerm {
                         
                         continue;
                     } else if (expand) {
+                        /* add NonAscii to Buffer after backslash */
+                        if(!Encoding.isAscii((byte) c)) {
+                            if (addNonAsciiToBuffer(c, src, encoding, lexer, buffer) == RubyYaccLexer.EOF) return RubyYaccLexer.EOF;
+
+                            continue;
+                        }
+                        
                         src.unread(c);
                         if (escape) buffer.append('\\');
                         c = lexer.readEscape();
@@ -266,6 +273,13 @@ public class StringTerm extends StrTerm {
                         /* ignore backslashed spaces in %w */
                     } else if (c != end && !(begin != '\0' && c == begin)) {
                         buffer.append('\\');
+                        
+                        /* add NonAscii to Buffer after backslash */
+                        if(!Encoding.isAscii((byte) c)) {
+                            if (addNonAsciiToBuffer(c, src, encoding, lexer, buffer) == RubyYaccLexer.EOF) return RubyYaccLexer.EOF;
+
+                            continue;
+                        }
                     }
                 }
             } else if (!lexer.isOneEight() && !Encoding.isAscii((byte) c)) {

--- a/core/src/test/java/org/jruby/lexer/yacc/StringTermTest.java
+++ b/core/src/test/java/org/jruby/lexer/yacc/StringTermTest.java
@@ -1,0 +1,59 @@
+package org.jruby.lexer.yacc;
+
+import org.jruby.CompatVersion;
+import org.jruby.Ruby;
+import org.jruby.RubyInstanceConfig;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.KCode;
+
+import junit.framework.TestCase;
+
+public class StringTermTest extends TestCase {
+
+    /**
+     * @see https://github.com/jruby/jruby/issues/1069
+     */
+    public void testGH1069() {
+        final String testScriptUsingSingleQuote = "# encoding: utf-8\n'\\Ã¢â‚¬â„¢'";
+        final String testScriptUsingDoubleQuote = "# encoding: utf-8\n\"\\Ã¢â‚¬â„¢\"";
+
+        CompatVersion[] versions = new CompatVersion[] { CompatVersion.RUBY1_8,
+                CompatVersion.RUBY1_9, CompatVersion.RUBY2_0 };
+
+        for (CompatVersion v : versions) {
+            RubyInstanceConfig config = new RubyInstanceConfig();
+            config.setCompatVersion(v);
+            Ruby runtime = Ruby.newInstance(config);
+
+            IRubyObject eval1 = runtime.evalScriptlet(testScriptUsingSingleQuote);
+            assertEquals("\\Ã¢â‚¬â„¢", eval1.toJava(String.class));
+
+            IRubyObject eval2 = runtime.evalScriptlet(testScriptUsingDoubleQuote);
+            assertEquals("Ã¢â‚¬â„¢", eval2.toJava(String.class));
+        }
+    }
+
+    /**
+     * @see https://github.com/jruby/jruby/issues/1390
+     */
+    public void testGH1390() {
+        final String testScriptUsingSingleQuote = "# encoding: utf-8\n'\\\\あ'";
+        final String testScriptUsingDoubleQuote = "# encoding: utf-8\n\"\\\\あ\"";
+
+        CompatVersion[] versions = new CompatVersion[] { CompatVersion.RUBY1_8,
+                CompatVersion.RUBY1_9, CompatVersion.RUBY2_0 };
+
+        for (CompatVersion v : versions) {
+            RubyInstanceConfig config = new RubyInstanceConfig();
+            config.setCompatVersion(v);
+            Ruby runtime = Ruby.newInstance(config);
+
+            IRubyObject eval1 = runtime.evalScriptlet(testScriptUsingSingleQuote);
+            assertEquals("\\あ", eval1.toJava(String.class));
+
+            IRubyObject eval2 = runtime.evalScriptlet(testScriptUsingDoubleQuote);
+            assertEquals("\\あ", eval2.toJava(String.class));
+        }
+    }
+
+}

--- a/core/src/test/java/org/jruby/test/MainTestSuite.java
+++ b/core/src/test/java/org/jruby/test/MainTestSuite.java
@@ -87,6 +87,7 @@ public class MainTestSuite extends TestSuite {
         suite.addTestSuite(TestMethodFactories.class);
         suite.addTestSuite(RubyTimeOutputFormatterTest.class);
         suite.addTestSuite(org.jruby.lexer.yacc.ByteArrayLexerSourceTest.class);
+        suite.addTestSuite(org.jruby.lexer.yacc.StringTermTest.class);
         suite.addTestSuite(org.jruby.runtime.load.LoadServiceResourceInputStreamTest.class);
         suite.addTestSuite(TestRubyString.class);
         suite.addTestSuite(TestRubyNKF.class);


### PR DESCRIPTION
This pull request improves handling of non ascii character after backslash of `org.jruby.lexer.yacc.StringTerm` class.  This change fixes #1069 and #1390.
