### PR TITLE
[Truffle] Lazy translation

### DIFF
--- a/tool/truffle/options.yml
+++ b/tool/truffle/options.yml
@@ -31,6 +31,7 @@ INLINE_JS: [inline_js, boolean, false, Allow inline JavaScript]
 
 CORE_LOAD_PATH: [core.load_path, string, 'truffle:/jruby-truffle', Location to load the Truffle core library from]
 CORE_PARALLEL_LOAD: [core.parallel_load, boolean, false, Load the Truffle core library in parallel]
+LAZY_TRANSLATION: [lazy_translation, boolean, false, Lazily translate from the parser AST to the Truffle AST]
 
 ARRAY_UNINITIALIZED_SIZE: [array.uninitialized_size, integer, 32, How large an Array to allocate when we have no other information to go on]
 ARRAY_SMALL: [array.small, integer, 3, Maximum size of an Array to consider small for optimisations]

--- a/truffle/src/main/java/org/jruby/truffle/options/Options.java
+++ b/truffle/src/main/java/org/jruby/truffle/options/Options.java
@@ -45,6 +45,7 @@ public class Options {
     public final boolean INLINE_JS;
     public final String CORE_LOAD_PATH;
     public final boolean CORE_PARALLEL_LOAD;
+    public final boolean LAZY_TRANSLATION;
     public final int ARRAY_UNINITIALIZED_SIZE;
     public final int ARRAY_SMALL;
     public final int HASH_PACKED_ARRAY_MAX;
@@ -136,6 +137,7 @@ public class Options {
         INLINE_JS = builder.getOrDefault(OptionsCatalog.INLINE_JS);
         CORE_LOAD_PATH = builder.getOrDefault(OptionsCatalog.CORE_LOAD_PATH);
         CORE_PARALLEL_LOAD = builder.getOrDefault(OptionsCatalog.CORE_PARALLEL_LOAD);
+        LAZY_TRANSLATION = builder.getOrDefault(OptionsCatalog.LAZY_TRANSLATION);
         ARRAY_UNINITIALIZED_SIZE = builder.getOrDefault(OptionsCatalog.ARRAY_UNINITIALIZED_SIZE);
         ARRAY_SMALL = builder.getOrDefault(OptionsCatalog.ARRAY_SMALL);
         HASH_PACKED_ARRAY_MAX = builder.getOrDefault(OptionsCatalog.HASH_PACKED_ARRAY_MAX);

--- a/truffle/src/main/java/org/jruby/truffle/options/OptionsCatalog.java
+++ b/truffle/src/main/java/org/jruby/truffle/options/OptionsCatalog.java
@@ -43,6 +43,7 @@ public class OptionsCatalog {
     public static final OptionDescription INLINE_JS = new BooleanOptionDescription("inline_js", "Allow inline JavaScript", false);
     public static final OptionDescription CORE_LOAD_PATH = new StringOptionDescription("core.load_path", "Location to load the Truffle core library from", "truffle:/jruby-truffle");
     public static final OptionDescription CORE_PARALLEL_LOAD = new BooleanOptionDescription("core.parallel_load", "Load the Truffle core library in parallel", false);
+    public static final OptionDescription LAZY_TRANSLATION = new BooleanOptionDescription("lazy_translation", "Lazily translate from the parser AST to the Truffle AST", false);
     public static final OptionDescription ARRAY_UNINITIALIZED_SIZE = new IntegerOptionDescription("array.uninitialized_size", "How large an Array to allocate when we have no other information to go on", 32);
     public static final OptionDescription ARRAY_SMALL = new IntegerOptionDescription("array.small", "Maximum size of an Array to consider small for optimisations", 3);
     public static final OptionDescription HASH_PACKED_ARRAY_MAX = new IntegerOptionDescription("hash.packed_array.max", "Maximum size of a Hash to consider using the packed array storage strategy for", 3);
@@ -162,6 +163,8 @@ public class OptionsCatalog {
                 return CORE_LOAD_PATH;
             case "core.parallel_load":
                 return CORE_PARALLEL_LOAD;
+            case "lazy_translation":
+                return LAZY_TRANSLATION;
             case "array.uninitialized_size":
                 return ARRAY_UNINITIALIZED_SIZE;
             case "array.small":

--- a/truffle/src/main/java/org/jruby/truffle/parser/LazyTranslationNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/parser/LazyTranslationNode.java
@@ -32,9 +32,11 @@ public class LazyTranslationNode extends RubyNode {
     }
 
     public RubyNode resolve() {
-        final RubyNode resolved = resolver.get();
-        replace(resolved, "lazy translation node resolved");
-        return resolved;
+        return atomic(() -> {
+            final RubyNode resolved = resolver.get();
+            replace(resolved, "lazy translation node resolved");
+            return resolved;
+        });
     }
 
 }

--- a/truffle/src/main/java/org/jruby/truffle/parser/LazyTranslationNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/parser/LazyTranslationNode.java
@@ -19,26 +19,15 @@ import java.util.function.Supplier;
 
 public class LazyTranslationNode extends RubyNode {
 
-    private static final AtomicLong createdCount = new AtomicLong();
-    private static final AtomicLong resolvedCount = new AtomicLong();
-
-    static {
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            Log.info("lazy translation %d/%d", resolvedCount.get(), createdCount.get());
-        }));
-    }
-
     private final Supplier<RubyNode> resolver;
 
     public LazyTranslationNode(Supplier<RubyNode> resolver) {
         this.resolver = resolver;
-        createdCount.getAndIncrement();
     }
 
     @Override
     public Object execute(VirtualFrame frame) {
         CompilerDirectives.transferToInterpreterAndInvalidate();
-        resolvedCount.getAndIncrement();
         final RubyNode resolved = resolver.get();
         replace(resolved, "lazy translation node resolved");
         return resolved.execute(frame);

--- a/truffle/src/main/java/org/jruby/truffle/parser/LazyTranslationNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/parser/LazyTranslationNode.java
@@ -15,6 +15,7 @@ import org.jruby.truffle.Log;
 import org.jruby.truffle.language.RubyNode;
 
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
 public class LazyTranslationNode extends RubyNode {
 
@@ -27,10 +28,10 @@ public class LazyTranslationNode extends RubyNode {
         }));
     }
 
