### PR TITLE
Update to Rubygems 2.6.11

### DIFF
--- a/lib/ruby/stdlib/rubygems.rb
+++ b/lib/ruby/stdlib/rubygems.rb
@@ -10,7 +10,7 @@ require 'rbconfig'
 require 'thread'
 
 module Gem
-  VERSION = "2.6.10"
+  VERSION = "2.6.11"
 end
 
 # Must be first since it unloads the prelude from 1.9.2
@@ -296,7 +296,10 @@ module Gem
 
   def self.activate_bin_path name, exec_name, requirement # :nodoc:
     spec = find_spec_for_exe name, exec_name, [requirement]
-    Gem::LOADED_SPECS_MUTEX.synchronize { spec.activate }
+    Gem::LOADED_SPECS_MUTEX.synchronize do
+      spec.activate
+      finish_resolve
+    end
     spec.bin_file exec_name
   end
 
@@ -355,10 +358,14 @@ module Gem
   # package is not available as a gem, return nil.
 
   def self.datadir(gem_name)
-# TODO: deprecate
     spec = @loaded_specs[gem_name]
     return nil if spec.nil?
     spec.datadir
+  end
+
+  class << self
+    extend Gem::Deprecate
+    deprecate :datadir, "spec.datadir", 2016, 10
   end
 
   ##
@@ -593,7 +600,6 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # Zlib::GzipReader wrapper that unzips +data+.
 
   def self.gunzip(data)
-    require 'rubygems/util'
     Gem::Util.gunzip data
   end
 
@@ -601,7 +607,6 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # Zlib::GzipWriter wrapper that zips +data+.
 
   def self.gzip(data)
-    require 'rubygems/util'
     Gem::Util.gzip data
   end
 
@@ -609,7 +614,6 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   # A Zlib::Inflate#inflate wrapper
 
   def self.inflate(data)
-    require 'rubygems/util'
     Gem::Util.inflate data
   end
 
@@ -1147,8 +1151,6 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     path = path.dup
 
     if path == "-" then
-      require 'rubygems/util'
-
       Gem::Util.traverse_parents Dir.pwd do |directory|
         dep_file = GEM_DEP_FILES.find { |f| File.file?(f) }
 
@@ -1167,18 +1169,24 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
       raise ArgumentError, "Unable to find gem dependencies file at #{path}"
     end
 
-    rs = Gem::RequestSet.new
-    @gemdeps = rs.load_gemdeps path
-
-    rs.resolve_current.map do |s|
-      sp = s.full_spec
-      sp.activate
-      sp
+    ENV["BUNDLE_GEMFILE"] ||= File.expand_path(path)
+    require 'rubygems/user_interaction'
+    Gem::DefaultUserInteraction.use_ui(ui) do
+      require "bundler/postit_trampoline" unless ENV["BUNDLE_TRAMPOLINE_DISABLE"]
+      require "bundler"
+      @gemdeps = Bundler.setup
+      Bundler.ui = nil
+      @gemdeps.requested_specs.map(&:to_spec).sort_by(&:name)
     end
-  rescue Gem::LoadError, Gem::UnsatisfiableDependencyError => e
-    warn e.message
-    warn "You may need to `gem install -g` to install missing gems"
-    warn ""
+  rescue => e
+    case e
+    when Gem::LoadError, Gem::UnsatisfiableDependencyError, (defined?(Bundler::GemNotFound) ? Bundler::GemNotFound : Gem::LoadError)
+      warn e.message
+      warn "You may need to `gem install -g` to install missing gems"
+      warn ""
+    else
+      raise
+    end
   end
 
   class << self
@@ -1224,6 +1232,8 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
         prefix_pattern = /^(#{prefix_group})/
       end
 
+      suffix_pattern = /#{Regexp.union(Gem.suffixes)}\z/
+
       spec.files.each do |file|
         if new_format
           file = file.sub(prefix_pattern, "")
@@ -1231,6 +1241,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
         end
 
         @path_to_default_spec_map[file] = spec
+        @path_to_default_spec_map[file.sub(suffix_pattern, "")] = spec
       end
     end
 
@@ -1238,11 +1249,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
     # Find a Gem::Specification of default gem from +path+
 
     def find_unresolved_default_spec(path)
-      Gem.suffixes.each do |suffix|
-        spec = @path_to_default_spec_map["#{path}#{suffix}"]
-        return spec if spec
-      end
-      nil
+      @path_to_default_spec_map[path]
     end
 
     ##
@@ -1328,6 +1335,7 @@ An Array (#{env.inspect}) was passed in from #{caller[3]}
   autoload :SourceList,         'rubygems/source_list'
   autoload :SpecFetcher,        'rubygems/spec_fetcher'
   autoload :Specification,      'rubygems/specification'
+  autoload :Util,               'rubygems/util'
   autoload :Version,            'rubygems/version'
 
   require "rubygems/specification"

--- a/lib/ruby/stdlib/rubygems/basic_specification.rb
+++ b/lib/ruby/stdlib/rubygems/basic_specification.rb
@@ -71,7 +71,7 @@ class Gem::BasicSpecification
     elsif missing_extensions? then
       @ignored = true
 
-      warn "Ignoring #{full_name} because its extensions are not built.  " +
+      warn "Ignoring #{full_name} because its extensions are not built. " +
         "Try: gem pristine #{name} --version #{version}"
       return false
     end

--- a/lib/ruby/stdlib/rubygems/command.rb
+++ b/lib/ruby/stdlib/rubygems/command.rb
@@ -527,7 +527,7 @@ class Gem::Command
   end
 
   add_common_option("--silent",
-                    "Silence rubygems output") do |value, options|
+                    "Silence RubyGems output") do |value, options|
     options[:silent] = true
   end
 

--- a/lib/ruby/stdlib/rubygems/command_manager.rb
+++ b/lib/ruby/stdlib/rubygems/command_manager.rb
@@ -161,7 +161,7 @@ class Gem::CommandManager
       say Gem::VERSION
       terminate_interaction 0
     when /^-/ then
-      alert_error "Invalid option: #{args.first}.  See 'gem --help'."
+      alert_error "Invalid option: #{args.first}. See 'gem --help'."
       terminate_interaction 1
     else
       cmd_name = args.shift.downcase

--- a/lib/ruby/stdlib/rubygems/commands/cert_command.rb
+++ b/lib/ruby/stdlib/rubygems/commands/cert_command.rb
@@ -84,6 +84,11 @@ class Gem::Commands::CertCommand < Gem::Command
 
       options[:sign] << cert_file
     end
+
+    add_option('-d', '--days NUMBER_OF_DAYS',
+               'Days before the certificate expires') do |days, options|
+                options[:expiration_length_days] = days.to_i
+    end
   end
 
   def add_certificate certificate # :nodoc:
@@ -105,16 +110,20 @@ class Gem::Commands::CertCommand < Gem::Command
       list_certificates_matching filter
     end
 
-    options[:build].each do |name|
-      build name
+    options[:build].each do |email|
+      build email
     end
 
     sign_certificates unless options[:sign].empty?
   end
 
-  def build name
+  def build email
+    if !valid_email?(email)
+      raise Gem::CommandLineError, "Invalid email address #{email}"
+    end
+
     key, key_path = build_key
-    cert_path = build_cert name, key
+    cert_path = build_cert email, key
 
     say "Certificate: #{cert_path}"
 
@@ -124,8 +133,16 @@ class Gem::Commands::CertCommand < Gem::Command
     end
   end
 
-  def build_cert name, key # :nodoc:
-    cert = Gem::Security.create_cert_email name, key
+  def build_cert email, key # :nodoc:
+    expiration_length_days = options[:expiration_length_days]
+    age =
+      if expiration_length_days.nil? || expiration_length_days == 0
+        Gem::Security::ONE_YEAR
+      else
+        Gem::Security::ONE_DAY * expiration_length_days
+      end
+
+    cert = Gem::Security.create_cert_email email, key, age
     Gem::Security.write cert, "gem-public_cert.pem"
   end
 
@@ -272,6 +289,14 @@ For further reading on signing gems see `ri Gem::Security`.
       sign cert_file
     end
   end
+
+  private
+
+  def valid_email? email
+    # It's simple, but is all we need
+    email =~ /\A.+@.+\z/
+  end
+
 
 end if defined?(OpenSSL::SSL)
 

--- a/lib/ruby/stdlib/rubygems/commands/cleanup_command.rb
+++ b/lib/ruby/stdlib/rubygems/commands/cleanup_command.rb
@@ -66,7 +66,7 @@ If no gems are named all gems in GEM_HOME are cleaned.
       clean_gems
     end
 
-    say "Clean Up Complete"
+    say "Clean up complete"
 
     verbose do
       skipped = @default_gems.map { |spec| spec.full_name }

--- a/lib/ruby/stdlib/rubygems/commands/help_command.rb
+++ b/lib/ruby/stdlib/rubygems/commands/help_command.rb
@@ -367,7 +367,7 @@ platform.
     elsif possibilities.size > 1 then
       alert_warning "Ambiguous command #{command_name} (#{possibilities.join(', ')})"
     else
-      alert_warning "Unknown command #{command_name}.  Try: gem help commands"
+      alert_warning "Unknown command #{command_name}. Try: gem help commands"
     end
   end
 

--- a/lib/ruby/stdlib/rubygems/commands/owner_command.rb
+++ b/lib/ruby/stdlib/rubygems/commands/owner_command.rb
@@ -40,7 +40,9 @@ permission to.
       options[:remove] << value
     end
 
-    add_option '-h', '--host HOST', 'Use another gemcutter-compatible host' do |value, options|
+    add_option '-h', '--host HOST',
+               'Use another gemcutter-compatible host',
+               '  (e.g. https://rubygems.org)' do |value, options|
       options[:host] = value
     end
   end

--- a/lib/ruby/stdlib/rubygems/commands/push_command.rb
+++ b/lib/ruby/stdlib/rubygems/commands/push_command.rb
@@ -33,7 +33,8 @@ command.  For further discussion see the help for the yank command.
     add_key_option
 
     add_option('--host HOST',
-               'Push to another gemcutter-compatible host') do |value, options|
+               'Push to another gemcutter-compatible host',
+               '  (e.g. https://rubygems.org)') do |value, options|
       options[:host] = value
     end
 

