### PR TITLE
[Truffle] No more global lock!

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/TrufflePrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/TrufflePrimitiveNodes.java
@@ -15,8 +15,10 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.FrameInstance;
 import com.oracle.truffle.api.frame.FrameInstanceVisitor;
 import com.oracle.truffle.api.frame.MaterializedFrame;
+import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
+
 import org.jruby.Ruby;
 import org.jruby.RubyGC;
 import org.jruby.ext.rbconfig.RbConfigLibrary;
@@ -518,6 +520,22 @@ public abstract class TrufflePrimitiveNodes {
             return CoreLibrary.fitsIntoInteger(value);
         }
 
+    }
+
+    @CoreMethod(names = "synchronized", isModuleFunction = true, required = 1, needsBlock = true)
+    public abstract static class SynchronizedPrimitiveNode extends YieldingCoreMethodNode {
+
+        public SynchronizedPrimitiveNode(RubyContext context, SourceSection sourceSection) {
+            super(context, sourceSection);
+        }
+
+        // We must not allow to synchronize on boxed primitives.
+        @Specialization(guards = "isRubyProc(block)")
+        public Object synchronize(VirtualFrame frame, RubyBasicObject self, RubyBasicObject block) {
+            synchronized (self) {
+                return yield(frame, block);
+            }
+        }
     }
 
 }

--- a/truffle/src/main/ruby/core/shims.rb
+++ b/truffle/src/main/ruby/core/shims.rb
@@ -152,12 +152,10 @@ class Rubinius::ByteArray
 
 end
 
-# Don't apply any synchronization at the moment
-
 module Rubinius
 
-  def self.synchronize(object)
-    yield
+  def self.synchronize(object, &block)
+    Truffle::Primitive.synchronized(object, &block)
   end
 
 end


### PR DESCRIPTION
@chrisseaton @nirvdrum @pitr-ch 
This is the very simple commit to remove the GIL (cleanup will be done later when merged).
I tried a few trivial parallelism problems, a parallel `richards` benchmark and a few benchmarks from [NPB](http://www.nas.nasa.gov/publications/npb.html) ([Ruby version](http://www-hiraki.is.s.u-tokyo.ac.jp/members/tknose/)).

Multi-threaded programs need to be properly synchronized or they might crash in various ways (as in standard JRuby).