### PR TITLE
Implement Thread#report_on_exception

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1451,6 +1451,8 @@ public final class Ruby implements Constantizable {
         falseObject.setFrozen(true);
         trueObject = new RubyBoolean.True(this);
         trueObject.setFrozen(true);
+
+        reportOnException = nilObject;
     }
 
     private void initCore() {
@@ -4328,6 +4330,14 @@ public final class Ruby implements Constantizable {
         globalAbortOnExceptionEnabled = enable;
     }
 
+    public IRubyObject getReportOnException() {
+        return reportOnException;
+    }
+
+    public void setReportOnException(IRubyObject enable) {
+        reportOnException = enable;
+    }
+
     public boolean isDoNotReverseLookupEnabled() {
         return doNotReverseLookupEnabled;
     }
@@ -5150,6 +5160,7 @@ public final class Ruby implements Constantizable {
     private volatile EventHook[] eventHooks = EMPTY_HOOKS;
     private boolean hasEventHooks;
     private boolean globalAbortOnExceptionEnabled = false;
+    private IRubyObject reportOnException;
     private boolean doNotReverseLookupEnabled = false;
     private volatile boolean objectSpaceEnabled;
     private boolean siphashEnabled;

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -56,6 +56,7 @@ import org.joni.Region;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.ast.util.ArgsUtil;
+import org.jruby.exceptions.RaiseException;
 import org.jruby.platform.Platform;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ClassIndex;
@@ -112,7 +113,7 @@ import static org.jruby.RubyEnumerator.SizeFn;
  *
  */
 @JRubyClass(name="String", include={"Enumerable", "Comparable"})
-public class RubyString extends RubyObject implements EncodingCapable, MarshalEncoding, CodeRangeable {
+public class RubyString extends RubyObject implements EncodingCapable, MarshalEncoding, CodeRangeable, CharSequence {
     public static final String DEBUG_INFO_FIELD = "@debug_created_info";
 
     private static final ASCIIEncoding ASCII = ASCIIEncoding.INSTANCE;
@@ -2145,16 +2146,45 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         return value.getRealSize();
     }
 
-    /** rb_str_length
-     *
-     */
-    public RubyFixnum length() {
-        return length19();
+    // MRI: rb_str_length
+    public RubyFixnum rubyLength() {
+        return getRuntime().newFixnum(strLength());
+    }
+
+    @Override
+    public int length() {
+        return strLength();
+    }
+
+    @Override
+    public char charAt(int offset) {
+        int length = value.getRealSize();
+
+        if (length < 1) throw new ArrayIndexOutOfBoundsException(offset);
+
+        Encoding enc = value.getEncoding();
+        if (singleByteOptimizable(enc)) {
+            if (offset >= length || offset < 0) throw new ArrayIndexOutOfBoundsException(offset);
+            return (char) value.get(offset);
+        }
+
+        return multibyteCharAt(getRuntime(), enc, offset, length);
+    }
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+        try {
+            return (RubyString) substr19(getRuntime(), start, end);
+        } catch (RaiseException re) {
+            StringIndexOutOfBoundsException t = new StringIndexOutOfBoundsException(re.getMessage());
+            t.setStackTrace(re.getStackTrace());
+            throw t;
+        }
     }
 
     @JRubyMethod(name = {"length", "size"})
     public RubyFixnum length19() {
-        return getRuntime().newFixnum(strLength());
+        return rubyLength();
     }
 
     @JRubyMethod(name = "bytesize")
@@ -2926,6 +2956,38 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
             len = StringSupport.offset(enc, bytes, p, end, len);
         }
         return makeShared19(runtime, p - s, len);
+    }
+
+    private char multibyteCharAt(Ruby runtime, Encoding enc, int beg, int length) {
+        int p;
+        int s = value.getBegin();
+        int end = s + length;
+        byte[]bytes = value.getUnsafeBytes();
+
+
+        if (beg > 0 && beg > StringSupport.strLengthFromRubyString(this, enc)) {
+            throw new StringIndexOutOfBoundsException(beg);
+        }
+
+        if (isCodeRangeValid() && enc.isUTF8()) {
+            p = StringSupport.utf8Nth(bytes, s, end, beg);
+        } else if (enc.isFixedWidth()) {
+            int w = enc.maxLength();
+            p = s + beg * w;
+            if (p > end || w > end - p) {
+                throw new StringIndexOutOfBoundsException(beg);
+            }
+        } else if ((p = StringSupport.nth(enc, bytes, s, end, beg)) == end) {
+            throw new StringIndexOutOfBoundsException(beg);
+        }
+        int codepoint = enc.mbcToCode(bytes, p, end);
+
+        if (Character.isBmpCodePoint(codepoint)) {
+            return (char) codepoint;
+        }
+
+        // we can only return high surrogate here
+        return Character.highSurrogate(codepoint);
     }
 
     /* rb_str_splice */
@@ -4975,7 +5037,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         return new SizeFn() {
             @Override
             public IRubyObject size(IRubyObject[] args) {
-                return self.length();
+                return self.rubyLength();
             }
         };
     }
