### PR TITLE
Fix Digest bubblebabble incorrect output on empty string

### DIFF
--- a/core/src/main/java/org/jruby/ext/digest/BubbleBabble.java
+++ b/core/src/main/java/org/jruby/ext/digest/BubbleBabble.java
@@ -65,6 +65,13 @@ public class BubbleBabble {
                             ((((int) (message[begin + 2 * i])) * 7) +
                                     ((int) (message[begin + (2 * i) + 1])))) % 36;
                 }
+            } else {
+                idx0 = seed % 6;
+                idx1 = 16;
+                idx2 = seed / 6;
+                retval.append(vowels[idx0]);
+                retval.append(consonants[idx1]);
+                retval.append(vowels[idx2]);
             }
         }
         retval.append('x');


### PR DESCRIPTION
Hey guys

Before:
```
bin/jruby -rdigest -e "p Digest.bubblebabble ''"
"xx"
```

After:
```
bin/jruby -rdigest -e "p Digest.bubblebabble ''"
"xexax"
```

MRI:

```
ruby -rdigest/bubblebabble -e "p Digest.bubblebabble ''"
"xexax"
```

and http://web.mit.edu/kenta/www/one/bubblebabble/spec/jrtrjwzi/draft-huima-01.txt

> Test Vectors
>
>   ASCII Input       Encoding
>   ------------------------------------------------------------------
>   `' (empty string) `xexax'

Fixes #2956 