### PR TITLE
compile back to hard scope when closure compile/build requested

### DIFF
--- a/core/src/main/java/org/jruby/compiler/FullBuildTask.java
+++ b/core/src/main/java/org/jruby/compiler/FullBuildTask.java
@@ -16,6 +16,8 @@ class FullBuildTask implements Runnable {
 
     public void run() {
         try {
+            method.getIRScope().getTopLevelScope().prepareFullBuild();
+
             method.completeBuild(method.getIRScope().prepareFullBuild());
 
             if (jitCompiler.config.isJitLogging()) {

--- a/core/src/main/java/org/jruby/ir/IRScope.java
+++ b/core/src/main/java/org/jruby/ir/IRScope.java
@@ -562,6 +562,10 @@ public abstract class IRScope implements ParseResult {
         // or generated instructions.
         if (fullInterpreterContext != null && fullInterpreterContext.buildComplete()) return fullInterpreterContext;
 
+        for (IRScope scope: getClosures()) {
+            scope.prepareFullBuild();
+        }
+
         prepareFullBuildCommon();
         runCompilerPasses(getManager().getCompilerPasses(this));
         getManager().optimizeIfSimpleScope(this);
@@ -580,6 +584,10 @@ public abstract class IRScope implements ParseResult {
         // for any nested closures which got a a fullInterpreterContext but have not run any passes
         // or generated instructions.
         if (fullInterpreterContext != null && fullInterpreterContext.buildComplete()) return fullInterpreterContext.getLinearizedBBList();
+
+        for (IRScope scope: getClosures()) {
+            scope.prepareForCompilation();
+        }
 
         prepareFullBuildCommon();
 

--- a/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
@@ -166,7 +166,7 @@ public class MixedModeIRBlockBody extends IRBlockBody implements Compilable<Comp
         if (callCount >= 0) {
             // ensure we've got code ready for JIT
             ensureInstrsReady();
-            closure.prepareForCompilation();
+            closure.getNearestTopLocalVariableScope().prepareForCompilation();
 
             // if we don't have an explicit protocol, disable JIT
             if (!closure.hasExplicitCallProtocol()) {


### PR DESCRIPTION
tbh I am super bothered I cannot figure out a test case to at least occasionally fail.   I explain the basic issue in #4304 (more specifically https://github.com/jruby/jruby/issues/4304#issuecomment-266764789).   Summarized as two threads both decide to build something and one is a child closure and the other is a parent of that closure.  We get a sequence like:

1. child starts
2. parent starts
3. parent accesses childs CFG
4. child changes CFG
5. parent accesses childs CFG
6. BB is missing

This code will ask hard scope to full build itself for blocks and the two entry points to building on IRScope will built the closures before the parent.  It does not appear to infinite loop so yay?  I could not see anything bust with this change and I think the intent is clear but I am unsure in best particular impl to use.  Part of it is based on children wanting parent info for passes vs parents wanting children info for passes.

@subbuss I think you have best knowledge of these expectations and @headius I would like your thoughts as well.