### PR TITLE
Fix some issues with Fiddle

### DIFF
--- a/lib/ruby/stdlib/ffi/libc.rb
+++ b/lib/ruby/stdlib/ffi/libc.rb
@@ -1,0 +1,216 @@
+module FFI
+  module LibC
+    extend FFI::Library
+
+    typedef :pointer, :FILE
+    typedef :uint32, :in_addr_t
+    typedef :uint16, :in_port_t
+
+    # time.h
+    typedef :long, :clock_t
+
+    ffi_lib [FFI::CURRENT_PROCESS, 'c']
+
+    # The NULL constant
+    NULL = nil
+
+    # errno.h
+    attach_variable :sys_errlist, :pointer
+    attach_variable :sys_nerr, :int
+    attach_variable :errno, :int
+
+    def self.raise_error(error=self.errno)
+      raise(strerror(error))
+    end
+
+    # unistd.h
+    attach_function :brk, [:pointer], :int
+    attach_function :sbrk, [:pointer], :pointer
+    attach_function :getpid, [], :pid_t
+    attach_function :getppid, [], :pid_t
+    attach_function :getuid, [], :uid_t
+    attach_function :geteuid, [], :uid_t
+    attach_function :getgid, [], :gid_t
+    attach_function :getegid, [], :gid_t
+    attach_function :alarm, [:uint], :uint
+
+    # stdlib.h
+    attach_function :calloc, [:size_t, :size_t], :pointer
+    attach_function :malloc, [:size_t], :pointer
+    FREE = attach_function :free, [:pointer], :void
+    attach_function :realloc, [:pointer, :size_t], :pointer
+    attach_function :getenv, [:string], :string
+    attach_function :putenv, [:string], :int
+    attach_function :unsetenv, [:string], :int
+
+    begin
+      attach_function :clearenv, [], :int
+    rescue FFI::NotFoundError
+      # clearenv is not available on OSX
+    end
+
+    # time.h
+    attach_function :clock, [], :clock_t
+    attach_function :time, [:pointer], :time_t
+
+    # sys/time.h
+    attach_function :gettimeofday, [:pointer, :pointer], :int
+    attach_function :settimeofday, [:pointer, :pointer], :int
+
+    # sys/mman.h
+    attach_function :mmap, [:pointer, :size_t, :int, :int, :int, :off_t], :pointer
+    attach_function :munmap, [:pointer, :size_t], :int
+
+    # string.h
+    attach_function :bzero, [:pointer, :size_t], :void
+    attach_function :memset, [:pointer, :int, :size_t], :pointer
+    attach_function :memcpy, [:buffer_out, :buffer_in, :size_t], :pointer
+    attach_function :memcmp, [:buffer_in, :buffer_in, :size_t], :int
+    attach_function :memchr, [:buffer_in, :int, :size_t], :pointer
+
+    begin
+      attach_function :memrchr, [:buffer_in, :int, :size_t], :pointer
+    rescue FFI::NotFoundError
+      # memrchr is not available on OSX
+    end
+
+    attach_function :strcpy, [:buffer_out, :string], :pointer
+    attach_function :strncpy, [:buffer_out, :string, :size_t], :pointer
+    attach_function :strcmp, [:buffer_in, :buffer_in], :int
+    attach_function :strncmp, [:buffer_in, :buffer_in, :size_t], :int
+    attach_function :strlen, [:buffer_in], :size_t
+    attach_function :index, [:buffer_in, :int], :pointer
+    attach_function :rindex, [:buffer_in, :int], :pointer
+    attach_function :strchr, [:buffer_in, :int], :pointer
+    attach_function :strrchr, [:buffer_in, :int], :pointer
+    attach_function :strstr, [:buffer_in, :string], :pointer
+    attach_function :strerror, [:int], :string
+
+    begin
+      attach_variable :stdin, :pointer
+      attach_variable :stdout, :pointer
+      attach_variable :stderr, :pointer
+    rescue FFI::NotFoundError
+      # stdin, stdout, stderr are not available on OSX
+    end
+
+    attach_function :fopen, [:string, :string], :FILE
+    attach_function :fdopen, [:int, :string], :FILE
+    attach_function :freopen, [:string, :string, :FILE], :FILE
+    attach_function :fseek, [:FILE, :long, :int], :int
+    attach_function :ftell, [:FILE], :long
+    attach_function :rewind, [:FILE], :void
+    attach_function :fread, [:buffer_out, :size_t, :size_t, :FILE], :size_t
+    attach_function :fwrite, [:buffer_in, :size_t, :size_t, :FILE], :size_t
+    attach_function :fgetc, [:FILE], :int
+    attach_function :fgets, [:buffer_out, :int, :FILE], :pointer
+    attach_function :fputc, [:int, :FILE], :int
+    attach_function :fputs, [:buffer_in, :FILE], :int
+    attach_function :fflush, [:FILE], :int
+    attach_function :fclose, [:FILE], :int
+    attach_function :clearerr, [:FILE], :void
+    attach_function :feof, [:FILE], :int
+    attach_function :ferror, [:FILE], :int
+    attach_function :fileno, [:FILE], :int
+    attach_function :perror, [:string], :void
+
+    attach_function :getc, [:FILE], :int
+    attach_function :getchar, [], :int
+    attach_function :gets, [:buffer_out], :int
+    attach_function :ungetc, [:int, :pointer], :int
+
+    attach_function :putc, [:int, :FILE], :int
+    attach_function :putchar, [:int], :int
+    attach_function :puts, [:string], :int
+
+    # netdb.h
+    attach_function :getnameinfo, [
+      :pointer,
+      :socklen_t, :pointer,
+      :socklen_t, :pointer,
+      :socklen_t, :int
+    ], :int
+
+    NI_MAXHOST = 1024
+    NI_MAXSERV = 32
+
+    NI_NUMERICHOST = 1       # Don't try to look up hostname.
+    NI_NUMERICSERV = 2       # Don't convert port number to name.
+    NI_NOFQDN      = 4       # Only return nodename portion.
+    NI_NAMEREQD    = 8       # Don't return numeric addresses.
+    NI_DGRAM       = 16      # Look up UDP service rather than TCP.
+
+    # ifaddrs.h
+    attach_function :getifaddrs, [:pointer], :int
+    attach_function :freeifaddrs, [:pointer], :void
+
+    #
+    # Enumerates over the Interface Addresses.
+    #
+    # @yield [ifaddr]
+    #   The given block will be passed each Interface Address.
+    #
+    # @yieldparam [Ifaddrs] ifaddr
+    #   An Interface Address.
+    #
+    # @return [Enumerator]
+    #   If no block is given, an enumerator will be returned.
+    #
+    # @since 0.1.0
+    #
+    def self.each_ifaddr
+      return enum_for(__method__) unless block_given?
+
+      ptr = MemoryPointer.new(:pointer)
+
+      if getifaddrs(ptr) == -1
+        raise_error
+      end
+
+      if (ifaddrs = ptr.get_pointer(0)).null?
+        return
+      end
+
+      ifaddr = Ifaddrs.new(ifaddrs)
+
+      while ifaddr
+        yield ifaddr
+
+        ifaddr = ifaddr.next
+      end
+
+      freeifaddrs(ifaddrs)
+    end
+
+    # bits/resource.h (Linux) / sys/resource.h (Darwin)
+    RUSAGE_SELF = 0
+    RUSAGE_CHILDREN = -1
+    RUSAGE_THREAD = 1 # Linux/glibc only
+
+    attach_function :getrusage, [:int, :pointer], :int
+
+    #
+    # Gets the RUsage for the user.
+    #
+    # @param [RUSAGE_SELF, RUSAGE_CHILDREN, RUSAGE_THREAD] who
+    #   Whome to get RUsage statistics for.
+    #
+    # @return [RUsage]
+    #   The RUsage statistics.
+    #
+    # @raise [RuntimeError]
+    #   An error has occurred.
+    #
+    # @since 0.1.0
+    #
+    def self.rusage(who=RUSAGE_SELF)
+      rusage = RUsage.new
+
+      unless (ret = getrusage(who,rusage)) == 0
+        raise_error(ret)
+      end
+
+      return rusage
+    end
+  end
+end

