### PR TITLE
(MAINT) fix jnr-constants version in pom

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-constants</artifactId>
-      <version>0.8.5</version>
+      <version>0.8.6</version>
       <type>jar</type>
     </dependency>
     <dependency>


### PR DESCRIPTION
jnr-posix 3.0.9 depends on jnr-constants 0.8.6, but jruby-core is still
specifying 0.8.5.