### PR TITLE
RubyHash's compare_by_identify Java method naming is confusing

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1865,14 +1865,14 @@ public class RubyHash extends RubyObject implements Map {
     }
 
     @JRubyMethod(name = "compare_by_identity")
-    public IRubyObject getCompareByIdentity(ThreadContext context) {
+    public IRubyObject compare_by_identity(ThreadContext context) {
         modify();
         setComparedByIdentity(true);
         return rehash();
     }
 
     @JRubyMethod(name = "compare_by_identity?")
-    public IRubyObject getCompareByIdentity_p(ThreadContext context) {
+    public IRubyObject compare_by_identity_p(ThreadContext context) {
         return context.runtime.newBoolean(isComparedByIdentity());
     }
 

--- a/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
@@ -293,7 +293,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         }
 
         @Override
-        public RubyBoolean getCompareByIdentity_p(ThreadContext context) {
+        public RubyBoolean compare_by_identity_p(ThreadContext context) {
             // NOTE: obviously little we can do to detect - but at least report Java built-in one :
             return context.runtime.newBoolean( mapDelegate() instanceof java.util.IdentityHashMap );
         }
@@ -770,13 +770,13 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
     }
 
     @JRubyMethod(name = "compare_by_identity")
-    public IRubyObject getCompareByIdentity(ThreadContext context) {
+    public IRubyObject compare_by_identity(ThreadContext context) {
         return this; // has no effect - mostly for compatibility
     }
 
     @JRubyMethod(name = "compare_by_identity?")
-    public IRubyObject getCompareByIdentity_p(ThreadContext context) {
-        return getOrCreateRubyHashMap().getCompareByIdentity_p(context);
+    public IRubyObject compare_by_identity_p(ThreadContext context) {
+        return getOrCreateRubyHashMap().compare_by_identity_p(context);
     }
 
     @Override


### PR DESCRIPTION
`Hash#compare_by_identity` is more of a writer (does call a setter)

... looks esp. weird since there's a java get/setCompareByIdentity