### PR TITLE
Fix support of const_get with leading colons

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -3022,7 +3022,10 @@ public class RubyModule extends RubyObject {
 
         RubyModule mod = this;
 
-        if (symbol.startsWith("::")) mod = runtime.getObject();
+        if (symbol.startsWith("::")) {
+          mod = runtime.getObject();
+          symbol = symbol.substring(2);
+        }
 
         int sep;
         while((sep = symbol.indexOf("::")) != -1) {

--- a/spec/regression/GH-2635_const_get_with_leading_colons_spec.rb
+++ b/spec/regression/GH-2635_const_get_with_leading_colons_spec.rb
@@ -1,0 +1,19 @@
+describe ".const_get" do
+
+  module Example
+    class Foo
+      Bar = "bar"
+    end
+  end
+
+  context "with leading colons" do
+    it "finds the toplevel constant" do
+      Object.const_get("::Example").should == Example
+    end
+
+    it "works with arbitrarily nested constants" do
+      Object.const_get("::Example::Foo::Bar").should == "bar"
+    end
+  end
+
+end


### PR DESCRIPTION
RE: #2635 

Run via `bin/jruby bin/jirb`
```ruby
2.1.1 :002 > module Bar
2.1.1 :003?>   module Foo
2.1.1 :004?>     class B
2.1.1 :005?>       A = "hey"
2.1.1 :006?>       end
2.1.1 :007?>     end
2.1.1 :008?>   end
 => "hey"
2.1.1 :010 > Object.const_get("::Bar::Foo::B::A")
 => "hey"
```