### PR TITLE
Adopting to Redesigned Truffle Inter-operability API

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/TruffleInteropNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/TruffleInteropNodes.java
@@ -14,20 +14,10 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.interop.ForeignAccess;
 import com.oracle.truffle.api.interop.TruffleObject;
+import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
-import com.oracle.truffle.interop.messages.Argument;
-import com.oracle.truffle.interop.messages.Execute;
-import com.oracle.truffle.interop.messages.GetSize;
-import com.oracle.truffle.interop.messages.HasSize;
-import com.oracle.truffle.interop.messages.IsBoxed;
-import com.oracle.truffle.interop.messages.IsExecutable;
-import com.oracle.truffle.interop.messages.IsNull;
-import com.oracle.truffle.interop.messages.Read;
-import com.oracle.truffle.interop.messages.Receiver;
-import com.oracle.truffle.interop.messages.Unbox;
-import com.oracle.truffle.interop.messages.Write;
-import com.oracle.truffle.interop.node.ForeignObjectAccessNode;
 import org.jruby.truffle.runtime.RubyContext;
 import org.jruby.truffle.runtime.core.RubyString;
 import org.jruby.truffle.runtime.core.RubySymbol;
@@ -87,16 +77,16 @@ public abstract class TruffleInteropNodes {
     @CoreMethod(names = "executable?", isModuleFunction = true, needsSelf = false, required = 1)
     public abstract static class IsExecutableNode extends CoreMethodArrayArgumentsNode {
 
-        @Child private ForeignObjectAccessNode node;
+        @Child private Node node;
 
         public IsExecutableNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
-            this.node = ForeignObjectAccessNode.getAccess(IsExecutable.create(Receiver.create()));
+            this.node = ForeignAccess.node(ForeignAccess.msgIsExecutable());
         }
 
         @Specialization
         public boolean isExecutable(VirtualFrame frame, TruffleObject receiver) {
-            return (boolean) node.executeForeign(frame, receiver);
+            return (boolean) ForeignAccess.execute(node, frame, receiver, receiver);
         }
 
     }
@@ -104,16 +94,16 @@ public abstract class TruffleInteropNodes {
     @CoreMethod(names = "boxed_primitive?", isModuleFunction = true, needsSelf = false, required = 1)
     public abstract static class IsBoxedPrimitiveNode extends CoreMethodArrayArgumentsNode {
 
-        @Child private ForeignObjectAccessNode node;
+        @Child private Node node;
 
         public IsBoxedPrimitiveNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
-            this.node = ForeignObjectAccessNode.getAccess(IsBoxed.create(Receiver.create()));
+            this.node = ForeignAccess.node(ForeignAccess.msgIsBoxed());
         }
 
         @Specialization
         public boolean isBoxedPrimitive(VirtualFrame frame, TruffleObject receiver) {
-            return (boolean) node.executeForeign(frame, receiver);
+            return (boolean) ForeignAccess.execute(node, frame, receiver);
         }
 
     }
@@ -121,16 +111,16 @@ public abstract class TruffleInteropNodes {
     @CoreMethod(names = "null?", isModuleFunction = true, needsSelf = false, required = 1)
     public abstract static class IsNullNode extends CoreMethodArrayArgumentsNode {
 
-        @Child private ForeignObjectAccessNode node;
+        @Child private Node node;
 
         public IsNullNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
-            this.node = ForeignObjectAccessNode.getAccess(IsNull.create(Receiver.create()));
+            this.node = ForeignAccess.node(ForeignAccess.msgIsNull());
         }
 
         @Specialization
         public boolean isNull(VirtualFrame frame, TruffleObject receiver) {
-            return (boolean) node.executeForeign(frame, receiver);
+            return (boolean) ForeignAccess.execute(node, frame, receiver);
         }
 
     }
@@ -138,16 +128,16 @@ public abstract class TruffleInteropNodes {
     @CoreMethod(names = "has_size_property?", isModuleFunction = true, needsSelf = false, required = 1)
     public abstract static class HasSizePropertyNode extends CoreMethodArrayArgumentsNode {
 
-        @Child private ForeignObjectAccessNode node;
+        @Child private Node node;
 
         public HasSizePropertyNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
-            this.node = ForeignObjectAccessNode.getAccess(HasSize.create(Receiver.create()));
+            this.node = ForeignAccess.node(ForeignAccess.msgHasSize());
         }
 
         @Specialization
         public boolean hasSizeProperty(VirtualFrame frame, TruffleObject receiver) {
-            return (boolean) node.executeForeign(frame, receiver);
+            return (boolean) ForeignAccess.execute(node, frame, receiver);
         }
 
     }
