### PR TITLE
Specific arity jit cleanup

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
@@ -40,6 +40,8 @@ public class CompiledIRMethod extends AbstractIRMethod {
         this.method.getStaticScope().determineModule();
         this.hasKwargs = hasKwargs;
 
+        assert method.hasExplicitCallProtocol();
+
         setHandle(variable);
     }
 
@@ -65,16 +67,6 @@ public class CompiledIRMethod extends AbstractIRMethod {
         InterpreterContext ic = method.getInterpreterContext();
 
         return ic;
-    }
-
-    protected void post(ThreadContext context) {
-        // update call stacks (pop: ..)
-        context.postMethodFrameAndScope();
-    }
-
-    protected void pre(ThreadContext context, StaticScope staticScope, RubyModule implementationClass, IRubyObject self, String name, Block block) {
-        // update call stacks (push: frame, class, scope, etc.)
-        context.preMethodFrameAndScope(implementationClass, name, self, block, staticScope);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/internal/runtime/methods/InvokeDynamicMethodFactory.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InvokeDynamicMethodFactory.java
@@ -121,7 +121,7 @@ public class InvokeDynamicMethodFactory extends InvocationMethodFactory {
                 implementationClass,
                 desc1.anno.visibility(),
                 (min == max) ?
-                        org.jruby.runtime.Signature.from(min, 0, 0, 0, 0, org.jruby.runtime.Signature.Rest.NONE, false).encode() :
+                        org.jruby.runtime.Signature.from(min, 0, 0, 0, 0, org.jruby.runtime.Signature.Rest.NONE, -1).encode() :
                         org.jruby.runtime.Signature.OPTIONAL.encode(),
                 true,
                 notImplemented,

--- a/core/src/main/java/org/jruby/ir/Compiler.java
+++ b/core/src/main/java/org/jruby/ir/Compiler.java
@@ -63,12 +63,13 @@ public class Compiler extends IRTranslator<ScriptAndCode, ClassDefiningClassLoad
         }
 
         final MethodHandle compiledHandle = _compiledHandle;
+        final StaticScope staticScope = scope.getStaticScope();
 
         Script script = new AbstractScript() {
             @Override
             public IRubyObject __file__(ThreadContext context, IRubyObject self, IRubyObject[] args, Block block) {
                 try {
-                    return (IRubyObject) compiledHandle.invokeWithArguments(context, scope.getStaticScope(), self, IRubyObject.NULL_ARRAY, block, self.getMetaClass(), Interpreter.ROOT);
+                    return (IRubyObject) compiledHandle.invokeWithArguments(context, staticScope, self, IRubyObject.NULL_ARRAY, block, self.getMetaClass(), Interpreter.ROOT);
                 } catch (Throwable t) {
                     Helpers.throwException(t);
                     return null; // not reached
@@ -78,45 +79,21 @@ public class Compiler extends IRTranslator<ScriptAndCode, ClassDefiningClassLoad
             @Override
             public IRubyObject load(ThreadContext context, IRubyObject self, boolean wrap) {
                 // Compiler does not support BEGIN/END yet and should fail to compile above
-                {
-//                BeginEndInterpreterContext ic = (BeginEndInterpreterContext) irScope.prepareForInterpretation();
 
-                    // We get the live object ball rolling here.
-                    // This give a valid value for the top of this lexical tree.
-                    // All new scopes can then retrieve and set based on lexical parent.
-//                StaticScope scope = ic.getStaticScope();
-                }
                 // Copied from Interpreter
-                StaticScope sscope = scope.getStaticScope();
-                RubyModule currModule = sscope.getModule();
-                if (currModule == null) {
-                    // SSS FIXME: Looks like this has to do with Kernel#load
-                    // and the wrap parameter. Figure it out and document it here.
-                    currModule = context.getRuntime().getObject();
-                }
+                RubyModule currModule = staticScope.getModule();
 
-                sscope.setModule(currModule);
-                DynamicScope tlbScope = scope.getToplevelScope();
-                if (tlbScope == null) {
-                    context.preMethodScopeOnly(sscope);
-                } else {
-                    sscope = tlbScope.getStaticScope();
-                    context.preScopedBody(tlbScope);
-                    tlbScope.growIfNeeded();
-                }
+                staticScope.setModule(currModule);
                 context.setCurrentVisibility(Visibility.PRIVATE);
 
                 try {
-//                    runBeginEndBlocks(ic.getBeginBlocks(), context, self, scope, null);
-                    return (IRubyObject) compiledHandle.invokeWithArguments(context, sscope, self, IRubyObject.NULL_ARRAY, Block.NULL_BLOCK, currModule, Interpreter.ROOT);
+                    return (IRubyObject) compiledHandle.invokeWithArguments(context, staticScope, self, IRubyObject.NULL_ARRAY, Block.NULL_BLOCK, currModule, Interpreter.ROOT);
                 } catch (IRBreakJump bj) {
                     throw IRException.BREAK_LocalJumpError.getException(context.runtime);
                 } catch (Throwable t) {
                     Helpers.throwException(t);
                     return null; // not reached
                 } finally {
-//                    runEndBlocks(ic.getEndBlocks(), context, self, scope, null);
-                    context.popScope();
                 }
             }
         };

--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -2144,7 +2144,6 @@ public class IRBuilder {
 
     protected void receiveNonBlockArgs(final ArgsNode argsNode) {
         Signature signature = scope.getStaticScope().getSignature();
-        KeywordRestArgNode keyRest = argsNode.getKeyRest();
 
         // For closures, we don't need the check arity call
         if (scope instanceof IRMethod) {
@@ -2155,12 +2154,12 @@ public class IRBuilder {
             // But later, perhaps can make this implicit in the method setup preamble?
 
             addInstr(new CheckArityInstr(signature.required(), signature.opt(), signature.hasRest(), argsNode.hasKwargs(),
-                    keyRest == null ? -1 : keyRest.getIndex()));
+                    signature.keyRest()));
         } else if (scope instanceof IRClosure && argsNode.hasKwargs()) {
             // FIXME: This is added to check for kwargs correctness but bypass regular correctness.
             // Any other arity checking currently happens within Java code somewhere (RubyProc.call?)
             addInstr(new CheckArityInstr(signature.required(), signature.opt(), signature.hasRest(), argsNode.hasKwargs(),
-                    keyRest == null ? -1 : keyRest.getIndex()));
+                    signature.keyRest()));
         }
 
         // Other args begin at index 0

--- a/core/src/main/java/org/jruby/ir/passes/AddCallProtocolInstructions.java
+++ b/core/src/main/java/org/jruby/ir/passes/AddCallProtocolInstructions.java
@@ -22,8 +22,10 @@ public class AddCallProtocolInstructions extends CompilerPass {
 
     private boolean explicitCallProtocolSupported(IRScope scope) {
         return scope instanceof IRMethod
-            || (scope instanceof IRClosure && !(scope instanceof IREvalScript))
-            || (scope instanceof IRModuleBody && !(scope instanceof IRMetaClassBody));
+                || (scope instanceof IRClosure && !(scope instanceof IREvalScript))
+                || (scope instanceof IRModuleBody && !(scope instanceof IRMetaClassBody)
+                || (scope instanceof IRScriptBody)
+        );
     }
 
     /*

--- a/core/src/main/java/org/jruby/ir/persistence/IRWriter.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRWriter.java
@@ -88,7 +88,7 @@ public class IRWriter {
         if (scope instanceof IRClosure) {
             IRClosure closure = (IRClosure) scope;
 
-            file.encode(closure.getSignature().encode());
+            file.encode(closure.getSignature());
         }
 
         persistStaticScope(file, scope.getStaticScope());

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -6,7 +6,7 @@ import org.jruby.*;
 import org.jruby.common.IRubyWarnings;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.Unrescuable;
-import org.jruby.internal.runtime.methods.CompiledIRMetaClassBody;
+import org.jruby.internal.runtime.methods.CompiledIRNoProtocolMethod;
 import org.jruby.internal.runtime.methods.CompiledIRMethod;
 import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.internal.runtime.methods.InterpretedIRBodyMethod;
@@ -1240,7 +1240,7 @@ public class IRRuntimeHelpers {
     public static DynamicMethod newCompiledMetaClass(ThreadContext context, MethodHandle handle, IRScope metaClassBody, IRubyObject obj) {
         RubyClass singletonClass = newMetaClassFromIR(context.runtime, metaClassBody, obj);
 
-        return new CompiledIRMetaClassBody(handle, metaClassBody, singletonClass);
+        return new CompiledIRNoProtocolMethod(handle, metaClassBody, singletonClass);
     }
 
     private static RubyClass newMetaClassFromIR(Ruby runtime, IRScope metaClassBody, IRubyObject obj) {

--- a/core/src/main/java/org/jruby/parser/StaticScope.java
+++ b/core/src/main/java/org/jruby/parser/StaticScope.java
@@ -244,6 +244,9 @@ public class StaticScope implements Serializable {
 
         if (slot >= 0) return slot;
 
+        // Clear constructor since we are adding a name
+        constructor = null;
+
         // This is perhaps innefficient timewise?  Optimal spacewise
         growVariableNames(name);
 
@@ -277,6 +280,9 @@ public class StaticScope implements Serializable {
 
         if (slot >= 0) return slot;
 
+        // Clear constructor since we are adding a name
+        constructor = null;
+
         // This is perhaps innefficient timewise?  Optimal spacewise
         growVariableNames(name);
 
@@ -295,6 +301,9 @@ public class StaticScope implements Serializable {
     public void setVariables(String[] names) {
         assert names != null : "names is not null";
         assert namesAreInterned(names);
+
+        // Clear constructor since we are changing names
+        constructor = null;
 
         variableNames = new String[names.length];
         variableNamesLength = names.length;

--- a/core/src/main/java/org/jruby/runtime/Signature.java
+++ b/core/src/main/java/org/jruby/runtime/Signature.java
@@ -31,14 +31,14 @@ public class Signature {
         }
     }
 
-    public static final Signature NO_ARGUMENTS = new Signature(0, 0, 0, Rest.NONE, 0, 0, false);
-    public static final Signature ONE_ARGUMENT = new Signature(1, 0, 0, Rest.NONE, 0, 0, false);
-    public static final Signature TWO_ARGUMENTS = new Signature(2, 0, 0, Rest.NONE, 0, 0, false);
-    public static final Signature THREE_ARGUMENTS = new Signature(3, 0, 0, Rest.NONE, 0, 0, false);
-    public static final Signature OPTIONAL = new Signature(0, 0, 0, Rest.NORM, 0, 0, false);
-    public static final Signature ONE_REQUIRED = new Signature(1, 0, 0, Rest.NORM, 0, 0, false);
-    public static final Signature TWO_REQUIRED = new Signature(2, 0, 0, Rest.NORM, 0, 0, false);
-    public static final Signature THREE_REQUIRED = new Signature(3, 0, 0, Rest.NORM, 0, 0, false);
+    public static final Signature NO_ARGUMENTS = new Signature(0, 0, 0, Rest.NONE, 0, 0, -1);
+    public static final Signature ONE_ARGUMENT = new Signature(1, 0, 0, Rest.NONE, 0, 0, -1);
+    public static final Signature TWO_ARGUMENTS = new Signature(2, 0, 0, Rest.NONE, 0, 0, -1);
+    public static final Signature THREE_ARGUMENTS = new Signature(3, 0, 0, Rest.NONE, 0, 0, -1);
+    public static final Signature OPTIONAL = new Signature(0, 0, 0, Rest.NORM, 0, 0, -1);
+    public static final Signature ONE_REQUIRED = new Signature(1, 0, 0, Rest.NORM, 0, 0, -1);
+    public static final Signature TWO_REQUIRED = new Signature(2, 0, 0, Rest.NORM, 0, 0, -1);
+    public static final Signature THREE_REQUIRED = new Signature(3, 0, 0, Rest.NORM, 0, 0, -1);
 
     private final short pre;
     private final short opt;
@@ -47,16 +47,16 @@ public class Signature {
     private final short kwargs;
     private final short requiredKwargs;
     private final Arity arity;
-    private final boolean restKwargs;
+    private final int keyRest;
 
-    public Signature(int pre, int opt, int post, Rest rest, int kwargs, int requiredKwargs, boolean restKwargs) {
+    public Signature(int pre, int opt, int post, Rest rest, int kwargs, int requiredKwargs, int keyRest) {
         this.pre = (short) pre;
         this.opt = (short) opt;
         this.post = (short) post;
         this.rest = rest;
         this.kwargs = (short) kwargs;
         this.requiredKwargs = (short) requiredKwargs;
-        this.restKwargs = restKwargs;
+        this.keyRest = keyRest;
 
         // NOTE: Some logic to *assign* variables still uses Arity, which treats Rest.ANON (the
         //       |a,| form) as a rest arg for destructuring purposes. However ANON does *not*
@@ -74,15 +74,16 @@ public class Signature {
     }
 
     public boolean restKwargs() {
-        return restKwargs;
+        return keyRest != -1;
     }
 
     public int pre() { return pre; }
     public int opt() { return opt; }
     public Rest rest() { return rest; }
     public int post() { return post; }
-    public boolean hasKwargs() { return kwargs > 0 || restKwargs; }
+    public boolean hasKwargs() { return kwargs > 0 || restKwargs(); }
     public boolean hasRest() { return rest != Rest.NONE; }
+    public int keyRest() { return keyRest; }
 
     /**
      * Are there an exact (fixed) number of parameters to this signature?
@@ -128,8 +129,8 @@ public class Signature {
         throw new UnsupportedOperationException("We do not know enough about the arity to convert it to a signature");
     }
 
-    public static Signature from(int pre, int opt, int post, int kwargs, int requiredKwargs, Rest rest, boolean restKwargs) {
-        if (opt == 0 && post == 0 && kwargs == 0 && !restKwargs) {
+    public static Signature from(int pre, int opt, int post, int kwargs, int requiredKwargs, Rest rest, int keyRest) {
+        if (opt == 0 && post == 0 && kwargs == 0 && keyRest == -1) {
             switch (pre) {
                 case 0:
                     switch (rest) {
@@ -165,7 +166,7 @@ public class Signature {
                     break;
             }
         }
-        return new Signature(pre, opt, post, rest, kwargs, requiredKwargs, restKwargs);
+        return new Signature(pre, opt, post, rest, kwargs, requiredKwargs, keyRest);
     }
 
     public static Signature from(ArgsNode args) {
@@ -173,7 +174,7 @@ public class Signature {
         Rest rest = restArg != null ? restFromArg(restArg) : Rest.NONE;
 
         return Signature.from(args.getPreCount(), args.getOptionalArgsCount(), args.getPostCount(),
-                args.getKeywordCount(), args.getRequiredKeywordCount(),rest,args.hasKeyRest());
+                args.getKeywordCount(), args.getRequiredKeywordCount(),rest,args.hasKeyRest() ? args.getKeyRest().getIndex() : -1);
     }
 
     public static Signature from(IterNode iter) {
@@ -213,7 +214,7 @@ public class Signature {
                 Node restArg = masgn.getRest();
                 rest = restFromArg(restArg);
             }
-            return Signature.from(masgn.getPreCount(), 0, masgn.getPostCount(), 0, 0, rest, false);
+            return Signature.from(masgn.getPreCount(), 0, masgn.getPostCount(), 0, 0, rest, -1);
         }
         return Signature.ONE_ARGUMENT;
     }
@@ -229,7 +230,7 @@ public class Signature {
     private static final int MAX_ENCODED_ARGS_EXPONENT = 8;
     private static final int MAX_ENCODED_ARGS_MASK = 0xFF;
     private static final int ENCODE_RESTKWARGS_SHIFT = 0;
-    private static final int ENCODE_REST_SHIFT = ENCODE_RESTKWARGS_SHIFT + 1;
+    private static final int ENCODE_REST_SHIFT = ENCODE_RESTKWARGS_SHIFT + MAX_ENCODED_ARGS_EXPONENT;
     private static final int ENCODE_REQKWARGS_SHIFT = ENCODE_REST_SHIFT + MAX_ENCODED_ARGS_EXPONENT;
     private static final int ENCODE_KWARGS_SHIFT = ENCODE_REQKWARGS_SHIFT + MAX_ENCODED_ARGS_EXPONENT;
     private static final int ENCODE_POST_SHIFT = ENCODE_KWARGS_SHIFT + MAX_ENCODED_ARGS_EXPONENT;
@@ -244,24 +245,24 @@ public class Signature {
                         ((long)kwargs << ENCODE_KWARGS_SHIFT) |
                         ((long)requiredKwargs << ENCODE_REQKWARGS_SHIFT) |
                         (rest.ordinal() << ENCODE_REST_SHIFT) |
-                        ((restKwargs?1:0) << ENCODE_RESTKWARGS_SHIFT);
+                        (keyRest & 0xFF) << ENCODE_RESTKWARGS_SHIFT;
     }
 
     public static Signature decode(long l) {
         return Signature.from(
-                (int)(l >> ENCODE_PRE_SHIFT) & MAX_ENCODED_ARGS_MASK,
-                (int)(l >> ENCODE_OPT_SHIFT) & MAX_ENCODED_ARGS_MASK,
-                (int)(l >> ENCODE_POST_SHIFT) & MAX_ENCODED_ARGS_MASK,
-                (int)(l >> ENCODE_KWARGS_SHIFT) & MAX_ENCODED_ARGS_MASK,
-                (int)(l >> ENCODE_REQKWARGS_SHIFT) & MAX_ENCODED_ARGS_MASK,
-                Rest.fromOrdinal((int)((l >> ENCODE_REST_SHIFT) & MAX_ENCODED_ARGS_MASK)),
-                ((int)(l >> ENCODE_RESTKWARGS_SHIFT) & 0x1)==1 ? true : false
+                (int)(l >>> ENCODE_PRE_SHIFT) & MAX_ENCODED_ARGS_MASK,
+                (int)(l >>> ENCODE_OPT_SHIFT) & MAX_ENCODED_ARGS_MASK,
+                (int)(l >>> ENCODE_POST_SHIFT) & MAX_ENCODED_ARGS_MASK,
+                (int)(l >>> ENCODE_KWARGS_SHIFT) & MAX_ENCODED_ARGS_MASK,
+                (int)(l >>> ENCODE_REQKWARGS_SHIFT) & MAX_ENCODED_ARGS_MASK,
+                Rest.fromOrdinal((int)((l >>> ENCODE_REST_SHIFT) & MAX_ENCODED_ARGS_MASK)),
+                (byte)(l >>> ENCODE_RESTKWARGS_SHIFT) & MAX_ENCODED_ARGS_MASK
 
         );
     }
 
     public String toString() {
-        return "signature(pre=" + pre + ",opt=" + opt + ",post=" + post + ",rest=" + rest + ",kwargs=" + kwargs + ",kwreq=" + requiredKwargs + ",kwrest=" + restKwargs + ")";
+        return "signature(pre=" + pre + ",opt=" + opt + ",post=" + post + ",rest=" + rest + ",kwargs=" + kwargs + ",kwreq=" + requiredKwargs + ",kwrest=" + keyRest + ")";
     }
 
     public void checkArity(Ruby runtime, IRubyObject[] args) {

--- a/core/src/test/java/org/jruby/test/TestRubyBase.java
+++ b/core/src/test/java/org/jruby/test/TestRubyBase.java
@@ -81,9 +81,7 @@ public class TestRubyBase extends TestCase {
         runtime.getGlobalVariables().set("$>", lStream);
         runtime.getGlobalVariables().set("$stderr", lStream);
 
-        runtime.runNormally(
-            runtime.parseFile(new ByteArrayInputStream(script.getBytes()), fileName, runtime.getCurrentContext().getCurrentScope())
-        );
+        runtime.runFromMain(new ByteArrayInputStream(script.getBytes()), fileName);
         StringBuffer sb = new StringBuffer(new String(result.toByteArray()));
         for (int idx = sb.indexOf("\n"); idx != -1; idx = sb.indexOf("\n")) {
             sb.deleteCharAt(idx);


### PR DESCRIPTION
This PR cleans up method jit by only emitting one body regardless of whether there's a specific-arity path or not. Previously, both variable and specific paths were emitted in full. With this PR, the variable path will call the specific path. This reduces bytecode generated for a given method body by up to 50%, including all contained blocks and metaclass bodies.