### PR TITLE
Improve stack depth

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
@@ -142,6 +142,71 @@ public class CompiledIRMethod extends AbstractIRMethod {
         }
     }
 
+    @Override
+    public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject[] args) {
+        if (hasKwargs) args = IRRuntimeHelpers.frobnicateKwargsArgument(context, args, getSignature().required());
+
+        try {
+            return (IRubyObject) this.variable.invokeExact(context, staticScope, self, args, Block.NULL_BLOCK, implementationClass, name);
+        }
+        catch (Throwable t) {
+            Helpers.throwException(t);
+            return null; // not reached
+        }
+    }
+
+    @Override
+    public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name) {
+        if (specificArity != 0) return call(context, self, clazz, name, IRubyObject.NULL_ARRAY, Block.NULL_BLOCK);
+
+        try {
+            return (IRubyObject) this.specific.invokeExact(context, staticScope, self, Block.NULL_BLOCK, implementationClass, name);
+        }
+        catch (Throwable t) {
+            Helpers.throwException(t);
+            return null; // not reached
+        }
+    }
+
+    @Override
+    public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject arg0) {
+        if (specificArity != 1) return call(context, self, clazz, name, new IRubyObject[]{arg0}, Block.NULL_BLOCK);
+
+        try {
+            return (IRubyObject) this.specific.invokeExact(context, staticScope, self, arg0, Block.NULL_BLOCK, implementationClass, name);
+        }
+        catch (Throwable t) {
+            Helpers.throwException(t);
+            return null; // not reached
+        }
+    }
+
+    @Override
+    public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject arg0, IRubyObject arg1) {
+        if (specificArity != 2) return call(context, self, clazz, name, new IRubyObject[] {arg0, arg1}, Block.NULL_BLOCK);
+
+        try {
+            return (IRubyObject) this.specific.invokeExact(context, staticScope, self, arg0, arg1, Block.NULL_BLOCK, implementationClass, name);
+        }
+        catch (Throwable t) {
+            Helpers.throwException(t);
+            return null; // not reached
+        }
+    }
+
+    @Override
+    public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
+        if (specificArity != 3) return call(context, self, clazz, name, new IRubyObject[] {arg0, arg1, arg2 }, Block.NULL_BLOCK);
+
+        try {
+            return (IRubyObject) this.specific.invokeExact(context, staticScope, self, arg0, arg1, arg2, Block.NULL_BLOCK, implementationClass, name);
+        }
+        catch (Throwable t) {
+            Helpers.throwException(t);
+            return null; // not reached
+        }
+    }
+
     public String getFile() {
         return method.getFileName();
     }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