--- a/lib/ruby/stdlib/ffi/libc.rb
+++ b/lib/ruby/stdlib/ffi/libc.rb
@@ -1,3 +1,5 @@
+# Originally from https://github.com/postmodern/ffi-libc
+
 module FFI
   module LibC
     extend FFI::Library

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -228,6 +228,8 @@ module Fiddle
       else
         ffi_ptr.get_int8(index)
       end
+    rescue FFI::NullPointerError
+      raise DLError.new('NULL pointer dereference')
     end
 
     def []=(index, length = nil, value)
@@ -236,6 +238,8 @@ module Fiddle
       else
         ffi_ptr.put_int8(index, value)
       end
+    rescue FFI::NullPointerError
+      raise DLError.new('NULL pointer dereference')
     end
 
     def to_i

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -160,9 +160,8 @@ module Fiddle
     def initialize(addr, size = 0, freefunc = nil)
       ptr = if addr.is_a?(FFI::Pointer)
               addr
-
-            elsif addr.is_a?(Integer)
-              FFI::Pointer.new(addr)
+            else
+              FFI::Pointer.new(Integer(addr))
             end
 
       @size = size

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -234,7 +234,12 @@ module Fiddle
 
     def []=(index, length = nil, value)
       if length
-        ffi_ptr.put_bytes(index, value, 0, [length, value.bytesize].min)
+        if value.is_a?(Integer)
+          value_str = Pointer.new(value).to_s
+        else
+          value_str = value.to_str
+        end
+        ffi_ptr.put_bytes(index, value_str, 0, [length, value_str.bytesize].min)
       else
         ffi_ptr.put_int8(index, value)
       end

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -263,6 +263,16 @@ module Fiddle
 
     def -(delta)
       self.class.new(ffi_ptr - delta, @size + delta)
