### PR TITLE
Add Etc::nprocessors

### DIFF
--- a/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
+++ b/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
@@ -10,6 +10,7 @@ import jnr.posix.Group;
 import jnr.posix.POSIX;
 import jnr.posix.util.Platform;
 import org.jruby.Ruby;
+import org.jruby.RubyFixnum;
 import org.jruby.RubyModule;
 import org.jruby.RubyNumeric;
 import org.jruby.RubyString;
@@ -423,6 +424,12 @@ public class RubyEtc {
         ret.untaint(context);
 
         return ret;
+    }
+
+    @JRubyMethod(module = true)
+    public static IRubyObject nprocessors(ThreadContext context, IRubyObject recv) {
+        int nprocs = Runtime.getRuntime().availableProcessors();
+        return RubyFixnum.newFixnum(context.getRuntime(), nprocs);
     }
     
     private static final AtomicBoolean iteratingPasswd = new AtomicBoolean(false);


### PR DESCRIPTION
This PR implements Etc::nprocessors. Its behavior should be the same as MRI; Runtime.getAvailableProcessors() and MRI both implement this method with `sysconf (_SC_NPROCESSORS_ONLN)`, so it should vary accordingly with bound CPUs.
