### PR TITLE
Fix for issue 2896 on master : Symbol#inspect with utf8 encode string

### DIFF
--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -239,8 +239,15 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, Constanti
 
         RubyString str = RubyString.newString(runtime, result); 
         // TODO: 1.9 rb_enc_symname_p
-        if (isPrintable() && isSymbolName19(symbol)) return str;
-            
+        Encoding resenc = runtime.getDefaultInternalEncoding();
+        if (resenc == null) {
+            resenc = runtime.getDefaultExternalEncoding();
+        }
+
+        if (isPrintable() && (resenc.equals(symbolBytes.getEncoding()) || str.isAsciiOnly()) && isSymbolName19(symbol)) {
+            return str;
+        }
+    
         str = (RubyString)str.inspect19();
         ByteList bytes = str.getByteList();
         bytes.set(0, ':');
@@ -478,11 +485,11 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, Constanti
     }
     
     private static boolean isIdentStart(char c) {
-        return ((c >= 'a' && c <= 'z')|| (c >= 'A' && c <= 'Z') || c == '_');
+        return ((c >= 'a' && c <= 'z')|| (c >= 'A' && c <= 'Z') || c == '_' || !(c < 128));
     }
     
     private static boolean isIdentChar(char c) {
-        return ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || c == '_');
+        return ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || c == '_' || !(c < 128));
     }
     
     private static boolean isIdentifier(String s) {

--- a/spec/regression/GH-2896_symbol_inspect_spec.rb
+++ b/spec/regression/GH-2896_symbol_inspect_spec.rb
@@ -1,0 +1,12 @@
+# encoding: utf-8
+
+# https://github.com/jruby/jruby/issues/2896
+if RUBY_VERSION > '1.9'
+  describe 'Symbol#inspect' do
+    it 'returns correct value' do
+      :"Ãa1".inspect.should == ":Ãa1"
+      :"a1".inspect.should == ":a1"
+      :"1".inspect.should == ":\"1\""
+    end
+  end
+end


### PR DESCRIPTION
This commit fixes issue #2896 on master and closes #2713. 
This patch is partial ports of the MRI *rb_str_symname_p* and *rb_enc_symname_p*.
Please review, @enebo.  If this patch is OK, I also hope that this patch is applied to 1_7 branch.

Thanks!