### PR TITLE
[Truffle] Encoding#replicate

### DIFF
--- a/spec/truffle/tags/core/encoding/replicate_tags.txt
+++ b/spec/truffle/tags/core/encoding/replicate_tags.txt
@@ -1,4 +1,0 @@
-fails:Encoding#replicate returns a replica of ASCII
-fails:Encoding#replicate returns a replica of UTF-8
-fails:Encoding#replicate returns a replica of UTF-16BE
-fails:Encoding#replicate returns a replica of ISO-2022-JP

--- a/truffle/src/main/java/org/jruby/truffle/core/encoding/EncodingManager.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/encoding/EncodingManager.java
@@ -61,6 +61,7 @@ public class EncodingManager {
         return ENCODING_LIST_BY_ENCODING_LIST_INDEX;
     }
 
+    @TruffleBoundary
     public DynamicObject getRubyEncoding(Encoding encoding) {
         DynamicObject rubyEncoding = ENCODING_LIST_BY_ENCODING_INDEX.get(encoding.getIndex());
 

--- a/truffle/src/main/java/org/jruby/truffle/core/encoding/EncodingNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/encoding/EncodingNodes.java
@@ -581,7 +581,7 @@ public abstract class EncodingNodes {
 
     }
 
-    @Primitive(name = "encoding_get_object_encoding_by_index", needsSelf = false)
+    @Primitive(name = "encoding_get_encoding_by_index", needsSelf = false)
     public static abstract class EncodingGetObjectEncodingByIndexNode extends PrimitiveArrayArgumentsNode {
 
         @Specialization

--- a/truffle/src/main/java/org/jruby/truffle/core/encoding/EncodingNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/encoding/EncodingNodes.java
@@ -559,6 +559,16 @@ public abstract class EncodingNodes {
 
     }
 
+    @Primitive(name = "encoding_get_object_encoding_by_index", needsSelf = false)
+    public static abstract class EncodingGetObjectEncodingByIndexNode extends PrimitiveArrayArgumentsNode {
+
+        @Specialization
+        public DynamicObject encodingGetObjectEncodingByIndex(int index) {
+            return getContext().getEncodingManager().getRubyEncoding(index);
+        }
+
+    }
+
     @Primitive(name = "encoding_replicate")
     public static abstract class EncodingReplicateNode extends PrimitiveArrayArgumentsNode {
 

--- a/truffle/src/main/java/org/jruby/truffle/core/encoding/EncodingNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/encoding/EncodingNodes.java
@@ -44,11 +44,16 @@ import org.jruby.truffle.core.cast.ToStrNode;
 import org.jruby.truffle.core.cast.ToStrNodeGen;
 import org.jruby.truffle.core.rope.CodeRange;
 import org.jruby.truffle.core.rope.Rope;
+import org.jruby.truffle.core.rope.RopeOperations;
 import org.jruby.truffle.core.string.StringOperations;
 import org.jruby.truffle.language.RubyGuards;
 import org.jruby.truffle.language.RubyNode;
 import org.jruby.truffle.language.control.RaiseException;
 import org.jruby.util.ByteList;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
 
 @CoreClass("Encoding")
 public abstract class EncodingNodes {
@@ -409,10 +414,10 @@ public abstract class EncodingNodes {
         @TruffleBoundary
         @Specialization
         public DynamicObject list() {
-            final DynamicObject[] encodings = getContext().getEncodingManager().getUnsafeEncodingList();
-            final Object[] arrayStore = new Object[encodings.length];
+            final List<DynamicObject> encodingsList = getContext().getEncodingManager().getUnsafeEncodingList();
 
-            System.arraycopy(encodings, 0, arrayStore, 0, encodings.length);
+            final Object[] arrayStore = new Object[encodingsList.size()];
+            getContext().getEncodingManager().getUnsafeEncodingList().toArray(arrayStore);
 
             return createArray(arrayStore, arrayStore.length);
         }
@@ -550,6 +555,26 @@ public abstract class EncodingNodes {
         public DynamicObject encodingGetObjectEncodingNil(DynamicObject object) {
             // TODO(CS, 26 Jan 15) something to do with __encoding__ here?
             return nil();
+        }
+
+    }
+
+    @Primitive(name = "encoding_replicate")
+    public static abstract class EncodingReplicateNode extends PrimitiveArrayArgumentsNode {
+
+        @Specialization(guards = "isRubyString(name)")
+        @TruffleBoundary
+        public DynamicObject encodingReplicate(DynamicObject self, DynamicObject name) {
+            final String nameString = StringOperations.getString(name);
+            final DynamicObject existing = getContext().getEncodingManager().getRubyEncoding(nameString);
+            if (existing != null) {
+                throw new RaiseException(coreExceptions().argumentErrorEncodingAlreadyRegistered(nameString, this));
+            }
+            final Encoding base = EncodingOperations.getEncoding(self);
+            EncodingDB.replicate(nameString, new String(base.getName()));
+            final Entry entry = EncodingDB.getEncodings().get(nameString.getBytes());
+            getContext().getEncodingManager().defineEncoding(entry, nameString.getBytes(), 0, nameString.getBytes().length);
+            return getContext().getEncodingManager().getRubyEncoding(nameString.toLowerCase(Locale.ENGLISH));
         }
 
     }

--- a/truffle/src/main/java/org/jruby/truffle/core/encoding/EncodingNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/encoding/EncodingNodes.java
@@ -559,16 +559,6 @@ public abstract class EncodingNodes {
 
     }
 
-    @Primitive(name = "encoding_get_object_encoding_by_index", needsSelf = false)
-    public static abstract class EncodingGetObjectEncodingByIndexNode extends PrimitiveArrayArgumentsNode {
-
-        @Specialization
-        public DynamicObject encodingGetObjectEncodingByIndex(int index) {
-            return getContext().getEncodingManager().getRubyEncoding(index);
-        }
-
-    }
-
     @Primitive(name = "encoding_replicate")
     public static abstract class EncodingReplicateNode extends PrimitiveArrayArgumentsNode {
 

--- a/truffle/src/main/java/org/jruby/truffle/core/exception/CoreExceptions.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/exception/CoreExceptions.java
@@ -129,6 +129,11 @@ public class CoreExceptions {
     }
 
     @TruffleBoundary
+    public DynamicObject argumentErrorEncodingAlreadyRegistered(String nameString, Node currentNode) {
+        return argumentError(StringUtils.format("encoding %s is already registered", nameString), currentNode);
+    }
+
+    @TruffleBoundary
     public DynamicObject argumentError(String message, Node currentNode, Throwable javaThrowable) {
         return argumentError(StringOperations.encodeRope(message, UTF8Encoding.INSTANCE), currentNode, javaThrowable);
     }

--- a/truffle/src/main/ruby/core/encoding.rb
+++ b/truffle/src/main/ruby/core/encoding.rb
@@ -548,7 +548,7 @@ class Encoding
       next unless index
 
       aname = r.first
-      aliases[aname] = Truffle.invoke_primitive(:encoding_get_object_encoding_by_index, index).name if aname
+      aliases[aname] = Truffle.invoke_primitive(:encoding_get_encoding_by_index, index).name if aname
     end
 
     aliases
@@ -612,7 +612,7 @@ class Encoding
   def self.name_list
     EncodingMap.map do |n, r|
       index = r.last
-      r.first or (index and Truffle.invoke_primitive(:encoding_get_object_encoding_by_index, index).name)
+      r.first or (index and Truffle.invoke_primitive(:encoding_get_encoding_by_index, index).name)
     end
   end
 

--- a/truffle/src/main/ruby/core/encoding.rb
+++ b/truffle/src/main/ruby/core/encoding.rb
@@ -57,7 +57,7 @@ class Encoding
   class << self
     def build_encoding_map
       map = Rubinius::LookupTable.new
-      EncodingList.each_with_index { |encoding, index|
+      Encoding.list.each_with_index { |encoding, index|
         key = encoding.name.upcase.to_sym
         map[key] = [nil, index]
       }
@@ -79,7 +79,6 @@ class Encoding
   end
 
   TranscodingMap = Encoding::Converter.transcoding_map
-  EncodingList = Encoding.list.freeze
   EncodingMap = build_encoding_map
 
   @default_external = undefined
@@ -549,7 +548,7 @@ class Encoding
       next unless index
 
       aname = r.first
-      aliases[aname] = EncodingList[index].name if aname
+      aliases[aname] = Truffle.invoke_primitive(:encoding_get_object_encoding_by_index, index).name if aname
     end
 
     aliases
@@ -613,7 +612,7 @@ class Encoding
   def self.name_list
     EncodingMap.map do |n, r|
       index = r.last
-      r.first or (index and EncodingList[index].name)
+      r.first or (index and Truffle.invoke_primitive(:encoding_get_object_encoding_by_index, index).name)
     end
   end
 

--- a/truffle/src/main/ruby/core/encoding.rb
+++ b/truffle/src/main/ruby/core/encoding.rb
@@ -55,9 +55,9 @@ class Encoding
   end
 
   class << self
-    def encoding_map
+    def build_encoding_map
       map = Rubinius::LookupTable.new
-      Encoding.list.each_with_index { |encoding, index|
+      EncodingList.each_with_index { |encoding, index|
         key = encoding.name.upcase.to_sym
         map[key] = [nil, index]
       }
@@ -75,9 +75,12 @@ class Encoding
       }
       map
     end
+    private :build_encoding_map
   end
 
   TranscodingMap = Encoding::Converter.transcoding_map
+  EncodingList = Encoding.list.freeze
+  EncodingMap = build_encoding_map
 
   @default_external = undefined
   @default_internal = undefined
@@ -541,12 +544,12 @@ class Encoding
 
   def self.aliases
     aliases = {}
-    Encoding.encoding_map.each do |n, r|
+    EncodingMap.each do |n, r|
       index = r.last
       next unless index
 
       aname = r.first
-      aliases[aname] = Truffle.invoke_primitive(:encoding_get_object_encoding_by_index, index).name if aname
+      aliases[aname] = EncodingList[index].name if aname
     end
 
     aliases
@@ -559,17 +562,17 @@ class Encoding
     when Encoding
       source_name = obj.name
     when nil
-      Encoding.encoding_map[key][1] = nil
+      EncodingMap[key][1] = nil
       return
     else
       source_name = StringValue(obj)
     end
 
-    entry = Encoding.encoding_map[source_name.upcase.to_sym]
+    entry = EncodingMap[source_name.upcase.to_sym]
     raise ArgumentError, "unknown encoding name - #{source_name}" unless entry
     index = entry.last
 
-    Encoding.encoding_map[key][1] = index
+    EncodingMap[key][1] = index
   end
   private_class_method :set_alias_index
 
@@ -608,9 +611,9 @@ class Encoding
   end
 
   def self.name_list
-    Encoding.encoding_map.map do |n, r|
+    EncodingMap.map do |n, r|
       index = r.last
-      r.first or (index and Truffle.invoke_primitive(:encoding_get_object_encoding_by_index, index).name)
+      r.first or (index and EncodingList[index].name)
     end
   end
 
@@ -619,9 +622,9 @@ class Encoding
   end
 
   def names
-    entry = Encoding.encoding_map[name.upcase.to_sym]
+    entry = EncodingMap[name.upcase.to_sym]
     names = [name]
-    Encoding.encoding_map.each do |k, r|
+    EncodingMap.each do |k, r|
       aname = r.first
       names << aname if aname and r.last == entry.last
     end

--- a/truffle/src/main/ruby/core/encoding.rb
+++ b/truffle/src/main/ruby/core/encoding.rb
@@ -631,6 +631,10 @@ class Encoding
     names
   end
 
+  def replicate(name)
+    Truffle.invoke_primitive(:encoding_replicate, self, StringValue(name))
+  end
+
   def _dump(depth)
     name
   end

--- a/truffle/src/main/ruby/core/type.rb
+++ b/truffle/src/main/ruby/core/type.rb
@@ -459,10 +459,10 @@ module Rubinius
 
       key = str.upcase.to_sym
 
-      pair = Encoding.encoding_map[key]
+      pair = Encoding::EncodingMap[key]
       if pair
         index = pair.last
-        return index && Truffle.invoke_primitive(:encoding_get_object_encoding_by_index, index)
+        return index && Encoding::EncodingList[index]
       end
 
       return undefined

--- a/truffle/src/main/ruby/core/type.rb
+++ b/truffle/src/main/ruby/core/type.rb
@@ -459,10 +459,10 @@ module Rubinius
 
       key = str.upcase.to_sym
 
-      pair = Encoding::EncodingMap[key]
+      pair = Encoding.encoding_map[key]
       if pair
         index = pair.last
-        return index && Encoding::EncodingList[index]
+        return index && Truffle.invoke_primitive(:encoding_get_object_encoding_by_index, index)
       end
 
       return undefined

--- a/truffle/src/main/ruby/core/type.rb
+++ b/truffle/src/main/ruby/core/type.rb
@@ -462,7 +462,7 @@ module Rubinius
       pair = Encoding::EncodingMap[key]
       if pair
         index = pair.last
-        return index && Truffle.invoke_primitive(:encoding_get_object_encoding_by_index, index)
+        return index && Truffle.invoke_primitive(:encoding_get_encoding_by_index, index)
       end
 
       return undefined

--- a/truffle/src/main/ruby/core/type.rb
+++ b/truffle/src/main/ruby/core/type.rb
@@ -462,7 +462,7 @@ module Rubinius
       pair = Encoding::EncodingMap[key]
       if pair
         index = pair.last
-        return index && Encoding::EncodingList[index]
+        return index && Truffle.invoke_primitive(:encoding_get_object_encoding_by_index, index)
       end
 
       return undefined


### PR DESCRIPTION
Work In Progress.

I've got one known failure here which I think is due to the following from `encoding.rb` not recognizing the encodings added at runtime. I'm still thinking about a fix for this. I'll probably replace these with a primitive for the few places these are used.
```
  EncodingList = Encoding.list.freeze
  EncodingMap = build_encoding_map
```

Please review @nirvdrum 