### PR TITLE
log exception backtrace in one log record

### DIFF
--- a/core/src/main/java/org/jruby/exceptions/RaiseException.java
+++ b/core/src/main/java/org/jruby/exceptions/RaiseException.java
@@ -203,7 +203,7 @@ public class RaiseException extends JumpException {
 
         exception.prepareIntegratedBacktrace(context, javaTrace);
 
-        if (RubyInstanceConfig.LOG_EXCEPTIONS) TraceType.dumpException(exception);
+        if (RubyInstanceConfig.LOG_EXCEPTIONS) TraceType.logException(exception);
     }
 
     private void preRaise(ThreadContext context, IRubyObject backtrace) {
@@ -227,7 +227,7 @@ public class RaiseException extends JumpException {
             setStackTrace(RaiseException.javaTraceFromRubyTrace(exception.getBacktraceElements()));
         }
 
-        if (RubyInstanceConfig.LOG_EXCEPTIONS) TraceType.dumpException(exception);
+        if (RubyInstanceConfig.LOG_EXCEPTIONS) TraceType.logException(exception);
     }
 
     private static void doCallEventHook(final ThreadContext context) {

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -807,9 +807,9 @@ public final class ThreadContext {
             RubyString str = RubyString.newString(runtime, trace[i - level].mriStyleString());
             newTrace.append(str);
         }
-        
-        if (RubyInstanceConfig.LOG_CALLERS) TraceType.dumpCaller(newTrace);
-        
+
+        if (RubyInstanceConfig.LOG_CALLERS) TraceType.logCaller(newTrace);
+
         return newTrace;
     }
 
@@ -842,9 +842,9 @@ public final class ThreadContext {
         if (traceLength < 0) return null;
         
         trace = Arrays.copyOfRange(trace, level, level + traceLength);
-        
-        if (RubyInstanceConfig.LOG_CALLERS) TraceType.dumpCaller(trace);
-        
+
+        if (RubyInstanceConfig.LOG_CALLERS) TraceType.logCaller(trace);
+
         return trace;
     }
     
@@ -863,7 +863,7 @@ public final class ThreadContext {
 
         RubyStackTraceElement[] trace = gatherCallerBacktrace();
 
-        if (RubyInstanceConfig.LOG_WARNINGS) TraceType.dumpWarning(trace);
+        if (RubyInstanceConfig.LOG_WARNINGS) TraceType.logWarning(trace);
 
         return trace;
     }

--- a/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
@@ -63,10 +63,14 @@ public class TraceType {
     }
 
     public static void logBacktrace(RubyStackTraceElement[] trace) {
-        LOG.info("Backtrace generated:");
-        for (RubyStackTraceElement element : trace) {
-            LOG.info("  " + element.getFileName() + ":" + element.getLineNumber() + " in " + element.getMethodName());
+        if (trace == null) trace = RubyStackTraceElement.EMPTY_ARRAY;
+        final StringBuilder buffer = new StringBuilder(128);
+        renderBacktraceJRuby(trace, buffer, false);
+        final int len = buffer.length();
+        if ( len > 0 && buffer.charAt(len - 1) == '\n' ) {
+            buffer.setLength(len - 1); // remove last '\n'
         }
+        LOG.info("Backtrace generated:\n{}", buffer);
     }
 
     public static void dumpException(RubyException exception) {
@@ -75,7 +79,7 @@ public class TraceType {
 
     public static void dumpBacktrace(RubyException exception) {
         Ruby runtime = exception.getRuntime();
-        System.err.println("Backtrace generated:\n" + Format.JRUBY.printBacktrace(exception, runtime.getPosix().isatty(FileDescriptor.err)));
+        System.err.println("Backtrace generated:\n" + printBacktraceJRuby(exception, runtime.getPosix().isatty(FileDescriptor.err)));
     }
 
     public static void dumpCaller(RubyArray trace) {

--- a/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
@@ -73,8 +73,15 @@ public class TraceType {
         LOG.info("Backtrace generated:\n{}", buffer);
     }
 
-    public static void dumpException(RubyException exception) {
+    public static void logException(RubyException exception) {
         LOG.info("Exception raised: {} : {}", exception.getMetaClass(), exception);
+    }
+
+    /**
+     * @deprecated use {@link #logException(org.jruby.RubyException)}
+     */
+    public static void dumpException(RubyException exception) {
+        logException(exception);
     }
 
     public static void dumpBacktrace(RubyException exception) {
@@ -82,16 +89,37 @@ public class TraceType {
         System.err.println("Backtrace generated:\n" + printBacktraceJRuby(exception, runtime.getPosix().isatty(FileDescriptor.err)));
     }
 
+    public static void logCaller(RubyArray trace) {
+        LOG.info("Caller backtrace generated:\n{}", trace);
+    }
+
+    /**
+     * @deprecated use {@link #logCaller(org.jruby.RubyArray)}
+     */
     public static void dumpCaller(RubyArray trace) {
-        LOG.info("Caller backtrace generated:\n" + trace);
+        logCaller(trace);
     }
 
+    public static void logCaller(RubyStackTraceElement[] trace) {
+        LOG.info("Caller backtrace generated:\n{}", Arrays.toString(trace));
+    }
+
+    /**
+     * @deprecated use {@link #logCaller(org.jruby.runtime.backtrace.RubyStackTraceElement[]) }
+     */
     public static void dumpCaller(RubyStackTraceElement[] trace) {
-        LOG.info("Caller backtrace generated:\n" + Arrays.toString(trace));
+        logCaller(trace);
     }
 
+    public static void logWarning(RubyStackTraceElement[] trace) {
+        LOG.info("Warning backtrace generated:\n{}", Arrays.toString(trace));
+    }
+
+    /**
+     * @deprecated use {@link #logWarning(org.jruby.runtime.backtrace.RubyStackTraceElement[])
+     */
     public static void dumpWarning(RubyStackTraceElement[] trace) {
-        LOG.info("Warning backtrace generated:\n" + Arrays.toString(trace));
+        logWarning(trace);
     }
 
     public static TraceType traceTypeFor(String style) {


### PR DESCRIPTION
`jruby -Xlog.backtraces=true ...` currently logs backtraces in multiple log records, 
this can easily become an issue e.g. when multiple threads are logging backtraces at the same time.

this PR fixes the logging to produce one multi-line log item per backtrace and to use the JRuby format. seems that it could be useful for JRuby 1.7.x but in case of compatibility worries, I'm happy to target 9K only.