### PR TITLE
cleanup NativeException

### DIFF
--- a/core/src/main/java/org/jruby/exceptions/RaiseException.java
+++ b/core/src/main/java/org/jruby/exceptions/RaiseException.java
@@ -194,10 +194,10 @@ public class RaiseException extends JumpException {
     }
 
     private boolean requiresBacktrace(ThreadContext context) {
-        IRubyObject debugMode = context.runtime.getGlobalVariables().get("$DEBUG");
+        IRubyObject debugMode;
         // We can only omit backtraces of descendents of Standard error for 'foo rescue nil'
         return context.exceptionRequiresBacktrace ||
-                (debugMode != null && debugMode.isTrue()) ||
+                ((debugMode = context.runtime.getGlobalVariables().get("$DEBUG")) != null && debugMode.isTrue()) ||
                 ! context.runtime.getStandardError().isInstance(exception);
     }
 

--- a/core/src/test/java/org/jruby/javasupport/TestJava.java
+++ b/core/src/test/java/org/jruby/javasupport/TestJava.java
@@ -2,27 +2,17 @@ package org.jruby.javasupport;
 
 import java.lang.reflect.Method;
 
-import org.jruby.RubyModule;
-import org.jruby.RubyString;
+import org.jruby.*;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.junit.Test;
 
-import org.jruby.Ruby;
+import org.jruby.test.ThrowingConstructor;
 
 class A {
     public static class C extends B {}
 }
