### PR TITLE
[Truffle] Implemented Regexp#match_start for strscan.

### DIFF
--- a/spec/ruby/core/regexp/match_start_spec.rb
+++ b/spec/ruby/core/regexp/match_start_spec.rb
@@ -1,0 +1,21 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+describe "Regexp#match_start" do
+  it "matches a string N bytes from the beginning" do
+    m = /b/.match_start("ab", 1)
+    m[0].should == "b"
+  end
+
+  it "preserves zero length captures" do
+    r = /(a)?/
+    str = "ab"
+
+    m = r.match_start(str, 0)
+    m[0].should == "a"
+    m[1].should == "a"
+
+    m = r.match_start(str, 1)
+    m[0].should == ""
+    m[1].should be_nil
+  end
+end

--- a/spec/truffle/spec/rubysl/rubysl-strscan/spec/match_start_spec.rb
+++ b/spec/truffle/spec/rubysl/rubysl-strscan/spec/match_start_spec.rb
@@ -1,3 +1,4 @@
+require File.expand_path('../../../../../../ruby/spec_helper', __FILE__)
 
 describe "Regexp#match_start" do
   it "matches a string N bytes from the beginning" do

--- a/spec/truffle/spec/rubysl/rubysl-strscan/spec/match_start_spec.rb
+++ b/spec/truffle/spec/rubysl/rubysl-strscan/spec/match_start_spec.rb
@@ -1,4 +1,3 @@
-require File.expand_path('../../../spec_helper', __FILE__)
 
 describe "Regexp#match_start" do
   it "matches a string N bytes from the beginning" do

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/beginning_of_line_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/beginning_of_line_tags.txt
@@ -1,1 +1,0 @@
-fails:StringScanner#beginning_of_line? returns true if the scan pointer is at the beginning of the line, false otherwise

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/bol_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/bol_tags.txt
@@ -1,1 +1,0 @@
-fails:StringScanner#bol? returns true if the scan pointer is at the beginning of the line, false otherwise

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/check_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/check_tags.txt
@@ -1,1 +1,0 @@
-fails:StringScanner#check returns the value that scan would return, without advancing the scan pointer

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/check_until_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/check_until_tags.txt
@@ -1,1 +1,0 @@
-fails:StringScanner#check_until returns the same value of scan_until, but don't advances the scan pointer

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/dup_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/dup_tags.txt
@@ -1,1 +1,0 @@
-fails:StringScanner#dup copies previous match state

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/element_reference_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/element_reference_tags.txt
@@ -1,6 +1,3 @@
 fails:StringScanner#[] returns the n-th subgroup in the most recent match
 fails:StringScanner#[] returns nil if index is outside of self
 fails:StringScanner#[] calls to_int on the given index
-fails:StringScanner#[] raises a TypeError if the given index is nil
-fails:StringScanner#[] raises a TypeError when a String is as argument
-fails:StringScanner#[] raises a TypeError when a Range is as argument

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/element_reference_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/element_reference_tags.txt
@@ -1,3 +1,2 @@
 fails:StringScanner#[] returns the n-th subgroup in the most recent match
-fails:StringScanner#[] returns nil if index is outside of self
 fails:StringScanner#[] calls to_int on the given index

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/exist_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/exist_tags.txt
@@ -1,3 +1,0 @@
-fails:StringScanner#exist? returns the index of the first occurrence of the given pattern
-fails:StringScanner#exist? returns 0 if the pattern is empty
-fails:StringScanner#exist? returns nil if the pattern isn't found in the string

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/get_byte_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/get_byte_tags.txt
@@ -1,3 +1,0 @@
-fails:StringScanner#get_byte scans one byte and returns it
-fails:StringScanner#get_byte is not multi-byte character sensitive
-fails:StringScanner#get_byte returns nil at the end of the string

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/getbyte_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/getbyte_tags.txt
@@ -1,6 +1,1 @@
-fails:StringScanner#getbyte scans one byte and returns it
-fails:StringScanner#getbyte is not multi-byte character sensitive
-fails:StringScanner#getbyte returns nil at the end of the string
-fails:StringScanner#getbyte warns in verbose mode that the method is obsolete
-fails:StringScanner#getbyte returns an instance of String when passed a String subclass
 fails:StringScanner#getbyte taints the returned String if the input was tainted

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/getch_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/getch_tags.txt
@@ -1,5 +1,2 @@
-fails:StringScanner#getch scans one character and returns it
 fails:StringScanner#getch is multi-byte character sensitive
-fails:StringScanner#getch returns nil at the end of the string
-fails:StringScanner#getch returns an instance of String when passed a String subclass
 fails:StringScanner#getch taints the returned String if the input was tainted

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/inspect_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/inspect_tags.txt
@@ -1,1 +1,0 @@
-fails:StringScanner#inspect returns a string that represents the StringScanner object

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/match_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/match_tags.txt
@@ -1,3 +1,1 @@
-fails:StringScanner#match? returns the length of the match and the scan pointer is not advanced
 fails:StringScanner#match? returns nil if there's no match
