### PR TITLE
Move #itself and #object_id from Object to Kernel

### DIFF
--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1948,6 +1948,11 @@ public class RubyKernel {
         return ((RubyBasicObject)self).instance_of_p(context, type);
     }
 
+    @JRubyMethod(name = "itself")
+    public static IRubyObject itself(IRubyObject self) {
+        return self;
+    }
+
     @JRubyMethod(name = {"kind_of?", "is_a?"}, required = 1)
     public static RubyBoolean kind_of_p(ThreadContext context, IRubyObject self, IRubyObject type) {
         return ((RubyBasicObject)self).kind_of_p(context, type);
@@ -1956,6 +1961,11 @@ public class RubyKernel {
     @JRubyMethod(name = "methods", optional = 1)
     public static IRubyObject methods19(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         return ((RubyBasicObject)self).methods19(context, args);
+    }
+
+    @JRubyMethod(name = "object_id")
+    public static IRubyObject object_id(IRubyObject self) {
+        return self.id();
     }
 
     @JRubyMethod(name = "public_methods", optional = 1)

--- a/core/src/main/java/org/jruby/RubyObject.java
+++ b/core/src/main/java/org/jruby/RubyObject.java
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.jruby.anno.JRubyClass;
-import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ClassIndex;
@@ -319,25 +318,6 @@ public class RubyObject extends RubyBasicObject {
      */
     public static void puts(Object obj) {
         System.out.println(obj.toString());
-    }
-
-    /** rb_obj_id
-     *
-     * Return the internal id of an object.
-     */
-    @JRubyMethod(name = "object_id")
-    @Override
-    public IRubyObject id() {
-        return super.id();
-    }
-
-    /** rb_obj_itself
-     *
-     * Identity method for the object.
-     */
-    @JRubyMethod
-    public IRubyObject itself() {
-        return this;
     }
 
     /**


### PR DESCRIPTION
[I was previously unaware](https://github.com/jruby/jruby/pull/2520) that Ruby does not define any methods directly on the `Object` class. [`Object` is merely `BasicObject` with `Kernel` mixed in.](https://twitter.com/sferik/status/560537968624951297)

This pull request makes this right.