### PR TITLE
[Truffle] Compiled Ruby snippets in Java.

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/core/array/ArrayNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/array/ArrayNodes.java
@@ -63,6 +63,7 @@ import org.jruby.truffle.language.NotProvided;
 import org.jruby.truffle.language.RubyGuards;
 import org.jruby.truffle.language.RubyNode;
 import org.jruby.truffle.language.RubyRootNode;
+import org.jruby.truffle.language.SnippetNode;
 import org.jruby.truffle.language.arguments.MissingArgumentBehavior;
 import org.jruby.truffle.language.arguments.ReadPreArgumentNode;
 import org.jruby.truffle.language.arguments.RubyArguments;
@@ -3972,9 +3973,17 @@ public abstract class ArrayNodes {
             return createArray(getContext(), store, size);
         }
 
+        public static final String SNIPPET = "sorted = dup; Rubinius.privately { sorted.isort_block!(0, right, block) }; sorted";
+        public static final String RIGHT = "right";
+        public static final String BLOCK = "block";
+
         @Specialization(guards = { "!isNullArray(array)" })
-        public Object sortUsingRubinius(VirtualFrame frame, DynamicObject array, DynamicObject block) {
-            return ruby("sorted = dup; Rubinius.privately { sorted.isort_block!(0, right, block) }; sorted", "right", getSize(array), "block", block);
+        public Object sortUsingRubinius(
+                VirtualFrame frame,
+                DynamicObject array,
+                DynamicObject block,
+                @Cached("new(SNIPPET, RIGHT, BLOCK)") SnippetNode snippet) {
+            return snippet.execute(frame, getSize(array), block);
         }
 
         @Specialization(guards = { "!isNullArray(array)", "!isSmall(array)" })

--- a/truffle/src/main/java/org/jruby/truffle/core/kernel/KernelNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/kernel/KernelNodes.java
@@ -710,7 +710,7 @@ public abstract class KernelNodes {
 
             final TranslatorDriver translator = new TranslatorDriver(getContext());
 
-            return new RootNodeWrapper(translator.parse(getContext(), source, encoding, ParserContext.EVAL, null, parentFrame, true, this));
+            return new RootNodeWrapper(translator.parse(getContext(), source, encoding, ParserContext.EVAL, null, null, parentFrame, true, this));
         }
 
         protected boolean parseDependsOnDeclarationFrame(RootNodeWrapper rootNode) {

--- a/truffle/src/main/java/org/jruby/truffle/core/string/StringNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/string/StringNodes.java
@@ -82,6 +82,7 @@ import org.jruby.truffle.core.rubinius.StringPrimitiveNodesFactory;
 import org.jruby.truffle.language.NotProvided;
 import org.jruby.truffle.language.RubyGuards;
 import org.jruby.truffle.language.RubyNode;
+import org.jruby.truffle.language.SnippetNode;
 import org.jruby.truffle.language.control.RaiseException;
 import org.jruby.truffle.language.dispatch.CallDispatchHeadNode;
 import org.jruby.truffle.language.dispatch.DispatchHeadNodeFactory;
@@ -406,9 +407,18 @@ public abstract class StringNodes {
         }
 
         @Specialization(guards = "!isRubyString(other)")
-        public Object concat(DynamicObject string, Object other) {
-            return ruby("string.concat_internal(other)", "string", string, "other", other);
+        public Object concat(
+                VirtualFrame frame,
+                DynamicObject string,
+                Object other,
+                @Cached("createSnippet()") SnippetNode snippet) {
+            return snippet.execute(frame, string, other);
         }
+
+        protected SnippetNode createSnippet() {
+            return new SnippetNode("string.concat_internal(other)", "string", "other");
+        }
+
     }
 
     @CoreMethod(names = {"[]", "slice"}, required = 1, optional = 1, lowerFixnumParameters = {0, 1}, taintFromSelf = true)

--- a/truffle/src/main/java/org/jruby/truffle/core/string/StringNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/string/StringNodes.java
@@ -411,12 +411,8 @@ public abstract class StringNodes {
                 VirtualFrame frame,
                 DynamicObject string,
                 Object other,
-                @Cached("createSnippet()") SnippetNode snippet) {
-            return snippet.execute(frame, string, other);
-        }
-
-        protected SnippetNode createSnippet() {
-            return new SnippetNode("string.concat_internal(other)", "string", "other");
+                @Cached("createMethodCall()") CallDispatchHeadNode callNode) {
+            return callNode.call(frame, string, "concat_internal", null, other);
         }
 
     }

--- a/truffle/src/main/java/org/jruby/truffle/language/LazyRubyRootNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/language/LazyRubyRootNode.java
@@ -86,7 +86,7 @@ public class LazyRubyRootNode extends RootNode implements InternalRootNode {
                 final TranslatorDriver translator = new TranslatorDriver(context);
 
                 final RubyRootNode rootNode = translator.parse(context, source, UTF8Encoding.INSTANCE,
-                        ParserContext.TOP_LEVEL, argumentNames, null, true, null);
+                        ParserContext.TOP_LEVEL, argumentNames, null, null, true, null);
 
                 final CallTarget callTarget = Truffle.getRuntime().createCallTarget(rootNode);
 

--- a/truffle/src/main/java/org/jruby/truffle/language/SnippetNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/language/SnippetNode.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 1.0
+ * GNU General Public License version 2
+ * GNU Lesser General Public License version 2.1
+ */
+package org.jruby.truffle.language;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.frame.FrameDescriptor;
+import com.oracle.truffle.api.frame.FrameSlot;
+import com.oracle.truffle.api.frame.MaterializedFrame;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
+import com.oracle.truffle.api.source.Source;
+import org.jcodings.specific.UTF8Encoding;
+import org.jruby.truffle.core.string.StringOperations;
+import org.jruby.truffle.language.arguments.RubyArguments;
+import org.jruby.truffle.language.methods.DeclarationContext;
+import org.jruby.truffle.language.parser.ParserContext;
+
+public class SnippetNode extends RubyBaseNode {
+
+    private final String expression;
+    private final String[] parameters;
+
+    @CompilationFinal private FrameDescriptor frameDescriptor;
+    @CompilationFinal private FrameSlot[] parameterFrameSlots;
+
+    @Child private DirectCallNode directCallNode;
+
+    public SnippetNode(String expression, String... parameters) {
+        this.expression = expression;
+        this.parameters = parameters;
+    }
+
+    @ExplodeLoop
+    public Object execute(VirtualFrame frame, Object... arguments) {
+        if (directCallNode == null) {
+            CompilerDirectives.transferToInterpreter();
+
+            frameDescriptor = new FrameDescriptor(nil());
+            parameterFrameSlots = new FrameSlot[parameters.length];
+
+            for (int n = 0; n < parameters.length; n++) {
+                parameterFrameSlots[n] = frameDescriptor.findOrAddFrameSlot(parameters[n]);
+            }
+
+            final Source source = Source.fromText(StringOperations.createByteList(expression), "(snippet)");
+
+            final RubyRootNode rootNode = getContext().getCodeLoader().parse(
+                    source,
+                    UTF8Encoding.INSTANCE,
+                    ParserContext.INLINE,
+                    frameDescriptor,
+                    null,
+                    true,
+                    this);
+
+            directCallNode = insert(Truffle.getRuntime().createDirectCallNode(Truffle.getRuntime().createCallTarget(rootNode)));
+
+            if (directCallNode.isInlinable()) {
+                directCallNode.forceInlining();
+            }
+        }
+
+        final Object[] parentFrameArguments = RubyArguments.pack(
+                null,
+                null,
+                RubyArguments.getMethod(frame),
+                DeclarationContext.INSTANCE_EVAL,
+                null,
+                RubyArguments.getSelf(frame),
+                null,
+                new Object[]{});
+
+        final MaterializedFrame parentFrame = Truffle.getRuntime().createMaterializedFrame(
+                parentFrameArguments,
+                frameDescriptor);
+
+        if (arguments.length != parameterFrameSlots.length) {
+            CompilerDirectives.transferToInterpreter();
+            throw new UnsupportedOperationException("number of arguments doesn't match number of parameters");
+        }
+
+        for (int n = 0; n < parameters.length; n++) {
+            parentFrame.setObject(parameterFrameSlots[n], arguments[n]);
+        }
+
+        final Object[] callArguments = RubyArguments.pack(
+                parentFrame,
+                null,
+                RubyArguments.getMethod(frame),
+                DeclarationContext.INSTANCE_EVAL,
+                null,
+                RubyArguments.getSelf(frame),
+                null,
+                new Object[]{});
+
+        return directCallNode.call(frame, callArguments);
+    }
+
+}

--- a/truffle/src/main/java/org/jruby/truffle/language/SnippetNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/language/SnippetNode.java
@@ -35,6 +35,10 @@ public class SnippetNode extends RubyBaseNode {
 
     @Child private DirectCallNode directCallNode;
 
+    public SnippetNode(String expression, String a, String b) {
+        this(expression, new String[]{a, b});
+    }
+
     public SnippetNode(String expression, String... parameters) {
         this.expression = expression;
         this.parameters = parameters;

--- a/truffle/src/main/java/org/jruby/truffle/language/dispatch/CallDispatchHeadNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/language/dispatch/CallDispatchHeadNode.java
@@ -21,6 +21,13 @@ public class CallDispatchHeadNode extends DispatchHeadNode {
 
     @Child private BooleanCastNode booleanCastNode;
 
+    public static CallDispatchHeadNode createMethodCall() {
+        return new CallDispatchHeadNode(
+                null,
+                false,
+                MissingBehavior.CALL_METHOD_MISSING);
+    }
+
     public CallDispatchHeadNode(RubyContext context, boolean ignoreVisibility, MissingBehavior missingBehavior) {
         super(context, ignoreVisibility, missingBehavior, DispatchAction.CALL_METHOD);
     }

--- a/truffle/src/main/java/org/jruby/truffle/language/loader/CodeLoader.java
+++ b/truffle/src/main/java/org/jruby/truffle/language/loader/CodeLoader.java
@@ -45,13 +45,23 @@ public class CodeLoader {
     public RubyRootNode parse(Source source,
                               Encoding defaultEncoding,
                               ParserContext parserContext,
+                              FrameDescriptor frameDescriptor,
                               MaterializedFrame parentFrame,
                               boolean ownScopeForAssignments,
                               Node currentNode) {
         final TranslatorDriver translator = new TranslatorDriver(context);
-
-        return translator.parse(context, source, defaultEncoding, parserContext, null, parentFrame,
+        return translator.parse(context, source, defaultEncoding, parserContext, null, frameDescriptor, parentFrame,
                 ownScopeForAssignments, currentNode);
+    }
+
+    @TruffleBoundary
+    public RubyRootNode parse(Source source,
+                              Encoding defaultEncoding,
+                              ParserContext parserContext,
+                              MaterializedFrame parentFrame,
+                              boolean ownScopeForAssignments,
+                              Node currentNode) {
+        return parse(source, defaultEncoding, parserContext, null, parentFrame, ownScopeForAssignments, currentNode);
     }
 
     @TruffleBoundary

--- a/truffle/src/main/java/org/jruby/truffle/language/parser/Parser.java
+++ b/truffle/src/main/java/org/jruby/truffle/language/parser/Parser.java
@@ -9,6 +9,7 @@
  */
 package org.jruby.truffle.language.parser;
 
+import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.Source;
@@ -23,6 +24,7 @@ public interface Parser {
                        Encoding defaultEncoding,
                        ParserContext parserContext,
                        String[] argumentNames,
+                       FrameDescriptor frameDescriptor,
                        MaterializedFrame parentFrame,
                        boolean ownScopeForAssignments,
                        Node currentNode);


### PR DESCRIPTION
We use `ruby("...")` to execute Ruby inline in Java, when that's more convenient than creating a load of nodes. It parses each time like MRI's `eval` and so obviously doesn't compile and is very slow.

This new node allows us to use snippets on the relatively fast path. It compiles the expression once and then calls. It supports inlining etc.

I think it's fast enough to use without worrying too much. I can't really tell though as I think the Ruby code we call using in the first case I've tried it is slow.

I was hoping that using it with `@Cached` would be really elegant, but because the DSL doesn't support string literals I'm afraid that's not quite the case and we need a helper method. I wish we could write something like `@CachedStrings("string.concat_internal(other)", "string", "other")` (calling the constructor of the parameter type with those arguments). Even if we could have string literals the escaping would be ugly. cc @chumer

Example use: https://github.com/jruby/jruby/compare/truffle-snippets?expand=1#diff-26cfc1760a6d8c34ba92d2e8ea40136dR409

Benchmark:

```ruby
require 'benchmark/ips'

Benchmark.ips do |x|

  x.iterations = 5
  
  x.report("concat") do
    "foo".concat(14)
  end

end
```

MRI:

```
Warming up --------------------------------------
              concat   156.227k i/100ms
              concat   156.679k i/100ms
              concat   155.219k i/100ms
              concat   137.855k i/100ms
              concat   130.787k i/100ms
Calculating -------------------------------------
              concat      6.173M (± 9.2%) i/s -     30.735M
              concat      6.471M (± 9.7%) i/s -     32.043M
              concat      6.108M (±12.6%) i/s -     29.950M
              concat      5.226M (±26.4%) i/s -     23.411M
              concat      4.956M (±25.6%) i/s -     22.103M
```

With old `ruby()`:

```
Warming up --------------------------------------
              concat   317.000  i/100ms
              concat   217.000  i/100ms
              concat   275.000  i/100ms
              concat   301.000  i/100ms
              concat   261.000  i/100ms
Calculating -------------------------------------
              concat      5.766k (± 44.6%) i/s -     25.578k in   5.022988s
              concat      5.065k (± 10.3%) i/s -     25.056k in   5.017998s
              concat      5.158k (± 6.8%) i/s -     25.839k in   5.039072s
              concat      5.262k (± 6.9%) i/s -     26.361k in   5.038556s
              concat      5.411k (± 6.1%) i/s -     27.144k in   5.041226s
```

With new snippet node:

```
Warming up --------------------------------------
              concat     3.297k i/100ms
              concat   159.340k i/100ms
              concat   169.392k i/100ms
              concat   247.458k i/100ms
              concat   182.472k i/100ms
Calculating -------------------------------------
              concat      3.119M (± 19.0%) i/s -     13.503M in   5.017577s
              concat      3.162M (± 8.5%) i/s -     15.693M in   5.001186s
              concat      3.326M (± 8.5%) i/s -     16.605M in   5.040981s
              concat      3.196M (± 6.6%) i/s -     16.058M in   5.046234s
              concat      3.330M (± 7.1%) i/s -     16.605M in   5.013123s
```

JRuby+indy:

```
Warming up --------------------------------------
              concat   211.919k i/100ms
              concat   241.921k i/100ms
              concat   233.782k i/100ms
              concat   208.173k i/100ms
              concat   244.494k i/100ms
Calculating -------------------------------------
              concat     12.562M (±13.3%) i/s -     60.879M in   4.987114s
              concat     13.098M (±10.3%) i/s -     64.791M in   5.002235s
              concat     13.082M (±10.2%) i/s -     64.791M in   5.006485s
              concat     12.889M (±10.0%) i/s -     63.568M in   5.003120s
              concat     12.906M (± 7.6%) i/s -     64.302M in   5.012395s
```

So it's 1000x faster than before, but we are still slow and JRuby is 4x faster than us. We're using Rubinius code for this action, and they're very slow, so maybe that's it?

Rubinius:

```
Warming up --------------------------------------
              concat    96.939k i/100ms
              concat   161.354k i/100ms
              concat   161.083k i/100ms
              concat   156.297k i/100ms
              concat   159.044k i/100ms
Calculating -------------------------------------
              concat      2.145M (± 5.4%) i/s -     10.815M
              concat      2.162M (± 5.4%) i/s -     10.815M
              concat      2.169M (± 6.0%) i/s -     10.815M
              concat      2.058M (± 7.6%) i/s -     10.338M
              concat      2.132M (± 6.7%) i/s -     10.656M
```

There are 77 uses of `ruby()` so it will take a little while to replace them. I'm hoping spec times drop when I do.

cc @jruby/truffle 