### PR TITLE
Bring BigMath::log behaviour closer to MRI

### DIFF
--- a/core/src/main/ruby/jruby/bigdecimal.rb
+++ b/core/src/main/ruby/jruby/bigdecimal.rb
@@ -28,7 +28,7 @@ module BigMath
       return BigDecimal::INFINITY if x.infinite?
       return BigDecimal::NAN if x.nan?
     end
-    x = x.is_a?(Rational) ? x.to_d(Float::DIG) : x.to_d
+    x = x.is_a?(Rational) ? x.to_d(prec) : x.to_d
     return BigDecimal::INFINITY if x.infinite?
     return BigDecimal::NAN if x.nan?
 
@@ -59,9 +59,12 @@ module BigMath
       element_exponent = series_element.exponent
       remaining_precision = n - (sum_exponent - element_exponent).abs
       break if remaining_precision < 0
+      if remaining_precision < rmpd_double_figures
+        remaining_precision = rmpd_double_figures
+      end
       z = z.mult(z2, n)
       i += 2
-      series_element = z.div(i, n)
+      series_element = z.div(i, remaining_precision)
       series_sum += series_element
     end
 

--- a/test/mri/bigdecimal/test_bigdecimal.rb
+++ b/test/mri/bigdecimal/test_bigdecimal.rb
@@ -1497,6 +1497,13 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_in_delta(3, log_3, 0.0000000000_0000000000_0000000000_0000000000_0000000001)
   end
 
+  def test_BigMath_log_with_rational_high_precision_case
+    # From MRI
+    result = BigDecimal('0.22314354220170971436137296411949880462556361100856391620766259404746040597133837784E0')
+    r = Rational(1_234_567_890, 987_654_321)
+    assert_in_delta(result, BigMath.log(r, 50), 0.0000000000_0000000000_0000000000_0000000000_0000000001)
+  end
+
   def test_BigMath_log_with_42
     assert_in_delta(Math.log(42), BigMath.log(42, 20))
     assert_in_delta(Math.log(42), BigMath.log(42.0, 20))

--- a/test/mri/bigdecimal/testbase.rb
+++ b/test/mri/bigdecimal/testbase.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: false
 require "test/unit"
+require_relative "../lib/envutil"
 require "bigdecimal"
 
 module TestBigDecimalBase


### PR DESCRIPTION
Especially for a Rational, high precision use-case

Fixes #4158