### PR TITLE
Replace BigDecimal#!= by BigDecimal#nonzero?.

### DIFF
--- a/core/src/main/ruby/jruby/bigdecimal.rb
+++ b/core/src/main/ruby/jruby/bigdecimal.rb
@@ -54,7 +54,7 @@ module BigMath
     series_element = z
 
     i = 1
-    while series_element != 0 do
+    while series_element.nonzero? do
       sum_exponent = series_sum.exponent
       element_exponent = series_element.exponent
       remaining_precision = n - (sum_exponent - element_exponent).abs


### PR DESCRIPTION
The comparison is very expensive, because it first tries to convert the operand (which is a constant Integer 0 here) into a BigDecimal. This in turn is very expensive (because the Integer is first converted into a String, and then, for operating on that String, a java.util.regex.Pattern object is compiled (in line https://github.com/felixvf/jruby/blob/cc79119315496ea019496affe7a6a79ebc1dbed9/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java#L533)). Using #nonzero? should speed-up the loop considerably.