--- a/lib/ruby/stdlib/rubygems/commands/query_command.rb
+++ b/lib/ruby/stdlib/rubygems/commands/query_command.rb
@@ -255,22 +255,21 @@ is too hard to use.
         name_tuples.map { |n| n.version }.uniq
       else
         platforms.sort.reverse.map do |version, pls|
-          if pls == [Gem::Platform::RUBY] then
-            if options[:domain] == :remote || specs.all? { |spec| spec.is_a? Gem::Source }
-              version
-            else
-              spec = specs.select { |s| s.version == version }
-              if spec.first.default_gem?
-                "default: #{version}"
-              else
-                version
-              end
+          out = version.to_s
+
+          if options[:domain] == :local
+            default = specs.any? do |s|
+              !s.is_a?(Gem::Source) && s.version == version && s.default_gem?
             end
-          else
-            ruby = pls.delete Gem::Platform::RUBY
-            platform_list = [ruby, *pls.sort].compact
-            "#{version} #{platform_list.join ' '}"
+            out = "default: #{out}" if default
           end
+
+          if pls != [Gem::Platform::RUBY] then
+            platform_list = [pls.delete(Gem::Platform::RUBY), *pls.sort].compact
+            out = platform_list.unshift(out).join(' ')
+          end
+
+          out
         end
       end
 

--- a/lib/ruby/stdlib/rubygems/commands/which_command.rb
+++ b/lib/ruby/stdlib/rubygems/commands/which_command.rb
@@ -56,7 +56,7 @@ requiring to see why it does not behave as you expect.
       paths = find_paths arg, dirs
 
       if paths.empty? then
-        alert_error "Can't find ruby library file or shared library #{arg}"
+        alert_error "Can't find Ruby library file or shared library #{arg}"
 
         found &&= false
       else

--- a/lib/ruby/stdlib/rubygems/commands/yank_command.rb
+++ b/lib/ruby/stdlib/rubygems/commands/yank_command.rb
@@ -42,7 +42,8 @@ as the reason for the removal request.
     add_platform_option("remove")
 
     add_option('--host HOST',
-               'Yank from another gemcutter-compatible host') do |value, options|
+               'Yank from another gemcutter-compatible host',
+               '  (e.g. https://rubygems.org)') do |value, options|
       options[:host] = value
     end
 

--- a/lib/ruby/stdlib/rubygems/config_file.rb
+++ b/lib/ruby/stdlib/rubygems/config_file.rb
@@ -419,31 +419,11 @@ if you believe they were disclosed to a third party.
   # to_yaml only overwrites things you can't override on the command line.
   def to_yaml # :nodoc:
     yaml_hash = {}
-    yaml_hash[:backtrace] = if @hash.key?(:backtrace)
-                              @hash[:backtrace]
-                            else
-                              DEFAULT_BACKTRACE
-                            end
-
-    yaml_hash[:bulk_threshold] = if @hash.key?(:bulk_threshold)
-                                   @hash[:bulk_threshold]
-                                 else
-                                   DEFAULT_BULK_THRESHOLD
-                                 end
-
+    yaml_hash[:backtrace] = @hash.fetch(:backtrace, DEFAULT_BACKTRACE)
+    yaml_hash[:bulk_threshold] = @hash.fetch(:bulk_threshold, DEFAULT_BULK_THRESHOLD)
     yaml_hash[:sources] = Gem.sources.to_a
-
-    yaml_hash[:update_sources] = if @hash.key?(:update_sources)
-                                   @hash[:update_sources]
-                                 else
-                                   DEFAULT_UPDATE_SOURCES
-                                 end
-
-    yaml_hash[:verbose] = if @hash.key?(:verbose)
-                            @hash[:verbose]
-                          else
-                            DEFAULT_VERBOSITY
-                          end
+    yaml_hash[:update_sources] = @hash.fetch(:update_sources, DEFAULT_UPDATE_SOURCES)
+    yaml_hash[:verbose] = @hash.fetch(:verbose, DEFAULT_VERBOSITY)
 
     yaml_hash[:ssl_verify_mode] =
       @hash[:ssl_verify_mode] if @hash.key? :ssl_verify_mode

--- a/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb
+++ b/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb
@@ -41,8 +41,7 @@ module Kernel
 
     path = path.to_path if path.respond_to? :to_path
 
-    spec = Gem.find_unresolved_default_spec(path)
-    if spec
+    if spec = Gem.find_unresolved_default_spec(path)
       Gem.remove_unresolved_default_spec(spec)
       Kernel.send(:gem, spec.name)
     end
@@ -61,12 +60,10 @@ module Kernel
     #--
     # TODO request access to the C implementation of this to speed up RubyGems
 
-    spec = Gem::Specification.find_active_stub_by_path path
-
-    begin
+    if Gem::Specification.find_active_stub_by_path(path)
       RUBYGEMS_ACTIVATION_MONITOR.exit
       return gem_original_require(path)
-    end if spec
+    end
 
     # Attempt to find +path+ in any unresolved gems...
 
@@ -104,7 +101,7 @@ module Kernel
 
       # Ok, now find a gem that has no conflicts, starting
       # at the highest version.
-      valid = found_specs.reject { |s| s.has_conflicts? }.first
+      valid = found_specs.find { |s| !s.has_conflicts? }
 
       unless valid then
         le = Gem::LoadError.new "unable to find a version of '#{names.first}' to activate"
