### PR TITLE
Fix for issue 2050 : BigDecimal and nil multiplication

### DIFF
--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -425,7 +425,9 @@ public class RubyBigDecimal extends RubyNumeric {
         if (must) {
             String err;
             
-            if (v.isImmediate()) {
+            if (v == null) {
+            	err = "nil";
+            } else if (v.isImmediate()) {
                 err = RubyObject.inspect(context, v).toString();
             } else {
                 err = v.getMetaClass().getBaseName();


### PR DESCRIPTION
This commit fixes issue #2050. This change adds null check  into  RubyBigDecimal cannotBeCoerced method.
