### PR TITLE
Add File.empty?

### DIFF
--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -784,6 +784,24 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         return result;
     }
 
+    @JRubyMethod(name = {"empty?", "zero?"}, required = 1, meta = true)
+    public static IRubyObject empty(ThreadContext context, IRubyObject self, IRubyObject str) {
+        Ruby runtime = context.runtime;
+        String f = StringSupport.checkEmbeddedNulls(runtime, get_path(context, str)).getUnicodeValue();
+
+        if ( ! new File(f).exists() ) {
+            return runtime.getFalse();
+        }
+
+        int size = runtime.newFileStat(f, false).size().convertToInteger().getIntValue();
+        if (size == 0) {
+            return runtime.getTrue();
+        }
+        else {
+            return runtime.getFalse();
+        }
+    }
+
     /**
      * Returns the extension name of the file. An empty string is returned if
      * the filename (not the entire path) starts or ends with a dot.


### PR DESCRIPTION
This PR adds the class methods `File.empty?` (and `File.zero?`). I included `File.zero?` because `File.empty?` in the docs links to `File.zero?`. https://ruby-doc.org/core-2.4.0_preview3/File.html#method-c-empty-3F (I'm guessing one is an alias of the other)

See #4293 where feature is originally mentioned.

This PR gets the test `test_empty_p` in "test/mri/ruby/test_file_exhaustive.rb" to pass. I figured that I didn't need to add any other tests since this functionality is tested by the MRI tests. Let me know if I do need to add more tests.

I did run into an issue while testing with just that file. If I ran just this command

```
bin/jruby test/mri/ruby/test_file_exhaustive.rb -n test_empty_p
```

I get an error about missing `assert_file`.

```
Error: test_empty_p(TestFileExhaustive):
  NameError: undefined local variable or method `assert_file' for #<TestFileExhaustive:0x29a5f4e7>
```

I needed to add `require_relative 'envutil'` (which adds `assert_file`) in order to run the tests. I would have included that change in this PR but it looks like those tests are generated based on the tests in Ruby and I wasn't sure if changes to those files would be overridden when new tests are brought in. That file is probably eventually required when the whole suite is run.

This is my first time contributing to JRuby so let me know if there is something missing that I need to include.