### PR TITLE
[Truffle] Passing through encoding information from SymbolNode

### DIFF
--- a/spec/truffle/tags/core/symbol/length_tags.txt
+++ b/spec/truffle/tags/core/symbol/length_tags.txt
@@ -1,1 +1,0 @@
-fails:Symbol#length returns 4 for name formed by 1 multibyte and 3 ASCII characters

--- a/spec/truffle/tags/core/symbol/size_tags.txt
+++ b/spec/truffle/tags/core/symbol/size_tags.txt
@@ -1,1 +1,0 @@
-fails:Symbol#size returns 4 for name formed by 1 multibyte and 3 ASCII characters

--- a/spec/truffle/tags/core/symbol/versions/encoding_1.9_tags.txt
+++ b/spec/truffle/tags/core/symbol/versions/encoding_1.9_tags.txt
@@ -1,2 +1,0 @@
-fails:Symbol#encoding for UTF-8 symbols is UTF-8
-fails:Symbol#encoding for UTF-8 symbols is UTF-8 after converting to string

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/SymbolNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/SymbolNodes.java
@@ -335,7 +335,7 @@ public abstract class SymbolNodes {
 
         @Specialization
         public int size(RubySymbol symbol) {
-            return StringSupport.strLengthFromRubyString(symbol);
+            return symbol.getByteList().lengthEnc();
         }
 
     }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/RubyContext.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/RubyContext.java
@@ -17,6 +17,7 @@ import com.oracle.truffle.api.source.BytesDecoder;
 import com.oracle.truffle.api.source.Source;
 
 import org.jcodings.Encoding;
+import org.jcodings.specific.ASCIIEncoding;
 import org.jcodings.specific.UTF8Encoding;
 import org.jruby.Ruby;
 import org.jruby.RubyNil;
@@ -193,9 +194,15 @@ public class RubyContext extends ExecutionContext {
         return symbolTable;
     }
 
+
     @CompilerDirectives.TruffleBoundary
     public RubySymbol newSymbol(String name) {
-        return symbolTable.getSymbol(name);
+        return symbolTable.getSymbol(name, ASCIIEncoding.INSTANCE);
+    }
+
+    @CompilerDirectives.TruffleBoundary
+    public RubySymbol newSymbol(String name, Encoding encoding) {
+        return symbolTable.getSymbol(name, encoding);
     }
 
     @CompilerDirectives.TruffleBoundary

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/RubySymbol.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/RubySymbol.java
@@ -16,6 +16,7 @@ import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.source.SourceSection;
 
 import org.jcodings.Encoding;
+import org.jcodings.specific.ASCIIEncoding;
 import org.jruby.truffle.nodes.RubyNode;
 import org.jruby.truffle.nodes.RubyRootNode;
 import org.jruby.truffle.nodes.methods.SymbolProcNode;
@@ -45,7 +46,7 @@ public class RubySymbol extends RubyBasicObject implements CodeRangeable {
     }
 
     public static RubySymbol newSymbol(RubyContext runtime, String name) {
-        return runtime.getSymbolTable().getSymbol(name);
+        return runtime.getSymbolTable().getSymbol(name, ASCIIEncoding.INSTANCE);
     }
 
     public RubyProc toProc(SourceSection sourceSection, final RubyNode currentNode) {
@@ -155,7 +156,13 @@ public class RubySymbol extends RubyBasicObject implements CodeRangeable {
 
         @TruffleBoundary
         public RubySymbol getSymbol(String name) {
-            ByteList byteList = org.jruby.RubySymbol.symbolBytesFromString(context.getRuntime(), name);
+            return getSymbol(name, ASCIIEncoding.INSTANCE);
+        }
+
+        @TruffleBoundary
+        public RubySymbol getSymbol(String name, Encoding encoding) {
+            final ByteList byteList = org.jruby.RubySymbol.symbolBytesFromString(context.getRuntime(), name);
+            byteList.setEncoding(encoding);
 
             RubySymbol symbol = symbolsTable.get(byteList);
 

--- a/truffle/src/main/java/org/jruby/truffle/translator/BodyTranslator.java
+++ b/truffle/src/main/java/org/jruby/truffle/translator/BodyTranslator.java
@@ -2541,7 +2541,7 @@ public class BodyTranslator extends Translator {
 
     @Override
     public RubyNode visitSymbolNode(org.jruby.ast.SymbolNode node) {
-        return new ObjectLiteralNode(context, translate(node.getPosition()), context.newSymbol(node.getName()));
+        return new ObjectLiteralNode(context, translate(node.getPosition()), context.newSymbol(node.getName(), node.getEncoding()));
     }
 
     @Override


### PR DESCRIPTION
 to RubySymbol. Previously all were encoding as ASCII. A few string only methods are here to keep it backward compatible. I wasn't sure how to facture out the method calls to these.

I think SymbolNode could be considered to use ByteList instead of a String in the future.

