### PR TITLE
Fix a bug where NameError#receiver raises an ArgumentError after #to_s is called

### DIFF
--- a/core/src/main/java/org/jruby/RubyNameError.java
+++ b/core/src/main/java/org/jruby/RubyNameError.java
@@ -45,6 +45,7 @@ import org.jruby.util.Sprintf;
 @JRubyClass(name="NameError", parent="StandardError")
 public class RubyNameError extends RubyException {
     private IRubyObject name;
+    private IRubyObject receiver;
 
     /**
      * Nested class whose instances act as thunks reacting to to_str method
@@ -207,6 +208,7 @@ public class RubyNameError extends RubyException {
     @Override
     public IRubyObject initialize(IRubyObject[] args, Block block) {
         if ( args.length > 0 ) this.message = args[0];
+        if (message instanceof RubyNameErrorMessage) this.receiver = ((RubyNameErrorMessage) message).object;
         if ( args.length > 1 ) this.name = args[1];
         else this.name = getRuntime().getNil();
         super.initialize(NULL_ARRAY, block); // message already set
@@ -231,8 +233,8 @@ public class RubyNameError extends RubyException {
 
     @JRubyMethod
     public IRubyObject receiver(ThreadContext context) {
-        if (message instanceof RubyNameErrorMessage) {
-            return ((RubyNameErrorMessage) message).object;
+        if (receiver != null) {
+            return receiver;
         }
 
         throw context.runtime.newArgumentError("no receiver is available");


### PR DESCRIPTION
If the `NameError#to_s` is called before `NameError#receiver` is called, the NameError object will [lose the source of the receiver object](https://github.com/jruby/jruby/blob/b856557/core/src/main/java/org/jruby/RubyNameError.java#L223) and the `NameError#receiver` method will raise an ArgumentError when it shouldn't:

```ruby
error = (1.foo rescue $!)
error.receiver # => 1
error.to_s     # => NameError: ... <= This call replaces the internal `message` object
error.receiver # => ArgumentError: no receiver is available
```

This commit changes the initializer to retrieve the receiver object so that the behavior of the method will be consistent.