### PR TITLE
RubyEnumerator implements java.util.Iterator

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -434,20 +434,30 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
     }
 
     @JRubyMethod
-    public IRubyObject size(ThreadContext context) {
+    public final IRubyObject size(ThreadContext context) {
         if (sizeFn != null) {
             return sizeFn.size(methodArgs);
         }
 
+        IRubyObject size = this.size;
         if (size != null) {
             if (size.respondsTo("call")) {
+                if (context == null) context = getRuntime().getCurrentContext();
                 return size.callMethod(context, "call");
             }
 
             return size;
         }
 
-        return context.nil;
+        return context == null ? null : context.nil;
+    }
+
+    public long size() {
+        final IRubyObject size = size(null);
+        if ( size instanceof RubyNumeric ) {
+            return ((RubyNumeric) size).getLongValue();
+        }
+        return -1;
     }
 
     private SizeFn enumSizeFn(final ThreadContext context) {

--- a/core/src/main/ruby/jruby/java.rb
+++ b/core/src/main/ruby/jruby/java.rb
@@ -38,3 +38,4 @@ load 'jruby/java/java_utilities.rb'
 
 load 'jruby/java/core_ext.rb'
 load 'jruby/java/java_ext.rb'
+load 'jruby/java/java_8.rb' if java.util.Spliterator rescue nil

--- a/core/src/main/ruby/jruby/java/java_8.rb
+++ b/core/src/main/ruby/jruby/java/java_8.rb
@@ -1,0 +1,19 @@
+# Extensions for Java 8
+
+# @private shall be moved to Java when compiling against Java 8
+org.jruby.RubyEnumerator.class_eval do
+
+  def stream(parallel = false)
+    java.util.stream.StreamSupport.stream spliterator, parallel
+  end
+
+  def spliterator(mod = nil)
+    size = self.size
+    # mod = java.util.Spliterator::NONNULL
+    # we do not have ArrayNexter detection - assume immutable
+    mod ||= java.util.Spliterator::IMMUTABLE
+    mod ||= java.util.Spliterator::SIZED if size >= 0
+    java.util.Spliterators.spliterator(self, size, mod)
+  end
+
+end


### PR DESCRIPTION
feels like a good fit and this makes enumerator usable with Java 8 (with some boilerplate) : 
`java.util.Spliterators.spliterator(enum.to_java, enum.size || -1, charactestistics)`

... ideally some more integration would be handy but JRuby would need compiling under Java 8 for easy : `[1, 2, 3, 4, 5].each.to_java.stream` or `Enumerator.new { ... }.to_java.spliterator` implementations.
esp. since the Enumeration's size and the spliterator characteristic are depend on internals. so this would like get revisited after a potential compilation switch in another release.

Ruby enumerator (and thus Ruby array) usability with 8 streaming is confirmed with test-cases.