### PR TITLE
Removing no longer needed import of a deprecated class

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/PolyglotEngineMain.java
+++ b/truffle/src/main/java/org/jruby/truffle/PolyglotEngineMain.java
@@ -11,7 +11,6 @@ package org.jruby.truffle;
 
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.vm.PolyglotEngine;
-import com.oracle.truffle.api.vm.TruffleVM;
 import org.jruby.truffle.runtime.RubyLanguage;
 
 import java.io.*;


### PR DESCRIPTION
I've removed the TruffleVM from main development line of Truffle. Consider stop using it.