### PR TITLE
TCK expects execution of each test in an isolated environment. Creati…

### DIFF
--- a/truffle/src/test/java/org/jruby/truffle/tck/RubyTckTest.java
+++ b/truffle/src/test/java/org/jruby/truffle/tck/RubyTckTest.java
@@ -14,27 +14,15 @@ import com.oracle.truffle.api.vm.PolyglotEngine;
 import com.oracle.truffle.tck.TruffleTCK;
 
 import org.jruby.truffle.RubyLanguage;
-import org.junit.Test;
 
 import static org.junit.Assert.*;
 
 public class RubyTckTest extends TruffleTCK {
-
-    private static PolyglotEngine engine;
-
-    @Test
-    public void checkVM() {
+    @Override
+    protected PolyglotEngine prepareVM() throws Exception {
         PolyglotEngine engine = PolyglotEngine.newBuilder().build();
         assertNotNull(engine.getLanguages().get(mimeType()));
-    }
-
-    @Override
-    protected synchronized PolyglotEngine prepareVM() throws Exception {
-        if (engine == null) {
-            engine = PolyglotEngine.newBuilder().build();
-            engine.eval(Source.fromFileName("src/test/ruby/tck.rb"));
-        }
-
+        engine.eval(Source.fromFileName("src/test/ruby/tck.rb"));
         return engine;
     }
 


### PR DESCRIPTION
TCK expects execution of each test in an isolated environment. Creating the `PolyglotEngine` instance in each invocation of `prepareVM`. With this change the https://github.com/graalvm/truffle/pull/146 request seems to pass OK.