### PR TITLE
Show that ArgumentError from encoding error is recursive

### DIFF
--- a/test/mri/ruby/test_exception.rb
+++ b/test/mri/ruby/test_exception.rb
@@ -625,6 +625,18 @@ end.join
     assert_not_same(e, e.cause, "#{msg}: should not be recursive")
   end
 
+  def test_cause_reraised_for_encoding_error
+    msg = "ArgumentError from encoding problems"
+    e = assert_raise(ArgumentError) {
+      begin
+        "hi \255".split
+      rescue => e
+        raise e
+      end
+    }
+    assert_not_same(e, e.cause, "#{msg}: should not be recursive")
+  end
+
   def test_raise_with_cause
     msg = "[Feature #8257]"
     cause = ArgumentError.new("foobar")


### PR DESCRIPTION
In general Java exceptions should not have themselves as cause and JRuby in most cases handles this correctly.
We just ran into a problem where an `ArgumentError` raised due to an encoding problem does have itself as cause which leads to a [problem in an ActiveSupport method](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/rescuable.rb#L124).
The ActiveSupport method is [a little dangerous/questionable by itself](https://github.com/rails/rails/pull/26246), but the recursive cause should be prevented in JRuby nonetheless and there is also a test that checks this for `RuntimeError`s.
We're not sure if this is the most general reproduction, so feel free to ignore this PR if you find a more general test.
