### PR TITLE
__dir__ won't work with embed paths such as uri:classloader: (#4611)

### DIFF
--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1781,7 +1781,8 @@ public class RubyKernel {
 
     @JRubyMethod(name = "__dir__", module = true, visibility = PRIVATE, reads = FILENAME)
     public static IRubyObject __dir__(ThreadContext context, IRubyObject recv) {
-        final String __FILE__ = context.getFile();
+        // NOTE: not using __FILE__ = context.getFile() since it won't work with JIT
+        final String __FILE__ = context.gatherCallerBacktrace()[1].getFileName();
         String dir = RubyFile.dirname(context, __FILE__);
         return RubyString.newString(context.runtime, dir);
     }

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1781,7 +1781,8 @@ public class RubyKernel {
 
     @JRubyMethod(name = "__dir__", module = true, visibility = PRIVATE, reads = FILENAME)
     public static IRubyObject __dir__(ThreadContext context, IRubyObject recv) {
-        String dir = RubyFile.dirname(context, new File(context.gatherCallerBacktrace()[1].getFileName()).getAbsolutePath());
+        final String __FILE__ = context.getFile();
+        String dir = RubyFile.dirname(context, __FILE__);
         return RubyString.newString(context.runtime, dir);
     }
 


### PR DESCRIPTION
... if `File#getAbsolutePath()` is used - which seems like its not necessary
and we can pretty much just do what MRI does `File.dirname(__FILE__)`

##

wonder if caller is actually necessary in `__dir__` // cc @headius @enebo 
- initially it was caller-less https://github.com/jruby/jruby/commit/3efc72f47bace5aad4719362fa370c46e76fe1ee#diff-73ba50d02cf75f651e0b9d581d6bd4d5R1867
- caller has been added at https://github.com/jruby/jruby/commit/5fc06a0480011a5c35339a68116dd81d88b1876d#diff-e2320b4f8ce4644f50eb844d06a5de2eR1930

as adviced in https://github.com/jruby/jruby/issues/4611#issuecomment-307215241

> @kares I think we need the same special-case logic here, or better, make this call hopefully-existing logic that does the right thing already.

... this is relying on the existing uri:classloader: handling logic in `RubyFile.dirname`

verified this works fine for liquid gem's case presented in https://github.com/jruby/jruby/issues/4611

still need to figure out a where to put a test-case to test this properly