### PR TITLE
Fix ascii-only detection of symbol names.

### DIFF
--- a/core/src/main/java/org/jruby/ast/SymbolNode.java
+++ b/core/src/main/java/org/jruby/ast/SymbolNode.java
@@ -32,7 +32,6 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby.ast;
 
-import java.awt.image.ByteLookupTable;
 import java.util.List;
 
 import org.jcodings.Encoding;
@@ -44,10 +43,8 @@ import org.jruby.ast.types.ILiteralNode;
 import org.jruby.ast.types.INameNode;
 import org.jruby.ast.visitor.NodeVisitor;
 import org.jruby.lexer.yacc.ISourcePosition;
-import org.jruby.runtime.Block;
-import org.jruby.runtime.ThreadContext;
-import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
+import org.jruby.util.StringSupport;
 
 /**
  * Represents a symbol (:symbol_name).
@@ -68,7 +65,7 @@ public class SymbolNode extends Node implements ILiteralNode, INameNode {
         super(position);
         this.name = value.toString().intern();
         // FIXME: A full scan to determine whether we should back off to US-ASCII.  Lexer should just do this properly.
-        if (value.lengthEnc() == value.length()) {
+        if (value.getEncoding().isAsciiCompatible() && StringSupport.codeRangeScan(value.getEncoding(), value) == StringSupport.CR_7BIT) {
             this.encoding = USASCIIEncoding.INSTANCE;
         } else {
             this.encoding = value.getEncoding();


### PR DESCRIPTION
If you run the issue described in #1328 with `-J-Dfile.encoding=CP1252`
then the string length comparison fails. This smoothes over the issue,
but it is still possible that there are problems with bytes being read
with the JVM's file.encoding rather than the encoding specified in the
magic comment.

Closes #1328
