### PR TITLE
Remove unsafe-mock from our build altogether.

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -13,9 +13,6 @@ project 'JRuby Core' do
               'tzdata.version' => '2013d',
               'tzdata.scope' => 'provided',
 
-              'unsafe.version' => '8.92.1',
-              'unsafe.jar' => '${settings.localRepository}/com/headius/unsafe-mock/${unsafe.version}/unsafe-mock-${unsafe.version}.jar',
-
               'maven.build.timestamp.format' => 'yyyy-MM-dd',
               'maven.test.skip' => 'true',
               'build.date' => '${maven.build.timestamp}',
@@ -63,7 +60,7 @@ project 'JRuby Core' do
   jar 'com.headius:invokebinder:1.7'
   jar 'com.headius:options:1.4'
   jar 'com.headius:coro-mock:1.0', :scope => 'provided'
-  jar 'com.headius:unsafe-mock', '${unsafe.version}', :scope => 'provided'
+  jar 'com.headius:unsafe-fences:1.0-SNAPSHOT'
 
   jar 'bsf:bsf:2.4.0', :scope => 'provided'
   jar 'com.jcraft:jzlib:1.1.3'
@@ -192,8 +189,6 @@ project 'JRuby Core' do
                    'compilerArgs' => [ '-XDignore.symbol.file=true',
                                        '-J-Duser.language=en',
                                        '-J-Dfile.encoding=UTF-8',
-                                       '-J-Xbootclasspath/p:${unsafe.jar}',
-                                       '-Xbootclasspath/p:${unsafe.jar}',
                                        '-J-Xmx${jruby.compile.memory}' ] )
     execute_goals( 'compile',
                    :id => 'populators',
@@ -201,8 +196,6 @@ project 'JRuby Core' do
                    'compilerArgs' => [ '-XDignore.symbol.file=true',
                                        '-J-Duser.language=en',
                                        '-J-Dfile.encoding=UTF-8',
-                                       '-J-Xbootclasspath/p:${unsafe.jar}',
-                                       '-Xbootclasspath/p:${unsafe.jar}',
                                        '-J-Xmx${jruby.compile.memory}' ],
                    'includes' => [ 'org/jruby/gen/**/*.java' ] )
     execute_goals( 'compile',

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,7 +22,6 @@ DO NOT MODIFIY - GENERATED CODE
     <spec.tags.dir>${spec.dir}/tags</spec.tags.dir>
     <polyglot.dump.pom>pom.xml</polyglot.dump.pom>
     <pkg.dir>${build.dir}/pkg</pkg.dir>
-    <unsafe.jar>${settings.localRepository}/com/headius/unsafe-mock/${unsafe.version}/unsafe-mock-${unsafe.version}.jar</unsafe.jar>
     <spec.dir>spec</spec.dir>
     <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
     <jruby.test.memory.permgen>2G</jruby.test.memory.permgen>
@@ -41,7 +40,6 @@ DO NOT MODIFIY - GENERATED CODE
     <jruby.launch.memory>1024M</jruby.launch.memory>
     <jruby.compile.memory>2G</jruby.compile.memory>
     <version.ruby.major>2.3</version.ruby.major>
-    <unsafe.version>8.92.1</unsafe.version>
     <release.dir>release</release.dir>
     <create.sources.jar>false</create.sources.jar>
     <lib.dir>lib</lib.dir>
@@ -210,9 +208,8 @@ DO NOT MODIFIY - GENERATED CODE
     </dependency>
     <dependency>
       <groupId>com.headius</groupId>
-      <artifactId>unsafe-mock</artifactId>
-      <version>${unsafe.version}</version>
-      <scope>provided</scope>
+      <artifactId>unsafe-fences</artifactId>
+      <version>1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>bsf</groupId>
@@ -496,8 +493,6 @@ DO NOT MODIFIY - GENERATED CODE
                 <compilerArg>-XDignore.symbol.file=true</compilerArg>
                 <compilerArg>-J-Duser.language=en</compilerArg>
                 <compilerArg>-J-Dfile.encoding=UTF-8</compilerArg>
-                <compilerArg>-J-Xbootclasspath/p:${unsafe.jar}</compilerArg>
-                <compilerArg>-Xbootclasspath/p:${unsafe.jar}</compilerArg>
                 <compilerArg>-J-Xmx${jruby.compile.memory}</compilerArg>
               </compilerArgs>
             </configuration>
@@ -513,8 +508,6 @@ DO NOT MODIFIY - GENERATED CODE
                 <compilerArg>-XDignore.symbol.file=true</compilerArg>
                 <compilerArg>-J-Duser.language=en</compilerArg>
                 <compilerArg>-J-Dfile.encoding=UTF-8</compilerArg>
-                <compilerArg>-J-Xbootclasspath/p:${unsafe.jar}</compilerArg>
-                <compilerArg>-Xbootclasspath/p:${unsafe.jar}</compilerArg>
                 <compilerArg>-J-Xmx${jruby.compile.memory}</compilerArg>
               </compilerArgs>
               <includes>

--- a/core/src/main/java/org/jruby/runtime/ivars/StampedVariableAccessor.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/StampedVariableAccessor.java
@@ -26,6 +26,7 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby.runtime.ivars;
 
+import com.headius.unsafe.fences.UnsafeFences;
 import org.jruby.RubyBasicObject;
 import org.jruby.RubyClass;
 import org.jruby.util.ArraySupport;
@@ -151,9 +152,9 @@ public class StampedVariableAccessor extends VariableAccessor {
      */
     private static boolean updateTableUnsafe(RubyBasicObject self, int currentStamp, Object[] currentTable, int index, Object value) {
         // shared access to varTable field.
-        if(UnsafeHolder.SUPPORTS_FENCES) {
+        if(UnsafeFences.SUPPORTS_FENCES) {
             currentTable[index] = value;
-            UnsafeHolder.fullFence();
+            UnsafeFences.fullFence();
         } else {
             // TODO: maybe optimize by read and checking current value before setting
             UnsafeHolder.U.putObjectVolatile(currentTable, UnsafeHolder.ARRAY_OBJECT_BASE_OFFSET + UnsafeHolder.ARRAY_OBJECT_INDEX_SCALE * index, value);

--- a/core/src/main/java/org/jruby/util/unsafe/UnsafeHolder.java
+++ b/core/src/main/java/org/jruby/util/unsafe/UnsafeHolder.java
@@ -37,8 +37,7 @@ public final class UnsafeHolder {
      * Holds a reference to Unsafe if available, null otherwise.    
      */
     public static final sun.misc.Unsafe U = loadUnsafe();
-    
-    public static final boolean SUPPORTS_FENCES = supportsFences();
+
     public static final long    ARRAY_OBJECT_BASE_OFFSET = arrayObjectBaseOffset();
     public static final long    ARRAY_OBJECT_INDEX_SCALE = arrayObjectIndexScale();
     
@@ -89,20 +88,4 @@ public final class UnsafeHolder {
             return sun.misc.Unsafe.INVALID_FIELD_OFFSET;
         }
     }
-    
-    //// The following methods are Java8 only. They will throw undefined method errors if invoked without checking for fence support 
-    
-    public static void fullFence() {
-        U.fullFence();
-    }
-    
-    public static void loadFence() {
-        U.loadFence();
-    }
-    
-    public static void storeFence() {
-        U.storeFence();
-    }
-
-
 }


### PR DESCRIPTION
This commit replaces the unsafe-mock dependency -- which caused
various build problems living in boot classpath -- with a new
library that just shims the three Unsafe methods added in Java 8:
fullFence, loadFence, and storeFence. This allows us to eliminate
all calls to those methods from JRuby proper as well as the build
tricks.

Fixes #4103.