### PR TITLE
Remove unnecessary puts for GC::Profiler.total_time

### DIFF
--- a/core/src/main/ruby/jruby/kernel/gc.rb
+++ b/core/src/main/ruby/jruby/kernel/gc.rb
@@ -224,8 +224,6 @@ module GC
             duration = 0
 
             @gc_listener.lines.each_with_index do |line, i|
-              puts HEADER if i % 20 == 0
-
               gc_notification = com.sun.management.GarbageCollectionNotificationInfo.from(line.user_data)
               gc_info = gc_notification.gc_info
 


### PR DESCRIPTION
Calling `GC::Profiler.total_time` dumps the headers used by `GC::Profiler.result` when the `GC::Profiler::NotifiedProfiler` is being used. Given the method doesn't dump anything, it looks like this isn't needed and could be dropped.