### PR TITLE
Kwargs should not need dynamic scope, since we have static handy.

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRScope.java
+++ b/core/src/main/java/org/jruby/ir/IRScope.java
@@ -662,13 +662,15 @@ public abstract class IRScope implements ParseResult {
         }
     }
 
+    private static final EnumSet<IRFlags> NEEDS_DYNAMIC_SCOPE_FLAGS =
+            EnumSet.of(
+                    CAN_RECEIVE_BREAKS,
+                    HAS_NONLOCAL_RETURNS,CAN_RECEIVE_NONLOCAL_RETURNS,
+                    BINDING_HAS_ESCAPED,
+                    USES_ZSUPER);
+
     private void computeNeedsDynamicScopeFlag() {
-        // SSS FIXME: checkArity for keyword args looks up a keyword arg in the static scope which
-        // currently requires a dynamic scope to be recovered. If there is another way to do this,
-        // we can get rid of this.
-        if (flags.contains(CAN_RECEIVE_BREAKS) || flags.contains(HAS_NONLOCAL_RETURNS) ||
-                flags.contains(CAN_RECEIVE_NONLOCAL_RETURNS) || flags.contains(BINDING_HAS_ESCAPED) ||
-                flags.contains(USES_ZSUPER) || flags.contains(RECEIVES_KEYWORD_ARGS)) {
+        if (flags.containsAll(NEEDS_DYNAMIC_SCOPE_FLAGS)) {
             flags.add(REQUIRES_DYNSCOPE);
         }
     }

--- a/core/src/main/java/org/jruby/ir/IRScope.java
+++ b/core/src/main/java/org/jruby/ir/IRScope.java
@@ -670,8 +670,11 @@ public abstract class IRScope implements ParseResult {
                     USES_ZSUPER);
 
     private void computeNeedsDynamicScopeFlag() {
-        if (flags.containsAll(NEEDS_DYNAMIC_SCOPE_FLAGS)) {
-            flags.add(REQUIRES_DYNSCOPE);
+        for (IRFlags f : NEEDS_DYNAMIC_SCOPE_FLAGS) {
+            if (flags.contains(f)) {
+                flags.add(REQUIRES_DYNSCOPE);
+                return;
+            }
         }
     }
 

--- a/core/src/main/java/org/jruby/ir/instructions/CheckArityInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CheckArityInstr.java
@@ -66,7 +66,7 @@ public class CheckArityInstr extends NoOperandInstr implements FixedArityInstr {
     }
 
     public void checkArity(ThreadContext context, Object[] args, Block.Type blockType) {
-        IRRuntimeHelpers.checkArity(context, args, required, opt, rest, receivesKeywords, restKey, blockType);
+        IRRuntimeHelpers.checkArity(context.runtime, context.getCurrentStaticScope(), args, required, opt, rest, receivesKeywords, restKey, blockType);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -535,12 +535,12 @@ public class IRRuntimeHelpers {
         return block;
     }
 
-    public static void checkArity(ThreadContext context, Object[] args, int required, int opt, boolean rest,
+    public static void checkArity(Ruby runtime, StaticScope scope, Object[] args, int required, int opt, boolean rest,
                                   boolean receivesKwargs, int restKey, Block.Type blockType) {
         int argsLength = args.length;
         RubyHash keywordArgs = extractKwargsHash(args, required, receivesKwargs);
 
-        if (restKey == -1 && keywordArgs != null) checkForExtraUnwantedKeywordArgs(context, keywordArgs);
+        if (restKey == -1 && keywordArgs != null) checkForExtraUnwantedKeywordArgs(runtime, scope, keywordArgs);
 
         // keyword arguments value is not used for arity checking.
         if (keywordArgs != null) argsLength -= 1;
@@ -549,7 +549,7 @@ public class IRRuntimeHelpers {
 //            System.out.println("NUMARGS: " + argsLength + ", REQUIRED: " + required + ", OPT: " + opt + ", AL: " + args.length + ",RKW: " + receivesKwargs );
 //            System.out.println("ARGS[0]: " + args[0]);
 
-            Arity.raiseArgumentError(context.runtime, argsLength, required, required + opt);
+            Arity.raiseArgumentError(runtime, argsLength, required, required + opt);
         }
     }
 
@@ -588,9 +588,7 @@ public class IRRuntimeHelpers {
         return null;
     }
 
-    public static void checkForExtraUnwantedKeywordArgs(final ThreadContext context, RubyHash keywordArgs) {
-        final StaticScope scope = context.getCurrentStaticScope();
-
+    public static void checkForExtraUnwantedKeywordArgs(final Ruby runtime, final StaticScope scope, RubyHash keywordArgs) {
         keywordArgs.visitAll(new RubyHash.Visitor() {
             @Override
             public void visit(IRubyObject key, IRubyObject value) {
@@ -598,9 +596,9 @@ public class IRRuntimeHelpers {
                 int slot = scope.isDefined((keyAsString));
 
                 // Found name in higher variable scope.  Therefore non for this block/method def.
-                if ((slot >> 16) > 0) throw context.runtime.newArgumentError("unknown keyword: " + keyAsString);
+                if ((slot >> 16) > 0) throw runtime.newArgumentError("unknown keyword: " + keyAsString);
                 // Could not find it anywhere.
-                if (((short) (slot & 0xffff)) < 0) throw context.runtime.newArgumentError("unknown keyword: " + keyAsString);
+                if (((short) (slot & 0xffff)) < 0) throw runtime.newArgumentError("unknown keyword: " + keyAsString);
             }
         });
     }

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -968,7 +968,8 @@ public class JVMVisitor extends IRVisitor {
         if (jvm.methodData().specificArity >= 0) {
             // no arity check in specific arity path
         } else {
-            jvmMethod().loadContext();
+            jvmMethod().loadRuntime();
+            jvmMethod().loadStaticScope();
             jvmMethod().loadArgs();
             jvmAdapter().ldc(checkarityinstr.required);
             jvmAdapter().ldc(checkarityinstr.opt);
@@ -976,7 +977,7 @@ public class JVMVisitor extends IRVisitor {
             jvmAdapter().ldc(checkarityinstr.receivesKeywords);
             jvmAdapter().ldc(checkarityinstr.restKey);
             jvmMethod().loadBlockType();
-            jvmAdapter().invokestatic(p(IRRuntimeHelpers.class), "checkArity", sig(void.class, ThreadContext.class, Object[].class, int.class, int.class, boolean.class, boolean.class, int.class, Block.Type.class));
+            jvmAdapter().invokestatic(p(IRRuntimeHelpers.class), "checkArity", sig(void.class, Ruby.class, StaticScope.class, Object[].class, int.class, int.class, boolean.class, boolean.class, int.class, Block.Type.class));
         }
     }
 


### PR DESCRIPTION
...unfortunately...

In the process of getting the JIT to work properly without the AddLocalVarLoadStore pass, I ran into an issue with Block getting set into DynamicScope and blowing up (caused by OptimizeDelegation, fixed in 88a8896782b17dd797964f368f6b5796d3b66065). In fixing that I realized that this particular method was always requiring a dynamic scope, for no obvious reason:

```ruby
  def popen3(*cmd, **opts, &block)
    in_r, in_w = IO.pipe
    opts[:in] = in_r
    in_w.sync = true

    out_r, out_w = IO.pipe
    opts[:out] = out_w

    err_r, err_w = IO.pipe
    opts[:err] = err_w

    popen_run(cmd, opts, [in_r, out_w, err_w], [in_w, out_r, err_r], &block)
  end
```

It turned out that arity-checking of keyword arguments forced a DynamicScope so it could get to StaticScope. However, all Ruby bodies have direct access to their StaticScope now, so the DynamicScope was unnecessary.

Unfortunately, after I came up with this patch to remove that flag, I ran into another crash due to CheckLJE not reporting that it required DynamicScope.

I fixed that (on master) in 434e54ef42e17394533cc0766648dbd2dbed0f39, but it just left me stranded on another mysterious failure in Rake's helpers.rb:

Error:
```
XXXXX
```

Method:
```ruby
def permute_task(task_desc, task_type, base_name, options, *prereqs, &block)
  default_task = nil
  all_tasks = nil

  # iterate over all flag sets, noting default mapping
  tasks = {}
  options.each do |name, flags|
    if name == :default
      default_task = flags
      next
    end

    if name == :all
      all_tasks = flags
      next
    end

    test_task = task_type.new("#{base_name}:#{name}", &block).tap do |t|
      t.ruby_opts ||= []
      # THIS IS THE LINE THAT BLOWS UP
      flags.each do |flag|
        t.ruby_opts.unshift flag
      end
    end
    tasks[name] = test_task.name
    Rake::Task[test_task.name].tap do |t|
      t.add_description "#{flags.inspect}"
      t.prerequisites.concat prereqs
    end
  end

  # set up default, if specified
  if default_task
    desc "Run #{task_desc}s for #{default_task}"
    task base_name => tasks[default_task]
  end

  # set up "all", if specified, or make it run everything
  all_tasks ||= tasks.keys
  desc "Run #{task_desc}s for #{all_tasks.inspect}"
  task "#{base_name}:all" => all_tasks.map {|key| tasks[key]}
end
```

For some reason, variables are now getting crossed. The block param `flags` is getting mixed up with `test_task later on`, at least from the perspective of the inner block.

I have not provided the IR for brevity, but `-Xir.print` should be working properly now...build this branch and try to run anything with rake.

So, this is a work in progress. I expect this latest issue is another problem with scope optimizations killing a scope that should be there or vice versa...something that was masked before by the arity check's dynscope requirement. Any thoughts?

cc @subbuss @enebo 