@@ -22,7 +22,6 @@ public class CompiledIRMethod extends AbstractIRMethod {
     protected final MethodHandle specific;
     protected final int specificArity;
 
-    private final boolean hasExplicitCallProtocol;
     private final boolean hasKwargs;
 
     public CompiledIRMethod(MethodHandle variable, IRScope method, Visibility visibility,
@@ -39,7 +38,6 @@ public class CompiledIRMethod extends AbstractIRMethod {
         // unboxing -- it was a simple path to hacking this in).
         this.specificArity = hasKwargs ? -1 : specificArity;
         this.method.getStaticScope().determineModule();
-        this.hasExplicitCallProtocol = method.hasExplicitCallProtocol();
         this.hasKwargs = hasKwargs;
 
         setHandle(variable);
@@ -81,112 +79,67 @@ public class CompiledIRMethod extends AbstractIRMethod {
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject[] args, Block block) {
-        if (!hasExplicitCallProtocol) return callNoProtocol(context, self, name, args, block);
-
         if (hasKwargs) args = IRRuntimeHelpers.frobnicateKwargsArgument(context, args, getSignature().required());
 
-        return invokeExact(this.variable, context, staticScope, self, args, block, implementationClass, name);
+        try {
+            return (IRubyObject) this.variable.invokeExact(context, staticScope, self, args, block, implementationClass, name);
+        }
+        catch (Throwable t) {
+            Helpers.throwException(t);
+            return null; // not reached
+        }
     }
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, Block block) {
         if (specificArity != 0) return call(context, self, clazz, name, IRubyObject.NULL_ARRAY, block);
 
-        if (!hasExplicitCallProtocol) return callNoProtocol(context, self, clazz, name, block);
-
-        return invokeExact(this.specific, context, staticScope, self, block, implementationClass, name);
+        try {
+            return (IRubyObject) this.specific.invokeExact(context, staticScope, self, block, implementationClass, name);
+        }
+        catch (Throwable t) {
+            Helpers.throwException(t);
+            return null; // not reached
+        }
     }
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject arg0, Block block) {
-        if (!hasExplicitCallProtocol) return callNoProtocol(context, self, clazz, name, arg0, block);
-
         if (specificArity != 1) return call(context, self, clazz, name, new IRubyObject[]{arg0}, block);
 
-        return invokeExact(this.specific, context, staticScope, self, arg0, block, implementationClass, name);
+        try {
+            return (IRubyObject) this.specific.invokeExact(context, staticScope, self, arg0, block, implementationClass, name);
+        }
+        catch (Throwable t) {
+            Helpers.throwException(t);
+            return null; // not reached
+        }
     }
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject arg0, IRubyObject arg1, Block block) {
-        if (!hasExplicitCallProtocol) return callNoProtocol(context, self, clazz, name, arg0, arg1, block);
-
         if (specificArity != 2) return call(context, self, clazz, name, new IRubyObject[] {arg0, arg1}, block);
 
-        return invokeExact(this.specific, context, staticScope, self, arg0, arg1, block, implementationClass, name);
+        try {
+            return (IRubyObject) this.specific.invokeExact(context, staticScope, self, arg0, arg1, block, implementationClass, name);
+        }
+        catch (Throwable t) {
+            Helpers.throwException(t);
+            return null; // not reached
+        }
     }
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
-        if (!hasExplicitCallProtocol) return callNoProtocol(context, self, clazz, name, arg0, arg1, arg2, block);
-
         if (specificArity != 3) return call(context, self, clazz, name, new IRubyObject[] {arg0, arg1, arg2 }, block);
 
