### PR TITLE
Enable AppVeyor tests on 64-bit Java on Windows as well.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ build: off
 
 environment:
   matrix:
+    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
     - JAVA_HOME: C:\Program Files (x86)\Java\jdk1.8.0
 
 install:


### PR DESCRIPTION
It was already enabled on the master branch, but not here.

Side note: Should we also add the ant MRI tests on master? I noted that it was only enabled in the jruby-1_7 branch, but not in the appveyor.yml on master.

(@enebo - I happened to see this after your comment in #3767)