### PR TITLE
missing throw statements on ffi callback

### DIFF
--- a/core/src/main/java/org/jruby/ext/ffi/CallbackInfo.java
+++ b/core/src/main/java/org/jruby/ext/ffi/CallbackInfo.java
@@ -110,6 +110,10 @@ public class CallbackInfo extends Type {
                     + returnType.getMetaClass().getName() + " (expected FFI::Type)");
         }
 
+        if (returnType instanceof MappedType) {
+            returnType = ((MappedType) returnType).getRealType();
+        }
+
         if (!(paramTypes instanceof RubyArray)) {
             throw context.runtime.newTypeError("wrong argument type "
                     + paramTypes.getMetaClass().getName() + " (expected Array)");

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/NativeCallbackFactory.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/NativeCallbackFactory.java
@@ -90,7 +90,7 @@ public class NativeCallbackFactory {
         }
 
         if (!isReturnTypeValid(cbInfo.getReturnType()) || FFIUtil.getFFIType(cbInfo.getReturnType()) == null) {
-            runtime.newTypeError("invalid callback return type: " + cbInfo.getReturnType());
+            throw runtime.newTypeError("invalid callback return type: " + cbInfo.getReturnType());
         }
 
         return new NativeFunctionInfo(runtime, cbInfo.getReturnType(), cbInfo.getParameterTypes(),


### PR DESCRIPTION
not sure about this one **spec:ffi** fails when the error is actually thrown

someone more familiar with the piece should look at it ...

HEREs the failed job: https://travis-ci.org/kares/jruby/jobs/241153466