### PR TITLE
[ruby-2.3 feature #10769] add Enumerable#chunk_while, spec for it

### DIFF
--- a/core/src/main/ruby/jruby/kernel/enumerable.rb
+++ b/core/src/main/ruby/jruby/kernel/enumerable.rb
@@ -91,6 +91,35 @@ module Enumerable
       end
     end
   end
+  
+  def chunk_while(&block)
+    raise ArgumentError.new("missing block") unless block
+    return Enumerator.new {|e| } if empty?
+    return Enumerator.new {|e| e.yield self } if length < 2
+
+    Enumerator.new do |enum|
+      ary = nil
+      last_after = nil
+      each_cons(2) do |before, after|
+        last_after = after
+        match = block.call before, after
+
+        ary ||= []
+        if match
+          ary << before
+        else
+          ary << before
+          enum.yield ary
+          ary = []
+        end
+      end
+
+      unless ary.nil?
+        ary << last_after
+        enum.yield ary
+      end
+    end
+  end
 
   def lazy
     klass = Enumerator::Lazy::LAZY_WITH_NO_BLOCK # Note: class_variable_get is private in 1.8

--- a/test/mri/ruby/test_enum.rb
+++ b/test/mri/ruby/test_enum.rb
@@ -598,6 +598,11 @@ class TestEnumerable < Test::Unit::TestCase
     assert_equal([[1], [4], [9,10,11,12], [15,16], [19,20,21]], e.to_a)
   end
 
+  def test_chunk_while_contiguously_increasing_integers
+    e = [1,4,9,10,11,12,15,16,19,20,21].chunk_while {|i, j| i+1 == j }
+    assert_equal([[1], [4], [9,10,11,12], [15,16], [19,20,21]], e.to_a)
+  end
+
   def test_detect
     @obj = ('a'..'z')
     assert_equal('c', @obj.detect {|x| x == 'c' })


### PR DESCRIPTION
Implemented as #slice_when, but slice when block does not match rather than when it does.
Also added merged over ruby spec for it.