### PR TITLE
Soften this restriction to just readable resources.

### DIFF
--- a/core/src/main/java/org/jruby/RubyInstanceConfig.java
+++ b/core/src/main/java/org/jruby/RubyInstanceConfig.java
@@ -412,7 +412,7 @@ public class RubyInstanceConfig {
                 final String script = getScriptFileName();
                 FileResource resource = JRubyFile.createRestrictedResource(getCurrentDirectory(), getScriptFileName());
                 if (resource != null && resource.exists()) {
-                    if (resource.isFile() || resource.isSymLink()) {
+                    if (resource.canRead()) {
                         if (isXFlag()) {
                             // search for a shebang line and
                             // return the script between shebang and __END__ or CTRL-Z (0x1A)


### PR DESCRIPTION
Additional fix for issue exposed by #3901. Devices, like ttys,
pipes, fifos and the like may be neither file nor symlink, but
still readable as script source. The restriction here is
unnecessary.

Ping @mkristian... I softened this test but I'm not sure why it was so restrictive in the first place. Is this change ok?