### PR TITLE
Mimic MRI's openssl when jopenssl require fails.

### DIFF
--- a/lib/ruby/shared/openssl.rb
+++ b/lib/ruby/shared/openssl.rb
@@ -1,1 +1,5 @@
-require 'jopenssl/load'
+begin
+  require 'jopenssl/load'
+rescue LoadError => e
+  e.message.sub! 'jopenssl/load', 'openssl'
+end


### PR DESCRIPTION
Some libraries (such as RubyGems [1]) rescues openssl load errors and
adjusts their behavior depending if the openssl is properly required.
However, prior this commit, require 'openssl' succeeded just fine, but
the subsequent requires failed, which makes RubyGems (and similar) to
fail unexpectedly.

[1] https://github.com/rubygems/rubygems/blob/master/lib/rubygems/security.rb#L14