### PR TITLE
[packaging] ensure licensing info is included in artifacts

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -251,6 +251,12 @@ project 'JRuby Core' do
       target_path '${project.build.sourceDirectory}'
       filtering 'true'
     end
+
+    resource do
+      directory '${project.basedir}/..'
+      includes [ 'BSDL', 'COPYING', 'LEGAL', 'LICENSE.RUBY' ]
+      target_path '${project.build.outputDirectory}/META-INF/'
+    end
   end
 
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -300,6 +300,16 @@ DO NOT MODIFIY - GENERATED CODE
           <include>${Constants.java}</include>
         </includes>
       </resource>
+      <resource>
+        <targetPath>${project.build.outputDirectory}/META-INF/</targetPath>
+        <directory>${project.basedir}/..</directory>
+        <includes>
+          <include>BSDL</include>
+          <include>COPYING</include>
+          <include>LEGAL</include>
+          <include>LICENSE.RUBY</include>
+        </includes>
+      </resource>
     </resources>
     <pluginManagement>
       <plugins>

--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -276,5 +276,11 @@ project 'JRuby Lib Setup' do
         'lib/ruby/stdlib/gauntlet*.rb' # gauntlet_rdoc.rb, gauntlet_rubygems.rb
       target_path '${jruby.complete.home}'
     end
+
+    resource do
+      directory '${project.basedir}/..'
+      includes [ 'BSDL', 'COPYING', 'LEGAL', 'LICENSE.RUBY' ]
+      target_path '${project.build.outputDirectory}/META-INF/'
+    end
   end
 end

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -225,6 +225,16 @@ DO NOT MODIFIY - GENERATED CODE
           <exclude>lib/ruby/stdlib/gauntlet*.rb</exclude>
         </excludes>
       </resource>
+      <resource>
+        <targetPath>${project.build.outputDirectory}/META-INF/</targetPath>
+        <directory>${project.basedir}/..</directory>
+        <includes>
+          <include>BSDL</include>
+          <include>COPYING</include>
+          <include>LEGAL</include>
+          <include>LICENSE.RUBY</include>
+        </includes>
+      </resource>
     </resources>
     <plugins>
       <plugin>

--- a/maven/jruby-complete/pom.rb
+++ b/maven/jruby-complete/pom.rb
@@ -10,6 +10,14 @@ project 'JRuby Complete' do
   inherit "org.jruby:jruby-artifacts:#{version}"
   packaging 'bundle'
 
+  build do
+    resource do
+      directory '${project.basedir}/../..'
+      includes [ 'BSDL', 'COPYING', 'LEGAL', 'LICENSE.RUBY' ]
+      target_path '${project.build.outputDirectory}/META-INF/'
+    end
+  end
+
   plugin_repository( :id => 'rubygems-releases',
                      :url => 'https://otto.takari.io/content/repositories/rubygems/maven/releases' )
 

--- a/maven/jruby-dist/src/main/assembly/common.xml
+++ b/maven/jruby-dist/src/main/assembly/common.xml
@@ -50,6 +50,8 @@
       <includes>
         <include>LICENSE*</include>
         <include>COPYING*</include>
+        <include>BSDL</include>
+        <include>LEGAL</include>
         <include>lib/jni/**/*</include>
         <include>samples/**/*</include>
         <include>docs/**/*</include>

--- a/maven/jruby/pom.rb
+++ b/maven/jruby/pom.rb
@@ -22,6 +22,14 @@ project 'JRuby Main Maven Artifact' do
 
   plugin( :invoker, :properties => { 'localRepository' => '${settings.localRepository}' } )
 
+  build do
+    resource do
+      directory '${project.basedir}/../..'
+      includes [ 'BSDL', 'COPYING', 'LEGAL', 'LICENSE.RUBY' ]
+      target_path '${project.build.outputDirectory}/META-INF/'
+    end
+  end
+
   profile :apps do
     activation do
       property :name => 'invoker.test'

--- a/truffle/pom.rb
+++ b/truffle/pom.rb
@@ -70,6 +70,12 @@ project 'JRuby Truffle' do
       includes '**/*rb'
       target_path '${project.build.directory}/classes/jruby-truffle'
     end
+
+    resource do
+      directory '${project.basedir}/..'
+      includes [ 'BSDL', 'COPYING', 'LEGAL', 'LICENSE.RUBY' ]
+      target_path '${project.build.outputDirectory}/META-INF/'
+    end
   end
 
   [ :dist, :'jruby-jars', :all, :release ].each do |name|

--- a/truffle/pom.xml
+++ b/truffle/pom.xml
@@ -77,6 +77,16 @@ DO NOT MODIFIY - GENERATED CODE
           <include>**/*rb</include>
         </includes>
       </resource>
+      <resource>
+        <targetPath>${project.build.outputDirectory}/META-INF/</targetPath>
+        <directory>${project.basedir}/..</directory>
+        <includes>
+          <include>BSDL</include>
+          <include>COPYING</include>
+          <include>LEGAL</include>
+          <include>LICENSE.RUBY</include>
+        </includes>
+      </resource>
     </resources>
     <plugins>
       <plugin>


### PR DESCRIPTION
* jars should have them in META-INF
* bin tarball/zip should have them in top level

Right now there's still a gap, namely aggregate NOTICE files for those artifacts that bundle 3rd party ASL licensed dependencies. I've done this before in other maven-based projects, but navigating JRuby's build is taking me a bit of time.