### PR TITLE
Close any open selectors when tearing down a runtime.

### DIFF
--- a/core/src/main/java/org/jruby/util/io/SelectorPool.java
+++ b/core/src/main/java/org/jruby/util/io/SelectorPool.java
@@ -31,6 +31,7 @@ package org.jruby.util.io;
 
 import java.io.IOException;
 import java.nio.channels.Selector;
+import java.util.ArrayList;
 import java.util.List;
 
 import java.nio.channels.spi.SelectorProvider;
@@ -52,6 +53,7 @@ import java.util.Map;
  */
 public class SelectorPool {
     private final Map<SelectorProvider, List<Selector>> pool = new HashMap<SelectorProvider, List<Selector>>();
+    private final List<Selector> openSelectors = new ArrayList<Selector>();
 
     /**
      * Get a selector from the pool (or create a new one). Selectors come from
@@ -87,7 +89,8 @@ public class SelectorPool {
     /**
      * Clean up a pool.
      * 
-     * All selectors in a pool are closed and the pool gets empty.
+     * All selectors in a pool or handed out from the pool are closed
+     * and the pool gets emptied.
      * 
      */
     public synchronized void cleanup() {
@@ -103,18 +106,32 @@ public class SelectorPool {
             }
         }
         pool.clear();
+
+        for (Selector selector : openSelectors) {
+            try {
+                selector.close();
+            } catch (IOException ioe) {
+                // ignore IOException at termination.
+            }
+        }
+        openSelectors.clear();
     }
 
     private Selector retrieveFromPool(SelectorProvider provider) throws IOException {
         List<Selector> providerPool = pool.get(provider);
+        Selector selector;
         if (providerPool != null && !providerPool.isEmpty()) {
-            return providerPool.remove(providerPool.size() - 1);
+            selector = providerPool.remove(providerPool.size() - 1);
+        } else {
+            selector = SelectorFactory.openWithRetryFrom(null, provider);
         }
 
-        return SelectorFactory.openWithRetryFrom(null, provider);
+        openSelectors.add(selector);
+        return selector;
     }
 
     private void returnToPool(Selector selector) {
+        openSelectors.remove(selector);
         if (selector.isOpen()) {
             SelectorProvider provider = selector.provider();
             List<Selector> providerPool = pool.get(provider);

--- a/spec/regression/embedded_runtime_leak_spec.rb
+++ b/spec/regression/embedded_runtime_leak_spec.rb
@@ -1,18 +1,48 @@
 describe "embedded runtimes" do
   it "should not leak runtimes after tearing them down" do
-    num_runtimes = 10
-    mbean = java.lang.management.ManagementFactory.getMemoryMXBean
-    num_runtimes.times do
-      instance = org.jruby.Ruby.newInstance
-      instance.evalScriptlet <<-EOS
-        # eat up some memory in each runtime
-        $arr = 500000.times.map { |i| "foobarbaz\#{i}" }
-      EOS
-      instance.tearDown(false)
-      # Make sure GC can keep up
-      while mbean.getObjectPendingFinalizationCount > 0
-        sleep 0.2
+    create_runtimes(10) do |runtime|
+      # nothing to do actually - the runtimes will by default build up
+      # and OOM if they aren't being garbage collected
+    end
+  end
+
+  it "should not leak runtimes blocked on IO" do
+    create_runtimes(10) do |runtime|
+      latch = java.util.concurrent.CountDownLatch.new(1)
+      Thread.new do
+        latch.countDown
+        # we'll get an OOM if the blocking TCPServer#accept call below
+        # doesn't get interrupted during runtime teardown
+        runtime.evalScriptlet <<-EOS
+          require "socket"
+          server = TCPServer.new(0)
+          begin
+            server.accept
+          rescue Exception
+          end
+        EOS
       end
-    end.should_not raise_error
+      latch.await # spawned thread has started
+      sleep 0.5 # give time for the new runtime to block on accept
+    end
+  end
+
+  def create_runtimes(num_runtimes)
+    mbean = java.lang.management.ManagementFactory.getMemoryMXBean
+    expect do
+      num_runtimes.times do
+        runtime = org.jruby.Ruby.newInstance
+        runtime.evalScriptlet <<-EOS
+          # eat up some memory in each runtime
+          $arr = 500000.times.map { |i| "foobarbaz\#{i}" }
+        EOS
+        yield runtime if block_given?
+        runtime.tearDown(false)
+        # Make sure GC can keep up
+        while mbean.getObjectPendingFinalizationCount > 0
+          sleep 0.2
+        end
+      end
+    end.not_to raise_error
   end
 end


### PR DESCRIPTION
This fixes a runtime leak in embedded scenarios where a runtime may
never get garbage collected because it has a thread blocked on a
select call. This leak exists in JRuby 1.7.x as well, but for some
reason I'm seeing it more often in JRuby 9.x when running TorqueBox 3
integration tests. Perhaps there is more IO that uses select in 9.x
than 1.7.x?

Here's a gist with a fairly simple reproducer and results on 1.7.21, 9.0.0.0, and 9.0.1.0-SNAPSHOT with this patch applied - https://gist.github.com/bbrowning/3cbb3901d4facd7fc99f