### PR TITLE
Fix homepage of jruby-jars.gemspec

### DIFF
--- a/maven/jruby-jars/jruby-jars.gemspec
+++ b/maven/jruby-jars/jruby-jars.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.authors = ['Charles Oliver Nutter']
   s.email = 'headius@headius.com'
   s.summary = 'The core JRuby code and the JRuby stdlib as jar files.'
-  s.homepage = 'http://github.com/jruby/jruby/tree/master/gem/jruby-jars'
+  s.homepage = 'https://github.com/jruby/jruby/tree/master/maven/jruby-jars'
   s.description = File.read('README.txt', encoding: 'UTF-8').split(/\n{2,}/)[3]
   s.rubyforge_project = 'jruby/jruby'
   s.licenses = %w(EPL-1.0 GPL-2.0 LGPL-2.1)


### PR DESCRIPTION
"Homepage" link shown at https://rubygems.org/gems/jruby-jars is 404 Not Found.