### PR TITLE
Fix JsonProfilePrinter

### DIFF
--- a/core/src/main/java/org/jruby/runtime/profile/builtin/ProfilePrinter.java
+++ b/core/src/main/java/org/jruby/runtime/profile/builtin/ProfilePrinter.java
@@ -98,7 +98,7 @@ public abstract class ProfilePrinter {
     public void printFooter(PrintStream out) { }
     
     public void printProfile(PrintStream out) {
-        printProfile(out, false);
+        printProfile(out, true);
     }
 
     public abstract void printProfile(PrintStream out, boolean first) ;

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -22,7 +22,7 @@ namespace :test do
   short_tests_19 = short_tests_18.map {|test| test + "19"}
   short_tests = short_tests_18 + short_tests_19
   long_tests_18 = short_tests_18 + ['spec:ji', 'spec:compiler', 'spec:ffi', 'spec:regression']
-  long_tests_19 = long_tests_18.map {|test| test + "19"}
+  long_tests_19 = long_tests_18.map {|test| test + "19"} + ['spec:profiler19']
   slow_tests = ['test:slow', 'test:objectspace']
   long_tests = ['test:tracing'] + long_tests_18 + long_tests_19 + slow_tests
   all_tests_18 = long_tests_18.map {|test| test + ':all'}

--- a/spec/profiler/json_profile_printer_spec.rb
+++ b/spec/profiler/json_profile_printer_spec.rb
@@ -9,7 +9,7 @@ describe JRuby::Profiler, "::JsonProfilePrinter" do
     end
     
     it 'contains only the top invocation' do
-      json_output['methods'].should have(1).items
+      json_output['methods'].length.should equal(1)
       json_output['methods'].first['name'].should == '(top)'
     end
 
@@ -53,7 +53,7 @@ describe JRuby::Profiler, "::JsonProfilePrinter" do
       end
 
       it 'contains data on the calls from parents, including calls, total, self and child time' do
-        method_invocation['parents'].should have(1).item
+        method_invocation['parents'].length.should equal(1)
         call_data = method_invocation['parents'].find { |c| c['id'] == top_invocation['id'] }
         call_data.should include('total_calls' => 1, 'total_time' => anything, 'self_time' => anything, 'child_time' => anything)
       end

--- a/spec/profiler/runtime_spec.rb
+++ b/spec/profiler/runtime_spec.rb
@@ -35,10 +35,10 @@ describe Java::OrgJruby::Ruby do
       check_passed_spec @runtime.evalScriptlet("RSpec::Core::Runner.run([ 'spec/profiler/graph_profile_printer_spec.rb' ], ERR_IO, OUT_IO)")
     end
     
-    def check_passed_spec(outcome)
+    def check_passed_spec(exit_status)
       # print any errors if occured :
       @runtime.evalScriptlet("puts ERR_IO.string unless ERR_IO.string.empty?")
-      passed = (outcome.to_s.should == true.to_s)
+      passed = (exit_status == 0)
     ensure
       unless passed
         puts "spec not passed, output: \n"


### PR DESCRIPTION
`first` flag was incorrectly set, resulting in a leading comma for json profile output.

Also remove some calls to rspec's `have`, which has been removed from rspec since the profiler specs were last run.

@headius, with this the spec/profiler specs are green for 1.7.  Do you want to re-enable on Travis?