### PR TITLE
do not eagerly set eval-type in a thread-local

### DIFF
--- a/core/src/main/java/org/jruby/runtime/IRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/IRBlockBody.java
@@ -11,19 +11,22 @@ public abstract class IRBlockBody extends ContextAwareBlockBody {
     protected final String fileName;
     protected final int lineNumber;
     protected final IRClosure closure;
-    protected ThreadLocal<EvalType> evalType;
+    protected ThreadLocal<EvalType> evalType; // null is treated as NONE (@see getEvalType())
 
     public IRBlockBody(IRScope closure, Signature signature) {
         super(closure.getStaticScope(), signature);
         this.closure = (IRClosure) closure;
         this.fileName = closure.getFileName();
         this.lineNumber = closure.getLineNumber();
+        // null (not set) by default to avoid having many thread-local values initialized
+        // servers such as Tomcat tend to do thread-local checks when un-deploying apps,
+        // for JRuby leads to 100s of SEVERE warnings for a mid-size (booted) Rails app
         this.evalType = new ThreadLocal();
-        this.evalType.set(EvalType.NONE);
     }
 
-    public EvalType getEvalType() {
-        return this.evalType.get();
+    public final EvalType getEvalType() {
+        final EvalType type = this.evalType.get();
+        return type == null ? EvalType.NONE : type;
     }
 
     public void setEvalType(EvalType evalType) {


### PR DESCRIPTION
instead treat `null` as `NONE`

this is more of a cosmetic issue where on Tomcat JRuby 9K prints a lot of SEVERE warning due Tomcat's leak detection : 

```
04-Oct-2016 11:45:01.304 SEVERE [localhost-startStop-2] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [sblending] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@1311e832]) and a value of type [org.jruby.EvalType] (value [NONE]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
04-Oct-2016 11:45:01.304 SEVERE [localhost-startStop-2] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [sblending] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@7ca33465]) and a value of type [org.jruby.EvalType] (value [NONE]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
04-Oct-2016 11:45:01.305 SEVERE [localhost-startStop-2] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [sblending] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@3ec512d0]) and a value of type [org.jruby.EvalType] (value [NONE]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
04-Oct-2016 11:45:01.305 SEVERE [localhost-startStop-2] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [sblending] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@7c5635e1]) and a value of type [org.jruby.EvalType] (value [NONE]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
04-Oct-2016 11:45:01.305 SEVERE [localhost-startStop-2] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [sblending] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@7feb868c]) and a value of type [org.jruby.EvalType] (value [NONE]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
04-Oct-2016 11:45:01.305 SEVERE [localhost-startStop-2] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [sblending] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@3fce92f0]) and a value of type [org.jruby.EvalType] (value [NONE]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
04-Oct-2016 11:45:01.305 SEVERE [localhost-startStop-2] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [sblending] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@1310eb4a]) and a value of type [org.jruby.EvalType] (value [NONE]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
04-Oct-2016 11:45:01.305 SEVERE [localhost-startStop-2] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [sblending] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@3bc7510d]) and a value of type [org.jruby.EvalType] (value [NONE]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
04-Oct-2016 11:45:01.305 SEVERE [localhost-startStop-2] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [sblending] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@1a9a4b24]) and a value of type [org.jruby.EvalType] (value [NONE]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
04-Oct-2016 11:45:01.305 SEVERE [localhost-startStop-2] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [sblending] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@7bb3621]) and a value of type [org.jruby.EvalType] (value [NONE]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
...
... (400 lines of the same on a booted mid-size Rails app)
```
