### PR TITLE
Fix missing callMethod override

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -376,6 +376,10 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         return Helpers.invoke(getRuntime().getCurrentContext(), this, name, args);
     }
 
+    public final IRubyObject callMethod(String name, IRubyObject arg) {
+        return Helpers.invoke(getRuntime().getCurrentContext(), this, name, arg);
+    }
+
     public final IRubyObject callMethod(String name) {
         return Helpers.invoke(getRuntime().getCurrentContext(), this, name);
     }


### PR DESCRIPTION
Although not used by default, the Reificator class at https://github.com/jruby/jruby/blob/9.1.10.0/core/src/main/java/org/jruby/RubyClass.java#L1583 checks which version of callMethod it should use, and needs all three versions: no argument, one argument, and more than one argument.

One of these overrides did not exist, and thus would result on a

```
java.lang.NoSuchMethodError: rubyobj.BrokenReify.callMethod(Ljava/lang/String;Lorg/jruby/runtime/builtin/IRubyObject;)Lorg/jruby/runtime/builtin/IRubyObject;
```

when running an example with -Xreify.classes=true

```ruby
class BrokenReify
  def initialize_copy(other)
    super
  end
end

puts BrokenReify.new.clone
```

With this fix, the above example starts instead giving a java.lang.StackOverflowError due to another bug/bad interaction of the reify.classes option, which I'll report separately.

Issue #4444