### PR TITLE
[Truffle] Polyglot eval io exception

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/JRubyTruffleImpl.java
+++ b/truffle/src/main/java/org/jruby/truffle/JRubyTruffleImpl.java
@@ -55,6 +55,8 @@ public class JRubyTruffleImpl implements JRubyTruffleInterface {
 
         try {
             return engine.eval(loadSource("Truffle::Boot.run_jruby_root", "run_jruby_root")).get();
+        } catch (RuntimeException ex) {
+            throw ex;
         } catch (Exception e) {
             if (e.getCause() instanceof ExitException) {
                 final ExitException exit = (ExitException) e.getCause();

--- a/truffle/src/main/java/org/jruby/truffle/JRubyTruffleImpl.java
+++ b/truffle/src/main/java/org/jruby/truffle/JRubyTruffleImpl.java
@@ -34,9 +34,13 @@ public class JRubyTruffleImpl implements JRubyTruffleInterface {
                 .build();
         try {
             context = (RubyContext) engine.eval(loadSource("Truffle::Boot.context", "context")).get();
+            emitIO();
         } catch (IOException e) {
             throw new JavaException(e);
         }
+    }
+
+    private static void emitIO() throws IOException {
     }
 
     @Override
@@ -51,9 +55,13 @@ public class JRubyTruffleImpl implements JRubyTruffleInterface {
 
         try {
             return engine.eval(loadSource("Truffle::Boot.run_jruby_root", "run_jruby_root")).get();
-        } catch (IOException e) {
+        } catch (Exception e) {
             if (e.getCause() instanceof ExitException) {
                 final ExitException exit = (ExitException) e.getCause();
+                throw new org.jruby.exceptions.MainExitException(exit.getCode());
+            }
+            if (e instanceof ExitException) {
+                final ExitException exit = (ExitException) e;
                 throw new org.jruby.exceptions.MainExitException(exit.getCode());
             }
 

--- a/truffle/src/main/java/org/jruby/truffle/interop/InteropNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/interop/InteropNodes.java
@@ -47,7 +47,6 @@ import org.jruby.truffle.language.RubyNode;
 import org.jruby.truffle.language.control.JavaException;
 import org.jruby.truffle.language.control.RaiseException;
 import org.jruby.truffle.util.ByteListUtils;
-import org.jruby.util.ByteList;
 
 import java.io.File;
 import java.io.IOException;
@@ -649,6 +648,7 @@ public abstract class InteropNodes {
             final Source sourceObject = Source.newBuilder(source.toString()).name("(eval)").mimeType(mimeTypeString).build();
 
             try {
+                emitIO();
                 return getContext().getEnv().parse(sourceObject);
             } catch (IOException e) {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
@@ -660,6 +660,8 @@ public abstract class InteropNodes {
             return getContext().getOptions().EVAL_CACHE;
         }
 
+        private void emitIO() throws IOException {
+        }
     }
 
     @CoreMethod(names = "to_java_string", isModuleFunction = true, required = 1)


### PR DESCRIPTION
Truffle's `PolyglotEngine.eval` no longer throws `IOException` after https://github.com/graalvm/truffle/commit/5e141bd0895239307edb5a4c64eaccb7d37409ef

This change adjust JRuby code to be compilable with both versions. The old one that throws `IOException` and the new one which doesn't.