### PR TITLE
[ruby-2.3 Feature #11785] add `encoding:` optional argument to String.new

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1487,12 +1487,14 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         return this;
     }
 
+    // TODO: Fold kwargs into the @JRubyMethod decorator
+    final String[] validInitializeArgs = new String[]{"encoding"};
+
     @JRubyMethod(name = "initialize", visibility = PRIVATE, optional = 2)
     public IRubyObject initialize19(ThreadContext context, IRubyObject[] args) {
-        final String[] validArgs = new String[]{"encoding"};
-        IRubyObject[] extractedArgs = ArgsUtil.extractKeywordArgs(context, args, validArgs);
+        IRubyObject[] extractedArgs = ArgsUtil.extractKeywordArgs(context, args, validInitializeArgs);
 
-        if (args.length > 0 && args[0] instanceof RubyString) {
+        if ((args.length == 1 && extractedArgs == null) || args.length > 1) {
             replace19(args[0]);
         }
 

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -55,6 +55,7 @@ import org.joni.Regex;
 import org.joni.Region;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.ast.util.ArgsUtil;
 import org.jruby.platform.Platform;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ClassIndex;
@@ -1476,8 +1477,8 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         return initialize19(context);
     }
 
-    public IRubyObject initialize(ThreadContext context, IRubyObject arg0) {
-        return initialize19(context, arg0);
+    public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
+        return initialize19(context, args);
     }
 
     @JRubyMethod(name = "initialize", visibility = PRIVATE)
@@ -1486,9 +1487,18 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         return this;
     }
 
-    @JRubyMethod(name = "initialize", visibility = PRIVATE)
-    public IRubyObject initialize19(ThreadContext context, IRubyObject arg0) {
-        replace19(arg0);
+    @JRubyMethod(name = "initialize", visibility = PRIVATE, optional = 2)
+    public IRubyObject initialize19(ThreadContext context, IRubyObject[] args) {
+        final String[] validArgs = new String[]{"encoding"};
+        IRubyObject[] extractedArgs = ArgsUtil.extractKeywordArgs(context, args, validArgs);
+
+        if (args.length > 0 && args[0] instanceof RubyString) {
+            replace19(args[0]);
+        }
+
+        if (extractedArgs != null) {
+            force_encoding(context, extractedArgs[0]);
+        }
         return this;
     }
 

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1488,7 +1488,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     }
 
     // TODO: Fold kwargs into the @JRubyMethod decorator
-    final String[] validInitializeArgs = new String[]{"encoding"};
+    final static String[] validInitializeArgs = new String[]{"encoding"};
 
     @JRubyMethod(name = "initialize", visibility = PRIVATE, optional = 2)
     public IRubyObject initialize19(ThreadContext context, IRubyObject[] args) {

--- a/test/mri/ruby/test_string.rb
+++ b/test/mri/ruby/test_string.rb
@@ -16,12 +16,39 @@ class TestString < Test::Unit::TestCase
     super
   end
 
-  def S(str)
-    @cls.new(str)
+  def S(*args)
+    @cls.new(*args)
   end
 
   def test_s_new
-    assert_equal("RUBY", S("RUBY"))
+    assert_equal("", S())
+    assert_equal(Encoding::ASCII_8BIT, S().encoding)
+
+    assert_equal("", S(""))
+    assert_equal(__ENCODING__, S("").encoding)
+
+    src = "RUBY"
+    assert_equal(src, S(src))
+    assert_equal(__ENCODING__, S(src).encoding)
+
+    src.force_encoding("euc-jp")
+    assert_equal(src, S(src))
+    assert_equal(Encoding::EUC_JP, S(src).encoding)
+
+
+    assert_equal("", S(encoding: "euc-jp"))
+    assert_equal(Encoding::EUC_JP, S(encoding: "euc-jp").encoding)
+
+    assert_equal("", S("", encoding: "euc-jp"))
+    assert_equal(Encoding::EUC_JP, S("", encoding: "euc-jp").encoding)
+
+    src = "RUBY"
+    assert_equal(src, S(src, encoding: "euc-jp"))
+    assert_equal(Encoding::EUC_JP, S(src, encoding: "euc-jp").encoding)
+
+    src.force_encoding("euc-jp")
+    assert_equal(src, S(src, encoding: "utf-8"))
+    assert_equal(Encoding::UTF_8, S(src, encoding: "utf-8").encoding)
   end
 
   def test_AREF # '[]'


### PR DESCRIPTION
Adds kwargs support to String#initialize such that it will accept an optional :encoding argument.