### PR TITLE
Implement slice_after and slice_when

### DIFF
--- a/core/src/main/ruby/jruby/kernel/enumerable.rb
+++ b/core/src/main/ruby/jruby/kernel/enumerable.rb
@@ -1,23 +1,17 @@
 module Enumerable
   def slice_before(filter = (no_filter = true; nil), &block)
-    if no_filter && !block
-      raise ArgumentError.new("wrong number of arguments (0 for 1)")
-    end
+    raise ArgumentError.new("wrong number of arguments (0 for 1)") if no_filter && !block
 
-    if block
-      if no_filter
-        state = nil
-      else
-        initial_state = filter.dup
-        state = initial_state
-      end
-    else
-      state = nil
+    state = nil
+
+    if block && !no_filter
+      initial_state = filter.dup
+      state = initial_state
     end
 
     Enumerator.new do |yielder|
       ary = nil
-      self.each do |*elt|
+      each do |*elt|
         if elt.size < 2
           elt = elt.size == 0 ? nil : elt[0]
         end
@@ -44,6 +38,66 @@ module Enumerable
         end
       end
       yielder.yield ary unless ary.nil?
+    end
+  end
+
+  def slice_after(filter = (no_filter = true; nil), &block)
+    raise ArgumentError.new("wrong number of arguments (0 for 1)") if no_filter && !block
+    raise ArgumentError.new("cannot pass both filter argument and block") if !no_filter && block
+
+    state = nil
+
+    Enumerator.new do |enum|
+      ary = []
+      each do |*element|
+        if element.size < 2
+          element = element.size == 0 ? nil : element[0]
+        end
+
+        if block
+          state = block.call element
+        else
+          state = (filter === element)
+        end
+
+        if state
+          ary << element
+          enum.yield ary
+          ary = []
+        else
+          ary << element
+        end
+      end
+      enum.yield ary unless ary.nil? || ary.empty?
+    end
+  end
+
+  def slice_when(&block)
+    raise ArgumentError.new("missing block") unless block
+    return Enumerator.new {|e| } if empty?
+    return Enumerator.new {|e| e.yield self } if length < 2
+
+    Enumerator.new do |enum|
+      ary = nil
+      last_after = nil
+      each_cons(2) do |before, after|
+        last_after = after
+        match = block.call before, after
+
+        ary ||= []
+        if match
+          ary << before
+          enum.yield ary
+          ary = []
+        else
+          ary << before
+        end
+      end
+
+      unless ary.nil?
+        ary << last_after
+        enum.yield ary
+      end
     end
   end
 


### PR DESCRIPTION
Satisfies #2116

Rubyspace implementations of `Enumerable#slice_after` and `Enumerable#slice_when`. I'm pretty sure they're right per the discussion at https://bugs.ruby-lang.org/issues/9826 and https://bugs.ruby-lang.org/issues/9071, and they pass the tests given, but I'd appreciate more eyes on them.
