### PR TITLE
Allow reads after calling BasicSocket#close_write.

### DIFF
--- a/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
@@ -456,7 +456,8 @@ public class RubyBasicSocket extends RubyIO {
         }
 
         // shutdown half
-        shutdownInternal(context, fptr, 0);
+        int how = closeHalf == OpenFile.READABLE ? 0 : 1;
+        shutdownInternal(context, fptr, how);
         fptr.setMode(fptr.getMode() & ~closeHalf);
 
         return context.nil;

--- a/spec/ruby/library/socket/basicsocket/close_write_spec.rb
+++ b/spec/ruby/library/socket/basicsocket/close_write_spec.rb
@@ -26,6 +26,11 @@ describe "Socket::BasicSocket#close_write" do
     @server.closed?.should be_false
   end
 
+  it "does not prevent reading" do
+    @server.close_write
+    @server.read(0).should == ""
+  end
+
   it "fully closes the socket if it was already closed for reading" do
     @server.close_read
     @server.close_write


### PR DESCRIPTION
`shutdownInternal` was always shutting down the read side, even when we were trying to close the write side of the socket.

Fixes #4500.