### PR TITLE
Format initial string to specific precision, so rounding works.

### DIFF
--- a/core/src/main/java/org/jruby/util/Sprintf.java
+++ b/core/src/main/java/org/jruby/util/Sprintf.java
@@ -864,8 +864,12 @@ public class Sprintf {
                         break;
                     }
 
+                    if ((flags & FLAG_PRECISION) == 0) {
+                        precision = 6;
+                    }
+
                     NumberFormat nf = getNumberFormat(args.locale);
-                    nf.setMaximumFractionDigits(Integer.MAX_VALUE);
+                    nf.setMaximumFractionDigits(precision);
                     String str = nf.format(dval);
 
                     // grrr, arghh, want to subclass sun.misc.FloatingDecimal, but can't,
@@ -962,9 +966,6 @@ public class Sprintf {
                         width--;
                     } else {
                         signChar = 0;
-                    }
-                    if ((flags & FLAG_PRECISION) == 0) {
-                        precision = 6;
                     }
 
                     switch(fchar) {


### PR DESCRIPTION
The logic in our double-based sprintf logic attempts to round
values manually by inspecting a long-form version of the double.
If we need to round, and the next digit is a five, it will round
toward zero (truncate) iff that five is the last digit in the long
unrounded string. This appears to have been an attempt to mimic
C printf's behavior of rounding "true half" to even in the
presence of inaccurately-represented IEEE754 decimals.

This commit changes the pre-formatting to actually format with the
specified precision, allowing NumberFormat's default HALF_EVEN
logic to to the work for us.

Fixes #4157.