### PR TITLE
Implicit type conversion error + String#start_with? and #end_with? error

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -4147,9 +4147,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     }
 
     private boolean start_with_pCommon(IRubyObject arg) {
-        IRubyObject tmp = arg.checkStringType();
-        if (tmp.isNil()) return false;
-        RubyString otherString = (RubyString)tmp;
+        RubyString otherString = arg.convertToString();
         checkEncoding(otherString);
         if (value.getRealSize() < otherString.value.getRealSize()) return false;
         return value.startsWith(otherString.value);
@@ -4174,9 +4172,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     }
 
     private boolean end_with_pCommon(IRubyObject arg) {
-        IRubyObject tmp = arg.checkStringType();
-        if (tmp.isNil()) return false;
-        RubyString otherString = (RubyString)tmp;
+        RubyString otherString = arg.convertToString();
         int otherLength = otherString.value.getRealSize();
         Encoding enc = checkEncoding(otherString);
         if (value.getRealSize() < otherLength) return false;


### PR DESCRIPTION
As of 2.0, MRI raises "no implicit conversion..." `TypeError` in certain situations. I've tried to make respective changes to `TypeConverter`. While not being sure it's 100%  right, at least the following also seems to behave correctly with the patch.
```bash
$ rbenv shell 2.0.0-p598
$ ruby -e '"a" + 1'
no implicit conversion of Fixnum into String (TypeError)

$ rbenv shell jruby-9.0.0.0-dev
$ ruby -e '"a" + 1'
TypeError: can't convert Fixnum into String
```
The String part addresses then `test_start_with?`and `test_end_with?` in test_string.rb