### PR TITLE
Feature#12217 Enumerable/Array sum

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -4280,7 +4280,6 @@ public class RubyArray extends RubyObject implements List, RandomAccess {
         final Ruby runtime = context.runtime;
         RubyFixnum zero = RubyFixnum.zero(runtime);
 
-        /* NB: MRI says "Enumerable#sum method may not respect method redefinition of "+" methods such as Integer#+." */
         if (!isBuiltin("each")) return RubyEnumerable.sumCommon(context, this, zero, block);
 
         return sumCommon(context, self, zero, block);
@@ -4288,12 +4287,13 @@ public class RubyArray extends RubyObject implements List, RandomAccess {
 
     @JRubyMethod
     public static IRubyObject sum(final ThreadContext context, IRubyObject self, IRubyObject init, final Block block) {
-        /* NB: MRI says "Enumerable#sum method may not respect method redefinition of "+" methods such as Integer#+." */
         if (!isBuiltin("each")) return RubyEnumerable.sumCommon(context, this, init, block);
 
         return sumCommon(context, self, init, block);
     }
 
+    /* FIXME: optimise for special types (e.g. Integer)? */
+    /* NB: MRI says "Enumerable#sum method may not respect method redefinition of "+" methods such as Integer#+." */
     public static IRubyObject sumCommon(final ThreadContext context, IRubyObject self, IRubyObject init, final Block block) {
         final Ruby runtime = context.runtime;
         final IRubyObject result[] = new IRubyObject[] { init };

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -4275,6 +4275,44 @@ public class RubyArray extends RubyObject implements List, RandomAccess {
         return context.runtime.getFalse();
     }
 
+    @JRubyMethod
+    public static IRubyObject sum(final ThreadContext context, IRubyObject self, final Block block) {
+        final Ruby runtime = context.runtime;
+        RubyFixnum zero = RubyFixnum.zero(runtime);
+
+        /* NB: MRI says "Enumerable#sum method may not respect method redefinition of "+" methods such as Integer#+." */
+        if (!isBuiltin("each")) return RubyEnumerable.sumCommon(context, this, zero, block);
+
+        return sumCommon(context, self, zero, block);
+    }
+
+    @JRubyMethod
+    public static IRubyObject sum(final ThreadContext context, IRubyObject self, IRubyObject init, final Block block) {
+        /* NB: MRI says "Enumerable#sum method may not respect method redefinition of "+" methods such as Integer#+." */
+        if (!isBuiltin("each")) return RubyEnumerable.sumCommon(context, this, init, block);
+
+        return sumCommon(context, self, init, block);
+    }
+
+    public static IRubyObject sumCommon(final ThreadContext context, IRubyObject self, IRubyObject init, final Block block) {
+        final Ruby runtime = context.runtime;
+        final IRubyObject result[] = new IRubyObject[] { init };
+
+        if (block.isGiven()) {
+            for (int i = 0; i < realLength; i++) {
+                IRubyObject value = block.yield(context, eltOk(i));
+                result[0] = result[0].callMethod(context, "+", value);
+            }
+        } else {
+            for (int i = 0; i < realLength; i++) {
+                IRubyObject value = eltOk(i);
+                result[0] = result[0].callMethod(context, "+", value);
+            }
+        }
+
+        return result[0];
+    }
+
     public IRubyObject find(ThreadContext context, IRubyObject ifnone, Block block) {
         if (!isBuiltin("each")) return RubyEnumerable.detectCommon(context, this, block);
 

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -4293,7 +4293,7 @@ public class RubyArray extends RubyObject implements List, RandomAccess {
     }
 
     /* FIXME: optimise for special types (e.g. Integer)? */
-    /* NB: MRI says "Enumerable#sum method may not respect method redefinition of "+" methods such as Integer#+." */
+    /* NB: MRI says "Array#sum method may not respect method redefinition of "+" methods such as Integer#+." */
     public static IRubyObject sumCommon(final ThreadContext context, IRubyObject self, IRubyObject init, final Block block) {
         final Ruby runtime = context.runtime;
         final IRubyObject result[] = new IRubyObject[] { init };

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -4276,25 +4276,25 @@ public class RubyArray extends RubyObject implements List, RandomAccess {
     }
 
     @JRubyMethod
-    public static IRubyObject sum(final ThreadContext context, IRubyObject self, final Block block) {
+    public IRubyObject sum(final ThreadContext context, final Block block) {
         final Ruby runtime = context.runtime;
         RubyFixnum zero = RubyFixnum.zero(runtime);
 
         if (!isBuiltin("each")) return RubyEnumerable.sumCommon(context, this, zero, block);
 
-        return sumCommon(context, self, zero, block);
+        return sumCommon(context, zero, block);
     }
 
     @JRubyMethod
-    public static IRubyObject sum(final ThreadContext context, IRubyObject self, IRubyObject init, final Block block) {
+    public IRubyObject sum(final ThreadContext context, IRubyObject init, final Block block) {
         if (!isBuiltin("each")) return RubyEnumerable.sumCommon(context, this, init, block);
 
-        return sumCommon(context, self, init, block);
+        return sumCommon(context, init, block);
     }
 
     /* FIXME: optimise for special types (e.g. Integer)? */
     /* NB: MRI says "Array#sum method may not respect method redefinition of "+" methods such as Integer#+." */
-    public static IRubyObject sumCommon(final ThreadContext context, IRubyObject self, IRubyObject init, final Block block) {
+    public IRubyObject sumCommon(final ThreadContext context, IRubyObject init, final Block block) {
         final Ruby runtime = context.runtime;
         final IRubyObject result[] = new IRubyObject[] { init };
 

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -896,13 +896,8 @@ public class RubyEnumerable {
         if (block.isGiven()) {
             callEach(runtime, context, self, Signature.OPTIONAL, new BlockCallback() {
                 public IRubyObject call(ThreadContext ctx, IRubyObject[] largs, Block blk) {
-                    final IRubyObject larg; boolean ary = false;
-                    switch (largs.length) {
-                        case 0:  larg = ctx.nil; break;
-                        case 1:  larg = largs[0]; break;
-                        default: larg = RubyArray.newArrayMayCopy(ctx.runtime, largs); ary = true;
-                    }
-                    IRubyObject val = ary ? block.yieldArray(ctx, larg, null) : block.yield(ctx, larg);
+                    IRubyObject larg = packEnumValues(ctx, largs);
+                    IRubyObject val = block.yieldArray(ctx, larg, null);
                     result[0] = result[0].callMethod(context, "+", val);
 
                     return ctx.nil;
@@ -911,12 +906,7 @@ public class RubyEnumerable {
         } else {
             callEach(runtime, context, self, Signature.OPTIONAL, new BlockCallback() {
                 public IRubyObject call(ThreadContext ctx, IRubyObject[] largs, Block blk) {
-                    final IRubyObject larg;
-                    switch (largs.length) {
-                        case 0:  larg = ctx.nil; break;
-                        case 1:  larg = largs[0]; break;
-                        default: larg = RubyArray.newArrayMayCopy(ctx.runtime, largs);;
-                    }
+                    IRubyObject larg = packEnumValues(ctx, largs);
                     result[0] = result[0].callMethod(context, "+", larg);
 
                     return ctx.nil;

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -889,6 +889,8 @@ public class RubyEnumerable {
         return sumCommon(context, self, init, block);
     }
 
+    /* FIXME: optimise for special types (e.g. Integer)? */
+    /* NB: MRI says "Enumerable#sum method may not respect method redefinition of "+" methods such as Integer#+." */
     public static IRubyObject sumCommon(final ThreadContext context, IRubyObject self, IRubyObject init, final Block block) {
         final Ruby runtime = context.runtime;
         final IRubyObject result[] = new IRubyObject[] { init };

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -877,6 +877,56 @@ public class RubyEnumerable {
         }
     }
 
+    @JRubyMethod
+    public static IRubyObject sum(ThreadContext context, IRubyObject self, final Block block) {
+        final Ruby runtime = context.runtime;
+        RubyFixnum zero = RubyFixnum.zero(runtime);
+        return sumCommon(context, self, zero, block);
+    }
+
+    @JRubyMethod
+    public static IRubyObject sum(ThreadContext context, IRubyObject self, IRubyObject init, final Block block) {
+        return sumCommon(context, self, init, block);
+    }
+
+    public static IRubyObject sumCommon(final ThreadContext context, IRubyObject self, IRubyObject init, final Block block) {
+        final Ruby runtime = context.runtime;
+        final IRubyObject result[] = new IRubyObject[] { init };
+
+        if (block.isGiven()) {
+            callEach(runtime, context, self, Signature.OPTIONAL, new BlockCallback() {
+                public IRubyObject call(ThreadContext ctx, IRubyObject[] largs, Block blk) {
+                    final IRubyObject larg; boolean ary = false;
+                    switch (largs.length) {
+                        case 0:  larg = ctx.nil; break;
+                        case 1:  larg = largs[0]; break;
+                        default: larg = RubyArray.newArrayMayCopy(ctx.runtime, largs); ary = true;
+                    }
+                    IRubyObject val = ary ? block.yieldArray(ctx, larg, null) : block.yield(ctx, larg);
+                    result[0] = result[0].callMethod(context, "+", val);
+
+                    return ctx.nil;
+                }
+            });
+        } else {
+            callEach(runtime, context, self, Signature.OPTIONAL, new BlockCallback() {
+                public IRubyObject call(ThreadContext ctx, IRubyObject[] largs, Block blk) {
+                    final IRubyObject larg;
+                    switch (largs.length) {
+                        case 0:  larg = ctx.nil; break;
+                        case 1:  larg = largs[0]; break;
+                        default: larg = RubyArray.newArrayMayCopy(ctx.runtime, largs);;
+                    }
+                    result[0] = result[0].callMethod(context, "+", larg);
+
+                    return ctx.nil;
+                }
+            });
+        }
+
+        return result[0];
+    }
+
     public static IRubyObject injectCommon(final ThreadContext context, IRubyObject self, IRubyObject init, final Block block) {
         final Ruby runtime = context.runtime;
         final IRubyObject result[] = new IRubyObject[] { init };


### PR DESCRIPTION
Adds `Enumerable#sum` and `Array#sum` from [Feature #12217](https://bugs.ruby-lang.org/issues/12217).

I'm parking this PR here in its current state to encourage discussion and feedback.