### PR TITLE
Fixed a bug where NameError#receiver didn't return receiver when it's caused by Struct#[]

### DIFF
--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -498,7 +498,7 @@ public class RubyStruct extends RubyObject {
     }
 
     private RaiseException notStructMemberError(String name) {
-        return getRuntime().newNameError("no member '" + name + "' in struct", name);
+        return getRuntime().newNameError("no member '" + name + "' in struct", this, name);
     }
 
     public final IRubyObject get(int index) {

--- a/test/jruby/test_name_error.rb
+++ b/test/jruby/test_name_error.rb
@@ -1,0 +1,10 @@
+require 'test/unit'
+
+class TestNameError < Test::Unit::TestCase
+  def test_receiver_on_name_error_coming_from_struct
+    obj = Struct.new(:does_exist).new(nil)
+    name_error = assert_raise(NameError) { obj[:doesnt_exist] }
+
+    assert_equal obj, name_error.receiver
+  end
+end


### PR DESCRIPTION
When a NameError is raised from `Struct#[]`, the `NameError#receiver` method should return the receiver object rather than raising `ArgumentError: no receiver is available`.

Actual:

```ruby
(Struct.new(:does_exist).new(nil)[:doesnt_exist] rescue $!).receiver
# => ArgumentError: no receiver is available
```

Expected:

```ruby
(Struct.new(:does_exist).new(nil)[:doesnt_exist] rescue $!).receiver
# => #<struct does_exist=nil>
```