@@ -138,4 +135,3 @@ module Kernel
   private :require
 
 end
-

--- a/lib/ruby/stdlib/rubygems/dependency_installer.rb
+++ b/lib/ruby/stdlib/rubygems/dependency_installer.rb
@@ -7,6 +7,7 @@ require 'rubygems/spec_fetcher'
 require 'rubygems/user_interaction'
 require 'rubygems/source'
 require 'rubygems/available_set'
+require 'rubygems/deprecate'
 
 ##
 # Installs a gem along with all its dependencies from local and remote gems.
@@ -45,6 +46,9 @@ class Gem::DependencyInstaller
   # TODO remove, no longer used
 
   attr_reader :gems_to_install # :nodoc:
+
+  extend Gem::Deprecate
+  deprecate :gems_to_install, :none, 2016, 10
 
   ##
   # List of gems installed by #install in alphabetic order

--- a/lib/ruby/stdlib/rubygems/exceptions.rb
+++ b/lib/ruby/stdlib/rubygems/exceptions.rb
@@ -154,6 +154,12 @@ class Gem::ImpossibleDependenciesError < Gem::Exception
 end
 
 class Gem::InstallError < Gem::Exception; end
+class Gem::RuntimeRequirementNotMetError < Gem::InstallError
+  attr_accessor :suggestion
+  def message
+    [suggestion, super].compact.join("\n\t")
+  end
+end
 
 ##
 # Potentially raised when a specification is validated.

--- a/lib/ruby/stdlib/rubygems/ext/builder.rb
+++ b/lib/ruby/stdlib/rubygems/ext/builder.rb
@@ -183,7 +183,7 @@ EOF
     return if @spec.extensions.empty?
 
     if @build_args.empty?
-      say "Building native extensions.  This could take a while..."
+      say "Building native extensions. This could take a while..."
     else
       say "Building native extensions with: '#{@build_args.join ' '}'"
       say "This could take a while..."

--- a/lib/ruby/stdlib/rubygems/gem_runner.rb
+++ b/lib/ruby/stdlib/rubygems/gem_runner.rb
@@ -8,6 +8,7 @@
 require 'rubygems'
 require 'rubygems/command_manager'
 require 'rubygems/config_file'
+require 'rubygems/deprecate'
 
 ##
 # Load additional plugins from $LOAD_PATH
@@ -26,7 +27,10 @@ Gem.load_env_plugins rescue nil
 class Gem::GemRunner
 
   def initialize(options={})
-    # TODO: nuke these options
+    if !options.empty? && !Gem::Deprecate.skip
+      Kernel.warn "NOTE: passing options to Gem::GemRunner.new is deprecated with no replacement. It will be removed on or after 2016-10-01."
+    end
+
     @command_manager_class = options[:command_manager] || Gem::CommandManager
     @config_file_class = options[:config_file] || Gem::ConfigFile
   end

--- a/lib/ruby/stdlib/rubygems/install_update_options.rb
+++ b/lib/ruby/stdlib/rubygems/install_update_options.rb
@@ -6,37 +6,18 @@
 #++
 
 require 'rubygems'
-
-# forward-declare
-
-module Gem::Security # :nodoc:
-  class Policy # :nodoc:
-  end
-end
+require 'rubygems/security_option'
 
 ##
 # Mixin methods for install and update options for Gem::Commands
 
 module Gem::InstallUpdateOptions
+  include Gem::SecurityOption
 
   ##
   # Add the install/update options to the option parser.
 
   def add_install_update_options
-    # TODO: use @parser.accept
-    OptionParser.accept Gem::Security::Policy do |value|
-      require 'rubygems/security'
-
-      raise OptionParser::InvalidArgument, 'OpenSSL not installed' unless
-        defined?(Gem::Security::HighSecurity)
-
-      value = Gem::Security::Policies[value]
-      valid = Gem::Security::Policies.keys.sort
-      message = "#{value} (#{valid.join ', '} are valid)"
-      raise OptionParser::InvalidArgument, message if value.nil?
-      value
-    end
-
     add_option(:"Install/Update", '-i', '--install-dir DIR',
                'Gem repository directory to get installed',
                'gems') do |value, options|
@@ -124,11 +105,7 @@ module Gem::InstallUpdateOptions
       options[:wrappers] = value
     end
 
-    add_option(:"Install/Update", '-P', '--trust-policy POLICY',
-               Gem::Security::Policy,
-               'Specify gem trust policy') do |value, options|
-      options[:security_policy] = value
-    end
+    add_security_option
 
     add_option(:"Install/Update", '--ignore-dependencies',
                'Do not install any required dependent gems') do |value, options|
@@ -136,8 +113,8 @@ module Gem::InstallUpdateOptions
     end
 
     add_option(:"Install/Update",       '--[no-]format-executable',
-               'Make installed executable names match ruby.',
-               'If ruby is ruby18, foo_exec will be',
+               'Make installed executable names match Ruby.',
+               'If Ruby is ruby18, foo_exec will be',
                'foo_exec18') do |value, options|
       options[:format_executable] = value
     end

--- a/lib/ruby/stdlib/rubygems/installer.rb
+++ b/lib/ruby/stdlib/rubygems/installer.rb
@@ -608,7 +608,9 @@ class Gem::Installer
   def ensure_required_ruby_version_met # :nodoc:
     if rrv = spec.required_ruby_version then
       unless rrv.satisfied_by? Gem.ruby_version then
-        raise Gem::InstallError, "#{spec.name} requires Ruby version #{rrv}."
+        ruby_version = Gem.ruby_api_version
+        raise Gem::RuntimeRequirementNotMetError,
+          "#{spec.name} requires Ruby version #{rrv}. The current ruby version is #{ruby_version}."
       end
     end
   end
@@ -616,8 +618,9 @@ class Gem::Installer
   def ensure_required_rubygems_version_met # :nodoc:
     if rrgv = spec.required_rubygems_version then
       unless rrgv.satisfied_by? Gem.rubygems_version then
-        raise Gem::InstallError,
-          "#{spec.name} requires RubyGems version #{rrgv}. " +
+        rg_version = Gem::VERSION
+        raise Gem::RuntimeRequirementNotMetError,
+          "#{spec.name} requires RubyGems version #{rrgv}. The current RubyGems version is #{rg_version}. " +
           "Try 'gem update --system' to update RubyGems itself."
       end
     end

--- a/lib/ruby/stdlib/rubygems/installer_test_case.rb
+++ b/lib/ruby/stdlib/rubygems/installer_test_case.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'rubygems/test_case'
 require 'rubygems/installer'
+require 'rubygems/deprecate'
 
 class Gem::Installer
 
@@ -72,7 +73,7 @@ class Gem::InstallerTestCase < Gem::TestCase
   #   a spec named 'a', intended for regular installs
   # @user_spec::
   #   a spec named 'b', intended for user installs
-
+  #
   # @gem::
   #   the path to a built gem from @spec
   # @user_spec::
@@ -107,14 +108,16 @@ class Gem::InstallerTestCase < Gem::TestCase
   end
 
   def util_gem_bindir spec = @spec # :nodoc:
-    # TODO: deprecate
     spec.bin_dir
   end
 
   def util_gem_dir spec = @spec # :nodoc:
-    # TODO: deprecate
     spec.gem_dir
   end
+
+  extend Gem::Deprecate
+  deprecate :util_gem_bindir, "@spec.bin_dir", 2016, 10
+  deprecate :util_gem_dir, "@spec.gem_dir", 2016, 10
 
   ##
   # The path where installed executables live

--- a/lib/ruby/stdlib/rubygems/package/old.rb
+++ b/lib/ruby/stdlib/rubygems/package/old.rb
@@ -124,7 +124,7 @@ class Gem::Package::Old < Gem::Package
       break unless line
     end
 
-    raise Gem::Exception, "Failed to find end of ruby script while reading gem"
+    raise Gem::Exception, "Failed to find end of Ruby script while reading gem"
   end
 
   ##

