### PR TITLE
[Truffle] Complain when running with an incompatible Graal version.

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/runtime/RubyContext.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/RubyContext.java
@@ -119,6 +119,13 @@ public class RubyContext extends ExecutionContext implements TruffleContextInter
 
         assert runtime != null;
 
+        String graalVersion = System.getProperty("graal.version", "unknown");
+        if (!graalVersion.equals("unknown") && !graalVersion.equals("0.7")) {
+            final String message = "When using Graal, you must use version 0.7 (found " + graalVersion + ")";
+            System.out.println(message + "\n");
+            throw new UnsupportedOperationException(message);
+        }
+
         compilerOptions = Truffle.getRuntime().createCompilerOptions();
 
         if (compilerOptions.supportsOption("MinTimeThreshold")) {


### PR DESCRIPTION
@chrisseaton What should we do?

In the particular case of 0.8, there was no warning before this, and the program would run like on a stock JDK (because truffle is not on the bootclasspath I suppose).

We should probably also make the requirement of Graal 0.7 clearer in the wiki/README.