### PR TITLE
 lazy secure random

### DIFF
--- a/core/src/main/java/org/jruby/ext/securerandom/SecureRandomLibrary.java
+++ b/core/src/main/java/org/jruby/ext/securerandom/SecureRandomLibrary.java
@@ -37,7 +37,7 @@ public class SecureRandomLibrary {
     }
 
     private static byte[] nextBytes(ThreadContext context, IRubyObject n) {
-        int size = n.isNil() ? 16 : (int)n.convertToInteger().getLongValue();
+        int size = n.isNil() ? 16 : (int) n.convertToInteger().getLongValue();
 
         return nextBytes(context, size);
     }
@@ -46,7 +46,7 @@ public class SecureRandomLibrary {
         if (size < 0) throw context.runtime.newArgumentError("negative argument: " + size);
 
         byte[] bytes = new byte[size];
-        context.secureRandom.nextBytes(bytes);
+        context.getSecureRandom().nextBytes(bytes);
 
         return bytes;
     }

--- a/core/src/main/java/org/jruby/ext/securerandom/SecureRandomLibrary.java
+++ b/core/src/main/java/org/jruby/ext/securerandom/SecureRandomLibrary.java
@@ -1,6 +1,5 @@
 package org.jruby.ext.securerandom;
 
-import org.jruby.CompatVersion;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
@@ -31,7 +30,7 @@ public class SecureRandomLibrary {
         return RubyString.newStringNoCopy(context.runtime, ConvertBytes.twosComplementToHexBytes(nextBytes(context, n), false));
     }
 
