### PR TITLE
[Truffle] Added a new internal method for taking ownership of an array store from another array.

### DIFF
--- a/spec/truffle/specs/truffle/array/steal_storage.rb
+++ b/spec/truffle/specs/truffle/array/steal_storage.rb
@@ -9,7 +9,7 @@
 
 require_relative '../../../../ruby/spec_helper'
 
-describe "Truffle::Array.take_ownership_of_store" do
+describe "Truffle::Array.steal_storage" do
   def storage(ary)
     Truffle::Debug.array_storage(ary)
   end
@@ -21,7 +21,7 @@ describe "Truffle::Array.take_ownership_of_store" do
   it "should no-op when called on itself" do
     copy = @array.dup
 
-    Truffle::Array.take_ownership_of_store(@array, @array)
+    Truffle::Array.steal_storage(@array, @array)
 
     storage(@array).should == "Object[]"
     @array.should == copy
@@ -31,7 +31,7 @@ describe "Truffle::Array.take_ownership_of_store" do
     other = [1, 2, 3, 4, 5]
     other_copy = other.dup
 
-    Truffle::Array.take_ownership_of_store(@array, other)
+    Truffle::Array.steal_storage(@array, other)
 
     storage(@array).should == "int[]"
     @array.should == other_copy

--- a/spec/truffle/specs/truffle/array/take_ownership_of_store_spec.rb
+++ b/spec/truffle/specs/truffle/array/take_ownership_of_store_spec.rb
@@ -1,0 +1,42 @@
+# Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+# OTHER DEALINGS IN THE SOFTWARE.
+
+require_relative '../../../../ruby/spec_helper'
+
+describe "Truffle::Array.take_ownership_of_store" do
+  def storage(ary)
+    Truffle::Debug.array_storage(ary)
+  end
+
+  before :each do
+    @array = %i[first second third]
+  end
+
+  it "should no-op when called on itself" do
+    copy = @array.dup
+
+    Truffle::Array.take_ownership_of_store(@array, @array)
+
+    storage(@array).should == "Object[]"
+    @array.should == copy
+  end
+
+  it "should take ownership of the store" do
+    other = [1, 2, 3, 4, 5]
+    other_copy = other.dup
+
+    Truffle::Array.take_ownership_of_store(@array, other)
+
+    storage(@array).should == "int[]"
+    @array.should == other_copy
+
+    storage(other).should == "null"
+    other.empty?.should == true
+  end
+end

--- a/truffle/src/main/java/org/jruby/truffle/core/CoreLibrary.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/CoreLibrary.java
@@ -33,6 +33,7 @@ import org.jruby.truffle.RubyContext;
 import org.jruby.truffle.builtins.CoreMethodNodeManager;
 import org.jruby.truffle.core.array.ArrayNodes;
 import org.jruby.truffle.core.array.ArrayNodesFactory;
+import org.jruby.truffle.core.array.TruffleArrayNodesFactory;
 import org.jruby.truffle.core.basicobject.BasicObjectNodesFactory;
 import org.jruby.truffle.core.binding.BindingNodesFactory;
 import org.jruby.truffle.core.binding.TruffleBindingNodesFactory;
