### PR TITLE
[Truffle] Adding fallback Specialization for Fixnum#<.

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/FixnumNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/FixnumNodes.java
@@ -724,6 +724,17 @@ public abstract class FixnumNodes {
         public boolean less(long a, RubyBignum b) {
             return BigInteger.valueOf(a).compareTo(b.bigIntegerValue()) < 0;
         }
+
+        @Specialization(guards = {"!isRubyBignum(arguments[1])", "!isInteger(arguments[1])", "!isLong(arguments[1])", "!isDouble(arguments[1])"})
+        public Object less(VirtualFrame frame, int a, Object b) {
+            return ruby(frame, "b, a = math_coerce other, :compare_error; a < b", "other", b);
+        }
+
+        @Specialization(guards = {"!isRubyBignum(arguments[1])", "!isInteger(arguments[1])", "!isLong(arguments[1])", "!isDouble(arguments[1])"})
+        public Object less(VirtualFrame frame, long a, Object b) {
+            return ruby(frame, "b, a = math_coerce other, :compare_error; a < b", "other", b);
+        }
+
     }
 
     @CoreMethod(names = "<=", required = 1, unsupportedOperationBehavior = UnsupportedOperationBehavior.ARGUMENT_ERROR)


### PR DESCRIPTION
For example, `jruby -X+T -e 'puts 1 < Rational(“1.3”)’`