### PR TITLE
Update rubygems to 2.4.8 to mitigate CVE-2015-4020

### DIFF
--- a/lib/ruby/shared/rubygems.rb
+++ b/lib/ruby/shared/rubygems.rb
@@ -9,7 +9,7 @@ require 'rbconfig'
 require 'thread'
 
 module Gem
-  VERSION = '2.4.6'
+  VERSION = '2.4.8'
 end
 
 # Must be first since it unloads the prelude from 1.9.2

--- a/lib/ruby/shared/rubygems/remote_fetcher.rb
+++ b/lib/ruby/shared/rubygems/remote_fetcher.rb
@@ -94,7 +94,13 @@ class Gem::RemoteFetcher
     rescue Resolv::ResolvError
       uri
     else
-      URI.parse "#{uri.scheme}://#{res.target}#{uri.path}"
+      target = res.target.to_s.strip
+
+      if /\.#{Regexp.quote(host)}\z/ =~ target
+        return URI.parse "#{uri.scheme}://#{target}#{uri.path}"
+      end
+
+      uri
     end
   end
 


### PR DESCRIPTION
CVE-2015-4020 was announced today. It is described here:
https://www.trustwave.com/Resources/Security-Advisories/Advisories/TWSL2015-009/?fid=6478.
The security vulnerability has been addressed in rubygems 2.4.8. As
jruby 1.7 has 2.4.6 included, this commit updates it to 2.4.8.