### PR TITLE
Made changes to RubyArray hash to not use PerlHash/SipHash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
 
 jdk:
   - openjdk7
-  - oraclejdk8
+#  - oraclejdk8
 
 os:
   - linux

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -58,10 +58,8 @@ import org.jruby.runtime.marshal.MarshalStream;
 import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.util.ByteList;
 import org.jruby.util.Pack;
-import org.jruby.util.PerlHash;
 import org.jruby.util.Qsort;
 import org.jruby.util.RecursiveComparator;
-import org.jruby.util.SipHashInline;
 import org.jruby.util.TypeConverter;
 
 import java.io.IOException;

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -668,13 +668,14 @@ public class RubyArray extends RubyObject implements List, RandomAccess {
             public IRubyObject call(IRubyObject obj, boolean recur) {
                 int begin = RubyArray.this.begin;
                 long h = realLength;
+                h ^= System.identityHashCode(getRuntime());
+                long n;
                 if (recur) {
                     h ^= RubyNumeric.num2long(invokedynamic(context, context.runtime.getArray(), HASH));
                 } else {
                     for (int i = begin; i < begin + realLength; i++) {
-                        h = (h << 1) | (h < 0 ? 1 : 0);
-                        final IRubyObject value = safeArrayRef(values, i);
-                        h ^= RubyNumeric.num2long(invokedynamic(context, value, HASH));
+                        n = RubyHash.hashValue(safeArrayRef(values, i).hashCode());
+                        h ^= n;
                     }
                 }
                 return getRuntime().newFixnum(h);


### PR DESCRIPTION
Fixes #2437, this time I have used RubyHash.hashValue with identityHash as salt to replicate what MRI does, hopefully hashValue is similar to MRI's rb_hash function (https://github.com/ruby/ruby/blob/7e8795e3935c9cbf4fe9ed24872a49d31a3a33cf/hash.c#L110).

Let me know if this works.
