### PR TITLE
remove support for aliasing Java indexed getters as Ruby readers

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/binding/Initializer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/Initializer.java
@@ -182,9 +182,7 @@ public abstract class Initializer {
             if (javaPropertyName != null) {
                 if (rubyCasedName.startsWith("get_")) {
                     rubyPropertyName = rubyCasedName.substring(4);
-                    if (argCount == 0 ||                                // getFoo      => foo
-                            argCount == 1 && argTypes[0] == int.class) {    // getFoo(int) => foo(int)
-
+                    if (argCount == 0) {                                // getFoo      => foo
                         addUnassignedAlias(javaPropertyName, assignedNames, installer);
                         addUnassignedAlias(rubyPropertyName, assignedNames, installer);
                     }
@@ -207,8 +205,7 @@ public abstract class Initializer {
             if (resultType == boolean.class) {
                 // is_something?, contains_thing?
                 addUnassignedAlias(rubyCasedName + '?', assignedNames, installer);
-                if (rubyPropertyName != null) {
-                    // something?
+                if (rubyPropertyName != null) { // something?
                     addUnassignedAlias(rubyPropertyName + '?', assignedNames, installer);
                 }
             }

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -1359,6 +1359,16 @@ CLASSDEF
     end
   end
 
+  # GH-3262
+  def test_indexed_bean_style_accessors_are_not_aliased
+    # ArgumentError: wrong number of arguments (0 for 1)
+    assert java.lang.Character.name
+    java.lang.Character.getName(42) # nothing raised
+    assert_raises(ArgumentError) do
+      java.lang.Character.name(42) # `getName(int)' NOT mapped to `name(i)'
+    end
+  end
+
   def test_no_warnings_on_concurrent_package_const_initialization
     output = with_stderr_captured do
       threads = (0..10).map do # smt not yet initialized :


### PR DESCRIPTION
fixes #3262 ... its a non-backward compatible change thus fired up here to decide