@@ -5017,7 +5079,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
                 // this code should be live in 3.0
                 if (false) { // #if STRING_ENUMERATORS_WANTARRAY
                     runtime.getWarnings().warn("given block not used");
-                    ary = RubyArray.newArray(runtime, str.length().getLongValue());
+                    ary = RubyArray.newArray(runtime, str.length());
                 } else {
                     runtime.getWarnings().warning("passing a block to String#chars is deprecated");
                     wantarray = false;
@@ -5026,7 +5088,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         }
         else {
             if (wantarray)
-                ary = RubyArray.newArray(runtime, str.length().getLongValue());
+                ary = RubyArray.newArray(runtime, str.length());
             else
                 return enumeratorizeWithSize(context, this, name, eachCharSizeFn());
         }
@@ -5086,7 +5148,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
                 // this code should be live in 3.0
                 if (false) { // #if STRING_ENUMERATORS_WANTARRAY
                     runtime.getWarnings().warn("given block not used");
-                    ary = RubyArray.newArray(runtime, str.length().getLongValue());
+                    ary = RubyArray.newArray(runtime, str.length());
                 } else {
                     runtime.getWarnings().warning("passing a block to String#codepoints is deprecated");
                     wantarray = false;
@@ -5095,7 +5157,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         }
         else {
             if (wantarray)
-                ary = RubyArray.newArray(runtime, str.length().getLongValue());
+                ary = RubyArray.newArray(runtime, str.length());
             else
                 return enumeratorizeWithSize(context, str, name, eachCodepointSizeFn());
         }
@@ -5158,7 +5220,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         return new SizeFn() {
             @Override
             public IRubyObject size(IRubyObject[] args) {
-                return self.length();
+                return self.rubyLength();
             }
         };
     }

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -33,6 +33,7 @@
 package org.jruby;
 
 import java.io.IOException;
+import java.io.PrintStream;
 import java.lang.ref.WeakReference;
 import java.nio.channels.Channel;
 import java.nio.channels.SelectableChannel;
@@ -58,6 +59,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 
 import org.jcodings.Encoding;
+import org.jcodings.specific.USASCIIEncoding;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.common.IRubyWarnings.ID;
@@ -121,10 +123,15 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     /** Whether this thread should try to abort the program on exception */
     private volatile boolean abortOnException;
 
+    /** Whether this thread should report_on_exception when this thread GCs, when it terminates, or never */
+    private volatile IRubyObject reportOnException;
+
+    /** Whether this thread's terminating exception has been captured by any code *after* the thread terminated. */
+    private volatile boolean exceptionCaptured;
+
     /** The final value resulting from the thread's execution */
     private volatile IRubyObject finalResult;
 
