### PR TITLE
improved method arities on become_java!

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -825,6 +825,10 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      */
     @Override
     public Object toJava(Class target) {
+        return defaultToJava(target);
+    }
+
+    final <T> T defaultToJava(Class<T> target) {
         // for callers that unconditionally pass null retval type (JRUBY-4737)
         if (target == void.class) return null;
 
@@ -838,7 +842,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
             if (target.isAssignableFrom(value.getClass())) {
                 getRuntime().getJavaSupport().getObjectProxyCache().put(value, this);
 
-                return value;
+                return (T) value;
             }
         }
         else if (JavaUtil.isDuckTypeConvertable(getClass(), target)) {
@@ -847,7 +851,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
             }
         }
         else if (target.isAssignableFrom(getClass())) {
-            return this;
+            return (T) this;
         }
 
         throw getRuntime().newTypeError("cannot convert instance of " + getClass() + " to " + target);

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -51,7 +51,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -928,7 +927,7 @@ public class RubyClass extends RubyModule {
     public IRubyObject initialize19(ThreadContext context, IRubyObject superObject, Block block) {
         checkNotInitialized();
         checkInheritable(superObject);
-        return initializeCommon(context, (RubyClass)superObject, block, true);
+        return initializeCommon(context, (RubyClass) superObject, block, true);
     }
 
     private IRubyObject initializeCommon(ThreadContext context, RubyClass superClazz, Block block, boolean ruby1_9 /*callInheritBeforeSuper*/) {
@@ -1640,10 +1639,10 @@ public class RubyClass extends RubyModule {
     }
 
     public synchronized void addParameterAnnotation(String method, int i, Class annoClass, Map<String,Object> value) {
-        if (parameterAnnotations == null) parameterAnnotations = new Hashtable<String,List<Map<Class,Map<String,Object>>>>();
+        if (parameterAnnotations == null) parameterAnnotations = new HashMap<>(8);
         List<Map<Class,Map<String,Object>>> paramList = parameterAnnotations.get(method);
         if (paramList == null) {
-            paramList = new ArrayList<Map<Class,Map<String,Object>>>(i + 1);
+            paramList = new ArrayList<>(i + 1);
             parameterAnnotations.put(method, paramList);
         }
         if (paramList.size() < i + 1) {
@@ -1654,8 +1653,7 @@ public class RubyClass extends RubyModule {
         if (annoClass != null && value != null) {
             Map<Class, Map<String, Object>> annos = paramList.get(i);
             if (annos == null) {
-                annos = new HashMap<Class, Map<String, Object>>();
-                paramList.set(i, annos);
+                paramList.set(i, annos = new LinkedHashMap<>(4));
             }
             annos.put(annoClass, value);
         } else {
@@ -1676,24 +1674,22 @@ public class RubyClass extends RubyModule {
     }
 
     public synchronized void addMethodAnnotation(String methodName, Class annotation, Map fields) {
-        if (methodAnnotations == null) methodAnnotations = new Hashtable<String,Map<Class,Map<String,Object>>>();
+        if (methodAnnotations == null) methodAnnotations = new HashMap<>(8);
 
         Map<Class,Map<String,Object>> annos = methodAnnotations.get(methodName);
         if (annos == null) {
-            annos = new Hashtable<Class,Map<String,Object>>();
-            methodAnnotations.put(methodName, annos);
+            methodAnnotations.put(methodName, annos = new LinkedHashMap<>(4));
         }
 
         annos.put(annotation, fields);
     }
 
     public synchronized void addFieldAnnotation(String fieldName, Class annotation, Map fields) {
-        if (fieldAnnotations == null) fieldAnnotations = new Hashtable<String,Map<Class,Map<String,Object>>>();
+        if (fieldAnnotations == null) fieldAnnotations = new HashMap<>(8);
 
         Map<Class,Map<String,Object>> annos = fieldAnnotations.get(fieldName);
         if (annos == null) {
-            annos = new Hashtable<Class,Map<String,Object>>();
-            fieldAnnotations.put(fieldName, annos);
+            fieldAnnotations.put(fieldName, annos = new LinkedHashMap<>(4));
         }
 
         annos.put(annotation, fields);
@@ -1713,13 +1709,13 @@ public class RubyClass extends RubyModule {
     }
 
     public synchronized void addMethodSignature(String methodName, Class[] types) {
-        if (methodSignatures == null) methodSignatures = new Hashtable<String,Class[]>();
+        if (methodSignatures == null) methodSignatures = new HashMap<>(16);
 
         methodSignatures.put(methodName, types);
     }
 
     public synchronized void addFieldSignature(String fieldName, Class type) {
-        if (fieldSignatures == null) fieldSignatures = new LinkedHashMap<String, Class>();
+        if (fieldSignatures == null) fieldSignatures = new LinkedHashMap<>(8);
 
         fieldSignatures.put(fieldName, type);
     }
@@ -1731,7 +1727,7 @@ public class RubyClass extends RubyModule {
     }
 
     public synchronized void addClassAnnotation(Class annotation, Map fields) {
-        if (classAnnotations == null) classAnnotations = new Hashtable<Class,Map<String,Object>>();
+        if (classAnnotations == null) classAnnotations = new LinkedHashMap<>(4);
 
         classAnnotations.put(annotation, fields);
     }

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -810,23 +810,22 @@ public class RubyClass extends RubyModule {
 
     private void dumpReifiedClass(String dumpDir, String javaPath, byte[] classBytes) {
         if (dumpDir != null) {
-            if (dumpDir.equals("")) {
-                dumpDir = ".";
-            }
+            if (dumpDir.length() == 0) dumpDir = ".";
+
             java.io.FileOutputStream classStream = null;
             try {
                 java.io.File classFile = new java.io.File(dumpDir, javaPath + ".class");
                 classFile.getParentFile().mkdirs();
                 classStream = new java.io.FileOutputStream(classFile);
                 classStream.write(classBytes);
-            } catch (IOException io) {
+            }
+            catch (IOException io) {
                 getRuntime().getWarnings().warn("unable to dump class file: " + io.getMessage());
-            } finally {
+            }
+            finally {
                 if (classStream != null) {
-                    try {
-                        classStream.close();
-                    } catch (IOException ignored) {
-                    }
+                    try { classStream.close(); }
+                    catch (IOException ignored) { /* no-op */ }
                 }
             }
         }
@@ -1289,44 +1288,27 @@ public class RubyClass extends RubyModule {
         // re-check reifiable in case another reify call has jumped in ahead of us
         if (!isReifiable()) return;
 
-        Class reifiedParent = RubyObject.class;
-
         // calculate an appropriate name, using "Anonymous####" if none is present
-        String name;
-        if (getBaseName() == null) {
-            name = "AnonymousRubyClass__" + id;
-        } else {
-            name = getName();
-        }
+        final String name = getBaseName() != null ? getName() : ("AnonymousRubyClass__" + id);
 
-        String javaName = "rubyobj." + name.replaceAll("::", ".");
-        String javaPath = "rubyobj/" + name.replaceAll("::", "/");
-        ClassDefiningClassLoader parentCL;
-        Class parentReified = superClass.getRealClass().getReifiedClass();
+        final String javaName = "rubyobj." + name.replaceAll("::", ".");
+        final String javaPath = "rubyobj/" + name.replaceAll("::", "/");
+
+        final Class parentReified = superClass.getRealClass().getReifiedClass();
         if (parentReified == null) {
             throw getClassRuntime().newTypeError("class " + getName() + " parent class is not yet reified");
         }
 
-        if (parentReified.getClassLoader() instanceof OneShotClassLoader) {
-            parentCL = (OneShotClassLoader)superClass.getRealClass().getReifiedClass().getClassLoader();
-        } else {
-            if (useChildLoader) {
-                parentCL = new OneShotClassLoader(runtime.getJRubyClassLoader());
-            } else {
-                parentCL = runtime.getJRubyClassLoader();
-            }
-        }
+        Class reifiedParent = RubyObject.class;
 
         if (superClass.reifiedClass != null) {
             reifiedParent = superClass.reifiedClass;
         }
 
-        Class[] interfaces = Java.getInterfacesFromRubyClass(this);
-        String[] interfaceNames = new String[interfaces.length + 1];
-
+        final Class[] interfaces = Java.getInterfacesFromRubyClass(this);
+        final String[] interfaceNames = new String[interfaces.length + 1];
         // mark this as a Reified class
         interfaceNames[0] = p(Reified.class);
-
         // add the other user-specified interfaces
         for (int i = 0; i < interfaces.length; i++) {
             interfaceNames[i + 1] = p(interfaces[i]);
@@ -1387,9 +1369,7 @@ public class RubyClass extends RubyModule {
 
             FieldVisitor fieldVisitor = cw.visitField(ACC_PUBLIC, fieldName, ci(type), null, null);
 
-            if (fieldAnnos == null) {
-              continue;
-            }
+            if (fieldAnnos == null) continue;
 
             for (Map.Entry<Class, Map<String, Object>> fieldAnno : fieldAnnos.entrySet()) {
                 Class annoType = fieldAnno.getKey();
@@ -1400,11 +1380,11 @@ public class RubyClass extends RubyModule {
         }
 
         // gather a list of instance methods, so we don't accidentally make static ones that conflict
-        Set<String> instanceMethods = new HashSet<String>();
+        final Set<String> instanceMethods = new HashSet<String>(getMethods().size());
 
         // define instance methods
         for (Map.Entry<String,DynamicMethod> methodEntry : getMethods().entrySet()) {
-            String methodName = methodEntry.getKey();
+            final String methodName = methodEntry.getKey();
 
             if (!JavaNameMangler.willMethodMangleOk(methodName)) continue;
 
@@ -1444,14 +1424,8 @@ public class RubyClass extends RubyModule {
                 // indices for temp values
                 Class[] params = new Class[methodSignature.length - 1];
                 System.arraycopy(methodSignature, 1, params, 0, params.length);
-                int baseIndex = 1;
-                for (Class paramType : params) {
-                    if (paramType == double.class || paramType == long.class) {
-                        baseIndex += 2;
-                    } else {
-                        baseIndex += 1;
-                    }
-                }
+                final int baseIndex = RealClassGenerator.calcBaseIndex(params, 1);
+
                 int rubyIndex = baseIndex;
 
                 signature = sig(methodSignature[0], params);
@@ -1521,14 +1495,7 @@ public class RubyClass extends RubyModule {
                 // indices for temp values
                 Class[] params = new Class[methodSignature.length - 1];
                 System.arraycopy(methodSignature, 1, params, 0, params.length);
-                int baseIndex = 0;
-                for (Class paramType : params) {
-                    if (paramType == double.class || paramType == long.class) {
-                        baseIndex += 2;
-                    } else {
-                        baseIndex += 1;
-                    }
-                }
+                final int baseIndex = RealClassGenerator.calcBaseIndex(params, 0);
                 int rubyIndex = baseIndex;
 
                 signature = sig(methodSignature[0], params);
@@ -1555,16 +1522,24 @@ public class RubyClass extends RubyModule {
 
 
         cw.visitEnd();
-        byte[] classBytes = cw.toByteArray();
 
-
-
+        final ClassDefiningClassLoader parentCL;
+        if (parentReified.getClassLoader() instanceof OneShotClassLoader) {
+            parentCL = (OneShotClassLoader) parentReified.getClassLoader();
+        } else {
+            if (useChildLoader) {
+                parentCL = new OneShotClassLoader(runtime.getJRubyClassLoader());
+            } else {
+                parentCL = runtime.getJRubyClassLoader();
+            }
+        }
         // Attempt to load the name we plan to use; skip reification if it exists already (see #1229).
-        Throwable failure = null;
         try {
+            final byte[] classBytes = cw.toByteArray();
             Class result = parentCL.defineClass(javaName, classBytes);
             dumpReifiedClass(classDumpDir, javaPath, classBytes);
 
+            @SuppressWarnings("unchecked")
             java.lang.reflect.Method clinit = result.getDeclaredMethod("clinit", Ruby.class, RubyClass.class);
             clinit.invoke(null, runtime, this);
 
@@ -1572,19 +1547,22 @@ public class RubyClass extends RubyModule {
             reifiedClass = result;
 
             return; // success
-        } catch (LinkageError le) {
-            // fall through to failure path
-            failure = le;
-        } catch (Exception e) {
-            failure = e;
+        }
+        catch (LinkageError error) { // fall through to failure path
+            final String msg = error.getMessage();
+            if ( msg != null && msg.contains("duplicate class definition for name") ) {
+                logReifyException(error, false);
+            }
+            else {
+                logReifyException(error, true);
+            }
+        }
+        catch (Exception ex) {
+            logReifyException(ex, true);
         }
 
         // If we get here, there's some other class in this classloader hierarchy with the same name. In order to
         // avoid a naming conflict, we set reified class to parent and skip reification.
-        if (RubyInstanceConfig.REIFY_LOG_ERRORS) {
-            LOG.error("failed to reify class " + getName() + " due to:");
-            LOG.error(failure);
-        }
 
         if (superClass.reifiedClass != null) {
             reifiedClass = superClass.reifiedClass;
@@ -1592,8 +1570,16 @@ public class RubyClass extends RubyModule {
         }
     }
 
-    public void setReifiedClass(Class<? extends IRubyObject> newReifiedClass) {
-        this.reifiedClass = newReifiedClass;
+    private void logReifyException(final Throwable failure, final boolean error) {
+        if (RubyInstanceConfig.REIFY_LOG_ERRORS) {
+            final String msg = "failed to reify class " + getName() + " due to: ";
+            if ( error ) LOG.error(msg, failure);
+            else LOG.info(msg, failure);
+        }
+    }
+
+    public void setReifiedClass(Class<? extends IRubyObject> reifiedClass) {
+        this.reifiedClass = reifiedClass;
     }
 
     public Class<? extends IRubyObject> getReifiedClass() {

--- a/core/src/main/java/org/jruby/java/codegen/RealClassGenerator.java
+++ b/core/src/main/java/org/jruby/java/codegen/RealClassGenerator.java
@@ -187,14 +187,7 @@ public abstract class RealClassGenerator {
                         implementedNames.add(fullName);
 
                         // indices for temp values
-                        int baseIndex = 1;
-                        for (Class paramType : paramTypes) {
-                            if (paramType == double.class || paramType == long.class) {
-                                baseIndex += 2;
-                            } else {
-                                baseIndex += 1;
-                            }
-                        }
+                        final int baseIndex = calcBaseIndex(paramTypes, 1);
 
                         SkinnyMethodAdapter mv = new SkinnyMethodAdapter(
                                 cw, ACC_PUBLIC, simpleName, sig(returnType, paramTypes), null, null);
@@ -414,14 +407,7 @@ public abstract class RealClassGenerator {
                 implementedNames.add(fullName);
 
                 // indices for temp values
-                int baseIndex = 1;
-                for (Class paramType : paramTypes) {
-                    if (paramType == double.class || paramType == long.class) {
-                        baseIndex += 2;
-                    } else {
-                        baseIndex += 1;
-                    }
-                }
+                final int baseIndex = calcBaseIndex(paramTypes, 1);
 
                 SkinnyMethodAdapter mv = new SkinnyMethodAdapter(
                         cw, ACC_PUBLIC, simpleName, sig(returnType, paramTypes), null, null);
@@ -782,4 +768,16 @@ public abstract class RealClassGenerator {
     public static boolean isCacheOk(CacheEntry entry, IRubyObject self) {
         return CacheEntry.typeOk(entry, self.getMetaClass()) && entry.method != UndefinedMethod.INSTANCE;
     }
+
+    public static int calcBaseIndex(final Class[] params, int baseIndex) {
+        for (Class paramType : params) {
+            if (paramType == double.class || paramType == long.class) {
+                baseIndex += 2;
+            } else {
+                baseIndex += 1;
+            }
+        }
+        return baseIndex;
+    }
+
 }

--- a/spec/java_integration/fixtures/Reflector.java
+++ b/spec/java_integration/fixtures/Reflector.java
@@ -1,0 +1,92 @@
+package java_integration.fixtures;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Array;
+import java.util.Collection;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public abstract class Reflector {
+
+    public static Object invoke(final Object obj, final Method method) throws Exception {
+        if ( method.isVarArgs() ) {
+            final Class type = method.getParameterTypes()[0].getComponentType();
+            Object array = Array.newInstance(type, 0);
+            return method.invoke(obj, array);
+        }
+        return method.invoke(obj);
+    }
+
+    public static Object invoke(final Object obj, final Method method, Object arg) throws Exception {
+        if ( method.isVarArgs() && ! arg.getClass().isArray() ) {
+            final Class type = method.getParameterTypes()[0].getComponentType();
+            Object[] array = (Object[]) Array.newInstance(type, 1);
+            array[0] = arg;
+            return method.invoke(obj, (Object) array);
+        }
+        return method.invoke(obj, arg);
+    }
+
+    public static Object invoke(final Object obj, final Class klass, final String method) throws Exception {
+        Method instanceMethod = klass.getMethod(method, (Class[]) null);
+        return instanceMethod.invoke(obj, (Object[]) null);
+    }
+
+    public static Object invoke(final Object obj, final String method) throws Exception {
+        return invoke(obj, obj.getClass(), method);
+    }
+
+    public static Object invokeMatch(final Object obj, final String method, final Object... args) throws Exception {
+        final Method[] methods = obj.getClass().getMethods();
+        ArrayList<Method> matchedMethods = new ArrayList<Method>();
+        for ( Method m : methods ) {
+            if ( method.equals(m.getName()) ) {
+                if ( m.isVarArgs() ) matchedMethods.add(m);
+                else {
+                    if (m.getParameterTypes().length == args.length) {
+                        matchedMethods.add(m);
+                    }
+                }
+            }
+        }
+        if ( matchedMethods.isEmpty() ) {
+            throw new IllegalArgumentException("no methods of name " + method + " matched in " + obj.getClass());
+        }
+        if ( matchedMethods.size() > 1 ) {
+            throw new IllegalArgumentException("multiple methods matched for name " + method + " and arguments " + Arrays.toString(args));
+        }
+        return matchedMethods.get(0).invoke(obj, args);
+    }
+
+    public static Method resolveMethod(final Object obj, final String method, final Class... types) throws Exception {
+        final Method[] methods = obj.getClass().getMethods();
+        ArrayList<Method> matchedMethods = new ArrayList<Method>();
+        for ( Method m : methods ) {
+            if ( method.equals(m.getName()) ) {
+                if ( Arrays.equals(m.getParameterTypes(), types) ) {
+                    matchedMethods.add(m);
+                }
+            }
+        }
+        if ( matchedMethods.isEmpty() ) {
+            throw new IllegalArgumentException("no methods of name " + method + " matched in " + obj.getClass());
+        }
+        if ( matchedMethods.size() > 1 ) {
+            throw new IllegalArgumentException("multiple methods matched for name " + method + " and param types " + Arrays.toString(types));
+        }
+        return matchedMethods.get(0);
+    }
+
+    public static Collection<Method> findMethods(final Object obj, final String method) throws Exception {
+        final Method[] methods = obj.getClass().getMethods();
+        ArrayList<Method> matchedMethods = new ArrayList<Method>();
+        for ( Method m : methods ) {
+            if ( method.equals(m.getName()) ) {
+                matchedMethods.add(m);
+            }
+        }
+        return matchedMethods;
+    }
+
+}
+

--- a/spec/java_integration/types/coercion_spec.rb
+++ b/spec/java_integration/types/coercion_spec.rb
@@ -728,15 +728,17 @@ describe "Class\#to_java" do
       end
     end
 
-    it "provides nearest reified class for unreified user classes" do
-      rubycls = Class.new
-      expect(rubycls.to_java(cls)).to eq(cls.forName('org.jruby.RubyObject'));
+    class UserKlass < Object; end
+
+    it "reifies user class on-demand" do
+      expect(klass = UserKlass.to_java(cls)).to be_a java.lang.Class
+      expect( klass.getSuperclass ).to be cls.forName('org.jruby.RubyObject')
     end
 
     it "returns reified class for reified used classes" do
       rubycls = Class.new; require 'jruby/core_ext'
       rubycls.become_java!
-      expect(rubycls.to_java(cls)).to eq(JRuby.reference(rubycls).reified_class)
+      expect(rubycls.to_java(cls)).to be JRuby.reference(rubycls).getReifiedClass
     end
 
     it "converts Java proxy classes to their JavaClass/java.lang.Class equivalent" do

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -2,7 +2,6 @@ require 'java'
 require 'rbconfig'
 require 'test/unit'
 require 'test/jruby/test_helper'
-require 'jruby/core_ext'
 
 TopLevelConstantExistsProc = Proc.new do
   java_import 'java.lang.String'
@@ -28,6 +27,7 @@ class TestHigherJavasupport < Test::Unit::TestCase
 
   class JRUBY5564; end
   def test_reified_class_in_jruby_class_loader
+    require 'jruby/core_ext'
     a_class = JRUBY5564.become_java!(false)
 
     # load the java class from the classloader

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -39,6 +39,21 @@ class TestHigherJavasupport < Test::Unit::TestCase
     end
   end
 
+  class Klass1 < Object
+    def method1(arg); arg end
+  end
+  class Klass2 < Klass1
+    def self.method2; end
+  end
+
+  def test_passing_a_java_class_auto_reifies
+    assert_nil Klass2.to_java.getReifiedClass
+    # previously TestHelper.getClassName(Klass2) returned 'org.jruby.RubyObject'
+    assert_equal 'rubyobj.TestHigherJavasupport.Klass2', TestHelper.getClassName(Klass2)
+    assert_not_nil Klass2.to_java.getReifiedClass
+    assert_not_nil Klass1.to_java.getReifiedClass
+  end
+
   def test_java_passing_class
     assert_equal("java.util.ArrayList", TestHelper.getClassName(ArrayList))
   end


### PR DESCRIPTION
just in time for 9.1 as this might be considered a "breaking" change at the binary (Java reflective) level.

the change is pretty much explained in the commit message: 2f363d0766417c1decc4045add9e5c80242c8a13

> previously all method arities ended up as var-args : `foo(IRubyObject[] args)`
>
> now for fixed arities we'll have correct number of args e.g. `foo(IRubyObject arg1)`
> ... we still generate var-args: `foo(IRubyObject[] args)` for all non-fixed arity sizes!

most users, of Ruby user-types entering Java land, complained about the previous behaviour - so this is a welcoming change. Ruby fixed arities will now be much more intuitive on the Java side.

// cc @Lan5432 
... if you're interested you could confirm whether this resolves some/all of the related issues :

- fixes https://github.com/jruby/jruby/issues/3206
- fixes https://github.com/jruby/jruby/issues/3454
- NOT ~~https://github.com/jruby/jruby/issues/449~~
- https://github.com/jruby/jruby/issues/3366