### PR TITLE
Move methods from BasicObject to Object

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -1024,15 +1024,6 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         return getRuntime().newFixnum(getObjectId());
     }
 
-    /** rb_obj_itself
-     *
-     * Identity method for the object.
-     */
-    @JRubyMethod
-    public IRubyObject itself() {
-        return this;
-    }
-
     /**
      * The logic here is to use the special objectId accessor slot from the
      * parent as a lazy store for an object ID. IDs are generated atomically,

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -2035,15 +2035,6 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         return respond;
     }
 
-    /** rb_obj_id_obsolete
-     *
-     * Old id version. This one is bound to the "id" name and will emit a deprecation warning.
-     */
-    public IRubyObject id_deprecated() {
-        getRuntime().getWarnings().warn(ID.DEPRECATED_METHOD, "Object#id will be deprecated; use Object#object_id");
-        return id();
-    }
-
     /** rb_obj_id
      *
      * Will return the hash code of this object. In comparison to MRI,

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -1018,7 +1018,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      *
      * Return the internal id of an object.
      */
-    @JRubyMethod(name = {"object_id", "__id__"})
+    @JRubyMethod(name = "__id__")
     @Override
     public IRubyObject id() {
         return getRuntime().newFixnum(getObjectId());

--- a/core/src/main/java/org/jruby/RubyObject.java
+++ b/core/src/main/java/org/jruby/RubyObject.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ClassIndex;
@@ -318,6 +319,15 @@ public class RubyObject extends RubyBasicObject {
      */
     public static void puts(Object obj) {
         System.out.println(obj.toString());
+    }
+
+    /** rb_obj_itself
+     *
+     * Identity method for the object.
+     */
+    @JRubyMethod
+    public IRubyObject itself() {
+        return this;
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyObject.java
+++ b/core/src/main/java/org/jruby/RubyObject.java
@@ -321,6 +321,16 @@ public class RubyObject extends RubyBasicObject {
         System.out.println(obj.toString());
     }
 
+    /** rb_obj_id
+     *
+     * Return the internal id of an object.
+     */
+    @JRubyMethod(name = "object_id")
+    @Override
+    public IRubyObject id() {
+        return super.id();
+    }
+
     /** rb_obj_itself
      *
      * Identity method for the object.

--- a/test/jruby/test_object_id.rb
+++ b/test/jruby/test_object_id.rb
@@ -1,11 +1,18 @@
 require 'test/unit'
 
 class TestObjectId < Test::Unit::TestCase
+  def test_basic_object_does_not_respond_to_object_id
+    o = BasicObject.new
+
+    o.__id__
+    assert_raises(NoMethodError) { o.object_id }
+  end
+
   def test_dup_object_gets_new_object_id
     o = Object.new
-    o.__id__
+    o.object_id
     o.instance_variable_set(:@foo, "foo")
 
-    assert_not_equal o.__id__, o.dup.__id__
+    assert_not_equal o.object_id, o.dup.object_id
   end
 end


### PR DESCRIPTION
In the process of debugging an [unrelated issue](https://github.com/avdi/naught/issues/65#issuecomment-71541149), I came across an inconsistency between JRuby and CRuby: the `#itself` and `#object_id` methods are defined on `BasicObject` instead of `Object`.

# WARNING #

![i-have-no-idea-what-im-doing-5](https://cloud.githubusercontent.com/assets/10308/5910159/2ff90322-a56c-11e4-892d-f82bce9ae25d.jpg)

I am not an expert :coffee: programmer nor am I particularly familiar with the JRuby codebase, however I’ve made an attempt to fix this issue myself, as it appears to be mostly a :scissors: and :spaghetti: job.

I’ve also attempted to add a test to prevent this behavior from regressing, however I may have put it in the wrong place, as JRuby appears to have multiple test suites.

I’ve also taken the liberty to remove the `Object#id` method, which was deprecated when Ruby 1.9 was released and removed from CRuby in version 1.9.3.