### PR TITLE
Fix for issue 1069 and 1390 on master: improve handling of non ascii character after backslash

### DIFF
--- a/core/src/main/java/org/jruby/lexer/yacc/StringTerm.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/StringTerm.java
@@ -317,6 +317,13 @@ public class StringTerm extends StrTerm {
                         
                         continue;
                     } else if (expand) {
+                        /* add NonAscii to Buffer after backslash */
+                        if (!Encoding.isAscii((byte) c)) {
+                            if (addNonAsciiToBuffer(c, src, encoding, lexer, buffer) == RubyLexer.EOF) return RubyLexer.EOF;
+
+                            continue;
+                        }
+
                         src.unread(c);
                         if (escape) buffer.append('\\');
                         c = lexer.readEscape();
@@ -324,6 +331,13 @@ public class StringTerm extends StrTerm {
                         /* ignore backslashed spaces in %w */
                     } else if (c != end && !(begin != '\0' && c == begin)) {
                         buffer.append('\\');
+
+                        /* add NonAscii to Buffer after backslash */
+                        if (!Encoding.isAscii((byte) c)) {
+                            if (addNonAsciiToBuffer(c, src, encoding, lexer, buffer) == RubyLexer.EOF) return RubyLexer.EOF;
+
+                            continue;
+                        }
                     }
                 }
             } else if (!Encoding.isAscii((byte) c)) {

--- a/core/src/test/java/org/jruby/lexer/yacc/StringTermTest.java
+++ b/core/src/test/java/org/jruby/lexer/yacc/StringTermTest.java
@@ -17,20 +17,14 @@ public class StringTermTest extends TestCase {
         final String testScriptUsingSingleQuote = "# encoding: utf-8\n'\\Ã¢â‚¬â„¢'";
         final String testScriptUsingDoubleQuote = "# encoding: utf-8\n\"\\Ã¢â‚¬â„¢\"";
 
-        CompatVersion[] versions = new CompatVersion[] { CompatVersion.RUBY1_8,
-                CompatVersion.RUBY1_9, CompatVersion.RUBY2_0 };
+        RubyInstanceConfig config = new RubyInstanceConfig();
+        Ruby runtime = Ruby.newInstance(config);
 
-        for (CompatVersion v : versions) {
-            RubyInstanceConfig config = new RubyInstanceConfig();
-            config.setCompatVersion(v);
-            Ruby runtime = Ruby.newInstance(config);
+        IRubyObject eval1 = runtime.evalScriptlet(testScriptUsingSingleQuote);
+        assertEquals("\\Ã¢â‚¬â„¢", eval1.toJava(String.class));
 
-            IRubyObject eval1 = runtime.evalScriptlet(testScriptUsingSingleQuote);
-            assertEquals("\\Ã¢â‚¬â„¢", eval1.toJava(String.class));
-
-            IRubyObject eval2 = runtime.evalScriptlet(testScriptUsingDoubleQuote);
-            assertEquals("Ã¢â‚¬â„¢", eval2.toJava(String.class));
-        }
+        IRubyObject eval2 = runtime.evalScriptlet(testScriptUsingDoubleQuote);
+        assertEquals("Ã¢â‚¬â„¢", eval2.toJava(String.class));
     }
 
     /**
@@ -40,20 +34,14 @@ public class StringTermTest extends TestCase {
         final String testScriptUsingSingleQuote = "# encoding: utf-8\n'\\\\あ'";
         final String testScriptUsingDoubleQuote = "# encoding: utf-8\n\"\\\\あ\"";
 
-        CompatVersion[] versions = new CompatVersion[] { CompatVersion.RUBY1_8,
-                CompatVersion.RUBY1_9, CompatVersion.RUBY2_0 };
+        RubyInstanceConfig config = new RubyInstanceConfig();
+        Ruby runtime = Ruby.newInstance(config);
 
-        for (CompatVersion v : versions) {
-            RubyInstanceConfig config = new RubyInstanceConfig();
-            config.setCompatVersion(v);
-            Ruby runtime = Ruby.newInstance(config);
+        IRubyObject eval1 = runtime.evalScriptlet(testScriptUsingSingleQuote);
+        assertEquals("\\あ", eval1.toJava(String.class));
 
-            IRubyObject eval1 = runtime.evalScriptlet(testScriptUsingSingleQuote);
-            assertEquals("\\あ", eval1.toJava(String.class));
-
-            IRubyObject eval2 = runtime.evalScriptlet(testScriptUsingDoubleQuote);
-            assertEquals("\\あ", eval2.toJava(String.class));
-        }
+        IRubyObject eval2 = runtime.evalScriptlet(testScriptUsingDoubleQuote);
+        assertEquals("\\あ", eval2.toJava(String.class));
     }
 
 }

--- a/core/src/test/java/org/jruby/test/MainTestSuite.java
+++ b/core/src/test/java/org/jruby/test/MainTestSuite.java
@@ -87,6 +87,7 @@ public class MainTestSuite extends TestSuite {
         suite.addTestSuite(TestMethodFactories.class);
         suite.addTestSuite(RubyTimeOutputFormatterTest.class);
         suite.addTestSuite(org.jruby.lexer.yacc.ByteArrayLexerSourceTest.class);
+        suite.addTestSuite(org.jruby.lexer.yacc.StringTermTest.class);
         suite.addTestSuite(DetailedSourcePositionTest.class);
         suite.addTestSuite(org.jruby.runtime.load.LoadServiceResourceInputStreamTest.class);
         suite.addTestSuite(TestRubyString.class);


### PR DESCRIPTION
I create this pull request #2210, since the pull request #2064 for 1_7 branch can not be merged into master branch. This pull request improves handling of non ascii character after backslash of `org.jruby.lexer.yacc.StringTerm` class on master.  This change fixes #1069 and #1390.