### PR TITLE
[Truffle] Hash merge check for splatted elements

### DIFF
--- a/spec/truffle/tags/language/hash_tags.txt
+++ b/spec/truffle/tags/language/hash_tags.txt
@@ -1,1 +1,0 @@
-fails:Hash literal raises a TypeError if any splatted elements keys are not symbols

--- a/truffle/src/main/java/org/jruby/truffle/core/hash/EnsureSymbolKeysNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/hash/EnsureSymbolKeysNode.java
@@ -1,0 +1,34 @@
+package org.jruby.truffle.core.hash;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.object.DynamicObject;
+import com.oracle.truffle.api.profiles.BranchProfile;
+import com.oracle.truffle.api.source.SourceSection;
+import org.jruby.truffle.RubyContext;
+import org.jruby.truffle.language.RubyGuards;
+import org.jruby.truffle.language.RubyNode;
+import org.jruby.truffle.language.control.RaiseException;
+
+public class EnsureSymbolKeysNode extends RubyNode {
+
+    @Child private RubyNode child;
+
+    private final BranchProfile errorProfile = BranchProfile.create();
+
+    public EnsureSymbolKeysNode(RubyContext context, SourceSection sourceSection, RubyNode child) {
+        super(context, sourceSection);
+        this.child = child;
+    }
+
+    @Override
+    public Object execute(VirtualFrame frame) {
+        final Object hash = child.execute(frame);
+        for (KeyValue keyValue : HashOperations.iterableKeyValues((DynamicObject) hash)) {
+            if (!RubyGuards.isRubySymbol(keyValue.getKey())) {
+                errorProfile.enter();
+                throw new RaiseException(coreExceptions().typeErrorWrongArgumentType(keyValue.getKey(), "Symbol", this));
+            }
+        }
+        return hash;
+    }
+}

--- a/truffle/src/main/java/org/jruby/truffle/parser/BodyTranslator.java
+++ b/truffle/src/main/java/org/jruby/truffle/parser/BodyTranslator.java
@@ -44,6 +44,7 @@ import org.jruby.truffle.core.cast.ToProcNodeGen;
 import org.jruby.truffle.core.cast.ToSNode;
 import org.jruby.truffle.core.cast.ToSNodeGen;
 import org.jruby.truffle.core.hash.ConcatHashLiteralNode;
+import org.jruby.truffle.core.hash.EnsureSymbolKeysNode;
 import org.jruby.truffle.core.hash.HashLiteralNode;
 import org.jruby.truffle.core.hash.HashNodesFactory;
 import org.jruby.truffle.core.kernel.KernelNodesFactory;
@@ -1831,9 +1832,11 @@ public class BodyTranslator extends Translator {
 
         for (KeyValuePair<ParseNode, ParseNode> pair: node.getPairs()) {
             if (pair.getKey() == null) {
+                // This null case is for splats {a: 1, **{b: 2}, c: 3}
                 final RubyNode hashLiteralSoFar = HashLiteralNode.create(context, fullSourceSection, keyValues.toArray(new RubyNode[keyValues.size()]));
                 hashConcats.add(hashLiteralSoFar);
-                hashConcats.add(HashCastNodeGen.create(context, fullSourceSection, pair.getValue().accept(this)));
+                hashConcats.add(new EnsureSymbolKeysNode(context, fullSourceSection,
+                    HashCastNodeGen.create(context, fullSourceSection, pair.getValue().accept(this))));
                 keyValues.clear();
             } else {
                 keyValues.add(pair.getKey().accept(this));


### PR DESCRIPTION
This should raise a type error:
```
h = {1 => 2, b: 3}
{"a" => "b", **h}
```
As far as I can tell, this ConcatHashLiteralNode is used for merging hashes with the splat `**` operator. I observed that the pair matching the `pair.getKey() == null` statement in the body translator is what is to be merged into the hash literal. These null key pairs need to check that all their keys are symbols after they are executed. So, I added an array of booleans to track which hashes were being merged in to pass to the concat node.

This is done here in MRI:
`core_hash_merge_kwd`
https://github.com/ruby/ruby/blob/22c0994bc8b34e4b8b80de3259363b0f27c24988/vm.c#L2675
