### PR TITLE
Fix Socket.tcp connect_timeout option

### DIFF
--- a/core/src/main/java/org/jruby/ext/io/wait/IOWaitLibrary.java
+++ b/core/src/main/java/org/jruby/ext/io/wait/IOWaitLibrary.java
@@ -155,7 +155,8 @@ public class IOWaitLibrary implements Library {
             if (tv < 0) throw runtime.newArgumentError("time interval must be positive");
         }
 
-        boolean ready = fptr.ready(runtime, context.getThread(), SelectionKey.OP_WRITE, tv);
+        boolean ready = fptr.ready(runtime, context.getThread(), SelectionKey.OP_CONNECT | SelectionKey.OP_WRITE, tv);
+
         fptr.checkClosed();
         if (ready)
             return io;

--- a/core/src/main/java/org/jruby/ext/socket/RubySocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubySocket.java
@@ -530,7 +530,7 @@ public class RubySocket extends RubyBasicSocket {
             }
 
             if ( ! result ) {
-                if (!ex) return runtime.newSymbol("wait_readable");
+                if (!ex) return runtime.newSymbol("wait_writable");
                 throw runtime.newErrnoEINPROGRESSWritableError();
             }
         }


### PR DESCRIPTION
Before commit `Socket.tcp(host, port, connect_timeout: 0.1)`
ignored timeout option. This happened because `connect_internal`
mistakenly responded with `:wait_readable` instead `:wait_writable`.
After fixing it this code started to constantly fail with timeout error.
Checking for `OP_CONNECT` in `IO#wait_writable` fixed this issue.

Added adopted spec from MRI, because it's excluded by other reasons.