### PR TITLE
[Truffle] Limit the number of methods available for runtime compilation

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/nodes/cast/CmpIntNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/cast/CmpIntNode.java
@@ -21,6 +21,7 @@
 package org.jruby.truffle.nodes.cast;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -86,6 +87,7 @@ public abstract class CmpIntNode extends RubyNode {
         return BignumNodes.getBigIntegerValue(value).signum();
     }
 
+    @TruffleBoundary
     @Specialization(guards = "isNil(nil)")
     public int cmpNil(Object nil, Object receiver, Object other) {
         throw new RaiseException(

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/EncodingNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/EncodingNodes.java
@@ -435,15 +435,20 @@ public abstract class EncodingNodes {
             final Object externalTuple = getContext().makeTuple(frame, newTupleNode, createString("external"), indexLookup(encodings, defaultExternalEncoding));
             lookupTableWriteNode.call(frame, ret, "[]=", null, getSymbol("EXTERNAL"), externalTuple);
 
-            final Encoding localeEncoding = getContext().getRuntime().getEncodingService().getLocaleEncoding();
+            final Encoding localeEncoding = getLocaleEncoding();
             final Object localeTuple = getContext().makeTuple(frame, newTupleNode, createString("locale"), indexLookup(encodings, localeEncoding));
             lookupTableWriteNode.call(frame, ret, "[]=", null, getSymbol("LOCALE"), localeTuple);
 
-            final Encoding filesystemEncoding = getContext().getRuntime().getEncodingService().getLocaleEncoding();
+            final Encoding filesystemEncoding = getLocaleEncoding();
             final Object filesystemTuple = getContext().makeTuple(frame, newTupleNode, createString("filesystem"), indexLookup(encodings, filesystemEncoding));
             lookupTableWriteNode.call(frame, ret, "[]=", null, getSymbol("FILESYSTEM"), filesystemTuple);
 
             return ret;
+        }
+
+        @TruffleBoundary
+        private Encoding getLocaleEncoding() {
+            return getContext().getRuntime().getEncodingService().getLocaleEncoding();
         }
 
         @TruffleBoundary

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/ExceptionNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/ExceptionNodes.java
@@ -9,6 +9,7 @@
  */
 package org.jruby.truffle.nodes.core;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
@@ -114,6 +115,7 @@ public abstract class ExceptionNodes {
             readCustomBacktrace = new ReadHeadObjectFieldNode("@custom_backtrace");
         }
 
+        @TruffleBoundary
         @Specialization
         public Object backtrace(RubyBasicObject exception) {
             if (readCustomBacktrace.isSet(exception)) {

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/KernelNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/KernelNodes.java
@@ -889,6 +889,7 @@ public abstract class KernelNodes {
             return Boolean.valueOf(value).hashCode();
         }
 
+        @TruffleBoundary
         @Specialization
         public int hash(RubyBasicObject self) {
             // TODO(CS 8 Jan 15) we shouldn't use the Java class hierarchy like this - every class should define it's
@@ -1969,6 +1970,7 @@ public abstract class KernelNodes {
             return string;
         }
 
+        @TruffleBoundary
         protected CallTarget compileFormat(RubyBasicObject format) {
             assert RubyGuards.isRubyString(format);
 

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/MethodNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/MethodNodes.java
@@ -304,6 +304,7 @@ public abstract class MethodNodes {
                     null);
         }
 
+        @TruffleBoundary
         protected CallTarget method2proc(RubyBasicObject methodObject) {
             // translate to something like:
             // lambda { |same args list| method.call(args) }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/ProcessNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/ProcessNodes.java
@@ -84,6 +84,7 @@ public abstract class ProcessNodes {
             return timeToUnit(time, unit);
         }
 
+        @TruffleBoundary
         @Specialization(guards = { "isThreadCPUTime(clock_id)", "isRubySymbol(unit)" })
         protected Object clock_gettime_thread_cputime(int clock_id, RubyBasicObject unit,
                 @Cached("getLibCClockGetTime()") LibCClockGetTime libCClockGetTime) {

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/QueueNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/QueueNodes.java
@@ -76,6 +76,7 @@ public abstract class QueueNodes {
             super(context, sourceSection);
         }
 
+        @TruffleBoundary
         @Specialization
         public RubyBasicObject push(RubyBasicObject self, final Object value) {
             final BlockingQueue<Object> queue = getQueue(self);
@@ -102,6 +103,7 @@ public abstract class QueueNodes {
             return BooleanCastWithDefaultNodeGen.create(getContext(), getSourceSection(), false, nonBlocking);
         }
 
+        @TruffleBoundary
         @Specialization(guards = "!nonBlocking")
         public Object popBlocking(RubyBasicObject self, boolean nonBlocking) {
             final BlockingQueue<Object> queue = getQueue(self);
@@ -114,6 +116,7 @@ public abstract class QueueNodes {
             });
         }
 
+        @TruffleBoundary
         @Specialization(guards = "nonBlocking")
         public Object popNonBlock(RubyBasicObject self, boolean nonBlocking) {
             final BlockingQueue<Object> queue = getQueue(self);
@@ -187,6 +190,7 @@ public abstract class QueueNodes {
             super(context, sourceSection);
         }
 
+        @TruffleBoundary
         @Specialization
         public boolean empty(RubyBasicObject self) {
             final BlockingQueue<Object> queue = getQueue(self);
@@ -202,6 +206,7 @@ public abstract class QueueNodes {
             super(context, sourceSection);
         }
 
+        @TruffleBoundary
         @Specialization
         public int size(RubyBasicObject self) {
             final BlockingQueue<Object> queue = getQueue(self);
@@ -217,6 +222,7 @@ public abstract class QueueNodes {
             super(context, sourceSection);
         }
 
+        @TruffleBoundary
         @Specialization
         public RubyBasicObject clear(RubyBasicObject self) {
             final BlockingQueue<Object> queue = getQueue(self);

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/RegexpNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/RegexpNodes.java
@@ -640,6 +640,7 @@ public abstract class RegexpNodes {
             super(context, sourceSection);
         }
 
+        @TruffleBoundary
         @Specialization
         public RubyBasicObject toS(RubyBasicObject regexp) {
             return createString(((org.jruby.RubyString) org.jruby.RubyRegexp.newRegexp(getContext().getRuntime(), getSource(regexp), getRegex(regexp).getOptions()).to_s()).getByteList());

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/SizedQueueNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/SizedQueueNodes.java
@@ -10,6 +10,7 @@
 package org.jruby.truffle.nodes.core;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.CreateCast;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
@@ -107,6 +108,7 @@ public abstract class SizedQueueNodes {
             super(context, sourceSection);
         }
 
+        @TruffleBoundary
         @Specialization
         public int setMax(RubyBasicObject self, int newCapacity) {
             if (newCapacity <= 0) {
@@ -136,6 +138,7 @@ public abstract class SizedQueueNodes {
             super(context, sourceSection);
         }
 
+        @TruffleBoundary
         @Specialization
         public int max(RubyBasicObject self) {
             final BlockingQueue<Object> queue = getQueue(self);
@@ -178,6 +181,7 @@ public abstract class SizedQueueNodes {
             return self;
         }
 
+        @TruffleBoundary
         @Specialization(guards = "nonBlocking")
         public RubyBasicObject pushNonBlock(RubyBasicObject self, final Object value, boolean nonBlocking) {
             final BlockingQueue<Object> queue = getQueue(self);
@@ -221,6 +225,7 @@ public abstract class SizedQueueNodes {
             });
         }
 
+        @TruffleBoundary
         @Specialization(guards = "nonBlocking")
         public Object popNonBlock(RubyBasicObject self, boolean nonBlocking) {
             final BlockingQueue<Object> queue = getQueue(self);
@@ -243,6 +248,7 @@ public abstract class SizedQueueNodes {
             super(context, sourceSection);
         }
 
+        @TruffleBoundary
         @Specialization
         public boolean empty(RubyBasicObject self) {
             final BlockingQueue<Object> queue = getQueue(self);
@@ -273,6 +279,7 @@ public abstract class SizedQueueNodes {
             super(context, sourceSection);
         }
 
+        @TruffleBoundary
         @Specialization
         public RubyBasicObject clear(RubyBasicObject self) {
             final BlockingQueue<Object> queue = getQueue(self);

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/StringNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/StringNodes.java
@@ -1477,6 +1477,7 @@ public abstract class StringNodes {
             super(context, sourceSection);
         }
 
+        @TruffleBoundary
         @Specialization(guards = "isSingleByteOptimizable(string)")
         public Object lstripBangSingleByte(RubyBasicObject string) {
             // Taken from org.jruby.RubyString#lstrip_bang19 and org.jruby.RubyString#singleByteLStrip.
@@ -1501,6 +1502,7 @@ public abstract class StringNodes {
             return nil();
         }
 
+        @TruffleBoundary
         @Specialization(guards = "!isSingleByteOptimizable(string)")
         public Object lstripBang(RubyBasicObject string) {
             // Taken from org.jruby.RubyString#lstrip_bang19 and org.jruby.RubyString#multiByteLStrip.
@@ -1615,6 +1617,7 @@ public abstract class StringNodes {
             super(context, sourceSection);
         }
 
+        @TruffleBoundary
         @Specialization(guards = "isSingleByteOptimizable(string)")
         public Object rstripBangSingleByte(RubyBasicObject string) {
             // Taken from org.jruby.RubyString#rstrip_bang19 and org.jruby.RubyString#singleByteRStrip19.
@@ -1640,6 +1643,7 @@ public abstract class StringNodes {
             return nil();
         }
 
+        @TruffleBoundary
         @Specialization(guards = "!isSingleByteOptimizable(string)")
         public Object rstripBang(RubyBasicObject string) {
             // Taken from org.jruby.RubyString#rstrip_bang19 and org.jruby.RubyString#multiByteRStrip19.
@@ -1687,6 +1691,7 @@ public abstract class StringNodes {
             super(context, sourceSection);
         }
 
+        @TruffleBoundary
         @Specialization
         public RubyBasicObject swapcaseSingleByte(RubyBasicObject string) {
             // Taken from org.jruby.RubyString#swapcase_bang19.
@@ -1747,6 +1752,7 @@ public abstract class StringNodes {
             return result;
         }
 
+        @TruffleBoundary
         @Specialization(guards = "!isAsciiCompatible(string)")
         public RubyBasicObject dump(RubyBasicObject string) {
             // Taken from org.jruby.RubyString#dump
@@ -1887,6 +1893,11 @@ public abstract class StringNodes {
             for (int i = 0; i < args.length; i++) {
                 otherStrings[i] = toStrNode.executeToStr(frame, args[i]);
             }
+            return performSqueezeBang(string, otherStrings);
+        }
+
+        @TruffleBoundary
+        private Object performSqueezeBang(RubyBasicObject string, RubyBasicObject[] otherStrings) {
 
             RubyBasicObject otherStr = otherStrings[0];
             Encoding enc = checkEncoding(string, getCodeRangeable(otherStr), this);

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/ThreadNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/ThreadNodes.java
@@ -10,6 +10,7 @@
 package org.jruby.truffle.nodes.core;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
@@ -377,6 +378,7 @@ public abstract class ThreadNodes {
             super(context, sourceSection);
         }
 
+        @TruffleBoundary
         @Specialization(guards = "isRubyProc(block)")
         public RubyBasicObject initialize(RubyBasicObject thread, Object[] arguments, RubyBasicObject block) {
             ThreadNodes.initialize(thread, getContext(), this, arguments, block);

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/TimeNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/TimeNodes.java
@@ -9,6 +9,7 @@
  */
 package org.jruby.truffle.nodes.core;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -97,6 +98,7 @@ public abstract class TimeNodes {
             super(context, sourceSection);
         }
 
+        @TruffleBoundary
         @Specialization
         public boolean internalSetGMT(RubyBasicObject time, boolean isGMT) {
             if (isGMT) {

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/array/ArrayBuilderNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/array/ArrayBuilderNode.java
@@ -494,10 +494,6 @@ public abstract class ArrayBuilderNode extends Node {
 
         @Override
         public Object appendValue(Object store, int index, Object value) {
-            if (index >= ((Object[]) store).length) {
-                new Exception().printStackTrace();
-            }
-
             ((Object[]) store)[index] = value;
             return store;
         }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/array/ArrayNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/array/ArrayNodes.java
@@ -12,6 +12,7 @@ package org.jruby.truffle.nodes.core.array;
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.*;
 import com.oracle.truffle.api.frame.FrameDescriptor;
@@ -2830,6 +2831,7 @@ public abstract class ArrayNodes {
             return ruby(frame, "pack(format.to_str)", "format", format);
         }
 
+        @TruffleBoundary
         protected CallTarget compileFormat(RubyBasicObject format) {
             assert RubyGuards.isRubyString(format);
             try {

--- a/truffle/src/main/java/org/jruby/truffle/nodes/exceptions/TopLevelRaiseHandler.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/exceptions/TopLevelRaiseHandler.java
@@ -9,6 +9,7 @@
  */
 package org.jruby.truffle.nodes.exceptions;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
 import org.jruby.truffle.nodes.RubyNode;
@@ -33,18 +34,23 @@ public class TopLevelRaiseHandler extends RubyNode {
         try {
             return body.execute(frame);
         } catch (RaiseException e) {
-            final Object rubyException = e.getRubyException();
-
-            for (String line : Backtrace.DISPLAY_FORMATTER.format(getContext(), (RubyBasicObject) rubyException, ExceptionNodes.getBacktrace((RubyBasicObject) rubyException))) {
-                System.err.println(line);
-            }
-
-            System.exit(1);
+            handleException(e);
         } catch (ThreadExitException e) {
             // Ignore
         }
 
         return nil();
+    }
+
+    @TruffleBoundary
+    private void handleException(RaiseException e) {
+        final Object rubyException = e.getRubyException();
+
+        for (String line : Backtrace.DISPLAY_FORMATTER.format(getContext(), (RubyBasicObject) rubyException, ExceptionNodes.getBacktrace((RubyBasicObject) rubyException))) {
+            System.err.println(line);
+        }
+
+        System.exit(1);
     }
 
 }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/globals/GetFromThreadLocalNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/globals/GetFromThreadLocalNode.java
@@ -9,6 +9,7 @@
  */
 package org.jruby.truffle.nodes.globals;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
@@ -32,6 +33,7 @@ public abstract class GetFromThreadLocalNode extends RubyNode {
         super(context, sourceSection);
     }
 
+    @TruffleBoundary
     @Specialization
     public Object get(ThreadLocalObject threadLocal) {
         return threadLocal.get();

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/EncodingConverterPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/EncodingConverterPrimitiveNodes.java
@@ -12,6 +12,7 @@
 package org.jruby.truffle.nodes.rubinius;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
@@ -82,6 +83,7 @@ public abstract class EncodingConverterPrimitiveNodes {
             return primitiveConvertHelper(encodingConverter, StringNodes.getByteList(source), source, target, offset, size, options);
         }
 
+        @TruffleBoundary
         private Object primitiveConvertHelper(RubyBasicObject encodingConverter, ByteList inBytes, RubyBasicObject source,
                                               RubyBasicObject target, int offset, int size, int options) {
             // Taken from org.jruby.RubyConverter#primitive_convert.

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/IOPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/IOPrimitiveNodes.java
@@ -186,6 +186,7 @@ public abstract class IOPrimitiveNodes {
             return true;
         }
 
+        @TruffleBoundary
         private void newOpenFd(int newFd) {
             final int FD_CLOEXEC = 1;
 
@@ -378,8 +379,8 @@ public abstract class IOPrimitiveNodes {
             resetBufferingNode = DispatchHeadNodeFactory.createMethodCall(context);
         }
 
-        @Specialization
-        public Object reopen(VirtualFrame frame, RubyBasicObject file, RubyBasicObject io) {
+        @TruffleBoundary
+        private void performReopen(RubyBasicObject file, RubyBasicObject io) {
             final int fd = getDescriptor(file);
             final int fdOther = getDescriptor(io);
 
@@ -395,6 +396,11 @@ public abstract class IOPrimitiveNodes {
                 throw new RaiseException(getContext().getCoreLibrary().errnoError(posix().errno(), this));
             }
             setMode(file, mode);
+        }
+
+        @Specialization
+        public Object reopen(VirtualFrame frame, RubyBasicObject file, RubyBasicObject io) {
+            performReopen(file, io);
 
             resetBufferingNode.call(frame, io, "reset_buffering", null);
 
@@ -413,8 +419,8 @@ public abstract class IOPrimitiveNodes {
             resetBufferingNode = DispatchHeadNodeFactory.createMethodCall(context);
         }
 
-        @Specialization(guards = "isRubyString(path)")
-        public Object reopenPath(VirtualFrame frame, RubyBasicObject file, RubyBasicObject path, int mode) {
+        @TruffleBoundary
+        public void performReopenPath(RubyBasicObject file, RubyBasicObject path, int mode) {
             int fd = getDescriptor(file);
             final String pathString = StringNodes.getString(path);
 
@@ -449,6 +455,11 @@ public abstract class IOPrimitiveNodes {
                 throw new RaiseException(getContext().getCoreLibrary().errnoError(posix().errno(), this));
             }
             setMode(file, newMode);
+        }
+
+        @Specialization(guards = "isRubyString(path)")
+        public Object reopenPath(VirtualFrame frame, RubyBasicObject file, RubyBasicObject path, int mode) {
+            performReopenPath(file, path, mode);
 
             resetBufferingNode.call(frame, file, "reset_buffering", null);
 
@@ -464,8 +475,9 @@ public abstract class IOPrimitiveNodes {
             super(context, sourceSection);
         }
 
+        @TruffleBoundary
         @Specialization(guards = "isRubyString(string)")
-        public int write(VirtualFrame frame, RubyBasicObject file, RubyBasicObject string) {
+        public int write(RubyBasicObject file, RubyBasicObject string) {
             final int fd = getDescriptor(file);
 
             final ByteList byteList = StringNodes.getByteList(string);
@@ -559,8 +571,9 @@ public abstract class IOPrimitiveNodes {
             super(context, sourceSection);
         }
 
+        @TruffleBoundary
         @Specialization
-        public int accept(VirtualFrame frame, RubyBasicObject io) {
+        public int accept(RubyBasicObject io) {
             final int fd = getDescriptor(io);
 
             final int[] addressLength = {16};

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/PointerPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/PointerPrimitiveNodes.java
@@ -10,6 +10,7 @@
 package org.jruby.truffle.nodes.rubinius;
 
 import com.kenai.jffi.MemoryIO;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
@@ -256,6 +257,7 @@ public abstract class PointerPrimitiveNodes {
             return PointerNodes.getPointer(pointer).getLongLong(offset);
         }
 
+        @TruffleBoundary
         @Specialization(guards = "type == TYPE_STRING")
         public RubyBasicObject getAtOffsetString(RubyBasicObject pointer, int offset, int type) {
             return createString(PointerNodes.getPointer(pointer).getString(offset));
@@ -304,6 +306,7 @@ public abstract class PointerPrimitiveNodes {
             return StringNodes.createEmptyString(getContext().getCoreLibrary().getStringClass());
         }
 
+        @TruffleBoundary
         @Specialization(guards = "!isNullPointer(pointer)")
         public RubyBasicObject readStringToNull(RubyBasicObject pointer) {
             return createString(MemoryIO.getInstance().getZeroTerminatedByteArray(PointerNodes.getPointer(pointer).address()));

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/PosixNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/PosixNodes.java
@@ -858,6 +858,7 @@ public abstract class PosixNodes {
             return getaddrinfoString(createString("0.0.0.0"), serviceName, hintsPointer, resultsPointer);
         }
 
+        @CompilerDirectives.TruffleBoundary
         @Specialization(guards = {"isRubyString(hostName)", "isRubyString(serviceName)", "isRubyPointer(hintsPointer)", "isRubyPointer(resultsPointer)"})
         public int getaddrinfoString(RubyBasicObject hostName, RubyBasicObject serviceName, RubyBasicObject hintsPointer, RubyBasicObject resultsPointer) {
             return nativeSockets().getaddrinfo(
@@ -867,6 +868,7 @@ public abstract class PosixNodes {
                     PointerNodes.getPointer(resultsPointer));
         }
 
+        @CompilerDirectives.TruffleBoundary
         @Specialization(guards = {"isRubyString(hostName)", "isNil(serviceName)", "isRubyPointer(hintsPointer)", "isRubyPointer(resultsPointer)"})
         public int getaddrinfo(RubyBasicObject hostName, RubyBasicObject serviceName, RubyBasicObject hintsPointer, RubyBasicObject resultsPointer) {
             return nativeSockets().getaddrinfo(
@@ -885,6 +887,7 @@ public abstract class PosixNodes {
             super(context, sourceSection);
         }
 
+        @CompilerDirectives.TruffleBoundary
         @Specialization(guards = "isRubyPointer(address)")
         public int connect(int socket, RubyBasicObject address, int address_len) {
             return nativeSockets().connect(socket, PointerNodes.getPointer(address), address_len);
@@ -899,6 +902,7 @@ public abstract class PosixNodes {
             super(context, sourceSection);
         }
 
+        @CompilerDirectives.TruffleBoundary
         @Specialization(guards = "isRubyPointer(addrInfo)")
         public RubyBasicObject freeaddrinfo(RubyBasicObject addrInfo) {
             nativeSockets().freeaddrinfo(PointerNodes.getPointer(addrInfo));
@@ -914,6 +918,7 @@ public abstract class PosixNodes {
             super(context, sourceSection);
         }
 
+        @CompilerDirectives.TruffleBoundary
         @Specialization(guards = {"isRubyPointer(sa)", "isRubyPointer(host)", "isRubyPointer(serv)"})
         public int getnameinfo(RubyBasicObject sa, int salen, RubyBasicObject host, int hostlen, RubyBasicObject serv, int servlen, int flags) {
             return nativeSockets().getnameinfo(
@@ -935,6 +940,7 @@ public abstract class PosixNodes {
             super(context, sourceSection);
         }
 
+        @CompilerDirectives.TruffleBoundary
         @Specialization
         public int getnameinfo(int domain, int type, int protocol) {
             return nativeSockets().socket(domain, type, protocol);
@@ -949,6 +955,7 @@ public abstract class PosixNodes {
             super(context, sourceSection);
         }
 
+        @CompilerDirectives.TruffleBoundary
         @Specialization(guards = "isRubyPointer(optionValue)")
         public int setsockopt(int socket, int level, int optionName, RubyBasicObject optionValue, int optionLength) {
             return nativeSockets().setsockopt(socket, level, optionName, PointerNodes.getPointer(optionValue), optionLength);
@@ -963,6 +970,7 @@ public abstract class PosixNodes {
             super(context, sourceSection);
         }
 
+        @CompilerDirectives.TruffleBoundary
         @Specialization(guards = "isRubyPointer(address)")
         public int bind(int socket, RubyBasicObject address, int addressLength) {
             return nativeSockets().bind(socket, PointerNodes.getPointer(address), addressLength);
@@ -977,6 +985,7 @@ public abstract class PosixNodes {
             super(context, sourceSection);
         }
 
+        @CompilerDirectives.TruffleBoundary
         @Specialization
         public int listen(int socket, int backlog) {
             return nativeSockets().listen(socket, backlog);
@@ -991,6 +1000,7 @@ public abstract class PosixNodes {
             super(context, sourceSection);
         }
 
+        @CompilerDirectives.TruffleBoundary
         @Specialization(guards = "isRubyPointer(name)")
         public int getHostName(RubyBasicObject name, int nameLength) {
             return nativeSockets().gethostname(PointerNodes.getPointer(name), nameLength);
@@ -1005,6 +1015,7 @@ public abstract class PosixNodes {
             super(context, sourceSection);
         }
 
+        @CompilerDirectives.TruffleBoundary
         @Specialization(guards = {"isRubyPointer(address)", "isRubyPointer(addressLength)"})
         public int getPeerName(int socket, RubyBasicObject address, RubyBasicObject addressLength) {
             return nativeSockets().getpeername(socket, PointerNodes.getPointer(address), PointerNodes.getPointer(addressLength));
@@ -1019,6 +1030,7 @@ public abstract class PosixNodes {
             super(context, sourceSection);
         }
 
+        @CompilerDirectives.TruffleBoundary
         @Specialization(guards = {"isRubyPointer(address)", "isRubyPointer(addressLength)"})
         public int getSockName(int socket, RubyBasicObject address, RubyBasicObject addressLength) {
             return nativeSockets().getsockname(socket, PointerNodes.getPointer(address), PointerNodes.getPointer(addressLength));

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/RubiniusLastStringReadNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/RubiniusLastStringReadNode.java
@@ -10,6 +10,7 @@
 
 package org.jruby.truffle.nodes.rubinius;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.frame.*;
 import com.oracle.truffle.api.source.SourceSection;
 import org.jruby.truffle.nodes.RubyNode;
@@ -32,9 +33,14 @@ public class RubiniusLastStringReadNode extends RubyNode {
         final FrameSlot slot = callerFrame.getFrameDescriptor().findFrameSlot("$_");
         try {
             final ThreadLocalObject threadLocalObject = (ThreadLocalObject) callerFrame.getObject(slot);
-            return threadLocalObject.get();
+            return getThreadLocal(threadLocalObject);
         } catch (FrameSlotTypeException e) {
             throw new UnsupportedOperationException(e);
         }
+    }
+
+    @TruffleBoundary
+    private static Object getThreadLocal(ThreadLocalObject threadLocalObject) {
+        return threadLocalObject.get();
     }
 }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/StatPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/StatPrimitiveNodes.java
@@ -9,6 +9,7 @@
  */
 package org.jruby.truffle.nodes.rubinius;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.object.HiddenKey;
@@ -165,6 +166,7 @@ public abstract class StatPrimitiveNodes {
             writeStatNode = new WriteHeadObjectFieldNode(STAT_IDENTIFIER);
         }
 
+        @TruffleBoundary
         @Specialization(guards = "isRubyString(path)")
         public int stat(RubyBasicObject rubyStat, RubyBasicObject path) {
             final FileStat stat = posix().allocateStat();
@@ -196,6 +198,7 @@ public abstract class StatPrimitiveNodes {
             writeStatNode = new WriteHeadObjectFieldNode(STAT_IDENTIFIER);
         }
 
+        @TruffleBoundary
         @Specialization
         public int fstat(RubyBasicObject rubyStat, int fd) {
             final FileStat stat = posix().allocateStat();
@@ -220,6 +223,7 @@ public abstract class StatPrimitiveNodes {
             writeStatNode = new WriteHeadObjectFieldNode(STAT_IDENTIFIER);
         }
 
+        @TruffleBoundary
         @Specialization(guards = "isRubyString(path)")
         public int lstat(RubyBasicObject rubyStat, RubyBasicObject path) {
             final FileStat stat = posix().allocateStat();

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/StringPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/StringPrimitiveNodes.java
@@ -590,6 +590,7 @@ public abstract class StringPrimitiveNodes {
             super(context, sourceSection);
         }
 
+        @TruffleBoundary
         @Specialization
         public Object stringToF(RubyBasicObject string) {
             try {

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/TimePrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/TimePrimitiveNodes.java
@@ -299,6 +299,7 @@ public abstract class TimePrimitiveNodes {
             super(context, sourceSection);
         }
 
+        @TruffleBoundary
         @Specialization
         public long timeSetNSeconds(RubyBasicObject time, int nanoseconds) {
             TimeNodes.setDateTime(time, TimeNodes.getDateTime(time).withMillisOfSecond(nanoseconds / 1_000_000));

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/VMPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/VMPrimitiveNodes.java
@@ -339,6 +339,7 @@ public abstract class VMPrimitiveNodes {
             super(context, sourceSection);
         }
 
+        @TruffleBoundary
         @Specialization
         public RubyBasicObject times() {
             // Copied from org/jruby/RubyProcess.java - see copyright and license information there

--- a/truffle/src/main/java/org/jruby/truffle/runtime/subsystems/ThreadManager.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/subsystems/ThreadManager.java
@@ -95,6 +95,7 @@ public class ThreadManager {
         currentThread.set(thread);
     }
 
+    @TruffleBoundary
     public RubyBasicObject getCurrentThread() {
         return currentThread.get();
     }

--- a/truffle/src/main/java/org/jruby/truffle/translator/DeadNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/translator/DeadNode.java
@@ -9,6 +9,7 @@
  */
 package org.jruby.truffle.translator;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.source.SourceSection;
 import org.jruby.truffle.nodes.RubyNode;
@@ -29,6 +30,11 @@ public class DeadNode extends RubyNode {
 
     @Override
     public Object execute(VirtualFrame frame) {
-        throw new UnsupportedOperationException(reason);
+        throw exception();
+    }
+
+    @TruffleBoundary
+    private RuntimeException exception() {
+        return new UnsupportedOperationException(reason);
     }
 }


### PR DESCRIPTION
This pull request lowers the number of methods available for runtime
compilation from over 33,000 to less than 15,000. Some methods that
could not be annotated with TruffleBoundary were split in order to
introduce a boundary.

I used a static analysis tool to determine what methods were causing a large number of other methods to be included for runtime compilation and added Truffle boundaries to limit this. 