### PR TITLE
Fix cache-constructed-proxies

### DIFF
--- a/core/src/main/java/org/jruby/java/invokers/ConstructorInvoker.java
+++ b/core/src/main/java/org/jruby/java/invokers/ConstructorInvoker.java
@@ -7,6 +7,7 @@ import org.jruby.Ruby;
 import org.jruby.RubyModule;
 import org.jruby.RubyProc;
 import org.jruby.java.proxies.JavaProxy;
+import org.jruby.javasupport.Java;
 import org.jruby.javasupport.JavaCallable;
 import org.jruby.javasupport.JavaConstructor;
 import org.jruby.runtime.Block;
@@ -55,7 +56,7 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
         JavaConstructor constructor = (JavaConstructor) findCallable(self, name, args, args.length);
 
         final Object[] convertedArgs = convertArguments(constructor, args);
-        setAndCacheProxyObject(context, proxy, constructor.newInstanceDirect(context, convertedArgs));
+        setAndCacheProxyObject(context, clazz, proxy, constructor.newInstanceDirect(context, convertedArgs));
 
         return self;
     }
@@ -66,7 +67,7 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
         JavaProxy proxy = castJavaProxy(self);
         JavaConstructor constructor = (JavaConstructor) findCallableArityZero(self, name);
 
-        setAndCacheProxyObject(context, proxy, constructor.newInstanceDirect(context));
+        setAndCacheProxyObject(context, clazz, proxy, constructor.newInstanceDirect(context));
 
         return self;
     }
@@ -79,7 +80,7 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
         final Class<?>[] paramTypes = constructor.getParameterTypes();
         Object cArg0 = arg0.toJava(paramTypes[0]);
 
-        setAndCacheProxyObject(context, proxy, constructor.newInstanceDirect(context, cArg0));
+        setAndCacheProxyObject(context, clazz, proxy, constructor.newInstanceDirect(context, cArg0));
 
         return self;
     }
@@ -93,7 +94,7 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
         Object cArg0 = arg0.toJava(paramTypes[0]);
         Object cArg1 = arg1.toJava(paramTypes[1]);
 
-        setAndCacheProxyObject(context, proxy, constructor.newInstanceDirect(context, cArg0, cArg1));
+        setAndCacheProxyObject(context, clazz, proxy, constructor.newInstanceDirect(context, cArg0, cArg1));
 
         return self;
     }
@@ -108,7 +109,7 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
         Object cArg1 = arg1.toJava(paramTypes[1]);
         Object cArg2 = arg2.toJava(paramTypes[2]);
 
-        setAndCacheProxyObject(context, proxy, constructor.newInstanceDirect(context, cArg0, cArg1, cArg2));
+        setAndCacheProxyObject(context, clazz, proxy, constructor.newInstanceDirect(context, cArg0, cArg1, cArg2));
 
         return self;
     }
@@ -131,7 +132,7 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
                 convertedArgs[i] = intermediate[i].toJava(paramTypes[i]);
             }
 
-            setAndCacheProxyObject(context, proxy, constructor.newInstanceDirect(context, convertedArgs));
+            setAndCacheProxyObject(context, clazz, proxy, constructor.newInstanceDirect(context, convertedArgs));
 
             return self;
         }
@@ -148,7 +149,7 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
             final Class<?>[] paramTypes = constructor.getParameterTypes();
             Object cArg0 = proc.toJava(paramTypes[0]);
 
-            setAndCacheProxyObject(context, proxy, constructor.newInstanceDirect(context, cArg0));
+            setAndCacheProxyObject(context, clazz, proxy, constructor.newInstanceDirect(context, cArg0));
 
             return self;
         }
@@ -166,7 +167,7 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
             Object cArg0 = arg0.toJava(paramTypes[0]);
             Object cArg1 = proc.toJava(paramTypes[1]);
 
-            setAndCacheProxyObject(context, proxy, constructor.newInstanceDirect(context, cArg0, cArg1));
+            setAndCacheProxyObject(context, clazz, proxy, constructor.newInstanceDirect(context, cArg0, cArg1));
 
             return self;
         }
@@ -185,7 +186,7 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
             Object cArg1 = arg1.toJava(paramTypes[1]);
             Object cArg2 = proc.toJava(paramTypes[2]);
 
