### PR TITLE
Travis: Do not retry the install step.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ branches:
     - /^ha-feature/
     - ruby-2.4
 
-install: travis_retry tool/travis-install.sh
+install: tool/travis-install.sh
 script: tool/travis-script.sh
 
 notifications:


### PR DESCRIPTION
* In general install failures are either
  network issues which will not solve in the next 5 minutes
  or compilation issues which needs a proper fix.