### PR TITLE
Fix for issue 1675 on jruby-1_7: String#casecmp on UTF-16LE encoded string

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1674,7 +1674,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
             }
 
             int cl, ocl;
-            if (Encoding.isAscii(c) && Encoding.isAscii(oc)) {
+            if (enc.isAsciiCompatible() && Encoding.isAscii(c) && Encoding.isAscii(oc)) {
                 byte uc = AsciiTables.ToUpperCaseTable[c];
                 byte uoc = AsciiTables.ToUpperCaseTable[oc];
                 if (uc != uoc) {

--- a/core/src/main/java/org/jruby/util/StringSupport.java
+++ b/core/src/main/java/org/jruby/util/StringSupport.java
@@ -352,7 +352,7 @@ public final class StringSupport {
 
     public static int preciseCodePoint(Encoding enc, byte[]bytes, int p, int end) {
         int l = preciseLength(enc, bytes, p, end);
-        if (l > 0) enc.mbcToCode(bytes, p, end);
+        if (l > 0) return enc.mbcToCode(bytes, p, end);
         return -1;
     }
 

--- a/spec/regression/GH-1675_casecmp_on_UTF16LE_encoded_string_spec.rb
+++ b/spec/regression/GH-1675_casecmp_on_UTF16LE_encoded_string_spec.rb
@@ -1,0 +1,19 @@
+# https://github.com/jruby/jruby/issues/1675
+if RUBY_VERSION > '1.9'
+  describe 'String#casecmp' do
+    it 'returns correct value' do
+      Encoding.name_list.each do |enc_name|
+        if (enc_name != "UTF-7") && (enc_name != "CP65000")
+          # this condition statement escape the following error:
+          # Encoding::ConverterNotFoundError: 
+          # code converter not found for UTF-7
+
+          # using "UTF-16LE", "UTF-8", "Shift_JIS", and other available encodings
+          a = 'ABC'.encode(enc_name)
+          b = 'ABC'.encode(enc_name)
+          b.casecmp(a).should be_true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit fixes issue #1675 on jruby-1_7 branch. I wrote a rspec test using the available encodings in addition to UTF-16LE. See *GH-1675_casecmp_on_UTF16LE_encoded_string_spec.rb* for details.