### PR TITLE
Add --dev to the output of --help

### DIFF
--- a/core/src/main/java/org/jruby/util/cli/OutputStrings.java
+++ b/core/src/main/java/org/jruby/util/cli/OutputStrings.java
@@ -64,6 +64,7 @@ public class OutputStrings {
                 .append("  --client          use the non-optimizing \"client\" JVM\n")
                 .append("                      (improves startup; default)\n")
                 .append("  --server          use the optimizing \"server\" JVM (improves perf)\n")
+                .append("  --dev             prioritize startup time over long term performance\n")
                 .append("  --manage          enable remote JMX management and monitoring of the VM\n")
                 .append("                      and JRuby\n")
                 .append("  --headless        do not launch a GUI window, no matter what\n")


### PR DESCRIPTION
I don't know if not including `--dev` in the output when running `ruby --help` is an oversight or intentional. I didn't know about it before today, and a big part of that is that it's not shown when you run `ruby --help`.