### PR TITLE
trivial: restkwargs => kwargs in FIXME comment

### DIFF
--- a/core/src/main/java/org/jruby/RubyProc.java
+++ b/core/src/main/java/org/jruby/RubyProc.java
@@ -270,7 +270,7 @@ public class RubyProc extends RubyObject implements DataType {
         int actual = args.length;
         boolean kwargs = blockBody instanceof IRBlockBody && signature.hasKwargs();
 
-        // FIXME: This is a hot mess.  restkwargs factors into destructing a single element array as well.  I just weaved it into this logic.
+        // FIXME: This is a hot mess.  kwargs factors into destructing a single element array as well.  I just weaved it into this logic.
         // for procs and blocks, single array passed to multi-arg must be spread
         if ((signature != Signature.ONE_ARGUMENT &&  required != 0 && (isFixed || signature != Signature.OPTIONAL) || kwargs) &&
                 actual == 1 && args[0].respondsTo("to_ary")) {


### PR DESCRIPTION
This makes the FIXME comment match the code next to it. 

See 4e4935ed6fad1b71111ff2da96a489570870a725