### PR TITLE
Fix for issue 2524 on jruby-1_7: [BigDecimal] Loss of precision with different execution order 

### DIFF
--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -1091,10 +1091,16 @@ public class RubyBigDecimal extends RubyNumeric {
     }
     
     private IRubyObject op_quo19_20(ThreadContext context, IRubyObject other) {
-        RubyObject preciseOther = getVpValue19(context, other, true);
+        RubyBigDecimal preciseOther = getVpValue19(context, other, true);
         // regular division with some default precision
-        // TODO: proper algorithm to set the precision
-        return op_div(context, preciseOther, getRuntime().newFixnum(200));
+        // proper algorithm to set the precision
+        // the precision is multiple of 4
+        // and the precision is larger than len * 2
+        int len = value.precision() + preciseOther.value.precision();
+        int pow = len / 4;
+        int precision = (pow + 1) * 4 * 2;
+
+        return op_div(context, preciseOther, getRuntime().newFixnum(precision));
     }
     
     private IRubyObject convertDivResult(ThreadContext context, IRubyObject other, IRubyObject result) {
@@ -1188,10 +1194,9 @@ public class RubyBigDecimal extends RubyNumeric {
             // MRI behavior: "If digits is 0, the result is the same as the / operator."
             return op_quo(context, other);
         } else {
-            // TODO: better algorithm to set precision needed
-            int prec = Math.max(200, scale);
+            MathContext mathContext = new MathContext(scale, getRoundingMode(context.runtime));
             return new RubyBigDecimal(getRuntime(),
-                    value.divide(val.value, new MathContext(prec, RoundingMode.HALF_UP))).setResult(scale);
+                    value.divide(val.value, mathContext)).setResult(scale);
         }
     }
     

--- a/spec/regression/GH-2524_bigdecimal_loss_of_precision_with_different_excution_order_spec.rb
+++ b/spec/regression/GH-2524_bigdecimal_loss_of_precision_with_different_excution_order_spec.rb
@@ -1,0 +1,13 @@
+require 'bigdecimal'
+
+# https://github.com/jruby/jruby/issues/2524
+if RUBY_VERSION > '1.9'
+  describe 'BigDecimal precision test with different execution order' do
+    it 'returns same precision ' do
+      fraction = BigDecimal.new("0.0095") / 365 * BigDecimal.new(50_000)
+      r1 = fraction * BigDecimal.new(50_000) / BigDecimal.new(100_000)
+      r2 = fraction * (BigDecimal.new(50_000) / BigDecimal.new(100_000))
+      expect(r1).to eq(r2)
+    end
+  end
+end


### PR DESCRIPTION
This commit fixes issue #2524 on jruby-1_7 branch. Improved algorithm to set the precision of BigDecimal#op_quo19_20 method.