### PR TITLE
refactor FileResource.inputStream to be easier to use

### DIFF
--- a/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
+++ b/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
@@ -1,5 +1,6 @@
 package org.jruby.runtime.load;
 
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -235,8 +236,11 @@ class LibrarySearcher {
 
         @Override
         public void load(Ruby runtime, boolean wrap) {
-            InputStream is = resource.openInputStream();
-            if (is == null) {
+            InputStream is = null;
+            try {
+                is = new BufferedInputStream(resource.inputStream(), 32768);
+            }
+            catch(IOException e) {
                 throw runtime.newLoadError("no such file to load -- " + searchName, searchName);
             }
 

--- a/core/src/main/java/org/jruby/util/AbstractFileResource.java
+++ b/core/src/main/java/org/jruby/util/AbstractFileResource.java
@@ -1,0 +1,26 @@
+package org.jruby.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+abstract class AbstractFileResource implements FileResource {
+
+    @Override
+    public InputStream inputStream() throws ResourceException {
+        if (!exists()) {
+            throw new ResourceException.NotFound(absolutePath());
+        }
+        if (isDirectory()) {
+            throw new ResourceException.FileIsDirectory(absolutePath());
+        }
+        try {
+            return openInputStream();
+        }
+        catch (IOException e) {
+            throw new ResourceException.IOError(e);
+        }
+    }
+
+    abstract InputStream openInputStream() throws IOException;
+
+}

--- a/core/src/main/java/org/jruby/util/ClasspathResource.java
+++ b/core/src/main/java/org/jruby/util/ClasspathResource.java
@@ -10,7 +10,7 @@ import jnr.posix.POSIX;
 import org.jruby.util.io.ChannelDescriptor;
 import org.jruby.util.io.ModeFlags;
 
-public class ClasspathResource implements FileResource {
+public class ClasspathResource extends AbstractFileResource {
 
     public static final String CLASSPATH = "classpath:/";
 
@@ -137,12 +137,8 @@ public class ClasspathResource implements FileResource {
     }
 
     @Override
-    public InputStream openInputStream() {
-        try {
-            return getResourceURL(uri).openStream();
-        } catch (IOException ioE) {
-            return null;
-        }
+    InputStream openInputStream() throws IOException {
+        return getResourceURL(uri).openStream();
     }
 
     @Override

--- a/core/src/main/java/org/jruby/util/EmptyFileResource.java
+++ b/core/src/main/java/org/jruby/util/EmptyFileResource.java
@@ -91,8 +91,8 @@ class EmptyFileResource implements FileResource {
     }
 
     @Override
-    public InputStream openInputStream() {
-      return null;
+    public InputStream inputStream() throws ResourceException {
+        throw new ResourceException.NotFound("");
     }
 
     @Override

--- a/core/src/main/java/org/jruby/util/FileResource.java
+++ b/core/src/main/java/org/jruby/util/FileResource.java
@@ -1,10 +1,11 @@
 package org.jruby.util;
 
+import java.io.InputStream;
+
 import jnr.posix.FileStat;
-import jnr.posix.POSIX;
+
 import org.jruby.util.io.ChannelDescriptor;
 import org.jruby.util.io.ModeFlags;
-import java.io.InputStream;
 
 /**
  * This is a shared interface for files loaded as {@link java.io.File} and {@link java.util.zip.ZipEntry}.
@@ -38,9 +39,15 @@ public interface FileResource {
     // otherwise.
     JRubyFile hackyGetJRubyFile();
 
-    // Opens a new input stream to read the contents of a resource and returns it.
-    // Note that implementations may be allocating native memory for the stream, so
-    // callers need to close this when they are done with it.
-    InputStream openInputStream();
+
+    /**
+     * opens input-stream to the underlying resource. this is place where
+     * the input-stream gets opened. users of this method should follow the pattern:
+     * close the stream where you open it.
+     *
+     * @return just opened InputStream
+     * @throws ResourceException is the file does not exists or if the resource is a directory
+     */
+    InputStream inputStream() throws ResourceException;
     ChannelDescriptor openDescriptor(ModeFlags flags, int perm) throws ResourceException;
 }

--- a/core/src/main/java/org/jruby/util/JarDirectoryResource.java
+++ b/core/src/main/java/org/jruby/util/JarDirectoryResource.java
@@ -4,6 +4,7 @@ import jnr.posix.POSIX;
 import org.jruby.Ruby;
 import org.jruby.util.io.ChannelDescriptor;
 import org.jruby.util.io.ModeFlags;
+import java.io.IOException;
 import java.io.InputStream;
 
 /**
@@ -61,8 +62,8 @@ class JarDirectoryResource extends JarResource {
     }
 
     @Override
-    public InputStream openInputStream() {
-      return null;
+    InputStream openInputStream() throws IOException {
+        throw new ResourceException.FileIsDirectory(path);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/util/JarFileResource.java
+++ b/core/src/main/java/org/jruby/util/JarFileResource.java
@@ -5,6 +5,7 @@ import org.jruby.Ruby;
 import org.jruby.util.io.ChannelDescriptor;
 import org.jruby.util.io.ModeFlags;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.channels.Channels;
 import java.util.jar.JarEntry;
@@ -60,12 +61,12 @@ class JarFileResource extends JarResource {
   }
 
   @Override
-  public InputStream openInputStream() {
+  InputStream openInputStream() {
     return index.getInputStream(entry);
   }
 
   @Override
   public ChannelDescriptor openDescriptor(ModeFlags flags, int perm) throws ResourceException {
-    return new ChannelDescriptor(Channels.newChannel(openInputStream()), flags);
+    return new ChannelDescriptor(Channels.newChannel(inputStream()), flags);
   }
 }

--- a/core/src/main/java/org/jruby/util/JarResource.java
+++ b/core/src/main/java/org/jruby/util/JarResource.java
@@ -9,7 +9,7 @@ import java.util.jar.JarEntry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-abstract class JarResource implements FileResource {
+abstract class JarResource extends AbstractFileResource {
     private static Pattern PREFIX_MATCH = Pattern.compile("^(?:jar:)?(?:file:)?(.*)$");
 
     private static final JarCache jarCache = new JarCache();

--- a/core/src/main/java/org/jruby/util/RegularFileResource.java
+++ b/core/src/main/java/org/jruby/util/RegularFileResource.java
@@ -20,7 +20,7 @@ import org.jruby.util.io.ModeFlags;
 /**
  * Represents a "regular" file, backed by regular file system.
  */
-class RegularFileResource implements FileResource {
+class RegularFileResource extends AbstractFileResource {
     private final JRubyFile file;
     private final POSIX posix;
 
@@ -136,12 +136,8 @@ class RegularFileResource implements FileResource {
     }
 
     @Override
-    public InputStream openInputStream() {
-        try {
-            return new java.io.BufferedInputStream(new FileInputStream(file), 32768);
-        } catch (FileNotFoundException fnfe) {
-            return null;
-        }
+    InputStream openInputStream() throws IOException {
+        return new FileInputStream(file);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/util/URLResource.java
+++ b/core/src/main/java/org/jruby/util/URLResource.java
@@ -15,9 +15,11 @@ import java.util.Set;
 import jnr.posix.FileStat;
 
 import org.jruby.util.io.ChannelDescriptor;
+import org.jruby.Ruby;
+import org.jruby.exceptions.RaiseException;
 import org.jruby.util.io.ModeFlags;
 
-public class URLResource implements FileResource {
+public class URLResource extends AbstractFileResource {
 
     public static String URI = "uri:";
     public static String CLASSLOADER = "classloader:/";
@@ -130,27 +132,16 @@ public class URLResource implements FileResource {
     }
 
     @Override
-    public InputStream openInputStream()
-    {
-        try
-        {
-            if (pathname != null) {
-                return Thread.currentThread().getContextClassLoader().getResourceAsStream(pathname);
-            }
-            return url.openStream();
+    InputStream openInputStream() throws IOException {
+        if (pathname != null) {
+            return Thread.currentThread().getContextClassLoader().getResourceAsStream(pathname);
         }
-        catch (IOException e)
-        {
-            return null;
-        }
+        return url.openStream();
     }
 
     @Override
     public ChannelDescriptor openDescriptor(ModeFlags flags, int perm) throws ResourceException {
-        if (!exists()) {
-            throw new ResourceException.NotFound(absolutePath());
-        }
-        return new ChannelDescriptor(openInputStream(), flags);
+        return new ChannelDescriptor(inputStream(), flags);
     }
 
     public static FileResource createClassloaderURI(String pathname) {


### PR DESCRIPTION
for any client code which needs to convert a uri-like path to an inputstream
the way to go is `JRubyFile.create(runtime, path).inputStream()`

the motivation for this PR comes from jruby-openssl-0.9.6.dev:

from the user there comes a String with path to a PEM resource. as it turns out this path can be any uri-like path (like from rubygems: https://github.com/jruby/jruby/blob/master/lib/ruby/stdlib/rubygems/request.rb#L42).

the following boilerplate code to convert a uri-like path into an input-stream:
https://github.com/jruby/jruby-openssl/commit/aa51d9ba1d55dfad31943fadc95c8889ebbe456d#diff-67972a6a9364f41a90295ceabf0e9180R298
is a fix for jruby-1.7.16.1

this PR cleans up the API for such "conversion" and to release jruby-openssl with this clean API it needs a released jruby version with this PR merged.
