### PR TITLE
Fix for issue 3402: String#encode with :replace option does not return correct value

### DIFF
--- a/core/src/main/java/org/jruby/util/io/EncodingUtils.java
+++ b/core/src/main/java/org/jruby/util/io/EncodingUtils.java
@@ -879,7 +879,7 @@ public class EncodingUtils {
                 if ((ecflags & EConvFlags.INVALID_MASK) != 0 && explicitlyInvalidReplace) {
                     IRubyObject rep = context.nil;
                     if (!ecopts.isNil()) {
-                        rep = ((RubyHash)ecopts).op_aref(context, runtime.newString("replace"));
+                        rep = ((RubyHash)ecopts).op_aref(context, runtime.newSymbol("replace"));
                     }
                     dest = ((RubyString)str).scrub(context, rep, Block.NULL_BLOCK);
                     if (dest.isNil()) dest = str;

--- a/spec/regression/GH-3402_spec.rb
+++ b/spec/regression/GH-3402_spec.rb
@@ -1,0 +1,12 @@
+# coding: utf-8
+
+require 'rspec'
+
+# https://github.com/jruby/jruby/issues/3402
+describe 'String#encode with :replace option' do
+  it 'returns correct value' do
+    str = "testing\xC2".encode("UTF-8", :invalid => :replace, :undef => :replace, :replace => "foo123")
+    expect(str).to eq "testingfoo123"
+  end
+end
+


### PR DESCRIPTION
This commit fixes issue #3402 on master.
@enebo and @headius please review my PR. Thanks!