### PR TITLE
Fix strftime %Z to act like CRuby

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -896,17 +896,13 @@ public class RubyTime extends RubyObject {
         Matcher offsetMatcher = TIME_OFFSET_PATTERN.matcher(zone);
 
         if (offsetMatcher.matches()) {
-            boolean minus_p = offsetMatcher.group(1).equals("-");
-            int hourOffset  = Integer.valueOf(offsetMatcher.group(2));
-
             if (zone.equals("+00:00")) {
                 zone = "UTC";
             } else {
                 // try non-localized time zone name
                 zone = dt.getZone().getNameKey(dt.getMillis());
                 if (zone == null) {
-                    char sign = minus_p ? '+' : '-';
-                    zone = "UTC" + sign + hourOffset;
+                    zone = "";
                 }
             }
         }


### PR DESCRIPTION
Based on Issue https://github.com/jruby/jruby/issues/3702

In CRuby when a timezone is not found with %Z option nothing is returned.
In strftime method when a timezone is not found, return an empty string as opposed to UTC +X
