### PR TITLE
[Truffle] Fix null FrameSlot when kwarg is not used

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/translator/LoadArgumentsTranslator.java
+++ b/truffle/src/main/java/org/jruby/truffle/translator/LoadArgumentsTranslator.java
@@ -193,7 +193,7 @@ public class LoadArgumentsTranslator extends Translator {
         excludedKeywords.add(name);
 
         final RubyNode readNode = new ReadKeywordArgumentNode(context, sourceSection, required, name, defaultValue);
-        final FrameSlot slot = methodBodyTranslator.getEnvironment().getFrameDescriptor().findFrameSlot(name);
+        final FrameSlot slot = methodBodyTranslator.getEnvironment().getFrameDescriptor().findOrAddFrameSlot(name);
 
         return WriteLocalVariableNodeFactory.create(context, sourceSection, slot, readNode);
     }


### PR DESCRIPTION
When calling a method having a keyword argument that is not used in the method body the frame descriptor cannot find a frame slot and returns `null`.

Example:

```ruby
def method(a: 1)
end

method(a: 2)
```

With assertions enabled it returns the following:

```
> JAVA_OPTS="-ea" ./bin/jruby -X+T -e "def method(a: 1); end; method(a: 2)"
Truffle internal error: java.lang.AssertionError
java.lang.AssertionError
        at org.jruby.truffle.nodes.methods.locals.FrameSlotNode.<init>(FrameSlotNode.java:27)
        at org.jruby.truffle.nodes.methods.locals.WriteLocalVariableNode.<init>(WriteLocalVariableNode.java:25)
        at org.jruby.truffle.nodes.methods.locals.WriteLocalVariableNodeFactory$WriteLocalVariableBaseNode.<init>(WriteLocalVariableNodeFactory.java:81)
        at org.jruby.truffle.nodes.methods.locals.WriteLocalVariableNodeFactory$WriteLocalVariableUninitializedNode.<init>(WriteLocalVariableNodeFactory.java:180)
        at org.jruby.truffle.nodes.methods.locals.WriteLocalVariableNodeFactory$WriteLocalVariableUninitializedNode.create0(WriteLocalVariableNodeFactory.java:233)
        at org.jruby.truffle.nodes.methods.locals.WriteLocalVariableNodeFactory.create(WriteLocalVariableNodeFactory.java:64)
        at org.jruby.truffle.translator.LoadArgumentsTranslator.visitKeywordArgNode(LoadArgumentsTranslator.java:198)
        at org.jruby.truffle.translator.LoadArgumentsTranslator.visitKeywordArgNode(LoadArgumentsTranslator.java:36)
        at org.jruby.ast.KeywordArgNode.accept(KeywordArgNode.java:25)
        at org.jruby.truffle.translator.LoadArgumentsTranslator.visitArgsNode(LoadArgumentsTranslator.java:131)
        at org.jruby.truffle.translator.LoadArgumentsTranslator.visitArgsNode(LoadArgumentsTranslator.java:36)
        at org.jruby.ast.ArgsNode.accept(ArgsNode.java:168)
        at org.jruby.truffle.translator.MethodTranslator.compileFunctionNode(MethodTranslator.java:91)
        at org.jruby.truffle.translator.BodyTranslator.translateMethodDefinition(BodyTranslator.java:1036)
        at org.jruby.truffle.translator.BodyTranslator.visitDefnNode(BodyTranslator.java:1011)
        at org.jruby.truffle.translator.BodyTranslator.visitDefnNode(BodyTranslator.java:68)
        at org.jruby.ast.DefnNode.accept(DefnNode.java:56)
        at org.jruby.truffle.translator.BodyTranslator.visitNewlineNode(BodyTranslator.java:1961)
        at org.jruby.truffle.translator.BodyTranslator.visitNewlineNode(BodyTranslator.java:68)
        at org.jruby.ast.NewlineNode.accept(NewlineNode.java:71)
        at org.jruby.truffle.translator.BodyTranslator.visitBlockNode(BodyTranslator.java:309)
        at org.jruby.truffle.translator.BodyTranslator.visitBlockNode(BodyTranslator.java:68)
        at org.jruby.ast.BlockNode.accept(BlockNode.java:58)
        at org.jruby.truffle.translator.TranslatorDriver.parse(TranslatorDriver.java:154)
        at org.jruby.truffle.translator.TranslatorDriver.parse(TranslatorDriver.java:116)
        at org.jruby.truffle.runtime.RubyContext.execute(RubyContext.java:216)
        at org.jruby.truffle.runtime.RubyContext.load(RubyContext.java:183)
        at org.jruby.truffle.TruffleBridgeImpl.execute(TruffleBridgeImpl.java:176)
        at org.jruby.truffle.TruffleBridgeImpl.execute(TruffleBridgeImpl.java:155)
        at org.jruby.Ruby.runInterpreter(Ruby.java:856)
        at org.jruby.Ruby.runInterpreter(Ruby.java:870)
        at org.jruby.Ruby.runNormally(Ruby.java:766)
        at org.jruby.Ruby.runFromMain(Ruby.java:569)
        at org.jruby.Main.doRunFromMain(Main.java:404)
        at org.jruby.Main.internalRun(Main.java:299)
        at org.jruby.Main.run(Main.java:226)
        at org.jruby.Main.main(Main.java:198)
```

Without assertions it will end in a NullPointerException when trying to write the keyword argument to the frame as a local variable.

This patch simply changes `findFrameSlot` to `findOrAddFrameSlot` when transforming the AST to Truffle nodes. I did not (yet) found out why there is no slot.

I am not sure if there is no better solution. If you can point me somewhere else that would be great. Also what would be the best place to add a test for that if wanted?