### PR TITLE
[Truffle] Enhanced byte array.

### DIFF
--- a/spec/truffle/specs/truffle/byte_array/append_spec.rb
+++ b/spec/truffle/specs/truffle/byte_array/append_spec.rb
@@ -1,0 +1,56 @@
+# Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+# OTHER DEALINGS IN THE SOFTWARE.
+
+require_relative '../../../../ruby/spec_helper'
+
+describe 'Rubinius::ByteArray#append' do
+
+  before :each do
+    @byte_array = Rubinius::ByteArray.new(16, 0xff)
+  end
+
+  describe 'with string' do
+
+    before :each  do
+      @string = "\u{6666}"
+    end
+
+    it "should add the string's bytes to the end of the byte array" do
+      original_size = @byte_array.size
+      @byte_array.append(@string)
+
+      @byte_array.size.should == original_size + @string.bytesize
+
+      @string.bytes.each_with_index do |value, index|
+        @byte_array[original_size + index].should == value
+      end
+    end
+
+  end
+
+  describe 'with byte array' do
+
+    before :each do
+      @other_byte_array = Rubinius::ByteArray.new(3, 0xaa)
+    end
+
+    it "should add the other byte array's bytes to the end of the byte array" do
+      original_size = @byte_array.size
+      @byte_array.append(@other_byte_array)
+
+      @byte_array.size.should == original_size + @other_byte_array.size
+
+      @other_byte_array.size.times do |index|
+        @byte_array[original_size + index].should == @other_byte_array[index]
+      end
+    end
+
+  end
+
+end

--- a/spec/truffle/specs/truffle/byte_array/chomp_bang_spec.rb
+++ b/spec/truffle/specs/truffle/byte_array/chomp_bang_spec.rb
@@ -1,0 +1,41 @@
+# Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+# OTHER DEALINGS IN THE SOFTWARE.
+
+require_relative '../../../../ruby/spec_helper'
+
+describe 'Rubinius::ByteArray#chomp!' do
+
+  before :each do
+    @byte_array = Rubinius::ByteArray.new(16, 0xff)
+  end
+
+  describe 'with value present at end of byte array' do
+
+    it 'should truncate the portion of the byte array after the found byte' do
+      original_size = @byte_array.size
+
+      @byte_array.chomp!(0xff).should_not be_nil
+      @byte_array.size.should == original_size - 1
+    end
+
+  end
+
+  describe 'viwth value present, but not at end of byte array' do
+
+    it 'should truncate the portion of the byte array after the found byte' do
+      @byte_array[@byte_array.size - 1] = 0xcc
+      original_size = @byte_array.size
+
+      @byte_array.chomp!(0xff).should be_nil
+      @byte_array.size.should == original_size
+    end
+
+  end
+
+end

--- a/spec/truffle/specs/truffle/byte_array/element_reference_spec.rb
+++ b/spec/truffle/specs/truffle/byte_array/element_reference_spec.rb
@@ -1,0 +1,50 @@
+# Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+# OTHER DEALINGS IN THE SOFTWARE.
+
+require_relative '../../../../ruby/spec_helper'
+
+describe 'Rubinius::ByteArray#[]' do
+
+  before :each do
+    @byte_array = Rubinius::ByteArray.new(16, 0xff)
+  end
+
+  describe 'with index' do
+
+    it 'should return return a single byte value if in range' do
+      @byte_array[0].should == 0xff
+    end
+
+    it 'should raise an error if out of range (negative indices do not wrap around)' do
+      lambda { @byte_array[-1] }.should raise_error(IndexError)
+      lambda { @byte_array[@byte_array.length + 1] }.should raise_error(IndexError)
+    end
+
+  end
+
+  describe 'with index and length' do
+
+    it 'should return a newly allocated Rubinius::ByteArray' do
+      @byte_array.size.times { |i| @byte_array[i] = i }
+
+      new_byte_array = @byte_array[1, 3]
+      new_byte_array.size.should == 3
+      new_byte_array[0].should == 0x01
+      new_byte_array[1].should == 0x02
+      new_byte_array[2].should == 0x03
+    end
+
+    it 'should raise an error if out of range (negative indices do not wrap around)' do
+      lambda { @byte_array[-1, 3] }.should raise_error(IndexError)
+      lambda { @byte_array[@byte_array.length + 1, 3] }.should raise_error(IndexError)
+    end
+
+  end
+
+end