--- a/lib/ruby/stdlib/rubygems/request.rb
+++ b/lib/ruby/stdlib/rubygems/request.rb
@@ -83,7 +83,7 @@ class Gem::Request
                  e.message =~ / -- openssl$/
 
     raise Gem::Exception.new(
-            'Unable to require openssl, install OpenSSL and rebuild ruby (preferred) or use non-HTTPS sources')
+            'Unable to require openssl, install OpenSSL and rebuild Ruby (preferred) or use non-HTTPS sources')
   end
 
   def self.verify_certificate store_context

--- a/lib/ruby/stdlib/rubygems/request_set.rb
+++ b/lib/ruby/stdlib/rubygems/request_set.rb
@@ -163,9 +163,26 @@ class Gem::RequestSet
         end
       end
 
-      spec = req.spec.install options do |installer|
-        yield req, installer if block_given?
-      end
+      spec =
+        begin
+          req.spec.install options do |installer|
+            yield req, installer if block_given?
+          end
+        rescue Gem::RuntimeRequirementNotMetError => e
+          recent_match = req.spec.set.find_all(req.request).sort_by(&:version).reverse_each.find do |s|
+            s = s.spec
+            s.required_ruby_version.satisfied_by?(Gem.ruby_version) && s.required_rubygems_version.satisfied_by?(Gem.rubygems_version)
+          end
+          if recent_match
+            suggestion = "The last version of #{req.request} to support your Ruby & RubyGems was #{recent_match.version}. Try installing it with `gem install #{recent_match.name} -v #{recent_match.version}`"
+            suggestion += " and then running the current command again" unless @always_install.include?(req.spec.spec)
+          else
+            suggestion = "There are no versions of #{req.request} compatible with your Ruby & RubyGems"
+            suggestion += ". Maybe try installing an older version of the gem you're looking for?" unless @always_install.include?(req.spec.spec)
+          end
+          e.suggestion = suggestion
+          raise
+        end
 
       requests << spec
     end

--- a/lib/ruby/stdlib/rubygems/request_set/gem_dependency_api.rb
+++ b/lib/ruby/stdlib/rubygems/request_set/gem_dependency_api.rb
@@ -786,7 +786,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
     engine_version = options[:engine_version]
 
     raise ArgumentError,
-          'you must specify engine_version along with the ruby engine' if
+          'You must specify engine_version along with the Ruby engine' if
             engine and not engine_version
 
     return true if @installing
@@ -799,7 +799,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
     end
 
     if engine and engine != Gem.ruby_engine then
-      message = "Your ruby engine is #{Gem.ruby_engine}, " +
+      message = "Your Ruby engine is #{Gem.ruby_engine}, " +
                 "but your #{gem_deps_file} requires #{engine}"
 
       raise Gem::RubyVersionMismatch, message
@@ -810,7 +810,7 @@ Gem dependencies file #{@path} includes git reference for both ref/branch and ta
 
       if engine_version != my_engine_version then
         message =
-          "Your ruby engine version is #{Gem.ruby_engine} #{my_engine_version}, " +
+          "Your Ruby engine version is #{Gem.ruby_engine} #{my_engine_version}, " +
           "but your #{gem_deps_file} requires #{engine} #{engine_version}"
 
         raise Gem::RubyVersionMismatch, message

--- a/lib/ruby/stdlib/rubygems/request_set/lockfile/tokenizer.rb
+++ b/lib/ruby/stdlib/rubygems/request_set/lockfile/tokenizer.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'strscan'
 require 'rubygems/request_set/lockfile/parser'
 
 class Gem::RequestSet::Lockfile::Tokenizer
@@ -58,6 +57,7 @@ class Gem::RequestSet::Lockfile::Tokenizer
   private
 
   def tokenize input
+    require 'strscan'
     s = StringScanner.new input
 
     until s.eos? do

--- a/lib/ruby/stdlib/rubygems/requirement.rb
+++ b/lib/ruby/stdlib/rubygems/requirement.rb
@@ -51,7 +51,11 @@ class Gem::Requirement
   # If the input is "weird", the default version requirement is
   # returned.
 
-  def self.create input
+  def self.create *inputs
+    return new inputs if inputs.length > 1
+
+    input = inputs.shift
+
     case input
     when Gem::Requirement then
       input

--- a/lib/ruby/stdlib/rubygems/resolver.rb
+++ b/lib/ruby/stdlib/rubygems/resolver.rb
@@ -4,9 +4,6 @@ require 'rubygems/exceptions'
 require 'rubygems/util'
 require 'rubygems/util/list'
 
-require 'uri'
-require 'net/http'
-
 ##
 # Given a set of Gem::Dependency objects as +needed+ and a way to query the
 # set of available specs via +set+, calculates a set of ActivationRequest
@@ -233,8 +230,29 @@ class Gem::Resolver
       exc.errors = @set.errors
       raise exc
     end
-    possibles.sort_by { |s| [s.source, s.version, Gem::Platform.local =~ s.platform ? 1 : 0] }.
-      map { |s| ActivationRequest.new s, dependency, [] }
+
+    sources = []
+
+    groups = Hash.new { |hash, key| hash[key] = [] }
+
+    possibles.each do |spec|
+      source = spec.source
+
+      sources << source unless sources.include? source
+
+      groups[source] << spec
+    end
+
+    activation_requests = []
+
+    sources.sort.each do |source|
+      groups[source].
+        sort_by { |spec| [spec.version, Gem::Platform.local =~ spec.platform ? 1 : 0] }.
+        map { |spec| ActivationRequest.new spec, dependency, [] }.
+        each { |activation_request| activation_requests << activation_request }
+    end
+
+    activation_requests
   end
 
   def dependencies_for(specification)
@@ -255,6 +273,44 @@ class Gem::Resolver
     @missing << dependency
     @soft_missing
   end
+
+  def sort_dependencies(dependencies, activated, conflicts)
+    dependencies.sort_by do |dependency|
+      name = name_for(dependency)
+      [
+        activated.vertex_named(name).payload ? 0 : 1,
+        amount_constrained(dependency),
+        conflicts[name] ? 0 : 1,
+        activated.vertex_named(name).payload ? 0 : search_for(dependency).count,
+      ]
+    end
+  end
+
+  SINGLE_POSSIBILITY_CONSTRAINT_PENALTY = 1_000_000
+  private_constant :SINGLE_POSSIBILITY_CONSTRAINT_PENALTY if defined?(private_constant)
+
+  # returns an integer \in (-\infty, 0]
+  # a number closer to 0 means the dependency is less constraining
+  #
+  # dependencies w/ 0 or 1 possibilities (ignoring version requirements)
+  # are given very negative values, so they _always_ sort first,
+  # before dependencies that are unconstrained
+  def amount_constrained(dependency)
+    @amount_constrained ||= {}
+    @amount_constrained[dependency.name] ||= begin
+      name_dependency = Gem::Dependency.new(dependency.name)
+      dependency_request_for_name = Gem::Resolver::DependencyRequest.new(name_dependency, dependency.requester)
+      all = @set.find_all(dependency_request_for_name).size
+
+      if all <= 1
+        all - SINGLE_POSSIBILITY_CONSTRAINT_PENALTY
+      else
+        search = search_for(dependency).size
+        search - all
+      end
+    end
+  end
+  private :amount_constrained
 
 end
 

--- a/lib/ruby/stdlib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph.rb
+++ b/lib/ruby/stdlib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph.rb
@@ -98,18 +98,27 @@ module Gem::Resolver::Molinillo
       "#{self.class}:#{vertices.values.inspect}"
     end
 
+    # @param [Hash] options options for dot output.
     # @return [String] Returns a dot format representation of the graph