-fails:StringScanner#match? effects pre_match

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/match_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/match_tags.txt
@@ -1,1 +1,0 @@
-fails:StringScanner#match? returns nil if there's no match

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/matched_size_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/matched_size_tags.txt
@@ -1,2 +1,0 @@
-fails:StringScanner#matched_size returns the size of the most recent match
-fails:StringScanner#matched_size returns nil if there was no recent match

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/matched_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/matched_tags.txt
@@ -1,6 +1,1 @@
-fails:StringScanner#matched returns the last matched string
-fails:StringScanner#matched returns nil if there's no match
-fails:StringScanner#matched returns an instance of String when passed a String subclass
 fails:StringScanner#matched taints the returned String if the input was tainted
-fails:StringScanner#matched? returns true if the last match was successful
-fails:StringScanner#matched? returns false if there's no match

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/pointer_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/pointer_tags.txt
@@ -1,2 +1,0 @@
-fails:StringScanner#pointer returns the position of the scan pointer
-fails:StringScanner#pointer returns the position of the scan pointer for multibyte string

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/pos_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/pos_tags.txt
@@ -1,2 +1,0 @@
-fails:StringScanner#pos returns the position of the scan pointer
-fails:StringScanner#pos returns the position of the scan pointer for multibyte string

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/post_match_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/post_match_tags.txt
@@ -1,2 +1,1 @@
-fails:StringScanner#post_match returns nil if there's no match
 fails:StringScanner#post_match taints the returned String if the input was tainted

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/post_match_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/post_match_tags.txt
@@ -1,4 +1,2 @@
-fails:StringScanner#post_match returns the post-match (in the regular expression sense) of the last scan
 fails:StringScanner#post_match returns nil if there's no match
-fails:StringScanner#post_match returns an instance of String when passed a String subclass
 fails:StringScanner#post_match taints the returned String if the input was tainted

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/pre_match_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/pre_match_tags.txt
@@ -1,4 +1,1 @@
-fails:StringScanner#pre_match returns nil if there's no match
-fails:StringScanner#pre_match is more than just the data from the last match
-fails:StringScanner#pre_match is not changed when the scanner's position changes
 fails:StringScanner#pre_match taints the returned String if the input was tainted

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/pre_match_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/pre_match_tags.txt
@@ -1,6 +1,4 @@
-fails:StringScanner#pre_match returns the pre-match (in the regular expression sense) of the last scan
 fails:StringScanner#pre_match returns nil if there's no match
 fails:StringScanner#pre_match is more than just the data from the last match
 fails:StringScanner#pre_match is not changed when the scanner's position changes
-fails:StringScanner#pre_match returns an instance of String when passed a String subclass
 fails:StringScanner#pre_match taints the returned String if the input was tainted

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/reset_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/reset_tags.txt
@@ -1,1 +1,0 @@
-fails:StringScanner#reset reset the scan pointer and clear matching data

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/rest_size_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/rest_size_tags.txt
@@ -1,2 +1,0 @@
-fails:StringScanner#rest_size Returns the length of the rest of the string
-fails:StringScanner#rest_size is equivalent to rest.size

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/rest_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/rest_tags.txt
@@ -1,4 +1,1 @@
-fails:StringScanner#rest returns the rest of the string
-fails:StringScanner#rest returns an instance of String when passed a String subclass
 fails:StringScanner#rest taints the returned String if the input was tainted
-fails:StringScanner#rest? returns true if there is more data in the string

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/restsize_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/restsize_tags.txt
@@ -1,2 +1,0 @@
-fails:StringScanner#restsize Returns the length of the rest of the string
-fails:StringScanner#restsize is equivalent to rest.size

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/scan_full_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/scan_full_tags.txt
@@ -1,4 +1,0 @@
-fails:StringScanner#scan_full returns the number of bytes advanced
-fails:StringScanner#scan_full returns the number of bytes advanced and advances the scan pointer if the second argument is true
-fails:StringScanner#scan_full returns the matched string if the third argument is true
-fails:StringScanner#scan_full returns the matched string if the third argument is true and advances the scan pointer if the second argument is true

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/scan_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/scan_tags.txt
@@ -1,9 +1,2 @@
-fails:StringScanner#scan returns the matched string
 fails:StringScanner#scan returns the first character for a multi byte string with no KCODE
-fails:StringScanner#scan returns the matched string for a multi byte string with KCODE
-fails:StringScanner#scan returns the matched string for a multi byte string with unicode regexp
-fails:StringScanner#scan returns the matched string for a multi byte string
 fails:StringScanner#scan treats ^ as matching from the beginning of the current position
