### PR TITLE
Implement `String#casecmp?` and `Symbol#casecmp?`

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1596,8 +1596,14 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
 
     @JRubyMethod(name = "casecmp?")
     public IRubyObject casecmp_p(ThreadContext context, IRubyObject other) {
+        Ruby runtime = context.runtime;
+        RubyString otherStr = other.convertToString();
+
+        Encoding enc = StringSupport.areCompatible(this, otherStr);
+        if (enc == null) return runtime.getNil();
+
         RubyString downcasedString = this.downcase19(context);
-        RubyString otherDowncasedString = other.convertToString().downcase19(context);
+        RubyString otherDowncasedString = otherStr.downcase19(context);
         return downcasedString.equals(otherDowncasedString) ? context.runtime.getTrue() : context.runtime.getFalse();
     }
 

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1594,6 +1594,13 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         }
     }
 
+    @JRubyMethod(name = "casecmp?")
+    public IRubyObject casecmp_p(ThreadContext context, IRubyObject other) {
+        RubyString downcasedString = this.downcase19(context);
+        RubyString otherDowncasedString = other.convertToString().downcase19(context);
+        return downcasedString.equals(otherDowncasedString) ? context.runtime.getTrue() : context.runtime.getFalse();
+    }
+
     /** rb_str_match
      *
      */

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -406,6 +406,14 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
                 newShared(runtime).casecmp19(context, ((RubySymbol) other).newShared(runtime));
     }
 
+    @JRubyMethod(name = "casecmp?")
+    public IRubyObject casecmp_p(ThreadContext context, IRubyObject other) {
+        Ruby runtime = context.runtime;
+
+        return !(other instanceof RubySymbol) ? runtime.getNil() :
+            newShared(runtime).casecmp_p(context, ((RubySymbol) other).newShared(runtime));
+    }
+
     @JRubyMethod(name = "=~")
     @Override
     public IRubyObject op_match(ThreadContext context, IRubyObject other) {

--- a/test/mri/ruby/test_string.rb
+++ b/test/mri/ruby/test_string.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: false
 require 'test/unit'
 
@@ -2208,6 +2209,13 @@ CODE
 
   def test_casecmp
     assert_equal(1, "\u3042B".casecmp("\u3042a"))
+  end
+
+  def test_casecmp?
+    assert_equal(true, 'FoO'.casecmp?('fOO'))
+    assert_equal(false, 'FoO'.casecmp?('BaR'))
+    assert_equal(false, 'baR'.casecmp?('FoO'))
+    assert_equal(true, 'äöü'.casecmp?('ÄÖÜ'))
   end
 
   def test_upcase2

--- a/test/mri/ruby/test_symbol.rb
+++ b/test/mri/ruby/test_symbol.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: false
 require 'test/unit'
 
@@ -274,6 +275,14 @@ class TestSymbol < Test::Unit::TestCase
     assert_equal(1, :FoO.casecmp(:BaR))
     assert_equal(-1, :baR.casecmp(:FoO))
     assert_nil(:foo.casecmp("foo"))
+  end
+
+  def test_casecmp?
+    assert_equal(true, :FoO.casecmp?(:fOO))
+    assert_equal(false, :FoO.casecmp?(:BaR))
+    assert_equal(false, :baR.casecmp?(:FoO))
+    assert_nil(:foo.casecmp?("foo"))
+    assert_equal(true, :äöü.casecmp?(:ÄÖÜ))
   end
 
   def test_length


### PR DESCRIPTION
* Adds implementation of `casecmp?` based on downcasing the string and comparing
* Adds unit tests for `casecmp?` from MRI

There is a test failing in each of the tests (the last assertion in each method) I brought over. This is because the MRI implementation (https://github.com/ruby/ruby/commit/ad619e02c465eebd15fa57dc658f8e042decdebb) of `casecmp?` relies on passing the `:fold` option to `downcase` however that option has not been added yet in JRuby. It is referenced in #4293 though.

I decided to keep the failing tests in for completeness since they will need to be fixed anyway for 2.4 support. I figured that this PR would be fine without those specific cases supported but maybe it would be better to wait until `:fold` is implemented.

See #4293
