### PR TITLE
[Truffle] Add TruffleBoundary to RubyString.toString().

### DIFF
--- a/core/src/main/java/org/jruby/truffle/runtime/core/RubyString.java
+++ b/core/src/main/java/org/jruby/truffle/runtime/core/RubyString.java
@@ -9,6 +9,7 @@
  */
 package org.jruby.truffle.runtime.core;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import org.jcodings.Encoding;
 import org.jcodings.specific.UTF8Encoding;
 import org.jruby.runtime.Helpers;
@@ -140,6 +141,7 @@ public class RubyString extends RubyObject {
     }
 
     @Override
+    @TruffleBoundary
     public String toString() {
         RubyNode.notDesignedForCompilation();
 


### PR DESCRIPTION
It looks like `toString()` is triggering some code that truffle refuses to compile.

A script like `1_000_000.times { [1,2,3].inspect }` triggers:

```
Found illegal recursive call to HotSpotMethod<Utility.recursiveAppendNumber(StringBuffer, int, int, int)>, must annotate such calls with @TruffleBoundary!
```

Not sure if this is the best fix, still trying to wrap my head around truffle/graal. The full backtrace is below.

```
Context obj com.oracle.graal.nodes.util.GraphUtil$2: Found illegal recursive call to HotSpotMethod<Utility.recursiveAppendNumber(StringBuffer, int, int, int)>, must annotate such calls with @TruffleBoundary!
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<Utility.recursiveAppendNumber(StringBuffer, int, int, int)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<Utility.appendNumber(StringBuffer, int, int, int)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<Utility.hex(int, int)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<UnicodeSet.complement(int, int)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<UnicodeSet.<init>(int, int)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<NormalizerImpl.internalGetNXHangul()>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<NormalizerImpl.internalGetNX(int)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<NormalizerImpl.getNX(int)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<NormalizerBase.decompose(String, boolean, int)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<NormalizerBase$NFKDMode.normalize(String, int)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<NormalizerBase.normalize(String, Normalizer$Form, int)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<NormalizerBase.normalize(String, Normalizer$Form)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<Normalizer.normalize(CharSequence, Normalizer$Form)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<Pattern.normalize()>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<Pattern.compile()>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<Pattern.<init>(String, int)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<Pattern.compile(String)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<String.split(String, int)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<String.split(String)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<ExtendedCharsets.init()>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<AbstractCharsetProvider.charsetForName(String)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<Charset.lookupExtendedCharset(String)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<Charset.lookup2(String)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<Charset.lookup(String)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<Charset.defaultCharset()>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<StringCoding.decode(byte[], int, int)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<String.<init>(byte[], int, int)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<String.<init>(byte[])>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<Encoding.toString()>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<EncodingService.charsetForEncoding(Encoding)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<Helpers.decodeByteList(Ruby, ByteList)>
                                                                            Context obj com.oracle.graal.hotspot.meta.HotSpotMetaAccessProvider@19e332a3
                                                                            Context obj HotSpotMethod<RubyString.toString()>

```
