### PR TITLE
Fix an embedded runtime memory leak in Java7ClassValue

### DIFF
--- a/core/src/main/java/org/jruby/util/collections/Java7ClassValue.java
+++ b/core/src/main/java/org/jruby/util/collections/Java7ClassValue.java
@@ -1,5 +1,9 @@
 package org.jruby.util.collections;
 
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A proxy cache that uses Java 7's ClassValue.
  */
@@ -10,13 +14,27 @@ public class Java7ClassValue<T> extends ClassValue<T> {
     }
 
     public T get(Class cls) {
-        return proxy.get(cls);
+        // We don't check for null on the WeakReference since the
+        // value is strongly referenced by proxy's list
+        return proxy.get(cls).get();
     }
 
-    private final java.lang.ClassValue<T> proxy = new java.lang.ClassValue<T>() {
+    // If we put any objects that reference an org.jruby.Ruby runtime
+    // (like RubyClass instances) in here we run into a circular
+    // reference situation that GC isn't handling where they will
+    // always be strongly referenced and never garbage collected. We
+    // break that by holding the computed values with a WeakReference.
+    private final java.lang.ClassValue<WeakReference<T>> proxy = new java.lang.ClassValue<WeakReference<T>>() {
+        // Strongly reference all computed values so they don't get
+        // garbage collected until this Java7ClassValue instance goes
+        // out of scope
+        private final List<T> values = new ArrayList<T>();
+
         @Override
-        protected T computeValue(Class<?> type) {
-            return calculator.computeValue(type);
+        protected WeakReference<T> computeValue(Class<?> type) {
+            T value = calculator.computeValue(type);
+            values.add(value);
+            return new WeakReference(value);
         }
     };
 }

--- a/spec/regression/embedded_runtime_leak_spec.rb
+++ b/spec/regression/embedded_runtime_leak_spec.rb
@@ -1,0 +1,18 @@
+describe "embedded runtimes" do
+  it "should not leak runtimes after tearing them down" do
+    num_runtimes = 10
+    mbean = java.lang.management.ManagementFactory.getMemoryMXBean
+    num_runtimes.times do
+      instance = org.jruby.Ruby.newInstance
+      instance.evalScriptlet <<-EOS
+        # eat up some memory in each runtime
+        $arr = 500000.times.map { |i| "foobarbaz\#{i}" }
+      EOS
+      instance.tearDown(false)
+      # Make sure GC can keep up
+      while mbean.getObjectPendingFinalizationCount > 0
+        sleep 0.2
+      end
+    end.should_not raise_error
+  end
+end


### PR DESCRIPTION
Commit 09f15f902ee14a848387b9f126cb731941a0a8be enabled the
Java7ClassValue implementation by default which exposed a runtime
memory leak in the embedded use case. This fixes that leak by wrapping
values stored in the java.lang.ClassValue instance with a
WeakReference.