### PR TITLE
[Truffle] Discussion: introducing first-class Array strategies

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/core/array/ArrayAppendOneNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/array/ArrayAppendOneNode.java
@@ -36,65 +36,22 @@ public abstract class ArrayAppendOneNode extends RubyNode {
 
     // Append into an empty array
 
-    @Specialization(guards = "isNullArray(array)")
-    public DynamicObject appendOneEmpty(DynamicObject array, int value) {
-        Layouts.ARRAY.setStore(array, new int[]{value});
-        Layouts.ARRAY.setSize(array, 1);
-        return array;
-    }
-
-    @Specialization(guards = "isNullArray(array)")
-    public DynamicObject appendOneEmpty(DynamicObject array, long value) {
-        Layouts.ARRAY.setStore(array, new long[]{value});
-        Layouts.ARRAY.setSize(array, 1);
-        return array;
-    }
-
-    @Specialization(guards = "isNullArray(array)")
-    public DynamicObject appendOneEmpty(DynamicObject array, double value) {
-        Layouts.ARRAY.setStore(array, new double[]{value});
-        Layouts.ARRAY.setSize(array, 1);
-        return array;
-    }
-
-    @Specialization(guards = "isNullArray(array)")
-    public DynamicObject appendOneEmpty(DynamicObject array, Object value) {
-        Layouts.ARRAY.setStore(array, new Object[]{value});
+    @Specialization(guards = { "isNullArray(array)", "strategy.accepts(value)" }, limit = "ARRAY_STRATEGIES")
+    public DynamicObject appendOneEmpty(DynamicObject array, Object value,
+            @Cached("forValue(value)") ArrayStrategy strategy) {
+        Layouts.ARRAY.setStore(array, strategy.newArrayWith(value));
         Layouts.ARRAY.setSize(array, 1);
         return array;
     }
 
     // Append of the correct type
 
-    @Specialization(guards = "isIntArray(array)")
-    public DynamicObject appendOneSameType(DynamicObject array, int value,
-                                   @Cached("createBinaryProfile()") ConditionProfile extendProfile) {
-        appendOneSameTypeGeneric(array, ArrayReflector.reflect((int[]) Layouts.ARRAY.getStore(array)), value, extendProfile);
-        return array;
-    }
-
-    @Specialization(guards = "isLongArray(array)")
-    public DynamicObject appendOneSameType(DynamicObject array, long value,
-                                @Cached("createBinaryProfile()") ConditionProfile extendProfile) {
-        appendOneSameTypeGeneric(array, ArrayReflector.reflect((long[]) Layouts.ARRAY.getStore(array)), value, extendProfile);
-        return array;
-    }
-
-    @Specialization(guards = "isDoubleArray(array)")
-    public DynamicObject appendOneSameType(DynamicObject array, double value,
-                                @Cached("createBinaryProfile()") ConditionProfile extendProfile) {
-        appendOneSameTypeGeneric(array, ArrayReflector.reflect((double[]) Layouts.ARRAY.getStore(array)), value, extendProfile);
-        return array;
-    }
-
-    @Specialization(guards = "isObjectArray(array)")
+    // TODO (long[] << int) case
+    @Specialization(guards = { "strategy.matches(array)", "strategy.accepts(value)" }, limit = "ARRAY_STRATEGIES")
     public DynamicObject appendOneSameType(DynamicObject array, Object value,
-                                  @Cached("createBinaryProfile()") ConditionProfile extendProfile) {
-        appendOneSameTypeGeneric(array, ArrayReflector.reflect((Object[]) Layouts.ARRAY.getStore(array)), value, extendProfile);
-        return array;
-    }
-
-    public void appendOneSameTypeGeneric(DynamicObject array, ArrayMirror storeMirror, Object value, ConditionProfile extendProfile) {
+            @Cached("of(array)") ArrayStrategy strategy,
+            @Cached("createBinaryProfile()") ConditionProfile extendProfile) {
+        final ArrayMirror storeMirror = strategy.newMirror(array);
         final int oldSize = Layouts.ARRAY.getSize(array);
         final int newSize = oldSize + 1;
 
@@ -107,6 +64,7 @@ public abstract class ArrayAppendOneNode extends RubyNode {
             storeMirror.set(oldSize, value);
             Layouts.ARRAY.setSize(array, newSize);
         }
+        return array;
     }
 
     // Append forcing a generalization from int[] to long[]

--- a/truffle/src/main/java/org/jruby/truffle/core/array/ArrayGuards.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/array/ArrayGuards.java
@@ -15,6 +15,8 @@ import org.jruby.truffle.language.RubyGuards;
 
 public class ArrayGuards {
 
+    public static final int ARRAY_STRATEGIES = 4; // int[], long[], double[], Object[]
+
     // Storage strategies
 
     public static boolean isNullArray(DynamicObject array) {

--- a/truffle/src/main/java/org/jruby/truffle/core/array/ArrayStrategy.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/array/ArrayStrategy.java
@@ -1,0 +1,178 @@
+package org.jruby.truffle.core.array;
+
+import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.object.DynamicObject;
+import org.jruby.truffle.core.Layouts;
+
+public abstract class ArrayStrategy {
+
+    public static ArrayStrategy of(DynamicObject array) {
+        CompilerAsserts.neverPartOfCompilation();
+        if (ArrayGuards.isIntArray(array)) {
+            return IntArrayStrategy.INSTANCE;
+        } else if (ArrayGuards.isLongArray(array)) {
+            return LongArrayStrategy.INSTANCE;
+        } else if (ArrayGuards.isDoubleArray(array)) {
+            return DoubleArrayStrategy.INSTANCE;
+        } else if (ArrayGuards.isObjectArray(array)) {
+            return ObjectArrayStrategy.INSTANCE;
+        } else {
+            return NullArrayStrategy.INSTANCE;
+            // throw new UnsupportedOperationException();
+        }
+    }
+
+    public static ArrayStrategy forValue(Object value) {
+        CompilerAsserts.neverPartOfCompilation();
+        if (value instanceof Integer) {
+            return IntArrayStrategy.INSTANCE;
+        } else if (value instanceof Long) {
+            return LongArrayStrategy.INSTANCE;
+        } else if (value instanceof Double) {
+            return DoubleArrayStrategy.INSTANCE;
+        } else {
+            return ObjectArrayStrategy.INSTANCE;
+        }
+    }
+
+    private static class IntArrayStrategy extends ArrayStrategy {
+
+        static final ArrayStrategy INSTANCE = new IntArrayStrategy();
+
+        public ArrayMirror newArray(int size) {
+            return new IntegerArrayMirror(new int[size]);
+        }
+
+        public Object newArrayWith(Object value) {
+            return new int[] { (int) value };
+        }
+
+        public ArrayMirror newMirror(DynamicObject array) {
+            return new IntegerArrayMirror((int[]) Layouts.ARRAY.getStore(array));
+        }
+
+        public boolean accepts(Object value) {
+            return value instanceof Integer;
+        }
+
+        public boolean matches(DynamicObject array) {
+            return ArrayGuards.isIntArray(array);
+        }
+
+    }
+
+    private static class LongArrayStrategy extends ArrayStrategy {
+
+        static final ArrayStrategy INSTANCE = new LongArrayStrategy();
+
+        public ArrayMirror newArray(int size) {
+            return new LongArrayMirror(new long[size]);
+        }
+
+        public Object newArrayWith(Object value) {
+            return new long[] { (long) value };
+        }
+
+        public ArrayMirror newMirror(DynamicObject array) {
+            return new LongArrayMirror((long[]) Layouts.ARRAY.getStore(array));
+        }
+
+        public boolean accepts(Object value) {
+            return value instanceof Long;
+        }
+
+        public boolean matches(DynamicObject array) {
+            return ArrayGuards.isLongArray(array);
+        }
+
+    }
+
+    private static class DoubleArrayStrategy extends ArrayStrategy {
+
+        static final ArrayStrategy INSTANCE = new DoubleArrayStrategy();
+
+        public ArrayMirror newArray(int size) {
+            return new DoubleArrayMirror(new double[size]);
+        }
+
+        public Object newArrayWith(Object value) {
+            return new double[] { (double) value };
+        }
+
+        public ArrayMirror newMirror(DynamicObject array) {
+            return new DoubleArrayMirror((double[]) Layouts.ARRAY.getStore(array));
+        }
+
+        public boolean accepts(Object value) {
+            return value instanceof Double;
+        }
+
+        public boolean matches(DynamicObject array) {
+            return ArrayGuards.isDoubleArray(array);
+        }
+
+    }
+
+    private static class ObjectArrayStrategy extends ArrayStrategy {
+
+        static final ArrayStrategy INSTANCE = new ObjectArrayStrategy();
+
+        public ArrayMirror newArray(int size) {
+            return new ObjectArrayMirror(new Object[size]);
+        }
+
+        public Object newArrayWith(Object value) {
+            return new Object[] { value };
+        }
+
+        public ArrayMirror newMirror(DynamicObject array) {
+            return new ObjectArrayMirror((Object[]) Layouts.ARRAY.getStore(array));
+        }
+
+        public boolean accepts(Object value) {
+            return true;
+        }
+
+        public boolean matches(DynamicObject array) {
+            return ArrayGuards.isObjectArray(array);
+        }
+
+    }
+
+    private static class NullArrayStrategy extends ArrayStrategy {
+
+        static final ArrayStrategy INSTANCE = new NullArrayStrategy();
+
+        public ArrayMirror newArray(int size) {
+            throw new UnsupportedOperationException();
+        }
+
+        public Object newArrayWith(Object value) {
+            throw new UnsupportedOperationException();
+        }
+
+        public ArrayMirror newMirror(DynamicObject array) {
+            throw new UnsupportedOperationException();
+        }
+
+        public boolean accepts(Object value) {
+            return false;
+        }
+
+        public boolean matches(DynamicObject array) {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+
+    public abstract ArrayMirror newArray(int size);
+
+    public abstract Object newArrayWith(Object value);
+
+    public abstract ArrayMirror newMirror(DynamicObject array);
+
+    public abstract boolean accepts(Object value);
+
+    public abstract boolean matches(DynamicObject array);
+
+}


### PR DESCRIPTION
@chrisseaton @nirvdrum @pitr-ch I am thinking to use `ArrayStrategy` objects for our strategies on Array to reduces the number of specialization and duplication by 4.
This is only a preview to get some feedback (do not merge).
What do you think?
Is it nice / too complex / not that helpful?

This is maybe slightly overlapping with ArrayMirror, although ArrayMirror is really about helpers for Java arrays, and this is really about the storage strategies for our Ruby Arrays.
In the current version, an ArrayStrategy can build an ArrayMirror easily so there is no conflict of features. There are only 5 ArrayStrategy which are singleton instances, so this also avoids potential allocation in the interpreter.

An alternative solution would be to have one node per "functionality" of Array, like "get at index", "set at index", "grow", "delete/shrink", etc. This already exists to some extent but it's underused because it's quite verbose, there would be many many features like that for Ruby Array and it's not obvious to identify them either while still keeping the performance.