### PR TITLE
change status array of ints to an int

### DIFF
--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1537,7 +1537,7 @@ public class RubyKernel {
         if (!needChdir && runtime.getPosix().isNative() && !Platform.IS_WINDOWS) {
             // MRI: rb_f_system
             long pid;
-            int[] status = new int[1];
+            int status;
 
 //            #if defined(SIGCLD) && !defined(SIGCHLD)
 //            # define SIGCHLD SIGCLD
@@ -1565,8 +1565,8 @@ public class RubyKernel {
             if (pid < 0) {
                 return runtime.getNil();
             }
-            status[0] = (int)((RubyProcess.RubyStatus) context.getLastExitStatus()).getStatus();
-            if (status[0] == 0) return runtime.getTrue();
+            status = (int)((RubyProcess.RubyStatus) context.getLastExitStatus()).getStatus();
+            if (status == 0) return runtime.getTrue();
             return runtime.getFalse();
         }
 


### PR DESCRIPTION
First of all, thanks for JRuby! 😄 

I was just wandering around JRuby's code and I found this array of ints which I think can be replaced by a simple `int`.

Maybe it was done for something that I don't fully understand... what do you think?