### PR TITLE
Deprecate framed invoke

### DIFF
--- a/core/src/main/java/org/jruby/ir/instructions/AttrAssignInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/AttrAssignInstr.java
@@ -18,7 +18,7 @@ import static org.jruby.ir.IRFlags.*;
 // Instruction representing Ruby code of the form: "a[i] = 5"
 // which is equivalent to: a.[]=(i,5)
 public class AttrAssignInstr extends NoResultCallInstr {
-    private transient CallSite functionalSite;
+    protected transient final CallSite functionalSite;
 
     public static AttrAssignInstr create(Operand obj, String attr, Operand[] args, boolean isPotentiallyRefined) {
         if (!containsArgSplat(args) && args.length == 1) {

--- a/core/src/main/java/org/jruby/ir/instructions/CallBase.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CallBase.java
@@ -143,7 +143,7 @@ public abstract class CallBase extends NOperandInstr implements ClosureAccepting
         return dontInline;
     }
 
-    private static CallSite getCallSiteFor(CallType callType, String name, boolean potentiallyRefined) {
+    protected static CallSite getCallSiteFor(CallType callType, String name, boolean potentiallyRefined) {
         assert callType != null: "Calltype should never be null";
 
         if (potentiallyRefined) return new RefinedCachingCallSite(name, callType);

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneArgOperandAttrAssignInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneArgOperandAttrAssignInstr.java
@@ -23,8 +23,9 @@ public class OneArgOperandAttrAssignInstr extends AttrAssignInstr {
         IRubyObject object = (IRubyObject) getReceiver().retrieve(context, self, currScope, dynamicScope, temp);
         IRubyObject value = (IRubyObject) getArg1().retrieve(context, self, currScope, dynamicScope, temp);
 
-        CallType callType = self == object ? CallType.FUNCTIONAL : CallType.NORMAL;
-        Helpers.invoke(context, object, getName(), value, callType, Block.NULL_BLOCK);
+        CallSite callSite = self == object ? this.functionalSite : this.callSite;
+        callSite.call(context, self, object, value);
+        
         return null;
     }
 }

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneArgOperandAttrAssignInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneArgOperandAttrAssignInstr.java
@@ -23,9 +23,8 @@ public class OneArgOperandAttrAssignInstr extends AttrAssignInstr {
         IRubyObject object = (IRubyObject) getReceiver().retrieve(context, self, currScope, dynamicScope, temp);
         IRubyObject value = (IRubyObject) getArg1().retrieve(context, self, currScope, dynamicScope, temp);
 
-        CallSite callSite = self == object ? this.functionalSite : this.callSite;
         callSite.call(context, self, object, value);
-        
+
         return null;
     }
 }

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -411,17 +411,6 @@ public class Helpers {
         return self.getMetaClass().finvoke(context, self, name, args);
     }
 
-    public static IRubyObject invoke(ThreadContext context, IRubyObject self, String name, CallType callType) {
-        return Helpers.invoke(context, self, name, IRubyObject.NULL_ARRAY, callType, Block.NULL_BLOCK);
-    }
-    public static IRubyObject invoke(ThreadContext context, IRubyObject self, String name, IRubyObject[] args, CallType callType, Block block) {
-        return self.getMetaClass().invoke(context, self, name, args, callType, block);
-    }
-
-    public static IRubyObject invoke(ThreadContext context, IRubyObject self, String name, IRubyObject arg, CallType callType, Block block) {
-        return self.getMetaClass().invoke(context, self, name, arg, callType, block);
-    }
-
     public static IRubyObject invokeAs(ThreadContext context, RubyClass asClass, IRubyObject self, String name, IRubyObject[] args, Block block) {
         return asClass.finvoke(context, self, name, args, block);
     }
@@ -440,6 +429,27 @@ public class Helpers {
 
     public static IRubyObject invokeAs(ThreadContext context, RubyClass asClass, IRubyObject self, String name, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
         return asClass.finvoke(context, self, name, arg0, arg1, arg2, block);
+    }
+
+    /**
+     * Same behavior as invoke, but uses the given caller object to check visibility if callType demands it.
+     */
+    public static IRubyObject invokeFrom(ThreadContext context, IRubyObject caller, IRubyObject self, String name, IRubyObject[] args, CallType callType, Block block) {
+        return self.getMetaClass().invokeFrom(context, callType, caller, self, name, args, block);
+    }
+
+    /**
+     * Same behavior as invoke, but uses the given caller object to check visibility if callType demands it.
+     */
+    public static IRubyObject invokeFrom(ThreadContext context, IRubyObject caller, IRubyObject self, String name, IRubyObject arg, CallType callType, Block block) {
+        return self.getMetaClass().invokeFrom(context, callType, caller, self, name, arg, block);
+    }
+
+    /**
+     * Same behavior as invoke, but uses the given caller object to check visibility if callType demands it.
+     */
+    public static IRubyObject invokeFrom(ThreadContext context, IRubyObject caller, IRubyObject self, String name, CallType callType) {
+        return self.getMetaClass().invokeFrom(context, callType, caller, self, name, IRubyObject.NULL_ARRAY, Block.NULL_BLOCK);
     }
 
     // MRI: rb_check_funcall
@@ -2789,6 +2799,42 @@ public class Helpers {
         }
 
         return builder.toString();
+    }
+
+    /**
+     * This method is deprecated because it depends on having a Ruby frame pushed for checking method visibility,
+     * and there's no way to enforce that. Most users of this method probably don't need to check visibility.
+     *
+     * See https://github.com/jruby/jruby/issues/4134
+     *
+     * @deprecated Use finvoke if you do not want visibility-checking or invokeFrom if you do.
+     */
+    public static IRubyObject invoke(ThreadContext context, IRubyObject self, String name, IRubyObject[] args, CallType callType, Block block) {
+        return self.getMetaClass().invoke(context, self, name, args, callType, block);
+    }
+
+    /**
+     * This method is deprecated because it depends on having a Ruby frame pushed for checking method visibility,
+     * and there's no way to enforce that. Most users of this method probably don't need to check visibility.
+     *
+     * See https://github.com/jruby/jruby/issues/4134
+     *
+     * @deprecated Use finvoke if you do not want visibility-checking or invokeFrom if you do.
+     */
+    public static IRubyObject invoke(ThreadContext context, IRubyObject self, String name, IRubyObject arg, CallType callType, Block block) {
+        return self.getMetaClass().invoke(context, self, name, arg, callType, block);
+    }
+
+    /**
+     * This method is deprecated because it depends on having a Ruby frame pushed for checking method visibility,
+     * and there's no way to enforce that. Most users of this method probably don't need to check visibility.
+     *
+     * See https://github.com/jruby/jruby/issues/4134
+     *
+     * @deprecated Use finvoke if you do not want visibility-checking or invokeFrom if you do.
+     */
+    public static IRubyObject invoke(ThreadContext context, IRubyObject self, String name, CallType callType) {
+        return Helpers.invoke(context, self, name, IRubyObject.NULL_ARRAY, callType, Block.NULL_BLOCK);
     }
 
 }


### PR DESCRIPTION
This deprecates the "invoke" forms in Helpers and RubyClass that depended on having a Ruby frame pushed to get "self" for visibility checking. Improper use of this method (in this case, frame was eliminated) caused #4134.

This PR is expected to be applied after #4138, which fixes #4134 by changing attribute assigns to use a CallSite like any other invocation.