### PR TITLE
Implemented Enumerator#feed method

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -490,7 +490,7 @@ public class RubyEnumerator extends RubyObject {
     @JRubyMethod(name = "next_values")
     public synchronized IRubyObject nextValues(ThreadContext context) {
         ensureNexter(context);
-
+        if (!feedValue.isNil()) feedValue = context.runtime.getNil();
         return RubyArray.newArray(context.runtime, nexter.next());
     }
 

--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -257,15 +257,16 @@ public class RubyEnumerator extends RubyObject {
     }
 
     private IRubyObject initialize20(IRubyObject object, IRubyObject method, IRubyObject[] methodArgs, IRubyObject size, SizeFn sizeFn) {
+        final Ruby runtime = getRuntime();
         this.object = object;
         this.method = method.asJavaString();
         this.methodArgs = methodArgs;
         this.size = size;
         this.sizeFn = sizeFn;
-        this.feedValue = getRuntime().getNil();
+        this.feedValue = runtime.getNil();
         setInstanceVariable("@__object__", object);
         setInstanceVariable("@__method__", method);
-        setInstanceVariable("@__args__", RubyArray.newArrayNoCopyLight(getRuntime(), methodArgs));
+        setInstanceVariable("@__args__", RubyArray.newArrayNoCopyLight(runtime, methodArgs));
         return this;
     }
 
@@ -278,8 +279,8 @@ public class RubyEnumerator extends RubyObject {
         copy.method     = this.method;
         copy.methodArgs = this.methodArgs;
         copy.size       = this.size;
-        copy.sizeFn       = this.sizeFn;
-        copy.feedValue = getRuntime().getNil();
+        copy.sizeFn     = this.sizeFn;
+        copy.feedValue  = getRuntime().getNil();
         return copy;
     }
 
@@ -456,8 +457,7 @@ public class RubyEnumerator extends RubyObject {
     @JRubyMethod
     public synchronized IRubyObject next(ThreadContext context) {
         ensureNexter(context);
-
-        if (!feedValue.isNil()) feedValue = context.runtime.getNil();
+        if (!feedValue.isNil()) feedValue = context.nil;
         return nexter.next();
     }
     
@@ -490,19 +490,19 @@ public class RubyEnumerator extends RubyObject {
     @JRubyMethod(name = "next_values")
     public synchronized IRubyObject nextValues(ThreadContext context) {
         ensureNexter(context);
-        if (!feedValue.isNil()) feedValue = context.runtime.getNil();
+        if (!feedValue.isNil()) feedValue = context.nil;
         return RubyArray.newArray(context.runtime, nexter.next());
     }
 
     @JRubyMethod
     public IRubyObject feed(ThreadContext context, IRubyObject val) {
         ensureNexter(context);
-        if (!feedValue.isNil())
-            throw getRuntime().newTypeError("feed value already set");
-
+        if (!feedValue.isNil()) {
+            throw context.runtime.newTypeError("feed value already set");
+        }
         feedValue = val;
         nexter.setFeedValue(val);
-        return getRuntime().getNil();
+        return context.nil;
     }
 
     private void ensureNexter(ThreadContext context) {


### PR DESCRIPTION
This PR implements Enumerator#feed and addresses #1571.  However the behaviour is not same as MRI because of the difference in implementation of next in JRuby and MRI.

Here is an example to demonstrate the difference,

**MRI**

```Ruby
a = [1, 2, 3]
m = a.to_enum(:map!)

m.next # a -> [1, 2, 3], returns 1
m.next # a -> [nil, 2, 3], returns 2
m.next # a -> [nil, nil, 3], returns 3
m.next # a -> [nil, nil, nil],  throws StopIteration exception and calls the yield/method

```

**JRuby**

```Ruby
a = [1, 2, 3]
m = a.to_enum(:map!)

m.next # a -> [nil, 2, 3], returns 1
m.next # a -> [nil, nil, 3], returns 2
m.next # a -> [nil, nil, nil], returns 3
m.next # a -> [nil, nil, nil],  throws StopIteration exception and doesn't call yield/method

```

So basically when you call next first time in MRI, it actually initialises the block but doesn't call it yet unlike JRuby. 

So because of this I haven't included test_feed specs in TestEnumerable (test:mri), as they fail because of the different order of evaluation of yield/method.

Though this PR does implement feed correctly for JRuby's next implementation, so I am raising it.