### PR TITLE
ZSuper does not require caller's binding/scope.

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRScope.java
+++ b/core/src/main/java/org/jruby/ir/IRScope.java
@@ -666,8 +666,7 @@ public abstract class IRScope implements ParseResult {
             EnumSet.of(
                     CAN_RECEIVE_BREAKS,
                     HAS_NONLOCAL_RETURNS,CAN_RECEIVE_NONLOCAL_RETURNS,
-                    BINDING_HAS_ESCAPED,
-                    USES_ZSUPER);
+                    BINDING_HAS_ESCAPED);
 
     private void computeNeedsDynamicScopeFlag() {
         for (IRFlags f : NEEDS_DYNAMIC_SCOPE_FLAGS) {

--- a/core/src/main/java/org/jruby/ir/instructions/ZSuperInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ZSuperInstr.java
@@ -26,7 +26,6 @@ public class ZSuperInstr extends UnresolvedSuperInstr {
     public boolean computeScopeFlags(IRScope scope) {
         super.computeScopeFlags(scope);
         scope.getFlags().add(IRFlags.USES_ZSUPER);
-        scope.getFlags().add(IRFlags.CAN_CAPTURE_CALLERS_BINDING);
         return true;
     }
 


### PR DESCRIPTION
This appears to pass all tests, and I could find no path from ZSuper's interpret method to anything requiring DynamicScope.