### PR TITLE
Use .equals instead of == to compare strings in findVariableName

### DIFF
--- a/core/src/main/java/org/jruby/parser/StaticScope.java
+++ b/core/src/main/java/org/jruby/parser/StaticScope.java
@@ -325,7 +325,8 @@ public class StaticScope implements Serializable {
 
     private int findVariableName(String name) {
         for (int i = 0; i < variableNames.length; i++) {
-            if (name.equals(variableNames[i])) return i;
+            String varName = variableNames[i];
+            if (name == varName || (name != null && name.equals(varName))) return i;
         }
         return -1;
     }

--- a/core/src/main/java/org/jruby/parser/StaticScope.java
+++ b/core/src/main/java/org/jruby/parser/StaticScope.java
@@ -325,7 +325,7 @@ public class StaticScope implements Serializable {
 
     private int findVariableName(String name) {
         for (int i = 0; i < variableNames.length; i++) {
-            if (name == variableNames[i]) return i;
+            if (name.equals(variableNames[i])) return i;
         }
         return -1;
     }


### PR DESCRIPTION
The `==` string comparison works for some cases but the `.exists` method will break when we try to look for a dynamically created string. Like in this snippet:

```java
    StaticScope scope = StaticScopeFactory.newStaticScope(null, StaticScope.Type.LOCAL, null);
    SimpleSourcePosition pos = new SimpleSourcePosition("<eval>", 0);
    scope.assign(pos, "a", new TrueNode(pos));
    String a = new StringBuilder().append('a').toString();
    assertTrue(scope.exists(a) >= 0); // assertion fails as .exists returns -1
```