### PR TITLE
implement Coverage.peek_result

### DIFF
--- a/core/src/main/java/org/jruby/ext/coverage/CoverageData.java
+++ b/core/src/main/java/org/jruby/ext/coverage/CoverageData.java
@@ -42,6 +42,10 @@ public class CoverageData {
         return coverage != null;
     }
 
+    public Map<String, int[]> getCoverage() {
+      return this.coverage;
+    }
+
     public synchronized void setCoverageEnabled(Ruby runtime, boolean enabled) {
         if (enabled) {
             coverage = new HashMap<String, int[]>();

--- a/core/src/main/java/org/jruby/ext/coverage/CoverageModule.java
+++ b/core/src/main/java/org/jruby/ext/coverage/CoverageModule.java
@@ -58,8 +58,21 @@ public class CoverageModule {
             throw runtime.newRuntimeError("coverage measurement is not enabled");
         }
         
-        Map<String, int[]> coverage = runtime.getCoverageData().resetCoverage(runtime);
+        return convertCoverageToRuby(context, runtime, runtime.getCoverageData().resetCoverage(runtime));
+    }
+
+    @JRubyMethod(module = true)
+    public static IRubyObject peekResult(ThreadContext context, IRubyObject self) {
+        Ruby runtime = context.runtime;
+
+        if (!runtime.getCoverageData().isCoverageEnabled()) {
+            throw runtime.newRuntimeError("coverage measurement is not enabled");
+        }
         
+        return convertCoverageToRuby(context, runtime, runtime.getCoverageData().getCoverage());
+    }
+
+    private static IRubyObject convertCoverageToRuby(ThreadContext context, Ruby runtime, Map<String, int[]> coverage) {
         // populate a Ruby Hash with coverage data
         RubyHash covHash = RubyHash.newHash(runtime);
         for (Map.Entry<String, int[]> entry : coverage.entrySet()) {


### PR DESCRIPTION
This patch implements `Coverage.peek_result` that was implemented in MRI
here:

  https://bugs.ruby-lang.org/issues/10816

I didn't add any tests because there are test in the MRI suite that cover this.  Also, I admit that I haven't run the JRuby tests but it does compile? ¯\_(⊙︿⊙)_/¯ 