### PR TITLE
Fix date.rewrite_frags

### DIFF
--- a/lib/ruby/stdlib/date.rb
+++ b/lib/ruby/stdlib/date.rb
@@ -882,6 +882,7 @@ class Date
   def self.rewrite_frags(elem) # :nodoc:
     elem ||= {}
     if seconds = elem[:seconds]
+      seconds += elem[:offset] unless elem[:offset].nil?
       d,   fr = seconds.divmod(86400)
       h,   fr = fr.divmod(3600)
       min, fr = fr.divmod(60)
@@ -892,7 +893,6 @@ class Date
       elem[:sec] = s
       elem[:sec_fraction] = fr
       elem.delete(:seconds)
-      elem.delete(:offset)
     end
     elem
   end


### PR DESCRIPTION
According to MRI, offset should be preserved and
added to the seconds.

Fixes #2149

For reference, https://github.com/ruby/ruby/blob/39051ba1b94c61e92f333e514982c8f1333c7223/ext/date/date_core.c#L3682.

DateTime.strptime ignored timezone offsets when initialized via seconds, which is the cause of the test fail on #2149. If offset is dropped, the timezone information is lost.