### PR TITLE
Fix infinite loop in module name parsing for RubyModule.const_get_2_0

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2675,6 +2675,7 @@ public class RubyModule extends RubyObject {
 
         while ( ( sep = name.indexOf("::") ) != -1 ) {
             final String segment = name.substring(0, sep);
+            name = name.substring(sep + 2);
             IRubyObject obj = mod.getConstant(validateConstant(segment, symbol), inherit, inherit);
             if (obj instanceof RubyModule) {
                 mod = (RubyModule) obj;


### PR DESCRIPTION
Fix for #4613, an infinite loop in module name parsing logic which
had been introduced into RubyModule.const_get_2_0 in 45047a.