### PR TITLE
Minor fixes to Dir methods

### DIFF
--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -514,7 +514,9 @@ public class RubyDir extends RubyObject {
         Ruby runtime = getRuntime();
         StringBuilder part = new StringBuilder();
         String cname = getMetaClass().getRealClass().getName();
-        part.append("#<").append(cname).append(":").append(path.asJavaString()).append(">");
+        part.append("#<").append(cname).append(":");
+        if (path != null) { part.append(path.asJavaString()); }
+        part.append(">");
 
         return runtime.newString(part.toString());
     }
@@ -550,7 +552,7 @@ public class RubyDir extends RubyObject {
 
     @JRubyMethod(name = {"path", "to_path"})
     public IRubyObject path(ThreadContext context) {
-        return path.strDup(context.runtime);
+        return path == null ? context.runtime.getNil() : path.strDup(context.runtime);
     }
     
     @JRubyMethod

--- a/test/mri/excludes/TestDir.rb
+++ b/test/mri/excludes/TestDir.rb
@@ -1,8 +1,6 @@
-exclude :test_chdir, "needs investigation"
-exclude :test_dir_enc, "needs investigation"
-exclude :test_glob, "needs investigation"
+exclude :test_chdir, "uses user.home as a fallback home path"
+exclude :test_dir_enc, "second argument (hash with encoding) for Dir.open is not supported"
+exclude :test_glob, '\0 delimiter is not handled'
 exclude :test_glob_cases, "fails to return files with their correct casing (#2150)"
-exclude :test_home, "needs investigation"
-exclude :test_inspect, "needs investigation"
-exclude :test_path, "needs investigation"
+exclude :test_home, "uses user.home as a fallback home path"
 exclude :test_unknown_keywords, "https://github.com/jruby/jruby/issues/1368"


### PR DESCRIPTION
* Make Dir#inspect and Dir#path work with empty path.
* Remove redundant test exclusions and replace "needs investigation"
  with a proper description for others.