--- a/spec/truffle/specs/truffle/byte_array/from_string_spec.rb
+++ b/spec/truffle/specs/truffle/byte_array/from_string_spec.rb
@@ -1,0 +1,33 @@
+# Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+# OTHER DEALINGS IN THE SOFTWARE.
+
+require_relative '../../../../ruby/spec_helper'
+
+describe 'Rubinius::ByteArray.from_string' do
+
+  before :each do
+    @string = "\u{6666}"
+    @byte_array = Rubinius::ByteArray.from_string(@string)
+  end
+
+  describe 'with variable-width character string' do
+
+    it 'should have the same byte length as the string' do
+      @byte_array.size.should == @string.bytesize
+    end
+
+    it 'should have the same bytes as the string' do
+      @string.bytes.each_with_index do |value, index|
+        @byte_array[index].should == value
+      end
+    end
+
+  end
+
+end

--- a/spec/truffle/specs/truffle/byte_array/index_spec.rb
+++ b/spec/truffle/specs/truffle/byte_array/index_spec.rb
@@ -1,0 +1,40 @@
+# Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+# OTHER DEALINGS IN THE SOFTWARE.
+
+require_relative '../../../../ruby/spec_helper'
+
+describe 'Rubinius::ByteArray#index' do
+
+  before :each do
+    @byte_array = Rubinius::ByteArray.new(16, 0xff)
+  end
+
+  describe 'with value not in string' do
+
+    it 'should return nil' do
+      @byte_array.index(0xbb).should be_nil
+    end
+
+  end
+
+  describe 'with index and length' do
+
+    it 'should return the index corresponding to the first occurrence of the value' do
+
+      @byte_array[5] = 0xcc
+      @byte_array.index(0xcc).should == 5
+
+      @byte_array[2] = 0xcc
+      @byte_array.index(0xcc).should == 2
+
+    end
+
+  end
+
+end

--- a/spec/truffle/specs/truffle/byte_array/to_str_spec.rb
+++ b/spec/truffle/specs/truffle/byte_array/to_str_spec.rb
@@ -1,0 +1,30 @@
+# Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+# OTHER DEALINGS IN THE SOFTWARE.
+
+require_relative '../../../../ruby/spec_helper'
+
+describe 'Rubinius::ByteArray.to_str' do
+
+  before :each do
+    @byte_array = Rubinius::ByteArray.new(3, 0)
+    @byte_array[0] = 'a'.ord
+    @byte_array[1] = 'b'.ord
+    @byte_array[2] = 'c'.ord
+  end
+
+  describe 'with ASCII characters' do
+
+    it 'should be an ASCII-8BIT (binary) string' do
+      @byte_array.to_str.encoding.should == Encoding::ASCII_8BIT
+      @byte_array.to_str.should == 'abc'
+    end
+
+  end
+
+end

--- a/truffle/src/main/java/org/jruby/truffle/core/CoreLibrary.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/CoreLibrary.java
@@ -1764,6 +1764,7 @@ public class CoreLibrary {
             "/core/truffle/cext.rb",
             "/core/truffle/interop.rb",
             "/core/rbconfig.rb",
+            "/core/byte_array.rb",
             "/core/main.rb",
             "/core/post.rb"
     };

--- a/truffle/src/main/java/org/jruby/truffle/core/rubinius/ByteArrayLayout.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/rubinius/ByteArrayLayout.java
@@ -27,5 +27,6 @@ public interface ByteArrayLayout extends BasicObjectLayout {
     boolean isByteArray(DynamicObject object);
 
     ByteList getBytes(DynamicObject object);
+    void setBytes(DynamicObject object, ByteList value);
 
 }