+
+    def ==(value)
+      return false unless value.is_a?(Pointer)
+      self.ffi_ptr.address == value.ffi_ptr.address
+    end
+    alias eql? ==
+
+    def <=>(value)
+      return nil unless value.is_a?(Pointer)
+      self.ffi_ptr.address <=> value.ffi_ptr.address
     end
 
     def ptr

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -21,9 +21,14 @@ module Fiddle
   WINDOWS = FFI::Platform.windows?
 
   LibC = FFI::LibC
+  RUBY_FREE = LibC::FREE.address
 
   def self.malloc(size)
     LibC.malloc(size)
+  end
+
+  def self.free(ptr)
+    LibC.free(Pointer.to_native(ptr, nil))
   end
 
   module JRuby

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -142,7 +142,11 @@ module Fiddle
 
       elsif value.respond_to?(:to_ptr)
         ptr = value.to_ptr
-        ptr.is_a?(Pointer) ? ptr : Pointer.new(ptr)
+        if ptr.is_a?(Pointer)
+          ptr
+        else
+          raise DLError.new('to_ptr should return a Fiddle::Pointer object')
+        end
 
       else
         Pointer.new(value)

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -11,6 +11,12 @@ module Fiddle
   TYPE_FLOAT        = 7
   TYPE_DOUBLE       = 8
 
+  TYPE_SIZE_T       = -5
+  TYPE_SSIZE_T      = 5
+  TYPE_PTRDIFF_T    = 5
+  TYPE_INTPTR_T     = 5
+  TYPE_UINTPTR_T    = -5
+
   WINDOWS = FFI::Platform.windows?
 
   module JRuby
@@ -303,4 +309,16 @@ module Fiddle
   SIZEOF_LONG_LONG   = Fiddle::JRuby::FFITypes[TYPE_LONG_LONG].size
   SIZEOF_FLOAT       = Fiddle::JRuby::FFITypes[TYPE_FLOAT].size
   SIZEOF_DOUBLE      = Fiddle::JRuby::FFITypes[TYPE_DOUBLE].size
+
+  ALIGN_SIZE_T       = ALIGN_VOIDP
+  ALIGN_SSIZE_T      = ALIGN_VOIDP
+  ALIGN_PTRDIFF_T    = ALIGN_VOIDP
+  ALIGN_INTPTR_T     = ALIGN_VOIDP
+  ALIGN_UINTPTR_T    = ALIGN_VOIDP
+
+  SIZEOF_SIZE_T      = SIZEOF_VOIDP
+  SIZEOF_SSIZE_T     = SIZEOF_VOIDP
+  SIZEOF_PTRDIFF_T   = SIZEOF_VOIDP
+  SIZEOF_INTPTR_T    = SIZEOF_VOIDP
+  SIZEOF_UINTPTR_T   = SIZEOF_VOIDP
 end

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -250,6 +250,8 @@ module Fiddle
     end
   end
 
+  NULL = Pointer.new(0, 0)
+
   class Handle
     RTLD_GLOBAL = FFI::DynamicLibrary::RTLD_GLOBAL
     RTLD_LAZY = FFI::DynamicLibrary::RTLD_LAZY

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -23,6 +23,8 @@ module Fiddle
   LibC = FFI::LibC
   RUBY_FREE = LibC::FREE.address
 
