### PR TITLE
[ruby-2.3] Feature #10984 - Hash comparison operators

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1212,6 +1212,51 @@ public class RubyHash extends RubyObject implements Map {
         return ((value = internalGet(key)) == null) ? invokedynamic(context, this, DEFAULT, key) : value;
     }
 
+    /** hash_le_i
+     *
+     */
+    private boolean hash_le(RubyHash other) {
+        RubyArray keys = keys();
+        for (Object key : keys) {
+            if (!other.get(key).equals( get(key) )) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @JRubyMethod(name = "<", required = 1)
+    public IRubyObject op_lt(ThreadContext context, IRubyObject other) {
+        final RubyHash otherHash = other.convertToHash();
+        if (size() >= otherHash.size()) {
+            return RubyBoolean.newBoolean(context.runtime, false);
+        }
+
+        return RubyBoolean.newBoolean(context.runtime, hash_le(otherHash));
+    }
+
+    @JRubyMethod(name = "<=", required = 1)
+    public IRubyObject op_le(ThreadContext context, IRubyObject other) {
+        final RubyHash otherHash = other.convertToHash();
+        if (size() > otherHash.size()) {
+            return RubyBoolean.newBoolean(context.runtime, false);
+        }
+
+        return RubyBoolean.newBoolean(context.runtime, hash_le(otherHash));
+    }
+
+    @JRubyMethod(name = ">", required = 1)
+    public IRubyObject op_gt(ThreadContext context, IRubyObject other) {
+        final RubyHash otherHash = other.convertToHash();
+        return otherHash.op_lt(context, this);
+    }
+
+    @JRubyMethod(name = ">=", required = 1)
+    public IRubyObject op_ge(ThreadContext context, IRubyObject other) {
+        final RubyHash otherHash = other.convertToHash();
+        return otherHash.op_le(context, this);
+    }
+
     /** rb_hash_hash
      *
      */

--- a/test/mri/ruby/test_hash.rb
+++ b/test/mri/ruby/test_hash.rb
@@ -1286,6 +1286,31 @@ class TestHash < Test::Unit::TestCase
     assert_equal({:foo => 1, :'foo-bar' => 2, :'hello-world' => 3, :'hello-#{x}' => 4, :bar => {}}, hash)
   end
 
+  def test_cmp
+    h1 = {a:1, b:2}
+    h2 = {a:1, b:2, c:3}
+
+    assert_operator(h1, :<=, h1)
+    assert_operator(h1, :<=, h2)
+    assert_not_operator(h2, :<=, h1)
+    assert_operator(h2, :<=, h2)
+
+    assert_operator(h1, :>=, h1)
+    assert_not_operator(h1, :>=, h2)
+    assert_operator(h2, :>=, h1)
+    assert_operator(h2, :>=, h2)
+
+    assert_not_operator(h1, :<, h1)
+    assert_operator(h1, :<, h2)
+    assert_not_operator(h2, :<, h1)
+    assert_not_operator(h2, :<, h2)
+
+    assert_not_operator(h1, :>, h1)
+    assert_not_operator(h1, :>, h2)
+    assert_operator(h2, :>, h1)
+    assert_not_operator(h2, :>, h2)
+  end
+
   class TestSubHash < TestHash
     class SubHash < Hash
       def reject(*)


### PR DESCRIPTION
Implements Hash#<=, #<, #>=, #>. Tests copied from the MRI commit.

I'd like review on RubyHash.hash_le to make sure it's implemented as efficiently as possible.