-        return invokeExact(this.specific, context, staticScope, self, arg0, arg1, arg2, block, implementationClass, name);
-    }
-
-    private IRubyObject callNoProtocol(ThreadContext context, IRubyObject self, String name, IRubyObject[] args, Block block) {
-        StaticScope staticScope = this.staticScope;
-        RubyModule implementationClass = this.implementationClass;
-        pre(context, staticScope, implementationClass, self, name, block);
-
-        if (hasKwargs) args = IRRuntimeHelpers.frobnicateKwargsArgument(context, args, getSignature().required());
-
         try {
-            return invokeExact(this.variable, context, staticScope, self, args, block, implementationClass, name);
+            return (IRubyObject) this.specific.invokeExact(context, staticScope, self, arg0, arg1, arg2, block, implementationClass, name);
         }
-        finally { post(context); }
-    }
-
-    public final IRubyObject callNoProtocol(ThreadContext context, IRubyObject self, RubyModule clazz, String name, Block block) {
-        if (specificArity != 0) return call(context, self, clazz, name, IRubyObject.NULL_ARRAY, block);
-
-        StaticScope staticScope = this.staticScope;
-        RubyModule implementationClass = this.implementationClass;
-        pre(context, staticScope, implementationClass, self, name, block);
-
-        try {
-            return invokeExact(this.specific, context, staticScope, self, block, implementationClass, name);
+        catch (Throwable t) {
+            Helpers.throwException(t);
+            return null; // not reached
         }
-        finally { post(context); }
-    }
-
-    public final IRubyObject callNoProtocol(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject arg0, Block block) {
-        if (specificArity != 1) return call(context, self, clazz, name, Helpers.arrayOf(arg0), block);
-
-        StaticScope staticScope = this.staticScope;
-        RubyModule implementationClass = this.implementationClass;
-        pre(context, staticScope, implementationClass, self, name, block);
-
-        try {
-            return invokeExact(this.specific, context, staticScope, self, arg0, block, implementationClass, name);
-        }
-        finally { post(context); }
-    }
-
-    public final IRubyObject callNoProtocol(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject arg0, IRubyObject arg1, Block block) {
-        if (specificArity != 2) return call(context, self, clazz, name, Helpers.arrayOf(arg0, arg1), block);
-
-        StaticScope staticScope = this.staticScope;
-        RubyModule implementationClass = this.implementationClass;
-        pre(context, staticScope, implementationClass, self, name, block);
-
-        try {
-            return invokeExact(this.specific, context, staticScope, self, arg0, arg1, block, implementationClass, name);
-        }
-        finally { post(context); }
-    }
-
-    public final IRubyObject callNoProtocol(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
-        if (specificArity != 3) return call(context, self, clazz, name, Helpers.arrayOf(arg0, arg1, arg2), block);
-
-        StaticScope staticScope = this.staticScope;
-        RubyModule implementationClass = this.implementationClass;
-        pre(context, staticScope, implementationClass, self, name, block);
-
-        try {
-            return invokeExact(this.specific, context, staticScope, self, arg0, arg1, arg2, block, implementationClass, name);
-        }
-        finally { post(context); }
     }
 
     public String getFile() {
@@ -200,71 +153,6 @@ public class CompiledIRMethod extends AbstractIRMethod {
     @Override
     public String toString() {
         return getClass().getName() + '@' + Integer.toHexString(hashCode()) + ' ' + method + ' ' + getSignature();
-    }
-
-    private static IRubyObject invokeExact(MethodHandle method,
-            ThreadContext context, StaticScope staticScope, IRubyObject self,
-            IRubyObject[] args, Block block,
-            RubyModule implementationClass, String name) {
-        try {
-            return (IRubyObject) method.invokeExact(context, staticScope, self, args, block, implementationClass, name);
-        }
-        catch (Throwable t) {
-            Helpers.throwException(t);
-            return null; // not reached
-        }
-    }
-
-    private static IRubyObject invokeExact(MethodHandle method,
-            ThreadContext context, StaticScope staticScope, IRubyObject self,
-            Block block,
-            RubyModule implementationClass, String name) {
-        try {
-            return (IRubyObject) method.invokeExact(context, staticScope, self, block, implementationClass, name);
-        }
-        catch (Throwable t) {
-            Helpers.throwException(t);
-            return null; // not reached
-        }
-    }
-
-    private static IRubyObject invokeExact(MethodHandle method,
-            ThreadContext context, StaticScope staticScope, IRubyObject self,
-            IRubyObject arg0, Block block,
-            RubyModule implementationClass, String name) {
-        try {
-            return (IRubyObject) method.invokeExact(context, staticScope, self, arg0, block, implementationClass, name);
-        }
-        catch (Throwable t) {
-            Helpers.throwException(t);
-            return null; // not reached
-        }
-    }
-
-    private static IRubyObject invokeExact(MethodHandle method,
-            ThreadContext context, StaticScope staticScope, IRubyObject self,
-            IRubyObject arg0, IRubyObject arg1, Block block,
-            RubyModule implementationClass, String name) {
-        try {
-            return (IRubyObject) method.invokeExact(context, staticScope, self, arg0, arg1, block, implementationClass, name);
-        }
-        catch (Throwable t) {
-            Helpers.throwException(t);
-            return null; // not reached
-        }
-    }
-
-    private static IRubyObject invokeExact(MethodHandle method,
-            ThreadContext context, StaticScope staticScope, IRubyObject self,
-            IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block,
-            RubyModule implementationClass, String name) {
-        try {
-            return (IRubyObject) method.invokeExact(context, staticScope, self, arg0, arg1, arg2, block, implementationClass, name);
-        }
-        catch (Throwable t) {
-            Helpers.throwException(t);
-            return null; // not reached
-        }
     }
 
 }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
@@ -91,6 +91,14 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
         return INTERPRET_METHOD(context, ensureInstrsReady(), getImplementationClass(), self, name, args, block);
     }
 
+    @Override
+    public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject[] args) {
+        if (IRRuntimeHelpers.isDebug()) doDebug();
+
+        if (callCount >= 0) promoteToFullBuild(context);
+        return INTERPRET_METHOD(context, ensureInstrsReady(), getImplementationClass(), self, name, args, Block.NULL_BLOCK);
+    }
+
     private IRubyObject INTERPRET_METHOD(ThreadContext context, InterpreterContext ic, RubyModule implClass,
                                          IRubyObject self, String name, IRubyObject[] args, Block block) {
         try {
@@ -118,6 +126,15 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
         if (callCount >= 0) promoteToFullBuild(context);
 
         return INTERPRET_METHOD(context, ensureInstrsReady(), getImplementationClass(), self, name, block);
+    }
+
+    @Override
+    public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name) {
+        if (IRRuntimeHelpers.isDebug()) doDebug();
+
+        if (callCount >= 0) promoteToFullBuild(context);
+
+        return INTERPRET_METHOD(context, ensureInstrsReady(), getImplementationClass(), self, name, Block.NULL_BLOCK);
     }
 
     private IRubyObject INTERPRET_METHOD(ThreadContext context, InterpreterContext ic, RubyModule implClass,
@@ -148,6 +165,14 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
         return INTERPRET_METHOD(context, ensureInstrsReady(), getImplementationClass(), self, name, arg0, block);
     }
 