-    @JRubyMethod(meta = true, compat = CompatVersion.RUBY1_9)
+    @JRubyMethod(meta = true)
     public static IRubyObject uuid(ThreadContext context, IRubyObject self) {
         return RubyString.newStringNoCopy(context.runtime, ConvertBytes.bytesToUUIDBytes(nextBytes(context, 16), false));
     }

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -132,21 +132,32 @@ public final class ThreadContext {
     private Block.Type currentBlockType; // See prepareBlockArgs code in IRRuntimeHelpers
     private Throwable savedExcInLambda;  // See handleBreakAndReturnsInLambda in IRRuntimeHelpers
 
-    public final SecureRandom secureRandom = getSecureRandom();
+    /**
+     * This fields is no longer initialized, is null by default!
+     * Use {@link #getSecureRandom()} instead.
+     * @deprecated
+     */
+    @Deprecated
+    public transient SecureRandom secureRandom;
 
     private static boolean trySHA1PRNG = true;
 
-    private static SecureRandom getSecureRandom() {
-        SecureRandom sr;
-        try {
-            sr = trySHA1PRNG ?
-                    SecureRandom.getInstance("SHA1PRNG") :
-                    new SecureRandom();
-        } catch (Exception e) {
-            trySHA1PRNG = false;
-            sr = new SecureRandom();
+    public SecureRandom getSecureRandom() {
+        SecureRandom secureRandom = this.secureRandom;
+        if (secureRandom == null) {
+            if (trySHA1PRNG) {
+                try {
+                    secureRandom = SecureRandom.getInstance("SHA1PRNG");
+                } catch (Exception e) {
+                    trySHA1PRNG = false;
+                }
+            }
+            if (secureRandom == null) {
+                secureRandom = new SecureRandom();
+            }
+            this.secureRandom = secureRandom;
         }
-        return sr;
+        return secureRandom;
     }
 
     /**


### PR DESCRIPTION
`ThreadContext.secureRandom` field was introduced as an optimization for the `SecureRandomLibrary`
... however as its a final field initialized on `new ThreadContext` all Ruby thread allocations potentially pay the cost of creating a secure random generator. which under some circumstances might get slow as they all seed themselves using a shared seeder (from a single source of entropy e.g. /dev/random under *nix).

numbers show a noticeable improvement on Ubuntu (rng-pack installed thus I rarely deplete /dev/random) :

100_000 threads BEFORE :
```
Rehearsal ----------------------------------------------------------
Thread.new [100000x]    12.840000   6.640000  19.480000 ( 10.336762)
Thread.start [100000x]  12.490000   5.760000  18.250000 (  9.539517)
------------------------------------------------ total: 37.730000sec

                             user     system      total        real
Thread.new [100000x]    12.850000   5.690000  18.540000 (  9.667767)
Thread.start [100000x]  12.280000   5.830000  18.110000 (  9.503311)

Rehearsal ----------------------------------------------------------
Thread.new [100000x]    12.190000   5.930000  18.120000 (  9.515859)
Thread.start [100000x]  12.030000   5.880000  17.910000 (  9.406770)
------------------------------------------------ total: 36.030000sec

                             user     system      total        real
Thread.new [100000x]    12.270000   5.920000  18.190000 (  9.577951)
Thread.start [100000x]  11.800000   5.690000  17.490000 (  9.167615)
```

100_000 threads AFTER :
```
Rehearsal ----------------------------------------------------------
Thread.new [100000x]    11.040000   5.560000  16.600000 (  8.708792)
Thread.start [100000x]  10.740000   5.520000  16.260000 (  8.400990)
------------------------------------------------ total: 32.860000sec

                             user     system      total        real
Thread.new [100000x]    10.840000   5.620000  16.460000 (  8.506339)
Thread.start [100000x]  10.460000   5.560000  16.020000 (  8.323819)

Rehearsal ----------------------------------------------------------
Thread.new [100000x]    10.990000   5.540000  16.530000 (  8.610879)
Thread.start [100000x]  10.960000   5.200000  16.160000 (  8.449772)
------------------------------------------------ total: 32.690000sec

                             user     system      total        real
Thread.new [100000x]    11.170000   5.590000  16.760000 (  8.749497)
Thread.start [100000x]  11.120000   5.370000  16.490000 (  8.661327)
```

with 10_000 threads : 
```
Rehearsal ---------------------------------------------------------
Thread.new [10000x]     1.650000   0.710000   2.360000 (  1.182017)
Thread.start [10000x]   1.240000   0.560000   1.800000 (  0.940092)
------------------------------------------------ total: 4.160000sec

                            user     system      total        real
Thread.new [10000x]     1.280000   0.550000   1.830000 (  1.026601)
Thread.start [10000x]   1.200000   0.540000   1.740000 (  0.911941)

Rehearsal ---------------------------------------------------------
Thread.new [10000x]     1.730000   0.600000   2.330000 (  1.170421)
Thread.start [10000x]   1.220000   0.550000   1.770000 (  0.947210)
------------------------------------------------ total: 4.100000sec

                            user     system      total        real
Thread.new [10000x]     1.190000   0.590000   1.780000 (  0.938240)
Thread.start [10000x]   1.180000   0.590000   1.770000 (  0.978640)
```

```
Rehearsal ---------------------------------------------------------
Thread.new [10000x]     1.350000   0.700000   2.050000 (  1.046323)
Thread.start [10000x]   1.060000   0.540000   1.600000 (  0.847617)
------------------------------------------------ total: 3.650000sec

                            user     system      total        real
Thread.new [10000x]     1.070000   0.530000   1.600000 (  0.824071)
Thread.start [10000x]   0.990000   0.580000   1.570000 (  0.802974)

Rehearsal ---------------------------------------------------------
Thread.new [10000x]     1.300000   0.780000   2.080000 (  1.046365)
Thread.start [10000x]   1.060000   0.520000   1.580000 (  0.823744)
------------------------------------------------ total: 3.660000sec

                            user     system      total        real
Thread.new [10000x]     0.990000   0.580000   1.570000 (  0.806058)
Thread.start [10000x]   1.020000   0.580000   1.600000 (  0.847847)
```