### PR TITLE
Don't call modify() on RubyStrings so eagerly when freezing them

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -965,7 +965,6 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         klass = getMetaClass();
         str = strDup(klass.getClassRuntime());
         str.setCodeRange(getCodeRange());
-        str.modify();
         str.setFrozen(true);
         return str;
     }
@@ -973,10 +972,11 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     /** rb_str_resize
      */
     public final void resize(int length) {
-        modify();
         if (value.getRealSize() > length) {
+            modify();
             value.setRealSize(length);
         } else if (value.length() < length) {
+            modify();
             value.length(length);
         }
     }


### PR DESCRIPTION
This fixes #3019, where in certain cases it's possible to end up with
RubyString instances backed by very large unique ByteLists where only
a tiny portion of the bytes in the ByteList are actually needed.

What was happening is `modify` was being called on RubyString
instances too eagerly, resulting in unnecessary duplication of their
underlying ByteList instances instead of sharing when possible.

The two changes here are in `RubyString#newFrozen` and
`RubyString#resize` and I believe are more correct based on the C
implementation of these methods.

For `RubyString#newFrozen`, which roughly corresponds to
`rb_str_new_frozen` in
C (https://github.com/ruby/ruby/blob/v2_2_2/string.c#L932), the logic
looks to me to return the shared string and I don't see it calling
`str_make_independent`, which is roughly the same thing as
`RubyString#modify`. So, I just removed the call to `modify`.

For `RubyString#resize`, which roughly corresponds to to
`rb_str_resize` in C, shared strings are only made independent if
their length
differ (https://github.com/ruby/ruby/blob/v2_2_2/string.c#L2155). Thus,
instead of unconditionally calling `modify` here, I moved it into the
conditions that are true when the length differs.