### PR TITLE
Limit padding width for strftime.

### DIFF
--- a/core/src/main/java/org/jruby/util/RubyDateFormatter.java
+++ b/core/src/main/java/org/jruby/util/RubyDateFormatter.java
@@ -43,6 +43,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 
+import jnr.constants.platform.Errno;
 import org.jcodings.Encoding;
 import org.jcodings.specific.ASCIIEncoding;
 import org.joda.time.Chronology;
@@ -548,7 +549,12 @@ public class RubyDateFormatter {
                     throw new Error("FORMAT_SPECIAL is a special token only for the lexer.");
             }
 
-            output = formatter.format(output, value, type);
+            try {
+                output = formatter.format(output, value, type);
+            } catch (IndexOutOfBoundsException ioobe) {
+                throw context.runtime.newErrnoFromErrno(Errno.ERANGE, "strftime");
+            }
+
             // reset formatter
             formatter = RubyTimeOutputFormatter.DEFAULT_FORMATTER;
 

--- a/core/src/main/java/org/jruby/util/RubyTimeOutputFormatter.java
+++ b/core/src/main/java/org/jruby/util/RubyTimeOutputFormatter.java
@@ -119,10 +119,14 @@ public class RubyTimeOutputFormatter {
         }
     }
 
+    private static final int SMALLBUF = 100;
+
     static String padding(String sequence, int width, char padder) {
         if (sequence.length() >= width) {
             return sequence;
         }
+
+        if (width > SMALLBUF) throw new IndexOutOfBoundsException("padding width " + width + " too large");
 
         StringBuilder buf = new StringBuilder(width + sequence.length());
         for (int i = sequence.length(); i < width; i++) {


### PR DESCRIPTION
See https://bugs.ruby-lang.org/issues/4456. I'm not certain MRI
has a hard limit in place, but that's the approach I went with.

The original test that started failing (usually timing out) is
from MRI's TestTimeExtension#test_huge_precision:

```
  def test_huge_precision
    bug4456 = '[ruby-dev:43284]'
    assert_normal_exit %q{ Time.now.strftime("%1000000000F") }, bug4456
  end
```

We attempted to honor that giant padding width blindly, usually
running out of memory or timing out while the GC thrashed.