### PR TITLE
Explicitly close input stream in CompoundJarURLStreamHandler

### DIFF
--- a/core/src/main/java/org/jruby/util/CompoundJarURLStreamHandler.java
+++ b/core/src/main/java/org/jruby/util/CompoundJarURLStreamHandler.java
@@ -155,13 +155,11 @@ public class CompoundJarURLStreamHandler extends URLStreamHandler {
                 try {
                     result = openEntryWithCache(path, baseInputStream, 1);
                 } catch (IOException ex) {
-                    close(baseInputStream);
-
                     throw ex;
                 } catch (RuntimeException ex) {
-                    close(baseInputStream);
-
                     throw ex;
+                } finally {
+                    close(baseInputStream);
                 }
             } else {
                 result = baseInputStream;


### PR DESCRIPTION
This commit ensures that the stream which is opened for a `URL` within
`CompoundJarURLStreamHandler` is explicitly closed before it falls out
of scope.  Previously, the stream would still eventually be closed but
only after Garbage Collection.