### PR TITLE
Forgot to match the order of JRuby local variables spec to MRI

### DIFF
--- a/test/jruby/test_kernel.rb
+++ b/test/jruby/test_kernel.rb
@@ -269,9 +269,9 @@ class TestKernel < Test::Unit::TestCase
   def test_local_variables
     if RbConfig::CONFIG['ruby_install_name'] == 'jruby'
       a = lambda do
-        assert_equal [:a, :b], local_variables
+        assert_equal [:b, :a], local_variables
         b = 1
-        assert_equal [:a, :b], local_variables
+        assert_equal [:b, :a], local_variables
       end
       a.call
     else


### PR DESCRIPTION
Opening a new PR since last one was merged, but this fixes the order to match MRI.