### PR TITLE
No need to synchronise a newly created local RubyArray

### DIFF
--- a/core/src/main/java/org/jruby/RubyThreadGroup.java
+++ b/core/src/main/java/org/jruby/RubyThreadGroup.java
@@ -145,13 +145,14 @@ public class RubyThreadGroup extends RubyObject {
     @JRubyMethod
     public IRubyObject list(Block block) {
         RubyArray ary = RubyArray.newArray(getRuntime());
-        for (RubyThread thread : rubyThreadList) {
-            if (thread != null) {
-                ary.append(thread);
+        synchronized (rubyThreadList) {
+            for (RubyThread thread : rubyThreadList) {
+                if (thread != null) {
+                    ary.append(thread);
+                }
             }
         }
         return ary;
-
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyThreadGroup.java
+++ b/core/src/main/java/org/jruby/RubyThreadGroup.java
@@ -145,14 +145,13 @@ public class RubyThreadGroup extends RubyObject {
     @JRubyMethod
     public IRubyObject list(Block block) {
         RubyArray ary = RubyArray.newArray(getRuntime());
-            synchronized (ary) {
-            for (RubyThread thread : rubyThreadList) {
-                if (thread != null) {
-                    ary.append(thread);
-                }
+        for (RubyThread thread : rubyThreadList) {
+            if (thread != null) {
+                ary.append(thread);
             }
-            return ary;
         }
+        return ary;
+
     }
 
     /**


### PR DESCRIPTION
Possibly fixes #2446, we don't need synchronise for a locally created RubyArray .