### PR TITLE
Fixed Math.lgamma with input -0.0

### DIFF
--- a/core/src/main/java/org/jruby/RubyMath.java
+++ b/core/src/main/java/org/jruby/RubyMath.java
@@ -758,7 +758,7 @@ public class RubyMath {
             }
 
             double int_part = (int) x;
-            sign = (int_part % 2 == 0 && (x - int_part) != 0.0 && (x < 0)) ? -1 : 1;
+            sign = ((x == -0.0) || (int_part % 2 == 0 && (x - int_part) != 0.0 && (x < 0))) ? -1 : 1;
             if ((x - int_part) == 0.0 && 0 < int_part && int_part <= FACTORIAL.length) {
                 value = Math.log(FACTORIAL[(int) int_part - 1]);
             }


### PR DESCRIPTION
There is a cornercase in Math.lgamma if the input is a negative zero.
This patch fixes it by adding that explicit corner case to the if
statement.