### PR TITLE
forcing a nil (no) backtrace with Java APIs

### DIFF
--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -21,7 +21,7 @@
  * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
  * Copyright (C) 2005 David Corbin <dcorbin@users.sf.net>
  * Copyright (C) 2006 Michael Studman <codehaus@michaelstudman.com>
- * 
+ *
  * Alternatively, the contents of this file may be used under the terms of
  * either of the GNU General Public License Version 2 or later (the "GPL"),
  * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
@@ -68,7 +68,7 @@ public class RubyException extends RubyObject {
 
     public RubyException(Ruby runtime, RubyClass rubyClass, String message) {
         super(runtime, rubyClass);
-        
+
         this.message = message == null ? runtime.getNil() : runtime.newString(message);
     }
 
@@ -101,12 +101,12 @@ public class RubyException extends RubyObject {
 
         return backtrace();
     }
-    
+
     @JRubyMethod(omit = true)
     public IRubyObject backtrace_locations(ThreadContext context) {
         Ruby runtime = context.runtime;
         RubyStackTraceElement[] elements = backtraceData.getBacktrace(runtime);
-        
+
         return RubyThread.Location.newLocationArray(runtime, elements);
     }
 
@@ -239,17 +239,17 @@ public class RubyException extends RubyObject {
     }
 
     public void forceBacktrace(IRubyObject backtrace) {
-        backtraceData = BacktraceData.EMPTY;
+        backtraceData = (backtrace != null && backtrace.isNil()) ? null : BacktraceData.EMPTY;
         set_backtrace(backtrace);
     }
-    
+
     public IRubyObject getBacktrace() {
         if (backtrace == null) {
             initBacktrace();
         }
         return backtrace;
     }
-    
+
     public void initBacktrace() {
         Ruby runtime = getRuntime();
         if (backtraceData == null) {
@@ -300,16 +300,16 @@ public class RubyException extends RubyObject {
     private void printStackTraceLine(PrintStream errorStream, IRubyObject stackTraceLine) {
             errorStream.print("\tfrom " + stackTraceLine + '\n');
     }
-	
+
     private boolean isArrayOfStrings(IRubyObject backtrace) {
-        if (!(backtrace instanceof RubyArray)) return false; 
-            
+        if (!(backtrace instanceof RubyArray)) return false;
+
         IRubyObject[] elements = ((RubyArray) backtrace).toJavaArray();
-        
+
         for (int i = 0 ; i < elements.length ; i++) {
             if (!(elements[i] instanceof RubyString)) return false;
         }
-            
+
         return true;
     }
 

--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -83,12 +83,16 @@ public class RubyException extends RubyObject {
 
     @JRubyMethod
     public IRubyObject backtrace() {
-        IRubyObject bt = getBacktrace();
-        return bt;
+        return getBacktrace();
     }
 
     @JRubyMethod(required = 1)
     public IRubyObject set_backtrace(IRubyObject obj) {
+        setBacktrace(obj);
+        return backtrace();
+    }
+
+    private void setBacktrace(IRubyObject obj) {
         if (obj.isNil()) {
             backtrace = null;
         } else if (isArrayOfStrings(obj)) {
@@ -98,8 +102,6 @@ public class RubyException extends RubyObject {
         } else {
             throw getRuntime().newTypeError("backtrace must be Array of String or a single String");
         }
-
-        return backtrace();
     }
 
     @JRubyMethod(omit = true)
@@ -240,7 +242,7 @@ public class RubyException extends RubyObject {
 
     public void forceBacktrace(IRubyObject backtrace) {
         backtraceData = (backtrace != null && backtrace.isNil()) ? null : BacktraceData.EMPTY;
-        set_backtrace(backtrace);
+        setBacktrace(backtrace);
     }
 
     public IRubyObject getBacktrace() {

--- a/core/src/main/java/org/jruby/exceptions/RaiseException.java
+++ b/core/src/main/java/org/jruby/exceptions/RaiseException.java
@@ -213,7 +213,7 @@ public class RaiseException extends JumpException {
         // We can only omit backtraces of descendents of Standard error for 'foo rescue nil'
         return context.exceptionRequiresBacktrace ||
                 (debugMode != null && debugMode.isTrue()) ||
-                !exception.kind_of_p(context, context.runtime.getStandardError()).isTrue();
+                ! context.runtime.getStandardError().isInstance(exception);
     }
 
     private void preRaise(ThreadContext context, IRubyObject backtrace) {

--- a/core/src/main/java/org/jruby/exceptions/RaiseException.java
+++ b/core/src/main/java/org/jruby/exceptions/RaiseException.java
@@ -229,6 +229,7 @@ public class RaiseException extends JumpException {
                 exception.prepareBacktrace(context, nativeException);
             } else {
                 exception.forceBacktrace(backtrace);
+                if ( backtrace.isNil() ) return;
             }
 
             // call Throwable.setStackTrace so that when RaiseException appears nested inside another exception,

--- a/core/src/main/java/org/jruby/exceptions/RaiseException.java
+++ b/core/src/main/java/org/jruby/exceptions/RaiseException.java
@@ -131,13 +131,13 @@ public class RaiseException extends JumpException {
         preRaise(context, backtrace);
     }
 
-    public RaiseException(RubyException exception, boolean isNativeException) {
+    public RaiseException(RubyException exception, boolean nativeException) {
         super(exception.message.toString());
         if (DEBUG) {
             Thread.dumpStack();
         }
-        this.nativeException = isNativeException;
-        setException(exception, isNativeException);
+        this.nativeException = nativeException;
+        setException(exception, nativeException);
         preRaise(exception.getRuntime().getCurrentContext());
     }
 

--- a/core/src/test/java/org/jruby/exceptions/TestRaiseException.java
+++ b/core/src/test/java/org/jruby/exceptions/TestRaiseException.java
@@ -6,6 +6,7 @@ package org.jruby.exceptions;
 import org.jruby.RubyArray;
 import org.jruby.RubyClass;
 import org.jruby.RubyException;
+import org.jruby.runtime.backtrace.RubyStackTraceElement;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.test.TestRubyBase;
 
@@ -30,6 +31,8 @@ public class TestRaiseException extends TestRubyBase {
         assertNotNil( backtrace );
         assertTrue( ((RubyArray) backtrace).isEmpty() );
 
+        assertNotSame( RubyStackTraceElement.EMPTY_ARRAY, re.getException().getBacktraceElements() );
+
         assertEquals( count + 1, runtime.getBacktraceCount() );
     }
 
@@ -41,6 +44,9 @@ public class TestRaiseException extends TestRubyBase {
         RaiseException re = new RaiseException(runtime, RuntimeError, "", backtrace, false);
         backtrace = re.getException().backtrace();
         assertNil( backtrace );
+
+        assertNil( re.getException().getBacktrace() );
+        assertSame( RubyStackTraceElement.EMPTY_ARRAY, re.getException().getBacktraceElements() );
 
         assertEquals( count, runtime.getBacktraceCount() );
     }

--- a/core/src/test/java/org/jruby/exceptions/TestRaiseException.java
+++ b/core/src/test/java/org/jruby/exceptions/TestRaiseException.java
@@ -33,6 +33,22 @@ public class TestRaiseException extends TestRubyBase {
         assertEquals( count + 1, runtime.getBacktraceCount() );
     }
 
+    public void testJavaGeneratedNilBacktrace() {
+        final int count = runtime.getBacktraceCount();
+        IRubyObject backtrace = runtime.getNil();
+
+        final RubyClass RuntimeError = runtime.getRuntimeError();
+        RaiseException re = new RaiseException(runtime, RuntimeError, "", backtrace, false);
+        backtrace = re.getException().backtrace();
+        assertNil( backtrace );
+
+        assertEquals( count, runtime.getBacktraceCount() );
+    }
+
+    private void assertNil(IRubyObject val) {
+        assertTrue("expected: " + val.inspect() + " to be nil", val.isNil());
+    }
+
     private void assertNotNil(IRubyObject val) {
         assertFalse("expected: " + val.inspect() + " to not be nil", val.isNil());
     }

--- a/core/src/test/java/org/jruby/exceptions/TestRaiseException.java
+++ b/core/src/test/java/org/jruby/exceptions/TestRaiseException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2015 JRuby.
+ */
+package org.jruby.exceptions;
+
+import org.jruby.RubyArray;
+import org.jruby.RubyClass;
+import org.jruby.RubyException;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.test.TestRubyBase;
+
+public class TestRaiseException extends TestRubyBase {
+
+    public void testBacktrace() {
+        IRubyObject ex = runtime.evalScriptlet("ex = nil; " +
+            "begin; raise 'with-bracktrace'; rescue => e; ex = e end; ex"
+        );
+        assertEquals("org.jruby.RubyException", ex.getClass().getName());
+        IRubyObject backtrace = ((RubyException) ex).getBacktrace();
+        assertNotNil( backtrace );
+        assertFalse( ((RubyArray) backtrace).isEmpty() );
+    }
+
+    public void testJavaGeneratedBacktrace() {
+        final int count = runtime.getBacktraceCount();
+
+        final RubyClass RuntimeError = runtime.getRuntimeError();
+        RaiseException re = new RaiseException(runtime, RuntimeError, "", false);
+        IRubyObject backtrace = re.getException().backtrace();
+        assertNotNil( backtrace );
+        assertTrue( ((RubyArray) backtrace).isEmpty() );
+
+        assertEquals( count + 1, runtime.getBacktraceCount() );
+    }
+
+    private void assertNotNil(IRubyObject val) {
+        assertFalse("expected: " + val.inspect() + " to not be nil", val.isNil());
+    }
+
+}


### PR DESCRIPTION
`RaiseException(Ruby runtime, RubyClass type, String msg, IRubyObject backtrace, boolean native)` constructor despite accepting an `IRubyObject` **backtrace** parameter (and not just `RubyArray`), passing a nil does not end up with the `RubyException#backtrace` being `nil` but rather an empty array which is not fortunate as in user-land its easy to dismiss and confusing.

like to use the constructor for optional "lightweight" exception raising such as jruby/jruby-openssl#55

p.s. I'd like to consider backporting these changes to **jruby-1_7** if there's no objections to that.