### PR TITLE
Full Socket::Option support

### DIFF
--- a/core/src/main/java/org/jruby/ext/socket/Option.java
+++ b/core/src/main/java/org/jruby/ext/socket/Option.java
@@ -19,6 +19,7 @@ import org.jruby.runtime.Visibility;
 import org.jruby.util.ByteList;
 import org.jruby.util.Pack;
 import org.jruby.util.Sprintf;
+import org.jruby.util.TypeConverter;
 
 import java.nio.ByteBuffer;
 import java.text.NumberFormat;
@@ -42,19 +43,17 @@ public class Option extends RubyObject {
         super(runtime, klass);
     }
 
-    public Option(Ruby runtime, ProtocolFamily family, SocketLevel level, SocketOption option, int data) {
+    public Option(Ruby runtime, ProtocolFamily family, SocketLevel level, SocketOption option, ByteList data) {
         this(runtime, (RubyClass)runtime.getClassFromPath("Socket::Option"), family, level, option, data);
     }
 
-    public Option(Ruby runtime, RubyClass klass, ProtocolFamily family, SocketLevel level, SocketOption option, int data) {
+    public Option(Ruby runtime, RubyClass klass, ProtocolFamily family, SocketLevel level, SocketOption option, ByteList data) {
         super(runtime, klass);
 
         this.family = family;
         this.level = level;
         this.option = option;
-        this.intData = data;
-        ByteList result = new ByteList(4);
-        this.data = Pack.packInt_i(result, data);
+        this.data = data;
     }
 
     @JRubyMethod(required = 4, visibility = Visibility.PRIVATE)
@@ -63,7 +62,7 @@ public class Option extends RubyObject {
         level = SocketUtils.levelFromArg(args[1]);
         option = SocketUtils.optionFromArg(args[2]);
         data = args[3].convertToString().getByteList();
-        intData = Pack.unpackInt_i(ByteBuffer.wrap(data.bytes()));
+
         return this;
     }
 
@@ -95,7 +94,7 @@ public class Option extends RubyObject {
 
         buf
             .append(metaClass.getRealClass().getName())
-            .append(' ')
+            .append(": ")
             .append(noPrefix(family));
 
         if (level == SocketLevel.SOL_SOCKET) {
@@ -146,25 +145,50 @@ public class Option extends RubyObject {
             case SO_DONTROUTE:
             case SO_RCVLOWAT:
             case SO_SNDLOWAT:
-                return String.valueOf(intData);
+                return String.valueOf(unpackInt(data));
 
             case SO_LINGER:
-                return intData == -1 ? "off" :
-                        intData == 0 ? "on" :
-                                "on(" + intData + ")";
+                int[] linger = Option.unpackLinger(data);
+
+                return ((linger[0] == 0) ? "off " : "on ")  + linger[1] + "sec";
 
             case SO_RCVTIMEO:
             case SO_SNDTIMEO:
-                return Sprintf.getNumberFormat(Locale.getDefault()).format(intData / 1000.0);
+                return Sprintf.getNumberFormat(Locale.getDefault()).format(unpackInt(data) / 1000.0);
 
             case SO_ERROR:
-                return Errno.valueOf(intData).description();
+                return Errno.valueOf(unpackInt(data)).description();
 
             case SO_TYPE:
-                return Sock.valueOf(intData).description();
+                return Sock.valueOf(unpackInt(data)).description();
         }
 
         return "";
+    }
+
+    public static ByteList packInt(int i) {
+        ByteList result = new ByteList(4);
+        Pack.packInt_i(result, i);
+        return result;
+    }
+
+    public static ByteList packLinger(int vonoff, int vsecs) {
+        ByteList result = new ByteList(8);
+        Pack.packInt_i(result, vonoff);
+        Pack.packInt_i(result, vsecs);
+        return result;
+    }
+
+    public static int unpackInt(ByteList data) {
+        return Pack.unpackInt_i(ByteBuffer.wrap(data.unsafeBytes(), data.begin(), data.realSize()));
+    }
+
+    public static int[] unpackLinger(ByteList data) {
+        ByteList result = new ByteList(8);
+        ByteBuffer buf = ByteBuffer.wrap(data.unsafeBytes(), data.begin(), data.realSize());
+        int vonoff = Pack.unpackInt_i(buf);
+        int vsecs = Pack.unpackInt_i(buf);
+        return new int[] {vonoff, vsecs};
     }
 
     @JRubyMethod(name = "int", required = 4, meta = true)
@@ -172,14 +196,18 @@ public class Option extends RubyObject {
         ProtocolFamily family = SocketUtils.protocolFamilyFromArg(args[0]);
         SocketLevel level = SocketUtils.levelFromArg(args[1]);
         SocketOption option = SocketUtils.optionFromArg(args[2]);
-        int intData = RubyNumeric.fix2int(args[3]);
+        ByteList data = packInt(RubyNumeric.fix2int(args[3]));
 
-        return new Option(context.getRuntime(), family, level, option, intData);
+        return new Option(context.getRuntime(), family, level, option, data);
     }
 
     @JRubyMethod(name = "int")
     public IRubyObject asInt(ThreadContext context) {
-        return context.getRuntime().newFixnum((int) intData);
+        final Ruby runtime = context.getRuntime();
+
+        validateDataSize(runtime, data, 4);
+
+        return runtime.newFixnum(unpackInt(data));
     }
 
     @JRubyMethod(required = 4, meta = true)
@@ -187,24 +215,47 @@ public class Option extends RubyObject {
         ProtocolFamily family = SocketUtils.protocolFamilyFromArg(args[0]);
         SocketLevel level = SocketUtils.levelFromArg(args[1]);
         SocketOption option = SocketUtils.optionFromArg(args[2]);
-        int intData = args[3].isTrue() ? 1 : 0;
+        ByteList data = packInt(args[3].isTrue() ? 1 : 0);
 
-        return new Option(context.getRuntime(), family, level, option, intData);
+        return new Option(context.getRuntime(), family, level, option, data);
     }
 
     @JRubyMethod
     public IRubyObject bool(ThreadContext context) {
-        return context.getRuntime().newBoolean(intData != 0);
+        final Ruby runtime = context.getRuntime();
+
+        validateDataSize(runtime, data, 4);
+
+        return runtime.newBoolean(unpackInt(data) != 0);
     }
 
     @JRubyMethod(meta = true)
-    public IRubyObject linger(ThreadContext context, IRubyObject self) {
-        return context.nil;
-    }
+    public static IRubyObject linger(ThreadContext context, IRubyObject self, IRubyObject vonoff, IRubyObject vsecs) {
+        ProtocolFamily family = ProtocolFamily.PF_UNSPEC;
+        SocketLevel level = SocketLevel.SOL_SOCKET;
+        SocketOption option = SocketOption.SO_LINGER;
+        int coercedVonoff;
+
+        if (!TypeConverter.checkIntegerType(context, vonoff).isNil()) {
+            coercedVonoff = vonoff.convertToInteger().getIntValue();
+        } else {
+            coercedVonoff = vonoff.isTrue() ? 1 : 0;
+        }
+
+        ByteList data = packLinger(coercedVonoff, vsecs.convertToInteger().getIntValue());
+
+        return new Option(context.getRuntime(), family, level, option, data);
+     }
 
     @JRubyMethod
     public IRubyObject linger(ThreadContext context) {
-        return context.nil;
+        final Ruby runtime = context.runtime;
+
+        validateDataSize(runtime, data, 8);
+
+        int[] linger = Option.unpackLinger(data);
+
+        return runtime.newArray(runtime.newBoolean(linger[0] != 0), runtime.newFixnum(linger[1]));
     }
 
     @JRubyMethod
@@ -217,9 +268,16 @@ public class Option extends RubyObject {
         return RubyString.newString(context.runtime, data);
     }
 
+    private static void validateDataSize(Ruby runtime, ByteList data, int size) {
+        int realSize = data.realSize();
+
+        if (realSize != size) {
+            throw runtime.newTypeError("size differ.  expected as sizeof(int)=" + size + " but " + realSize);
+        }
+    }
+
     private ProtocolFamily family;
     private SocketLevel level;
     private SocketOption option;
     private ByteList data;
-    private long intData;
 }

--- a/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
@@ -279,6 +279,16 @@ public class RubyBasicSocket extends RubyIO {
     }
 
     @JRubyMethod
+    public IRubyObject setsockopt(ThreadContext context, IRubyObject option) {
+        if (option instanceof Option) {
+            Option rsockopt = (Option) option;
+            return setsockopt(context, rsockopt.level(context), rsockopt.optname(context), rsockopt.data(context));
+        } else {
+            throw context.runtime.newArgumentError(option.toString() + " is not a Socket::Option");
+        }
+    }
+
+    @JRubyMethod
     public IRubyObject setsockopt(ThreadContext context, IRubyObject _level, IRubyObject _opt, IRubyObject val) {
         Ruby runtime = context.runtime;
 

--- a/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
@@ -266,8 +266,8 @@ public class RubyBasicSocket extends RubyIO {
                 }
 
                 int value = SocketType.forChannel(channel).getSocketOption(channel, opt);
-
-                return new Option(runtime, ProtocolFamily.PF_INET, level, opt, value);
+                ByteList packedValue = Option.packInt(value);
+                return new Option(runtime, ProtocolFamily.PF_INET, level, opt, packedValue);
 
             default:
                 throw runtime.newErrnoENOPROTOOPTError();

--- a/core/src/main/java/org/jruby/ext/socket/SocketType.java
+++ b/core/src/main/java/org/jruby/ext/socket/SocketType.java
@@ -177,7 +177,7 @@ public enum SocketType {
         private DatagramSocket toSocket(Channel channel) {
             return ((DatagramChannel)channel).socket();
         }
-        
+
         public int getSoTimeout(Channel channel) throws IOException {
             return toSocket(channel).getSoTimeout();
         }
@@ -241,14 +241,14 @@ public enum SocketType {
     },
 
     UNKNOWN(Sock.SOCK_STREAM);
-    
+
     public static SocketType forChannel(Channel channel) {
         if (channel instanceof SocketChannel) {
             return SOCKET;
-            
+
         } else if (channel instanceof ServerSocketChannel) {
             return SERVER;
-        
+
         } else if (channel instanceof DatagramChannel) {
             return DATAGRAM;
 
@@ -301,7 +301,7 @@ public enum SocketType {
     public Sock getSocketType() {
         return sock;
     }
-    
+
     public int getSocketOption(Channel channel, SocketOption option) throws IOException {
         switch (option) {
 
@@ -312,8 +312,7 @@ public enum SocketType {
                 return getKeepAlive(channel) ? 1 : 0;
 
             case SO_LINGER: {
-                int linger = getSoLinger(channel);
-                return linger < 0 ? 0 : linger;
+                return getSoLinger(channel);
             }
 
             case SO_OOBINLINE:

--- a/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
+++ b/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
@@ -655,24 +655,44 @@ public class SocketUtils {
         }
     }
 
-    static SocketLevel levelFromArg(IRubyObject _level) {
-        if (_level instanceof RubyString || _level instanceof RubySymbol) {
-            String levelString = _level.toString();
-            if(levelString.startsWith("SOL_")) return SocketLevel.valueOf(levelString);
-            return SocketLevel.valueOf("SOL_" + levelString);
+    static SocketLevel levelFromArg(IRubyObject level) {
+        IRubyObject maybeString = TypeConverter.checkStringType(level.getRuntime(), level);
+
+        if (!maybeString.isNil()) {
+            level = maybeString;
         }
 
-        return SocketLevel.valueOf(RubyNumeric.fix2int(_level));
+        try {
+            if (level instanceof RubyString || level instanceof RubySymbol) {
+                String levelString = level.toString();
+                if(levelString.startsWith("SOL_")) return SocketLevel.valueOf(levelString);
+                return SocketLevel.valueOf("SOL_" + levelString);
+            }
+
+            return SocketLevel.valueOf(RubyNumeric.fix2int(level));
+        } catch (IllegalArgumentException iae) {
+            throw SocketUtils.sockerr(level.getRuntime(), "invalid socket level: " + level);
+        }
     }
 
-    static SocketOption optionFromArg(IRubyObject _opt) {
-        if (_opt instanceof RubyString || _opt instanceof RubySymbol) {
-            String optString = _opt.toString();
-            if (optString.startsWith("SO_")) return SocketOption.valueOf(optString);
-            return SocketOption.valueOf("SO_" + optString);
+    static SocketOption optionFromArg(IRubyObject opt) {
+        IRubyObject maybeString = TypeConverter.checkStringType(opt.getRuntime(), opt);
+
+        if (!maybeString.isNil()) {
+            opt = maybeString;
         }
 
-        return SocketOption.valueOf(RubyNumeric.fix2int(_opt));
+        try {
+            if (opt instanceof RubyString || opt instanceof RubySymbol) {
+                String optString = opt.toString();
+                if (optString.startsWith("SO_")) return SocketOption.valueOf(optString);
+                return SocketOption.valueOf("SO_" + optString);
+            }
+
+            return SocketOption.valueOf(RubyNumeric.fix2int(opt));
+        } catch (IllegalArgumentException iae) {
+            throw SocketUtils.sockerr(opt.getRuntime(), "invalid socket option: " + opt);
+        }
     }
 
     public static int portToInt(IRubyObject port) {

--- a/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
+++ b/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
@@ -638,13 +638,13 @@ public class SocketUtils {
     }
 
     static SocketOption optionFromArg(IRubyObject _opt) {
-        SocketOption opt;
         if (_opt instanceof RubyString || _opt instanceof RubySymbol) {
-            opt = SocketOption.valueOf("SO_" + _opt.toString());
-        } else {
-            opt = SocketOption.valueOf(RubyNumeric.fix2int(_opt));
+            String optString = _opt.toString();
+            if (optString.startsWith("SO_")) return SocketOption.valueOf(optString);
+            return SocketOption.valueOf("SO_" + optString);
         }
-        return opt;
+
+        return SocketOption.valueOf(RubyNumeric.fix2int(_opt));
     }
 
     public static int portToInt(IRubyObject port) {

--- a/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
+++ b/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
@@ -46,6 +46,7 @@ import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
+import org.jruby.util.TypeConverter;
 import org.jruby.util.io.Sockaddr;
 
 import java.net.Inet6Address;
@@ -569,62 +570,89 @@ public class SocketUtils {
     private static final byte[] INADDR_ANY = new byte[] {0,0,0,0}; // 0.0.0.0
 
     static AddressFamily addressFamilyFromArg(IRubyObject domain) {
-        AddressFamily addressFamily = null;
+        IRubyObject maybeString = TypeConverter.checkStringType(domain.getRuntime(), domain);
 
-        if(domain instanceof RubyString || domain instanceof RubySymbol) {
-            String domainString = domain.toString();
-            if (!domainString.startsWith("AF_")) domainString = "AF_" + domainString;
-            addressFamily = AddressFamily.valueOf(domainString);
-        } else {
-            int domainInt = RubyNumeric.fix2int(domain);
-            addressFamily = AddressFamily.valueOf(domainInt);
+        if (!maybeString.isNil()) {
+            domain = maybeString;
         }
 
-        return addressFamily;
+        try {
+            if (domain instanceof RubyString || domain instanceof RubySymbol) {
+                String domainString = domain.toString();
+                if (domainString.startsWith("AF_")) return AddressFamily.valueOf(domainString);
+                if (domainString.startsWith("PF_"))
+                    return AddressFamily.valueOf(ProtocolFamily.valueOf(domainString).intValue());
+                return AddressFamily.valueOf("AF_" + domainString);
+            }
+
+            int domainInt = RubyNumeric.fix2int(domain);
+            return AddressFamily.valueOf(domainInt);
+        } catch (IllegalArgumentException iae) {
+            throw SocketUtils.sockerr(domain.getRuntime(), "invalid address family: " + domain);
+        }
     }
 
     static Sock sockFromArg(IRubyObject type) {
-        Sock sockType = null;
+        IRubyObject maybeString = TypeConverter.checkStringType(type.getRuntime(), type);
 
-        if(type instanceof RubyString || type instanceof RubySymbol) {
-            String typeString = type.toString();
-            if (!typeString.startsWith("SOCK_")) typeString = "SOCK_" + typeString;
-            sockType = Sock.valueOf(typeString);
-        } else {
-            int typeInt = RubyNumeric.fix2int(type);
-            sockType = Sock.valueOf(typeInt);
+        if (!maybeString.isNil()) {
+            type = maybeString;
         }
 
-        return sockType;
+        try {
+            if(type instanceof RubyString || type instanceof RubySymbol) {
+                String typeString = type.toString();
+                if (typeString.startsWith("SOCK_")) return Sock.valueOf(typeString.toString());
+                return Sock.valueOf("SOCK_" + typeString);
+            }
+
+            int typeInt = RubyNumeric.fix2int(type);
+            return Sock.valueOf(typeInt);
+        } catch (IllegalArgumentException iae) {
+            throw SocketUtils.sockerr(type.getRuntime(), "invalid socket type: " + type);
+        }
     }
 
     static ProtocolFamily protocolFamilyFromArg(IRubyObject protocol) {
-        ProtocolFamily protocolFamily = null;
+        IRubyObject maybeString = TypeConverter.checkStringType(protocol.getRuntime(), protocol);
 
-        if(protocol instanceof RubyString || protocol instanceof RubySymbol) {
-            String protocolString = protocol.toString();
-            protocolFamily = ProtocolFamily.valueOf("PF_" + protocolString);
-        } else {
-            int protocolInt = RubyNumeric.fix2int(protocol);
-            if (protocolInt == 0) return null;
-            protocolFamily = ProtocolFamily.valueOf(protocolInt);
+        if (!maybeString.isNil()) {
+            protocol = maybeString;
         }
 
-        return protocolFamily;
+        try {
+            if (protocol instanceof RubyString || protocol instanceof RubySymbol) {
+                String protocolString = protocol.toString();
+                if (protocolString.startsWith("PF_")) return ProtocolFamily.valueOf(protocolString);
+                if (protocolString.startsWith("AF_")) return ProtocolFamily.valueOf(AddressFamily.valueOf(protocolString).intValue());
+                return ProtocolFamily.valueOf("PF_" + protocolString);
+            }
+
+            int protocolInt = RubyNumeric.fix2int(protocol);
+            return ProtocolFamily.valueOf(protocolInt);
+        } catch (IllegalArgumentException iae) {
+            throw SocketUtils.sockerr(protocol.getRuntime(), "invalid protocol family: " + protocol);
+        }
     }
 
     static Protocol protocolFromArg(IRubyObject protocol) {
-        Protocol proto;
+        IRubyObject maybeString = TypeConverter.checkStringType(protocol.getRuntime(), protocol);
 
-        if(protocol instanceof RubyString || protocol instanceof RubySymbol) {
-            String protocolString = protocol.toString();
-            proto = Protocol.getProtocolByName(protocolString);
-        } else {
-            int protocolInt = RubyNumeric.fix2int(protocol);
-            proto = Protocol.getProtocolByNumber(protocolInt);
+        if (!maybeString.isNil()) {
+            protocol = maybeString;
         }
 
-        return proto;
+        try {
+            if(protocol instanceof RubyString || protocol instanceof RubySymbol) {
+                String protocolString = protocol.toString();
+                return Protocol.getProtocolByName(protocolString);
+            }
+
+            int protocolInt = RubyNumeric.fix2int(protocol);
+            return Protocol.getProtocolByNumber(protocolInt);
+        } catch (IllegalArgumentException iae) {
+            throw SocketUtils.sockerr(protocol.getRuntime(), "invalid protocol: " + protocol);
+        }
     }
 
     static SocketLevel levelFromArg(IRubyObject _level) {

--- a/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
+++ b/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
@@ -656,13 +656,13 @@ public class SocketUtils {
     }
 
     static SocketLevel levelFromArg(IRubyObject _level) {
-        SocketLevel level;
         if (_level instanceof RubyString || _level instanceof RubySymbol) {
-            level = SocketLevel.valueOf("SOL_" + _level.toString());
-        } else {
-            level = SocketLevel.valueOf(RubyNumeric.fix2int(_level));
+            String levelString = _level.toString();
+            if(levelString.startsWith("SOL_")) return SocketLevel.valueOf(levelString);
+            return SocketLevel.valueOf("SOL_" + levelString);
         }
-        return level;
+
+        return SocketLevel.valueOf(RubyNumeric.fix2int(_level));
     }
 
     static SocketOption optionFromArg(IRubyObject _opt) {

--- a/spec/tags/ruby/library/socket/option/bool_tags.txt
+++ b/spec/tags/ruby/library/socket/option/bool_tags.txt
@@ -1,1 +1,0 @@
-fails:Socket::Option#bool raises TypeError if option has not good size

--- a/spec/tags/ruby/library/socket/option/inspect_tags.txt
+++ b/spec/tags/ruby/library/socket/option/inspect_tags.txt
@@ -1,1 +1,0 @@
-fails:Socket::Option#inspect correctly returns SO_LINGER value

--- a/spec/tags/ruby/library/socket/option/int_tags.txt
+++ b/spec/tags/ruby/library/socket/option/int_tags.txt
@@ -1,3 +1,0 @@
-fails:Socket::Option.int creates a new Socket::Option for SO_LINGER
-fails:Socket::Option#int returns int option
-fails:Socket::Option#int raises TypeError if option has not good size

--- a/spec/tags/ruby/library/socket/option/linger_tags.txt
+++ b/spec/tags/ruby/library/socket/option/linger_tags.txt
@@ -1,5 +1,2 @@
-fails:Socket::Option.linger creates a new Socket::Option for SO_LINGER
-fails:Socket::Option.linger accepts boolean as onoff argument
-fails:Socket::Option#linger returns linger option
 fails:Socket::Option#linger raises TypeError if not a SO_LINGER
 fails:Socket::Option#linger raises TypeError if option has not good size

--- a/spec/tags/ruby/library/socket/option/linger_tags.txt
+++ b/spec/tags/ruby/library/socket/option/linger_tags.txt
@@ -1,2 +1,0 @@
-fails:Socket::Option#linger raises TypeError if not a SO_LINGER
-fails:Socket::Option#linger raises TypeError if option has not good size

--- a/spec/tags/ruby/library/socket/option/new_tags.txt
+++ b/spec/tags/ruby/library/socket/option/new_tags.txt
@@ -1,3 +1,0 @@
-fails:Socket::Option.new should accept symbols
-fails:Socket::Option.new should raise error on unknown level
-fails:Socket::Option.new should raise error on unknown option name

--- a/spec/tags/ruby/library/socket/option/new_tags.txt
+++ b/spec/tags/ruby/library/socket/option/new_tags.txt
@@ -1,4 +1,3 @@
 fails:Socket::Option.new should accept symbols
-fails:Socket::Option.new should raise error on unknown family
 fails:Socket::Option.new should raise error on unknown level
 fails:Socket::Option.new should raise error on unknown option name


### PR DESCRIPTION
This PR includes:
- full (I hope) `Socket::Option` support;
- passing `Socket::Option` as `setsockopt` argument;
- fix for the #4040;
- properly handles socket prefixed options/levels (`SOL_LEVEL`, `SO_OPTION`) (fix for the #3438); 
- properly handles unsupported socket constants;