### PR TITLE
Handle nil buffer in Zlib::GzipReader#readpartial

### DIFF
--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
@@ -363,7 +363,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
                 throw getRuntime().newArgumentError("negative length " + len + " given");
             }
 
-            if (args.length > 1) {
+            if (args.length > 1 && !args[1].isNil()) {
                 if (!(args[1] instanceof RubyString)) {
                     throw getRuntime().newTypeError(
                             "wrong argument type " + args[1].getMetaClass().getName()

--- a/spec/ruby/library/zlib/gzipreader/readpartial_spec.rb
+++ b/spec/ruby/library/zlib/gzipreader/readpartial_spec.rb
@@ -1,0 +1,17 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'stringio'
+require 'zlib'
+
+describe 'GzipReader#readpartial' do
+  before :each do
+    @data = '12345abcde'
+    @zip = [31, 139, 8, 0, 44, 220, 209, 71, 0, 3, 51, 52, 50, 54, 49, 77,
+            76, 74, 78, 73, 5, 0, 157, 5, 0, 36, 10, 0, 0, 0].pack('C*')
+    @io = StringIO.new(@zip)
+  end
+
+  it 'accepts nil buffer' do
+    gz = Zlib::GzipReader.new(@io)
+    gz.readpartial(5, nil).should == '12345'
+  end
+end


### PR DESCRIPTION
In MRI it's ok to explicitly pass a nil buffer to `#readpartial`. However, JRuby currently throws a `TypeError`.

This adds a nil-check to bring JRuby in line with MRI's behaviour.