### PR TITLE
Fix for issue 2182 on master : Struct#inspect with utf8 encode string member

### DIFF
--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -547,37 +547,37 @@ public class RubyStruct extends RubyObject {
     private IRubyObject inspectStruct(final ThreadContext context, boolean recur) {
         Ruby runtime = context.runtime;
         RubyArray member = __member__();
-        ByteList buffer = new ByteList("#<struct ".getBytes());
+        RubyString buffer = RubyString.newString(getRuntime(), new ByteList("#<struct ".getBytes()));
         String cpath = getMetaClass().getRealClass().getName();
         char first = cpath.charAt(0);
 
         if (recur || first != '#') {
-            buffer.append(cpath.getBytes());
-            buffer.append(' ');
+            buffer.cat(cpath.getBytes());
+            buffer.cat(' ');
         }
 
         if (recur) {
-            buffer.append(":...>".getBytes());
-            return runtime.newString(buffer);
+            buffer.cat(":...>".getBytes());
+            return buffer.dup();
         }
 
         for (int i = 0,k=member.getLength(); i < k; i++) {
             if (i > 0) {
-                buffer.append(',').append(' ');
+                buffer.cat(',').cat(' ');
             }
             RubySymbol slot = (RubySymbol)member.eltInternal(i);
             String name = slot.toString();
             if (IdUtil.isLocal(name) || IdUtil.isConstant(name)) {
-                buffer.append(RubyString.objAsString(context, slot).getByteList());
+                buffer.cat19(RubyString.objAsString(context, slot));
             } else {
-                buffer.append(((RubyString) slot.inspect(context)).getByteList());
+                buffer.cat19(((RubyString) slot.inspect(context)));
             }
-            buffer.append('=');
-            buffer.append(inspect(context, values[i]).getByteList());
+            buffer.cat('=');
+            buffer.cat19(inspect(context, values[i]));
         }
 
-        buffer.append('>');
-        return getRuntime().newString(buffer); // OBJ_INFECT
+        buffer.cat('>');
+        return buffer.dup(); // OBJ_INFECT
     }
 
     @JRubyMethod(name = {"inspect", "to_s"})

--- a/spec/regression/GH-2182_struct_inspect_has_ascii_encoding_spec.rb
+++ b/spec/regression/GH-2182_struct_inspect_has_ascii_encoding_spec.rb
@@ -1,0 +1,24 @@
+# -*- encoding: utf-8 -*-
+
+# https://github.com/jruby/jruby/issues/2182
+if RUBY_VERSION > '1.9'
+  describe 'Struct#inspect' do
+    it 'returns correct value' do
+      s1 = Struct.new(:aa).new("ΆἅἇἈ")
+      s1.inspect.should == "#<struct aa=\"ΆἅἇἈ\">"
+      s1.inspect.encoding.should == Encoding::UTF_8
+
+      s2 = Struct.new(:a, :b).new("ΆἅἇἈ", "abc")
+      s2.inspect.should == "#<struct a=\"ΆἅἇἈ\", b=\"abc\">"
+      s2.inspect.encoding.should == Encoding::UTF_8
+
+      s3 = Struct.new(:b).new("abc")
+      s3.inspect.should == "#<struct b=\"abc\">"
+      s3.inspect.encoding.should == Encoding::ASCII_8BIT
+
+      s4 = Struct.new(:"ΆἅἇἈ").new("aa")
+      s4.inspect.should == "#<struct ΆἅἇἈ=\"aa\">"
+      s4.inspect.encoding.should == Encoding::UTF_8
+    end
+  end
+end


### PR DESCRIPTION
This commit fixes issue #2182 on master. Inspect method of Struct with utf8 string member should return a utf8 string. Please review, @enebo and @headius. Thanks!