### PR TITLE
Make Dir raise Errno::EACCES

### DIFF
--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -283,6 +283,7 @@ public class RubyDir extends RubyObject {
     private static final String[] NO_FILES = new String[] {};
     private static String[] getEntries(ThreadContext context, FileResource dir, String path) {
         if (!dir.isDirectory()) throw context.runtime.newErrnoENOENTError("No such directory: " + path);
+        if (!dir.canRead()) throw context.runtime.newErrnoEACCESError(path);
 
         String[] list = dir.list();
 

--- a/test/mri/excludes/TestFind.rb
+++ b/test/mri/excludes/TestFind.rb
@@ -1,3 +1,2 @@
 exclude :test_encoding_non_ascii, ""
-exclude :test_unreadable_dir, "not raising EACCESS when trying to find through an unreadable dir"
 exclude :test_unsearchable_dir, "fails on travis"


### PR DESCRIPTION
The change affects at least Dir.new, Dir.open and Dir.entries.
Errno::EACCES is now raised unless access to the directory is
permitted.