### PR TITLE
[Truffle] Add to loadedFeatures before loading

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/runtime/subsystems/FeatureManager.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/subsystems/FeatureManager.java
@@ -135,8 +135,8 @@ public class FeatureManager {
                 System.err.printf("resolved %s -> %s%n", feature, coreFileName);
             }
 
-            context.getCoreLibrary().loadRubyCore(coreFileName, "uri:classloader:/");
             ArrayNodes.slowPush(loadedFeatures, StringNodes.createString(context.getCoreLibrary().getStringClass(), path));
+            context.getCoreLibrary().loadRubyCore(coreFileName, "uri:classloader:/");
 
             return true;
         }
@@ -157,8 +157,8 @@ public class FeatureManager {
                 System.err.printf("resolved %s -> %s%n", feature, coreFileName);
             }
 
-            context.getCoreLibrary().loadRubyCore(coreFileName, "core:/");
             ArrayNodes.slowPush(loadedFeatures, StringNodes.createString(context.getCoreLibrary().getStringClass(), path));
+            context.getCoreLibrary().loadRubyCore(coreFileName, "core:/");
 
             return true;
         } else {


### PR DESCRIPTION
For classloader and core features, add the feature to the collection of
loaded features before performing the load to break endless recursion in
the presence of cyclic dependencies.

This brings the behavior of core and classloader features in line with file features. I am encountering a cyclic dependency when doing ahead of time compilation. Since I include all ruby files in the image, features that would have been resolved as files instead are found with the classloader.

A quick way to expose this issue is to add `require_relative 'core.rb'` to truffle/src/main/ruby/core.rb.

