### PR TITLE
Copy-editing: misspellings

### DIFF
--- a/core/src/main/java/org/jruby/FlagRegistry.java
+++ b/core/src/main/java/org/jruby/FlagRegistry.java
@@ -24,7 +24,7 @@ public class FlagRegistry {
      *
      * The bit index for the new flag will be calculated at runtime, by walking parent classes
      * and looking for previously-registered flags. Ancestors should register all their flags
-     * before decendants (which means they should not be registered in a static initializer
+     * before descendants (which means they should not be registered in a static initializer
      * unless the parent is known to have fully run its own static initializers).
      *
      * @param klass the class for which to register a new flag

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -646,7 +646,7 @@ public final class Ruby implements Constantizable {
     public IRubyObject runWithGetsLoop(RootNode scriptNode, boolean printing, boolean processLineEnds, boolean split) {
         ThreadContext context = getCurrentContext();
 
-        // We do not want special scope types in IR so we ammend the AST tree to contain the elements representing
+        // We do not want special scope types in IR so we amend the AST tree to contain the elements representing
         // a while gets; ...your code...; end
         scriptNode = addGetsLoop(scriptNode, printing, processLineEnds, split);
 

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -943,7 +943,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      *
      * The internal helper that ensures a RubyString instance is returned
      * so dangerous casting can be omitted
-     * Prefered over callMethod(context, "inspect")
+     * Preferred over callMethod(context, "inspect")
      */
     static RubyString inspect(ThreadContext context, IRubyObject object) {
         return RubyString.objAsString(context, invokedynamic(context, object, INSPECT));

--- a/core/src/main/java/org/jruby/RubyFileTest.java
+++ b/core/src/main/java/org/jruby/RubyFileTest.java
@@ -204,7 +204,7 @@ public class RubyFileTest {
         return runtime.newBoolean(fileResource(filename).canRead());
     }
 
-    // Not exposed by filetest, but so similiar in nature that it is stored here
+    // Not exposed by filetest, but so similar in nature that it is stored here
     public static IRubyObject rowned_p(IRubyObject recv, IRubyObject filename) {
         FileStat stat = fileResource(filename).stat();
 

--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -214,7 +214,7 @@ public class RubyGlobal {
         runtime.defineVariable(new LastMatchGlobalVariable(runtime, "$+"), FRAME);
         runtime.defineVariable(new BackRefGlobalVariable(runtime, "$~"), FRAME);
 
-        // On platforms without a c-library accessable through JNA, getpid will return hashCode
+        // On platforms without a c-library accessible through JNA, getpid will return hashCode
         // as $$ used to. Using $$ to kill processes could take down many runtimes, but by basing
         // $$ on getpid() where available, we have the same semantics as MRI.
         globals.defineReadonly("$$", new PidAccessor(runtime), GLOBAL);

--- a/core/src/main/java/org/jruby/RubyObject.java
+++ b/core/src/main/java/org/jruby/RubyObject.java
@@ -524,7 +524,7 @@ public class RubyObject extends RubyBasicObject {
      *
      * The internal helper that ensures a RubyString instance is returned
      * so dangerous casting can be omitted
-     * Prefered over callMethod(context, "inspect")
+     * Preferred over callMethod(context, "inspect")
      */
     public static RubyString inspect(ThreadContext context, IRubyObject object) {
         return (RubyString)rbInspect(context, object);

--- a/core/src/main/java/org/jruby/ast/ConstDeclNode.java
+++ b/core/src/main/java/org/jruby/ast/ConstDeclNode.java
@@ -44,7 +44,7 @@ public class ConstDeclNode extends AssignableNode implements INameNode {
     private final String name;
     private final INameNode constNode;
 
-    // TODO: Split this into two sub-classes so that name and constNode can be specified seperately.
+    // TODO: Split this into two sub-classes so that name and constNode can be specified separately.
     public ConstDeclNode(ISourcePosition position, String name, INameNode constNode, Node valueNode) {
         super(position, valueNode, valueNode != null && valueNode.containsVariableAssignment());
         

--- a/core/src/main/java/org/jruby/ast/DRegexpNode.java
+++ b/core/src/main/java/org/jruby/ast/DRegexpNode.java
@@ -39,7 +39,7 @@ import org.jruby.lexer.yacc.ISourcePosition;
 import org.jruby.util.RegexpOptions;
 
 /**
- * A regexp which contains some expressions which will need to be evaluated everytime the regexp 
+ * A regexp which contains some expressions which will need to be evaluated every time the regexp 
  * is used for a match.
  */
 public class DRegexpNode extends DNode implements ILiteralNode {

--- a/core/src/main/java/org/jruby/ast/NilImplicitNode.java
+++ b/core/src/main/java/org/jruby/ast/NilImplicitNode.java
@@ -4,7 +4,7 @@ import org.jruby.lexer.yacc.InvalidSourcePosition;
 
 /**
  * A node which behaves like a nil node, but is not actually present in the AST as a syntactical
- * element (e.g. IDE's should ignore occurences of this node.  We have this as seperate subclass
+ * element (e.g. IDE's should ignore occurrences of this node. We have this as separate subclass
  * so that IDE consumers can more easily ignore these.
  */
 public class NilImplicitNode extends NilNode implements InvisibleNode {

--- a/core/src/main/java/org/jruby/ast/java_signature/ParameterNode.java
+++ b/core/src/main/java/org/jruby/ast/java_signature/ParameterNode.java
@@ -28,7 +28,7 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby.ast.java_signature;
 
-// Fixme: varargs and variableNames with [] on them should ammend type on construction to save
+// Fixme: varargs and variableNames with [] on them should amend type on construction to save
 // consumer the effort.
 public class ParameterNode {
     private final TypeNode type;

--- a/core/src/main/java/org/jruby/embed/variable/GlobalVariable.java
+++ b/core/src/main/java/org/jruby/embed/variable/GlobalVariable.java
@@ -94,7 +94,7 @@ public class GlobalVariable extends AbstractVariable {
         for ( final String name : globalVars.getNames() ) {
             if ( isPredefined(name) ) continue;
             IRubyObject value = globalVars.get(name);
-            // reciever of gvar should to topSelf always
+            // receiver of gvar should to topSelf always
             updateGlobalVar(vars, getTopSelf(receiver), name, value);
         }
     }

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -1185,7 +1185,7 @@ public class RubyBigDecimal extends RubyNumeric {
 
         int n = RubyNumeric.fix2int(arg);
 
-        if (value.scale() <= n) return this; // no rounding neccessary
+        if (value.scale() <= n) return this; // no rounding necessary
 
         return new RubyBigDecimal(getRuntime(), value.setScale(n, RoundingMode.CEILING));
     }
@@ -1203,7 +1203,7 @@ public class RubyBigDecimal extends RubyNumeric {
         return RubyBignum.newBignum(context.runtime, ceil);
     }
 
-    // FIXME: Do we really need this Java inheritence for coerce?
+    // FIXME: Do we really need this Java inheritance for coerce?
     @Override
     public IRubyObject coerce(IRubyObject other) {
         return coerce(getRuntime().getCurrentContext(), other);

--- a/core/src/main/java/org/jruby/ext/fiber/FiberQueue.java
+++ b/core/src/main/java/org/jruby/ext/fiber/FiberQueue.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
 /**
- * A RubyThread-aware BlockingQueue wrapper used by Fiber for transfering values.
+ * A RubyThread-aware BlockingQueue wrapper used by Fiber for transferring values.
  */
 public class FiberQueue {
     protected BlockingQueue<IRubyObject> queue;

--- a/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
+++ b/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
@@ -215,7 +215,7 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
         
         if (currentFiberData.parent == null) throw runtime.newFiberError("can't yield from root fiber");
 
-        if (currentFiberData.prev == null) throw runtime.newFiberError("BUG: yield occured with null previous fiber. Report this at http://bugs.jruby.org");
+        if (currentFiberData.prev == null) throw runtime.newFiberError("BUG: yield occurred with null previous fiber. Report this at http://bugs.jruby.org");
 
         if (currentFiberData.queue.isShutdown()) throw runtime.newFiberError("dead fiber yielded");
         

--- a/core/src/main/java/org/jruby/ext/ripper/RipperLexer.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperLexer.java
@@ -2133,7 +2133,7 @@ public class RipperLexer extends LexingCommon {
      *  Parse a number from the input stream.
      *
      *@param c The first character of the number.
-     *@return A int constant wich represents a token.
+     *@return A int constant which represents a token.
      */
     private int parseNumber(int c) throws IOException {
         setState(EXPR_END);

--- a/core/src/main/java/org/jruby/ext/socket/SocketUtilsIPV6.java
+++ b/core/src/main/java/org/jruby/ext/socket/SocketUtilsIPV6.java
@@ -217,7 +217,7 @@ public class SocketUtilsIPV6 {
          * Subtraction. Will never underflow, but wraps around when the lowest
          * ip address has been reached.
          *
-         * @param value value to substract
+         * @param value value to subtract
          * @return new IPv6 address
          */
         public IPv6Address subtract(int value) {
@@ -225,7 +225,7 @@ public class SocketUtilsIPV6 {
 
             if (value >= 0) {
                 if (isLessThanUnsigned(lowBits, newLowBits)) {
-                    // oops, we subtracted something postive and the result is bigger -> overflow detected (carry over one bit from high to low)
+                    // oops, we subtracted something positive and the result is bigger -> overflow detected (carry over one bit from high to low)
                     return new IPv6Address(highBits - 1, newLowBits);
                 } else {
                     // no overflow

--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -3230,7 +3230,7 @@ public class IRBuilder {
 
             // set attr
             addInstr(CallInstr.create(scope, callType, writerValue, opAsgnNode.getVariableNameAsgn(), v1, new Operand[] {setValue}, null));
-            // Returning writerValue is incorrect becuase the assignment method
+            // Returning writerValue is incorrect because the assignment method
             // might return something else other than the value being set!
             if (!opAsgnNode.isLazy()) return setValue;
 

--- a/core/src/main/java/org/jruby/ir/IRScope.java
+++ b/core/src/main/java/org/jruby/ir/IRScope.java
@@ -582,7 +582,7 @@ public abstract class IRScope implements ParseResult {
         // Always add call protocol instructions now since we are removing support for implicit stuff in interp.
         if (!isUnsafeScope()) new AddCallProtocolInstructions().run(this);
 
-        fullInterpreterContext.generateInstructionsForIntepretation();
+        fullInterpreterContext.generateInstructionsForInterpretation();
 
         return fullInterpreterContext;
     }

--- a/core/src/main/java/org/jruby/ir/instructions/ModuleVersionGuardInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ModuleVersionGuardInstr.java
@@ -36,7 +36,7 @@ public class ModuleVersionGuardInstr extends TwoOperandInstr implements FixedAri
         return (Label) getOperand2();
     }
 
-    // FIXME: We should remove this and only save what we care about..live Module cannot be neccesary here?
+    // FIXME: We should remove this and only save what we care about..live Module cannot be necessary here?
     public RubyModule getModule() {
         return module;
     }

--- a/core/src/main/java/org/jruby/ir/instructions/SearchConstInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/SearchConstInstr.java
@@ -18,7 +18,7 @@ import org.jruby.runtime.opto.Invalidator;
 
 // Const search:
 // - looks up lexical scopes
-// - then inheritance hierarcy if lexical search fails
+// - then inheritance hierarchy if lexical search fails
 // - then invokes const_missing if inheritance search fails
 public class SearchConstInstr extends OneOperandResultBaseInstr implements FixedArityInstr {
     private final String   constName;

--- a/core/src/main/java/org/jruby/ir/interpreter/FullInterpreterContext.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/FullInterpreterContext.java
@@ -48,7 +48,7 @@ public class FullInterpreterContext extends InterpreterContext {
 
     /**
      * have this interpretercontext fully built?  This is slightly more complicated than this simple check, but it
-     * should work.  In -X-C full builds we linearize at the beginning of our generateInstructionsForIntepretation
+     * should work.  In -X-C full builds we linearize at the beginning of our generateInstructionsForInterpretation
      * method.  Last thing we do essentially is set instructions to be something.  For JIT builds last thing we
      * need to check is whether we have linearized the BB list.
      */
@@ -91,7 +91,7 @@ public class FullInterpreterContext extends InterpreterContext {
     }
 
     /** We plan on running this in full interpreted mode.  This will fixup ipc, rpc, and generate instr list */
-    public void generateInstructionsForIntepretation() {
+    public void generateInstructionsForInterpretation() {
         linearizeBasicBlocks();
 
         // Pass 1. Set up IPCs for labels and instructions and build linear instr list

--- a/core/src/main/java/org/jruby/ir/operands/ImmutableLiteral.java
+++ b/core/src/main/java/org/jruby/ir/operands/ImmutableLiteral.java
@@ -75,7 +75,7 @@ public abstract class ImmutableLiteral extends Operand {
     /**
      * retrieve the live value represented by this immutable literal.  An
      * interesting property of knowing something cannot change at compile
-     * time is that all information neccesary to construct it is also known
+     * time is that all information necessary to construct it is also known
      * at compile time.  We don't pre-create these since we don't want to
      * assume the cost of constructing literals which may never be used.
      */

--- a/core/src/main/java/org/jruby/ir/operands/Operand.java
+++ b/core/src/main/java/org/jruby/ir/operands/Operand.java
@@ -39,7 +39,7 @@ public abstract class Operand {
      *
      * Ex: v = [1,2,3];  x = v; y = v
      *
-     * In this case, we cannot replace the occurences of 'v' because we would then get
+     * In this case, we cannot replace the occurrences of 'v' because we would then get
      * x = [1,2,3]; y = [1,2,3] which would then result in two different array objects
      * being constructed instead of a single one.
      *

--- a/core/src/main/java/org/jruby/ir/persistence/IRReader.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRReader.java
@@ -33,7 +33,7 @@ public class IRReader implements IRPersistenceValues {
         int version = file.decodeIntRaw();
 
         if (version != VERSION) {
-            throw new IOException("Trying to read incompatable persistence format (version found: " +
+            throw new IOException("Trying to read incompatible persistence format (version found: " +
                     version + ", version expected: " + VERSION);
         }
         int headersOffset = file.decodeIntRaw();

--- a/core/src/main/java/org/jruby/ir/targets/DRegexpObjectSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/DRegexpObjectSite.java
@@ -71,7 +71,7 @@ public class DRegexpObjectSite extends ConstructObjectSite {
                 return cache;
             }
 
-            // we don't care if this suceeds, just that it ony gets set once
+            // we don't care if this succeeds, just that it only gets set once
             UPDATER.compareAndSet(this, null, cache);
 
             setTarget(Binder.from(type()).dropAll().constant(cache));

--- a/core/src/main/java/org/jruby/ir/transformations/inlining/CloneInfo.java
+++ b/core/src/main/java/org/jruby/ir/transformations/inlining/CloneInfo.java
@@ -78,7 +78,7 @@ public abstract class CloneInfo {
 
     /**
      * Return a new instance of a variable for the newly cloned scope.  Maps are maintained
-     * because Variables typically share the same instance accross a CFG (of the same lexical depth).
+     * because Variables typically share the same instance across a CFG (of the same lexical depth).
      *
      * @param variable to be renamed
      * @return the new Variable

--- a/core/src/main/java/org/jruby/lexer/JavaSignatureLexer.java
+++ b/core/src/main/java/org/jruby/lexer/JavaSignatureLexer.java
@@ -630,7 +630,7 @@ public class JavaSignatureLexer {
 
 
   /**
-   * Reports an error that occured while scanning.
+   * Reports an error that occurred while scanning.
    *
    * In a wellformed scanner (no or only correct usage of 
    * yypushback(int) and a match-all fallback rule) this method 

--- a/core/src/main/java/org/jruby/lexer/StrftimeLexer.java
+++ b/core/src/main/java/org/jruby/lexer/StrftimeLexer.java
@@ -433,7 +433,7 @@ public class StrftimeLexer {
 
 
   /**
-   * Reports an error that occured while scanning.
+   * Reports an error that occurred while scanning.
    *
    * In a wellformed scanner (no or only correct usage of 
    * yypushback(int) and a match-all fallback rule) this method 

--- a/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
@@ -2020,7 +2020,7 @@ public class RubyLexer extends LexingCommon {
      *  Parse a number from the input stream.
      *
      *@param c The first character of the number.
-     *@return A int constant wich represents a token.
+     *@return An int constant which represents a token.
      */
     private int parseNumber(int c) throws IOException {
         setState(EXPR_END);

--- a/core/src/main/java/org/jruby/parser/JavaSignatureParser.java
+++ b/core/src/main/java/org/jruby/parser/JavaSignatureParser.java
@@ -978,7 +978,7 @@ case 97:
 case 98:
 					// line 423 "core/src/main/java/org/jruby/parser/JavaSignatureParser.y"
   {
-     /* We know this is always preceeded by 'type' production.*/
+     /* We know this is always preceded by 'type' production.*/
      yyVals[-3+yyTop] = new ArrayTypeNode(((TypeNode)yyVals[-3+yyTop])); 
      yyVal = ((String)yyVals[-2+yyTop]);
  }

--- a/core/src/main/java/org/jruby/parser/JavaSignatureParser.y
+++ b/core/src/main/java/org/jruby/parser/JavaSignatureParser.y
@@ -421,7 +421,7 @@ formal_parameter : type variable_declarator_id {
 variable_declarator_id : IDENTIFIER {
      $$ = $1;
  } | variable_declarator_id LBRACK RBRACK {
-     // We know this is always preceeded by 'type' production.
+     // We know this is always preceded by 'type' production.
      $<Object>0 = new ArrayTypeNode($<TypeNode>0); 
      $$ = $1;
  }

--- a/core/src/main/java/org/jruby/parser/ParserSupport.java
+++ b/core/src/main/java/org/jruby/parser/ParserSupport.java
@@ -454,7 +454,7 @@ public class ParserSupport {
     /**
      * Is this a literal in the sense that MRI has a NODE_LIT for.  This is different than
      * ILiteralNode.  We should pick a different name since ILiteralNode is something we created
-     * which is similiar but used for a slightly different condition (can I do singleton things).
+     * which is similar but used for a slightly different condition (can I do singleton things).
      * 
      * @param node to be tested
      * @return true if it is a literal

--- a/core/src/main/java/org/jruby/parser/StaticScope.java
+++ b/core/src/main/java/org/jruby/parser/StaticScope.java
@@ -332,7 +332,7 @@ public class StaticScope implements Serializable {
     public IRubyObject getConstant(String internedName) {
         IRubyObject result = getConstantInner(internedName);
 
-        // If we could not find the constant from cref..then try getting from inheritence hierarchy
+        // If we could not find the constant from cref, then try getting from inheritance hierarchy
         return result == null ? cref.getConstantNoConstMissing(internedName) : result;
     }
 

--- a/core/src/main/java/org/jruby/runtime/Binding.java
+++ b/core/src/main/java/org/jruby/runtime/Binding.java
@@ -199,7 +199,7 @@ public class Binding {
      * Gets the dynamicVariables that are local to this block.   Parent dynamic scopes are also
      * accessible via the current dynamic scope.
      * 
-     * @return Returns all relevent variable scoping information
+     * @return Returns all relevant variable scoping information
      */
     public DynamicScope getDynamicScope() {
         return dynamicScope;

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -2505,7 +2505,7 @@ public class Helpers {
     // . Array given to rest should pass itself
     // . Array with rest + other args should extract array
     // . Array with multiple values and NO rest should extract args if there are more than one argument
-    // Note: In 1.9 alreadyArray is only relevent from our internal Java code in core libs.  We never use it
+    // Note: In 1.9 alreadyArray is only relevant from our internal Java code in core libs.  We never use it
     // from interpreter or JIT.  FIXME: Change core lib consumers to stop using alreadyArray param.
     public static IRubyObject[] restructureBlockArgs19(IRubyObject value, Signature signature, Block.Type type, boolean needsSplat, boolean alreadyArray) {
         if (!type.checkArity && signature == Signature.NO_ARGUMENTS) return IRubyObject.NULL_ARRAY;

--- a/core/src/main/java/org/jruby/runtime/IRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/IRBlockBody.java
@@ -101,7 +101,7 @@ public abstract class IRBlockBody extends ContextAwareBlockBody {
                 // Unwrap the array arg
                 args = IRRuntimeHelpers.convertValueIntoArgArray(context, arg0, signature, true);
 
-                // FIXME: arity error is aginst new args but actual error shows arity of original args.
+                // FIXME: arity error is against new args but actual error shows arity of original args.
                 if (block.type == Block.Type.LAMBDA) signature.checkArity(context.runtime, args);
 
                 return commonYieldPath(context, block, Block.Type.NORMAL, args, null, Block.NULL_BLOCK);

--- a/core/src/main/java/org/jruby/runtime/load/LoadService.java
+++ b/core/src/main/java/org/jruby/runtime/load/LoadService.java
@@ -1239,7 +1239,7 @@ public class LoadService {
         }
 
         Outer: for (int i = 0; i < loadPath.size(); i++) {
-            // TODO this is really inefficient, and potentially a problem everytime anyone require's something.
+            // TODO this is really inefficient, and potentially a problem every time anyone require's something.
             // we should try to make LoadPath a special array object.
             String loadPathEntry = getLoadPathEntry(loadPath.eltInternal(i));
 
@@ -1478,7 +1478,7 @@ public class LoadService {
         }
 
         for (int i = 0; i < loadPath.size(); i++) {
-            // TODO this is really inefficient, and potentially a problem everytime anyone require's something.
+            // TODO this is really inefficient, and potentially a problem every time anyone require's something.
             // we should try to make LoadPath a special array object.
             String entry = getLoadPathEntry(loadPath.eltInternal(i));
 

--- a/core/src/main/java/org/jruby/runtime/marshal/DataType.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/DataType.java
@@ -2,7 +2,7 @@ package org.jruby.runtime.marshal;
 
 /**
  *
- * DataType is similiar to T_DATA to represent types which are incapable of getting
+ * DataType is similar to T_DATA to represent types which are incapable of getting
  * marshalled.  This is just a marker interface.
  */
 public interface DataType {

--- a/core/src/main/java/org/jruby/util/Pack.java
+++ b/core/src/main/java/org/jruby/util/Pack.java
@@ -915,14 +915,14 @@ public class Pack {
 
                         result.append(RubyString.newString(runtime, new ByteList(potential, 0, t, ASCIIEncoding.INSTANCE, false)));
 
-                        // In case when the number of occurences is
+                        // When the number of occurrences is
                         // explicitly specified, we have to read up
                         // the remaining garbage after the '\0' to
                         // satisfy the requested pattern.
                         if (!isStar) {
                             if (t < occurrences) {
                                 // We encountered '\0' when
-                                // were reading the buffer above,
+                                // reading the buffer above,
                                 // increment the number of read bytes.
                                 t++;
                             }

--- a/core/src/main/java/org/jruby/util/SipHashInline.java
+++ b/core/src/main/java/org/jruby/util/SipHashInline.java
@@ -42,7 +42,7 @@ public class SipHashInline {
             // MSGROUND {
                 v3 ^= m;
 
-                /* SIPROUND wih hand reordering
+                /* SIPROUND with hand reordering
                  *
                  * SIPROUND in siphash24.c:
                  *   A: v0 += v1;

--- a/core/src/main/java/org/jruby/util/cli/OutputStrings.java
+++ b/core/src/main/java/org/jruby/util/cli/OutputStrings.java
@@ -95,7 +95,7 @@ public class OutputStrings {
         "  -X+CIR        force compilation and use IR runtime\n" +
         "  -X+JIR        JIT compilation and use IR runtime\n" +
         "  -Xsubstring?  list options that contain substring in their name\n" +
-        "  -Xprefix...   list options that are prefixed wtih prefix\n" ;
+        "  -Xprefix...   list options that are prefixed with prefix\n" ;
     }
 
     public static String getPropertyHelp() {

--- a/core/src/main/java/org/jruby/util/collections/NonBlockingHashMapLong.java
+++ b/core/src/main/java/org/jruby/util/collections/NonBlockingHashMapLong.java
@@ -1176,7 +1176,7 @@ public class NonBlockingHashMapLong<TypeV>
    *  requires the creation of {@link java.util.Map.Entry} objects with each
    *  iteration.  The {@link org.cliffc.high_scale_lib.NonBlockingHashMap}
    *  does not normally create or using {@link java.util.Map.Entry} objects so
-   *  they will be created soley to support this iteration.  Iterating using
+   *  they will be created solely to support this iteration.  Iterating using
    *  {@link #keySet} or {@link #values} will be more efficient.  In addition,
    *  this version requires <strong>auto-boxing</strong> the keys.
    */
@@ -1221,7 +1221,7 @@ public class NonBlockingHashMapLong<TypeV>
       final long K = s.readLong();
       final TypeV V = (TypeV) s.readObject();
       if( K == NO_KEY && V == null ) break;
-      put(K,V);               // Insert with an offical put
+      put(K,V);               // Insert with an official put
     }
   }
 

--- a/core/src/main/java/org/jruby/util/io/ChannelDescriptor.java
+++ b/core/src/main/java/org/jruby/util/io/ChannelDescriptor.java
@@ -57,7 +57,8 @@ import org.jruby.util.log.LoggerFactory;
  * ChannelDescriptor provides an abstraction similar to the concept of a
  * "file descriptor" on any POSIX system. In our case, it's a numbered object
  * (fileno) enclosing a Channel (@see java.nio.channels.Channel), FileDescriptor
- * (@see java.io.FileDescriptor), and flags under which the original open occured
+ * (@see java.io.FileDescriptor), and flags under which the original open
+ * occurred
  * (@see org.jruby.util.io.ModeFlags). Several operations you would normally
  * expect to use with a POSIX file descriptor are implemented here and used by
  * higher-level classes to implement higher-level IO behavior.


### PR DESCRIPTION
This PR fixes various misspellings.

All of these were located by [the misspellings tool](https://github.com/lyda/misspell-check), but edited manually.

In a separate commit, I renamed a method.

## Questions:

- Are any of the files I edited "sealed", and should not be touched?