### PR TITLE
Default "first" item is "true" in ProfilePrinter

### DIFF
--- a/core/src/main/java/org/jruby/runtime/profile/builtin/ProfilePrinter.java
+++ b/core/src/main/java/org/jruby/runtime/profile/builtin/ProfilePrinter.java
@@ -98,7 +98,7 @@ public abstract class ProfilePrinter {
     public void printFooter(PrintStream out) { }
     
     public void printProfile(PrintStream out) {
-        printProfile(out, false);
+        printProfile(out, true);
     }
 
     public abstract void printProfile(PrintStream out, boolean first) ;


### PR DESCRIPTION
fixes many spec:profiler errors
bacports parts of https://github.com/jruby/jruby/commit/f1eab903b967c8e6b7a0859437c9ecf5d177788d