### PR TITLE
Truffle cext sketch

### DIFF
--- a/bin/jruby-cext-c
+++ b/bin/jruby-cext-c
@@ -51,7 +51,7 @@ LL = []
 
 SRC.each do |src|
   ll = File.join(File.dirname(src), File.basename(src, '.*') + '.ll')
-  mx 'su-clang', '-Ilib/ruby/truffle/cext', '-S', '-emit-llvm', src, '-o', ll
+  mx 'su-clang', "-I#{SULONG_DIR}/include", '-Ilib/ruby/truffle/cext', '-S', '-emit-llvm', src, '-o', ll
   LL.push ll
 end
 

--- a/lib/ruby/truffle/cext/ruby.h
+++ b/lib/ruby/truffle/cext/ruby.h
@@ -26,15 +26,25 @@ extern "C" {
 typedef void *ID;
 typedef void *VALUE;
 
-extern VALUE Qfalse;
-extern VALUE Qtrue;
-extern VALUE Qnil;
+VALUE get_Qfalse();
+VALUE get_Qtrue();
+VALUE get_Qnil();
 
-extern VALUE rb_cObject;
-extern VALUE rb_cArray;
-extern VALUE rb_cHash;
+#define Qfalse get_Qfalse()
+#define Qtrue get_Qtrue()
+#define Qnil get_Qnil()
 
-extern VALUE rb_eRuntimeError;
+VALUE get_rb_cObject();
+VALUE get_rb_cArray();
+VALUE get_rb_cHash();
+
+#define rb_cObject get_rb_cObject()
+#define rb_cArray get_rb_cArray()
+#define rb_cHash get_rb_cHash()
+
+VALUE get_rb_eRuntimeError();
+
+#define rb_eRuntimeError get_rb_eRuntimeError();
 
 int NUM2INT(VALUE value);
 unsigned int NUM2UINT(VALUE value);
@@ -53,14 +63,14 @@ VALUE LONG2FIX(long value);
 
 int FIXNUM_P(VALUE value);
 
-char* RSTRING_PTR(VALUE string);
+char *RSTRING_PTR(VALUE string);
 int RSTRING_LEN(VALUE string);
 ID rb_intern(const char *string);
 VALUE rb_intern_str(VALUE string);
 void rb_str_cat(VALUE string, char *to_concat, long length);
 
 int RARRAY_LEN(VALUE array);
-VALUE* RARRAY_PTR(VALUE array);
+VALUE *RARRAY_PTR(VALUE array);
 VALUE rb_ary_new_capa(long capacity);
 VALUE rb_ary_new2();
 VALUE rb_ary_new();
@@ -71,9 +81,9 @@ VALUE rb_ary_entry(VALUE array, long index);
 VALUE rb_hash_aref(VALUE hash, VALUE key);
 void rb_hash_aset(VALUE hash, VALUE key, VALUE value);
 
-void rb_scan_args(int, VALUE*, char *, ...);
+void rb_scan_args(int argc, VALUE *argv, char *format, ...);
 
-VALUE rb_funcall(VALUE object, ID, int, ...);
+VALUE rb_funcall(VALUE object, ID name, int argc, ...);
 
 VALUE rb_iv_get(VALUE object, const char *name);
 VALUE rb_iv_set(VALUE object, const char *name, VALUE value);

--- a/truffle/src/main/c/cext/.jruby-cext-build.yml
+++ b/truffle/src/main/c/cext/.jruby-cext-build.yml
@@ -1,0 +1,2 @@
+src: ./*.c
+out: ruby.su

--- a/truffle/src/main/c/cext/ruby.c
+++ b/truffle/src/main/c/cext/ruby.c
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 1.0
+ * GNU General Public License version 2
+ * GNU Lesser General Public License version 2.1
+ */
+
+#include <truffle.h>
+
+#include <ruby.h>
+
+static void *ruby_cext;
+
+__attribute__((constructor))
+void truffle_ruby_load() {
+  ruby_cext = truffle_import("ruby_cext");
+}
+
+VALUE get_Qfalse() {
+  return (VALUE) truffle_read(ruby_cext, "qfalse");
+}
+
+VALUE get_Qtrue() {
+  return (VALUE) truffle_read(ruby_cext, "qtrue");
+}
+
+VALUE get_Qnil() {
+  return (VALUE) truffle_read(ruby_cext, "qnil");
+}
+
+VALUE get_rb_cObject() {
+  return (VALUE) truffle_read(ruby_cext, "object");
+}
+
+VALUE get_rb_cArray() {
+  return (VALUE) truffle_read(ruby_cext, "array");
+}
+
+VALUE get_rb_cHash() {
+  return (VALUE) truffle_read(ruby_cext, "hash");
+}
+
+VALUE get_rb_eRuntimeError() {
+  return (VALUE) truffle_read(ruby_cext, "runtime_error");
+}
+
+int NUM2INT(VALUE value) {
+  return *((int*) truffle_invoke(ruby_cext, "num2int", value));
+}
+
+unsigned int NUM2UINT(VALUE value) {
+  return *((unsigned int*) truffle_invoke(ruby_cext, "num2uint", value));
+}
+
+long NUM2LONG(VALUE value) {
+  return *((long*) truffle_invoke(ruby_cext, "num2long", value));
+}
+
+int FIX2INT(VALUE value) {
+  return *((int*) truffle_invoke(ruby_cext, "fix2int", value));
+}
+
+unsigned int FIX2UINT(VALUE value) {
+  return *((unsigned int*) truffle_invoke(ruby_cext, "fix2uint", value));
+}
+
+long FIX2LONG(VALUE value) {
+  return *((long*) truffle_invoke(ruby_cext, "fix2long", value));
+}
+
+VALUE INT2NUM(int value) {
+  return (VALUE) truffle_invoke(ruby_cext, "int2num", value);
+}
+
+VALUE INT2FIX(int value) {
+  return (VALUE) truffle_invoke(ruby_cext, "int2fix", value);
+}
+
+VALUE UINT2NUM(unsigned int value) {
+  return (VALUE) truffle_invoke(ruby_cext, "uint2num", value);
+}
+
+VALUE LONG2NUM(long value) {
+  return (VALUE) truffle_invoke(ruby_cext, "long2num", value);
+}
+
+VALUE LONG2FIX(long value) {
+  return (VALUE) truffle_invoke(ruby_cext, "long2fix", value);
+}
+
+int FIXNUM_P(VALUE value) {
+  return *((int*) truffle_invoke(ruby_cext, "fixnum?", value));
+}
+
+char *RSTRING_PTR(VALUE string) {
+  // Needs to return a fake char* which actually calls back into Ruby when read or written
+  return (char*) truffle_invoke(ruby_cext, "string_ptr", string);
+}
+
+int RSTRING_LEN(VALUE string) {
+  return *((int*) truffle_get_size(string));
+}
+
+ID rb_intern(const char *string) {
+  return (ID) truffle_invoke(ruby_cext, "intern", string);
+}
+
+VALUE rb_intern_str(VALUE string) {
+  return (VALUE) truffle_invoke(ruby_cext, "intern", string);
+}
+
+void rb_str_cat(VALUE string, char *to_concat, long length) {
+  truffle_invoke(ruby_cext, "string_cat", string, to_concat, length);
+}
+
+int RARRAY_LEN(VALUE array) {
+  return *((int*) truffle_get_size(array));
+}
+
+VALUE *RARRAY_PTR(VALUE array) {
+  // Needs to return a fake VALUE* which actually calls back into Ruby when read or written
+  return (VALUE*) truffle_invoke(ruby_cext, "array_ptr", array);
+}
+
+VALUE rb_ary_new_capa(long capacity) {
+  return (VALUE) truffle_invoke(ruby_cext, "array_new_capa", capacity);
+}
+
+VALUE rb_ary_new2() {
+  return (VALUE) truffle_invoke(ruby_cext, "array_new2");
+}
+
+VALUE rb_ary_new() {
+  return (VALUE) truffle_invoke(ruby_cext, "array_new");
+}
+
+void rb_ary_push(VALUE array, VALUE value) {
+  truffle_invoke(array, "push", value);
+}
+
+void rb_ary_store(VALUE array, long index, VALUE value) {
+  truffle_write(array, &index, value);
+}
+
+VALUE rb_ary_entry(VALUE array, long index) {
+  return truffle_read(array, &index);
+}
+
+VALUE rb_hash_aref(VALUE hash, VALUE key) {
+  return truffle_read(hash, key);
+}
+
+void rb_hash_aset(VALUE hash, VALUE key, VALUE value) {
+  truffle_write(hash, key, value);
+}
+
+void rb_scan_args(int argc, VALUE *argv, char *format, ...) {
+  truffle_invoke(ruby_cext, "scan_args", argc, argv, format /*, where to get args? */);
+}
+
+VALUE rb_funcall(VALUE object, ID name, int argc, ...) {
+  return truffle_invoke(object, name /*, where to get args? */);
+}
+
+VALUE rb_iv_get(VALUE object, const char *name) {
+  return truffle_read(object, (void*) name);
+}
+
+VALUE rb_iv_set(VALUE object, const char *name, VALUE value) {
+  truffle_write(object, (void*) name, value);
+  return value;
+}
+
+VALUE rb_const_get(VALUE object, ID name) {
+  return truffle_invoke(ruby_cext, "const_get", object, name);
+}
+
+void rb_raise(VALUE exception, const char *format, ...) {
+  truffle_invoke(ruby_cext, "raise", format /*, where to get args? */);
+}
+
+VALUE rb_define_module(char *name) {
+  return truffle_invoke(ruby_cext, "define_module", name);
+}
+
+VALUE rb_define_module_under(VALUE module, char *name) {
+  return truffle_invoke(ruby_cext, "define_module_under", module, name);
+}
+
+void rb_define_method(VALUE module, char *name, void *function, int args) {
+  truffle_invoke(ruby_cext, "define_method", module, name, function, args);
+}
+
+void rb_define_private_method(VALUE module, char *name, void *function, int args) {
+  truffle_invoke(ruby_cext, "define_private_method", module, name, function, args);
+}
+
+int rb_define_module_function(VALUE module, char *name, void *function, int args) {
+  return *((int*) truffle_invoke(ruby_cext, "define_module_function", module, name, function, args));
+}

--- a/truffle/src/main/java/org/jruby/truffle/core/CoreLibrary.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/CoreLibrary.java
@@ -80,6 +80,7 @@ import org.jruby.truffle.core.thread.ThreadNodesFactory;
 import org.jruby.truffle.core.time.TimeNodesFactory;
 import org.jruby.truffle.core.tracepoint.TracePointNodesFactory;
 import org.jruby.truffle.extra.TrufflePrimitiveNodesFactory;
+import org.jruby.truffle.interop.CExtNodesFactory;
 import org.jruby.truffle.interop.TruffleInteropNodesFactory;
 import org.jruby.truffle.language.RubyGuards;
 import org.jruby.truffle.language.RubyNode;
@@ -496,6 +497,7 @@ public class CoreLibrary {
 
         truffleModule = defineModule("Truffle");
         defineModule(truffleModule, "Interop");
+        defineModule(truffleModule, "CExt");
         defineModule(truffleModule, "Debug");
         final DynamicObject primitiveModule = defineModule(truffleModule, "Primitive");
         defineModule(truffleModule, "Digest");
@@ -630,6 +632,7 @@ public class CoreLibrary {
         coreMethodNodeManager.addCoreMethodNodes(EncodingNodesFactory.getFactories());
         coreMethodNodeManager.addCoreMethodNodes(EncodingConverterNodesFactory.getFactories());
         coreMethodNodeManager.addCoreMethodNodes(TruffleInteropNodesFactory.getFactories());
+        coreMethodNodeManager.addCoreMethodNodes(CExtNodesFactory.getFactories());
         coreMethodNodeManager.addCoreMethodNodes(MethodNodesFactory.getFactories());
         coreMethodNodeManager.addCoreMethodNodes(UnboundMethodNodesFactory.getFactories());
         coreMethodNodeManager.addCoreMethodNodes(ByteArrayNodesFactory.getFactories());

--- a/truffle/src/main/java/org/jruby/truffle/interop/CExtNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/interop/CExtNodes.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 1.0
+ * GNU General Public License version 2
+ * GNU Lesser General Public License version 2.1
+ */
+package org.jruby.truffle.interop;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.source.SourceSection;
+import org.jruby.truffle.RubyContext;
+import org.jruby.truffle.core.CoreClass;
+import org.jruby.truffle.core.CoreMethod;
+import org.jruby.truffle.core.CoreMethodArrayArgumentsNode;
+
+@CoreClass(name = "Truffle::CExt")
+public class CExtNodes {
+
+    @CoreMethod(names = "qfalse", isModuleFunction = true, needsSelf = false)
+    public abstract static class QFalseNode extends CoreMethodArrayArgumentsNode {
+
+        public QFalseNode(RubyContext context, SourceSection sourceSection) {
+            super(context, sourceSection);
+        }
+
+        @Specialization
+        public boolean qfalse() {
+            return false;
+        }
+
+    }
+
+}


### PR DESCRIPTION
Depends on https://github.com/graalvm/sulong/pull/157

This is a sketch of how I think we could support the Ruby C API using interop. When we used Truffle C, we had several intrinsic nodes, so Ruby functionality implemented in Truffle C. I guess we want to avoid that? Otherwise we'll have to define an API that Sulong provides to register those intrinsics. If we can do it with just normal interop that's probably better.

We have a header that describes the Ruby C API.

We then have a library that implements that in terms of the interop functions that Sulong can provide. That library is compiled into a `.su` and shipped with JRuby+Truffle, and loaded whenever the first C extension is loaded.

Most of the C API is implemented by `INVOKE`ing methods that are implemented by JRuby+Truffle, in a `Truffle::CExt` module, that is exported by default as `ruby_cext`.

There are a lot of open questions here.

If the return type of interop functions like `READ` are `void*`, to read it do I do `*((int*) READ`, or `(int) READ`? What do I do with variadic arguments to pass them on a second time? `RSTRING_PTR` needs to provide what appears to be a `char*` but actually allows me to intercept read and write operations, and that needs to work with pointer arithmetic. We solved all these with Truffle C, so they're all do-able.