### PR TITLE
Fix exponential expansion of work in method lookup

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1190,11 +1190,7 @@ public class RubyModule extends RubyObject {
 
     // The local method resolution logic. Overridden in IncludedModuleWrapper for recursion.
     protected DynamicMethod searchMethodCommon(String name) {
-        DynamicMethod method = getMethods().get(name);
-
-        if (method != null) return method;
-
-        return superClass == null ? null : superClass.searchMethodInner(name);
+        return getMethods().get(name);
     }
 
     public void invalidateCacheDescendants() {


### PR DESCRIPTION
Fix for #2217. I'm not quite sure I grok the whole setup here (particularly with respect to the prepend work being done), but it fixes the issue nicely and returns method lookup to linear time.

There are module failures in the test suite, but they were introduced in 98fa7a673141c808361f793d6805e8339c54e1b7.
