### PR TITLE
Ensure that Selectors from SelectorPool don't have old keys in them

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -1768,14 +1768,6 @@ public class RubyThread extends RubyObject implements ExecutionContext {
                     // so that we can ensure one failing does not affect the others
                     // running.
 
-                    // clean up the key in the selector
-                    try {
-                        if (key != null) key.cancel();
-                        if (currentSelector != null) currentSelector.selectNow();
-                    } catch (Exception e) {
-                        // ignore
-                    }
-
                     // shut down and null out the selector
                     try {
                         if (currentSelector != null) {


### PR DESCRIPTION
(Note this is the same as https://github.com/jruby/jruby/pull/3951 but targeting master, sorry for the confusion!)

This PR fixes https://github.com/jruby/jruby-openssl/issues/93

To summarize: I found that many times when you get a `Selector` from `SelectorPool`, it already had old keys in it, and that was causing problems as reported in the issue. Something somewhere was returning selectors without cleaning up its keys properly, I think possibly [this line](https://github.com/jruby/jruby/blob/915993886ae6663586d893b7d237f750068aceb5/core/src/main/java/org/jruby/util/io/SelectExecutor.java#L290) (perhaps the key needs to be cancelled even if its invalid or it may still show up in `selectedKeys()` under certain conditions?). Its also possible that some gem out there I don't know about uses the method and doesn't clean the keys properly.

Instead of repeating the key-cleaning code in (at least) the 3 places in jruby and jruby-openssl, I figure the best fix is to do the cleaning inside of `SelectorPool#put`, so its only done in one place, and done correctly.

I've been running this patch in production and its completely fixed this issue, and I don't see any `Selector`s with old keys any more, and haven't seen any unwanted side effects