### PR TITLE
Fix Kernel#set_trace_func invocation after native Java EventHooks

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -3106,6 +3106,9 @@ public final class Ruby implements Constantizable {
                 found = true;
                 continue;
             }
+            if (j >= newHooks.length) {
+                break;
+            }
             newHooks[j] = hooks[i];
             j++;
         }


### PR DESCRIPTION
Hello,

Currently, registering plain Ruby `Kernel#set_trace_func` after native
extensions EventHooks fails with:

```
bug.rb:2 warning: tracing (e.g. set_trace_func) will not capture all events without --debug flag
Ruby.java:3058:in `removeEventHook': java.lang.ArrayIndexOutOfBoundsException: 0
         from Ruby.java:3066:in `setTraceFunction'
         from RubyKernel.java:1206:in `set_trace_func'
         from RubyKernel$INVOKER$s$1$0$set_trace_func.gen:-1:in `call'
         from JavaMethod.java:364:in `call'
         from CachingCallSite.java:317:in `cacheAndCall'
         from CachingCallSite.java:167:in `call'
         from Interpreter.java:293:in `processCall'
         from Interpreter.java:550:in `interpret'
         from Interpreter.java:617:in `INTERPRET_ROOT'
         from Interpreter.java:112:in `execute'
         from Interpreter.java:28:in `execute'
         from IRTranslator.java:39:in `execute'
         from Ruby.java:855:in `runInterpreter'
         from Ruby.java:863:in `runInterpreter'
         from Ruby.java:759:in `runNormally'
         from Ruby.java:564:in `runFromMain'
         from Main.java:405:in `doRunFromMain'
         from Main.java:300:in `internalRun'
         from Main.java:227:in `run'
         from Main.java:199:in `main'
```

I have a small reproduction script, which uses `Coverage`'s native
EventHook, however the problem is present in custom extensions that
implement EventHooks themselves as well.

Here is the script:

```ruby
require 'coverage'
Coverage.start

set_trace_func proc { |*args| p args }
```

I'm not sure whether my current solution is good enough, since I don't
know if the bargain with removeEventHook is to always find the previous
eventHook before, however it does prevent the crash in my tests.

Hope it helps!