### PR TITLE
[ruby-2.3] Feature #10730: Implement Array#bsearch_index

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -2116,7 +2116,7 @@ public class RubyArray extends RubyObject implements List, RandomAccess {
         }
 
         int rVal = bsearch_index_internal(context, block);
-        if(rVal == -1) {
+        if (rVal == -1) {
             return context.nil;
         } else {
             return eltOk(rVal);
@@ -2129,7 +2129,7 @@ public class RubyArray extends RubyObject implements List, RandomAccess {
             return enumeratorize(context.runtime, this, "bsearch_index");
         }
         int rVal = bsearch_index_internal(context, block);
-        if(rVal == -1) {
+        if (rVal == -1) {
             return context.nil;
         } else {
             return RubyFixnum.newFixnum(context.runtime, rVal);

--- a/test/mri/ruby/test_array.rb
+++ b/test/mri/ruby/test_array.rb
@@ -2473,6 +2473,41 @@ class TestArray < Test::Unit::TestCase
     assert_include([4, 7], a.bsearch {|x| (2**100).coerce((1 - x / 4) * (2**100)).first })
   end
 
+  def test_bsearch_index_typechecks_return_values
+    assert_raise(TypeError) do
+      [1, 2, 42, 100, 666].bsearch_index {"not ok"}
+    end
+    assert_equal [1, 2, 42, 100, 666].bsearch_index {}, [1, 2, 42, 100, 666].bsearch_index {false}
+  end
+
+  def test_bsearch_index_with_no_block
+    enum = [1, 2, 42, 100, 666].bsearch_index
+    assert_nil enum.size
+    assert_equal 2, enum.each{|x| x >= 33 }
+  end
+
+  def test_bsearch_index_in_find_minimum_mode
+    a = [0, 4, 7, 10, 12]
+    assert_equal(1, a.bsearch_index {|x| x >=   4 })
+    assert_equal(2, a.bsearch_index {|x| x >=   6 })
+    assert_equal(0, a.bsearch_index {|x| x >=  -1 })
+    assert_equal(nil, a.bsearch_index {|x| x >= 100 })
+  end
+
+  def test_bsearch_index_in_find_any_mode
+    a = [0, 4, 7, 10, 12]
+    assert_include([1, 2], a.bsearch_index {|x| 1 - x / 4 })
+    assert_equal(nil, a.bsearch_index {|x| 4 - x / 2 })
+    assert_equal(nil, a.bsearch_index {|x| 1 })
+    assert_equal(nil, a.bsearch_index {|x| -1 })
+
+    assert_include([1, 2], a.bsearch_index {|x| (1 - x / 4) * (2**100) })
+    assert_equal(nil, a.bsearch_index {|x|   1  * (2**100) })
+    assert_equal(nil, a.bsearch_index {|x| (-1) * (2**100) })
+
+    assert_include([1, 2], a.bsearch_index {|x| (2**100).coerce((1 - x / 4) * (2**100)).first })
+  end
+  
   def test_shared_marking
     reduce = proc do |s|
       s.gsub(/(verify_internal_consistency_reachable_i:\sWB\smiss\s\S+\s\(T_ARRAY\)\s->\s)\S+\s\((proc|T_NONE)\)\n


### PR DESCRIPTION
Implements Array#bsearch_index. The binary search is now a private method which returns an int
index, and the public #bsearch and #bsearch_index methods utilize it to return an appropriate
IRubyObject instance.

This is functionally identical to how the MRI changes were implemented.