### PR TITLE
Fix #3799 again.

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -45,7 +45,7 @@ project 'JRuby Core' do
   jar 'com.github.jnr:jnr-netdb:1.1.6', :exclusions => ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-enxio:0.14', :exclusions => ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-x86asm:1.0.2', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-unixsocket:0.15', :exclusions => ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-unixsocket:0.16-SNAPSHOT', :exclusions => ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-posix:3.0.35-SNAPSHOT', :exclusions => ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-constants:0.9.6', :exclusions => ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-ffi:2.1.2'

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -124,7 +124,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-unixsocket</artifactId>
-      <version>0.15</version>
+      <version>0.16-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <artifactId>jnr-ffi</artifactId>


### PR DESCRIPTION
See https://github.com/jnr/jnr-unixsocket/pull/38
Fixed code from jnr-enxio is not used anymore after updating to
jnr-unixsocket 0.15.
Regression spec accidentally passes on TravisCI and Ubuntu xenial.
In the meantime there are bug reports that issue still
reproduces in some environments. Personally I caught it under macOS.