### PR TITLE
support new JDK version string scheme

### DIFF
--- a/core/src/main/java/org/jruby/ext/ffi/Platform.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Platform.java
@@ -232,8 +232,11 @@ public class Platform {
         try {
             String versionString = System.getProperty("java.version");
             if (versionString != null) {
+                // remove additional version identifiers, e.g. -ea
+                versionString = versionString.split("-|\\+")[0];
                 String[] v = versionString.split("\\.");
-                version = Integer.valueOf(v[1]);
+                // starting from JDK 9, there is no leading "1." in java.version
+                version = Integer.valueOf(v.length > 1 ? v[1] : v[0]);
             }
         } catch (Exception ex) {
             version = 0;


### PR DESCRIPTION
jruby should be updated to support new JDK version string scheme -- [JEP 223](http://openjdk.java.net/jeps/223).

before this JEP, java.version property was 1.X.Y_Z, where X is major version number of JDK, now it is '$VNUM(-$PRE)?(\+($BUILD)?(-$OPT)?)?' where VNUM is $MAJOR.$MINOR.$SECURITY.