-    def to_dot
+    def to_dot(options = {})
+      edge_label = options.delete(:edge_label)
+      raise ArgumentError, "Unknown options: #{options.keys}" unless options.empty?
+
       dot_vertices = []
       dot_edges = []
       vertices.each do |n, v|
         dot_vertices << "  #{n} [label=\"{#{n}|#{v.payload}}\"]"
         v.outgoing_edges.each do |e|
-          dot_edges << "  #{e.origin.name} -> #{e.destination.name} [label=\"#{e.requirement}\"]"
+          label = edge_label ? edge_label.call(e) : e.requirement
+          dot_edges << "  #{e.origin.name} -> #{e.destination.name} [label=#{label.to_s.dump}]"
         end
       end
+
+      dot_vertices.uniq!
       dot_vertices.sort!
+      dot_edges.uniq!
       dot_edges.sort!
+
       dot = dot_vertices.unshift('digraph G {').push('') + dot_edges.push('}')
       dot.join("\n")
     end
@@ -123,7 +132,8 @@ module Gem::Resolver::Molinillo
       vertices.each do |name, vertex|
         other_vertex = other.vertex_named(name)
         return false unless other_vertex
-        return false unless other_vertex.successors.map(&:name).to_set == vertex.successors.map(&:name).to_set
+        return false unless vertex.payload == other_vertex.payload
+        return false unless other_vertex.successors.to_set == vertex.successors.to_set
       end
     end
 

--- a/lib/ruby/stdlib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/add_edge_no_circular.rb
+++ b/lib/ruby/stdlib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/add_edge_no_circular.rb
@@ -23,8 +23,8 @@ module Gem::Resolver::Molinillo
       # (see Action#down)
       def down(graph)
         edge = make_edge(graph)
-        edge.origin.outgoing_edges.delete(edge)
-        edge.destination.incoming_edges.delete(edge)
+        delete_first(edge.origin.outgoing_edges, edge)
+        delete_first(edge.destination.incoming_edges, edge)
       end
 
       # @!group AddEdgeNoCircular
@@ -52,6 +52,13 @@ module Gem::Resolver::Molinillo
         @origin = origin
         @destination = destination
         @requirement = requirement
+      end
+
+      private
+
+      def delete_first(array, item)
+        return unless index = array.index(item)
+        array.delete_at(index)
       end
     end
   end

--- a/lib/ruby/stdlib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/vertex.rb
+++ b/lib/ruby/stdlib/rubygems/resolver/molinillo/lib/molinillo/dependency_graph/vertex.rb
@@ -10,7 +10,7 @@ module Gem::Resolver::Molinillo
       # @return [Object] the payload the vertex holds
       attr_accessor :payload
 
-      # @return [Arrary<Object>] the explicit requirements that required
+      # @return [Array<Object>] the explicit requirements that required
       #   this vertex
       attr_reader :explicit_requirements
 

--- a/lib/ruby/stdlib/rubygems/resolver/molinillo/lib/molinillo/gem_metadata.rb
+++ b/lib/ruby/stdlib/rubygems/resolver/molinillo/lib/molinillo/gem_metadata.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 module Gem::Resolver::Molinillo
   # The version of Gem::Resolver::Molinillo.
-  VERSION = '0.5.5'.freeze
+  VERSION = '0.5.7'.freeze
 end

--- a/lib/ruby/stdlib/rubygems/resolver/molinillo/lib/molinillo/modules/ui.rb
+++ b/lib/ruby/stdlib/rubygems/resolver/molinillo/lib/molinillo/modules/ui.rb
@@ -48,7 +48,7 @@ module Gem::Resolver::Molinillo
       if debug?
         debug_info = yield
         debug_info = debug_info.inspect unless debug_info.is_a?(String)
-        output.puts debug_info.split("\n").map { |s| '  ' * depth + s }
+        output.puts debug_info.split("\n").map { |s| ' ' * depth + s }
       end
     end
 

--- a/lib/ruby/stdlib/rubygems/resolver/molinillo/lib/molinillo/resolution.rb
+++ b/lib/ruby/stdlib/rubygems/resolver/molinillo/lib/molinillo/resolution.rb
@@ -52,7 +52,7 @@ module Gem::Resolver::Molinillo
         @base = base
         @states = []
         @iteration_counter = 0
-        @parent_of = {}
+        @parents_of = Hash.new { |h, k| h[k] = [] }
       end
 
       # Resolves the {#original_requested} dependencies into a full dependency
@@ -105,7 +105,7 @@ module Gem::Resolver::Molinillo
 
         handle_missing_or_push_dependency_state(initial_state)
 
-        debug { "Starting resolution (#{@started_at})" }
+        debug { "Starting resolution (#{@started_at})\nUser-requested dependencies: #{original_requested}" }
         resolver_ui.before_resolution
       end
 
@@ -178,14 +178,14 @@ module Gem::Resolver::Molinillo
       # Unwinds the states stack because a conflict has been encountered
       # @return [void]
       def unwind_for_conflict
-        debug(depth) { "Unwinding for conflict: #{requirement}" }
+        debug(depth) { "Unwinding for conflict: #{requirement} to #{state_index_for_unwind / 2}" }
         conflicts.tap do |c|
           sliced_states = states.slice!((state_index_for_unwind + 1)..-1)
           raise VersionConflict.new(c) unless state
           activated.rewind_to(sliced_states.first || :initial_state) if sliced_states
           state.conflicts = c
           index = states.size - 1
-          @parent_of.reject! { |_, i| i >= index }
+          @parents_of.each { |_, a| a.reject! { |i| i >= index } }
         end
       end
 
@@ -214,7 +214,7 @@ module Gem::Resolver::Molinillo
       #   to the list of requirements.
       def parent_of(requirement)
         return unless requirement
-        return unless index = @parent_of[requirement]
+        return unless index = @parents_of[requirement].last
         return unless parent_state = @states[index]
         parent_state.requirement
       end
@@ -356,16 +356,25 @@ module Gem::Resolver::Molinillo
       # Ensures there are no orphaned successors to the given {vertex}.
       # @param [DependencyGraph::Vertex] vertex the vertex to fix up.
       # @return [void]
-      def fixup_swapped_children(vertex)
+      def fixup_swapped_children(vertex) # rubocop:disable Metrics/CyclomaticComplexity
         payload = vertex.payload
         deps = dependencies_for(payload).group_by(&method(:name_for))
         vertex.outgoing_edges.each do |outgoing_edge|
-          @parent_of[outgoing_edge.requirement] = states.size - 1
+          requirement = outgoing_edge.requirement
+          parent_index = @parents_of[requirement].last
           succ = outgoing_edge.destination
           matching_deps = Array(deps[succ.name])
+          dep_matched = matching_deps.include?(requirement)
+
+          # only push the current index when it was originally required by the
+          # same named spec
+          if parent_index && states[parent_index].name == name
+            @parents_of[requirement].push(states.size - 1)
+          end
+
           if matching_deps.empty? && !succ.root? && succ.predecessors.to_a == [vertex]
             debug(depth) { "Removing orphaned spec #{succ.name} after swapping #{name}" }
-            succ.requirements.each { |r| @parent_of.delete(r) }
+            succ.requirements.each { |r| @parents_of.delete(r) }
 
             removed_names = activated.detach_vertex_named(succ.name).map(&:name)
             requirements.delete_if do |r|
@@ -373,9 +382,14 @@ module Gem::Resolver::Molinillo
               # so it's safe to delete only based upon name here
               removed_names.include?(name_for(r))
             end
-          elsif !matching_deps.include?(outgoing_edge.requirement)
+          elsif !dep_matched
+            debug(depth) { "Removing orphaned dependency #{requirement} after swapping #{name}" }
+            # also reset if we're removing the edge, but only if its parent has
+            # already been fixed up
+            @parents_of[requirement].push(states.size - 1) if @parents_of[requirement].empty?
+
             activated.delete_edge(outgoing_edge)
-            requirements.delete(outgoing_edge.requirement)
+            requirements.delete(requirement)
           end
         end
       end
