### PR TITLE
Enable caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: java
 
 sudo: false
 
-#cache:
-#  directories:
-#    - $HOME/.m2
+cache:
+ directories:
+   - $HOME/.m2
 
 before_install:
   - export MAVEN_SKIP_RC=true


### PR DESCRIPTION
Travis CI has deployed code to take certain extra factors into
consideration when computing cache names.

Our jobs in the build matrix should each receive unique cache names
and we should be able to avoid cache corruption

See https://github.com/jruby/jruby/commit/a60bd1ffaf5fc59542532397a6c946826a4d52aa