### PR TITLE
Implement Method#curry, which simply delegates to Proc#curry.

### DIFF
--- a/core/src/main/java/org/jruby/RubyMethod.java
+++ b/core/src/main/java/org/jruby/RubyMethod.java
@@ -299,5 +299,10 @@ public class RubyMethod extends RubyObject implements DataType {
     public IRubyObject parameters(ThreadContext context) {
         return JRubyLibrary.MethodExtensions.methodArgs(this);
     }
+
+    @JRubyMethod(optional = 1)
+    public IRubyObject curry(ThreadContext context, IRubyObject[] args) {
+        return to_proc(context, null).callMethod(context, "curry", args);
+    }
 }
 

--- a/core/src/main/ruby/jruby/kernel/proc.rb
+++ b/core/src/main/ruby/jruby/kernel/proc.rb
@@ -2,21 +2,21 @@ class Proc
   def curry(curried_arity = nil)
     if lambda? && curried_arity
       if arity > 0 && curried_arity != arity
-        raise ArgumentError, "Wrong number of arguments (%i for %i)" % [
+        raise ArgumentError, "wrong number of arguments (%i for %i)" % [
           curried_arity,
           arity
         ]
       end
 
       if arity < 0 && curried_arity < (-arity - 1)
-        raise ArgumentError, "Wrong number of arguments (%i for %i)" % [
+        raise ArgumentError, "wrong number of arguments (%i for %i)" % [
           curried_arity,
           -arity - 1
         ]
       end
     end
 
-    Proc.__make_curry_proc__(self, [], arity)
+    Proc.__make_curry_proc__(self, [], curried_arity || arity)
   end
 
   # Create a singleton class based on Proc that re-defines these methods but


### PR DESCRIPTION
Also fixes an existing bug in JRuby which would ignore the argument
passed to `Proc#curry()` and would instead always use the Proc's arity.
With that fixed, `Proc#curry` properly works with varargs now.

The fixed regression was introduced in 72703450108175e45fb4b21fb7d07676e001c952
