### PR TITLE
Fixed yielded arrays of 1 element bug when using Enumerator#first

### DIFF
--- a/core/src/main/java/org/jruby/RubyYielder.java
+++ b/core/src/main/java/org/jruby/RubyYielder.java
@@ -103,6 +103,10 @@ public class RubyYielder extends RubyObject {
 
     @JRubyMethod(name = "<<", rest = true)
     public IRubyObject op_lshift(ThreadContext context, IRubyObject[]args) {
+        if (args.length == 1 &&
+                args[0] instanceof RubyArray &&
+                ((RubyArray) args[0]).getLength() == 1)
+            args[0] = RubyArray.newArray(context.runtime, args[0]);
         yield(context, args);
         return this;
     }


### PR DESCRIPTION
Fixes an old issue #2376 with RubyYielder class.

This fix passes Rubyspecs and MRI specs, however let me know if there any changes required.