### PR TITLE
Add optional digits for Float#floor

### DIFF
--- a/core/src/main/java/org/jruby/RubyFloat.java
+++ b/core/src/main/java/org/jruby/RubyFloat.java
@@ -814,11 +814,29 @@ public class RubyFloat extends RubyNumeric {
     /** floor
      *
      */
-    @JRubyMethod(name = "floor")
-    @Override
-    public IRubyObject floor() {
-        return dbl2num(getRuntime(), Math.floor(value));
-    }
+     @Override
+     public IRubyObject floor() {
+         return dbl2num(getRuntime(), Math.floor(value));
+     }
+
+     @JRubyMethod(name = "floor", optional = 1)
+     public IRubyObject floor(ThreadContext context, IRubyObject[] args) {
+         if (args.length == 0) return floor();
+
+         double digits = num2long(args[0]);
+         double magnifier = Math.pow(10.0, Math.abs(digits));
+         double reducer   = Math.pow(10.0, -Math.abs(digits));
+
+         if (digits > 0) {
+           return RubyFloat.newFloat(context.runtime, Math.floor(value * magnifier) / magnifier);
+         }
+
+         if (digits < 0) {
+           return dbl2num(context.runtime, Math.floor(value * reducer) * magnifier);
+         }
+
+         return dbl2num(context.runtime, Math.floor(value));
+     }
 
     /** flo_ceil
      *

--- a/test/mri/ruby/test_float.rb
+++ b/test/mri/ruby/test_float.rb
@@ -423,6 +423,20 @@ class TestFloat < Test::Unit::TestCase
     assert_raise(FloatDomainError) { inf.truncate }
   end
 
+  def test_floor_with_ndigits_positive
+    assert_equal(2.34, (2.3456).floor(2))
+    assert_equal(2.345, (2.3456).floor(3))
+    assert_equal(2.3456, (2.3456).floor(4))
+  end
+
+  def test_floor_with_ndigits_negative
+    assert_equal(34560, (34567.89).floor(-1))
+    assert_equal(34500, (34567.89).floor(-2))
+    assert_equal(34000, (34567.89).floor(-3))
+    assert_equal(30000, (34567.89).floor(-4))
+    assert_equal(0, (34567.89).floor(-5))
+  end
+
   def test_round_with_precision
     assert_equal(1.100, 1.111.round(1))
     assert_equal(1.110, 1.111.round(2))


### PR DESCRIPTION
Hey!

I implemented the 1st part of this:

- "Float#ceil, **Float#floor**, and Float#truncate now take optional digits, as well as Float#round. [Feature #12245](https://bugs.ruby-lang.org/issues/12245)"

It's my first time working on JRuby code, so I hope this is ok :)

