### PR TITLE
Use shutdown hook to delete temp files instead of File.deleteOnExit

### DIFF
--- a/core/src/main/java/org/jruby/util/JRubyClassLoader.java
+++ b/core/src/main/java/org/jruby/util/JRubyClassLoader.java
@@ -117,9 +117,17 @@ public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
             Runtime.getRuntime().addShutdownHook(new Thread() {
                 public void run() {
                     for (File f : tempDir.listFiles()) {
-                        f.delete();
+                        try {
+                            f.delete();
+                        } catch (Exception ex) {
+                            LOG.debug(ex);
+                        }
                     }
-                    tempDir.delete();
+                    try {
+                        tempDir.delete();
+                    } catch (Exception ex) {
+                        LOG.info("failed to delete temp dir " + tempDir + " : " + ex);
+                    }
                 }
             });
         }

--- a/core/src/main/java/org/jruby/util/JRubyClassLoader.java
+++ b/core/src/main/java/org/jruby/util/JRubyClassLoader.java
@@ -60,7 +60,7 @@ public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
 
     private Runnable unloader;
 
-    private File tempDir;
+    private static volatile File tempDir;
 
     public JRubyClassLoader(ClassLoader parent) {
         super(parent);
@@ -76,7 +76,6 @@ public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
             InputStream in = null; OutputStream out = null;
             try {
                 File f = File.createTempFile("jruby", new File(url.getFile()).getName(), getTempDir());
-                f.deleteOnExit();
                 out = new BufferedOutputStream( new FileOutputStream( f ) );
                 in = new BufferedInputStream( url.openStream() );
                 int i = in.read();
@@ -110,15 +109,21 @@ public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
         super.addURL( url );
     }
 
-    private File getTempDir() {
-        File tempDir = this.tempDir;
+    private static synchronized File getTempDir() {
         if (tempDir != null) return tempDir;
 
         tempDir = new File(systemTmpDir(), tempDirName());
         if (tempDir.mkdirs()) {
-            tempDir.deleteOnExit();
+            Runtime.getRuntime().addShutdownHook(new Thread() {
+                public void run() {
+                    for (File f : tempDir.listFiles()) {
+                        f.delete();
+                    }
+                    tempDir.delete();
+                }
+            });
         }
-        return this.tempDir = tempDir;
+        return tempDir;
     }
 
     private static final String TEMP_DIR_PREFIX = "jruby-";


### PR DESCRIPTION
Previously, the JRubyClassLoader would make a .deleteOnExit() call for
the temp directory and each temp file it needed to create.  This results
in the string for each registered path being stored in a hash that
increases each time a new URL is loaded or new ScriptingContainer is
created.

This commit removes the .deleteOnExit() calls and instead registers a
shutdown hook just after the temp directory is initially created.  At
shutdown time, the hook would delete any remaining files and the temp
directory itself.  This should effectively result in the same user
behavior as before but with the benefit of the temp path strings no
longer taking up an increasing amount of memory the longer the process
runs.