### PR TITLE
Follow MRI implementation for RubyArray hash

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -666,13 +666,18 @@ public class RubyArray extends RubyObject implements List, RandomAccess {
             public IRubyObject call(IRubyObject obj, boolean recur) {
                 int begin = RubyArray.this.begin;
                 long h = realLength;
+                long n;
                 if (recur) {
                     h ^= RubyNumeric.num2long(invokedynamic(context, context.runtime.getArray(), HASH));
                 } else {
                     for (int i = begin; i < begin + realLength; i++) {
-                        h = (h << 1) | (h < 0 ? 1 : 0);
                         final IRubyObject value = safeArrayRef(values, i);
-                        h ^= RubyNumeric.num2long(invokedynamic(context, value, HASH));
+                        n = getRuntime().isSiphashEnabled() ? SipHashInline.hash24(
+                                getRuntime().getHashSeedK0(), 0,
+                                value.toString().getBytes(), begin, realLength) :
+                                PerlHash.hash(getRuntime().getHashSeedK0(),
+                                value.toString().getBytes(), begin, realLength);
+                        h ^= n;
                     }
                 }
                 return getRuntime().newFixnum(h);


### PR DESCRIPTION
This fixes #2437 and follows MRI approach for RubyArray hash method,  however for consistency across the codebase I have made use of SipHashInline and PerlHash unlike MRI which makes use of MurMurHash. 