### PR TITLE
[Truffle] Shim to make it easier to use bundler.

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/CoreLibrary.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/CoreLibrary.java
@@ -586,6 +586,7 @@ public class CoreLibrary {
         Layouts.MODULE.getFields(objectClass).setConstant(node, "RUBY_PATCHLEVEL", 0);
         Layouts.MODULE.getFields(objectClass).setConstant(node, "RUBY_REVISION", Constants.RUBY_REVISION);
         Layouts.MODULE.getFields(objectClass).setConstant(node, "RUBY_ENGINE", Layouts.STRING.createString(Layouts.CLASS.getInstanceFactory(stringClass), RubyString.encodeBytelist(Constants.ENGINE + "+truffle", UTF8Encoding.INSTANCE), StringSupport.CR_UNKNOWN, null));
+        Layouts.MODULE.getFields(objectClass).setConstant(node, "JRUBY_ENGINE", Layouts.STRING.createString(Layouts.CLASS.getInstanceFactory(stringClass), RubyString.encodeBytelist(Constants.ENGINE, UTF8Encoding.INSTANCE), StringSupport.CR_UNKNOWN, null));
         Layouts.MODULE.getFields(objectClass).setConstant(node, "RUBY_PLATFORM", Layouts.STRING.createString(Layouts.CLASS.getInstanceFactory(stringClass), RubyString.encodeBytelist(Constants.PLATFORM, UTF8Encoding.INSTANCE), StringSupport.CR_UNKNOWN, null));
         Layouts.MODULE.getFields(objectClass).setConstant(node, "RUBY_RELEASE_DATE", Layouts.STRING.createString(Layouts.CLASS.getInstanceFactory(stringClass), RubyString.encodeBytelist(Constants.COMPILE_DATE, UTF8Encoding.INSTANCE), StringSupport.CR_UNKNOWN, null));
         Layouts.MODULE.getFields(objectClass).setConstant(node, "RUBY_DESCRIPTION", Layouts.STRING.createString(Layouts.CLASS.getInstanceFactory(stringClass), RubyString.encodeBytelist(OutputStrings.getVersionString(), UTF8Encoding.INSTANCE), StringSupport.CR_UNKNOWN, null));


### PR DESCRIPTION
@nirvdrum had a script to run bundler with JRuby and then patch up the files it produced to let us use that. This shim simplifies that. For example you can now do:

```
$ bundler install --standalone --path vendor
$ bin/jruby -X+T -r ./vendor/bundler/setup.rb app.rb
```

This is something that we could start suggesting people try out on their own apps at some point soon.

I was also thinking about taking this a couple of steps further. Can we autodetect and run that `setup.rb`? Can we provide a command bin/truffle-bundle that then lets you do just:

```
$ bin/truffle-bundle
$ bin/jruby -X+T app.rb
```

@nirvdrum @pitr-ch @eregon please comment