### PR TITLE
Fix jar loading test in test/test_file.rb

### DIFF
--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -528,7 +528,7 @@ class TestFile < Test::Unit::TestCase
         assert $LOADED_FEATURES.pop =~ /foo\.rb$/
       end
 
-      with_load_path(File.expand_path("test/dir with spaces/test_jar.jar")) do
+      with_load_path(File.expand_path("test/dir with spaces/test_jar.jar!/")) do
         assert require('abc/foo')
         assert $LOADED_FEATURES.pop =~ /foo\.rb$/
       end


### PR DESCRIPTION
This is a similar fix as for: https://github.com/jruby/jruby/commit/ed0b7ab1dfa76dee16ecfacbd07624a55b264c69

Generally, the workflow of adding foo/bar.jar to $LOAD_PATH and then expecting require 'bar' to load foo/bar.jar!/bar.rb doesn't work anymore. Instead, if you want it to search inside that jar, use foo/bar.jar!/
