### PR TITLE
No more wrapper

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
@@ -34,7 +34,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class AbstractIRMethod extends DynamicMethod implements IRMethodArgs, PositionAware {
+public abstract class AbstractIRMethod extends DynamicMethod implements IRMethodArgs, PositionAware, Cloneable {
 
     private Signature signature;
     protected final IRScope method;
@@ -88,7 +88,18 @@ public abstract class AbstractIRMethod extends DynamicMethod implements IRMethod
     }
 
     @Override
-    public abstract DynamicMethod dup();
+    public DynamicMethod dup() {
+        return (DynamicMethod) clone();
+    }
+
+    @Override
+    public Object clone() {
+        try {
+            return super.clone();
+        } catch (CloneNotSupportedException cnse) {
+            throw new RuntimeException("not cloneable: " + this);
+        }
+    }
 
     public String getClassName(ThreadContext context) {
         return null;

--- a/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMetaClassBody.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMetaClassBody.java
@@ -50,9 +50,4 @@ public class CompiledIRMetaClassBody extends CompiledIRMethod {
         }
         context.setCurrentVisibility(getVisibility());
     }
-
-    @Override
-    public DynamicMethod dup() {
-        return new CompiledIRMetaClassBody(variable, method, implementationClass);
-    }
 }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
@@ -189,11 +189,6 @@ public class CompiledIRMethod extends AbstractIRMethod {
         finally { post(context); }
     }
 
-    @Override
-    public DynamicMethod dup() {
-        return new CompiledIRMethod(variable, specific, specificArity, method, getVisibility(), implementationClass, hasKwargs);
-    }
-
     public String getFile() {
         return method.getFileName();
     }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
@@ -255,11 +255,6 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
         if (callCount++ >= Options.JIT_THRESHOLD.load()) runtime.getJITCompiler().buildThresholdReached(context, this);
     }
 
-    @Override
-    public DynamicMethod dup() {
-        return new InterpretedIRMethod(method, getVisibility(), implementationClass);
-    }
-
     public String getClassName(ThreadContext context) {
         return null;
     }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
@@ -314,7 +314,7 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
 
     @Override
     public DynamicMethod dup() {
-        MixedModeIRMethod x = new MixedModeIRMethod(method, getVisibility(), implementationClass);
+        MixedModeIRMethod x = (MixedModeIRMethod) super.dup();
         x.box = box;
 
         return x;

--- a/core/src/main/java/org/jruby/internal/runtime/methods/WrapperMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/WrapperMethod.java
@@ -39,6 +39,7 @@ import org.jruby.runtime.builtin.IRubyObject;
  * 
  * @author jpetersen
  */
+@Deprecated
 public class WrapperMethod extends DynamicMethod {
     private DynamicMethod method;
 


### PR DESCRIPTION
These commits remove all remaining uses of WrapperMethod, which fixes issues like #3708 and #3869.

See the commits for the longer story, but basically WrapperMethod does not pass through the "new" impl class to the contained method, which results in it supering up the wrong hierarchy.

I have a few concerns, which is why I opened a PR for review:

* Methods that were wrapped before will now be their own true instances of the original method.
* Because we now attempt to dup rather than wrap, I had to modify duping of IR-based methods to always use clone. This makes them have the same serial number, so that transplanted methods (e.g. those in #3869) will still be `==` and `eql?`. The wrapper previously made them appear to be two methods with the same serial, so this may be ok...but if we depend on the serial number being unique after a method dup, that will no longer work (I don't know that we do).
* This is a relatively deep change right before 9.1.3.0, but it fixes known bugs with super that have dogged us for a long time.