-            setAndCacheProxyObject(context, proxy, constructor.newInstanceDirect(context, cArg0, cArg1, cArg2));
+            setAndCacheProxyObject(context, clazz, proxy, constructor.newInstanceDirect(context, cArg0, cArg1, cArg2));
 
             return self;
         }
@@ -205,15 +206,18 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
             Object cArg2 = arg2.toJava(paramTypes[2]);
             Object cArg3 = proc.toJava(paramTypes[3]);
 
-            setAndCacheProxyObject(context, proxy, constructor.newInstanceDirect(context, cArg0, cArg1, cArg2, cArg3));
+            setAndCacheProxyObject(context, clazz, proxy, constructor.newInstanceDirect(context, cArg0, cArg1, cArg2, cArg3));
 
             return self;
         }
         return call(context, self, clazz, name, arg0, arg1, arg2);
     }
 
-    private void setAndCacheProxyObject(ThreadContext context, JavaProxy proxy, Object object) {
+    private void setAndCacheProxyObject(ThreadContext context, RubyModule clazz, JavaProxy proxy, Object object) {
         proxy.setObject(object);
-        context.runtime.getJavaSupport().getObjectProxyCache().put(object, proxy);
+
+        if (Java.OBJECT_PROXY_CACHE || clazz.getCacheProxy()) {
+            context.runtime.getJavaSupport().getObjectProxyCache().put(object, proxy);
+        }
     }
 }

--- a/spec/java_integration/types/wrapping_spec.rb
+++ b/spec/java_integration/types/wrapping_spec.rb
@@ -64,6 +64,47 @@ describe "A Java method returning/receiving uncoercible Java types" do
       expect(rsojo2.foo).to eq(true)
     end
   end
+
+  describe "with persistence off" do
+    before { java.lang.Object.__persistent__ = false }
+    let(:object_proxy_cache) { JRuby.runtime.java_support.object_proxy_cache }
+
+    it "doesn't cache the proxy when directly constructed" do
+      object = java.lang.Object.new
+      expect(object_proxy_cache.get(object)).to be_nil
+    end
+
+    it "doesn't cache the proxy when retrieved from a Java instance method" do
+      object = JavaTypeMethods.new.newObject
+      expect(object_proxy_cache.get(object)).to be_nil
+    end
+
+    it "doesn't cache the proxy when retrieved from a Java static method" do
+      object = JavaTypeMethods.staticNewObject
+      expect(object_proxy_cache.get(object)).to be_nil
+    end
+  end
+
+  describe "with persistence on" do
+    before { java.lang.Object.__persistent__ = true }
+    after { java.lang.Object.__persistent__ = false }
+    let(:object_proxy_cache) { JRuby.runtime.java_support.object_proxy_cache }
+
+    it "doesn't cache the proxy when directly constructed" do
+      object = java.lang.Object.new
+      expect(object_proxy_cache.get(object)).to eq(object)
+    end
+
+    it "doesn't cache the proxy when retrieved from a Java instance method" do
+      object = JavaTypeMethods.new.newObject
+      expect(object_proxy_cache.get(object)).to eq(object)
+    end
+
+    it "doesn't cache the proxy when retrieved from a Java static method" do
+      object = JavaTypeMethods.staticNewObject
+      expect(object_proxy_cache.get(object)).to eq(object)
+    end
+  end
 end
 
 describe "Java::JavaObject.wrap" do


### PR DESCRIPTION
Replicate the logic from org.jruby.javasupport.Java which determines whether an object should be cached.

I added some specs to ensure the caching is properly honored. If I comment out the new conditional, you can see that one of the new specs will correctly fail:
```
$ jruby -S rspec spec/java_integration/object/singleton_spec.rb spec/java_integration/types/wrapping_spec.rb
......F........

Failures:

  1) A Java method returning/receiving uncoercible Java types with persistence off doesn't cache the proxy when directly constructed
     Failure/Error: expect(object_proxy_cache.get(object)).to be_nil

       expected: nil
            got: #<Java::JavaLang::Object:0x38c6f217>
     # ./spec/java_integration/types/wrapping_spec.rb:74:in `block in (root)'

Finished in 0.103 seconds (files took 0.916 seconds to load)
15 examples, 1 failure

Failed examples:

rspec ./spec/java_integration/types/wrapping_spec.rb:72 # A Java method returning/receiving uncoercible Java types with persistence off doesn't cache the proxy when directly constructed
```

I wasn't sure if this was the right place to put these new specs, but it seemed like the most appropriate to me. Please let me know if I should move them.