@@ -395,13 +409,18 @@ module Gem::Resolver::Molinillo
       # @return [Boolean] whether the current spec is satisfied as a new
       # possibility.
       def new_spec_satisfied?
+        unless requirement_satisfied_by?(requirement, activated, possibility)
+          debug(depth) { 'Unsatisfied by requested spec' }
+          return false
+        end
+
         locked_requirement = locked_requirement_named(name)
-        requested_spec_satisfied = requirement_satisfied_by?(requirement, activated, possibility)
+
         locked_spec_satisfied = !locked_requirement ||
           requirement_satisfied_by?(locked_requirement, activated, possibility)
-        debug(depth) { 'Unsatisfied by requested spec' } unless requested_spec_satisfied
         debug(depth) { 'Unsatisfied by locked spec' } unless locked_spec_satisfied
-        requested_spec_satisfied && locked_spec_satisfied
+
+        locked_spec_satisfied
       end
 
       # @param [String] requirement_name the spec name to search for
@@ -417,7 +436,7 @@ module Gem::Resolver::Molinillo
       # @return [void]
       def activate_spec
         conflicts.delete(name)
-        debug(depth) { 'Activated ' + name + ' at ' + possibility.to_s }
+        debug(depth) { "Activated #{name} at #{possibility}" }
         activated.set_payload(name, possibility)
         require_nested_dependencies_for(possibility)
       end
@@ -432,7 +451,8 @@ module Gem::Resolver::Molinillo
         nested_dependencies.each do |d|
           activated.add_child_vertex(name_for(d), nil, [name_for(activated_spec)], d)
           parent_index = states.size - 1
-          @parent_of[d] ||= parent_index
+          parents = @parents_of[d]
+          parents << parent_index if parents.empty?
         end
 
         push_state_for_requirements(requirements + nested_dependencies, !nested_dependencies.empty?)

--- a/lib/ruby/stdlib/rubygems/resolver/set.rb
+++ b/lib/ruby/stdlib/rubygems/resolver/set.rb
@@ -21,6 +21,7 @@ class Gem::Resolver::Set
   attr_accessor :prerelease
 
   def initialize # :nodoc:
+    require 'uri'
     @prerelease = false
     @remote     = true
     @errors     = []
@@ -54,4 +55,3 @@ class Gem::Resolver::Set
   end
 
 end
-

--- a/lib/ruby/stdlib/rubygems/security.rb
+++ b/lib/ruby/stdlib/rubygems/security.rb
@@ -340,7 +340,9 @@ module Gem::Security
   # Digest algorithm used to sign gems
 
   DIGEST_ALGORITHM =
-    if defined?(OpenSSL::Digest::SHA1) then
+    if defined?(OpenSSL::Digest::SHA256) then
+      OpenSSL::Digest::SHA256
+    elsif defined?(OpenSSL::Digest::SHA1) then
       OpenSSL::Digest::SHA1
     end
 
@@ -363,7 +365,7 @@ module Gem::Security
   ##
   # Length of keys created by KEY_ALGORITHM
 
-  KEY_LENGTH = 2048
+  KEY_LENGTH = 3072
 
   ##
   # Cipher used to encrypt the key pair used to sign gems.
@@ -372,9 +374,14 @@ module Gem::Security
   KEY_CIPHER = OpenSSL::Cipher.new('AES-256-CBC') if defined?(OpenSSL::Cipher)
 
   ##
+  # One day in seconds
+
+  ONE_DAY = 86400
+
+  ##
   # One year in seconds
 
-  ONE_YEAR = 86400 * 365
+  ONE_YEAR = ONE_DAY * 365
 
   ##
   # The default set of extensions are:

--- a/lib/ruby/stdlib/rubygems/security_option.rb
+++ b/lib/ruby/stdlib/rubygems/security_option.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+#--
+# Copyright 2006 by Chad Fowler, Rich Kilmer, Jim Weirich and others.
+# All rights reserved.
+# See LICENSE.txt for permissions.
+#++
+
+require 'rubygems'
+
+# forward-declare
+
+module Gem::Security # :nodoc:
+  class Policy # :nodoc:
+  end
+end
+
+##
+# Mixin methods for security option for Gem::Commands
+
+module Gem::SecurityOption
+  def add_security_option
+    # TODO: use @parser.accept
+    OptionParser.accept Gem::Security::Policy do |value|
+      require 'rubygems/security'
+
+      raise OptionParser::InvalidArgument, 'OpenSSL not installed' unless
+        defined?(Gem::Security::HighSecurity)
+
+      policy = Gem::Security::Policies[value]
+      unless policy
+        valid = Gem::Security::Policies.keys.sort
+        raise OptionParser::InvalidArgument, "#{value} (#{valid.join ', '} are valid)"
+      end
+      policy
+    end
+
+    add_option(:"Install/Update", '-P', '--trust-policy POLICY',
+               Gem::Security::Policy,
+               'Specify gem trust policy') do |value, options|
+      options[:security_policy] = value
+    end
+  end
+end

--- a/lib/ruby/stdlib/rubygems/source.rb
+++ b/lib/ruby/stdlib/rubygems/source.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'uri'
+autoload :URI, 'uri'
 require 'fileutils'
 
 ##
@@ -67,7 +67,11 @@ class Gem::Source
 
       return -1 if !other.uri
 
-      @uri.to_s <=> other.uri.to_s
+      # Returning 1 here ensures that when sorting a list of sources, the
+      # original ordering of sources supplied by the user is preserved.
+      return 1 unless @uri.to_s == other.uri.to_s
+
+      0
     else
       nil
     end
@@ -232,4 +236,3 @@ require 'rubygems/source/specific_file'
 require 'rubygems/source/local'
 require 'rubygems/source/lock'
 require 'rubygems/source/vendor'
-

--- a/lib/ruby/stdlib/rubygems/source/lock.rb
+++ b/lib/ruby/stdlib/rubygems/source/lock.rb
@@ -34,6 +34,10 @@ class Gem::Source::Lock < Gem::Source
     0 == (self <=> other)
   end
 
+  def hash # :nodoc:
+    @wrapped.hash ^ 3
+  end
+
   ##
   # Delegates to the wrapped source's fetch_spec method.
 
@@ -46,4 +50,3 @@ class Gem::Source::Lock < Gem::Source
   end
 
 end
-

--- a/lib/ruby/stdlib/rubygems/spec_fetcher.rb
+++ b/lib/ruby/stdlib/rubygems/spec_fetcher.rb
@@ -184,10 +184,10 @@ class Gem::SpecFetcher
   # Suggests gems based on the supplied +gem_name+. Returns an array of
   # alternative gem names.
 
-  def suggest_gems_from_name gem_name
+  def suggest_gems_from_name(gem_name, type = :latest)
     gem_name        = gem_name.downcase.tr('_-', '')
     max             = gem_name.size / 2
-    names           = available_specs(:latest).first.values.flatten(1)
+    names           = available_specs(type).first.values.flatten(1)
 
     matches = names.map { |n|
       next unless n.match_platform?
@@ -201,7 +201,11 @@ class Gem::SpecFetcher
       [n.name, distance]
     }.compact
 
-    matches = matches.uniq.sort_by { |name, dist| dist }
+    matches = if matches.empty? && type != :prerelease
+      suggest_gems_from_name gem_name, :prerelease
+    else
+      matches.uniq.sort_by { |name, dist| dist }
+    end
 
     matches.first(5).map { |name, dist| name }
   end

--- a/lib/ruby/stdlib/rubygems/specification.rb
+++ b/lib/ruby/stdlib/rubygems/specification.rb
@@ -155,16 +155,20 @@ class Gem::Specification < Gem::BasicSpecification
     :summary                   => nil,
     :test_files                => [],
     :version                   => nil,
-  }
+  }.freeze
 
