### PR TITLE
Support respond_to_missing? in respondsTo() lookups

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -583,33 +583,33 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
 
     /**
      * Does this object respond to the specified message? Uses a
-     * shortcut if it can be proved that respond_to? haven't been
-     * overridden.
+     * shortcut if it can be proved that respond_to? and respond_to_missing?
+     * haven't been overridden.
      */
     @Override
     public final boolean respondsTo(String name) {
         Ruby runtime = getRuntime();
 
-        DynamicMethod method = getMetaClass().searchMethod("respond_to?");
-        if(method.equals(runtime.getRespondToMethod())) {
+        DynamicMethod respondTo = getMetaClass().searchMethod("respond_to?");
+        DynamicMethod respondToMissing = getMetaClass().searchMethod("respond_to_missing?");
+
+        if(respondTo.equals(runtime.getRespondToMethod()) && respondToMissing.equals(runtime.getRespondToMissingMethod())) {
             // fastest path; builtin respond_to? which just does isMethodBound
             return getMetaClass().isMethodBound(name, false);
-        } else if (!method.isUndefined()) {
-            // medium path, invoke user's respond_to? if defined
+        } else if (!(respondTo.isUndefined() && respondToMissing.isUndefined())) {
+            DynamicMethod method = respondTo.isUndefined() ? respondToMissing : respondTo;
+            // medium path, invoke user's respond_to?/respond_to_missing? if defined
 
             // We have to check and enforce arity
             Arity arity = method.getArity();
             ThreadContext context = runtime.getCurrentContext();
             if (arity.isFixed() && arity.required() == 1) {
-                return method.call(context, this, metaClass, "respond_to?", runtime.newSymbol(name)).isTrue();
+                return method.call(context, this, metaClass, method.getName(), runtime.newSymbol(name)).isTrue();
             } else if (arity.isFixed() && arity.required() != 2) {
-                throw runtime.newArgumentError("respond_to? must accept 1 or 2 arguments (requires " + arity.getValue() + ")");
-            } else {
-
+                throw runtime.newArgumentError(method.getName() + " must accept 1 or 2 arguments (requires " + arity.getValue() + ")");
             }
 
-            return method.call(context, this, metaClass, "respond_to?", runtime.newSymbol(name), runtime.newBoolean(true)).isTrue();
-
+            return method.call(context, this, metaClass, method.getName(), runtime.newSymbol(name), runtime.newBoolean(true)).isTrue();
         } else {
             // slowest path, full callMethod to hit method_missing if present, or produce error
             return callMethod(runtime.getCurrentContext(), "respond_to?", runtime.newSymbol(name)).isTrue();

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -462,7 +462,7 @@ public class RubyNumeric extends RubyObject {
         Ruby runtime = context.runtime;
         IRubyObject result;
 
-        IRubyObject savedError = runtime.getGlobalVariables().get("$!"); // Svae $!
+        IRubyObject savedError = runtime.getGlobalVariables().get("$!"); // Save $!
 
         if (!other.respondsTo("coerce")) {
             if (err) {

--- a/test/jruby/test_respond_to.rb
+++ b/test/jruby/test_respond_to.rb
@@ -107,3 +107,24 @@ class TestRespondToViaMethodMissing < Test::Unit::TestCase
     end
   end
 end
+
+class TestRespondToMissingFastPath < Test::Unit::TestCase
+  class Duration
+    def initialize
+      @value = 10
+    end
+
+    def respond_to_missing?(method, include_private=false)
+      @value.respond_to?(method, include_private)
+    end
+
+    def method_missing(method, *args, &block)
+      @value.send(method, *args, &block)
+    end
+  end
+
+  def test_respond_to_doesnt_fastpath_if_respond_to_missing_exists
+    obj = Duration.new
+    assert(10 * obj == 100)
+  end
+end


### PR DESCRIPTION
RubyBasicObject assumes that if respond_to? is undefined, it can just fast-track
method lookups. We have to also check for respond_to_missing?; failure to do so causes
Javaland respondsTo() calls to fail when an object defines respond_to_missing? (despite
the documentation's admonishment to not use it)

The practical case for this is ActiveSupport::Duration in ActiveSupport 4.2.1