### PR TITLE
[ruby 2.3 Feature #10718] IO#close should not raise IOError on closed IO objects.

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1943,14 +1943,16 @@ public class RubyIO extends RubyObject implements IOEncodable {
      * <p>Closes all open resources for the IO.  It also removes
      * it from our magical all open file descriptor pool.</p>
      *
-     * @return The IO.
+     * @return The IO. Returns nil if the IO was already closed.
      *
      * MRI: rb_io_close_m
      */
     @JRubyMethod
     public IRubyObject close() {
         Ruby runtime = getRuntime();
-
+        if (isClosed()) {
+            return runtime.getNil();
+        }
         openFile.checkClosed();
         return rbIoClose(runtime);
     }

--- a/test/mri/ruby/test_io.rb
+++ b/test/mri/ruby/test_io.rb
@@ -3146,4 +3146,16 @@ End
       end
     end
   end
+
+  def test_close_twice
+    open(__FILE__) {|f|
+      assert_equal(nil, f.close)
+      assert_equal(nil, f.close)
+    }
+  end
+
+  def test_close_uninitialized
+    io = IO.allocate
+    assert_raise(IOError) { io.close }
+  end
 end

--- a/test/mri/socket/test_basicsocket.rb
+++ b/test/mri/socket/test_basicsocket.rb
@@ -9,7 +9,7 @@ class TestSocket_BasicSocket < Test::Unit::TestCase
     sock = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
     yield sock
   ensure
-    assert_raise(IOError) {sock.close}
+    assert(sock.closed?)
   end
 
   def test_getsockopt

--- a/test/mri/zlib/test_zlib.rb
+++ b/test/mri/zlib/test_zlib.rb
@@ -929,7 +929,7 @@ if defined? Zlib
         f = open(t.path)
         f.binmode
         assert_equal("foo", Zlib::GzipReader.wrap(f) {|gz| gz.read })
-        assert_raise(IOError) { f.close }
+        assert(f.closed?)
       }
     end
 


### PR DESCRIPTION
IO#close now silently returns nil if called on an already-closed IO object.