### PR TITLE
return UTC instead of GMT (fixes #3304)

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -896,13 +896,13 @@ public class RubyTime extends RubyObject {
             int hourOffset  = Integer.valueOf(offsetMatcher.group(2));
 
             if (zone.equals("+00:00")) {
-                zone = "GMT";
+                zone = "UTC";
             } else {
                 // try non-localized time zone name
                 zone = dt.getZone().getNameKey(dt.getMillis());
                 if (zone == null) {
                     char sign = minus_p ? '+' : '-';
-                    zone = "GMT" + sign + hourOffset;
+                    zone = "UTC" + sign + hourOffset;
                 }
             }
         }


### PR DESCRIPTION
As per Ruby's Time#zone [1] UTC should be used instead of GMT
since Ruby 1.8. The spec also expects UTC. 

spec/ruby/core/time/zone_spec.rb:
```ruby
  it "returns UTC when called on a UTC time" do
    Time.now.utc.zone.should == "UTC"
  end
```
This also fixes #3304.

[1] http://ruby-doc.org/core-2.2.3/Time.html#method-i-zone