### PR TITLE
README: Mention jruby-9.1.10.0 in rbenv note

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For [`rbenv`](https://github.com/sstephenson/rbenv) you will need the
 package manager can provide these. Then you can run:
 
 ```
-$ rbenv install jruby-9.1.9.0
+$ rbenv install jruby-9.1.10.0
 ```
 
 For [`rvm`](https://rvm.io) you can simply do:


### PR DESCRIPTION
This PR updates the README so that it refers to the latest release of JRuby when explaining how to install it using `rbenv`.

See #4622 for a PR that does the same thing for last version.

