### PR TITLE
Fix for #4147

### DIFF
--- a/lib/ruby/stdlib/logger.rb
+++ b/lib/ruby/stdlib/logger.rb
@@ -742,7 +742,7 @@ private
       end
     end
 
-    if /mswin|mingw/ =~ RUBY_PLATFORM
+    if /mswin|mingw/ =~ RbConfig::CONFIG['host_os']
       def lock_shift_log
         yield
       end


### PR DESCRIPTION
When check the OS platform, the RUBY_PLATFORM return 'java' in JRuby.
It is better to use RbConfig::CONFIG['host_os'] .

fixes #4147