### PR TITLE
Separate varargs and specific-arity names in JIT. Fixes #4482

### DIFF
--- a/core/src/main/java/org/jruby/compiler/BlockJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/BlockJITTask.java
@@ -76,7 +76,7 @@ class BlockJITTask implements Runnable {
                 JITCompiler.log(body.getImplementationClass(), body.getFile(), body.getLine(), className + "." + methodName, "done jitting");
             }
 
-            String jittedName = context.getJittedName();
+            String jittedName = context.getVariableName();
 
             // blocks only have variable-arity
             body.completeBuild(

--- a/core/src/main/java/org/jruby/compiler/MethodJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/MethodJITTask.java
@@ -112,8 +112,8 @@ class MethodJITTask implements Runnable {
                 JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), className + '.' + methodName, "done jitting");
             }
 
-            final String jittedName = context.getJittedName();
-            MethodHandle variable = JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, jittedName, context.getNativeSignature(-1));
+            String variableName = context.getVariableName();
+            MethodHandle variable = JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, variableName, context.getNativeSignature(-1));
             IntHashMap<MethodType> signatures = context.getNativeSignaturesExceptVariable();
 
             if (signatures.size() == 0) {
@@ -132,7 +132,7 @@ class MethodJITTask implements Runnable {
                     method.completeBuild(
                             new CompiledIRMethod(
                                     variable,
-                                    JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, jittedName, entry.getValue()),
+                                    JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, context.getSpecificName(), entry.getValue()),
                                     entry.getKey(),
                                     method.getIRScope(),
                                     method.getVisibility(),

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitorMethodContext.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitorMethodContext.java
@@ -8,19 +8,41 @@ import org.jruby.util.collections.IntHashMap;
  * Context for JITing methods.  Temporary data.
  */
 public class JVMVisitorMethodContext {
-    // Method name in the jitted version of this method
-    private String jittedName;
+    // The base name of this method. It will match specific if non-null, otherwise varargs.
+    private String baseName;
+
+    // Method name in the specific-arity version of this method. May be null
+    private String specificName;
+
+    // Method name in the variable-arity version of this method
+    private String variableName;
 
     // Signatures to the jitted versions of this method
     private IntHashMap<MethodType> signatures;
     private MethodType varSignature; // for arity == -1
 
-    public void setJittedName(String jittedName) {
-        this.jittedName = jittedName;
+    public void setSpecificName(String specificName) {
+        this.specificName = specificName;
     }
 
-    public String getJittedName() {
-        return jittedName;
+    public void setVariableName(String variableName) {
+        this.variableName = variableName;
+    }
+
+    public void setBaseName(String baseName) {
+        this.baseName = baseName;
+    }
+
+    public String getSpecificName() {
+        return specificName;
+    }
+
+    public String getVariableName() {
+        return variableName;
+    }
+
+    public String getBaseName() {
+        return baseName;
     }
 
     public void addNativeSignature(int arity, MethodType signature) {

--- a/core/src/main/java/org/jruby/util/JavaNameMangler.java
+++ b/core/src/main/java/org/jruby/util/JavaNameMangler.java
@@ -311,8 +311,12 @@ public class JavaNameMangler {
         throw new IllegalStateException("unknown scope type for backtrace encoding: " + scope.getClass());
     }
 
+    public static final String VARARGS_MARKER = "$__VARARGS__";
+
     public static String decodeMethodForBacktrace(String methodName) {
-        if ( ! methodName.startsWith("RUBY$") ) return null;
+        if (!methodName.startsWith("RUBY$")) return null;
+
+        if (methodName.contains(VARARGS_MARKER)) return null;
 
         final List<String> name = StringSupport.split(methodName, '$');
         final String type = name.get(1); // e.g. RUBY $ class $ methodName


### PR DESCRIPTION
Originally, varargs and specific-arity paths were emitted in toto
as their own JVM method bodies. With recent changes, the varargs
path now calls the specific-arity path, causing an extra
synthetic entry in the JVM stack trace. This confounded the
backtrace miner, since it had no marker with which to omit the
synthetic version, and so Kernel#caller and friends contained an
additional invalid entry. This in turn caused require_relative to
fail to find the caller's path, resulting in a nil path value
passed to File.realpath, which triggered this bug.

It likely only affected invokedynamic because our indy logic must
be calling no-arg methods via the varargs path (a separate issue
to be fixed).

My modification here explicitly separates the synthetic varargs
name from the specific-arity name by adding a known varargs marker
that can be filtered out when mining the backtrace.

This is a big hacky; the state being managed by the jit is very
ad-hoc and prone to bugs. It will need some additional cleanup
after 9.1.8.0.

See #4482.