### PR TITLE
README: latest stable JRuby in install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For [`rbenv`](https://github.com/sstephenson/rbenv) you will need the
 package manager can provide these. Then you can run:
 
 ```
-$ rbenv install jruby-9.1.6.0
+$ rbenv install jruby-9.1.9.0
 ```
 
 For [`rvm`](https://rvm.io) you can simply do:


### PR DESCRIPTION
This PR updates the instruction about the README to point to latest stable where a version is mentioned.