### PR TITLE
support for easy (Ruby) String to (Java) char conversion

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -106,7 +106,7 @@ import org.jruby.util.io.EncodingUtils;
 
 /**
  * Implementation of Ruby String class
- * 
+ *
  * Concurrency: no synchronization is required among readers, but
  * all users must synchronize externally with writers.
  *
@@ -128,20 +128,20 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     private volatile int shareLevel = SHARE_LEVEL_NONE;
 
     private ByteList value;
-    
+
     private static final String[][] opTable19 = {
-        { "+", "+(binary)" }, 
+        { "+", "+(binary)" },
         { "-", "-(binary)" }
     };
-    
+
     private static final String[][] opTable18 = {
         { "!", "!@" },
         { "~", "~@" },
-        { "+", "+(binary)" }, 
+        { "+", "+(binary)" },
         { "-", "-(binary)" },
-        { "+@", "+(unary)" }, 
+        { "+@", "+(unary)" },
         { "-@", "-(unary)" },
-        { "!", "!(unary)" }, 
+        { "!", "!(unary)" },
         { "~", "~(unary)" }
     };
 
@@ -253,7 +253,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
             } else {
                 setCodeRange(CR_7BIT);
             }
-        } else{ 
+        } else{
             if (value.getRealSize() == 0) {
                 setCodeRange(!enc.isAsciiCompatible() ? CR_VALID : CR_7BIT);
             }
@@ -284,7 +284,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     }
 
     // rb_enc_compatible
-    private Encoding isCompatibleWith(RubyString other) { 
+    private Encoding isCompatibleWith(RubyString other) {
         Encoding enc1 = value.getEncoding();
         Encoding enc2 = other.value.getEncoding();
 
@@ -316,14 +316,14 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     // rb_enc_check
     public final Encoding checkEncoding(RubyString other) {
         Encoding enc = isCompatibleWith(other);
-        if (enc == null) throw getRuntime().newEncodingCompatibilityError("incompatible character encodings: " + 
+        if (enc == null) throw getRuntime().newEncodingCompatibilityError("incompatible character encodings: " +
                                 value.getEncoding() + " and " + other.value.getEncoding());
         return enc;
     }
 
     final Encoding checkEncoding(EncodingCapable other) {
         Encoding enc = isCompatibleWith(other);
-        if (enc == null) throw getRuntime().newEncodingCompatibilityError("incompatible character encodings: " + 
+        if (enc == null) throw getRuntime().newEncodingCompatibilityError("incompatible character encodings: " +
                                 value.getEncoding() + " and " + other.getEncoding());
         return enc;
     }
@@ -380,7 +380,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     }
 
     /** short circuit for String key comparison
-     * 
+     *
      */
     @Override
     public final boolean eql(IRubyObject other) {
@@ -465,7 +465,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
      *  class like this String.
      *
      *  This method should be used to satisfy RCR #38.
-     *  @deprecated  
+     *  @deprecated
      */
     @Deprecated
     public RubyString newString(CharSequence s) {
@@ -499,7 +499,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     public static RubyString newStringLight(Ruby runtime, int size, Encoding encoding) {
         return new RubyString(runtime, runtime.getString(), new ByteList(size), encoding, false);
     }
-  
+
     public static RubyString newString(Ruby runtime, CharSequence str) {
         return new RubyString(runtime, runtime.getString(), str);
     }
@@ -511,7 +511,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     public static RubyString newUSASCIIString(Ruby runtime, String str) {
         return new RubyString(runtime, runtime.getString(), str, USASCIIEncoding.INSTANCE);
     }
-    
+
     public static RubyString newString(Ruby runtime, byte[] bytes) {
         return new RubyString(runtime, runtime.getString(), bytes);
     }
@@ -548,7 +548,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         ByteList byteList = new ByteList(RubyEncoding.encodeUTF16(str), UTF16BEEncoding.INSTANCE, false);
         return new RubyString(runtime, runtime.getString(), byteList);
     }
-    
+
     public static RubyString newUnicodeString(Ruby runtime, CharSequence str) {
         Encoding defaultInternal = runtime.getDefaultInternalEncoding();
         if (defaultInternal == UTF16BEEncoding.INSTANCE) {
@@ -597,13 +597,13 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         }
     }
 
-    // String construction routines by NOT byte[] buffer and making the target String shared 
+    // String construction routines by NOT byte[] buffer and making the target String shared
     public static RubyString newStringShared(Ruby runtime, RubyString orig) {
         orig.shareLevel = SHARE_LEVEL_BYTELIST;
         RubyString str = new RubyString(runtime, runtime.getString(), orig.value);
         str.shareLevel = SHARE_LEVEL_BYTELIST;
         return str;
-    }       
+    }
 
     public static RubyString newStringShared(Ruby runtime, ByteList bytes) {
         return newStringShared(runtime, runtime.getString(), bytes);
@@ -667,14 +667,14 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         return empty;
     }
 
-    // String construction routines by NOT byte[] buffer and NOT making the target String shared 
+    // String construction routines by NOT byte[] buffer and NOT making the target String shared
     public static RubyString newStringNoCopy(Ruby runtime, ByteList bytes) {
         return newStringNoCopy(runtime, runtime.getString(), bytes);
-    }    
+    }
 
     public static RubyString newStringNoCopy(Ruby runtime, RubyClass clazz, ByteList bytes) {
         return new RubyString(runtime, clazz, bytes);
-    }    
+    }
 
     public static RubyString newStringNoCopy(Ruby runtime, byte[] bytes, int start, int length) {
         return newStringNoCopy(runtime, new ByteList(bytes, start, length, false));
@@ -685,7 +685,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     }
 
     /** Encoding aware String construction routines for 1.9
-     * 
+     *
      */
     private static final class EmptyByteListHolder {
         final ByteList bytes;
@@ -747,7 +747,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         str.shareLevel = SHARE_LEVEL_BYTELIST;
         return str;
     }
-    
+
     public static RubyString newUsAsciiStringShared(Ruby runtime, byte[] bytes, int start, int length) {
         byte[] copy = new byte[length];
         System.arraycopy(bytes, start, copy, 0, length);
@@ -797,17 +797,17 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     }
 
     /** rb_str_dup
-     * 
+     *
      */
     @Deprecated
     public final RubyString strDup() {
         return strDup(getRuntime(), getMetaClass());
     }
