### PR TITLE
Make loading service extensions work with classloader path

### DIFF
--- a/core/src/main/java/org/jruby/runtime/load/JarredScript.java
+++ b/core/src/main/java/org/jruby/runtime/load/JarredScript.java
@@ -43,9 +43,11 @@ import org.jruby.Ruby;
  */
 public class JarredScript implements Library {
     private final LoadServiceResource resource;
+    private final String searchName;
 
-    public JarredScript(LoadServiceResource resource) {
+    public JarredScript(LoadServiceResource resource, String searchName) {
         this.resource = resource;
+        this.searchName = searchName;
     }
 
     public LoadServiceResource getResource() {
@@ -60,6 +62,12 @@ public class JarredScript implements Library {
             runtime.getJRubyClassLoader().addURL(jarFile);
         } catch (IOException e) {
             throw runtime.newIOErrorFromException(e);
+        }
+
+        // If an associated Service library exists, load it as well
+        ClassExtensionLibrary serviceExtension = ClassExtensionLibrary.tryFind(runtime, searchName);
+        if (serviceExtension != null) {
+          serviceExtension.load(runtime, wrap);
         }
     }
 }

--- a/core/src/main/java/org/jruby/runtime/load/LoadService.java
+++ b/core/src/main/java/org/jruby/runtime/load/LoadService.java
@@ -1080,7 +1080,7 @@ public class LoadService {
                 throw runtime.newLoadError("C extensions are disabled, can't load `" + resource.getName() + "'", resource.getName());
             }
         } else if (file.endsWith(".jar")) {
-            return new JarredScript(resource);
+            return new JarredScript(resource, state.searchFile);
         } else if (file.endsWith(".class")) {
             return new JavaCompiledScript(resource);
         } else {


### PR DESCRIPTION
Fixed: https://github.com/jruby/jruby/issues/2055

Note that the logic added to JarredScript is almost identical to logic in LibrarySearcher when dealing with loading a jar file (https://github.com/jruby/jruby/blob/jruby-1_7/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java#L309)

It may make sense to see if the logic can be combined. On other hand, since mkristian is pretty close to killing findLibraryWithClassloaders in master, maybe the effort is not necessary.
