### PR TITLE
Fix bigdecimal infinity round

### DIFF
--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -1354,14 +1354,12 @@ public class RubyBigDecimal extends RubyNumeric {
 
     @JRubyMethod(name = "round", optional = 2)
     public IRubyObject round(ThreadContext context, IRubyObject[] args) {
-        final int scale = args.length > 0 ? num2int(args[0]) : 0;
-
         // Special treatment for BigDecimal::NAN and BigDecimal::INFINITY
         //
         // If round is called without any argument, we should raise a
         // FloatDomainError. Otherwise, we don't have to call round ;
         // we can simply return the number itself.
-        if (scale == 0 && isInfinity()) {
+        if (args.length == 0 && isInfinity()) {
             StringBuilder message = new StringBuilder("Computation results to ");
             message.append('\'').append(callMethod(context, "to_s")).append('\'');
 
@@ -1373,6 +1371,7 @@ public class RubyBigDecimal extends RubyNumeric {
             }
         }
 
+        final int scale = args.length > 0 ? num2int(args[0]) : 0;
         RoundingMode mode = (args.length > 1) ? javaRoundingModeFromRubyRoundingMode(context.runtime, args[1]) : getRoundingMode(context.runtime);
         // JRUBY-914: Java 1.4 BigDecimal does not allow a negative scale, so we have to simulate it
         final RubyBigDecimal bigDecimal;

--- a/test/mri/bigdecimal/test_bigdecimal.rb
+++ b/test/mri/bigdecimal/test_bigdecimal.rb
@@ -946,6 +946,13 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_equal([-1, "Infinity", 10, 0], BigDecimal.new("-Infinity").split)
   end
 
+  def test_round_infinity
+    assert_equal "Infinity", BigDecimal("Infinity").round(0).to_s
+    assert_raise(FloatDomainError) do
+      BigDecimal("Infinity").round
+    end
+  end
+
   def test_exponent
     x = BigDecimal.new('-123.45678901234567890')
     assert_equal(3, x.exponent)


### PR DESCRIPTION
Expected: MRI can `round(0)` Infinity:
```
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin16]

BigDecimal("Infinity").round(0)
=> #<BigDecimal:7fad7f83d798,'Infinity',9(18)>
```

But JRuby-master raises an error:

```
jruby 9.1.7.0-SNAPSHOT (2.3.1) 2016-12-12 fd9515b Java HotSpot(TM) 64-Bit Server VM 25.45-b02 on 1.8.0_45-b14 +jit [darwin-x86_64]

BigDecimal("Infinity").round(0)
FloatDomainError: Computation results to 'Infinity'
    org/jruby/ext/bigdecimal/RubyBigDecimal.java:1368:in `round'
```

We raised an error when the method was called with no argument, but we checked it in the wrong way so `round(0)` was broken.

@enebo @headius