### PR TITLE
Partially fix set_trace_func line numbers

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -965,6 +965,10 @@ public class IRBuilder {
         addInstr(new ReceiveJRubyExceptionInstr(exc));
 
         if (RubyInstanceConfig.FULL_TRACE_ENABLED) {
+            // FIXME: We also should add a line number instruction so that backtraces
+            // inside the trace function get the correct line. Unfortunately, we don't
+            // have one here and we can't do it dynamically like TraceInstr does.
+            // See https://github.com/jruby/jruby/issues/4051
             addInstr(new TraceInstr(RubyEvent.RETURN, getName(), getFileName(), -1));
         }
 
@@ -1761,6 +1765,10 @@ public class IRBuilder {
         Operand rv = build(defNode.getBodyNode());
 
         if (RubyInstanceConfig.FULL_TRACE_ENABLED) {
+            // FIXME: We also should add a line number instruction so that backtraces
+            // inside the trace function get the correct line. Unfortunately, we don't
+            // have one here and we can't do it dynamically like TraceInstr does.
+            // See https://github.com/jruby/jruby/issues/4051
             addInstr(new TraceInstr(RubyEvent.RETURN, getName(), getFileName(), -1));
         }
 
@@ -3714,6 +3722,10 @@ public class IRBuilder {
         Operand bodyReturnValue = build(bodyNode);
 
         if (RubyInstanceConfig.FULL_TRACE_ENABLED) {
+            // FIXME: We also should add a line number instruction so that backtraces
+            // inside the trace function get the correct line. Unfortunately, we don't
+            // have one here and we can't do it dynamically like TraceInstr does.
+            // See https://github.com/jruby/jruby/issues/4051
             addInstr(new TraceInstr(RubyEvent.END, null, getFileName(), -1));
         }
 

--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -371,13 +371,13 @@ public class IRBuilder {
         if (node.isNewline()) {
             int currLineNum = node.getLine();
             if (currLineNum != _lastProcessedLineNum) { // Do not emit multiple line number instrs for the same line
+                addInstr(manager.newLineNumber(currLineNum));
                 if (RubyInstanceConfig.FULL_TRACE_ENABLED) {
                     addInstr(new TraceInstr(RubyEvent.LINE, methodNameFor(), getFileName(), currLineNum));
                     if (needsCodeCoverage()) {
                         addInstr(new TraceInstr(RubyEvent.COVERAGE, methodNameFor(), getFileName(), currLineNum));
                     }
                 }
-                addInstr(manager.newLineNumber(currLineNum));
                 _lastProcessedLineNum = currLineNum;
             }
         }
@@ -1740,6 +1740,7 @@ public class IRBuilder {
         this.needsCodeCoverage = needsCodeCoverage;
 
         if (RubyInstanceConfig.FULL_TRACE_ENABLED) {
+            addInstr(manager.newLineNumber(scope.getLineNumber()));
             addInstr(new TraceInstr(RubyEvent.CALL, getName(), getFileName(), scope.getLineNumber()));
         }
 


### PR DESCRIPTION
After reporting issue #4051 I decided to look at the generated IR and noticed that trace instructions were being added without line numbers. This led to the observed issue there stack traces generated inside `set_trace_func` did not have the correct line numbers.

For the `LINE` and `CALL` events the fix is straightforward: just add a line number instruction **before** the trace instruction, as the line number was already known statically by the `IRBuilder`.

Unfortunately, for the `RETURN` and `END` events the parser does not include this information and thus there's no simple way of adding line number instructions before those. I think that particular fix is a bit beyond my capabilities so I added some `FIXME`s so at least this doesn't get forgotten.

Nevertheless, and happily, the partial fix seems to be enough to get [`pry-nav`](https://github.com/ivoanjo/pry-nav) to work!

On a side note, I must admit that
![](http://herbookthoughts.reads-it.com/wp-content/uploads/2014/06/d6a1143f571184db25f94613edd43b40af6d3a629221aba00d9efdcfef5efd84.jpg)
but nevertheless for a first time diving inside JRuby's codebase, this went better than expected :smile: 

Please let me know if there's some way I can help fix this further!

Issue #4051 