-    private volatile IRubyObject threadName;
     private String file; private int line; // Thread.new location (for inspect)
 
     /**
@@ -214,6 +221,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         super(runtime, type);
 
         finalResult = errorInfo = runtime.getNil();
+        reportOnException = runtime.getReportOnException();
     }
 
     public RubyThread(Ruby runtime, RubyClass klass, Runnable runnable) {
@@ -575,7 +583,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
             thread.setDaemon(true);
             this.file = context.getFile();
             this.line = context.getLine();
-            setThreadName(runtime, thread, file, line, true);
+            initThreadName(runtime, thread, file, line);
             threadImpl = new NativeThread(this, thread);
 
             addToCorrectThreadGroup(context);
@@ -604,44 +612,27 @@ public class RubyThread extends RubyObject implements ExecutionContext {
 
     private static final String RUBY_THREAD_PREFIX = "Ruby-";
 
-    private void setThreadName(final Ruby runtime, final Thread thread,
-        final String file, final int line, final boolean newThread) {
+    private static void initThreadName(final Ruby runtime, final Thread thread, final String file, final int line) {
         // "Ruby-0-Thread-16: (irb):21"
-        // "Ruby-0-Thread-17@worker#1: (irb):21"
         final String newName;
-        final String setName = getNameOrNull();
-        final String currentName = thread.getName();
-        if ( currentName != null && currentName.startsWith(RUBY_THREAD_PREFIX) ) {
-            final int i = currentName.indexOf('@'); // Thread#name separator
-            if ( i == -1 ) { // name not set yet: "Ruby-0-Thread-42: FILE:LINE"
-                int end = currentName.indexOf(':');
-                if ( end == -1 ) end = currentName.length();
-                final String prefix = currentName.substring(0, end);
-                newName = currentName.replace(prefix, prefix + '@' + setName);
+        final StringBuilder name = new StringBuilder(24);
+        name
+                .append(RUBY_THREAD_PREFIX)
+                .append(runtime.getRuntimeNumber())
+                .append('-')
+                .append("Thread-")
+                .append(incAndGetThreadCount(runtime));
+        if ( file != null ) {
+            name
+                    .append(':')
+                    .append(' ')
+                    .append(file)
+                    .append(':')
+                    .append(line + 1);
+        }
+        newName = name.toString();
 
-            }
-            else { // name previously set: "Ruby-0-Thread-42@foo: FILE:LINE"
-                final String prefix = currentName.substring(0, i); // Ruby-0-Thread-42
-                int end = currentName.indexOf(':', i);
-                if ( end == -1 ) end = currentName.length();
-                final String prefixWithName = currentName.substring(0, end); // Ruby-0-Thread-42@foo:
-                newName = currentName.replace(prefixWithName, setName == null ? prefix : (prefix + '@' + setName));
-            }
-        }
-        else if ( newThread ) {
-            final StringBuilder name = new StringBuilder(24);
-            name.append(RUBY_THREAD_PREFIX).append(runtime.getRuntimeNumber());
-            name.append('-').append("Thread-").append(incAndGetThreadCount(runtime));
-            if ( setName != null ) name.append('@').append(setName);
-            if ( file != null ) { // in JIT we seem to get "" as file and line 0
-                name.append(':').append(' ').append(file).append(':').append(line + 1);
-            }
-            newName = name.toString();
-        }
-        else return; // not a new-thread that and does not match out Ruby- prefix
-        // ... very likely user-code set the java thread name - thus do not mess!
-        try { thread.setName(newName); }
-        catch (SecurityException ignore) { } // current thread can not modify
+        thread.setName(newName);
     }
 
     // TODO likely makes sense to have a counter or the Ruby class directly (could be included with JMX)
@@ -781,21 +772,17 @@ public class RubyThread extends RubyObject implements ExecutionContext {
             if (!enc.isAsciiCompatible()) {
                 throw runtime.newArgumentError("ASCII incompatible encoding (" + enc + ")");
             }
-            name = nameStr.newFrozen();
+            threadImpl.setRubyName(runtime.freezeAndDedupString(nameStr));
+        } else {
+            threadImpl.setRubyName(null);
         }
-        this.threadName = name;
-        setThreadName(runtime, getNativeThread(), null, -1, false);
+
         return name;
     }
 
     @JRubyMethod(name = "name")
     public IRubyObject getName() {
-        return this.threadName;
-    }
-
-    private String getNameOrNull() {
-        final IRubyObject name = getName();
-        return ( name == null || name.isNil() ) ? null : name.asJavaString();
+        return (IRubyObject) threadImpl.getRubyName();
     }
 
     private boolean pendingInterruptInclude(IRubyObject err) {
@@ -1059,6 +1046,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         if (exitingException != null) {
             // Set $! in the current thread before exiting
             runtime.getGlobalVariables().set("$!", (IRubyObject)exitingException.getException());
+            exceptionCaptured = true;
             throw exitingException;
 
         }
@@ -1102,17 +1090,21 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         String cname = getMetaClass().getRealClass().getName();
         part.append("#<").append(cname).append(':');
         part.append(identityString());
-        final String name = getNameOrNull(); // thread.name
-        if ( name != null ) {
+        CharSequence name = threadImpl.getRubyName(); // thread.name
+        if (notEmpty(name)) {
             part.append('@').append(name);
         }
-        if ( file != null && file.length() > 0 && line >= 0 ) {
+        if (notEmpty(file) && line >= 0) {
             part.append('@').append(file).append(':').append(line + 1);
         }
         part.append(' ');
         part.append(status.toString().toLowerCase());
         part.append('>');
         return getRuntime().newString(part.toString());
+    }
+
+    private boolean notEmpty(CharSequence str) {
+        return str != null && str.toString().length() > 0;
     }
 
     @JRubyMethod(name = "key?", required = 1)
@@ -1568,6 +1560,39 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         return myContext.createCallerLocations(level, length, getNativeThread().getStackTrace());
     }
 
+    @JRubyMethod(name = "report_on_exception=")
+    public IRubyObject report_on_exception_set(ThreadContext context, IRubyObject state) {
+        if (state.isNil()) {
+            reportOnException = state;
+        } else {
+            reportOnException = context.runtime.newBoolean(state.isTrue());
+        }
+        return this;
+    }
+
+    @JRubyMethod(name = "report_on_exception")
+    public IRubyObject report_on_exception(ThreadContext context) {
+        return reportOnException;
+    }
+
+    @JRubyMethod(name = "report_on_exception=", meta = true)
+    public static IRubyObject report_on_exception_set(ThreadContext context, IRubyObject self, IRubyObject state) {
+        Ruby runtime = context.runtime;
+        
+        if (state.isNil()) {
+            runtime.setReportOnException(state);
+        } else {
+            runtime.setReportOnException(runtime.newBoolean(state.isTrue()));
+        }
+
+        return self;
+    }
+
+    @JRubyMethod(name = "report_on_exception", meta = true)
+    public static IRubyObject report_on_exception(ThreadContext context, IRubyObject self) {
+        return context.runtime.getReportOnException();
+    }
+
     public StackTraceElement[] javaBacktrace() {
         if (threadImpl instanceof NativeThread) {
             return ((NativeThread)threadImpl).getThread().getStackTrace();
@@ -1593,10 +1618,25 @@ public class RubyThread extends RubyObject implements ExecutionContext {
             runtime.getThreadService().getMainThread().raise(rubyException);
             return;
         }
-        else if (runtime.isDebug()) {
+        else if (runtime.isDebug() || reportOnException.isTrue()) {
+            printReportExceptionWarning();
             runtime.printError(exception.getException());
         }
         exitingException = exception;
+    }
+
+    @Override
+    protected void finalize() {
+        if (exitingException != null && reportOnException.isNil() && !exceptionCaptured) {
+            printReportExceptionWarning();
+            getRuntime().printError(exitingException.getException());
+        }
+    }
+
+    protected void printReportExceptionWarning() {
+        PrintStream errorStream = getRuntime().getErrorStream();
+        String name = threadImpl.getReportName();
+        errorStream.println("warning: thread \"" + name + "\" terminated with exception:");
     }
 
     /**
@@ -1615,6 +1655,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         Ruby runtime = getRuntime();
         if (abortOnException(runtime) && exception instanceof Error) {
             // re-propagate on main thread
+            exceptionCaptured = true;
             runtime.getThreadService().getMainThread().raise(JavaUtil.convertJavaToUsableRubyObject(runtime, exception));
         } else {
             // just rethrow on this thread, let system handlers report it

--- a/core/src/main/java/org/jruby/internal/runtime/ThreadLike.java
+++ b/core/src/main/java/org/jruby/internal/runtime/ThreadLike.java
@@ -49,4 +49,14 @@ public interface ThreadLike {
     public boolean isInterrupted();
 
     public Thread nativeThread();
+
+    public void setNativeName(String name);
+
+    public String getNativeName();
+
+    public void setRubyName(CharSequence name);
+
+    public CharSequence getRubyName();
+
+    public String getReportName();
 }


### PR DESCRIPTION
This impl is a work in progress and has not been finalized yet.

It works as follows:
- nil = report when thread is finalized if nobody has captured the
  exception (i.e. called #join or #value or abort_on_exception
  logic has fired).
- true = report when the thread terminates, regardless of capture.
- false = never report.
- Default global value is nil.
- New threads inherit the current global setting.
- If a thread name has been set from Ruby, it will be combined
  with JRuby's internal name for the report. If it has not been
  set, we will just report the internal thread name.

There are some open questions for this feature:
- If join/value are interrupted, should they still set the capture
  bit? My impl does not; they must complete.
- Is the VERBOSE-like nil/true/false clear enough or should we use
  symbols like :off, :gc, :on?

See the Ruby feature here: https://bugs.ruby-lang.org/issues/6647
