### PR TITLE
Truffle ropes 2

### DIFF
--- a/test/truffle/compiler/pe/core/string_pe.rb
+++ b/test/truffle/compiler/pe/core/string_pe.rb
@@ -17,9 +17,10 @@ example "'こにちわ'.length", 4
 example "'abc'.bytesize", 3
 example "'こにちわ'.bytesize", 12
 
-tagged_example "'abc' == 'abc'", true # seems to fail sometimes
+example "'abc' == 'abc'", true
 example "x = 'abc'; x == x", true
 example "x = 'abc'; x == x.dup", true
+example "x = 'abc'; 'abc' == x.dup", true
 
 example "'abc'.ascii_only?", true
 example "'こにちわ'.ascii_only?", false

--- a/truffle/src/main/java/org/jruby/truffle/nodes/RubyNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/RubyNode.java
@@ -157,6 +157,10 @@ public abstract class RubyNode extends Node {
         return getContext().getSymbol(name);
     }
 
+    public DynamicObject getSymbol(Rope name) {
+        return getContext().getSymbol(name);
+    }
+
     /** Creates a String from the ByteList, with unknown CR */
     protected DynamicObject createString(ByteList bytes) {
         return StringOperations.createString(getContext(), bytes);

--- a/truffle/src/main/java/org/jruby/truffle/nodes/StringCachingGuards.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/StringCachingGuards.java
@@ -13,33 +13,37 @@ package org.jruby.truffle.nodes;
 import com.oracle.truffle.api.object.DynamicObject;
 import org.jruby.truffle.runtime.core.StringOperations;
 import org.jruby.truffle.runtime.layouts.Layouts;
+import org.jruby.truffle.runtime.rope.Rope;
 import org.jruby.util.ByteList;
 
 public abstract class StringCachingGuards {
 
-    public static ByteList privatizeByteList(DynamicObject string) {
+    public static Rope privatizeRope(DynamicObject string) {
         if (RubyGuards.isRubyString(string)) {
-            return StringOperations.getByteListReadOnly(string).dup();
+            // TODO (nirvdrum 25-Jan-16) Should we flatten the rope to avoid caching a potentially deep rope tree?
+            return StringOperations.rope(string);
         } else {
             return null;
         }
     }
 
-    public static boolean byteListsEqual(DynamicObject string, ByteList byteList) {
+    public static boolean ropesEqual(DynamicObject string, Rope rope) {
         if (RubyGuards.isRubyString(string)) {
+            final Rope stringRope = StringOperations.rope(string);
+
             // equal below does not check encoding
-            if (Layouts.STRING.getRope(string).getEncoding() != byteList.getEncoding()) {
+            if (stringRope.getEncoding() != rope.getEncoding()) {
                 return false;
             }
-            // TODO CS 8-Nov-15 this code goes off into the woods - need to break it apart and branch profile it
-            return StringOperations.getByteListReadOnly(string).equal(byteList);
+
+            return stringRope.equals(rope);
         } else {
             return false;
         }
     }
 
-    public static int byteListLength(ByteList byteList) {
-        return byteList.length();
+    public static int ropeLength(Rope rope) {
+        return rope.byteLength();
     }
 
 }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/conversion/ToSymbolNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/conversion/ToSymbolNode.java
@@ -36,7 +36,7 @@ public abstract class ToSymbolNode extends RubyNode {
 
     @Specialization(guards = "isRubyString(string)")
     protected DynamicObject toSymbolString(DynamicObject string) {
-        return getSymbol(StringOperations.getByteListReadOnly(string));
+        return getSymbol(StringOperations.rope(string));
     }
 
     @Specialization

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/EncodingNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/EncodingNodes.java
@@ -192,7 +192,7 @@ public abstract class EncodingNodes {
         @TruffleBoundary
         @Specialization(guards = {"isRubyRegexp(first)", "isRubySymbol(second)"})
         public Object isCompatibleRegexpSymbol(DynamicObject first, DynamicObject second) {
-            final Encoding compatibleEncoding = org.jruby.RubyEncoding.areCompatible(Layouts.REGEXP.getRegex(first).getEncoding(), Layouts.SYMBOL.getByteList(second).getEncoding());
+            final Encoding compatibleEncoding = org.jruby.RubyEncoding.areCompatible(Layouts.REGEXP.getRegex(first).getEncoding(), Layouts.SYMBOL.getRope(second).getEncoding());
 
             if (compatibleEncoding != null) {
                 return getEncoding(compatibleEncoding);
@@ -204,7 +204,7 @@ public abstract class EncodingNodes {
         @TruffleBoundary
         @Specialization(guards = {"isRubySymbol(first)", "isRubyRegexp(second)"})
         public Object isCompatibleSymbolRegexp(DynamicObject first, DynamicObject second) {
-            final Encoding compatibleEncoding = org.jruby.RubyEncoding.areCompatible(Layouts.SYMBOL.getByteList(first).getEncoding(), Layouts.REGEXP.getRegex(second).getEncoding());
+            final Encoding compatibleEncoding = org.jruby.RubyEncoding.areCompatible(Layouts.SYMBOL.getRope(first).getEncoding(), Layouts.REGEXP.getRegex(second).getEncoding());
 
             if (compatibleEncoding != null) {
                 return getEncoding(compatibleEncoding);

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/EncodingNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/EncodingNodes.java
@@ -32,7 +32,9 @@ import org.jruby.truffle.runtime.control.RaiseException;
 import org.jruby.truffle.runtime.core.EncodingOperations;
 import org.jruby.truffle.runtime.core.StringOperations;
 import org.jruby.truffle.runtime.layouts.Layouts;
+import org.jruby.truffle.runtime.rope.Rope;
 import org.jruby.util.ByteList;
+import org.jruby.util.StringSupport;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -128,7 +130,7 @@ public abstract class EncodingNodes {
                 "isRubyString(first)", "isRubyString(second)"
         }, contains =  "isCompatibleStringStringCached")
         public DynamicObject isCompatibleStringStringUncached(DynamicObject first, DynamicObject second) {
-            final Encoding compatibleEncoding = areCompatible(first, second);
+            final Encoding compatibleEncoding = compatibleEncodingForStrings(first, second);
 
             if (compatibleEncoding != null) {
                 return getEncoding(compatibleEncoding);
@@ -248,18 +250,41 @@ public abstract class EncodingNodes {
         }
 
         @TruffleBoundary
-        public static Encoding areCompatible(DynamicObject first, DynamicObject second) {
+        public static Encoding compatibleEncodingForStrings(DynamicObject first, DynamicObject second) {
+            // Taken from org.jruby.RubyEncoding#areCompatible.
+
             assert RubyGuards.isRubyString(first);
             assert RubyGuards.isRubyString(second);
 
-            final Encoding firstEncoding = Layouts.STRING.getRope(first).getEncoding();
-            final Encoding secondEncoding = Layouts.STRING.getRope(second).getEncoding();
+            final Rope firstRope = StringOperations.rope(first);
+            final Rope secondRope = StringOperations.rope(second);
 
-            if (firstEncoding == secondEncoding) {
-                return firstEncoding;
+            final Encoding firstEncoding = firstRope.getEncoding();
+            final Encoding secondEncoding = secondRope.getEncoding();
+
+            if (firstEncoding == null || secondEncoding == null) return null;
+            if (firstEncoding == secondEncoding) return firstEncoding;
+
+            if (secondRope.isEmpty()) return firstEncoding;
+            if (firstRope.isEmpty()) {
+                return firstEncoding.isAsciiCompatible() && isAsciiOnly(secondRope) ? firstEncoding : secondEncoding;
             }
 
-            return org.jruby.RubyEncoding.areCompatible(StringOperations.getCodeRangeableReadOnly(first), StringOperations.getCodeRangeableReadOnly(second));
+            if (!firstEncoding.isAsciiCompatible() || !secondEncoding.isAsciiCompatible()) return null;
+
+            if (firstRope.getCodeRange() != secondRope.getCodeRange()) {
+                if (firstRope.getCodeRange() == StringSupport.CR_7BIT) return secondEncoding;
+                if (secondRope.getCodeRange() == StringSupport.CR_7BIT) return firstEncoding;
+            }
+            if (secondRope.getCodeRange() == StringSupport.CR_7BIT) return firstEncoding;
+            if (firstRope.getCodeRange() == StringSupport.CR_7BIT) return secondEncoding;
+
+            return null;
+        }
+
+        @TruffleBoundary
+        private static boolean isAsciiOnly(Rope rope) {
+            return rope.getEncoding().isAsciiCompatible() && rope.getCodeRange() == StringSupport.CR_7BIT;
         }
 
         protected Encoding extractEncoding(DynamicObject string) {

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/InterpolatedRegexpNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/InterpolatedRegexpNode.java
@@ -19,6 +19,8 @@ import org.jruby.truffle.nodes.dispatch.DispatchHeadNodeFactory;
 import org.jruby.truffle.runtime.RubyContext;
 import org.jruby.truffle.runtime.core.StringOperations;
 import org.jruby.truffle.runtime.layouts.Layouts;
+import org.jruby.truffle.runtime.rope.Rope;
+import org.jruby.truffle.runtime.rope.RopeOperations;
 import org.jruby.truffle.translator.BodyTranslator;
 import org.jruby.util.RegexpOptions;
 
@@ -48,13 +50,15 @@ public class InterpolatedRegexpNode extends RubyNode {
 
         final org.jruby.RubyString preprocessed = org.jruby.RubyRegexp.preprocessDRegexp(getContext().getRuntime(), strings, options);
 
-        final DynamicObject regexp = RegexpNodes.createRubyRegexp(getContext(), this, getContext().getCoreLibrary().getRegexpClass(), preprocessed.getByteList(), options);
+        final DynamicObject regexp = RegexpNodes.createRubyRegexp(getContext(), this, getContext().getCoreLibrary().getRegexpClass(), StringOperations.ropeFromByteList(preprocessed.getByteList()), options);
 
         if (options.isEncodingNone()) {
+            final Rope source = Layouts.REGEXP.getSource(regexp);
+
             if (!BodyTranslator.all7Bit(preprocessed.getByteList().bytes())) {
-                Layouts.REGEXP.getSource(regexp).setEncoding(getContext().getRuntime().getEncodingService().getAscii8bitEncoding());
+                Layouts.REGEXP.setSource(regexp, RopeOperations.withEncoding(source, getContext().getRuntime().getEncodingService().getAscii8bitEncoding()));
             } else {
-                Layouts.REGEXP.getSource(regexp).setEncoding(getContext().getRuntime().getEncodingService().getUSAsciiEncoding());
+                Layouts.REGEXP.setSource(regexp, RopeOperations.withEncoding(source, getContext().getRuntime().getEncodingService().getUSAsciiEncoding()));
             }
         }
 

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/KernelNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/KernelNodes.java
@@ -72,6 +72,7 @@ import org.jruby.truffle.runtime.layouts.ThreadBacktraceLocationLayoutImpl;
 import org.jruby.truffle.runtime.loader.FeatureLoader;
 import org.jruby.truffle.runtime.methods.InternalMethod;
 import org.jruby.truffle.runtime.methods.SharedMethodInfo;
+import org.jruby.truffle.runtime.rope.Rope;
 import org.jruby.truffle.runtime.subsystems.ThreadManager.BlockingAction;
 import org.jruby.truffle.translator.TranslatorDriver;
 import org.jruby.truffle.translator.TranslatorDriver.ParserContext;
@@ -511,7 +512,7 @@ public abstract class KernelNodes {
 
         @Specialization(guards = {
                 "isRubyString(source)",
-                "byteListsEqual(source, cachedSource)",
+                "ropesEqual(source, cachedSource)",
                 "!parseDependsOnDeclarationFrame(cachedRootNode)"
         }, limit = "getCacheLimit()")
         public Object evalNoBindingCached(
@@ -520,7 +521,7 @@ public abstract class KernelNodes {
                 NotProvided binding,
                 NotProvided filename,
                 NotProvided lineNumber,
-                @Cached("privatizeByteList(source)") ByteList cachedSource,
+                @Cached("privatizeRope(source)") Rope cachedSource,
                 @Cached("compileSource(frame, source)") RootNodeWrapper cachedRootNode,
                 @Cached("createCallTarget(cachedRootNode)") CallTarget cachedCallTarget,
                 @Cached("create(cachedCallTarget)") DirectCallNode callNode
@@ -1870,13 +1871,13 @@ public abstract class KernelNodes {
             super(context, sourceSection);
         }
 
-        @Specialization(guards = { "isRubyString(format)", "byteListsEqual(format, cachedFormat)" })
+        @Specialization(guards = { "isRubyString(format)", "ropesEqual(format, cachedFormat)" })
         public DynamicObject formatCached(
                 VirtualFrame frame,
                 DynamicObject format,
                 Object[] arguments,
-                @Cached("privatizeByteList(format)") ByteList cachedFormat,
-                @Cached("byteListLength(cachedFormat)") int cachedFormatLength,
+                @Cached("privatizeRope(format)") Rope cachedFormat,
+                @Cached("ropeLength(cachedFormat)") int cachedFormatLength,
                 @Cached("create(compileFormat(format))") DirectCallNode callPackNode) {
             final PackResult result;
 

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/MatchDataNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/MatchDataNodes.java
@@ -33,6 +33,7 @@ import org.jruby.truffle.runtime.control.RaiseException;
 import org.jruby.truffle.runtime.core.ArrayOperations;
 import org.jruby.truffle.runtime.core.StringOperations;
 import org.jruby.truffle.runtime.layouts.Layouts;
+import org.jruby.truffle.runtime.rope.Rope;
 import org.jruby.util.ByteList;
 import org.jruby.util.StringSupport;
 
@@ -197,8 +198,8 @@ public abstract class MatchDataNodes {
         @Specialization(guards = "isRubySymbol(index)")
         public Object getIndexSymbol(DynamicObject matchData, DynamicObject index, NotProvided length) {
             try {
-                ByteList value = Layouts.SYMBOL.getByteList(index);
-                final int i = Layouts.REGEXP.getRegex(Layouts.MATCH_DATA.getRegexp(matchData)).nameToBackrefNumber(value.getUnsafeBytes(), value.getBegin(), value.getBegin() + value.getRealSize(), Layouts.MATCH_DATA.getRegion(matchData));
+                final Rope value = Layouts.SYMBOL.getRope(index);
+                final int i = Layouts.REGEXP.getRegex(Layouts.MATCH_DATA.getRegexp(matchData)).nameToBackrefNumber(value.getBytes(), value.getBegin(), value.getBegin() + value.getRealSize(), Layouts.MATCH_DATA.getRegion(matchData));
 
                 return getIndex(matchData, i, NotProvided.INSTANCE);
             } catch (final ValueException e) {

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/RegexpGuards.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/RegexpGuards.java
@@ -26,7 +26,7 @@ public class RegexpGuards {
     }
 
     public static boolean isValidEncoding(DynamicObject string) {
-        return StringOperations.scanForCodeRange(string) != StringSupport.CR_BROKEN;
+        return StringOperations.codeRange(string) != StringSupport.CR_BROKEN;
     }
 
 }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/RegexpNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/RegexpNodes.java
@@ -40,6 +40,7 @@ import org.jruby.truffle.runtime.RubyContext;
 import org.jruby.truffle.runtime.core.StringOperations;
 import org.jruby.truffle.runtime.layouts.Layouts;
 import org.jruby.truffle.runtime.rope.Rope;
+import org.jruby.truffle.runtime.rope.RopeOperations;
 import org.jruby.util.*;
 
 import java.nio.charset.StandardCharsets;
@@ -55,17 +56,17 @@ public abstract class RegexpNodes {
         assert RubyGuards.isRubyRegexp(regexp);
         assert RubyGuards.isRubyString(source);
 
-        final ByteList sourceByteList = StringOperations.getByteListReadOnly(source);
+        final Rope sourceRope = StringOperations.rope(source);
 
-        final ByteList bl = Layouts.REGEXP.getSource(regexp);
-        final Encoding enc = checkEncoding(regexp, StringOperations.getCodeRangeableReadOnly(source), true);
-        final ByteList preprocessed = RegexpSupport.preprocess(context.getRuntime(), bl, enc, new Encoding[] { null }, RegexpSupport.ErrorMode.RAISE);
+        final Rope regexpSourceRope = Layouts.REGEXP.getSource(regexp);
+        final Encoding enc = checkEncoding(regexp, sourceRope, true);
+        final ByteList preprocessed = RegexpSupport.preprocess(context.getRuntime(), regexpSourceRope.getUnsafeByteList(), enc, new Encoding[] { null }, RegexpSupport.ErrorMode.RAISE);
 
-        final Regex r = new Regex(preprocessed.getUnsafeBytes(), preprocessed.getBegin(), preprocessed.getBegin() + preprocessed.getRealSize(), Layouts.REGEXP.getOptions(regexp).toJoniOptions(), checkEncoding(regexp, StringOperations.getCodeRangeableReadOnly(source), true));
-        final Matcher matcher = r.matcher(sourceByteList.unsafeBytes(), sourceByteList.begin(), sourceByteList.begin() + sourceByteList.realSize());
-        int range = sourceByteList.begin() + sourceByteList.realSize();
+        final Regex r = new Regex(preprocessed.getUnsafeBytes(), preprocessed.getBegin(), preprocessed.getBegin() + preprocessed.getRealSize(), Layouts.REGEXP.getOptions(regexp).toJoniOptions(), checkEncoding(regexp, sourceRope, true));
+        final Matcher matcher = r.matcher(sourceRope.getBytes(), sourceRope.begin(), sourceRope.begin() + sourceRope.realSize());
+        int range = sourceRope.begin() + sourceRope.realSize();
 
-        return matchCommon(context, regexp, source, operator, setNamedCaptures, matcher, sourceByteList.begin() + startPos, range);
+        return matchCommon(context, regexp, source, operator, setNamedCaptures, matcher, sourceRope.begin() + startPos, range);
     }
 
     @TruffleBoundary
@@ -197,7 +198,7 @@ public abstract class RegexpNodes {
         }
     }
 
-    public static ByteList shimModifiers(ByteList bytes) {
+    public static Rope shimModifiers(Rope bytes) {
         // Joni doesn't support (?u) etc but we can shim some common cases
 
         String bytesString = bytes.toString();
@@ -223,14 +224,15 @@ public abstract class RegexpNodes {
                     throw new UnsupportedOperationException();
             }
 
-            bytes = ByteList.create(bytesString);
+            // TODO (nirvdrum 25-Jan-16): We probably just want a way to create a Rope from a java.lang.String.
+            bytes = StringOperations.ropeFromByteList(ByteList.create(bytesString));
         }
 
         return bytes;
     }
 
     @TruffleBoundary
-    public static Regex compile(Node currentNode, RubyContext context, ByteList bytes, RegexpOptions options) {
+    public static Regex compile(Node currentNode, RubyContext context, Rope bytes, RegexpOptions options) {
         bytes = shimModifiers(bytes);
 
         try {
@@ -249,13 +251,14 @@ public abstract class RegexpNodes {
         }
              */
 
+            final ByteList byteList = bytes.getUnsafeByteList();
             Encoding enc = bytes.getEncoding();
             Encoding[] fixedEnc = new Encoding[]{null};
-            ByteList unescaped = RegexpSupport.preprocess(context.getRuntime(), bytes, enc, fixedEnc, RegexpSupport.ErrorMode.RAISE);
+            ByteList unescaped = RegexpSupport.preprocess(context.getRuntime(), byteList, enc, fixedEnc, RegexpSupport.ErrorMode.RAISE);
             if (fixedEnc[0] != null) {
                 if ((fixedEnc[0] != enc && options.isFixed()) ||
                         (fixedEnc[0] != ASCIIEncoding.INSTANCE && options.isEncodingNone())) {
-                    RegexpSupport.raiseRegexpError19(context.getRuntime(), bytes, enc, options, "incompatible character encoding");
+                    RegexpSupport.raiseRegexpError19(context.getRuntime(), byteList, enc, options, "incompatible character encoding");
                 }
                 if (fixedEnc[0] != ASCIIEncoding.INSTANCE) {
                     options.setFixed(true);
@@ -268,10 +271,8 @@ public abstract class RegexpNodes {
             if (fixedEnc[0] != null) options.setFixed(true);
             //if (regexpOptions.isEncodingNone()) setEncodingNone();
 
-            bytes.setEncoding(enc);
-
             Regex ret = new Regex(unescaped.getUnsafeBytes(), unescaped.getBegin(), unescaped.getBegin() + unescaped.getRealSize(), options.toJoniOptions(), enc, Syntax.RUBY);
-            ret.setUserObject(bytes);
+            ret.setUserObject(RopeOperations.withEncoding(bytes, enc));
 
             return ret;
         } catch (ValueException e) {
@@ -293,7 +294,7 @@ public abstract class RegexpNodes {
         Layouts.REGEXP.setRegex(regexp, regex);
     }
 
-    public static void setSource(DynamicObject regexp, ByteList source) {
+    public static void setSource(DynamicObject regexp, Rope source) {
         Layouts.REGEXP.setSource(regexp, source);
     }
 
@@ -302,7 +303,7 @@ public abstract class RegexpNodes {
     }
 
     // TODO (nirvdrum 03-June-15) Unify with JRuby in RegexpSupport.
-    public static Encoding checkEncoding(DynamicObject regexp, CodeRangeable str, boolean warn) {
+    public static Encoding checkEncoding(DynamicObject regexp, Rope str, boolean warn) {
         assert RubyGuards.isRubyRegexp(regexp);
 
         final Regex pattern = Layouts.REGEXP.getRegex(regexp);
@@ -313,7 +314,7 @@ public abstract class RegexpNodes {
         }
         */
         //check();
-        Encoding enc = str.getByteList().getEncoding();
+        Encoding enc = str.getEncoding();
         if (!enc.isAsciiCompatible()) {
             if (enc != pattern.getEncoding()) {
                 //encodingMatchError(getRuntime(), pattern, enc);
@@ -336,31 +337,42 @@ public abstract class RegexpNodes {
         return enc;
     }
 
-    public static void initialize(RubyContext context, DynamicObject regexp, Node currentNode, ByteList setSource, int options) {
+    public static void initialize(RubyContext context, DynamicObject regexp, Node currentNode, Rope setSource, int options) {
         assert RubyGuards.isRubyRegexp(regexp);
-        setSource(regexp, setSource);
-        setOptions(regexp, RegexpOptions.fromEmbeddedOptions(options));
-        setRegex(regexp, compile(currentNode, context, setSource, Layouts.REGEXP.getOptions(regexp)));
+        final RegexpOptions regexpOptions = RegexpOptions.fromEmbeddedOptions(options);
+        final Regex regex = compile(currentNode, context, setSource, regexpOptions);
+
+        // The RegexpNodes.compile operation may modify the encoding of the source rope. This modified copy is stored
+        // in the Regex object as the "user object". Since ropes are immutable, we need to take this updated copy when
+        // constructing the final regexp.
+        setSource(regexp, (Rope) regex.getUserObject());
+        setOptions(regexp, regexpOptions);
+        setRegex(regexp, regex);
     }
 
-    public static void initialize(DynamicObject regexp, Regex setRegex, ByteList setSource) {
+    public static void initialize(DynamicObject regexp, Regex setRegex, Rope setSource) {
         assert RubyGuards.isRubyRegexp(regexp);
         setRegex(regexp, setRegex);
         setSource(regexp, setSource);
     }
 
-    public static DynamicObject createRubyRegexp(RubyContext context, Node currentNode, DynamicObject regexpClass, ByteList regex, RegexpOptions options) {
-        return Layouts.REGEXP.createRegexp(Layouts.CLASS.getInstanceFactory(regexpClass), RegexpNodes.compile(currentNode, context, regex, options), regex, options, null);
+    public static DynamicObject createRubyRegexp(RubyContext context, Node currentNode, DynamicObject regexpClass, Rope source, RegexpOptions options) {
+        final Regex regexp = RegexpNodes.compile(currentNode, context, source, options);
+
+        // The RegexpNodes.compile operation may modify the encoding of the source rope. This modified copy is stored
+        // in the Regex object as the "user object". Since ropes are immutable, we need to take this updated copy when
+        // constructing the final regexp.
+        return Layouts.REGEXP.createRegexp(Layouts.CLASS.getInstanceFactory(regexpClass), regexp, (Rope) regexp.getUserObject(), options, null);
     }
 
-    public static DynamicObject createRubyRegexp(DynamicObject regexpClass, Regex regex, ByteList source, RegexpOptions options) {
+    public static DynamicObject createRubyRegexp(DynamicObject regexpClass, Regex regex, Rope source, RegexpOptions options) {
         final DynamicObject regexp = Layouts.REGEXP.createRegexp(Layouts.CLASS.getInstanceFactory(regexpClass), null, null, RegexpOptions.NULL_OPTIONS, null);
         RegexpNodes.setOptions(regexp, options);
         RegexpNodes.initialize(regexp, regex, source);
         return regexp;
     }
 
-    public static DynamicObject createRubyRegexp(DynamicObject regexpClass, Regex regex, ByteList source) {
+    public static DynamicObject createRubyRegexp(DynamicObject regexpClass, Regex regex, Rope source) {
         final DynamicObject regexp = Layouts.REGEXP.createRegexp(Layouts.CLASS.getInstanceFactory(regexpClass), null, null, RegexpOptions.NULL_OPTIONS, null);
         RegexpNodes.initialize(regexp, regex, source);
         return regexp;
@@ -502,7 +514,7 @@ public abstract class RegexpNodes {
 
         @Specialization
         public DynamicObject source(DynamicObject regexp) {
-            return createString(Layouts.REGEXP.getSource(regexp).dup());
+            return createString(Layouts.REGEXP.getSource(regexp));
         }
 
     }
@@ -517,7 +529,7 @@ public abstract class RegexpNodes {
         @TruffleBoundary
         @Specialization
         public DynamicObject toS(DynamicObject regexp) {
-            return createString(((org.jruby.RubyString) org.jruby.RubyRegexp.newRegexp(getContext().getRuntime(), Layouts.REGEXP.getSource(regexp), Layouts.REGEXP.getRegex(regexp).getOptions()).to_s()).getByteList());
+            return createString(((org.jruby.RubyString) org.jruby.RubyRegexp.newRegexp(getContext().getRuntime(), Layouts.REGEXP.getSource(regexp).getUnsafeByteList(), Layouts.REGEXP.getRegex(regexp).getOptions()).to_s()).getByteList());
         }
 
     }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/RegexpNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/RegexpNodes.java
@@ -39,6 +39,7 @@ import org.jruby.truffle.runtime.RubyCallStack;
 import org.jruby.truffle.runtime.RubyContext;
 import org.jruby.truffle.runtime.core.StringOperations;
 import org.jruby.truffle.runtime.layouts.Layouts;
+import org.jruby.truffle.runtime.rope.Rope;
 import org.jruby.util.*;
 
 import java.nio.charset.StandardCharsets;
@@ -466,7 +467,8 @@ public abstract class RegexpNodes {
         @TruffleBoundary
         @Specialization(guards = "isRubyString(raw)")
         public DynamicObject quoteString(DynamicObject raw) {
-            boolean isAsciiOnly = Layouts.STRING.getRope(raw).getEncoding().isAsciiCompatible() && StringOperations.scanForCodeRange(raw) == CR_7BIT;
+            final Rope rope = StringOperations.rope(raw);
+            boolean isAsciiOnly = rope.getEncoding().isAsciiCompatible() && rope.getCodeRange() == CR_7BIT;
             return createString(org.jruby.RubyRegexp.quote19(StringOperations.getByteListReadOnly(raw), isAsciiOnly));
         }
 

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/RopeNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/RopeNodes.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 1.0
+ * GNU General Public License version 2
+ * GNU Lesser General Public License version 2.1
+ */
+
+package org.jruby.truffle.nodes.core;
+
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.NodeChildren;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.source.SourceSection;
+import com.oracle.truffle.api.utilities.ConditionProfile;
+import org.jruby.truffle.nodes.RubyNode;
+import org.jruby.truffle.runtime.RubyContext;
+import org.jruby.truffle.runtime.rope.ConcatRope;
+import org.jruby.truffle.runtime.rope.LeafRope;
+import org.jruby.truffle.runtime.rope.Rope;
+import org.jruby.truffle.runtime.rope.RopeOperations;
+import org.jruby.truffle.runtime.rope.SubstringRope;
+import org.jruby.util.StringSupport;
+
+public abstract class RopeNodes {
+
+    @NodeChildren({
+            @NodeChild(type = RubyNode.class, value = "base"),
+            @NodeChild(type = RubyNode.class, value = "offset"),
+            @NodeChild(type = RubyNode.class, value = "byteLength")
+    })
+    public abstract static class MakeSubstringNode extends RubyNode {
+
+        public MakeSubstringNode(RubyContext context, SourceSection sourceSection) {
+            super(context, sourceSection);
+        }
+
+        public abstract Rope executeMake(Rope base, int offset, int byteLength);
+
+        @Specialization(guards = "byteLength == 0")
+        public Rope substringZeroLength(Rope base, int offset, int byteLength) {
+            return RopeOperations.withEncoding(RopeOperations.EMPTY_UTF8_ROPE, base.getEncoding());
+        }
+
+        @Specialization(guards = { "byteLength > 0", "sameAsBase(base, offset, byteLength)" })
+        public Rope substringSameAsBase(Rope base, int offset, int byteLength) {
+            return base;
+        }
+
+        @Specialization(guards = { "byteLength > 0", "!sameAsBase(base, offset, byteLength)", "isLeafRope(base)" })
+        public Rope substringLeafRope(LeafRope base, int offset, int byteLength,
+                                  @Cached("createBinaryProfile()") ConditionProfile is7BitProfile) {
+            return makeSubstring(base, offset, byteLength, is7BitProfile);
+        }
+
+        @Specialization(guards = { "byteLength > 0", "!sameAsBase(base, offset, byteLength)", "isSubstringRope(base)" })
+        public Rope substringSubstringRope(SubstringRope base, int offset, int byteLength,
+                                      @Cached("createBinaryProfile()") ConditionProfile is7BitProfile) {
+            return makeSubstring(base.getChild(), offset + base.getOffset(), byteLength, is7BitProfile);
+        }
+
+        @Specialization(guards = { "byteLength > 0", "!sameAsBase(base, offset, byteLength)", "isConcatRope(base)" })
+        public Rope substringConcatRope(ConcatRope base, int offset, int byteLength,
+                                      @Cached("createBinaryProfile()") ConditionProfile is7BitProfile) {
+            Rope root = base;
+
+            while (root instanceof ConcatRope) {
+                ConcatRope concatRoot = (ConcatRope) root;
+                Rope left = concatRoot.getLeft();
+                Rope right = concatRoot.getRight();
+
+                // CASE 1: Fits in left.
+                if (offset + byteLength <= left.byteLength()) {
+                    root = left;
+                    continue;
+                }
+
+                // CASE 2: Fits in right.
+                if (offset >= left.byteLength()) {
+                    offset -= left.byteLength();
+                    root = right;
+                    continue;
+                }
+
+                // CASE 3: Spans left and right.
+                if (byteLength == root.byteLength()) {
+                    return root;
+                } else {
+                    return makeSubstring(root, offset, byteLength, is7BitProfile);
+                }
+            }
+
+            return executeMake(root, offset, byteLength);
+        }
+
+        private Rope makeSubstring(Rope base, int offset, int byteLength, ConditionProfile is7BitProfile) {
+            if (is7BitProfile.profile(base.getCodeRange() == StringSupport.CR_7BIT)) {
+                return new SubstringRope(base, offset, byteLength, byteLength, StringSupport.CR_7BIT);
+            }
+
+            return makeSubstringNon7Bit(base, offset, byteLength);
+        }
+
+        @CompilerDirectives.TruffleBoundary
+        private Rope makeSubstringNon7Bit(Rope base, int offset, int byteLength) {
+            final long packedLengthAndCodeRange = RopeOperations.calculateCodeRangeAndLength(base.getEncoding(), base.getBytes(), offset, offset + byteLength);
+            final int codeRange = StringSupport.unpackArg(packedLengthAndCodeRange);
+            final int characterLength = StringSupport.unpackResult(packedLengthAndCodeRange);
+
+            return new SubstringRope(base, offset, byteLength, characterLength, codeRange);
+        }
+
+        protected static boolean sameAsBase(Rope base, int offset, int byteLength) {
+            return (byteLength - offset) == base.byteLength();
+        }
+
+        protected static boolean is7Bit(Rope base) {
+            return base.getCodeRange() == StringSupport.CR_7BIT;
+        }
+
+        protected static boolean isLeafRope(Rope rope) {
+            return (rope instanceof LeafRope);
+        }
+
+        protected static boolean isSubstringRope(Rope rope) {
+            return (rope instanceof SubstringRope);
+        }
+
+        protected static boolean isConcatRope(Rope rope) {
+            return (rope instanceof ConcatRope);
+        }
+    }
+
+}

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/RopeNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/RopeNodes.java
@@ -57,19 +57,19 @@ public abstract class RopeNodes {
             return base;
         }
 
-        @Specialization(guards = { "byteLength > 0", "!sameAsBase(base, offset, byteLength)", "isLeafRope(base)" })
+        @Specialization(guards = { "byteLength > 0", "!sameAsBase(base, offset, byteLength)" })
         public Rope substringLeafRope(LeafRope base, int offset, int byteLength,
                                   @Cached("createBinaryProfile()") ConditionProfile is7BitProfile) {
             return makeSubstring(base, offset, byteLength, is7BitProfile);
         }
 
-        @Specialization(guards = { "byteLength > 0", "!sameAsBase(base, offset, byteLength)", "isSubstringRope(base)" })
+        @Specialization(guards = { "byteLength > 0", "!sameAsBase(base, offset, byteLength)" })
         public Rope substringSubstringRope(SubstringRope base, int offset, int byteLength,
                                       @Cached("createBinaryProfile()") ConditionProfile is7BitProfile) {
             return makeSubstring(base.getChild(), offset + base.getOffset(), byteLength, is7BitProfile);
         }
 
-        @Specialization(guards = { "byteLength > 0", "!sameAsBase(base, offset, byteLength)", "isConcatRope(base)" })
+        @Specialization(guards = { "byteLength > 0", "!sameAsBase(base, offset, byteLength)" })
         public Rope substringConcatRope(ConcatRope base, int offset, int byteLength,
                                       @Cached("createBinaryProfile()") ConditionProfile is7BitProfile) {
             Rope root = base;
@@ -128,22 +128,6 @@ public abstract class RopeNodes {
 
         protected static boolean sameAsBase(Rope base, int offset, int byteLength) {
             return (byteLength - offset) == base.byteLength();
-        }
-
-        protected static boolean is7Bit(Rope base) {
-            return base.getCodeRange() == StringSupport.CR_7BIT;
-        }
-
-        protected static boolean isLeafRope(Rope rope) {
-            return (rope instanceof LeafRope);
-        }
-
-        protected static boolean isSubstringRope(Rope rope) {
-            return (rope instanceof SubstringRope);
-        }
-
-        protected static boolean isConcatRope(Rope rope) {
-            return (rope instanceof ConcatRope);
         }
 
     }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/StringGuards.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/StringGuards.java
@@ -68,4 +68,9 @@ public class StringGuards {
         assert RubyGuards.isRubyString(string);
         return Layouts.STRING.getRope(string).isEmpty();
     }
+
+    public static boolean isBrokenCodeRange(DynamicObject string) {
+        assert RubyGuards.isRubyString(string);
+        return StringOperations.codeRange(string) == StringSupport.CR_BROKEN;
+    }
 }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/StringNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/StringNodes.java
@@ -1350,7 +1350,7 @@ public abstract class StringNodes {
             final Rope left = rope(other);
             final Rope right = rope(string);
 
-            final Encoding compatibleEncoding = EncodingNodes.CompatibleQueryNode.areCompatible(string, other);
+            final Encoding compatibleEncoding = EncodingNodes.CompatibleQueryNode.compatibleEncodingForStrings(string, other);
 
             if (compatibleEncoding == null) {
                 CompilerDirectives.transferToInterpreter();
@@ -1386,7 +1386,7 @@ public abstract class StringNodes {
 
             final Rope source = rope(string);
             final Rope insert = rope(other);
-            final Encoding compatibleEncoding = EncodingNodes.CompatibleQueryNode.areCompatible(string, other);
+            final Encoding compatibleEncoding = EncodingNodes.CompatibleQueryNode.compatibleEncodingForStrings(string, other);
 
             if (compatibleEncoding == null) {
                 CompilerDirectives.transferToInterpreter();

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/StringNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/StringNodes.java
@@ -2546,15 +2546,21 @@ public abstract class StringNodes {
     }
 
     @CoreMethod(names = "valid_encoding?")
+    @ImportStatic(StringGuards.class)
     public abstract static class ValidEncodingQueryNode extends CoreMethodArrayArgumentsNode {
 
         public ValidEncodingQueryNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
         }
 
-        @Specialization
+        @Specialization(guards = "isBrokenCodeRange(string)")
+        public boolean validEncodingQueryBroken(DynamicObject string) {
+            return false;
+        }
+
+        @Specialization(guards = "!isBrokenCodeRange(string)")
         public boolean validEncodingQuery(DynamicObject string) {
-            return codeRange(string) != StringSupport.CR_BROKEN;
+            return true;
         }
 
     }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/StringNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/StringNodes.java
@@ -2073,7 +2073,7 @@ public abstract class StringNodes {
 
         @Specialization
         public DynamicObject toSym(DynamicObject string) {
-            return getSymbol(StringOperations.getByteListReadOnly(string));
+            return getSymbol(rope(string));
         }
     }
 

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/StringNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/StringNodes.java
@@ -123,7 +123,7 @@ public abstract class StringNodes {
             final Rope left = rope(string);
             final Rope right = rope(other);
 
-            final Encoding enc = StringOperations.checkEncoding(getContext(), string, StringOperations.getCodeRangeableReadOnly(other), this);
+            final Encoding enc = StringOperations.checkEncoding(getContext(), string, other, this);
 
             final Rope concatRope = RopeOperations.concat(left, right, enc);
 
@@ -800,7 +800,7 @@ public abstract class StringNodes {
 
                 assert RubyGuards.isRubyString(otherStr);
 
-                enc = StringOperations.checkEncoding(getContext(), string, StringOperations.getCodeRangeableReadOnly(otherStr), this);
+                enc = StringOperations.checkEncoding(getContext(), string, otherStr, this);
                 tables = StringSupport.trSetupTable(StringOperations.getByteListReadOnly(otherStr), getContext().getRuntime(), table, tables, false, enc);
             }
 
@@ -924,7 +924,7 @@ public abstract class StringNodes {
             assert RubyGuards.isRubyString(string);
 
             DynamicObject otherString = otherStrings[0];
-            Encoding enc = StringOperations.checkEncoding(getContext(), string, StringOperations.getCodeRangeableReadOnly(otherString), this);
+            Encoding enc = StringOperations.checkEncoding(getContext(), string, otherString, this);
 
             boolean[] squeeze = new boolean[StringSupport.TRANS_SIZE + 1];
             StringSupport.TrTables tables = StringSupport.trSetupTable(StringOperations.getByteListReadOnly(otherString),
@@ -934,7 +934,7 @@ public abstract class StringNodes {
             for (int i = 1; i < otherStrings.length; i++) {
                 assert RubyGuards.isRubyString(otherStrings[i]);
 
-                enc = StringOperations.checkEncoding(getContext(), string, StringOperations.getCodeRangeableReadOnly(otherStrings[i]), this);
+                enc = StringOperations.checkEncoding(getContext(), string, otherStrings[i], this);
                 tables = StringSupport.trSetupTable(StringOperations.getByteListReadOnly(otherStrings[i]), getContext().getRuntime(), squeeze, tables, false, enc);
             }
 
@@ -1866,7 +1866,7 @@ public abstract class StringNodes {
 
             DynamicObject otherStr = otherStrings[0];
             Rope otherRope = rope(otherStr);
-            Encoding enc = StringOperations.checkEncoding(getContext(), string, StringOperations.getCodeRangeableReadOnly(otherStr), this);
+            Encoding enc = StringOperations.checkEncoding(getContext(), string, otherStr, this);
             final boolean squeeze[] = new boolean[StringSupport.TRANS_SIZE + 1];
             StringSupport.TrTables tables = StringSupport.trSetupTable(otherRope.getUnsafeByteList(), getContext().getRuntime(), squeeze, null, true, enc);
 
@@ -1875,7 +1875,7 @@ public abstract class StringNodes {
             for (int i = 1; i < otherStrings.length; i++) {
                 otherStr = otherStrings[i];
                 otherRope = rope(otherStr);
-                enc = StringOperations.checkEncoding(getContext(), string, StringOperations.getCodeRangeableReadOnly(otherStr), this);
+                enc = StringOperations.checkEncoding(getContext(), string, otherStr, this);
                 singlebyte = singlebyte && otherRope.isSingleByteOptimizable();
                 tables = StringSupport.trSetupTable(otherRope.getUnsafeByteList(), getContext().getRuntime(), squeeze, tables, false, enc);
             }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/StringNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/StringNodes.java
@@ -75,6 +75,7 @@ import org.jruby.util.io.EncodingUtils;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 
+import static org.jruby.truffle.runtime.core.StringOperations.codeRange;
 import static org.jruby.truffle.runtime.rope.RopeOperations.EMPTY_ASCII_8BIT_ROPE;
 import static org.jruby.truffle.runtime.rope.RopeOperations.EMPTY_UTF8_ROPE;
 import static org.jruby.truffle.runtime.core.StringOperations.rope;
@@ -472,10 +473,11 @@ public abstract class StringNodes {
 
         @Specialization(guards = "wasNotProvided(length) || isRubiniusUndefined(length)")
         public Object getIndex(VirtualFrame frame, DynamicObject string, int index, Object length) {
-            final int stringLength = StringOperations.rope(string).characterLength();
+            final Rope rope = rope(string);
+            final int stringLength = rope.characterLength();
             int normalizedIndex = StringOperations.normalizeIndex(stringLength, index);
 
-            if (normalizedIndex < 0 || normalizedIndex >= StringOperations.byteLength(string)) {
+            if (normalizedIndex < 0 || normalizedIndex >= rope.byteLength()) {
                 outOfBounds.enter();
                 return nil();
             } else {
@@ -2552,7 +2554,7 @@ public abstract class StringNodes {
 
         @Specialization
         public boolean validEncodingQuery(DynamicObject string) {
-            return StringOperations.scanForCodeRange(string) != StringSupport.CR_BROKEN;
+            return codeRange(string) != StringSupport.CR_BROKEN;
         }
 
     }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/StringNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/StringNodes.java
@@ -1266,7 +1266,7 @@ public abstract class StringNodes {
 
         @Specialization
         public int hash(DynamicObject string) {
-            return StringOperations.getByteListReadOnly(string).hashCode();
+            return rope(string).hashCode();
         }
 
     }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/SymbolNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/SymbolNodes.java
@@ -94,7 +94,7 @@ public abstract class SymbolNodes {
 
         @Specialization
         public DynamicObject encoding(DynamicObject symbol) {
-            return EncodingNodes.getEncoding(Layouts.SYMBOL.getByteList(symbol).getEncoding());
+            return EncodingNodes.getEncoding(Layouts.SYMBOL.getRope(symbol).getEncoding());
         }
 
     }
@@ -176,7 +176,7 @@ public abstract class SymbolNodes {
 
         @Specialization
         public DynamicObject toS(DynamicObject symbol) {
-            return createString(Layouts.SYMBOL.getByteList(symbol).dup());
+            return createString(Layouts.SYMBOL.getRope(symbol));
         }
 
     }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/TruffleInteropNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/TruffleInteropNodes.java
@@ -28,6 +28,7 @@ import org.jruby.truffle.nodes.StringCachingGuards;
 import org.jruby.truffle.runtime.RubyContext;
 import org.jruby.truffle.runtime.core.StringOperations;
 import org.jruby.truffle.runtime.layouts.Layouts;
+import org.jruby.truffle.runtime.rope.Rope;
 import org.jruby.truffle.runtime.rope.RopeOperations;
 import org.jruby.util.ByteList;
 import org.jruby.util.StringSupport;
@@ -234,11 +235,11 @@ public abstract class TruffleInteropNodes {
             return ForeignAccess.execute(readNode, frame, receiver, identifierString);
         }
 
-        @Specialization(guards = {"isRubyString(identifier)", "byteListsEqual(identifier, cachedIdentifier)"})
+        @Specialization(guards = {"isRubyString(identifier)", "ropesEqual(identifier, cachedIdentifier)"})
         public Object readProperty(VirtualFrame frame,
                                    TruffleObject receiver,
                                    DynamicObject identifier,
-                                   @Cached("privatizeByteList(identifier)") ByteList cachedIdentifier,
+                                   @Cached("privatizeRope(identifier)") Rope cachedIdentifier,
                                    @Cached("identifier.toString()") String identifierString,
                                    @Cached("createReadNode()") Node readNode) {
             return ForeignAccess.execute(readNode, frame, receiver, identifierString);
@@ -282,12 +283,12 @@ public abstract class TruffleInteropNodes {
             return ForeignAccess.execute(writeNode, frame, receiver, identifierString, value);
         }
 
-        @Specialization(guards = {"isRubyString(identifier)", "byteListsEqual(identifier, cachedIdentifier)"})
+        @Specialization(guards = {"isRubyString(identifier)", "ropesEqual(identifier, cachedIdentifier)"})
         public Object writeProperty(VirtualFrame frame,
                                     TruffleObject receiver,
                                     DynamicObject identifier,
                                     Object value,
-                                    @Cached("privatizeByteList(identifier)") ByteList cachedIdentifier,
+                                    @Cached("privatizeRope(identifier)") Rope cachedIdentifier,
                                     @Cached("identifier.toString()") String identifierString,
                                     @Cached("createWriteNode()") Node writeNode) {
             return ForeignAccess.execute(writeNode, frame, receiver, identifierString, value);
@@ -439,15 +440,15 @@ public abstract class TruffleInteropNodes {
         @Specialization(guards = {
                 "isRubyString(mimeType)",
                 "isRubyString(source)",
-                "byteListsEqual(mimeType, cachedMimeType)",
-                "byteListsEqual(source, cachedSource)"
+                "ropesEqual(mimeType, cachedMimeType)",
+                "ropesEqual(source, cachedSource)"
         }, limit = "getCacheLimit()")
         public Object evalCached(
                 VirtualFrame frame,
                 DynamicObject mimeType,
                 DynamicObject source,
-                @Cached("privatizeByteList(mimeType)") ByteList cachedMimeType,
-                @Cached("privatizeByteList(source)") ByteList cachedSource,
+                @Cached("privatizeRope(mimeType)") Rope cachedMimeType,
+                @Cached("privatizeRope(source)") Rope cachedSource,
                 @Cached("create(parse(mimeType, source))") DirectCallNode callNode
         ) {
             return callNode.call(frame, new Object[]{});

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/TrufflePrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/TrufflePrimitiveNodes.java
@@ -43,6 +43,7 @@ import org.jruby.truffle.runtime.core.StringOperations;
 import org.jruby.truffle.runtime.hash.BucketsStrategy;
 import org.jruby.truffle.runtime.layouts.Layouts;
 import org.jruby.truffle.runtime.methods.InternalMethod;
+import org.jruby.truffle.runtime.rope.Rope;
 import org.jruby.truffle.runtime.rope.RopeOperations;
 import org.jruby.truffle.runtime.subsystems.SimpleShell;
 import org.jruby.util.ByteList;
@@ -486,6 +487,23 @@ public abstract class TrufflePrimitiveNodes {
             System.err.println("RD = Right Depth (ConcatRope only)");
 
             return debugPrintRopeNode.executeDebugPrint(StringOperations.rope(string), 0, printString);
+        }
+
+    }
+
+    @CoreMethod(names = "flatten_rope", onSingleton = true, required = 1)
+    public abstract static class FlattenRopeNode extends CoreMethodArrayArgumentsNode {
+
+        public FlattenRopeNode(RubyContext context, SourceSection sourceSection) {
+            super(context, sourceSection);
+        }
+
+        @TruffleBoundary
+        @Specialization(guards = "isRubyString(string)")
+        public DynamicObject debugPrint(DynamicObject string) {
+            final Rope flattened = RopeOperations.flatten(StringOperations.rope(string));
+
+            return createString(flattened);
         }
 
     }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/TrufflePrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/TrufflePrimitiveNodes.java
@@ -456,6 +456,40 @@ public abstract class TrufflePrimitiveNodes {
 
     }
 
+    @CoreMethod(names = "debug_print_rope", onSingleton = true, required = 1, optional = 1)
+    public abstract static class DebugPrintRopeNode extends CoreMethodArrayArgumentsNode {
+
+        @Child private RopeNodes.DebugPrintRopeNode debugPrintRopeNode;
+
+        public DebugPrintRopeNode(RubyContext context, SourceSection sourceSection) {
+            super(context, sourceSection);
+            debugPrintRopeNode = RopeNodesFactory.DebugPrintRopeNodeGen.create(context, sourceSection, null, null, null);
+        }
+
+        @TruffleBoundary
+        @Specialization(guards = "isRubyString(string)")
+        public DynamicObject debugPrintDefault(DynamicObject string, NotProvided printString) {
+            return debugPrint(string, true);
+        }
+
+        @TruffleBoundary
+        @Specialization(guards = "isRubyString(string)")
+        public DynamicObject debugPrint(DynamicObject string, boolean printString) {
+            System.err.println("Legend: ");
+            System.err.println("BN = Bytes Null? (byte[] not yet populated)");
+            System.err.println("BL = Byte Length");
+            System.err.println("CL = Character Length");
+            System.err.println("CR = Code Range");
+            System.err.println("O = Offset (SubstringRope only)");
+            System.err.println("D = Depth");
+            System.err.println("LD = Left Depth (ConcatRope only)");
+            System.err.println("RD = Right Depth (ConcatRope only)");
+
+            return debugPrintRopeNode.executeDebugPrint(StringOperations.rope(string), 0, printString);
+        }
+
+    }
+
     @CoreMethod(names = "jruby_home_directory", onSingleton = true)
     public abstract static class JRubyHomeDirectoryNode extends CoreMethodNode {
 

--- a/truffle/src/main/java/org/jruby/truffle/nodes/core/array/ArrayNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/core/array/ArrayNodes.java
@@ -62,6 +62,7 @@ import org.jruby.truffle.runtime.layouts.Layouts;
 import org.jruby.truffle.runtime.methods.Arity;
 import org.jruby.truffle.runtime.methods.InternalMethod;
 import org.jruby.truffle.runtime.methods.SharedMethodInfo;
+import org.jruby.truffle.runtime.rope.Rope;
 import org.jruby.util.ByteList;
 import org.jruby.util.Memo;
 
@@ -2403,13 +2404,13 @@ public abstract class ArrayNodes {
             super(context, sourceSection);
         }
 
-        @Specialization(guards = {"isRubyString(format)", "byteListsEqual(format, cachedFormat)"}, limit = "getCacheLimit()")
+        @Specialization(guards = {"isRubyString(format)", "ropesEqual(format, cachedFormat)"}, limit = "getCacheLimit()")
         public DynamicObject packCached(
                 VirtualFrame frame,
                 DynamicObject array,
                 DynamicObject format,
-                @Cached("privatizeByteList(format)") ByteList cachedFormat,
-                @Cached("byteListLength(cachedFormat)") int cachedFormatLength,
+                @Cached("privatizeRope(format)") Rope cachedFormat,
+                @Cached("ropeLength(cachedFormat)") int cachedFormatLength,
                 @Cached("create(compileFormat(format))") DirectCallNode callPackNode) {
             final PackResult result;
 

--- a/truffle/src/main/java/org/jruby/truffle/nodes/dispatch/CachedDispatchNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/dispatch/CachedDispatchNode.java
@@ -44,7 +44,7 @@ public abstract class CachedDispatchNode extends DispatchNode {
         if (RubyGuards.isRubySymbol(cachedName)) {
             cachedNameAsSymbol = (DynamicObject) cachedName;
         } else if (RubyGuards.isRubyString(cachedName)) {
-            cachedNameAsSymbol = context.getSymbol(StringOperations.getByteListReadOnly((DynamicObject) cachedName));
+            cachedNameAsSymbol = context.getSymbol(StringOperations.rope((DynamicObject) cachedName));
         } else if (cachedName instanceof String) {
             cachedNameAsSymbol = context.getSymbol((String) cachedName);
         } else {

--- a/truffle/src/main/java/org/jruby/truffle/nodes/dispatch/CachedDispatchNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/dispatch/CachedDispatchNode.java
@@ -72,7 +72,7 @@ public abstract class CachedDispatchNode extends DispatchNode {
             // TODO(CS, 11-Jan-15) this just repeats the above guard...
             return cachedName == methodName;
         } else if (RubyGuards.isRubyString(cachedName)) {
-            return (RubyGuards.isRubyString(methodName)) && StringOperations.getByteListReadOnly((DynamicObject) cachedName).equal(StringOperations.getByteListReadOnly((DynamicObject) methodName));
+            return (RubyGuards.isRubyString(methodName)) && StringOperations.rope((DynamicObject) cachedName).equals(StringOperations.rope((DynamicObject) methodName));
         } else {
             throw new UnsupportedOperationException();
         }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/literal/StringLiteralNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/literal/StringLiteralNode.java
@@ -16,20 +16,19 @@ import org.jruby.truffle.nodes.RubyNode;
 import org.jruby.truffle.nodes.objects.AllocateObjectNode;
 import org.jruby.truffle.nodes.objects.AllocateObjectNodeGen;
 import org.jruby.truffle.runtime.RubyContext;
-import org.jruby.truffle.runtime.rope.LeafRope;
-import org.jruby.truffle.runtime.rope.RopeOperations;
+import org.jruby.truffle.runtime.rope.Rope;
 import org.jruby.util.ByteList;
 
 public class StringLiteralNode extends RubyNode {
 
-    private final LeafRope rope;
+    private final Rope rope;
 
     @Child private AllocateObjectNode allocateObjectNode;
 
     public StringLiteralNode(RubyContext context, SourceSection sourceSection, ByteList byteList, int codeRange) {
         super(context, sourceSection);
         assert byteList != null;
-        this.rope = RopeOperations.create(byteList.bytes(), byteList.getEncoding(), codeRange);
+        this.rope = context.getRopeTable().getRope(byteList.bytes(), byteList.getEncoding(), codeRange);
         allocateObjectNode = AllocateObjectNodeGen.create(context, sourceSection, false, null, null);
     }
 

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/ByteArrayNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/ByteArrayNodes.java
@@ -104,21 +104,18 @@ public abstract class ByteArrayNodes {
     @CoreMethod(names = "locate", required = 3, lowerFixnumParameters = {1, 2})
     public abstract static class LocateNode extends CoreMethodArrayArgumentsNode {
 
-        @Child private StringNodes.SizeNode sizeNode;
-
         public LocateNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
-            sizeNode = StringNodesFactory.SizeNodeFactory.create(context, sourceSection, new RubyNode[] {});
         }
 
         @Specialization(guards = "isRubyString(pattern)")
-        public Object getByte(VirtualFrame frame, DynamicObject bytes, DynamicObject pattern, int start, int length) {
+        public Object getByte(DynamicObject bytes, DynamicObject pattern, int start, int length) {
             final int index = new ByteList(Layouts.BYTE_ARRAY.getBytes(bytes), start, length).indexOf(StringOperations.getByteListReadOnly(pattern));
 
             if (index == -1) {
                 return nil();
             } else {
-                return start + index + sizeNode.executeInteger(frame, pattern);
+                return start + index + StringOperations.rope(pattern).characterLength();
             }
         }
 

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/EncodingConverterPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/EncodingConverterPrimitiveNodes.java
@@ -23,6 +23,8 @@ import org.jcodings.transcode.EConv;
 import org.jcodings.transcode.EConvResult;
 import org.jruby.truffle.nodes.RubyGuards;
 import org.jruby.truffle.nodes.core.EncodingConverterNodes;
+import org.jruby.truffle.nodes.core.RopeNodes;
+import org.jruby.truffle.nodes.core.RopeNodesFactory;
 import org.jruby.truffle.nodes.dispatch.CallDispatchHeadNode;
 import org.jruby.truffle.nodes.dispatch.DispatchHeadNodeFactory;
 import org.jruby.truffle.runtime.NotProvided;
@@ -57,8 +59,11 @@ public abstract class EncodingConverterPrimitiveNodes {
     @RubiniusPrimitive(name = "encoding_converter_primitive_convert")
     public static abstract class PrimitiveConvertNode extends RubiniusPrimitiveNode {
 
+        @Child private RopeNodes.MakeSubstringNode makeSubstringNode;
+
         public PrimitiveConvertNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
+            makeSubstringNode = RopeNodesFactory.MakeSubstringNodeGen.create(context, sourceSection, null, null, null);
         }
 
         @Specialization(guards = {"isRubyString(source)", "isRubyString(target)", "isRubyHash(options)"})
@@ -141,7 +146,7 @@ public abstract class EncodingConverterPrimitiveNodes {
                 outBytes.setRealSize(outPtr.p - outBytes.begin());
 
                 if (nonNullSource) {
-                    sourceRope = RopeOperations.substring(sourceRope, inPtr.p, sourceRope.byteLength() - inPtr.p);
+                    sourceRope = makeSubstringNode.executeMake(sourceRope, inPtr.p, sourceRope.byteLength() - inPtr.p);
                     Layouts.STRING.setRope(source, sourceRope);
                 }
 

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/EncodingConverterPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/EncodingConverterPrimitiveNodes.java
@@ -147,7 +147,7 @@ public abstract class EncodingConverterPrimitiveNodes {
 
                 if (nonNullSource) {
                     sourceRope = makeSubstringNode.executeMake(sourceRope, inPtr.p, sourceRope.byteLength() - inPtr.p);
-                    Layouts.STRING.setRope(source, sourceRope);
+                    StringOperations.setRope(source, sourceRope);
                 }
 
                 if (growOutputBuffer && res == EConvResult.DestinationBufferFull) {
@@ -164,7 +164,7 @@ public abstract class EncodingConverterPrimitiveNodes {
                     outBytes.setEncoding(ec.destinationEncoding);
                 }
 
-                Layouts.STRING.setRope(target, StringOperations.ropeFromByteList(outBytes));
+                StringOperations.setRope(target, StringOperations.ropeFromByteList(outBytes));
 
                 return getSymbol(res.symbolicName());
             }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/EncodingPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/EncodingPrimitiveNodes.java
@@ -36,7 +36,7 @@ public abstract class EncodingPrimitiveNodes {
 
         @Specialization(guards = "isRubySymbol(symbol)")
         public DynamicObject encodingGetObjectEncodingSymbol(DynamicObject symbol) {
-            return EncodingNodes.getEncoding(Layouts.SYMBOL.getByteList(symbol).getEncoding());
+            return EncodingNodes.getEncoding(Layouts.SYMBOL.getRope(symbol).getEncoding());
         }
 
         @Specialization(guards = "isRubyEncoding(encoding)")

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/PosixNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/PosixNodes.java
@@ -713,7 +713,7 @@ public abstract class PosixNodes {
             // We just ignore maxSize - I think this is ok
 
             final String path = getContext().getRuntime().getCurrentDirectory();
-            Layouts.STRING.setRope(resultPath, makeLeafRopeNode.executeMake(path.getBytes(StandardCharsets.UTF_8), Layouts.STRING.getRope(resultPath).getEncoding(), StringSupport.CR_UNKNOWN));
+            StringOperations.setRope(resultPath, makeLeafRopeNode.executeMake(path.getBytes(StandardCharsets.UTF_8), Layouts.STRING.getRope(resultPath).getEncoding(), StringSupport.CR_UNKNOWN));
             return resultPath;
         }
 

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/PosixNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/PosixNodes.java
@@ -21,6 +21,8 @@ import org.jruby.platform.Platform;
 import org.jruby.truffle.nodes.core.CoreClass;
 import org.jruby.truffle.nodes.core.CoreMethod;
 import org.jruby.truffle.nodes.core.CoreMethodArrayArgumentsNode;
+import org.jruby.truffle.nodes.core.RopeNodes;
+import org.jruby.truffle.nodes.core.RopeNodesFactory;
 import org.jruby.truffle.nodes.objects.AllocateObjectNode;
 import org.jruby.truffle.nodes.objects.AllocateObjectNodeGen;
 import org.jruby.truffle.runtime.RubyContext;
@@ -698,8 +700,11 @@ public abstract class PosixNodes {
     @CoreMethod(names = "getcwd", isModuleFunction = true, required = 2)
     public abstract static class GetcwdNode extends CoreMethodArrayArgumentsNode {
 
+        @Child private RopeNodes.MakeLeafRopeNode makeLeafRopeNode;
+
         public GetcwdNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
+            makeLeafRopeNode = RopeNodesFactory.MakeLeafRopeNodeGen.create(context, sourceSection, null, null, null);
         }
 
         @CompilerDirectives.TruffleBoundary
@@ -708,7 +713,7 @@ public abstract class PosixNodes {
             // We just ignore maxSize - I think this is ok
 
             final String path = getContext().getRuntime().getCurrentDirectory();
-            Layouts.STRING.setRope(resultPath, RopeOperations.create(path.getBytes(StandardCharsets.UTF_8), Layouts.STRING.getRope(resultPath).getEncoding(), StringSupport.CR_UNKNOWN));
+            Layouts.STRING.setRope(resultPath, makeLeafRopeNode.executeMake(path.getBytes(StandardCharsets.UTF_8), Layouts.STRING.getRope(resultPath).getEncoding(), StringSupport.CR_UNKNOWN));
             return resultPath;
         }
 

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/StringPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/StringPrimitiveNodes.java
@@ -576,7 +576,7 @@ public abstract class StringPrimitiveNodes {
                 return false;
             }
 
-            return Arrays.equals(a.getBytes(), b.getBytes());
+            return a.equals(b);
         }
 
         protected boolean areComparable(DynamicObject first, DynamicObject second,

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/StringPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/StringPrimitiveNodes.java
@@ -1061,7 +1061,7 @@ public abstract class StringPrimitiveNodes {
                 return nil();
             }
 
-            final Encoding encoding = StringOperations.checkEncoding(getContext(), string, StringOperations.getCodeRangeableReadOnly(pattern), this);
+            final Encoding encoding = StringOperations.checkEncoding(getContext(), string, pattern, this);
             int p = stringRope.getBegin();
             final int e = p + stringRope.getRealSize();
             int pp = patternRope.getBegin();

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/StringPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/StringPrimitiveNodes.java
@@ -171,7 +171,7 @@ public abstract class StringPrimitiveNodes {
                         String.format("incompatible encodings: %s and %s", left.getEncoding(), right.getEncoding()), this));
             }
 
-            Layouts.STRING.setRope(string, makeConcatNode.executeMake(left, right, compatibleEncoding));
+            StringOperations.setRope(string, makeConcatNode.executeMake(left, right, compatibleEncoding));
 
             return string;
         }
@@ -1169,7 +1169,7 @@ public abstract class StringPrimitiveNodes {
 
             System.arraycopy(otherRope.getBytes(), otherRope.begin() + src, stringBytes.getUnsafeBytes(), stringBytes.begin() + dest, cnt);
 
-            Layouts.STRING.setRope(string, StringOperations.ropeFromByteList(stringBytes));
+            StringOperations.setRope(string, StringOperations.ropeFromByteList(stringBytes));
 
             return string;
         }
@@ -1357,7 +1357,7 @@ public abstract class StringPrimitiveNodes {
             final Rope left = rope(other);
             final Rope right = prependMakeSubstringNode.executeMake(original, byteCountToReplace, original.byteLength() - byteCountToReplace);
 
-            Layouts.STRING.setRope(string, prependMakeConcatNode.executeMake(left, right, right.getEncoding()));
+            StringOperations.setRope(string, prependMakeConcatNode.executeMake(left, right, right.getEncoding()));
 
             return string;
         }
@@ -1372,7 +1372,7 @@ public abstract class StringPrimitiveNodes {
                 appendMakeConcatNode = insert(RopeNodesFactory.MakeConcatNodeGen.create(getContext(), getSourceSection(), null, null, null));
             }
 
-            Layouts.STRING.setRope(string, appendMakeConcatNode.executeMake(left, right, left.getEncoding()));
+            StringOperations.setRope(string, appendMakeConcatNode.executeMake(left, right, left.getEncoding()));
 
             return string;
         }
@@ -1408,7 +1408,7 @@ public abstract class StringPrimitiveNodes {
             final Rope joinedLeft = leftMakeConcatNode.executeMake(splitLeft, insert, source.getEncoding());
             final Rope joinedRight = rightMakeConcatNode.executeMake(joinedLeft, splitRight, source.getEncoding());
 
-            Layouts.STRING.setRope(string, joinedRight);
+            StringOperations.setRope(string, joinedRight);
 
             return string;
         }
@@ -1482,7 +1482,7 @@ public abstract class StringPrimitiveNodes {
 
             final Rope rightConverted = makeLeafRopeNode.executeMake(right.getBytes(), left.getEncoding(), left.getCodeRange());
 
-            Layouts.STRING.setRope(string, makeConcatNode.executeMake(left, rightConverted, left.getEncoding()));
+            StringOperations.setRope(string, makeConcatNode.executeMake(left, rightConverted, left.getEncoding()));
 
             return string;
         }

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/StringPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/StringPrimitiveNodes.java
@@ -1287,10 +1287,12 @@ public abstract class StringPrimitiveNodes {
     public static abstract class StringPatternPrimitiveNode extends RubiniusPrimitiveNode {
 
         @Child private AllocateObjectNode allocateObjectNode;
+        @Child private RopeNodes.MakeLeafRopeNode makeLeafRopeNode;
 
         public StringPatternPrimitiveNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
             allocateObjectNode = AllocateObjectNodeGen.create(context, sourceSection, null, null);
+            makeLeafRopeNode = RopeNodesFactory.MakeLeafRopeNodeGen.create(context, sourceSection, null, null, null);
         }
 
         @Specialization(guards = "value == 0")
@@ -1319,7 +1321,7 @@ public abstract class StringPrimitiveNodes {
             }
 
             // TODO (nirvdrum 21-Jan-16): Verify the encoding and code range are correct.
-            return allocateObjectNode.allocate(stringClass, RopeOperations.create(bytes, encoding(string), StringSupport.CR_UNKNOWN), null);
+            return allocateObjectNode.allocate(stringClass, makeLeafRopeNode.executeMake(bytes, encoding(string), StringSupport.CR_UNKNOWN), null);
         }
 
     }
@@ -1456,10 +1458,12 @@ public abstract class StringPrimitiveNodes {
     public static abstract class StringByteAppendPrimitiveNode extends RubiniusPrimitiveNode {
 
         @Child private RopeNodes.MakeConcatNode makeConcatNode;
+        @Child private RopeNodes.MakeLeafRopeNode makeLeafRopeNode;
 
         public StringByteAppendPrimitiveNode(RubyContext context, SourceSection sourceSection) {
             super(context, sourceSection);
             makeConcatNode = RopeNodesFactory.MakeConcatNodeGen.create(context, sourceSection, null, null, null);
+            makeLeafRopeNode = RopeNodesFactory.MakeLeafRopeNodeGen.create(context, sourceSection, null, null, null);
         }
 
         @Specialization(guards = "isRubyString(other)")
@@ -1476,7 +1480,7 @@ public abstract class StringPrimitiveNodes {
             // this, StringIO ceases to work -- the resulting string must retain the original CR_7BIT code range. It's
             // ugly, but seems to be due to a difference in how Rubinius keeps track of byte optimizable strings.
 
-            final Rope rightConverted = RopeOperations.create(right.getBytes(), left.getEncoding(), left.getCodeRange());
+            final Rope rightConverted = makeLeafRopeNode.executeMake(right.getBytes(), left.getEncoding(), left.getCodeRange());
 
             Layouts.STRING.setRope(string, makeConcatNode.executeMake(left, rightConverted, left.getEncoding()));
 

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/StringPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/StringPrimitiveNodes.java
@@ -605,8 +605,8 @@ public abstract class StringPrimitiveNodes {
                 return true;
             }
 
-            final int firstCodeRange = StringOperations.scanForCodeRange(first);
-            final int secondCodeRange = StringOperations.scanForCodeRange(second);
+            final int firstCodeRange = firstRope.getCodeRange();
+            final int secondCodeRange = secondRope.getCodeRange();
 
             if (firstStringCR7BitProfile.profile(firstCodeRange == StringSupport.CR_7BIT)) {
                 if (secondStringCR7BitProfile.profile(secondCodeRange == StringSupport.CR_7BIT)) {
@@ -1066,7 +1066,7 @@ public abstract class StringPrimitiveNodes {
 
             if (emptyPatternProfile.profile(patternRope.isEmpty())) return offset;
 
-            if (brokenCodeRangeProfile.profile(StringOperations.scanForCodeRange(string) == StringSupport.CR_BROKEN)) {
+            if (brokenCodeRangeProfile.profile(stringRope.getCodeRange() == StringSupport.CR_BROKEN)) {
                 return nil();
             }
 

--- a/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/StringPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/nodes/rubinius/StringPrimitiveNodes.java
@@ -160,7 +160,7 @@ public abstract class StringPrimitiveNodes {
             final Rope left = rope(string);
             final Rope right = rope(other);
 
-            final Encoding compatibleEncoding = EncodingNodes.CompatibleQueryNode.areCompatible(string, other);
+            final Encoding compatibleEncoding = EncodingNodes.CompatibleQueryNode.compatibleEncodingForStrings(string, other);
 
             if (compatibleEncoding == null) {
                 CompilerDirectives.transferToInterpreter();

--- a/truffle/src/main/java/org/jruby/truffle/runtime/RubyContext.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/RubyContext.java
@@ -57,6 +57,7 @@ import org.jruby.truffle.runtime.loader.SourceLoader;
 import org.jruby.truffle.runtime.methods.InternalMethod;
 import org.jruby.truffle.runtime.object.ObjectIDOperations;
 import org.jruby.truffle.runtime.platform.CrtExterns;
+import org.jruby.truffle.runtime.rope.Rope;
 import org.jruby.truffle.runtime.rubinius.RubiniusConfiguration;
 import org.jruby.truffle.runtime.sockets.NativeSockets;
 import org.jruby.truffle.runtime.subsystems.*;
@@ -397,6 +398,10 @@ public class RubyContext extends ExecutionContext {
     }
 
     public DynamicObject getSymbol(ByteList name) {
+        return symbolTable.getSymbol(name);
+    }
+
+    public DynamicObject getSymbol(Rope name) {
         return symbolTable.getSymbol(name);
     }
 

--- a/truffle/src/main/java/org/jruby/truffle/runtime/RubyContext.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/RubyContext.java
@@ -46,6 +46,7 @@ import org.jruby.truffle.nodes.rubinius.RubiniusPrimitiveManager;
 import org.jruby.truffle.runtime.control.RaiseException;
 import org.jruby.truffle.runtime.core.ArrayOperations;
 import org.jruby.truffle.runtime.core.CoreLibrary;
+import org.jruby.truffle.runtime.core.RopeTable;
 import org.jruby.truffle.runtime.core.StringOperations;
 import org.jruby.truffle.runtime.core.SymbolTable;
 import org.jruby.truffle.runtime.ffi.LibCClockGetTime;
@@ -96,6 +97,7 @@ public class RubyContext extends ExecutionContext {
     private final ObjectSpaceManager objectSpaceManager;
     private final ThreadManager threadManager;
     private final AtExitManager atExitManager;
+    private final RopeTable ropeTable = new RopeTable();
     private final SymbolTable symbolTable = new SymbolTable(this);
     private final Warnings warnings;
     private final SafepointManager safepointManager;
@@ -380,6 +382,10 @@ public class RubyContext extends ExecutionContext {
 
     public void load(Source source, Node currentNode) {
         parseAndExecute(source, UTF8Encoding.INSTANCE, ParserContext.TOP_LEVEL, coreLibrary.getMainObject(), null, true, DeclarationContext.TOP_LEVEL, currentNode);
+    }
+
+    public RopeTable getRopeTable() {
+        return ropeTable;
     }
 
     public SymbolTable getSymbolTable() {

--- a/truffle/src/main/java/org/jruby/truffle/runtime/RubyObjectType.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/RubyObjectType.java
@@ -17,6 +17,7 @@ import org.jruby.runtime.Helpers;
 import org.jruby.truffle.nodes.RubyGuards;
 import org.jruby.truffle.runtime.core.*;
 import org.jruby.truffle.runtime.layouts.Layouts;
+import org.jruby.truffle.runtime.rope.RopeOperations;
 
 public class RubyObjectType extends ObjectType {
 
@@ -25,7 +26,7 @@ public class RubyObjectType extends ObjectType {
         CompilerAsserts.neverPartOfCompilation();
 
         if (RubyGuards.isRubyString(object)) {
-            return Helpers.decodeByteList(getContext().getRuntime(), StringOperations.getByteListReadOnly(object));
+            return RopeOperations.decodeRope(getContext().getRuntime(), StringOperations.rope(object));
         } else if (RubyGuards.isRubySymbol(object)) {
             return Layouts.SYMBOL.getString(object);
         } else if (RubyGuards.isRubyException(object)) {

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/RopeTable.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/RopeTable.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2013, 2016 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 1.0
+ * GNU General Public License version 2
+ * GNU Lesser General Public License version 2.1
+ */
+
+package org.jruby.truffle.runtime.core;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import org.jcodings.Encoding;
+import org.jruby.truffle.runtime.rope.Rope;
+import org.jruby.truffle.runtime.rope.RopeOperations;
+
+import java.lang.ref.WeakReference;
+import java.util.Arrays;
+import java.util.WeakHashMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class RopeTable {
+
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private final WeakHashMap<Key, WeakReference<Rope>> ropesTable = new WeakHashMap<>();
+
+    @CompilerDirectives.TruffleBoundary
+    public Rope getRope(byte[] bytes, Encoding encoding, int codeRange) {
+        final Key key = new Key(bytes, encoding);
+
+        lock.readLock().lock();
+
+        try {
+            final WeakReference<Rope> ropeReference = ropesTable.get(key);
+
+            if (ropeReference != null) {
+                final Rope rope = ropeReference.get();
+
+                if (rope != null) {
+                    return rope;
+                }
+            }
+        } finally {
+            lock.readLock().unlock();
+        }
+
+        lock.writeLock().lock();
+
+        try {
+            final WeakReference<Rope> ropeReference = ropesTable.get(key);
+
+            if (ropeReference != null) {
+                final Rope rope = ropeReference.get();
+
+                if (rope != null) {
+                    return rope;
+                }
+            }
+
+            final Rope rope = RopeOperations.create(bytes, encoding, codeRange);
+
+            ropesTable.put(key, new WeakReference<>(rope));
+
+            return rope;
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private static class Key {
+
+        private final byte[] bytes;
+        private final Encoding encoding;
+        private int hashCode;
+
+        public Key(byte[] bytes, Encoding encoding) {
+            this.bytes = bytes;
+            this.encoding = encoding;
+            this.hashCode = Arrays.hashCode(bytes);
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o instanceof Key) {
+                final Key other = (Key) o;
+
+                return encoding == other.encoding && Arrays.equals(bytes, other.bytes);
+            }
+
+            return false;
+        }
+    }
+
+}

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/RopeTable.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/RopeTable.java
@@ -14,6 +14,7 @@ import com.oracle.truffle.api.CompilerDirectives;
 import org.jcodings.Encoding;
 import org.jruby.truffle.runtime.rope.Rope;
 import org.jruby.truffle.runtime.rope.RopeOperations;
+import org.jruby.util.StringSupport;
 
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
@@ -69,7 +70,7 @@ public class RopeTable {
         }
     }
 
-    private static class Key {
+    public static class Key {
 
         private final byte[] bytes;
         private final Encoding encoding;
@@ -96,6 +97,12 @@ public class RopeTable {
 
             return false;
         }
+
+        @Override
+        public String toString() {
+            return RopeOperations.create(bytes, encoding, StringSupport.CR_UNKNOWN).toString();
+        }
+
     }
 
 }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/StringCodeRangeableWrapper.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/StringCodeRangeableWrapper.java
@@ -80,4 +80,8 @@ public class StringCodeRangeableWrapper implements CodeRangeable {
         return StringOperations.getByteList(string);
     }
 
+
+    public DynamicObject getString() {
+        return string;
+    }
 }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/StringCodeRangeableWrapper.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/StringCodeRangeableWrapper.java
@@ -32,7 +32,7 @@ public class StringCodeRangeableWrapper implements CodeRangeable {
 
     @Override
     public int scanForCodeRange() {
-        return StringOperations.scanForCodeRange(string);
+        return StringOperations.codeRange(string);
     }
 
     @Override

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/StringOperations.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/StringOperations.java
@@ -199,14 +199,13 @@ public abstract class StringOperations {
         return ArrayOperations.clampExclusiveIndex(StringOperations.rope(string).byteLength(), index);
     }
 
-    @CompilerDirectives.TruffleBoundary
-    public static Encoding checkEncoding(RubyContext context, DynamicObject string, CodeRangeable other, Node node) {
-        final Encoding encoding = StringSupport.areCompatible(getCodeRangeableReadOnly(string), other);
+    public static Encoding checkEncoding(RubyContext context, DynamicObject string, DynamicObject other, Node node) {
+        final Encoding encoding = EncodingNodes.CompatibleQueryNode.compatibleEncodingForStrings(string, other);
 
         if (encoding == null) {
             throw new RaiseException(context.getCoreLibrary().encodingCompatibilityErrorIncompatible(
-                    Layouts.STRING.getRope(string).getEncoding().toString(),
-                    other.getByteList().getEncoding().toString(),
+                    rope(string).getEncoding().toString(),
+                    rope(other).getEncoding().toString(),
                     node));
         }
 

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/StringOperations.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/StringOperations.java
@@ -64,17 +64,6 @@ public abstract class StringOperations {
         return RopeOperations.decodeRope(context.getRuntime(), StringOperations.rope(string));
     }
 
-    public static StringCodeRangeableWrapper getCodeRangeable(DynamicObject string) {
-        StringCodeRangeableWrapper wrapper = Layouts.STRING.getCodeRangeableWrapper(string);
-
-        if (wrapper == null) {
-            wrapper = new StringCodeRangeableWrapper(string);
-            Layouts.STRING.setCodeRangeableWrapper(string, wrapper);
-        }
-
-        return wrapper;
-    }
-
     public static StringCodeRangeableWrapper getCodeRangeableReadWrite(final DynamicObject string) {
         return new StringCodeRangeableWrapper(string) {
             private final ByteList byteList = StringOperations.rope(string).toByteListCopy();
@@ -168,7 +157,7 @@ public abstract class StringOperations {
     public static void forceEncoding(DynamicObject string, Encoding encoding) {
         modify(string);
         final Rope oldRope = Layouts.STRING.getRope(string);
-        Layouts.STRING.setRope(string, RopeOperations.withEncoding(oldRope, encoding, StringSupport.CR_UNKNOWN));
+        StringOperations.setRope(string, RopeOperations.withEncoding(oldRope, encoding, StringSupport.CR_UNKNOWN));
     }
 
     public static int normalizeIndex(int length, int index) {
@@ -226,6 +215,13 @@ public abstract class StringOperations {
         assert RubyGuards.isRubyString(string);
 
         return Layouts.STRING.getRope(string);
+    }
+
+    public static void setRope(DynamicObject string, Rope rope) {
+        assert RubyGuards.isRubyString(string);
+
+        Layouts.STRING.setRope(string, rope);
+        Layouts.STRING.setRubiniusDataArray(string, null);
     }
 
     public static Encoding encoding(DynamicObject string) {

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/StringOperations.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/StringOperations.java
@@ -58,7 +58,7 @@ public abstract class StringOperations {
     }
 
     // Since ByteList.toString does not decode properly
-    @TruffleBoundary
+    @CompilerDirectives.TruffleBoundary
     public static String getString(RubyContext context, DynamicObject string) {
         return Helpers.decodeByteList(context.getRuntime(), StringOperations.getByteListReadOnly(string));
     }
@@ -159,7 +159,7 @@ public abstract class StringOperations {
         keepCodeRange(string);
     }
 
-    @TruffleBoundary
+    @CompilerDirectives.TruffleBoundary
     public static Encoding checkEncoding(DynamicObject string, CodeRangeable other) {
         final Encoding encoding = StringSupport.areCompatible(getCodeRangeableReadOnly(string), other);
 
@@ -174,7 +174,7 @@ public abstract class StringOperations {
         return encoding;
     }
 
-    @TruffleBoundary
+    @CompilerDirectives.TruffleBoundary
     private static int slowCodeRangeScan(DynamicObject string) {
         final ByteList byteList = StringOperations.getByteListReadOnly(string);
         return StringSupport.codeRangeScan(byteList.getEncoding(), byteList);
@@ -195,7 +195,7 @@ public abstract class StringOperations {
         return ArrayOperations.clampExclusiveIndex(StringOperations.getByteListReadOnly(string).length(), index);
     }
 
-    @TruffleBoundary
+    @CompilerDirectives.TruffleBoundary
     public static Encoding checkEncoding(RubyContext context, DynamicObject string, CodeRangeable other, Node node) {
         final Encoding encoding = StringSupport.areCompatible(getCodeRangeableReadOnly(string), other);
 

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/StringOperations.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/StringOperations.java
@@ -230,23 +230,6 @@ public abstract class StringOperations {
         return Layouts.STRING.getRope(object).byteLength();
     }
 
-    public static int commonCodeRange(int first, int second) {
-        if (first == second) {
-            return first;
-        }
-
-        if ((first == StringSupport.CR_UNKNOWN) || (second == StringSupport.CR_UNKNOWN)) {
-            return StringSupport.CR_UNKNOWN;
-        }
-
-        if ((first == StringSupport.CR_BROKEN) || (second == StringSupport.CR_BROKEN)) {
-            return StringSupport.CR_BROKEN;
-        }
-
-        // If we get this far, one must be CR_7BIT and the other must be CR_VALID, so promote to the more general code range.
-        return StringSupport.CR_VALID;
-    }
-
     public static Rope ropeFromByteList(ByteList byteList) {
         return RopeOperations.create(byteList.bytes(), byteList.getEncoding(), StringSupport.CR_UNKNOWN);
     }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/StringOperations.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/StringOperations.java
@@ -60,7 +60,7 @@ public abstract class StringOperations {
     // Since ByteList.toString does not decode properly
     @CompilerDirectives.TruffleBoundary
     public static String getString(RubyContext context, DynamicObject string) {
-        return Helpers.decodeByteList(context.getRuntime(), StringOperations.getByteListReadOnly(string));
+        return RopeOperations.decodeRope(context.getRuntime(), StringOperations.rope(string));
     }
 
     public static StringCodeRangeableWrapper getCodeRangeable(DynamicObject string) {
@@ -192,7 +192,9 @@ public abstract class StringOperations {
 
     public static int clampExclusiveIndex(DynamicObject string, int index) {
         assert RubyGuards.isRubyString(string);
-        return ArrayOperations.clampExclusiveIndex(StringOperations.getByteListReadOnly(string).length(), index);
+
+        // TODO (nirvdrum 21-Jan-16): Verify this is supposed to be the byteLength and not the characterLength.
+        return ArrayOperations.clampExclusiveIndex(StringOperations.rope(string).byteLength(), index);
     }
 
     @CompilerDirectives.TruffleBoundary

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/StringOperations.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/StringOperations.java
@@ -32,6 +32,7 @@ import org.jcodings.Encoding;
 import org.jruby.RubyString;
 import org.jruby.runtime.Helpers;
 import org.jruby.truffle.nodes.RubyGuards;
+import org.jruby.truffle.nodes.core.EncodingNodes;
 import org.jruby.truffle.runtime.RubyContext;
 import org.jruby.truffle.runtime.control.RaiseException;
 import org.jruby.truffle.runtime.layouts.Layouts;
@@ -161,10 +162,11 @@ public abstract class StringOperations {
 
     @CompilerDirectives.TruffleBoundary
     public static Encoding checkEncoding(DynamicObject string, CodeRangeable other) {
-        final Encoding encoding = StringSupport.areCompatible(getCodeRangeableReadOnly(string), other);
+        final Encoding encoding = EncodingNodes.CompatibleQueryNode.compatibleEncodingForStrings(string, ((StringCodeRangeableWrapper) other).getString());
 
         // TODO (nirvdrum 23-Mar-15) We need to raise a proper Truffle+JRuby exception here, rather than a non-Truffle JRuby exception.
         if (encoding == null) {
+            CompilerDirectives.transferToInterpreter();
             throw Layouts.MODULE.getFields(Layouts.BASIC_OBJECT.getLogicalClass(string)).getContext().getRuntime().newEncodingCompatibilityError(
                     String.format("incompatible character encodings: %s and %s",
                             Layouts.STRING.getRope(string).getEncoding().toString(),

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/StringOperations.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/StringOperations.java
@@ -120,17 +120,6 @@ public abstract class StringOperations {
         }
     }
 
-    public static int scanForCodeRange(DynamicObject string) {
-        int cr = StringOperations.getCodeRange(string);
-
-        if (cr == StringSupport.CR_UNKNOWN) {
-            cr = slowCodeRangeScan(string);
-            StringOperations.setCodeRange(string, cr);
-        }
-
-        return cr;
-    }
-
     public static boolean isCodeRangeValid(DynamicObject string) {
         return StringOperations.getCodeRange(string) == StringSupport.CR_VALID;
     }
@@ -176,12 +165,6 @@ public abstract class StringOperations {
         return encoding;
     }
 
-    @CompilerDirectives.TruffleBoundary
-    private static int slowCodeRangeScan(DynamicObject string) {
-        final ByteList byteList = StringOperations.getByteListReadOnly(string);
-        return StringSupport.codeRangeScan(byteList.getEncoding(), byteList);
-    }
-
     public static void forceEncoding(DynamicObject string, Encoding encoding) {
         modify(string);
         final Rope oldRope = Layouts.STRING.getRope(string);
@@ -223,11 +206,6 @@ public abstract class StringOperations {
 
     public static ByteList getByteListReadOnly(DynamicObject object) {
         return Layouts.STRING.getRope(object).getUnsafeByteList();
-    }
-
-    // TODO (nirdvrum 07-Jan-16) Either remove this method or Rope#byteLength -- the latter doesn't require materializing the full byte array.
-    public static int byteLength(DynamicObject object) {
-        return Layouts.STRING.getRope(object).byteLength();
     }
 
     public static Rope ropeFromByteList(ByteList byteList) {

--- a/truffle/src/main/java/org/jruby/truffle/runtime/core/SymbolCodeRangeableWrapper.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/core/SymbolCodeRangeableWrapper.java
@@ -32,19 +32,17 @@ public class SymbolCodeRangeableWrapper implements CodeRangeable {
 
     @Override
     public int getCodeRange() {
-        return Layouts.SYMBOL.getCodeRange(symbol);
+        return Layouts.SYMBOL.getRope(symbol).getCodeRange();
     }
 
     @CompilerDirectives.TruffleBoundary
     @Override
     public int scanForCodeRange() {
-        final ByteList byteList = Layouts.SYMBOL.getByteList(symbol);
-
-        int cr = Layouts.SYMBOL.getCodeRange(symbol);
+        int cr = Layouts.SYMBOL.getRope(symbol).getCodeRange();
 
         if (cr == StringSupport.CR_UNKNOWN) {
-            cr = StringSupport.codeRangeScan(byteList.getEncoding(), byteList);
-            Layouts.SYMBOL.setCodeRange(symbol, cr);
+            CompilerDirectives.transferToInterpreter();
+            throw new UnsupportedOperationException("The code range should never be unknown");
         }
 
         return cr;
@@ -52,24 +50,22 @@ public class SymbolCodeRangeableWrapper implements CodeRangeable {
 
     @Override
     public boolean isCodeRangeValid() {
-        return Layouts.SYMBOL.getCodeRange(symbol) == StringSupport.CR_VALID;
+        return Layouts.SYMBOL.getRope(symbol).getCodeRange() == StringSupport.CR_VALID;
     }
 
     @Override
     public void setCodeRange(int codeRange) {
-        Layouts.SYMBOL.setCodeRange(symbol, codeRange);
+        throw new UnsupportedOperationException("Can't set code range on a Symbol");
     }
 
     @Override
     public void clearCodeRange() {
-        Layouts.SYMBOL.setCodeRange(symbol, StringSupport.CR_UNKNOWN);
+        throw new UnsupportedOperationException("Can't clear code range on a Symbol");
     }
 
     @Override
     public void keepCodeRange() {
-        if (Layouts.SYMBOL.getCodeRange(symbol) == StringSupport.CR_BROKEN) {
-            Layouts.SYMBOL.setCodeRange(symbol, StringSupport.CR_UNKNOWN);
-        }
+        throw new UnsupportedOperationException("Can't keep code range on a Symbol");
     }
 
     @Override
@@ -90,12 +86,12 @@ public class SymbolCodeRangeableWrapper implements CodeRangeable {
     @Override
     public Encoding checkEncoding(CodeRangeable other) {
         // TODO (nirvdrum Jan. 13, 2015): This should check if the encodings are compatible rather than just always succeeding.
-        return Layouts.SYMBOL.getByteList(symbol).getEncoding();
+        return Layouts.SYMBOL.getRope(symbol).getEncoding();
     }
 
     @Override
     public ByteList getByteList() {
-        return Layouts.SYMBOL.getByteList(symbol);
+        return Layouts.SYMBOL.getRope(symbol).getUnsafeByteList();
     }
 
 }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/layouts/RegexpLayout.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/layouts/RegexpLayout.java
@@ -14,7 +14,7 @@ import com.oracle.truffle.api.object.DynamicObjectFactory;
 import org.joni.Regex;
 import org.jruby.truffle.om.dsl.api.Layout;
 import org.jruby.truffle.om.dsl.api.Nullable;
-import org.jruby.util.ByteList;
+import org.jruby.truffle.runtime.rope.Rope;
 import org.jruby.util.RegexpOptions;
 
 @Layout
@@ -25,7 +25,7 @@ public interface RegexpLayout extends BasicObjectLayout {
 
     DynamicObject createRegexp(DynamicObjectFactory factory,
                                @Nullable Regex regex,
-                               @Nullable ByteList source,
+                               @Nullable Rope source,
                                RegexpOptions options,
                                @Nullable Object cachedNames);
 
@@ -35,8 +35,8 @@ public interface RegexpLayout extends BasicObjectLayout {
     Regex getRegex(DynamicObject object);
     void setRegex(DynamicObject object, Regex value);
 
-    ByteList getSource(DynamicObject object);
-    void setSource(DynamicObject object, ByteList value);
+    Rope getSource(DynamicObject object);
+    void setSource(DynamicObject object, Rope value);
 
     RegexpOptions getOptions(DynamicObject object);
     void setOptions(DynamicObject object, RegexpOptions value);

--- a/truffle/src/main/java/org/jruby/truffle/runtime/layouts/StringLayout.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/layouts/StringLayout.java
@@ -25,7 +25,7 @@ public interface StringLayout extends BasicObjectLayout {
 
     DynamicObject createString(DynamicObjectFactory factory,
                                Rope rope,
-                               @Nullable StringCodeRangeableWrapper codeRangeableWrapper);
+                               @Nullable DynamicObject rubiniusDataArray);
 
     boolean isString(ObjectType objectType);
     boolean isString(DynamicObject dynamicObject);
@@ -34,7 +34,7 @@ public interface StringLayout extends BasicObjectLayout {
     Rope getRope(DynamicObject object);
     void setRope(DynamicObject object, Rope rope);
 
-    StringCodeRangeableWrapper getCodeRangeableWrapper(DynamicObject object);
-    void setCodeRangeableWrapper(DynamicObject object, StringCodeRangeableWrapper codeRangeableWrapper);
+    DynamicObject getRubiniusDataArray(DynamicObject object);
+    void setRubiniusDataArray(DynamicObject object, DynamicObject rubiniusDataArray);
 
 }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/layouts/SymbolLayout.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/layouts/SymbolLayout.java
@@ -13,6 +13,7 @@ import com.oracle.truffle.api.object.DynamicObject;
 import com.oracle.truffle.api.object.DynamicObjectFactory;
 import org.jruby.truffle.om.dsl.api.Nullable;
 import org.jruby.truffle.runtime.core.SymbolCodeRangeableWrapper;
+import org.jruby.truffle.runtime.rope.Rope;
 import org.jruby.util.ByteList;
 
 @org.jruby.truffle.om.dsl.api.Layout
@@ -23,9 +24,8 @@ public interface SymbolLayout extends BasicObjectLayout {
 
     DynamicObject createSymbol(DynamicObjectFactory factory,
                                String string,
-                               ByteList byteList,
+                               Rope rope,
                                int hashCode,
-                               int codeRange,
                                @Nullable SymbolCodeRangeableWrapper codeRangeableWrapper);
 
     boolean isSymbol(Object object);
@@ -33,12 +33,9 @@ public interface SymbolLayout extends BasicObjectLayout {
 
     String getString(DynamicObject object);
 
-    ByteList getByteList(DynamicObject object);
+    Rope getRope(DynamicObject object);
 
     int getHashCode(DynamicObject object);
-
-    int getCodeRange(DynamicObject object);
-    void setCodeRange(DynamicObject object, int codeRange);
 
     SymbolCodeRangeableWrapper getCodeRangeableWrapper(DynamicObject object);
     void setCodeRangeableWrapper(DynamicObject object, SymbolCodeRangeableWrapper codeRangeableWrapper);

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/ConcatRope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/ConcatRope.java
@@ -19,13 +19,13 @@ public class ConcatRope extends Rope {
 
     private byte[] bytes;
 
-    public ConcatRope(Rope left, Rope right, Encoding encoding, int codeRange) {
+    public ConcatRope(Rope left, Rope right, Encoding encoding, int codeRange, boolean singleByteOptimizable, int depth) {
         super(encoding,
                 codeRange,
-                left.isSingleByteOptimizable() && right.isSingleByteOptimizable(),
+                singleByteOptimizable,
                 left.byteLength() + right.byteLength(),
                 left.characterLength() + right.characterLength(),
-                Math.max(left.depth(), right.depth()) + 1);
+                depth);
 
         this.left = left;
         this.right = right;

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/ConcatRope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/ConcatRope.java
@@ -9,6 +9,7 @@
  */
 package org.jruby.truffle.runtime.rope;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import org.jcodings.Encoding;
 import org.jruby.truffle.runtime.core.StringOperations;
 
@@ -29,6 +30,16 @@ public class ConcatRope extends Rope {
 
         this.left = left;
         this.right = right;
+    }
+
+    @Override
+    @TruffleBoundary
+    public int get(int index) {
+        if (index < left.byteLength()) {
+            return left.get(index);
+        }
+
+        return right.get(index - left.byteLength());
     }
 
     @Override

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/ConcatRope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/ConcatRope.java
@@ -11,7 +11,6 @@ package org.jruby.truffle.runtime.rope;
 
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import org.jcodings.Encoding;
-import org.jruby.truffle.runtime.core.StringOperations;
 
 public class ConcatRope extends Rope {
 
@@ -20,9 +19,9 @@ public class ConcatRope extends Rope {
 
     private byte[] bytes;
 
-    public ConcatRope(Rope left, Rope right, Encoding encoding) {
+    public ConcatRope(Rope left, Rope right, Encoding encoding, int codeRange) {
         super(encoding,
-                StringOperations.commonCodeRange(left.getCodeRange(), right.getCodeRange()),
+                codeRange,
                 left.isSingleByteOptimizable() && right.isSingleByteOptimizable(),
                 left.byteLength() + right.byteLength(),
                 left.characterLength() + right.characterLength(),

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/ConcatRope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/ConcatRope.java
@@ -42,19 +42,6 @@ public class ConcatRope extends Rope {
 
     @Override
     @TruffleBoundary
-    public byte[] calculateBytes() {
-        final byte[] leftBytes = left.getBytes();
-        final byte[] rightBytes = right.getBytes();
-
-        final byte[] bytes = new byte[leftBytes.length + rightBytes.length];
-        System.arraycopy(leftBytes, 0, bytes, 0, leftBytes.length);
-        System.arraycopy(rightBytes, 0, bytes, leftBytes.length, rightBytes.length);
-
-        return bytes;
-    }
-
-    @Override
-    @TruffleBoundary
     public byte[] extractRange(int offset, int length) {
         byte[] leftBytes;
         byte[] rightBytes;
@@ -99,28 +86,4 @@ public class ConcatRope extends Rope {
         return left.toString() + right.toString();
     }
 
-    @Override
-    protected void fillBytes(byte[] buffer, int bufferPosition, int offset, int byteLength) {
-        if (getRawBytes() != null) {
-            System.arraycopy(getRawBytes(), offset, buffer, bufferPosition, byteLength);
-        } else {
-            final int leftLength = left.byteLength();
-
-            if (offset < leftLength) {
-                // The left branch might not be large enough to extract the full hash code we want. In that case,
-                // we'll extract what we can and extract the difference from the right side.
-                if (offset + byteLength > leftLength) {
-                    final int coveredByLeft = leftLength - offset;
-
-                    left.fillBytes(buffer, bufferPosition, offset, coveredByLeft);
-                    right.fillBytes(buffer, bufferPosition + coveredByLeft, 0, byteLength - coveredByLeft);
-
-                } else {
-                    left.fillBytes(buffer, bufferPosition, offset, byteLength);
-                }
-            } else {
-                right.fillBytes(buffer, bufferPosition, offset - leftLength, byteLength);
-            }
-        }
-    }
 }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/ConcatRope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/ConcatRope.java
@@ -96,7 +96,7 @@ public class ConcatRope extends Rope {
     @Override
     public String toString() {
         // This should be used for debugging only.
-        return RopeOperations.decodeUTF8(left) + RopeOperations.decodeUTF8(right);
+        return left.toString() + right.toString();
     }
 
     @Override

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/ConcatRope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/ConcatRope.java
@@ -99,4 +99,29 @@ public class ConcatRope extends Rope {
         // This should be used for debugging only.
         return RopeOperations.decodeUTF8(left) + RopeOperations.decodeUTF8(right);
     }
+
+    @Override
+    protected void fillBytes(byte[] buffer, int bufferPosition, int offset, int byteLength) {
+        if (bytes != null) {
+            System.arraycopy(bytes, offset, buffer, bufferPosition, byteLength);
+        } else {
+            final int leftLength = left.byteLength();
+
+            if (offset < leftLength) {
+                // The left branch might not be large enough to extract the full hash code we want. In that case,
+                // we'll extract what we can and extract the difference from the right side.
+                if (offset + byteLength > leftLength) {
+                    final int coveredByLeft = leftLength - offset;
+
+                    left.fillBytes(buffer, bufferPosition, offset, coveredByLeft);
+                    right.fillBytes(buffer, bufferPosition + coveredByLeft, 0, byteLength - coveredByLeft);
+
+                } else {
+                    left.fillBytes(buffer, bufferPosition, offset, byteLength);
+                }
+            } else {
+                right.fillBytes(buffer, bufferPosition, offset - leftLength, byteLength);
+            }
+        }
+    }
 }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/ConcatRope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/ConcatRope.java
@@ -87,26 +87,6 @@ public class ConcatRope extends Rope {
         return right.extractRange(offset - leftLength, length);
     }
 
-    @Override
-    public int hashCode() {
-        return left.hashCode() + right.hashCode();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-
-        if (o instanceof ConcatRope) {
-            final ConcatRope other = (ConcatRope) o;
-
-            return left.equals(other.left) && right.equals(other.right);
-        }
-
-        return false;
-    }
-
     public Rope getLeft() {
         return left;
     }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/ConcatRope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/ConcatRope.java
@@ -103,4 +103,10 @@ public class ConcatRope extends Rope {
     public Rope getRight() {
         return right;
     }
+
+    @Override
+    public String toString() {
+        // This should be used for debugging only.
+        return RopeOperations.decodeUTF8(left) + RopeOperations.decodeUTF8(right);
+    }
 }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/LeafRope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/LeafRope.java
@@ -63,4 +63,10 @@ public abstract class LeafRope extends Rope {
 
         return false;
     }
+
+    @Override
+    public String toString() {
+        // This should be used for debugging only.
+        return RopeOperations.decodeUTF8(this);
+    }
 }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/LeafRope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/LeafRope.java
@@ -49,4 +49,11 @@ public abstract class LeafRope extends Rope {
         // This should be used for debugging only.
         return RopeOperations.decodeUTF8(this);
     }
+
+    @Override
+    protected void fillBytes(byte[] buffer, int bufferPosition, int offset, int byteLength) {
+        assert offset + byteLength <= bytes.length;
+
+        System.arraycopy(bytes, offset, buffer, bufferPosition, byteLength);
+    }
 }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/LeafRope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/LeafRope.java
@@ -25,11 +25,6 @@ public abstract class LeafRope extends Rope {
     }
 
     @Override
-    public byte[] calculateBytes() {
-        throw new UnsupportedOperationException("LeafRope's bytes are always known. There is no need to calculate them.");
-    }
-
-    @Override
     public byte[] extractRange(int offset, int length) {
         assert offset + length <= byteLength();
 
@@ -47,10 +42,4 @@ public abstract class LeafRope extends Rope {
         return RopeOperations.decodeUTF8(this);
     }
 
-    @Override
-    protected void fillBytes(byte[] buffer, int bufferPosition, int offset, int byteLength) {
-        assert offset + byteLength <= byteLength();
-
-        System.arraycopy(getRawBytes(), offset, buffer, bufferPosition, byteLength);
-    }
 }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/LeafRope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/LeafRope.java
@@ -15,31 +15,28 @@ import java.util.Arrays;
 
 public abstract class LeafRope extends Rope {
 
-    private final byte[] bytes;
-
     public LeafRope(byte[] bytes, Encoding encoding, int codeRange, boolean singleByteOptimizable, int characterLength) {
-        super(encoding, codeRange, singleByteOptimizable, bytes.length, characterLength, 1);
-        this.bytes = bytes;
+        super(encoding, codeRange, singleByteOptimizable, bytes.length, characterLength, 1, bytes);
     }
 
     @Override
     public int get(int index) {
-        return bytes[index];
+        return getRawBytes()[index];
     }
 
     @Override
-    public byte[] getBytes() {
-        return bytes;
+    public byte[] calculateBytes() {
+        throw new UnsupportedOperationException("LeafRope's bytes are always known. There is no need to calculate them.");
     }
 
     @Override
     public byte[] extractRange(int offset, int length) {
-        assert offset + length <= bytes.length;
+        assert offset + length <= byteLength();
 
         final int trueLength = Math.min(length, byteLength());
         final byte[] ret = new byte[trueLength];
 
-        System.arraycopy(bytes, offset, ret, 0, trueLength);
+        System.arraycopy(getRawBytes(), offset, ret, 0, trueLength);
 
         return ret;
     }
@@ -52,8 +49,8 @@ public abstract class LeafRope extends Rope {
 
     @Override
     protected void fillBytes(byte[] buffer, int bufferPosition, int offset, int byteLength) {
-        assert offset + byteLength <= bytes.length;
+        assert offset + byteLength <= byteLength();
 
-        System.arraycopy(bytes, offset, buffer, bufferPosition, byteLength);
+        System.arraycopy(getRawBytes(), offset, buffer, bufferPosition, byteLength);
     }
 }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/LeafRope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/LeafRope.java
@@ -24,6 +24,11 @@ public abstract class LeafRope extends Rope {
     }
 
     @Override
+    public int get(int index) {
+        return bytes[index];
+    }
+
+    @Override
     public byte[] getBytes() {
         return bytes;
     }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/LeafRope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/LeafRope.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
 public abstract class LeafRope extends Rope {
 
     private final byte[] bytes;
-    private int hashCode = -1;
 
     public LeafRope(byte[] bytes, Encoding encoding, int codeRange, boolean singleByteOptimizable, int characterLength) {
         super(encoding, codeRange, singleByteOptimizable, bytes.length, characterLength, 1);
@@ -43,30 +42,6 @@ public abstract class LeafRope extends Rope {
         System.arraycopy(bytes, offset, ret, 0, trueLength);
 
         return ret;
-    }
-
-    @Override
-    public int hashCode() {
-        if (hashCode == -1) {
-            hashCode = Arrays.hashCode(bytes) + getEncoding().hashCode();
-        }
-
-        return hashCode;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-
-        if (o instanceof LeafRope) {
-            final LeafRope other = (LeafRope) o;
-
-            return getEncoding() == other.getEncoding() && Arrays.equals(bytes, other.getBytes());
-        }
-
-        return false;
     }
 
     @Override

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/Rope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/Rope.java
@@ -9,7 +9,6 @@
  */
 package org.jruby.truffle.runtime.rope;
 
-import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import org.jcodings.Encoding;
 import org.jruby.util.ByteList;
 
@@ -122,5 +121,7 @@ public abstract class Rope {
 
         return false;
     }
+
+    protected abstract void fillBytes(byte[] buffer, int bufferPosition, int offset, int byteLength);
 
 }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/Rope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/Rope.java
@@ -63,7 +63,7 @@ public abstract class Rope {
     public final byte[] getBytes() {
         if (bytes == null) {
             CompilerDirectives.transferToInterpreter();
-            bytes = calculateBytes();
+            bytes = RopeOperations.flattenBytes(this);
         }
 
         return bytes;

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/Rope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/Rope.java
@@ -23,7 +23,7 @@ public abstract class Rope {
     private final int byteLength;
     private final int characterLength;
     private final int ropeDepth;
-    @CompilationFinal private int hashCode = -1;
+    @CompilationFinal private int hashCode = 0;
 
     protected Rope(Encoding encoding, int codeRange, boolean singleByteOptimizable, int byteLength, int characterLength, int ropeDepth) {
         this.encoding = encoding;
@@ -111,6 +111,10 @@ public abstract class Rope {
 
         if (o instanceof Rope) {
             final Rope other = (Rope) o;
+
+            if ((hashCode != 0) && (other.hashCode != 0) && (hashCode != other.hashCode)) {
+                return false;
+            }
 
             // TODO (nirvdrum 21-Jan-16): We really should be taking the encoding into account here. We're currenly not because it breaks the symbol table.
             return byteLength() == other.byteLength() && Arrays.equals(getBytes(), other.getBytes());

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/Rope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/Rope.java
@@ -72,12 +72,6 @@ public abstract class Rope {
         return ropeDepth;
     }
 
-    @Override
-    public String toString() {
-        // This should be used for debugging only.
-        return new String(getBytes());
-    }
-
     public int begin() {
         return 0;
     }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/Rope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/Rope.java
@@ -75,8 +75,6 @@ public abstract class Rope {
 
     public abstract byte[] extractRange(int offset, int length);
 
-    public abstract byte[] calculateBytes();
-
     public final Encoding getEncoding() {
         return encoding;
     }
@@ -137,7 +135,5 @@ public abstract class Rope {
 
         return false;
     }
-
-    protected abstract void fillBytes(byte[] buffer, int bufferPosition, int offset, int byteLength);
 
 }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/Rope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/Rope.java
@@ -9,6 +9,7 @@
  */
 package org.jruby.truffle.runtime.rope;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import org.jcodings.Encoding;
 import org.jruby.util.ByteList;
 
@@ -23,14 +24,16 @@ public abstract class Rope {
     private final int characterLength;
     private final int ropeDepth;
     private int hashCode = 0;
+    private byte[] bytes;
 
-    protected Rope(Encoding encoding, int codeRange, boolean singleByteOptimizable, int byteLength, int characterLength, int ropeDepth) {
+    protected Rope(Encoding encoding, int codeRange, boolean singleByteOptimizable, int byteLength, int characterLength, int ropeDepth, byte[] bytes) {
         this.encoding = encoding;
         this.codeRange = codeRange;
         this.singleByteOptimizable = singleByteOptimizable;
         this.byteLength = byteLength;
         this.characterLength = characterLength;
         this.ropeDepth = ropeDepth;
+        this.bytes = bytes;
     }
 
     public final int characterLength() {
@@ -53,13 +56,26 @@ public abstract class Rope {
 
     public abstract int get(int index);
 
-    public abstract byte[] getBytes();
+    public final byte[] getRawBytes() {
+        return bytes;
+    }
+
+    public final byte[] getBytes() {
+        if (bytes == null) {
+            CompilerDirectives.transferToInterpreter();
+            bytes = calculateBytes();
+        }
+
+        return bytes;
+    }
 
     public byte[] getBytesCopy() {
         return getBytes().clone();
     }
 
     public abstract byte[] extractRange(int offset, int length);
+
+    public abstract byte[] calculateBytes();
 
     public final Encoding getEncoding() {
         return encoding;

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/Rope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/Rope.java
@@ -48,6 +48,8 @@ public abstract class Rope {
 
     public final ByteList toByteListCopy() { return new ByteList(getBytes(), getEncoding(), true); }
 
+    public abstract int get(int index);
+
     public abstract byte[] getBytes();
 
     public byte[] getBytesCopy() {
@@ -87,4 +89,5 @@ public abstract class Rope {
     public int getRealSize() {
         return realSize();
     }
+
 }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/Rope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/Rope.java
@@ -9,8 +9,11 @@
  */
 package org.jruby.truffle.runtime.rope;
 
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import org.jcodings.Encoding;
 import org.jruby.util.ByteList;
+
+import java.util.Arrays;
 
 public abstract class Rope {
 
@@ -20,6 +23,7 @@ public abstract class Rope {
     private final int byteLength;
     private final int characterLength;
     private final int ropeDepth;
+    @CompilationFinal private int hashCode = -1;
 
     protected Rope(Encoding encoding, int codeRange, boolean singleByteOptimizable, int byteLength, int characterLength, int ropeDepth) {
         this.encoding = encoding;
@@ -88,6 +92,31 @@ public abstract class Rope {
 
     public int getRealSize() {
         return realSize();
+    }
+
+    @Override
+    public int hashCode() {
+        if (hashCode == -1) {
+            hashCode = RopeOperations.hashForRange(this, 1, 0, byteLength);
+        }
+
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o instanceof Rope) {
+            final Rope other = (Rope) o;
+
+            // TODO (nirvdrum 21-Jan-16): We really should be taking the encoding into account here. We're currenly not because it breaks the symbol table.
+            return byteLength() == other.byteLength() && Arrays.equals(getBytes(), other.getBytes());
+        }
+
+        return false;
     }
 
 }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/Rope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/Rope.java
@@ -23,7 +23,7 @@ public abstract class Rope {
     private final int byteLength;
     private final int characterLength;
     private final int ropeDepth;
-    @CompilationFinal private int hashCode = 0;
+    private int hashCode = 0;
 
     protected Rope(Encoding encoding, int codeRange, boolean singleByteOptimizable, int byteLength, int characterLength, int ropeDepth) {
         this.encoding = encoding;
@@ -96,7 +96,7 @@ public abstract class Rope {
 
     @Override
     public int hashCode() {
-        if (hashCode == -1) {
+        if (hashCode == 0) {
             hashCode = RopeOperations.hashForRange(this, 1, 0, byteLength);
         }
 

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/RopeOperations.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/RopeOperations.java
@@ -25,6 +25,8 @@ import org.jruby.util.io.EncodingUtils;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 public class RopeOperations {
 
@@ -134,7 +136,162 @@ public class RopeOperations {
             return (LeafRope) rope;
         }
 
-        return create(rope.getBytes(), rope.getEncoding(), rope.getCodeRange());
+        return create(flattenBytes(rope), rope.getEncoding(), rope.getCodeRange());
+    }
+
+    @TruffleBoundary
+    /**
+     * Performs an iterative depth first search of the Rope tree to calculate its byte[] without needing to populate
+     * the byte[] for each level beneath. Every LeafRope has its byte[] populated by definition. The goal is to determine
+     * which descendant LeafRopes contribute bytes to the top-most Rope's logical byte[] and how many bytes they should
+     * contribute. Then each such LeafRope copies the appropriate range of bytes to a shared byte[].
+     *
+     * Rope trees can be very deep. An iterative algorithm is preferable to recursion because it removes the overhead
+     * of stack frame management. Additionally, a recursive algorithm will eventually overflow the stack if the Rope
+     * tree is too deep.
+     */
+    public static byte[] flattenBytes(Rope rope) {
+        if (rope instanceof LeafRope) {
+            return rope.getRawBytes();
+        }
+
+        int bufferPosition = 0;
+        int offset = 0;
+
+        final byte[] buffer = new byte[rope.byteLength()];
+
+        // As we traverse the rope tree, we need to keep track of any bounded lengths of SubstringRopes. LeafRopes always
+        // provide their full byte[]. ConcatRope always provides the full byte[] of each of its children. SubstringRopes,
+        // in contrast, may bound the length of their children. Since we may have SubstringRopes of SubstringRopes, we
+        // need to track each SubstringRope's bounded length and how much that bounded length contributes to the total
+        // byte[] for any ancestor (e.g., a SubstringRope of a ConcatRope with SubstringRopes for each of its children).
+        // Because we need to track multiple levels, we can't use a single updated int.
+        final Deque<Integer> substringLengths = new ArrayDeque<>();
+
+        final Deque<Rope> workStack = new ArrayDeque<>();
+        workStack.push(rope);
+
+        while (!workStack.isEmpty()) {
+            final Rope current = workStack.pop();
+
+            // An empty rope trivially cannot contribute to filling the output buffer.
+            if (current.isEmpty()) {
+                continue;
+            }
+
+            if (current instanceof ConcatRope) {
+                final ConcatRope concatRope = (ConcatRope) current;
+
+                // In the absence of any SubstringRopes, we always take the full contents of the ConcatRope.
+                if (substringLengths.isEmpty()) {
+                    workStack.push(concatRope.getRight());
+                    workStack.push(concatRope.getLeft());
+                } else {
+                    final int leftLength = concatRope.getLeft().byteLength();
+
+                    // If we reach here, this ConcatRope is a descendant of a SubstringRope at some level. Based on
+                    // the currently calculated byte[] offset and the number of bytes to extract, determine which of
+                    // the ConcatRope's children we need to visit.
+                    if (offset < leftLength) {
+                        if ((offset + substringLengths.peek()) > leftLength) {
+                            workStack.push(concatRope.getRight());
+                            workStack.push(concatRope.getLeft());
+                        } else {
+                            workStack.push(concatRope.getLeft());
+                        }
+                    } else {
+                        // If we can skip the left child entirely, we need to update the offset so it's accurate for
+                        // the right child as each child's starting point is 0.
+                        offset -= leftLength;
+                        workStack.push(concatRope.getRight());
+                    }
+                }
+            } else if (current instanceof SubstringRope) {
+                final SubstringRope substringRope = (SubstringRope) current;
+
+                // If this SubstringRope is a descendant of another SubstringRope, we need to increment the offset
+                // so that when we finally reach a LeafRope, we're extracting bytes from the correct location.
+                offset += substringRope.getOffset();
+
+                workStack.push(substringRope.getChild());
+
+                // Either we haven't seen another SubstringRope or it's been cleared off the work queue. In either case,
+                // we can start fresh.
+                if (substringLengths.isEmpty()) {
+                    substringLengths.push(substringRope.byteLength());
+                } else {
+                    // Since we may be taking a substring of a substring, we need to note that we're not extracting the
+                    // entirety of the current SubstringRope.
+                    final int adjustedByteLength = substringRope.byteLength() - (offset - substringRope.getOffset());
+
+                    // We have to do some bookkeeping once we encounter multiple SubstringRopes along the same ancestry
+                    // chain. The top of the stack always indicates the number of bytes to extract from any descendants.
+                    // Any bytes extracted from this SubstringRope must contribute to the total of the parent SubstringRope
+                    // and are thus deducted. We can't simply update a total byte count, however, because we need distinct
+                    // counts for each level.
+                    //
+                    // For example:                    SubstringRope (byteLength = 6)
+                    //                                       |
+                    //                                   ConcatRope (byteLength = 20)
+                    //                                    /      \
+                    //         SubstringRope (byteLength = 4)  LeafRope (byteLength = 16)
+                    //               |
+                    //           LeafRope (byteLength = 50)
+                    //
+                    // In this case we need to know that we're only extracting 4 bytes from descendants of the second
+                    // SubstringRope. And those 4 bytes contribute to the total 6 bytes from the ancestor SubstringRope.
+                    // The top of stack manipulation performed here maintains that invariant.
+
+                    if (substringLengths.peek() > adjustedByteLength) {
+                        final int bytesToCopy = substringLengths.pop();
+                        substringLengths.push(bytesToCopy - adjustedByteLength);
+                        substringLengths.push(adjustedByteLength);
+                    }
+                }
+            } else if (current instanceof LeafRope) {
+                // In the absence of any SubstringRopes, we always take the full contents of the LeafRope.
+                if (substringLengths.isEmpty()) {
+                    System.arraycopy(current.getRawBytes(), offset, buffer, bufferPosition, current.byteLength());
+                    bufferPosition += current.byteLength();
+                } else {
+                    int bytesToCopy = substringLengths.pop();
+                    final int currentBytesToCopy;
+
+                    // If we reach here, this LeafRope is a descendant of a SubstringRope at some level. Based on
+                    // the currently calculated byte[] offset and the number of bytes to extract, determine how many
+                    // bytes we can copy to the buffer.
+                    if (bytesToCopy > (current.byteLength() - offset)) {
+                        currentBytesToCopy = current.byteLength() - offset;
+                    } else {
+                        currentBytesToCopy = bytesToCopy;
+                    }
+
+                    System.arraycopy(current.getRawBytes(), offset, buffer, bufferPosition, currentBytesToCopy);
+                    bufferPosition += currentBytesToCopy;
+                    bytesToCopy -= currentBytesToCopy;
+
+                    // If this LeafRope wasn't able to satisfy the remaining byte count from the ancestor SubstringRope,
+                    // update the byte count for the next item in the work queue.
+                    if (bytesToCopy > 0) {
+                        substringLengths.push(bytesToCopy);
+                    }
+                }
+
+                // By definition, offsets only affect the start of the rope. Once we've copied bytes out of a LeafRope,
+                // we need to reset the offset or subsequent items in the work queue will copy from the wrong location.
+                //
+                // NB: In contrast to the number of bytes to extract, the offset can be shared and updated by multiple
+                // levels of SubstringRopes. Thus, we do not need to maintain offsets in a stack and it is appropriate
+                // to clear the offset after the first time we use it, since it will have been updated accordingly at
+                // each SubstringRope encountered for this SubstringRope ancestry chain.
+                offset = 0;
+            } else {
+                CompilerDirectives.transferToInterpreter();
+                throw new UnsupportedOperationException("Don't know how to flatten rope of type: " + rope.getClass().getName());
+            }
+        }
+
+        return buffer;
     }
 
     public static int hashCodeForLeafRope(byte[] bytes, int startingHashCode, int offset, int length) {

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/RopeOperations.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/RopeOperations.java
@@ -105,6 +105,11 @@ public class RopeOperations {
             return new SubstringRope(base, offset, byteLength, byteLength, StringSupport.CR_7BIT);
         }
 
+        return makeSubstringNon7Bit(base, offset, byteLength);
+    }
+
+    @TruffleBoundary
+    private static Rope makeSubstringNon7Bit(Rope base, int offset, int byteLength) {
         final long packedLengthAndCodeRange = calculateCodeRangeAndLength(base.getEncoding(), base.getBytes(), offset, offset + byteLength);
         final int codeRange = StringSupport.unpackArg(packedLengthAndCodeRange);
         final int characterLength = StringSupport.unpackResult(packedLengthAndCodeRange);

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/RopeOperations.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/RopeOperations.java
@@ -54,19 +54,6 @@ public class RopeOperations {
         }
     }
 
-    @TruffleBoundary
-    public static Rope concat(Rope left, Rope right, Encoding encoding) {
-        if (right.isEmpty()) {
-            return withEncoding(left, encoding);
-        }
-
-        if (left.isEmpty()) {
-            return withEncoding(right, encoding);
-        }
-
-        return new ConcatRope(left, right, encoding);
-    }
-
     public static Rope withEncoding(Rope originalRope, Encoding newEncoding, int newCodeRange) {
         if ((originalRope.getEncoding() == newEncoding) && (originalRope.getCodeRange() == newCodeRange)) {
             return originalRope;
@@ -75,7 +62,6 @@ public class RopeOperations {
         return create(originalRope.getBytes(), newEncoding, newCodeRange);
     }
 
-    @TruffleBoundary
     public static Rope withEncoding(Rope originalRope, Encoding newEncoding) {
         return withEncoding(originalRope, newEncoding, originalRope.getCodeRange());
     }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/SubstringRope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/SubstringRope.java
@@ -17,11 +17,9 @@ public class SubstringRope extends Rope {
     private final Rope child;
     private final int offset;
 
-    private byte[] bytes;
-
     public SubstringRope(Rope child, int offset, int byteLength, int characterLength, int codeRange) {
         // TODO (nirvdrum 07-Jan-16) Verify that this rope is only used for character substrings and not arbitrary byte slices. The former should always have the child's code range while the latter may not.
-        super(child.getEncoding(), codeRange, child.isSingleByteOptimizable(), byteLength, characterLength, child.depth() + 1);
+        super(child.getEncoding(), codeRange, child.isSingleByteOptimizable(), byteLength, characterLength, child.depth() + 1, null);
         this.child = child;
         this.offset = offset;
     }
@@ -32,12 +30,8 @@ public class SubstringRope extends Rope {
     }
 
     @Override
-    public byte[] getBytes() {
-        if (bytes == null) {
-            bytes = child.extractRange(offset, byteLength());
-        }
-
-        return bytes;
+    public byte[] calculateBytes() {
+        return child.extractRange(offset, byteLength());
     }
 
     @Override
@@ -63,8 +57,8 @@ public class SubstringRope extends Rope {
 
     @Override
     protected void fillBytes(byte[] buffer, int bufferPosition, int offset, int byteLength) {
-        if (bytes != null) {
-            System.arraycopy(bytes, offset, buffer, bufferPosition, byteLength);
+        if (getRawBytes() != null) {
+            System.arraycopy(getRawBytes(), offset, buffer, bufferPosition, byteLength);
         } else {
             child.fillBytes(buffer, bufferPosition, offset + this.offset, byteLength);
         }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/SubstringRope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/SubstringRope.java
@@ -27,6 +27,11 @@ public class SubstringRope extends Rope {
     }
 
     @Override
+    public int get(int index) {
+        return child.get(index + offset);
+    }
+
+    @Override
     public byte[] getBytes() {
         if (bytes == null) {
             bytes = child.extractRange(offset, byteLength());

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/SubstringRope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/SubstringRope.java
@@ -60,4 +60,13 @@ public class SubstringRope extends Rope {
         // This should be used for debugging only.
         return RubyEncoding.decodeUTF8(child.getBytes(), offset, byteLength());
     }
+
+    @Override
+    protected void fillBytes(byte[] buffer, int bufferPosition, int offset, int byteLength) {
+        if (bytes != null) {
+            System.arraycopy(bytes, offset, buffer, bufferPosition, byteLength);
+        } else {
+            child.fillBytes(buffer, bufferPosition, offset + this.offset, byteLength);
+        }
+    }
 }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/SubstringRope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/SubstringRope.java
@@ -52,7 +52,7 @@ public class SubstringRope extends Rope {
     @Override
     public String toString() {
         // This should be used for debugging only.
-        return RubyEncoding.decodeUTF8(child.getBytes(), offset, byteLength());
+        return child.toString().substring(offset, offset + byteLength());
     }
 
     @Override

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/SubstringRope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/SubstringRope.java
@@ -10,6 +10,8 @@
 
 package org.jruby.truffle.runtime.rope;
 
+import org.jruby.RubyEncoding;
+
 public class SubstringRope extends Rope {
 
     private final Rope child;
@@ -48,4 +50,9 @@ public class SubstringRope extends Rope {
         return offset;
     }
 
+    @Override
+    public String toString() {
+        // This should be used for debugging only.
+        return RubyEncoding.decodeUTF8(child.getBytes(), offset, byteLength());
+    }
 }

--- a/truffle/src/main/java/org/jruby/truffle/runtime/rope/SubstringRope.java
+++ b/truffle/src/main/java/org/jruby/truffle/runtime/rope/SubstringRope.java
@@ -10,8 +10,6 @@
 
 package org.jruby.truffle.runtime.rope;
 
-import org.jruby.RubyEncoding;
-
 public class SubstringRope extends Rope {
 
     private final Rope child;
@@ -27,11 +25,6 @@ public class SubstringRope extends Rope {
     @Override
     public int get(int index) {
         return child.get(index + offset);
-    }
-
-    @Override
-    public byte[] calculateBytes() {
-        return child.extractRange(offset, byteLength());
     }
 
     @Override
@@ -55,12 +48,4 @@ public class SubstringRope extends Rope {
         return child.toString().substring(offset, offset + byteLength());
     }
 
-    @Override
-    protected void fillBytes(byte[] buffer, int bufferPosition, int offset, int byteLength) {
-        if (getRawBytes() != null) {
-            System.arraycopy(getRawBytes(), offset, buffer, bufferPosition, byteLength);
-        } else {
-            child.fillBytes(buffer, bufferPosition, offset + this.offset, byteLength);
-        }
-    }
 }

--- a/truffle/src/main/java/org/jruby/truffle/translator/BodyTranslator.java
+++ b/truffle/src/main/java/org/jruby/truffle/translator/BodyTranslator.java
@@ -1771,10 +1771,7 @@ public class BodyTranslator extends Translator {
                 ret = StringNodesFactory.ByteSizeNodeFactory.create(context, sourceSection, new RubyNode[]{ self });
                 return addNewlineIfNeeded(node, ret);
             } else if (name.equals("@data")) {
-                final RubyNode bytes = StringNodesFactory.BytesNodeFactory.create(context, sourceSection, new RubyNode[]{ self });
-                // Wrap in a StringData instance, see shims.
-                LiteralNode stringDataClass = new LiteralNode(context, sourceSection, context.getCoreLibrary().getStringDataClass());
-                ret = new RubyCallNode(context, sourceSection, "new", stringDataClass, null, false, bytes);
+                ret = StringNodesFactory.DataNodeFactory.create(context, sourceSection, new RubyNode[]{ self });
                 return addNewlineIfNeeded(node, ret);
             }
         } else if (path.equals(corePath + "rubinius/common/time.rb")) {

--- a/truffle/src/main/ruby/core/shims.rb
+++ b/truffle/src/main/ruby/core/shims.rb
@@ -69,34 +69,7 @@ class Rational
   alias :__slash__ :/
 end
 
-# Wrapper class for Rubinius's exposure of @data within String.
-#
-# We can't use Array directly because we don't currently guarantee that we'll always return the same
-# exact underlying byte array.  Rubinius calls #equal? rather than #== throughout its code, making a tighter
-# assumption than we provide.  This wrapper provides the semantics we need in the interim.
 module Rubinius
-  class StringData
-    attr_accessor :array
-
-    def initialize(array)
-      @array = array
-    end
-
-    def equal?(other)
-      @array == other.array
-    end
-
-    alias_method :==, :equal?
-
-    def size
-      @array.size
-    end
-
-    def [](index)
-      @array[index]
-    end
-  end
-
   class Mirror
     module Process
       def self.set_status_global(status)


### PR DESCRIPTION
@chrisseaton @pitr-ch @eregon This is the additional work I've done on ropes since the last pull request. I did it as a separate pull request against the branch you've already reviewed so you can see the new changes more easily.

The work here was primarily to improve performance over the original branch. The first one was basically just functionally complete. This PR has a larger emphasis on doing things more efficiently with ropes. There's still a lot more we can do, particularly in the area of regular expressions.

Notable highlights:

* Introduced a rope table for StringLiteralNodes (NB: There's a problem with the key being removed as it's a WeakHashMap, but everything still works if the cached entry isn't available and these are all built during parse, so the effect of GC is minimized).
* Symbols are now based ropes.
* Rope construction methods have been converted to nodes.
* Some primitives to help in debugging ropes were added.
* Fixed `Rope#hashCode` and `Rope#equals`.
* Replaced recursive byte[] building with an iterative algorithm.
* Removed a bunch of places where we were constructing ByteLists (and subsequently materializing the rope's byte[]) unnecessarily. 