### PR TITLE
Implement Process#groups for non-Windows machines

### DIFF
--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -573,7 +573,16 @@ public class RubyProcess {
 
     @JRubyMethod(name = "groups", module = true, visibility = PRIVATE)
     public static IRubyObject groups(IRubyObject recv) {
-        throw recv.getRuntime().newNotImplementedError("Process#groups not yet implemented");
+        if(Platform.IS_WINDOWS) {
+            throw recv.getRuntime().newNotImplementedError("groups() function is unimplemented on this machine");
+        } else {
+            long[] groups = (new com.sun.security.auth.module.UnixSystem()).getGroups();
+            RubyArray ary = RubyArray.newArray(recv.getRuntime(), groups.length);
+            for(int i = 0; i < groups.length; i++) {
+                ary.push(RubyFixnum.newFixnum(recv.getRuntime(), groups[i]));
+            }
+            return ary;
+        }
     }
 
     @JRubyMethod(name = "setrlimit", rest = true, module = true, visibility = PRIVATE)


### PR DESCRIPTION
Implements `Process#groups`. This relies on the `com.sun.security.auth.module.UnixSystem` class, which is only present in *nix distributions of the JRE; it is actually not present on Windows (a similar NTSystem module is instead present).

I've attempted to build JRuby on Windows, but my Windows build environment is sadly not up to date. However, based on some Googling, avoiding the import and instead referencing the full package name at runtime should allow the project to compile on Windows while still avoiding referencing classes that don't exist at runtime.
