### PR TITLE
[Truffle] Adding additional long handling for multiple specializations.

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/StringPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/StringPrimitiveNodes.java
@@ -266,6 +266,27 @@ public abstract class StringPrimitiveNodes {
         }
 
         @Specialization
+        public Object stringByteSubstring(RubyString string, long index, int length) {
+            return stringByteSubstring(string, index, (long) length);
+        }
+
+        @Specialization
+        public Object stringByteSubstring(RubyString string, int index, long length) {
+            return stringByteSubstring(string, (long) index, length);
+        }
+
+        @Specialization
+        public Object stringByteSubstring(RubyString string, long index, long length) {
+            if (index > Integer.MAX_VALUE || index < Integer.MIN_VALUE) {
+                throw new RaiseException(getContext().getCoreLibrary().argumentError("index out of int range", this));
+            }
+            if (length > Integer.MAX_VALUE || length < Integer.MIN_VALUE) {
+                throw new RaiseException(getContext().getCoreLibrary().argumentError("length out of int range", this));
+            }
+            return stringByteSubstring(string, (int) index, (int) length);
+        }
+
+        @Specialization
         public Object stringByteSubstring(RubyString string, double index, double length) {
             return stringByteSubstring(string, (int) index, (int) length);
         }


### PR DESCRIPTION
I believe somewhere while running the MRI tests an edge case is causing the AST to change to use some specialization which returns long frequently (possibly Fixnum#-). I’d like to add these specializations to handle long. I’ve added a TODO to indicate these should be reviewed later on for correctness.