### PR TITLE
String#new throws an unknown kwarg exception if passed an unknown option

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1497,6 +1497,8 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         return this;
     }
 
+    private static String[] validInitArgs = new String[]{"encoding"};
+
     @JRubyMethod(name = "initialize", visibility = PRIVATE, optional = 2)
     public IRubyObject initialize19(ThreadContext context, IRubyObject[] args) {
         if ( args.length == 0 ) return this;
@@ -1505,8 +1507,8 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
 
         final IRubyObject string; final IRubyObject encoding;
         if ( arg instanceof RubyHash ) { // new encoding: ...
-            final RubySymbol enc = context.runtime.newSymbol("encoding");
-            encoding = ( (RubyHash) arg ).fastARef(enc);
+            IRubyObject[] kwargs = ArgsUtil.extractKeywordArgs(context, (RubyHash)arg, validInitArgs);
+            encoding = kwargs[0];
             string = args.length > 1 ? args[0] : null;
         }
         else {

--- a/test/jruby/test_string.rb
+++ b/test/jruby/test_string.rb
@@ -96,6 +96,11 @@ class TestString < Test::Unit::TestCase
     assert_equal(2, "abc\u{3042 3044 3046}".count("^\u3042", "^\u3044", "^\u3046", "^c"))
   end
 
+  def test_arguments
+    assert_raises(TypeError) { String.new encoding: :"utf-8" }
+    assert_raises(ArgumentError) { String.new bad_parameter: "whatever" }
+  end
+
   private
 
   def do_sub buf, e1, e2, e3


### PR DESCRIPTION
MRI uses kwargs to accept the `encoding` parameter for String#new. This patch causes JRuby to emulate that behavior, so it'll noisily complain if you pass an unknown parameter, rather than just silently swallowing it. Tests included.