-  Dupable = { } # :nodoc:
+  INITIALIZE_CODE_FOR_DEFAULTS = { } # :nodoc:
 
   @@default_value.each do |k,v|
-    case v
-    when Time, Numeric, Symbol, true, false, nil
-      Dupable[k] = false
+    INITIALIZE_CODE_FOR_DEFAULTS[k] = case v
+    when [], {}, true, false, nil, Numeric, Symbol
+      v.inspect
+    when String
+      v.dump
+    when Numeric
+       "default_value(:#{k})"
     else
-      Dupable[k] = true
+       "default_value(:#{k}).dup"
     end
   end
 
@@ -392,8 +396,6 @@ class Gem::Specification < Gem::BasicSpecification
   attr_reader :description
 
   ##
-  # :category: Recommended gemspec attributes
-  #
   # A contact email address (or addresses) for this gem
   #
   # Usage:
@@ -453,9 +455,22 @@ class Gem::Specification < Gem::BasicSpecification
   #   bytes
   # * All strings must be UTF-8, no binary data is allowed
   #
-  # To add metadata for the location of a issue tracker:
+  # You can use metadata to specify links to your gem's homepage, codebase,
+  # documentation, wiki, mailing list and issue tracker.
   #
-  #   s.metadata = { "issue_tracker" => "https://example/issues" }
+  #   s.metadata = {
+  #     "home" => "https://bestgemever.example.io",
+  #     "code" => "https://example.com/user/bestgemever",
+  #     "docs" => "https://www.example.info/gems/bestgemever/0.0.1",
+  #     "wiki" => "https://example.com/user/bestgemever/wiki",
+  #     "mail" => "https://groups.example.com/bestgemever",
+  #     "bugs" => "https://example.com/user/bestgemever/issues"
+  #   }
+  #
+  # These links will be used on your gem's page on rubygems.org and must pass
+  # validation against following regex.
+  #
+  #   %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}
 
   attr_accessor :metadata
 
@@ -471,7 +486,7 @@ class Gem::Specification < Gem::BasicSpecification
   # activated when a gem is required.
 
   def add_development_dependency(gem, *requirements)
-    add_dependency_with_type(gem, :development, *requirements)
+    add_dependency_with_type(gem, :development, requirements)
   end
 
   ##
@@ -482,7 +497,7 @@ class Gem::Specification < Gem::BasicSpecification
   #   spec.add_runtime_dependency 'example', '~> 1.1', '>= 1.1.4'
 
   def add_runtime_dependency(gem, *requirements)
-    add_dependency_with_type(gem, :runtime, *requirements)
+    add_dependency_with_type(gem, :runtime, requirements)
   end
 
   ##
@@ -880,7 +895,7 @@ class Gem::Specification < Gem::BasicSpecification
   # properly sorted.
 
   def self.add_spec spec
-    warn "Gem::Specification.add_spec is deprecated and will be removed in Rubygems 3.0" unless Gem::Deprecate.skip
+    warn "Gem::Specification.add_spec is deprecated and will be removed in RubyGems 3.0" unless Gem::Deprecate.skip
     # TODO: find all extraneous adds
     # puts
     # p :add_spec => [spec.full_name, caller.reject { |s| s =~ /minitest/ }]
@@ -905,7 +920,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Adds multiple specs to the known specifications.
 
   def self.add_specs *specs
-    warn "Gem::Specification.add_specs is deprecated and will be removed in Rubygems 3.0" unless Gem::Deprecate.skip
+    warn "Gem::Specification.add_specs is deprecated and will be removed in RubyGems 3.0" unless Gem::Deprecate.skip
 
     raise "nil spec!" if specs.any?(&:nil?) # TODO: remove once we're happy
 
@@ -1244,7 +1259,7 @@ class Gem::Specification < Gem::BasicSpecification
   # Removes +spec+ from the known specs.
 
   def self.remove_spec spec
-    warn "Gem::Specification.remove_spec is deprecated and will be removed in Rubygems 3.0" unless Gem::Deprecate.skip
+    warn "Gem::Specification.remove_spec is deprecated and will be removed in RubyGems 3.0" unless Gem::Deprecate.skip
     _all.delete spec
     stubs.delete_if { |s| s.full_name == spec.full_name }
     (@@stubs_by_name[spec.name] || []).delete_if { |s| s.full_name == spec.full_name }
@@ -1514,7 +1529,7 @@ class Gem::Specification < Gem::BasicSpecification
   # +requirements+.  Valid types are currently <tt>:runtime</tt> and
   # <tt>:development</tt>.
 
-  def add_dependency_with_type(dependency, type, *requirements)
+  def add_dependency_with_type(dependency, type, requirements)
     requirements = if requirements.empty? then
                      Gem::Requirement.default
                    else
@@ -2020,6 +2035,20 @@ class Gem::Specification < Gem::BasicSpecification
     yaml_initialize coder.tag, coder.map
   end
 
+
+
+  eval <<-RB, binding, __FILE__, __LINE__ + 1
+    def set_nil_attributes_to_nil
+      #{@@nil_attributes.map {|key| "@#{key} = nil" }.join "; "}
+    end
+    private :set_nil_attributes_to_nil
+
+    def set_not_nil_attributes_to_default_values
+      #{@@non_nil_attributes.map {|key| "@#{key} = #{INITIALIZE_CODE_FOR_DEFAULTS[key]}" }.join ";"}
+    end
+    private :set_not_nil_attributes_to_default_values
+  RB
+
   ##
   # Specification constructor. Assigns the default values to the attributes
   # and yields itself for further initialization.  Optionally takes +name+ and
@@ -2035,15 +2064,8 @@ class Gem::Specification < Gem::BasicSpecification
     @original_platform = nil
     @installed_by_version = nil
 
-    @@nil_attributes.each do |key|
-      instance_variable_set "@#{key}", nil
-    end
-
-    @@non_nil_attributes.each do |key|
-      default = default_value(key)
-      value = Dupable[key] ? default.dup : default
-      instance_variable_set "@#{key}", value
-    end
+    set_nil_attributes_to_nil
+    set_not_nil_attributes_to_default_values
 
     @new_platform = Gem::Platform::RUBY
 
@@ -2734,29 +2756,7 @@ class Gem::Specification < Gem::BasicSpecification
               'metadata must be a hash'
     end
 
