### PR TITLE
Disable the AddLocalVarLoadStore pass to fix #3891.

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRManager.java
+++ b/core/src/main/java/org/jruby/ir/IRManager.java
@@ -30,7 +30,7 @@ import static org.jruby.ir.IRFlags.REQUIRES_DYNSCOPE;
 public class IRManager {
     public static final String SAFE_COMPILER_PASSES = "";
     public static final String DEFAULT_BUILD_PASSES = "";
-    public static final String DEFAULT_JIT_PASSES = "LocalOptimizationPass,OptimizeDelegationPass,DeadCodeElimination,AddLocalVarLoadStoreInstructions,OptimizeDynScopesPass,AddCallProtocolInstructions,EnsureTempsAssigned";
+    public static final String DEFAULT_JIT_PASSES = "LocalOptimizationPass,OptimizeDelegationPass,DeadCodeElimination,OptimizeDynScopesPass,AddCallProtocolInstructions,EnsureTempsAssigned";
     public static final String DEFAULT_INLINING_COMPILER_PASSES = "LocalOptimizationPass";
 
     private final CompilerPass deadCodeEliminationPass = new DeadCodeElimination();

--- a/core/src/main/java/org/jruby/ir/IRManager.java
+++ b/core/src/main/java/org/jruby/ir/IRManager.java
@@ -30,7 +30,7 @@ import static org.jruby.ir.IRFlags.REQUIRES_DYNSCOPE;
 public class IRManager {
     public static final String SAFE_COMPILER_PASSES = "";
     public static final String DEFAULT_BUILD_PASSES = "";
-    public static final String DEFAULT_JIT_PASSES = "LocalOptimizationPass,OptimizeDelegationPass,DeadCodeElimination,OptimizeDynScopesPass,AddCallProtocolInstructions,EnsureTempsAssigned";
+    public static final String DEFAULT_JIT_PASSES = "LocalOptimizationPass,DeadCodeElimination,OptimizeDynScopesPass,OptimizeDelegationPass,AddCallProtocolInstructions,EnsureTempsAssigned";
     public static final String DEFAULT_INLINING_COMPILER_PASSES = "LocalOptimizationPass";
 
     private final CompilerPass deadCodeEliminationPass = new DeadCodeElimination();

--- a/core/src/main/java/org/jruby/ir/passes/OptimizeDelegationPass.java
+++ b/core/src/main/java/org/jruby/ir/passes/OptimizeDelegationPass.java
@@ -6,6 +6,7 @@ import org.jruby.ir.instructions.ClosureAcceptingInstr;
 import org.jruby.ir.instructions.CopyInstr;
 import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.instructions.ReifyClosureInstr;
+import org.jruby.ir.operands.LocalVariable;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.representations.BasicBlock;
@@ -41,6 +42,11 @@ public class OptimizeDelegationPass extends CompilerPass {
             for (Instr i: bb.getInstrs()) {
                 if (i instanceof ReifyClosureInstr) {
                     ReifyClosureInstr ri = (ReifyClosureInstr) i;
+
+                    // can't store un-reified block in DynamicScope (only accepts IRubyObject)
+                    // FIXME: (con) it would be nice to not have this limitation
+                    if (ri.getResult() instanceof LocalVariable) continue;
+
                     unusedExplicitBlocks.put(ri.getResult(), ri.getSource());
                 } else {
                     Iterator<Operand> it = unusedExplicitBlocks.keySet().iterator();

--- a/core/src/main/java/org/jruby/runtime/DynamicScope.java
+++ b/core/src/main/java/org/jruby/runtime/DynamicScope.java
@@ -220,6 +220,17 @@ public abstract class DynamicScope {
     }
 
     /**
+     * Set value in current dynamic scope or one of its captured scopes.
+     *
+     * @param offset zero-indexed value that represents where variable lives
+     * @param value to set
+     * @param depth how many captured scopes down this variable should be set
+     */
+    public void setValueVoid(IRubyObject value, int offset, int depth) {
+        setValue(offset, value, depth);
+    }
+
+    /**
      * setValue for depth zero
      *
      * @param value to set
@@ -228,9 +239,26 @@ public abstract class DynamicScope {
     public abstract IRubyObject setValueDepthZero(IRubyObject value, int offset);
 
     /**
+     * setValue for depth zero
+     *
+     * @param value to set
+     * @param offset zero-indexed value that represents where variable lives
+     */
+    public void setValueDepthZeroVoid(IRubyObject value, int offset) {
+        setValueDepthZero(value, offset);
+    }
+
+    /**
      * Set value zero in this scope;
      */
     public abstract IRubyObject setValueZeroDepthZero(IRubyObject value);
+
+    /**
+     * Set value zero in this scope;
+     */
+    public void setValueZeroDepthZeroVoid(IRubyObject value) {
+        setValueZeroDepthZero(value);
+    }
 
     /**
      * Set value one in this scope.
@@ -238,14 +266,35 @@ public abstract class DynamicScope {
     public abstract IRubyObject setValueOneDepthZero(IRubyObject value);
 
     /**
+     * Set value one in this scope.
+     */
+    public void setValueOneDepthZeroVoid(IRubyObject value) {
+        setValueOneDepthZero(value);
+    }
+
+    /**
      * Set value two in this scope.
      */
     public abstract IRubyObject setValueTwoDepthZero(IRubyObject value);
 
     /**
+     * Set value two in this scope.
+     */
+    public void setValueTwoDepthZeroVoid(IRubyObject value) {
+        setValueTwoDepthZero(value);
+    }
+
+    /**
      * Set value three in this scope.
      */
     public abstract IRubyObject setValueThreeDepthZero(IRubyObject value);
+
+    /**
+     * Set value three in this scope.
+     */
+    public void setValueThreeDepthZeroVoid(IRubyObject value) {
+        setValueThreeDepthZero(value);
+    }
 
     @Override
     public String toString() {


### PR DESCRIPTION
This was a good experiment, but we're not properly ensuring the
heap variables are being loaded live when needed, causing examples
like that in #3891 to fail to propagate changes across threads.
By implementing LocalVariable load/store logic in JIT and turning
off the "Add" pass, we basically revert heap vars to always being
read/written immediately, as in JRuby 1.7.25.

It may be possible to improve the pass so that it localizes the
loads and stores better and ensures we don't miss updates we
should see, but this commit will test whether the "nuclear option"
passes all our suites.

cc @subbuss @enebo