### PR TITLE
Fix File.read with UTF-16LE

### DIFF
--- a/core/src/main/java/org/jruby/util/io/EncodingUtils.java
+++ b/core/src/main/java/org/jruby/util/io/EncodingUtils.java
@@ -1357,7 +1357,8 @@ public class EncodingUtils {
                 if ((b2 = io.getbyte(context)).isNil()) break;
                 if (((RubyFixnum)b2).getLongValue() == 0xFE) {
                     b3 = io.getbyte(context);
-                    if (((RubyFixnum)b3).getLongValue() == 0 && !(b4 = io.getbyte(context)).isNil()) {
+                    if (!b3.isNil() && ((RubyFixnum)b3).getLongValue() == 0
+                            && !(b4 = io.getbyte(context)).isNil()) {
                         if (((RubyFixnum)b4).getLongValue() == 0) {
                             return UTF32LEEncoding.INSTANCE;
                         }

--- a/test/mri/excludes/TestFile.rb
+++ b/test/mri/excludes/TestFile.rb
@@ -1,3 +1,1 @@
-exclude :test_bom_16le, "needs investigation"
 exclude :test_stat , "birthtime does not match MRI behavior (#2152)"
-exclude :test_truncate_wbuf, "fails on Linux"


### PR DESCRIPTION
```shell
File.open("a.txt", "w+") do |f|
  f.write "\xFF\xFE"
  f.close
end
File.read("a.txt", mode: "rb:bom|utf-8")
```
...results in...
```
<java.lang.ClassCastException: org.jruby.RubyNil cannot be cast to org.jruby.RubyFixnum>
```

A check for a null value seems to be missing after the BOM. 

The `test_truncate_wbuf` removal is just general cleanup. It doesn't have anything to do with the fix. I guess it's ok. :)