### PR TITLE
Change decimal length for result of time subtraction

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -640,11 +640,14 @@ public class RubyTime extends RubyObject {
         }
     }
 
-    private IRubyObject opMinus(RubyTime other) {
+    private IRubyObject opMinus(ThreadContext context, RubyTime other) {
         long timeInMillis = (getTimeInMillis() - other.getTimeInMillis());
         double timeInSeconds = timeInMillis/1000.0 + (getNSec() - other.getNSec())/1000000000.0;
 
-        return RubyFloat.newFloat(getRuntime(), timeInSeconds); // float number of seconds
+        IRubyObject[] args = new IRubyObject[]{
+         new RubyFixnum(getRuntime(), (long) 10)
+        };
+        return RubyFloat.newFloat(getRuntime(), timeInSeconds).round(context, args); // float number of seconds
     }
 
     public IRubyObject op_minus(IRubyObject other) {
@@ -654,7 +657,7 @@ public class RubyTime extends RubyObject {
     @JRubyMethod(name = "-", required = 1)
     public IRubyObject op_minus19(ThreadContext context, IRubyObject other) {
         checkOpCoercion(context, other);
-        if (other instanceof RubyTime) return opMinus((RubyTime) other);
+        if (other instanceof RubyTime) return opMinus(context, (RubyTime) other);
         return opMinusCommon(other.callMethod(context, "to_r"));
     }
 

--- a/test/jruby/test_time_subtract.rb
+++ b/test/jruby/test_time_subtract.rb
@@ -1,0 +1,10 @@
+require 'test/unit'
+
+class TestTimeSubtract < Test::Unit::TestCase
+  def test_subtract_decimal_length
+    time1 = Time.utc(2000, 1, 2, 23, 59, 59, Rational(999999999, 1000))
+    time2 = Time.utc(2000, 1, 2, 0, 0, 0, Rational(1, 1000))
+
+    assert_equal 86_399.999999998, time1 - time2
+  end
+end


### PR DESCRIPTION
This fixes an inconsistency between MRI and JRuby while trying to get
the Active Support test suite passing on JRuby.