### PR TITLE
Extra tests for symbol encoding Re: #4070 + #3719 and possibly #3880

### DIFF
--- a/spec/regression/symbol_encoding_spec.rb
+++ b/spec/regression/symbol_encoding_spec.rb
@@ -8,4 +8,21 @@ describe "symbol encoding" do
   it "should be US-ASCII after converting to string" do
     expect(:foo.to_s.encoding.name).to eq("US-ASCII")
   end
+
+  it "symbol with accents should preserve accents when converted to string" do
+    expect(:Renè.to_s).to eq("Renè")
+  end
+
+  it "symbol with accents should inspect to appropriate string" do
+    expect(:Renè.inspect).to eq(":Renè")
+  end
+
+  it "symbol of lambda character should convert to string" do
+    expect(:λ.to_s).to eq("λ")
+  end
+
+  it "symbol of lambda character should inspect properly" do
+    expect(:λ.inspect).to eq(":λ")
+  end
+  
 end


### PR DESCRIPTION
Saw this tweet https://twitter.com/headius/status/766771177301774337

So I decided to write a few simple failing tests isolating issues issues discussed in #4070 and #3719. This could also overlap with #3880 so I figured I would mention that too.

Very happy to rename specs since I'm bad at naming them or committing these into ruby/spec if that is appropriate. I just put them here because of similar specs relating to #2896.