-    @Child private RubyNode resolved;
+    private final Supplier<RubyNode> resolver;
 
-    public LazyTranslationNode(RubyNode resolved) {
-        this.resolved = resolved;
+    public LazyTranslationNode(Supplier<RubyNode> resolver) {
+        this.resolver = resolver;
         createdCount.getAndIncrement();
     }
 
@@ -38,6 +39,7 @@ public class LazyTranslationNode extends RubyNode {
     public Object execute(VirtualFrame frame) {
         CompilerDirectives.transferToInterpreterAndInvalidate();
         resolvedCount.getAndIncrement();
+        final RubyNode resolved = resolver.get();
         replace(resolved, "lazy translation node resolved");
         return resolved.execute(frame);
     }

--- a/truffle/src/main/java/org/jruby/truffle/parser/LazyTranslationNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/parser/LazyTranslationNode.java
@@ -28,9 +28,13 @@ public class LazyTranslationNode extends RubyNode {
     @Override
     public Object execute(VirtualFrame frame) {
         CompilerDirectives.transferToInterpreterAndInvalidate();
+        return resolve().execute(frame);
+    }
+
+    public RubyNode resolve() {
         final RubyNode resolved = resolver.get();
         replace(resolved, "lazy translation node resolved");
-        return resolved.execute(frame);
+        return resolved;
     }
 
 }

--- a/truffle/src/main/java/org/jruby/truffle/parser/LazyTranslationNode.java
+++ b/truffle/src/main/java/org/jruby/truffle/parser/LazyTranslationNode.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 1.0
+ * GNU General Public License version 2
+ * GNU Lesser General Public License version 2.1
+ */
+package org.jruby.truffle.parser;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import org.jruby.truffle.Log;
+import org.jruby.truffle.language.RubyNode;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class LazyTranslationNode extends RubyNode {
+
+    private static final AtomicLong createdCount = new AtomicLong();
+    private static final AtomicLong resolvedCount = new AtomicLong();
+
+    static {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            Log.info("lazy translation %d/%d", resolvedCount.get(), createdCount.get());
+        }));
+    }
+
+    @Child private RubyNode resolved;
+
+    public LazyTranslationNode(RubyNode resolved) {
+        this.resolved = resolved;
+        createdCount.getAndIncrement();
+    }
+
+    @Override
+    public Object execute(VirtualFrame frame) {
+        CompilerDirectives.transferToInterpreterAndInvalidate();
+        resolvedCount.getAndIncrement();
+        replace(resolved, "lazy translation node resolved");
+        return resolved.execute(frame);
+    }
+
+}

