### PR TITLE
Exit iterator when `RubyHash#any?` short-circuits

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1892,25 +1892,29 @@ public class RubyHash extends RubyObject implements Map {
 
     private IRubyObject any_p_i(ThreadContext context, Block block) {
         iteratorEntry();
-        for (RubyHashEntry entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
-            IRubyObject newAssoc = RubyArray.newArray(context.runtime, entry.key, entry.value);
-            if (block.yield(context, newAssoc).isTrue())
-                return context.getRuntime().getTrue();
+        try {
+            for (RubyHashEntry entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
+                IRubyObject newAssoc = RubyArray.newArray(context.runtime, entry.key, entry.value);
+                if (block.yield(context, newAssoc).isTrue())
+                    return context.getRuntime().getTrue();
+            }
+            return context.getRuntime().getFalse();
+        } finally {
+            iteratorExit();
         }
-        iteratorExit();
-
-        return context.getRuntime().getFalse();
     }
 
     private IRubyObject any_p_i_fast(ThreadContext context, Block block) {
         iteratorEntry();
-        for (RubyHashEntry entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
-            if (block.yieldSpecific(context, entry.key, entry.value).isTrue())
-                return context.getRuntime().getTrue();
+        try {
+            for (RubyHashEntry entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
+                if (block.yieldSpecific(context, entry.key, entry.value).isTrue())
+                    return context.getRuntime().getTrue();
+            }
+            return context.getRuntime().getFalse();
+        } finally {
+            iteratorExit();
         }
-        iteratorExit();
-
-        return context.getRuntime().getFalse();
     }
 
     /**


### PR DESCRIPTION
Previously, if `any?` returned true early (or threw an exception) the hash would be marked as still iterating, and thus prevent updates.

Expressed in Ruby code, the following results in "can't add a new key into hash during iteration" errors:

```ruby
h = {1 => 2}; h.any? { true }; h[2] = 1
h = {1 => 2}; h.any? { raise } rescue nil; h[2] = 1
```

I would have liked to put them into tests, but wasn't completely sure were would be most appropriate.