-
-class B extends A {
-    public B() {}
-
-    B(int param) {
-        if (param == -1) {
-            throw new IllegalStateException("param == -1");
-        }
-    }
-}
+class B extends A { }
 
 public class TestJava extends junit.framework.TestCase {
 
@@ -101,6 +91,7 @@ public class TestJava extends junit.framework.TestCase {
             assert false;
         }
         catch (RaiseException ex) {
+            assertEquals("(NameError) cannot load Java class java.lang.BOGUS22", ex.getMessage());
             assertNotNull(ex.getCause());
             assertEquals(ClassNotFoundException.class, ex.getCause().getClass());
         }
@@ -109,7 +100,9 @@ public class TestJava extends junit.framework.TestCase {
     @Test
     public void testJavaConstructorExceptionHandling() throws Exception {
         final Ruby runtime = Ruby.newInstance();
-        JavaConstructor constructor = JavaConstructor.create(runtime, B.class.getDeclaredConstructor(int.class));
+        JavaConstructor constructor = JavaConstructor.create(runtime,
+                ThrowingConstructor.class.getDeclaredConstructor(Integer.class)
+        );
         assert constructor.new_instance(new IRubyObject[] { runtime.newFixnum(0) }) != null;
 
         assert constructor.new_instance(new Object[] { 1 }) != null;
@@ -121,6 +114,58 @@ public class TestJava extends junit.framework.TestCase {
         catch (RaiseException ex) {
             assertEquals("(ArgumentError) wrong number of arguments (0 for 1)", ex.getMessage());
             assertNull(ex.getCause());
+            assertNotNull(ex.getException());
+            assertEquals("wrong number of arguments (0 for 1)", ex.getException().getMessage().toString());
+        }
+
+        try {
+            constructor.new_instance(new Object[] { -1 });
+            assert false;
+        }
+        catch (RaiseException ex) {
+            // ex.printStackTrace();
+            assertEquals("java.lang.IllegalStateException: param == -1", ex.getMessage());
+            StackTraceElement e0 = ex.getStackTrace()[0];
+            assertEquals("org.jruby.test.ThrowingConstructor", e0.getClassName());
+            assertEquals("<init>", e0.getMethodName());
+
+            assertNotNull(ex.getCause());
+            assert ex.getCause() instanceof IllegalStateException;
+
+            assertNotNull(ex.getException());
+            assert ex.getException() instanceof NativeException;
+            assertEquals("java.lang.IllegalStateException: param == -1", ex.getException().message(runtime.getCurrentContext()).toString());
+            assertEquals("java.lang.IllegalStateException: param == -1", ex.getException().getMessage().toString());
+            assertEquals("param == -1", ex.getCause().getMessage());
+
+            assert ex.getException().backtrace() instanceof RubyArray;
+            RubyArray backtrace = (RubyArray) ex.getException().backtrace();
+            //    org/jruby/test/ThrowingConstructor.java:8:in `<init>'
+            //    java/lang/reflect/Constructor.java:423:in `newInstance'
+            //    org/jruby/javasupport/JavaConstructor.java:222:in `new_instance'
+            //    java/lang/reflect/Method.java:498:in `invoke'
+            //    junit/framework/TestCase.java:176:in `runTest'
+            assert backtrace.get(0).toString().contains("org/jruby/test/ThrowingConstructor.java");
+        }
+
+        try {
+            constructor.new_instance(new Object[] { null }); // new IllegalStateException() null cause message
+            assert false;
+        }
+        catch (RaiseException ex) {
+            // ex.printStackTrace();
+            assertEquals("java.lang.IllegalStateException: null", ex.getMessage());
+
+            assertNotNull(ex.getCause());
+            assert ex.getCause() instanceof IllegalStateException;
+
+            assertNotNull(ex.getException());
+            assert ex.getException() instanceof NativeException;
+            assertEquals("java.lang.IllegalStateException: null", ex.getException().message(runtime.getCurrentContext()).toString());
+            assertEquals("java.lang.IllegalStateException: null", ex.getException().getMessage().toString());
+            assertNull(ex.getCause().getMessage());
+
+            assert ex.getException().backtrace() instanceof RubyArray;
         }
     }
 

--- a/core/src/test/java/org/jruby/test/ThrowingConstructor.java
+++ b/core/src/test/java/org/jruby/test/ThrowingConstructor.java
@@ -1,0 +1,10 @@
+package org.jruby.test;
+
+public class ThrowingConstructor {
+    // public ThrowingConstructor() { }
+
+    public ThrowingConstructor(Integer param) {
+        if (param == null) throw new IllegalStateException();
+        if (param < 0) throw new IllegalStateException("param == " + param);
+    }
+}

--- a/test/jruby/test_backtraces.rb
+++ b/test/jruby/test_backtraces.rb
@@ -20,8 +20,10 @@ class TestBacktraces < Test::Unit::TestCase
   def test_native_java_backtrace
     # TestHelperException extends RuntimeException
     TestHelper.throwTestHelperException
+    fail 'did no raise exception'
   rescue NativeException => ex
     assert_equal '#<NativeException: org.jruby.test.TestHelper$TestHelperException: null>', ex.inspect
+    assert_equal 'org.jruby.test.TestHelper$TestHelperException: null', ex.message
     assert_not_nil ex.cause
     assert_instance_of org.jruby.test.TestHelper::TestHelperException, ex.cause
 
@@ -48,9 +50,28 @@ class TestBacktraces < Test::Unit::TestCase
     end
   end
 
+  def test_native_java_backtrace2
+    # TestHelperException extends RuntimeException
+    sample_class = Java::JavaClass.for_name('org.jruby.javasupport.test.name.Sample')
+    constructor = sample_class.constructor(Java::int)
+    constructor.new_instance 0
+    begin
+      constructor.new_instance -1
+      fail 'did no raise exception'
+    rescue NativeException => ex
+      assert_equal 'java.lang.IllegalStateException: param == -1', ex.message
+      assert_equal '#<NativeException: java.lang.IllegalStateException: param == -1>', ex.inspect
+      assert_instance_of java.lang.IllegalStateException, ex.cause
+      # NOTE: backtrace will be messed in this case as long as there's filtering
+      # clases org.jruby.javasupport.test.name.Sample "org.jruby.javasupport" prefix is considered internal
+      # ex.backtrace.each { |b| puts "  #{b.inspect}" }
+    end
+  end
+
   def test_java_backtrace
     # TestHelperException extends RuntimeException
     TestHelper.throwTestHelperException
+    fail 'did no raise exception'
   rescue java.lang.Exception => ex
     # assert_nil ex.message
 

--- a/test/jruby/test_backtraces.rb
+++ b/test/jruby/test_backtraces.rb
@@ -17,14 +17,56 @@ class TestBacktraces < Test::Unit::TestCase
 
   import org.jruby.test.TestHelper
 
-  def test_java_backtrace
+  def test_native_java_backtrace
+    # TestHelperException extends RuntimeException
     TestHelper.throwTestHelperException
   rescue NativeException => ex
-    backtrace = ex.backtrace.join("\r\n")
+    assert_equal '#<NativeException: org.jruby.test.TestHelper$TestHelperException: null>', ex.inspect
+    assert_not_nil ex.cause
+    assert_instance_of org.jruby.test.TestHelper::TestHelperException, ex.cause
 
-    if (!backtrace.include?("test_java_backtrace"))
+    # ex.backtrace.each { |b| puts b.inspect }
+
+    # starts with Java stack trace part :
+    _throwTestHelperException = /org.jruby.test.TestHelper\.java:\d+:in `throwTestHelperException'/
+    assert_match _throwTestHelperException, ex.backtrace[0]
+    java_trace = ex.backtrace.find_all do |trace|
+      trace =~ _throwTestHelperException
+    end
+    assert_equal 1, java_trace.length # only once!
+
+    _test_native_java_backtrace = /test\/jruby\/test_backtraces.rb:\d+:in `test_native_java_backtrace'/
+
+    ruby_trace = ex.backtrace.find_all do |trace|
+      trace =~ _test_native_java_backtrace
+    end
+    assert_equal 1, ruby_trace.length # only once!
+
+    backtrace = ex.backtrace.join("\r\n")
+    unless backtrace.include?('test_native_java_backtrace')
       flunk("test_java_backtrace not in backtrace")
     end
+  end
+
+  def test_java_backtrace
+    # TestHelperException extends RuntimeException
+    TestHelper.throwTestHelperException
+  rescue java.lang.Exception => ex
+    # assert_nil ex.message
+
+    # ex.backtrace.each { |b| puts b.inspect }
+
+    _throwTestHelperException = /org.jruby.test.TestHelper.throwTestHelperException/
+    assert_match _throwTestHelperException, ex.backtrace[0]
+    java_trace = ex.backtrace.find_all do |trace|
+      trace =~ _throwTestHelperException
+    end
+    assert_equal 1, java_trace.length # only once!
+
+    ruby_trace = ex.backtrace.find_all do |trace|
+      trace.index('test_java_backtrace') && trace =~ /test\/jruby\/test_backtraces.rb:\d+/
+    end
+    assert_equal 1, ruby_trace.length # only once!
   end
 
   def test_simple_exception_recursive

--- a/test/org/jruby/javasupport/test/name/Sample.java
+++ b/test/org/jruby/javasupport/test/name/Sample.java
@@ -1,3 +1,11 @@
 package org.jruby.javasupport.test.name;
 
-public class Sample { /* */ }
+public class Sample {
+    public Sample() { }
+
+    public Sample(int param) { // @see test_backtraces.rb
+        if (param == -1) {
+            throw new IllegalStateException("param == -1");
+        }
+    }
+}


### PR DESCRIPTION
wasn't able to find a test/spec or a reason why `RaiseException` did (for `NativeException`) : 
```
-    private static String buildMessage(Throwable exception) {
-        StringBuilder sb = new StringBuilder();
-        StringWriter stackTrace = new StringWriter();
-        exception.printStackTrace(new PrintWriter(stackTrace));
-
-        sb.append("Native Exception: '").append(exception.getClass()).append("'; ");
-        sb.append("Message: ").append(exception.getMessage()).append("; ");
-        sb.append("StackTrace: ").append(stackTrace.getBuffer());
-
-        return sb.toString();
-    }
```

**9.1** sounds like a good place to break away from that message building - which would actually only be seen very rarely (effectively almost never without hacks) even without the patch as `RaiseException` does re-set the `providedMessage` field in case of the `NativeException` constructor path.

another annoyance with `NativeException` is the `cause.stackTrace + backtrace` join-ing - which shouldn't be necessary at all ... for now I've kept it for cases where the trace heads do not point to the same location. that means 99% cases it won't show up. except when the head would be filtered away as a JRuby internal. there seem to have been some special `NativeException` filtering in place previously but with filtering going on elsewhere I did not want to filter twice esp as it seemed unnecessary.

tests on Java as well as Ruby side to cover functionality.

p.s. `RubyException` got a `getMessageAsJavaString` (would love to have been able to just change `getMessage` to return `String` :) which is used by `RaiseException` - this way at least for `NativeException` the **String -> RubyString -> String** message conversion can be avoided :tada: 