### PR TITLE
Workaround for JRuby bug with UTF-8 encoding on non-English Windows

### DIFF
--- a/lib/ruby/1.9/win32/registry.rb
+++ b/lib/ruby/1.9/win32/registry.rb
@@ -63,6 +63,10 @@ For detail, see the MSDN[http://msdn.microsoft.com/library/en-us/sysinfo/base/pr
 
 =end rdoc
 
+  WCHAR = Encoding::UTF_16LE
+  WCHAR_SPACE = "\0".encode(WCHAR).freeze
+  LOCALE = Encoding.find(Encoding.locale_charmap)
+
   class Registry
 
     #
@@ -160,22 +164,13 @@ For detail, see the MSDN[http://msdn.microsoft.com/library/en-us/sysinfo/base/pr
     # Error
     #
     class Error < ::StandardError
-      FormatMessageA = Win32API.new('kernel32.dll', 'FormatMessageA', 'LPLLPLP', 'L')
+      FormatMessageW = Win32API.new('kernel32.dll', 'FormatMessageW', 'LPLLPLP', 'L')
       def initialize(code)
         @code = code
-        lang = 0
-        begin
-          msg = "\0".force_encoding(Encoding::ASCII_8BIT) * 1024
-          len = FormatMessageA.call(0x1200, 0, code, lang, msg, 1024, 0)
-          len = msg.length
-          msg = msg[0, len].force_encoding(Encoding.find(Encoding.locale_charmap))
-          msg = msg.tr("\r", '').chomp
-        rescue ArgumentError, EncodingError => e
-          raise unless lang == 0
-          lang = 0x0409 # en_US
-          retry
-        end
-        super(msg)
+        msg = WCHAR_SPACE * 1024
+        len = FormatMessageW.call(0x1200, 0, code, 0, msg, 1024, 0)
+        msg = msg[0, len].encode(Encoding.locale_charmap)
+        super msg.tr("\r", '').chomp
       end
       attr_reader :code
     end


### PR DESCRIPTION
We discovered this with a customer yesterday. DNS resolving (using `Resolv::DNS#getaddresses`) failed. It turned out that the underlying problem was that the way `win32/registry.rb` retrieves error messages from Windows is flawed, under certain circumstances.

The bug only appears if:

- `JAVA_OPTS` includes `-Dfile.encoding=UTF-8`
- The environment you run it on is a _non-English_ Windows installation, or more specifically: a Windows installation where the error message(s) include some non-ASCII character. The specific use case here is a Swedish Windows installation, where the error message for error number 2 (File not found) reads as "Filen du söker finns inte", or something similar. (The debugging here was complicated by the fact that I don't have a Swedish Windows myself, only the customer).

Here is a test script that reproduces the problem given that you have a Swedish Windows:

```ruby

require 'win32/resolv'
puts Encoding.locale_charmap
puts Win32::Resolv.send(:get_info).inspect
```

Since I don't have a Swedish Windows, I managed to reproduce the same error locally by adding this code into the `Error` constructor:

```ruby
msg = "Malm\xf6, G\xf6teborg och V\xe4xj\xf6"
```

That gives me the same error: `ArgumentError: invalid byte sequence in UTF-8`. The original bug occurs in the `msg.tr` call, since the string it operates on is _marked_ as UTF-8 (because of the `force_encoding` call), where it is in fact Windows-1252 encoded (since we call `FormatMessageA`, which returns Windows-1252 encoded strings...). IMHO, this is clearly a bug.

---

Now, to the solution. The "correct" approach would be to not use the ANSI version of the system call _at all_, but instead use the "wide" version. This is the approach MRI has taken, the bug was fixed there almost 3 years ago. :) https://github.com/ruby/ruby/commit/9db6beb0d08ff17880fac9559b48375be2805580 is the specific commit, fixing the bug reported in this issue: https://bugs.ruby-lang.org/issues/8508

I tried that first, by copying over their current version of the `Error` class. The only problem is that it depends on `win32/importer`, which we don't have, which in turn depends on `fiddle/import` which we don't seem to have either. You get the picture.

Therefore, I tried with a simpler workaround instead: _if_ we get an exception in this method, let's just retry by fetching the `en-US` error message instead. (inspired by how the code on the MRI side now looks: https://github.com/ruby/ruby/blob/trunk/ext/win32/lib/win32/registry.rb)
I have tested this with the customer; it works correctly as far as the code no longer crashes. _But_, it fails to retrieve the English error message (possibly because it's not available on that Windows installation). I am willing to live with that for now; if someone wants to fix that part as well, be my guest. The critical part for me and the customer is that the code must not crash on non-ASCII Windows installations.