### PR TITLE
Produce a warning on private attribute accessors

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1420,10 +1420,10 @@ public class RubyModule extends RubyObject {
         final Ruby runtime = context.runtime;
 
         if (visibility == PRIVATE) {
-            //FIXME warning
+            runtime.getWarnings().warn(ID.PRIVATE_ACCESSOR, "private attribute?");
         } else if (visibility == MODULE_FUNCTION) {
+            runtime.getWarnings().warn(ID.ACCESSOR_MODULE_FUNCTION, "attribute accessor as module_function");
             visibility = PRIVATE;
-            // FIXME warning
         }
 
         if (!(IdUtil.isLocal(internedName) || IdUtil.isConstant(internedName))) {

--- a/core/src/main/java/org/jruby/common/IRubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/IRubyWarnings.java
@@ -40,6 +40,7 @@ public interface IRubyWarnings {
     public enum ID {
         AMBIGUOUS_ARGUMENT,
         ACCESSOR_NOT_INITIALIZED,
+        ACCESSOR_MODULE_FUNCTION,
         ARGUMENT_AS_PREFIX,
         ARGUMENT_EXTRA_SPACE,
         ASSIGNMENT_IN_CONDITIONAL,
@@ -72,6 +73,7 @@ public interface IRubyWarnings {
         NOT_IMPLEMENTED,
         OBSOLETE_ARGUMENT,
         PARENTHISE_ARGUMENTS,
+        PRIVATE_ACCESSOR,
         PROXY_EXTENDED_LATE,
         STATEMENT_NOT_REACHED, 
         LITERAL_IN_CONDITIONAL_RANGE,


### PR DESCRIPTION
People seem to do that a lot after Sandi's book and not many of them
realize it actually produces a warning in CRuby.

Tried getting TestModule#test_attr out of the CRuby excluded failures,
because it was the only existing test I saw hinting of the behaviour,
however it also test that attribute names can't be a invalid
identifiers, which seems to go fine in JRuby.