### PR TITLE
Set toplevel module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ env:
     - PHASE='-Prake -Dtask=test:jruby'
     - PHASE='-Prake -Dtask=test:jruby:fullint'
     - PHASE='-Prake -Dtask=test:jruby:jit'
+    - PHASE='-Prake -Dtask=test:jruby:aot'
     - PHASE='-Prake -Dtask=test:mri'
     - PHASE='-Prake -Dtask=test:mri:fullint'
     - PHASE='-Prake -Dtask=test:mri:jit'


### PR DESCRIPTION
This includes a fix for #4416 (setting top-level module when running with -X+C) and enables the `test:jruby:aot` suite to verify the AOT mode.