### PR TITLE
[Truffle] Adding Implementations for Symbol#slice specs.

### DIFF
--- a/spec/truffle/tags/core/symbol/element_reference_tags.txt
+++ b/spec/truffle/tags/core/symbol/element_reference_tags.txt
@@ -13,9 +13,7 @@ fails:Symbol#[] with a Range slice with Float values converts the first value to
 fails:Symbol#[] with a Range slice with Float values converts the last value to an Integer
 fails:Symbol#[] with a Range subclass slice returns a slice
 fails:Symbol#[] with a Regex slice without a capture index returns a string of the match
-fails:Symbol#[] with a Regex slice without a capture index returns nil if the expression does not match
 fails:Symbol#[] with a Regex slice without a capture index sets $~ to the MatchData if there is a match
-fails:Symbol#[] with a Regex slice without a capture index does not set $~ if there if there is not a match
 fails:Symbol#[] with a Regex slice without a capture index returns a tainted string if the regexp is tainted
 fails:Symbol#[] with a Regex slice without a capture index returns an untrusted string if the regexp is untrusted
 fails:Symbol#[] with a String slice does not set $~

--- a/spec/truffle/tags/core/symbol/element_reference_tags.txt
+++ b/spec/truffle/tags/core/symbol/element_reference_tags.txt
@@ -18,13 +18,6 @@ fails:Symbol#[] with a Regex slice without a capture index sets $~ to the MatchD
 fails:Symbol#[] with a Regex slice without a capture index does not set $~ if there if there is not a match
 fails:Symbol#[] with a Regex slice without a capture index returns a tainted string if the regexp is tainted
 fails:Symbol#[] with a Regex slice without a capture index returns an untrusted string if the regexp is untrusted
-fails:Symbol#[] with a Regex slice with a capture index returns a string of the complete match if the capture index is 0
-fails:Symbol#[] with a Regex slice with a capture index returns a string for the matched capture at the given index
-fails:Symbol#[] with a Regex slice with a capture index returns nil if there is no capture for the index
-fails:Symbol#[] with a Regex slice with a capture index converts the index to an Integer
-fails:Symbol#[] with a Regex slice with a capture index returns a tainted string if the regexp is tainted
-fails:Symbol#[] with a Regex slice with a capture index returns an untrusted string if the regexp is untrusted
-fails:Symbol#[] with a Regex slice with a capture index sets $~ to the MatchData if there is a match
 fails:Symbol#[] with a String slice does not set $~
 fails:Symbol#[] with a String slice returns a string if there is match
 fails:Symbol#[] with a String slice returns nil if there is not a match

--- a/spec/truffle/tags/core/symbol/element_reference_tags.txt
+++ b/spec/truffle/tags/core/symbol/element_reference_tags.txt
@@ -12,8 +12,6 @@ fails:Symbol#[] with a Range slice that is out of bounds returns nil if the firs
 fails:Symbol#[] with a Range slice with Float values converts the first value to an Integer
 fails:Symbol#[] with a Range slice with Float values converts the last value to an Integer
 fails:Symbol#[] with a Range subclass slice returns a slice
-fails:Symbol#[] with a Regex slice without a capture index returns a string of the match
-fails:Symbol#[] with a Regex slice without a capture index sets $~ to the MatchData if there is a match
 fails:Symbol#[] with a Regex slice without a capture index returns a tainted string if the regexp is tainted
 fails:Symbol#[] with a Regex slice without a capture index returns an untrusted string if the regexp is untrusted
 fails:Symbol#[] with a String slice does not set $~

--- a/spec/truffle/tags/core/symbol/match_tags.txt
+++ b/spec/truffle/tags/core/symbol/match_tags.txt
@@ -1,5 +1,0 @@
-fails:Symbol#=~ returns the index of the beginning of the match
-fails:Symbol#=~ sets the last match pseudo-variables
-fails:Symbol#match returns the index of the beginning of the match
-fails:Symbol#match returns nil if there is no match
-fails:Symbol#match sets the last match pseudo-variables

--- a/spec/truffle/tags/core/symbol/slice_tags.txt
+++ b/spec/truffle/tags/core/symbol/slice_tags.txt
@@ -12,8 +12,6 @@ fails:Symbol#slice with a Range slice that is out of bounds returns nil if the f
 fails:Symbol#slice with a Range slice with Float values converts the first value to an Integer
 fails:Symbol#slice with a Range slice with Float values converts the last value to an Integer
 fails:Symbol#slice with a Range subclass slice returns a slice
-fails:Symbol#slice with a Regex slice without a capture index returns a string of the match
-fails:Symbol#slice with a Regex slice without a capture index sets $~ to the MatchData if there is a match
 fails:Symbol#slice with a Regex slice without a capture index returns a tainted string if the regexp is tainted
 fails:Symbol#slice with a Regex slice without a capture index returns an untrusted string if the regexp is untrusted
 fails:Symbol#slice with a String slice does not set $~

