### PR TITLE
Preserve ThreadGroup#list order with WeakIdentityLinkedHashSet

### DIFF
--- a/core/src/main/java/org/jruby/util/WeakIdentityLinkedHashMap.java
+++ b/core/src/main/java/org/jruby/util/WeakIdentityLinkedHashMap.java
@@ -1,0 +1,98 @@
+
+package org.jruby.util;
+
+import java.lang.ref.ReferenceQueue;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public class WeakIdentityLinkedHashMap extends WeakIdentityHashMap {
+    public WeakIdentityLinkedHashMap() {
+        super();
+    }
+
+    public WeakIdentityLinkedHashMap(int size) {
+        super(size);
+    }
+
+    class Entry extends WeakIdentityHashMap.Entry {
+        Entry before, after;
+
+        Entry(int hash, Object masked_key, Object value, WeakIdentityHashMap.Entry next, ReferenceQueue queue, Entry tail) {
+            super(hash, masked_key, value, next, queue);
+            before = tail;
+            if (tail != null) {
+                tail.after = this;
+            }
+        }
+    }
+
+    // The head (eldest) of the doubly linked list.
+    transient Entry head;
+
+    // The tail (youngest) of the doubly linked list.
+    transient Entry tail;
+
+    @Override
+    public void clear() {
+        head = tail = null;
+        super.clear();
+    }
+
+    @Override
+    protected WeakIdentityHashMap.Entry newEntry(int hash, Object masked_key, Object value, WeakIdentityHashMap.Entry next, ReferenceQueue queue) {
+        Entry newTail = new Entry(hash, masked_key, value, next, queue, tail);
+        if (head == null) {
+            head = newTail;
+        }
+        tail = newTail;
+        return newTail;
+    }
+
+    @Override
+    protected void entryRemoved(WeakIdentityHashMap.Entry entry) {
+        Entry ent = (Entry) entry;
+        if (ent.before == null) {
+            head = ent;
+        }
+        else {
+            ent.before.after = ent.after;
+        }
+        super.entryRemoved(entry);
+    }
+
+    @Override
+    protected Iterator entryIterator() {
+        return new EntryIterator();
+    }
+
+    final class EntryIterator implements Iterator {
+        private Entry entry;
+
+        EntryIterator() {
+            expunge();
+            entry = head;
+        }
+
+        public boolean hasNext() {
+            return (entry != null);
+        }
+
+        public Object next() {
+            Object result = entry;
+
+            if (result == null) {
+                throw new NoSuchElementException();
+            } else {
+                entry = entry.after;
+                return result;
+            }
+        }
+
+        public void remove() {
+            Entry removed = entry;
+            expunge();
+            entry = entry.after;
+            WeakIdentityLinkedHashMap.this.removeEntry(removed);
+        }
+    }
+}

--- a/core/src/main/java/org/jruby/util/WeakIdentityLinkedHashMap.java
+++ b/core/src/main/java/org/jruby/util/WeakIdentityLinkedHashMap.java
@@ -52,7 +52,7 @@ public class WeakIdentityLinkedHashMap extends WeakIdentityHashMap {
     protected void entryRemoved(WeakIdentityHashMap.Entry entry) {
         Entry ent = (Entry) entry;
         if (ent.before == null) {
-            head = ent;
+            head = ent.after;
         }
         else {
             ent.before.after = ent.after;

--- a/core/src/main/java/org/jruby/util/WeakIdentityLinkedHashSet.java
+++ b/core/src/main/java/org/jruby/util/WeakIdentityLinkedHashSet.java
@@ -1,0 +1,71 @@
+
+package org.jruby.util;
+
+import java.util.AbstractSet;
+import java.util.Set;
+import java.util.Iterator;
+
+public class WeakIdentityLinkedHashSet extends AbstractSet implements Set {
+
+    private transient WeakIdentityLinkedHashMap map;
+
+    // Dummy value to associate with an Object in the backing Map
+    private static final Object PRESENT = new Object();
+
+    public WeakIdentityLinkedHashSet() {
+        map = new WeakIdentityLinkedHashMap();
+    }
+
+    public WeakIdentityLinkedHashSet(int size) {
+        map = new WeakIdentityLinkedHashMap(size);
+    }
+
+    final class EntryIterator implements Iterator {
+        private Iterator iter;
+
+        EntryIterator() {
+            iter = map.entryIterator();
+        }
+
+        public boolean hasNext() {
+            return iter.hasNext();
+        }
+
+        public Object next() {
+            return ((WeakIdentityLinkedHashMap.Entry) iter.next()).getKey();
+        }
+
+        public void remove() {
+            iter.remove();
+        }
+    }
+
+
+    public Iterator iterator() {
+        return new EntryIterator();
+    }
+
+    public void clear() {
+        map.clear();
+    }
+
+    public boolean containsKey(Object key) {
+        return map.containsKey(key);
+    }
+
+    public boolean add(Object key) {
+        return map.put(key, PRESENT) == null;
+    }
+
+    public boolean remove(Object key) {
+        return map.remove(key) == PRESENT;
+    }
+
+    public int size() {
+        return map.size();
+    }
+
+    public boolean isEmpty() {
+        return map.size() == 0;
+    }
+}


### PR DESCRIPTION
Because MRI uses a linked list which preserves the order of the threads.
https://github.com/ruby/ruby/blob/2a754a733045da9965e88d1f31e650ea6b3f2b6c/vm_core.h#L973-L978
This is useful to assume the first thread in the list is the root of a
group, and saving values in the thread could be shared amongst the
thread group. If we ever have thread group local variable, this is not
really needed.