### PR TITLE
Module#include is public for a while now.

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2205,7 +2205,7 @@ public class RubyModule extends RubyObject {
     /** rb_mod_include
      *
      */
-    @JRubyMethod(name = "include", rest = true, visibility = PRIVATE)
+    @JRubyMethod(name = "include", rest = true, visibility = PUBLIC)
     public RubyModule include(IRubyObject[] modules) {
         ThreadContext context = getRuntime().getCurrentContext();
         // MRI checks all types first:


### PR DESCRIPTION
Could verify this by running:

    ruby -ve 'Module.new.include Module.new'

We should probably have a test for this somewhere.