### PR TITLE
Typecheck arg for op_mod19

### DIFF
--- a/core/src/main/java/org/jruby/RubyFloat.java
+++ b/core/src/main/java/org/jruby/RubyFloat.java
@@ -452,11 +452,18 @@ public class RubyFloat extends RubyNumeric {
     
     @JRubyMethod(name = "**", required = 1)
     public IRubyObject op_pow19(ThreadContext context, IRubyObject other) {
-        double d_other = ((RubyNumeric) other).getDoubleValue();
-        if (value < 0 && (d_other != Math.round(d_other))) {
-            return RubyComplex.newComplexRaw(getRuntime(), this).callMethod(context, "**", other);
-        } else {
-            return op_pow(context, other);
+        switch (other.getMetaClass().getClassIndex()) {
+            case FIXNUM:
+            case BIGNUM:
+            case FLOAT:
+                double d_other = ((RubyNumeric) other).getDoubleValue();
+                if (value < 0 && (d_other != Math.round(d_other))) {
+                    return RubyComplex.newComplexRaw(getRuntime(), this).callMethod(context, "**", other);
+                } else {
+                    return op_pow(context, other);
+                }
+            default:
+                return coerceBin(context, "**", other);
         }
     }
 


### PR DESCRIPTION
Check for fixnum/float/bignum before casting `other`, and coerce if not a known good type.
Fixes cases like (1.23 *\* nil) throwing a Java exception rather than a TypeError.
