### PR TITLE
[Truffle] Use the new getgroups POSIX call.

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -49,7 +49,7 @@ project 'JRuby Core' do
   jar 'com.github.jnr:jnr-enxio:0.13', :exclusions => ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-x86asm:1.0.2', :exclusions => ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-unixsocket:0.13', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-posix:3.0.30', :exclusions => ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-posix:3.0.31-SNAPSHOT', :exclusions => ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-constants:0.9.4', :exclusions => ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-ffi:2.1.0'
   jar 'com.github.jnr:jffi:${jffi.version}'

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -137,7 +137,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
-      <version>3.0.30</version>
+      <version>3.0.31-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <artifactId>jnr-ffi</artifactId>

--- a/truffle/src/main/java/org/jruby/truffle/platform/posix/JNRTrufflePosix.java
+++ b/truffle/src/main/java/org/jruby/truffle/platform/posix/JNRTrufflePosix.java
@@ -438,6 +438,6 @@ public class JNRTrufflePosix implements TrufflePosix {
 
     @Override
     public long[] getgroups() {
-        return Platform.getPlatform().getGroups(null);
+        return posix.getgroups();
     }
 }


### PR DESCRIPTION
Depends on https://github.com/jnr/jnr-posix/pull/82.

So far I'm just using this for Truffle, but that shows it works. I'm not sure what priority you want to give using your Java method for this compared to the JNR version in JRuby classic.