### PR TITLE
[Truffle] Decode the path parameter to open

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/IOPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/IOPrimitiveNodes.java
@@ -216,7 +216,7 @@ public abstract class IOPrimitiveNodes {
 
         @Specialization(guards = "isRubyString(path)")
         public int open(RubyBasicObject path, int mode, int permission) {
-            return posix().open(StringNodes.getByteList(path), mode, permission);
+            return posix().open(path.toString(), mode, permission);
         }
 
     }


### PR DESCRIPTION
This allows the path to contain characters not represented by
ISO-8859-1, which is the default encoding used for ByteLists.

Here is a test case to expose this problem:
````
filename = "こんにちは.txt"
File.open(filename, "w").close
File.delete(filename)
````

This results in an error: "No such file or directory". Delete (unlink) does do the decoding, but always assumes utf-8. Calling toString will use the encoding specified by the backing ByteList. It seems like some functions decode utf-8 always, others call toString.