### PR TITLE
Add Method#super_method

### DIFF
--- a/core/src/main/java/org/jruby/RubyMethod.java
+++ b/core/src/main/java/org/jruby/RubyMethod.java
@@ -36,11 +36,13 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyClass;
 import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.internal.runtime.methods.ProcMethod;
+import org.jruby.internal.runtime.methods.UndefinedMethod;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.BlockBody;
 import org.jruby.runtime.ClassIndex;
 import org.jruby.runtime.CompiledBlockCallback19;
 import org.jruby.runtime.CompiledBlockLight19;
+import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.PositionAware;
 import org.jruby.runtime.ThreadContext;
@@ -298,6 +300,25 @@ public class RubyMethod extends RubyObject implements DataType {
     @JRubyMethod
     public IRubyObject parameters(ThreadContext context) {
         return JRubyLibrary.MethodExtensions.methodArgs(this);
+    }
+
+    @JRubyMethod
+    public IRubyObject super_method(ThreadContext context) {
+        RubyModule superClass = Helpers.findImplementerIfNecessary(receiver.getMetaClass(), implementationModule).getSuperClass();
+        return super_method(context, receiver, superClass);
+    }
+
+    protected IRubyObject super_method(ThreadContext context, IRubyObject receiver, RubyModule superClass) {
+        if (superClass == null) return context.runtime.getNil();
+
+        DynamicMethod newMethod = superClass.searchMethod(methodName);
+        if (newMethod == UndefinedMethod.INSTANCE) return context.runtime.getNil();
+
+        if (receiver == null) {
+            return RubyUnboundMethod.newUnboundMethod(superClass, methodName, superClass, originName, newMethod);
+        } else {
+            return newMethod(superClass, methodName, superClass, originName, newMethod, receiver);
+        }
     }
 }
 

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1811,7 +1811,14 @@ public class RubyModule extends RubyObject {
     @JRubyMethod(name = "==", required = 1)
     @Override
     public IRubyObject op_equal(ThreadContext context, IRubyObject other) {
-        return super.op_equal(context, other);
+        if(!(other instanceof RubyModule))
+            return context.runtime.getFalse();
+        RubyModule otherModule = (RubyModule)other;
+        if(otherModule.isIncluded()) {
+            return context.runtime.newBoolean(otherModule.isSame(this));
+        } else {
+            return context.runtime.newBoolean(isSame(otherModule));
+        }
     }
 
     /** rb_mod_freeze

--- a/core/src/main/java/org/jruby/RubyUnboundMethod.java
+++ b/core/src/main/java/org/jruby/RubyUnboundMethod.java
@@ -135,4 +135,9 @@ public class RubyUnboundMethod extends RubyMethod {
     public IRubyObject owner(ThreadContext context) {
         return implementationModule;
     }
+
+    @JRubyMethod
+    public IRubyObject super_method(ThreadContext context ) {
+        return super_method(context, null, implementationModule.getSuperClass());
+    }
 }


### PR DESCRIPTION
Implements `Method#super_method` per https://bugs.ruby-lang.org/issues/9781

I'd like some extra review on this one, due to the RubyModule#== change I made. This change was made because `Module#==(IncludedModuleWrapper)` would always return false (even if the IncludedModuleWrapper instance wrapped the receiver), while `IncludedModuleWrapper#==(Module)` would return true. I'm not sure if this is the right change, but it _seems_ to not break anything.

There is one outstanding stdlib test failure which is due to a difference in undef behavior in MRI and JRuby. I'm filing an issue for it.
