### PR TITLE
Add regression test for shell exit

### DIFF
--- a/test/jruby/test_kernel.rb
+++ b/test/jruby/test_kernel.rb
@@ -492,7 +492,7 @@ class TestKernel < Test::Unit::TestCase
   end
 
   def test_system_shell_exit
-    `exit 0`
+    system('exit 0')
     assert_equal 0, $?.exitstatus
   end
   

--- a/test/jruby/test_kernel.rb
+++ b/test/jruby/test_kernel.rb
@@ -491,6 +491,11 @@ class TestKernel < Test::Unit::TestCase
     assert !res
   end
 
+  def test_system_shell_exit
+    `exit 0`
+    assert_equal 0, $?.exitstatus
+  end
+  
   def test_exec_empty
       assert_raise(Errno::ENOENT) {
         exec("")


### PR DESCRIPTION
Adds a regression test for 69da0af4f5af2615640f5575ef80ba288fb4eb5f reported in in #4361.