### PR TITLE
Cache proxies of newly constructed Java objects

### DIFF
--- a/core/src/main/java/org/jruby/java/invokers/ConstructorInvoker.java
+++ b/core/src/main/java/org/jruby/java/invokers/ConstructorInvoker.java
@@ -55,7 +55,7 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
         JavaConstructor constructor = (JavaConstructor) findCallable(self, name, args, args.length);
 
         final Object[] convertedArgs = convertArguments(constructor, args);
-        proxy.setObject( constructor.newInstanceDirect(context, convertedArgs) );
+        setAndCacheProxyObject(context, proxy, constructor.newInstanceDirect(context, convertedArgs));
 
         return self;
     }
@@ -66,7 +66,7 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
         JavaProxy proxy = castJavaProxy(self);
         JavaConstructor constructor = (JavaConstructor) findCallableArityZero(self, name);
 
-        proxy.setObject(constructor.newInstanceDirect(context));
+        setAndCacheProxyObject(context, proxy, constructor.newInstanceDirect(context));
 
         return self;
     }
@@ -79,7 +79,7 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
         final Class<?>[] paramTypes = constructor.getParameterTypes();
         Object cArg0 = arg0.toJava(paramTypes[0]);
 
-        proxy.setObject(constructor.newInstanceDirect(context, cArg0));
+        setAndCacheProxyObject(context, proxy, constructor.newInstanceDirect(context, cArg0));
 
         return self;
     }
@@ -93,7 +93,7 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
         Object cArg0 = arg0.toJava(paramTypes[0]);
         Object cArg1 = arg1.toJava(paramTypes[1]);
 
-        proxy.setObject(constructor.newInstanceDirect(context, cArg0, cArg1));
+        setAndCacheProxyObject(context, proxy, constructor.newInstanceDirect(context, cArg0, cArg1));
 
         return self;
     }
@@ -108,7 +108,7 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
         Object cArg1 = arg1.toJava(paramTypes[1]);
         Object cArg2 = arg2.toJava(paramTypes[2]);
 
-        proxy.setObject(constructor.newInstanceDirect(context, cArg0, cArg1, cArg2));
+        setAndCacheProxyObject(context, proxy, constructor.newInstanceDirect(context, cArg0, cArg1, cArg2));
 
         return self;
     }
@@ -131,7 +131,7 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
                 convertedArgs[i] = intermediate[i].toJava(paramTypes[i]);
             }
 
-            proxy.setObject(constructor.newInstanceDirect(context, convertedArgs));
+            setAndCacheProxyObject(context, proxy, constructor.newInstanceDirect(context, convertedArgs));
 
             return self;
         }
@@ -148,7 +148,7 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
             final Class<?>[] paramTypes = constructor.getParameterTypes();
             Object cArg0 = proc.toJava(paramTypes[0]);
 
-            proxy.setObject(constructor.newInstanceDirect(context, cArg0));
+            setAndCacheProxyObject(context, proxy, constructor.newInstanceDirect(context, cArg0));
 
             return self;
         }
@@ -166,7 +166,7 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
             Object cArg0 = arg0.toJava(paramTypes[0]);
             Object cArg1 = proc.toJava(paramTypes[1]);
 
-            proxy.setObject(constructor.newInstanceDirect(context, cArg0, cArg1));
+            setAndCacheProxyObject(context, proxy, constructor.newInstanceDirect(context, cArg0, cArg1));
 
             return self;
         }
@@ -185,7 +185,7 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
             Object cArg1 = arg1.toJava(paramTypes[1]);
             Object cArg2 = proc.toJava(paramTypes[2]);
 
-            proxy.setObject(constructor.newInstanceDirect(context, cArg0, cArg1, cArg2));
+            setAndCacheProxyObject(context, proxy, constructor.newInstanceDirect(context, cArg0, cArg1, cArg2));
 
             return self;
         }
@@ -205,10 +205,15 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
             Object cArg2 = arg2.toJava(paramTypes[2]);
             Object cArg3 = proc.toJava(paramTypes[3]);
 
-            proxy.setObject(constructor.newInstanceDirect(context, cArg0, cArg1, cArg2, cArg3));
+            setAndCacheProxyObject(context, proxy, constructor.newInstanceDirect(context, cArg0, cArg1, cArg2, cArg3));
 
             return self;
         }
         return call(context, self, clazz, name, arg0, arg1, arg2);
+    }
+
+    private void setAndCacheProxyObject(ThreadContext context, JavaProxy proxy, Object object) {
+        proxy.setObject(object);
+        context.runtime.getJavaSupport().getObjectProxyCache().put(object, proxy);
     }
 }

--- a/spec/java_integration/fixtures/CachedInJava.java
+++ b/spec/java_integration/fixtures/CachedInJava.java
@@ -7,6 +7,14 @@ public class CachedInJava {
         lastInstance.set(this);
     }
 
