### PR TITLE
Remove the requirement for varargs when generating Class objects

### DIFF
--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -1391,7 +1391,7 @@ public class RubyClass extends RubyModule {
                 switch (methodEntry.getValue().getArity().getValue()) {
                 case 0:
                     signature = sig(IRubyObject.class);
-                    m = new SkinnyMethodAdapter(cw, ACC_PUBLIC | ACC_VARARGS, javaMethodName, signature, null, null);
+                    m = new SkinnyMethodAdapter(cw, ACC_PUBLIC, javaMethodName, signature, null, null);
                     generateMethodAnnotations(methodAnnos, m, parameterAnnos);
 
                     m.aload(0);
@@ -1426,7 +1426,7 @@ public class RubyClass extends RubyModule {
                 int rubyIndex = baseIndex;
 
                 signature = sig(methodSignature[0], params);
-                m = new SkinnyMethodAdapter(cw, ACC_PUBLIC | ACC_VARARGS, javaMethodName, signature, null, null);
+                m = new SkinnyMethodAdapter(cw, ACC_PUBLIC, javaMethodName, signature, null, null);
                 generateMethodAnnotations(methodAnnos, m, parameterAnnos);
 
                 m.getstatic(javaPath, "ruby", ci(Ruby.class));


### PR DESCRIPTION
This is effectively a patch written by @headius and tested locally and applied
by me. In my use-case this allows Java code to properly reflect back into a
Ruby-generated Class and invoke a method which takes no arguments.

Fixes #3206