### PR TITLE
Don't dup every element in Enumerator#drop (1.7)

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -320,15 +320,12 @@ public class RubyEnumerable {
         final RubyArray result = runtime.newArray();
 
         try {
-            each(context, self, new JavaInternalBlockBody(runtime, Arity.NO_ARGUMENTS) {
+            each(context, self, new JavaInternalBlockBody(runtime, Arity.ONE_ARGUMENT) {
                 long i = len; // Atomic ?
                 public IRubyObject yield(ThreadContext context, IRubyObject arg) {
                     synchronized (result) {
                         if (i == 0) {
-                            // While iterating over an RubyEnumerator, "arg"
-                            // gets overwritten by the new value, leading to JRUBY-6892.
-                            // So call .dup() whenever appropriate.
-                            result.append(arg.isImmediate() ? arg : arg.dup());
+                            result.append(arg);
                         } else {
                             --i;
                         }

--- a/spec/regression/GH-4218_enumerable_drop_should_not_change_identities.rb
+++ b/spec/regression/GH-4218_enumerable_drop_should_not_change_identities.rb
@@ -1,0 +1,20 @@
+class GH4218Enumerable
+  include Enumerable
+
+  def initialize(elements)
+    @elements = elements
+  end
+
+  def each(&block)
+    @elements.each(&block)
+  end
+end
+
+describe '#4218 Enumerable#drop' do
+  it 'does not change the identity of the elements' do
+    original = [Object.new, Object.new, Object.new]
+    enumerable = GH4218Enumerable.new(original)
+    expect(original[1]).to be_equal(enumerable.drop(1).first)
+    expect(enumerable.to_a[1]).to be_equal(enumerable.drop(1).first)
+  end
+end


### PR DESCRIPTION
This fixes #4218 in JRuby 1.7.

In 06f0441 (JRUBY-6892) `Enumerable#drop` was changed to call `#dup` on every element that ended up in the result, but that might not work. Not all objects correctly implement `#dup`, or are even allocatable.

`#take` was not changed, and looking at the differences between `#take` and `#drop` the only thing that stood out was that the signature of the #each call was different. Changing from `Arity.NO_ARGUMENTS` to `Arity.ONE_REQUIRED` make the issue that 06f0441 tried to fix go away.