### PR TITLE
Ruby 2.3's #dig

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -81,7 +81,6 @@ import java.util.concurrent.Callable;
 import static org.jruby.RubyEnumerator.enumeratorize;
 import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
 import static org.jruby.runtime.Helpers.invokedynamic;
-import static org.jruby.runtime.Helpers.memchr;
 import static org.jruby.runtime.Visibility.PRIVATE;
 import static org.jruby.runtime.invokedynamic.MethodNames.HASH;
 import static org.jruby.runtime.invokedynamic.MethodNames.OP_CMP;
@@ -4095,6 +4094,16 @@ public class RubyArray extends RubyObject implements List, RandomAccess {
             concurrentModification();
             return null; // not reached
         }
+    }
+
+    @JRubyMethod(name = "dig", required = 1, rest = true)
+    public IRubyObject dig(ThreadContext context, IRubyObject[] args) {
+        return dig(context, args, 0);
+    }
+
+    final IRubyObject dig(ThreadContext context, IRubyObject[] args, int idx) {
+        final IRubyObject val = at( args[idx++] );
+        return idx == args.length ? val : RubyObject.dig(context, val, args, idx);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1932,6 +1932,16 @@ public class RubyHash extends RubyObject implements Map {
         return ifNone;
     }
 
+    @JRubyMethod(name = "dig", required = 1, rest = true)
+    public IRubyObject dig(ThreadContext context, IRubyObject[] args) {
+        return dig(context, args, 0);
+    }
+
+    final IRubyObject dig(ThreadContext context, IRubyObject[] args, int idx) {
+        final IRubyObject val = op_aref( context, args[idx++] );
+        return idx == args.length ? val : RubyObject.dig(context, val, args, idx);
+    }
+
     private static class VisitorIOException extends RuntimeException {
         VisitorIOException(Throwable cause) {
             super(cause);

--- a/core/src/main/java/org/jruby/RubyObject.java
+++ b/core/src/main/java/org/jruby/RubyObject.java
@@ -559,7 +559,7 @@ public class RubyObject extends RubyBasicObject {
                     return obj.callMethod(context, "dig", rest);
             }
         }
-        return obj;
+        return context.nil; // can not dig further (there's still args left)
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyObject.java
+++ b/core/src/main/java/org/jruby/RubyObject.java
@@ -537,6 +537,31 @@ public class RubyObject extends RubyBasicObject {
         return str;
     }
 
+    // MRI: rb_obj_dig
+    static IRubyObject dig(ThreadContext context, IRubyObject obj, IRubyObject[] args, int idx) {
+        if ( obj.isNil() ) return context.nil;
+        if ( obj instanceof RubyArray ) {
+            return ((RubyArray) obj).dig(context, args, idx);
+        }
+        if ( obj instanceof RubyHash ) {
+            return ((RubyHash) obj).dig(context, args, idx);
+        }
+        if ( obj.respondsTo("dig") ) {
+            final int len = args.length - idx;
+            switch ( len ) {
+                case 1:
+                    return obj.callMethod(context, "dig", args[idx]);
+                case 2:
+                    return obj.callMethod(context, "dig", new IRubyObject[] { args[idx], args[idx+1] });
+                default:
+                    IRubyObject[] rest = new IRubyObject[len];
+                    System.arraycopy(args, idx, rest, 0, len);
+                    return obj.callMethod(context, "dig", rest);
+            }
+        }
+        return obj;
+    }
+
     /**
      * Tries to support Java serialization of Ruby objects. This is
      * still experimental and might not work.

--- a/spec/ruby/core/array/dig_spec.rb
+++ b/spec/ruby/core/array/dig_spec.rb
@@ -1,0 +1,21 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+describe "Array#dig" do
+
+  it "returns at with one arg" do
+    ['a'].dig(0).should == 'a'
+    ['a'].dig(1).should be_nil
+  end
+
+  it "recurses array elements" do
+    a = [ [ 1, [2, '3'] ] ]
+    a.dig(0, 0).should == 1
+    a.dig(0, 1, 1).should == '3'
+    a.dig(0, -1, 0).should == 2
+  end
+
+  it "raises without any args" do
+    lambda { [10].dig() }.should raise_error(ArgumentError)
+  end
+
+end

--- a/spec/ruby/core/hash/dig_spec.rb
+++ b/spec/ruby/core/hash/dig_spec.rb
@@ -20,4 +20,19 @@ describe "Hash#dig" do
     lambda { { the: 'borg' }.dig() }.should raise_error(ArgumentError)
   end
 
+  it "handles type-mixed deep digging" do
+    h = {}
+    h[:foo] = [ { :bar => [ 1 ] }, [ obj = Object.new, 'str' ] ]
+    def obj.dig(*args); [ 42 ] end
+
+    h.dig(:foo, 0, :bar).should == [ 1 ]
+    h.dig(:foo, 0, :bar, 0).should == 1
+    h.dig(:foo, 0, :bar, 0, 0).should be_nil
+    h.dig(:foo, 1, 1).should == 'str'
+    h.dig(:foo, 1, 1, 0).should be_nil
+    # MRI does not recurse values returned from `obj.dig`
+    h.dig(:foo, 1, 0, 0).should == [ 42 ]
+    h.dig(:foo, 1, 0, 0, 10).should == [ 42 ]
+  end
+
 end

--- a/spec/ruby/core/hash/dig_spec.rb
+++ b/spec/ruby/core/hash/dig_spec.rb
@@ -1,0 +1,23 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+describe "Hash#dig" do
+
+  it "returns [] with one arg" do
+    h = { 0 => false, :a => 1 }
+    h.dig(:a).should == 1
+    h.dig(0).should be_false
+    h.dig(1).should be_nil
+  end
+
+  it "does recurse" do
+    h = { foo: { bar: { baz: 1 } } }
+    h.dig(:foo, :bar, :baz).should == 1
+    h.dig(:foo, :baz).should be_nil
+    h.dig(:bar, :baz, :foo).should be_nil
+  end
+
+  it "raises without args" do
+    lambda { { the: 'borg' }.dig() }.should raise_error(ArgumentError)
+  end
+
+end

--- a/spec/truffle/tags/core/array/dig_tags.txt
+++ b/spec/truffle/tags/core/array/dig_tags.txt
@@ -1,0 +1,3 @@
+fails:Array#dig returns at with one arg
+fails:Array#dig recurses array elements
+fails:Array#dig raises without any args

--- a/spec/truffle/tags/core/hash/dig_tags.txt
+++ b/spec/truffle/tags/core/hash/dig_tags.txt
@@ -1,0 +1,4 @@
+fails:Hash#dig returns [] with one arg
+fails:Hash#dig does recurse
+fails:Hash#dig raises without args
+fails:Hash#dig handles type-mixed deep digging


### PR DESCRIPTION
`[].dig(0)` and `{}.dig(:a)` as introduced by MRI [**2.3.0.preview1**](https://github.com/ruby/ruby/commit/29862685c0acf3a40c6b1f9e8780cbbd86cba658)