### PR TITLE
Fix for issue 2591 on master : double-quoted UTF8 hash key encoding

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -3491,6 +3491,11 @@ public final class Ruby implements Constantizable {
         return symbolTable.getSymbol(name);
     }
 
+    public RubySymbol newSymbol(String name, Encoding encoding) {
+        ByteList byteList = RubyString.encodeBytelist(name, encoding);
+        return symbolTable.getSymbol(byteList);
+    }
+
     public RubySymbol newSymbol(ByteList name) {
         return symbolTable.getSymbol(name);
     }

--- a/core/src/main/java/org/jruby/ir/operands/DynamicSymbol.java
+++ b/core/src/main/java/org/jruby/ir/operands/DynamicSymbol.java
@@ -7,6 +7,7 @@ import org.jruby.parser.StaticScope;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jcodings.Encoding;
 
 import java.util.List;
 import java.util.Map;
@@ -43,7 +44,10 @@ public class DynamicSymbol extends Operand {
 
     @Override
     public Object retrieve(ThreadContext context, IRubyObject self, StaticScope currScope, DynamicScope currDynScope, Object[] temp) {
-        return context.runtime.newSymbol(((IRubyObject) symbolName.retrieve(context, self, currScope, currDynScope, temp)).asJavaString());
+        IRubyObject obj = (IRubyObject) symbolName.retrieve(context, self, currScope, currDynScope, temp);
+        String str = obj.asJavaString();
+        Encoding encoding = obj.asString().getByteList().getEncoding();
+        return context.runtime.newSymbol(str, encoding);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -2,6 +2,7 @@ package org.jruby.ir.targets;
 
 import com.headius.invokebinder.Signature;
 import org.jcodings.specific.USASCIIEncoding;
+import org.jcodings.Encoding;
 import org.jruby.*;
 import org.jruby.compiler.NotCompilableException;
 import org.jruby.compiler.impl.SkinnyMethodAdapter;
@@ -1989,8 +1990,19 @@ public class JVMVisitor extends IRVisitor {
     public void DynamicSymbol(DynamicSymbol dynamicsymbol) {
         jvmMethod().loadRuntime();
         visit(dynamicsymbol.getSymbolName());
+        jvmAdapter().dup();
+
+        // get symbol name
         jvmAdapter().invokeinterface(p(IRubyObject.class), "asJavaString", sig(String.class));
-        jvmAdapter().invokevirtual(p(Ruby.class), "newSymbol", sig(RubySymbol.class, String.class));
+        jvmAdapter().swap();
+
+        // get encoding of symbol name
+        jvmAdapter().invokeinterface(p(IRubyObject.class), "asString", sig(RubyString.class));
+        jvmAdapter().invokevirtual(p(RubyString.class), "getByteList", sig(ByteList.class));
+        jvmAdapter().invokevirtual(p(ByteList.class), "getEncoding", sig(Encoding.class));
+
+        // keeps encoding of symbol name
+        jvmAdapter().invokevirtual(p(Ruby.class), "newSymbol", sig(RubySymbol.class, String.class, Encoding.class));
     }
 
     @Override

--- a/core/src/test/java/org/jruby/test/TestRubyHash.java
+++ b/core/src/test/java/org/jruby/test/TestRubyHash.java
@@ -188,4 +188,9 @@ public class TestRubyHash extends TestRubyBase {
         RubyHash rubyHash = new RubyHash(Ruby.getGlobalRuntime());
         assertEquals(null, rubyHash.get("Non matching key"));
     }
+
+    // https://github.com/jruby/jruby/issues/2591
+    public void testDoubleQuotedUtf8HashKey() throws Exception {
+        assertEquals("UTF-8", eval("# encoding: utf-8\n h = { \"Ãa1\": true }\n puts h.keys.first.encoding"));
+    }
 }

--- a/spec/regression/GH-2591_double-quoted_UTF8_hash_key_has_the_wrong_encoding_spec.rb
+++ b/spec/regression/GH-2591_double-quoted_UTF8_hash_key_has_the_wrong_encoding_spec.rb
@@ -1,0 +1,10 @@
+# -*- encoding: utf-8 -*-
+
+# https://github.com/jruby/jruby/issues/2591
+describe 'double-quoted UTF8 hash key' do
+  it 'returns collect encoding' do
+    h = { "Ãa1": "true" }
+    expect(h.keys.first.encoding.to_s).to eq("UTF-8")
+    expect(h.keys.first.to_s).to eq("Ãa1")
+  end
+end


### PR DESCRIPTION
This commit fixes issue #2591 on master. Double-quoted UTF8 hash key encoding should be UTF8. @enebo and @headius please review my PR. Thanks!