### PR TITLE
Fix assignment of test options

### DIFF
--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -12,6 +12,8 @@ if ENV['CI']
 
   # for normal test/unit tests
   ENV['TESTOPT'] = "-v --no-use-color"
+else
+  ADDITIONAL_TEST_OPTIONS = ""
 end
 
 namespace :test do


### PR DESCRIPTION
ADDITIONAL_TEST_OPTIONS needs to be visible when not running under CI.
