### PR TITLE
Fix IO#syswrite. Fixes #3799

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -46,7 +46,7 @@ project 'JRuby Core' do
 
   # exclude jnr-ffi to avoid problems with shading and relocation of the asm packages
   jar 'com.github.jnr:jnr-netdb:1.1.6', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-enxio:0.13', :exclusions => ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-enxio:0.14-SNAPSHOT', :exclusions => ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-x86asm:1.0.2', :exclusions => ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-unixsocket:0.14', :exclusions => ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-posix:3.0.32', :exclusions => ['com.github.jnr:jnr-ffi']

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -104,7 +104,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-enxio</artifactId>
-      <version>0.13</version>
+      <version>0.14-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <artifactId>jnr-ffi</artifactId>

--- a/spec/regression/GH-3799_spec.rb
+++ b/spec/regression/GH-3799_spec.rb
@@ -1,0 +1,41 @@
+require 'rspec'
+require 'socket'
+require 'io/nonblock'
+
+describe "syswrite called on unix socket in nonblocking mode" do
+  # Based on https://github.com/puma/puma/blob/3f66b3d7d4413f843e4e541c4d282238318c4cd2/lib/puma/server.rb#L903
+  def fast_write(io, str)
+    n = 0
+    while true
+      begin
+        n = io.syswrite str
+      rescue Errno::EAGAIN, Errno::EWOULDBLOCK
+        retry
+      end
+
+      return if n == str.bytesize
+      str = str.byteslice(n..-1)
+    end
+  end
+
+  it "should not fail with 'SystemCallError: Unknown error -'" do
+    begin
+      # On my machine error appears when more than two writes needed.
+      # Buffer size equals to 8192, so input size should be
+      # bigger thatn 8192 * 2 + 1
+      input = ' ' * 16385
+
+      s1, s2 = UNIXSocket.pair
+      s1.nonblock = true
+      s2.nonblock = true
+
+      t = Thread.new { s2.read(input.bytesize).bytesize }
+
+      expect { fast_write(s1, input) }.not_to raise_error
+      expect(t.join(1).value).to eq(16385)
+    ensure
+      s1.close
+      s2.close
+    end
+  end
+end


### PR DESCRIPTION
As a result of debugging I found out that `SystemCallError` that happens during `syswrite` is actually `"Resource temporarily unavailable"` that corresponds to `EAGAIN`. So first idea of fix was to put `select` somewhere. Related fix for `IO#sysread` gave me hope that I'm moving in right direction. 

As a result I did similar fix as in 857b76f461acb5cbb67d582b864145e617ccaee8
