### PR TITLE
get zone from RubyTime (fixes #3303)

### DIFF
--- a/core/src/main/java/org/jruby/util/RubyDateFormatter.java
+++ b/core/src/main/java/org/jruby/util/RubyDateFormatter.java
@@ -51,6 +51,7 @@ import org.joda.time.chrono.GJChronology;
 import org.joda.time.chrono.JulianChronology;
 import org.jruby.RubyEncoding;
 import org.jruby.RubyString;
+import org.jruby.RubyTime;
 import org.jruby.lexer.StrftimeLexer;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -487,7 +488,7 @@ public class RubyDateFormatter {
                     output = formatZone(colons, (int) value, formatter);
                     break;
                 case FORMAT_ZONE_ID:
-                    output = dt.getZone().getShortName(dt.getMillis());
+                    output = RubyTime.newTime(context.runtime, dt).zone().asJavaString();
                     break;
                 case FORMAT_CENTURY:
                     type = NUMERIC;


### PR DESCRIPTION
According to the spec `spec/ruby/core/time/strftime_spec.rb` *"%Z"* and *RubyTime#zone* should behave the same:
```ruby
  it "returns the timezone with %Z" do
    time = Time.local(2009, 9, 18, 12, 0, 0)
    zone = time.zone
    time.strftime("%Z").should == zone
  end
```

This fixes #3303 by calling *RubyTime#zone* directly.