### PR TITLE
Define packages for classes in nested JARs

### DIFF
--- a/core/src/main/java/org/jruby/util/JRubyClassLoader.java
+++ b/core/src/main/java/org/jruby/util/JRubyClassLoader.java
@@ -210,6 +210,11 @@ public class JRubyClassLoader extends URLClassLoader implements ClassDefiningCla
                         }
 
                         byte[] data = output.toByteArray();
+                        int dotIndex = className.lastIndexOf(".");
+                        if (dotIndex != -1) {
+                            String packageName = className.substring(0, dotIndex);
+                            definePackageInternal(packageName);
+                        }
                         return defineClass(className, data, 0, data.length);
                     } finally {
                         close(input);
@@ -326,6 +331,18 @@ public class JRubyClassLoader extends URLClassLoader implements ClassDefiningCla
             try {
                 resource.close();
             } catch (IOException ignore) {
+            }
+        }
+    }
+
+    private void definePackageInternal(String pkgname) {
+        if (getPackage(pkgname) == null) {
+            try {
+                definePackage(pkgname, null, null, null, null, null, null, null);
+            } catch (IllegalArgumentException iae) {
+                if (getPackage(pkgname) == null) {
+                    throw new AssertionError("Cannot find package " + pkgname);
+                }
             }
         }
     }

--- a/test/test_load.rb
+++ b/test/test_load.rb
@@ -103,6 +103,15 @@ class TestLoad < Test::Unit::TestCase
     }
   end
 
+  def test_require_nested_jar_defines_packages_for_classes_in_that_jar
+    assert_equal "test", run_in_sub_runtime(%{
+      require 'test/jar_with_nested_classes_jar'
+      require 'jar_with_classes'
+      java_import "test.HelloThere"
+      HelloThere.java_class.package.name
+    })
+  end
+
   def call_extern_load_foo_bar(classpath = nil)
     cmd = ""
     cmd += "env CLASSPATH=#{classpath}" # classpath=nil, becomes empty CLASSPATH


### PR DESCRIPTION
`JRubyClassLoader` doesn't define packages for classes found in JARs in JARs in JRuby 1.7 (it works as expected on master). The following example demonstrates the behavior:

```sh
mkdir -p src/{main,nested} bin build
echo "package main; class Main { }" > src/main/Main.java
echo "package nested; class Nested { }" > src/nested/Nested.java
javac -sourcepath src -d bin src/*/*.java
jar cf build/main.jar -C bin main
jar cf build/nested.jar -C bin nested
jar uf build/main.jar -C build nested.jar
ruby -rbuild/main -rnested -e'[Java::Main::Main, Java::Nested::Nested].each { |c| printf("%s.java_class.package # => %s\n", c.name, c.java_class.package) }'
```

In the example, a JAR containing the class `main.Main` and another JAR containing the class `nested.Nested` created. The Ruby script then loads these classes and prints out the package names; which is `main` for `main.Main`, but empty for `nested.Nested`.

Packages are defined in the private `defineClass(String name, Resource res)` of `URLClassLoader`, which is only called from `findClass(final String name)`. Thus, whenever `findClass()` in `URLClassLoader` throws `ClassNotFoundException` (e.g. for JARs within JARs), the package doesn't get defined, even if `findClass(String className)` in `JRubyClassLoader` is able to find and define the sought class. I've used http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/net/URLClassLoader.java for reference.

This proposed solution is a simplified version of that in the `URLClassLoader` in that it doesn't care about versioning information and sealing. The reason for this is that I really don't know anything about it and `URLClassLoader` defaults to defining packages in the same manner whenever a manifest isn't available.

I didn't know whether to include the example above as an integration test example or not? If I would, I thought I'd add the JAR as a fixture and then simply assert on the package name. I'd really appreciate feedback on my code, as well as on the PR description, so that I can improve.