### PR TITLE
help classpath: canonicalization on Windows to fully resolve #4145

### DIFF
--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -1663,8 +1663,8 @@ public class RubyFile extends RubyIO implements EncodingCapable {
             relativePath = relativePath.substring(offset);
 
             if (classloaderURI) {
-                String fakePrefix = "/THIS_IS_A_FAKE_PATH_FOR_JRUBY";
-                relativePath = canonicalizePath(fakePrefix + "/" + relativePath).substring(fakePrefix.length());
+                String fakePrefix = Platform.IS_WINDOWS ? "C:/FAKEPATH_PREFIX__" : "/FAKEPATH_PREFIX__";
+                relativePath = canonicalizePath(fakePrefix + '/' + relativePath).substring(fakePrefix.length());
             } else {
                 relativePath = canonicalizePath(relativePath);
             }


### PR DESCRIPTION
has been attempted at cbf9a7d156f42eb640b3a20e100793b516bf58c9
... using a fake root path, however on Windows /SMT expands as C:\SMT

got a bit inspired by `C:/fakepath` which browsers use but than I wasn't 100% sure
@headius' previous `/THIS_IS_A_FAKE_PATH_FOR_JRUBY` is probably a 'safer' bet ?

added '__' at the end so its more obvious if this is slightly off again (`classpath:BY\path` was confusing)

closes #4630 (also #4645)