### PR TITLE
remove "initial_state" argument of Enumerable#{slice_before,chunk}

### DIFF
--- a/core/src/main/ruby/jruby/kernel/enumerable.rb
+++ b/core/src/main/ruby/jruby/kernel/enumerable.rb
@@ -4,11 +4,6 @@ module Enumerable
 
     state = nil
 
-    if block && !no_filter
-      initial_state = filter.dup
-      state = initial_state
-    end
-
     Enumerator.new do |yielder|
       ary = nil
       each do |*elt|
@@ -17,11 +12,7 @@ module Enumerable
         end
 
         if block
-          if no_filter
-            state = block.call elt
-          else
-            state = block.call elt, initial_state
-          end
+          state = block.call elt
         else
           state = (filter === elt)
         end

--- a/test/mri/ruby/test_enum.rb
+++ b/test/mri/ruby/test_enum.rb
@@ -465,22 +465,6 @@ class TestEnumerable < Test::Unit::TestCase
     e = @obj.chunk {|elt| elt & 2 == 0 ? false : true }
     assert_equal([[false, [1]], [true, [2, 3]], [false, [1]], [true, [2]]], e.to_a)
 
-    e = @obj.chunk(acc: 0) {|elt, h| h[:acc] += elt; h[:acc].even? }
-    assert_equal([[false, [1,2]], [true, [3]], [false, [1,2]]], e.to_a)
-    assert_equal([[false, [1,2]], [true, [3]], [false, [1,2]]], e.to_a) # this tests h is duplicated.
-
-    hs = [{}]
-    e = [:foo].chunk(hs[0]) {|elt, h|
-      hs << h
-      true
-    }
-    assert_equal([[true, [:foo]]], e.to_a)
-    assert_equal([[true, [:foo]]], e.to_a)
-    assert_equal([{}, {}, {}], hs)
-    assert_not_same(hs[0], hs[1])
-    assert_not_same(hs[0], hs[2])
-    assert_not_same(hs[1], hs[2])
-
     e = @obj.chunk {|elt| elt < 3 ? :_alone : true }
     assert_equal([[:_alone, [1]],
                   [:_alone, [2]],
@@ -509,22 +493,6 @@ class TestEnumerable < Test::Unit::TestCase
 
     e = @obj.slice_before {|elt| elt.odd? }
     assert_equal([[1,2], [3], [1,2]], e.to_a)
-
-    e = @obj.slice_before(acc: 0) {|elt, h| h[:acc] += elt; h[:acc].even? }
-    assert_equal([[1,2], [3,1,2]], e.to_a)
-    assert_equal([[1,2], [3,1,2]], e.to_a) # this tests h is duplicated.
-
-    hs = [{}]
-    e = [:foo].slice_before(hs[0]) {|elt, h|
-      hs << h
-      true
-    }
-    assert_equal([[:foo]], e.to_a)
-    assert_equal([[:foo]], e.to_a)
-    assert_equal([{}, {}, {}], hs)
-    assert_not_same(hs[0], hs[1])
-    assert_not_same(hs[0], hs[2])
-    assert_not_same(hs[1], hs[2])
 
     ss = %w[abc defg h ijk l mno pqr st u vw xy z]
     assert_equal([%w[abc defg h], %w[ijk l], %w[mno], %w[pqr st u vw xy z]],


### PR DESCRIPTION
Enumerable#chunk and Enumerable#slice_before no longer takes the initial_state argument [Feature #10958]