### PR TITLE
Actually cache the idTest on the module.

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -302,7 +302,7 @@ public class RubyModule extends RubyObject {
     public MethodHandle getIdTest() {
         MethodHandle idTest = this.idTest;
         if (idTest != null) return idTest;
-        return idTest = newIdTest();
+        return this.idTest = newIdTest();
     }
 
     protected MethodHandle newIdTest() {


### PR DESCRIPTION
This was assigning to the local variable, so the `MethodHandle` would be created ever time this is called.