### PR TITLE
Test indy invokers

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -138,19 +138,6 @@ project 'JRuby Core' do
                      :id => 'add-populators',
                      'sources' => [ '${anno.sources}' ] )
     end
-
-    plugin 'org.codehaus.mojo:exec-maven-plugin' do
-      execute_goals( 'exec',
-                     :id => 'invoker-generator',
-                     'arguments' => [ '-Djruby.bytecode.version=${base.java.version}',
-                                      '-classpath',
-                                      xml( '<classpath/>' ),
-                                      'org.jruby.anno.InvokerGenerator',
-                                      '${anno.sources}/annotated_classes.txt',
-                                      '${project.build.outputDirectory}' ],
-                     'executable' =>  'java',
-                     'classpathScope' =>  'compile' )
-    end
   end
 
   plugin( :compiler,
@@ -168,32 +155,25 @@ project 'JRuby Core' do
                    :id => 'anno',
                    :phase => 'process-resources',
                    'includes' => [ 'org/jruby/anno/FrameField.java',
-                                   'org/jruby/anno/AnnotationBinder.java',
+                                   'org/jruby/anno/IndyBinder.java',
                                    'org/jruby/anno/JRubyMethod.java',
                                    'org/jruby/anno/FrameField.java',
                                    'org/jruby/CompatVersion.java',
                                    'org/jruby/runtime/Visibility.java',
                                    'org/jruby/util/CodegenUtils.java',
-                                   'org/jruby/util/SafePropertyAccessor.java' ] )
+                                   'org/jruby/util/SafePropertyAccessor.java',
+                                   'org/jruby/anno/JavaMethodDescriptorLight.java',
+                                   'org/jruby/internal/runtime/methods/DescriptorInfoLight.java'] )
     execute_goals( 'compile',
                    :id => 'default-compile',
                    :phase => 'compile',
-                   'annotationProcessors' => [ 'org.jruby.anno.AnnotationBinder' ],
-                   'generatedSourcesDirectory' =>  'target/generated-sources',
+                   'annotationProcessors' => [ 'org.jruby.anno.IndyBinder' ],
+                   'generatedSourcesDirectory' =>  'target/classes',
                    'compilerArgs' => [ '-XDignore.symbol.file=true',
                                        '-J-Duser.language=en',
                                        '-J-Dfile.encoding=UTF-8',
                                        '-J-Xbootclasspath/p:${unsafe.jar}',
                                        '-J-Xmx${jruby.compile.memory}' ] )