--- a/spec/truffle/tags/core/symbol/slice_tags.txt
+++ b/spec/truffle/tags/core/symbol/slice_tags.txt
@@ -18,13 +18,6 @@ fails:Symbol#slice with a Regex slice without a capture index sets $~ to the Mat
 fails:Symbol#slice with a Regex slice without a capture index does not set $~ if there if there is not a match
 fails:Symbol#slice with a Regex slice without a capture index returns a tainted string if the regexp is tainted
 fails:Symbol#slice with a Regex slice without a capture index returns an untrusted string if the regexp is untrusted
-fails:Symbol#slice with a Regex slice with a capture index returns a string of the complete match if the capture index is 0
-fails:Symbol#slice with a Regex slice with a capture index returns a string for the matched capture at the given index
-fails:Symbol#slice with a Regex slice with a capture index returns nil if there is no capture for the index
-fails:Symbol#slice with a Regex slice with a capture index converts the index to an Integer
-fails:Symbol#slice with a Regex slice with a capture index returns a tainted string if the regexp is tainted
-fails:Symbol#slice with a Regex slice with a capture index returns an untrusted string if the regexp is untrusted
-fails:Symbol#slice with a Regex slice with a capture index sets $~ to the MatchData if there is a match
 fails:Symbol#slice with a String slice does not set $~
 fails:Symbol#slice with a String slice returns a string if there is match
 fails:Symbol#slice with a String slice returns nil if there is not a match

--- a/spec/truffle/tags/core/symbol/slice_tags.txt
+++ b/spec/truffle/tags/core/symbol/slice_tags.txt
@@ -13,9 +13,7 @@ fails:Symbol#slice with a Range slice with Float values converts the first value
 fails:Symbol#slice with a Range slice with Float values converts the last value to an Integer
 fails:Symbol#slice with a Range subclass slice returns a slice
 fails:Symbol#slice with a Regex slice without a capture index returns a string of the match
-fails:Symbol#slice with a Regex slice without a capture index returns nil if the expression does not match
 fails:Symbol#slice with a Regex slice without a capture index sets $~ to the MatchData if there is a match
-fails:Symbol#slice with a Regex slice without a capture index does not set $~ if there if there is not a match
 fails:Symbol#slice with a Regex slice without a capture index returns a tainted string if the regexp is tainted
 fails:Symbol#slice with a Regex slice without a capture index returns an untrusted string if the regexp is untrusted
 fails:Symbol#slice with a String slice does not set $~

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/MatchDataNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/MatchDataNodes.java
@@ -184,6 +184,24 @@ public abstract class MatchDataNodes {
         }
     }
 
+    @CoreMethod(names = {"length", "size"})
+    public abstract static class LengthNode extends CoreMethodNode {
+
+        public LengthNode(RubyContext context, SourceSection sourceSection) {
+            super(context, sourceSection);
+        }
+
+        public LengthNode(LengthNode prev) {
+            super(prev);
+        }
+
+        @Specialization
+        public int length(RubyMatchData matchData) {
+            return matchData.getValues().length;
+        }
+
+    }
+
     @CoreMethod(names = "pre_match")
     public abstract static class PreMatchNode extends CoreMethodNode {
 

--- a/truffle/src/main/ruby/core/rubinius/bootstrap/string.rb
+++ b/truffle/src/main/ruby/core/rubinius/bootstrap/string.rb
@@ -76,4 +76,8 @@ class String
     raise PrimitiveFailure, "String#find_character primitive failed"
   end
 
+  def num_bytes
+    @num_bytes
+  end
+
 end

--- a/truffle/src/main/ruby/core/rubinius/common/symbol.rb
+++ b/truffle/src/main/ruby/core/rubinius/common/symbol.rb
@@ -45,7 +45,7 @@ class Symbol
       Regexp.last_match = match_data
       if match_data
         result = match_data.to_s
-        Rubinius::Type.infect str, pattern
+        Rubinius::Type.infect result, index
         return result
       end
     else

--- a/truffle/src/main/ruby/core/rubinius/common/symbol.rb
+++ b/truffle/src/main/ruby/core/rubinius/common/symbol.rb
@@ -26,6 +26,23 @@
 
 class Symbol
 
+  def match(pattern)
+    str = to_s
+
+    case pattern
+      when Regexp
+        match_data = pattern.search_region(str, 0, str.bytesize, true)
+        Regexp.last_match = match_data
+        return match_data.full[0] if match_data
+      when String
+        raise TypeError, "type mismatch: String given"
+      else
+        pattern =~ str
+    end
+  end
+
+  alias_method :=~, :match
+
   def succ
     to_s.succ.to_sym
   end


### PR DESCRIPTION
String#num_bytes was added as a regular method because adding it as an attr_reader did not appear to work.