### PR TITLE
Disable notifying travis-rubies of passing [skip ci]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,10 +98,6 @@ notifications:
       - "%{repository} (%{branch}:%{commit} by %{author}): %{message} (%{build_url})"
     skip_join: true
 
-  # update jruby-head installed on Travis CI
-  webhooks:
-    urls:
-      - "https://rubies.travis-ci.org/rebuild/jruby-head"
 # we are on a branch
     on_success: always
     on_failure: never


### PR DESCRIPTION
`teavis-rubies` now uses 3 Mac jobs to create archives for various OS
releases.

This is a bit wasteful if multiple builds pass in a short period.

Instead, Travis CI is now running a nightly build of jruby-head
(around 22:30 UTC). This will happen regardless of the state of the
`master` branch.