### PR TITLE
Collect all DNS sections by calling to each_resource instead of each_answer

### DIFF
--- a/lib/ruby/stdlib/resolv.rb
+++ b/lib/ruby/stdlib/resolv.rb
@@ -37,10 +37,10 @@ end
 # * /etc/nsswitch.conf is not supported.
 
 class Resolv
-
+  
   ##
   # Tests whether we're running on Windows
-
+  
   WINDOWS = /mswin|cygwin|mingw|bccwin/ =~ RUBY_PLATFORM || ::RbConfig::CONFIG['host_os'] =~ /mswin/
 
   ##
@@ -2856,3 +2856,4 @@ class Resolv
   AddressRegex = /(?:#{IPv4::Regex})|(?:#{IPv6::Regex})/
 
 end
+

--- a/lib/ruby/stdlib/resolv.rb
+++ b/lib/ruby/stdlib/resolv.rb
@@ -37,10 +37,10 @@ end
 # * /etc/nsswitch.conf is not supported.
 
 class Resolv
-  
+
   ##
   # Tests whether we're running on Windows
-  
+
   WINDOWS = /mswin|cygwin|mingw|bccwin/ =~ RUBY_PLATFORM || ::RbConfig::CONFIG['host_os'] =~ /mswin/
 
   ##
@@ -576,13 +576,13 @@ class Resolv
     def extract_resources(msg, name, typeclass) # :nodoc:
       if typeclass < Resource::ANY
         n0 = Name.create(name)
-        msg.each_answer {|n, ttl, data|
+        msg.each_resource {|n, ttl, data|
           yield data if n0 == n
         }
       end
       yielded = false
       n0 = Name.create(name)
-      msg.each_answer {|n, ttl, data|
+      msg.each_resource {|n, ttl, data|
         if n0 == n
           case data
           when typeclass
@@ -594,7 +594,7 @@ class Resolv
         end
       }
       return if yielded
-      msg.each_answer {|n, ttl, data|
+      msg.each_resource {|n, ttl, data|
         if n0 == n
           case data
           when typeclass
@@ -2856,4 +2856,3 @@ class Resolv
   AddressRegex = /(?:#{IPv4::Regex})|(?:#{IPv6::Regex})/
 
 end
-


### PR DESCRIPTION
Disclaimer: same pull request on mruby impl (https://github.com/ruby/ruby/pull/797), and bug open (https://bugs.ruby-lang.org/issues/12372). Not sure if I should report here a bug for the stdlib. For completeness:

A call to `Message#each_answer` does only include answers, however there are also two more kinds of
responses: Authority and Additional. Iterating through `Message#each_resource` allows us to retrieve
all information from the `Message` object.

This is specially important if, for example, we are trying to retrieve nameservers for a certain domain.

```
require 'resolv'
=> true
dns = Resolv::DNS.new(:nameserver => ['199.19.56.1']) # a0.org.afilias-nst.info
=> #<Resolv::DNS:0x3578436e ...>
puts dns.getresources('jruby.org', Resolv::DNS::Resource::IN::NS).map(&:name)
=> nil
```

`nil` is returned. This, in a terminal fashion is equivalent to:

```
~ > dig ns jruby.org @a0.org.afilias-nst.info
;; AUTHORITY SECTION:
jruby.org.      86400   IN  NS  ns25.domaincontrol.com.
jruby.org.      86400   IN  NS  ns26.domaincontrol.com.
```

There is indeed a response, but in the authority section, that is right now not collected by `Resolv::DNS::getresource(s)`.