+  BUILD_RUBY_PLATFORM = RUBY_PLATFORM
+
   def self.malloc(size)
     LibC.malloc(size)
   end

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -200,7 +200,7 @@ module Fiddle
 
     def []=(index, length = nil, value)
       if length
-        ffi_ptr.put_bytes(index, value, 0, length)
+        ffi_ptr.put_bytes(index, value, 0, [length, value.length].min)
       else
         ffi_ptr.put_int8(index, value)
       end

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -78,7 +78,7 @@ module Fiddle
       raise TypeError.new "invalid return type" unless args.is_a?(Array)
 
       @function = FFI::Function.new(
-        __ffi_type__(@ctype),
+        Fiddle::JRuby::__ffi_type__(@ctype),
         @args.map { |t| Fiddle::JRuby.__ffi_type__(t) },
         self,
         :convention => abi

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -192,9 +192,17 @@ module Fiddle
 
     def [](index, length = nil)
       if length
-        ffi_ptr.get_string(index, length)
+        ffi_ptr.get_bytes(index, length)
       else
-        ffi_ptr.get_int(index)
+        ffi_ptr.get_int8(index)
+      end
+    end
+
+    def []=(index, length = nil, value)
+      if length
+        ffi_ptr.put_bytes(index, value, 0, length)
+      else
+        ffi_ptr.put_int8(index, value)
       end
     end
 

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -1,4 +1,5 @@
 require 'ffi'
+require 'ffi/libc'
 
 module Fiddle
   TYPE_VOID         = 0
@@ -18,6 +19,12 @@ module Fiddle
   TYPE_UINTPTR_T    = -5
 
   WINDOWS = FFI::Platform.windows?
+
+  LibC = FFI::LibC
+
+  def self.malloc(size)
+    LibC.malloc(size)
+  end
 
   module JRuby
     FFITypes = {
@@ -63,7 +70,7 @@ module Fiddle
       @ptr, @args, @return_type, @abi = ptr, args, return_type, abi
       raise TypeError.new "invalid return type" unless return_type.is_a?(Integer)
       raise TypeError.new "invalid return type" unless args.is_a?(Array)
-      
+
       @function = FFI::Function.new(
         Fiddle::JRuby::__ffi_type__(@return_type),
         @args.map { |t| Fiddle::JRuby.__ffi_type__(t) },
@@ -171,7 +178,7 @@ module Fiddle
     end
 
     def self.malloc(size, free = nil)
-      self.new(LibC.malloc(size), size, free ? free : LibC::FREE)
+      self.new(Fiddle.malloc(size), size, free ? free : LibC::FREE)
     end
 
     def null?

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -243,14 +243,17 @@ module Fiddle
     end
     alias to_int to_i
 
-    def to_str(len = nil)
+    def to_s(len = nil)
       if len
-        ffi_ptr.get_string(0, len)
+        ffi_ptr.get_bytes(0, len)
       else
         ffi_ptr.get_string(0)
       end
     end
-    alias to_s to_str
+
+    def to_str(len = size)
+      ffi_ptr.get_bytes(0, len)
+    end
 
     def inspect
       "#<#{self.class.name} ptr=#{ffi_ptr.address.to_s(16)} size=#{@size} free=#{@free.to_s(16)}>"

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -258,11 +258,12 @@ module Fiddle
     end
 
     def +(delta)
-      self.class.new(ffi_ptr + delta, @size - delta)
+      self.class.new(ffi_ptr.address + delta, @size - delta)
     end
 
     def -(delta)
-      self.class.new(ffi_ptr - delta, @size + delta)
+      self.class.new(ffi_ptr.address - delta, @size + delta)
+    end
 
     def ==(value)
       return false unless value.is_a?(Pointer)

--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -207,7 +207,7 @@ module Fiddle
 
     def []=(index, length = nil, value)
       if length
-        ffi_ptr.put_bytes(index, value, 0, [length, value.length].min)
+        ffi_ptr.put_bytes(index, value, 0, [length, value.bytesize].min)
       else
         ffi_ptr.put_int8(index, value)
       end

--- a/test/mri/fiddle/helper.rb
+++ b/test/mri/fiddle/helper.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: false
 require 'minitest/autorun'
 require 'fiddle'
+require 'rbconfig'
 
 # FIXME: this is stolen from DL and needs to be refactored.
 
 libc_so = libm_so = nil
 
-case RUBY_PLATFORM
+platform = RUBY_PLATFORM
+platform = RbConfig::CONFIG['target_os'] if platform == 'java'
+
+case platform
 when /cygwin/
   libc_so = "cygwin1.dll"
   libm_so = "cygwin1.dll"


### PR DESCRIPTION
After having some trouble getting Mittsu working in JRuby, I thought I'd have a look at JRuby's Fiddle implementation. There are quite a number of inconsistencies and straight-up broken bits, so I thought I'd take a crack at some of them. This is not a conclusive fix or anything, but hopefully I can get it working enough for most.

Here are the list of the bigger changes:
1. `TYPE_PTRDIFF_T` was not defined. This has been voiced before (#3477). I had a look, and other types such as `TYPE_SIZE_T`, etc. were also missing. I've added all the missing types, basing their byte sizes and alignment on `TYPE_VOIDP`
2. Make `Fiddle::Pointer` behave more like MRI
  a. `#[]` now gets the correct number of bytes, regardless of null-terminators
  b. Added `Pointer#[]=`
  c. `#to_s` and `#to_str` should behave differently when `len` is omitted. Notably, `#to_s` takes in to account null-terminators, while `to_str` uses the Pointer size
  d. Throw `DLError` instead of FFI errors in some cases
  e. `Pointer.new` accepts anything that can be converted to an Integer as an address, using `Integer()`
  f. Added `Pointer#free` and `Pointer#free=`. `@free` is now stored as an integer.
  g. `Pointer.malloc` does not assign a default `free` function to the resulting pointer
  h. Added `Ponter#==` and `Pointer#<=>`
3. Added some missing items in the `Fiddle` module, notably
  a. `Fiddle.malloc` and `Fiddle.free`, which map directly to their `libc` counterparts
  b. `Fiddle::RUBY_FREE`, which is just the Integer memory address of the `libc` `free` function
  c. `Fiddle::BUILD_RUBY_PLATFORM`, which I've just set to `RUBY_PLATFORM`, which is always `"java"`
  d. `Fiddle::NULL`, a null pointer
  e. `Fiddle::LibC`, an FFI wrapper to `libc`, not exactly required, but it serves to facilitate the implementation of `malloc` and `free` (also resolves #3462)
4. Added a check to `fiddle/helper` in the tests, where the location of `libc` dynamic library could not be found because platform is always `"java"`. Changed it so that it uses `RbConfig` to detect the _actual_ OS.

There are a great deal of things I have not been able to address thus far, most notably:
1. `Pointer.to_ptr(string)` makes a copy of the given string instead of wrapping the string itself. This is evident when you attempt to modify the data through the pointer, only to find the string was not modified. This issue affects the case of shovelling into the string, where in JRuby the Pointer data is then not reflected. I believe in order to rectify this we would have to get the address of the underlying `ByteList` of the string, but i worry that this will be infeasible in Java, especially with the JVM not guaranteeing the memory address of all it's object all the time.
2. `Pointer.to_ptr(file)` does not work. Right not it will use `File#to_i` to get the address, which is obviously incorrect. MRI converts the File object to a `libc` FILE, and I am unsure as to how that could be achieved in JRuby.
3. `Fiddle::Function` returns an `FFI::Pointer` instead of `Fiddle::Pointer`. I've made an issue here (#4510)
4. `Fiddle::Function` does not accept certain values where MRI's fiddle does. For example, it does not appear to accept integers in place of pointers, or even subclasses of `Fiddle::Closure` for that matter. This, and point 3, seem to be that `Fiddle::Function` is just a straight-up wrapper of `FFI::Function`, so it only accepts FFI arguments and returns FFI values.
5. Related to point 1, and probably an easy fix, is that `Pointer.to_ptr(string)` returns a Pointer 1 byte bigger than on MRI. I think that probably has to do with null-terminators or something, although the behaviour doesn't seem to be affected if I "fix" the issue. I reverted the fix since I wanted some more input on the matter.

My personal observation is that it seems JRuby's Fiddle implementation was hastily put together on top of FFI once Ruby adopted Fiddle as the defacto foreign-function interface. MRI's Fiddle is written directly on top of libffi, and in C. Perhaps it is time that JRuby's Fiddle was build directly on top of libffi/jffi, and in Java instead of Ruby.
