### PR TITLE
Fix marshaling Hash with default_proc set to nil

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -766,6 +766,7 @@ public class RubyHash extends RubyObject implements Map {
 
         if (proc.isNil()) {
             ifNone = proc;
+            flags &= ~PROCDEFAULT_HASH_F;
             return proc;
         }
 

--- a/test/mri/ruby/marshaltestlib.rb
+++ b/test/mri/ruby/marshaltestlib.rb
@@ -143,6 +143,13 @@ module MarshalTestLib
     assert_raise(TypeError) { marshaltest(h) }
   end
 
+  def test_hash_default_proc_that_was_set_to_nil
+    h = Hash.new {}
+    h[4] = 5
+    h.default_proc = nil
+    marshal_equal(h)
+  end
+
   def test_hash_ivar
     o1 = Hash.new
     o1.instance_eval { @iv = 1 }


### PR DESCRIPTION
When we set `default_proc` to nil, we also have to update the internal flag.

Fixes https://github.com/jruby/jruby/issues/4302

@enebo 