### PR TITLE
[Truffle] Move Float#round to float.rb

### DIFF
--- a/spec/truffle/tags/core/float/round_tags.txt
+++ b/spec/truffle/tags/core/float/round_tags.txt
@@ -1,9 +1,0 @@
-fails:Float#round rounds self to an optionally given precision
-fails:Float#round returns zero when passed a negative argument with magitude greater the magitude of the whole number portion of the Float
-fails:Float#round raises a TypeError when its argument can not be converted to an Integer
-fails:Float#round raises FloatDomainError for exceptional values when passed a non-positive precision
-fails:Float#round raises RangeError for NAN when passed a non-positive precision
-fails:Float#round returns self for exceptional values when passed a non-negative precision
-fails:Float#round works for corner cases
-fails:Float#round returns rounded values for big argument
-fails:Float#round returns rounded values for big values

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/FloatNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/FloatNodes.java
@@ -21,6 +21,7 @@ import org.jruby.truffle.nodes.dispatch.DispatchHeadNodeFactory;
 import org.jruby.truffle.runtime.DebugOperations;
 import org.jruby.truffle.runtime.RubyCallStack;
 import org.jruby.truffle.runtime.RubyContext;
+import org.jruby.truffle.runtime.UndefinedPlaceholder;
 import org.jruby.truffle.runtime.control.RaiseException;
 import org.jruby.truffle.runtime.core.*;
 
@@ -729,7 +730,7 @@ public abstract class FloatNodes {
 
     }
 
-    @CoreMethod(names = "round")
+    @CoreMethod(names = "round", optional = 1)
     public abstract static class RoundNode extends CoreMethodNode {
 
         @Child private FixnumOrBignumNode fixnumOrBignum;
@@ -748,7 +749,7 @@ public abstract class FloatNodes {
         }
 
         @Specialization
-        public Object round(double n) {
+        public Object round(double n, UndefinedPlaceholder undefinedPlaceholder) {
             // Algorithm copied from JRuby - not shared as we want to branch profile it
 
             if (Double.isInfinite(n)) {
@@ -782,6 +783,11 @@ public abstract class FloatNodes {
             }
 
             return fixnumOrBignum.fixnumOrBignum(f);
+        }
+
+        @Specialization(guards = "!isUndefinedPlaceholder(arguments[1])")
+        public Object round(VirtualFrame frame, double n, Object ndigits) {
+            return ruby(frame, "round_internal(ndigits)", "ndigits", ndigits);
         }
 
     }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/FloatPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/FloatPrimitiveNodes.java
@@ -9,9 +9,13 @@
  */
 package org.jruby.truffle.nodes.rubinius;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
+import com.oracle.truffle.api.utilities.BranchProfile;
+import org.jruby.truffle.nodes.core.FixnumOrBignumNode;
 import org.jruby.truffle.runtime.RubyContext;
+import org.jruby.truffle.runtime.control.RaiseException;
 import org.jruby.truffle.runtime.core.RubyArray;
 
 import java.util.Locale;
@@ -82,6 +86,63 @@ public abstract class FloatPrimitiveNodes {
         public boolean floatNegative(double value) {
             // Edge-cases: 0, NaN and infinity can all be negative
             return (Double.doubleToLongBits(value) >>> 63) == 1;
+        }
+
+    }
+
+    @RubiniusPrimitive(name = "float_round")
+    public static abstract class FloatRoundPrimitiveNode extends RubiniusPrimitiveNode {
+
+        @Child private FixnumOrBignumNode fixnumOrBignum;
+
+        private final BranchProfile greaterZero = BranchProfile.create();
+        private final BranchProfile lessZero = BranchProfile.create();
+
+        public FloatRoundPrimitiveNode(RubyContext context, SourceSection sourceSection) {
+            super(context, sourceSection);
+            fixnumOrBignum = new FixnumOrBignumNode(context, sourceSection);
+        }
+
+        public FloatRoundPrimitiveNode(FloatRoundPrimitiveNode prev) {
+            super(prev);
+            fixnumOrBignum = prev.fixnumOrBignum;
+        }
+
+        @Specialization
+        public Object round(double n) {
+            // Algorithm copied from JRuby - not shared as we want to branch profile it
+
+            if (Double.isInfinite(n)) {
+                CompilerDirectives.transferToInterpreter();
+                throw new RaiseException(getContext().getCoreLibrary().floatDomainError("Infinity", this));
+            }
+
+            if (Double.isNaN(n)) {
+                CompilerDirectives.transferToInterpreter();
+                throw new RaiseException(getContext().getCoreLibrary().floatDomainError("NaN", this));
+            }
+
+            double f = n;
+
+            if (f > 0.0) {
+                greaterZero.enter();
+
+                f = Math.floor(f);
+
+                if (n - f >= 0.5) {
+                    f += 1.0;
+                }
+            } else if (f < 0.0) {
+                lessZero.enter();
+
+                f = Math.ceil(f);
+
+                if (f - n >= 0.5) {
+                    f -= 1.0;
+                }
+            }
+
+            return fixnumOrBignum.fixnumOrBignum(f);
         }
 
     }


### PR DESCRIPTION
I don’t believe this is used in any benchmarks but wasn’t 100% sure.