@@ -155,16 +145,16 @@ public abstract class TruffleInteropNodes {
     @CoreMethod(names = "read_property", isModuleFunction = true, needsSelf = false, required = 2)
     public abstract static class ReadPropertyNode extends CoreMethodArrayArgumentsNode {
 
-        @Child private ForeignObjectAccessNode node;
+        @Child private Node node;
 
         public ReadPropertyNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
-            this.node = ForeignObjectAccessNode.getAccess(Read.create(Receiver.create(), Argument.create()));
+            this.node = ForeignAccess.node(ForeignAccess.msgRead());
         }
 
         @Specialization
         public Object executeForeign(VirtualFrame frame, TruffleObject receiver, int identifier) {
-            return node.executeForeign(frame, receiver, identifier);
+            return ForeignAccess.execute(node, frame, receiver, identifier);
         }
 
         @Specialization
@@ -174,7 +164,7 @@ public abstract class TruffleInteropNodes {
 
         @Specialization
         public Object executeForeign(VirtualFrame frame, TruffleObject receiver, long identifier) {
-            return node.executeForeign(frame, receiver, identifier);
+            return ForeignAccess.execute(node, frame, receiver, identifier);
         }
 
         @CompilerDirectives.CompilationFinal private String identifier;
@@ -185,12 +175,12 @@ public abstract class TruffleInteropNodes {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
                 this.identifier = identifier.toString().intern();
             }
-            return node.executeForeign(frame, receiver, this.identifier);
+            return ForeignAccess.execute(node, frame, receiver, this.identifier);
         }
 
         @Specialization
         public Object executeForeign(VirtualFrame frame, TruffleObject receiver, RubyString identifier) {
-            return node.executeForeign(frame, receiver, slowPathToString(identifier));
+            return ForeignAccess.execute(node, frame, receiver, slowPathToString(identifier));
         }
 
         @TruffleBoundary
@@ -203,21 +193,21 @@ public abstract class TruffleInteropNodes {
     @CoreMethod(names = "write_property", isModuleFunction = true, needsSelf = false, required = 3)
     public abstract static class WritePropertyNode extends CoreMethodArrayArgumentsNode {
 
-        @Child private ForeignObjectAccessNode node;
+        @Child private Node node;
 
         public WritePropertyNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
-            this.node = ForeignObjectAccessNode.getAccess(Write.create(Receiver.create(), Argument.create(), Argument.create()));
+            this.node = ForeignAccess.node(ForeignAccess.msgWrite());
         }
 
         @Specialization
         public Object executeForeign(VirtualFrame frame, TruffleObject receiver, int identifier,  Object value) {
-            return node.executeForeign(frame, receiver, identifier, value);
+            return ForeignAccess.execute(node, frame, receiver, identifier, value);
         }
 
         @Specialization
         public Object executeForeign(VirtualFrame frame, TruffleObject receiver, long identifier,  Object value) {
-            return node.executeForeign(frame, receiver, identifier, value);
+            return ForeignAccess.execute(node, frame, receiver, identifier, value);
         }
 
         @CompilerDirectives.CompilationFinal private String identifier;
@@ -228,12 +218,12 @@ public abstract class TruffleInteropNodes {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
                 this.identifier = identifier.toString().intern();
             }
-            return node.executeForeign(frame, receiver, this.identifier, value);
+            return ForeignAccess.execute(node, frame, receiver, this.identifier, value);
         }
 
         @Specialization
         public Object executeForeign(VirtualFrame frame, TruffleObject receiver, RubyString identifier, Object value) {
-            return node.executeForeign(frame, receiver, slowPathToString(identifier), value);
+            return ForeignAccess.execute(node, frame, receiver, slowPathToString(identifier), value);
         }
 
         @TruffleBoundary
@@ -246,16 +236,16 @@ public abstract class TruffleInteropNodes {
     @CoreMethod(names = "unbox_value", isModuleFunction = true, needsSelf = false, required = 1)
     public abstract static class UnboxValueNode extends CoreMethodArrayArgumentsNode {
 
-        @Child private ForeignObjectAccessNode node;
+        @Child private Node node;
 
         public UnboxValueNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
-            this.node = ForeignObjectAccessNode.getAccess(Unbox.create(Receiver.create()));
+            this.node = ForeignAccess.node(ForeignAccess.msgUnbox());
         }
 
         @Specialization
         public Object executeForeign(VirtualFrame frame, TruffleObject receiver) {
-            return node.executeForeign(frame, receiver);
+            return ForeignAccess.execute(node, frame, receiver);
         }
 
     }
@@ -263,7 +253,7 @@ public abstract class TruffleInteropNodes {
     @CoreMethod(names = "execute", isModuleFunction = true, needsSelf = false, required = 1, argumentsAsArray = true)
     public abstract static class ExecuteNode extends CoreMethodArrayArgumentsNode {
 
-        @Child private ForeignObjectAccessNode node;
+        @Child private Node node;
 
         public ExecuteNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
@@ -273,9 +263,9 @@ public abstract class TruffleInteropNodes {
         public Object executeForeign(VirtualFrame frame, TruffleObject receiver, Object[] arguments) {
             if (node == null) {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
-                this.node = ForeignObjectAccessNode.getAccess(Execute.create(Receiver.create(), arguments.length));
+                this.node = ForeignAccess.node(ForeignAccess.msgExecute(arguments.length));
             }
-            return node.executeForeign(frame, receiver, arguments);
+            return ForeignAccess.execute(node, frame, receiver, arguments);
         }
 
     }
@@ -283,11 +273,11 @@ public abstract class TruffleInteropNodes {
     @CoreMethod(names = "size", isModuleFunction = true, needsSelf = false, required = 1)
     public abstract static class GetSizeNode extends CoreMethodArrayArgumentsNode {
 
-        @Child private ForeignObjectAccessNode node;
+        @Child private Node node;
 
         public GetSizeNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
-            this.node = ForeignObjectAccessNode.getAccess(GetSize.create(Receiver.create()));
+            this.node = ForeignAccess.node(ForeignAccess.msgGetSize());
         }
 
         @Specialization
@@ -297,7 +287,7 @@ public abstract class TruffleInteropNodes {
 
         @Specialization
         public Object executeForeign(VirtualFrame frame, TruffleObject receiver) {
-            return node.executeForeign(frame, receiver);
+            return ForeignAccess.execute(node, frame, receiver);
         }
 
     }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/TruffleInteropNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/TruffleInteropNodes.java
@@ -15,6 +15,7 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.ForeignAccess;
+import com.oracle.truffle.api.interop.Message;
 import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
@@ -81,7 +82,7 @@ public abstract class TruffleInteropNodes {
 
         public IsExecutableNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
-            this.node = ForeignAccess.node(ForeignAccess.msgIsExecutable());
+            this.node = Message.IS_EXECUTABLE.createNode();
         }
 
         @Specialization
@@ -98,7 +99,7 @@ public abstract class TruffleInteropNodes {
 
         public IsBoxedPrimitiveNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
-            this.node = ForeignAccess.node(ForeignAccess.msgIsBoxed());
+            this.node = Message.IS_BOXED.createNode();
         }
 
         @Specialization
@@ -115,7 +116,7 @@ public abstract class TruffleInteropNodes {
 
         public IsNullNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
-            this.node = ForeignAccess.node(ForeignAccess.msgIsNull());
+            this.node = Message.IS_NULL.createNode();
         }
 
         @Specialization
@@ -132,7 +133,7 @@ public abstract class TruffleInteropNodes {
 
         public HasSizePropertyNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
-            this.node = ForeignAccess.node(ForeignAccess.msgHasSize());
+            this.node = Message.HAS_SIZE.createNode();
         }
 
         @Specialization
@@ -149,7 +150,7 @@ public abstract class TruffleInteropNodes {
 
         public ReadPropertyNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
-            this.node = ForeignAccess.node(ForeignAccess.msgRead());
+            this.node = Message.READ.createNode();
         }
 
         @Specialization
@@ -197,7 +198,7 @@ public abstract class TruffleInteropNodes {
 
         public WritePropertyNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
-            this.node = ForeignAccess.node(ForeignAccess.msgWrite());
+            this.node = Message.WRITE.createNode();
         }
 
         @Specialization
@@ -240,7 +241,7 @@ public abstract class TruffleInteropNodes {
 
         public UnboxValueNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
-            this.node = ForeignAccess.node(ForeignAccess.msgUnbox());
+            this.node = Message.UNBOX.createNode();
         }
 
         @Specialization
@@ -263,7 +264,7 @@ public abstract class TruffleInteropNodes {
         public Object executeForeign(VirtualFrame frame, TruffleObject receiver, Object[] arguments) {
             if (node == null) {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
-                this.node = ForeignAccess.node(ForeignAccess.msgExecute(arguments.length));
+                this.node = Message.createExecute(arguments.length).createNode();
             }
             return ForeignAccess.execute(node, frame, receiver, arguments);
         }
@@ -277,7 +278,7 @@ public abstract class TruffleInteropNodes {
 
         public GetSizeNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
-            this.node = ForeignAccess.node(ForeignAccess.msgGetSize());
+            this.node = Message.GET_SIZE.createNode();
         }
 
         @Specialization

--- a/truffle/src/main/java/org/jruby/truffle/nodes/dispatch/CachedForeignDispatchNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/dispatch/CachedForeignDispatchNode.java
@@ -18,6 +18,7 @@ import org.jruby.truffle.runtime.core.RubyProc;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.ForeignAccess;
+import com.oracle.truffle.api.interop.Message;
 import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.Node;
@@ -54,21 +55,21 @@ public final class CachedForeignDispatchNode extends CachedDispatchNode {
 
     private void initializeNodes(RubyContext context, int arity) {
         if (name.equals("[]")) {
-            directArray = ForeignAccess.node(ForeignAccess.msgRead());
+            directArray = Message.READ.createNode();
         } else if (name.equals("[]=")) {
-        	directArray = ForeignAccess.node(ForeignAccess.msgWrite());
+        	directArray = Message.WRITE.createNode();
         } else if (name.endsWith("=") && arity == 1) {
-            directField = ForeignAccess.node(ForeignAccess.msgWrite());
+            directField = Message.WRITE.createNode();
         } else if (name.endsWith("call")) {// arity + 1 for receiver
-        	directCall = ForeignAccess.node(ForeignAccess.msgExecute(arity + 1));
+        	directCall = Message.createExecute(arity + 1).createNode();
         } else if (name.endsWith("nil?")) {
-        	nullCheck = ForeignAccess.node(ForeignAccess.msgIsNull());
+        	nullCheck = Message.IS_NULL.createNode();
         } else if (arity == 0) {
-        	directField = ForeignAccess.node(ForeignAccess.msgRead());
+        	directField = Message.READ.createNode();
         } else {
             // do not forget to pass the receiver!
             // EXECUTE(READ(rec, a0), a1<receiver>, ...)
-            access = ForeignAccess.node(ForeignAccess.msgInvoke(arity + 1));
+            access = Message.createInvoke(arity + 1).createNode();
         }
         prepareArguments = new PrepareArguments(context, getSourceSection(), arity);
     }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/dispatch/CachedForeignGlobalDispatchNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/dispatch/CachedForeignGlobalDispatchNode.java
@@ -11,12 +11,9 @@ package org.jruby.truffle.nodes.dispatch;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.interop.ForeignAccess;
 import com.oracle.truffle.api.interop.TruffleObject;
-import com.oracle.truffle.interop.messages.Argument;
-import com.oracle.truffle.interop.messages.Execute;
-import com.oracle.truffle.interop.messages.Read;
-import com.oracle.truffle.interop.messages.Receiver;
-import com.oracle.truffle.interop.node.ForeignObjectAccessNode;
+import com.oracle.truffle.api.nodes.Node;
 import org.jruby.truffle.runtime.RubyContext;
 import org.jruby.truffle.runtime.array.ArrayUtils;
 import org.jruby.truffle.runtime.core.RubyBasicObject;
@@ -27,7 +24,7 @@ public final class CachedForeignGlobalDispatchNode extends CachedDispatchNode {
     private final TruffleObject language;
     private final int numberOfArguments;
 
-    @Child private ForeignObjectAccessNode access;
+    @Child private Node access;
 
     public CachedForeignGlobalDispatchNode(RubyContext context, DispatchNode next, Object cachedName, TruffleObject language, int numberOfArguments) {
         super(context, cachedName, next, false, DispatchAction.CALL_METHOD);
@@ -37,9 +34,9 @@ public final class CachedForeignGlobalDispatchNode extends CachedDispatchNode {
         this.access = create();
     }
 
-    private ForeignObjectAccessNode create() {
+    private Node create() {
         // + 1 because language is the first argument
-        return ForeignObjectAccessNode.getAccess(Execute.create(Read.create(Receiver.create(), Argument.create()), numberOfArguments + 1));
+        return ForeignAccess.node(ForeignAccess.msgInvoke(numberOfArguments + 1));
     }
 
     @Override
@@ -56,7 +53,7 @@ public final class CachedForeignGlobalDispatchNode extends CachedDispatchNode {
                 ArrayUtils.arraycopy(arguments, 0, args, 2, arguments.length);
                 args[0] = cachedName;
                 args[1] = language;
-                return access.executeForeign(frame, language, args);
+                return ForeignAccess.execute(access, frame, language, args);
             } else {
                 CompilerDirectives.transferToInterpreter();
                 throw new IllegalStateException("Varargs are not supported");

--- a/truffle/src/main/java/org/jruby/truffle/nodes/dispatch/CachedForeignGlobalDispatchNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/dispatch/CachedForeignGlobalDispatchNode.java
@@ -12,6 +12,7 @@ package org.jruby.truffle.nodes.dispatch;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.ForeignAccess;
+import com.oracle.truffle.api.interop.Message;
 import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.nodes.Node;
 import org.jruby.truffle.runtime.RubyContext;
@@ -36,7 +37,7 @@ public final class CachedForeignGlobalDispatchNode extends CachedDispatchNode {
 
     private Node create() {
         // + 1 because language is the first argument
-        return ForeignAccess.node(ForeignAccess.msgInvoke(numberOfArguments + 1));
+        return Message.createInvoke(numberOfArguments + 1).createNode();
     }
 
     @Override

--- a/truffle/src/main/java/org/jruby/truffle/nodes/dispatch/UnresolvedDispatchNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/dispatch/UnresolvedDispatchNode.java
@@ -10,14 +10,8 @@
 package org.jruby.truffle.nodes.dispatch;
 
 import com.oracle.truffle.api.Assumption;
-import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.interop.TruffleObject;
-import com.oracle.truffle.interop.messages.Argument;
-import com.oracle.truffle.interop.messages.Read;
-import com.oracle.truffle.interop.messages.Receiver;
-import com.oracle.truffle.interop.node.ForeignObjectAccessNode;
 import org.jruby.truffle.nodes.RubyGuards;
 import org.jruby.truffle.nodes.objects.SingletonClassNode;
 import org.jruby.truffle.runtime.RubyArguments;

--- a/truffle/src/main/java/org/jruby/truffle/nodes/interop/InteropNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/interop/InteropNode.java
@@ -108,7 +108,7 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-        	Object result = execute.executeWithTarget(frame, ForeignAccessArguments.getReceiver(frame.getArguments()));
+        	Object result = execute.executeWithTarget(frame, ForeignAccess.getReceiver(frame));
             return result;
         }
     }
@@ -169,7 +169,7 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            return RubyGuards.isRubyMethod(ForeignAccessArguments.getReceiver(frame.getArguments()));
+            return RubyGuards.isRubyMethod(ForeignAccess.getReceiver(frame));
         }
 
     }
@@ -193,7 +193,7 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            return ForeignAccessArguments.getReceiver(frame.getArguments()) == nil();
+            return ForeignAccess.getReceiver(frame) == nil();
         }
     }
 
@@ -229,7 +229,7 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            return head.dispatch(frame, ForeignAccessArguments.getReceiver(frame.getArguments()), "size", null, new Object[] {});
+            return head.dispatch(frame, ForeignAccess.getReceiver(frame), "size", null, new Object[] {});
         }
     }
 
@@ -241,7 +241,7 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            Object o = ForeignAccessArguments.getReceiver(frame.getArguments());
+            Object o = ForeignAccess.getReceiver(frame);
             return o instanceof RubyString && StringNodes.getByteList(((RubyString) o)).length() == 1;
         }
     }
@@ -254,7 +254,7 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            return StringNodes.getByteList(((RubyString) ForeignAccessArguments.getReceiver(frame.getArguments()))).get(0);
+            return StringNodes.getByteList(((RubyString) ForeignAccess.getReceiver(frame))).get(0);
         }
     }
 
