### PR TITLE
[Truffle] Canonicalize input file name

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/runtime/RubyContext.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/RubyContext.java
@@ -641,13 +641,12 @@ public class RubyContext extends ExecutionContext implements TruffleContextInter
 
         String inputFile = rootNode.getPosition().getFile();
 
-        if (!inputFile.equals("-e")) {
-            inputFile = new File(inputFile).getAbsolutePath();
-        }
-
         final Source source;
 
         try {
+            if (!inputFile.equals("-e")) {
+                inputFile = new File(inputFile).getCanonicalPath();
+            }
             source = sourceCache.getSource(inputFile);
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Currently, if the input file name is something like "./hello.rb", the assertion at https://github.com/jruby/jruby/blob/master/truffle/src/main/java/org/jruby/truffle/runtime/loader/SourceLoader.java#L37 will fail. Getting the canonical name for the file fixes this.