### PR TITLE
added String#b method

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -7765,4 +7765,13 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
 
         return cr2;
     }
+    
+    @JRubyMethod(name ="b", compat = RUBY2_0)
+    public IRubyObject b(ThreadContext context) {
+      Encoding encoding = ASCIIEncoding.INSTANCE;
+      RubyString dup = (RubyString)dup();
+      dup.associateEncoding(encoding);
+      dup.clearCodeRange();
+      return dup;
+    }
 }


### PR DESCRIPTION
This missing method is a problem for simple WEBrick apps.  For example:

``` sh-session
$ cat config.ru
ruby_info = `ruby -v`
run Proc.new {|env| [200, {"Content-Type" => "text/plain"}, [ruby_info]]}

$ JRUBY_OPTS=--2.0 bundle exec backup
file:/Users/jkutner/.rvm/rubies/jruby-1.7.17/lib/jruby.jar!/jruby/kernel19/kernel.rb:28 warning: unsupported exec option: close_others
[2014-12-15 17:04:48] INFO  WEBrick 1.3.1
[2014-12-15 17:04:48] INFO  ruby 2.0.0 (2014-12-09) [java]
[2014-12-15 17:04:48] INFO  WEBrick::HTTPServer#start: pid=24489 port=9292
[2014-12-15 17:05:06] ERROR bad URI `/'.
[2014-12-15 17:05:06] ERROR NoMethodError: undefined method `b' for "Bad Request":String
    /Users/jkutner/.rvm/rubies/jruby-1.7.17/lib/ruby/2.0/webrick/htmlutils.rb:19:in `escape'
    /Users/jkutner/.rvm/rubies/jruby-1.7.17/lib/ruby/2.0/webrick/httpresponse.rb:356:in `set_error'
    /Users/jkutner/.rvm/rubies/jruby-1.7.17/lib/ruby/2.0/webrick/httpserver.rb:99:in `run'
    /Users/jkutner/.rvm/rubies/jruby-1.7.17/lib/ruby/2.0/webrick/server.rb:295:in `start_thread'
```

This shouldn't be used by any one in production -- I only ran into it during a test. But I guess it could happen for someone trying to get started with JRuby