+    @Override
+    public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject arg0) {
+        if (IRRuntimeHelpers.isDebug()) doDebug();
+
+        if (callCount >= 0) promoteToFullBuild(context);
+        return INTERPRET_METHOD(context, ensureInstrsReady(), getImplementationClass(), self, name, arg0, Block.NULL_BLOCK);
+    }
+
     private IRubyObject INTERPRET_METHOD(ThreadContext context, InterpreterContext ic, RubyModule implClass,
                                          IRubyObject self, String name, IRubyObject arg1, Block block) {
         try {
@@ -176,6 +201,14 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
         return INTERPRET_METHOD(context, ensureInstrsReady(), getImplementationClass(), self, name, arg0, arg1, block);
     }
 
+    @Override
+    public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject arg0, IRubyObject arg1) {
+        if (IRRuntimeHelpers.isDebug()) doDebug();
+
+        if (callCount >= 0) promoteToFullBuild(context);
+        return INTERPRET_METHOD(context, ensureInstrsReady(), getImplementationClass(), self, name, arg0, arg1, Block.NULL_BLOCK);
+    }
+
     private IRubyObject INTERPRET_METHOD(ThreadContext context, InterpreterContext ic, RubyModule implClass,
                                          IRubyObject self, String name, IRubyObject arg1, IRubyObject arg2,  Block block) {
         try {
@@ -202,6 +235,14 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
 
         if (callCount >= 0) promoteToFullBuild(context);
         return INTERPRET_METHOD(context, ensureInstrsReady(), getImplementationClass(), self, name, arg0, arg1, arg2, block);
+    }
+
+    @Override
+    public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
+        if (IRRuntimeHelpers.isDebug()) doDebug();
+
+        if (callCount >= 0) promoteToFullBuild(context);
+        return INTERPRET_METHOD(context, ensureInstrsReady(), getImplementationClass(), self, name, arg0, arg1, arg2, Block.NULL_BLOCK);
     }
 
     private IRubyObject INTERPRET_METHOD(ThreadContext context, InterpreterContext ic, RubyModule implClass,


### PR DESCRIPTION
These commits add more call paths through a few of our DynamicMethod subclasses for Ruby methods, to reduce the number of stack frames they consume. This improves JIT stack depth for the examples in #3810 by nearly 50%, with a somewhat smaller gain for the interpreter (which has more frames).