### PR TITLE
Don't yieldSpecific to allow arrays through normal block params.

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -1085,7 +1085,7 @@ public class RubyEnumerable {
     public static IRubyObject each_entryCommon(ThreadContext context, final IRubyObject self, final IRubyObject[] args, final Block block) {
         callEach(context.runtime, context, self, args, Signature.OPTIONAL, new BlockCallback() {
             public IRubyObject call(ThreadContext ctx, IRubyObject[] largs, Block blk) {
-                return block.yieldSpecific(ctx, packEnumValues(ctx, largs));
+                return block.yield(ctx, packEnumValues(ctx, largs));
             }
         });
         return self;


### PR DESCRIPTION
Fixes #4532.