### PR TITLE
Fixing RangeError with code from 1.7 branch

### DIFF
--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -659,7 +659,11 @@ public class RubyRange extends RubyObject {
             if (!(begin instanceof RubyInteger)) {
                 throw context.runtime.newTypeError("cannot exclude end value with non Integer begin value");
             }
-            rangeEnd = RubyFixnum.newFixnum(context.runtime, ((RubyInteger) end).getLongValue() - 1);
+            if (end instanceof RubyFixnum) {
+                rangeEnd = RubyFixnum.newFixnum(context.runtime, ((RubyFixnum)end).getLongValue() - 1);
+            } else {
+                rangeEnd =  end.callMethod(context, "-", RubyFixnum.one(context.runtime));
+            }
         } else {
             rangeEnd = end;
         }

--- a/test/mri/ruby/test_range.rb
+++ b/test/mri/ruby/test_range.rb
@@ -69,6 +69,7 @@ class TestRange < Test::Unit::TestCase
     assert_equal(2, (1..2).max)
     assert_equal(nil, (2..1).max)
     assert_equal(1, (1...2).max)
+    assert_equal(18446744073709551615, (0...2**64).max)
 
     assert_equal(2.0, (1.0..2.0).max)
     assert_equal(nil, (2.0..1.0).max)


### PR DESCRIPTION
With my previous commit, RangeError: bignum too big to convert into `long' was the result when running (0...2**64).max

This commit ports handling for non-RubyFixnums from the 1.7.20 branch.

Addresses, https://github.com/jruby/jruby/issues/3118

.. follow-up on PR #3196