### PR TITLE
[Truffle] Provide an empty implementation of find_classes_with_matching...

### DIFF
--- a/mx.jruby/mx_jruby.py
+++ b/mx.jruby/mx_jruby.py
@@ -41,6 +41,8 @@ class MavenProject(mx.Project):
     def annotation_processors(self):
         return []
 
+    def find_classes_with_matching_source_line(self, pkgRoot, function, includeInnerClasses=False):
+        return dict()
 
 class MavenBuildTask(mx.BuildTask):
     def __init__(self, project, args, vmbuild, vm):


### PR DESCRIPTION
Without it I have problems using unit testing in other `mx` suites:
```
    mx_unittest.unittest(['-cmd', '-polyglot', 'com.oracle.truffle.pe.test'])
  File "mx/mx_unittest.py", line 317, in unittest
    _unittest(args, ['@Test', '@Parameters'], **parsed_args.__dict__)
  File "mx/mx_unittest.py", line 217, in _unittest
    _run_tests(args, harness, vmLauncher, annotations, testfile, blacklist, whitelist, regex, mx.suite(suite) if suite else None)
  File "mx/mx_unittest.py", line 91, in _run_tests
    for c in _find_classes_with_annotations(p, None, annotations):
  File "mx/mx_unittest.py", line 45, in _find_classes_with_annotations
    return p.find_classes_with_matching_source_line(pkgRoot, matches, includeInnerClasses)
AttributeError: 'MavenProject' object has no attribute 'find_classes_with_matching_source_line'
```