### PR TITLE
waitReadable should block

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -2853,9 +2853,10 @@ public class RubyIO extends RubyObject implements IOEncodable {
                     //                n = arg.len;
                     n = OpenFile.readInternal(context, fptr, fptr.fd(), strByteList.unsafeBytes(), strByteList.begin(), len);
                     if (n < 0) {
+                        Errno e = fptr.errno();
                         if (!nonblock && fptr.waitReadable(context))
                             continue again;
-                        if (nonblock && (fptr.errno() == Errno.EWOULDBLOCK || fptr.errno() == Errno.EAGAIN)) {
+                        if (nonblock && (e == Errno.EWOULDBLOCK || e == Errno.EAGAIN)) {
                             if (noException) return runtime.newSymbol("wait_readable");
                             throw runtime.newErrnoEAGAINReadableError("read would block");
                         }

--- a/core/src/main/java/org/jruby/util/io/OpenFile.java
+++ b/core/src/main/java/org/jruby/util/io/OpenFile.java
@@ -492,7 +492,7 @@ public class OpenFile implements Finalizable {
 
     // rb_io_wait_readable
     public boolean waitReadable(ThreadContext context) {
-        return waitReadable(context, 0);
+        return waitReadable(context, -1);
     }
 
     /**


### PR DESCRIPTION
This attempts to fix some sporadic readpartial tests and specs in the suite, specifically in this case a failure in MRI's `test_readpartial.rb` in `test_open_pipe`. Our old old would never properly wait for the pipe to become readable and would keep spinning and trying to do nonblocking reads followed by waitReadable that never waited. As a result we could have interrupts happen at unexpected times, leaving IO in a weird state that probably caused sporadic `close` errors like in https://travis-ci.org/jruby/jruby/jobs/132959357