### PR TITLE
Don't allow null method names

### DIFF
--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -974,9 +974,10 @@ public class Helpers {
         if (klass == null) {
             if (name != null) {
                 throw context.runtime.newNameError("superclass method '" + name + "' disabled", name);
-            } else {
-                throw context.runtime.newNoMethodError("super called outside of method", null, context.nil);
             }
+        }
+        if (name == null) {
+            throw context.runtime.newNoMethodError("super called outside of method", null, context.nil);
         }
     }
 


### PR DESCRIPTION
Are there any cases where null names make sense/should be allowed? If so we probably need to be more specific than this patch.

Solves problem of #4426 
