### PR TITLE
Fix SizedQueue#num_waiting regression

### DIFF
--- a/core/src/main/java/org/jruby/ext/thread/SizedQueue.java
+++ b/core/src/main/java/org/jruby/ext/thread/SizedQueue.java
@@ -12,7 +12,7 @@
  * rights and limitations under the License.
  *
  * Copyright (C) 2006 MenTaLguY <mental@rydia.net>
- * 
+ *
  * Alternatively, the contents of this file may be used under the terms of
  * either of the GNU General Public License Version 2 or later (the "GPL"),
  * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
@@ -100,5 +100,20 @@ public class SizedQueue extends Queue {
         this.queue = new ArrayBlockingQueue<IRubyObject>(new_capacity, false);
 
         return this;
+    }
+
+    @JRubyMethod(name = {"push", "<<", "enq"}, required = 1, optional = 1)
+    @Override
+    public IRubyObject push(ThreadContext context, final IRubyObject[] args) {
+        checkShutdown();
+        numWaiting.incrementAndGet();
+        try {
+            context.getThread().executeTask(context, args, putTask);
+            return this;
+        } catch (InterruptedException ie) {
+            throw context.runtime.newThreadError("interrupted in " + getMetaClass().getName() + "#push");
+        } finally {
+            numWaiting.decrementAndGet();
+        }
     }
 }

--- a/spec/ruby/library/thread/sizedqueue/num_waiting_spec.rb
+++ b/spec/ruby/library/thread/sizedqueue/num_waiting_spec.rb
@@ -4,4 +4,15 @@ require File.expand_path('../../shared/queue/num_waiting', __FILE__)
 
 describe "Thread::SizedQueue#num_waiting" do
   it_behaves_like :queue_num_waiting, :num_waiting, SizedQueue.new(10)
+
+  it "reports the number of threads waiting to push" do
+    q = SizedQueue.new(1)
+    q.push(1)
+    t = Thread.new { q.push(2) }
+    sleep 0.05 until t.stop?
+    q.num_waiting.should == 1
+
+    q.pop
+    t.join
+  end
 end


### PR DESCRIPTION
Introduced in d13405b222f6d98177.

JRuby 1.7 and MRI 2.2.3:

```ruby
>> sq = SizedQueue.new(1)
=> #<SizedQueue:0x61f8bee4>
>> sq.push(1)
=> nil
>> Thread.new { sq.push(2) }
=> #<Thread:0x7fac631b run>
>> sq.num_waiting
=> 1
```

JRuby 9.0.4.0:

```ruby
>> sq = SizedQueue.new(1)
=> #<SizedQueue:0x103f852>
>> sq.push(1)
=> #<SizedQueue:0x103f852>
>> Thread.new { sq.push(2) }
=> #<Thread:0x4ae82894 sleep>
>> sq.num_waiting
=> 0
```

P.S. I'm not specialized in Java, but it seems to work.