--- a/truffle/src/main/java/org/jruby/truffle/parser/MethodTranslator.java
+++ b/truffle/src/main/java/org/jruby/truffle/parser/MethodTranslator.java
@@ -293,13 +293,13 @@ public class MethodTranslator extends BodyTranslator {
     }
 
     public MethodDefinitionNode compileMethodNode(RubySourceSection sourceSection, String methodName, MethodDefParseNode defNode, ParseNode bodyNode, SharedMethodInfo sharedMethodInfo) {
-        final TranslatorState state = getCurrentState();
-
         final SourceSection fullMethodSourceSection = new RubySourceSection(defNode.getLine() + 1, defNode.getEndLine() + 1).toSourceSection(source);
 
         final RubyNode body;
 
         if (context.getOptions().LAZY_TRANSLATION) {
+            final TranslatorState state = getCurrentState();
+
             body = new LazyTranslationNode(() -> {
                 restoreState(state);
                 return compileMethodBody(sourceSection, methodName, bodyNode, sharedMethodInfo);

--- a/truffle/src/main/java/org/jruby/truffle/parser/MethodTranslator.java
+++ b/truffle/src/main/java/org/jruby/truffle/parser/MethodTranslator.java
@@ -295,7 +295,12 @@ public class MethodTranslator extends BodyTranslator {
         final SourceSection fullMethodSourceSection = new RubySourceSection(defNode.getLine() + 1, defNode.getEndLine() + 1).toSourceSection(source);
 
         final RubyRootNode rootNode = new RubyRootNode(
-                context, fullMethodSourceSection, environment.getFrameDescriptor(), environment.getSharedMethodInfo(), body, environment.needsDeclarationFrame());
+                context,
+                fullMethodSourceSection,
+                environment.getFrameDescriptor(),
+                environment.getSharedMethodInfo(),
+                new LazyTranslationNode(body),
+                environment.needsDeclarationFrame());
 
         final CallTarget callTarget = Truffle.getRuntime().createCallTarget(rootNode);
         return new MethodDefinitionNode(context, fullMethodSourceSection, methodName, environment.getSharedMethodInfo(), callTarget);

--- a/truffle/src/main/java/org/jruby/truffle/parser/MethodTranslator.java
+++ b/truffle/src/main/java/org/jruby/truffle/parser/MethodTranslator.java
@@ -20,6 +20,7 @@ import org.jruby.truffle.RubyContext;
 import org.jruby.truffle.core.IsNilNode;
 import org.jruby.truffle.core.cast.ArrayCastNodeGen;
 import org.jruby.truffle.core.proc.ProcType;
+import org.jruby.truffle.language.LexicalScope;
 import org.jruby.truffle.language.RubyNode;
 import org.jruby.truffle.language.RubyRootNode;
 import org.jruby.truffle.language.RubySourceSection;
@@ -65,7 +66,9 @@ import org.jruby.truffle.parser.ast.UnnamedRestArgParseNode;
 import org.jruby.truffle.parser.ast.ZSuperParseNode;
 import org.jruby.truffle.tools.ChaosNodeGen;
 
+import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Deque;
 
 public class MethodTranslator extends BodyTranslator {
 
@@ -290,7 +293,7 @@ public class MethodTranslator extends BodyTranslator {
     }
 
     public MethodDefinitionNode compileMethodNode(RubySourceSection sourceSection, String methodName, MethodDefParseNode defNode, ParseNode bodyNode, SharedMethodInfo sharedMethodInfo) {
-        final RubyNode body = compileMethodBody(sourceSection, methodName, bodyNode, sharedMethodInfo);
+        final TranslatorState state = getCurrentState();
 
         final SourceSection fullMethodSourceSection = new RubySourceSection(defNode.getLine() + 1, defNode.getEndLine() + 1).toSourceSection(source);
 
@@ -299,10 +302,14 @@ public class MethodTranslator extends BodyTranslator {
                 fullMethodSourceSection,
                 environment.getFrameDescriptor(),
                 environment.getSharedMethodInfo(),
-                new LazyTranslationNode(body),
+                new LazyTranslationNode(() -> {
+                    restoreState(state);
+                    return compileMethodBody(sourceSection, methodName, bodyNode, sharedMethodInfo);
+                }),
                 environment.needsDeclarationFrame());
 
         final CallTarget callTarget = Truffle.getRuntime().createCallTarget(rootNode);
+
         return new MethodDefinitionNode(context, fullMethodSourceSection, methodName, environment.getSharedMethodInfo(), callTarget);
     }
 
@@ -452,6 +459,35 @@ public class MethodTranslator extends BodyTranslator {
         }
 
         return "";
+    }
+
+    /*
+     * The following methods allow us to save and restore enough of
+     * the current state of the Translator to allow lazy parsing. When
+     * the lazy parsing is actually performed, the state is restored
+     * to what it would have been if the method had been parsed
+     * eagerly.
+     */
+    public TranslatorState getCurrentState() {
+        return new TranslatorState(getEnvironment().unsafeGetLexicalScope(), getEnvironment().isDynamicConstantLookup(), new ArrayDeque<>(parentSourceSection));
+    }
+
+    public void restoreState(TranslatorState state) {
+        getEnvironment().getParseEnvironment().setDynamicConstantLookup(state.dynamicConstantLookup);
+        getEnvironment().getParseEnvironment().resetLexicalScope(state.scope);
+        parentSourceSection = state.parentSourceSection;
+    }
+
+    public static class TranslatorState {
+        private final LexicalScope scope;
+        private final boolean dynamicConstantLookup;
+        private final Deque<RubySourceSection> parentSourceSection;
+
+        private TranslatorState(LexicalScope scope, boolean dynamicConstantLookup, Deque<RubySourceSection> parentSourceSection) {
+            this.scope = scope;
+            this.dynamicConstantLookup = dynamicConstantLookup;
+            this.parentSourceSection = parentSourceSection;
+        }
     }
 
 }

--- a/truffle/src/main/java/org/jruby/truffle/parser/TranslatorEnvironment.java
+++ b/truffle/src/main/java/org/jruby/truffle/parser/TranslatorEnvironment.java
@@ -241,4 +241,7 @@ public class TranslatorEnvironment {
         this.breakID = breakID;
     }
 
+    public LexicalScope unsafeGetLexicalScope() {
+        return parseEnvironment.getLexicalScope();
+    }
 }


### PR DESCRIPTION
Add support for lazy translation, as a first step towards lazy parsing and maybe serialisation.

It's quite effective on its own though. For `-e 14` minimum heap goes from 35 to 27 MB (saves 8 MB), total allocation from 177.85 MB ± 2.75 MB to 125.78 MB ± 2.2 MB (saves 52 MB), time from 3.47 to 3.13 s (saves 0.34 s).

We can't turn it on however, as it interferes with Truffle instrumentation. I think that's a Truffle bug and I'll be using this new lazy translation as a test case to show that. It's off by default for that reason. There might be a couple of other bugs that are ours which I'll look at after the Truffle issues is fixed.

Contains some work by Brian Belleville.