### PR TITLE
[Truffle] Remove unused frame parameter in guards.

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/language/locals/WriteFrameSlotNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/language/locals/WriteFrameSlotNode.java
@@ -29,54 +29,54 @@ public abstract class WriteFrameSlotNode extends Node {
 
     public abstract Object executeWrite(Frame frame, Object value);
 
-    @Specialization(guards = "checkBooleanKind(frame)")
+    @Specialization(guards = "checkBooleanKind()")
     public boolean writeBoolean(Frame frame, boolean value) {
         frame.setBoolean(frameSlot, value);
         return value;
     }
 
-    @Specialization(guards = "checkIntegerKind(frame)")
+    @Specialization(guards = "checkIntegerKind()")
     public int writeInteger(Frame frame, int value) {
         frame.setInt(frameSlot, value);
         return value;
     }
 
-    @Specialization(guards = "checkLongKind(frame)")
+    @Specialization(guards = "checkLongKind()")
     public long writeLong(Frame frame, long value) {
         frame.setLong(frameSlot, value);
         return value;
     }
 
-    @Specialization(guards = "checkDoubleKind(frame)")
+    @Specialization(guards = "checkDoubleKind()")
     public double writeDouble(Frame frame, double value) {
         frame.setDouble(frameSlot, value);
         return value;
     }
 
-    @Specialization(guards = "checkObjectKind(frame)")
+    @Specialization(guards = "checkObjectKind()")
     public Object writeObject(Frame frame, Object value) {
         assert RubyGuards.wasProvided(value); // Useful debug aid to catch a running-away NotProvided
         frame.setObject(frameSlot, value);
         return value;
     }
 
-    protected boolean checkBooleanKind(Frame frame) {
+    protected boolean checkBooleanKind() {
         return checkKind(FrameSlotKind.Boolean);
     }
 
-    protected boolean checkIntegerKind(Frame frame) {
+    protected boolean checkIntegerKind() {
         return checkKind(FrameSlotKind.Int);
     }
 
-    protected boolean checkLongKind(Frame frame) {
+    protected boolean checkLongKind() {
         return checkKind(FrameSlotKind.Long);
     }
 
-    protected boolean checkDoubleKind(Frame frame) {
+    protected boolean checkDoubleKind() {
         return checkKind(FrameSlotKind.Double);
     }
 
-    protected boolean checkObjectKind(Frame frame) {
+    protected boolean checkObjectKind() {
         if (frameSlot.getKind() != FrameSlotKind.Object) {
             CompilerDirectives.transferToInterpreter();
             frameSlot.setKind(FrameSlotKind.Object);


### PR DESCRIPTION
@chumer this modification makes my program fail on this assert in the generated code

```java
    @GeneratedBy(methodName = "writeInteger(Frame, int)", value = WriteFrameSlotNode.class)
    private static final class WriteIntegerNode_ extends BaseNode_ {

        WriteIntegerNode_(WriteFrameSlotNodeGen root) {
            super(root, 2);
        }

        @Override
        public Object execute(Frame frameValue, Object arg0Value) {
            if (arg0Value instanceof Integer) {
                int arg0Value_ = (int) arg0Value;
                assert (root.checkIntegerKind());
                return root.writeInteger(frameValue, arg0Value_);
            }
            return getNext().execute(frameValue, arg0Value);
        }

        static BaseNode_ create(WriteFrameSlotNodeGen root) {
            return new WriteIntegerNode_(root);
        }

    }
```

With the frame parameter in, the generated code is

```java
    @GeneratedBy(methodName = "writeInteger(Frame, int)", value = WriteFrameSlotNode.class)
    private static final class WriteIntegerNode_ extends BaseNode_ {

        WriteIntegerNode_(WriteFrameSlotNodeGen root) {
            super(root, 2);
        }

        @Override
        public Object execute(Frame frameValue, Object arg0Value) {
            if (arg0Value instanceof Integer) {
                int arg0Value_ = (int) arg0Value;
                if ((root.checkIntegerKind(frameValue))) {
                    return root.writeInteger(frameValue, arg0Value_);
                }
            }
            return getNext().execute(frameValue, arg0Value);
        }

        static BaseNode_ create(WriteFrameSlotNodeGen root) {
            return new WriteIntegerNode_(root);
        }

    }
```

Do you know what could be wrong? Why is the generated code so different? The `frame` variable in my code isn't even used.