--- a/truffle/src/main/java/org/jruby/truffle/core/rubinius/ByteArrayNodes.java
+++ b/truffle/src/main/java/org/jruby/truffle/core/rubinius/ByteArrayNodes.java
@@ -16,7 +16,10 @@ import com.oracle.truffle.api.object.DynamicObject;
 import com.oracle.truffle.api.object.DynamicObjectFactory;
 import com.oracle.truffle.api.profiles.BranchProfile;
 import com.oracle.truffle.api.profiles.ConditionProfile;
+import com.oracle.truffle.api.source.SourceSection;
+import org.jcodings.specific.ASCIIEncoding;
 import org.jruby.truffle.Layouts;
+import org.jruby.truffle.RubyContext;
 import org.jruby.truffle.builtins.CoreClass;
 import org.jruby.truffle.builtins.CoreMethod;
 import org.jruby.truffle.builtins.CoreMethodArrayArgumentsNode;
@@ -24,7 +27,11 @@ import org.jruby.truffle.builtins.UnaryCoreMethodNode;
 import org.jruby.truffle.core.rope.Rope;
 import org.jruby.truffle.core.string.ByteList;
 import org.jruby.truffle.core.string.StringOperations;
+import org.jruby.truffle.language.NotProvided;
 import org.jruby.truffle.language.control.RaiseException;
