### PR TITLE
Improve some of the debug logging in ConstantLookupSite.

### DIFF
--- a/core/src/main/java/org/jruby/ir/targets/ConstantLookupSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/ConstantLookupSite.java
@@ -97,7 +97,7 @@ public class ConstantLookupSite extends MutableCallSite {
         setTarget(switchPoint.guardWithTest(target, fallback));
 
         if (Options.INVOKEDYNAMIC_LOG_CONSTANTS.load()) {
-            LOG.info(name + "\tretrieved and cached from scope " + staticScope.getIRScope());
+            LOG.info(name + "\tretrieved and cached from scope (searchConst) " + staticScope.getIRScope());
         }
 
         return constant;
@@ -121,6 +121,10 @@ public class ConstantLookupSite extends MutableCallSite {
 
         // bind constant until invalidated
         bind(runtime, module, constant, SMFC());
+
+        if (Options.INVOKEDYNAMIC_LOG_CONSTANTS.load()) {
+            LOG.info(name + "\tretrieved and cached from module (searchModuleForConst) " + cmVal.getMetaClass());// + " added to PIC" + extractSourceInfo(site));
+        }
 
         return constant;
     }
@@ -166,7 +170,7 @@ public class ConstantLookupSite extends MutableCallSite {
         tracker.addType(module.id);
 
         if (Options.INVOKEDYNAMIC_LOG_CONSTANTS.load()) {
-            LOG.info(name + "\tconstant cached from type " + cmVal.getMetaClass());
+            LOG.info(name + "\tconstant cached from type (inheritanceSearchConst) " + cmVal.getMetaClass());
         }
 
         return constant;
@@ -277,7 +281,7 @@ public class ConstantLookupSite extends MutableCallSite {
         setTarget(switchPoint.guardWithTest(target, fallback));
 
         if (Options.INVOKEDYNAMIC_LOG_CONSTANTS.load()) {
-            LOG.info(name + "\tretrieved and cached from scope " + scope.getIRScope());// + " added to PIC" + extractSourceInfo(site));
+            LOG.info(name + "\tretrieved and cached from scope (lexicalSearchConst) " + scope.getIRScope());// + " added to PIC" + extractSourceInfo(site));
         }
 
         return constant;


### PR DESCRIPTION
Added this while debugging an issue, figured it'd be useful
upstream. Adds the method name to the log statement + adds
logging for searchModuleForConst. Spelling out the method
name is useful to distinguish between lexicalSearchConst
and searchConst, but also makes it easier to map the log
statements with the origin method when you're not familiar
with the code.

Happy to change the format of the logs if there's any objections, 
this is just what I ended up using.