@@ -269,7 +269,7 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            Object label = ForeignAccessArguments.getArgument(frame.getArguments(), labelIndex);
+            Object label = ForeignAccess.getArguments(frame).get(labelIndex);
             if (label instanceof  String || label instanceof  RubySymbol || label instanceof Integer) {
                 if (label instanceof  String) {
                     String name = (String) label;
@@ -277,7 +277,7 @@ public abstract class InteropNode extends RubyNode {
                         return this.replace(new InteropInstanceVariableReadNode(getContext(), getSourceSection(), name, labelIndex)).execute(frame);
                     }
                 }
-                RubyBasicObject receiver = (RubyBasicObject) ForeignAccessArguments.getReceiver(frame.getArguments());
+                RubyBasicObject receiver = (RubyBasicObject) ForeignAccess.getReceiver(frame);
                 InternalMethod labelMethod = ModuleOperations.lookupMethod(getContext().getCoreLibrary().getMetaClass(receiver), label.toString());
                 InternalMethod indexedSetter = ModuleOperations.lookupMethod(getContext().getCoreLibrary().getMetaClass(receiver), "[]=");
                 if (labelMethod == null && indexedSetter != null) {
@@ -308,7 +308,7 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            Object label = ForeignAccessArguments.getArgument(frame.getArguments(), labelIndex);
+            Object label = ForeignAccess.getArguments(frame).get(labelIndex);
             if (label instanceof  String || label instanceof  RubySymbol || label instanceof Integer) {
                 if (label instanceof  String) {
                     String name = (String) label;
@@ -345,9 +345,9 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            if (ForeignAccessArguments.getReceiver(frame.getArguments()) instanceof RubyString) {
-                final RubyString string = (RubyString) ForeignAccessArguments.getReceiver(frame.getArguments());
-                final int index = (int) ForeignAccessArguments.getArgument(frame.getArguments(), labelIndex);
+            if (ForeignAccess.getReceiver(frame) instanceof RubyString) {
+                final RubyString string = (RubyString) ForeignAccess.getReceiver(frame);
+                final int index = (int) ForeignAccess.getArguments(frame).get(labelIndex);
                 if (index >= StringNodes.getByteList(string).length()) {
                     return 0;
                 } else {
@@ -377,8 +377,8 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            Object index = toRubyIndex.executeWithTarget(frame, ForeignAccessArguments.getArgument(frame.getArguments(), indexIndex));
-            return head.dispatch(frame, ForeignAccessArguments.getReceiver(frame.getArguments()), name, null, new Object[] {index});
+            Object index = toRubyIndex.executeWithTarget(frame, ForeignAccess.getArguments(frame).get(indexIndex));
+            return head.dispatch(frame, ForeignAccess.getReceiver(frame), name, null, new Object[] {index});
         }
     }
 
@@ -397,7 +397,7 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            if (name.equals((String) ForeignAccessArguments.getArgument(frame.getArguments(), labelIndex))) {
+            if (name.equals((String) ForeignAccess.getArguments(frame).get(labelIndex))) {
                 return read.execute(frame);
             } else {
                 CompilerDirectives.transferToInterpreter();
@@ -421,7 +421,7 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            if (name.equals((String) ForeignAccessArguments.getArgument(frame.getArguments(), labelIndex))) {
+            if (name.equals((String) ForeignAccess.getArguments(frame).get(labelIndex))) {
                 return write.execute(frame);
             } else {
                 CompilerDirectives.transferToInterpreter();
@@ -437,7 +437,7 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            return ForeignAccessArguments.getReceiver(frame.getArguments());
+            return ForeignAccess.getReceiver(frame);
         }
     }
 
@@ -452,7 +452,7 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            return ForeignAccessArguments.getArgument(frame.getArguments(), index);
+            return ForeignAccess.getArguments(frame).get(index);
         }
     }
 
@@ -471,8 +471,8 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            if (name.equals(ForeignAccessArguments.getArgument(frame.getArguments(), labelIndex))) {
-                return head.dispatch(frame, ForeignAccessArguments.getReceiver(frame.getArguments()), name, null, new Object[]{});
+            if (name.equals(ForeignAccess.getArguments(frame).get(labelIndex))) {
+                return head.dispatch(frame, ForeignAccess.getReceiver(frame), name, null, new Object[]{});
             } else {
                 CompilerDirectives.transferToInterpreter();
                 throw new IllegalStateException("Name changed");
@@ -495,8 +495,8 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            if (name.equals(ForeignAccessArguments.getArgument(frame.getArguments(), labelIndex))) {
-                return head.dispatch(frame, ForeignAccessArguments.getReceiver(frame.getArguments()), name, null, new Object[]{});
+            if (name.equals(ForeignAccess.getArguments(frame).get(labelIndex))) {
+                return head.dispatch(frame, ForeignAccess.getReceiver(frame), name, null, new Object[]{});
             } else {
                 CompilerDirectives.transferToInterpreter();
                 throw new IllegalStateException("Name changed");
@@ -517,7 +517,7 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            Object label = ForeignAccessArguments.getArgument(frame.getArguments(), labelIndex);
+            Object label = ForeignAccess.getArguments(frame).get(labelIndex);
             if (label instanceof  String || label instanceof  RubySymbol || label instanceof Integer) {
                 if (label instanceof  String) {
                     String name = (String) label;
@@ -525,7 +525,7 @@ public abstract class InteropNode extends RubyNode {
                         return this.replace(new InteropInstanceVariableWriteNode(getContext(), getSourceSection(), name, labelIndex, valueIndex)).execute(frame);
                     }
                 }
-                RubyBasicObject receiver = (RubyBasicObject) ForeignAccessArguments.getReceiver(frame.getArguments());
+                RubyBasicObject receiver = (RubyBasicObject) ForeignAccess.getReceiver(frame);
                 InternalMethod labelMethod = ModuleOperations.lookupMethod(getContext().getCoreLibrary().getMetaClass(receiver), label.toString());
                 InternalMethod indexedSetter = ModuleOperations.lookupMethod(getContext().getCoreLibrary().getMetaClass(receiver), "[]=");
                 if (labelMethod == null && indexedSetter != null) {
@@ -564,9 +564,9 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            Object index = toRubyIndex.executeWithTarget(frame, ForeignAccessArguments.getArgument(frame.getArguments(), indexIndex));
-            Object value = ForeignAccessArguments.getArgument(frame.getArguments(), valueIndex);
-            return head.dispatch(frame, ForeignAccessArguments.getReceiver(frame.getArguments()), name, null, new Object[] {index, value});
+            Object index = toRubyIndex.executeWithTarget(frame, ForeignAccess.getArguments(frame).get(indexIndex));
+            Object value = ForeignAccess.getArguments(frame).get(valueIndex);
+            return head.dispatch(frame, ForeignAccess.getReceiver(frame), name, null, new Object[] {index, value});
         }
     }
 
@@ -589,9 +589,9 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            if (name.equals(ForeignAccessArguments.getArgument(frame.getArguments(), labelIndex))) {
-                Object value = ForeignAccessArguments.getArgument(frame.getArguments(), valueIndex);
-                return head.dispatch(frame, ForeignAccessArguments.getReceiver(frame.getArguments()), accessName, null, new Object[]{value});
+            if (name.equals(ForeignAccess.getArguments(frame).get(labelIndex))) {
+                Object value = ForeignAccess.getArguments(frame).get(valueIndex);
+                return head.dispatch(frame, ForeignAccess.getReceiver(frame), accessName, null, new Object[]{value});
             } else {
                 CompilerDirectives.transferToInterpreter();
                 throw new IllegalStateException("Name changed");
@@ -618,9 +618,9 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            if (name.equals(ForeignAccessArguments.getArgument(frame.getArguments(), labelIndex))) {
-                Object value = ForeignAccessArguments.getArgument(frame.getArguments(), valueIndex);
-                return head.dispatch(frame, ForeignAccessArguments.getReceiver(frame.getArguments()), accessName, null, new Object[]{value});
+            if (name.equals(ForeignAccess.getArguments(frame).get(labelIndex))) {
+                Object value = ForeignAccess.getArguments(frame).get(valueIndex);
+                return head.dispatch(frame, ForeignAccess.getReceiver(frame), accessName, null, new Object[]{value});
             } else {
                 CompilerDirectives.transferToInterpreter();
                 throw new IllegalStateException("Name changed");
@@ -641,11 +641,11 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            if (ForeignAccessArguments.getArgument(frame.getArguments(), labelIndex) instanceof  String) {
-                return this.replace(new ResolvedInteropExecuteAfterReadNode(getContext(), getSourceSection(), (String) ForeignAccessArguments.getArgument(frame.getArguments(), labelIndex), arity)).execute(frame);
+            if (ForeignAccess.getArguments(frame).get(labelIndex) instanceof  String) {
+                return this.replace(new ResolvedInteropExecuteAfterReadNode(getContext(), getSourceSection(), (String) ForeignAccess.getArguments(frame).get(labelIndex), arity)).execute(frame);
             } else {
                 CompilerDirectives.transferToInterpreter();
-                throw new IllegalStateException(ForeignAccessArguments.getArgument(frame.getArguments(), 0) + " not allowed as name");
+                throw new IllegalStateException(ForeignAccess.getArguments(frame).get(0) + " not allowed as name");
             }
         }
     }
@@ -669,10 +669,10 @@ public abstract class InteropNode extends RubyNode {
 
         @Override
         public Object execute(VirtualFrame frame) {
-            if (name.equals(ForeignAccessArguments.getArgument(frame.getArguments(), labelIndex))) {
+            if (name.equals(ForeignAccess.getArguments(frame).get(labelIndex))) {
                 Object[] args = new Object[arguments.getCount(frame)];
                 arguments.executeFillObjectArray(frame, args);
-                return head.dispatch(frame, ForeignAccessArguments.getArgument(frame.getArguments(), receiverIndex), ForeignAccessArguments.getArgument(frame.getArguments(), labelIndex), null, args);
+                return head.dispatch(frame, ForeignAccess.getArguments(frame).get(receiverIndex), ForeignAccess.getArguments(frame).get(labelIndex), null, args);
             } else {
                 CompilerDirectives.transferToInterpreter();
                 throw new IllegalStateException("Name changed");
@@ -689,7 +689,7 @@ public abstract class InteropNode extends RubyNode {
         }
 
         public Object execute(VirtualFrame frame) {
-            return ForeignAccessArguments.extractUserArguments(frame.getArguments())[index];
+            return ForeignAccess.getArguments(frame).get(index);
         }
 
     }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/ArrayForeignAccessFactory.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/ArrayForeignAccessFactory.java
@@ -12,56 +12,78 @@ package org.jruby.truffle.runtime.core;
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.interop.ForeignAccessFactory;
-import com.oracle.truffle.api.interop.InteropPredicate;
-import com.oracle.truffle.api.interop.TruffleObject;
-import com.oracle.truffle.api.interop.exception.UnsupportedMessageException;
-import com.oracle.truffle.api.interop.messages.Message;
+import com.oracle.truffle.api.interop.ForeignAccess;
+import com.oracle.truffle.api.interop.Message;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.NullSourceSection;
-import com.oracle.truffle.interop.messages.*;
 import org.jruby.truffle.nodes.RubyNode;
 import org.jruby.truffle.nodes.interop.InteropNode;
 import org.jruby.truffle.runtime.RubyContext;
 
-public class ArrayForeignAccessFactory implements ForeignAccessFactory {
-
+public class ArrayForeignAccessFactory implements ForeignAccess.Factory10 {
     private final RubyContext context;
 
-    public ArrayForeignAccessFactory(RubyContext context) {
+    private ArrayForeignAccessFactory(RubyContext context) {
         this.context = context;
     }
 
-    @Override
-    public InteropPredicate getLanguageCheck() {
-        return new InteropPredicate() {
-            @Override
-            public boolean test(TruffleObject o) {
-                return o instanceof  RubyArray;
-            }
-        };
+    public static ForeignAccess create(RubyContext context) {
+        return ForeignAccess.create(RubyArray.class, new ArrayForeignAccessFactory(context));
     }
 
-    public CallTarget getAccess(Message tree) {
-        if (Read.create(Receiver.create(), Argument.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createRead(context, new NullSourceSection("", ""), (Read) tree)));
-        } else if (Execute.create(Read.create(Receiver.create(), Argument.create()),0).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createExecuteAfterRead(context, new NullSourceSection("", ""), (Execute) tree)));
-        } else if (Write.create(Receiver.create(), Argument.create(), Argument.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createWrite(context, new NullSourceSection("", ""), (Write) tree)));
-        } else if (IsExecutable.create(Receiver.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsExecutable(context, new NullSourceSection("", ""))));
-        } else if (IsBoxed.create(Receiver.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsBoxedPrimitive(context, new NullSourceSection("", ""))));
-        } else if (IsNull.create(Receiver.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsNull(context, new NullSourceSection("", ""))));
-        } else if (HasSize.create(Receiver.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createHasSizePropertyTrue(context, new NullSourceSection("", ""))));
-        } else if (GetSize.create(Receiver.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createGetSize(context, new NullSourceSection("", ""))));
-        } else {
-            throw new UnsupportedMessageException("Message not supported: " + tree.toString());
-        }
+    @Override
+    public CallTarget accessIsNull() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsNull(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessIsExecutable() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsExecutable(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessIsBoxed() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsBoxedPrimitive(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessHasSize() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createHasSizePropertyTrue(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessGetSize() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createGetSize(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessUnbox() {
+        return null;
+    }
+
+    @Override
+    public CallTarget accessRead() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createRead(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessWrite() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createWrite(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessExecute(int i) {
+        return null;
+    }
+
+    @Override
+    public CallTarget accessInvoke(int arity) {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createExecuteAfterRead(context, new NullSourceSection("", ""), arity)));
+    }
+
+    @Override
+    public CallTarget accessMessage(Message msg) {
+        return null;
     }
 
     protected static final class RubyInteropRootNode extends RootNode {

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/BasicForeignAccessFactory.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/BasicForeignAccessFactory.java
@@ -12,54 +12,79 @@ package org.jruby.truffle.runtime.core;
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.interop.ForeignAccessFactory;
-import com.oracle.truffle.api.interop.InteropPredicate;
-import com.oracle.truffle.api.interop.TruffleObject;
-import com.oracle.truffle.api.interop.exception.UnsupportedMessageException;
-import com.oracle.truffle.api.interop.messages.Message;
+import com.oracle.truffle.api.interop.ForeignAccess;
+import com.oracle.truffle.api.interop.Message;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.NullSourceSection;
-import com.oracle.truffle.interop.messages.*;
 import org.jruby.truffle.nodes.RubyNode;
 import org.jruby.truffle.nodes.interop.InteropNode;
 import org.jruby.truffle.runtime.RubyContext;
 
-public class BasicForeignAccessFactory implements ForeignAccessFactory {
+public class BasicForeignAccessFactory implements ForeignAccess.Factory10 {
 
     private final RubyContext context;
 
-    public BasicForeignAccessFactory(RubyContext context) {
+    private BasicForeignAccessFactory(RubyContext context) {
         this.context = context;
     }
 
-    @Override
-    public InteropPredicate getLanguageCheck() {
-        return new InteropPredicate() {
-            @Override
-            public boolean test(TruffleObject o) {
-                return o instanceof  RubyBasicObject;
-            }
-        };
+    public static ForeignAccess create(RubyContext context) {
+        return ForeignAccess.create(RubyBasicObject.class, new BasicForeignAccessFactory(context));
     }
 
-    public CallTarget getAccess(Message tree) {
-    	if (Read.create(Receiver.create(), Argument.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createRead(context, new NullSourceSection("", ""), (Read) tree)));
-    	} else if (Execute.create(Read.create(Receiver.create(), Argument.create()),0).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createExecuteAfterRead(context, new NullSourceSection("", ""), (Execute) tree)));
-    	} else if (Write.create(Receiver.create(), Argument.create(), Argument.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createWrite(context, new NullSourceSection("", ""), (Write) tree)));
-        } else if (IsExecutable.create(Receiver.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsExecutable(context, new NullSourceSection("", ""))));
-        } else if (IsBoxed.create(Receiver.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsBoxedPrimitive(context, new NullSourceSection("", ""))));
-        } else if (IsNull.create(Receiver.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsNull(context, new NullSourceSection("", ""))));
-        } else if (HasSize.create(Receiver.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createHasSizePropertyFalse(context, new NullSourceSection("", ""))));
-        } else {
-            throw new UnsupportedMessageException("Message not supported: " + tree.toString());
-        }
+    @Override
+    public CallTarget accessIsNull() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsNull(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessIsExecutable() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsExecutable(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessIsBoxed() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsBoxedPrimitive(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessHasSize() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createHasSizePropertyFalse(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessGetSize() {
+        return null;
+    }
+
+    @Override
+    public CallTarget accessUnbox() {
+        return null;
+    }
+
+    @Override
+    public CallTarget accessRead() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createRead(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessWrite() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createWrite(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessExecute(int i) {
+        return null;
+    }
+
+    @Override
+    public CallTarget accessInvoke(int arity) {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createExecuteAfterRead(context, new NullSourceSection("", ""), arity)));
+    }
+
+    @Override
+    public CallTarget accessMessage(Message msg) {
+        return null;
     }
 
     protected static final class RubyInteropRootNode extends RootNode {

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/HashForeignAccessFactory.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/HashForeignAccessFactory.java
@@ -12,57 +12,89 @@ package org.jruby.truffle.runtime.core;
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.interop.ForeignAccessFactory;
-import com.oracle.truffle.api.interop.InteropPredicate;
+import com.oracle.truffle.api.interop.ForeignAccess;
+import com.oracle.truffle.api.interop.Message;
 import com.oracle.truffle.api.interop.TruffleObject;
-import com.oracle.truffle.api.interop.exception.UnsupportedMessageException;
-import com.oracle.truffle.api.interop.messages.Message;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.NullSourceSection;
-import com.oracle.truffle.interop.messages.*;
 import org.jruby.truffle.nodes.RubyGuards;
 import org.jruby.truffle.nodes.RubyNode;
 import org.jruby.truffle.nodes.interop.InteropNode;
 import org.jruby.truffle.runtime.RubyContext;
 
-public class HashForeignAccessFactory implements ForeignAccessFactory {
+public class HashForeignAccessFactory
+implements ForeignAccess.Factory10, ForeignAccess.Factory {
 
     private final RubyContext context;
 
-    public HashForeignAccessFactory(RubyContext context) {
+    private HashForeignAccessFactory(RubyContext context) {
         this.context = context;
     }
 
-    @Override
-    public InteropPredicate getLanguageCheck() {
-        return new InteropPredicate() {
-            @Override
-            public boolean test(TruffleObject o) {
-                return RubyGuards.isRubyHash(o);
-            }
-        };
+    public static ForeignAccess create(RubyContext context) {
+        final HashForeignAccessFactory hashFactory = new HashForeignAccessFactory(context);
+        return ForeignAccess.create(null, hashFactory);
     }
 
-    public CallTarget getAccess(Message tree) {
-    	if (Read.create(Receiver.create(), Argument.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createRead(context, new NullSourceSection("", ""), (Read) tree)));
-    	} else if (Execute.create(Read.create(Receiver.create(), Argument.create()),0).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createExecuteAfterRead(context, new NullSourceSection("", ""), (Execute) tree)));
-    	} else if (Write.create(Receiver.create(), Argument.create(), Argument.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createWrite(context, new NullSourceSection("", ""), (Write) tree)));
-        } else if (IsExecutable.create(Receiver.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsExecutable(context, new NullSourceSection("", ""))));
-        } else if (IsBoxed.create(Receiver.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsBoxedPrimitive(context, new NullSourceSection("", ""))));
-        } else if (IsNull.create(Receiver.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsNull(context, new NullSourceSection("", ""))));
-        } else if (HasSize.create(Receiver.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createHasSizePropertyTrue(context, new NullSourceSection("", ""))));
-        } else if (GetSize.create(Receiver.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createGetSize(context, new NullSourceSection("", ""))));
-        } else {
-            throw new UnsupportedMessageException("Message not supported: " + tree.toString());
-        }
+
+    @Override
+    public boolean canHandle(TruffleObject to) {
+        return RubyGuards.isRubyHash(to);
+    }
+
+    @Override
+    public CallTarget accessIsNull() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsNull(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessIsExecutable() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsExecutable(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessIsBoxed() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsBoxedPrimitive(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessHasSize() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createHasSizePropertyTrue(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessGetSize() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createGetSize(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessUnbox() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsBoxedPrimitive(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessRead() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createRead(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessWrite() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createWrite(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessExecute(int i) {
+        return null;
+    }
+
+    @Override
+    public CallTarget accessInvoke(int arity) {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createExecuteAfterRead(context, new NullSourceSection("", ""), arity)));
+    }
+
+    @Override
+    public CallTarget accessMessage(Message msg) {
+        return null;
     }
 
     protected static final class RubyInteropRootNode extends RootNode {

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/RubyBasicObject.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/RubyBasicObject.java
@@ -12,12 +12,11 @@ package org.jruby.truffle.runtime.core;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import com.oracle.truffle.api.interop.ForeignAccessFactory;
+import com.oracle.truffle.api.interop.ForeignAccess;
 import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.object.*;
 
-import org.jruby.truffle.nodes.RubyGuards;
 import org.jruby.runtime.Helpers;
 import org.jruby.truffle.nodes.RubyGuards;
 import org.jruby.truffle.nodes.core.StringNodes;
@@ -121,17 +120,17 @@ public class RubyBasicObject implements TruffleObject {
     }
 
     @Override
-    public ForeignAccessFactory getForeignAccessFactory() {
+    public ForeignAccess getForeignAccess() {
         if (RubyGuards.isRubyMethod(this)) {
-            return new RubyMethodForeignAccessFactory(getContext());
+            return RubyMethodForeignAccessFactory.create(getContext());
         } else if (RubyGuards.isRubyArray(this)) {
-            return new ArrayForeignAccessFactory(getContext());
+            return ArrayForeignAccessFactory.create(getContext());
         } else if (RubyGuards.isRubyHash(this)) {
-            return new HashForeignAccessFactory(getContext());
+            return HashForeignAccessFactory.create(getContext());
         } else if (RubyGuards.isRubyString(this)) {
-            return new StringForeignAccessFactory(getContext());
+            return StringForeignAccessFactory.create(getContext());
         } else {
-            return new BasicForeignAccessFactory(getContext());
+            return BasicForeignAccessFactory.create(getContext());
         }
     }
 

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/RubyMethodForeignAccessFactory.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/RubyMethodForeignAccessFactory.java
@@ -16,52 +16,74 @@ import org.jruby.truffle.runtime.RubyContext;
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.interop.ForeignAccessFactory;
-import com.oracle.truffle.api.interop.InteropPredicate;
-import com.oracle.truffle.api.interop.TruffleObject;
-import com.oracle.truffle.api.interop.exception.UnsupportedMessageException;
-import com.oracle.truffle.api.interop.messages.Message;
+import com.oracle.truffle.api.interop.ForeignAccess;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.NullSourceSection;
-import com.oracle.truffle.interop.messages.Execute;
-import com.oracle.truffle.interop.messages.HasSize;
-import com.oracle.truffle.interop.messages.IsBoxed;
-import com.oracle.truffle.interop.messages.IsExecutable;
-import com.oracle.truffle.interop.messages.IsNull;
-import com.oracle.truffle.interop.messages.Receiver;
 
-public class RubyMethodForeignAccessFactory implements ForeignAccessFactory {
-
+public class RubyMethodForeignAccessFactory implements ForeignAccess.Factory10 {
     private final RubyContext context;
 
-    public RubyMethodForeignAccessFactory(RubyContext context) {
+    private RubyMethodForeignAccessFactory(RubyContext context) {
         this.context = context;
     }
 
-    @Override
-    public InteropPredicate getLanguageCheck() {
-        return new InteropPredicate() {
-            @Override
-            public boolean test(TruffleObject o) {
-                return o instanceof  RubyBasicObject;
-            }
-        };
+    public static ForeignAccess create(RubyContext context) {
+        return ForeignAccess.create(RubyBasicObject.class, new RubyMethodForeignAccessFactory(context));
     }
 
-    public CallTarget getAccess(Message tree) {
-    	if (Execute.create(Receiver.create() ,0).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createExecute(context, new NullSourceSection("", ""))));
-        } else if (IsExecutable.create(Receiver.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsExecutable(context, new NullSourceSection("", ""))));
-        } else if (IsBoxed.create(Receiver.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsBoxedPrimitive(context, new NullSourceSection("", ""))));
-        } else if (IsNull.create(Receiver.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsNull(context, new NullSourceSection("", ""))));
-        } else if (HasSize.create(Receiver.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createHasSizePropertyFalse(context, new NullSourceSection("", ""))));
-        } else {
-            throw new UnsupportedMessageException("Message not supported: " + tree.toString());
-        }
+    @Override
+    public CallTarget accessIsNull() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsNull(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessIsExecutable() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsExecutable(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessIsBoxed() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsBoxedPrimitive(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessHasSize() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createHasSizePropertyFalse(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessGetSize() {
+        return null;
+    }
+
+    @Override
+    public CallTarget accessUnbox() {
+        return null;
+    }
+
+    @Override
+    public CallTarget accessRead() {
+        return null;
+    }
+
+    @Override
+    public CallTarget accessWrite() {
+        return null;
+    }
+
+    @Override
+    public CallTarget accessExecute(int i) {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createExecute(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessInvoke(int i) {
+        return null;
+    }
+
+    @Override
+    public CallTarget accessMessage(com.oracle.truffle.api.interop.Message msg) {
+        return null;
     }
 
     protected static final class RubyInteropRootNode extends RootNode {

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/StringForeignAccessFactory.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/StringForeignAccessFactory.java
@@ -12,58 +12,79 @@ package org.jruby.truffle.runtime.core;
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.interop.ForeignAccessFactory;
-import com.oracle.truffle.api.interop.InteropPredicate;
-import com.oracle.truffle.api.interop.TruffleObject;
-import com.oracle.truffle.api.interop.exception.UnsupportedMessageException;
-import com.oracle.truffle.api.interop.messages.Message;
+import com.oracle.truffle.api.interop.ForeignAccess;
+import com.oracle.truffle.api.interop.Message;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.NullSourceSection;
-import com.oracle.truffle.interop.messages.*;
 import org.jruby.truffle.nodes.RubyNode;
 import org.jruby.truffle.nodes.interop.InteropNode;
 import org.jruby.truffle.runtime.RubyContext;
 
-public class StringForeignAccessFactory implements ForeignAccessFactory {
+public class StringForeignAccessFactory implements ForeignAccess.Factory10 {
 
     private final RubyContext context;
 
-    public StringForeignAccessFactory(RubyContext context) {
+    private StringForeignAccessFactory(RubyContext context) {
         this.context = context;
     }
 
-    @Override
-    public InteropPredicate getLanguageCheck() {
-        return new InteropPredicate() {
-            @Override
-            public boolean test(TruffleObject o) {
-                return o instanceof  RubyString;
-            }
-        };
+    public static ForeignAccess create(RubyContext context) {
+        return ForeignAccess.create(RubyString.class, new StringForeignAccessFactory(context));
     }
 
-    public CallTarget getAccess(Message tree) {
-        if (Read.create(Receiver.create(), Argument.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createStringRead(context, new NullSourceSection("", ""), (Read) tree)));
-        } else if (Execute.create(Read.create(Receiver.create(), Argument.create()),0).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createExecuteAfterRead(context, new NullSourceSection("", ""), (Execute) tree)));
-        } else if (Write.create(Receiver.create(), Argument.create(), Argument.create()).matchStructure(tree)) {
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createWrite(context, new NullSourceSection("", ""), (Write) tree)));
-        } else if (IsExecutable.create(Receiver.create()).matchStructure(tree)) { //ok
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsExecutable(context, new NullSourceSection("", ""))));
-        } else if (IsBoxed.create(Receiver.create()).matchStructure(tree)) { //ok
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createStringIsBoxed(context, new NullSourceSection("", ""))));
-        } else if (IsNull.create(Receiver.create()).matchStructure(tree)) {  //ok
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsNull(context, new NullSourceSection("", ""))));
-        } else if (HasSize.create(Receiver.create()).matchStructure(tree)) { //ok
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createHasSizePropertyTrue(context, new NullSourceSection("", ""))));
-        } else if (GetSize.create(Receiver.create()).matchStructure(tree)) { //ok
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createGetSize(context, new NullSourceSection("", ""))));
-        } else if (Unbox.create(Receiver.create()).matchStructure(tree)) { //ok
-            return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createStringUnbox(context, new NullSourceSection("", ""))));
-        } else {
-            throw new UnsupportedMessageException("Message not supported: " + tree.toString());
-        }
+    @Override
+    public CallTarget accessIsNull() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsNull(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessIsExecutable() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createIsExecutable(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessIsBoxed() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createStringIsBoxed(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessHasSize() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createHasSizePropertyTrue(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessGetSize() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createGetSize(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessUnbox() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createStringUnbox(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessRead() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createStringRead(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessWrite() {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createWrite(context, new NullSourceSection("", ""))));
+    }
+
+    @Override
+    public CallTarget accessExecute(int arity) {
+        return null;
+    }
+
+    @Override
+    public CallTarget accessInvoke(int arity) {
+        return Truffle.getRuntime().createCallTarget(new RubyInteropRootNode(InteropNode.createExecuteAfterRead(context, new NullSourceSection("", ""), arity)));
+    }
+
+    @Override
+    public CallTarget accessMessage(Message msg) {
+        return null;
     }
 
     protected static final class RubyInteropRootNode extends RootNode {


### PR DESCRIPTION
I am in process of redesigning com.oracle.truffle.api.interop API. Once that gets into development version of Truffle, JRuby+Truffle will need to be adopted. This pull request shows what changes I had to do make things running.