### PR TITLE
[Truffle] Updating to most recent version of Truffle API. Compiles, but does no…

### DIFF
--- a/truffle/pom.rb
+++ b/truffle/pom.rb
@@ -15,10 +15,10 @@ project 'JRuby Truffle' do
   repository( :url => 'http://lafo.ssw.uni-linz.ac.at/nexus/content/repositories/snapshots/',
               :id => 'truffle' )
 
-  truffle_version = '0.9-09531c471176ec637e92d3279ece721dd83b8868-SNAPSHOT'
-  jar 'com.oracle:truffle-api:' + truffle_version
-  jar 'com.oracle:truffle-dsl-processor:' + truffle_version, :scope => 'provided'
-  jar 'com.oracle:truffle-tck:' + truffle_version, :scope => 'test'
+  truffle_version = '60f3cb2c3a567e53c58e955486b64c7993bb2765-SNAPSHOT'
+  jar 'com.oracle.truffle:truffle-api:' + truffle_version
+  jar 'com.oracle.truffle:truffle-dsl-processor:' + truffle_version, :scope => 'provided'
+  jar 'com.oracle.truffle:truffle-tck:' + truffle_version, :scope => 'test'
   jar 'junit:junit', :scope => 'test'
 
   plugin( :compiler,

--- a/truffle/pom.xml
+++ b/truffle/pom.xml
@@ -29,20 +29,20 @@ DO NOT MODIFIY - GENERATED CODE
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.oracle</groupId>
+      <groupId>com.oracle.truffle</groupId>
       <artifactId>truffle-api</artifactId>
-      <version>0.9-09531c471176ec637e92d3279ece721dd83b8868-SNAPSHOT</version>
+      <version>60f3cb2c3a567e53c58e955486b64c7993bb2765-SNAPSHOT</version>
     </dependency>
     <dependency>
-      <groupId>com.oracle</groupId>
+      <groupId>com.oracle.truffle</groupId>
       <artifactId>truffle-dsl-processor</artifactId>
-      <version>0.9-09531c471176ec637e92d3279ece721dd83b8868-SNAPSHOT</version>
+      <version>60f3cb2c3a567e53c58e955486b64c7993bb2765-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.oracle</groupId>
+      <groupId>com.oracle.truffle</groupId>
       <artifactId>truffle-tck</artifactId>
-      <version>0.9-09531c471176ec637e92d3279ece721dd83b8868-SNAPSHOT</version>
+      <version>60f3cb2c3a567e53c58e955486b64c7993bb2765-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/truffle/src/main/java/org/jruby/truffle/runtime/RubyLanguage.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/RubyLanguage.java
@@ -9,43 +9,42 @@
  */
 package org.jruby.truffle.runtime;
 
+import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.debug.DebugSupportProvider;
 import com.oracle.truffle.api.instrument.ToolSupportProvider;
+import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.Source;
 
 import java.io.IOException;
 import org.jruby.Ruby;
 import org.jruby.runtime.Constants;
-import org.jruby.truffle.runtime.core.RubyBasicObject;
 
 @TruffleLanguage.Registration(name = "Ruby", version = Constants.RUBY_VERSION, mimeType = "application/x-ruby")
-public class RubyLanguage extends TruffleLanguage {
+public class RubyLanguage extends TruffleLanguage<RubyContext> {
+    private RubyLanguage() {
+    }
 
-    private final RubyContext context;
+    public static final RubyLanguage INSTANCE = new RubyLanguage();
 
-    public RubyLanguage(Env env) {
-        super(env);
+    @Override
+    public RubyContext createContext(Env env) {
         Ruby r = Ruby.newInstance();
-        this.context = new RubyContext(r, env);
+        return new RubyContext(r, env);
     }
 
     @Override
-    protected Object eval(Source source) throws IOException {
-        try {
-            return context.eval(source);
-        } catch (Exception e) {
-            throw new IOException(e);
-        }
+    protected CallTarget parse(Source source, Node node, String... strings) throws IOException {
+        throw new IOException();
     }
 
     @Override
-    protected Object findExportedSymbol(String s, boolean b) {
+    protected Object findExportedSymbol(RubyContext context, String s, boolean b) {
         return context.findExportedObject(s);
     }
 
     @Override
-    protected Object getLanguageGlobal() {
+    protected Object getLanguageGlobal(RubyContext context) {
         return context.getCoreLibrary().getObjectClass();
     }
 

--- a/truffle/src/test/java/org/jruby/truffle/tck/RubyTckTest.java
+++ b/truffle/src/test/java/org/jruby/truffle/tck/RubyTckTest.java
@@ -77,5 +77,10 @@ public class RubyTckTest extends TruffleTCK {
     protected String invalidCode() {
         return "def something\n  ret urn 4.2\ne n d";
     }
+
+    @Override
+    protected String countInvocations() {
+        throw new UnsupportedOperationException();
+    }
     
 }


### PR DESCRIPTION
…t implement TruffleLanguage.parse yet. 

Here are the syntactic changes needed to update to new version of Truffle API. However the bigger change is the *parse* method - it is supposed to be context-less - I have no idea how to implement it properly, the parsing seems to require reference to context right now.