### PR TITLE
Truffle fix match backref

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/core/binding/BindingNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/binding/BindingNodes.java
@@ -35,6 +35,7 @@ import org.jruby.truffle.language.locals.ReadFrameSlotNodeGen;
 import org.jruby.truffle.language.locals.WriteFrameSlotNode;
 import org.jruby.truffle.language.locals.WriteFrameSlotNodeGen;
 import org.jruby.truffle.language.objects.AllocateObjectNode;
+import org.jruby.truffle.language.parser.jruby.Translator;
 import org.jruby.truffle.language.threadlocal.ThreadLocalObject;
 
 import java.util.ArrayList;
@@ -309,7 +310,9 @@ public abstract class BindingNodes {
             final List<Object> names = new ArrayList<>();
             while (frame != null) {
                 for (FrameSlot slot : frame.getFrameDescriptor().getSlots()) {
-                    if (slot.getIdentifier() instanceof String && !((String) slot.getIdentifier()).startsWith("rubytruffle_temp_frame_on_stack_marker")) {
+                    if (slot.getIdentifier() instanceof String &&
+                            !((String) slot.getIdentifier()).startsWith("rubytruffle_temp_frame_on_stack_marker") &&
+                            !Translator.FRAME_LOCAL_GLOBAL_VARIABLES.contains(slot.getIdentifier())) {
                         names.add(context.getSymbolTable().getSymbol((String) slot.getIdentifier()));
                     }
                 }

--- a/truffle/src/main/java/org/jruby/truffle/core/regexp/MatchDataNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/regexp/MatchDataNodes.java
@@ -35,6 +35,7 @@ import org.jruby.truffle.core.cast.TaintResultNode;
 import org.jruby.truffle.core.cast.ToIntNode;
 import org.jruby.truffle.core.rope.Rope;
 import org.jruby.truffle.core.string.StringGuards;
+import org.jruby.truffle.core.string.StringNodesFactory;
 import org.jruby.truffle.core.string.StringOperations;
 import org.jruby.truffle.language.NotProvided;
 import org.jruby.truffle.language.RubyGuards;
@@ -173,6 +174,12 @@ public abstract class MatchDataNodes {
     public abstract static class GetIndexNode extends CoreMethodArrayArgumentsNode {
 
         @Child private ToIntNode toIntNode;
+
+        public static GetIndexNode create() {
+            return MatchDataNodesFactory.GetIndexNodeFactory.create(null);
+        }
+
+        public abstract Object executeGetIndex(VirtualFrame frame, Object matchData, Object index, Object length);
 
         @Specialization
         public Object getIndex(DynamicObject matchData, int index, NotProvided length,

--- a/truffle/src/main/java/org/jruby/truffle/core/regexp/RegexpNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/regexp/RegexpNodes.java
@@ -514,7 +514,7 @@ public abstract class RegexpNodes {
 
         @TruffleBoundary
         private Object getMatchData() {
-            Frame frame = getContext().getCallStack().getCallerFrameIgnoringSend().getFrame(FrameInstance.FrameAccess.READ_WRITE, true);
+            Frame frame = getContext().getCallStack().getCallerFrameIgnoringSend().getFrame(FrameAccess.READ_ONLY, true);
             FrameSlot slot = frame.getFrameDescriptor().findFrameSlot("$~");
 
             while (slot == null) {

--- a/truffle/src/main/java/org/jruby/truffle/core/regexp/RegexpNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/regexp/RegexpNodes.java
@@ -528,19 +528,14 @@ public abstract class RegexpNodes {
                 }
             }
 
-            final Object previousMatchData;
-            try {
-                previousMatchData = frame.getObject(slot);
+            final Object previousMatchData = frame.getValue(slot);
 
-                if (previousMatchData instanceof ThreadLocalObject) {
-                    final ThreadLocalObject threadLocalObject = (ThreadLocalObject) previousMatchData;
+            if (previousMatchData instanceof ThreadLocalObject) {
+                final ThreadLocalObject threadLocalObject = (ThreadLocalObject) previousMatchData;
 
-                    return threadLocalObject.get();
-                } else {
-                    return previousMatchData;
-                }
-            } catch (FrameSlotTypeException e) {
-                throw new IllegalStateException(e);
+                return threadLocalObject.get();
+            } else {
+                return previousMatchData;
             }
         }
 

--- a/truffle/src/main/java/org/jruby/truffle/core/rope/RopeNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/rope/RopeNodes.java
@@ -731,7 +731,7 @@ public abstract class RopeNodes {
         @Specialization(guards = {
                 "rope.getEncoding() != encoding",
                 "rope.getCodeRange() != codeRange",
-                "isAsciiCompatbileChange(rope, encoding)",
+                "isAsciiCompatibleChange(rope, encoding)",
                 "rope.getClass() == cachedRopeClass"
         }, limit = "getCacheLimit()")
         public Rope withEncodingCr7Bit(Rope rope, Encoding encoding, CodeRange codeRange,
@@ -742,14 +742,14 @@ public abstract class RopeNodes {
         @Specialization(guards = {
                 "rope.getEncoding() != encoding",
                 "rope.getCodeRange() != codeRange",
-                "!isAsciiCompatbileChange(rope, encoding)"
+                "!isAsciiCompatibleChange(rope, encoding)"
         })
         public Rope withEncoding(Rope rope, Encoding encoding, CodeRange codeRange,
                                  @Cached("create()") MakeLeafRopeNode makeLeafRopeNode) {
             return makeLeafRopeNode.executeMake(rope.getBytes(), encoding, codeRange, NotProvided.INSTANCE);
         }
 
-        protected static boolean isAsciiCompatbileChange(Rope rope, Encoding encoding) {
+        protected static boolean isAsciiCompatibleChange(Rope rope, Encoding encoding) {
             return rope.getCodeRange() == CR_7BIT && encoding.isAsciiCompatible();
         }
 

--- a/truffle/src/main/java/org/jruby/truffle/core/rubinius/RegexpPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/rubinius/RegexpPrimitiveNodes.java
@@ -188,20 +188,20 @@ public abstract class RegexpPrimitiveNodes {
         @Specialization(guards = { "isRubyProc(block)", "isSuitableMatchDataType(getContext(), matchData)" })
         public Object setBlockLastMatch(DynamicObject block, DynamicObject matchData) {
 
-            Frame callerFrame = Layouts.PROC.getDeclarationFrame(block);
+            Frame methodFrame = Layouts.PROC.getDeclarationFrame(block);
 
-            if (callerFrame == null) {
+            if (methodFrame == null) {
                 return matchData;
             }
 
-            Frame tempFrame = RubyArguments.getDeclarationFrame(callerFrame);
+            Frame tempFrame = RubyArguments.getDeclarationFrame(methodFrame);
 
             while (tempFrame != null) {
-                callerFrame = tempFrame;
-                tempFrame = RubyArguments.getDeclarationFrame(callerFrame);
+                methodFrame = tempFrame;
+                tempFrame = RubyArguments.getDeclarationFrame(methodFrame);
             }
 
-            final FrameDescriptor callerFrameDescriptor = callerFrame.getFrameDescriptor();
+            final FrameDescriptor callerFrameDescriptor = methodFrame.getFrameDescriptor();
 
             try {
                 final FrameSlot frameSlot = callerFrameDescriptor.findFrameSlot("$~");
@@ -210,12 +210,12 @@ public abstract class RegexpPrimitiveNodes {
                     return matchData;
                 }
 
-                final Object matchDataHolder = callerFrame.getObject(frameSlot);
+                final Object matchDataHolder = methodFrame.getObject(frameSlot);
 
                 if (matchDataHolder instanceof ThreadLocalObject) {
                     ((ThreadLocalObject) matchDataHolder).set(matchData);
                 } else {
-                    callerFrame.setObject(frameSlot, ThreadLocalObject.wrap(getContext(), matchData));
+                    methodFrame.setObject(frameSlot, ThreadLocalObject.wrap(getContext(), matchData));
                 }
             } catch (FrameSlotTypeException e) {
                 throw new IllegalStateException(e);

--- a/truffle/src/main/java/org/jruby/truffle/core/rubinius/RegexpPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/rubinius/RegexpPrimitiveNodes.java
@@ -118,10 +118,10 @@ public abstract class RegexpPrimitiveNodes {
 
             if (forward) {
                 // Search forward through the string.
-                return RegexpNodes.matchCommon(getContext(), this, makeSubstringNode, regexp, string, false, false, matcher, start, end);
+                return RegexpNodes.matchCommon(getContext(), this, makeSubstringNode, regexp, string, false, matcher, start, end);
             } else {
                 // Search backward through the string.
-                return RegexpNodes.matchCommon(getContext(), this, makeSubstringNode, regexp, string, false, false, matcher, end, start);
+                return RegexpNodes.matchCommon(getContext(), this, makeSubstringNode, regexp, string, false, matcher, end, start);
             }
         }
 

--- a/truffle/src/main/java/org/jruby/truffle/core/rubinius/RegexpPrimitiveNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/rubinius/RegexpPrimitiveNodes.java
@@ -87,17 +87,6 @@ public abstract class RegexpPrimitiveNodes {
 
     }
 
-    @Primitive(name = "regexp_propagate_last_match")
-    public static abstract class RegexpPropagateLastMatchPrimitiveNode extends PrimitiveArrayArgumentsNode {
-
-        @Specialization
-        public DynamicObject propagateLastMatch(DynamicObject regexpClass) {
-            // TODO (nirvdrum 08-Jun-15): This method seems to exist just to fix Rubinius's broken frame-local scoping.  This assertion needs to be verified, however.
-            return nil();
-        }
-
-    }
-
     @Primitive(name = "regexp_search_region", lowerFixnum = { 2, 3 })
     @ImportStatic(RegexpGuards.class)
     public static abstract class RegexpSearchRegionPrimitiveNode extends PrimitiveArrayArgumentsNode {

--- a/truffle/src/main/java/org/jruby/truffle/core/string/StringNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/string/StringNodes.java
@@ -581,18 +581,7 @@ public abstract class StringNodes {
                 Object capture,
                 @Cached("createMethodCallIgnoreVisibility()") CallDispatchHeadNode callNode,
                 @Cached("create()") RegexpPrimitiveNodes.RegexpSetLastMatchPrimitiveNode setLastMatchNode) {
-            final Object matchStrPair = callNode.call(frame, string, "subpattern", regexp, 0);
-
-            if (matchStrPair == nil()) {
-                setLastMatchNode.executeSetLastMatch(nil());
-                return nil();
-            }
-
-            final Object[] array = (Object[]) Layouts.ARRAY.getStore((DynamicObject) matchStrPair);
-
-            setLastMatchNode.executeSetLastMatch(array[0]);
-
-            return array[1];
+            return sliceCapture(frame, string, regexp, 0, callNode, setLastMatchNode);
         }
 
         @Specialization(guards = {"isRubyRegexp(regexp)", "wasProvided(capture)"})

--- a/truffle/src/main/java/org/jruby/truffle/core/string/StringNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/string/StringNodes.java
@@ -126,6 +126,7 @@ import org.jruby.truffle.core.rope.RopeNodes.MakeRepeatingNode;
 import org.jruby.truffle.core.rope.RopeNodesFactory;
 import org.jruby.truffle.core.rope.RopeOperations;
 import org.jruby.truffle.core.rope.SubstringRope;
+import org.jruby.truffle.core.rubinius.RegexpPrimitiveNodes;
 import org.jruby.truffle.core.string.StringNodesFactory.StringAreComparableNodeGen;
 import org.jruby.truffle.core.string.StringNodesFactory.StringEqualNodeGen;
 import org.jruby.truffle.language.CheckLayoutNode;
@@ -578,8 +579,20 @@ public abstract class StringNodes {
                 DynamicObject string,
                 DynamicObject regexp,
                 Object capture,
-                @Cached("new()") SnippetNode snippetNode) {
-            return snippetNode.execute(frame, "match, str = subpattern(index, 0); Regexp.last_match = match; str", "index", regexp);
+                @Cached("createMethodCallIgnoreVisibility()") CallDispatchHeadNode callNode,
+                @Cached("create()") RegexpPrimitiveNodes.RegexpSetLastMatchPrimitiveNode setLastMatchNode) {
+            final Object matchStrPair = callNode.call(frame, string, "subpattern", regexp, 0);
+
+            if (matchStrPair == nil()) {
+                setLastMatchNode.executeSetLastMatch(nil());
+                return nil();
+            }
+
+            final Object[] array = (Object[]) Layouts.ARRAY.getStore((DynamicObject) matchStrPair);
+
+            setLastMatchNode.executeSetLastMatch(array[0]);
+
+            return array[1];
         }
 
         @Specialization(guards = {"isRubyRegexp(regexp)", "wasProvided(capture)"})
@@ -588,8 +601,20 @@ public abstract class StringNodes {
                 DynamicObject string,
                 DynamicObject regexp,
                 Object capture,
-                @Cached("new()") SnippetNode snippetNode) {
-            return snippetNode.execute(frame, "match, str = subpattern(index, other); Regexp.last_match = match; str", "index", regexp, "other", capture);
+                @Cached("createMethodCallIgnoreVisibility()") CallDispatchHeadNode callNode,
+                @Cached("create()") RegexpPrimitiveNodes.RegexpSetLastMatchPrimitiveNode setLastMatchNode) {
+            final Object matchStrPair = callNode.call(frame, string, "subpattern", regexp, capture);
+
+            if (matchStrPair == nil()) {
+                setLastMatchNode.executeSetLastMatch(nil());
+                return nil();
+            }
+
+            final Object[] array = (Object[]) Layouts.ARRAY.getStore((DynamicObject) matchStrPair);
+
+            setLastMatchNode.executeSetLastMatch(array[0]);
+
+            return array[1];
         }
 
         @Specialization(guards = {"wasNotProvided(length) || isRubiniusUndefined(length)", "isRubyString(matchStr)"})

--- a/truffle/src/main/java/org/jruby/truffle/language/globals/ReadMatchReferenceNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/language/globals/ReadMatchReferenceNode.java
@@ -9,7 +9,6 @@
  */
 package org.jruby.truffle.language.globals;
 
-import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.object.DynamicObject;
 import com.oracle.truffle.api.profiles.ConditionProfile;
@@ -17,6 +16,7 @@ import com.oracle.truffle.api.source.SourceSection;
 import org.jruby.truffle.Layouts;
 import org.jruby.truffle.RubyContext;
 import org.jruby.truffle.language.RubyNode;
+import org.jruby.truffle.language.threadlocal.GetFromThreadLocalNode;
 
 public class ReadMatchReferenceNode extends RubyNode {
 
@@ -27,18 +27,23 @@ public class ReadMatchReferenceNode extends RubyNode {
 
     private final int index;
 
-    @Child private ReadThreadLocalGlobalVariableNode readMatchNode;
+    @Child private GetFromThreadLocalNode readMatchNode;
 
     private final ConditionProfile matchNilProfile = ConditionProfile.createBinaryProfile();
 
-    public ReadMatchReferenceNode(RubyContext context, SourceSection sourceSection, int index) {
+    public ReadMatchReferenceNode(RubyContext context, SourceSection sourceSection, GetFromThreadLocalNode readMatchNode, int index) {
         super(context, sourceSection);
+        this.readMatchNode = readMatchNode;
         this.index = index;
     }
 
     @Override
     public Object execute(VirtualFrame frame) {
-        final Object match = getReadMatchNode().execute(frame);
+        if (readMatchNode == null) {
+            return nil();
+        }
+
+        final Object match = readMatchNode.execute(frame);
 
         if (matchNilProfile.profile(match == nil())) {
             return nil();
@@ -86,15 +91,6 @@ public class ReadMatchReferenceNode extends RubyNode {
         } else {
             return coreStrings().GLOBAL_VARIABLE.createInstance();
         }
-    }
-
-    private ReadThreadLocalGlobalVariableNode getReadMatchNode() {
-        if (readMatchNode == null) {
-            CompilerDirectives.transferToInterpreterAndInvalidate();
-            readMatchNode = insert(new ReadThreadLocalGlobalVariableNode(getContext(), null, "$~", true));
-        }
-
-        return readMatchNode;
     }
 
 }

--- a/truffle/src/main/java/org/jruby/truffle/language/parser/jruby/Translator.java
+++ b/truffle/src/main/java/org/jruby/truffle/language/parser/jruby/Translator.java
@@ -33,8 +33,8 @@ import java.util.Set;
 
 public abstract class Translator extends org.jruby.ast.visitor.AbstractNodeVisitor<RubyNode> {
 
-    public static final Set<String> ALWAYS_DEFINED_GLOBALS = new HashSet<>(Arrays.asList("$~", "$!"));
-    public static final Set<String> FRAME_LOCAL_GLOBAL_VARIABLES = new HashSet<>(Arrays.asList("$_", "$+", "$&", "$`", "$'"));
+    public static final Set<String> ALWAYS_DEFINED_GLOBALS = new HashSet<>(Arrays.asList("$!", "$~"));
+    public static final Set<String> FRAME_LOCAL_GLOBAL_VARIABLES = new HashSet<>(Arrays.asList("$_", "$+", "$&", "$`", "$'", "$~", "$1", "$2", "$3", "$4", "$5", "$6", "$7", "$8", "$9"));
 
     protected final Node currentNode;
     protected final RubyContext context;

--- a/truffle/src/main/ruby/core/enumerable.rb
+++ b/truffle/src/main/ruby/core/enumerable.rb
@@ -345,14 +345,14 @@ module Enumerable
     self
   end
 
-  def grep(pattern)
+  def grep(pattern, &block)
     ary = []
 
     if block_given?
       each do
         o = Truffle.single_block_arg
         if pattern === o
-          Regexp.set_block_last_match
+          Regexp.set_block_last_match(block, $~)
           ary << yield(o)
         end
       end
@@ -360,10 +360,11 @@ module Enumerable
       each do
         o = Truffle.single_block_arg
         if pattern === o
-          Regexp.set_block_last_match
           ary << o
         end
       end
+
+      Truffle.invoke_primitive(:regexp_set_last_match, $~)
     end
 
     ary

--- a/truffle/src/main/ruby/core/enumerator.rb
+++ b/truffle/src/main/ruby/core/enumerator.rb
@@ -370,23 +370,28 @@ module Enumerable
         end
       end
 
-      def grep(pattern)
+      def grep(pattern, &block)
         if block_given?
           Lazy.new(self, nil) do |yielder, *args|
             val = args.length >= 2 ? args : args.first
             if pattern === val
-              Regexp.set_block_last_match
+              Regexp.set_block_last_match(block, $~)
               yielder.yield yield(val)
             end
           end
         else
-          Lazy.new(self, nil) do |yielder, *args|
+          lazy = Lazy.new(self, nil) do |yielder, *args|
             val = args.length >= 2 ? args : args.first
             if pattern === val
-              Regexp.set_block_last_match
               yielder.yield val
             end
+
+            Truffle.invoke_primitive(:regexp_set_last_match, $~)
           end
+
+          Truffle.invoke_primitive(:regexp_set_last_match, $~)
+
+          lazy
         end
       end
 

--- a/truffle/src/main/ruby/core/regexp.rb
+++ b/truffle/src/main/ruby/core/regexp.rb
@@ -222,7 +222,7 @@ class Regexp
 
   def match(str, pos=0)
     unless str
-      Regexp.last_match = nil
+      Truffle.invoke_primitive(:regexp_set_last_match, nil)
       return nil
     end
 
@@ -233,7 +233,7 @@ class Regexp
     pos = pos < 0 ? pos + str.size : pos
     pos = m.character_to_byte_index pos
     result = search_region(str, pos, str.bytesize, true)
-    Regexp.last_match = result
+    Truffle.invoke_primitive(:regexp_set_last_match, result)
 
     if result && block_given?
       yield result
@@ -248,16 +248,16 @@ class Regexp
     elsif !other.kind_of? String
       other = Rubinius::Type.check_convert_type other, String, :to_str
       unless other
-        Regexp.last_match = nil
+        Truffle.invoke_primitive(:regexp_set_last_match, nil)
         return false
       end
     end
 
     if match = match_from(other, 0)
-      Regexp.last_match = match
+      Truffle.invoke_primitive(:regexp_set_last_match, match)
       true
     else
-      Regexp.last_match = nil
+      Truffle.invoke_primitive(:regexp_set_last_match, nil)
       false
     end
   end
@@ -286,7 +286,7 @@ class Regexp
     line = $_
 
     unless line.kind_of?(String)
-      Regexp.last_match = nil
+      Truffle.invoke_primitive(:regexp_set_last_match, nil)
       return nil
     end
 

--- a/truffle/src/main/ruby/core/regexp.rb
+++ b/truffle/src/main/ruby/core/regexp.rb
@@ -113,11 +113,6 @@ class Regexp
     raise PrimitiveFailure, "Regexp#set_last_match primitive failed"
   end
 
-  def self.propagate_last_match
-    Truffle.primitive :regexp_propagate_last_match
-    raise PrimitiveFailure, "Regexp#propagate_last_match primitive failed"
-  end
-
   def self.set_block_last_match(block, match_data)
     Truffle.primitive :regexp_set_block_last_match
     raise PrimitiveFailure, "Regexp#set_block_last_match primitive failed"

--- a/truffle/src/main/ruby/core/regexp.rb
+++ b/truffle/src/main/ruby/core/regexp.rb
@@ -103,15 +103,6 @@ class Regexp
     raise PrimitiveFailure, "Regexp#options primitive failed"
   end
     
-  def self.last_match(n = nil)
-    if n
-      # TODO (nirvdrum Jan. 8, 2015) Make sure this supports symbol keys for named capture lookup.
-      $~.values_at(n).first
-    else
-      $~
-    end
-  end
-
   def self.last_match=(match)
     Truffle.primitive :regexp_set_last_match
 
@@ -127,7 +118,7 @@ class Regexp
     raise PrimitiveFailure, "Regexp#propagate_last_match primitive failed"
   end
 
-  def self.set_block_last_match
+  def self.set_block_last_match(block, match_data)
     Truffle.primitive :regexp_set_block_last_match
     raise PrimitiveFailure, "Regexp#set_block_last_match primitive failed"
   end

--- a/truffle/src/main/ruby/core/string.rb
+++ b/truffle/src/main/ruby/core/string.rb
@@ -133,7 +133,7 @@ class String
     case pattern
       when Regexp
         match_data = pattern.search_region(self, 0, bytesize, true)
-        Regexp.last_match = match_data
+        Truffle.invoke_primitive(:regexp_set_last_match, match_data)
         return match_data.begin(0) if match_data
       when String
         raise TypeError, "type mismatch: String given"
@@ -191,7 +191,7 @@ class String
 
     if pattern.kind_of? Regexp
       if m = pattern.match(self)
-        Regexp.last_match = m
+        Truffle.invoke_primitive(:regexp_set_last_match, m)
         return [m.pre_match, m.to_s, m.post_match]
       end
     else
@@ -213,7 +213,7 @@ class String
   def rpartition(pattern)
     if pattern.kind_of? Regexp
       if m = pattern.search_region(self, 0, size, false)
-        Regexp.last_match = m
+        Truffle.invoke_primitive(:regexp_set_last_match, m)
         [m.pre_match, m[0], m.post_match]
       end
     else
@@ -268,14 +268,14 @@ class String
       val.taint if taint
 
       if block_given?
-        Regexp.last_match = match
+        Truffle.invoke_primitive(:regexp_set_last_match, match)
         yield(val)
       else
         ret << val
       end
     end
 
-    Regexp.last_match = last_match
+    Truffle.invoke_primitive(:regexp_set_last_match, last_match)
     return ret
   end
 
@@ -628,7 +628,7 @@ class String
     pattern = Rubinius::Type.coerce_to_regexp(pattern, true) unless pattern.kind_of? Regexp
     match = pattern.match_from(dup, 0)
 
-    Regexp.last_match = match
+    Truffle.invoke_primitive(:regexp_set_last_match, match)
 
     ret = byteslice(0, 0) # Empty string and string subclass
 
@@ -636,7 +636,7 @@ class String
       ret.append match.pre_match
 
       if use_yield || hash
-        Regexp.last_match = match
+        Truffle.invoke_primitive(:regexp_set_last_match, match)
 
         if use_yield
           val = yield match.to_s
@@ -697,7 +697,7 @@ class String
     pattern = Rubinius::Type.coerce_to_regexp(pattern, true) unless pattern.kind_of? Regexp
     match = pattern.match_from(self, 0)
 
-    Regexp.last_match = match
+    Truffle.invoke_primitive(:regexp_set_last_match, match)
 
     ret = byteslice(0, 0) # Empty string and string subclass
 
@@ -705,7 +705,7 @@ class String
       ret.append match.pre_match
 
       if use_yield || hash
-        Regexp.last_match = match
+        Truffle.invoke_primitive(:regexp_set_last_match, match)
 
         duped = dup
         if use_yield
@@ -750,7 +750,7 @@ class String
       if one.kind_of? Regexp
         lm = Regexp.last_match
         self[one] = '' if result
-        Regexp.last_match = lm
+        Truffle.invoke_primitive(:regexp_set_last_match, lm)
       else
         self[one] = '' if result
       end
@@ -760,7 +760,7 @@ class String
       if one.kind_of? Regexp
         lm = Regexp.last_match
         self[one, two] = '' if result
-        Regexp.last_match = lm
+        Truffle.invoke_primitive(:regexp_set_last_match, lm)
       else
         self[one, two] = '' if result
       end
@@ -1009,7 +1009,7 @@ class String
     match = pattern.search_region(self, 0, bytesize, true)
 
     unless match
-      Regexp.last_match = nil
+      Truffle.invoke_primitive(:regexp_set_last_match, nil)
     end
 
     duped = dup
@@ -1028,7 +1028,7 @@ class String
       end
 
       if use_yield || hash
-        Regexp.last_match = match
+        Truffle.invoke_primitive(:regexp_set_last_match, match)
 
         if use_yield
           val = yield match.to_s
@@ -1071,7 +1071,7 @@ class String
       offset = match.byte_begin(0)
     end
 
-    Regexp.last_match = last_match
+    Truffle.invoke_primitive(:regexp_set_last_match, last_match)
 
     str = byteslice(last_end, bytesize-last_end+1)
     if str
@@ -1117,7 +1117,7 @@ class String
     match = pattern.search_region(self, 0, bytesize, true)
 
     unless match
-      Regexp.last_match = nil
+      Truffle.invoke_primitive(:regexp_set_last_match, nil)
       return nil
     end
 
@@ -1137,7 +1137,7 @@ class String
       end
 
       if use_yield || hash
-        Regexp.last_match = match
+        Truffle.invoke_primitive(:regexp_set_last_match, match)
 
         if use_yield
           val = yield match.to_s
@@ -1180,7 +1180,7 @@ class String
       offset = match.byte_begin(0)
     end
 
-    Regexp.last_match = last_match
+    Truffle.invoke_primitive(:regexp_set_last_match, last_match)
 
     str = byteslice(last_end, bytesize-last_end+1)
     if str
@@ -1551,10 +1551,10 @@ class String
       m = Rubinius::Mirror.reflect self
       start = m.character_to_byte_index start
       if match = str.match_from(self, start)
-        Regexp.last_match = match
+        Truffle.invoke_primitive(:regexp_set_last_match, match)
         return match.begin(0)
       else
-        Regexp.last_match = nil
+        Truffle.invoke_primitive(:regexp_set_last_match, nil)
         return
       end
     end
@@ -1604,7 +1604,7 @@ class String
         Rubinius::Type.compatible_encoding self, sub
 
         match_data = sub.search_region(self, 0, byte_finish, false)
-        Regexp.last_match = match_data
+        Truffle.invoke_primitive(:regexp_set_last_match, match_data)
         return match_data.begin(0) if match_data
 
       else

--- a/truffle/src/main/ruby/core/string.rb
+++ b/truffle/src/main/ruby/core/string.rb
@@ -1204,7 +1204,7 @@ class String
              else
                pattern.match self, pos
              end
-    Regexp.propagate_last_match
+    Truffle.invoke_primitive(:regexp_set_last_match, $~)
     result
   end
 

--- a/truffle/src/main/ruby/core/string.rb
+++ b/truffle/src/main/ruby/core/string.rb
@@ -916,113 +916,14 @@ class String
   end
 
 
-  def gsub(pattern, replacement=undefined)
-    # Because of the behavior of $~, this is duplicated from gsub! because
-    # if we call gsub! from gsub, the last_match can't be updated properly.
-
-    unless valid_encoding?
-      raise ArgumentError, "invalid byte sequence in #{encoding}"
-    end
-
-    if undefined.equal? replacement
-      unless block_given?
-        return to_enum(:gsub, pattern, replacement)
-      end
-      use_yield = true
-      tainted = false
-    else
-      tainted = replacement.tainted?
-      untrusted = replacement.untrusted?
-
-      unless replacement.kind_of?(String)
-        hash = Rubinius::Type.check_convert_type(replacement, Hash, :to_hash)
-        replacement = StringValue(replacement) unless hash
-        tainted ||= replacement.tainted?
-        untrusted ||= replacement.untrusted?
-      end
-      use_yield = false
-    end
-
-    pattern = Rubinius::Type.coerce_to_regexp(pattern, true) unless pattern.kind_of? Regexp
-    match = pattern.search_region(self, 0, bytesize, true)
-
-    unless match
-      Truffle.invoke_primitive(:regexp_set_last_match, nil)
-    end
-
-    duped = dup
-
-    last_end = 0
-    offset = nil
-
-    last_match = nil
-
-    ret = byteslice(0, 0) # Empty string and string subclass
-    offset = match.byte_begin(0) if match
-
-    while match
-      if str = match.pre_match_from(last_end)
-        ret.append str
-      end
-
-      if use_yield || hash
-        Truffle.invoke_primitive(:regexp_set_last_match, match)
-
-        if use_yield
-          val = yield match.to_s
-        else
-          val = hash[match.to_s]
-        end
-        untrusted = true if val.untrusted?
-        val = val.to_s unless val.kind_of?(String)
-
-        tainted ||= val.tainted?
-
-        ret.append val
-
-        if duped != self
-          raise RuntimeError, "string modified"
-        end
-      else
-        replacement.to_sub_replacement(ret, match)
-      end
-
-      tainted ||= val.tainted?
-
-      last_end = match.byte_end(0)
-
-      if match.collapsing?
-        if char = find_character(offset)
-          offset += char.bytesize
-        else
-          offset += 1
-        end
-      else
-        offset = match.byte_end(0)
-      end
-
-      last_match = match
-
-      match = pattern.match_from self, offset
-      break unless match
-
-      offset = match.byte_begin(0)
-    end
-
-    Truffle.invoke_primitive(:regexp_set_last_match, last_match)
-
-    str = byteslice(last_end, bytesize-last_end+1)
-    if str
-      ret.append str
-    end
-
-    ret.taint if tainted
-    ret.untrust if untrusted
-
-    ret
+  def gsub(pattern, replacement=undefined, &block)
+    s = dup
+    ret = s.gsub!(pattern, replacement, &block)
+    Truffle.invoke_primitive(:regexp_set_last_match, $~)
+    ret || s
   end
 
-  def gsub!(pattern, replacement=undefined)
+  def gsub!(pattern, replacement=undefined, &block)
     # Because of the behavior of $~, this is duplicated from gsub! because
     # if we call gsub! from gsub, the last_match can't be updated properly.
 
@@ -1053,6 +954,8 @@ class String
 
     pattern = Rubinius::Type.coerce_to_regexp(pattern, true) unless pattern.kind_of? Regexp
     match = pattern.search_region(self, 0, bytesize, true)
+
+    Regexp.set_block_last_match(block, match) if block_given?
 
     unless match
       Truffle.invoke_primitive(:regexp_set_last_match, nil)
@@ -1113,6 +1016,7 @@ class String
       last_match = match
 
       match = pattern.match_from self, offset
+      Regexp.set_block_last_match(block, match) if block_given?
       break unless match
 
       offset = match.byte_begin(0)

--- a/truffle/src/main/ruby/core/symbol.rb
+++ b/truffle/src/main/ruby/core/symbol.rb
@@ -83,7 +83,7 @@ class Symbol
     case pattern
     when Regexp
       match_data = pattern.search_region(str, 0, str.bytesize, true)
-      Regexp.last_match = match_data
+      Truffle.invoke_primitive(:regexp_set_last_match, match_data)
       return match_data.byte_begin(0) if match_data
     when String
       raise TypeError, "type mismatch: String given"
@@ -112,13 +112,13 @@ class Symbol
     if index.kind_of?(Regexp)
       unless undefined.equal?(other)
         match, str = to_s.send(:subpattern, index, other)
-        Regexp.last_match = match
+        Truffle.invoke_primitive(:regexp_set_last_match, match)
         return str
       end
 
       str = to_s
       match_data = index.search_region(str, 0, str.bytesize, true)
-      Regexp.last_match = match_data
+      Truffle.invoke_primitive(:regexp_set_last_match, match_data)
       if match_data
         result = match_data.to_s
         Rubinius::Type.infect result, index


### PR DESCRIPTION
@jruby/truffle 

This fixes $~ to be frame-local (and thread-local), which addresses some issues where values were leaking in places they shouldn't have been. I don't think I've handled every case accurately, but I do think this is more accurate than what we had before and all specs continue to pass.

Since it was a bit involved, I'd appreciate a careful review.
