### PR TITLE
Make sure to iterate over all keys when cancelling keys in a SelectorPool

### DIFF
--- a/core/src/main/java/org/jruby/util/io/SelectorPool.java
+++ b/core/src/main/java/org/jruby/util/io/SelectorPool.java
@@ -85,8 +85,11 @@ public class SelectorPool {
      * @param selector the selector to put back
      */
     public void put(Selector selector) {
-        Iterator<SelectionKey> key_iterator = selector.keys().iterator();
-        while(key_iterator.hasNext()) key_iterator.next().cancel();
+        for (SelectionKey key : selector.keys()) {
+            if (key != null) {
+                key.cancel();
+            }
+        }
 
         try {
             selector.selectNow();


### PR DESCRIPTION
When we updated our server from 9.1.2.0 to 9.1.7.0 we started seeing a file descriptor leak which, if left for long enough, would run the machine out of file descriptors.

We tracked down the problem to https://github.com/jruby/jruby/pull/3952 which changed how SelectionKeys were closed.  

It looks like if exceptions aren't caught while calling `cancel` on the SelectionKeys then the loop can exit early and leave some keys un-cancelled.

When we went back to the same key cancelling code that was used in 9.1.2.0 the problem went away.