### PR TITLE
Fix ruby-bug 8625 and ruby-bug 9847

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -2972,7 +2972,10 @@ public class RubyIO extends RubyObject implements IOEncodable {
         boolean locked = fptr.lock();
         try {
             fptr.checkByteReadable(context);
-            if (len == 0) return str;
+            if (len == 0) {
+                ((RubyString)str).setReadLength(0);
+                return str;
+            }
 
             fptr.READ_CHECK(context);
             //        #if defined(RUBY_TEST_CRLF_ENVIRONMENT) || defined(_WIN32)
@@ -2982,6 +2985,7 @@ public class RubyIO extends RubyObject implements IOEncodable {
         } finally {
             if (locked) fptr.unlock();
         }
+
         ((RubyString)str).setReadLength(n);
 //        #if defined(RUBY_TEST_CRLF_ENVIRONMENT) || defined(_WIN32)
 //        if (previous_mode == O_TEXT) {

--- a/core/src/main/java/org/jruby/util/io/EncodingUtils.java
+++ b/core/src/main/java/org/jruby/util/io/EncodingUtils.java
@@ -1072,10 +1072,7 @@ public class EncodingUtils {
             RubyString s = str.convertToString();
             int clen = s.size();
             if (clen >= len) {
-                if (clen != len) {
-                    s.modify();
-                    s.getByteList().setRealSize(len);
-                }
+                s.modify();
                 return s;
             }
             str = s;


### PR DESCRIPTION
Bug 9847 caused backing strings to be erroneously re-used when reading via IO
Bug 8625 caused buffers to be errouneously sized, resulting in data loss

Both patches are effectively direct ports of the MRI fixes
