### PR TITLE
Return Process::Waiter with pid in Process.detach

### DIFF
--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -704,7 +704,7 @@ public class RubyProcess {
     // MRI: rlimit_resource_name2int
     private static int rlimitResourceName2int(String name, int casetype) {
         RLIMIT resource;
-            
+
         OUTER: while (true) {
             switch (Character.toUpperCase(name.charAt(0))) {
                 case 'A':
@@ -1369,9 +1369,9 @@ public class RubyProcess {
             }
         };
 
-        return RubyThread.newInstance(
-                runtime.getThread(),
-                IRubyObject.NULL_ARRAY,
+        return RubyThread.startWaiterThread(
+                runtime,
+                pid,
                 CallBlock.newCallClosure(recv, (RubyModule)recv, Signature.NO_ARGUMENTS, callback, context));
     }
 

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -679,6 +679,14 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         return rubyThread;
     }
 
+    protected static RubyThread startWaiterThread(final Ruby runtime, int pid, Block block) {
+        final IRubyObject waiter = runtime.getClassFromPath("Process::Waiter");
+        final RubyThread rubyThread = new RubyThread(runtime, (RubyClass) waiter);
+        rubyThread.op_aset(runtime.newSymbol("pid"), runtime.newFixnum(pid));
+        rubyThread.callInit(IRubyObject.NULL_ARRAY, block);
+        return rubyThread;
+    }
+
     public synchronized void cleanTerminate(IRubyObject result) {
         finalResult = result;
     }

--- a/core/src/main/ruby/jruby/kernel/process.rb
+++ b/core/src/main/ruby/jruby/kernel/process.rb
@@ -4,7 +4,18 @@ module Process
     class << self
       private :new
     end
-    
+
+    def pid
+      self[:pid]
+    end
+  end
+
+  class Waiter < Thread
+    # only created from Java and used for Process.detach right now
+    class << self
+      private :new
+    end
+
     def pid
       self[:pid]
     end


### PR DESCRIPTION
This adds a `pid` method to threads returned by `Process.detach`,
as described in the open3.rb documentation. The thread is a
`Process::Waiter` to be consistent with standard Ruby.

I haven't worked in Java much before, so please let me know if there's
anything I'm missing.

Before:

```
>> JRUBY_VERSION
=> "9.1.4.0"
>> pid = Process.spawn('sleep 10')
=> 58487
>> thr = Process.detach(_)
=> #<Thread:0x45752059@(irb):3 run>
>> thr.pid
NoMethodError: undefined method `pid' for #<Thread:0x45752059@(irb):3 dead>
```

After:

```
>> JRUBY_VERSION
=> "9.1.9.0-SNAPSHOT"
>> pid = Process.spawn('sleep 10')
=> 59018
>> thr = Process.detach(_)
=> #<Process::Waiter:0x5acf93bb@(irb):3 run>
>> thr.pid
=> 59018
```