### PR TITLE
Fix the slow test indexes so test:slow_suites runs tests again

### DIFF
--- a/test/objectspace.index
+++ b/test/objectspace.index
@@ -1,2 +1,2 @@
-test_objectspace
-test_cache_map_leak
+jruby/test_objectspace
+jruby/test_cache_map_leak

--- a/test/slow.index
+++ b/test/slow.index
@@ -1,2 +1,2 @@
-test_command_line_switches
-test_launching_by_shell_script
+jruby/test_command_line_switches
+jruby/test_launching_by_shell_script


### PR DESCRIPTION
This has been broken since July 2014 when some tests were moved from
test/ to test/jruby/. Thus, once reenabled some of these tests have
failures.

If for some reason they were purposely left disabled then we need to remove the test:slow_suites matrix from .travis.yml.