### PR TITLE
Improved String#to_i performance for base <= 10 

### DIFF
--- a/core/src/main/java/org/jruby/util/ConvertBytes.java
+++ b/core/src/main/java/org/jruby/util/ConvertBytes.java
@@ -619,10 +619,13 @@ public class ConvertBytes {
             return runtime.newFixnum(0);
         }
 
-        len *= (end-str);
+        if (base <= 10) {
+            len *= (trailingLength());
+        } else {
+            len *= (end-str);
+        }
 
         //System.err.println(" main/len=" + len);
-
         if(len < Long.SIZE-1) {
             int[] endPlace = new int[]{str};
             long val = stringToLong(str, endPlace, base);
@@ -651,6 +654,15 @@ public class ConvertBytes {
             }
         }
         return bigParse(len, sign);
+    }
+
+    private int trailingLength() {
+        int newLen = 0;
+        for (int i=str; i < end; i++) {
+            if (Character.isDigit(data[i])) newLen++;
+            else return newLen;
+        }
+        return newLen;
     }
 
     private RubyInteger bigParse(int len, boolean sign) {


### PR DESCRIPTION
Addresses issue #2360 for base <= 10, both MRI and Rubyspecs test suites pass.

Running the benchmark provided without the patch

```
Calculating -------------------------------------
#to_i with an integer in a string
                       141.004k i/100ms
#to_i with a float in a string
                       157.672k i/100ms
#to_i with an empty string
                       172.789k i/100ms
#to_i with an integer and extra text
                       134.750k i/100ms
-------------------------------------------------
#to_i with an integer in a string
                         17.907M (±17.1%) i/s -     86.153M
#to_i with a float in a string
                         14.668M (±12.6%) i/s -     72.056M
#to_i with an empty string
                         32.909M (±24.9%) i/s -    153.437M
#to_i with an integer and extra text
                          7.122M (±11.9%) i/s -     34.900M
```

Running with the patch

```
Calculating -------------------------------------
#to_i with an integer in a string
                       124.910k i/100ms
#to_i with a float in a string
                       153.217k i/100ms
#to_i with an empty string
                       162.923k i/100ms
#to_i with an integer and extra text
                       151.294k i/100ms
-------------------------------------------------
#to_i with an integer in a string
                         18.690M (±14.5%) i/s -     90.810M
#to_i with a float in a string
                         14.590M (±14.2%) i/s -     71.093M
#to_i with an empty string
                         38.312M (±18.8%) i/s -    184.103M
#to_i with an integer and extra text
                         14.730M (±13.8%) i/s -     72.016M
```