### PR TITLE
Cache RubyDateParser object in ThreadContext to reduce the cost of object creations

### DIFF
--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -63,6 +63,7 @@ import org.jruby.runtime.profile.ProfileCollection;
 import org.jruby.runtime.scope.ManyVarsDynamicScope;
 import org.jruby.util.RecursiveComparator;
 import org.jruby.util.RubyDateFormatter;
+import org.jruby.util.RubyDateParser;
 import org.jruby.util.cli.Options;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
@@ -107,6 +108,7 @@ public final class ThreadContext {
     private ThreadFiber rootFiber; // hard anchor for root threads' fibers
     // Cache format string because it is expensive to create on demand
     private RubyDateFormatter dateFormatter;
+    private RubyDateParser dateParser;
 
     private Frame[] frameStack = new Frame[INITIAL_FRAMES_SIZE];
     private int frameIndex = -1;
@@ -358,6 +360,12 @@ public final class ThreadContext {
         if (dateFormatter == null)
             dateFormatter = new RubyDateFormatter(this);
         return dateFormatter;
+    }
+
+    public RubyDateParser getRubyDateParser() {
+        if (dateParser == null)
+            dateParser = new RubyDateParser();
+        return dateParser;
     }
 
     public void setThread(RubyThread thread) {

--- a/lib/ruby/stdlib/date/format.rb
+++ b/lib/ruby/stdlib/date/format.rb
@@ -376,8 +376,7 @@ class Date
   private_class_method :_strptime_i
 
   def self._strptime(str, fmt='%F')
-    parser = org.jruby.util.RubyDateParser.new
-    map = parser.parse(JRuby.runtime.current_context, fmt, str)
+    map = JRuby.runtime.current_context.getRubyDateParser.parse(JRuby.runtime.current_context, fmt, str)
     return map.nil? ? nil : map.to_hash.inject({}){|hash,(k,v)| hash[k.to_sym] = v; hash}
   end
 


### PR DESCRIPTION
To improve performance of Java strptime implemented on https://github.com/jruby/jruby/pull/4635, this PR caches a `RubyDateParser` object in `ThreadContext` to reduce the cost of `RubyDateParser` object creations. The cache is basically similar approach to `RubyDateFormatter` in `ThreadContext`. 

The following is my micro benchmark based on https://github.com/macournoyer/tinyrb. The performance by this PR is 1.5 times faster maximumly. 

```
1,000 times Date._strptime('2001-02-03', '%Y-%m-%d')
                     user     system      total        real
mri 2.4.1        0.000000   0.000000   0.070000 (  0.092492)
jruby 9.1.9.0    0.000000   0.000000   8.220000 (  3.861129)
jruby (master)   0.000000   0.000000   7.130000 (  3.671143)

10,000 times Date._strptime('2001-02-03', '%Y-%m-%d')
                     user     system      total        real
mri 2.4.1        0.000000   0.000000   0.100000 (  0.126605)
jruby 9.1.9.0    0.000000   0.000000  11.570000 (  5.183052)
jruby (master)   0.000000   0.000000   8.280000 (  3.905535)

100,000 times Date._strptime('2001-02-03', '%Y-%m-%d')
                     user     system      total        real
mri 2.4.1        0.000000   0.000000   0.200000 (  0.219390)
jruby 9.1.9.0    0.000000   0.000000  17.000000 ( 10.131313)
jruby (master)   0.000000   0.000000  10.620000 (  5.003686)

1,000,000 times Date._strptime('2001-02-03', '%Y-%m-%d')
                     user     system      total        real
mri 2.4.1        0.000000   0.000000   1.240000 (  1.361164)
jruby 9.1.9.0    0.000000   0.000000  57.490000 ( 51.720962)
jruby (master)   0.000000   0.000000  17.010000 ( 10.431316)

10,000,000 times Date._strptime('2001-02-03', '%Y-%m-%d')
                     user     system      total        real
mri 2.4.1        0.000000   0.000000  12.750000 ( 15.315754)
jruby 9.1.9.0    0.000000   0.000000 525.980000 (586.105106)
jruby (master)   0.000000   0.000000  66.050000 ( 65.739327)
```
The raw test data: https://gist.github.com/muga/b83262ed03009d2f765f8fd0c5319e54