### PR TITLE
[ji] support 'native' method arguments (e.g. org.jruby.RubyObject)

### DIFF
--- a/core/src/main/java/org/jruby/java/dispatch/CallableSelector.java
+++ b/core/src/main/java/org/jruby/java/dispatch/CallableSelector.java
@@ -594,7 +594,9 @@ public class CallableSelector {
     }
 
     private static boolean assignable(Class<?> type, final IRubyObject arg) {
-        return JavaClass.assignable(type, getJavaClass(arg));
+        return JavaClass.assignable(type, getJavaClass(arg)) ||
+                // handle 'native' signatures e.g. method with a (org.jruby.RubyArray arg)
+                ( arg != null && type.isAssignableFrom(arg.getClass()) );
     }
 
     /**

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -1549,6 +1549,21 @@ CLASSDEF
     assert(x.java_class.kind_of?Java::JavaClass)
   end
 
+  java_import 'org.jruby.javasupport.test.name.Sample'
+
+  def test_native_ruby_array_java_argument
+    assert_equal '10', Sample.test(16)
+    assert_equal 3, Sample.test([1, 2.0, 3])
+  end
+
+  def test_ruby_object_java_argument
+    assert_equal 'RubyString',  Sample.rubyObj('s')
+    assert_equal 'RubyInteger', Sample.rubyObj(100)
+    assert_equal 'RubyObject',  Sample.rubyObj([1])
+    # undefined territory as nil gets into null early
+    #assert_equal 'RubyObject',  Sample.rubyObj(nil)
+  end
+
   # JRUBY-4524
   class IncludePackageSuper
     def self.const_missing(a)

--- a/test/org/jruby/javasupport/test/name/Sample.java
+++ b/test/org/jruby/javasupport/test/name/Sample.java
@@ -8,4 +8,29 @@ public class Sample {
             throw new IllegalStateException("param == -1");
         }
     }
+
+    public static String test(int x) {
+        return Integer.toHexString(x);
+    }
+
+    public static Object test(org.jruby.RubyArray array) {
+        return array.length();
+    }
+
+    public static String rubyObj(org.jruby.RubyString obj) {
+        return "RubyString";
+    }
+
+    public static String rubyObj(org.jruby.RubyInteger obj) {
+        return "RubyInteger";
+    }
+
+    public static String rubyObj(org.jruby.RubyObject obj) {
+        return "RubyObject";
+    }
+
+    public static String rubyObj(java.lang.Object obj) {
+        return "";
+    }
+
 }


### PR DESCRIPTION
for (backwards) safety this has lower priority than an exact match
and thus is not expected to cause any regressions

resolves #1643 