-    
+
     public final RubyString strDup(Ruby runtime) {
         return strDup(runtime, getMetaClass());
     }
-    
+
     @Deprecated
     final RubyString strDup(RubyClass clazz) {
         return strDup(getRuntime(), getMetaClass());
@@ -818,17 +818,17 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         RubyString dup = new RubyString(runtime, clazz, value);
         dup.shareLevel = SHARE_LEVEL_BYTELIST;
         dup.flags |= flags & (CR_MASK | TAINTED_F | UNTRUSTED_F);
-        
+
         return dup;
     }
-    
+
     /* rb_str_subseq */
     public final RubyString makeSharedString(Ruby runtime, int index, int len) {
         return runtime.is1_9()
                 ? makeShared19(runtime, runtime.getString(), index, len)
                 : makeShared(runtime, runtime.getString(), index, len);
     }
-    
+
     public RubyString makeSharedString19(Ruby runtime, int index, int len) {
         return makeShared19(runtime, runtime.getString(), value, index, len);
     }
@@ -844,7 +844,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         if (len == 0) {
             shared = newEmptyString(runtime, meta);
         } else if (len == 1) {
-            shared = newStringShared(runtime, meta, 
+            shared = newStringShared(runtime, meta,
                     RubyInteger.SINGLE_CHAR_BYTELISTS[value.getUnsafeBytes()[value.getBegin() + index] & 0xff]);
         } else {
             if (shareLevel == SHARE_LEVEL_NONE) shareLevel = SHARE_LEVEL_BUFFER;
@@ -867,7 +867,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     private RubyString makeShared19(Ruby runtime, ByteList value, int index, int len) {
         return makeShared19(runtime, getType(), value, index, len);
     }
-    
+
     private RubyString makeShared19(Ruby runtime, RubyClass meta, ByteList value, int index, int len) {
         final RubyString shared;
         Encoding enc = value.getEncoding();
@@ -2401,7 +2401,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
             }
         }
         result.cat('"');
-        return result.infectBy(this);        
+        return result.infectBy(this);
     }
 
     @JRubyMethod(name = "inspect", compat = RUBY1_9)
@@ -2425,7 +2425,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         if (enc == encodings.get("UTF-16".getBytes()).getEncoding() && end - p > 1) {
             int c0 = bytes[p] & 0xff;
             int c1 = bytes[p + 1] & 0xff;
-            
+
             if (c0 == 0xFE && c1 == 0xFF) {
                 e = encodings.get("UTF-16BE".getBytes());
             } else if (c0 == 0xFF && c1 == 0xFE) {
@@ -2438,7 +2438,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
             int c1 = bytes[p + 1] & 0xff;
             int c2 = bytes[p + 2] & 0xff;
             int c3 = bytes[p + 3] & 0xff;
-            
+
             if (c0 == 0 && c1 == 0 && c2 == 0xFE && c3 == 0xFF) {
                 e = encodings.get("UTF-32BE".getBytes());
             } else if (c3 == 0 && c2 == 0 && c1 == 0xFE && c0 == 0xFF) {
@@ -2609,7 +2609,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
             long c = ((RubyBignum) other).getLongValue();
             return concatNumeric(runtime, (int) c);
         }
-        
+
         if (other instanceof RubySymbol) throw runtime.newTypeError("can't convert Symbol into String");
         return append19(other);
     }
@@ -2704,7 +2704,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     public IRubyObject sub_bang(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Block block) {
         return subBangNoIter(context, getQuotedPattern(arg0), arg1.convertToString());
     }
-    
+
     private IRubyObject subBangIter(ThreadContext context, Regex pattern, Block block) {
         int range = value.getBegin() + value.getRealSize();
         Matcher matcher = pattern.matcher(value.getUnsafeBytes(), value.getBegin(), range);
@@ -3133,9 +3133,9 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
             if (repl != null) {     // string given
                 val = RubyRegexp.regsub19(repl, this, matcher, pattern);
             } else {
-                final RubyString substr = makeShared19(runtime, begz, endz - begz);  
+                final RubyString substr = makeShared19(runtime, begz, endz - begz);
                 if (hash != null) { // hash given
-                    val = objAsString(context, hash.op_aref(context, substr)); 
+                    val = objAsString(context, hash.op_aref(context, substr));
                 } else {            // block given
                     match = RubyRegexp.createMatchData19(context, this, matcher, pattern);
                     match.regexp = regexp;
@@ -3262,7 +3262,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     public IRubyObject index19(ThreadContext context, IRubyObject arg0) {
         return indexCommon19(context.runtime, context, arg0, 0);
     }
-    
+
     @JRubyMethod(name = "index", reads = BACKREF, writes = BACKREF, compat = RUBY1_9)
     public IRubyObject index19(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
         int pos = RubyNumeric.num2int(arg1);
@@ -3281,7 +3281,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         if (sub instanceof RubyRegexp) {
             if (pos > strLength()) return context.nil;
             RubyRegexp regSub = (RubyRegexp) sub;
-            pos = singleByteOptimizable() ? pos : 
+            pos = singleByteOptimizable() ? pos :
                     StringSupport.nth(checkEncoding(regSub), value.getUnsafeBytes(), value.getBegin(),
                             value.getBegin() + value.getRealSize(),
                                       pos) - value.getBegin();
@@ -3353,7 +3353,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
                 if (arg0 instanceof RubyRegexp) context.setBackRef(runtime.getNil());
                 return runtime.getNil();
             }
-        }            
+        }
         if (pos > value.getRealSize()) pos = value.getRealSize();
         return rindexCommon(runtime, context, arg0, pos);
     }
@@ -3402,7 +3402,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
 
     private int strRindex(RubyString sub, int pos) {
         int subLength = sub.value.getRealSize();
-        
+
         /* substring longer than string */
         if (value.getRealSize() < subLength) return -1;
         if (value.getRealSize() - pos < subLength) pos = value.getRealSize() - subLength;
@@ -3426,7 +3426,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
                 if (arg0 instanceof RubyRegexp) context.setBackRef(runtime.getNil());
                 return runtime.getNil();
             }
-        }            
+        }
         if (pos > length) pos = length;
         return rindexCommon19(runtime, context, arg0, pos);
     }
