### PR TITLE
Skip block-to-proc conversion for explicit block syntax when possible

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRManager.java
+++ b/core/src/main/java/org/jruby/ir/IRManager.java
@@ -18,7 +18,7 @@ import java.util.Set;
 public class IRManager {
     public static final String SAFE_COMPILER_PASSES = "";
     public static final String DEFAULT_COMPILER_PASSES = "OptimizeTempVarsPass,LocalOptimizationPass";
-    public static final String DEFAULT_JIT_PASSES = "DeadCodeElimination,AddLocalVarLoadStoreInstructions,OptimizeDynScopesPass,AddCallProtocolInstructions,EnsureTempsAssigned";
+    public static final String DEFAULT_JIT_PASSES = "OptimizeDelegationPass,DeadCodeElimination,AddLocalVarLoadStoreInstructions,OptimizeDynScopesPass,AddCallProtocolInstructions,EnsureTempsAssigned";
     public static final String DEFAULT_INLINING_COMPILER_PASSES = "LocalOptimizationPass";
 
     private int dummyMetaClassCount = 0;

--- a/core/src/main/java/org/jruby/ir/IRScope.java
+++ b/core/src/main/java/org/jruby/ir/IRScope.java
@@ -566,6 +566,8 @@ public abstract class IRScope implements ParseResult {
         // stymied by escaped bindings. We can also eliminate
         // dynscopes for these scopes.
         if (!isUnsafeScope() && !flags.contains(REQUIRES_DYNSCOPE)) {
+            if (flags.contains(RECEIVES_CLOSURE_ARG))
+                (new OptimizeDelegationPass()).run(this);
             (new DeadCodeElimination()).run(this);
             (new OptimizeDynScopesPass()).run(this);
         }

--- a/core/src/main/java/org/jruby/ir/passes/OptimizeDelegationPass.java
+++ b/core/src/main/java/org/jruby/ir/passes/OptimizeDelegationPass.java
@@ -1,0 +1,144 @@
+package org.jruby.ir.passes;
+
+import org.jruby.ir.IRClosure;
+import org.jruby.ir.IRScope;
+import org.jruby.ir.IRFlags;
+import org.jruby.ir.instructions.*;
+import org.jruby.ir.operands.Operand;
+import org.jruby.ir.operands.Variable;
+import org.jruby.ir.representations.BasicBlock;
+
+import java.util.*;
+
+public class OptimizeDelegationPass extends CompilerPass {
+    public static List<Class<? extends CompilerPass>> DEPENDENCIES = Arrays.<Class<? extends CompilerPass>>asList(CFGBuilder.class);
+
+    @Override
+    public String getLabel() {
+        return "Delegated Variable Removal";
+    }
+
+    @Override
+    public List<Class<? extends CompilerPass>> getDependencies() {
+        return DEPENDENCIES;
+    }
+
+    @Override
+    public Object execute(IRScope s, Object... data) {
+        for (IRClosure c: s.getClosures()) {
+            run(c, false, true);
+        }
+
+        s.computeScopeFlags();
+
+        if (s.getFlags().contains(IRFlags.BINDING_HAS_ESCAPED))
+            return null;
+
+        if (!s.getFlags().contains(IRFlags.RECEIVES_CLOSURE_ARG))
+            return null;
+
+        optimizeDelegatedVars(s);
+
+        return true;
+    }
+
+    @Override
+    public boolean invalidate(IRScope s) {
+        // Not reversible right now
+        return false;
+    }
+
+    private static void optimizeDelegatedVars(IRScope s) {
+        for (BasicBlock bb: s.cfg().getBasicBlocks()) {
+            DelegatedImplicitClosureTracker tracker = new DelegatedImplicitClosureTracker(s);
+
+            for (Instr i: bb.getInstrs()) {
+                if (i instanceof ReifyClosureInstr) {
+                    tracker.addUnusedExplicitBlock((ReifyClosureInstr) i);
+                } else {
+                    Iterator<Variable> it = tracker.iterator();
+                    while (it.hasNext()) {
+                        Variable explicitBlock = it.next();
+                        if (usesVariableAsNonClosureArg(i, explicitBlock)) {
+                            it.remove();
+                        }
+                    }
+                }
+            }
+
+            for (Instr i: bb.getInstrs()) {
+                tracker.renameVarsOnInstr(i);
+            }
+        }
+    }
+
+    private static boolean usesVariableAsNonClosureArg(Instr i, Variable v) {
+        List<Variable> usedVariables = i.getUsedVariables();
+        if (usedVariables.contains(v)) {
+            if (i instanceof ClosureAcceptingInstr) {
+                return usedVariables.indexOf(v) != usedVariables.lastIndexOf(v) ||
+                    v != ((ClosureAcceptingInstr) i).getClosureArg();
+            } else
+                return true;
+        }
+        return false;
+    }
+
+    private static class DelegatedImplicitClosureTracker {
+        private final IRScope scope;
+        private final Map<Operand, Operand> unusedExplicitBlocks;
+        private final Map<Operand, Operand> procToNewTempRename;
+        private final Map<Operand, Operand> blockToNewTempRename;
+
+        public DelegatedImplicitClosureTracker(IRScope scope) {
+            this.scope = scope;
+            unusedExplicitBlocks = new HashMap<Operand, Operand>();
+            procToNewTempRename = new HashMap<Operand, Operand>();
+            blockToNewTempRename = new HashMap<Operand, Operand>();
+        }
+
+        public void addUnusedExplicitBlock(ReifyClosureInstr i) {
+            Operand proc = i.getResult();
+            Operand block = i.getSource();
+            Operand newTemp = scope.createTemporaryVariable();
+
+            unusedExplicitBlocks.put(proc, block);
+            procToNewTempRename.put(proc, newTemp);
+            blockToNewTempRename.put(block, newTemp);
+        }
+
+        public Iterator<Variable> iterator() {
+            final Iterator<Map.Entry<Operand, Operand>> it = unusedExplicitBlocks.entrySet().iterator();
+
+            return new Iterator<Variable>() {
+                private Variable currentProc;
+                private Operand currentBlock;
+
+                public boolean hasNext() {
+                    return it.hasNext();
+                }
+
+                public Variable next() {
+                    Map.Entry<Operand, Operand> e = it.next();
+                    currentProc = (Variable) e.getKey();
+                    currentBlock = e.getValue();
+                    return currentProc;
+                }
+
+                public void remove() {
+                    procToNewTempRename.remove(currentProc);
+                    blockToNewTempRename.remove(currentBlock);
+                    it.remove();
+                }
+            };
+        }
+
+        public void renameVarsOnInstr(Instr i) {
+            if (i instanceof ClosureAcceptingInstr) {
+                i.renameVars(procToNewTempRename);
+            } else if (i instanceof LoadImplicitClosureInstr) {
+                i.renameVars(blockToNewTempRename);
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/jruby/ir/passes/OptimizeDelegationPass.java
+++ b/core/src/main/java/org/jruby/ir/passes/OptimizeDelegationPass.java
@@ -49,9 +49,9 @@ public class OptimizeDelegationPass extends CompilerPass {
     }
 
     private static void optimizeDelegatedVars(IRScope s) {
-        for (BasicBlock bb: s.cfg().getBasicBlocks()) {
-            Map<Operand, Operand> unusedExplicitBlocks = new HashMap<Operand, Operand>();
+        Map<Operand, Operand> unusedExplicitBlocks = new HashMap<Operand, Operand>();
 
+        for (BasicBlock bb: s.cfg().getBasicBlocks()) {
             for (Instr i: bb.getInstrs()) {
                 if (i instanceof ReifyClosureInstr) {
                     ReifyClosureInstr ri = (ReifyClosureInstr) i;
@@ -66,7 +66,9 @@ public class OptimizeDelegationPass extends CompilerPass {
                     }
                 }
             }
+        }
 
+        for (BasicBlock bb: s.cfg().getBasicBlocks()) {
             ListIterator<Instr> instrs = bb.getInstrs().listIterator();
             while (instrs.hasNext()) {
                 Instr i = instrs.next();


### PR DESCRIPTION
If an explicit block is captured as a proc, but its only usage is
converting it back to a block and passing it through, we can skip the
conversion entirely, and just pass through the original block.

This pass looks for all explicit block conversions, and checks if
they're ever used in any context besides being passed as a block. If
not, we rewrite all uses of the proc to pass the block through instead.
The dead code elimination will remove the proc as an unused variable.

It may be possible to implement this without adding another compiler
pass, but I had trouble finding a place where it fit nicely, especially
since it needs to run before the LiveVariableAnalysis.

I believe the same optimization could occur to skip array allocation for splatted args, and hash allocation for double splatted args, in this same compiler pass.

Given the following Ruby code:

```ruby
def foo(&block)
  bar(&block)
end
```

The instruction sequence before was:

```
%self = recv_self
check_arity req: 0, opt: 0, *r: -1, kw: false, **r: -1
%v_1 = load_implicit_closure
%t_block_2 = reify_closure(%v_1)
line_num(1)
%v_1 = call(FUNCTIONAL, bar, %self, [], &%t_block_2)
return(%v_1)
```

With this patch, the instruction sequence changes to:

```
%self = recv_self
check_arity req: 0, opt: 0, *r: -1, kw: false, **r: -1
%v_1 = load_implicit_closure
line_num(1)
%v_1 = call(FUNCTIONAL, bar, %self, [], &%v_1)
return(%v_1)
```

Which gives a healthy boost to performance on any code which passes
blocks through explicitly.