### PR TITLE
Simplify appveyor.yml, Maven is now a pre-installed package

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,21 +8,11 @@ environment:
     - JAVA_HOME: C:\Program Files (x86)\Java\jdk1.8.0
 
 install:
-  - ps: >-
-      Add-Type -AssemblyName System.IO.Compression.FileSystem
-          if (!(Test-Path -Path "C:\maven\apache-maven-3.3.9" )) {
-            (new-object System.Net.WebClient).DownloadFile(
-              'https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip',
-              'C:\maven-bin.zip'
-            )
-            [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
-          }
-  - cmd: SET PATH=C:\maven\apache-maven-3.3.9\bin;%JAVA_HOME%\bin;%PATH%
   - cmd: echo %PATH%
   - cmd: java -version
+  - mvn -X -v
 
 cache:
-  - C:\maven -> appveyor.yml
   - C:\Users\appveyor\.m2\repository -> pom.xml
 
 test_script:


### PR DESCRIPTION
AppVeyor added Maven 3.3.9 as a pre-installed package, so we don't have to install manually anymore. It is available in their build image of [September 19, 2016](https://www.appveyor.com/updates/)

refs: 
  - https://github.com/jruby/jruby/issues/4075#issuecomment-241072333
  - appveyor/ci#998