### PR TITLE
Implement key conversions with symbol by Java within Date._strptime

### DIFF
--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -63,6 +63,7 @@ import org.jruby.runtime.profile.ProfileCollection;
 import org.jruby.runtime.scope.ManyVarsDynamicScope;
 import org.jruby.util.RecursiveComparator;
 import org.jruby.util.RubyDateFormatter;
+import org.jruby.util.RubyDateParser;
 import org.jruby.util.cli.Options;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
@@ -107,6 +108,7 @@ public final class ThreadContext {
     private ThreadFiber rootFiber; // hard anchor for root threads' fibers
     // Cache format string because it is expensive to create on demand
     private RubyDateFormatter dateFormatter;
+    private RubyDateParser dateParser;
 
     private Frame[] frameStack = new Frame[INITIAL_FRAMES_SIZE];
     private int frameIndex = -1;
@@ -358,6 +360,12 @@ public final class ThreadContext {
         if (dateFormatter == null)
             dateFormatter = new RubyDateFormatter(this);
         return dateFormatter;
+    }
+
+    public RubyDateParser getRubyDateParser() {
+        if (dateParser == null)
+            dateParser = new RubyDateParser();
+        return dateParser;
     }
 
     public void setThread(RubyThread thread) {

--- a/core/src/main/java/org/jruby/util/RubyDateParser.java
+++ b/core/src/main/java/org/jruby/util/RubyDateParser.java
@@ -25,14 +25,19 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby.util;
 
+import org.jruby.Ruby;
 import org.jruby.RubyBignum;
 import org.jruby.RubyFixnum;
+import org.jruby.RubyHash;
 import org.jruby.RubyRational;
 import org.jruby.RubyString;
+import org.jruby.RubySymbol;
 import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.jruby.util.StrptimeParser.FormatBag.has;
 
@@ -63,6 +68,10 @@ public class RubyDateParser {
         } else {
             return null;
         }
+    }
+
+    public IRubyObject parseAndCreateHash(ThreadContext context, final RubyString format, final RubyString text) {
+        return createHash(context, parse(context, format, text));
     }
 
     private HashMap<String, Object> convertFormatBagToHash(ThreadContext context, StrptimeParser.FormatBag bag, boolean tainted) {
@@ -147,5 +156,24 @@ public class RubyDateParser {
         }
 
         return map;
+    }
+
+    private IRubyObject createHash(ThreadContext context, HashMap<String, Object> map) {
+        final Ruby runtime = context.getRuntime();
+        if (map == null) {
+            return runtime.getNil();
+        }
+
+        final RubyHash hash = RubyHash.newHash(runtime);
+        if (map.isEmpty()) {
+            return hash;
+        }
+
+        for (final Map.Entry<String, Object> entry : map.entrySet()) {
+            final RubySymbol sym = RubySymbol.newSymbol(runtime, entry.getKey());
+            final Object value = entry.getValue();
+            hash.put(sym, value);
+        }
+        return hash;
     }
 }

--- a/lib/ruby/stdlib/date/format.rb
+++ b/lib/ruby/stdlib/date/format.rb
@@ -376,8 +376,7 @@ class Date
   private_class_method :_strptime_i
 
   def self._strptime(str, fmt='%F')
-    parser = org.jruby.util.RubyDateParser.new
-    map = parser.parse(JRuby.runtime.current_context, fmt, str)
+    map = JRuby.runtime.current_context.getRubyDateParser.parse(JRuby.runtime.current_context, fmt, str)
     return map.nil? ? nil : map.to_hash.inject({}){|hash,(k,v)| hash[k.to_sym] = v; hash}
   end
 

--- a/lib/ruby/stdlib/date/format.rb
+++ b/lib/ruby/stdlib/date/format.rb
@@ -376,8 +376,7 @@ class Date
   private_class_method :_strptime_i
 
   def self._strptime(str, fmt='%F')
-    map = JRuby.runtime.current_context.getRubyDateParser.parse(JRuby.runtime.current_context, fmt, str)
-    return map.nil? ? nil : map.to_hash.inject({}){|hash,(k,v)| hash[k.to_sym] = v; hash}
+    return JRuby.runtime.current_context.getRubyDateParser.parseAndCreateHash(JRuby.runtime.current_context, fmt, str)
   end
 
   def self.s3e(e, y, m, d, bc=false)


### PR DESCRIPTION
To improve performance of Java strptime implemented on #4635, this PR fixes `Date._strptime` to implement key conversions with symbol in Java. Because It reduces the count of objects passing between JRuby and Java. 

a RubyDateParser object in ThreadContext to reduce the cost of RubyDateParser object creations. The cache is basically similar approach to RubyDateFormatter in ThreadContext. And this PR assumes #4675.

The following is my micro benchmark based on https://github.com/macournoyer/tinyrb. The performance by this PR is 2.5 times faster maximumly.

```
1,000 times Date._strptime('2001-02-03', '%Y-%m-%d')
                     user     system      total        real
mri 2.4.1        0.000000   0.000000   0.070000 (  0.086790)
jruby 9.1.9.0    0.000000   0.000000   8.020000 (  3.789310)
jruby (master)   0.000000   0.000000   7.290000 (  4.043696)

10,000 times Date._strptime('2001-02-03', '%Y-%m-%d')
                     user     system      total        real
mri 2.4.1        0.000000   0.000000   0.090000 (  0.142577)
jruby 9.1.9.0    0.000000   0.000000  12.450000 (  7.671689)
jruby (master)   0.000000   0.000000   8.180000 (  4.401070)

100,000 times Date._strptime('2001-02-03', '%Y-%m-%d')
                     user     system      total        real
mri 2.4.1        0.000000   0.000000   0.200000 (  0.209632)
jruby 9.1.9.0    0.000000   0.000000  17.420000 ( 10.452343)
jruby (master)   0.000000   0.000000   9.010000 (  4.304226)

1,000,000 times Date._strptime('2001-02-03', '%Y-%m-%d')
                     user     system      total        real
mri 2.4.1        0.000000   0.000000   1.260000 (  1.362743)
jruby 9.1.9.0    0.000000   0.000000  60.650000 ( 59.166195)
jruby (master)   0.000000   0.000000  12.170000 (  7.638632)

10,000,000 times Date._strptime('2001-02-03', '%Y-%m-%d')
                     user     system      total        real
mri 2.4.1        0.000000   0.000000  11.970000 ( 12.952664)
jruby 9.1.9.0    0.000000   0.000000 482.880000 (516.068042)
jruby (master)   0.000000   0.000000  36.650000 ( 35.192336)
```
The raw test data: https://gist.github.com/muga/e566299fc9afdaa0511a8bb7804d5a7f
