### PR TITLE
[Truffle] Allow for lazy parsing

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/translator/MethodTranslator.java
+++ b/truffle/src/main/java/org/jruby/truffle/translator/MethodTranslator.java
@@ -42,7 +42,7 @@ import org.jruby.truffle.runtime.RubyContext;
 import org.jruby.truffle.runtime.methods.Arity;
 import org.jruby.truffle.runtime.methods.SharedMethodInfo;
 
-class MethodTranslator extends BodyTranslator {
+public class MethodTranslator extends BodyTranslator {
 
     private final org.jruby.ast.ArgsNode argsNode;
     private boolean isBlock;

--- a/truffle/src/main/java/org/jruby/truffle/translator/MethodTranslator.java
+++ b/truffle/src/main/java/org/jruby/truffle/translator/MethodTranslator.java
@@ -156,7 +156,16 @@ class MethodTranslator extends BodyTranslator {
         return body;
     }
 
-    public MethodDefinitionNode compileMethodNode(SourceSection sourceSection, String methodName, org.jruby.ast.Node bodyNode, SharedMethodInfo sharedMethodInfo) {
+    /*
+     * This method exists solely to be substituted to support lazy
+     * method parsing. The substitution returns a node which performs
+     * the parsing lazily and then calls doCompileMethodBody.
+     */
+    public RubyNode compileMethodBody(SourceSection sourceSection, String methodName, org.jruby.ast.Node bodyNode, SharedMethodInfo sharedMethodInfo) {
+        return doCompileMethodBody(sourceSection, methodName, bodyNode, sharedMethodInfo);
+    }
+
+    public RubyNode doCompileMethodBody(SourceSection sourceSection, String methodName, org.jruby.ast.Node bodyNode, SharedMethodInfo sharedMethodInfo) {
         final ParameterCollector parameterCollector = declareArguments(sourceSection, methodName, sharedMethodInfo);
         final Arity arity = getArity(argsNode);
 
@@ -194,7 +203,11 @@ class MethodTranslator extends BodyTranslator {
 
         // TODO(CS, 10-Jan-15) why do we only translate exceptions in methods and not blocks?
         body = new ExceptionTranslatingNode(context, sourceSection, body);
+        return body;
+    }
 
+    public MethodDefinitionNode compileMethodNode(SourceSection sourceSection, String methodName, org.jruby.ast.Node bodyNode, SharedMethodInfo sharedMethodInfo) {
+        final RubyNode body = compileMethodBody(sourceSection,  methodName, bodyNode, sharedMethodInfo);
         final RubyRootNode rootNode = new RubyRootNode(
                 context, sourceSection, environment.getFrameDescriptor(), environment.getSharedMethodInfo(), body, environment.needsDeclarationFrame());
 


### PR DESCRIPTION
These changes make it possible to lazily parse methods in ahead of time compiled images. During image generation method bodies are elided from the core source files and stored in a separate data structure. When the file is initially parsed, the method body is replaced with a node to perform the lazy parsing. When this node is executed, it performs the parsing and then replaces itself with the code of the method.