### PR TITLE
Use platform defaults from defaults file rather than eager load.

### DIFF
--- a/lib/ruby/stdlib/rubygems/config_file.rb
+++ b/lib/ruby/stdlib/rubygems/config_file.rb
@@ -54,7 +54,7 @@ class Gem::ConfigFile
   # For Ruby implementers to set configuration defaults.  Set in
   # rubygems/defaults/#{RUBY_ENGINE}.rb
 
-  PLATFORM_DEFAULTS = {}
+  PLATFORM_DEFAULTS = Gem.platform_defaults
 
   # :stopdoc:
 

--- a/lib/ruby/stdlib/rubygems/defaults/jruby.rb
+++ b/lib/ruby/stdlib/rubygems/defaults/jruby.rb
@@ -1,11 +1,7 @@
-require 'rubygems/config_file'
 require 'rbconfig'
 require 'jruby/util'
 
 module Gem
-
-  ConfigFile::PLATFORM_DEFAULTS['install'] = '--no-rdoc --no-ri --env-shebang'
-  ConfigFile::PLATFORM_DEFAULTS['update']  = '--no-rdoc --no-ri --env-shebang'
 
   class << self
     alias_method :original_ruby, :ruby
@@ -20,6 +16,13 @@ module Gem
     def jarred_path?(p)
       p =~ /^(file|uri|jar|classpath):/
     end
+  end
+
+  def self.platform_defaults
+    return {
+        'install' => '--no-rdoc --no-ri --env-shebang',
+        'update' => '--no-rdoc --no-ri --env-shebang'
+    }
   end
 
   # Default home directory path to be used if an alternate value is not


### PR DESCRIPTION
This trims off a bit of startup time by not loading more of RG
than is necessary. Pending release of rubygems/rubygems#1644 (and install of that release into JRuby).

Before:

```
[] ~/projects/jruby $ time jruby -e 1

real	0m2.397s
user	0m6.476s
sys	0m0.310s

[] ~/projects/jruby $ time jruby --dev -e 1

real	0m1.884s
user	0m2.717s
sys	0m0.223s
```

After:

```
[] ~/projects/jruby $ time jruby -e 1

real	0m2.181s
user	0m5.681s
sys	0m0.295s

[] ~/projects/jruby $ time jruby --dev -e 1

real	0m1.733s
user	0m2.493s
sys	0m0.214s
```