### PR TITLE
Fix for issue 2524 on master: [BigDecimal] Loss of precision with different execution order 

### DIFF
--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -869,10 +869,16 @@ public class RubyBigDecimal extends RubyNumeric {
     }
     
     private IRubyObject op_quo19_20(ThreadContext context, IRubyObject other) {
-        RubyObject preciseOther = getVpValue19(context, other, true);
+        RubyBigDecimal preciseOther = getVpValue19(context, other, true);
         // regular division with some default precision
-        // TODO: proper algorithm to set the precision
-        return op_div(context, preciseOther, getRuntime().newFixnum(200));
+        // proper algorithm to set the precision
+        // the precision is multiple of 4
+        // and the precision is larger than len * 2
+        int len = value.precision() + preciseOther.value.precision();
+        int pow = len / 4;
+        int precision = (pow + 1) * 4 * 2;
+        
+        return op_div(context, preciseOther, getRuntime().newFixnum(precision));
     }
     
     public IRubyObject op_div(ThreadContext context, IRubyObject other) {
@@ -923,10 +929,9 @@ public class RubyBigDecimal extends RubyNumeric {
         // MRI behavior: "If digits is 0, the result is the same as the / operator."
         if (scale == 0) return op_quo(context, other);
 
-        // TODO: better algorithm to set precision needed
-        int prec = Math.max(200, scale);
+        MathContext mathContext = new MathContext(scale, getRoundingMode(context.runtime));
         return new RubyBigDecimal(context.runtime,
-                value.divide(val.value, new MathContext(prec, RoundingMode.HALF_UP))).setResult(scale);
+                value.divide(val.value, mathContext)).setResult(scale);
     }
     
     @JRubyMethod(name = "div")

--- a/spec/regression/GH-2524_bigdecimal_loss_of_precision_with_different_excution_order_spec.rb
+++ b/spec/regression/GH-2524_bigdecimal_loss_of_precision_with_different_excution_order_spec.rb
@@ -1,0 +1,12 @@
+require 'bigdecimal'
+
+# https://github.com/jruby/jruby/issues/2524
+describe 'BigDecimal precision test with different execution order' do
+  it 'returns same precision ' do
+    fraction = BigDecimal.new("0.0095") / 365 * BigDecimal.new(50_000)
+    r1 = fraction * BigDecimal.new(50_000) / BigDecimal.new(100_000)
+    r2 = fraction * (BigDecimal.new(50_000) / BigDecimal.new(100_000))
+    expect(r1).to eq(r2)
+  end
+end
+


### PR DESCRIPTION
This commit fixes issue #2524 on master.  Improved algorithm to set the precision of BigDecimal#op_quo19_20 method.