### PR TITLE
Add call protocol to script body and separate non-protocol metas.

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
@@ -40,6 +40,8 @@ public class CompiledIRMethod extends AbstractIRMethod {
         this.method.getStaticScope().determineModule();
         this.hasKwargs = hasKwargs;
 
+        assert method.hasExplicitCallProtocol();
+
         setHandle(variable);
     }
 
@@ -65,16 +67,6 @@ public class CompiledIRMethod extends AbstractIRMethod {
         InterpreterContext ic = method.getInterpreterContext();
 
         return ic;
-    }
-
-    protected void post(ThreadContext context) {
-        // update call stacks (pop: ..)
-        context.postMethodFrameAndScope();
-    }
-
-    protected void pre(ThreadContext context, StaticScope staticScope, RubyModule implementationClass, IRubyObject self, String name, Block block) {
-        // update call stacks (push: frame, class, scope, etc.)
-        context.preMethodFrameAndScope(implementationClass, name, self, block, staticScope);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/Compiler.java
+++ b/core/src/main/java/org/jruby/ir/Compiler.java
@@ -63,12 +63,13 @@ public class Compiler extends IRTranslator<ScriptAndCode, ClassDefiningClassLoad
         }
 
         final MethodHandle compiledHandle = _compiledHandle;
+        final StaticScope staticScope = scope.getStaticScope();
 
         Script script = new AbstractScript() {
             @Override
             public IRubyObject __file__(ThreadContext context, IRubyObject self, IRubyObject[] args, Block block) {
                 try {
-                    return (IRubyObject) compiledHandle.invokeWithArguments(context, scope.getStaticScope(), self, IRubyObject.NULL_ARRAY, block, self.getMetaClass(), Interpreter.ROOT);
+                    return (IRubyObject) compiledHandle.invokeWithArguments(context, staticScope, self, IRubyObject.NULL_ARRAY, block, self.getMetaClass(), Interpreter.ROOT);
                 } catch (Throwable t) {
                     Helpers.throwException(t);
                     return null; // not reached
@@ -78,45 +79,21 @@ public class Compiler extends IRTranslator<ScriptAndCode, ClassDefiningClassLoad
             @Override
             public IRubyObject load(ThreadContext context, IRubyObject self, boolean wrap) {
                 // Compiler does not support BEGIN/END yet and should fail to compile above
-                {
-//                BeginEndInterpreterContext ic = (BeginEndInterpreterContext) irScope.prepareForInterpretation();
 
-                    // We get the live object ball rolling here.
-                    // This give a valid value for the top of this lexical tree.
-                    // All new scopes can then retrieve and set based on lexical parent.
-//                StaticScope scope = ic.getStaticScope();
-                }
                 // Copied from Interpreter
-                StaticScope sscope = scope.getStaticScope();
-                RubyModule currModule = sscope.getModule();
-                if (currModule == null) {
-                    // SSS FIXME: Looks like this has to do with Kernel#load
-                    // and the wrap parameter. Figure it out and document it here.
-                    currModule = context.getRuntime().getObject();
-                }
+                RubyModule currModule = staticScope.getModule();
 
-                sscope.setModule(currModule);
-                DynamicScope tlbScope = scope.getToplevelScope();
-                if (tlbScope == null) {
-                    context.preMethodScopeOnly(sscope);
-                } else {
-                    sscope = tlbScope.getStaticScope();
-                    context.preScopedBody(tlbScope);
-                    tlbScope.growIfNeeded();
-                }
+                staticScope.setModule(currModule);
                 context.setCurrentVisibility(Visibility.PRIVATE);
 
                 try {
-//                    runBeginEndBlocks(ic.getBeginBlocks(), context, self, scope, null);
-                    return (IRubyObject) compiledHandle.invokeWithArguments(context, sscope, self, IRubyObject.NULL_ARRAY, Block.NULL_BLOCK, currModule, Interpreter.ROOT);
+                    return (IRubyObject) compiledHandle.invokeWithArguments(context, staticScope, self, IRubyObject.NULL_ARRAY, Block.NULL_BLOCK, currModule, Interpreter.ROOT);
                 } catch (IRBreakJump bj) {
                     throw IRException.BREAK_LocalJumpError.getException(context.runtime);
                 } catch (Throwable t) {
                     Helpers.throwException(t);
                     return null; // not reached
                 } finally {
-//                    runEndBlocks(ic.getEndBlocks(), context, self, scope, null);
-                    context.popScope();
                 }
             }
         };

--- a/core/src/main/java/org/jruby/ir/passes/AddCallProtocolInstructions.java
+++ b/core/src/main/java/org/jruby/ir/passes/AddCallProtocolInstructions.java
@@ -22,8 +22,10 @@ public class AddCallProtocolInstructions extends CompilerPass {
 
     private boolean explicitCallProtocolSupported(IRScope scope) {
         return scope instanceof IRMethod
-            || (scope instanceof IRClosure && !(scope instanceof IREvalScript))
-            || (scope instanceof IRModuleBody && !(scope instanceof IRMetaClassBody));
+                || (scope instanceof IRClosure && !(scope instanceof IREvalScript))
+                || (scope instanceof IRModuleBody && !(scope instanceof IRMetaClassBody)
+                || (scope instanceof IRScriptBody)
+        );
     }
 
     /*

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -6,7 +6,7 @@ import org.jruby.*;
 import org.jruby.common.IRubyWarnings;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.Unrescuable;
-import org.jruby.internal.runtime.methods.CompiledIRMetaClassBody;
+import org.jruby.internal.runtime.methods.CompiledIRNoProtocolMethod;
 import org.jruby.internal.runtime.methods.CompiledIRMethod;
 import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.internal.runtime.methods.InterpretedIRBodyMethod;
@@ -1240,7 +1240,7 @@ public class IRRuntimeHelpers {
     public static DynamicMethod newCompiledMetaClass(ThreadContext context, MethodHandle handle, IRScope metaClassBody, IRubyObject obj) {
         RubyClass singletonClass = newMetaClassFromIR(context.runtime, metaClassBody, obj);
 
-        return new CompiledIRMetaClassBody(handle, metaClassBody, singletonClass);
+        return new CompiledIRNoProtocolMethod(handle, metaClassBody, singletonClass);
     }
 
     private static RubyClass newMetaClassFromIR(Ruby runtime, IRScope metaClassBody, IRubyObject obj) {

--- a/core/src/main/java/org/jruby/parser/StaticScope.java
+++ b/core/src/main/java/org/jruby/parser/StaticScope.java
@@ -244,6 +244,9 @@ public class StaticScope implements Serializable {
 
         if (slot >= 0) return slot;
 
+        // Clear constructor since we are adding a name
+        constructor = null;
+
         // This is perhaps innefficient timewise?  Optimal spacewise
         growVariableNames(name);
 
@@ -277,6 +280,9 @@ public class StaticScope implements Serializable {
 
         if (slot >= 0) return slot;
 
+        // Clear constructor since we are adding a name
+        constructor = null;
+
         // This is perhaps innefficient timewise?  Optimal spacewise
         growVariableNames(name);
 
@@ -295,6 +301,9 @@ public class StaticScope implements Serializable {
     public void setVariables(String[] names) {
         assert names != null : "names is not null";
         assert namesAreInterned(names);
+
+        // Clear constructor since we are changing names
+        constructor = null;
 
         variableNames = new String[names.length];
         variableNamesLength = names.length;

--- a/core/src/test/java/org/jruby/test/TestRubyBase.java
+++ b/core/src/test/java/org/jruby/test/TestRubyBase.java
@@ -81,9 +81,7 @@ public class TestRubyBase extends TestCase {
         runtime.getGlobalVariables().set("$>", lStream);
         runtime.getGlobalVariables().set("$stderr", lStream);
 
-        runtime.runNormally(
-            runtime.parseFile(new ByteArrayInputStream(script.getBytes()), fileName, runtime.getCurrentContext().getCurrentScope())
-        );
+        runtime.runFromMain(new ByteArrayInputStream(script.getBytes()), fileName);
         StringBuffer sb = new StringBuffer(new String(result.toByteArray()));
         for (int idx = sb.indexOf("\n"); idx != -1; idx = sb.indexOf("\n")) {
             sb.deleteCharAt(idx);


### PR DESCRIPTION
This PR adds call protocol to script bodies. This fixes recent compiler regressions caused by ripping the non-protocol logic out of CompiledIRMethod (#4382).

It appears the only scopes which do not get call protocol now are eval scopes and singleton class scopes (IRMetaClassBody). The former is never jitted and never put into CompiledIRMethod or any other context where its protocol is not already handled. The latter had its own CompiledIRMetaClassBody whose sole difference was to do pre/post call protocol, so it is renamed to reflect that.