@@ -3491,7 +3491,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     }
 
     /* rb_str_substr */
-    public final IRubyObject substr(Ruby runtime, int beg, int len) {    
+    public final IRubyObject substr(Ruby runtime, int beg, int len) {
         int length = value.length();
         if (len < 0 || beg > length) return runtime.getNil();
 
@@ -3509,7 +3509,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     /* str_byte_substr */
     private IRubyObject byteSubstr(Ruby runtime, int beg, int len) {
         int length = value.length();
-        
+
         if (len < 0 || beg > length) return runtime.getNil();
 
         if (beg < 0) {
@@ -3517,7 +3517,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
             if (beg < 0) return runtime.getNil();
         }
         if (beg + len > length) len = length - beg;
-            
+
         if (len <= 0) {
             len = 0;
         }
@@ -3542,11 +3542,11 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         if (obj.isNil() || ((RubyString)obj).getByteList().length() == 0) return runtime.getNil();
         return obj;
     }
-            
+
     public final IRubyObject substr19(Ruby runtime, int beg, int len) {
         if (len < 0) return runtime.getNil();
         int length = value.getRealSize();
-        if (length == 0) len = 0; 
+        if (length == 0) len = 0;
 
         Encoding enc = value.getEncoding();
         if (singleByteOptimizable(enc)) {
@@ -3607,7 +3607,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         } else if ((p = StringSupport.nth(enc, bytes, s, end, beg)) == end) {
             len = 0;
         } else {
-            len = StringSupport.offset(enc, bytes, p, end, len); 
+            len = StringSupport.offset(enc, bytes, p, end, len);
         }
         return makeShared19(runtime, p - s, len);
     }
@@ -3736,14 +3736,14 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     private void subpatSet(ThreadContext context, RubyRegexp regexp, int nth, IRubyObject repl) {
         Ruby runtime = context.runtime;
         IRubyObject[] holder = {context.nil};
-        
+
         int result = regexp.search(context, this, 0, false, holder);
         context.setBackRef(holder[0]);
-        
+
         if (result < 0) {
             throw runtime.newIndexError("regexp not matched");
         }
-        
+
         // this cast should be ok, since nil matchdata will be < 0 above
         RubyMatchData match = (RubyMatchData)holder[0];
 
@@ -3786,12 +3786,12 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     private void subpatSet19(ThreadContext context, RubyRegexp regexp, IRubyObject backref, IRubyObject repl) {
         Ruby runtime = context.runtime;
         IRubyObject[] holder = {context.nil};
-        
+
         int result = regexp.search19(context, this, 0, false, holder);
         context.setBackRef(holder[0]);
-        
+
         if (result < 0) throw runtime.newIndexError("regexp not matched");
-        
+
         // this cast should be ok, since nil matchdata will be < 0 above
         RubyMatchData match = (RubyMatchData)holder[0];
 
@@ -3815,28 +3815,28 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
 
     private IRubyObject subpat19(Ruby runtime, ThreadContext context, RubyRegexp regex, IRubyObject backref) {
         IRubyObject[] holder = {context.nil};
-        
+
         int result = regex.search19(context, this, 0, false, holder);
         context.setBackRef(holder[0]);
-        
+
         if (result >= 0) {
             RubyMatchData match = (RubyMatchData)holder[0];
             return RubyRegexp.nth_match(match.backrefNumber(backref), match);
         }
-        
+
         return runtime.getNil();
     }
 
     private IRubyObject subpat19(Ruby runtime, ThreadContext context, RubyRegexp regex) {
         IRubyObject[] holder = {context.nil};
-        
+
         int result = regex.search19(context, this, 0, false, holder);
         context.setBackRef(holder[0]);
-        
+
         if (result >= 0) {
             return RubyRegexp.nth_match(0, holder[0]);
         }
-        
+
         return runtime.getNil();
     }
 
@@ -3938,7 +3938,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         return beg >= 0 && len > 0 && (beg + len) == value.getRealSize();
     }
 
-    
+
     /**
      * Excises (removes) a slice of the string that starts at index zero
      *
@@ -3958,7 +3958,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         // just adjust the view length
         view(0, value.getRealSize() - len);
     }
-    
+
     /** rb_str_slice_bang
      *
      */
@@ -3977,7 +3977,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
                 beg = begLen[0];
                 len = begLen[1];
             }
-            
+
             if (isHeadSlice(beg, len)) {
                 exciseHead(len);
 
@@ -4059,7 +4059,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         int p = value.getBegin();
         int end = p + value.getRealSize();
         byte[]bytes = value.getUnsafeBytes();
-        
+
         for (int i = end - 1; i >= p; i--) {
             int c = bytes[i] & 0xff;
             if (ASCII.isAlnum(c)) {
@@ -4122,7 +4122,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
             }
         }
     }
-    
+
     private static NeighborChar predChar(Encoding enc, byte[]bytes, int p, int len) {
         while (true) {
             int i = len - 1;
@@ -4327,7 +4327,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
 
     @JRubyMethod(name = "upto", compat = RUBY1_9)
     public IRubyObject upto19(ThreadContext context, IRubyObject end, IRubyObject excl, Block block) {
-        return block.isGiven() ? uptoCommon19(context, end, excl.isTrue(), block) : 
+        return block.isGiven() ? uptoCommon19(context, end, excl.isTrue(), block) :
             enumeratorize(context.runtime, this, "upto", new IRubyObject[]{end, excl});
     }
 
@@ -4381,7 +4381,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
             IRubyObject[]args = new IRubyObject[2];
             args[0] = RubyFixnum.newFixnum(runtime, value.length());
             RubyArray argsArr = runtime.newArrayNoCopy(args);
-            
+
             if (b instanceof RubyFixnum && e instanceof RubyFixnum) {
                 int bi = RubyNumeric.fix2int(b);
                 int ei = RubyNumeric.fix2int(e);
@@ -4514,7 +4514,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     }
 
     /** rb_str_to_inum
-     * 
+     *
      */
     public IRubyObject stringToInum(int base, boolean badcheck) {
         ByteList s = this.value;
@@ -4664,7 +4664,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
             if (limit && lim <= ++i) break;
         }
 
-        // only this case affects backrefs 
+        // only this case affects backrefs
         context.setBackRef(runtime.getNil());
 
         if (len > 0 && (limit || len > beg || lim < 0)) result.append(makeShared(runtime, beg, len - beg));
@@ -4702,7 +4702,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
 
         boolean skip = true;
 
-        int e = 0, b = 0;        
+        int e = 0, b = 0;
         while (p < end) {
             int c = bytes[p++] & 0xff;
             if (skip) {
@@ -4749,7 +4749,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
             return splitCommon19(arg0, true, lim, 1, context, true);
         }
     }
-    
+
     public RubyArray split19(ThreadContext context, IRubyObject arg0, boolean useBackref) {
         return splitCommon19(arg0, useBackref, flags, flags, context, useBackref);
     }
@@ -4779,7 +4779,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
                 }
             } else {
                 final Regex pattern, prepared;
-                
+
                 Ruby runtime = context.runtime;
                 if (spat instanceof RubyRegexp) {
                     RubyRegexp regexp = (RubyRegexp)spat;
@@ -4843,7 +4843,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
             if (limit && lim <= ++i) break;
         }
 
-        // only this case affects backrefs 
+        // only this case affects backrefs
         if (useBackref) context.setBackRef(runtime.getNil());
 
         if (len > 0 && (limit || len > beg || lim < 0)) result.append(makeShared19(runtime, beg, len - beg));
@@ -4915,7 +4915,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         int realSize = value.getRealSize();
 
         int e, p = 0;
-        
+
         while (p < realSize && (e = indexOf(bytes, begin, realSize, patternBytes, patternBegin, patternRealSize, p)) >= 0) {
             int t = enc.rightAdjustCharHead(bytes, p + begin, e + begin, begin + realSize) - begin;
             if (t != e) {
@@ -4965,7 +4965,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     }
 
     /** get_pat (used by match/match19)
-     * 
+     *
      */
     private RubyRegexp getPattern(IRubyObject obj) {
         if (obj instanceof RubyRegexp) return (RubyRegexp)obj;
@@ -4991,7 +4991,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         if (str.value.getEncoding().isDummy()) {
             throw runtime.newArgumentError("can't make regexp with dummy encoding");
         }
-        
+
         return RubyRegexp.getQuotedRegexpFromCache19(runtime, str.value, new RegexpOptions(), str.isAsciiOnly());
     }
 
@@ -5011,7 +5011,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         } else {
             pattern = getStringPattern(runtime, enc, arg);
             if (arg.isTaint()) {
-              tuFlags = RubyBasicObject.TAINTED_F; 
+              tuFlags = RubyBasicObject.TAINTED_F;
             }
             else {
               tuFlags = 0;
@@ -5052,7 +5052,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
                 end = positionEnd(matcher, enc, begin, range);
                 match = RubyRegexp.createMatchData(context, this, matcher, pattern);
                 match.infectBy(tuFlags);
-                context.setBackRef(match);  
+                context.setBackRef(match);
                 block.yield(context, populateCapturesForScan(runtime, matcher, range, tuFlags, false));
                 modifyCheck(bytes, size);
             }
@@ -5107,7 +5107,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         Region region = matcher.getRegion();
         RubyArray result = getRuntime().newArray(region.numRegs);
         for (int i=1; i<region.numRegs; i++) {
-            int beg = region.beg[i]; 
+            int beg = region.beg[i];
             if (beg == -1) {
                 result.append(runtime.getNil());
             } else {
@@ -5395,7 +5395,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
 
     private IRubyObject justify19(IRubyObject arg0, int jflag) {
         Ruby runtime = getRuntime();
-        RubyString result = justifyCommon(runtime, SPACE_BYTELIST, 
+        RubyString result = justifyCommon(runtime, SPACE_BYTELIST,
                                                    1,
                                                    true, value.getEncoding(), RubyFixnum.num2int(arg0), jflag);
         if (getCodeRange() != CR_BROKEN) result.setCodeRange(getCodeRange());
@@ -5410,9 +5410,9 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         int padCharLen = padStr.strLength(enc);
         if (pad.getRealSize() == 0 || padCharLen == 0) throw runtime.newArgumentError("zero width padding");
         int width = RubyFixnum.num2int(arg0);
-        RubyString result = justifyCommon(runtime, pad, 
-                                                   padCharLen, 
-                                                   padStr.singleByteOptimizable(), 
+        RubyString result = justifyCommon(runtime, pad,
+                                                   padCharLen,
+                                                   padStr.singleByteOptimizable(),
                                                    enc, width, jflag);
         if (RubyFixnum.num2int(result.length19()) > RubyFixnum.num2int(length19())) result.infectBy(padStr);
         int cr = codeRangeAnd(getCodeRange(), padStr.getCodeRange());
@@ -5438,7 +5438,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         byte bytes[] = res.getUnsafeBytes();
 
         while (llen > 0) {
-            if (padLen <= 1) { 
+            if (padLen <= 1) {
                 bytes[p++] = padBytes[padP];
                 llen--;
             } else if (llen > padCharLen) {
@@ -5458,7 +5458,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         p += value.getRealSize();
 
         while (rlen > 0) {
-            if (padLen <= 1) { 
+            if (padLen <= 1) {
                 bytes[p++] = padBytes[padP];
                 rlen--;
             } else if (rlen > padCharLen) {
@@ -5473,7 +5473,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
                 break;
             }
         }
-        
+
         res.setRealSize(p);
 
         RubyString result = new RubyString(runtime, getMetaClass(), res);
@@ -5567,7 +5567,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         if (arg instanceof RubyRegexp) {
             RubyRegexp regex = (RubyRegexp)arg;
             IRubyObject[] holder = {context.nil};
-        
+
             pos = regex.search19(context, this, 0, false, holder);
             context.setBackRef(holder[0]);
             if (pos < 0) return partitionMismatch(runtime);
@@ -5590,7 +5590,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     private IRubyObject partitionMismatch(Ruby runtime) {
         return RubyArray.newArray(runtime, new IRubyObject[]{this, newEmptyString(runtime), newEmptyString(runtime)});
     }
-    
+
     @JRubyMethod(name = "rpartition", reads = BACKREF, writes = BACKREF)
     public IRubyObject rpartition(ThreadContext context, IRubyObject arg) {
         Ruby runtime = context.runtime;
@@ -5599,10 +5599,10 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         if (arg instanceof RubyRegexp) {
             RubyRegexp regex = (RubyRegexp)arg;
             IRubyObject[] holder = {context.nil};
-        
+
             pos = regex.search19(context, this, value.getRealSize(), true, holder);
             context.setBackRef(holder[0]);
-            
+
             if (pos < 0) return rpartitionMismatch(runtime);
             sep = (RubyString)RubyRegexp.nth_match(0, holder[0]);
         } else {
@@ -5622,9 +5622,9 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     private IRubyObject rpartitionMismatch(Ruby runtime) {
         return RubyArray.newArray(runtime, new IRubyObject[]{newEmptyString(runtime), newEmptyString(runtime), this});
     }
-    
+
     /** rb_str_chop / rb_str_chop_bang
-     * 
+     *
      */
     @JRubyMethod(name = "chop", compat = RUBY1_8)
     public IRubyObject chop(ThreadContext context) {
@@ -5682,7 +5682,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     }
 
     /** rb_str_chop
-     * 
+     *
      */
     @JRubyMethod(name = "chomp", compat = RUBY1_8)
     public RubyString chomp(ThreadContext context) {
@@ -5757,7 +5757,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         }
         return runtime.getNil();
     }
-    
+
     private IRubyObject smartChopBangCommon(Ruby runtime) {
         ByteList v = this.value;
         int len = v.getRealSize();
@@ -5775,7 +5775,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
             modifyCheck();
             return runtime.getNil();
         }
-        return this; 
+        return this;
     }
 
     @JRubyMethod(name = "chomp", compat = RUBY1_9)
@@ -5810,14 +5810,14 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         if (value.getRealSize() == 0) return runtime.getNil();
         return chompBangCommon19(runtime, arg0);
     }
-    
+
     private IRubyObject chompBangCommon19(Ruby runtime, IRubyObject rsObj) {
         if (rsObj.isNil()) return rsObj;
 
         RubyString rs = rsObj.convertToString();
         int p = value.getBegin();
         int len = value.getRealSize();
-        int end = p + len;  
+        int end = p + len;
         byte[] bytes = value.getUnsafeBytes();
 
         int rslen = rs.value.getRealSize();
@@ -5841,7 +5841,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         Encoding enc = checkEncoding(rs);
         if (rs.scanForCodeRange() == CR_BROKEN) return runtime.getNil();
 
-        int pp = end - rslen; 
+        int pp = end - rslen;
         if (bytes[p + len - 1] == newline && rslen <= 1 || value.endsWith(rs.value)) {
             if (enc.leftAdjustCharHead(bytes, p, pp, end) != pp) return runtime.getNil();
             if (getCodeRange() != CR_7BIT) clearCodeRange();
@@ -5850,7 +5850,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         }
         return runtime.getNil();
     }
-    
+
     private IRubyObject smartChopBangCommon19(Ruby runtime) {
         final int p = value.getBegin();
         int len = value.getRealSize();
@@ -5865,7 +5865,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
             pp = end - enc.minLength();
             if (pp >= p) {
                 pp = enc.leftAdjustCharHead(bytes, p, pp, end);
-                if (StringSupport.preciseLength(enc, bytes, pp, end) > 0 && 
+                if (StringSupport.preciseLength(enc, bytes, pp, end) > 0 &&
                         enc.mbcToCode(bytes, pp, end) == '\r') end = pp;
             }
             if (end == p + value.getRealSize()) {
@@ -5891,7 +5891,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     }
 
     /** rb_str_lstrip / rb_str_lstrip_bang
-     * 
+     *
      */
     @JRubyMethod(name = "lstrip", compat = RUBY1_8)
     public IRubyObject lstrip(ThreadContext context) {
@@ -5965,7 +5965,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     }
 
     /** rb_str_rstrip / rb_str_rstrip_bang
-     *  
+     *
      */
     @JRubyMethod(name = "rstrip", compat = RUBY1_8)
     public IRubyObject rstrip(ThreadContext context) {
@@ -6015,24 +6015,24 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         }
         return runtime.getNil();
     }
-    
+
     // In 1.9 we strip any combination of \0 and \s
     private IRubyObject singleByteRStrip19(Ruby runtime) {
         byte[] bytes = value.getUnsafeBytes();
         int start = value.getBegin();
         int end = start + value.getRealSize();
         int endp = end - 1;
-        while (endp >= start && (bytes[endp] == 0 || 
+        while (endp >= start && (bytes[endp] == 0 ||
                 ASCII.isSpace(bytes[endp] & 0xff))) endp--;
 
         if (endp < end - 1) {
             view(0, endp - start + 1);
             return this;
         }
-        
+
         return runtime.getNil();
-    }    
-    
+    }
+
     // In 1.9 we strip any combination of \0 and \s
     private IRubyObject multiByteRStrip19(Ruby runtime) {
         byte[] bytes = value.getUnsafeBytes();
@@ -6081,10 +6081,10 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     @JRubyMethod(name = "strip!", compat = RUBY1_9)
     public IRubyObject strip_bang19(ThreadContext context) {
         modifyCheck();
-        
+
         IRubyObject left = lstrip_bang19(context);
         IRubyObject right = rstrip_bang19(context);
-        
+
         return left.isNil() && right.isNil() ? context.runtime.getNil() : this;
     }
 
@@ -6101,7 +6101,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         }
         return runtime.getNil();
     }
-    
+
     /** rb_str_count
      *
      */
@@ -6153,7 +6153,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
 
         RubyString otherStr = arg.convertToString();
         Encoding enc = checkEncoding(otherStr);
-        
+
         int c;
         if (otherStr.value.length() == 1 && enc.isAsciiCompatible() &&
                 ((c = otherStr.value.unsafeBytes()[otherStr.value.getBegin()] & 0xff)) < 0x80 && scanForCodeRange() != CR_BROKEN) {
@@ -6168,7 +6168,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
             }
             return RubyFixnum.newFixnum(runtime, n);
         }
-        
+
         final boolean[]table = new boolean[TRANS_SIZE + 1];
         TrTables tables = otherStr.trSetupTable(context.runtime, table, null, true, enc);
         return countCommon19(runtime, table, tables, enc);
@@ -6283,7 +6283,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         }
         value.setRealSize(t - value.getBegin());
 
-        return modify ? this : runtime.getNil();        
+        return modify ? this : runtime.getNil();
     }
 
     @JRubyMethod(name = "delete", compat = RUBY1_9)
@@ -6349,7 +6349,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         byte[]bytes = value.getUnsafeBytes();
         boolean modify = false;
         boolean asciiCompatible = enc.isAsciiCompatible();
-        int cr = asciiCompatible ? CR_7BIT : CR_VALID; 
+        int cr = asciiCompatible ? CR_7BIT : CR_VALID;
         while (s < send) {
             int c;
             if (asciiCompatible && Encoding.isAscii(c = bytes[s] & 0xff)) {
@@ -6376,7 +6376,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         value.setRealSize(t - value.getBegin());
         setCodeRange(cr);
 
-        return modify ? this : runtime.getNil();        
+        return modify ? this : runtime.getNil();
     }
 
     /** rb_str_squeeze / rb_str_squeeze_bang
@@ -6432,7 +6432,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     @JRubyMethod(name = "squeeze!", rest = true, compat = RUBY1_8)
     public IRubyObject squeeze_bang(ThreadContext context, IRubyObject[] args) {
         if (args.length == 0) return squeeze_bang(context);
-        
+
         Ruby runtime = context.runtime;
         if (value.getRealSize() == 0) {
             modifyCheck();
@@ -6466,7 +6466,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
             return this;
         }
 
-        return runtime.getNil();        
+        return runtime.getNil();
     }
 
     @JRubyMethod(name = "squeeze", compat = RUBY1_9)
@@ -6526,7 +6526,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         } else {
             return squeezeCommon19(runtime, squeeze, tables, value.getEncoding(), true);
         }
-        
+
     }
 
     @JRubyMethod(name = "squeeze!", rest = true, compat = RUBY1_9)
@@ -6587,7 +6587,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
             return this;
         }
 
-        return runtime.getNil();   
+        return runtime.getNil();
     }
 
     /** rb_str_tr / rb_str_tr_bang
@@ -6603,7 +6603,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     @JRubyMethod(name = "tr!", compat = RUBY1_8)
     public IRubyObject tr_bang(ThreadContext context, IRubyObject src, IRubyObject repl) {
         return trTrans(context, src, repl, false);
-    }    
+    }
 
     @JRubyMethod(name = "tr", compat = RUBY1_9)
     public IRubyObject tr19(ThreadContext context, IRubyObject src, IRubyObject repl) {
@@ -6615,7 +6615,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     @JRubyMethod(name = "tr!")
     public IRubyObject tr_bang19(ThreadContext context, IRubyObject src, IRubyObject repl) {
         return trTrans19(context, src, repl, false);
-    }    
+    }
 
     private static final class TR {
         TR(ByteList bytes) {
@@ -6634,7 +6634,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     private static final int TRANS_SIZE = 256;
 
     /** tr_setup_table
-     * 
+     *
      */
     private void trSetupTable(boolean[]table, boolean init) {
         final TR tr = new TR(value);
@@ -6682,7 +6682,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         } else if (table[TRANS_SIZE] && !cflag) {
             table[TRANS_SIZE] = false;
         }
-        
+
         final boolean[]buf = new boolean[TRANS_SIZE];
         for (int i=0; i<TRANS_SIZE; i++) buf[i] = cflag;
 
@@ -6726,7 +6726,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
 
     /** tr_trans
     *
-    */    
+    */
     private IRubyObject trTrans(ThreadContext context, IRubyObject src, IRubyObject repl, boolean sflag) {
         Ruby runtime = context.runtime;
         if (value.getRealSize() == 0) return runtime.getNil();
@@ -6740,7 +6740,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         if (srcList.getRealSize() >= 2 && srcList.getUnsafeBytes()[srcList.getBegin()] == '^') {
             cflag = true;
             trSrc.p++;
-        }       
+        }
 
         int c;
         final int[]trans = new int[TRANS_SIZE];
@@ -6830,7 +6830,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
                     cflag = true;
                     trSrc.p += cl;
                 }
-            }            
+            }
         }
 
         boolean singlebyte = singleByteOptimizable();
@@ -6840,10 +6840,10 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         IntHash<Integer> hash = null;
         final TR trRepl = new TR(replList);
 
-        int last = 0;        
+        int last = 0;
         if (cflag) {
             for (int i=0; i<TRANS_SIZE; i++) trans[i] = 1;
-            
+
             while ((c = trNext(trSrc, runtime, enc)) >= 0) {
                 if (c < TRANS_SIZE) {
                     trans[c & 0xff] = -1;
@@ -6964,7 +6964,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
                     buf = tbuf;
                 }
                 enc.codeToMbc(c, buf, t);
-                if (mayModify && (tlen == 1 ? sbytes[s] != buf[t] : ByteList.memcmp(sbytes, s, buf, t, tlen) != 0)) modify = true;  
+                if (mayModify && (tlen == 1 ? sbytes[s] != buf[t] : ByteList.memcmp(sbytes, s, buf, t, tlen) != 0)) modify = true;
 
                 if (cr == CR_7BIT && !Encoding.isAscii(c)) cr = CR_VALID;
                 s += clen;
@@ -6993,16 +6993,16 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
                 return cflag ? -1 : tmp;
             }
         } else {
-            return cflag && set ? last : -1; 
+            return cflag && set ? last : -1;
         }
     }
 
     /** trnext
     *
-    */    
+    */
     private int trNext(TR t) {
         byte[]buf = t.buf;
-        
+
         for (;;) {
             if (!t.gen) {
                 if (t.p == t.pend) return -1;
@@ -7031,7 +7031,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
 
     private int trNext(TR t, Ruby runtime, Encoding enc) {
         byte[]buf = t.buf;
-        
+
         for (;;) {
             if (!t.gen) {
                 if (t.p == t.pend) return -1;
@@ -7103,7 +7103,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         return each_lineCommon(context, arg, block);
     }
 
-    public IRubyObject each_lineCommon(ThreadContext context, IRubyObject sep, Block block) {        
+    public IRubyObject each_lineCommon(ThreadContext context, IRubyObject sep, Block block) {
         Ruby runtime = context.runtime;
         if (sep.isNil()) {
             block.yield(context, this);
@@ -7135,7 +7135,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
                 while(p < end && bytes[p] == '\n') p++;
             }
             if (ptr < p && bytes[p - 1] == newline &&
-               (rslen <= 1 || 
+               (rslen <= 1 ||
                 ByteList.memcmp(sepValue.getUnsafeBytes(), sepValue.getBegin(), rslen, bytes, p - rslen, rslen) == 0)) {
                 block.yield(context, makeShared(runtime, s - ptr, p - s).infectBy(this));
                 modifyCheck(bytes, len);
@@ -7153,61 +7153,61 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
 
     @JRubyMethod(name = "each", compat = RUBY1_8)
     public IRubyObject each18(ThreadContext context, Block block) {
-        return block.isGiven() ? each_line(context, block) : 
+        return block.isGiven() ? each_line(context, block) :
             enumeratorize(context.runtime, this, "each");
     }
 
     @JRubyMethod(name = "each", compat = RUBY1_8)
     public IRubyObject each18(ThreadContext context, IRubyObject arg, Block block) {
-        return block.isGiven() ? each_lineCommon(context, arg, block) : 
+        return block.isGiven() ? each_lineCommon(context, arg, block) :
             enumeratorize(context.runtime, this, "each", arg);
     }
 
     @JRubyMethod(name = "each_line", compat = RUBY1_8)
     public IRubyObject each_line18(ThreadContext context, Block block) {
-        return block.isGiven() ? each_line(context, block) : 
+        return block.isGiven() ? each_line(context, block) :
             enumeratorize(context.runtime, this, "each_line");
     }
 
     @JRubyMethod(name = "each_line", compat = RUBY1_8)
     public IRubyObject each_line18(ThreadContext context, IRubyObject arg, Block block) {
-        return block.isGiven() ? each_lineCommon(context, arg, block) : 
+        return block.isGiven() ? each_lineCommon(context, arg, block) :
             enumeratorize(context.runtime, this, "each_line", arg);
     }
 
     @JRubyMethod(name = "lines", compat = RUBY1_8)
     public IRubyObject lines18(ThreadContext context, Block block) {
-        return block.isGiven() ? each_line(context, block) : 
+        return block.isGiven() ? each_line(context, block) :
             enumeratorize(context.runtime, this, "lines");
     }
 
     @JRubyMethod(name = "lines", compat = RUBY1_8)
     public IRubyObject lines18(ThreadContext context, IRubyObject arg, Block block) {
-        return block.isGiven() ? each_lineCommon(context, arg, block) : 
+        return block.isGiven() ? each_lineCommon(context, arg, block) :
             enumeratorize(context.runtime, this, "lines", arg);
     }
 
     @JRubyMethod(name = "each_line", compat = RUBY1_9)
     public IRubyObject each_line19(ThreadContext context, Block block) {
-        return block.isGiven() ? each_lineCommon19(context, block) : 
+        return block.isGiven() ? each_lineCommon19(context, block) :
             enumeratorize(context.runtime, this, "each_line");
     }
 
     @JRubyMethod(name = "each_line", compat = RUBY1_9)
     public IRubyObject each_line19(ThreadContext context, IRubyObject arg, Block block) {
-        return block.isGiven() ? each_lineCommon19(context, arg, block) : 
+        return block.isGiven() ? each_lineCommon19(context, arg, block) :
             enumeratorize(context.runtime, this, "each_line", arg);
     }
 
     @JRubyMethod(compat = RUBY1_9)
     public IRubyObject lines(ThreadContext context, Block block) {
-        return block.isGiven() ? each_lineCommon19(context, block) : 
+        return block.isGiven() ? each_lineCommon19(context, block) :
             enumeratorize(context.runtime, this, "lines");
     }
 
     @JRubyMethod(compat = RUBY1_9)
     public IRubyObject lines(ThreadContext context, IRubyObject arg, Block block) {
-        return block.isGiven() ? each_lineCommon19(context, arg, block) : 
+        return block.isGiven() ? each_lineCommon19(context, arg, block) :
             enumeratorize(context.runtime, this, "lines", arg);
     }
 
@@ -7227,7 +7227,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         return each_lineCommon19(context, context.runtime.getGlobalVariables().get("$/"), block);
     }
 
-    private IRubyObject each_lineCommon19(ThreadContext context, IRubyObject sep, Block block) {        
+    private IRubyObject each_lineCommon19(ThreadContext context, IRubyObject sep, Block block) {
         Ruby runtime = context.runtime;
         if (sep.isNil()) {
             block.yield(context, this);
@@ -7324,7 +7324,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     }
 
     /** rb_str_each_char
-     * 
+     *
      */
     @JRubyMethod(name = "each_char", compat = RUBY1_8)
     public IRubyObject each_char18(ThreadContext context, Block block) {
@@ -7372,7 +7372,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         ByteList val = value.shallowDup();
         boolean isUSASCII = val.getEncoding() == USASCIIEncoding.INSTANCE;
         boolean is7bit = getCodeRange() == StringSupport.CR_7BIT;
-        
+
         // if 7bit, don't use more expensive length logic
         // if USASCII, use preallocated single-byte ByteLists
         while (p < end) {
@@ -7390,7 +7390,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     }
 
     /** rb_str_each_codepoint
-     * 
+     *
      */
     @JRubyMethod(compat = RUBY1_9)
     public IRubyObject each_codepoint(ThreadContext context, Block block) {
@@ -7426,22 +7426,22 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     private RubySymbol to_sym() {
         RubySymbol specialCaseIntern = checkSpecialCasesIntern(value);
         if (specialCaseIntern != null) return specialCaseIntern;
-        
+
         RubySymbol symbol = getRuntime().getSymbolTable().getSymbol(value);
         if (symbol.getBytes() == value) shareLevel = SHARE_LEVEL_BYTELIST;
         return symbol;
     }
-    
+
     private RubySymbol checkSpecialCasesIntern(ByteList value) {
         String[][] opTable = getRuntime().is1_8() ? opTable18 : opTable19;
-        
+
         for (int i = 0; i < opTable.length; i++) {
             String op = opTable[i][1];
             if (value.toString().equals(op)) {
                 return getRuntime().getSymbolTable().getSymbol(opTable[i][0]);
             }
         }
-        
+
         return null;
     }
 
@@ -7459,7 +7459,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     public RubySymbol intern19() {
         return to_sym();
     }
-    
+
     @JRubyMethod(name = "ord", compat = RUBY1_9)
     public IRubyObject ord(ThreadContext context) {
         Ruby runtime = context.runtime;
@@ -7483,7 +7483,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         byte[]bytes = value.getUnsafeBytes();
         int p = value.getBegin();
         int len = value.getRealSize();
-        int end = p + len; 
+        int end = p + len;
 
         if (bits >= 8 * 8) { // long size * bits in byte
             IRubyObject one = RubyFixnum.one(runtime);
@@ -7508,7 +7508,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     }
 
     /** string_to_c
-     * 
+     *
      */
     @JRubyMethod(name = "to_c", compat = RUBY1_9)
     public IRubyObject to_c(ThreadContext context) {
@@ -7528,7 +7528,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     }
 
     /** string_to_r
-     * 
+     *
      */
     @JRubyMethod(name = "to_r", compat = RUBY1_9)
     public IRubyObject to_r(ThreadContext context) {
@@ -7545,7 +7545,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         } else {
             return RubyRational.newRationalCanonicalize(context, RubyFixnum.zero(runtime));
         }
-    }    
+    }
 
     public static RubyString unmarshalFrom(UnmarshalStream input) throws java.io.IOException {
         RubyString result = newString(input.getRuntime(), input.unmarshalString());
@@ -7570,16 +7570,16 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     public IRubyObject encoding(ThreadContext context) {
         return context.runtime.getEncodingService().getEncoding(value.getEncoding());
     }
-    
+
     // TODO: re-split this
     public IRubyObject encode_bang(ThreadContext context, IRubyObject arg0) {
         return encode_bang(context, new IRubyObject[]{arg0});
     }
-    
+
     public IRubyObject encode_bang(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
         return encode_bang(context, new IRubyObject[]{arg0,arg1});
     }
-    
+
     public IRubyObject encode_bang(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
         return encode_bang(context, new IRubyObject[]{arg0,arg1,arg2});
     }
@@ -7588,12 +7588,12 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     public IRubyObject encode_bang(ThreadContext context, IRubyObject[] args) {
         IRubyObject[] newstr_p;
         Encoding encindex;
-        
+
         modify19();
-        
+
         newstr_p = new IRubyObject[]{this};
         encindex = EncodingUtils.strTranscode(context, args, newstr_p);
-        
+
         if (encindex == null) return this;
         if (newstr_p[0] == this) {
             this.setEncoding(encindex);
@@ -7622,7 +7622,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     @JRubyMethod(name = "encode", compat = RUBY1_9)
     public IRubyObject encode(ThreadContext context, IRubyObject toEncoding,
             IRubyObject forcedEncoding, IRubyObject opts) {
-        
+
         return EncodingUtils.strEncode(context, this, toEncoding, forcedEncoding, opts);
     }
 
@@ -7685,7 +7685,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     }
 
     /** used by ar-jdbc
-     * 
+     *
      */
     public String getUnicodeValue() {
         return RubyEncoding.decodeUTF8(value.getUnsafeBytes(), value.getBegin(), value.getRealSize());
@@ -7714,11 +7714,17 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     public Object toJava(Class target) {
         if (target.isAssignableFrom(String.class)) {
             return decodeString();
-        } else if (target.isAssignableFrom(ByteList.class)) {
-            return value;
-        } else {
-            return super.toJava(target);
         }
+        if (target.isAssignableFrom(ByteList.class)) {
+            return value;
+        }
+        if (target == Character.class || target == Character.TYPE) {
+            if ( strLength() != 1 ) {
+                throw getRuntime().newArgumentError("could not coerce string of length " + strLength() + " (!= 1) into a char");
+            }
+            return decodeString().charAt(0);
+        }
+        return super.toJava(target);
     }
 
     // old port of rb_enc_cr_str_buf_cat
@@ -7794,7 +7800,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
 
         return cr2;
     }
-    
+
     @JRubyMethod(name ="b", compat = RUBY2_0)
     public IRubyObject b(ThreadContext context) {
         RubyString dup = strDup(context.runtime);

--- a/test/test_primitive_to_java.rb
+++ b/test/test_primitive_to_java.rb
@@ -1,11 +1,35 @@
+# encoding: UTF-8
 require 'test/unit'
-require 'java'
 
 class TestPrimitiveToJava < Test::Unit::TestCase
+
+  def setup; super; require 'java' end
+
   def test_primitive_conversion
     t = Time.now
     date = t.to_java(java.util.Date)
 
     assert_equal(t.to_i, date.time / 1000, "Ruby time #{t} not converted to java date correctly: #{date}")
   end
+
+  def test_char_conversion
+    str = 'a'
+    char = str.to_java(:char)
+    assert_instance_of Java::JavaLang::Character, char
+
+    str = ' '
+    char = str.to_java(Java::char)
+    assert_equal 32, char.charValue
+
+    str = '0'
+    char = str.to_java(java.lang.Character)
+    assert_equal 48.to_java(:char), char
+
+    assert_equal 228, 'ä'.to_java(:char).charValue
+
+    assert_raises(ArgumentError) { ''.to_java(:char) }
+    assert_raises(ArgumentError) { 'už'.to_java('java.lang.Character') }
+    'už'[1].to_java('java.lang.Character')
+  end
+
 end

--- a/test/test_primitive_to_java.rb
+++ b/test/test_primitive_to_java.rb
@@ -25,11 +25,11 @@ class TestPrimitiveToJava < Test::Unit::TestCase
     char = str.to_java(java.lang.Character)
     assert_equal 48.to_java(:char), char
 
-    assert_equal 228, 'ä'.to_java(:char).charValue
+    assert_equal 228, 'ä'.to_java(:char).charValue unless RUBY_VERSION.index('1.8') == 0
 
     assert_raises(ArgumentError) { ''.to_java(:char) }
     assert_raises(ArgumentError) { 'už'.to_java('java.lang.Character') }
-    'už'[1].to_java('java.lang.Character')
+    'už'[1].to_java('java.lang.Character') unless RUBY_VERSION.index('1.8') == 0
   end
 
 end


### PR DESCRIPTION
currently one can `42.to_java(:char)` to get a char (java.lang.Character) instance put it's certainly not the most obvious way to do it.

this PR adds support for converting strings of length 1 to (native) char objects e.g. `'A'.to_java(:char)`