### PR TITLE
Propagate coderange from StrNode -> StringLiteral

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -3290,7 +3290,7 @@ public class IRBuilder {
     }
 
     public Operand buildStr(StrNode strNode, IRScope s) {
-        return copyAndReturnValue(s, new StringLiteral(strNode.getValue()));
+        return copyAndReturnValue(s, new StringLiteral(strNode.getValue(), strNode.getCodeRange()));
     }
 
     private Operand buildSuperInstr(IRScope s, Operand block, Operand[] args, int linenumber) {

--- a/core/src/main/java/org/jruby/ir/instructions/BuildCompoundStringInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/BuildCompoundStringInstr.java
@@ -77,8 +77,8 @@ public class BuildCompoundStringInstr extends Instr implements ResultInstr {
         return new BuildCompoundStringInstr(ii.getRenamedVariable(result), newPieces, encoding);
     }
 
-    public boolean isSameEncoding(StringLiteral str) {
-        return str.bytelist.getEncoding() == encoding;
+    public boolean isSameEncodingAndCodeRange(RubyString str, StringLiteral newStr) {
+        return newStr.bytelist.getEncoding() == encoding && newStr.getCodeRange() == str.getCodeRange();
     }
 
     public RubyString[] retrievePieces(ThreadContext context, IRubyObject self, StaticScope currScope, DynamicScope currDynScope, Object[] temp) {
@@ -97,11 +97,12 @@ public class BuildCompoundStringInstr extends Instr implements ResultInstr {
         bytes.setEncoding(encoding);
         RubyString str = RubyString.newStringShared(context.runtime, bytes, StringSupport.CR_7BIT);
         for (Operand p : pieces) {
-            if ((p instanceof StringLiteral) && (isSameEncoding((StringLiteral)p))) {
+            if ((p instanceof StringLiteral) && (isSameEncodingAndCodeRange(str, (StringLiteral)p))) {
                 str.getByteList().append(((StringLiteral)p).bytelist);
+                str.setCodeRange(str.scanForCodeRange());
             } else {
-               IRubyObject pval = (IRubyObject)p.retrieve(context, self, currScope, currDynScope, temp);
-               str.append19(pval);
+                IRubyObject pval = (IRubyObject)p.retrieve(context, self, currScope, currDynScope, temp);
+                str.append19(pval);
             }
         }
 

--- a/core/src/main/java/org/jruby/ir/operands/StringLiteral.java
+++ b/core/src/main/java/org/jruby/ir/operands/StringLiteral.java
@@ -9,6 +9,7 @@ import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
+import org.jruby.util.StringSupport;
 
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.List;
@@ -25,11 +26,17 @@ public class StringLiteral extends Operand {
 
     final public ByteList bytelist;
     final public String   string;
+    final public int      coderange;
 
     public StringLiteral(ByteList val) {
+        this(val, StringSupport.CR_7BIT);
+    }
+
+    public StringLiteral(ByteList val, int coderange) {
         super(OperandType.STRING_LITERAL);
 
         bytelist = val;
+        this.coderange = coderange;
         String stringTemp;
         try {
             stringTemp = Helpers.byteListToString(bytelist);
@@ -43,11 +50,12 @@ public class StringLiteral extends Operand {
         this(s, ByteList.create(s));
     }
 
-    private StringLiteral(String string, ByteList byteList ) {
+    private StringLiteral(String string, ByteList byteList) {
         super(OperandType.STRING_LITERAL);
 
         this.bytelist = byteList;
         this.string = string;
+        this.coderange = StringSupport.CR_7BIT;
      }
 
     @Override
@@ -98,4 +106,6 @@ public class StringLiteral extends Operand {
     public String getString() {
         return string;
     }
+
+    public int getCodeRange() { return coderange; }
 }


### PR DESCRIPTION
 and use it when building compound strings. Fixes bug9882.

Will probably want to audit all `StringLiteral` usage in IR to make sure that CRs are preserved when they should be.

Also, `isSameEncodingAndCodeRange` might be optimizable by accepting strings where newStr's coderange is a subset of `str`'s coderange (ie, str == CR_VALID and newStr == CR_7BIT) to avoid extra multibyte work, but I went with this solution because optimization is probably what broke this in the first place.
