### PR TITLE
Fix small typo in readme: 'to uses' -> 'to use'

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It aims to be a complete, correct and fast implementation of Ruby, at the same
 time as providing powerful new features such as concurrency without a
 [global-interpreter-lock](http://en.wikipedia.org/wiki/Global_Interpreter_Lock),
 true parallelism, and tight integration to the Java language to allow you to
-uses Java classes in your Ruby program and to allow JRuby to be embedded into a
+use Java classes in your Ruby program and to allow JRuby to be embedded into a
 Java application.
 
 You can use JRuby simply as a faster version of Ruby, you can use it to run Ruby


### PR DESCRIPTION
Good day!

First of all, great thanks for the great project!

While glancing over the `README.md` I have noticed this small typo: `.. to allow you to uses Java classes ..` => `.. to allow you to use Java classes ..`.

Kind Regards,
Oleksii