### PR TITLE
"[2].to_enum.find_index(2.0)" returns 0 (to match MRI behavior)

### DIFF
--- a/core/src/main/java/org/jruby/RubyFixnum.java
+++ b/core/src/main/java/org/jruby/RubyFixnum.java
@@ -269,6 +269,8 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
             if (num.value == value) {
                 return true;
             }
+        } else if (other instanceof RubyFloat) {
+            return (double)value == ((RubyFloat) other).getDoubleValue();
         }
         
         return false;

--- a/spec/ruby/core/enumerable/find_index_spec.rb
+++ b/spec/ruby/core/enumerable/find_index_spec.rb
@@ -48,6 +48,11 @@ describe "Enumerable#find_index" do
     @numerous.find_index.should be_an_instance_of(enumerator_class)
   end
 
+  it "uses #== for testing equality" do
+    [2].to_enum.find_index(2.0).should == 0
+    [2.0].to_enum.find_index(2).should == 0
+  end
+
   describe "without block" do
     it "gathers whole arrays as elements when each yields multiple" do
       @yieldsmixed.find_index([0, 1, 2]).should == 3


### PR DESCRIPTION
This is a bug which I found while testing one of my gems on JRuby. Please have a look!