### PR TITLE
Fixnum#bit_length - uses bit inversion when the value is negative

### DIFF
--- a/core/src/main/java/org/jruby/RubyFixnum.java
+++ b/core/src/main/java/org/jruby/RubyFixnum.java
@@ -1194,7 +1194,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
     public IRubyObject bit_length(ThreadContext context) {
         long tmpValue = value;
         if (value < 0) {
-            tmpValue = Math.abs(value);
+            tmpValue = ~value;
         }
 
         return context.runtime.newFixnum(64 - Long.numberOfLeadingZeros(tmpValue));


### PR DESCRIPTION
Making sure the behaviour matches MRI https://github.com/ruby/ruby/blob/trunk/numeric.c#L4280

Thanks @jkr2255