### PR TITLE
AppVeyor: set MAVEN_OPTS=-Xmx3g

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
     - JAVA_HOME: C:\Program Files (x86)\Java\jdk1.8.0
 
 install:
+  - cmd: SET MAVEN_OPTS=-Xmx3g
   - cmd: echo %PATH%
   - cmd: java -version
   - mvn -X -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,8 @@ build: off
 
 environment:
   global:
-    - MAVEN_OPTS: -Xmx2g
-    - JAVA_OPTS: -Xmx2g
+    - MAVEN_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xmn48M -Xmx512M"
+    - JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xmn48M -Xmx512M"
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
     - JAVA_HOME: C:\Program Files (x86)\Java\jdk1.8.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,12 +3,14 @@ version: '{build}'
 build: off
 
 environment:
+  global:
+    - MAVEN_OPTS: -Xmx2g
+    - JAVA_OPTS: -Xmx2g
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
     - JAVA_HOME: C:\Program Files (x86)\Java\jdk1.8.0
 
 install:
-  - cmd: SET MAVEN_OPTS=-Xmx3g
   - cmd: echo %PATH%
   - cmd: java -version
   - mvn -X -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
   - mvn -X -v
 
 cache:
-  - C:\Users\appveyor\.m2\repository -> pom.xml
+  - C:\Users\appveyor\.m2\repository -> pom.rb
 
 test_script:
   - mvn -Ptest


### PR DESCRIPTION
This fiddle-with-the-appveyor-build PR tries to get around the issue in AppVeyor that Maven options are handed in a way that generates warnings on Java 8.

Example of build with warnings: https://ci.appveyor.com/project/jnr/jruby/build/2880/job/shniu1cn7yluu99o#L1692

The changes are:

- set JAVA_OPTS and MAVEN_OPTS as "global" environment variables (for all of the matrix participants)
- invalidate cache of downloaded Maven artifacts when the `pom.rb` changes

See #4075.

