### PR TITLE
Fix Java::JavaLangReflect::GenericSignatureFormatError when reflecting reified annotation values

### DIFF
--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -1407,7 +1407,7 @@ public class RubyClass extends RubyModule {
 
         // calculate an appropriate name, for anonymous using inspect like format e.g. "Class:0x628fad4a"
         final String name = getBaseName() != null ? getName() :
-                ( "Class:0x" + Integer.toHexString(System.identityHashCode(this)) );
+                ( "Class_0x" + Integer.toHexString(System.identityHashCode(this)) );
 
         final String javaName = "rubyobj." + name.replaceAll("::", ".");
         final String javaPath = "rubyobj/" + name.replaceAll("::", "/");

--- a/spec/java_integration/fixtures/Reflector.java
+++ b/spec/java_integration/fixtures/Reflector.java
@@ -1,5 +1,6 @@
 package java_integration.fixtures;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Array;
 import java.util.Collection;
@@ -88,5 +89,14 @@ public abstract class Reflector {
         return matchedMethods;
     }
 
+    public static <A extends Annotation> A getDeclaredAnnotation(Class<?> clazz,
+        Class<A> annotationType) {
+        for (Annotation a : clazz.getDeclaredAnnotations()) {
+            if (annotationType.isAssignableFrom(a.annotationType())) {
+                return (A) a;
+            }
+        }
+        return null;
+    }
 }
 

--- a/spec/java_integration/fixtures/Service.java
+++ b/spec/java_integration/fixtures/Service.java
@@ -1,0 +1,9 @@
+package java_integration.fixtures;
+
+import org.jruby.java.codegen.Reified;
+
+public class Service implements Reified {
+  public String getName() {
+    return "ServiceName";
+  }
+}

--- a/spec/java_integration/fixtures/ServiceAnnotation.java
+++ b/spec/java_integration/fixtures/ServiceAnnotation.java
@@ -1,0 +1,14 @@
+package java_integration.fixtures;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ServiceAnnotation {
+  Class<?> service();
+}

--- a/spec/java_integration/reify/become_java_spec.rb
+++ b/spec/java_integration/reify/become_java_spec.rb
@@ -195,7 +195,18 @@ describe "JRuby class reification" do
     klass = Class.new(ReifiedSample)
     hexid = klass.inspect.match(/(0x[0-9a-f]+)/)[1]
     klass = klass.become_java!
-    expect( klass.getName ).to match /^rubyobj.Class.?#{hexid}/ # rubyobj.Class:0x599f1b7
+    expect( klass.getName ).to match /^rubyobj\.Class_#{hexid}/ # rubyobj.Class_0x599f1b7
+  end
+
+  it 'works when reflecting annotations' do
+    klass = Class.new(ReifiedSample)
+    klass.add_class_annotations(Java::java_integration.fixtures.ServiceAnnotation => {
+        'service' => Class.new(Java::java_integration.fixtures.Service).become_java!(false)
+    })
+    klass = klass.become_java!(false)
+    annotation = Reflector.getDeclaredAnnotation(klass, Java::java_integration.fixtures.ServiceAnnotation)
+    expect( annotation ).not_to be_nil
+    expect( annotation.service ).not_to be_nil
   end
 
   describe "java fields" do


### PR DESCRIPTION
In https://github.com/jruby/jruby/commit/84eb04f62f0bac367aa6f162bdaadf56c0beb9c8 the java class names for anonymous classes were changed to have a colon in them.  This causes problems when java tries to use reflection to get the classname because colon isn't a valid classname character. 

The error from java is:

```
Failure/Error: Unable to find java.lang.Class.createAnnotationData(java/lang/Class.java to read failed line
     
     Java::JavaLangReflect::GenericSignatureFormatError:
       Signature Parse error: expected '<' or ';' but got :
       	Remaining input: :0x2b80e5a9;
     # java.lang.Class.createAnnotationData(java/lang/Class.java:3521)
     # java.lang.Class.annotationData(java/lang/Class.java:3510)
     # java.lang.Class.getDeclaredAnnotations(java/lang/Class.java:3477)
     # java_integration.fixtures.Reflector.getDeclaredAnnotation(java_integration/fixtures/Reflector.java:94)
     # java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:498)
     # org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(org/jruby/javasupport/JavaMethod.java:468)
     # org.jruby.javasupport.JavaMethod.invokeStaticDirect(org/jruby/javasupport/JavaMethod.java:370)
     # RUBY.block in (root)(/Users/cheister/Development/jruby/spec/java_integration/reify/become_java_spec.rb:207)
```

This PR just changes the classname back to using an underscore instead of a colon. 