### PR TITLE
Use a single write for IO#puts

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -2520,11 +2520,11 @@ public class RubyIO extends RubyObject implements IOEncodable {
             line = arg.asString().getByteList();
         }
 
-        write(context, maybeIO, line);
-
         if (line.length() == 0 || !line.endsWith(separator.getByteList())) {
-            write(context, maybeIO, separator.getByteList());
+            line.append(separator.getByteList());
         }
+
+        write(context, maybeIO, line);
     }
 
     private static IRubyObject inspectPuts(ThreadContext context, IRubyObject maybeIO, RubyArray array) {


### PR DESCRIPTION
This is a fix for #3182

Avoids interleaved writes across threads:

```
require 'thread'
8.times.map do
  Thread.new do
    1000.times do
      $stdout.puts "line"
      $stdout.fsync
    end
  end
end.map(&:join)
```

This can currently produce output like:

```
lineline


linelineline


lineline

lineline
```

After patching, output is consistently:

```
line
line
line
line
line
line
line
line
line
line
line
line
```
