### PR TITLE
Fix java_implements for multiple interfaces

### DIFF
--- a/lib/ruby/stdlib/jruby/compiler/java_class.rb
+++ b/lib/ruby/stdlib/jruby/compiler/java_class.rb
@@ -374,7 +374,7 @@ module JRuby::Compiler
 
     def interface_string
       if @interfaces.size > 0
-        "implements " + @interfaces.join('.')
+        "implements " + @interfaces.join(', ')
       else
         ""
       end

--- a/spec/jrubyc/java/implements_spec.rb
+++ b/spec/jrubyc/java/implements_spec.rb
@@ -17,7 +17,7 @@ describe "A Ruby class generating a Java stub" do
       cls.interfaces[0].should == "Runnable"
 
       java = cls.to_s
-      java.should match /public class Foo implements Runnable/
+      java.should match /^public class Foo extends RubyObject implements Runnable/
 
       cls = generate("class Foo; java_implements 'Runnable', 'Serializable'; end").classes[0]
 
@@ -26,7 +26,7 @@ describe "A Ruby class generating a Java stub" do
       cls.interfaces[1].should == "Serializable"
 
       java = cls.to_s
-      java.should match /public class Foo implements Runnable, Serializable/
+      java.should match /^public class Foo extends RubyObject implements Runnable, Serializable/
     end
   end
 end


### PR DESCRIPTION
Matching fix for ##3329 for the 9.x master branch.

Using multiple interfaces with java_implements is broken, and the specs that tests for this are also broken. This fixes it.

It also appears that many of the jrubyc specs are broken enough though they pass. Those are not fixed here. In general, it appears the specs attempt to do a regexp match against the generated Java code, but the tests pass not because the generated code is correct, but because the generated code includes a copy of the spec source code in the `source` variable. Thus, the regexp is matching itself and not the generated Java code.

It would appear that the call to `JRuby::Compiler::JavaGenerator.generate_java` results in the whole spec being included in the `source` variable rather than just the source for the Ruby code being compiled to Java.

E.g.
```
public class Foo extends RubyObject implements Runnable {
    private static final Ruby __ruby__ = Ruby.getGlobalRuntime();
    private static final RubyClass __metaclass__;

    static {
        String source = new StringBuilder("require File.dirname(__FILE__) + \"/../../spec_helper\"\n" +
            "require 'jruby'\n" +
            "require 'jruby/compiler'\n" +
            "\n" +
```