### PR TITLE
Use arity hashCode instead of proc#hash in CallableSelector

### DIFF
--- a/core/src/main/java/org/jruby/java/dispatch/CallableSelector.java
+++ b/core/src/main/java/org/jruby/java/dispatch/CallableSelector.java
@@ -744,7 +744,7 @@ public class CallableSelector {
     private static int javaClassOrProcHashCode(final IRubyObject arg) {
         // if ( arg == null ) return 0;
         final Class<?> javaClass = arg.getJavaClass();
-        return javaClass == RubyProc.class ? arg.hashCode() : javaClass.hashCode();
+        return javaClass == RubyProc.class ? ((RubyProc) arg).arity().hashCode() : javaClass.hashCode();
     }
 
     private static Class<?> getJavaClass(final IRubyObject arg) {


### PR DESCRIPTION
Using proc#hash as the cache key means that you're only
guaranteed to get a cache hit if exactly the same proc is
being passed. Using arity.hashCode instead should satisfy the
original reason for hashing the proc (disambiguate signatures
based on the arity of the proc) while preventing cache misses.

Also note that this was causing a memory leak: each time we get a cache miss it creates a new cache entry, and the cache is unbounded. 

Tried to add a test for this, but it doesn't seem like CallableSelectorTest runs / works. 