### PR TITLE
Add MRI test for proc visibility

### DIFF
--- a/test/mri/ruby/test_proc.rb
+++ b/test/mri/ruby/test_proc.rb
@@ -377,6 +377,16 @@ class TestProc < Test::Unit::TestCase
     assert_equal([1, 2, 3], b.eval("[x, y, z]"))
   end
 
+  def identity_proc
+    p = proc { p }
+  end
+
+  def test_visibility
+    p = identity_proc
+
+    assert_equal(p.call, p)
+  end
+
   def test_proc_lambda
     assert_raise(ArgumentError) { proc }
     assert_raise(ArgumentError) { lambda }


### PR DESCRIPTION
For #3173 and to check against future regression.

This was broken in 9.0.0.0 but seems to be fixed in 9.0.1.0.