### PR TITLE
Upgrade the version of the did_you_mean gem to 1.0.1

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -22,7 +22,7 @@ default_gems =
    ImportedGem.new( 'jar-dependencies', '${jar-dependencies.version}' ),
    ImportedGem.new( 'racc', '${racc.version}'),
    ImportedGem.new( 'net-telnet', '0.1.1'),
-   #ImportedGem.new( 'did_you_mean', '1.0.0'),
+   #ImportedGem.new( 'did_you_mean', '1.0.1'),
   ]
 
 project 'JRuby Lib Setup' do


### PR DESCRIPTION
This might be trivial since it's not enable at this moment, but I just wanted to let you know that this version includes a fix for a bug where most of DYM's features didn't work on JRuby 9.1.0.0.

#3480