### PR TITLE
Fix unexpected java.lang.ArithmeticException when converting Rational to BigDecimal

### DIFF
--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -487,7 +487,12 @@ public class RubyBigDecimal extends RubyNumeric {
     private static RubyBigDecimal newInstance(ThreadContext context, RubyRational arg, MathContext mathContext) {
         BigDecimal num = new BigDecimal(arg.numerator(context).convertToInteger().getLongValue());
         BigDecimal den = new BigDecimal(arg.denominator(context).convertToInteger().getLongValue());
-        BigDecimal value = num.divide(den, mathContext);
+        BigDecimal value;
+        try {
+          value = num.divide(den, mathContext);
+        } catch (ArithmeticException e){
+          value = num.divide(den, MathContext.DECIMAL64);
+        };
 
         return new RubyBigDecimal(context.runtime, value);
     }
@@ -550,7 +555,7 @@ public class RubyBigDecimal extends RubyNumeric {
         else if ( ( idx = matcher.start(3) ) > 0 ) {
             strValue = strValue.substring(0, idx); // ignored tail junk e.g. "5-6" -> "-6"
         }
-        
+
         BigDecimal decimal;
         try {
             decimal = new BigDecimal(strValue, mathContext);
@@ -1382,7 +1387,7 @@ public class RubyBigDecimal extends RubyNumeric {
         } else {
           bigDecimal = new RubyBigDecimal(context.runtime, value.setScale(scale, mode));
         }
-        
+
         return args.length == 0 ? bigDecimal.to_int() : bigDecimal;
     }
 

--- a/test/mri/bigdecimal/test_bigdecimal.rb
+++ b/test/mri/bigdecimal/test_bigdecimal.rb
@@ -75,6 +75,7 @@ class TestBigDecimal < Test::Unit::TestCase
   end
 
   def test_global_new_with_rational
+    assert_equal(BigDecimal("0.3333333333333333E0"), BigDecimal(Rational(1, 3), 0))
     assert_equal(BigDecimal("0.333333333333333333333"), BigDecimal(1.quo(3), 21))
     assert_equal(BigDecimal("-0.333333333333333333333"), BigDecimal(-1.quo(3), 21))
     assert_raise(ArgumentError) { BigDecimal(1.quo(3)) }


### PR DESCRIPTION
I'm not sure that `catch (ArithmeticException e)` is the best way to fix it, but at least this would emulate MRI behaviour (read #4324 for more context)

Fixes #4324 

@enebo @headius 