### PR TITLE
Check permission to AccessibleObject#setAccessible(boolean) a better way

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/DummyForJavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/DummyForJavaUtil.java
@@ -1,0 +1,11 @@
+package org.jruby.javasupport;
+
+/**
+ * This class exists only for access-checks to set {@linkplain JavaUtil#CAN_SET_ACCESSIBLE}
+ */
+public class DummyForJavaUtil {
+
+    private static final Object PRIVATE = new Object[0];
+    public static final Object PUBLIC = PRIVATE;
+
+}

--- a/core/src/main/java/org/jruby/javasupport/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtil.java
@@ -36,10 +36,10 @@ package org.jruby.javasupport;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Array;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.lang.reflect.ReflectPermission;
 import static java.lang.Character.isLetter;
 import static java.lang.Character.isLowerCase;
 import static java.lang.Character.isUpperCase;
@@ -99,9 +99,13 @@ public class JavaUtil {
 
         if (RubyInstanceConfig.CAN_SET_ACCESSIBLE) {
             try {
-                AccessController.checkPermission(new ReflectPermission("suppressAccessChecks"));
-                canSetAccessible = true;
-            } catch (Throwable t) {
+                // We want to check if we can access a commonly-existing private field through reflection. If so,
+                // we're probably able to access some other fields too later on.
+                Field f = Integer.class.getDeclaredField("value");
+                f.setAccessible(true);
+                Integer v = 1;
+                canSetAccessible = f.get(v).equals(v);
+            } catch (Exception t) {
                 // added this so if things are weird in the future we can debug without
                 // spinning a new binary
                 if (Options.JI_LOGCANSETACCESSIBLE.load()) {

--- a/core/src/main/java/org/jruby/javasupport/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtil.java
@@ -48,7 +48,6 @@ import static java.lang.Character.toLowerCase;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.security.AccessController;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
@@ -101,10 +100,9 @@ public class JavaUtil {
             try {
                 // We want to check if we can access a commonly-existing private field through reflection. If so,
                 // we're probably able to access some other fields too later on.
-                Field f = Integer.class.getDeclaredField("value");
+                Field f = DummyForJavaUtil.class.getDeclaredField("PRIVATE");
                 f.setAccessible(true);
-                Integer v = 1;
-                canSetAccessible = f.get(v).equals(v);
+                canSetAccessible = f.get(null).equals(DummyForJavaUtil.PUBLIC);
             } catch (Exception t) {
                 // added this so if things are weird in the future we can debug without
                 // spinning a new binary


### PR DESCRIPTION
In #4266, we noticed a difference what methods JRuby finds in Java-classes between JRuby-jar being in boot classpath and in the normal classpath. This change removes that difference.

The reason for the difference is that all classes in boot classpath are privileged and `AccessController#checkPermission(Permission)` will always return `true` to them, whereas for others the result depends on security policy in effect.

In normal (at least Oracle) JVM installations, the policy doesn't allow `suppressAccessChecks`, _but_ call to `AccessibleObject#setAccessible(boolean)` will still succeed as there's no `SecurityManager` set.

I posit that trying to call `setAccessible` is a better way to see if we might later on succeed in calling `setAccessible` than checking the permission.
