### PR TITLE
Fix 3303 refactor zoneHelper into getRubyTimeZoneName

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -832,15 +832,16 @@ public class RubyTime extends RubyObject {
 
     @JRubyMethod
     public IRubyObject zone() {
-        final String zone = RubyTime.zoneHelper(getEnvTimeZone(getRuntime()).toString(), dt, isTzRelative);
-        if (zone == null) return getRuntime().getNil();
-        return getRuntime().newString(zone);
+        if (isTzRelative) return getRuntime().getNil();
+        return getRuntime().newString(RubyTime.getRubyTimeZoneName(getRuntime(), dt));
     }
 
-    public static String zoneHelper(String envTZ, DateTime dt, boolean isTzRelative) {
-        if (isTzRelative) return null;
+	public static String getRubyTimeZoneName(Ruby runtime, DateTime dt) {
+        return RubyTime.getRubyTimeZoneName(getEnvTimeZone(runtime).toString(), dt);
+	}
 
-        // see declaration of SHORT_TZNAME
+	public static String getRubyTimeZoneName(String envTZ, DateTime dt) {
+		// see declaration of SHORT_TZNAME
         if (SHORT_STD_TZNAME.containsKey(envTZ) && ! dt.getZone().toTimeZone().inDaylightTime(dt.toDate())) {
             return SHORT_STD_TZNAME.get(envTZ);
         }
@@ -870,7 +871,7 @@ public class RubyTime extends RubyObject {
         }
 
         return zone;
-    }
+	}
 
     public void setDateTime(DateTime dt) {
         this.dt = dt;

--- a/core/src/main/java/org/jruby/util/RubyDateFormatter.java
+++ b/core/src/main/java/org/jruby/util/RubyDateFormatter.java
@@ -51,6 +51,7 @@ import org.joda.time.chrono.GJChronology;
 import org.joda.time.chrono.JulianChronology;
 import org.jruby.RubyEncoding;
 import org.jruby.RubyString;
+import org.jruby.RubyTime;
 import org.jruby.lexer.StrftimeLexer;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -488,7 +489,7 @@ public class RubyDateFormatter {
                     output = formatZone(colons, (int) value, formatter);
                     break;
                 case FORMAT_ZONE_ID:
-                    output = dt.getZone().getShortName(dt.getMillis());
+                    output = RubyTime.getRubyTimeZoneName(context.runtime, dt);
                     break;
                 case FORMAT_CENTURY:
                     type = NUMERIC;

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/TimePrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/TimePrimitiveNodes.java
@@ -179,7 +179,7 @@ public abstract class TimePrimitiveNodes {
             final boolean isdst = false;
 
             final String envTimeZoneString = readTimeZoneNode.execute(frame).toString();
-            String zoneString = org.jruby.RubyTime.zoneHelper(envTimeZoneString, dateTime, false);
+            String zoneString = org.jruby.RubyTime.getRubyTimeZoneName(envTimeZoneString, dateTime);
             Object zone;
             if (zoneString.matches(".*-\\d+")) {
                 zone = nil();


### PR DESCRIPTION
In order to fix #3303 and as requested in #3309 I have extracted the zone name logic into its own method (RubyTime.getRubyTimeZoneName) and reused it in RubyDateFormatter.