### PR TITLE
Correct a format string in Signal#trap.

### DIFF
--- a/core/src/main/ruby/jruby/kernel/signal.rb
+++ b/core/src/main/ruby/jruby/kernel/signal.rb
@@ -4,7 +4,7 @@ module Signal
     sig = sig.to_s.sub(/^SIG(.+)/,'\1')
 
     if RESERVED_SIGNALS.include?(sig)
-      raise ArgumentError.new("can't trap reserved signal: SIG%S" % sig)
+      raise ArgumentError.new("can't trap reserved signal: SIG%s" % sig)
     end
 
     oldhandler, installed = if block

--- a/spec/ruby/core/signal/trap_spec.rb
+++ b/spec/ruby/core/signal/trap_spec.rb
@@ -88,6 +88,12 @@ describe "Signal.trap" do
     Signal.trap(:HUP, "IGNORE").should == "IGNORE"
   end
 
+  it "raises ArgumentError when given a reserved signal" do
+    [:SEGV, :BUS, :ILL, :FPE, :VTALRM].each do
+      lambda { Signal.trap(:ILL) }.should raise_error(ArgumentError, /reserved signal/)
+    end
+  end
+
   describe "the special EXIT signal code" do
 
     it "accepts the EXIT code" do

--- a/test/mri/ruby/test_signal.rb
+++ b/test/mri/ruby/test_signal.rb
@@ -201,21 +201,11 @@ class TestSignal < Test::Unit::TestCase
   end if Signal.list.key?('QUIT')
 
   def test_reserved_signal
-    assert_raise(ArgumentError) {
-      Signal.trap(:SEGV) {}
-    }
-    assert_raise(ArgumentError) {
-      Signal.trap(:BUS) {}
-    }
-    assert_raise(ArgumentError) {
-      Signal.trap(:ILL) {}
-    }
-    assert_raise(ArgumentError) {
-      Signal.trap(:FPE) {}
-    }
-    assert_raise(ArgumentError) {
-      Signal.trap(:VTALRM) {}
-    }
+    [:SEGV, :BUS, :ILL, :FPE, :VTALRM].each do |signal|
+      assert_raise_with_message(ArgumentError, /reserved signal/) {
+        Signal.trap(signal) {}
+      }
+    end
   end
 
   def test_signame


### PR DESCRIPTION
Fixes #3208: Trapping reserved signals doesn't print a meaningful
message