### PR TITLE
fix RubyFile#rename when the source is a broken symlink

### DIFF
--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -934,7 +934,10 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         JRubyFile oldFile = JRubyFile.create(runtime.getCurrentDirectory(), oldNameJavaString);
         JRubyFile newFile = JRubyFile.create(runtime.getCurrentDirectory(), newNameJavaString);
         
-        if (!oldFile.exists() || !newFile.getParentFile().exists()) {
+        boolean isOldSymlink = RubyFileTest.symlink_p(recv, oldNameString).isTrue();
+        // Broken symlinks considered by exists() as non-existing,
+        // so we need to check for symlinks explicitly.
+        if (!(oldFile.exists() || isOldSymlink) || !newFile.getParentFile().exists()) {
             throw runtime.newErrnoENOENTError(oldNameJavaString + " or " + newNameJavaString);
         }
 


### PR DESCRIPTION
jruby/jruby#2153 became the first issue for me as a contributor. I tried to solve it pretty much the same way as it's been done elsewhere in RubyFile.
