### PR TITLE
[Truffle] Run irb instead of reading from stdin by default.

### DIFF
--- a/truffle/src/main/java/org/jruby/truffle/options/ArgumentProcessor.java
+++ b/truffle/src/main/java/org/jruby/truffle/options/ArgumentProcessor.java
@@ -615,7 +615,7 @@ public class ArgumentProcessor {
         return null;
     }
 
-    private String resolveScript(String scriptName) {
+    public String resolveScript(String scriptName) {
         // These try/catches are to allow failing over to the "commands" logic
         // when running from within a jruby-complete jar file, which has
         // jruby.home = a jar file URL that does not resolve correctly with

--- a/truffle/src/main/java/org/jruby/truffle/options/RubyInstanceConfig.java
+++ b/truffle/src/main/java/org/jruby/truffle/options/RubyInstanceConfig.java
@@ -93,8 +93,12 @@ public class RubyInstanceConfig {
     }
 
     public void processArguments(String[] arguments) {
-        new ArgumentProcessor(arguments, this).processArguments();
+        final ArgumentProcessor processor = new ArgumentProcessor(arguments, this);
+        processor.processArguments();
         tryProcessArgumentsWithRubyopts();
+        if (getInlineScript() == null && getScriptFileName() == null && System.console() != null) {
+            setScriptFileName(processor.resolveScript("irb"));
+        }
     }
 
     public void tryProcessArgumentsWithRubyopts() {


### PR DESCRIPTION
This continually confuses non-Ruby users who just run `ruby` and expect to see something.

I could be convinced to not commit this.