+import org.jruby.truffle.language.objects.AllocateObjectNode;
+
+import java.util.Arrays;
 
 @CoreClass("Rubinius::ByteArray")
 public abstract class ByteArrayNodes {
@@ -33,13 +40,19 @@ public abstract class ByteArrayNodes {
         return Layouts.BYTE_ARRAY.createByteArray(factory, bytes);
     }
 
-    @CoreMethod(names = {"get_byte", "[]"}, required = 1, lowerFixnum = 1)
+    @CoreMethod(names = {"get_byte", "getbyte", "[]"}, required = 1, optional = 1, lowerFixnum = { 1, 2 })
     public abstract static class GetByteNode extends CoreMethodArrayArgumentsNode {
 
-        @Specialization
-        public int getByte(DynamicObject bytes, int index,
+        @Specialization(guards = "wasNotProvided(length)")
+        public int getByte(DynamicObject bytes, int index, Object length,
+                              @Cached("create()") BranchProfile errorProfile,
                               @Cached("createBinaryProfile()") ConditionProfile nullByteIndexProfile) {
             final ByteList byteList = Layouts.BYTE_ARRAY.getBytes(bytes);
+
+            if (index < 0 || index >= byteList.length()) {
+                errorProfile.enter();
+                throw new RaiseException(coreExceptions().indexError("index out of bounds", this));
+            }
 
             // Handling out-of-bounds issues like this is non-standard. In Rubinius, it would raise an exception instead.
             // We're modifying the semantics to address a primary use case for this class: Rubinius's @data array
@@ -52,6 +65,62 @@ public abstract class ByteArrayNodes {
             }
 
             return byteList.get(index) & 0xff;
+        }
+
+        @Specialization
+        public DynamicObject getBytes(DynamicObject bytes, int index, int length,
+                                      @Cached("create()") BranchProfile errorProfile,
+                                      @Cached("createBinaryProfile()") ConditionProfile nullByteIndexProfile) {
+            final ByteList byteList = Layouts.BYTE_ARRAY.getBytes(bytes);
+
+            if (index < 0 || index >= byteList.length()) {
+                errorProfile.enter();
+                throw new RaiseException(coreExceptions().indexError("index out of bounds", this));
+            }
+
+            final byte[] newBytes = new byte[length];
+
+            System.arraycopy(byteList.unsafeBytes(), byteList.begin() + index, newBytes, 0, length);
+
+            return Layouts.BYTE_ARRAY.createByteArray(getContext().getCoreLibrary().getByteArrayFactory(), new ByteList(newBytes, ASCIIEncoding.INSTANCE, false));
+        }
+
+    }
+
+    @CoreMethod(names = "index", required = 1, lowerFixnum = 1)
+    public abstract static class IndexNode extends CoreMethodArrayArgumentsNode {
+
+        @Specialization
+        public Object index(DynamicObject byteArray, int value) {
+            final ByteList byteList = Layouts.BYTE_ARRAY.getBytes(byteArray);
+            final byte[] bytes = byteList.unsafeBytes();
+
+            for (int i = byteList.begin(); i < byteList.begin() + byteList.length(); i++) {
+                if (bytes[i] == (byte) value) {
+                    return i;
+                }
+            }
+
+            return nil();
+        }
+    }
+
+    @CoreMethod(names = {"append", "<<"}, required = 1)
+    public abstract static class AppendNode extends CoreMethodArrayArgumentsNode {
+
+        @Specialization(guards = "isRubyString(string)")
+        public DynamicObject appendString(DynamicObject bytes, DynamicObject string) {
+            final Rope rope = StringOperations.rope(string);
+            Layouts.BYTE_ARRAY.getBytes(bytes).append(rope.getBytes());
+
+            return bytes;
+        }
+
+        @Specialization(guards = "isRubiniusByteArray(otherBytes)")
+        public DynamicObject appendByteArray(DynamicObject bytes, DynamicObject otherBytes) {
+            Layouts.BYTE_ARRAY.getBytes(bytes).append(Layouts.BYTE_ARRAY.getBytes(otherBytes));
+
+            return bytes;
         }
 
     }
@@ -73,11 +142,11 @@ public abstract class ByteArrayNodes {
 
     }
 
-    @CoreMethod(names = {"set_byte", "[]="}, required = 2, lowerFixnum = { 1, 2 })
+    @CoreMethod(names = {"set_byte", "setbyte", "[]="}, required = 2, optional = 1, lowerFixnum = { 1, 2 })
     public abstract static class SetByteNode extends CoreMethodArrayArgumentsNode {
 
         @Specialization
-        public Object setByte(DynamicObject bytes, int index, int value,
+        public Object setByte(DynamicObject bytes, int index, int value, NotProvided otherByteArray,
                 @Cached("create()") BranchProfile errorProfile) {
             if (index < 0 || index >= Layouts.BYTE_ARRAY.getBytes(bytes).getRealSize()) {
                 errorProfile.enter();
@@ -88,9 +157,41 @@ public abstract class ByteArrayNodes {
             return Layouts.BYTE_ARRAY.getBytes(bytes).get(index);
         }
 
+        @Specialization(guards = "isRubiniusByteArray(otherByteArray)")
+        public Object setByte(DynamicObject bytes, int begin, int length, DynamicObject otherByteArray,
+                              @Cached("create()") BranchProfile errorProfile) {
+            if (begin < 0 || begin >= Layouts.BYTE_ARRAY.getBytes(bytes).getRealSize()) {
+                errorProfile.enter();
+                throw new RaiseException(coreExceptions().indexError("index out of bounds", this));
+            }
+
+            final ByteList byteList = Layouts.BYTE_ARRAY.getBytes(bytes);
+            final ByteList otherByteList = Layouts.BYTE_ARRAY.getBytes(otherByteArray);
+
+            if (byteList.length() < begin) {
+                errorProfile.enter();
+                throw new RaiseException(coreExceptions().indexError("index out of bounds", this));
+            }
+
+            if ((byteList.length() < length) || (byteList.length() < (begin + length))) {
+                length = byteList.length() - begin;
+            }
+
+            final int newArrayLength = (begin - byteList.begin()) + otherByteList.length() + (byteList.length() - (byteList.begin() + begin + length));
+            final byte[] newBytes = new byte[newArrayLength];
+
+            System.arraycopy(byteList.unsafeBytes(), byteList.begin(), newBytes, 0, byteList.begin() + begin);
+            System.arraycopy(otherByteList.unsafeBytes(), otherByteList.begin(), newBytes, begin, otherByteList.length());
+            System.arraycopy(byteList.unsafeBytes(), byteList.begin() + begin + length, newBytes, begin + otherByteList.length(), byteList.length() - (byteList.begin() + begin + length));
+
+            Layouts.BYTE_ARRAY.setBytes(bytes, new ByteList(newBytes, ASCIIEncoding.INSTANCE, false));
+
+            return otherByteArray;
+        }
+
     }
 
-    @CoreMethod(names = "size")
+    @CoreMethod(names = {"size", "length"})
     public abstract static class SizeNode extends CoreMethodArrayArgumentsNode {
 
         @Specialization
@@ -116,13 +217,46 @@ public abstract class ByteArrayNodes {
 
     }
 
+    @CoreMethod(names = "truncate", required = 1, lowerFixnum = 1)
+    public abstract static class TruncateNode extends CoreMethodArrayArgumentsNode {
+
+        @Specialization
+        public DynamicObject index(DynamicObject byteArray, int index) {
+            final ByteList byteList = Layouts.BYTE_ARRAY.getBytes(byteArray);
+            byteList.length(index);
+
+            return byteArray;
+        }
+    }
+
     @CoreMethod(names = "allocate", constructor = true)
     public abstract static class AllocateNode extends UnaryCoreMethodNode {
 
-        @TruffleBoundary
+        @Child private AllocateObjectNode allocateObjectNode;
+
+        public AllocateNode(RubyContext context, SourceSection sourceSection) {
+            super(context, sourceSection);
+            allocateObjectNode = AllocateObjectNode.create();
+        }
+
         @Specialization
         public DynamicObject allocate(DynamicObject rubyClass) {
-            throw new RaiseException(coreExceptions().typeErrorAllocatorUndefinedFor(rubyClass, this));
+            return allocateObjectNode.allocate(rubyClass, ByteList.EMPTY_BYTELIST);
+        }
+
+    }
+
+    @CoreMethod(names = "initialize", required = 2, lowerFixnum = { 1, 2 })
+    public abstract static class InitializeNode extends CoreMethodArrayArgumentsNode {
+
+        @Specialization
+        public DynamicObject initialize(DynamicObject byteArray, int size, int value) {
+            final byte[] bytes = new byte[size];
+            Arrays.fill(bytes, (byte) value);
+
+            Layouts.BYTE_ARRAY.setBytes(byteArray, new ByteList(bytes, ASCIIEncoding.INSTANCE, false));
+
+            return byteArray;
         }
 
     }

--- a/truffle/src/main/ruby/core/byte_array.rb
+++ b/truffle/src/main/ruby/core/byte_array.rb
@@ -1,0 +1,33 @@
+# Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+# OTHER DEALINGS IN THE SOFTWARE.
+
+module Rubinius
+class ByteArray
+
+  def self.from_string(string)
+    new(0, 0).append(string)
+  end
+
+  def to_str
+    String.from_bytearray(self, 0, size)
+  end
+
+  def chomp!(value)
+    if self[size - 1] == value
+      return truncate(size - 1)
+    end
+
+    nil
+  end
+
+  def unpack(format)
+    to_str.unpack(format)
+  end
+end
+end


### PR DESCRIPTION
Full disclosure: I don't have confidence I've accounted for every change in przlib here. However, with the change we still pass the zlib specs we passed prior to this change and I've managed to successfully install a gem with this code in place. So, while there may very well be something broken, we are able to run at least one complicated use case without incident.

The basic idea here is przlib really expects String to function well as a byte buffer. E.g., it'll allocate a 64 KB string and then execute `String#setbyte` on each position. Currently, with ropes, this results in the construction of 64K `ConcatRope` instances and degrades to linked list performance for any `String#getbyte` calls.

There are likely improvements we can make to ropes to better support this use case, but we need zlib working now. I anticipate all of this code being replaced with something native, so I took some liberties in modifying files in place. If we need to, we can also revert the commit or merge later on.

I've also added specs for `Rubinius::ByteArray`. They're not comprehensive and nor is the API -- it's for internal use so I don't think we need to support all the various call forms that `String` does. E.g., I rewrote any form of `String#[Range]` to `Rubinius::ByteArray[index, length]`.