### PR TITLE
[jrubyc] respect Ruby visibility rules (do not generate private methods)

### DIFF
--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -197,8 +197,9 @@ public class RubyClass extends RubyModule {
      * constructor (Ruby, RubyClass) on the given class via a static
      * __allocate__ method intermediate.
      *
-     * @param clazz The class from which to grab a standard Ruby __allocate__
-     *            method.
+     * @param clazz The class from which to grab a standard Ruby __allocate__ method.
+     *
+     * @note Used with `jrubyc --java` generated (interoperability) class files.
      */
     public void setRubyStaticAllocator(final Class<?> clazz) {
         try {

--- a/lib/ruby/stdlib/jruby/compiler.rb
+++ b/lib/ruby/stdlib/jruby/compiler.rb
@@ -56,10 +56,6 @@ module JRuby::Compiler
         options[:javac_options] << o
       end
 
-      #opts.on("-5"," --jdk5", "Generate JDK 5 classes (version 49)") do |x|
-      #  options[:jdk5] = true
-      #end
-
       opts.on("--java", "Generate Java classes (.java) for a script containing Ruby class definitions") do
         options[:java] = true
       end
@@ -146,7 +142,7 @@ module JRuby::Compiler
 
             FileUtils.mkdir_p java_dir
 
-            java_src = File.join(java_dir, cls.name + ".java")
+            java_src = File.join(java_dir, "#{cls.name}.java")
             puts "Generating Java class #{cls.name} to #{java_src}" if options[:verbose]
 
             files << java_src

--- a/lib/ruby/stdlib/jruby/compiler/java_class.rb
+++ b/lib/ruby/stdlib/jruby/compiler/java_class.rb
@@ -339,6 +339,9 @@ module JRuby::Compiler
   end
 
   class RubyClass
+
+    include_package 'org.jruby.ast.java_signature'
+
     def initialize(name, imports = [], script_name = nil, annotations = [], requires = [], package = '')
       @name = name
       @imports = imports
@@ -364,8 +367,7 @@ module JRuby::Compiler
     end
 
     def new_method(name, java_signature = nil, annotations = [])
-      is_constructor = name.eql?('initialize') ||
-          java_signature.is_a?(Java::OrgJrubyAstJava_signature::ConstructorSignatureNode)
+      is_constructor = name.eql?('initialize') || java_signature.is_a?(ConstructorSignatureNode)
       @has_constructor ||= is_constructor
 
       if is_constructor

--- a/spec/jrubyc/java/constructor_spec.rb
+++ b/spec/jrubyc/java/constructor_spec.rb
@@ -17,7 +17,7 @@ describe "A Ruby class generating a Java stub" do
   describe "with no initialize method" do
     it "generates a default constructor" do
       cls = generate("class Foo; end").classes[0]
-      cls.constructor?.should be false
+      expect( cls.has_constructor? ).to be false
 
       java = cls.to_s
       java.should match EMPTY_INITIALIZE_PATTERN
@@ -28,23 +28,21 @@ describe "A Ruby class generating a Java stub" do
     describe "and a constructor java_signature on a another method" do
       it "generates a default constructor" do
         cls = generate("class Foo; def initialize(a); end; java_signature 'Foo()'; def default_cnstr(); end; end").classes[0]
-        cls.constructor?.should be true
+        expect( cls.has_constructor? ).to be true
 
-        init = cls.methods[0]
-        init.should_not be nil
-        init.name.should == "initialize"
-        init.constructor?.should == true
-        init.java_signature.to_s.should == "Object initialize(Object a)"
-        init.args.length.should == 1
+        expect( init = cls.methods[0] ).to_not be nil
+        expect( init.name ).to eql "initialize"
+        expect( init.constructor? ).to be true
+        expect( init.java_signature.to_s ).to eql "Object initialize(Object a)"
+        expect( init.args.length ).to eql 1
 
         java = init.to_s
         java.should match OBJECT_INITIALIZE_PATTERN
 
-        def_cnstr = cls.methods[1]
-        def_cnstr.should_not be nil
-        def_cnstr.constructor?.should == true
-        def_cnstr.java_signature.to_s.should == "Foo()"
-        def_cnstr.args.length.should == 0
+        expect( def_cnstr = cls.methods[1] ).to_not be nil
+        expect( def_cnstr.constructor? ).to be true
+        expect( def_cnstr.java_signature.to_s ).to eql "Foo()"
+        expect( def_cnstr.args.length ).to eql 0
 
         java = def_cnstr.to_s
         java.should match EMPTY_INITIALIZE_PATTERN
@@ -54,7 +52,7 @@ describe "A Ruby class generating a Java stub" do
     describe "with no arguments" do
       it "generates a default constructor" do
         cls = generate("class Foo; def initialize; end; end").classes[0]
-        expect( cls.constructor? ).to be true
+        expect( cls.has_constructor? ).to be true
 
         expect( init = cls.methods[0] ).to_not be nil
         expect( init.name ).to eql 'initialize'
@@ -70,7 +68,7 @@ describe "A Ruby class generating a Java stub" do
     describe "with one argument and no java_signature" do
       it "generates an (Object) constructor" do
         cls = generate("class Foo; def initialize(a); end; end").classes[0]
-        expect( cls.constructor? ).to be true
+        expect( cls.has_constructor? ).to be true
 
         init = cls.methods[0]
         expect( init.name ).to eql 'initialize'
@@ -86,7 +84,7 @@ describe "A Ruby class generating a Java stub" do
     describe "with one argument and a java_signature" do
       it "generates a type-appropriate constructor" do
         cls = generate("class Foo; java_signature 'Foo(String)'; def initialize(a); end; end").classes[0]
-        expect( cls.constructor? ).to be true
+        expect( cls.has_constructor? ).to be true
 
         init = cls.methods[0]
         expect( init.name ).to eql 'initialize'

--- a/spec/jrubyc/java/files/method_visibility.rb
+++ b/spec/jrubyc/java/files/method_visibility.rb
@@ -1,0 +1,31 @@
+class MethodVisibility
+
+  private
+
+  def priv_method; false end
+
+  def publ_method; true end
+  public :publ_method
+
+  def prot_method; end
+  protected :prot_method
+
+  public
+
+  def hello(arg = there)
+    "Hello #{arg}"
+  end
+
+  def there
+    @there ||= 'World!'
+  end
+  private :there
+
+  protected
+
+  java_signature 'public int protMethodWithJSign(String)'
+  def prot_method_with_java_signature(str_arg)
+    return str_arg.size
+  end
+
+end

--- a/spec/jrubyc/java/method_spec.rb
+++ b/spec/jrubyc/java/method_spec.rb
@@ -411,6 +411,19 @@ describe "A Ruby class generating a Java stub" do
     end
   end
 
+  describe 'with private :method' do
+
+    it 'does not generate the given method' do
+      cls = generate("class Foo; def abar; end; private :abar; def afoo; true; end; end").classes[0]
+
+      java_source = cls.to_s
+
+      expect( java_source ).to_not include 'Object abar' + '()'
+      expect( java_source ).to include 'public Object afoo' + '()'
+    end
+
+  end
+
   describe "when no class definitions are present in the target script" do
     before do
       @source = Tempfile.new('jrubyc_method_spec')

--- a/spec/jrubyc/java/method_spec.rb
+++ b/spec/jrubyc/java/method_spec.rb
@@ -411,7 +411,7 @@ describe "A Ruby class generating a Java stub" do
     end
   end
 
-  describe 'with private :method' do
+  describe 'with private (Ruby) :method' do
 
     it 'does not generate the given method' do
       cls = generate("class Foo; def abar; end; private :abar; def afoo; true; end; end").classes[0]
@@ -420,6 +420,40 @@ describe "A Ruby class generating a Java stub" do
 
       expect( java_source ).to_not include 'Object abar' + '()'
       expect( java_source ).to include 'public Object afoo' + '()'
+    end
+
+  end
+
+  describe 'with (Ruby) visibility' do
+
+    METHOD_VISIBILITY_SOURCE = File.expand_path('files/method_visibility.rb', File.dirname(__FILE__))
+
+    it 'does map public and protected methods to Java with same modifiers' do
+      cls = generate(File.read(METHOD_VISIBILITY_SOURCE)).classes[0]
+
+      java_source = cls.to_s
+
+      expect( java_source ).to include 'public Object publ_method' + '()'
+      expect( java_source ).to include 'public Object hello' + '(Object arg)'
+
+      expect( java_source ).to include 'protected Object prot_method' + '()'
+    end
+
+    it 'does not generate private methods (by default)' do
+      cls = generate(File.read(METHOD_VISIBILITY_SOURCE)).classes[0]
+
+      java_source = cls.to_s
+
+      expect( java_source ).to_not include 'Object there' + '()'
+      expect( java_source ).to_not include 'Object priv_method' + '()'
+    end
+
+    it 'explicit java_signature with modifier overrides Ruby visibility' do
+      cls = generate(File.read(METHOD_VISIBILITY_SOURCE)).classes[0]
+
+      java_source = cls.to_s
+
+      expect( java_source ).to include 'public int protMethodWithJSign' + '(String str_arg)'
     end
 
   end


### PR DESCRIPTION
`jrubyc --java` generation updated to be a little smarter - trying to respect Ruby's visibility rules.

... `private, protected, public` as well as their `private :method, ...` counterparts now seamlessly 'work'

private Ruby methods (without an explicit `java_signature '...'` which is allowed to force generation) are no longer generated. also protected methods map to Java protected visibility by default.

(kind of) resolves #4469   (still undecided about what to do with with `xxx?` and `yyy!` methods)