### PR TITLE
Fix invalid signals passed to restorePlatformDefault.

### DIFF
--- a/core/src/main/java/org/jruby/util/SunSignalFacade.java
+++ b/core/src/main/java/org/jruby/util/SunSignalFacade.java
@@ -115,8 +115,12 @@ public class SunSignalFacade implements SignalFacade {
     public IRubyObject restorePlatformDefault(IRubyObject recv, IRubyObject sig) {
         SignalHandler handler;
         Ruby runtime = recv.getRuntime();
-        synchronized (original) {
-            handler = original.get(new Signal(sig.toString()));
+        try {
+            synchronized (original) {
+                handler = original.get(new Signal(sig.toString()));
+            }
+        } catch (IllegalArgumentException e) {
+            handler = null;
         }
         if (handler != null) {
             return trap(runtime, sig.toString(), handler);
@@ -188,12 +192,12 @@ public class SunSignalFacade implements SignalFacade {
                     return runtime.getNil();
                 }
             };
-            if (oldHandler == null) {
-                retVals[0] = runtime.newString("DEFAULT");
-            } else if (oldHandler == SignalHandler.SIG_DFL) {
+            if (oldHandler == SignalHandler.SIG_DFL) {
                 retVals[0] = runtime.newString("SYSTEM_DEFAULT");
             } else if (oldHandler == SignalHandler.SIG_IGN) {
                 retVals[0] = runtime.newString("IGNORE");
+            } else {
+                retVals[0] = runtime.newString("DEFAULT");
             }
         } else {
             final RubyModule signalModule = runtime.getModule("Signal");

--- a/test/mri/excludes/TestSignal.rb
+++ b/test/mri/excludes/TestSignal.rb
@@ -5,8 +5,6 @@ exclude :test_signal2, "SignalException needs to be its own class which provides
 exclude :test_trap, "SignalException needs to be its own class which provides a #signo accessor"
 exclude :test_signal_exception, "SignalException needs to be its own class which enforces args"
 exclude :test_signame, "needs investigation - OutOfMemoryError"
-
-# exclude :test_ignored_interrupt, "uses SIGINT which is already in use on the JVM"
 exclude :test_trap_uncatchable_KILL, "uses SIGKILL which is already in use on the JVM"
 exclude :test_trap_uncatchable_STOP, "uses SIGSTOP which is already in use on the JVM"
 exclude :test_trap_puts, "fails due to use of INT. Works when the test uses SIGUSR2"


### PR DESCRIPTION
Those need to be handled by the fake signal handler instead (ie, make the behavior symmetric to trap's behavior).
