### PR TITLE
Support building on Java 9

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>io.takari.polyglot</groupId>
     <artifactId>polyglot-ruby</artifactId>
-    <version>0.1.15</version>
+    <version>0.1.20-SNAPSHOT</version>
   </extension>
 </extensions>

--- a/core/pom.rb
+++ b/core/pom.rb
@@ -166,8 +166,8 @@ project 'JRuby Core' do
           'compilerArgs' => { 'arg' => '-J-Xmx1G' },
           'showWarnings' => 'true',
           'showDeprecation' => 'true',
-          'source' => [ '${base.java.version}', '1.7' ],
-          'target' => [ '${base.javac.version}', '1.7' ],
+          'source' => '${base.java.version}',
+          'target' => '${base.javac.version}',
           'useIncrementalCompilation' =>  'false' ) do
     execute_goals( 'compile',
                    :id => 'anno',
@@ -378,6 +378,19 @@ project 'JRuby Core' do
                      'quiet' =>  'true' )
     end
 
+  end
+
+  # TODO change to 1.9 when running with jdk9 as soon as core builds
+  #      with jdk9
+  { '52.0': '1.8', '53.0': '1.9' }.each do |class_version, java_version|
+    profile "#{class_version}" do
+      activation do
+        property name: 'java.class.version', value: class_version
+      end
+
+      properties( 'base.java.version': java_version,
+                  'base.javac.version': java_version )
+    end
   end
 
   profile 'tzdata' do

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -534,9 +534,7 @@ DO NOT MODIFIY - GENERATED CODE
           <showWarnings>true</showWarnings>
           <showDeprecation>true</showDeprecation>
           <source>${base.java.version}</source>
-          <source>1.7</source>
           <target>${base.javac.version}</target>
-          <target>1.7</target>
           <useIncrementalCompilation>false</useIncrementalCompilation>
         </configuration>
       </plugin>
@@ -1093,6 +1091,32 @@ DO NOT MODIFIY - GENERATED CODE
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>52.0</id>
+      <activation>
+        <property>
+          <name>java.class.version</name>
+          <value>52.0</value>
+        </property>
+      </activation>
+      <properties>
+        <base.javac.version>1.8</base.javac.version>
+        <base.java.version>1.8</base.java.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>53.0</id>
+      <activation>
+        <property>
+          <name>java.class.version</name>
+          <value>53.0</value>
+        </property>
+      </activation>
+      <properties>
+        <base.javac.version>1.9</base.javac.version>
+        <base.java.version>1.9</base.java.version>
+      </properties>
     </profile>
     <profile>
       <id>tzdata</id>

--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -62,7 +62,7 @@ project 'JRuby Lib Setup' do
   # just depends on jruby-core so we are sure the jruby.jar is in place
   jar "org.jruby:jruby-core:#{version}", :scope => 'test'
 
-  extension 'org.torquebox.mojo:mavengem-wagon:0.2.2-SNAPSHOT'
+  extension 'org.torquebox.mojo:mavengem-wagon:0.2.2'
 
   repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 

--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -62,9 +62,11 @@ project 'JRuby Lib Setup' do
   # just depends on jruby-core so we are sure the jruby.jar is in place
   jar "org.jruby:jruby-core:#{version}", :scope => 'test'
 
-  extension 'org.torquebox.mojo:mavengem-wagon:0.2.0'
+  extension 'org.torquebox.mojo:mavengem-wagon:0.2.2-SNAPSHOT'
 
   repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
+
+  snapshot_repository :id => :takari, :url => 'https://otto.takari.io/content/repositories/snapshots'
 
   # for testing out jruby-ossl before final release :
   #repository( :url => 'https://oss.sonatype.org/content/repositories/snapshots',

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -222,7 +222,7 @@ DO NOT MODIFIY - GENERATED CODE
       <extension>
         <groupId>org.torquebox.mojo</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>0.2.2-SNAPSHOT</version>
+        <version>0.2.2</version>
       </extension>
     </extensions>
     <resources>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -206,13 +206,23 @@ DO NOT MODIFIY - GENERATED CODE
       <id>mavengems</id>
       <url>mavengem:https://rubygems.org</url>
     </repository>
+    <repository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>takari</id>
+      <url>https://otto.takari.io/content/repositories/snapshots</url>
+    </repository>
   </repositories>
   <build>
     <extensions>
       <extension>
         <groupId>org.torquebox.mojo</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>0.2.0</version>
+        <version>0.2.2-SNAPSHOT</version>
       </extension>
     </extensions>
     <resources>
@@ -312,7 +322,7 @@ DO NOT MODIFIY - GENERATED CODE
       <plugin>
         <groupId>io.takari.polyglot</groupId>
         <artifactId>polyglot-maven-plugin</artifactId>
-        <version>0.1.15</version>
+        <version>0.1.20-SNAPSHOT</version>
         <executions>
           <execution>
             <id>install_gems</id>
@@ -363,7 +373,7 @@ DO NOT MODIFIY - GENERATED CODE
           <dependency>
             <groupId>io.takari.polyglot</groupId>
             <artifactId>polyglot-ruby</artifactId>
-            <version>0.1.15</version>
+            <version>0.1.20-SNAPSHOT</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/pom.rb
+++ b/pom.rb
@@ -119,7 +119,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
     plugin :clean, '2.5'
     plugin :dependency, '2.8'
     plugin :release, '2.4.1'
-    plugin :jar, '2.6'
+    plugin :jar, '3.0.2'
 
     rules = { :requireMavenVersion => { :version => '[3.3.0,)' } }
     unless model.version =~ /-SNAPSHOT/

--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@ DO NOT MODIFIY - GENERATED CODE
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>2.6</version>
+          <version>3.0.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
This was blocked by a few minor issues but these have been resolved now.

@mkristian can we get a release of `polyglot-ruby` so we don't need to use a `SNAPSHOT`?

Then @headius can we consider merging this to master. We can't build on Java 9 without it. I'm not sure if it has any side effects but it seems to work.