### PR TITLE
Fixed a bug with local_variables ordering and duplicate variables

### DIFF
--- a/test/mri/excludes/TestVariable.rb
+++ b/test/mri/excludes/TestVariable.rb
@@ -1,4 +1,2 @@
 exclude :test_global_variable_0, "needs investigation"
-exclude :test_shadowing_local_variables, "#2129"
-exclude :test_shadowing_block_local_variables, "#2129"
 exclude :test_variable, "needs investigation"


### PR DESCRIPTION
Fixes #2129 by removing the duplicate variables and matching the order across different scopes to MRI.