### PR TITLE
(MAINT) Fix pom deps re: asm

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -98,7 +98,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-ffi</artifactId>
-      <version>2.0.0</version>
+      <version>2.0.1</version>
       <type>jar</type>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <ant.version>1.9.2</ant.version>
     <joda.time.version>2.5</joda.time.version>
     <jffi.version>1.2.7</jffi.version>
-    <asm.version>4.0</asm.version>
+    <asm.version>5.0.3</asm.version>
     <base.java.version>1.6</base.java.version>
     <base.javac.version>1.6</base.javac.version>
     <version.jruby>${project.version}</version.jruby>


### PR DESCRIPTION
Recent versions of JRuby core bumped their jnr-posix dependencies
to version 3.0.9, which has transitive dependencies on jnr-ffi 2.0.1
and asm-\* 5.0.3.  However, JRuby core was still expressing explicit
dependencies on jnr-ffi 2.0.0 and asm-\* 4.0.  These conflicting
dependencies cause build failures when used with tools that do
strict validation.
