### PR TITLE
[Truffle] Don't taint from self in String#[](String).

### DIFF
--- a/spec/truffle/tags/core/string/element_reference_tags.txt
+++ b/spec/truffle/tags/core/string/element_reference_tags.txt
@@ -1,4 +1,3 @@
 fails:String#[] with Range calls to_int on range arguments
 fails:String#[] with Range works with Range subclasses
 fails:String#[] with Regexp, index returns nil if there is no capture for the given index
-fails:String#[] with String taints resulting strings when other is tainted

--- a/spec/truffle/tags/core/string/slice_tags.txt
+++ b/spec/truffle/tags/core/string/slice_tags.txt
@@ -1,7 +1,6 @@
 fails:String#slice with Range calls to_int on range arguments
 fails:String#slice with Range works with Range subclasses
 fails:String#slice with Regexp, index returns nil if there is no capture for the given index
-fails:String#slice with String taints resulting strings when other is tainted
 fails:String#slice! with index calls to_int on index
 fails:String#slice! with index returns the character given by the character index
 fails:String#slice! with index, length deletes and returns the substring at idx and the given length

--- a/truffle/src/main/java/org/jruby/truffle/nodes/cast/TaintResultNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/cast/TaintResultNode.java
@@ -12,6 +12,7 @@ package org.jruby.truffle.nodes.cast;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.ControlFlowException;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
 import com.oracle.truffle.api.source.SourceSection;
@@ -70,6 +71,8 @@ public class TaintResultNode extends RubyNode {
 
         try {
             result = method.executeRubyBasicObject(frame);
+        } catch (DoNotTaint e) {
+            return e.getResult();
         } catch (UnexpectedResultException e) {
             throw new UnsupportedOperationException(e);
         }
@@ -96,5 +99,19 @@ public class TaintResultNode extends RubyNode {
         }
 
         return result;
+    }
+
+    public static class DoNotTaint extends ControlFlowException {
+        private static final long serialVersionUID = 5321304910918469059L;
+
+        private final Object result;
+
+        public DoNotTaint(Object result) {
+            this.result = result;
+        }
+
+        public Object getResult() {
+            return result;
+        }
     }
 }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/StringNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/StringNodes.java
@@ -612,7 +612,7 @@ public abstract class StringNodes {
                     dupNode = insert(DispatchHeadNodeFactory.createMethodCall(getContext()));
                 }
 
-                return dupNode.call(frame, matchStr, "dup", null);
+                throw new TaintResultNode.DoNotTaint(dupNode.call(frame, matchStr, "dup", null));
             }
 
             return nil();


### PR DESCRIPTION
@chrisseaton @eregon This is one of the proposed solutions for dealing with the need to skip tainting for certain specializations.  I don't particularly like using exceptions this way, but using a wrapper object would likely add much greater overhead.  The third alternative is to not use the CoreMethod option for tainting at all, but rather have each specialization that needs it use the `TaintResultNode` in place; this seems both error-prone (easy to forget one) and verbose.

I'm doing this as a PR to get feedback.  No hard feelings if you think this is terrible.