### PR TITLE
Fix bootstrapping on AARCH64

### DIFF
--- a/test/pom.rb
+++ b/test/pom.rb
@@ -61,7 +61,7 @@ project 'JRuby Integration Tests' do
       'includeRubygemsInTestResources' => 'false' }
 
     if version =~ /-SNAPSHOT/
-      options[ 'jrubyVersion' ] = '1.7.12'
+      options[ 'jrubyVersion' ] = '9.1.8.0'
     else
       options[ 'libDirectory' ] = '${jruby.home}/lib'
       options[ 'jrubyJvmArgs' ] = '-Djruby.home=${jruby.home}'


### PR DESCRIPTION
It fails with:

```
[INFO] --- gem-maven-plugin:1.0.10:initialize (default) @ jruby-tests ---
[INFO] ERROR:  Loading command: install (LoadError)
[INFO]  Unsupported platform: unknown-linux
[INFO] ERROR:  While executing gem ... (NoMethodError)
[INFO]     undefined method `invoke_with_build_args' for nil:NilClass
[INFO]
```