### PR TITLE
Fix #4116. Make dirname aware of the file system's path separator

### DIFF
--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -651,38 +651,37 @@ public class RubyFile extends RubyIO implements EncodingCapable {
 
     static Pattern PROTOCOL_PATTERN = Pattern.compile(URI_PREFIX_STRING + ".*");
     public static String dirname(ThreadContext context, String jfilename) {
-        String name = jfilename.replace('\\', '/');
         int minPathLength = 1;
         boolean trimmedSlashes = false;
 
-        boolean startsWithDriveLetterOnWindows = startsWithDriveLetterOnWindows(name);
+        boolean startsWithDriveLetterOnWindows = startsWithDriveLetterOnWindows(jfilename);
 
         if (startsWithDriveLetterOnWindows) {
             minPathLength = 3;
         }
 
         // jar like paths
-        if (name.contains(".jar!/")) {
-            int start = name.indexOf("!/") + 1;
-            String path = dirname(context, name.substring(start));
+        if (jfilename.contains(".jar!/")) {
+            int start = jfilename.indexOf("!/") + 1;
+            String path = dirname(context, jfilename.substring(start));
             if (path.equals(".") || path.equals("/")) path = "";
-            return name.substring(0, start) + path;
+            return jfilename.substring(0, start) + path;
         }
         // address all the url like paths first
-        if (PROTOCOL_PATTERN.matcher(name).matches()) {
-            int start = name.indexOf(":/") + 2;
-            String path = dirname(context, name.substring(start));
+        if (PROTOCOL_PATTERN.matcher(jfilename).matches()) {
+            int start = jfilename.indexOf(":/") + 2;
+            String path = dirname(context, jfilename.substring(start));
             if (path.equals(".")) path = "";
-            return name.substring(0, start) + path;
+            return jfilename.substring(0, start) + path;
         }
 
-        while (name.length() > minPathLength && name.charAt(name.length() - 1) == '/') {
+        while (jfilename.length() > minPathLength && jfilename.charAt(jfilename.length() - 1) == '/') {
             trimmedSlashes = true;
-            name = name.substring(0, name.length() - 1);
+            jfilename = jfilename.substring(0, jfilename.length() - 1);
         }
 
         String result;
-        if (startsWithDriveLetterOnWindows && name.length() == 2) {
+        if (startsWithDriveLetterOnWindows && jfilename.length() == 2) {
             if (trimmedSlashes) {
                 // C:\ is returned unchanged
                 result = jfilename.substring(0, 3);
@@ -691,7 +690,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
             }
         } else {
             //TODO deal with UNC names
-            int index = name.lastIndexOf('/');
+            int index = jfilename.lastIndexOf('/');
 
             if (index == -1) {
                 if (startsWithDriveLetterOnWindows) {
@@ -727,7 +726,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         // trim trailing slashes
         while (result.length() > minPathLength) {
             endChar = result.charAt(result.length() - 1);
-            if (endChar == '/' || endChar == '\\') {
+            if (endChar == File.separatorChar) {
                 result = result.substring(0, result.length() - 1);
             } else {
                 break;

--- a/spec/ruby/core/file/dirname_spec.rb
+++ b/spec/ruby/core/file/dirname_spec.rb
@@ -54,6 +54,12 @@ describe "File.dirname" do
       File.dirname('/////').should == '/'
       File.dirname("//foo//").should == "/"
     end
+
+    context 'when given a path that contains both forward and backward slashes' do
+      it "returns all the components of the filename except the last one that's separated by a forward slash" do
+        File.dirname('/foo/bar\baz').should == '/foo'
+      end
+    end
   end
 
   platform_is :windows do
@@ -61,6 +67,12 @@ describe "File.dirname" do
       File.dirname("//foo").should == "//foo"
       File.dirname("//foo//").should == "//foo"
       File.dirname('/////').should == '//'
+    end
+
+    context 'when given a path that contains both forward and backward slashes' do
+      it "returns all the components of the filename except the last one that's separated by a backward slash" do
+        File.dirname('\foo\bar/baz').should == '\foo'
+      end
     end
   end
 


### PR DESCRIPTION
I removed the line that normalizes the path to be separated by `/` and instead make it aware of the file system's separator.