### PR TITLE
Add `Pathname#empty?`

### DIFF
--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -784,18 +784,6 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         return result;
     }
 
-    @JRubyMethod(name = {"empty?", "zero?"}, required = 1, meta = true)
-    public static IRubyObject empty_p(ThreadContext context, IRubyObject self, IRubyObject str) {
-        Ruby runtime = context.runtime;
-        String filename = StringSupport.checkEmbeddedNulls(runtime, get_path(context, str)).getUnicodeValue();
-
-        if (!new File(filename).exists()) return runtime.getFalse();
-
-        int size = runtime.newFileStat(filename, false).size().convertToInteger().getIntValue();
-
-        return runtime.newBoolean(size == 0);
-    }
-
     /**
      * Returns the extension name of the file. An empty string is returned if
      * the filename (not the entire path) starts or ends with a dot.

--- a/core/src/main/java/org/jruby/RubyFileTest.java
+++ b/core/src/main/java/org/jruby/RubyFileTest.java
@@ -307,7 +307,7 @@ public class RubyFileTest {
         return zero_p(recv.getRuntime().getCurrentContext(), recv, filename);
     }
 
-    @JRubyMethod(name = "zero?", required = 1, module = true)
+    @JRubyMethod(name = {"empty?", "zero?"}, required = 1, module = true)
     public static RubyBoolean zero_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
         Ruby runtime = context.runtime;
 
@@ -444,7 +444,7 @@ public class RubyFileTest {
             return RubyFileTest.writable_p(recv, filename);
         }
 
-        @JRubyMethod(name = "zero?", required = 1)
+        @JRubyMethod(name = {"empty?", "zero?"}, required = 1)
         public static RubyBoolean zero_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
             return RubyFileTest.zero_p(context, recv, filename);
         }

--- a/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
+++ b/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
@@ -406,6 +406,17 @@ public class RubyPathname extends RubyObject {
         }
     }
 
+    @JRubyMethod(name = "empty?")
+    public IRubyObject empty_p(ThreadContext context) {
+        RubyModule fileTest = context.runtime.getFileTest();
+        if (fileTest.callMethod(context, "directory?", getPath()).isTrue()) {
+            return context.runtime.getDir().callMethod(context, "empty?", getPath());
+        }
+        else {
+            return fileTest.callMethod(context, "empty?", getPath());
+        }
+    }
+
     /* Helpers */
 
     private IRubyObject[] insertPath(IRubyObject[] args, int i) {

--- a/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
+++ b/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
@@ -33,8 +33,6 @@ import static org.jruby.anno.FrameField.BACKREF;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyClass;
-import org.jruby.RubyDir;
-import org.jruby.RubyFileTest;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyModule;
 import org.jruby.RubyObject;
@@ -410,10 +408,11 @@ public class RubyPathname extends RubyObject {
 
     @JRubyMethod(name = "empty?")
     public IRubyObject empty_p(ThreadContext context) {
-        if (RubyFileTest.directory_p(context, this, getPath()).isTrue()) {
-            return RubyDir.empty_p(context, this, getPath());
+        RubyModule fileTest = context.runtime.getFileTest();
+        if (fileTest.callMethod(context, "directory?", getPath()).isTrue()) {
+            return context.runtime.getDir().callMethod(context, "empty?", getPath());
         } else {
-            return RubyFileTest.zero_p(context, this, getPath());
+            return fileTest.callMethod(context, "empty?", getPath());
         }
     }
 

--- a/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
+++ b/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
@@ -33,6 +33,8 @@ import static org.jruby.anno.FrameField.BACKREF;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyClass;
+import org.jruby.RubyDir;
+import org.jruby.RubyFileTest;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyModule;
 import org.jruby.RubyObject;
@@ -408,12 +410,10 @@ public class RubyPathname extends RubyObject {
 
     @JRubyMethod(name = "empty?")
     public IRubyObject empty_p(ThreadContext context) {
-        RubyModule fileTest = context.runtime.getFileTest();
-        if (fileTest.callMethod(context, "directory?", getPath()).isTrue()) {
-            return context.runtime.getDir().callMethod(context, "empty?", getPath());
-        }
-        else {
-            return fileTest.callMethod(context, "empty?", getPath());
+        if (RubyFileTest.directory_p(context, this, getPath()).isTrue()) {
+            return RubyDir.empty_p(context, this, getPath());
+        } else {
+            return RubyFileTest.zero_p(context, this, getPath());
         }
     }
 


### PR DESCRIPTION
* Add `Pathname#empty?`
* Remove `empty?` implementation on `File` since `FileTest` will assign its implementation of `empty?` to `File` (see `RubyFileTest.FileTestFileMethods`)
* Add `FileTest.empty?`

The last two steps were down in this PR in order to base the implementation of `Pathname#empty?` on the MRI implementation (which uses `Dir.empty?` and `FileTest.empty?`. see https://ruby-doc.org/stdlib-2.4.0_preview3/libdoc/pathname/rdoc/Pathname.html#method-i-empty-3F).

This PR gets the failing test in "test/mri/pathname/test_pathname.rb"  to pass. The tests in "test/mri/ruby/test_file_exhaustive.rb" are also still passing after the changes to `File`.

See #4293