### PR TITLE
Also allow access control to trigger quiet bail out of jar index.

### DIFF
--- a/core/src/main/java/org/jruby/util/JarCache.java
+++ b/core/src/main/java/org/jruby/util/JarCache.java
@@ -4,6 +4,7 @@ import static org.jruby.RubyFile.canonicalize;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.security.AccessControlException;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -146,6 +147,9 @@ class JarCache {
                     index = new JarIndex(jarPath);
                     indexCache.put(cacheKey, index);
                 } catch (IOException ioe) {
+                    return null;
+                } catch (AccessControlException ace) {
+                    // No permissions to index the given path, bail out
                     return null;
                 }
             }


### PR DESCRIPTION
Fixes #4633.