### PR TITLE
Skip less specs

### DIFF
--- a/spec/tags/ruby/core/hash/default_proc_tags.txt
+++ b/spec/tags/ruby/core/hash/default_proc_tags.txt
@@ -1,1 +1,0 @@
-fails:Hash#default_proc= clears the default proc if passed nil


### PR DESCRIPTION
With https://github.com/jruby/jruby/pull/4321 merged, we no longer have to skip that ruby spec.

@enebo 