### PR TITLE
embed internal fixes

### DIFF
--- a/core/src/main/java/org/jruby/embed/ScriptingContainer.java
+++ b/core/src/main/java/org/jruby/embed/ScriptingContainer.java
@@ -59,6 +59,7 @@ import org.jruby.embed.internal.ThreadSafeLocalContextProvider;
 import org.jruby.embed.io.ReaderInputStream;
 import org.jruby.embed.io.WriterOutputStream;
 import org.jruby.embed.util.SystemPropertyCatcher;
+import org.jruby.exceptions.RaiseException;
 import org.jruby.internal.runtime.GlobalVariable;
 import org.jruby.javasupport.JavaEmbedUtils;
 import org.jruby.runtime.Block;
@@ -227,14 +228,16 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
     public ScriptingContainer(LocalContextScope scope, LocalVariableBehavior behavior, boolean lazy) {
         provider = getProviderInstance(scope, behavior, lazy);
         try {
-            initConfig();
-        } catch (Exception ex) {
+            initRubyInstanceConfig();
+        }
+        catch (RaiseException ex) {
+            // TODO this seems useless - except that we get a Java stack trace
             throw new RuntimeException(ex);
         }
         basicProperties = getBasicProperties();
     }
 
-    private LocalContextProvider getProviderInstance(LocalContextScope scope, LocalVariableBehavior behavior, boolean lazy) {
+    static LocalContextProvider getProviderInstance(LocalContextScope scope, LocalVariableBehavior behavior, boolean lazy) {
         switch(scope) {
             case THREADSAFE :
                 return new ThreadSafeLocalContextProvider(behavior, lazy);
@@ -248,7 +251,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
         }
     }
 
-    private void initConfig() throws URISyntaxException, UnsupportedEncodingException {
+    private void initRubyInstanceConfig() throws RaiseException {
         List<String> paths = SystemPropertyCatcher.findLoadPaths();
         provider.getRubyInstanceConfig().setLoadPaths(paths);
         String home = SystemPropertyCatcher.findJRubyHome(this);

--- a/core/src/main/java/org/jruby/embed/ScriptingContainer.java
+++ b/core/src/main/java/org/jruby/embed/ScriptingContainer.java
@@ -33,7 +33,6 @@ import java.io.UnsupportedEncodingException;
 import org.jruby.embed.internal.LocalContextProvider;
 import java.io.InputStream;
 import java.io.PrintStream;
-import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.net.URISyntaxException;
@@ -172,11 +171,12 @@ import org.jruby.util.cli.Options;
  * @author Yoko Harada <yokolet@gmail.com>
  */
 public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
-    private Map basicProperties = null;
-    private LocalContextProvider provider = null;
-    private EmbedRubyRuntimeAdapter runtimeAdapter = new EmbedRubyRuntimeAdapterImpl(this);
-    private EmbedRubyObjectAdapter objectAdapter = new EmbedRubyObjectAdapterImpl(this);
-    private EmbedRubyInterfaceAdapter interfaceAdapter = new EmbedRubyInterfaceAdapterImpl(this);
+
+    private final Map<String, String[]> basicProperties;
+    private final LocalContextProvider provider;
+    private final EmbedRubyRuntimeAdapter runtimeAdapter = new EmbedRubyRuntimeAdapterImpl(this);
+    private final EmbedRubyObjectAdapter objectAdapter = new EmbedRubyObjectAdapterImpl(this);
+    private final EmbedRubyInterfaceAdapter interfaceAdapter = new EmbedRubyInterfaceAdapterImpl(this);
 
     /**
      * Constructs a ScriptingContainer with a default values.
@@ -231,7 +231,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }
-        setBasicProperties();
+        basicProperties = getBasicProperties();
     }
 
     private LocalContextProvider getProviderInstance(LocalContextScope scope, LocalVariableBehavior behavior, boolean lazy) {
@@ -259,12 +259,13 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
     }
 
     // maybe these properties are not used at all?
-    private void setBasicProperties() {
-        basicProperties = new HashMap();
-        basicProperties.put("container.ids", new String[]{"ruby", "jruby"});
-        basicProperties.put("language.extension", new String[]{"rb"});
-        basicProperties.put("language.name", new String[]{"ruby"});
-        basicProperties.put("language.mimetypes", new String[]{"application/x-ruby"});
+    private static Map<String, String[]> getBasicProperties() {
+        Map<String, String[]> properties = new HashMap<String, String[]>();
+        properties.put("container.ids", new String[]{"ruby", "jruby"});
+        properties.put("language.extension", new String[]{"rb"});
+        properties.put("language.name", new String[]{"ruby"});
+        properties.put("language.mimetypes", new String[]{"application/x-ruby"});
+        return properties;
     }
 
     /**
@@ -1063,10 +1064,9 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      */
     public String[] getProperty(String key) {
         if (basicProperties.containsKey(key)) {
-            return (String[]) basicProperties.get(key);
-        } else {
-            return null;
+            return basicProperties.get(key);
         }
+        return null;
     }
 
     /**

--- a/core/src/main/java/org/jruby/embed/ScriptingContainer.java
+++ b/core/src/main/java/org/jruby/embed/ScriptingContainer.java
@@ -75,12 +75,12 @@ import org.jruby.util.cli.Options;
  * for embedding Ruby in Java. Using this class, users can run Ruby scripts from
  * Java programs easily. Also, users can use methods defined or implemented by Ruby.
  *
- * ScriptingContainer allows users to set various configuration parameters. 
+ * ScriptingContainer allows users to set various configuration parameters.
  * Some of them are per-container properties, while others are per-evaluation attributes.
- * For example, a local context scope, local variable behavior, load paths are 
+ * For example, a local context scope, local variable behavior, load paths are
  * per-container properties. Please see {@link PropertyName} and {@link AttributeName}
  * for more details. Be aware that the per-container properties should be set prior to
- * get Ruby runtime be instantiated; otherwise, default values are applied to. 
+ * get Ruby runtime be instantiated; otherwise, default values are applied to.
  * ScriptingContainer delays Ruby runtime initialization as much as possible to
  * improve startup time. When values are put into the ScriptingContainer, or runScriptlet
  * method gets run Ruby runtime is created internally. However, the default, singleton
@@ -98,7 +98,7 @@ import org.jruby.util.cli.Options;
  *
  * Produces:
  * Hello World!</pre>
- * 
+ *
  * The second example shows how to share variables between Java and Ruby.
  * In this example, a local variable "x" is shared. To make this happen, a local variable
  * behavior should be transient or persistent. As for JSR223 JRuby engine, set these
@@ -107,7 +107,7 @@ import org.jruby.util.cli.Options;
  * Ruby's local, instance, global variables and constants are available to share
  * between Java and Ruby. (A class variable sharing does not work on current version)
  * Thus, "x" in Java is also "x" in Ruby.
- * 
+ *
  * <pre>Example 2:
  *
  *         ScriptingContainer container = new ScriptingContainer();
@@ -124,7 +124,7 @@ import org.jruby.util.cli.Options;
  * when the container is instantiated.
  *
  * <pre>Example 3:
- * 
+ *
  *         ScriptingContainer container = new ScriptingContainer(LocalVariableBehavior.PERSISTENT);
  *         container.runScriptlet("p=9.0");
  *         container.runScriptlet("q = Math.sqrt p");
@@ -135,7 +135,7 @@ import org.jruby.util.cli.Options;
  * Produces:
  * square root of 9.0 is 3.0
  * Ruby used values: p = 9.0, q = 3.0</pre>
- * 
+ *
  * Also, ScriptingContainer provides better i18n support. For example,
  * Unicode Escape Sequence can be included in Ruby scripts.
  *
@@ -160,15 +160,15 @@ import org.jruby.util.cli.Options;
  *         container.put("@message", "That's the way you are.");
  *         ret = unit.run();
  *         System.out.println(JavaEmbedUtils.rubyToJava(ret));
- * 
+ *
  * Produces:
  *     message: What's up?
  *     message: Fabulous!
  *     message: That's the way you are.</pre>
  *
- * See more details at project's 
+ * See more details at project's
  * {@see <a href="https://github.com/jruby/jruby/wiki/RedBridge">Wiki</a>}
- * 
+ *
  * @author Yoko Harada <yokolet@gmail.com>
  */
 public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
@@ -244,9 +244,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
                 return new SingleThreadLocalContextProvider(behavior, lazy);
             case SINGLETON :
             default :
-                LocalVariableBehavior b = SingletonLocalContextProvider.getLocalVariableBehaviorOrNull();
-                if (b == null) return new SingletonLocalContextProvider(behavior, lazy);
-                else return new SingletonLocalContextProvider(b, lazy);
+                return SingletonLocalContextProvider.getProvider(behavior, lazy);
         }
     }
 
@@ -753,7 +751,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      * initial configurations will work.
      *
      * ProfilingMode allows you to change profiling style.
-     * 
+     *
      * Profiling.OFF - default. profiling off.
      * Profiling.API - activates Ruby profiler API. equivalent to --profile.api command line option
      * Profiling.FLAT - synonym for --profile command line option equivalent to --profile.flat command line option
@@ -1072,11 +1070,11 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
     }
 
     /**
-     * Returns a provider instance of {@link LocalContextProvider}. When users 
+     * Returns a provider instance of {@link LocalContextProvider}. When users
      * want to configure Ruby runtime, they can do by setting class loading paths,
      * {@link org.jruby.RubyInstanceConfig} or {@link org.jruby.util.ClassCache}
      * to the provider before they get Ruby runtime.
-     * 
+     *
      * @return a provider of {@link LocalContextProvider}
      */
     public LocalContextProvider getProvider() {
@@ -1099,7 +1097,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      * Returns a variable map in one of {@link LocalContextScope}. Variables
      * in this map is used to share between Java and Ruby. Map keys are Ruby's
      * variable names, thus they must be valid Ruby names.
-     * 
+     *
      * @return a variable map specific to the current thread
      */
     public BiVariableMap getVarMap() {
@@ -1110,7 +1108,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      * Returns a attribute map in one of {@link LocalContextScope}. Attributes
      * in this map accept any key value pair, types of which are java.lang.Object.
      * Ruby scripts do not look up this map.
-     * 
+     *
      * @return an attribute map specific to the current thread
      */
     public Map getAttributeMap() {
@@ -1121,7 +1119,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      * Returns an attribute value associated with the specified key in
      * a attribute map. This is a short cut method of
      * ScriptingContainer#getAttributeMap().get(key).
-     * 
+     *
      * @param key is the attribute key
      * @return value is a value associated to the specified key
      */
@@ -1134,10 +1132,10 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      * attribute map. If the map previously contained a mapping for the key,
      * the old value is replaced. This is a short cut method of
      * ScriptingContainer#getAttributeMap().put(key, value).
-     * 
+     *
      * @param key is a key that the specified value is to be associated with
      * @param value is a value to be associated with the specified key
-     * @return the previous value associated with key, or null if there was no mapping for key. 
+     * @return the previous value associated with key, or null if there was no mapping for key.
      */
     public Object setAttribute(Object key, Object value) {
         return provider.getAttributeMap().put(key, value);
@@ -1160,7 +1158,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      * Returns a value of the specified key in a top level of runtime or null
      * if this map doesn't have a mapping for the key. The key
      * must be a valid Ruby variable or constant name.
-     * 
+     *
      * @param key is a key whose associated value is to be returned
      * @return a value to which the specified key is mapped, or null if this
      *         map contains no mapping for the key
@@ -1188,9 +1186,9 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      * Associates the specified value with the specified key in a
      * variable map. This key-value pair is injected to a top level of runtime
      * during evaluation. If the map previously contained a mapping for the key,
-     * the old value is replaced. The key must be a valid Ruby variable or 
-     * constant name. It will be a top level variable or constant. 
-     * 
+     * the old value is replaced. The key must be a valid Ruby variable or
+     * constant name. It will be a top level variable or constant.
+     *
      * @param key is a key that the specified value is to be associated with
      * @param value is a value to be associated with the specified key
      * @return a previous value associated with a key, or null if there was
@@ -1204,7 +1202,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      * Associates the specified value with the specified key in a variable map.
      * This key-value pair is injected to a given receiver during evaluation.
      * If the map previously contained a mapping for the key,
-     * the old value is replaced. The key must be a valid Ruby variable or 
+     * the old value is replaced. The key must be a valid Ruby variable or
      * constant name. A given receiver limits the scope of a variable or constant.
      * However, a global variable is accessible globally always.
      *
@@ -1261,7 +1259,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
     /**
      * Parses a script and return an object which can be run(). This allows
      * the script to be parsed once and evaluated many times.
-     * 
+     *
      * @param script is a Ruby script to be parsed
      * @param lines are linenumbers to display for parse errors and backtraces.
      *        This field is optional. Only the first argument is used for parsing.
@@ -1275,7 +1273,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
     /**
      * Parses a script given by a reader and return an object which can be run().
      * This allows the script to be parsed once and evaluated many times.
-     * 
+     *
      * @param reader is used to read a script from
      * @param filename is used as in information, for example, appears in a stack trace
      *        of an exception
@@ -1291,7 +1289,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
     /**
      * Parses a script read from a specified path and return an object which can be run().
      * This allows the script to be parsed once and evaluated many times.
-     * 
+     *
      * @param type is one of the types {@link PathType} defines
      * @param filename is used as in information, for example, appears in a stack trace
      *        of an exception
@@ -1307,7 +1305,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
     /**
      * Parses a script given by a input stream and return an object which can be run().
      * This allows the script to be parsed once and evaluated many times.
-     * 
+     *
      * @param istream is an input stream to get a script from
      * @param filename filename is used as in information, for example, appears in a stack trace
      *        of an exception
@@ -1345,7 +1343,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      * Evaluates a script read from a reader under the current scope
      * (perhaps the top-level scope) and returns a result only if a script
      * returns a value. Right after the parsing, the script is evaluated once.
-     * 
+     *
      * @param reader is used to read a script from
      * @param filename is used as in information, for example, appears in a stack trace
      *        of an exception
@@ -1375,7 +1373,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      * Reads a script file from specified path and evaluates it under the current
      * scope (perhaps the top-level scope) and returns a result only if a script
      * returns a value. Right after the parsing, the script is evaluated once.
-     * 
+     *
      * @param type is one of the types {@link PathType} defines
      * @param filename is used to read the script from and an information
      * @return an evaluated result converted to a Java object
@@ -1388,7 +1386,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
     /**
      * Returns an instance of {@link EmbedRubyRuntimeAdapter} for embedders to parse
      * scripts.
-     * 
+     *
      * @return an instance of {@link EmbedRubyRuntimeAdapter}.
      */
     public EmbedRubyRuntimeAdapter newRuntimeAdapter() {
@@ -1423,7 +1421,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      * Outputs:
      *     next year: 2010
      *     2009-05-19T17:46:44-04:00</pre>
-     * 
+     *
      * @return an instance of {@link EmbedRubyObjectAdapter}
      */
     public EmbedRubyObjectAdapter newObjectAdapter() {
@@ -1460,7 +1458,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
     public Object callMethod(Object receiver, String methodName, Block block, Object... args) {
         return objectAdapter.callMethod(receiver, methodName, block, args);
     }
-    
+
     /**
      * Executes a method defined in Ruby script. This method is used when a Ruby
      * method does not have any argument.
@@ -1605,7 +1603,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
     public <T> T callSuper(Object receiver, Object[] args, Block block, Class<T> returnType) {
         return objectAdapter.callSuper(receiver, args, block, returnType);
     }
-    
+
     /**
      * Executes a method defined in Ruby script. This method is used when a Ruby
      * method does not have any argument.
@@ -1685,10 +1683,10 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      *     }
      *
      * Output
-     *     -2.7416573867739413, 4.741657386773941, 
+     *     -2.7416573867739413, 4.741657386773941,
      * </pre>
      *
-     * 
+     *
      * @param receiver is an instance that implements the interface
      * @param clazz is a requested interface
      * @return an instance of a requested interface type
@@ -1699,7 +1697,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
 
     /**
      * Replaces a standard input by a specified reader
-     * 
+     *
      * @param reader is a reader to be set
      */
     public void setReader(Reader reader) {
@@ -1740,7 +1738,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      * Ruby runtime is initialized.
      *
      * @deprecated As of JRuby 1.5.0, replaced by getInput().
-     * 
+     *
      * @return an input stream that Ruby runtime has.
      */
     @Deprecated
@@ -1789,7 +1787,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
 
     /**
      * Returns a writer set in an attribute map.
-     * 
+     *
      * @return a writer in a attribute map
      */
     public Writer getWriter() {
@@ -1805,7 +1803,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      * Ruby runtime is initialized.
      *
      * @deprecated As of JRuby 1.5.0, replaced by getOutput().
-     * 
+     *
      * @return an output stream that Ruby runtime has
      */
     @Deprecated
@@ -1815,7 +1813,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
 
     /**
      * Replaces a standard error by a specified writer.
-     * 
+     *
      * @param errorWriter is a writer to be set
      */
     public void setErrorWriter(Writer errorWriter) {
@@ -1869,7 +1867,7 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
      * Ruby runtime is initialized.
      *
      * @deprecated As of JRuby 1.5.0, Replaced by getError()
-     * 
+     *
      * @return an error output stream that Ruby runtime has
      */
     @Deprecated
@@ -1892,9 +1890,9 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
     /**
      * Ensure this ScriptingContainer instance is terminated when nobody holds any
      * references to it (and GC wants to reclaim it).
-     * 
+     *
      * @throws Throwable
-     * 
+     *
      * @since JRuby 1.6.0
      */
     public void finalize() throws Throwable {

--- a/core/src/main/java/org/jruby/embed/internal/AbstractLocalContextProvider.java
+++ b/core/src/main/java/org/jruby/embed/internal/AbstractLocalContextProvider.java
@@ -39,33 +39,47 @@ import org.jruby.util.ClassCache;
  * @author Yoko Harada <yokolet@gmail.com>
  */
 public abstract class AbstractLocalContextProvider implements LocalContextProvider {
-    protected RubyInstanceConfig config = new RubyInstanceConfig();
-    protected LocalVariableBehavior behavior = LocalVariableBehavior.TRANSIENT;
+
+    protected final RubyInstanceConfig config;
+    protected final LocalVariableBehavior behavior;
     protected boolean lazy = true;
+
+    protected AbstractLocalContextProvider() {
+        this( new RubyInstanceConfig() );
+    }
+
+    protected AbstractLocalContextProvider(RubyInstanceConfig config) {
+        this.config = config; this.behavior = LocalVariableBehavior.TRANSIENT;
+    }
+
+    protected AbstractLocalContextProvider(RubyInstanceConfig config, LocalVariableBehavior behavior) {
+        this.config = config; this.behavior = behavior;
+    }
+
+    protected AbstractLocalContextProvider(LocalVariableBehavior behavior) {
+        this.config = new RubyInstanceConfig(); this.behavior = behavior;
+    }
 
     @Deprecated
     public void setLoadPaths(List loadPaths) {
-        if (config != null) {
-            config.setLoadPaths(loadPaths);
-        }
-        
+        config.setLoadPaths(loadPaths);
     }
 
     @Deprecated
     public void setClassCache(ClassCache classCache) {
-        if (config != null) {
-            config.setClassCache(classCache);
-        }
-    }
-
-    public RubyInstanceConfig getRubyInstanceConfig() {
-        return config;
+        config.setClassCache(classCache);
     }
 
     protected LocalContext getInstance() {
         return new LocalContext(config, behavior, lazy);
     }
-    
+
+    @Override
+    public RubyInstanceConfig getRubyInstanceConfig() {
+        return config;
+    }
+
+    @Override
     public LocalVariableBehavior getLocalVariableBehavior() {
         return behavior;
     }

--- a/core/src/main/java/org/jruby/embed/internal/AbstractLocalContextProvider.java
+++ b/core/src/main/java/org/jruby/embed/internal/AbstractLocalContextProvider.java
@@ -30,6 +30,7 @@
 package org.jruby.embed.internal;
 
 import java.util.List;
+import org.jruby.Ruby;
 import org.jruby.RubyInstanceConfig;
 import org.jruby.embed.LocalVariableBehavior;
 import org.jruby.util.ClassCache;
@@ -83,4 +84,26 @@ public abstract class AbstractLocalContextProvider implements LocalContextProvid
     public LocalVariableBehavior getLocalVariableBehavior() {
         return behavior;
     }
+
+    static Ruby getGlobalRuntime(AbstractLocalContextProvider provider) {
+        if ( Ruby.isGlobalRuntimeReady() ) {
+            return Ruby.getGlobalRuntime();
+        }
+        return Ruby.newInstance(provider.config);
+    }
+
+    static RubyInstanceConfig getGlobalRuntimeConfig(AbstractLocalContextProvider provider) {
+        // make sure we do not yet initialize the runtime here
+        if ( Ruby.isGlobalRuntimeReady() ) {
+            return Ruby.getGlobalRuntime().getInstanceConfig();
+        }
+        return provider.config;
+    }
+
+    static RubyInstanceConfig getGlobalRuntimeConfigOrNew() {
+        return Ruby.isGlobalRuntimeReady() ?
+                Ruby.getGlobalRuntime().getInstanceConfig() :
+                    new RubyInstanceConfig();
+    }
+
 }

--- a/core/src/main/java/org/jruby/embed/internal/AbstractLocalContextProvider.java
+++ b/core/src/main/java/org/jruby/embed/internal/AbstractLocalContextProvider.java
@@ -85,17 +85,19 @@ public abstract class AbstractLocalContextProvider implements LocalContextProvid
         return behavior;
     }
 
-    static Ruby getGlobalRuntime(AbstractLocalContextProvider provider) {
-        if ( Ruby.isGlobalRuntimeReady() ) {
+    boolean isGlobalRuntimeReady() { return Ruby.isGlobalRuntimeReady(); }
+
+    Ruby getGlobalRuntime(AbstractLocalContextProvider provider) {
+        if ( isGlobalRuntimeReady() ) {
             return Ruby.getGlobalRuntime();
         }
         return Ruby.newInstance(provider.config);
     }
 
-    static RubyInstanceConfig getGlobalRuntimeConfig(AbstractLocalContextProvider provider) {
+    RubyInstanceConfig getGlobalRuntimeConfig(AbstractLocalContextProvider provider) {
         // make sure we do not yet initialize the runtime here
-        if ( Ruby.isGlobalRuntimeReady() ) {
-            return Ruby.getGlobalRuntime().getInstanceConfig();
+        if ( isGlobalRuntimeReady() ) {
+            return getGlobalRuntime(provider).getInstanceConfig();
         }
         return provider.config;
     }

--- a/core/src/main/java/org/jruby/embed/internal/BiVariableMap.java
+++ b/core/src/main/java/org/jruby/embed/internal/BiVariableMap.java
@@ -32,11 +32,12 @@ package org.jruby.embed.internal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.jruby.Ruby;
 import org.jruby.RubyObject;
 import org.jruby.embed.LocalVariableBehavior;
 import org.jruby.embed.variable.BiVariable;
@@ -64,16 +65,18 @@ import org.jruby.runtime.scope.ManyVarsDynamicScope;
  *
  * @author Yoko Harada <yokolet@gmail.com>
  */
-public class BiVariableMap<K, V> implements Map<K, V> {
+public class BiVariableMap implements Map<String, Object> {
+
     private final LocalContextProvider provider;
-    private List<String> varNames = null;
-    private List<BiVariable> variables = null;
-    private boolean lazy;
+    private final boolean lazy;
+
+    private List<String> varNames;
+    private List<BiVariable> variables;
 
     /**
      * Constructs an empty map. Users do not instantiate this map. The map is created
      * internally.
-     * 
+     *
      * @param runtime is environment where variables are used to execute Ruby scripts.
      * @param behavior is one of variable behaviors defined in VariableBehavior.
      */
@@ -88,7 +91,7 @@ public class BiVariableMap<K, V> implements Map<K, V> {
      * @return a List of all names.
      */
     public List<String> getNames() {
-        return varNames;
+        return varNames == null ? varNames = new ArrayList<String>() : varNames;
     }
 
     /**
@@ -97,8 +100,10 @@ public class BiVariableMap<K, V> implements Map<K, V> {
      * @return a List of all values.
      */
     public List<BiVariable> getVariables() {
-        return variables;
+        return variables == null ? variables = new ArrayList<BiVariable>() : variables;
     }
+
+    public Ruby getRuntime() { return provider.getRuntime(); }
 
     /**
      * Returns a local variable behavior
@@ -114,73 +119,75 @@ public class BiVariableMap<K, V> implements Map<K, V> {
      *
      * @return a Map of key and value pair, in which values are simple Java objects.
      */
-    public Map getMap() {
-        Map m = new HashMap();
-        for (BiVariable v : variables) {
-            m.put(v.getName(), v.getJavaObject());
+    public Map<String, Object> getMap() {
+        HashMap<String, Object> map = new HashMap<String, Object>();
+        if ( variables != null ) {
+            for ( final BiVariable var : getVariables() ) {
+                map.put( var.getName(), var.getJavaObject() );
+            }
         }
-        return m;
+        return map;
     }
 
     /**
      * Returns the number of key-value mappings in this map.
-     * 
+     *
      * @return the number of key-value mappings in this map
      */
+    @Override
     public int size() {
-        if (varNames == null) return 0;
-        return varNames.size();
+        return variables == null ? 0 : variables.size();
     }
 
     /**
      * Returns <tt>true</tt> if this map contains no key-value mappings.
-     * 
+     *
      * @return <tt>true</tt> if this map contains no key-value mappings
      */
+    @Override
     public boolean isEmpty() {
-        return varNames == null || varNames.isEmpty();
+        return variables == null || variables.isEmpty();
     }
 
-    private void checkKey(Object key) {
-        if (key == null) {
+    private static String checkKey(final Object key) {
+        if ( key == null ) {
             throw new NullPointerException("key is null");
         }
-        if (!(key instanceof String)) {
+        if ( ! (key instanceof String) ) {
             throw new ClassCastException("key is NOT String");
         }
-        if (((String)key).length() == 0) {
+        if ( ( (String) key ).isEmpty() ) {
             throw new IllegalArgumentException("key is empty");
         }
+        return (String) key;
     }
 
     /**
      * Returns <tt>true</tt> if this map contains a mapping for the specified
      * key.
-     * 
+     *
      * @param key is a key to be tested its presence
      * @return <tt>true</tt> if this map contains a mapping for the specified key
      */
-    public boolean containsKey(Object key) {
-        if (varNames == null) return false;
-        checkKey(key);
-        return varNames.contains((String)key);
+    @Override
+    public boolean containsKey(final Object key) {
+        if ( varNames == null || key == null ) return false;
+        return varNames.contains( checkKey(key) );
     }
 
     /**
      * Returns <tt>true</tt> if this map maps one or more keys to the
      * specified value.
-     * 
+     *
      * @param value is a Java object to be tested it presence
      * @return Returns <tt>true</tt> if this map maps one or more keys to the
      * specified value.
      */
-    public boolean containsValue(Object value) {
-        Iterator itr = variables.iterator();
-        while (itr.hasNext()) {
-            BiVariable v = (BiVariable)itr.next();
-            if (value == v.getJavaObject()) {
-                return true;
-            }
+    @Override
+    public boolean containsValue(final Object value) {
+        if ( variables == null || value == null ) return false;
+        for ( final BiVariable var : getVariables() ) {
+            if ( value.equals( var.getJavaObject() ) ) return true;
         }
         return false;
     }
@@ -193,7 +200,8 @@ public class BiVariableMap<K, V> implements Map<K, V> {
      * @return the value in simple Java object to which the specified key is mapped, or
      *         {@code null} if this map contains no mapping for the key
      */
-    public V get(Object key) {
+    @Override
+    public Object get(Object key) {
         return get(null, key);
     }
 
@@ -207,33 +215,40 @@ public class BiVariableMap<K, V> implements Map<K, V> {
      * @return the value in simple Java object to which the specified key is mapped, or
      *         {@code null} if this map contains no mapping for the key
      */
-    public V get(Object receiver, Object key) {
+    public Object get(Object receiver, Object key) {
         checkKey(key);
-        RubyObject robj = getReceiverObject(receiver);
+        final RubyObject robj = getReceiverObject(receiver);
         // attemps to retrieve global variables
-        if (lazy) VariableInterceptor.tryLazyRetrieval(provider.getLocalVariableBehavior(), this, robj, key);
-        BiVariable var = getVariable(robj, (String)key);
-        if (var == null) return null;
-        else return (V) var.getJavaObject();
+        if ( isLazy() ) {
+            VariableInterceptor.tryLazyRetrieval(provider.getLocalVariableBehavior(), this, robj, key);
+        }
+        BiVariable var = getVariable(robj, (String) key);
+        return var == null ? null : var.getJavaObject();
     }
 
-    private RubyObject getReceiverObject(Object receiver) {
-        if (receiver == null || !(receiver instanceof IRubyObject)) return (RubyObject)provider.getRuntime().getTopSelf();
-        else if (receiver instanceof RubyObject) return (RubyObject)receiver;
-        else return (RubyObject)((IRubyObject)receiver).getRuntime().getTopSelf();
+    private RubyObject getReceiverObject(final Object receiver) {
+        if ( receiver instanceof RubyObject ) return (RubyObject) receiver;
+        //if ( receiver instanceof IRubyObject ) {
+        //    return (RubyObject) ( (IRubyObject) receiver ).getRuntime().getTopSelf();
+        //}
+        return getTopSelf();
+    }
+
+    private RubyObject getTopSelf() {
+        return (RubyObject) getRuntime().getTopSelf();
     }
 
     /**
      * Returns the value in BiVariable type to which the specified key is mapped,
      * or {@code null} if this map contains no mapping for the key.
-     * 
-     * @param key is the key whose associated BiVariable object is to be returned
+     *
+     * @param name is the key whose associated BiVariable object is to be returned
      * @return the BiVariable type object to which the specified key is mapped, or
      *         {@code null} if this map contains no mapping for the key
      */
-    @Deprecated
-    public BiVariable getVariable(String key) {
-        return getVariable((RubyObject)provider.getRuntime().getTopSelf(), key);
+    //@Deprecated
+    public BiVariable getVariable(final String name) {
+        return getVariable(getTopSelf(), name);
     }
 
     /**
@@ -241,41 +256,40 @@ public class BiVariableMap<K, V> implements Map<K, V> {
      * or {@code null} if this map contains no mapping for the key.
      *
      * @param receiver is a receiver object to get key-value pair from
-     * @param key is the key whose associated BiVariable object is to be returned
+     * @param name is the key whose associated BiVariable object is to be returned
      * @return the BiVariable type object to which the specified key is mapped, or
      *         {@code null} if this map contains no mapping for the key
      */
-    public BiVariable getVariable(RubyObject receiver, String key) {
-        if (varNames == null) return null;
-        for (int i=0; i<varNames.size(); i++) {
-            if (key.equals(varNames.get(i))) {
-                BiVariable var = null;
-                while (var == null) {
-                    try {
-                        var = variables.get(i);
-                    } catch (Exception e) {
-                        var = null;
-                    }
-                }
-                if (var.isReceiverIdentical(receiver)) {
+    public BiVariable getVariable(final RubyObject receiver, final String name) {
+        if ( variables == null ) return null;
+
+        for ( int i = 0; i < size(); i++ ) {
+            if ( name.equals( getNames().get(i) ) ) {
+                BiVariable var;
+                //try {
+                    var = getVariables().get(i);
+                //}
+                //catch (RuntimeException e) {
+                //    var = null;
+                //}
+                if ( var != null && var.isReceiverIdentical(receiver) ) {
                     return var;
                 }
             }
         }
+
         return null;
     }
 
-    @Deprecated
     public void setVariable(BiVariable var) {
-        setVariable((RubyObject)provider.getRuntime().getTopSelf(), var);
+        setVariable(getTopSelf(), var);
     }
 
     public void setVariable(RubyObject receiver, BiVariable var) {
-        if (var == null) {
-            return;
-        }
-        String key = var.getName();
-        BiVariable old = getVariable(receiver, key);
+        if ( var == null ) return;
+
+        final String key = var.getName();
+        final BiVariable old = getVariable(receiver, key);
         if (old != null) {
             // updates the value of an existing key-value pair
             old.setJavaObject(receiver.getRuntime(), var.getJavaObject());
@@ -288,13 +302,14 @@ public class BiVariableMap<K, V> implements Map<K, V> {
      * Associates the specified value with the specified key in this map.
      * The values is a simple Java object. If the map previously contained a mapping for
      * the key, the old value is replaced by the specified value.
-     * 
+     *
      * @param key the key with which the specified value is to be associated
      * @param value a simple Java object to be associated with the specified key
      * @return the previous value associated with <tt>key</tt>, or
      *         <tt>null</tt> if there was no mapping for <tt>key</tt>.
      */
-    public V put (K key, V value) {
+    @Override
+    public Object put(String key, Object value) {
         return put(null, key, value);
     }
 
@@ -309,24 +324,21 @@ public class BiVariableMap<K, V> implements Map<K, V> {
      * @return the previous value associated with <tt>key</tt>, or
      *         <tt>null</tt> if there was no mapping for <tt>key</tt>.
      */
-    public V put (Object receiver, K key, V value) {
+    public Object put(Object receiver, String key, Object value) {
         checkKey(key);
-        RubyObject robj = getReceiverObject(receiver);
-        String name = ((String)key).intern();
-        BiVariable v = getVariable(robj, name);
+        final RubyObject robj = getReceiverObject(receiver);
+        final String name = key.intern();
+        BiVariable var = getVariable(robj, name);
         Object oldValue = null;
-        if (v != null) {
-            // updates
-            oldValue = v.getJavaObject();
-            v.setJavaObject(robj.getRuntime(), value);
-        } else {
-            // creates new value
-            v = VariableInterceptor.getVariableInstance(provider.getLocalVariableBehavior(), robj, name, value);
-            if (v != null) {
-                update(name, v);
-            }
+        if ( var != null ) { // updates
+            oldValue = var.getJavaObject();
+            var.setJavaObject(robj.getRuntime(), value);
         }
-        return (V)oldValue;
+        else { // creates new value
+            var = VariableInterceptor.getVariableInstance(provider.getLocalVariableBehavior(), robj, name, value);
+            if ( var != null ) update(name, var);
+        }
+        return oldValue;
     }
 
     /**
@@ -336,51 +348,47 @@ public class BiVariableMap<K, V> implements Map<K, V> {
      * @return String array of Ruby's local variable names
      */
     public String[] getLocalVarNames() {
-        if (variables == null) return null;
+        if ( variables == null ) return new String[0];
+
         List<String> localVarNames = new ArrayList<String>();
-        for (BiVariable v : variables) {
-            if (v.getType() == BiVariable.Type.LocalVariable) {
-                localVarNames.add(v.getName());
+        for ( final BiVariable var : variables ) {
+            if ( var.getType() == BiVariable.Type.LocalVariable ) {
+                localVarNames.add( var.getName() );
             }
         }
-        if (localVarNames.size() > 0) {
-            return localVarNames.toArray(new String[localVarNames.size()]);
-        }
-        return null;
+        return localVarNames.toArray(new String[localVarNames.size()]);
     }
 
     /**
      * Returns Ruby's local variable values this map has. The returned array is
      * mainly used to inject local variables to Ruby scripts while evaluating.
-     * 
+     *
      * @return IRubyObject array of Ruby's local variable names.
      */
     public IRubyObject[] getLocalVarValues() {
-        if (variables == null) return null;
+        if ( variables == null ) return IRubyObject.NULL_ARRAY;
+
         List<IRubyObject> localVarValues = new ArrayList<IRubyObject>();
-        for (BiVariable v : variables) {
-            if (v.getType() == BiVariable.Type.LocalVariable) {
-                localVarValues.add(v.getRubyObject());
+        for ( final BiVariable var : variables ) {
+            if ( var.getType() == BiVariable.Type.LocalVariable ) {
+                localVarValues.add( var.getRubyObject() );
             }
         }
-        if (localVarValues.size() > 0) {
-            return localVarValues.toArray(new IRubyObject[localVarValues.size()]);
-        }
-        return null;
+        return localVarValues.toArray( new IRubyObject[ localVarValues.size() ] );
     }
 
-    void inject(ManyVarsDynamicScope scope, int depth, IRubyObject receiver) {
+    void inject(final ManyVarsDynamicScope scope, final int depth, final IRubyObject receiver) {
         VariableInterceptor.inject(this, provider.getRuntime(), scope, depth, receiver);
     }
 
-    void retrieve(IRubyObject receiver) {
-        RubyObject robj = getReceiverObject(receiver);
-        VariableInterceptor.retrieve(provider.getLocalVariableBehavior(), this, robj);
+    void retrieve(final IRubyObject receiver) {
+        final RubyObject robj = getReceiverObject(receiver);
+        VariableInterceptor.retrieve(getLocalVariableBehavior(), this, robj);
     }
 
     void terminate() {
-        VariableInterceptor.terminateGlobalVariables(provider.getLocalVariableBehavior(), variables, provider.getRuntime());
-        VariableInterceptor.terminateLocalVariables(provider.getLocalVariableBehavior(), varNames, variables);
+        VariableInterceptor.terminateGlobalVariables(getLocalVariableBehavior(), getVariables(), getRuntime());
+        VariableInterceptor.terminateLocalVariables(getLocalVariableBehavior(), getNames(), getVariables());
     }
 
     /**
@@ -393,8 +401,9 @@ public class BiVariableMap<K, V> implements Map<K, V> {
      * @return the previous value associated with <tt>key</tt>, or
      *         <tt>null</tt> if there was no mapping for <tt>key</tt>.
      */
-    public V remove(Object key) {
-        return removeFrom(provider.getRuntime().getTopSelf(), key);
+    @Override
+    public Object remove(final Object key) {
+        return removeFrom(getTopSelf(), key);
     }
 
     /**
@@ -408,19 +417,17 @@ public class BiVariableMap<K, V> implements Map<K, V> {
      * @return the previous value associated with <tt>key</tt>, or
      *         <tt>null</tt> if there was no mapping for <tt>key</tt>.
      */
-    public V removeFrom(Object receiver, Object key) {
-        if (varNames == null) return null;
+    public Object removeFrom(final Object receiver, final Object key) {
+        if ( variables == null ) return null;
         checkKey(key);
-        RubyObject robj = getReceiverObject(receiver);
-        String name = ((String)key).intern();
-        for (int i=0; i<varNames.size(); i++) {
-            if (name.equals(varNames.get(i))) {
-                BiVariable var = variables.get(i);
-                if (var.getReceiver() == robj) {
+        final RubyObject robj = getReceiverObject(receiver);
+        for ( int i = 0; i < size(); i++ ) {
+            if ( ((String) key).equals( varNames.get(i) ) ) {
+                final BiVariable var = variables.get(i);
+                if ( var.isReceiverIdentical(robj) ) {
                     varNames.remove(i);
-                    BiVariable v = variables.remove(i);
-                    v.remove();
-                    return (V)v.getJavaObject();
+                    variables.remove(i);
+                    return var.getJavaObject();
                 }
             }
         }
@@ -432,23 +439,21 @@ public class BiVariableMap<K, V> implements Map<K, V> {
      *
      * @param t mappings to be stored in this map
      */
-    public void putAll(Map<? extends K, ? extends V> t) {
-        if (t == null) {
+
+    @Override
+    public void putAll(final Map<? extends String, ? extends Object> map) {
+        if (map == null) {
             throw new NullPointerException("map is null");
         }
-        if (t.isEmpty()) {
+        if (map.isEmpty()) {
             throw new IllegalArgumentException("map is empty");
         }
-        Set set = t.entrySet();
-        Iterator itr = set.iterator();
-        while (itr.hasNext()) {
-            Map.Entry entry = (Map.Entry)itr.next();
-            if (entry.getKey() instanceof String) {
-                K key = (K)entry.getKey();
-                V value = (V)entry.getValue();
-                put(key, value);
+        for ( final Entry entry : map.entrySet() ) {
+            final Object key = entry.getKey();
+            if (key instanceof String) {
+                put( (String) key, entry.getValue());
             } else {
-                throw new ClassCastException("key is NOT String");
+                throw new ClassCastException("key is not String");
             }
         }
     }
@@ -459,24 +464,22 @@ public class BiVariableMap<K, V> implements Map<K, V> {
      * removed from Ruby instance. However, Ruby instance keep having global variable
      * names with null value.
      */
+    @Override
     public void clear() {
-        if (varNames == null) return;
-        boolean argv_presence = false;
-        if (varNames.contains("ARGV")) argv_presence = true;
-        varNames.clear();
-        if (argv_presence) varNames.add("ARGV");
+        if ( variables == null ) return;
         BiVariable argv_object = null;
-        for (BiVariable v : variables) {
-            if (v != null) {
-                if ("ARGV".equals(v.getName())) {
-                    argv_object = v;
-                } else {
-                    v.remove();
+        for ( BiVariable var : getVariables() ) {
+            if ( var != null ) {
+                if ( "ARGV".equals(var.getName()) ) {
+                    argv_object = var;
+                }
+                else {
+                    var.remove();
                 }
             }
         }
-        variables.clear();
-        if (argv_object != null) variables.add(argv_object);
+        getNames().clear(); getVariables().clear();
+        if ( argv_object != null ) put("ARGV", argv_object);
     }
 
     /**
@@ -484,16 +487,12 @@ public class BiVariableMap<K, V> implements Map<K, V> {
      * The set is backed by the map, so changes to the map should be
      * reflected in the set, and vice-versa. However, the implementation
      * does not reflect changes currently.
-     * 
+     *
      * @return a set view of the keys contained in this map
      */
-    public Set keySet() {
-        if (isEmpty()) return null;
-        Set s = new HashSet();
-        for (String name : varNames) {
-            s.add(name);
-        }
-        return s;
+    @Override
+    public Set<String> keySet() {
+        return new LinkedHashSet<String>( getNames() );
     }
 
     /**
@@ -501,16 +500,12 @@ public class BiVariableMap<K, V> implements Map<K, V> {
      * The collection is backed by the map, so changes to the map should be
      * reflected in the collection, and vice-versa. However, the implementation
      * does not reflect changes currently.
-     * 
+     *
      * @return a collection view of the values contained in this map
      */
-    public Collection values() {
-        if (isEmpty()) return null;
-        List l = new ArrayList();
-        for (BiVariable v : variables) {
-            l.add(v.getJavaObject());
-        }
-        return l;
+    @Override
+    public Collection<Object> values() {
+        return getMap().values();
     }
 
     /**
@@ -518,36 +513,34 @@ public class BiVariableMap<K, V> implements Map<K, V> {
      * The set is backed by the map, so changes to the map should be
      * reflected in the set, and vice-versa. However, the implementation
      * does not reflect changes currently.
-     * 
+     *
      * @return an entry set of a map
      */
-    public Set entrySet() {
-        if (isEmpty()) return null;
+    @Override
+    public Set<Entry<String, Object>> entrySet() {
         return getMap().entrySet();
     }
 
     /**
      * Adds a key-value pair of Ruby local variable to double array.
-     * 
+     *
      * @param name is a Ruby's local variable name
      * @param value is BiVariable type object corresponding to the name
      */
-    public void update(String name, BiVariable value) {
-        if (varNames == null) {
-            varNames = new ArrayList<String>();
-            variables = new ArrayList<BiVariable>();
-        }
-        varNames.add(name);
-        variables.add(value);
+    public void update(final String name, final BiVariable value) {
+        getNames().add(name);
+        getVariables().add(value);
     }
 
+
     /**
-     * Returns true when eager retrieval is requird or false when eager retrieval is
-     * unnecessary.
+     * Returns true when eager retrieval is required or false when eager
+     * retrieval is unnecessary.
      *
      * @return true for eager retrieve, false for on-demand retrieval
      */
     public boolean isLazy() {
         return lazy;
     }
+
 }

--- a/core/src/main/java/org/jruby/embed/internal/BiVariableMap.java
+++ b/core/src/main/java/org/jruby/embed/internal/BiVariableMap.java
@@ -577,4 +577,20 @@ public class BiVariableMap implements Map<String, Object> {
         return lazy;
     }
 
+    @Override
+    public String toString() {
+        final StringBuilder str = new StringBuilder();
+        str.append( getClass().getName() );
+
+        str.append('{');
+        for ( int i = 0; i < size(); i++ ) {
+            final String name = getNames().get(i);
+            final BiVariable variable = getVariables().get(i);
+            str.append(name).append('=').append(variable);
+            if ( i == size() - 1 ) break;
+            str.append(',').append(' ');
+        }
+        return str.append('}').toString();
+    }
+
 }

--- a/core/src/main/java/org/jruby/embed/internal/BiVariableMap.java
+++ b/core/src/main/java/org/jruby/embed/internal/BiVariableMap.java
@@ -287,7 +287,7 @@ public class BiVariableMap implements Map<String, Object> {
         setVariable(getTopSelf(), var);
     }
 
-    public void setVariable(RubyObject receiver, BiVariable var) {
+    public void setVariable(final RubyObject receiver, final BiVariable var) {
         if ( var == null ) return;
 
         final String key = var.getName();
@@ -469,11 +469,11 @@ public class BiVariableMap implements Map<String, Object> {
     @Override
     public void clear() {
         if ( variables == null ) return;
-        BiVariable argv_object = null;
+        BiVariable argv = null;
         for ( BiVariable var : getVariables() ) {
             if ( var != null ) {
                 if ( "ARGV".equals(var.getName()) ) {
-                    argv_object = var;
+                    argv = var;
                 }
                 else {
                     var.remove();
@@ -481,7 +481,7 @@ public class BiVariableMap implements Map<String, Object> {
             }
         }
         getNames().clear(); getVariables().clear();
-        if ( argv_object != null ) put("ARGV", argv_object);
+        if ( argv != null ) update("ARGV", argv);
     }
 
     /**
@@ -586,7 +586,7 @@ public class BiVariableMap implements Map<String, Object> {
         for ( int i = 0; i < size(); i++ ) {
             final String name = getNames().get(i);
             final BiVariable variable = getVariables().get(i);
-            str.append(name).append('=').append(variable);
+            str.append(name).append('=').append(variable.getJavaObject());
             if ( i == size() - 1 ) break;
             str.append(',').append(' ');
         }

--- a/core/src/main/java/org/jruby/embed/internal/EmbedEvalUnitImpl.java
+++ b/core/src/main/java/org/jruby/embed/internal/EmbedEvalUnitImpl.java
@@ -54,10 +54,11 @@ import org.jruby.runtime.scope.ManyVarsDynamicScope;
  * @author Yoko Harada <yokolet@gmail.com>
  */
 public class EmbedEvalUnitImpl implements EmbedEvalUnit {
-    private ScriptingContainer container;
-    private Node node;
-    private ManyVarsDynamicScope scope;
-    private Script script;
+
+    private final ScriptingContainer container;
+    private final Node node;
+    private final ManyVarsDynamicScope scope;
+    private final Script script;
 
     public EmbedEvalUnitImpl(ScriptingContainer container, Node node, ManyVarsDynamicScope scope) {
         this(container, node, scope, null);
@@ -82,7 +83,7 @@ public class EmbedEvalUnitImpl implements EmbedEvalUnit {
     /**
      * Returns a ManyVarsDynamicScope used to parse a script. A returned value
      * is used to inject Ruby's local variable when script is evaluated.
-     * 
+     *
      * @return a scope to refer local variables
      */
     public ManyVarsDynamicScope getScope() {
@@ -91,29 +92,26 @@ public class EmbedEvalUnitImpl implements EmbedEvalUnit {
 
     /**
      * Evaluates a Ruby script, which has been parsed before.
-     * 
+     *
      * @return results of executing this evaluation unit
      */
     public IRubyObject run() {
         if (node == null && script == null) {
             return null;
         }
-        Ruby runtime = container.getProvider().getRuntime();
-        BiVariableMap vars = container.getVarMap();
-        boolean sharing_variables = true;
-        Object obj = container.getAttribute(AttributeName.SHARING_VARIABLES);
-        if (obj != null && obj instanceof Boolean && ((Boolean) obj) == false) {
-            sharing_variables = false;
-        }
+        final Ruby runtime = container.getProvider().getRuntime();
+        final BiVariableMap vars = container.getVarMap();
+        final boolean sharing_variables = isSharingVariables();
 
         // Keep reference to current context to prevent it being collected.
-        ThreadContext threadContext = runtime.getCurrentContext();
+        final ThreadContext threadContext = runtime.getCurrentContext();
         try {
             if (sharing_variables) {
                 vars.inject(scope, 0, null);
                 threadContext.pushScope(scope);
             }
-            IRubyObject ret;
+            
+            final IRubyObject ret;
             CompileMode mode = runtime.getInstanceConfig().getCompileMode();
             if (mode == CompileMode.FORCE) {
                 ret = runtime.runScriptBody(script);
@@ -124,18 +122,22 @@ public class EmbedEvalUnitImpl implements EmbedEvalUnit {
                 vars.retrieve(ret);
             }
             return ret;
-        } catch (RaiseException e) {
+        }
+        catch (RaiseException e) {
             // handle exits as simple script termination
-            if (e.getException() instanceof RubySystemExit) {
-                return ((RubySystemExit)e.getException()).status();
+            if ( e.getException() instanceof RubySystemExit ) {
+                return ((RubySystemExit) e.getException()).status();
             }
             runtime.printError(e.getException());
             throw new EvalFailedException(e.getMessage(), e);
-        } catch (StackOverflowError soe) {
+        }
+        catch (StackOverflowError soe) {
             throw runtime.newSystemStackError("stack level too deep", soe);
-        } catch (Throwable e) {
+        }
+        catch (Throwable e) {
             throw new EvalFailedException(e);
-        } finally {
+        }
+        finally {
             if (sharing_variables) {
                 threadContext.popScope();
             }
@@ -146,4 +148,14 @@ public class EmbedEvalUnitImpl implements EmbedEvalUnit {
             */
         }
     }
+
+    private boolean isSharingVariables() {
+        final Object sharing = container.getAttribute(AttributeName.SHARING_VARIABLES);
+        if ( sharing != null && sharing instanceof Boolean &&
+                ((Boolean) sharing).booleanValue() == false ) {
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/core/src/main/java/org/jruby/embed/internal/EmbedRubyInterfaceAdapterImpl.java
+++ b/core/src/main/java/org/jruby/embed/internal/EmbedRubyInterfaceAdapterImpl.java
@@ -29,9 +29,6 @@
  */
 package org.jruby.embed.internal;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.Writer;
 import org.jruby.Ruby;
 import org.jruby.RubyNil;
 import org.jruby.embed.EmbedRubyInterfaceAdapter;
@@ -56,7 +53,7 @@ public class EmbedRubyInterfaceAdapterImpl implements EmbedRubyInterfaceAdapter 
 
     /**
      * Returns a instance of a requested interface type from a previously evaluated script.
-     * 
+     *
      * @param receiver a receiver of the previously evaluated script.
      * @param clazz an interface type of the returning instance.
      * @return an instance of requested interface type.

--- a/core/src/main/java/org/jruby/embed/internal/LocalContext.java
+++ b/core/src/main/java/org/jruby/embed/internal/LocalContext.java
@@ -51,12 +51,11 @@ public class LocalContext {
 
     private Ruby runtime = null;
 
-    private BiVariableMap varMap;  // singleton doesn't use this varMap.
+    private BiVariableMap varMap;
     private Map<AttributeName, Object> attributes;
 
     public LocalContext(RubyInstanceConfig config, LocalVariableBehavior behavior) {
-        this.config = config;
-        this.behavior = behavior;
+        this(config, behavior, false);
     }
 
     public LocalContext(RubyInstanceConfig config, LocalVariableBehavior behavior, boolean lazy) {

--- a/core/src/main/java/org/jruby/embed/internal/LocalContext.java
+++ b/core/src/main/java/org/jruby/embed/internal/LocalContext.java
@@ -32,6 +32,8 @@ package org.jruby.embed.internal;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.util.HashMap;
+import java.util.Map;
+
 import org.jruby.Ruby;
 import org.jruby.RubyInstanceConfig;
 import org.jruby.embed.AttributeName;
@@ -42,19 +44,22 @@ import org.jruby.embed.LocalVariableBehavior;
  * @author Yoko Harada <yokolet@gmail.com>
  */
 public class LocalContext {
-    private RubyInstanceConfig config;
-    private LocalVariableBehavior behavior;
-    private boolean lazy;
-    Ruby runtime = null;
-    private BiVariableMap varMap = null;  // singleton doesn't use this varMap.
-    private HashMap attribute = null;
-    boolean initialized = false;
 
-    public LocalContext(RubyInstanceConfig config, LocalVariableBehavior behavior, boolean lazy) {
-        initialize(config, behavior, lazy);
+    private final RubyInstanceConfig config;
+    private final LocalVariableBehavior behavior;
+    private boolean lazy;
+
+    private Ruby runtime = null;
+
+    private BiVariableMap varMap;  // singleton doesn't use this varMap.
+    private Map<AttributeName, Object> attributes;
+
+    public LocalContext(RubyInstanceConfig config, LocalVariableBehavior behavior) {
+        this.config = config;
+        this.behavior = behavior;
     }
 
-    private void initialize(RubyInstanceConfig config, LocalVariableBehavior behavior, boolean lazy) {
+    public LocalContext(RubyInstanceConfig config, LocalVariableBehavior behavior, boolean lazy) {
         this.config = config;
         this.behavior = behavior;
         this.lazy = lazy;
@@ -62,14 +67,9 @@ public class LocalContext {
 
     // This method is used only from ThreadLocalContextProvider.
     // Other providers should instantialte runtime in their own way.
+    @Deprecated
     public Ruby getThreadSafeRuntime() {
-        if (runtime == null) {
-            // stopped loading java library (runtime.getLoadService().require("java");)
-            // during the intialization process.
-            runtime = Ruby.newInstance(config);
-            initialized = true;
-        }
-        return runtime;
+        return getRuntime();
     }
 
     // this method is used in ConcurrentContextProvider. concurrent model uses
@@ -81,24 +81,38 @@ public class LocalContext {
         }
         return varMap;
     }
-    
+
     public LocalVariableBehavior getLocalVariableBehavior() {
         return behavior;
     }
 
-    public HashMap getAttributeMap() {
-        if (attribute == null) {
-            attribute = new HashMap();
-            attribute.put(AttributeName.READER, new InputStreamReader(System.in));
-            attribute.put(AttributeName.WRITER, new PrintWriter(System.out, true));
-            attribute.put(AttributeName.ERROR_WRITER, new PrintWriter(System.err, true));
+    @SuppressWarnings("MapReplaceableByEnumMap")
+    public Map<?, Object> getAttributeMap() {
+        if (attributes == null) {
+            synchronized(this) {
+                if (attributes == null) {
+                    attributes = new HashMap<AttributeName, Object>();
+                    attributes.put(AttributeName.READER, new InputStreamReader(System.in));
+                    attributes.put(AttributeName.WRITER, new PrintWriter(System.out, true));
+                    attributes.put(AttributeName.ERROR_WRITER, new PrintWriter(System.err, true));
+                }
+            }
         }
-        return attribute;
+        return attributes;
     }
-    
+
     public void remove() {
-        if (attribute == null) return;
-        attribute.clear();
-        varMap.clear();
+        if ( attributes != null ) attributes.clear();
+        if ( varMap != null ) varMap.clear();
     }
+
+    Ruby getRuntime() {
+        if (runtime == null) {
+            runtime = Ruby.newInstance(config);
+        }
+        return runtime;
+    }
+
+    boolean isInitialized() { return runtime != null; }
+
 }

--- a/core/src/main/java/org/jruby/embed/internal/LocalContext.java
+++ b/core/src/main/java/org/jruby/embed/internal/LocalContext.java
@@ -71,12 +71,13 @@ public class LocalContext {
         return getRuntime();
     }
 
-    // this method is used in ConcurrentContextProvider. concurrent model uses
-    // global runtime and thread local variable map. don't want to create
-    // local runtime
     public BiVariableMap getVarMap(LocalContextProvider provider) {
         if (varMap == null) {
-            varMap = new BiVariableMap(provider, lazy);
+            synchronized(this) {
+                if (varMap == null) {
+                    varMap = new BiVariableMap(provider, lazy);
+                }
+            }
         }
         return varMap;
     }
@@ -101,13 +102,21 @@ public class LocalContext {
     }
 
     public void remove() {
-        if ( attributes != null ) attributes.clear();
-        if ( varMap != null ) varMap.clear();
+        if (attributes != null) {
+            synchronized(this) { attributes.clear(); }
+        }
+        if (varMap != null) {
+            synchronized(this) { varMap.clear(); }
+        }
     }
 
     Ruby getRuntime() {
         if (runtime == null) {
-            runtime = Ruby.newInstance(config);
+            synchronized(this) {
+                if (runtime == null) {
+                    runtime = Ruby.newInstance(config);
+                }
+            }
         }
         return runtime;
     }

--- a/core/src/main/java/org/jruby/embed/internal/SingleThreadLocalContextProvider.java
+++ b/core/src/main/java/org/jruby/embed/internal/SingleThreadLocalContextProvider.java
@@ -39,21 +39,20 @@ import org.jruby.embed.LocalVariableBehavior;
  */
 public class SingleThreadLocalContextProvider extends AbstractLocalContextProvider {
 
-    private volatile LocalContext instance;
+    private final LocalContext instance;
 
     public SingleThreadLocalContextProvider(LocalVariableBehavior behavior) {
         super(behavior);
+        instance = getInstance();
     }
 
     public SingleThreadLocalContextProvider(LocalVariableBehavior behavior, boolean lazy) {
         super(behavior);
         this.lazy = lazy;
+        instance = getInstance();
     }
 
     private LocalContext getLocalContext() {
-        if (instance == null) {
-            return instance = getInstance();
-        }
         return instance;
     }
 
@@ -79,10 +78,7 @@ public class SingleThreadLocalContextProvider extends AbstractLocalContextProvid
 
     @Override
     public void terminate() {
-        if (instance != null) {
-            getLocalContext().remove();
-            instance = null;
-        }
+        getLocalContext().remove();
     }
 
 }

--- a/core/src/main/java/org/jruby/embed/internal/SingleThreadLocalContextProvider.java
+++ b/core/src/main/java/org/jruby/embed/internal/SingleThreadLocalContextProvider.java
@@ -38,49 +38,51 @@ import org.jruby.embed.LocalVariableBehavior;
  * @author Yoko Harada <yokolet@gmail.com>
  */
 public class SingleThreadLocalContextProvider extends AbstractLocalContextProvider {
-    private LocalContext localContext;
+
+    private volatile LocalContext instance;
+
+    public SingleThreadLocalContextProvider(LocalVariableBehavior behavior) {
+        super(behavior);
+    }
 
     public SingleThreadLocalContextProvider(LocalVariableBehavior behavior, boolean lazy) {
-        this.behavior = behavior;
+        super(behavior);
         this.lazy = lazy;
-        localContext = null;
-    }
-    
-    private void initializeLocalContext() {
-        if (localContext == null) {
-            localContext = getInstance();
-        }
     }
 
+    private LocalContext getLocalContext() {
+        if (instance == null) {
+            return instance = getInstance();
+        }
+        return instance;
+    }
+
+    @Override
     public Ruby getRuntime() {
-        initializeLocalContext();
-        if (localContext.runtime == null) {
-            // stopped loading java library (runtime.getLoadService().require("java");)
-            // during the intialization process.
-            localContext.runtime = Ruby.newInstance(config);
-            localContext.initialized = true;
-        }
-        return localContext.runtime;
+        return getLocalContext().getRuntime();
     }
 
+    @Override
     public BiVariableMap getVarMap() {
-        initializeLocalContext();
-        return localContext.getVarMap(this);
+        return getLocalContext().getVarMap(this);
     }
 
+    @Override
     public Map getAttributeMap() {
-        initializeLocalContext();
-        return localContext.getAttributeMap();
+        return getLocalContext().getAttributeMap();
     }
 
+    @Override
     public boolean isRuntimeInitialized() {
-        initializeLocalContext();
-        return localContext.initialized;
+        return getLocalContext().isInitialized();
     }
-    
+
+    @Override
     public void terminate() {
-        initializeLocalContext();
-        localContext.remove();
-        localContext = null;
+        if (instance != null) {
+            getLocalContext().remove();
+            instance = null;
+        }
     }
+
 }

--- a/core/src/main/java/org/jruby/embed/internal/ThreadSafeLocalContextProvider.java
+++ b/core/src/main/java/org/jruby/embed/internal/ThreadSafeLocalContextProvider.java
@@ -38,13 +38,14 @@ import org.jruby.embed.LocalVariableBehavior;
  * @author Yoko Harada <yokolet@gmail.com>
  */
 public class ThreadSafeLocalContextProvider extends AbstractLocalContextProvider {
-    private ThreadLocal<LocalContext> contextHolder =
+
+    private final ThreadLocal<LocalContext> contextHolder =
             new ThreadLocal<LocalContext>() {
                 @Override
                 public LocalContext initialValue() {
                     return getInstance();
                 }
-                
+
                 @Override
                 public void remove() {
                     LocalContext localContext = get();
@@ -52,29 +53,39 @@ public class ThreadSafeLocalContextProvider extends AbstractLocalContextProvider
                 }
             };
 
+    public ThreadSafeLocalContextProvider(LocalVariableBehavior behavior) {
+        super(behavior);
+    }
+
     public ThreadSafeLocalContextProvider(LocalVariableBehavior behavior, boolean lazy) {
-        this.behavior = behavior;
+        super(behavior);
         this.lazy = lazy;
     }
 
+    @Override
     public Ruby getRuntime() {
-        return contextHolder.get().getThreadSafeRuntime();
+        return contextHolder.get().getRuntime();
     }
 
+    @Override
     public BiVariableMap getVarMap() {
         return contextHolder.get().getVarMap(this);
     }
 
+    @Override
     public Map getAttributeMap() {
         return contextHolder.get().getAttributeMap();
     }
 
+    @Override
     public boolean isRuntimeInitialized() {
-        return contextHolder.get().initialized;
+        return contextHolder.get().isInitialized();
     }
-    
+
+    @Override
     public void terminate() {
         contextHolder.remove();
         contextHolder.set(null);
     }
+
 }

--- a/core/src/main/java/org/jruby/embed/jsr223/JRubyEngine.java
+++ b/core/src/main/java/org/jruby/embed/jsr223/JRubyEngine.java
@@ -52,7 +52,7 @@ import org.jruby.runtime.builtin.IRubyObject;
  */
 public class JRubyEngine implements Compilable, Invocable, ScriptEngine {
 
-    private final ScriptingContainer container;
+    final ScriptingContainer container;
     private JRubyEngineFactory factory;
     private ScriptContext context;
 

--- a/core/src/main/java/org/jruby/embed/variable/AbstractVariable.java
+++ b/core/src/main/java/org/jruby/embed/variable/AbstractVariable.java
@@ -94,7 +94,7 @@ abstract class AbstractVariable implements BiVariable {
         return (RubyObject) receiver.getRuntime().getTopSelf();
     }
 
-    protected void updateByJavaObject(Ruby runtime, Object... values) {
+    protected void updateByJavaObject(final Ruby runtime, Object... values) {
         assert values != null;
         javaObject = values[0];
         if (javaObject == null) {
@@ -108,11 +108,11 @@ abstract class AbstractVariable implements BiVariable {
         fromRuby = false;
     }
 
-    protected void updateRubyObject(IRubyObject rubyObject) {
-        if (rubyObject == null) {
-            return;
-        }
+    protected void updateRubyObject(final IRubyObject rubyObject) {
+        if ( rubyObject == null ) return;
         this.irubyObject = rubyObject;
+        // NOTE: quite weird - but won't pass tests otherwise !?!
+        //this.javaObject = null;
         // delays updating javaObject for performance.
     }
 
@@ -148,7 +148,7 @@ abstract class AbstractVariable implements BiVariable {
         return javaObject;
     }
 
-    public void setJavaObject(Ruby runtime, Object javaObject) {
+    public void setJavaObject(final Ruby runtime, Object javaObject) {
         updateByJavaObject(runtime, javaObject);
     }
 
@@ -156,7 +156,7 @@ abstract class AbstractVariable implements BiVariable {
         return irubyObject;
     }
 
-    public void setRubyObject(IRubyObject rubyObject) {
+    public void setRubyObject(final IRubyObject rubyObject) {
         updateRubyObject(rubyObject);
     }
 

--- a/core/src/main/java/org/jruby/embed/variable/AbstractVariable.java
+++ b/core/src/main/java/org/jruby/embed/variable/AbstractVariable.java
@@ -125,8 +125,8 @@ abstract class AbstractVariable implements BiVariable {
      *
      * @return true if identical otherwise false
      */
-    public boolean isReceiverIdentical(RubyObject recv) {
-        return this.receiver == recv;
+    public boolean isReceiverIdentical(final RubyObject receiver) {
+        return getReceiver() == receiver;
     }
 
     public String getName() {

--- a/core/src/main/java/org/jruby/embed/variable/Argv.java
+++ b/core/src/main/java/org/jruby/embed/variable/Argv.java
@@ -32,6 +32,7 @@ package org.jruby.embed.variable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyModule;
 import org.jruby.RubyNil;
@@ -44,7 +45,8 @@ import org.jruby.runtime.builtin.IRubyObject;
  * @author yoko
  */
 public class Argv extends AbstractVariable {
-    private static String pattern = "ARGV";
+
+    private static final String VALID_NAME = "ARGV";
 
     /**
      * Returns an instance of this class. This factory method is used when an ARGV
@@ -56,12 +58,12 @@ public class Argv extends AbstractVariable {
      * @return the instance of Constant
      */
     public static BiVariable getInstance(RubyObject receiver, String name, Object... javaObject) {
-        if (name.matches(pattern)) {
+        if (name.matches(VALID_NAME)) {
             return new Argv(receiver, name, javaObject);
         }
         return null;
     }
-    
+
     private Argv(RubyObject receiver, String name, Object... javaObjects) {
         super(receiver, name, false);
         assert javaObjects != null;
@@ -74,15 +76,14 @@ public class Argv extends AbstractVariable {
             javaType = javaObject.getClass();
         }
     }
-    
+
     private void updateArgvByJavaObject() {
-        RubyArray ary = RubyArray.newArray(receiver.getRuntime());
-        if (javaObject instanceof Collection) {
-            ary.addAll((Collection)javaObject);
-        } else if (javaObject instanceof String[]) {
-            for (String s : (String[])javaObject) {
-                ary.add(s);
-            }
+        RubyArray ary = RubyArray.newArray(getRuntime());
+        if ( javaObject instanceof Collection ) {
+            ary.addAll((Collection) javaObject);
+        }
+        else if ( javaObject instanceof Object[] ) {
+            for (Object s : (Object[]) javaObject) ary.add(s);
         }
         irubyObject = ary;
     }
@@ -95,7 +96,7 @@ public class Argv extends AbstractVariable {
      * @param name the constant name
      * @param irubyObject Ruby constant object
      */
-    Argv(IRubyObject receiver, String name, IRubyObject irubyObject) {
+    Argv(RubyObject receiver, String name, IRubyObject irubyObject) {
         super(receiver, name, true, irubyObject);
     }
 
@@ -104,10 +105,11 @@ public class Argv extends AbstractVariable {
      *
      * @return this enum type, BiVariable.Type.InstanceVariable.
      */
+    @Override
     public Type getType() {
         return Type.Argv;
     }
-    
+
     /**
      * Returns true if the given name is ARGV. Unless returns false.
      *
@@ -115,7 +117,7 @@ public class Argv extends AbstractVariable {
      * @return true if the given name is ARGV.
      */
     public static boolean isValidName(Object name) {
-        return isValidName(pattern, name);
+        return isValidName(VALID_NAME, name);
     }
 
     /**
@@ -125,27 +127,29 @@ public class Argv extends AbstractVariable {
      * @param runtime is environment where a variable injection occurs
      * @param receiver is the instance that will have variable injection.
      */
+    @Override
     public void inject() {
         updateArgvByJavaObject();
-        RubyModule rubyModule = getRubyClass(receiver.getRuntime());
-        if (rubyModule == null) rubyModule = receiver.getRuntime().getCurrentContext().getRubyClass();
+        final Ruby runtime = getRuntime();
+        RubyModule rubyModule = getRubyClass(runtime);
+        if (rubyModule == null) rubyModule = runtime.getCurrentContext().getRubyClass();
         if (rubyModule == null) return;
 
         rubyModule.storeConstant(name, irubyObject);
-        receiver.getRuntime().getConstantInvalidator(name).invalidate();
+        runtime.getConstantInvalidator(name).invalidate();
         fromRuby = true;
     }
 
     /**
      * Removes this object from {@link BiVariableMap}. Also, initialize
      * this variable in top self.
-     *
      */
+    @Override
     public void remove() {
         javaObject = new ArrayList();
         inject();
     }
-    
+
    /**
      * Retrieves ARGV from Ruby after the evaluation or method invocation.
      *
@@ -157,23 +161,23 @@ public class Argv extends AbstractVariable {
         if (vars.isLazy()) return;
         updateARGV(receiver, vars);
     }
-    
-    private static void updateARGV(IRubyObject receiver, BiVariableMap vars) {
-        String name = "ARGV".intern();
-        IRubyObject argv = receiver.getRuntime().getTopSelf().getMetaClass().getConstant(name);
+
+    private static void updateARGV(final IRubyObject receiver, final BiVariableMap vars) {
+        final String name = "ARGV";
+        final Ruby runtime = receiver.getRuntime();
+        IRubyObject argv = runtime.getTopSelf().getMetaClass().getConstant(name);
         if (argv == null || (argv instanceof RubyNil)) return;
-        BiVariable var;  // This var is for ARGV.
         // ARGV constant should be only one
-        if (vars.containsKey((Object)name)) {
-            var = vars.getVariable((RubyObject)receiver.getRuntime().getTopSelf(), name);
+        if (vars.containsKey(name)) {
+            BiVariable var = vars.getVariable(getTopSelf(receiver), name);
             var.setRubyObject(argv);
-        } else {
-            var = new Constant(receiver.getRuntime().getTopSelf(), name, argv);
-            ((Constant) var).markInitialized();
-            vars.update(name, var);
+        }
+        else {
+            Constant var = new Constant(getTopSelf(receiver), name, argv);
+            vars.update(name, var.markInitialized());
         }
     }
-    
+
     /**
      * Retrieves ARGV by key from Ruby runtime after the evaluation.
      * This method is used when eager retrieval is off.
@@ -186,28 +190,29 @@ public class Argv extends AbstractVariable {
         assert key.equals("ARGV");
         updateARGV(receiver, vars);
     }
-    
+
     @Override
+    @SuppressWarnings("unchecked")
     public Object getJavaObject() {
-        if (irubyObject == null || !fromRuby) {
-            return javaObject;
-        }
-        RubyArray ary = (RubyArray)irubyObject;
+        if ( irubyObject == null || ! fromRuby ) return javaObject;
+
+        final RubyArray ary = (RubyArray) irubyObject;
         if (javaType == null) { // firstly retrieved from Ruby
-            javaObject = new ArrayList<String>();
-            ((ArrayList)javaObject).addAll(ary);
-            return javaObject;
-        } else if (javaType == String[].class) {
-            javaObject = new String[ary.size()];
-            for (int i=0; i<ary.size(); i++) {
-                ((String[])javaObject)[i] = (String) ary.get(i);
+            return javaObject = new ArrayList<String>(ary);
+        }
+        else if (javaType == String[].class) {
+            String[] strArr = new String[ ary.size() ];
+            for ( int i=0; i<ary.size(); i++ ) {
+                strArr[i] = (String) ary.get(i);
             }
-            return javaObject;
-        } else if (javaObject instanceof List) {
+            return javaObject = strArr;
+        }
+        else if (javaObject instanceof List) {
             try {
-                ((List)javaObject).clear();
-                ((List)javaObject).addAll(ary);
-            } catch (UnsupportedOperationException e) {
+                ((List) javaObject).clear();
+                ((List) javaObject).addAll(ary);
+            }
+            catch (UnsupportedOperationException e) {
                 // no op. no way to update.
             }
             return javaObject;

--- a/core/src/main/java/org/jruby/embed/variable/ClassVariable.java
+++ b/core/src/main/java/org/jruby/embed/variable/ClassVariable.java
@@ -42,7 +42,8 @@ import org.jruby.runtime.builtin.IRubyObject;
  * @author Yoko Harada <yokolet@gmail.com>
  */
 public class ClassVariable extends AbstractVariable {
-    private static String pattern = "@@([a-zA-Z]|_)([a-zA-Z]|_|\\d)*";
+
+    private static final String VALID_NAME = "@@([a-zA-Z]|_)([a-zA-Z]|_|\\d)*";
 
     /**
      * Returns an instance of this class. This factory method is used when a class
@@ -54,7 +55,7 @@ public class ClassVariable extends AbstractVariable {
      * @return the instance of ClassVariable
      */
     public static BiVariable getInstance(RubyObject receiver, String name, Object... javaObject) {
-        if (name.matches(pattern)) {
+        if (name.matches(VALID_NAME)) {
             return new ClassVariable(receiver, name, javaObject);
         }
         return null;
@@ -62,7 +63,7 @@ public class ClassVariable extends AbstractVariable {
 
     /**
      * Constructor when the variable is originated from Java
-     * 
+     *
      * @param receiver
      * @param name
      * @param javaObject
@@ -80,7 +81,7 @@ public class ClassVariable extends AbstractVariable {
      * @param name the class variable name
      * @param irubyObject Ruby class variable object
      */
-    ClassVariable(IRubyObject receiver, String name, IRubyObject irubyObject) {
+    ClassVariable(RubyObject receiver, String name, IRubyObject irubyObject) {
         super(receiver, name, true, irubyObject);
     }
 
@@ -134,7 +135,7 @@ public class ClassVariable extends AbstractVariable {
             }
         }
         if (value == null) return;
-        
+
         BiVariable var = vars.getVariable(receiver, key);
         if (var != null) {
             var.setRubyObject(value);
@@ -149,6 +150,7 @@ public class ClassVariable extends AbstractVariable {
      *
      * @return this enum type, BiVariable.Type.ClassVariable.
      */
+    @Override
     public Type getType() {
         return Type.ClassVariable;
     }
@@ -161,16 +163,17 @@ public class ClassVariable extends AbstractVariable {
      * @return true if the given name is of a Ruby class variable.
      */
     public static boolean isValidName(Object name) {
-        return isValidName(pattern, name);
+        return isValidName(VALID_NAME, name);
     }
 
     /**
-     * Injects a class variable value to a parsed Ruby script. This method is 
+     * Injects a class variable value to a parsed Ruby script. This method is
      * invoked during EvalUnit#run() is executed.
      *
      * @param runtime is environment where a variable injection occurs
      * @param receiver is the instance that will have variable injection.
      */
+    @Override
     public void inject() {
         RubyModule rubyClass = getRubyClass(receiver.getRuntime());
         rubyClass.setClassVar(name, irubyObject);
@@ -178,8 +181,9 @@ public class ClassVariable extends AbstractVariable {
 
     /**
      * Attempts to remove this variable from top self or receiver.
-     * 
+     *
      */
+    @Override
     public void remove() {
         RubyModule rubyClass = getRubyClass(receiver.getRuntime());
         rubyClass.removeClassVariable(name);

--- a/core/src/main/java/org/jruby/embed/variable/Constant.java
+++ b/core/src/main/java/org/jruby/embed/variable/Constant.java
@@ -48,7 +48,7 @@ public class Constant extends AbstractVariable {
 
     private static final String VALID_NAME = "[A-Z]([a-zA-Z]|_)([a-zA-Z]|_|\\d)*";
 
-    private boolean initialized = false; // NOTE: seems to be not used ...
+    //private boolean initialized = false;
 
     /**
      * Returns an instance of this class. This factory method is used when a constant
@@ -83,7 +83,7 @@ public class Constant extends AbstractVariable {
         super(receiver, name, true, irubyObject);
     }
 
-    Constant markInitialized() { this.initialized = true; return this; }
+    //Constant markInitialized() { this.initialized = true; return this; }
 
     /**
      * Retrieves constants from Ruby after the evaluation or method invocation.
@@ -125,10 +125,9 @@ public class Constant extends AbstractVariable {
         for ( final String name : constantNames ) {
             final IRubyObject value = klazz.getConstant(name);
 
-            BiVariable var = vars.getVariable(receiver, name);
+            final BiVariable var = vars.getVariable(receiver, name);
             if (var == null) {
-                var = new Constant(receiver, name, value);
-                vars.update(name, ((Constant) var).markInitialized());
+                vars.update(name, new Constant(receiver, name, value));
             }
             else {
                 var.setRubyObject(value);
@@ -211,7 +210,7 @@ public class Constant extends AbstractVariable {
             receiver.getMetaClass().storeConstant(name, irubyObject);
         }
         runtime.getConstantInvalidator(name).invalidate();
-        initialized = true;
+        //initialized = true;
     }
 
     /**

--- a/core/src/main/java/org/jruby/embed/variable/GlobalVariable.java
+++ b/core/src/main/java/org/jruby/embed/variable/GlobalVariable.java
@@ -44,7 +44,8 @@ import org.jruby.runtime.builtin.IRubyObject;
  * @author Yoko Harada <yokolet@gmail.com>
  */
 public class GlobalVariable extends AbstractVariable {
-    private static String pattern = "\\$(([a-zA-Z]|_|\\d)*|-[a-zA-Z]|[!-~&&[^#%()-\\{\\}\\[\\]\\|\\^]])";
+
+    private static final String VALID_NAME = "\\$(([a-zA-Z]|_|\\d)*|-[a-zA-Z]|[!-~&&[^#%()-\\{\\}\\[\\]\\|\\^]])";
 
     /**
      * Returns an instance of this class. This factory method is used when a global
@@ -56,10 +57,10 @@ public class GlobalVariable extends AbstractVariable {
      * @return the instance of GlobalVariable
      */
     public static BiVariable getInstance(RubyObject receiver, String name, Object... javaObject) {
-        if (name.matches(pattern)) {
-            GlobalVariable gvar = new GlobalVariable(receiver, name, javaObject);
-            gvar.tryEagerInjection(receiver.getRuntime(), null);
-            return gvar;
+        if (name.matches(VALID_NAME)) {
+            GlobalVariable var = new GlobalVariable(receiver, name, javaObject);
+            var.tryEagerInjection(null);
+            return var;
         }
         return null;
     }
@@ -75,7 +76,7 @@ public class GlobalVariable extends AbstractVariable {
      * @param name the global variable name
      * @param irubyObject Ruby global object
      */
-    GlobalVariable(IRubyObject receiver, String name, IRubyObject irubyObject) {
+    GlobalVariable(RubyObject receiver, String name, IRubyObject irubyObject) {
         super(receiver, name, true, irubyObject);
     }
 
@@ -87,23 +88,21 @@ public class GlobalVariable extends AbstractVariable {
      * @param vars map to save retrieved global variables.
      */
     public static void retrieve(IRubyObject receiver, BiVariableMap vars) {
-        if (vars.isLazy()) return;
-        GlobalVariables gvars = receiver.getRuntime().getGlobalVariables();
-        Set<String> names = gvars.getNames();
-        for (String name : names) {
-            if (isPredefined(name)) {
-                continue;
-            }
-            IRubyObject value = gvars.get(name);
+        if ( vars.isLazy() ) return;
+
+        GlobalVariables globalVars = receiver.getRuntime().getGlobalVariables();
+        for ( final String name : globalVars.getNames() ) {
+            if ( isPredefined(name) ) continue;
+            IRubyObject value = globalVars.get(name);
             // reciever of gvar should to topSelf always
-            updateGlobalVar(vars, (RubyObject)receiver.getRuntime().getTopSelf(), name, value);
+            updateGlobalVar(vars, getTopSelf(receiver), name, value);
         }
     }
 
-    private static void updateGlobalVar(BiVariableMap vars, RubyObject receiver, String name, IRubyObject value) {
-        BiVariable var;
-        if (vars.containsKey((Object) name)) {
-            var = vars.getVariable(receiver, name);
+    private static void updateGlobalVar(final BiVariableMap vars,
+            final RubyObject receiver, final String name, final IRubyObject value) {
+        BiVariable var = vars.getVariable(receiver, name);
+        if (var != null) {
             var.setRubyObject(value);
         } else {
             var = new GlobalVariable(receiver, name, value);
@@ -120,14 +119,14 @@ public class GlobalVariable extends AbstractVariable {
      * @param key name of the global variable
      */
     public static void retrieveByKey(Ruby runtime, BiVariableMap vars, String key) {
-        GlobalVariables gvars = runtime.getGlobalVariables();
+        GlobalVariables globalVars = runtime.getGlobalVariables();
         // if the specified key doesn't exist, this method is called before the
         // evaluation. Don't update value in this case.
-        if (!gvars.getNames().contains(key)) return;
+        if ( ! globalVars.getNames().contains(key) ) return;
 
         // the specified key is found, so let's update
-        IRubyObject value = gvars.get(key);
-        updateGlobalVar(vars, (RubyObject)runtime.getTopSelf(), key, value);
+        IRubyObject value = globalVars.get(key);
+        updateGlobalVar(vars, (RubyObject) runtime.getTopSelf(), key, value);
     }
     
     private static String[] patterns = {
@@ -177,6 +176,7 @@ public class GlobalVariable extends AbstractVariable {
      *
      * @return this enum type, BiVariable.Type.GlobalVariable.
      */
+    @Override
     public Type getType() {
         return Type.GlobalVariable;
     }
@@ -189,7 +189,7 @@ public class GlobalVariable extends AbstractVariable {
      * @return true if the given name is of a Ruby global variable.
      */
     public static boolean isValidName(Object name) {
-        return isValidName(pattern, name);
+        return isValidName(VALID_NAME, name);
     }
 
     /**
@@ -199,6 +199,7 @@ public class GlobalVariable extends AbstractVariable {
      * @param runtime is used to convert a Java object to Ruby object.
      * @param javaObject is a variable value to be set.
      */
+    @Override
     public void setJavaObject(Ruby runtime, Object javaObject) {
         updateByJavaObject(runtime, javaObject);
         tryEagerInjection(runtime, null);
@@ -208,8 +209,14 @@ public class GlobalVariable extends AbstractVariable {
      * A global variable is injected when it is set. This method does nothing.
      * Instead injection is done by tryEagerInjection.
      */
+    @Override
     public void inject() {
         // do nothing
+    }
+
+    @Deprecated
+    public void tryEagerInjection(Ruby runtime, IRubyObject receiver) {
+        tryEagerInjection(receiver);
     }
 
     /**
@@ -219,25 +226,26 @@ public class GlobalVariable extends AbstractVariable {
      * @param runtime is environment where a variable injection occurs
      * @param receiver is the instance that will have variable injection.
      */
-    public void tryEagerInjection(Ruby runtime, IRubyObject receiver) {
+    public void tryEagerInjection(final IRubyObject receiver) {
         // wreckages of global local vars might remain on runtime, which may cause
         // assertion error since those names doesn't start from "$"
-        name = name.startsWith("$") ? name : ("$" + name).intern();
-        synchronized (this.getReceiver().getRuntime()) {
-            runtime.getGlobalVariables().set(name, irubyObject);
+        final String name = this.name.startsWith("$") ? this.name : ("$" + this.name);
+        synchronized (getRuntime()) {
+            getRuntime().getGlobalVariables().set(name.intern(), irubyObject);
         }
     }
 
     /**
      * Attempts to remove this variable from top self or receiver.
-     * 
+     *
      */
+    @Override
     public void remove() {
-        synchronized (receiver.getRuntime()) {
-            receiver.getRuntime().getGlobalVariables().clear(name.intern());
+        synchronized (getRuntime()) {
+            getRuntime().getGlobalVariables().clear(name.intern());
         }
     }
-    
+
     /**
      * Returns true if a given receiver is identical to the receiver this object has.
      *
@@ -247,4 +255,5 @@ public class GlobalVariable extends AbstractVariable {
     public boolean isReceiverIdentical(RubyObject recv) {
         return true;
     }
+
 }

--- a/core/src/main/java/org/jruby/embed/variable/GlobalVariable.java
+++ b/core/src/main/java/org/jruby/embed/variable/GlobalVariable.java
@@ -128,13 +128,15 @@ public class GlobalVariable extends AbstractVariable {
         IRubyObject value = globalVars.get(key);
         updateGlobalVar(vars, (RubyObject) runtime.getTopSelf(), key, value);
     }
-    
-    private static String[] patterns = {
-            "\\$([\\u0021-\\u0040]|\\u005c|[\\u005e-\\u0060]|\\u007e)",
-            "\\$-(\\d|[A-z])"
-        };
-    
-    private static String [] predefined_names = {
+
+    private static final String[] PREDEFINED_PATTERNS = {
+        "\\$([\\u0021-\\u0040]|\\u005c|[\\u005e-\\u0060]|\\u007e)",
+        "\\$-(\\d|[A-z])"
+    };
+    private static final Set<String> PREDEFINED_NAMES = new HashSet<String>();
+
+    static {
+        final String[] NAMES = {
             "$DEBUG", "$F", "$FILENAME", "$KCODE", "$LOAD_PATH", "$SAFE", "$VERBOSE", "$CLASSPATH", "$LOADED_FEATURES",
             "$PROGRAM_NAME", "$FIELD_SEPARATOR", "$ERROR_POSITION", "$DEFAULT_OUTPUT", "$PREMATCH", "$RS", "$MATCH",
             "$LAST_READ_LINE", "$FS", "$INPUT_RECORD_SEPARATOR", "$PID", "$NR", "$ERROR_INFO", "$PROCESS_ID",
@@ -142,33 +144,14 @@ public class GlobalVariable extends AbstractVariable {
             "$IGNORECASE", "$DEFAULT_INPUT", "$OFS", "$OUTPUT_FIELD_SEPARATOR", "$POSTMATCH", "$ORS",
             "$configure_args", "$deferr", "$defout", "$expect_verbose", "$stderr", "$stdin", "$stdout"
         };
-    private static Set<String> predefined = new HashSet<String>();
-    
-    static {
-        predefined.addAll(Arrays.asList(predefined_names));
+        PREDEFINED_NAMES.addAll(Arrays.asList(NAMES));
     }
 
-    protected static boolean isPredefined(String name) {
-        /*
-        String[] patterns = {
-            "\\$([\\u0021-\\u0040]|\\u005c|[\\u005e-\\u0060]|\\u007e)",
-            "\\$-(\\d|[A-z])",
-            "\\$(DEBUG|F|FILENAME|KCODE|LOAD_PATH|SAFE|VERBOSE|CLASSPATH|LOADED_FEATURES|PROGRAM_NAME)",
-            "\\$(FIELD_SEPARATOR|ERROR_POSITION|DEFAULT_OUTPUT|PREMATCH|RS|MATCH|LAST_READ_LINE|FS|INPUT_RECORD_SEPARATOR)",
-            "\\$(PID|NR|ERROR_INFO|PROCESS_ID|OUTPUT_RECORD_SEPARATOR|INPUT_LINE_NUMBER|LAST_PAREN_MATCH|LAST_MATCH_INFO|CHILD_STATUS)",
-            "\\$(IGNORECASE|DEFAULT_INPUT|OFS|OUTPUT_FIELD_SEPARATOR|POSTMATCH|ORS)",
-            "\\$(configure_args|deferr|defout|expect_verbose|stderr|stdin|stdout)"
-        };
-         */
-        
-        for (String p : GlobalVariable.patterns) {
-            if (name.matches(p)) {
-                return true;
-            }
+    protected static boolean isPredefined(final String name) {
+        for ( String pattern : PREDEFINED_PATTERNS ) {
+            if ( name.matches(pattern) ) return true;
         }
-        
-        if (GlobalVariable.predefined.contains(name)) return true;
-        return false;
+        return GlobalVariable.PREDEFINED_NAMES.contains(name);
     }
 
     /**

--- a/core/src/main/java/org/jruby/embed/variable/InstanceVariable.java
+++ b/core/src/main/java/org/jruby/embed/variable/InstanceVariable.java
@@ -41,7 +41,8 @@ import org.jruby.runtime.builtin.InstanceVariables;
  * @author Yoko Harada <yokolet@gmail.com>
  */
 public class InstanceVariable extends AbstractVariable {
-    private static String pattern = "@([a-zA-Z]|_)([a-zA-Z]|_|\\d)*";
+
+    private static final String VALID_NAME = "@([a-zA-Z]|_)([a-zA-Z]|_|\\d)*";
 
     /**
      * Returns an instance of this class. This factory method is used when an instance
@@ -53,7 +54,7 @@ public class InstanceVariable extends AbstractVariable {
      * @return the instance of InstanceVariable
      */
     public static BiVariable getInstance(RubyObject receiver, String name, Object... javaObject) {
-        if (name.matches(pattern)) {
+        if (name.matches(VALID_NAME)) {
             return new InstanceVariable(receiver, name, javaObject);
         }
         return null;
@@ -86,10 +87,10 @@ public class InstanceVariable extends AbstractVariable {
     public static void retrieve(RubyObject receiver, BiVariableMap vars) {
         if (vars.isLazy()) return;
         updateInstanceVar(receiver, vars);
-        updateInstanceVar((RubyObject)receiver.getRuntime().getTopSelf(), vars);
+        updateInstanceVar(getTopSelf(receiver), vars);
     }
 
-    static void updateInstanceVar(RubyObject receiver, BiVariableMap vars) {
+    static void updateInstanceVar(final RubyObject receiver, final BiVariableMap vars) {
         InstanceVariables ivars = receiver.getInstanceVariables();
         List<String> keys = ivars.getInstanceVariableNameList();
         for (String key : keys) {
@@ -136,6 +137,7 @@ public class InstanceVariable extends AbstractVariable {
      *
      * @return this enum type, BiVariable.Type.InstanceVariable.
      */
+    @Override
     public Type getType() {
         return Type.InstanceVariable;
     }
@@ -148,7 +150,7 @@ public class InstanceVariable extends AbstractVariable {
      * @return true if the given name is of a Ruby instance variable.
      */
     public static boolean isValidName(Object name) {
-        return isValidName(pattern, name);
+        return isValidName(VALID_NAME, name);
     }
 
     /**
@@ -158,15 +160,17 @@ public class InstanceVariable extends AbstractVariable {
      * @param runtime is environment where a variable injection occurs
      * @param receiver is the instance that will have variable injection.
      */
+    @Override
     public void inject() {
-        ((RubyObject)receiver).setInstanceVariable(name.intern(), getRubyObject());
+        ((RubyObject) getReceiver()).setInstanceVariable(name.intern(), getRubyObject());
     }
 
     /**
      * Attempts to remove this variable from top self or receiver.
-     * 
+     *
      */
+    @Override
     public void remove() {
-        ((RubyObject)receiver).removeInstanceVariable(name);
+        ((RubyObject) getReceiver()).removeInstanceVariable(name);
     }
 }

--- a/core/src/main/java/org/jruby/embed/variable/InstanceVariable.java
+++ b/core/src/main/java/org/jruby/embed/variable/InstanceVariable.java
@@ -77,6 +77,10 @@ public class InstanceVariable extends AbstractVariable {
         super(receiver, name, true, irubyObject);
     }
 
+    InstanceVariable(RubyObject receiver, String name, IRubyObject irubyObject) {
+        this((IRubyObject) receiver, name, irubyObject);
+    }
+
     /**
      * Retrieves instance variables from Ruby after the evaluation.
      *

--- a/core/src/main/java/org/jruby/embed/variable/TransientLocalVariable.java
+++ b/core/src/main/java/org/jruby/embed/variable/TransientLocalVariable.java
@@ -40,7 +40,8 @@ import org.jruby.RubyObject;
  * @author Yoko Harada <yokolet@gmail.com>
  */
 public class TransientLocalVariable extends AbstractVariable {
-    private static String pattern = "([a-z]|_)([a-zA-Z]|_|\\d)*";
+
+    private static final String VALID_NAME = "([a-z]|_)([a-zA-Z]|_|\\d)*";
 
     /**
      * Returns an instance of this class. This factory method is used when a
@@ -52,7 +53,7 @@ public class TransientLocalVariable extends AbstractVariable {
      * @return the instance of TransientLocalVariable
      */
     public static BiVariable getInstance(RubyObject receiver, String name, Object... javaObject) {
-        if (name.matches(pattern)) {
+        if (name.matches(VALID_NAME)) {
             return new TransientLocalVariable(receiver, name, javaObject);
         }
         return null;
@@ -68,6 +69,7 @@ public class TransientLocalVariable extends AbstractVariable {
      *
      * @return this enum type, BiVariable.Type.LocalVariable.
      */
+    @Override
     public Type getType() {
         return Type.LocalVariable;
     }
@@ -80,7 +82,7 @@ public class TransientLocalVariable extends AbstractVariable {
      * @return true if the given name is of a Ruby local variable.
      */
     public static boolean isValidName(Object name) {
-        return isValidName(pattern, name);
+        return isValidName(VALID_NAME, name);
     }
 
     /**
@@ -99,14 +101,16 @@ public class TransientLocalVariable extends AbstractVariable {
      * Injects a local variable value to a parsed Ruby script. This method is
      * invoked during EvalUnit#run() is executed.
      */
+    @Override
     public void inject() {
         //done in BiVariableMap.inject()
     }
 
     /**
      * Attempts to remove this variable from top self or receiver.
-     * 
+     *
      */
+    @Override
     public void remove() {
         // local variables won't survice over the eval on runime.
         // no need to remove lvar from runtime

--- a/core/src/main/java/org/jruby/embed/variable/VariableInterceptor.java
+++ b/core/src/main/java/org/jruby/embed/variable/VariableInterceptor.java
@@ -29,18 +29,21 @@
  */
 package org.jruby.embed.variable;
 
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+
 import org.jruby.Ruby;
 import org.jruby.RubyObject;
 import org.jruby.embed.internal.BiVariableMap;
 import org.jruby.embed.LocalVariableBehavior;
-import org.jruby.javasupport.JavaEmbedUtils;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.scope.ManyVarsDynamicScope;
 
 /**
  * This class is responsible to local variable behavior dependent processing.
- * 
+ *
  * @author Yoko Harada <yokolet@gmail.com>
  */
 public class VariableInterceptor {
@@ -54,7 +57,7 @@ public class VariableInterceptor {
     //public VariableInterceptor(LocalVariableBehavior behavior) {
     //    this.behavior = behavior;
     //}
-    
+
     //public LocalVariableBehavior getLocalVariableBehavior() {
     //    return behavior;
     //}
@@ -62,7 +65,7 @@ public class VariableInterceptor {
     /**
      * Returns an appropriate type of a variable instance to the specified local
      * variable behavior.
-     * 
+     *
      * @param runtime Ruby runtime
      * @param name variable name
      * @param value variable value
@@ -135,11 +138,9 @@ public class VariableInterceptor {
                 }
             }
         }
-        List<BiVariable> variables = map.getVariables();
-        if (variables == null) return;
-        for (int i=0; i<variables.size(); i++) {
-            variables.get(i).inject();
-        }
+        Collection<BiVariable> variables = map.getVariables();
+        if ( variables == null ) return;
+        for ( final BiVariable var : variables ) var.inject();
     }
 
     /**
@@ -213,12 +214,12 @@ public class VariableInterceptor {
      * @param variables a variable list to be cleared from Ruby runtime
      * @param runtime Ruby runtime
      */
-    public static void terminateGlobalVariables(LocalVariableBehavior behavior, List<BiVariable> variables, Ruby runtime) {
+    public static void terminateGlobalVariables(LocalVariableBehavior behavior, Collection<BiVariable> variables, Ruby runtime) {
         if (variables == null) return;
         if (LocalVariableBehavior.GLOBAL == behavior) {
-            for (int i = 0; i < variables.size(); i++) {
-                if (BiVariable.Type.LocalGlobalVariable == variables.get(i).getType()) {
-                    String name = variables.get(i).getName();
+            for ( final BiVariable var : variables ) {
+                if (BiVariable.Type.LocalGlobalVariable == var.getType()) {
+                    String name = var.getName();
                     name = name.startsWith("$") ? name : "$" + name;
                     runtime.getGlobalVariables().set(name, runtime.getNil());
                 }
@@ -257,37 +258,22 @@ public class VariableInterceptor {
             case GLOBAL:
                 return LocalGlobalVariable.isValidName(name);
             case BSF:
-                if (PersistentLocalVariable.isValidName(name)) {
-                    return true;
-                } else if (GlobalVariable.isValidName(name)) {
-                    return true;
-                }
+                if (PersistentLocalVariable.isValidName(name)) return true;
+                if (GlobalVariable.isValidName(name)) return true;
                 return false;
             case PERSISTENT:
-                if (GlobalVariable.isValidName(name)) {
-                    return true;
-                } else if (PersistentLocalVariable.isValidName(name)) {
-                    return true;
-                } else if (InstanceVariable.isValidName(name)) {
-                    return true;
-                } else if (Constant.isValidName(name)) {
-                    return true;
-                } else if (ClassVariable.isValidName(name)) {
-                    return true;
-                }
+                if (GlobalVariable.isValidName(name)) return true;
+                if (PersistentLocalVariable.isValidName(name)) return true;
+                if (InstanceVariable.isValidName(name)) return true;
+                if (Constant.isValidName(name)) return true;
+                if (ClassVariable.isValidName(name)) return true;
                 return false;
             default:
-                if (GlobalVariable.isValidName(name)) {
-                    return true;
-                } else if (TransientLocalVariable.isValidName(name)) {
-                    return true;
-                } else if (InstanceVariable.isValidName(name)) {
-                    return true;
-                } else if (Constant.isValidName(name)) {
-                    return true;
-                } else if (ClassVariable.isValidName(name)) {
-                    return true;
-                }
+                if (GlobalVariable.isValidName(name)) return true;
+                if (TransientLocalVariable.isValidName(name)) return true;
+                if (InstanceVariable.isValidName(name)) return true;
+                if (Constant.isValidName(name)) return true;
+                if (ClassVariable.isValidName(name)) return true;
                 return false;
         }
     }

--- a/core/src/test/java/org/jruby/embed/internal/BiVariableMapTest.java
+++ b/core/src/test/java/org/jruby/embed/internal/BiVariableMapTest.java
@@ -617,6 +617,8 @@ public class BiVariableMapTest {
         assertEquals( 1, container.getVarMap().size() );
 
         assertEquals( Arrays.asList("--hello", "there"), container.getVarMap().get("ARGV") );
+
+        assertTrue( container.getVarMap().getVariable("ARGV") instanceof org.jruby.embed.variable.Argv );
     }
 
     /**

--- a/core/src/test/java/org/jruby/embed/internal/BiVariableMapTest.java
+++ b/core/src/test/java/org/jruby/embed/internal/BiVariableMapTest.java
@@ -40,16 +40,18 @@ import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.OutputStream;
 import java.util.logging.Logger;
-import org.jruby.RubyClass;
-import java.util.Arrays;
-import org.jruby.embed.LocalVariableBehavior;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+
+import org.jruby.RubyClass;
+import org.jruby.embed.LocalVariableBehavior;
 import org.jruby.embed.ScriptingContainer;
 import org.jruby.embed.LocalContextScope;
-import java.util.List;
 import org.jruby.embed.variable.BiVariable;
-import org.jruby.embed.variable.VariableInterceptor;
-import org.jruby.runtime.builtin.IRubyObject;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -61,16 +63,16 @@ import static org.junit.Assert.*;
  *
  * @author yoko
  */
+@SuppressWarnings( { "unchecked", "deprecation" } )
 public class BiVariableMapTest {
-    private String basedir = System.getProperty("user.dir");
 
     static Logger logger0 = Logger.getLogger(BiVariableMapTest.class.getName());
     static Logger logger1 = Logger.getLogger(BiVariableMapTest.class.getName());
+
     static OutputStream outStream = null;
     FileWriter writer = null;
 
-    public BiVariableMapTest() {
-    }
+    private String basedir = System.getProperty("user.dir");
 
     @BeforeClass
     public static void setUpClass() throws Exception {
@@ -78,7 +80,7 @@ public class BiVariableMapTest {
 
     @AfterClass
     public static void tearDownClass() throws Exception {
-        outStream.close();
+        if ( outStream != null ) outStream.close();
     }
 
     @Before
@@ -97,7 +99,7 @@ public class BiVariableMapTest {
 
     @After
     public void tearDown() throws IOException {
-        writer.close();
+        if ( writer != null ) writer.close();
     }
 
     /**
@@ -109,24 +111,21 @@ public class BiVariableMapTest {
         ScriptingContainer container =
                 new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.TRANSIENT);
         BiVariableMap instance = container.getVarMap();
-        List<String> expResult = new ArrayList<String>();
-        List<String> result = instance.getNames();
-        assertEquals(result, result);
+        Collection<String> expResult = new ArrayList<String>();
+        assertEquals(expResult, instance.getNames());
         container.put("ARGV", new String[] {"spring", "fall"});
         container.put("SEASON", new String[] {"summer", "winter"});
         container.put("$sports", new String[] {"baseball", "hiking", "soccer", "ski"});
         container.put("@weather", new String[] {"snow", "sleet", "drizzle", "rain"});
         container.put("trees", new String[] {"cypress", "hemlock", "spruce"});
         expResult = Arrays.asList("ARGV", "SEASON", "$sports", "@weather", "trees");
-        result = instance.getNames();
-        assertEquals(expResult, result);
-        assertTrue(result.size() == 5);
-        
+        assertEquals(expResult, instance.getNames());
+        assertTrue(instance.size() == 5);
+
         // transient local variable should vanish after eval
         container.runScriptlet("a = 1");
         expResult = Arrays.asList("ARGV", "SEASON", "$sports", "@weather");
-        result = instance.getNames();
-        assertEquals(expResult, result);
+        assertEquals(expResult, instance.getNames());
 
         container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.GLOBAL);
         instance = container.getVarMap();
@@ -137,9 +136,8 @@ public class BiVariableMapTest {
         container.put("trees", new String[] {"cypress", "hemlock", "spruce"});
         // "$sports" and "@waether" are not eligible keys for localglobal type. Those are cut out.
         expResult = Arrays.asList("ARGV", "SEASON", "trees");
-        result = instance.getNames();
-        assertEquals(expResult, result);
-        assertTrue(result.size() == 3);
+        assertEquals(expResult, instance.getNames());
+        assertTrue(instance.size() == 3);
     }
 
     /**
@@ -151,23 +149,17 @@ public class BiVariableMapTest {
         ScriptingContainer container =
                 new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.TRANSIENT);
         BiVariableMap instance = container.getVarMap();
-        List<BiVariable> result = instance.getVariables();
         container.put("ARGV", new String[] {"spring", "fall"});
         container.put("SEASON", new String[] {"summer", "winter"});
         container.put("$sports", new String[] {"baseball", "hiking", "soccer", "ski"});
         container.put("@weather", new String[] {"snow", "sleet", "drizzle", "rain"});
         container.put("trees", new String[] {"cypress", "hemlock", "spruce"});
-        String[][] extResult = {{"spring", "fall"},
+        String[][] expected = { {"spring", "fall"},
                                 {"summer", "winter"},
                                 {"baseball", "hiking", "soccer", "ski"},
                                 {"snow", "sleet", "drizzle", "rain"},
-                                {"cypress", "hemlock", "spruce"}};
-        result = instance.getVariables();
-        for (int i=0; i<result.size(); i++) {
-            BiVariable var = result.get(i);
-            assertArrayEquals(extResult[i], (String[]) var.getJavaObject());
-        }
-        assertTrue(result.size() == 5);
+                                {"cypress", "hemlock", "spruce"} };
+        assertArrayEqualsContent(expected, instance.getVariables());
 
         container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.GLOBAL);
         instance = container.getVarMap();
@@ -176,15 +168,18 @@ public class BiVariableMapTest {
         container.put("$sports", new String[] {"baseball", "hiking", "soccer", "ski"});
         container.put("@weather", new String[] {"snow", "sleet", "drizzle", "rain"});
         container.put("trees", new String[] {"cypress", "hemlock", "spruce"});
-        String[][] extResult2 = {{"spring", "fall"},
+        String[][] expected2 = { {"spring", "fall"},
                                  {"summer", "winter"},
-                                 {"cypress", "hemlock", "spruce"}};
-        result = instance.getVariables();
-        for (int i=0; i<result.size(); i++) {
-            BiVariable var = result.get(i);
-            assertArrayEquals(extResult2[i], (String[]) var.getJavaObject());
-        }      
-        assertTrue(result.size() == 3);
+                                 {"cypress", "hemlock", "spruce"} };
+        assertArrayEqualsContent(expected2, instance.getVariables());
+    }
+
+    private static void assertArrayEqualsContent(final Object[][] expected, final Collection<BiVariable> actual) {
+        int i = 0;
+        for ( final BiVariable var : actual ) {
+            assertArrayEquals(expected[i++], (Object[]) var.getJavaObject());
+        }
+        assertEquals(expected.length, actual.size());
     }
 
     /**
@@ -227,16 +222,16 @@ public class BiVariableMapTest {
         container.put("@weather", new String[] {"snow", "sleet", "drizzle", "rain"});
         container.put("trees", new String[] {"cypress", "hemlock", "spruce"});
         assertTrue(instance.size() == 5);
-        
+
         String[] expResult = {"snow", "sleet", "drizzle", "rain"};
         String[] weather = (String[]) container.remove("@weather");
         assertArrayEquals(expResult, weather);
         assertTrue(instance.size() == 4);
-        
+
         // transient local variable should vanish after eval
         container.runScriptlet("a = 1");
         assertTrue(instance.size() == 3);
-        
+
         container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.PERSISTENT);
         instance = container.getVarMap();
         container.put("ARGV", new String[] {"spring", "fall"});
@@ -245,11 +240,11 @@ public class BiVariableMapTest {
         container.put("@weather", new String[] {"snow", "sleet", "drizzle", "rain"});
         container.put("trees", new String[] {"cypress", "hemlock", "spruce"});
         assertTrue(instance.size() == 5);
-        
+
         // persistent local variable should be kept even after eval, plus retrieved.
         container.runScriptlet("a = 1");
         assertTrue(instance.size() == 6);
-        
+
         container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.GLOBAL);
         instance = container.getVarMap();
         container.put("ARGV", new String[] {"spring", "fall"});
@@ -259,12 +254,12 @@ public class BiVariableMapTest {
         container.put("trees", new String[] {"cypress", "hemlock", "spruce"});
         // $sports and @weather are not eligible key for local global type.
         assertTrue(instance.size() == 3);
-        
+
         // local global variable should not be dropped.
         // "a" in Ruby code is not local global var.
         container.runScriptlet("a = 1");
         assertTrue(instance.size() == 3);
-        
+
     }
 
     /**
@@ -283,7 +278,7 @@ public class BiVariableMapTest {
         assertFalse(instance.isEmpty());
         container.clear();
         assertTrue(instance.isEmpty());
-        
+
         container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.GLOBAL);
         instance = container.getVarMap();
         container.put("SEASON", new String[] { "summer", "winter" });
@@ -324,7 +319,7 @@ public class BiVariableMapTest {
         assertFalse(instance.containsKey("$sports"));
         assertFalse(instance.containsKey("@weather"));
         assertTrue(instance.containsKey("trees"));
-        
+
         // eager retieval mode test
         container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.GLOBAL, false);
         instance = container.getVarMap();
@@ -334,7 +329,7 @@ public class BiVariableMapTest {
         assertTrue(instance.containsKey("ARGV"));
         assertFalse(instance.containsKey("trees"));
         assertEquals(2, instance.size());
-        
+
         // lazy retieval mode test
         container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.GLOBAL, true);
         instance = container.getVarMap();
@@ -345,7 +340,7 @@ public class BiVariableMapTest {
         List<String> result1 = (List<String>) container.get("SEASON");
         assertEquals(expResult1, result1);
         assertTrue(instance.containsKey("SEASON"));
-        
+
         assertFalse(instance.containsKey("ARGV"));
         List<String> expResult2 = new ArrayList<String>();
         expResult2.add("St. Patrick's day");
@@ -366,33 +361,33 @@ public class BiVariableMapTest {
         argv_values.add("spring"); argv_values.add("fall");
         container.put("ARGV", argv_values);
         assertTrue(instance.containsValue(argv_values));
-        
+
         ArrayList<String> const_values = new ArrayList<String>();
         const_values.add("summer"); const_values.add("winter");
         container.put("SEASON", const_values);
         assertTrue(instance.containsValue(argv_values));
-        
+
         ArrayList<String> gvar_values = new ArrayList<String>();
         gvar_values.add("baseball"); gvar_values.add("soccer"); gvar_values.add("ski");
         container.put("$sports", gvar_values);
         assertTrue(instance.containsValue(gvar_values));
-        
+
         ArrayList<String> ivar_values = new ArrayList<String>();
         ivar_values.add("snow"); ivar_values.add("sleet"); ivar_values.add("drizzle");
         container.put("@weather", ivar_values);
         assertTrue(instance.containsValue(ivar_values));
-        
+
         ArrayList<String> lvar_values = new ArrayList<String>();
         lvar_values.add("cypress"); lvar_values.add("hemlock"); lvar_values.add("spruce");
         container.put("trees", lvar_values);
         assertTrue(instance.containsValue(lvar_values));
-        
+
         container.runScriptlet("ARGV << \"late-fall\"; SEASON << \"mid-summer\"; $sports << \"basketball\"; @weather << \"freezing-rain\"");
         argv_values.add("late-fall");
         const_values.add("mid-summer");
         gvar_values.add("basketball");
         ivar_values.add("freezing-rain");
-        
+
         // transient type lvar should vanish after eval.
         assertFalse(instance.containsValue(lvar_values));
         // lazy retrieval mode. needs to get before containsValue method
@@ -401,13 +396,13 @@ public class BiVariableMapTest {
         assertEquals(gvar_values, container.get("$sports"));
         assertEquals(ivar_values, container.get("@weather"));
         assertNull(container.get("trees"));
-        
+
         assertTrue(instance.containsValue(argv_values));
         assertTrue(instance.containsValue(const_values));
         assertTrue(instance.containsValue(gvar_values));
         assertTrue(instance.containsValue(ivar_values));
         assertFalse(instance.containsValue(lvar_values));
-        
+
         container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.GLOBAL, false);
         instance = container.getVarMap();
         container.put("ARGV", argv_values);
@@ -420,17 +415,17 @@ public class BiVariableMapTest {
         assertFalse(instance.containsValue(ivar_values));
         container.put("trees", lvar_values);
         assertTrue(instance.containsValue(lvar_values));
- 
+
         container.runScriptlet("ARGV << \"early-winter\"; $SEASON << \"deep-fall\"; $trees << \"pine\"");
         argv_values.add("early-winter");
         const_values.add("deep-fall");
         lvar_values.add("pine");
-        
+
         // eager retrival mode. no need to get before containesValue method
         assertTrue(instance.containsValue(argv_values));
         assertTrue(instance.containsValue(const_values));
         assertTrue(instance.containsValue(lvar_values));
-        
+
         assertEquals(argv_values, container.get("ARGV"));
         assertEquals(const_values, container.get("SEASON"));
         assertEquals(lvar_values, container.get("trees"));
@@ -444,7 +439,7 @@ public class BiVariableMapTest {
         logger1.info("get");
         ScriptingContainer container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.TRANSIENT);
         BiVariableMap instance = container.getVarMap();
-        
+
         ArrayList<String> argv_values = new ArrayList<String>();
         argv_values.add("spring"); argv_values.add("fall");
         container.put("ARGV", argv_values);
@@ -469,7 +464,7 @@ public class BiVariableMapTest {
         assertEquals(ivar_values, instance.get("@weather"));
         assertEquals(cvar_values, instance.get("@@clouds"));
         assertEquals(lvar_values, instance.get("trees"));
-        
+
         String script =
             "class Forecast\n" +
             "  SEASON = 'halloween'\n" +
@@ -486,16 +481,18 @@ public class BiVariableMapTest {
             "  end\n" +
             "end";
         container.runScriptlet(script);
-     
+
         Object klazz = container.get("Forecast");
         assertEquals("Forecast", ((RubyClass)klazz).getName());
         Object receiver = container.callMethod(klazz, "new", "blizzard", "6F");
         assertEquals("blizzard", container.get(receiver, "@weather"));
         assertEquals("6F", container.callMethod(receiver, "temp"));
         assertEquals("halloween", container.get(receiver, "SEASON"));
+
         ArrayList<String> expResult = new ArrayList<String>();
         expResult.add("contrail"); expResult.add("snow laden clouds");
         //assertEquals(expResult, container.get(receiver, "@@clouds")); // why this fails?
+
         container.put(receiver, "@temp", "-5F");
         assertEquals("-5F", container.callMethod(receiver, "temp"));
         container.put(receiver, "SEASON", "colored leaves");
@@ -505,6 +502,7 @@ public class BiVariableMapTest {
         assertEquals("colored leaves", container.get(receiver, "SEASON"));
         assertEquals("thunder clouds", container.callMethod(receiver, "cloud_names"));
         assertEquals("thunder clouds", container.get(receiver, "@@clouds")); // this passes
+
         expResult.clear();
         expResult.add("cirrus"); expResult.add("stratus"); expResult.add("cumulus");
         assertEquals(expResult, container.get("@@clouds"));
@@ -514,13 +512,13 @@ public class BiVariableMapTest {
         assertEquals(expResult, container.get(receiver, "$sports"));
         container.put(receiver, "$team", "tigers");
         assertEquals("tigers", container.get("$team"));
-        
+
         container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.PERSISTENT);
-        instance = container.getVarMap();
+        //instance = container.getVarMap();
         container.put("trees", lvar_values);
         container.runScriptlet(script);
         klazz = container.get("Forecast");
-        receiver = container.callMethod(klazz, "new", "blizzard", "6F");
+        container.callMethod(klazz, "new", "blizzard", "6F");
         expResult.clear();
         expResult.add("cypress"); expResult.add("hemlock"); expResult.add("spruce");
         assertEquals(expResult, container.get("trees"));
@@ -614,6 +612,91 @@ public class BiVariableMapTest {
         container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.GLOBAL, false);
         instance = container.getVarMap();
         assertFalse(instance.isLazy());
+
+        container = new ScriptingContainer(LocalContextScope.THREADSAFE, LocalVariableBehavior.TRANSIENT);
+        assertTrue( container.getVarMap().isLazy() );
+        container = new ScriptingContainer(LocalContextScope.SINGLETON, LocalVariableBehavior.GLOBAL);
+        assertTrue( container.getVarMap().isLazy() );
+    }
+
+    @Test @Deprecated
+    public void testVariables() {
+        ScriptingContainer container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.TRANSIENT);
+        assertNotNull( container.getVarMap().getNames() );
+        assertNotNull( container.getVarMap().getVariables() );
+    }
+
+    @Test
+    public void testGetLocalVariables() {
+        ScriptingContainer container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.TRANSIENT);
+        assertNotNull( container.getVarMap().getLocalVarNames() );
+        assertEquals( 0, container.getVarMap().getLocalVarNames().length );
+        assertNotNull( container.getVarMap().getLocalVarValues() );
+        assertEquals( 0, container.getVarMap().getLocalVarValues().length );
+
+        container.getVarMap().put("loc1", "1");
+        container.getVarMap().put("loc2", "2");
+
+        assertArrayEquals( new String[] { "loc1", "loc2"}, container.getVarMap().getLocalVarNames() );
+        assertEquals( 2, container.getVarMap().getLocalVarValues().length );
+
+        container.getVarMap().clear();
+        assertEquals( 0, container.getVarMap().getLocalVarValues().length );
+    }
+
+    @Test
+    public void testMapIsEmpty() {
+        ScriptingContainer container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.TRANSIENT);
+        assertTrue( container.getVarMap().isEmpty() );
+    }
+
+    @Test
+    public void testMapClear() {
+        ScriptingContainer container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.TRANSIENT);
+        container.getVarMap().clear();
+        assertTrue( container.getVarMap().isEmpty() );
+
+        container.getVarMap().put("_1", new Object());
+        assertFalse( container.getVarMap().isEmpty() );
+
+        container.getVarMap().clear();
+        assertTrue( container.getVarMap().isEmpty() );
+
+        assertEquals( 0, container.getVarMap().getNames().size() );
+        assertEquals( 0, container.getVarMap().getVariables().size() );
+
+        assertTrue( container.getVarMap().values().isEmpty() );
+        assertTrue( container.getVarMap().keySet().isEmpty() );
+    }
+
+    @Test
+    public void testMapSize() {
+        ScriptingContainer container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.TRANSIENT);
+        assertEquals( 0, container.getVarMap().size() );
+    }
+
+    @Test
+    public void testMapViews() {
+        ScriptingContainer container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.TRANSIENT);
+        assertEquals( 0, container.getVarMap().entrySet().size() );
+        assertTrue( container.getVarMap().values().isEmpty() );
+        assertTrue( container.getVarMap().keySet().isEmpty() );
+    }
+
+    @Test
+    public void testMapPutAll() {
+        HashMap<String, String> vars = new HashMap<String, String>();
+        vars.put("$borg", "_global_");
+        vars.put("local", "variable");
+        vars.put("@ivar", "instance");
+
+        ScriptingContainer container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.TRANSIENT);
+        container.getVarMap().putAll(vars);
+        assertEquals( 3, container.getVarMap().size() );
+    }
+
+    public static void main(String[] args) {
+        org.junit.runner.JUnitCore.main(args);
     }
 
 }

--- a/core/src/test/java/org/jruby/embed/internal/BiVariableMapTest.java
+++ b/core/src/test/java/org/jruby/embed/internal/BiVariableMapTest.java
@@ -435,7 +435,7 @@ public class BiVariableMapTest {
      * Test of get method, of class BiVariableMap.
      */
     @Test
-    public void testGet_Object() {
+    public void testMapGet() {
         logger1.info("get");
         ScriptingContainer container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.TRANSIENT);
         BiVariableMap instance = container.getVarMap();
@@ -539,16 +539,30 @@ public class BiVariableMapTest {
     /**
      * Test of remove method, of class BiVariableMap.
      */
-    //@Test
-    public void testRemove_Object() {
+    @Test
+    public void testMapRemove() {
         logger1.info("remove");
-        /* add this test later
-        Object key = null;
-        BiVariableMap instance = null;
-        Object expResult = null;
-        Object result = instance.remove(key);
-        assertEquals(expResult, result);
-        */
+
+        ScriptingContainer container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.TRANSIENT);
+
+        container.put("ARGV", new String[] { "arg1", "arg2" });
+        container.put("SAMPLE", "42");
+
+        container.getVarMap().remove("SAMPLE");
+        assertEquals(1, container.getVarMap().size());
+
+        container.getVarMap().remove("ARGV");
+        assertTrue( container.getVarMap().isEmpty() );
+    }
+
+    @Test
+    public void testToString() {
+        ScriptingContainer container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.TRANSIENT);
+
+        container.put("ARGV", new String[] { "arg1", "arg2" });
+        container.put("SAMPLE", "42");
+
+        container.getVarMap().toString();
     }
 
     /**

--- a/core/src/test/java/org/jruby/embed/internal/BiVariableMapTest.java
+++ b/core/src/test/java/org/jruby/embed/internal/BiVariableMapTest.java
@@ -602,6 +602,23 @@ public class BiVariableMapTest {
         assertNull(container.runScriptlet("$a"));
     }
 
+    @Test
+    public void testClearKeepsARGV() {
+        ScriptingContainer container = new ScriptingContainer(LocalContextScope.SINGLETHREAD, LocalVariableBehavior.TRANSIENT);
+
+        container.put("$abc", "def");
+        final List<String> argv = new ArrayList<String>();
+        argv.add("--hello"); argv.add("there");
+        container.put("ARGV", argv);
+        container.put("NO77", 1234567);
+
+        container.getVarMap().clear();
+
+        assertEquals( 1, container.getVarMap().size() );
+
+        assertEquals( Arrays.asList("--hello", "there"), container.getVarMap().get("ARGV") );
+    }
+
     /**
      * Test of isLazy method, of class BiVariableMap.
      */

--- a/core/src/test/java/org/jruby/embed/internal/ConcurrentLocalContextProviderTest.java
+++ b/core/src/test/java/org/jruby/embed/internal/ConcurrentLocalContextProviderTest.java
@@ -189,6 +189,13 @@ public class ConcurrentLocalContextProviderTest {
         } else {
             // no need to test
         }
+
+        ConcurrentLocalContextProviderStub provider = new ConcurrentLocalContextProviderStub(LocalVariableBehavior.TRANSIENT);
+        provider.isGlobalRuntimeReady = false;
+        assertNotNull( provider.getRubyInstanceConfig() );
+        assertFalse( provider.runtimeInitialized ); // make sure we do not call getRuntime()
+
+
     }
 
     /**
@@ -246,7 +253,7 @@ public class ConcurrentLocalContextProviderTest {
         if (Ruby.isGlobalRuntimeReady()) assertTrue(result);
         else assertFalse(result);
     }
-    
+
     @Test
     public void testTerminate() {
         logger1.info("isTerminate");
@@ -258,4 +265,35 @@ public class ConcurrentLocalContextProviderTest {
             fail();
         }
     }
+
+    private static class ConcurrentLocalContextProviderStub extends ConcurrentLocalContextProvider {
+
+        Boolean isGlobalRuntimeReady = null;
+
+        ConcurrentLocalContextProviderStub(LocalVariableBehavior behavior) {
+            super( behavior );
+        }
+
+        ConcurrentLocalContextProviderStub(LocalVariableBehavior behavior, boolean lazy) {
+            super( behavior, lazy );
+        }
+
+        boolean runtimeInitialized = false;
+
+        @Override
+        public Ruby getRuntime() {
+            runtimeInitialized = true;
+            return super.getRuntime();
+        }
+
+        @Override
+        boolean isGlobalRuntimeReady() {
+            if ( isGlobalRuntimeReady != null ) {
+                return isGlobalRuntimeReady.booleanValue();
+            }
+            return super.isGlobalRuntimeReady();
+        }
+
+    }
+
 }

--- a/core/src/test/java/org/jruby/embed/internal/SingletonLocalContextProviderTest.java
+++ b/core/src/test/java/org/jruby/embed/internal/SingletonLocalContextProviderTest.java
@@ -1,0 +1,139 @@
+
+package org.jruby.embed.internal;
+
+import org.jruby.RubyInstanceConfig;
+import org.jruby.embed.LocalVariableBehavior;
+import java.util.concurrent.atomic.AtomicReference;
+import org.jruby.Ruby;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * @author kares
+ */
+public class SingletonLocalContextProviderTest {
+
+    @Test
+    public void testGetRuntime() {
+        SingletonLocalContextProvider provider = newProvider();
+        final Ruby providerRuntime = provider.getRuntime();
+        assertEquals(true, Ruby.isGlobalRuntimeReady());
+        assertEquals(Ruby.getGlobalRuntime(), providerRuntime);
+    }
+
+    @Test
+    public void testGetRubyInstanceConfig() {
+        if ( Ruby.isGlobalRuntimeReady() ) {
+            SingletonLocalContextProvider provider = newProvider();
+            assertTrue(Ruby.getGlobalRuntime().getInstanceConfig() == provider.getRubyInstanceConfig());
+        }
+
+        SingletonLocalContextProviderStub provider = newProviderStub();
+        provider.isGlobalRuntimeReady = false;
+        assertNotNull( provider.getRubyInstanceConfig() );
+        assertFalse( provider.runtimeInitialized ); // make sure we do not call getRuntime()
+
+        provider.isGlobalRuntimeReady = true;
+        assertNotNull( provider.getRubyInstanceConfig() );
+        assertSame(Ruby.getGlobalRuntime().getInstanceConfig(), provider.getRubyInstanceConfig());
+
+        final AtomicReference<Ruby> globalRuntimeHolder = new AtomicReference<Ruby>();
+        provider = new SingletonLocalContextProviderStub() {
+
+            {
+                isGlobalRuntimeReady = false;
+            }
+
+            @Override
+            Ruby getGlobalRuntime(AbstractLocalContextProvider provider) {
+                if ( isGlobalRuntimeReady ) return globalRuntimeHolder.get();
+
+                final Ruby globalRuntime = super.getGlobalRuntime(provider);
+                isGlobalRuntimeReady = true;
+                globalRuntimeHolder.set(globalRuntime);
+                return globalRuntime;
+            }
+
+        };
+
+        final RubyInstanceConfig config = provider.getRubyInstanceConfig();
+        assertNotNull( config );
+        assertNull( globalRuntimeHolder.get() );
+
+        provider.getRuntime();
+        assertNotNull( provider.getRuntime() );
+        assertSame( config, provider.getRubyInstanceConfig() );
+        assertNotNull( globalRuntimeHolder.get() );
+        assertSame( config, globalRuntimeHolder.get().getInstanceConfig() );
+    }
+
+    @Test
+    public void testIsRuntimeInitialized() {
+        SingletonLocalContextProvider provider = newProvider();
+        boolean result = provider.isRuntimeInitialized();
+        if ( Ruby.isGlobalRuntimeReady() ) {
+            assertTrue(result);
+        }
+        else assertFalse(result);
+    }
+
+    @Test
+    public void testTerminate() {
+        SingletonLocalContextProvider provider = newProvider();
+        //try {
+        provider.terminate();
+        //}
+        //catch (Exception e) {
+        //    fail();
+        //}
+    }
+
+    private SingletonLocalContextProvider newProvider() {
+        return new SingletonLocalContextProvider(LocalVariableBehavior.TRANSIENT, true);
+    }
+
+    private SingletonLocalContextProviderStub newProviderStub() {
+        return new SingletonLocalContextProviderStub();
+    }
+
+    private static class SingletonLocalContextProviderStub extends SingletonLocalContextProvider {
+
+        Boolean isGlobalRuntimeReady = null;
+
+        private SingletonLocalContextProviderStub() {
+            super( LocalVariableBehavior.TRANSIENT, true );
+        }
+
+        SingletonLocalContextProviderStub(LocalVariableBehavior behavior) {
+            super( behavior );
+        }
+
+        SingletonLocalContextProviderStub(LocalVariableBehavior behavior, boolean lazy) {
+            super( behavior, lazy );
+        }
+
+        boolean runtimeInitialized = false;
+
+        @Override
+        public Ruby getRuntime() {
+            runtimeInitialized = true;
+            return super.getRuntime();
+        }
+
+        @Override
+        boolean isGlobalRuntimeReady() {
+            if ( isGlobalRuntimeReady != null ) {
+                return isGlobalRuntimeReady.booleanValue();
+            }
+            return super.isGlobalRuntimeReady();
+        }
+
+        //@Override
+        //Ruby getGlobalRuntime(AbstractLocalContextProvider provider) {
+        //    if ( globalRuntime != null ) return globalRuntime;
+        //    return super.getGlobalRuntime(provider);
+        //}
+
+    }
+
+}

--- a/core/src/test/java/org/jruby/embed/jsr223/JRubyEngineTest.java
+++ b/core/src/test/java/org/jruby/embed/jsr223/JRubyEngineTest.java
@@ -63,6 +63,7 @@ import javax.script.SimpleBindings;
 import javax.script.SimpleScriptContext;
 import org.jruby.embed.PositionFunction;
 import org.jruby.embed.RadioActiveDecay;
+import org.jruby.embed.internal.BiVariableMap;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -161,7 +162,7 @@ public class JRubyEngineTest {
         }
         String filename = basedir + "/src/test/ruby/org/jruby/embed/ruby/proverbs_of_the_day.rb";
         Reader reader = new FileReader(filename);
-        
+
         instance.put("$day", -1);
         CompiledScript cs = ((Compilable)instance).compile(reader);
         String result = (String) cs.eval();
@@ -173,10 +174,10 @@ public class JRubyEngineTest {
         result = (String) cs.eval();
         expResult = "Every garden may have some weeds.";
         assertEquals(expResult, result);
-        
+
         instance.getBindings(ScriptContext.ENGINE_SCOPE).clear();
         instance = null;
-        
+
     }
 
     /**
@@ -231,7 +232,7 @@ public class JRubyEngineTest {
      */
     @Test
     public void testEval_String_ScriptContext2() throws Exception {
-        logger1.info("[eval String with ScriptContext 2]");       
+        logger1.info("[eval String with ScriptContext 2]");
         ScriptEngine instance = null;
         synchronized(this) {
             System.setProperty("org.jruby.embed.localcontext.scope", "singlethread");
@@ -326,7 +327,7 @@ public class JRubyEngineTest {
         }
         String filename = basedir + "/src/test/ruby/org/jruby/embed/ruby/next_year.rb";
         Reader reader = new FileReader(filename);
-        
+
         long expResult = getNextYear();
         Object result = instance.eval(reader);
         assertEquals(expResult, result);
@@ -534,7 +535,6 @@ public class JRubyEngineTest {
         assertNotSame(bindings, result);
 
         instance.getBindings(ScriptContext.ENGINE_SCOPE).clear();
-        instance = null;
     }
 
     /**
@@ -549,7 +549,6 @@ public class JRubyEngineTest {
         assertNotNull(result);
 
         instance.getBindings(ScriptContext.ENGINE_SCOPE).clear();
-        instance = null;
     }
 
     /**
@@ -572,7 +571,6 @@ public class JRubyEngineTest {
         assertEquals(expResult, (result.getWriter()).toString());
 
         instance.getBindings(ScriptContext.ENGINE_SCOPE).clear();
-        instance = null;
     }
 
     /**
@@ -590,7 +588,6 @@ public class JRubyEngineTest {
         assertEquals(expResult, ret);
 
         instance.getBindings(ScriptContext.ENGINE_SCOPE).clear();
-        instance = null;
     }
 
     /**
@@ -599,13 +596,7 @@ public class JRubyEngineTest {
     @Test
     public void testInvokeMethod() throws Exception {
         logger1.info("invokeMethod");
-        ScriptEngine instance;
-        synchronized(this) {
-            System.setProperty("org.jruby.embed.localcontext.scope", "singlethread");
-            System.setProperty("org.jruby.embed.localvariable.behavior", "transient");
-            ScriptEngineManager manager = new ScriptEngineManager();
-            instance = manager.getEngineByName("jruby");
-        }
+        ScriptEngine instance = newScriptEngine();
         String filename = basedir + "/src/test/ruby/org/jruby/embed/ruby/tree.rb";
         Reader reader = new FileReader(filename);
         Object receiver = instance.eval(reader);
@@ -630,7 +621,6 @@ public class JRubyEngineTest {
         assertTrue(result.startsWith(expResult));
 
         instance.getBindings(ScriptContext.ENGINE_SCOPE).clear();
-        instance = null;
     }
 
     /**
@@ -639,31 +629,24 @@ public class JRubyEngineTest {
     @Test
     public void testInvokeFunction() throws Exception {
         logger1.info("invokeFunction");
-        ScriptEngine instance;
-        synchronized(this) {
-            System.setProperty("org.jruby.embed.localcontext.scope", "singlethread");
-            System.setProperty("org.jruby.embed.localvariable.behavior", "transient");
-            ScriptEngineManager manager = new ScriptEngineManager();
-            instance = manager.getEngineByName("jruby");
-        }
+        ScriptEngine instance = newScriptEngine();
         String filename = basedir + "/src/test/ruby/org/jruby/embed/ruby/count_down.rb";
         Reader reader = new FileReader(filename);
         Bindings bindings = new SimpleBindings();
         bindings.put("@month", 6);
         bindings.put("@day", 3);
         instance.setBindings(bindings, ScriptContext.ENGINE_SCOPE);
-        Object result = instance.eval(reader, bindings);
+        instance.eval(reader, bindings);
 
         String method = "count_down_birthday";
         bindings.put("@month", 12);
         bindings.put("@day", 3);
         instance.setBindings(bindings, ScriptContext.ENGINE_SCOPE);
         Object[] args = null;
-        result = ((Invocable)instance).invokeFunction(method, args);
-        assertTrue(((String)result).startsWith("Happy") || ((String)result).startsWith("You have"));
+        Object result = ((Invocable)instance).invokeFunction(method, args);
+        assertTrue(((String)result).startsWith("Happy") || ((String) result).startsWith("You have"));
 
         instance.getBindings(ScriptContext.ENGINE_SCOPE).clear();
-        instance = null;
     }
 
     /**
@@ -672,13 +655,7 @@ public class JRubyEngineTest {
     @Test
     public void testGetInterface_Class() throws FileNotFoundException, ScriptException {
         logger1.info("getInterface (no receiver)");
-        ScriptEngine instance;
-        synchronized(this) {
-            System.setProperty("org.jruby.embed.localcontext.scope", "singlethread");
-            System.setProperty("org.jruby.embed.localvariable.behavior", "transient");
-            ScriptEngineManager manager = new ScriptEngineManager();
-            instance = (JRubyEngine) manager.getEngineByName("jruby");
-        }
+        ScriptEngine instance = newScriptEngine();
         Class returnType = RadioActiveDecay.class;
         String filename = basedir + "/src/test/ruby/org/jruby/embed/ruby/radioactive_decay.rb";
         Reader reader = new FileReader(filename);
@@ -692,7 +669,6 @@ public class JRubyEngineTest {
         assertEquals(expResult, result.yearsToAmount(10.0, 1.0), 0.000001);
 
         instance.getBindings(ScriptContext.ENGINE_SCOPE).clear();
-        instance = null;
     }
 
     /**
@@ -701,13 +677,7 @@ public class JRubyEngineTest {
     @Test
     public void testGetInterface_Object_Class() throws FileNotFoundException, ScriptException {
         logger1.info("getInterface (with receiver)");
-        ScriptEngine instance;
-        synchronized(this) {
-            System.setProperty("org.jruby.embed.localcontext.scope", "singlethread");
-            System.setProperty("org.jruby.embed.localvariable.behavior", "transient");
-            ScriptEngineManager manager = new ScriptEngineManager();
-            instance = manager.getEngineByName("jruby");
-        }
+        ScriptEngine instance = newScriptEngine();
         String filename = basedir + "/src/test/ruby/org/jruby/embed/ruby/position_function.rb";
         Reader reader = new FileReader(filename);
         Bindings bindings = instance.getBindings(ScriptContext.ENGINE_SCOPE);
@@ -726,7 +696,6 @@ public class JRubyEngineTest {
         assertEquals(expResult, result.getVelocity(t), 0.1);
 
         instance.getBindings(ScriptContext.ENGINE_SCOPE).clear();
-        instance = null;
     }
 
     /*
@@ -735,13 +704,7 @@ public class JRubyEngineTest {
     @Test
     public void testARGV() throws ScriptException {
         logger1.info("ScriptEngine.ARGV");
-        ScriptEngine instance;
-        synchronized(this) {
-            System.setProperty("org.jruby.embed.localcontext.scope", "singlethread");
-            System.setProperty("org.jruby.embed.localvariable.behavior", "transient");
-            ScriptEngineManager manager = new ScriptEngineManager();
-            instance = manager.getEngineByName("jruby");
-        }
+        ScriptEngine instance = newScriptEngine();
         instance.getContext().setErrorWriter(writer);
         String script = "" +
 //            "ARGV << 'foo' \n" +
@@ -750,8 +713,6 @@ public class JRubyEngineTest {
             "end";
         instance.put(ScriptEngine.ARGV,new String[]{"one param"});
         instance.eval(script);
-
-        instance = null;
     }
 
     /*
@@ -760,13 +721,7 @@ public class JRubyEngineTest {
     @Test
     public void testARGV_2() throws ScriptException {
         logger1.info("ScriptEngine.ARGV before initialization");
-        ScriptEngine instance;
-        synchronized(this) {
-            System.setProperty("org.jruby.embed.localcontext.scope", "singlethread");
-            System.setProperty("org.jruby.embed.localvariable.behavior", "transient");
-            ScriptEngineManager manager = new ScriptEngineManager();
-            instance = manager.getEngineByName("jruby");
-        }
+        ScriptEngine instance = newScriptEngine();
         instance.getContext().setErrorWriter(writer);
         Bindings bindings = instance.getBindings(ScriptContext.ENGINE_SCOPE);
         bindings.put(ScriptEngine.ARGV, new String[]{"init params"});
@@ -776,13 +731,11 @@ public class JRubyEngineTest {
             "  raise 'Error No argv passed'\n" +
             "end";
         instance.eval(script);
-
-        instance = null;
     }
 
     // This code worked successfully on command-line but never as JUnit test
     // <script>:1: undefined method `+' for nil:NilClass (NoMethodError)
-    // raised at "Object obj1 = engine1.eval("$Value + 2010.to_s");" 
+    // raised at "Object obj1 = engine1.eval("$Value + 2010.to_s");"
     //@Test
     public void testMultipleEngineStates() throws ScriptException {
         logger1.info("Multiple Engine States");
@@ -808,8 +761,6 @@ public class JRubyEngineTest {
         Object obj1 = engine1.eval("$Value + 2010.to_s");
         Object obj2 = engine2.eval("$Value + 2010");
         assertNotSame(obj1, obj2);
-        engine1 = null;
-        engine2 = null;
     }
 
     @Test
@@ -830,28 +781,45 @@ public class JRubyEngineTest {
         expResult = "GVar in an at_exit block";
         assertEquals(expResult, sw.toString().trim());
         instance.getContext().setAttribute("org.jruby.embed.termination", false, ScriptContext.ENGINE_SCOPE);
-        instance = null;
     }
-    
+
     @Test
     public void testClearVariables() throws ScriptException {
         logger1.info("Clear Variables Test");
-        ScriptEngine instance = null;
-        synchronized (this) {
-            System.setProperty("org.jruby.embed.localcontext.scope", "singlethread");
-            System.setProperty("org.jruby.embed.localvariable.behavior", "global");
-            ScriptEngineManager manager = new ScriptEngineManager();
-            instance = manager.getEngineByName("jruby");
-        }
+        final ScriptEngine instance = newScriptEngine("singlethread", "global");
+
         instance.put("gvar", ":Gvar");
         String result = (String) instance.eval("$gvar");
         assertEquals(":Gvar", result);
+
         instance.getBindings(ScriptContext.ENGINE_SCOPE).remove("gvar");
         instance.getContext().setAttribute("org.jruby.embed.clear.variables", true, ScriptContext.ENGINE_SCOPE);
+
         instance.eval("");
         instance.getContext().setAttribute("org.jruby.embed.clear.variables", false, ScriptContext.ENGINE_SCOPE);
+
         result = (String) instance.eval("$gvar");
         assertNull(result);
-        instance = null;
+        assertNull( getVarMap(instance).getVariable("$gvar") );
+
+        assertNotNull( instance.eval("ARGV") );
+        assertNotNull( getVarMap(instance).getVariable("ARGV") );
     }
+
+    private static BiVariableMap getVarMap(final ScriptEngine engine) {
+        return ((JRubyEngine) engine).container.getVarMap();
+    }
+
+    private ScriptEngine newScriptEngine() {
+        return newScriptEngine("singlethread", "transient");
+    }
+
+    private ScriptEngine newScriptEngine(final String scope, final String varBehavior) {
+        synchronized(this) {
+            System.setProperty("org.jruby.embed.localcontext.scope", scope);
+            System.setProperty("org.jruby.embed.localvariable.behavior", varBehavior);
+            return new ScriptEngineManager().getEngineByName("jruby");
+        }
+    }
+
 }


### PR DESCRIPTION
while using JRuby's embed APIs in a slightly more advanced scenarios I run into several issues :

- `BiVariableMap` is not behaving as a valid Map instance (throwing NPEs on methods if not used "right")

- `ARGV` was mean to be kept (as the map is cleared) but unfortunately not correctly

added some tests covering intended (existing and fixed) functionality. trying to understand the details of context providers (and related embed variable impls) was a bit hard to read thus the did clean-up some (helped my brain to process the code). 

let me know if smt needs more work, targeting **jruby-1_7** - there are no (existing) API incompatibilities ...