### PR TITLE
Resolves broken spec when `ANT_HOME` is set

### DIFF
--- a/spec/java_integration/ant/ant_spec.rb
+++ b/spec/java_integration/ant/ant_spec.rb
@@ -135,7 +135,7 @@ describe Ant, '.ant' do
     if ENV['ANT_HOME']
       hide_ant_from_path
       expect { Ant.ant(:basedir => File.join(File.dirname(__FILE__), '..', '..', '..')) }.
-        to raise_error
+        to_not raise_error
     else
       skip '$ANT_HOME is not set'
     end


### PR DESCRIPTION
The changes in 55f56c9 were not equivalent. Le sigh.