-    metadata.keys.each do |k|
-      if !k.kind_of?(String)
-        raise Gem::InvalidSpecificationException,
-                'metadata keys must be a String'
-      end
-
-      if k.size > 128
-        raise Gem::InvalidSpecificationException,
-                "metadata key too large (#{k.size} > 128)"
-      end
-    end
-
-    metadata.values.each do |k|
-      if !k.kind_of?(String)
-        raise Gem::InvalidSpecificationException,
-                'metadata values must be a String'
-      end
-
-      if k.size > 1024
-        raise Gem::InvalidSpecificationException,
-                "metadata value too large (#{k.size} > 1024)"
-      end
-    end
+    validate_metadata
 
     licenses.each { |license|
       if license.length > 64
@@ -2810,7 +2810,7 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
 
     # Warnings
 
-    %w[author email homepage summary].each do |attribute|
+    %w[author homepage summary files].each do |attribute|
       value = self.send attribute
       warning "no #{attribute} specified" if value.nil? or value.empty?
     end
@@ -2840,6 +2840,40 @@ http://spdx.org/licenses or '#{Gem::Licenses::NONSTANDARD}' for a nonstandard li
   ensure
     if $! or @warnings > 0 then
       alert_warning "See http://guides.rubygems.org/specification-reference/ for help"
+    end
+  end
+
+  def validate_metadata
+    url_validation_regex = %r{\Ahttps?:\/\/([^\s:@]+:[^\s:@]*@)?[A-Za-z\d\-]+(\.[A-Za-z\d\-]+)+\.?(:\d{1,5})?([\/?]\S*)?\z}
+    link_keys = ["home", "code", "docs", "wiki", "mail", "bugs"]
+
+    metadata.each do|key, value|
+      if !key.kind_of?(String)
+        raise Gem::InvalidSpecificationException,
+                "metadata keys must be a String"
+      end
+
+      if key.size > 128
+        raise Gem::InvalidSpecificationException,
+                "metadata key too large (#{key.size} > 128)"
+      end
+
+      if !value.kind_of?(String)
+        raise Gem::InvalidSpecificationException,
+                "metadata values must be a String"
+      end
+
+      if value.size > 1024
+        raise Gem::InvalidSpecificationException,
+                "metadata value too large (#{value.size} > 1024)"
+      end
+
+      if link_keys.include? key
+        if value !~ url_validation_regex
+          raise Gem::InvalidSpecificationException,
+                 "metadata['#{key}'] has invalid link: #{value.inspect}"
+        end
+      end
     end
   end
 

--- a/lib/ruby/stdlib/rubygems/ssl_certs/.document
+++ b/lib/ruby/stdlib/rubygems/ssl_certs/.document
@@ -1,0 +1,1 @@
+# Ignore all files in this directory

--- a/lib/ruby/stdlib/rubygems/stub_specification.rb
+++ b/lib/ruby/stdlib/rubygems/stub_specification.rb
@@ -188,9 +188,8 @@ class Gem::StubSpecification < Gem::BasicSpecification
 
   def to_spec
     @spec ||= if @data then
-                Gem.loaded_specs.values.find { |spec|
-                  spec.name == name and spec.version == version
-                }
+                loaded = Gem.loaded_specs[name]
+                loaded if loaded && loaded.version == version
               end
 
     @spec ||= Gem::Specification.load(loaded_from)

--- a/lib/ruby/stdlib/rubygems/test_case.rb
+++ b/lib/ruby/stdlib/rubygems/test_case.rb
@@ -25,6 +25,7 @@ unless Gem::Dependency.new('rdoc', '>= 3.10').matching_specs.empty?
   gem 'json'
 end
 
+require 'bundler'
 require 'minitest/autorun'
 
 require 'rubygems/deprecate'
@@ -222,17 +223,25 @@ class Gem::TestCase < MiniTest::Unit::TestCase
     @orig_gem_vendor = ENV['GEM_VENDOR']
     @orig_gem_spec_cache = ENV['GEM_SPEC_CACHE']
     @orig_rubygems_gemdeps = ENV['RUBYGEMS_GEMDEPS']
+    @orig_bundle_gemfile   = ENV['BUNDLE_GEMFILE']
     @orig_rubygems_host = ENV['RUBYGEMS_HOST']
+    @orig_bundle_disable_postit = ENV['BUNDLE_TRAMPOLINE_DISABLE']
     ENV.keys.find_all { |k| k.start_with?('GEM_REQUIREMENT_') }.each do |k|
       ENV.delete k
     end
     @orig_gem_env_requirements = ENV.to_hash
 
     ENV['GEM_VENDOR'] = nil
+    ENV['BUNDLE_TRAMPOLINE_DISABLE'] = 'true'
 
     @current_dir = Dir.pwd
     @fetcher     = nil
-    @ui          = Gem::MockGemUi.new
+
+    Bundler.ui                     = Bundler::UI::Silent.new
+    @ui                            = Gem::MockGemUi.new
+    # This needs to be a new instance since we call use_ui(@ui) when we want to
+    # capture output
+    Gem::DefaultUserInteraction.ui = Gem::MockGemUi.new
 
     tmpdir = File.expand_path Dir.tmpdir
     tmpdir.untaint
@@ -323,6 +332,7 @@ class Gem::TestCase < MiniTest::Unit::TestCase
     Gem.loaded_specs.clear
     Gem.clear_default_specs
     Gem::Specification.unresolved_deps.clear
+    Bundler.reset!
 
     Gem.configuration.verbose = true
     Gem.configuration.update_sources = true
@@ -394,7 +404,9 @@ class Gem::TestCase < MiniTest::Unit::TestCase
     ENV['GEM_VENDOR'] = @orig_gem_vendor
     ENV['GEM_SPEC_CACHE'] = @orig_gem_spec_cache
     ENV['RUBYGEMS_GEMDEPS'] = @orig_rubygems_gemdeps
+    ENV['BUNDLE_GEMFILE']   = @orig_bundle_gemfile
     ENV['RUBYGEMS_HOST'] = @orig_rubygems_host
+    ENV['BUNDLE_TRAMPOLINE_DISABLE'] = @orig_bundle_disable_postit
 
     Gem.ruby = @orig_ruby if @orig_ruby
 
@@ -1334,7 +1346,7 @@ Also, a list:
   end
 
   ##
-  # create_gemspec creates gem specification in given +direcotry+ or '.'
+  # create_gemspec creates gem specification in given +directory+ or '.'
   # for the given +name+ and +version+.
   #
   # Yields the +specification+ to the block, if given

--- a/lib/ruby/stdlib/rubygems/version.rb
+++ b/lib/ruby/stdlib/rubygems/version.rb
@@ -241,7 +241,7 @@ class Gem::Version
   end
 
   def hash # :nodoc:
-    @version.hash
+    canonical_segments.hash
   end
 
   def init_with coder # :nodoc:
@@ -335,7 +335,7 @@ class Gem::Version
 
   def <=> other
     return unless Gem::Version === other
-    return 0 if @version == other._version
+    return 0 if @version == other._version || canonical_segments == other.canonical_segments
 
     lhsegments = _segments
     rhsegments = other._segments
@@ -360,6 +360,13 @@ class Gem::Version
     return 0
   end
 
+  def canonical_segments
+    @canonical_segments ||=
+      _split_segments.map! do |segments|
+        segments.reverse_each.drop_while {|s| s == 0 }.reverse
+      end.reduce(&:concat)
+  end
+
   protected
 
   def _version
@@ -374,5 +381,12 @@ class Gem::Version
     @segments ||= @version.scan(/[0-9]+|[a-z]+/i).map do |s|
       /^\d+$/ =~ s ? s.to_i : s
     end.freeze
+  end
+
+  def _split_segments
+    string_start = _segments.index {|s| s.is_a?(String) }
+    string_segments  = segments
+    numeric_segments = string_segments.slice!(0, string_start || string_segments.size)
+    return numeric_segments, string_segments
   end
 end

--- a/lib/ruby/stdlib/rubygems/version_option.rb
+++ b/lib/ruby/stdlib/rubygems/version_option.rb
@@ -58,7 +58,12 @@ module Gem::VersionOption
     add_option('-v', '--version VERSION', Gem::Requirement,
                "Specify version of gem to #{task}", *wrap) do
                  |value, options|
-      options[:version] = value
+      # Allow handling for multiple --version operators
+      if options[:version] && !options[:version].none?
+        options[:version].concat([value])
+      else
+        options[:version] = value
+      end
 
       explicit_prerelease_set = !options[:explicit_prerelease].nil?
       options[:explicit_prerelease] = false unless explicit_prerelease_set


### PR DESCRIPTION
This PR copies the Rubygems library at v2.6.11 into this repo.

- [RubyGems v2.6.11 release post](http://blog.rubygems.org/2017/03/16/2.6.11-released.html)
- This is [the commit in Ruby](https://github.com/ruby/ruby/commit/fa59a2ea808e6b7af862462c764a2110f1ff7ab2) where they begin to use it
  >   This version fixed regression of rubygems-2.6.10.
  >  rubygems/rubygems#1856
  >  See details of changelogs for 2.6.11 release:
  > https://github.com/rubygems/rubygems/blob/adfcf40502716080bd9cdfdd2e43bd4296872784/History.txt#L3
- The 2.6.11 version gets a special mention in [the Rails 5.1 RC1 blog post](http://weblog.rubyonrails.org/2017/3/20/Rails-5-1-rc1/).