### PR TITLE
Expose two Enumerator-related bugs

### DIFF
--- a/spec/ruby/core/enumerator/first_spec.rb
+++ b/spec/ruby/core/enumerator/first_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+describe "Enumerator#first" do
+  it "returns arrays correctly when calling #first (2376)" do
+    Enumerator.new {|y| y << [42] }.first.should == [42]
+  end
+end

--- a/spec/ruby/core/enumerator/lazy/map_spec.rb
+++ b/spec/ruby/core/enumerator/lazy/map_spec.rb
@@ -5,4 +5,7 @@ require File.expand_path('../shared/collect', __FILE__)
 
 describe "Enumerator::Lazy#map" do
   it_behaves_like :enumerator_lazy_collect, :map
+  it "doesn't unwrap Arrays" do
+    Enumerator.new {|y| y.yield([1])}.lazy.to_a.should == [[1]]
+  end
 end

--- a/spec/ruby/core/enumerator/lazy/map_spec.rb
+++ b/spec/ruby/core/enumerator/lazy/map_spec.rb
@@ -5,6 +5,7 @@ require File.expand_path('../shared/collect', __FILE__)
 
 describe "Enumerator::Lazy#map" do
   it_behaves_like :enumerator_lazy_collect, :map
+
   it "doesn't unwrap Arrays" do
     Enumerator.new {|y| y.yield([1])}.lazy.to_a.should == [[1]]
   end

--- a/spec/ruby/core/enumerator/yielder/append_spec.rb
+++ b/spec/ruby/core/enumerator/yielder/append_spec.rb
@@ -10,6 +10,13 @@ describe "Enumerator::Yielder#<<" do
     ary.should == [1]
   end
 
+  it "doesn't double-wrap Arrays" do
+    yields = []
+    y = enumerator_class::Yielder.new {|args| yields << args }
+    y << [1]
+    yields.should == [[1]]
+  end
+
   it "returns self" do
     y = enumerator_class::Yielder.new {|x| x + 1}
     (y << 1).should equal(y)


### PR DESCRIPTION
JRuby seems to have two bugs related to Enumerators yielding Arrays. They can be reproduced when comparing the following code snippets which correctly return `true` for MRI, but `false` on JRuby.

1. `<<` should be an alias for `.yield`
    ```ruby
    Enumerator.new {|y| y.yield([1])}.to_a == [[1]] # MRI: true, JRuby: true
    Enumerator.new {|y| y << [1]}.to_a ==  [[1]] # MRI: true, JRuby: false ([[[1]]] instead)
    ```

2. `map` on lazy Enumerators should not unwrap Arrays
    ```ruby
    Enumerator.new {|y| y.yield([1])}.map {|e| e}.to_a == [[1]] # MRI: true, JRuby: true
    Enumerator.new {|y| y.yield([1])}.lazy.map {|e| e}.to_a == [[1]] # MRI: true, JRuby: false ([1] instead)
    ```

I added corresponding specs, but I'm not sure if they're in the right place and format.


