### PR TITLE
Fix GH-1960 rspec file

### DIFF
--- a/spec/regression/GH-1960_nonlocal_return_in_define_method_block_spec.rb
+++ b/spec/regression/GH-1960_nonlocal_return_in_define_method_block_spec.rb
@@ -8,6 +8,6 @@ end
 
 describe 'NonLocalReturn' do
   it 'inside a block of a define_method block body returns normally' do
-    C.new.foo.should_be :foo
+    C.new.foo.should be(:foo)
   end
 end


### PR DESCRIPTION
This commit fixes GH-1960 rspec file on master. Change the rspec file name is related to #2174.
