### PR TITLE
This is a fix for bug ID 2964.  The URL to see the write up is here:

### DIFF
--- a/core/src/main/java/org/jruby/util/JRubyFile.java
+++ b/core/src/main/java/org/jruby/util/JRubyFile.java
@@ -107,7 +107,7 @@ public class JRubyFile extends JavaSecuredFile {
 
     public static String normalizeSeps(String path) {
         if (Platform.IS_WINDOWS) {
-            return path.replace(File.separatorChar, '/');
+            return path.replace('/', File.separatorChar);
         } else {
             return path;
         }

--- a/core/src/test/java/org/jruby/test/TestKernel.java
+++ b/core/src/test/java/org/jruby/test/TestKernel.java
@@ -31,8 +31,7 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby.test;
 
-import java.util.ArrayList;
-
+import java.io.File;
 import org.jruby.Ruby;
 import org.jruby.RubyException;
 import org.jruby.RubyFixnum;
@@ -61,14 +60,16 @@ public class TestKernel extends TestRubyBase {
         assertEquals("load did not load the same file several times", "1", eval("load '../test/loadTest.rb'"));
     }
 
+
     public void testRequire() throws Exception {
+        char s = File.separatorChar;
         //reset the $loadTestvar
         eval("$loadTest = nil");
         assertEquals("failed to load the file test/loadTest", "0", eval("require '../test/loadTest'"));
         assertEquals("incorrectly reloaded the file test/loadTest", "", eval("require '../test/loadTest'"));
-
-        assertEquals("incorrect value for $\" variable", "true", eval("print $\"[-1].end_with?('test/loadTest.rb')"));
+        assertEquals("incorrect value for $\" variable", "true", eval("print $\"[-1].end_with?('test" + s + "loadTest.rb')"));
     }
+
 
     public void testPrintf() throws Exception {
         assertEquals("hello", eval("printf(\"%s\", \"hello\")"));


### PR DESCRIPTION
https://github.com/jruby/jruby/issues/2964

On windows the mvn -Ptest fails due to incorrect substitution of '/' and '\'.

 See the write up for more details.

 Cris Shupp
 Greg Bowman