### PR TITLE
File.basename should support windows1250

### DIFF
--- a/test/jruby/test_file.rb
+++ b/test/jruby/test_file.rb
@@ -222,6 +222,10 @@ class TestFile < Test::Unit::TestCase
       assert_equal('C:/', File.realpath('C:/'))
       assert_equal('C:/', File.realpath('C:\\'))
     end
+
+    def test_basename_windows_1250_encoding
+      assert_equal(Encoding.find('Windows-1250'), File.basename('/'.force_encoding('Windows-1250')).encoding)
+    end
   else
     def test_expand_path
       assert_equal("/bin", File.expand_path("../../bin", "/foo/bar"))


### PR DESCRIPTION
since #3871
File.basename doesn't seem to handle the Windows-1250 encoding properly

mri
```bash
File.basename('/'.force_encoding('Windows-1250')).encoding
#<Encoding:Windows-1250>
```

jruby
```bash
File.basename('/'.force_encoding('Windows-1250')).encoding
#<Encoding:UTF-8>
```

https://github.com/jruby/jruby/blob/master/core/src/main/java/org/jruby/RubyFile.java#L584

causes a bundler failure once again
```ruby
Encoding::CompatibilityError: incompatible character encodings: Windows-1250 and UTF-8
                    rindex at org/jruby/RubyString.java:2746
             chop_basename at C:/jruby_repo/jruby/lib/ruby/stdlib/pathname.rb:44
                      plus at C:/jruby_repo/jruby/lib/ruby/stdlib/pathname.rb:370
                         + at C:/jruby_repo/jruby/lib/ruby/stdlib/pathname.rb:350
                      join at C:/jruby_repo/jruby/lib/ruby/stdlib/pathname.rb:416
          user_bundle_path at C:/jruby_repo/jruby/lib/ruby/gems/shared/gems/bundler-1.12.3/lib/bundler.rb:142
        global_config_file at C:/jruby_repo/jruby/lib/ruby/gems/shared/gems/bundler-1.12.3/lib/bundler/settings.rb:216
                initialize at C:/jruby_repo/jruby/lib/ruby/gems/shared/gems/bundler-1.12.3/lib/bundler/settings.rb:13
                  settings at C:/jruby_repo/jruby/lib/ruby/gems/shared/gems/bundler-1.12.3/lib/bundler.rb:198
                    report at C:/jruby_repo/jruby/lib/ruby/gems/shared/gems/bundler-1.12.3/lib/bundler/env.rb:28
  request_issue_report_for at C:/jruby_repo/jruby/lib/ruby/gems/shared/gems/bundler-1.12.3/lib/bundler/friendly_errors.rb:74
                 log_error at C:/jruby_repo/jruby/lib/ruby/gems/shared/gems/bundler-1.12.3/lib/bundler/friendly_errors.rb:40
      with_friendly_errors at C:/jruby_repo/jruby/lib/ruby/gems/shared/gems/bundler-1.12.3/lib/bundler/friendly_errors.rb:100
                     <top> at C:/jruby_repo/jruby/lib/ruby/gems/shared/gems/bundler-1.12.3/exe/bundle:19
                      load at org/jruby/RubyKernel.java:962
                     <top> at C:/jruby_repo/jruby/bin/bundle:22
```