### PR TITLE
Fix the incorrect opscode mapping in f2i()

### DIFF
--- a/core/src/main/java/org/jruby/compiler/impl/SkinnyMethodAdapter.java
+++ b/core/src/main/java/org/jruby/compiler/impl/SkinnyMethodAdapter.java
@@ -799,7 +799,7 @@ public final class SkinnyMethodAdapter extends MethodVisitor {
     }
     
     public void f2i() {
-        getMethodVisitor().visitInsn(F2D);
+        getMethodVisitor().visitInsn(F2I);
     }
     
     public void f2l() {


### PR DESCRIPTION
 - f2i() should be mapped to F2I, instead of F2D. Note that F2I is a valid constant in org.objectweb.asm.Opcodes.
 - The incorrect mapping appears to be a copy-paste editing error from the above f2d() method.
 - Due to the error, when float-to-integer narrowing numeric conversion should occur, float-to-double widening numeric conversion was being done, which can have a negative impact on performance and memory usage.