### PR TITLE
Re-enblig memory fences

### DIFF
--- a/core/src/main/java/org/jruby/util/unsafe/UnsafeHolder.java
+++ b/core/src/main/java/org/jruby/util/unsafe/UnsafeHolder.java
@@ -93,18 +93,15 @@ public final class UnsafeHolder {
     //// The following methods are Java8 only. They will throw undefined method errors if invoked without checking for fence support 
     
     public static void fullFence() {
-        // CS: Seems to cause problems when I build with Maven
-        //U.fullFence();
+        U.fullFence();
     }
     
     public static void loadFence() {
-        // CS: Seems to cause problems when I build with Maven
-        //U.loadFence();
+        U.loadFence();
     }
     
     public static void storeFence() {
-        // CS: Seems to cause problems when I build with Maven
-        //U.storeFence();
+        U.storeFence();
     }
 
 


### PR DESCRIPTION
It was breaking `StampedVariableAccessor`, resulting in
not sinchronized access to instance variables
when `StampedVariableAccessor` was used.