### PR TITLE
Fix Fixnum#pred overflow

### DIFF
--- a/core/src/main/java/org/jruby/RubyFixnum.java
+++ b/core/src/main/java/org/jruby/RubyFixnum.java
@@ -587,7 +587,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
     }
 
     public IRubyObject pred(ThreadContext context) {
-        return context.runtime.newFixnum(value-1);
+        return op_minus_one(context);
     }
 
     public IRubyObject idiv(ThreadContext context, IRubyObject other, String method) {

--- a/spec/tags/ruby/core/integer/pred_tags.txt
+++ b/spec/tags/ruby/core/integer/pred_tags.txt
@@ -1,1 +1,0 @@
-fails:Integer#pred returns the Integer equal to self - 1


### PR DESCRIPTION
Without this `(-2**63+1).pred` returns a positive number. Given that the implementation hasn't changed (substantially) since the initial version in 2008, it seems all JRuby versions should be affected.