@@ -585,6 +586,7 @@ public class CoreLibrary {
         defineModule(truffleModule, "Graal");
         defineModule(truffleModule, "Ropes");
         defineModule(truffleModule, "GC");
+        defineModule(truffleModule, "Array");
         final DynamicObject attachments = defineModule(truffleModule, "Attachments");
         defineModule(attachments, "Internal");
         defineModule(truffleModule, "Boot");
@@ -758,6 +760,7 @@ public class CoreLibrary {
         coreMethodNodeManager.addCoreMethodNodes(TruffleProcessNodesFactory.getFactories());
         coreMethodNodeManager.addCoreMethodNodes(TruffleDebugNodesFactory.getFactories());
         coreMethodNodeManager.addCoreMethodNodes(TruffleBindingNodesFactory.getFactories());
+        coreMethodNodeManager.addCoreMethodNodes(TruffleArrayNodesFactory.getFactories());
         coreMethodNodeManager.addCoreMethodNodes(BCryptNodesFactory.getFactories());
 
         coreMethodNodeManager.allMethodInstalled();

--- a/truffle/src/main/java/org/jruby/truffle/core/array/TruffleArrayNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/array/TruffleArrayNodes.java
@@ -22,7 +22,7 @@ import static org.jruby.truffle.core.array.ArrayHelpers.setStoreAndSize;
 @CoreClass("Truffle::Array")
 public class TruffleArrayNodes {
 
-    @CoreMethod(names = "take_ownership_of_store", onSingleton = true, required = 2)
+    @CoreMethod(names = "steal_storage", onSingleton = true, required = 2)
     public abstract static class TakeOwnershipOfStoreNode extends CoreMethodArrayArgumentsNode {
 
         @Specialization(guards = "array == other")

--- a/truffle/src/main/java/org/jruby/truffle/core/array/TruffleArrayNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/array/TruffleArrayNodes.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 1.0
+ * GNU General Public License version 2
+ * GNU Lesser General Public License version 2.1
+ */
+package org.jruby.truffle.core.array;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.object.DynamicObject;
+import org.jruby.truffle.builtins.CoreClass;
+import org.jruby.truffle.builtins.CoreMethod;
+import org.jruby.truffle.builtins.CoreMethodArrayArgumentsNode;
+
+import static org.jruby.truffle.core.array.ArrayHelpers.getSize;
+import static org.jruby.truffle.core.array.ArrayHelpers.getStore;
+import static org.jruby.truffle.core.array.ArrayHelpers.setStoreAndSize;
+
+@CoreClass("Truffle::Array")
+public class TruffleArrayNodes {
+
+    @CoreMethod(names = "take_ownership_of_store", onSingleton = true, required = 2)
+    public abstract static class TakeOwnershipOfStoreNode extends CoreMethodArrayArgumentsNode {
+
+        @Specialization(guards = "array == other")
+        public DynamicObject takeOwnershipOfStoreNoOp(DynamicObject array, DynamicObject other) {
+            return array;
+        }
+
+        @Specialization(guards = { "array != other", "isRubyArray(other)" })
+        public DynamicObject takeOwnershipOfStore(DynamicObject array, DynamicObject other) {
+            final int size = getSize(other);
+            final Object store = getStore(other);
+            setStoreAndSize(array, store, size);
+            setStoreAndSize(other, null, 0);
+
+            return array;
+        }
+
+    }
+
+}

--- a/truffle/src/main/ruby/core/array.rb
+++ b/truffle/src/main/ruby/core/array.rb
@@ -811,7 +811,7 @@ class Array
 
     out = new_reserved size
     if recursively_flatten(self, out, level)
-      replace(out)
+      Truffle::Array.take_ownership_of_store(self, out)
       return self
     end
 
@@ -987,7 +987,7 @@ class Array
 
     Truffle.check_frozen
 
-    replace select(&block)
+    Truffle::Array.take_ownership_of_store(self, select(&block))
   end
 
   def last(n=undefined)
@@ -1337,7 +1337,7 @@ class Array
     return self if length == 0 || length == 1
 
     ary = rotate(cnt)
-    replace ary
+    Truffle::Array.take_ownership_of_store(self, ary)
   end
 
   class SampleRandom
@@ -1467,7 +1467,7 @@ class Array
     Truffle.check_frozen
 
     ary = select(&block)
-    replace ary unless size == ary.size
+    Truffle::Array.take_ownership_of_store(self, ary) unless size == ary.size
   end
 
   def set_index(index, ent, fin=undefined)
@@ -1748,7 +1748,7 @@ class Array
 
     return to_enum(:sort_by!) { size } unless block_given?
 
-    replace sort_by(&block)
+    Truffle::Array.take_ownership_of_store(self, sort_by(&block))
   end
 
   # Sorts this Array in-place. See #sort.
@@ -2044,7 +2044,7 @@ class Array
       width *= 2
     end
 
-    replace(source) if source != self
+    Truffle::Array.take_ownership_of_store(self, source)
 
     self
   end
@@ -2108,7 +2108,7 @@ class Array
       width *= 2
     end
 
-    replace(source) if source != self
+    Truffle::Array.take_ownership_of_store(self, source)
 
     self
   end
@@ -2397,7 +2397,9 @@ class Array
   end
 
   def sort!(&block)
-    replace sort(&block)
+    Truffle.check_frozen
+
+    Truffle::Array.take_ownership_of_store(self, sort(&block))
   end
   public :sort!
 end

--- a/truffle/src/main/ruby/core/array.rb
+++ b/truffle/src/main/ruby/core/array.rb
@@ -811,7 +811,7 @@ class Array
 
     out = new_reserved size
     if recursively_flatten(self, out, level)
-      Truffle::Array.take_ownership_of_store(self, out)
+      Truffle::Array.steal_storage(self, out)
       return self
     end
 
@@ -987,7 +987,7 @@ class Array
 
     Truffle.check_frozen
 
-    Truffle::Array.take_ownership_of_store(self, select(&block))
+    Truffle::Array.steal_storage(self, select(&block))
   end
 
   def last(n=undefined)
@@ -1337,7 +1337,7 @@ class Array
     return self if length == 0 || length == 1
 
     ary = rotate(cnt)
-    Truffle::Array.take_ownership_of_store(self, ary)
+    Truffle::Array.steal_storage(self, ary)
   end
 
   class SampleRandom
@@ -1467,7 +1467,7 @@ class Array
     Truffle.check_frozen
 
     ary = select(&block)
-    Truffle::Array.take_ownership_of_store(self, ary) unless size == ary.size
+    Truffle::Array.steal_storage(self, ary) unless size == ary.size
   end
 
   def set_index(index, ent, fin=undefined)
@@ -1748,7 +1748,7 @@ class Array
 
     return to_enum(:sort_by!) { size } unless block_given?
 
-    Truffle::Array.take_ownership_of_store(self, sort_by(&block))
+    Truffle::Array.steal_storage(self, sort_by(&block))
   end
 
   # Sorts this Array in-place. See #sort.
@@ -2044,7 +2044,7 @@ class Array
       width *= 2
     end
 
-    Truffle::Array.take_ownership_of_store(self, source)
+    Truffle::Array.steal_storage(self, source)
 
     self
   end
@@ -2108,7 +2108,7 @@ class Array
       width *= 2
     end
 
-    Truffle::Array.take_ownership_of_store(self, source)
+    Truffle::Array.steal_storage(self, source)
 
     self
   end
@@ -2399,7 +2399,7 @@ class Array
   def sort!(&block)
     Truffle.check_frozen
 
-    Truffle::Array.take_ownership_of_store(self, sort(&block))
+    Truffle::Array.steal_storage(self, sort(&block))
   end
   public :sort!
 end


### PR DESCRIPTION
This is intended to be a faster version of Array#replace when we know that the source array won't be used anywhere else.

While escape analysis may very well catch some of these, I don't think it would catch all of them (e.g., the mergesort! case). And this will work in the interpreter as well.

@jruby/truffle 