### PR TITLE
Add support for named captures in StringScanner (fixes #1067)

### DIFF
--- a/test/mri/excludes/TestStringScanner.rb
+++ b/test/mri/excludes/TestStringScanner.rb
@@ -1,4 +1,3 @@
-exclude :test_AREF, "needs investigation"
 exclude :test_pos_unicode, "needs investigation"
 exclude :test_string_append, "needs investigation"
 exclude :test_string_set_is_equal, "needs investigation"


### PR DESCRIPTION
#test_AREF should pass but fails locally with "undefined method `assert_raise_with_message'" and i'm not sure why. :sweat: