### PR TITLE
[Truffle] timeout stub

### DIFF
--- a/lib/ruby/truffle/mri/timeout.rb
+++ b/lib/ruby/truffle/mri/timeout.rb
@@ -1,0 +1,1 @@
+# Stub to satisfy `require "timeout"` for MRI tests


### PR DESCRIPTION
I’d like to add this stub to satisfy a require in the MRI tests.