### PR TITLE
README: Ruby version manager docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To run JRuby you will need a JRE (the JVM runtime environment) version 7 or high
 Your operating system may provide a JRE and JRuby in a package manager, but you may find that this
 version is very old.
 
-An alternative is to use one of the Ruby version managers.
+An alternative is to use one of the [Ruby version managers](https://www.ruby-lang.org/en/documentation/installation/#managers).
 
 For [`rbenv`](https://github.com/sstephenson/rbenv) you will need the
 [`ruby-build`](https://github.com/sstephenson/ruby-build) plugin. You may find that your system


### PR DESCRIPTION
This PR adds a link to ruby-lang.org's web page on Ruby version managers.