### PR TITLE
Fix getRealMethod for WrapperMethod which wraps a WrapperMethod

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/methods/WrapperMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/WrapperMethod.java
@@ -100,7 +100,7 @@ public class WrapperMethod extends DynamicMethod {
     }
     
     public DynamicMethod getRealMethod() {
-        return method;
+        return method.getRealMethod();
     }
 
     @Override


### PR DESCRIPTION
Ref: #3040

WrapperMethod can in some cases wrap a WrapperMethod, which causes `getRealMethod()` to return the wrapped WrapperMethod rather than the actual method at the bottom of the wrapping. This causes `Helpers.methodToArgumentDescriptors` to use the wrong logic for getting ArgumentDescriptors resulting in an NPE.

cc @enebo 