-    execute_goals( 'compile',
-                   :id => 'populators',
-                   :phase => 'process-classes',
-                   'compilerArgs' => [ '-XDignore.symbol.file=true',
-                                       '-J-Duser.language=en',
-                                       '-J-Dfile.encoding=UTF-8',
-                                       '-J-Xbootclasspath/p:${unsafe.jar}',
-                                       '-J-Xmx${jruby.compile.memory}' ],
-                   'includes' => [ 'org/jruby/gen/**/*.java' ] )
     execute_goals( 'compile',
                    :id => 'eclipse-hack',
                    :phase => 'process-classes',

--- a/core/pom.rb
+++ b/core/pom.rb
@@ -56,7 +56,7 @@ project 'JRuby Core' do
   jar 'org.jruby.jcodings:jcodings:1.0.16-SNAPSHOT'
   jar 'org.jruby:dirgra:0.3'
 
-  jar 'com.headius:invokebinder:1.5'
+  jar 'com.headius:invokebinder:1.7-SNAPSHOT'
   jar 'com.headius:options:1.4-SNAPSHOT'
   jar 'com.headius:coro-mock:1.0', :scope => 'provided'
   jar 'com.headius:unsafe-mock', '${unsafe.version}', :scope => 'provided'

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -194,7 +194,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>com.headius</groupId>
       <artifactId>invokebinder</artifactId>
-      <version>1.5</version>
+      <version>1.7-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.headius</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -406,31 +406,6 @@ DO NOT MODIFIY - GENERATED CODE
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>invoker-generator</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <arguments>
-                <argument>-Djruby.bytecode.version=${base.java.version}</argument>
-                <argument>-classpath</argument>
-                <classpath />
-                <argument>org.jruby.anno.InvokerGenerator</argument>
-                <argument>${anno.sources}/annotated_classes.txt</argument>
-                <argument>${project.build.outputDirectory}</argument>
-              </arguments>
-              <executable>java</executable>
-              <classpathScope>compile</classpathScope>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <executions>
           <execution>
@@ -442,13 +417,15 @@ DO NOT MODIFIY - GENERATED CODE
             <configuration>
               <includes>
                 <include>org/jruby/anno/FrameField.java</include>
-                <include>org/jruby/anno/AnnotationBinder.java</include>
+                <include>org/jruby/anno/IndyBinder.java</include>
                 <include>org/jruby/anno/JRubyMethod.java</include>
                 <include>org/jruby/anno/FrameField.java</include>
                 <include>org/jruby/CompatVersion.java</include>
                 <include>org/jruby/runtime/Visibility.java</include>
                 <include>org/jruby/util/CodegenUtils.java</include>
                 <include>org/jruby/util/SafePropertyAccessor.java</include>
+                <include>org/jruby/anno/JavaMethodDescriptorLight.java</include>
+                <include>org/jruby/internal/runtime/methods/DescriptorInfoLight.java</include>
               </includes>
             </configuration>
           </execution>
@@ -460,9 +437,9 @@ DO NOT MODIFIY - GENERATED CODE
             </goals>
             <configuration>
               <annotationProcessors>
-                <annotationProcessor>org.jruby.anno.AnnotationBinder</annotationProcessor>
+                <annotationProcessor>org.jruby.anno.IndyBinder</annotationProcessor>
               </annotationProcessors>
-              <generatedSourcesDirectory>target/generated-sources</generatedSourcesDirectory>
+              <generatedSourcesDirectory>target/classes</generatedSourcesDirectory>
               <compilerArgs>
                 <compilerArg>-XDignore.symbol.file=true</compilerArg>
                 <compilerArg>-J-Duser.language=en</compilerArg>
@@ -470,25 +447,6 @@ DO NOT MODIFIY - GENERATED CODE
                 <compilerArg>-J-Xbootclasspath/p:${unsafe.jar}</compilerArg>
                 <compilerArg>-J-Xmx${jruby.compile.memory}</compilerArg>
               </compilerArgs>
-            </configuration>
-          </execution>
-          <execution>
-            <id>populators</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <configuration>
-              <compilerArgs>
-                <compilerArg>-XDignore.symbol.file=true</compilerArg>
-                <compilerArg>-J-Duser.language=en</compilerArg>
-                <compilerArg>-J-Dfile.encoding=UTF-8</compilerArg>
-                <compilerArg>-J-Xbootclasspath/p:${unsafe.jar}</compilerArg>
-                <compilerArg>-J-Xmx${jruby.compile.memory}</compilerArg>
-              </compilerArgs>
-              <includes>
-                <include>org/jruby/gen/**/*.java</include>
-              </includes>
             </configuration>
           </execution>
           <execution>

--- a/core/src/main/java/org/jruby/anno/ExecutableElementDescriptor.java
+++ b/core/src/main/java/org/jruby/anno/ExecutableElementDescriptor.java
@@ -1,0 +1,110 @@
+/*
+ ***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 1.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 1.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2008-2013 Charles Oliver Nutter <headius@headius.com>
+ * 
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.anno;
+
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.NestingKind;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Modifier;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A version of MethodDescriptor that works against ExecutableElement during compile time annotation processing.
+ */
+public class ExecutableElementDescriptor extends MethodDescriptor<ExecutableElement> {
+    public final ExecutableElement method;
+
+    public ExecutableElementDescriptor(ExecutableElement method) {
+        super(method);
+        this.method = method;
+    }
+
+    protected <A extends Annotation> A getAnnotation(ExecutableElement methodObject, Class<A> annotationType) {
+        return methodObject.getAnnotation(annotationType);
+    }
+
+    protected int getModifiers(ExecutableElement methodObject) {
+        Set<javax.lang.model.element.Modifier> mods = methodObject.getModifiers();
+        int modifierTmp = 0;
+        try {
+            // TODO: gross
+            for (javax.lang.model.element.Modifier mod : mods) {
+                modifierTmp |= (Integer) Modifier.class.getField(mod.name()).get(null);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return modifierTmp;
+    }
+
+    protected String getDeclaringClassName(ExecutableElement methodObject) {
+        return getActualQualifiedName((TypeElement) methodObject.getEnclosingElement()).toString();
+    }
+
+    protected String getSimpleName(ExecutableElement methodObject) {
+        return methodObject.getSimpleName().toString();
+    }
+
+    protected boolean hasContext(ExecutableElement methodObject) {
+        List<? extends VariableElement> symbolicParameters = methodObject.getParameters();
+        if (symbolicParameters.size() > 0) {
+            return symbolicParameters.get(0).asType().toString().equals("org.jruby.runtime.ThreadContext");
+        }
+
+        return false;
+    }
+
+    protected boolean hasBlock(ExecutableElement methodObject) {
+        List<? extends VariableElement> symbolicParameters = methodObject.getParameters();
+
+        if (symbolicParameters.size() > 0) {
+            return symbolicParameters.get(symbolicParameters.size() - 1).asType().toString().equals("org.jruby.runtime.Block");
+        }
+
+        return false;
+    }
+
+    protected int parameterCount(ExecutableElement methodObject) {
+        return methodObject.getParameters().size();
+    }
+
+    protected String parameterAsString(ExecutableElement methodObject, int index) {
+        return methodObject.getParameters().get(index).asType().toString();
+    }
+
+    public static CharSequence getActualQualifiedName(TypeElement td) {
+        if (td.getNestingKind() == NestingKind.MEMBER) {
+            return getActualQualifiedName((TypeElement)td.getEnclosingElement()) + "$" + td.getSimpleName();
+        }
+        return td.getQualifiedName().toString();
+    }
+}

--- a/core/src/main/java/org/jruby/anno/IndyBinder.java
+++ b/core/src/main/java/org/jruby/anno/IndyBinder.java
@@ -1,0 +1,624 @@
+/*
+ ***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 1.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 1.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2008-2013 Charles Oliver Nutter <headius@headius.com>
+ * 
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.anno;
+
+import jnr.ffi.provider.jffi.SkinnyMethodAdapter;
+import org.jruby.internal.runtime.methods.DescriptorInfo;
+import org.jruby.runtime.Visibility;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.Method;
+
+import javax.annotation.Generated;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.NestingKind;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import static org.jruby.util.CodegenUtils.*;
+import static org.objectweb.asm.Opcodes.*;
+
+/**
+ * Annotation processor for generating "populators" to bind native Java methods as Ruby methods, and
+ * to gather a list of classes seen during compilation that should have their invokers regenerated.
+ *
+ * NOTE: This class must ONLY reference classes in the org.jruby.anno package, to avoid forcing
+ * a transitive dependency on any runtime JRuby classes.
+ */
+@SupportedAnnotationTypes({"org.jruby.anno.JRubyMethod"})
+public class IndyBinder extends AbstractProcessor {
+
+    public static final String POPULATOR_SUFFIX = "$POPULATOR";
+    private static final Logger LOG = Logger.getLogger("IndyBinder");
+    public static final String SRC_GEN_DIR = "target/classes/org/jruby/gen/";
+    public static final int CLASS = 1;
+    public static final int BASEMETHOD = 3;
+    public static final int MODULEMETHOD = 4;
+    public static final int RUNTIME = 5;
+    public static final int SINGLETONCLASS = 6;
+    public static final int RUBYMODULE = 1;
+    private final List<CharSequence> classNames = new ArrayList<CharSequence>();
+    private SkinnyMethodAdapter mv;
+    private static final boolean DEBUG = false;
+
+    @Override
+    public boolean process(Set<? extends TypeElement> typeElements, RoundEnvironment roundEnvironment) {
+        for (TypeElement element : ElementFilter.typesIn(roundEnvironment.getRootElements())) {
+            processType(element);
+        }
+
+        try {
+            FileWriter fw = new FileWriter("target/generated-sources/annotated_classes.txt");
+            for (CharSequence name : classNames) {
+                fw.write(name.toString());
+                fw.write('\n');
+            }
+            fw.close();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        return true;
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
+    }
+
+    public void processType(TypeElement cd) {
+        // process inner classes
+        for (TypeElement innerType : ElementFilter.typesIn(cd.getEnclosedElements())) {
+            processType(innerType);
+        }
+
+        try {
+            String qualifiedName = cd.getQualifiedName().toString().replace('.', '$');
+
+            // skip anything not related to jruby
+            if (!qualifiedName.contains("org$jruby")) {
+                return;
+            }
+
+            ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+
+            cw.visitAnnotation(p(Generated.class), true);
+
+            cw.visit(Opcodes.V1_7, ACC_PUBLIC, ("org.jruby.gen." + qualifiedName + POPULATOR_SUFFIX).replace('.', '/'), null, "org/jruby/anno/TypePopulator", null);
+
+            mv = new SkinnyMethodAdapter(cw, ACC_PUBLIC, "<init>", "()V", null, null);
+            mv.start();
+            mv.aload(0);
+            mv.invokespecial("org/jruby/anno/TypePopulator", "<init>", "()V");
+            mv.voidreturn();
+            mv.end();
+
+            mv = new SkinnyMethodAdapter(cw, ACC_PUBLIC, "populate", "(Lorg/jruby/RubyModule;Ljava/lang/Class;)V", null, null);
+
+            mv.start();
+
+            if (DEBUG) {
+                mv.ldc("Using pregenerated populator: " + qualifiedName + POPULATOR_SUFFIX);
+                mv.aprintln();
+            }
+
+            // scan for meta, compat, etc to reduce findbugs complaints about "dead assignments"
+            boolean hasAnno = false;
+            boolean hasMeta = false;
+            boolean hasModule = false;
+            for (ExecutableElement method : ElementFilter.methodsIn(cd.getEnclosedElements())) {
+                JRubyMethod anno = method.getAnnotation(JRubyMethod.class);
+                if (anno == null) {
+                    continue;
+                }
+                hasAnno = true;
+                hasMeta |= anno.meta();
+                hasModule |= anno.module();
+            }
+
+            if (!hasAnno) return;
+
+//            mv.local(BASEMETHOD, "javaMethod", "Lorg/jruby/internal/runtime/methods/HandleMethod;");
+//            mv.local(MODULEMETHOD, "moduleMethod", "Lorg/jruby/internal/runtime/methods/HandleMethod;");
+//
+//            mv.local(RUNTIME, "runtime", RUBY_TYPE);
+            mv.aload(RUBYMODULE);
+            mv.invokevirtual("org/jruby/RubyModule", "getRuntime", "()Lorg/jruby/Ruby;");
+            mv.astore(RUNTIME);
+
+            if (hasMeta || hasModule) {
+//                mv.local(SINGLETONCLASS, "singletonClass", RUBYMODULE_TYPE);
+                mv.aload(1);
+                mv.invokevirtual("org/jruby/RubyModule", "getSingletonClass", "()Lorg/jruby/RubyClass;");
+                mv.astore(SINGLETONCLASS);
+            }
+
+            Map<CharSequence, List<ExecutableElement>> annotatedMethods = new HashMap<CharSequence, List<ExecutableElement>>();
+            Map<CharSequence, List<ExecutableElement>> staticAnnotatedMethods = new HashMap<CharSequence, List<ExecutableElement>>();
+
+            Set<String> frameAwareMethods = new HashSet<String>();
+            Set<String> scopeAwareMethods = new HashSet<String>();
+
+            int methodCount = 0;
+            for (ExecutableElement method : ElementFilter.methodsIn(cd.getEnclosedElements())) {
+                JRubyMethod anno = method.getAnnotation(JRubyMethod.class);
+                if (anno == null) {
+                    continue;
+                }
+                methodCount++;
+
+                // warn if the method raises any exceptions (JRUBY-4494)
+                if (method.getThrownTypes().size() != 0) {
+                    System.err.print("Method " + cd.toString() + "." + method.toString() + " should not throw exceptions: ");
+                    boolean comma = false;
+                    for (TypeMirror thrownType : method.getThrownTypes()) {
+                        if (comma) System.err.print(", ");
+                        System.err.print(thrownType);
+                        comma = true;
+                    }
+                    System.err.print("\n");
+                }
+
+                CharSequence name = anno.name().length == 0 ? method.getSimpleName() : anno.name()[0];
+
+                List<ExecutableElement> methodDescs;
+                Map<CharSequence, List<ExecutableElement>> methodsHash = null;
+                if (method.getModifiers().contains(Modifier.STATIC)) {
+                    methodsHash = staticAnnotatedMethods;
+                } else {
+                    methodsHash = annotatedMethods;
+                }
+
+                methodDescs = methodsHash.get(name);
+                if (methodDescs == null) {
+                    methodDescs = new ArrayList<ExecutableElement>();
+                    methodsHash.put(name, methodDescs);
+                }
+
+                methodDescs.add(method);
+
+                // check for frame field reads or writes
+                boolean frame = false;
+                boolean scope = false;
+                if (anno.frame()) {
+                    if (DEBUG)
+                        System.out.println("Method has frame = true: " + methodDescs.get(0).getEnclosingElement() + ":" + methodDescs);
+                    frame = true;
+                }
+                if (anno.scope()) {
+                    if (DEBUG)
+                        System.out.println("Method has frame = true: " + methodDescs.get(0).getEnclosingElement() + ":" + methodDescs);
+                    scope = true;
+                }
+                for (FrameField field : anno.reads()) {
+                    frame |= field.needsFrame();
+                    scope |= field.needsScope();
+                }
+                for (FrameField field : anno.writes()) {
+                    frame |= field.needsFrame();
+                    scope |= field.needsScope();
+                }
+                
+                if (frame) addMethodNamesToSet(frameAwareMethods, anno, method.getSimpleName().toString());
+                if (scope) addMethodNamesToSet(scopeAwareMethods, anno, method.getSimpleName().toString());
+            }
+
+            if (methodCount == 0) {
+                // no annotated methods found, skip
+                return;
+            }
+
+            classNames.add(getActualQualifiedName(cd));
+
+            processMethodDeclarations(staticAnnotatedMethods);
+            for (Map.Entry<CharSequence, List<ExecutableElement>> entry : staticAnnotatedMethods.entrySet()) {
+                ExecutableElement decl = entry.getValue().get(0);
+                if (!decl.getAnnotation(JRubyMethod.class).omit()) addCoreMethodMapping(entry.getKey(), decl);
+            }
+
+            processMethodDeclarations(annotatedMethods);
+            for (Map.Entry<CharSequence, List<ExecutableElement>> entry : annotatedMethods.entrySet()) {
+                ExecutableElement decl = entry.getValue().get(0);
+                if (!decl.getAnnotation(JRubyMethod.class).omit()) addCoreMethodMapping(entry.getKey(), decl);
+            }
+
+            mv.voidreturn();
+            mv.end();
+
+            // write out a static initializer for frame names, so it only fires once
+            mv = new SkinnyMethodAdapter(cw, ACC_PUBLIC | ACC_STATIC, "<clinit>", "()V", null, null);
+
+            mv.start();
+
+            if (!frameAwareMethods.isEmpty()) {
+                mv.ldc(frameAwareMethods.size());
+                mv.anewarray("java/lang/String");
+                int index = 0;
+                for (CharSequence name : frameAwareMethods) {
+                    mv.dup();
+                    mv.ldc(index++);
+                    mv.ldc(name);
+                    mv.aastore();
+                }
+                mv.invokestatic("org/jruby/runtime/MethodIndex", "addFrameAwareMethods", "([Ljava/lang/String;)V");
+            }
+            if (!scopeAwareMethods.isEmpty()) {
+                mv.ldc(frameAwareMethods.size());
+                mv.anewarray("java/lang/String");
+                int index = 0;
+                for (CharSequence name : scopeAwareMethods) {
+                    mv.dup();
+                    mv.ldc(index++);
+                    mv.ldc(name);
+                    mv.aastore();
+                }
+                mv.invokestatic("org/jruby/runtime/MethodIndex", "addScopeAwareMethods", "([Ljava/lang/String;)V");
+            }
+
+            mv.voidreturn();
+            mv.end();
+
+            cw.visitEnd();
+
+            new File(SRC_GEN_DIR).mkdirs();
+            FileOutputStream fos = new FileOutputStream(SRC_GEN_DIR + qualifiedName + POPULATOR_SUFFIX + ".class");
+            fos.write(cw.toByteArray());
+            fos.close();
+        } catch (IOException ioe) {
+            LOG.severe("FAILED TO GENERATE: " + ioe);
+            System.exit(1);
+        }
+    }
+
+    // FIXME: Duplicated from AnnotationHelper, because it pulls in Signature which pulls in Ruby
+    public static void addMethodNamesToSet(Set<String> set, JRubyMethod jrubyMethod, String simpleName) {
+        if (jrubyMethod.name().length == 0) {
+            set.add(simpleName);
+        } else {
+            set.addAll(Arrays.asList(jrubyMethod.name()));
+        }
+
+        if (jrubyMethod.alias().length > 0) {
+            set.addAll(Arrays.asList(jrubyMethod.alias()));
+        }
+    }
+
+    public void processMethodDeclarations(Map<CharSequence, List<ExecutableElement>> declarations) {
+        for (Map.Entry<CharSequence, List<ExecutableElement>> entry : declarations.entrySet()) {
+            List<ExecutableElement> list = entry.getValue();
+
+            if (list.size() == 1) {
+                // single method, use normal logic
+                processMethodDeclaration(list.get(0));
+            } else {
+                // multimethod, new logic
+                processMethodDeclarationMulti(list);
+            }
+        }
+    }
+
+    public void processMethodDeclaration(ExecutableElement method) {
+        processMethodDeclarationMulti(Arrays.asList(method));
+    }
+
+    public static long getEncodedSignature(JRubyMethod anno) {
+        return encodeSignature(anno.required(), anno.optional(), 0, 0, 0, anno.rest(), false);
+    }
+
+    public void processMethodDeclarationMulti(List<ExecutableElement> methods) {
+        Handle[] handles = new Handle[5];
+        List<ExecutableElementDescriptor> descs = new ArrayList<>();
+        boolean meta = false;
+        boolean isStatic = false;
+        JRubyMethod anno = null;
+        int min = Integer.MAX_VALUE;
+        int max = 0;
+
+        Map<Handle, ExecutableElementDescriptor> handleToDesc = new HashMap<>();
+
+        for (ExecutableElement method : methods) {
+            anno = method.getAnnotation(JRubyMethod.class);
+            ExecutableElementDescriptor desc = new ExecutableElementDescriptor(method);
+            descs.add(desc);
+
+            if (anno != null && mv != null) {
+                isStatic |= desc.isStatic;
+                CharSequence qualifiedName = desc.declaringClassName;
+
+                boolean hasContext = desc.hasContext;
+                boolean hasBlock = desc.hasBlock;
+
+                StringBuffer buffer = new StringBuffer(method.getReturnType().toString() + " foo(");
+                boolean first = true;
+                for (VariableElement parameter : method.getParameters()) {
+                    if (!first) buffer.append(",");
+                    first = false;
+                    buffer.append(parameter.asType().toString());
+                }
+                buffer.append(')');
+
+                Handle handle = new Handle(isStatic ? H_INVOKESTATIC : H_INVOKEVIRTUAL, qualifiedName.toString().replace('.', '/'), method.getSimpleName().toString(), Method.getMethod(buffer.toString()).getDescriptor());
+
+                int handleOffset = calculateHandleOffset(method.getParameters().size(), anno.required(), anno.optional(), anno.rest(), isStatic, hasContext, hasBlock);
+
+                handles[handleOffset] = handle;
+                handleToDesc.put(handle, desc);
+
+                meta |= anno.meta();
+
+                int specificArity = -1;
+                if (desc.optional == 0 && !desc.rest) {
+                    if (desc.required == 0) {
+                        if (desc.actualRequired <= 3) {
+                            specificArity = desc.actualRequired;
+                        }
+                    } else if (desc.required >= 0 && desc.required <= 3) {
+                        specificArity = desc.required;
+                    }
+                }
+
+                if (specificArity != -1) {
+                    if (specificArity < min) min = specificArity;
+                    if (specificArity > max) max = specificArity;
+                } else {
+                    if (desc.required < min) min = desc.required;
+                    if (desc.rest) max = Integer.MAX_VALUE;
+                    if (desc.required + desc.optional > max) max = desc.required + desc.optional;
+                }
+            }
+        }
+
+        int implClass = meta ? SINGLETONCLASS : CLASS;
+
+        mv.newobj("org/jruby/internal/runtime/methods/HandleMethod");
+        mv.dup();
+
+        mv.aload(implClass);
+        mv.getstatic(p(Visibility.class), anno.visibility().name(), ci(Visibility.class));
+        mv.ldc(encodeSignature(0, 0, 0, 0, 0, true, false));
+        mv.ldc(true);
+        mv.ldc(anno.notImplemented());
+
+        DescriptorInfo info = new DescriptorInfo(descs);
+
+        mv.ldc(info.getParameterDesc());
+
+        mv.ldc(min);
+        mv.ldc(max);
+
+        for (int i = 0; i < 5; i++) {
+            if (handles[i] != null) {
+                mv.ldc(handles[i]);
+
+                adaptHandle(handleToDesc.get(handles[i]), implClass);
+            } else {
+                mv.aconst_null();
+            }
+        }
+
+        Method handleInit = Method.getMethod("void foo(org.jruby.RubyModule, org.jruby.runtime.Visibility, long, boolean, boolean, java.lang.String, int, int, java.util.concurrent.Callable, java.util.concurrent.Callable, java.util.concurrent.Callable, java.util.concurrent.Callable, java.util.concurrent.Callable)");
+        mv.invokespecial("org/jruby/internal/runtime/methods/HandleMethod", "<init>", handleInit.getDescriptor());
+
+        mv.astore(BASEMETHOD);
+
+        generateMethodAddCalls(methods.get(0), anno);
+    }
+
+    public void adaptHandle(ExecutableElementDescriptor executableElementDescriptor, int implClass) {
+        ExecutableElementDescriptor desc = executableElementDescriptor;
+
+        // adapt handle
+        mv.aload(RUNTIME);
+        mv.ldc(calculateActualRequired(desc.method, desc.method.getParameters().size(), desc.optional, desc.rest, desc.isStatic, desc.hasContext, desc.hasBlock));
+        mv.ldc(desc.required);
+        mv.ldc(desc.optional);
+        mv.ldc(desc.rest);
+        mv.ldc(desc.rubyName);
+        mv.ldc(Type.getObjectType(desc.declaringClassPath));
+        mv.ldc(desc.isStatic);
+        mv.ldc(desc.hasContext);
+        mv.ldc(desc.hasBlock);
+        mv.ldc(desc.anno.frame());
+        mv.aload(implClass);
+        mv.invokestatic("org/jruby/internal/runtime/methods/InvokeDynamicMethodFactory", "adaptHandle", Method.getMethod("java.util.concurrent.Callable adaptHandle(java.lang.invoke.MethodHandle, org.jruby.Ruby, int, int, int, boolean, java.lang.String, java.lang.Class, boolean, boolean, boolean, boolean, org.jruby.RubyModule)").getDescriptor());
+    }
+
+    private void addCoreMethodMapping(CharSequence rubyName, ExecutableElement decl) {
+        mv.aload(RUNTIME);
+        mv.ldc(((TypeElement) decl.getEnclosingElement()).getQualifiedName().toString());
+        mv.ldc(decl.getSimpleName().toString());
+        mv.ldc(rubyName.toString());
+        mv.invokevirtual("org/jruby/Ruby", "addBoundMethod", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+    }
+
+    private CharSequence getActualQualifiedName(TypeElement td) {
+        if (td.getNestingKind() == NestingKind.MEMBER) {
+            return getActualQualifiedName((TypeElement)td.getEnclosingElement()) + "$" + td.getSimpleName();
+        }
+        return td.getQualifiedName().toString();
+    }
+
+    // FIXME: duplicated from Signature, since it pulls in org.jruby.Ruby
+
+    private static final int MAX_ENCODED_ARGS_EXPONENT = 8;
+    private static final int MAX_ENCODED_ARGS_MASK = 0xFF;
+    private static final int ENCODE_RESTKWARGS_SHIFT = 0;
+    private static final int ENCODE_REST_SHIFT = ENCODE_RESTKWARGS_SHIFT + 1;
+    private static final int ENCODE_REQKWARGS_SHIFT = ENCODE_REST_SHIFT + MAX_ENCODED_ARGS_EXPONENT;
+    private static final int ENCODE_KWARGS_SHIFT = ENCODE_REQKWARGS_SHIFT + MAX_ENCODED_ARGS_EXPONENT;
+    private static final int ENCODE_POST_SHIFT = ENCODE_KWARGS_SHIFT + MAX_ENCODED_ARGS_EXPONENT;
+    private static final int ENCODE_OPT_SHIFT = ENCODE_POST_SHIFT + MAX_ENCODED_ARGS_EXPONENT;
+    private static final int ENCODE_PRE_SHIFT = ENCODE_OPT_SHIFT + MAX_ENCODED_ARGS_EXPONENT;
+
+    public static long encodeSignature(int pre, int opt, int post, int kwargs, int requiredKwargs, boolean rest, boolean restKwargs) {
+        return
+                ((long)pre << ENCODE_PRE_SHIFT) |
+                        ((long)opt << ENCODE_OPT_SHIFT) |
+                        ((long)post << ENCODE_POST_SHIFT) |
+                        ((long)kwargs << ENCODE_KWARGS_SHIFT) |
+                        ((long)requiredKwargs << ENCODE_REQKWARGS_SHIFT) |
+                        ((rest ? 1 : 0) << ENCODE_REST_SHIFT) |
+                        ((restKwargs?1:0) << ENCODE_RESTKWARGS_SHIFT);
+    }
+
+    private int calculateActualRequired(ExecutableElement md, int paramsLength, int optional, boolean rest, boolean isStatic, boolean hasContext, boolean hasBlock) {
+        int actualRequired;
+        if (optional == 0 && !rest) {
+            int args = paramsLength;
+            if (args == 0) {
+                actualRequired = 0;
+            } else {
+                if (isStatic) {
+                    args--;
+                }
+                if (hasContext) {
+                    args--;
+                }
+                if (hasBlock) {
+                    args--;                        // TODO: confirm expected args are IRubyObject (or similar)
+                }
+                actualRequired = args;
+            }
+        } else {
+            // optional args, so we have IRubyObject[]
+            // TODO: confirm
+            int args = paramsLength;
+            if (args == 0) {
+                actualRequired = 0;
+            } else {
+                if (isStatic) {
+                    args--;
+                }
+                if (hasContext) {
+                    args--;
+                }
+                if (hasBlock) {
+                    args--;                        // minus one more for IRubyObject[]
+                }
+                args--;
+
+                // TODO: confirm expected args are IRubyObject (or similar)
+                actualRequired = args;
+            }
+
+            if (actualRequired != 0) {
+                throw new RuntimeException("Combining specific args with IRubyObject[] is not yet supported: "
+                        + ((TypeElement)md.getEnclosingElement()).getQualifiedName() + "." + md.toString());
+            }
+        }
+
+        return actualRequired;
+    }
+
+    private int calculateHandleOffset(int paramsLength, int required, int optional, boolean rest, boolean isStatic, boolean hasContext, boolean hasBlock) {
+        if (required < 4 && optional == 0 && !rest) {
+            int args = paramsLength;
+            if (args == 0) {
+                return 0;
+            } else {
+                if (isStatic) {
+                    args--;
+                }
+                if (hasContext) {
+                    args--;
+                }
+                if (hasBlock) {
+                    args--;                        // TODO: confirm expected args are IRubyObject (or similar)
+                }
+                return args;
+            }
+        } else {
+            return 4;
+        }
+    }
+
+    public void generateMethodAddCalls(ExecutableElement md, JRubyMethod jrubyMethod) {
+        if (jrubyMethod.meta()) {
+            defineMethodOnClass(BASEMETHOD, SINGLETONCLASS, jrubyMethod, md);
+        } else {
+            defineMethodOnClass(BASEMETHOD, CLASS, jrubyMethod, md);
+            if (jrubyMethod.module()) {
+                mv.aload(CLASS);
+                mv.aload(BASEMETHOD);
+                mv.invokestatic("org/jruby/anno/TypePopulator", "populateModuleMethod", "(Lorg/jruby/RubyModule;Lorg/jruby/internal/runtime/methods/DynamicMethod;)Lorg/jruby/internal/runtime/methods/DynamicMethod;");
+                mv.astore(MODULEMETHOD);
+                defineMethodOnClass(MODULEMETHOD, SINGLETONCLASS, jrubyMethod, md);
+            }
+        }
+    }
+
+    private void defineMethodOnClass(int methodVar, int classVar, JRubyMethod jrubyMethod, ExecutableElement md) {
+        String baseName;
+        if (jrubyMethod.name().length == 0) {
+            baseName = md.getSimpleName().toString();
+            mv.aload(classVar);
+            mv.ldc(baseName);
+            mv.aload(methodVar);
+            mv.invokevirtual("org/jruby/RubyModule", "addMethodAtBootTimeOnly", "(Ljava/lang/String;Lorg/jruby/internal/runtime/methods/DynamicMethod;)V");
+        } else {
+            baseName = jrubyMethod.name()[0];
+            for (String name : jrubyMethod.name()) {
+                mv.aload(classVar);
+                mv.ldc(name);
+                mv.aload(methodVar);
+                mv.invokevirtual("org/jruby/RubyModule", "addMethodAtBootTimeOnly", "(Ljava/lang/String;Lorg/jruby/internal/runtime/methods/DynamicMethod;)V");
+            }
+        }
+
+        if (jrubyMethod.alias().length > 0) {
+            for (String alias : jrubyMethod.alias()) {
+                mv.aload(classVar);
+                mv.ldc(alias);
+                mv.ldc(baseName);
+                mv.invokevirtual("org/jruby/RubyModule", "defineAlias", "(Ljava/lang/String;Ljava/lang/String;)V");
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/jruby/anno/JRubyMethod.java
+++ b/core/src/main/java/org/jruby/anno/JRubyMethod.java
@@ -74,6 +74,7 @@ public @interface JRubyMethod {
     /**
      * Whether this method expects to have a heap-based variable scope allocated for it.
      */
+    @Deprecated
     boolean scope() default false;
     /**
      * Whether this method is specific to Ruby 1.9

--- a/core/src/main/java/org/jruby/anno/JavaMethodDescriptor.java
+++ b/core/src/main/java/org/jruby/anno/JavaMethodDescriptor.java
@@ -28,137 +28,86 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby.anno;
 
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import org.jruby.util.CodegenUtils;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
-import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.CodegenUtils;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 
-public class JavaMethodDescriptor {
-    public final boolean isStatic;
-    public final boolean hasContext;
-    public final boolean hasBlock;
-    public final boolean hasVarArgs;
-    public final int actualRequired;
-    public final int arity;
-    public final int required;
-    public final int optional;
-    public final boolean rest;
+public class JavaMethodDescriptor extends MethodDescriptor<Method> {
     public final Class[] parameters;
     public final Class returnClass;
-    public final JRubyMethod anno;
-    public final int modifiers;
     public final Class declaringClass;
-    public final String declaringClassName;
-    public final String declaringClassPath;
-    public final String name;
     public final String signature;
     public final Class[] argumentTypes;
-    
+
     public JavaMethodDescriptor(Method method) {
-        anno = method.getAnnotation(JRubyMethod.class);
-        
-        modifiers = method.getModifiers();
+        super(method);
+
         declaringClass = method.getDeclaringClass();
-        declaringClassName = declaringClass.getName();
-        declaringClassPath = CodegenUtils.p(declaringClass);
-        name = method.getName();
-        isStatic = Modifier.isStatic(modifiers);
         parameters = method.getParameterTypes();
         returnClass = method.getReturnType();
-        if (parameters.length > 0) {
-            hasContext = parameters[0] == ThreadContext.class;
-            hasBlock = parameters[parameters.length - 1] == Block.class;
-        } else {
-            hasContext = false;
-            hasBlock = false;
-        }
-        
-        if (hasContext) {
-            if (isStatic && (parameters.length < 2 || parameters[1] != IRubyObject.class)) {
-                throw new RuntimeException("static method without self argument: " + method);
-            }
-
-            if (hasBlock) {
-                // args should be before block
-                hasVarArgs = parameters[parameters.length - 2] == IRubyObject[].class;
-            } else {
-                // args should be at end
-                hasVarArgs = parameters[parameters.length - 1] == IRubyObject[].class;
-            }
-        } else {
-            if (isStatic && (parameters.length < 1 || parameters[0] != IRubyObject.class)) {
-                throw new RuntimeException("static method without self argument: " + method);
-            }
-
-            if (hasBlock) {
-                hasVarArgs = parameters.length > 1 && parameters[parameters.length - 2] == IRubyObject[].class;
-            } else {
-                hasVarArgs = parameters.length > 0 && parameters[parameters.length - 1] == IRubyObject[].class;
-            }
-        }
 
         int start = (hasContext ? 1 : 0) + (isStatic ? 1 : 0);
         int end = parameters.length - (hasBlock ? 1 : 0);
         argumentTypes = new Class[end - start];
         System.arraycopy(parameters, start, argumentTypes, 0, end - start);
-        
-        optional = anno.optional();
-        rest = anno.rest();
-        required = anno.required();
-        
-        if (optional == 0 && !rest) {
-            int args = parameters.length;
-            if (args == 0) {
-                actualRequired = 0;
-            } else {
-                if (isStatic) args--;
-                if (hasContext) args--;
-                if (hasBlock) args--;
 
-                // TODO: confirm expected args are IRubyObject (or similar)
-                actualRequired = args;
-            }
-        } else {
-            // optional args, so we have IRubyObject[]
-            // TODO: confirm
-            int args = parameters.length;
-            if (args == 0) {
-                actualRequired = 0;
-            } else {
-                if (isStatic) args--;
-                if (hasContext) args--;
-                if (hasBlock) args--;
-
-                // minus one more for IRubyObject[]
-                args--;
-
-                // TODO: confirm expected args are IRubyObject (or similar)
-                actualRequired = args;
-            }
-            
-            if (actualRequired != 0) {
-                throw new RuntimeException("Combining specific args with IRubyObject[] is not yet supported");
-            }
-        }
-        
-        int arityRequired = Math.max(required, actualRequired);
-        arity = (optional > 0 || rest) ? -(arityRequired + 1) : arityRequired;
-        
         signature = CodegenUtils.sig(method.getReturnType(), method.getParameterTypes());
     }
-    
+
     public Class getDeclaringClass() {
         return declaringClass;
     }
-    
+
     public Class[] getParameterClasses() {
         return parameters;
     }
 
     public Class getReturnClass() {
         return returnClass;
+    }
+
+    protected <A extends Annotation> A getAnnotation(Method methodObject, Class<A> annotationType) {
+        return methodObject.getAnnotation(annotationType);
+    }
+
+    protected int getModifiers(Method methodObject) {
+        return methodObject.getModifiers();
+    }
+
+    protected String getDeclaringClassName(Method methodObject) {
+        return methodObject.getDeclaringClass().getName();
+    }
+
+    protected String getSimpleName(Method methodObject) {
+        return methodObject.getName();
+    }
+
+    protected boolean hasContext(Method methodObject) {
+        Class[] parameters = methodObject.getParameterTypes();
+        if (parameters.length > 0) {
+            return parameters[0] == ThreadContext.class;
+        }
+
+        return false;
+    }
+
+    protected boolean hasBlock(Method methodObject) {
+        Class[] parameters = methodObject.getParameterTypes();
+        if (parameters.length > 0) {
+            return parameters[parameters.length - 1] == Block.class;
+        }
+
+        return false;
+    }
+
+    protected int parameterCount(Method methodObject) {
+        return methodObject.getParameterTypes().length;
+    }
+
+    protected String parameterAsString(Method methodObject, int index) {
+        return methodObject.getParameterTypes()[index].getName();
     }
 }

--- a/core/src/main/java/org/jruby/anno/MethodDescriptor.java
+++ b/core/src/main/java/org/jruby/anno/MethodDescriptor.java
@@ -1,0 +1,142 @@
+/*
+ ***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 1.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 1.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2008-2013 Charles Oliver Nutter <headius@headius.com>
+ * 
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.anno;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Modifier;
+
+public abstract class MethodDescriptor<T> {
+    public final boolean isStatic;
+    public final boolean hasContext;
+    public final boolean hasBlock;
+    public final boolean hasVarArgs;
+    public final int actualRequired;
+    public final int arity;
+    public final int required;
+    public final int optional;
+    public final boolean rest;
+    public final JRubyMethod anno;
+    public final int modifiers;
+    public final String declaringClassName;
+    public final String declaringClassPath;
+    public final String name;
+    public final String rubyName;
+
+    protected abstract <A extends Annotation> A getAnnotation(T methodObject, Class<A> annotationType);
+    protected abstract int getModifiers(T methodObject);
+    protected abstract String getDeclaringClassName(T methodObject);
+    protected abstract String getSimpleName(T methodObject);
+    protected abstract boolean hasContext(T methodObject);
+    protected abstract boolean hasBlock(T methodObject);
+    protected abstract int parameterCount(T methodObject);
+    protected abstract String parameterAsString(T methodObject, int index);
+
+    public MethodDescriptor(T methodObject) {
+        anno = getAnnotation(methodObject, JRubyMethod.class);
+        modifiers = getModifiers(methodObject);
+        declaringClassName = getDeclaringClassName(methodObject);
+        declaringClassPath = declaringClassName.replace('.', '/');
+        name = getSimpleName(methodObject);
+        if (anno.name() != null && anno.name().length > 0) {
+            rubyName = anno.name()[0];
+        } else {
+            rubyName = name;
+        }
+        isStatic = Modifier.isStatic(modifiers);
+        hasContext = hasContext(methodObject);
+        hasBlock = hasBlock(methodObject);
+
+        int parameterCount = parameterCount(methodObject);
+        if (hasContext) {
+            if (isStatic && (parameterCount < 2 || !parameterAsString(methodObject, 1).equals("org.jruby.runtime.builtin.IRubyObject"))) {
+                throw new RuntimeException("static method without self argument: " + methodObject);
+            }
+
+            if (hasBlock) {
+                // args should be before block
+                hasVarArgs = parameterAsString(methodObject, parameterCount - 2).equals("org.jruby.runtime.builtin.IRubyObject[]");
+            } else {
+                // args should be at end
+                hasVarArgs = parameterAsString(methodObject, parameterCount - 1).equals("org.jruby.runtime.builtin.IRubyObject[]");
+            }
+        } else {
+            if (isStatic && (parameterCount < 1 || !parameterAsString(methodObject, 0).equals("org.jruby.runtime.builtin.IRubyObject"))) {
+                throw new RuntimeException("static method without self argument: " + methodObject);
+            }
+
+            if (hasBlock) {
+                hasVarArgs = parameterCount > 1 && parameterAsString(methodObject, parameterCount - 2).equals("org.jruby.runtime.builtin.IRubyObject[]");
+            } else {
+                hasVarArgs = parameterCount > 0 && parameterAsString(methodObject, parameterCount - 1).equals("org.jruby.runtime.builtin.IRubyObject[]");
+            }
+        }
+
+        optional = anno.optional();
+        rest = anno.rest();
+        required = anno.required();
+
+        if (optional == 0 && !rest) {
+            int args = parameterCount;
+            if (args == 0) {
+                actualRequired = 0;
+            } else {
+                if (isStatic) args--;
+                if (hasContext) args--;
+                if (hasBlock) args--;
+
+                // TODO: confirm expected args are IRubyObject (or similar)
+                actualRequired = args;
+            }
+        } else {
+            // optional args, so we have IRubyObject[]
+            // TODO: confirm
+            int args = parameterCount;
+            if (args == 0) {
+                actualRequired = 0;
+            } else {
+                if (isStatic) args--;
+                if (hasContext) args--;
+                if (hasBlock) args--;
+
+                // minus one more for IRubyObject[]
+                args--;
+
+                // TODO: confirm expected args are IRubyObject (or similar)
+                actualRequired = args;
+            }
+
+            if (actualRequired != 0) {
+                throw new RuntimeException("Combining specific args with IRubyObject[] is not yet supported");
+            }
+        }
+
+        int arityRequired = Math.max(required, actualRequired);
+        arity = (optional > 0 || rest) ? -(arityRequired + 1) : arityRequired;
+    }
+}

--- a/core/src/main/java/org/jruby/anno/TypePopulator.java
+++ b/core/src/main/java/org/jruby/anno/TypePopulator.java
@@ -57,7 +57,7 @@ public abstract class TypePopulator {
         javaMethod.setNativeCall(nativeTarget, nativeName, nativeReturn, nativeArguments, isStatic, false);
     }
     
-    public static DynamicMethod populateModuleMethod(RubyModule cls, JavaMethod javaMethod) {
+    public static DynamicMethod populateModuleMethod(RubyModule cls, DynamicMethod javaMethod) {
         DynamicMethod moduleMethod = javaMethod.dup();
         moduleMethod.setImplementationClass(cls.getSingletonClass());
         moduleMethod.setVisibility(Visibility.PUBLIC);

--- a/core/src/main/java/org/jruby/internal/runtime/methods/DescriptorInfo.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/DescriptorInfo.java
@@ -1,0 +1,165 @@
+package org.jruby.internal.runtime.methods;
+
+import org.jruby.anno.MethodDescriptor;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * An aggregate data object based on a collection of MethodDescriptors. Provides information about the collectio
+ * of descriptors, such as min and max arguments.
+ */
+public class DescriptorInfo {
+    private int min;
+    private int max;
+    private boolean frame;
+    private boolean scope;
+    private boolean rest;
+    private boolean block;
+    private String parameterDesc;
+
+    private static final boolean RICH_NATIVE_METHOD_PARAMETERS = false;
+
+    public DescriptorInfo(MethodDescriptor... descs) {
+        this(Arrays.asList(descs));
+    }
+
+    public DescriptorInfo(List<? extends MethodDescriptor> descs) {
+        min = Integer.MAX_VALUE;
+        max = 0;
+        frame = false;
+        scope = false;
+        rest = false;
+        block = false;
+        boolean first = true;
+        boolean lastBlock = false;
+
+        for (MethodDescriptor desc : descs) {
+            // make sure we don't have some methods with blocks and others without
+            // the handle generation logic can't handle such cases yet
+            if (first) {
+                first = false;
+            } else {
+                if (lastBlock != desc.hasBlock) {
+                    throw new RuntimeException("Mismatched block parameters for method " + desc.declaringClassName + "." + desc.name);
+                }
+            }
+            lastBlock = desc.hasBlock;
+
+            int specificArity = -1;
+            if (desc.hasVarArgs) {
+                if (desc.optional == 0 && !desc.rest && desc.required == 0) {
+                    throw new RuntimeException("IRubyObject[] args but neither of optional or rest specified for method " + desc.declaringClassName + "." + desc.name);
+                }
+                rest = true;
+                if (descs.size() == 1) {
+                    min = -1;
+                }
+            } else {
+                if (desc.optional == 0 && !desc.rest) {
+                    if (desc.required == 0) {
+                        // No required specified, check actual number of required args
+                        if (desc.actualRequired <= 3) {
+                            // actual required is less than 3, so we use specific arity
+                            specificArity = desc.actualRequired;
+                        } else {
+                            // actual required is greater than 3, raise error (we don't support actual required > 3)
+                            throw new RuntimeException("Invalid specific-arity number of arguments (" + desc.actualRequired + ") on method " + desc.declaringClassName + "." + desc.name);
+                        }
+                    } else if (desc.required >= 0 && desc.required <= 3) {
+                        if (desc.actualRequired != desc.required) {
+                            throw new RuntimeException("Specified required args does not match actual on method " + desc.declaringClassName + "." + desc.name);
+                        }
+                        specificArity = desc.required;
+                    }
+                }
+
+                if (specificArity < min) {
+                    min = specificArity;
+                }
+
+                if (specificArity > max) {
+                    max = specificArity;
+                }
+            }
+
+            if (frame && !desc.anno.frame())
+                throw new RuntimeException("Unbalanced frame property on method " + desc.declaringClassName + "." + desc.name);
+            if (scope && !desc.anno.scope())
+                throw new RuntimeException("Unbalanced scope property on method " + desc.declaringClassName + "." + desc.name);
+            frame |= desc.anno.frame();
+            scope |= desc.anno.scope();
+            block |= desc.hasBlock;
+        }
+
+        // Core methods currently only show :req's for fixed-arity or a single
+        // :rest if it's variable arity. I have filed a bug to improve this
+        // (using the skipped logic below, when the time comes) but for now
+        // we follow suit. See https://bugs.ruby-lang.org/issues/8088
+
+        StringBuilder descBuilder = new StringBuilder();
+
+        // FIXME: argument type names duplicated from ArgumentType, because it pulls in org.jruby.Ruby
+        if (min == max) {
+            int i = 0;
+            for (; i < min; i++) {
+                if (i > 0) descBuilder.append(';');
+                descBuilder.append("n");
+            }
+            // variable arity
+        } else if (RICH_NATIVE_METHOD_PARAMETERS) {
+            int i = 0;
+            for (; i < min; i++) {
+                if (i > 0) descBuilder.append(';');
+                descBuilder.append("n");
+            }
+
+            for (; i < max; i++) {
+                if (i > 0) descBuilder.append(';');
+                descBuilder.append("O");
+            }
+
+            if (rest) {
+                if (i > 0) descBuilder.append(';');
+                descBuilder.append("R");
+            }
+        } else {
+            descBuilder.append("R");
+        }
+
+        parameterDesc = descBuilder.toString();
+    }
+
+    @Deprecated
+    public boolean isBacktrace() {
+        return false;
+    }
+
+    public boolean isFrame() {
+        return frame;
+    }
+
+    public int getMax() {
+        return max;
+    }
+
+    public int getMin() {
+        return min;
+    }
+
+    public boolean isScope() {
+        return scope;
+    }
+
+    public boolean isRest() {
+        return rest;
+    }
+
+    public boolean isBlock() {
+        return block;
+    }
+
+    public String getParameterDesc() {
+        return parameterDesc;
+    }
+}

--- a/core/src/main/java/org/jruby/internal/runtime/methods/HandleMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/HandleMethod.java
@@ -52,14 +52,20 @@ import org.jruby.runtime.builtin.IRubyObject;
  *
  * @author headius
  */
-public class HandleMethod extends DynamicMethod implements MethodArgs2 {
-    private final Callable<MethodHandle[]> targetsGenerator;
-    private volatile MethodHandle[] targets;
+public class HandleMethod extends DynamicMethod implements MethodArgs2, Cloneable {
+    private Callable<MethodHandle> maker0;
+    private Callable<MethodHandle> maker1;
+    private Callable<MethodHandle> maker2;
+    private Callable<MethodHandle> maker3;
+    private Callable<MethodHandle> maker4;
     private MethodHandle target0;
     private MethodHandle target1;
     private MethodHandle target2;
     private MethodHandle target3;
     private MethodHandle target4;
+    private volatile boolean initialized0, initialized1, initialized2, initialized3, initialized4;
+    private final int min;
+    private final int max;
     private final String parameterDesc;
     private final Signature signature;
     private final boolean builtin;
@@ -68,18 +74,55 @@ public class HandleMethod extends DynamicMethod implements MethodArgs2 {
     public HandleMethod(
             RubyModule implementationClass,
             Visibility visibility,
-            Callable<MethodHandle[]> targetsGenerator,
-            Signature signature,
+            long encodedSignature,
             boolean builtin,
             boolean notImplemented,
-            String parameterDesc) {
+            String parameterDesc,
+            final int min,
+            final int max,
+            final Callable<MethodHandle>... makers) {
 
         super(implementationClass, visibility);
-        this.targetsGenerator = targetsGenerator;
-        this.parameterDesc = parameterDesc;
-        this.signature = signature;
+        this.signature = Signature.decode(encodedSignature);
         this.builtin = builtin;
         this.notImplemented = notImplemented;
+        this.parameterDesc = parameterDesc;
+        this.min = min;
+        this.max = max;
+        this.maker0 = makers[0];
+        this.maker1 = makers[1];
+        this.maker2 = makers[2];
+        this.maker3 = makers[3];
+        this.maker4 = makers[4];
+    }
+
+    public HandleMethod(
+            RubyModule implementationClass,
+            Visibility visibility,
+            long encodedSignature,
+            boolean builtin,
+            boolean notImplemented,
+            String parameterDesc,
+            final int min,
+            final int max,
+            final Callable<MethodHandle> maker0,
+            final Callable<MethodHandle> maker1,
+            final Callable<MethodHandle> maker2,
+            final Callable<MethodHandle> maker3,
+            final Callable<MethodHandle> maker4) {
+
+        super(implementationClass, visibility);
+        this.signature = Signature.decode(encodedSignature);
+        this.builtin = builtin;
+        this.notImplemented = notImplemented;
+        this.parameterDesc = parameterDesc;
+        this.min = min;
+        this.max = max;
+        this.maker0 = maker0;
+        this.maker1 = maker1;
+        this.maker2 = maker2;
+        this.maker3 = maker3;
+        this.maker4 = maker4;
     }
 
     @Override
@@ -102,27 +145,79 @@ public class HandleMethod extends DynamicMethod implements MethodArgs2 {
         return true;
     }
 
-    private void ensureTargets() {
-        if (targets != null) return;
+    private MethodHandle ensureTarget0() {
+        if (!initialized0) {
+            this.target0 = safeCall(maker0);
+            initialized0 = true;
+            maker0 = null;
+        }
+        return this.target0;
+    }
+
+    private MethodHandle ensureTarget1() {
+        if (!initialized1) {
+            this.target1 = safeCall(maker1);
+            initialized1 = true;
+            maker1 = null;
+        }
+        return this.target1;
+    }
+
+    private MethodHandle ensureTarget2() {
+        if (!initialized2) {
+            this.target2 = safeCall(maker2);
+            initialized2 = true;
+            maker2 = null;
+        }
+        return this.target2;
+    }
+
+    private MethodHandle ensureTarget3() {
+        if (!initialized3) {
+            this.target3 = safeCall(maker3);
+            initialized3 = true;
+            maker3 = null;
+        }
+        return this.target3;
+    }
+
+    private MethodHandle ensureTarget4() {
+        if (!initialized4) {
+            this.target4 = safeCall(maker4);
+            initialized4 = true;
+            maker4 = null;
+        }
+        return this.target4;
+    }
+
+    private static MethodHandle safeCall(Callable<MethodHandle> maker) {
         try {
-            MethodHandle[] targets = targetsGenerator.call();
-            this.target0 = targets[0];
-            this.target1 = targets[1];
-            this.target2 = targets[2];
-            this.target3 = targets[3];
-            this.target4 = targets[4];
-            this.targets = targets;
+            if (maker == null) return null;
+            return maker.call();
         } catch (Exception e) {
-            e.printStackTrace();
-            // ignore
+            Helpers.throwException(e);
+            return null;
         }
     }
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject[] args, Block block) {
-        ensureTargets();
         try {
-            return (IRubyObject) target4.invokeExact(context, self, clazz, name, args, block);
+            MethodHandle target4 = ensureTarget4();
+            if (target4 != null) {
+                Arity.checkArgumentCount(context, args.length, min, max);
+                return (IRubyObject) target4.invokeExact(context, self, clazz, name, args, block);
+            } else {
+                int arity = Arity.checkArgumentCount(context, args.length, min, max);
+                switch (args.length) {
+                    case 0: return (IRubyObject) ensureTarget0().invokeExact(context, self, clazz, name, block);
+                    case 1: return (IRubyObject) ensureTarget1().invokeExact(context, self, clazz, name, args[0], block);
+                    case 2: return (IRubyObject) ensureTarget2().invokeExact(context, self, clazz, name, args[0], args[1], block);
+                    case 3: return (IRubyObject) ensureTarget3().invokeExact(context, self, clazz, name, args[0], args[1], args[2], block);
+                    default:
+                        throw new RuntimeException("invalid arity for call: " + arity);
+                }
+            }
         } catch (Throwable t) {
             Helpers.throwException(t);
             return null;
@@ -131,7 +226,7 @@ public class HandleMethod extends DynamicMethod implements MethodArgs2 {
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, Block block) {
-        ensureTargets();
+        MethodHandle target0 = ensureTarget0();
         if (target0 == null) {
             return call(context, self, clazz, name, IRubyObject.NULL_ARRAY, block);
         }
@@ -145,7 +240,7 @@ public class HandleMethod extends DynamicMethod implements MethodArgs2 {
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject arg0, Block block) {
-        ensureTargets();
+        MethodHandle target1 = ensureTarget1();
         if (target1 == null) {
             return call(context, self, clazz, name, new IRubyObject[]{arg0}, block);
         }
@@ -159,7 +254,7 @@ public class HandleMethod extends DynamicMethod implements MethodArgs2 {
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject arg0, IRubyObject arg1, Block block) {
-        ensureTargets();
+        MethodHandle target2 = ensureTarget2();
         if (target2 == null) {
             return call(context, self, clazz, name, new IRubyObject[]{arg0, arg1}, block);
         }
@@ -173,7 +268,7 @@ public class HandleMethod extends DynamicMethod implements MethodArgs2 {
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
-        ensureTargets();
+        MethodHandle target3 = ensureTarget3();
         if (target3 == null) {
             return call(context, self, clazz, name, new IRubyObject[]{arg0, arg1, arg2}, block);
         }
@@ -187,7 +282,7 @@ public class HandleMethod extends DynamicMethod implements MethodArgs2 {
 
     @Override
     public DynamicMethod dup() {
-        return new HandleMethod(implementationClass, getVisibility(), targetsGenerator, signature, builtin, notImplemented, parameterDesc);
+        return new HandleMethod(implementationClass, getVisibility(), signature.encode(), builtin, notImplemented, parameterDesc, min, max, maker0, maker1, maker2, maker3, maker4);
     }
 
     @Override
@@ -200,8 +295,14 @@ public class HandleMethod extends DynamicMethod implements MethodArgs2 {
     }
 
     public MethodHandle getHandle(int arity) {
-        ensureTargets();
-        return targets[arity];
+        switch (arity) {
+            case -1: return ensureTarget4();
+            case 0: return ensureTarget0();
+            case 1: return ensureTarget1();
+            case 2: return ensureTarget2();
+            case 3: return ensureTarget3();
+            default: return null;
+        }
     }
     
 }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/InvokeDynamicMethodFactory.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InvokeDynamicMethodFactory.java
@@ -34,6 +34,7 @@ import com.headius.invokebinder.SmartHandle;
 import org.jruby.RubyModule;
 import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
+import org.jruby.runtime.Helpers;
 import org.jruby.runtime.RubyEvent;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -42,7 +43,9 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Array;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
 import org.jruby.Ruby;
@@ -52,22 +55,14 @@ import org.jruby.util.cli.Options;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
 
-import static java.lang.invoke.MethodHandles.foldArguments;
-import static java.lang.invoke.MethodHandles.insertArguments;
 import static org.jruby.runtime.Helpers.arrayOf;
 
 /**
- * In order to avoid the overhead with reflection-based method handles, this
- * MethodFactory uses ASM to generate tiny invoker classes. This allows for
- * better performance and more specialization per-handle than can be supported
- * via reflection. It also allows optimizing away many conditionals that can
- * be determined once ahead of time.
- * 
- * When running in secured environments, this factory may not function. When
- * this can be detected, MethodFactory will fall back on the reflection-based
- * factory instead.
+ * This invoker uses MethodHandle for all bindings to Java code, rather than generating
+ * stubs or using reflection.
  * 
  * @see org.jruby.runtime.MethodFactory
+ * @see HandleMethod
  */
 public class InvokeDynamicMethodFactory extends InvocationMethodFactory {
 
@@ -84,6 +79,7 @@ public class InvokeDynamicMethodFactory extends InvocationMethodFactory {
     @Override
     public DynamicMethod getAnnotatedMethod(final RubyModule implementationClass, final List<JavaMethodDescriptor> descs) {
         JavaMethodDescriptor desc1 = descs.get(0);
+        DescriptorInfo info = new DescriptorInfo(desc1);
         
         if (desc1.anno.frame()) {
             // super logic does not work yet because we need to take impl class
@@ -124,29 +120,27 @@ public class InvokeDynamicMethodFactory extends InvocationMethodFactory {
             notImplemented = notImplemented || desc.anno.notImplemented();
         }
 
-        DescriptorInfo info = new DescriptorInfo(descs);
-        Callable<MethodHandle[]> targetsGenerator = new Callable<MethodHandle[]>() {
-            @Override
-            public MethodHandle[] call() throws Exception {
-                return buildAnnotatedMethodHandles(implementationClass.getRuntime(), descs, implementationClass);
-            }
-        };
+        Callable<MethodHandle>[] generators = buildAnnotatedMethodHandles(implementationClass.getRuntime(), descs, implementationClass);
         
         return new HandleMethod(
                 implementationClass,
                 desc1.anno.visibility(),
-                targetsGenerator,
                 (min == max) ?
-                        org.jruby.runtime.Signature.from(min, 0, 0, 0, 0, org.jruby.runtime.Signature.Rest.NONE, false) :
-                        org.jruby.runtime.Signature.OPTIONAL,
+                        org.jruby.runtime.Signature.from(min, 0, 0, 0, 0, org.jruby.runtime.Signature.Rest.NONE, false).encode() :
+                        org.jruby.runtime.Signature.OPTIONAL.encode(),
                 true,
                 notImplemented,
-                info.getParameterDesc());
+                info.getParameterDesc(),
+                min,
+                max,
+                generators[0],
+                generators[1],
+                generators[2],
+                generators[3],
+                generators[4]);
     }
 
-    private MethodHandle[] buildAnnotatedMethodHandles(Ruby runtime, List<JavaMethodDescriptor> descs, RubyModule implementationClass) {
-        MethodHandle[] targets = new MethodHandle[5];
-
+    private Callable<MethodHandle>[] buildAnnotatedMethodHandles(Ruby runtime, List<JavaMethodDescriptor> descs, RubyModule implementationClass) {
         int min = Integer.MAX_VALUE;
         int max = 0;
 
@@ -159,10 +153,21 @@ public class InvokeDynamicMethodFactory extends InvocationMethodFactory {
         } else {
             rubyName = desc1.name;
         }
+
+        Callable<MethodHandle>[] targets = new Callable[5];
         
         for (JavaMethodDescriptor desc: descs) {
+            MethodHandle method;
+
+            if (desc.isStatic) {
+                method = Binder.from(desc.returnClass, desc.parameters).invokeStaticQuiet(LOOKUP, desc.declaringClass, desc.name);
+            } else {
+                method = Binder.from(desc.returnClass, desc.declaringClass, desc.parameters).invokeVirtualQuiet(LOOKUP, desc.name);
+            }
+
+            Callable<MethodHandle> target = adaptHandle(method, runtime, desc.actualRequired, desc.required, desc.optional, desc.rest, rubyName, desc.declaringClass, desc.isStatic, desc.hasContext, desc.hasBlock, desc.anno.frame(), implementationClass);
             int specificArity = -1;
-            if (desc.optional == 0 && !desc.rest) {
+            if (desc.required < 4 && desc.optional == 0 && !desc.rest) {
                 if (desc.required == 0) {
                     if (desc.actualRequired <= 3) {
                         specificArity = desc.actualRequired;
@@ -181,179 +186,137 @@ public class InvokeDynamicMethodFactory extends InvocationMethodFactory {
                 if (desc.required + desc.optional > max) max = desc.required + desc.optional;
             }
 
-            String javaMethodName = desc.name;
-
-            SmartBinder targetBinder;
-            SmartHandle target;
-            Signature baseSignature;
             if (specificArity >= 0) {
-                baseSignature = SPECIFIC_ARITY_SIGNATURES[specificArity];
+                targets[specificArity] = target;
             } else {
-                baseSignature = VARIABLE_ARITY_SIGNATURE;
-            }
-            
-            targetBinder = SmartBinder.from(baseSignature);
-
-            // unused by Java-based methods
-            targetBinder = targetBinder
-                    .exclude("class", "name");
-            
-            MethodHandle returnFilter = null;
-            boolean castReturn = false;
-            if (desc.returnClass != IRubyObject.class) {
-                if (desc.returnClass == void.class) {
-                    returnFilter = MethodHandles.constant(IRubyObject.class, runtime.getNil());
-                } else {
-                    castReturn = true;
-                }
-            }
-            
-            if (desc.isStatic) {
-                if (desc.hasContext) {
-                    if (desc.hasBlock) {
-                        // straight through with no permutation necessary
-                    } else {
-                        targetBinder = targetBinder.exclude("block");
-                    }
-                } else {
-                    if (desc.hasBlock) {
-                        targetBinder = targetBinder.exclude("context");
-                    } else {
-                        targetBinder = targetBinder.exclude("context", "block");
-                    }
-                }
-                
-                if (returnFilter != null) {
-                    targetBinder = targetBinder
-                            .filterReturn(returnFilter);
-                } else if (castReturn) {
-                    targetBinder = targetBinder
-                            .castReturn(desc.returnClass);
-                }
-            } else {
-                if (desc.hasContext) {
-                    if (desc.hasBlock) {
-                        targetBinder = targetBinder.permute("self", "context", "arg*", "block");
-                    } else {
-                        targetBinder = targetBinder.permute("self", "context", "arg*");
-                    }
-                } else {
-                    if (desc.hasBlock) {
-                        targetBinder = targetBinder.permute("self", "arg*", "block");
-                    } else {
-                        targetBinder = targetBinder.permute("self", "arg*");
-                    }
-                }
-                
-                if (returnFilter != null) {
-                    targetBinder = targetBinder
-                            .filterReturn(returnFilter);
-                } else if (castReturn) {
-                    targetBinder = targetBinder
-                            .castReturn(desc.returnClass);
-                }
-                targetBinder = targetBinder
-                        .castArg("self", desc.getDeclaringClass());
-            }
-            
-            if (desc.isStatic) {
-                target = targetBinder
-                        .invokeStaticQuiet(LOOKUP, desc.getDeclaringClass(), javaMethodName);
-            } else {
-                target = targetBinder
-                        .invokeVirtualQuiet(LOOKUP, javaMethodName);
-            }
-
-            CallConfiguration callConfig = CallConfiguration.getCallConfigByAnno(desc.anno);
-            if (!callConfig.isNoop()) {
-                target = SmartHandle
-                        .from(target.signature(), InvocationLinker.wrapWithFraming(baseSignature, callConfig, implementationClass, rubyName, target.handle(), null));
-            }
-            
-            if (specificArity >= 0) {
-                targets[specificArity] = target.handle();
-            } else {
-                targets[4] = target.handle();
-            }
-        }
-
-        if (targets[4] == null) {
-            // provide a variable-arity path for all specific-arity targets, or error path
-
-            MethodHandle[] varargsTargets = new MethodHandle[4];
-            for (int i = 0; i < 4; i++) {
-                if (targets[i] == null) continue; // will never be retrieved; arity check will error first
-
-                if (i == 0) {
-                    varargsTargets[i] = MethodHandles.dropArguments(targets[i], 4, IRubyObject[].class);
-                } else {
-                    varargsTargets[i] = SmartBinder
-                            .from(VARIABLE_ARITY_SIGNATURE)
-                            .permute("context", "self", "class", "name", "block", "args")
-                            .spread("arg", i)
-                            .permute("context", "self", "class", "name", "arg*", "block")
-                            .invoke(targets[i]).handle();
-                }
-            }
-            
-            SmartHandle HANDLE_GETTER = SmartBinder
-                    .from(Signature.returning(MethodHandle.class).appendArg("targets", MethodHandle[].class).appendArg("arity", int.class))
-                    .arrayGet();
-            
-            SmartHandle handleLookup = SmartBinder
-                    .from(Signature.returning(MethodHandle.class).appendArg("args", IRubyObject[].class))
-                    .filterReturn(HANDLE_GETTER.bindTo(varargsTargets))
-                    .cast(int.class, Object.class)
-                    .invokeStaticQuiet(LOOKUP, Array.class, "getLength");
-
-            SmartHandle variableCall = SmartBinder
-                    .from(VARIABLE_ARITY_SIGNATURE)
-                    .fold("handle", handleLookup)
-                    .invoker();
-            
-            targets[4] = variableCall.handle();
-        }
-
-        // Add arity check of varargs path
-        targets[4] = SmartBinder
-                .from(VARIABLE_ARITY_SIGNATURE)
-                .foldVoid(SmartBinder
-                        .from(VARIABLE_ARITY_SIGNATURE.changeReturn(int.class))
-                        .permute("context", "name", "args")
-                        .append(arrayOf("min", "max"), arrayOf(int.class, int.class), min, max)
-                        .invokeStaticQuiet(LOOKUP, Arity.class, "checkArgumentCount")
-                        .handle())
-                .invoke(targets[4])
-                .handle();
-
-        // Add tracing of "C" call/return
-        if (Options.DEBUG_FULLTRACE.load()) {
-            for (int i = 0; i < targets.length; i++) {
-                MethodHandle target = targets[i];
-
-                if (target == null) continue;
-
-                MethodHandle traceCall = Binder
-                        .from(target.type().changeReturnType(void.class))
-                        .permute(0, 3, 2) // context, name, class
-                        .insert(1, RubyEvent.C_CALL)
-                        .invokeVirtualQuiet(LOOKUP, "trace");
-
-                MethodHandle traceReturn = Binder
-                        .from(target.type().changeReturnType(void.class))
-                        .permute(0, 3, 2) // context, name, class
-                        .insert(1, RubyEvent.C_RETURN)
-                        .invokeVirtualQuiet(LOOKUP, "trace");
-
-                targets[i] = Binder
-                        .from(target.type())
-                        .foldVoid(traceCall)
-                        .tryFinally(traceReturn)
-                        .invoke(target);
+                targets[4] = target;
             }
         }
         
         return targets;
+    }
+
+    public static SmartBinder preAdaptHandle(int specificArity, final boolean isStatic, final boolean hasContext, final boolean hasBlock) {
+        SmartBinder targetBinder;
+
+        Signature baseSignature;
+        if (specificArity >= 0) {
+            baseSignature = SPECIFIC_ARITY_SIGNATURES[specificArity];
+        } else {
+            baseSignature = VARIABLE_ARITY_SIGNATURE;
+        }
+
+        targetBinder = SmartBinder.from(baseSignature);
+
+        // unused by Java-based methods
+        targetBinder = targetBinder
+                .exclude("class", "name");
+
+        if (isStatic) {
+            if (hasContext) {
+                if (hasBlock) {
+                    // straight through with no permutation necessary
+                } else {
+                    targetBinder = targetBinder.exclude("block");
+                }
+            } else {
+                if (hasBlock) {
+                    targetBinder = targetBinder.exclude("context");
+                } else {
+                    targetBinder = targetBinder.exclude("context", "block");
+                }
+            }
+        } else {
+            if (hasContext) {
+                if (hasBlock) {
+                    targetBinder = targetBinder.permute("self", "context", "arg*", "block");
+                } else {
+                    targetBinder = targetBinder.permute("self", "context", "arg*");
+                }
+            } else {
+                if (hasBlock) {
+                    targetBinder = targetBinder.permute("self", "arg*", "block");
+                } else {
+                    targetBinder = targetBinder.permute("self", "arg*");
+                }
+            }
+        }
+
+        return targetBinder;
+    }
+
+    public static MethodHandle finishAdapting(final SmartBinder binder, final RubyModule implementationClass, String rubyName, final MethodHandle method, final Class declaringClass, final Ruby runtime, boolean isStatic, boolean frame) {
+        Class returnClass = method.type().returnType();
+        SmartBinder targetBinder = binder;
+
+        if (returnClass != IRubyObject.class) {
+            if (returnClass == void.class) {
+                targetBinder = targetBinder.filterReturn(MethodHandles.constant(IRubyObject.class, runtime.getNil()));
+            } else {
+                targetBinder = targetBinder
+                        .castReturn(returnClass);
+            }
+        }
+
+        if (!isStatic) {
+            targetBinder = targetBinder
+                    .castArg("self", declaringClass);
+        }
+
+        SmartHandle smartTarget = targetBinder.invoke(method);
+        if (frame) {
+            smartTarget = SmartHandle
+                    .from(smartTarget.signature(), InvocationLinker.wrapWithFrameOnly(binder.baseSignature(), implementationClass, rubyName, smartTarget.handle(), null));
+        }
+
+        MethodHandle target = smartTarget.handle();
+
+        // Add tracing of "C" call/return
+        if (Options.DEBUG_FULLTRACE.load()) {
+            MethodHandle traceCall = Binder
+                    .from(target.type().changeReturnType(void.class))
+                    .permute(0, 3, 2) // context, name, class
+                    .insert(1, RubyEvent.C_CALL)
+                    .invokeVirtualQuiet(LOOKUP, "trace");
+
+            MethodHandle traceReturn = Binder
+                    .from(target.type().changeReturnType(void.class))
+                    .permute(0, 3, 2) // context, name, class
+                    .insert(1, RubyEvent.C_RETURN)
+                    .invokeVirtualQuiet(LOOKUP, "trace");
+
+            target = Binder
+                    .from(target.type())
+                    .foldVoid(traceCall)
+                    .tryFinally(traceReturn)
+                    .invoke(target);
+        }
+
+        return target;
+    }
+
+    public static Callable<MethodHandle> adaptHandle(final MethodHandle method, final Ruby runtime, final int actualRequired, final int required, final int optional, final boolean rest, final String rubyName, final Class declaringClass, final boolean isStatic, final boolean hasContext, final boolean hasBlock, final boolean frame, final RubyModule implementationClass) {
+        return new Callable<MethodHandle>() {
+            @Override
+            public MethodHandle call() throws Exception {
+                Class returnClass = method.type().returnType();
+
+                int specificArity = -1;
+                if (optional == 0 && !rest) {
+                    if (required == 0) {
+                        if (actualRequired <= 3) {
+                            specificArity = actualRequired;
+                        }
+                    } else if (required >= 0 && required <= 3) {
+                        specificArity = required;
+                    }
+                }
+
+                SmartBinder targetBinder = getBinder(specificArity, isStatic, hasContext, hasBlock);
+
+                return finishAdapting(targetBinder, implementationClass, rubyName, method, declaringClass, runtime, isStatic, frame);
+            }
+        };
     }
 
     /**
@@ -405,5 +368,23 @@ public class InvokeDynamicMethodFactory extends InvocationMethodFactory {
                     .spread("arg", i)
                     .permute("context", "self", "arg*", "block");
         }
+    }
+
+    private static final Map<String, SmartBinder> BINDERS;
+    public static SmartBinder getBinder(int specific, final boolean b1, final boolean b2, final boolean b3) {
+        return BINDERS.get("" + specific + b1 + b2 + b3);
+    }
+    static {
+        Map<String, SmartBinder> binders = new HashMap<>(40);
+        for (int specific = -1; specific <= 3; specific++) {
+            for (boolean b1 : new boolean[] {false, true}) {
+                for (boolean b2 : new boolean[] {false, true}) {
+                    for (boolean b3 : new boolean[]{false, true}) {
+                        binders.put("" + specific + b1 + b2 + b3, preAdaptHandle(specific, b1, b2, b3));
+                    }
+                }
+            }
+        }
+        BINDERS = binders;
     }
 }

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -99,7 +99,7 @@ public class Options {
     // ClassValue in OpenJDK appears to root data even after it goes away, so this is disabled again. See jruby/jruby#3228
     public static final Option<Boolean> INVOKEDYNAMIC_CLASS_VALUES = bool(INVOKEDYNAMIC, "invokedynamic.class.values", false, "Use ClassValue to store class-specific data.");
     public static final Option<Integer> INVOKEDYNAMIC_GLOBAL_MAXFAIL = integer(INVOKEDYNAMIC, "invokedynamic.global.maxfail", 100, "Maximum global cache failures after which to use slow path.");
-    public static final Option<Boolean> INVOKEDYNAMIC_HANDLES = bool(INVOKEDYNAMIC, "invokedynamic.handles", false, "Use MethodHandles rather than generated code to bind Ruby methods.");
+    public static final Option<Boolean> INVOKEDYNAMIC_HANDLES = bool(INVOKEDYNAMIC, "invokedynamic.handles", true, "Use MethodHandles rather than generated code to bind Ruby methods.");
 
     public static final Option<Integer> JIT_THRESHOLD = integer(JIT, "jit.threshold", Constants.JIT_THRESHOLD, "Set the JIT threshold to the specified method invocation count.");
     public static final Option<Integer> JIT_MAX = integer(JIT, "jit.max", Constants.JIT_MAX_METHODS_LIMIT, "Set the max count of active methods eligible for JIT-compilation.");

--- a/pom.rb
+++ b/pom.rb
@@ -132,7 +132,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
     end
 
     plugin :compiler, '3.1'
-    plugin :shade, '2.1'
+    plugin :shade, '2.4.3'
     plugin :surefire, '2.15'
     plugin :plugin, '3.2'
     plugin( :invoker, '1.8',

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@ DO NOT MODIFIY - GENERATED CODE
         </plugin>
         <plugin>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>2.1</version>
+          <version>2.4.3</version>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
This change enables MethodHandle-based invokers for *all* native method binding, eliminating our pregenerated INVOKER classes and avoiding code generation at runtime for third-party extensions.

For my quick tests, it boots in about the same time or less time than the generated invokers and existing AnnotationBinder-created populators, but I'm also deferring a substantial amount of work until methods are first called. This could be smart, or it could be just delaying the inevitable...but so far it seems to balance out well.

See commit fc4bcb5 for a more detailed discussion of the changes. This PR should not be merged until it is passing tests and we have decided to commit to this direction.