### PR TITLE
[Truffle] Fixed Bignum#size implementation

### DIFF
--- a/spec/truffle/tags/core/bignum/size_tags.txt
+++ b/spec/truffle/tags/core/bignum/size_tags.txt
@@ -1,1 +1,0 @@
-fails:Bignum#size returns the number of bytes in the machine representation

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/BignumNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/BignumNodes.java
@@ -720,7 +720,7 @@ public abstract class BignumNodes {
 
         @Specialization
         public int size(RubyBignum value) {
-            return value.bigIntegerValue().bitLength();
+            return (value.bigIntegerValue().bitLength() + 7) / 8;
         }
 
     }


### PR DESCRIPTION
Used RubyBignum as a reference for size implementation: 
https://github.com/jruby/jruby/blob/master/core/src/main/java/org/jruby/RubyBignum.java#L891