### PR TITLE
Fix frozen checks and exceptions

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -65,7 +65,6 @@ import org.jruby.runtime.builtin.InternalVariables;
 import org.jruby.runtime.builtin.Variable;
 import org.jruby.runtime.component.VariableEntry;
 import org.jruby.runtime.marshal.CoreObjectType;
-import org.jruby.runtime.opto.OptoFactory;
 import org.jruby.util.IdUtil;
 import org.jruby.util.TypeConverter;
 import org.jruby.util.io.EncodingUtils;
@@ -1532,7 +1531,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      * tainted. Will throw a suitable exception in that case.
      */
     public final void ensureInstanceVariablesSettable() {
-        if (!isFrozen()) {
+        if (!isFrozen() || isImmediate()) {
             return;
         }
         raiseFrozenError();

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1171,11 +1171,11 @@ public class IRRuntimeHelpers {
     }
 
     private static RubyClass checkClassForDef(ThreadContext context, IRScope method, IRubyObject obj) {
-        if (obj instanceof RubyFixnum || obj instanceof RubySymbol) {
+        if (obj instanceof RubyFixnum || obj instanceof RubySymbol || obj instanceof RubyFloat) {
             throw context.runtime.newTypeError("can't define singleton method \"" + method.getName() + "\" for " + obj.getMetaClass().getBaseName());
         }
 
-        if (obj.isFrozen()) throw context.runtime.newFrozenError("object");
+        // if (obj.isFrozen()) throw context.runtime.newFrozenError("object");
 
         return obj.getSingletonClass();
     }


### PR DESCRIPTION
Fix freeze enforcement and exceptions for immediate values. Passes test suite and rubyspec suite.

I'd love some extra review on this, though - the JRuby code isn't directly analogous to the MRI code, and there is a whole set of checks (FL_ABLE, SPECIAL_CONST_P) that JRuby doesn't do which probably need evaluation.
