### PR TITLE
[Truffle] Polyglot eval prototype

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/JRubyTruffleImpl.java
+++ b/truffle/src/main/java/org/jruby/truffle/JRubyTruffleImpl.java
@@ -20,12 +20,16 @@ import java.io.IOException;
 
 public class JRubyTruffleImpl implements JRubyTruffleInterface {
 
+    public static PolyglotEngine mostRecentPolyglot;
+
     private final PolyglotEngine engine;
     private final RubyContext context;
 
     // Run by reflection from Ruby#loadTruffle
     public JRubyTruffleImpl(Ruby runtime) {
         engine = PolyglotEngine.buildNew().globalSymbol(JRubyTruffleInterface.RUNTIME_SYMBOL, new RubyLanguage.JRubyContextWrapper(runtime)).build();
+
+        mostRecentPolyglot = engine;
 
         try {
             context = (RubyContext) engine.eval(Source.fromText("Truffle::Primitive.context", "context").withMimeType(RubyLanguage.MIME_TYPE)).get();

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/TrufflePrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/TrufflePrimitiveNodes.java
@@ -13,6 +13,7 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.FrameInstance;
 import com.oracle.truffle.api.frame.FrameInstanceVisitor;
@@ -22,11 +23,13 @@ import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.object.DynamicObject;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
+import com.oracle.truffle.api.vm.PolyglotEngine;
 import jnr.posix.SpawnFileAction;
 import org.jcodings.specific.UTF8Encoding;
 import org.jruby.Ruby;
 import org.jruby.RubyGC;
 import org.jruby.ext.rbconfig.RbConfigLibrary;
+import org.jruby.truffle.JRubyTruffleImpl;
 import org.jruby.truffle.nodes.RubyGuards;
 import org.jruby.truffle.runtime.NotProvided;
 import org.jruby.truffle.runtime.RubyCallStack;
@@ -778,6 +781,47 @@ public abstract class TrufflePrimitiveNodes {
         @Specialization
         public Object runJRubyRootNode() {
             return getContext().execute(getContext().getInitialJRubyRootNode());
+        }
+    }
+
+    @CoreMethod(names = "polyglot_eval_supported", onSingleton = true)
+    public abstract static class PolyglotEvalSupportedNode extends CoreMethodArrayArgumentsNode {
+
+        public PolyglotEvalSupportedNode(RubyContext context, SourceSection sourceSection) {
+            super(context, sourceSection);
+        }
+
+        @TruffleBoundary
+        @Specialization
+        public DynamicObject polyglotEvalSupported() {
+            final String[] languages = JRubyTruffleImpl.mostRecentPolyglot.getLanguages().keySet().toArray(new String[]{});
+
+            final Object[] mimeTypes = new Object[languages.length];
+
+            for (int n = 0; n < languages.length; n++) {
+                mimeTypes[n] = createString(StringOperations.encodeByteList(languages[n], UTF8Encoding.INSTANCE));
+            }
+
+            return Layouts.ARRAY.createArray(getContext().getCoreLibrary().getArrayFactory(), mimeTypes, mimeTypes.length);
+        }
+    }
+
+    @CoreMethod(names = "polyglot_eval", onSingleton = true, required = 2)
+    public abstract static class PolyglotEvalNode extends CoreMethodArrayArgumentsNode {
+
+        public PolyglotEvalNode(RubyContext context, SourceSection sourceSection) {
+            super(context, sourceSection);
+        }
+
+        @TruffleBoundary
+        @Specialization(guards = {"isRubyString(mimeType)", "isRubyString(source)"})
+        public Object polyglotEval(DynamicObject mimeType, DynamicObject source) {
+            try {
+                return JRubyTruffleImpl.mostRecentPolyglot.eval(
+                        Source.fromNamedText(source.toString(), "(eval)").withMimeType(mimeType.toString())).get();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 


### PR DESCRIPTION
Experiment for review - do not merge.

This allows you to eval a foreign Truffle language from Ruby. You need another language to test it with unless you just want to eval Ruby. I used GraalJS from the release of Graal VM.

```
$ bin/jruby -X+T -J-classpath ../../graal/GraalVM-0.9/jre/language/js/trufflejs.jar -rirb -S irb
irb(main):001:0> Truffle::Primitive.polyglot_eval_supported
=> ["application/javascript", "text/javascript", "application/x-ruby"]
irb(main):002:0> Truffle::Primitive.polyglot_eval('application/javascript', '14 + 2')
=> 16
```

Currently inefficient and accesses the Truffle polyglot API in an unsafe way.

@snim2 please take a look