### PR TITLE
Move the logging of exceptions before the logging of backtraces

### DIFF
--- a/core/src/main/java/org/jruby/exceptions/RaiseException.java
+++ b/core/src/main/java/org/jruby/exceptions/RaiseException.java
@@ -199,16 +199,18 @@ public class RaiseException extends JumpException {
         doSetLastError(context);
         doCallEventHook(context);
 
-        exception.prepareIntegratedBacktrace(context, javaTrace);
-
         if (RubyInstanceConfig.LOG_EXCEPTIONS) TraceType.dumpException(exception);
+
+        exception.prepareIntegratedBacktrace(context, javaTrace);
     }
 
     private void preRaise(ThreadContext context, IRubyObject backtrace) {
         context.runtime.incrementExceptionCount();
         doSetLastError(context);
         doCallEventHook(context);
-        
+
+        if (RubyInstanceConfig.LOG_EXCEPTIONS) TraceType.dumpException(exception);
+
         if (backtrace == null) {
             exception.prepareBacktrace(context, nativeException);
         } else {
@@ -224,8 +226,6 @@ public class RaiseException extends JumpException {
         } else {
             setStackTrace(RaiseException.javaTraceFromRubyTrace(exception.getBacktraceElements()));
         }
-
-        if (RubyInstanceConfig.LOG_EXCEPTIONS) TraceType.dumpException(exception);
     }
 
     private void doCallEventHook(ThreadContext context) {


### PR DESCRIPTION
When `-Xlog.backtraces=true and -Xlog.exceptions=true` are used together the backtrace is logged before the exception, which is the opposite of what you would expect, and makes the output harder to understand.

This moves the logging of exceptions to before the code that triggers the logging of the backtraces.

This is not a fantastic solution, there’s nothing in this change that makes sure that the order stays this way, as soon as someone else does a refactoring of the code this will probably become inconsistent. 

---

Here's a flowchart of who's calling whom to print the exception and the backtraces. I made it just to see if I could find a better way of making sure the exception is printed before the backtrace, but I think it would be too dangerous if I tried, I don't know how to check for things that would break:

![img_1107_small](https://cloud.githubusercontent.com/assets/73330/4921503/c61d1fe8-650a-11e4-9a87-e010eafc2594.jpeg)
