### PR TITLE
Fix GzipWriter output

### DIFF
--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
@@ -176,7 +176,25 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
         try {
             // the 15+16 here is copied from a Deflater default constructor
             Deflater deflater = new Deflater(level, 15+16, false);
-            io = new GZIPOutputStream(new IOOutputStream(realIo, false, false), deflater, 512, false);
+            final IOOutputStream ioOutputStream = new IOOutputStream(realIo, false, false) {
+                /**
+                 * Customize IOOutputStream#write(byte[], int, int) to create a defensive copy of the byte array
+                 * that GZIPOutputStream hands us.
+                 *
+                 * That byte array is a reference to one of GZIPOutputStream's internal byte buffers.
+                 * The base IOOutputStream#write(byte[], int, int) uses the bytes it is handed to back a
+                 * copy-on-write ByteList.  So, without this defensive copy, those two classes overwrite each
+                 * other's bytes, corrupting our output.
+                 */
+                @Override
+                public void write(byte[] bytes, int off, int len) throws IOException {
+                    byte[] bytesCopy = new byte[len];
+                    System.arraycopy(bytes, off, bytesCopy, 0, len);
+                    super.write(bytesCopy, off, len);
+                }
+            };
+
+            io = new GZIPOutputStream(ioOutputStream, deflater, 512, false);
             return this;
         } catch (IOException ioe) {
             throw getRuntime().newIOErrorFromException(ioe);

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
@@ -190,7 +190,7 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
                 public void write(byte[] bytes, int off, int len) throws IOException {
                     byte[] bytesCopy = new byte[len];
                     System.arraycopy(bytes, off, bytesCopy, 0, len);
-                    super.write(bytesCopy, off, len);
+                    super.write(bytesCopy, 0, len);
                 }
             };
 

--- a/spec/regression/GH-1371_gzip_spec.rb
+++ b/spec/regression/GH-1371_gzip_spec.rb
@@ -1,0 +1,41 @@
+require 'zlib'
+
+class IoLikeObject
+  attr_reader :body
+
+  def initialize
+    @body = []
+  end
+
+  def write(str)
+    @body << str
+  end
+end
+
+describe Zlib::GzipWriter do
+  GZIP_MAGIC_1 = 0x1F
+  GZIP_MAGIC_2 = 0X8B
+
+  it "doesn't corrupt the output" do
+    io_like_object = IoLikeObject.new
+    gzip = Zlib::GzipWriter.new(io_like_object)
+
+    gzip.mtime = Time.now
+    gzip.write('something')
+    gzip.flush
+
+    # save off a copy of the first chunk
+    # (NOTE: the shared buffer at the root of this bug also means we need to concat to force a true copy)
+    first_chunk = '' + io_like_object.body[0]
+    gzip.write('else')
+    gzip.flush
+
+    # first chunk should still be intact (specifically: it should not be overwritten with the second)
+    first_chunk.should == io_like_object.body[0]
+
+    gzip.close
+
+    # extra sanity check of the gzip "magic bytes"
+    io_like_object.body[0].bytes.to_a[0..1].should == [GZIP_MAGIC_1, GZIP_MAGIC_2]
+  end
+end


### PR DESCRIPTION
GZIPOutputStream was passing one of its internal byte buffers to IOOutputStream#write, which in turn used those bytes to back the ByteList for its output.  So every subsequent time GZIPOutputStream wrote to that buffer, it overwrote the bytes behind the back of all the previous chunks of output.

Ensure that IOOutputStream is working on a copy of the bytes it gets from GZIPOutputStream to fix this issue.

Fixes #1371

Let me know if there's any questions, and thanks again!