### PR TITLE
[Truffle] Adding open3 to stdlib.

### DIFF
--- a/lib/ruby/truffle/mri/open3.rb
+++ b/lib/ruby/truffle/mri/open3.rb
@@ -1,0 +1,1 @@
+require_relative '../../stdlib/open3'

--- a/spec/truffle/tags/library/open3/popen3_tags.txt
+++ b/spec/truffle/tags/library/open3/popen3_tags.txt
@@ -1,0 +1,3 @@
+fails:Open3.popen3 executes a process with a pipe to read stdout
+fails:Open3.popen3 executes a process with a pipe to read stderr
+fails:Open3.popen3 executes a process with a pipe to write stdin

--- a/spec/truffle/truffle.mspec
+++ b/spec/truffle/truffle.mspec
@@ -87,6 +87,7 @@ class MSpecScript
     "spec/ruby/library/erb",
     "spec/ruby/library/getoptlong",
     "spec/ruby/library/observer",
+    "spec/ruby/library/open3",
     "spec/ruby/library/openstruct",
     "spec/ruby/library/matrix",
     "spec/ruby/library/set",


### PR DESCRIPTION
I’d like to add this to be able to run MRI tests which have a require to this.