### PR TITLE
Various literal to_proc'ed Symbol optimizations.

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -2338,7 +2338,11 @@ public class IRBuilder {
             case ITERNODE:
                 return build(node);
             case BLOCKPASSNODE:
-                return build(((BlockPassNode)node).getBodyNode());
+                Node bodyNode = ((BlockPassNode)node).getBodyNode();
+                if (bodyNode instanceof SymbolNode) {
+                    return new SymbolProc(((SymbolNode)bodyNode).getName(), ((SymbolNode)bodyNode).getEncoding());
+                }
+                return build(bodyNode);
             default:
                 throw new NotCompilableException("ERROR: Encountered a method with a non-block, non-blockpass iter node at: " + node);
         }

--- a/core/src/main/java/org/jruby/ir/IRVisitor.java
+++ b/core/src/main/java/org/jruby/ir/IRVisitor.java
@@ -188,6 +188,7 @@ public abstract class IRVisitor {
     public void StringLiteral(StringLiteral stringliteral) { error(stringliteral); }
     public void SValue(SValue svalue) { error(svalue); }
     public void Symbol(Symbol symbol) { error(symbol); }
+    public void SymbolProc(SymbolProc symbolproc) { error(symbolproc); }
     public void TemporaryVariable(TemporaryVariable temporaryvariable) { error(temporaryvariable); }
     public void TemporaryLocalVariable(TemporaryLocalVariable temporarylocalvariable) { error(temporarylocalvariable); }
     public void TemporaryFloatVariable(TemporaryFloatVariable temporaryfloatvariable) { error(temporaryfloatvariable); }

--- a/core/src/main/java/org/jruby/ir/operands/OperandType.java
+++ b/core/src/main/java/org/jruby/ir/operands/OperandType.java
@@ -43,7 +43,8 @@ public enum OperandType {
     WRAPPED_IR_CLOSURE((byte) 'w'),
     FROZEN_STRING((byte) 'z'),
     NULL_BLOCK((byte) 'o'),
-    FILENAME((byte) 'm')
+    FILENAME((byte) 'm'),
+    SYMBOL_PROC((byte) 'P')
     ;
 
     private final byte coded;

--- a/core/src/main/java/org/jruby/ir/operands/SymbolProc.java
+++ b/core/src/main/java/org/jruby/ir/operands/SymbolProc.java
@@ -1,0 +1,73 @@
+package org.jruby.ir.operands;
+
+import org.jcodings.Encoding;
+import org.jruby.ir.IRVisitor;
+import org.jruby.ir.persistence.IRReaderDecoder;
+import org.jruby.ir.persistence.IRWriterEncoder;
+import org.jruby.ir.runtime.IRRuntimeHelpers;
+import org.jruby.runtime.ThreadContext;
+
+/**
+ * A literal representing proc'ified symbols, as in &:foo.
+ *
+ * Used to cache a unique and constant proc at the use site to reduce allocation and improve caching.
+ */
+public class SymbolProc extends ImmutableLiteral {
+    private final String name;
+    private final Encoding encoding;
+
+    public SymbolProc(String name, Encoding encoding) {
+        super();
+        this.name = name;
+        this.encoding = encoding;
+    }
+
+    @Override
+    public OperandType getOperandType() {
+        return OperandType.SYMBOL_PROC;
+    }
+
+    @Override
+    public Object createCacheObject(ThreadContext context) {
+        return IRRuntimeHelpers.newSymbolProc(context, name, encoding);
+    }
+
+    @Override
+    public int hashCode() {
+        return 47 * 7 + (int) (this.name.hashCode() ^ (this.encoding.hashCode() >>> 32));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof SymbolProc && name.equals(((SymbolProc) other).name) && encoding.equals(((SymbolProc) other).encoding);
+    }
+
+    @Override
+    public void visit(IRVisitor visitor) {
+        visitor.SymbolProc(this);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Encoding getEncoding() {
+        return encoding;
+    }
+
+    @Override
+    public void encode(IRWriterEncoder e) {
+        super.encode(e);
+        e.encode(name);
+        e.encode(encoding);
+    }
+
+    public static SymbolProc decode(IRReaderDecoder d) {
+        return new SymbolProc(d.decodeString(), d.decodeEncoding());
+    }
+
+    @Override
+    public String toString() {
+        return "SymbolProc:" + name;
+    }
+}

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1698,4 +1698,28 @@ public class IRRuntimeHelpers {
 
         return self;
     }
+
+    /**
+     * Create a new Symbol.to_proc for the given symbol name and encoding.
+     *
+     * @param context
+     * @param symbol
+     * @return
+     */
+    @Interp
+    public static RubyProc newSymbolProc(ThreadContext context, String symbol, Encoding encoding) {
+        return (RubyProc)context.runtime.newSymbol(symbol, encoding).to_proc(context);
+    }
+
+    /**
+     * Create a new Symbol.to_proc for the given symbol name and encoding.
+     *
+     * @param context
+     * @param symbol
+     * @return
+     */
+    @JIT
+    public static RubyProc newSymbolProc(ThreadContext context, String symbol, String encoding) {
+        return newSymbolProc(context, symbol, retrieveJCodingsEncoding(context, encoding));
+    }
 }

--- a/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter.java
+++ b/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter.java
@@ -351,14 +351,25 @@ public abstract class IRBytecodeAdapter {
      * Stack required: none
      *
      * @param sym the symbol's string identifier
+     * @param encoding the symbol's encoding
      */
     public abstract void pushSymbol(String sym, Encoding encoding);
 
     /**
-     * Push the JRuby runtime on the stack.
+     * Push a Symbol.to_proc on the stack.
      *
      * Stack required: none
+     *
+     * @param name the symbol's string identifier
+     * @param encoding the symbol's encoding
      */
+    public abstract void pushSymbolProc(String name, Encoding encoding);
+
+        /**
+         * Push the JRuby runtime on the stack.
+         *
+         * Stack required: none
+         */
     public abstract void loadRuntime();
 
     /**

--- a/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter6.java
+++ b/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter6.java
@@ -20,6 +20,7 @@ import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
 import org.jruby.RubyHash;
 import org.jruby.RubyModule;
+import org.jruby.RubyProc;
 import org.jruby.RubyRegexp;
 import org.jruby.RubyString;
 import org.jruby.RubySymbol;
@@ -257,6 +258,18 @@ public class IRBytecodeAdapter6 extends IRBytecodeAdapter{
                 invokeIRHelper("retrieveJCodingsEncoding", sig(Encoding.class, ThreadContext.class, String.class));
 
                 adapter.invokestatic(p(RubySymbol.class), "newSymbol", sig(RubySymbol.class, Ruby.class, String.class, Encoding.class));
+            }
+        });
+    }
+
+    public void pushSymbolProc(final String name, final Encoding encoding) {
+        cacheValuePermanently("symbolProc", RubyProc.class, null, new Runnable() {
+            @Override
+            public void run() {
+                loadContext();
+                adapter.ldc(name);
+                adapter.ldc(encoding.toString());
+                invokeIRHelper("newSymbolProc", sig(RubyProc.class, ThreadContext.class, String.class, String.class));
             }
         });
     }

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -2307,6 +2307,11 @@ public class JVMVisitor extends IRVisitor {
     }
 
     @Override
+    public void SymbolProc(SymbolProc symbolproc) {
+        jvmMethod().pushSymbolProc(symbolproc.getName(), symbolproc.getEncoding());
+    }
+
+    @Override
     public void TemporaryVariable(TemporaryVariable temporaryvariable) {
         jvmLoadLocal(temporaryvariable);
     }

--- a/core/src/main/java/org/jruby/runtime/Binding.java
+++ b/core/src/main/java/org/jruby/runtime/Binding.java
@@ -33,15 +33,28 @@
 package org.jruby.runtime;
 
 import org.jruby.Ruby;
+import org.jruby.RubyBasicObject;
+import org.jruby.parser.StaticScopeFactory;
 import org.jruby.runtime.backtrace.BacktraceElement;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.scope.ManyVarsDynamicScope;
+import org.jruby.runtime.scope.NoVarsDynamicScope;
 
 /**
  *  Internal live representation of a block ({...} or do ... end).
  */
 public class Binding {
+
+    public static final Binding DUMMY =
+            new Binding(
+                    RubyBasicObject.NEVER,
+                    new Frame(),
+                    Visibility.PUBLIC,
+                    new NoVarsDynamicScope(StaticScopeFactory.newStaticScope(null, StaticScope.Type.BLOCK, null)),
+                    "<dummy>",
+                    "dummy",
+                    -1);
     
     /**
      * frame of method which defined this block


### PR DESCRIPTION
Does this seem like a good optimization? Are there any gotchas I've missed?

* Use a dummy binding rather than creating new every time.
* Cache the resulting proc at create site.

The second optimization results in a given &:foo in code only
creating a single Proc, ever, and caching it at that point in the
code. This is based on the observation that symbol procs typically
are used to iterate over homogeneous collections of objects, so
caching the proc allows its cache to stay populated and local to
the related code. This also eliminates the allocation of a Block,
BlockBody, and RubyProc for each encounter, which improves perf
also for heterogeneous collections with poor cacheability.

Benchmark:

```ruby
loop {
  puts Benchmark.measure {
    ary = [1,2,3,4]
    1_000_000.times {
      ary.each(&:object_id)
    }
  }
}
```

Before:

```
  1.270000   0.070000   1.340000 (  0.710043)
  0.640000   0.020000   0.660000 (  0.511692)
  0.470000   0.000000   0.470000 (  0.460667)
  0.490000   0.010000   0.500000 (  0.480732)
  0.470000   0.000000   0.470000 (  0.462888)
```

Just the dummy binding optimization:

```
  1.210000   0.070000   1.280000 (  0.660924)
  0.540000   0.020000   0.560000 (  0.432614)
  0.430000   0.000000   0.430000 (  0.422502)
  0.430000   0.000000   0.430000 (  0.416549)
  0.410000   0.010000   0.420000 (  0.412461)
```

And with proc caching:

```
  0.890000   0.060000   0.950000 (  0.456065)
  0.410000   0.020000   0.430000 (  0.279023)
  0.290000   0.000000   0.290000 (  0.282117)
  0.300000   0.010000   0.310000 (  0.288516)
  0.270000   0.000000   0.270000 (  0.270100)
```