### PR TITLE
[Truffle] Add MRI test profile to pom files.

### DIFF
--- a/pom.rb
+++ b/pom.rb
@@ -178,7 +178,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
   [
     'rake', 'exec', 'truffle-specs-language', 'truffle-specs-core',
     'truffle-specs-library', 'truffle-specs-language-report',
-    'truffle-specs-core-report', 'truffle-specs-library-report', 'truffle-test-pe'
+    'truffle-specs-core-report', 'truffle-specs-library-report', 'truffle-test-pe', 'truffle-mri-tests'
   ].each do |name|
     profile name do
 

--- a/pom.xml
+++ b/pom.xml
@@ -607,6 +607,15 @@
       </modules>
     </profile>
     <profile>
+      <id>truffle-mri-tests</id>
+      <build>
+        <defaultGoal>package</defaultGoal>
+      </build>
+      <modules>
+        <module>test</module>
+      </modules>
+    </profile>
+    <profile>
       <id>bootstrap</id>
       <modules>
         <module>test</module>

--- a/test/pom.rb
+++ b/test/pom.rb
@@ -333,4 +333,23 @@ project 'JRuby Integration Tests' do
 
   end
 
+
+  profile 'truffle-mri-tests' do
+
+    plugin :antrun do
+      execute_goals('run',
+                    :id => 'rake',
+                    :phase => 'test',
+                    :configuration => [xml(
+                                           '<target>' +
+                                               '<exec dir="${jruby.home}" executable="ruby" failonerror="true">' +
+                                               '<arg value="tool/jt.rb" />' +
+                                               '<arg value="test" />' +
+                                               '<arg value="mri" />' +
+                                               '</exec>' +
+                                               '</target>')])
+    end
+
+  end
+
 end

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -1023,5 +1023,33 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>truffle-mri-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>rake</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <exec dir="${jruby.home}" executable="ruby" failonerror="true">
+                      <arg value="tool/jt.rb" />
+                      <arg value="test" />
+                      <arg value="mri" />
+                    </exec>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
With workarounds (after current MRI test issues are fixed) `mvn -Ptruffle-mri-test` completes with:
```
     [exec] Finished tests in 43.266000s, 38.5291 tests/s, 3727.0836 assertions/s.
     [exec] 
     [exec] 1667 tests, 161256 assertions, 0 failures, 0 errors, 1
```