### PR TITLE
Use ipaddr to compare the sender's address

### DIFF
--- a/lib/ruby/stdlib/resolv.rb
+++ b/lib/ruby/stdlib/resolv.rb
@@ -4,6 +4,7 @@ require 'socket'
 require 'timeout'
 require 'thread'
 require 'io/wait'
+require 'ipaddr'
 
 begin
   require 'securerandom'
@@ -768,13 +769,13 @@ class Resolv
 
         def recv_reply(readable_socks)
           reply, from = readable_socks[0].recvfrom(UDPSize)
-          return reply, [from[3],from[1]]
+          return reply, [IPAddr.new(from[3]),from[1]]
         end
 
         def sender(msg, data, host, port=Port)
           sock = @socks_hash[host.index(':') ? "::" : "0.0.0.0"]
           return nil if !sock
-          service = [host, port]
+          service = [IPAddr.new(host), port]
           id = DNS.allocate_request_id(host, port)
           request = msg.encode
           request[0,2] = [id].pack('n')


### PR DESCRIPTION
When resolving names using compressed IPv6-only DNS servers, it could
happen that when processing the response of a name query, the IP of the
sender is not compressed so using a simple string comparison is not
safe.

This patch encapsulates the from address and the address of the sender in
IPAddr objects so the comparison is safe and just works in all cases.

This fixes #3663.