### PR TITLE
Unify super and call splatting logic in interpreter and JIT.

### DIFF
--- a/core/src/main/java/org/jruby/ir/instructions/ZSuperInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ZSuperInstr.java
@@ -67,8 +67,7 @@ public class ZSuperInstr extends UnresolvedSuperInstr {
     public Object interpret(ThreadContext context, StaticScope currScope, DynamicScope currDynScope, IRubyObject self, Object[] temp) {
         IRubyObject[] args = prepareArguments(context, self, currScope, currDynScope, temp);
         Block block = prepareBlock(context, self, currScope, currDynScope, temp);
-        if (block == null || !block.isGiven()) block = context.getFrameBlock();
-        return IRRuntimeHelpers.unresolvedSuper(context, self, args, block);
+        return IRRuntimeHelpers.zSuper(context, self, args, block);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1001,7 +1001,12 @@ public class IRRuntimeHelpers {
 
     public static IRubyObject zSuperSplatArgs(ThreadContext context, IRubyObject self, IRubyObject[] args, Block block, boolean[] splatMap) {
         if (block == null || !block.isGiven()) block = context.getFrameBlock();
-        return unresolvedSuperSplatArgs(context, self, args, block, splatMap);
+        return unresolvedSuper(context, self, splatArguments(args, splatMap), block);
+    }
+
+    public static IRubyObject zSuper(ThreadContext context, IRubyObject self, IRubyObject[] args, Block block) {
+        if (block == null || !block.isGiven()) block = context.getFrameBlock();
+        return unresolvedSuper(context, self, args, block);
     }
 
     public static IRubyObject[] splatArguments(IRubyObject[] args, boolean[] splatMap) {
@@ -1049,24 +1054,32 @@ public class IRRuntimeHelpers {
                 }
             }
         } else {
-            splatMap = new boolean[0];
+            splatMap = null;
         }
         return splatMap;
     }
 
-    public static boolean[] buildSplatMap(Operand[] args, boolean containsArgSplat) {
-        boolean[] splatMap = new boolean[args.length];
+    public static boolean[] buildSplatMap(Operand[] args) {
+        boolean[] splatMap = null;
 
-        if (containsArgSplat) {
-            for (int i = 0; i < args.length; i++) {
-                Operand operand = args[i];
-                if (operand instanceof Splat) {
-                    splatMap[i] = true;
-                }
+        for (int i = 0; i < args.length; i++) {
+            Operand operand = args[i];
+            if (operand instanceof Splat) {
+                if (splatMap == null) splatMap = new boolean[args.length];
+                splatMap[i] = true;
             }
         }
 
         return splatMap;
+    }
+
+    public static boolean anyTrue(boolean[] booleans) {
+        for (boolean b : booleans) if (b) return true;
+        return false;
+    }
+
+    public static boolean needsSplatting(boolean[] splatmap) {
+        return splatmap != null && splatmap.length > 0 && anyTrue(splatmap);
     }
 
     public static final Type[] typesFromSignature(Signature signature) {

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -995,10 +995,10 @@ public class JVMVisitor extends IRVisitor {
         String name = classsuperinstr.getName();
         Operand[] args = classsuperinstr.getCallArgs();
         Operand definingModule = classsuperinstr.getDefiningModule();
-        boolean containsArgSplat = classsuperinstr.containsArgSplat();
+        boolean[] splatMap = classsuperinstr.splatMap();
         Operand closure = classsuperinstr.getClosureArg(null);
 
-        superCommon(name, classsuperinstr, args, definingModule, containsArgSplat, closure);
+        superCommon(name, classsuperinstr, args, definingModule, splatMap, closure);
     }
 
     @Override
@@ -1230,13 +1230,13 @@ public class JVMVisitor extends IRVisitor {
         String name = instancesuperinstr.getName();
         Operand[] args = instancesuperinstr.getCallArgs();
         Operand definingModule = instancesuperinstr.getDefiningModule();
-        boolean containsArgSplat = instancesuperinstr.containsArgSplat();
+        boolean[] splatMap = instancesuperinstr.splatMap();
         Operand closure = instancesuperinstr.getClosureArg(null);
 
-        superCommon(name, instancesuperinstr, args, definingModule, containsArgSplat, closure);
+        superCommon(name, instancesuperinstr, args, definingModule, splatMap, closure);
     }
 
-    private void superCommon(String name, CallInstr instr, Operand[] args, Operand definingModule, boolean containsArgSplat, Operand closure) {
+    private void superCommon(String name, CallInstr instr, Operand[] args, Operand definingModule, boolean[] splatMap, Operand closure) {
         IRBytecodeAdapter m = jvmMethod();
         Operation operation = instr.getOperation();
 
@@ -1257,9 +1257,6 @@ public class JVMVisitor extends IRVisitor {
             Operand operand = args[i];
             visit(operand);
         }
-
-        // if there's splats, provide a map and let the call site sort it out
-        boolean[] splatMap = IRRuntimeHelpers.buildSplatMap(args, containsArgSplat);
 
         boolean hasClosure = closure != null;
         if (hasClosure) {
@@ -2045,10 +2042,10 @@ public class JVMVisitor extends IRVisitor {
         Operand[] args = unresolvedsuperinstr.getCallArgs();
         // this would be getDefiningModule but that is not used for unresolved super
         Operand definingModule = UndefinedValue.UNDEFINED;
-        boolean containsArgSplat = unresolvedsuperinstr.containsArgSplat();
+        boolean[] splatMap = unresolvedsuperinstr.splatMap();
         Operand closure = unresolvedsuperinstr.getClosureArg(null);
 
-        superCommon(name, unresolvedsuperinstr, args, definingModule, containsArgSplat, closure);
+        superCommon(name, unresolvedsuperinstr, args, definingModule, splatMap, closure);
     }
 
     @Override
@@ -2094,10 +2091,10 @@ public class JVMVisitor extends IRVisitor {
         Operand[] args = zsuperinstr.getCallArgs();
         // this would be getDefiningModule but that is not used for unresolved super
         Operand definingModule = UndefinedValue.UNDEFINED;
-        boolean containsArgSplat = zsuperinstr.containsArgSplat();
+        boolean[] splatMap = zsuperinstr.splatMap();
         Operand closure = zsuperinstr.getClosureArg(null);
 
-        superCommon(name, zsuperinstr, args, definingModule, containsArgSplat, closure);
+        superCommon(name, zsuperinstr, args, definingModule, splatMap, closure);
     }
 
     @Override


### PR DESCRIPTION
This improves things in a few ways:

* JIT and interpreter are calling through most of the same APIs.
* Fewer transient objects for calls with splats.
* Less duplication of code.

There are other ways we could split the super dispatch paths
apart to reduce overhead and allocation. This patch puts us on
that path.