### PR TITLE
Fix power of 0 and 1 issues in Rational

### DIFF
--- a/core/src/main/java/org/jruby/util/Numeric.java
+++ b/core/src/main/java/org/jruby/util/Numeric.java
@@ -35,6 +35,7 @@ import org.jruby.RubyBignum;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
 import org.jruby.RubyInteger;
+import org.jruby.RubyNumeric;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -347,7 +348,23 @@ public class Numeric {
         if (x instanceof RubyFixnum) return ((RubyFixnum)x).getLongValue() == 1;
         return x.callMethod(context, "==", RubyFixnum.one(context.runtime)).isTrue();
     }
-    
+
+   /** f_minus_one_p
+    *
+    */
+    public static boolean f_minus_one_p(ThreadContext context, IRubyObject x) {
+        if (x instanceof RubyFixnum) return ((RubyFixnum)x).getLongValue() == -1;
+        return x.callMethod(context, "==", RubyFixnum.minus_one(context.runtime)).isTrue();
+    }
+
+   /** f_odd_p
+    *
+    */
+    public static boolean f_odd_p(ThreadContext context, IRubyObject integer) {
+        Ruby runtime = context.runtime;
+        return (((RubyFixnum) integer.callMethod(context, "%", RubyFixnum.two(runtime))).getLongValue() != 0);
+    }
+
     /** i_gcd
      * 
      */
@@ -496,6 +513,14 @@ public class Numeric {
 
     public static boolean k_inexact_p(IRubyObject x) {
         return x instanceof RubyFloat;
+    }
+
+    public static boolean k_integer_p(IRubyObject x) {
+        return x instanceof RubyInteger;
+    }
+
+    public static boolean k_numeric_p(IRubyObject x) {
+        return x instanceof RubyNumeric;
     }
 
     public static final class ComplexPatterns {

--- a/test/mri/excludes/TestFixnum.rb
+++ b/test/mri/excludes/TestFixnum.rb
@@ -1,2 +1,1 @@
-exclude :test_power_of_0, "needs investigation"
 exclude :test_power_of_1_and_minus_1, "needs investigation"


### PR DESCRIPTION
The patch adds special case handling for `0**n` and `1**n` to match the
MRI behavior. For example, the following cases are affected:

```ruby
0**Rational(1, 2) # => 0/1 instead of 0.0
0**Rational(-1, 2) # => ZeroDivisionError instead of Infinity`
1**Rational(1, 2) # => 1/1 instead of 1.0
```