### PR TITLE
[Truffle] deduplicate getKeywordsHash into RubyArguments

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/nodes/methods/arguments/ReadKeywordArgumentNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/methods/arguments/ReadKeywordArgumentNode.java
@@ -35,7 +35,7 @@ public class ReadKeywordArgumentNode extends RubyNode {
     public Object execute(VirtualFrame frame) {
         notDesignedForCompilation();
 
-        final RubyHash hash = getKeywordsHash(frame);
+        final RubyHash hash = RubyArguments.getUserKeywordsHash(frame.getArguments(), minimum);
 
         if (hash == null) {
             return defaultValue.execute(frame);
@@ -55,20 +55,6 @@ public class ReadKeywordArgumentNode extends RubyNode {
         }
 
         return value;
-    }
-
-    private RubyHash getKeywordsHash(VirtualFrame frame) {
-        if (RubyArguments.getUserArgumentsCount(frame.getArguments()) <= minimum) {
-            return null;
-        }
-
-        final Object lastArgument = RubyArguments.getUserArgument(frame.getArguments(), RubyArguments.getUserArgumentsCount(frame.getArguments()) - 1);
-
-        if (lastArgument instanceof RubyHash) {
-            return (RubyHash) lastArgument;
-        }
-
-        return null;
     }
 
 }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/methods/arguments/ReadKeywordRestArgumentNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/methods/arguments/ReadKeywordRestArgumentNode.java
@@ -36,7 +36,7 @@ public class ReadKeywordRestArgumentNode extends RubyNode {
     public Object execute(VirtualFrame frame) {
         notDesignedForCompilation();
 
-        final RubyHash hash = getKeywordsHash(frame);
+        final RubyHash hash = RubyArguments.getUserKeywordsHash(frame.getArguments(), minimum);
 
         if (hash == null) {
             return new RubyHash(getContext().getCoreLibrary().getHashClass(), null, null, null, 0, null);
@@ -55,22 +55,6 @@ public class ReadKeywordRestArgumentNode extends RubyNode {
         }
 
         return HashOperations.verySlowFromEntries(getContext(), entries);
-    }
-
-    private RubyHash getKeywordsHash(VirtualFrame frame) {
-        // TODO(CS): duplicated in ReadKeywordArgumentNode
-
-        if (RubyArguments.getUserArgumentsCount(frame.getArguments()) <= minimum) {
-            return null;
-        }
-
-        final Object lastArgument = RubyArguments.getUserArgument(frame.getArguments(), RubyArguments.getUserArgumentsCount(frame.getArguments()) - 1);
-
-        if (lastArgument instanceof RubyHash) {
-            return (RubyHash) lastArgument;
-        }
-
-        return null;
     }
 
 }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/RubyArguments.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/RubyArguments.java
@@ -13,6 +13,7 @@ import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 
+import org.jruby.truffle.runtime.core.RubyHash;
 import org.jruby.truffle.runtime.core.RubyProc;
 import org.jruby.truffle.runtime.methods.MethodLike;
 import org.jruby.truffle.runtime.util.ArrayUtils;
@@ -83,6 +84,22 @@ public final class RubyArguments {
 
     public static Object getUserArgument(Object[] internalArguments, int index) {
         return internalArguments[RUNTIME_ARGUMENT_COUNT + index];
+    }
+
+    public static RubyHash getUserKeywordsHash(Object[] internalArguments, int minArgumentCount) {
+        final int argumentCount = getUserArgumentsCount(internalArguments);
+
+        if (argumentCount <= minArgumentCount) {
+            return null;
+        }
+
+        final Object lastArgument = getUserArgument(internalArguments, argumentCount - 1);
+
+        if (lastArgument instanceof RubyHash) {
+            return (RubyHash) lastArgument;
+        }
+
+        return null;
     }
 
     public static MaterializedFrame getDeclarationFrame(Object[] arguments) {


### PR DESCRIPTION
To get to know the keyword implementation, I did a little bit clean up:

To reduce duplicate code between CheckArityNode, ReadKeywordArgumentNode,
ReadKeywordRestArgumentNode move the getKeywordsHash method into
RubyArguments - where all the other argument helper functions live.