### PR TITLE
Make Time#utc and #localtime raise RuntimeError when the object is frozen

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -509,6 +509,9 @@ public class RubyTime extends RubyObject {
 
     @JRubyMethod(name = {"gmtime", "utc"})
     public RubyTime gmtime() {
+        if (isFrozen()) {
+          throw getRuntime().newFrozenError("Time", true);
+        }
         dt = dt.withZone(DateTimeZone.UTC);
         return this;
     }
@@ -519,6 +522,9 @@ public class RubyTime extends RubyObject {
 
     @JRubyMethod(name = "localtime", optional = 1)
     public RubyTime localtime19(ThreadContext context, IRubyObject[] args) {
+        if (isFrozen()) {
+          throw getRuntime().newFrozenError("Time", true);
+        }
         DateTimeZone newDtz;
         if (args.length == 0) {
             newDtz = getLocalTimeZone(context.runtime);

--- a/spec/ruby/core/time/dup_spec.rb
+++ b/spec/ruby/core/time/dup_spec.rb
@@ -36,4 +36,11 @@ describe "Time#dup" do
     t.dup.should be_an_instance_of(c)
     t.dup.should_not be_an_instance_of(Time)
   end
+
+  it "does not copy frozen status from the original" do
+    t = Time.now
+    t.freeze
+    t2 = t.dup
+    t2.frozen?.should be_false
+  end
 end

--- a/spec/ruby/core/time/localtime_spec.rb
+++ b/spec/ruby/core/time/localtime_spec.rb
@@ -22,6 +22,10 @@ describe "Time#localtime" do
     t.utc_offset.should == 3630
   end
 
+  it "raises a RuntimeError on a frozen time" do
+    lambda { Time.new.freeze.localtime }.should raise_error(RuntimeError)
+  end
+
   describe "with an argument that responds to #to_int" do
     it "coerces using #to_int" do
       o = mock('integer')

--- a/spec/ruby/core/time/shared/gmtime.rb
+++ b/spec/ruby/core/time/shared/gmtime.rb
@@ -7,4 +7,8 @@ describe :time_gmtime, shared: true do
       t.should == Time.gm(2007, 1, 9, 12, 0, 0)
     end
   end
+
+  it "raises a RuntimeError on a frozen time" do
+    lambda { Time.new.freeze.send(@method) }.should raise_error(RuntimeError)
+  end
 end


### PR DESCRIPTION
This is a fix for #4655 that replicates the MRI behaviour of frozen `Time` objects.

It adds three tests to `spec/ruby/core/time` that cover the MRI behaviour of frozen `Time` objects – I've tried to match the style of the existing tests and copied tests for the same behaviour in `Array`. I hope it looks ok.

The actual fix is very simple, in `#utc` and #localtime` I've added a check that will throw a `RuntimeError` when the instance is frozen.

There are two additional public methods that mutate `Time` objects, but they're not Ruby methods, and I'm unsure about whether or not they should throw errors:

* [`RubyTime#updateCal(DateTime)`](https://github.com/iconara/jruby/blob/d02707acaee08a36e5b37888d2a493e059539f74/core/src/main/java/org/jruby/RubyTime.java#L456-L458)
* [`RubyTime#setDateTime(DateTime)`]( https://github.com/iconara/jruby/blob/d02707acaee08a36e5b37888d2a493e059539f74/core/src/main/java/org/jruby/RubyTime.java#L963-L965)

They also seem to be duplicates of each other, an neither has been touched in 10 years.

Should they be changed to throw the same error, or how is frozen-ness handled when objects are changed from Java code?