### PR TITLE
[Truffle] Change signature of NativeSockets.accept

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/IOPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/IOPrimitiveNodes.java
@@ -564,8 +564,8 @@ public abstract class IOPrimitiveNodes {
         public int accept(VirtualFrame frame, RubyBasicObject io) {
             final int fd = getDescriptor(io);
 
-            final IntByReference addressLength = new IntByReference(16);
-            final long address = UnsafeHolder.U.allocateMemory(addressLength.intValue());
+            final int[] addressLength = {16};
+            final long address = UnsafeHolder.U.allocateMemory(addressLength[0]);
 
             final int newFd;
 

--- a/truffle/src/main/java/org/jruby/truffle/runtime/sockets/NativeSockets.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/sockets/NativeSockets.java
@@ -72,7 +72,7 @@ public interface NativeSockets {
      *        socklen_t *restrict address_len);
      */
 
-    int accept(int socket, Pointer address, IntByReference addressLength);
+    int accept(int socket, Pointer address, int[] addressLength);
 
     /*
      * int


### PR DESCRIPTION
This helps with ahead of time compilation. I can generate the bindings for NativeSockets during compilation, but only primitive, array, or string arguments are currently supported. Boxing the integer in an array has the same result when using jnr-ffi, it is translated into a int*. 