### PR TITLE
add to_h to the class used for ENV

### DIFF
--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -338,6 +338,12 @@ public class RubyGlobal {
             return getRuntime().newString("ENV");
         }
 
+        @JRubyMethod
+        public RubyHash to_h(){
+          return to_hash();
+        }
+
+
     }
 
     /**

--- a/spec/ruby/core/env/shared/to_hash.rb
+++ b/spec/ruby/core/env/shared/to_hash.rb
@@ -14,4 +14,9 @@ describe :env_to_hash, :shared => true do
   it "uses the locale encoding for values" do
     ENV.send(@method).values.all? {|v| v.encoding == Encoding.find('locale') }.should be_true
   end
+
+  it "duplicates the ENV when converting to a Hash" do
+    h = ENV.send(@method)
+    h.object_id.should_not == ENV.object_id
+  end
 end


### PR DESCRIPTION
That makes it so that it duplicates rather than returning the same object to make compatible with MRI

fixes #3162