### PR TITLE
thread-context refactor backtrace retrieval

### DIFF
--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -683,6 +683,8 @@ public final class ThreadContext {
      * @return an Array with the backtrace locations
      */
     public IRubyObject createCallerLocations(int level, Integer length, StackTraceElement[] stacktrace) {
+        runtime.incrementCallerCount();
+
         RubyStackTraceElement[] trace = getTraceSubset(level, length, stacktrace);
 
         if (trace == null) return nil;
@@ -691,7 +693,6 @@ public final class ThreadContext {
     }
 
     private RubyStackTraceElement[] getTraceSubset(int level, Integer length, StackTraceElement[] stacktrace) {
-        runtime.incrementCallerCount();
 
         if (length != null && length == 0) return RubyStackTraceElement.EMPTY_ARRAY;
 
@@ -751,8 +752,14 @@ public final class ThreadContext {
      * @return the backtrace
      */
     public BacktraceElement[] getBacktrace() {
-        BacktraceElement[] newTrace = new BacktraceElement[backtraceIndex + 1];
-        System.arraycopy(backtrace, 0, newTrace, 0, newTrace.length);
+        return getBacktrace(0);
+    }
+
+    public final BacktraceElement[] getBacktrace(int level) {
+        final int len = backtraceIndex + 1;
+        if ( level < 0 ) level = len + level;
+        BacktraceElement[] newTrace = new BacktraceElement[len - level];
+        System.arraycopy(backtrace, level, newTrace, 0, newTrace.length);
         return newTrace;
     }
 

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -266,7 +266,7 @@ public final class ThreadContext {
     }
 
     private void expandFrameStack() {
-        int newSize = frameStack.length * 2;
+        final int newSize = frameStack.length * 2;
         frameStack = fillNewFrameStack(new Frame[newSize], newSize);
     }
 
@@ -506,7 +506,7 @@ public final class ThreadContext {
     /////////////////// BACKTRACE ////////////////////
 
     private static void expandBacktraceStack(ThreadContext context) {
-        int newSize = context.backtrace.length * 2;
+        final int newSize = context.backtrace.length * 2;
         context.backtrace = fillNewBacktrace(context, new BacktraceElement[newSize], newSize);
     }
 
@@ -521,11 +521,11 @@ public final class ThreadContext {
     }
 
     public static void pushBacktrace(ThreadContext context, String method, String file, int line) {
-        int index = ++context.backtraceIndex;
-        BacktraceElement[] stack = context.backtrace;
-        BacktraceElement.update(stack[index], method, file, line);
-        if (index + 1 == stack.length) {
-            ThreadContext.expandBacktraceStack(context);
+        final int index = ++context.backtraceIndex;
+        BacktraceElement[] backtrace = context.backtrace;
+        BacktraceElement.update(backtrace[index], method, file, line);
+        if (index + 1 == backtrace.length) {
+            expandBacktraceStack(context);
         }
     }
 
@@ -741,14 +741,16 @@ public final class ThreadContext {
         eventHooksEnabled = flag;
     }
 
-    /**
-     * Create an Array with backtrace information.
-     * @param level
-     * @param nativeException
-     * @return an Array with the backtrace
-     */
+    @Deprecated
     public BacktraceElement[] createBacktrace2(int level, boolean nativeException) {
-        BacktraceElement[] backtrace = this.backtrace;
+        return getBacktrace();
+    }
+
+    /**
+     * Create a snapshot Array with current backtrace information.
+     * @return the backtrace
+     */
+    public BacktraceElement[] getBacktrace() {
         BacktraceElement[] newTrace = new BacktraceElement[backtraceIndex + 1];
         System.arraycopy(backtrace, 0, newTrace, 0, newTrace.length);
         return newTrace;

--- a/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
@@ -155,7 +155,7 @@ public class TraceType {
             public BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace, boolean nativeException) {
                 return new BacktraceData(
                         javaTrace,
-                        context.createBacktrace2(0, nativeException),
+                        context.getBacktrace(),
                         true,
                         false,
                         false);
@@ -169,7 +169,7 @@ public class TraceType {
             public BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace, boolean nativeException) {
                 return new BacktraceData(
                         javaTrace,
-                        context.createBacktrace2(0, nativeException),
+                        context.getBacktrace(),
                         false,
                         false,
                         true);
@@ -183,7 +183,7 @@ public class TraceType {
             public BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace, boolean nativeException) {
                 return new BacktraceData(
                         javaTrace,
-                        context.createBacktrace2(0, nativeException),
+                        context.getBacktrace(),
                         false,
                         context.runtime.getInstanceConfig().getBacktraceMask(),
                         false);
@@ -197,7 +197,7 @@ public class TraceType {
             public BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace, boolean nativeException) {
                 return new BacktraceData(
                         javaTrace,
-                        context.createBacktrace2(0, nativeException),
+                        context.getBacktrace(),
                         false,
                         true,
                         false);


### PR DESCRIPTION
historically there's `createBacktrace2(int level, boolean nativeException)`
... whose parameters are no longer used, proposing a `getBacktrace()` instead

getter name chosen since thread-context manages a backtrace state - does not need to create/generate one.

alternatively `getBacktrace(int level)` is added although we do not use the API.