### PR TITLE
Update RubyIO#ensureYieldClose to match ruby-bug 10153 behavior

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1105,11 +1105,14 @@ public class RubyIO extends RubyObject implements IOEncodable {
             } finally {
                 IRubyObject oldExc = runtime.getGlobalVariables().get("$!");
                 try {
-                    port.getMetaClass().finvoke(context, port, "close", IRubyObject.NULL_ARRAY, Block.NULL_BLOCK);
+                    if(!(port.respondsTo("closed?") && port.callMethod(context, "closed?").isTrue())) {
+                        if(port.respondsTo("close")) {
+                            port.getMetaClass().finvoke(context, port, "close", IRubyObject.NULL_ARRAY, Block.NULL_BLOCK);
+                        }
+                    }
                 } catch (RaiseException re) {
-                    RubyException rubyEx = re.getException();
-                    if (rubyEx.kind_of_p(context, runtime.getStandardError()).isTrue()) {
-                        // MRI behavior: swallow StandardErorrs
+                    // MRI behavior: Ignore "closed stream"
+                    if (re.getException().message.asJavaString().equals("closed stream")) {
                         runtime.getGlobalVariables().set("$!", oldExc);
                     } else {
                         throw re;

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -464,10 +464,12 @@ public class Helpers {
                 return Errno.ECONNABORTED;
             } else if (t.getMessage().equals("Broken pipe")) {
                 return Errno.EPIPE;
-            } else if ("Connection reset by peer".equals(t.getMessage())
-                    || "An existing connection was forcibly closed by the remote host".equals(t.getMessage()) ||
-                    (Platform.IS_WINDOWS && t.getMessage().contains("connection was aborted"))) {
+            } else if ("Connection reset by peer".equals(errorMessage) ||
+                       "An existing connection was forcibly closed by the remote host".equals(errorMessage) ||
+                    (Platform.IS_WINDOWS && errorMessage.contains("connection was aborted"))) {
                 return Errno.ECONNRESET;
+            } else if (errorMessage.equals("No space left on device")) {
+                return Errno.ENOSPC;
             }
         }
         return null;


### PR DESCRIPTION
2.2.0 now only swallows "closed stream" errors on IO close, and explicitly
checks for both respond_to?(:closed?) (and tests it) and respond_to?(:close)
before attempting to close an IO.

Added ENOSPC helper; the un-swallowing of errors exposed another bug where
JRuby was throwing an unknown SystemCallError on a full disk due to lack of
a string check for the ENOSPC IO error.