+    public CachedInJava newInstanceFromInstance() {
+        return new CachedInJava();
+    }
+
+    public static CachedInJava newInstanceFromStatic() {
+        return new CachedInJava();
+    }
+
     public static CachedInJava getLastInstance() {
         return lastInstance.get();
     }

--- a/spec/java_integration/fixtures/CachedInJava.java
+++ b/spec/java_integration/fixtures/CachedInJava.java
@@ -1,0 +1,13 @@
+package java_integration.fixtures;
+
+public class CachedInJava {
+    private static final ThreadLocal<CachedInJava> lastInstance = new ThreadLocal<CachedInJava>();
+
+    public CachedInJava() {
+        lastInstance.set(this);
+    }
+
+    public static CachedInJava getLastInstance() {
+        return lastInstance.get();
+    }
+}

--- a/spec/java_integration/object/singleton_spec.rb
+++ b/spec/java_integration/object/singleton_spec.rb
@@ -1,0 +1,31 @@
+require File.dirname(__FILE__) + "/../spec_helper"
+
+java_import "java_integration.fixtures.CachedInJava"
+
+describe "A singleton method added to a Java object from Ruby" do
+  before(:all) { CachedInJava.__persistent__ = true }
+
+  it "caches the proxy when directly constructed" do
+    object = CachedInJava.new
+    def object.answer; 42; end
+    expect(object.answer).to eq(42)
+    expect(CachedInJava.last_instance).to eq(object)
+    expect(CachedInJava.last_instance.answer).to eq(42)
+  end
+
+  it "caches the proxy when retrieved from a Java instance method" do
+    object = CachedInJava.new.new_instance_from_instance
+    def object.answer; 42; end
+    expect(object.answer).to eq(42)
+    expect(CachedInJava.last_instance).to eq(object)
+    expect(CachedInJava.last_instance.answer).to eq(42)
+  end
+
+  it "caches the proxy when retrieved from a Java static method" do
+    object = CachedInJava.new_instance_from_static
+    def object.answer; 42; end
+    expect(object.answer).to eq(42)
+    expect(CachedInJava.last_instance).to eq(object)
+    expect(CachedInJava.last_instance.answer).to eq(42)
+  end
+end

--- a/spec/java_integration/types/construction_spec.rb
+++ b/spec/java_integration/types/construction_spec.rb
@@ -3,6 +3,7 @@ require File.dirname(__FILE__) + "/../spec_helper"
 java_import "java_integration.fixtures.ArrayReceiver"
 java_import "java_integration.fixtures.ArrayReturningInterface"
 java_import "java_integration.fixtures.ArrayReturningInterfaceConsumer"
+java_import "java_integration.fixtures.CachedInJava"
 java_import "java_integration.fixtures.PublicConstructor"
 java_import "java_integration.fixtures.ProtectedConstructor"
 java_import "java_integration.fixtures.PackageConstructor"
@@ -837,3 +838,14 @@ describe "A Ruby class extending a Java class" do
 
 end
 
+describe "A Java class being constructed from Ruby" do
+  before(:all) { CachedInJava.__persistent__ = true }
+
+  it "should be stored in proxy cache" do
+    object = CachedInJava.new
+    def object.answer; 42; end
+    expect(object.answer).to eq(42)
+    expect(CachedInJava.last_instance).to eq(object)
+    expect(CachedInJava.last_instance.answer).to eq(42)
+  end
+end

--- a/spec/java_integration/types/construction_spec.rb
+++ b/spec/java_integration/types/construction_spec.rb
@@ -3,7 +3,6 @@ require File.dirname(__FILE__) + "/../spec_helper"
 java_import "java_integration.fixtures.ArrayReceiver"
 java_import "java_integration.fixtures.ArrayReturningInterface"
 java_import "java_integration.fixtures.ArrayReturningInterfaceConsumer"
-java_import "java_integration.fixtures.CachedInJava"
 java_import "java_integration.fixtures.PublicConstructor"
 java_import "java_integration.fixtures.ProtectedConstructor"
 java_import "java_integration.fixtures.PackageConstructor"
@@ -838,14 +837,3 @@ describe "A Ruby class extending a Java class" do
 
 end
 
-describe "A Java class being constructed from Ruby" do
-  before(:all) { CachedInJava.__persistent__ = true }
-
-  it "should be stored in proxy cache" do
-    object = CachedInJava.new
-    def object.answer; 42; end
-    expect(object.answer).to eq(42)
-    expect(CachedInJava.last_instance).to eq(object)
-    expect(CachedInJava.last_instance.answer).to eq(42)
-  end
-end


### PR DESCRIPTION
This fixes #3576

I added a few related specs while I was at it (only the constructor one failed before my changes though).

I noticed the warning at `spec/READ_ME_FIRST.txt`, but wasn't sure if that applied to the `java_integration` specs, so if I should have added my spec elsewhere, please let me know.