### PR TITLE
Fix JRuby embed crash after application reloading

### DIFF
--- a/core/src/main/java/org/jruby/runtime/scope/ManyVarsDynamicScope.java
+++ b/core/src/main/java/org/jruby/runtime/scope/ManyVarsDynamicScope.java
@@ -32,7 +32,8 @@ public class ManyVarsDynamicScope extends DynamicScope {
     public static final MethodHandle CONSTRUCTOR;
     static {
         try {
-            CONSTRUCTOR = MethodHandles.publicLookup()
+            // use lookup() to avoid IllegalAccessException with JRuby embed
+            CONSTRUCTOR = MethodHandles.lookup()
                     .findConstructor(ManyVarsDynamicScope.class, MethodType.methodType(void.class, StaticScope.class, DynamicScope.class))
                     .asType(MethodType.methodType(DynamicScope.class, StaticScope.class, DynamicScope.class));
         } catch (Exception e) {


### PR DESCRIPTION
We use JRuby `ScriptingContainer` in a tomcat servlet web
application.  After application reloading in tomcat, JRuby
runtime initialization fails with the error message.
"BUG: could not initialize constructor handle"

`MethodHandles.publicLookup().findConstructor()` fails with
`IllegalAccessException` in static initialization block.

The initialization does not work well with tomcat reloading.

As a workaround `MethodHandles.lookup()` without access check
works fine.