-fails:StringScanner#scan returns nil if there's no match
-fails:StringScanner#scan returns nil when there is no more to scan
-fails:StringScanner#scan returns an empty string when the pattern matches empty

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/scan_until_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/scan_until_tags.txt
@@ -1,3 +1,1 @@
-fails:StringScanner#scan_until returns the substring up to and including the end of the match
-fails:StringScanner#scan_until returns nil if there's no match
 fails:StringScanner#scan_until can match anchors properly

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/search_full_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/search_full_tags.txt
@@ -1,4 +1,0 @@
-fails:StringScanner#search_full returns the number of bytes advanced
-fails:StringScanner#search_full returns the number of bytes advanced and advances the scan pointer if the second argument is true
-fails:StringScanner#search_full returns the matched string if the third argument is true
-fails:StringScanner#search_full returns the matched string if the third argument is true and advances the scan pointer if the second argument is true

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/skip_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/skip_tags.txt
@@ -1,2 +1,1 @@
-fails:StringScanner#skip returns length of the match
 fails:StringScanner#skip returns nil if there's no match

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/skip_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/skip_tags.txt
@@ -1,1 +1,0 @@
-fails:StringScanner#skip returns nil if there's no match

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/skip_until_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/skip_until_tags.txt
@@ -1,2 +1,0 @@
-fails:StringScanner#skip_until returns the number of bytes advanced and advances the scan pointer until pattern is matched and consumed
-fails:StringScanner#skip_until returns nil if no match was found

--- a/spec/truffle/tags/rubysl/rubysl-strscan/spec/unscan_tags.txt
+++ b/spec/truffle/tags/rubysl/rubysl-strscan/spec/unscan_tags.txt
@@ -1,3 +1,0 @@
-fails:StringScanner#unscan set the scan pointer to the previous position
-fails:StringScanner#unscan remember only one previous position
-fails:StringScanner#unscan raises a ScanError when the previous match had failed

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/MatchDataNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/MatchDataNodes.java
@@ -44,7 +44,7 @@ public abstract class MatchDataNodes {
         public Object getIndex(RubyMatchData matchData, int index) {
             notDesignedForCompilation();
 
-            if (index >= matchData.getValues().length) {
+            if (index >= matchData.getValues().length || index < 0) {
                 return getContext().getCoreLibrary().getNilObject();
             } else {
                 return matchData.getValues()[index];

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/RegexpNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/RegexpNodes.java
@@ -15,6 +15,7 @@ import org.jruby.truffle.nodes.RubyNode;
 import org.jruby.truffle.runtime.RubyContext;
 import org.jruby.truffle.runtime.control.RaiseException;
 import org.jruby.truffle.runtime.core.RubyBasicObject;
+import org.jruby.truffle.runtime.core.RubyMatchData;
 import org.jruby.truffle.runtime.core.RubyRegexp;
 import org.jruby.truffle.runtime.core.RubyString;
 import org.jruby.truffle.runtime.core.RubySymbol;
@@ -228,6 +229,24 @@ public abstract class RegexpNodes {
         @Specialization
         public Object match(RubyRegexp regexp, RubyString string) {
             return regexp.matchCommon(string, false, false);
+        }
+
+    }
+
+    @CoreMethod(names = "match_start", required = 2)
+    public abstract static class MatchStartNode extends CoreMethodNode {
+
+        public MatchStartNode(RubyContext context, SourceSection sourceSection) {
+            super(context, sourceSection);
+        }
+
+        public MatchStartNode(MatchStartNode prev) {
+            super(prev);
+        }
+
+        @Specialization
+        public Object matchStart(RubyRegexp regexp, RubyString string, int startPos) {
+            return regexp.matchCommon(string, false, false, startPos);
         }
 
     }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/RubyMatchData.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/RubyMatchData.java
@@ -121,6 +121,10 @@ public class RubyMatchData extends RubyBasicObject {
         return global;
     }
 
+    public Region getRegion() {
+        return region;
+    }
+
     public RubyString getSource() {
         return source;
     }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/RubyRegexp.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/RubyRegexp.java
@@ -98,11 +98,16 @@ public class RubyRegexp extends RubyBasicObject {
 
     @CompilerDirectives.TruffleBoundary
     public Object matchCommon(RubyString source, boolean operator, boolean setNamedCaptures) {
+        return matchCommon(source, operator, setNamedCaptures, 0);
+    }
+
+    @CompilerDirectives.TruffleBoundary
+    public Object matchCommon(RubyString source, boolean operator, boolean setNamedCaptures, int startPos) {
         final byte[] stringBytes = source.getByteList().bytes();
         final Matcher matcher = regex.matcher(stringBytes);
         int range = stringBytes.length;
 
-        return matchCommon(source, operator, setNamedCaptures, matcher, 0, range);
+        return matchCommon(source, operator, setNamedCaptures, matcher, startPos, range);
     }
 
     @CompilerDirectives.TruffleBoundary


### PR DESCRIPTION
This passes the match_start_spec.rb which isn't in our repo currently: https://github.com/rubinius/rubinius/blob/58d397733b6ec1ae003b296ba4ab27a65e8629dc/spec/core/regexp/match_start_spec.rb

It would be nice to have more specs for this method to ensure correctness.