### PR TITLE
Write a log message when findClass IOException is caught

### DIFF
--- a/core/src/main/java/org/jruby/util/JRubyClassLoader.java
+++ b/core/src/main/java/org/jruby/util/JRubyClassLoader.java
@@ -259,6 +259,8 @@ public class JRubyClassLoader extends URLClassLoader implements ClassDefiningCla
                     }
                 } catch (IOException e) {
                     // just fall-through to the re-throw below
+                    LOG.debug("findClass IOException in getting class for url: " +
+                            classUrl + ", message: " + e.getMessage(), e);
                 }
             }
 


### PR DESCRIPTION
This commit just adds a simple `LOG.debug` message to output the contents of an `IOException` that might be caught by the JRubyClassLoader during a `findClass` call.  We were encountering the `IOException` in cases where our process ran out of file descriptors, leading the `classUrl.openStream` call to fail.  This manifested in our application as a `NoClassDefFoundError` downstream but because the `IOException` is swallowed higher up, it was initially hard for us to able to determine what the root cause was.  Being able to see this new debug message in the log output would significantly help with our ability to diagnose this kind of problem.