### PR TITLE
Allow File.open and File.new with 4 arguments

### DIFF
--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -321,7 +321,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
     }
 
     // rb_file_initialize
-    @JRubyMethod(name = "initialize", required = 1, optional = 2, visibility = PRIVATE)
+    @JRubyMethod(name = "initialize", required = 1, optional = 3, visibility = PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args, Block block) {
         if (openFile != null) {
             throw context.runtime.newRuntimeError("reinitializing File");
@@ -1225,7 +1225,12 @@ public class RubyFile extends RubyIO implements EncodingCapable {
                 break;
             }
             case 4:
-                options = args[3].convertToHash();
+                if (!args[3].isNil()) {
+                    options = TypeConverter.convertToTypeWithCheck(args[3], context.runtime.getHash(), "to_hash");
+                    if (options.isNil()) {
+                        throw runtime.newArgumentError("wrong number of arguments (4 for 1..3)");
+                    }
+                }
                 vperm(pm, args[2]);
                 vmode(pm, args[1]);
                 break;

--- a/test/mri/excludes/TestPathname.rb
+++ b/test/mri/excludes/TestPathname.rb
@@ -1,6 +1,5 @@
 exclude :test_find, "fails to EACCES an unreadable path, root cause of test_find.rb's test_unreadable_dir failure?"
 exclude :test_lchmod, "fails on Travis, maybe on Linux in general?"
-exclude :test_open, "4-args open()"
 exclude :test_realdirpath, "bad symlink resolution"
 exclude :test_realpath, "needs investigation"
 exclude :test_relative_path_from_casefold, "path encoding problems"


### PR DESCRIPTION
The methods now support filename, mode, permissions and options as
separate parameters.

The actual logic seems to be there already. For example, the following now has the same behavior as MRI 1.9+.
```ruby
File.open('test', 'w', 0777, cr_newline: true) { |f| f.puts 'test' }
```