### PR TITLE
native implementation of set.rb

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1719,6 +1719,7 @@ public final class Ruby implements Constantizable {
         addLazyBuiltin("tempfile.jar", "tempfile", "org.jruby.ext.tempfile.TempfileLibrary");
         addLazyBuiltin("fcntl.rb", "fcntl", "org.jruby.ext.fcntl.FcntlLibrary");
         addLazyBuiltin("pathname.jar", "pathname", "org.jruby.ext.pathname.PathnameLibrary");
+        addLazyBuiltin("set.rb", "set", "org.jruby.ext.set.SetLibrary");
 
         addLazyBuiltin("mathn/complex.jar", "mathn/complex", "org.jruby.ext.mathn.Complex");
         addLazyBuiltin("mathn/rational.jar", "mathn/rational", "org.jruby.ext.mathn.Rational");

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -3522,7 +3522,8 @@ public class RubyModule extends RubyObject {
         return context.nil;
     }
 
-    final void setConstantVisibility(Ruby runtime, String name, boolean hidden) {
+    // NOTE: internal API
+    public final void setConstantVisibility(Ruby runtime, String name, boolean hidden) {
         ConstantEntry entry = getConstantMap().get(name);
 
         if (entry == null) {

--- a/core/src/main/java/org/jruby/ext/set/EnumerableExt.java
+++ b/core/src/main/java/org/jruby/ext/set/EnumerableExt.java
@@ -1,0 +1,63 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 1.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 1.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2016 Karol Bucek
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.ext.set;
+
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.Block;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+/**
+ * Enumerable#to_set (from require 'set')
+ *
+ * @author kares
+ */
+public abstract class EnumerableExt {
+
+    //@JRubyMethod
+    public static IRubyObject to_set(final ThreadContext context, final IRubyObject self, final Block block) {
+        final Ruby runtime = context.runtime;
+
+        RubySet set = new RubySet(runtime, runtime.getClass("Set"));
+        set.initialize(context, self, block);
+        return set; // return runtime.getClass("Set").newInstance(context, self, block);
+    }
+
+    @JRubyMethod(rest = true) // to_set(klass = Set, *args, &block)
+    public static IRubyObject to_set(final ThreadContext context, final IRubyObject self,
+        final IRubyObject[] args, final Block block) {
+
+        if ( args.length == 0 ) return to_set(context, self, block);
+
+        final IRubyObject klass = args[0]; args[0] = self;
+        return ((RubyClass) klass).newInstance(context, args, block);
+    }
+
+}

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -104,13 +104,16 @@ public class RubySet extends RubyObject implements Set {
     }
 
     private RubySet newSet(final ThreadContext context, final RubyClass metaClass, final RubyArray elements) {
-        RubySet set = new RubySet(context.runtime, metaClass);
-        final int len = elements.size();
-        set.initHash(context.runtime, len);
-        for ( int i = 0; i < len; i++ ) {
-            set.invokeAdd(context, elements.eltInternal(i));
+        final RubySet set = new RubySet(context.runtime, metaClass);
+        return set.initSet(context, elements.toJavaArrayMaybeUnsafe(), 0, elements.size());
+    }
+
+    final RubySet initSet(final ThreadContext context, final IRubyObject[] elements, final int off, final int len) {
+        initHash(context.runtime, Math.max(4, len));
+        for ( int i = off; i < len; i++ ) {
+            invokeAdd(context, elements[i]);
         }
-        return set;
+        return this;
     }
 
     /**
@@ -121,9 +124,7 @@ public class RubySet extends RubyObject implements Set {
         final Ruby runtime = context.runtime;
 
         RubySet set = new RubySet(runtime, (RubyClass) self);
-        set.initHash(runtime, Math.max(4, ary.length));
-        for ( int i=0; i<ary.length; i++ ) set.invokeAdd(context, ary[i]);
-        return set;
+        return set.initSet(context, ary, 0, ary.length);
     }
 
     /**
@@ -204,7 +205,7 @@ public class RubySet extends RubyObject implements Set {
         throw context.runtime.newArgumentError("value must be enumerable");
     }
 
-    private IRubyObject invokeAdd(final ThreadContext context, final IRubyObject val) {
+    IRubyObject invokeAdd(final ThreadContext context, final IRubyObject val) {
         return this.callMethod(context,"add", val); // TODO site-cache
     }
 

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -114,12 +114,15 @@ public class RubySet extends RubyObject implements Set {
         allocHash(hash);
     } */
 
+    // since MRI uses Hash.new(false) we'll (initially) strive for maximum compatibility
+    // ... this is important with Rails using Sprockets at its marshalling Set instances
+
     final void allocHash(final Ruby runtime) {
-        setHash(new RubyHash(runtime));
+        setHash(new RubyHash(runtime, runtime.getFalse()));
     }
 
     final void allocHash(final Ruby runtime, final int size) {
-        setHash(new RubyHash(runtime, size));
+        setHash(new RubyHash(runtime, runtime.getFalse(), size));
     }
 
     final void setHash(final RubyHash hash) {

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -159,7 +159,7 @@ public class RubySet extends RubyObject { // implements Set {
         if ( enume instanceof RubySet ) {
             RubySet set = (RubySet) enume;
             initHash(context.runtime, set.size());
-            for ( IRubyObject elem : set.elements() ) {
+            for ( IRubyObject elem : set.elementsOrdered() ) {
                 invokeAdd(context, block.yield(context, elem));
             }
             return set; // done
@@ -280,7 +280,7 @@ public class RubySet extends RubyObject { // implements Set {
         return this;
     }
 
-    private void clearImpl() {
+    protected void clearImpl() {
         hash.rb_clear();
     }
 
@@ -291,7 +291,8 @@ public class RubySet extends RubyObject { // implements Set {
     public RubySet replace(final ThreadContext context, IRubyObject enume) {
         if ( enume instanceof RubySet ) {
             modifyCheck(context.runtime);
-            this.hash.replace(context, ((RubySet) enume).hash);
+            clearImpl();
+            addImplSet(context, (RubySet) enume);
         }
         else {
             final Ruby runtime = context.runtime;
@@ -323,7 +324,7 @@ public class RubySet extends RubyObject { // implements Set {
     public RubySet to_set(final ThreadContext context, final Block block) {
         if ( block.isGiven() ) {
             RubySet set = new RubySet(context.runtime, getMetaClass());
-            set.initialize(context, block);
+            set.initialize(context, this, block);
             return set;
         }
         return this;
@@ -363,7 +364,7 @@ public class RubySet extends RubyObject { // implements Set {
 
     private void flattenMerge(final ThreadContext context, final IRubyObject set, final IdentityHashMap seen) {
         if ( set instanceof RubySet ) {
-            for ( IRubyObject e : ((RubySet) set).elements() ) {
+            for ( IRubyObject e : ((RubySet) set).elementsOrdered() ) {
                 addFlattened(context, seen, e);
             }
         }
@@ -400,7 +401,7 @@ public class RubySet extends RubyObject { // implements Set {
 
     @JRubyMethod(name = "flatten!")
     public IRubyObject flatten_bang(final ThreadContext context) {
-        for ( IRubyObject e : elements() ) {
+        for ( IRubyObject e : elementsOrdered() ) {
             if ( e instanceof RubySet ) { // needs flatten
                 return replace(context, flatten(context));
             }
@@ -499,13 +500,13 @@ public class RubySet extends RubyObject { // implements Set {
     public boolean intersect(final ThreadContext context, final RubySet set) {
         if ( size() < set.size() ) {
             // any? { |o| set.include?(o) }
-            for ( IRubyObject o : elements() ) {
+            for ( IRubyObject o : elementsOrdered() ) {
                 if ( set.contains(context, o) ) return true;
             }
         }
         else {
             // set.any? { |o| include?(o) }
-            for ( IRubyObject o : set.elements() ) {
+            for ( IRubyObject o : set.elementsOrdered() ) {
                 if ( contains(context, o) ) return true;
             }
         }
@@ -530,7 +531,7 @@ public class RubySet extends RubyObject { // implements Set {
             return enumeratorizeWithSize(context, this, "each", enumSize());
         }
 
-        for (IRubyObject elem : elements()) block.yield(context, elem);
+        for (IRubyObject elem : elementsOrdered()) block.yield(context, elem);
         return this;
     }
 
@@ -549,12 +550,17 @@ public class RubySet extends RubyObject { // implements Set {
     @JRubyMethod(name = "add", alias = "<<")
     public RubySet add(final ThreadContext context, IRubyObject obj) {
         modifyCheck(context.runtime);
-        addObject(context.runtime, obj);
+        addImpl(context.runtime, obj);
         return this;
     }
 
-    protected void addObject(final Ruby runtime, final IRubyObject obj) {
+    protected void addImpl(final Ruby runtime, final IRubyObject obj) {
         hash.fastASetCheckString(runtime, obj, runtime.getTrue()); // @hash[obj] = true
+    }
+
+    protected void addImplSet(final ThreadContext context, final RubySet set) {
+        // NOTE: MRI cheats - does not call Set#add thus we do not care ...
+        hash.merge_bang(context, set.hash, Block.NULL_BLOCK);
     }
 
     /**
@@ -570,13 +576,17 @@ public class RubySet extends RubyObject { // implements Set {
     @JRubyMethod
     public IRubyObject delete(final ThreadContext context, IRubyObject obj) {
         modifyCheck(context.runtime);
-        deleteObject(obj);
+        deleteImpl(obj);
         return this;
     }
 
-    private void deleteObject(final IRubyObject obj) {
+    protected boolean deleteImpl(final IRubyObject obj) {
         hash.modify();
-        hash.fastDelete(obj);
+        return hash.fastDelete(obj);
+    }
+
+    protected void deleteImplIterator(final IRubyObject obj, final Iterator it) {
+        it.remove();
     }
 
     /**
@@ -598,7 +608,7 @@ public class RubySet extends RubyObject { // implements Set {
         Iterator<IRubyObject> it = elements().iterator();
         while ( it.hasNext() ) {
             IRubyObject elem = it.next();
-            if ( block.yield(context, elem).isTrue() ) it.remove();
+            if ( block.yield(context, elem).isTrue() ) deleteImplIterator(elem, it); // it.remove
         }
         return this;
     }
@@ -612,7 +622,7 @@ public class RubySet extends RubyObject { // implements Set {
         Iterator<IRubyObject> it = elements().iterator();
         while ( it.hasNext() ) {
             IRubyObject elem = it.next();
-            if ( ! block.yield(context, elem).isTrue() ) it.remove();
+            if ( ! block.yield(context, elem).isTrue() ) deleteImplIterator(elem, it); // it.remove
         }
         return this;
     }
@@ -625,7 +635,7 @@ public class RubySet extends RubyObject { // implements Set {
 
         final RubyArray elems = to_a(context); clearImpl();
         for ( int i=0; i<elems.size(); i++ ) {
-            addObject(context.runtime, block.yield(context, elems.eltInternal(i)));
+            addImpl(context.runtime, block.yield(context, elems.eltInternal(i)));
         }
         return this;
     }
@@ -641,7 +651,7 @@ public class RubySet extends RubyObject { // implements Set {
         Iterator<IRubyObject> it = elements().iterator();
         while ( it.hasNext() ) {
             IRubyObject elem = it.next();
-            if ( block.yield(context, elem).isTrue() ) it.remove();
+            if ( block.yield(context, elem).isTrue() ) deleteImplIterator(elem, it); // it.remove
         }
         return size == size() ? context.nil : this;
     }
@@ -657,7 +667,7 @@ public class RubySet extends RubyObject { // implements Set {
         Iterator<IRubyObject> it = elements().iterator();
         while ( it.hasNext() ) {
             IRubyObject elem = it.next();
-            if ( ! block.yield(context, elem).isTrue() ) it.remove();
+            if ( ! block.yield(context, elem).isTrue() ) deleteImplIterator(elem, it); // it.remove
         }
         return size == size() ? context.nil : this;
     }
@@ -671,20 +681,19 @@ public class RubySet extends RubyObject { // implements Set {
 
         if ( enume instanceof RubySet ) {
             modifyCheck(runtime);
-            // NOTE: MRI cheats - does not call Set#add thus we do not care ...
-            hash.merge_bang(context, ((RubySet) enume).hash, Block.NULL_BLOCK);
+            addImplSet(context, (RubySet) enume);
         }
         else if ( enume instanceof RubyArray ) {
             modifyCheck(runtime);
             RubyArray ary = (RubyArray) enume;
             for ( int i = 0; i < ary.size(); i++ ) {
-                addObject(runtime, ary.eltInternal(i));
+                addImpl(runtime, ary.eltInternal(i));
             }
         }
         else { // do_with_enum(enum) { |o| add(o) }
             doWithEnum(context, enume, new EachBody(runtime) {
                 IRubyObject yieldImpl(ThreadContext context, IRubyObject val) {
-                    addObject(context.runtime, val); return context.nil;
+                    addImpl(context.runtime, val); return context.nil;
                 }
             });
         }
@@ -701,21 +710,21 @@ public class RubySet extends RubyObject { // implements Set {
 
         if ( enume instanceof RubySet ) {
             modifyCheck(runtime);
-            for ( IRubyObject elem : ((RubySet) enume).elements() ) {
-                deleteObject(elem);
+            for ( IRubyObject elem : ((RubySet) enume).elementsOrdered() ) {
+                deleteImpl(elem);
             }
         }
         else if ( enume instanceof RubyArray ) {
             modifyCheck(runtime);
             RubyArray ary = (RubyArray) enume;
             for ( int i = 0; i < ary.size(); i++ ) {
-                deleteObject(ary.eltInternal(i));
+                deleteImpl(ary.eltInternal(i));
             }
         }
         else { // do_with_enum(enum) { |o| delete(o) }
             doWithEnum(context, enume, new EachBody(runtime) {
                 IRubyObject yieldImpl(ThreadContext context, IRubyObject val) {
-                    deleteObject(val); return context.nil;
+                    deleteImpl(val); return context.nil;
                 }
             });
         }
@@ -749,8 +758,8 @@ public class RubySet extends RubyObject { // implements Set {
         final RubySet newSet = new RubySet(runtime, getMetaClass());
         if ( enume instanceof RubySet ) {
             newSet.initHash(runtime, ((RubySet) enume).size());
-            for ( IRubyObject obj : ((RubySet) enume).elements() ) {
-                if ( contains(context, obj) ) newSet.addObject(runtime, obj);
+            for ( IRubyObject obj : ((RubySet) enume).elementsOrdered() ) {
+                if ( contains(context, obj) ) newSet.addImpl(runtime, obj);
             }
         }
         else if ( enume instanceof RubyArray ) {
@@ -758,7 +767,7 @@ public class RubySet extends RubyObject { // implements Set {
             newSet.initHash(runtime, ary.size());
             for ( int i = 0; i < ary.size(); i++ ) {
                 final IRubyObject obj = ary.eltInternal(i);
-                if ( contains(context, obj) ) newSet.addObject(runtime, obj);
+                if ( contains(context, obj) ) newSet.addImpl(runtime, obj);
             }
         }
         else {
@@ -766,7 +775,7 @@ public class RubySet extends RubyObject { // implements Set {
             // do_with_enum(enum) { |o| newSet.add(o) if include?(o) }
             doWithEnum(context, enume, new EachBody(runtime) {
                 IRubyObject yieldImpl(ThreadContext context, IRubyObject obj) {
-                    if ( contains(context, obj) ) newSet.addObject(runtime, obj);
+                    if ( contains(context, obj) ) newSet.addImpl(runtime, obj);
                     return context.nil;
                 }
             });
@@ -785,9 +794,9 @@ public class RubySet extends RubyObject { // implements Set {
 
         RubySet newSet = new RubySet(runtime, runtime.getClass("Set"));
         newSet.initialize(context, enume, Block.NULL_BLOCK); // Set.new(enum)
-        for ( IRubyObject o : elements() ) {
-            if ( newSet.contains(context, o) ) newSet.deleteObject(o); // exclusive or
-            else newSet.addObject(runtime, o);
+        for ( IRubyObject o : elementsOrdered() ) {
+            if ( newSet.contains(context, o) ) newSet.deleteImpl(o); // exclusive or
+            else newSet.addImpl(runtime, o);
         }
 
         return newSet;
@@ -803,7 +812,7 @@ public class RubySet extends RubyObject { // implements Set {
         if ( other instanceof RubySet ) {
             RubySet that = (RubySet) other;
             if ( this.size() == that.size() ) { // && includes all of our elements :
-                for ( IRubyObject obj : elements() ) {
+                for ( IRubyObject obj : elementsOrdered() ) {
                     if ( ! that.contains(context, obj) ) return context.runtime.getFalse();
                 }
                 return context.runtime.getTrue();
@@ -853,7 +862,7 @@ public class RubySet extends RubyObject { // implements Set {
 
         final RubyHash h = new RubyHash(runtime, size());
 
-        for ( IRubyObject i : elements() ) {
+        for ( IRubyObject i : elementsOrdered() ) {
             final IRubyObject key = block.yield(context, i);
             IRubyObject set;
             if ( ( set = h.fastARef(key) ) == null ) {
@@ -909,10 +918,10 @@ public class RubySet extends RubyObject { // implements Set {
 
         final RubyHash dig = DivideTSortHash.newInstance(context);
 
-        for ( IRubyObject u : elements() ) { // each
+        for ( IRubyObject u : elementsOrdered() ) { // each
             RubyArray a;
             dig.fastASet(u, a = runtime.newArray()); // dig[u] = a = []
-            for ( IRubyObject v : elements() ) { // each
+            for ( IRubyObject v : elementsOrdered() ) { // each
                 // func.call(u, v) and a << v
                 IRubyObject ret = block.call(context, u, v);
                 if ( ret.isTrue() ) a.append(v);
@@ -940,7 +949,7 @@ public class RubySet extends RubyObject { // implements Set {
                 public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
                     // final IRubyObject css = args[0];
                     // set.add( self.class.new(css) ) :
-                    set.addObject(runtime, RubySet.create(context, RubySet.this.getMetaClass(), args));
+                    set.addImpl(runtime, RubySet.create(context, RubySet.this.getMetaClass(), args));
                     return context.nil;
                 }
             })
@@ -1063,7 +1072,7 @@ public class RubySet extends RubyObject { // implements Set {
 
         boolean tainted = isTaint(); boolean notFirst = false;
 
-        for ( IRubyObject elem : elements() ) {
+        for ( IRubyObject elem : elementsOrdered() ) {
             final RubyString s = inspect(context, elem);
             if ( s.isTaint() ) tainted = true;
             if ( notFirst ) str.cat((byte) ',').cat((byte) ' ');
@@ -1080,6 +1089,11 @@ public class RubySet extends RubyObject { // implements Set {
 
     protected final Set<IRubyObject> elements() {
         return hash.directKeySet(); // Hash view -> no copying
+    }
+
+    // NOTE: implementation does not expect to be used for altering contents using iterator
+    protected Set<IRubyObject> elementsOrdered() {
+        return elements(); // potentially -> to be re-defined by SortedSet
     }
 
     protected final void modifyCheck(final Ruby runtime) {

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -864,8 +864,6 @@ public class RubySet extends RubyObject implements Set {
         return context.runtime.getFalse();
     }
 
-    // TODO Java (Collection) equals !
-
     @JRubyMethod(name = "eql?")
     public IRubyObject op_eql(ThreadContext context, IRubyObject other) {
         if ( other instanceof RubySet ) {
@@ -886,14 +884,8 @@ public class RubySet extends RubyObject implements Set {
     @Override
     @JRubyMethod
     public RubyFixnum hash() { // @hash.hash
-        return getRuntime().newFixnum(hashCode());
+        return hash.hash();
     }
-
-    @Override
-    public int hashCode() {
-        return hash.hashCode();
-    }
-
 
     @JRubyMethod(name = "classify")
     public IRubyObject classify(ThreadContext context, final Block block) {

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -615,7 +615,7 @@ public class RubySet extends RubyObject implements Set {
             return enumeratorizeWithSize(context, this, "delete_if", enumSize());
         }
 
-        Iterator<IRubyObject> it = elements().iterator();
+        Iterator<IRubyObject> it = elementsOrdered().iterator();
         while ( it.hasNext() ) {
             IRubyObject elem = it.next();
             if ( block.yield(context, elem).isTrue() ) deleteImplIterator(elem, it); // it.remove
@@ -629,7 +629,7 @@ public class RubySet extends RubyObject implements Set {
             return enumeratorizeWithSize(context, this, "keep_if", enumSize());
         }
 
-        Iterator<IRubyObject> it = elements().iterator();
+        Iterator<IRubyObject> it = elementsOrdered().iterator();
         while ( it.hasNext() ) {
             IRubyObject elem = it.next();
             if ( ! block.yield(context, elem).isTrue() ) deleteImplIterator(elem, it); // it.remove
@@ -658,7 +658,7 @@ public class RubySet extends RubyObject implements Set {
         }
 
         final int size = size();
-        Iterator<IRubyObject> it = elements().iterator();
+        Iterator<IRubyObject> it = elementsOrdered().iterator();
         while ( it.hasNext() ) {
             IRubyObject elem = it.next();
             if ( block.yield(context, elem).isTrue() ) deleteImplIterator(elem, it); // it.remove
@@ -674,7 +674,7 @@ public class RubySet extends RubyObject implements Set {
         }
 
         final int size = size();
-        Iterator<IRubyObject> it = elements().iterator();
+        Iterator<IRubyObject> it = elementsOrdered().iterator();
         while ( it.hasNext() ) {
             IRubyObject elem = it.next();
             if ( ! block.yield(context, elem).isTrue() ) deleteImplIterator(elem, it); // it.remove

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -59,6 +59,8 @@ public class RubySet extends RubyObject { // implements Set {
         Set.includeModule(runtime.getEnumerable());
         Set.defineAnnotatedMethods(RubySet.class);
 
+        runtime.getLoadService().require("jruby/set.rb");
+
         return Set;
     }
 

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -1,0 +1,1089 @@
+/*
+ **** BEGIN LICENSE BLOCK *****
+ * Version: EPL 1.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 1.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2016 Karol Bucek
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.ext.set;
+
+import org.jcodings.specific.USASCIIEncoding;
+import org.jruby.*;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.common.IRubyWarnings;
+import org.jruby.runtime.*;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.ArraySupport;
+
+import java.util.Collection;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.Set;
+
+import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
+
+/**
+ * Native implementation of Ruby's Set (set.rb replacement).
+ *
+ * @author kares
+ */
+@org.jruby.anno.JRubyClass(name="Set", include = { "Enumerable" })
+public class RubySet extends RubyObject { // implements Set {
+
+    static RubyClass createSetClass(final Ruby runtime) {
+        RubyClass Set = runtime.defineClass("Set", runtime.getObject(), ALLOCATOR);
+
+        Set.setReifiedClass(RubySet.class);
+
+        Set.includeModule(runtime.getEnumerable());
+        Set.defineAnnotatedMethods(RubySet.class);
+
+        return Set;
+    }
+
+    private static final ObjectAllocator ALLOCATOR = new ObjectAllocator() {
+        public RubySet allocate(Ruby runtime, RubyClass klass) {
+            return new RubySet(runtime, klass);
+        }
+    };
+
+    RubyHash hash; // @hash
+
+    protected RubySet(Ruby runtime, RubyClass klass) {
+        super(runtime, klass);
+    }
+
+    /*
+    private RubySet(Ruby runtime, RubyHash hash) {
+        super(runtime, runtime.getClass("Set"));
+        initHash(hash);
+    } */
+
+    final void initHash(final Ruby runtime) {
+        initHash(new RubyHash(runtime));
+    }
+
+    final void initHash(final Ruby runtime, final int size) {
+        initHash(new RubyHash(runtime, size));
+    }
+
+    final void initHash(final RubyHash hash) {
+        this.hash = hash;
+        setInstanceVariable("@hash", hash); // MRI compat with set.rb
+    }
+
+    RubySet newSet(final Ruby runtime) {
+        RubySet set = new RubySet(runtime, getMetaClass());
+        set.initHash(runtime); return set;
+    }
+
+    /**
+     * Creates a new set containing the given objects.
+     */
+    @JRubyMethod(name = "[]", rest = true, meta = true) // def self.[](*ary)
+    public static RubySet create(final ThreadContext context, IRubyObject self, IRubyObject... ary) {
+        final Ruby runtime = context.runtime;
+
+        RubySet set = new RubySet(runtime, (RubyClass) self);
+        set.initHash(runtime, Math.max(4, ary.length));
+        for ( int i=0; i<ary.length; i++ ) set.invokeAdd(context, ary[i]);
+        return set;
+    }
+
+    /**
+     * initialize(enum = nil, &block)
+     */
+    @JRubyMethod(visibility = Visibility.PRIVATE) // def initialize(enum = nil, &block)
+    public IRubyObject initialize(ThreadContext context, Block block) {
+        if ( block.isGiven() && context.runtime.isVerbose() ) {
+            context.runtime.getWarnings().warning(IRubyWarnings.ID.BLOCK_UNUSED, "given block not used");
+        }
+        initHash(context.runtime);
+        return this;
+    }
+
+    /**
+     * initialize(enum = nil, &block)
+     */
+    @JRubyMethod(required = 1, visibility = Visibility.PRIVATE)
+    public IRubyObject initialize(ThreadContext context, IRubyObject enume, Block block) {
+        if ( enume.isNil() ) return initialize(context, block);
+
+        if ( block.isGiven() ) {
+            return initWithEnum(context, enume, block);
+        }
+
+        initHash(context.runtime);
+        return callMethod(context, "merge", enume); // TODO site-cache
+    }
+
+    protected IRubyObject initialize(ThreadContext context, IRubyObject[] args, Block block) {
+        switch (args.length) {
+            case 0: return initialize(context, block);
+            case 1: return initialize(context, args[0], block);
+        }
+        throw context.runtime.newArgumentError(args.length, 1);
+    }
+
+    private IRubyObject initWithEnum(final ThreadContext context, final IRubyObject enume, final Block block) {
+        if ( enume instanceof RubyArray ) {
+            RubyArray ary = (RubyArray) enume;
+            initHash(context.runtime, ary.size());
+            for ( int i = 0; i < ary.size(); i++ ) {
+                invokeAdd(context, block.yield(context, ary.eltInternal(i)));
+            }
+            return ary; // done
+        }
+
+        if ( enume instanceof RubySet ) {
+            RubySet set = (RubySet) enume;
+            initHash(context.runtime, set.size());
+            for ( IRubyObject elem : set.elements() ) {
+                invokeAdd(context, block.yield(context, elem));
+            }
+            return set; // done
+        }
+
+        final Ruby runtime = context.runtime;
+
+        initHash(runtime);
+
+        // set.rb do_with_enum :
+        return doWithEnum(context, enume, new EachBody(runtime) {
+            IRubyObject yieldImpl(ThreadContext context, IRubyObject val) {
+                return invokeAdd(context, block.yield(context, val));
+            }
+        });
+    }
+
+    // set.rb do_with_enum (block is required)
+    private static IRubyObject doWithEnum(final ThreadContext context, final IRubyObject enume, final EachBody blockImpl) {
+        if ( enume.respondsTo("each_entry") ) {
+            return enume.callMethod(context, "each_entry", IRubyObject.NULL_ARRAY, new Block(blockImpl));
+        }
+        if ( enume.respondsTo("each") ) {
+            return enume.callMethod(context, "each", IRubyObject.NULL_ARRAY, new Block(blockImpl));
+        }
+
+        throw context.runtime.newArgumentError("value must be enumerable");
+    }
+
+    private IRubyObject invokeAdd(final ThreadContext context, final IRubyObject val) {
+        return this.callMethod(context,"add", val); // TODO site-cache
+    }
+
+    private static abstract class EachBody extends JavaInternalBlockBody {
+
+        EachBody(final Ruby runtime) {
+            super(runtime, Signature.ONE_REQUIRED);
+        }
+
+        @Override
+        public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
+            return yieldImpl(context, args[0]);
+        }
+
+        abstract IRubyObject yieldImpl(ThreadContext context, IRubyObject val) ;
+
+        @Override
+        protected final IRubyObject doYield(ThreadContext context, Block block, IRubyObject[] args, IRubyObject self) {
+            return yieldImpl(context, args[0]);
+        }
+
+        @Override
+        protected final IRubyObject doYield(ThreadContext context, Block block, IRubyObject value) {
+            return yieldImpl(context, value); // avoid new IRubyObject[] { value }
+        }
+
+    }
+
+    @JRubyMethod
+    public IRubyObject initialize_dup(ThreadContext context, IRubyObject orig) {
+        super.initialize_copy(orig);
+        initHash((RubyHash) (((RubySet) orig).hash).dup(context));
+        return this;
+    }
+
+    @JRubyMethod
+    public IRubyObject initialize_clone(ThreadContext context, IRubyObject orig) {
+        super.initialize_copy(orig);
+        initHash((RubyHash) (((RubySet) orig).hash).rbClone(context));
+        return this;
+    }
+
+    @Override
+    @JRubyMethod
+    public IRubyObject freeze(ThreadContext context) {
+        final RubyHash hash = this.hash;
+        if ( hash != null ) hash.freeze(context);
+        return super.freeze(context);
+    }
+
+    @Override
+    @JRubyMethod
+    public IRubyObject taint(ThreadContext context) {
+        final RubyHash hash = this.hash;
+        if ( hash != null ) hash.taint(context);
+        return super.taint(context);
+    }
+
+    @Override
+    @JRubyMethod
+    public IRubyObject untaint(ThreadContext context) {
+        final RubyHash hash = this.hash;
+        if ( hash != null ) hash.untaint(context);
+        return super.untaint(context);
+    }
+
+    public int size() { return hash.size(); }
+
+    @JRubyMethod(name = "size", alias = "length")
+    public IRubyObject length(ThreadContext context) {
+        return context.runtime.newFixnum( size() );
+    }
+
+    public boolean isEmpty() { return hash.isEmpty(); }
+
+    @JRubyMethod(name = "empty?")
+    public IRubyObject empty_p(ThreadContext context) {
+        return context.runtime.newBoolean( isEmpty() );
+    }
+
+    public void clear() { clearImpl(); }
+
+    @JRubyMethod(name = "clear")
+    public IRubyObject rb_clear(ThreadContext context) {
+        modifyCheck(context.runtime);
+
+        clearImpl();
+        return this;
+    }
+
+    private void clearImpl() {
+        hash.rb_clear();
+    }
+
+    /**
+     * Replaces the contents of the set with the contents of the given enumerable object and returns self.
+     */
+    @JRubyMethod
+    public RubySet replace(final ThreadContext context, IRubyObject enume) {
+        if ( enume instanceof RubySet ) {
+            modifyCheck(context.runtime);
+            this.hash.replace(context, ((RubySet) enume).hash);
+        }
+        else {
+            final Ruby runtime = context.runtime;
+            // do_with_enum(enum)  # make sure enum is enumerable before calling clear :
+            if ( ! enume.getMetaClass().hasModuleInHierarchy(runtime.getEnumerable()) ) {
+                // NOTE: likely no need to do this but due MRI compat (do_with_enum) :
+                if ( ! enume.respondsTo("each_entry") ) {
+                    throw runtime.newArgumentError("value must be enumerable");
+                }
+            }
+            clearImpl();
+            rb_merge(context, enume);
+        }
+
+        return this;
+    }
+
+    /**
+     * Converts the set to an array.  The order of elements is uncertain.
+     */
+    @JRubyMethod
+    public RubyArray to_a(final ThreadContext context) {
+        // except MRI relies on Hash order so we do as well
+        return this.hash.keys();
+    }
+
+    // Returns self if no arguments are given.
+    @JRubyMethod
+    public RubySet to_set(final ThreadContext context, final Block block) {
+        if ( block.isGiven() ) {
+            RubySet set = new RubySet(context.runtime, getMetaClass());
+            set.initialize(context, block);
+            return set;
+        }
+        return this;
+    }
+
+    // Otherwise, converts the set to another with klass.new(self, *args, &block).
+    @JRubyMethod(rest = true)
+    public RubySet to_set(final ThreadContext context, final IRubyObject[] args, final Block block) {
+        if ( args.length == 0 ) return to_set(context, block);
+
+        final Ruby runtime = context.runtime;
+
+        IRubyObject klass = args[0]; final RubyClass Set = runtime.getClass("Set");
+
+        if ( klass == Set && args.length == 1 & ! block.isGiven() ) {
+            return this;
+        }
+
+        final IRubyObject[] rest;
+        if ( klass instanceof RubyClass ) {
+            rest = ArraySupport.newCopy(args, 1, args.length - 1);
+        }
+        else {
+            klass = Set; rest = args;
+        }
+
+        RubySet set = new RubySet(context.runtime, (RubyClass) klass);
+        set.initialize(context, rest, block);
+        return set;
+    }
+
+    @JRubyMethod(visibility = Visibility.PROTECTED)
+    public RubySet flatten_merge(final ThreadContext context, IRubyObject set) {
+        flattenMerge(context, set, new IdentityHashMap());
+        return this;
+    }
+
+    private void flattenMerge(final ThreadContext context, final IRubyObject set, final IdentityHashMap seen) {
+        if ( set instanceof RubySet ) {
+            for ( IRubyObject e : ((RubySet) set).elements() ) {
+                addFlattened(context, seen, e);
+            }
+        }
+        else {
+            set.callMethod(context, "each", IRubyObject.NULL_ARRAY, new Block(
+                new EachBody(context.runtime) {
+                    IRubyObject yieldImpl(ThreadContext context, IRubyObject e) {
+                        addFlattened(context, seen, e); return context.nil;
+                    }
+                })
+            );
+        }
+    }
+
+    private void addFlattened(final ThreadContext context, final IdentityHashMap seen, IRubyObject e) {
+        if ( e instanceof RubySet ) {
+            if ( seen.containsKey(e) ) {
+                throw context.runtime.newArgumentError("tried to flatten recursive Set");
+            }
+            seen.put(e, null);
+            flattenMerge(context, e, seen);
+            seen.remove(e);
+        }
+        else {
+            add(context, e); // self.add(e)
+        }
+    }
+
+    // Returns a new set that is a copy of the set, flattening each containing set recursively.
+    @JRubyMethod
+    public RubySet flatten(final ThreadContext context) {
+        return newSet(context.runtime).flatten_merge(context, this);
+    }
+
+    @JRubyMethod(name = "flatten!")
+    public IRubyObject flatten_bang(final ThreadContext context) {
+        for ( IRubyObject e : elements() ) {
+            if ( e instanceof RubySet ) { // needs flatten
+                return replace(context, flatten(context));
+            }
+        }
+        return context.nil;
+    }
+
+    /**
+     * Returns true if the set contains the given object.
+     */
+    @JRubyMethod(name = "include?", alias = { "member?" })
+    public RubyBoolean include_p(final ThreadContext context, IRubyObject obj) {
+        return hash.has_key_p(context, obj);
+    }
+
+    final boolean contains(final ThreadContext context, IRubyObject obj) {
+        return include_p(context, obj) == context.runtime.getTrue();
+    }
+
+    private boolean allElementsIncluded(ThreadContext context, final RubySet set) {
+        for ( IRubyObject o : set.elements() ) { // set.all? { |o| include?(o) }
+            if ( ! contains(context, o) ) return false;
+        }
+        return true;
+    }
+
+    // Returns true if the set is a superset of the given set.
+    @JRubyMethod(name = "superset?", alias = { ">=" })
+    public IRubyObject superset_p(final ThreadContext context, IRubyObject set) {
+        if ( set instanceof RubySet ) {
+            if ( getMetaClass().isInstance(set) ) {
+                return this.hash.op_ge(context, ((RubySet) set).hash);
+            }
+            // size >= set.size && set.all? { |o| include?(o) }
+            return context.runtime.newBoolean(
+                    size() >= ((RubySet) set).size() && allElementsIncluded(context, (RubySet) set)
+            );
+        }
+        throw context.runtime.newArgumentError("value must be a set");
+    }
+
+    // Returns true if the set is a proper superset of the given set.
+    @JRubyMethod(name = "proper_superset?", alias = { ">" })
+    public IRubyObject proper_superset_p(final ThreadContext context, IRubyObject set) {
+        if ( set instanceof RubySet ) {
+            if ( getMetaClass().isInstance(set) ) {
+                return this.hash.op_gt(context, ((RubySet) set).hash);
+            }
+            // size >= set.size && set.all? { |o| include?(o) }
+            return context.runtime.newBoolean(
+                    size() > ((RubySet) set).size() && allElementsIncluded(context, (RubySet) set)
+            );
+        }
+        throw context.runtime.newArgumentError("value must be a set");
+    }
+
+    @JRubyMethod(name = "subset?", alias = { "<=" })
+    public IRubyObject subset_p(final ThreadContext context, IRubyObject set) {
+        if ( set instanceof RubySet ) {
+            if ( getMetaClass().isInstance(set) ) {
+                return this.hash.op_le(context, ((RubySet) set).hash);
+            }
+            // size >= set.size && set.all? { |o| include?(o) }
+            return context.runtime.newBoolean(
+                    size() <= ((RubySet) set).size() && allElementsIncluded(context, (RubySet) set)
+            );
+        }
+        throw context.runtime.newArgumentError("value must be a set");
+    }
+
+    @JRubyMethod(name = "proper_subset?", alias = { "<" })
+    public IRubyObject proper_subset_p(final ThreadContext context, IRubyObject set) {
+        if ( set instanceof RubySet ) {
+            if ( getMetaClass().isInstance(set) ) {
+                return this.hash.op_lt(context, ((RubySet) set).hash);
+            }
+            // size >= set.size && set.all? { |o| include?(o) }
+            return context.runtime.newBoolean(
+                    size() < ((RubySet) set).size() && allElementsIncluded(context, (RubySet) set)
+            );
+        }
+        throw context.runtime.newArgumentError("value must be a set");
+    }
+
+    /**
+     * Returns true if the set and the given set have at least one element in common.
+     */
+    @JRubyMethod(name = "intersect?")
+    public IRubyObject intersect_p(final ThreadContext context, IRubyObject set) {
+        if ( set instanceof RubySet ) {
+            return context.runtime.newBoolean( intersect(context, (RubySet) set) );
+        }
+        throw context.runtime.newArgumentError("value must be a set");
+    }
+
+    public boolean intersect(final ThreadContext context, final RubySet set) {
+        if ( size() < set.size() ) {
+            // any? { |o| set.include?(o) }
+            for ( IRubyObject o : elements() ) {
+                if ( set.contains(context, o) ) return true;
+            }
+        }
+        else {
+            // set.any? { |o| include?(o) }
+            for ( IRubyObject o : set.elements() ) {
+                if ( contains(context, o) ) return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if the set and the given set have no element in common.
+     * This method is the opposite of +intersect?+.
+     */
+    @JRubyMethod(name = "disjoint?")
+    public IRubyObject disjoint_p(final ThreadContext context, IRubyObject set) {
+        if ( set instanceof RubySet ) {
+            return context.runtime.newBoolean( ! intersect(context, (RubySet) set) );
+        }
+        throw context.runtime.newArgumentError("value must be a set");
+    }
+
+    @JRubyMethod
+    public IRubyObject each(final ThreadContext context, Block block) {
+        if ( ! block.isGiven() ) {
+            return enumeratorizeWithSize(context, this, "each", enumSize());
+        }
+
+        for (IRubyObject elem : elements()) block.yield(context, elem);
+        return this;
+    }
+
+    private RubyEnumerator.SizeFn enumSize() {
+        return new RubyEnumerator.SizeFn() {
+            @Override
+            public IRubyObject size(IRubyObject[] args) {
+                return getRuntime().newFixnum( RubySet.this.size() );
+            }
+        };
+    }
+
+    /**
+     * Adds the given object to the set and returns self.
+     */
+    @JRubyMethod(name = "add", alias = "<<")
+    public RubySet add(final ThreadContext context, IRubyObject obj) {
+        modifyCheck(context.runtime);
+        addObject(context.runtime, obj);
+        return this;
+    }
+
+    protected void addObject(final Ruby runtime, final IRubyObject obj) {
+        hash.fastASetCheckString(runtime, obj, runtime.getTrue()); // @hash[obj] = true
+    }
+
+    /**
+     * Adds the given object to the set and returns self.  If the object is already in the set, returns nil.
+     */
+    @JRubyMethod(name = "add?")
+    public IRubyObject add_p(final ThreadContext context, IRubyObject obj) {
+        // add(o) unless include?(o)
+        if ( contains(context, obj) ) return context.nil;
+        return add(context, obj);
+    }
+
+    @JRubyMethod
+    public IRubyObject delete(final ThreadContext context, IRubyObject obj) {
+        modifyCheck(context.runtime);
+        deleteObject(obj);
+        return this;
+    }
+
+    private void deleteObject(final IRubyObject obj) {
+        hash.modify();
+        hash.fastDelete(obj);
+    }
+
+    /**
+     * Deletes the given object from the set and returns self.  If the object is not in the set, returns nil.
+     */
+    @JRubyMethod(name = "delete?")
+    public IRubyObject delete_p(final ThreadContext context, IRubyObject obj) {
+        // delete(o) if include?(o)
+        if ( ! contains(context, obj) ) return context.nil;
+        return delete(context, obj);
+    }
+
+    @JRubyMethod
+    public IRubyObject delete_if(final ThreadContext context, Block block) {
+        if ( ! block.isGiven() ) {
+            return enumeratorizeWithSize(context, this, "delete_if", enumSize());
+        }
+
+        Iterator<IRubyObject> it = elements().iterator();
+        while ( it.hasNext() ) {
+            IRubyObject elem = it.next();
+            if ( block.yield(context, elem).isTrue() ) it.remove();
+        }
+        return this;
+    }
+
+    @JRubyMethod
+    public IRubyObject keep_if(final ThreadContext context, Block block) {
+        if ( ! block.isGiven() ) {
+            return enumeratorizeWithSize(context, this, "keep_if", enumSize());
+        }
+
+        Iterator<IRubyObject> it = elements().iterator();
+        while ( it.hasNext() ) {
+            IRubyObject elem = it.next();
+            if ( ! block.yield(context, elem).isTrue() ) it.remove();
+        }
+        return this;
+    }
+
+    @JRubyMethod(name = "collect!", alias = "map!")
+    public IRubyObject collect_bang(final ThreadContext context, Block block) {
+        if ( ! block.isGiven() ) {
+            return enumeratorizeWithSize(context, this, "collect!", enumSize());
+        }
+
+        final RubyArray elems = to_a(context); clearImpl();
+        for ( int i=0; i<elems.size(); i++ ) {
+            addObject(context.runtime, block.yield(context, elems.eltInternal(i)));
+        }
+        return this;
+    }
+
+    // Equivalent to Set#delete_if, but returns nil if no changes were made.
+    @JRubyMethod(name = "reject!")
+    public IRubyObject reject_bang(final ThreadContext context, Block block) {
+        if ( ! block.isGiven() ) {
+            return enumeratorizeWithSize(context, this, "reject!", enumSize());
+        }
+
+        final int size = size();
+        Iterator<IRubyObject> it = elements().iterator();
+        while ( it.hasNext() ) {
+            IRubyObject elem = it.next();
+            if ( block.yield(context, elem).isTrue() ) it.remove();
+        }
+        return size == size() ? context.nil : this;
+    }
+
+    // Equivalent to Set#keep_if, but returns nil if no changes were made.
+    @JRubyMethod(name = "select!")
+    public IRubyObject select_bang(final ThreadContext context, Block block) {
+        if ( ! block.isGiven() ) {
+            return enumeratorizeWithSize(context, this, "select!", enumSize());
+        }
+
+        final int size = size();
+        Iterator<IRubyObject> it = elements().iterator();
+        while ( it.hasNext() ) {
+            IRubyObject elem = it.next();
+            if ( ! block.yield(context, elem).isTrue() ) it.remove();
+        }
+        return size == size() ? context.nil : this;
+    }
+
+    /**
+     * Merges the elements of the given enumerable object to the set and returns self.
+     */
+    @JRubyMethod(name = "merge")
+    public RubySet rb_merge(final ThreadContext context, IRubyObject enume) {
+        final Ruby runtime = context.runtime;
+
+        if ( enume instanceof RubySet ) {
+            modifyCheck(runtime);
+            // NOTE: MRI cheats - does not call Set#add thus we do not care ...
+            hash.merge_bang(context, ((RubySet) enume).hash, Block.NULL_BLOCK);
+        }
+        else if ( enume instanceof RubyArray ) {
+            modifyCheck(runtime);
+            RubyArray ary = (RubyArray) enume;
+            for ( int i = 0; i < ary.size(); i++ ) {
+                addObject(runtime, ary.eltInternal(i));
+            }
+        }
+        else { // do_with_enum(enum) { |o| add(o) }
+            doWithEnum(context, enume, new EachBody(runtime) {
+                IRubyObject yieldImpl(ThreadContext context, IRubyObject val) {
+                    addObject(context.runtime, val); return context.nil;
+                }
+            });
+        }
+
+        return this;
+    }
+
+    /**
+     * Deletes every element that appears in the given enumerable object and returns self.
+     */
+    @JRubyMethod(name = "subtract")
+    public IRubyObject subtract(final ThreadContext context, IRubyObject enume) {
+        final Ruby runtime = context.runtime;
+
+        if ( enume instanceof RubySet ) {
+            modifyCheck(runtime);
+            for ( IRubyObject elem : ((RubySet) enume).elements() ) {
+                deleteObject(elem);
+            }
+        }
+        else if ( enume instanceof RubyArray ) {
+            modifyCheck(runtime);
+            RubyArray ary = (RubyArray) enume;
+            for ( int i = 0; i < ary.size(); i++ ) {
+                deleteObject(ary.eltInternal(i));
+            }
+        }
+        else { // do_with_enum(enum) { |o| delete(o) }
+            doWithEnum(context, enume, new EachBody(runtime) {
+                IRubyObject yieldImpl(ThreadContext context, IRubyObject val) {
+                    deleteObject(val); return context.nil;
+                }
+            });
+        }
+
+        return this;
+    }
+
+    /**
+     * Returns a new set built by merging the set and the elements of the given enumerable object.
+     */
+    @JRubyMethod(name = "|", alias = { "+", "union" })
+    public IRubyObject op_or(final ThreadContext context, IRubyObject enume) {
+        return ((RubySet) dup()).rb_merge(context, enume); // dup.merge(enum)
+    }
+
+    /**
+     * Returns a new set built by duplicating the set, removing every element that appears in the given enumerable object.
+     */
+    @JRubyMethod(name = "-", alias = { "difference" })
+    public IRubyObject op_diff(final ThreadContext context, IRubyObject enume) {
+        return ((RubySet) dup()).subtract(context, enume);
+    }
+
+    /**
+     * Returns a new set built by merging the set and the elements of the given enumerable object.
+     */
+    @JRubyMethod(name = "&", alias = { "intersection" })
+    public IRubyObject op_and(final ThreadContext context, IRubyObject enume) {
+        final Ruby runtime = context.runtime;
+
+        final RubySet newSet = new RubySet(runtime, getMetaClass());
+        if ( enume instanceof RubySet ) {
+            newSet.initHash(runtime, ((RubySet) enume).size());
+            for ( IRubyObject obj : ((RubySet) enume).elements() ) {
+                if ( contains(context, obj) ) newSet.addObject(runtime, obj);
+            }
+        }
+        else if ( enume instanceof RubyArray ) {
+            RubyArray ary = (RubyArray) enume;
+            newSet.initHash(runtime, ary.size());
+            for ( int i = 0; i < ary.size(); i++ ) {
+                final IRubyObject obj = ary.eltInternal(i);
+                if ( contains(context, obj) ) newSet.addObject(runtime, obj);
+            }
+        }
+        else {
+            newSet.initHash(runtime);
+            // do_with_enum(enum) { |o| newSet.add(o) if include?(o) }
+            doWithEnum(context, enume, new EachBody(runtime) {
+                IRubyObject yieldImpl(ThreadContext context, IRubyObject obj) {
+                    if ( contains(context, obj) ) newSet.addObject(runtime, obj);
+                    return context.nil;
+                }
+            });
+        }
+
+        return newSet;
+    }
+
+    /**
+     * Returns a new set containing elements exclusive between the set and the given enumerable object.
+     * `(set ^ enum)` is equivalent to `((set | enum) - (set & enum))`.
+     */
+    @JRubyMethod(name = "^")
+    public IRubyObject op_xor(final ThreadContext context, IRubyObject enume) {
+        final Ruby runtime = context.runtime;
+
+        RubySet newSet = new RubySet(runtime, runtime.getClass("Set"));
+        newSet.initialize(context, enume, Block.NULL_BLOCK); // Set.new(enum)
+        for ( IRubyObject o : elements() ) {
+            if ( newSet.contains(context, o) ) newSet.deleteObject(o); // exclusive or
+            else newSet.addObject(runtime, o);
+        }
+
+        return newSet;
+    }
+
+    @Override
+    @JRubyMethod(name = "==")
+    public IRubyObject op_equal(ThreadContext context, IRubyObject other) {
+        if ( this == other ) return context.runtime.getTrue();
+        if ( getMetaClass().isInstance(other) ) {
+            return this.hash.op_equal(context, ((RubySet) other).hash); // @hash == ...
+        }
+        if ( other instanceof RubySet ) {
+            RubySet that = (RubySet) other;
+            if ( this.size() == that.size() ) { // && includes all of our elements :
+                for ( IRubyObject obj : elements() ) {
+                    if ( ! that.contains(context, obj) ) return context.runtime.getFalse();
+                }
+                return context.runtime.getTrue();
+            }
+        }
+        return context.runtime.getFalse();
+    }
+
+    // TODO Java (Collection) equals !
+
+    @JRubyMethod(name = "eql?")
+    public IRubyObject op_eql(ThreadContext context, IRubyObject other) {
+        if ( other instanceof RubySet ) {
+            return this.hash.op_eql(context, ((RubySet) other).hash);
+        }
+        return context.runtime.getFalse();
+    }
+
+    @Override
+    public boolean eql(IRubyObject other) {
+        if ( other instanceof RubySet ) {
+            final Ruby runtime = getRuntime();
+            return this.hash.op_eql(runtime.getCurrentContext(), ((RubySet) other).hash) == runtime.getTrue();
+        }
+        return false;
+    }
+
+    @Override
+    @JRubyMethod
+    public RubyFixnum hash() { // @hash.hash
+        return getRuntime().newFixnum(hashCode());
+    }
+
+    @Override
+    public int hashCode() {
+        return hash.hashCode();
+    }
+
+
+    @JRubyMethod(name = "classify")
+    public IRubyObject classify(ThreadContext context, final Block block) {
+        if ( ! block.isGiven() ) {
+            return enumeratorizeWithSize(context, this, "classify", enumSize());
+        }
+
+        final Ruby runtime = context.runtime;
+
+        final RubyHash h = new RubyHash(runtime, size());
+
+        for ( IRubyObject i : elements() ) {
+            final IRubyObject key = block.yield(context, i);
+            IRubyObject set;
+            if ( ( set = h.fastARef(key) ) == null ) {
+                h.fastASet(key, set = newSet(runtime));
+            }
+            ((RubySet) set).invokeAdd(context, i);
+        }
+
+        return h;
+    }
+
+    /**
+      * Divides the set into a set of subsets according to the commonality
+      * defined by the given block.
+      *
+      * If the arity of the block is 2, elements o1 and o2 are in common
+      * if block.call(o1, o2) is true.  Otherwise, elements o1 and o2 are
+      * in common if block.call(o1) == block.call(o2).
+      *
+      * e.g.:
+      *
+      *   require 'set'
+      *   numbers = Set[1, 3, 4, 6, 9, 10, 11]
+      *   set = numbers.divide { |i,j| (i - j).abs == 1 }
+      *   p set     # => #<Set: {#<Set: {1}>,
+      *             #            #<Set: {11, 9, 10}>,
+      *             #            #<Set: {3, 4}>,
+      *             #            #<Set: {6}>}>
+      */
+    @JRubyMethod(name = "divide")
+    public IRubyObject divide(ThreadContext context, final Block block) {
+        if ( ! block.isGiven() ) {
+            return enumeratorizeWithSize(context, this, "divide", enumSize());
+        }
+
+        if ( block.getSignature().arityValue() == 2 ) {
+            return divideTSort(context, block);
+        }
+
+        final Ruby runtime = context.runtime; // Set.new(classify(&func).values) :
+
+        RubyHash vals = (RubyHash) classify(context, block);
+        final RubySet set = new RubySet(runtime, runtime.getClass("Set"));
+        set.initHash(runtime, vals.size());
+        for ( IRubyObject val : (Collection<IRubyObject>) vals.directValues() ) {
+            set.invokeAdd(context, val);
+        }
+        return set;
+    }
+
+    private IRubyObject divideTSort(ThreadContext context, final Block block) {
+        final Ruby runtime = context.runtime;
+
+        final RubyHash dig = DivideTSortHash.newInstance(context);
+
+        for ( IRubyObject u : elements() ) { // each
+            RubyArray a;
+            dig.fastASet(u, a = runtime.newArray()); // dig[u] = a = []
+            for ( IRubyObject v : elements() ) { // each
+                // func.call(u, v) and a << v
+                IRubyObject ret = block.call(context, u, v);
+                if ( ret.isTrue() ) a.append(v);
+            }
+        }
+
+        /*
+          each { |u|
+            dig[u] = a = []
+            each{ |v| func.call(u, v) and a << v }
+          }
+
+          set = Set.new()
+          dig.each_strongly_connected_component { |css|
+            set.add(self.class.new(css))
+          }
+          set
+         */
+
+        final RubySet set = new RubySet(runtime, runtime.getClass("Set"));
+        set.initHash(runtime, dig.size());
+        dig.callMethod(context, "each_strongly_connected_component", IRubyObject.NULL_ARRAY, new Block(
+            new JavaInternalBlockBody(runtime, Signature.ONE_REQUIRED) {
+                @Override
+                public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
+                    // final IRubyObject css = args[0];
+                    // set.add( self.class.new(css) ) :
+                    set.addObject(runtime, RubySet.create(context, RubySet.this.getMetaClass(), args));
+                    return context.nil;
+                }
+            })
+        );
+
+        return set;
+    }
+
+    public static final class DivideTSortHash extends RubyHash {
+
+        private static final String NAME = "DivideTSortHash"; // private constant under Set::
+
+        static DivideTSortHash newInstance(final ThreadContext context) {
+            final Ruby runtime = context.runtime;
+
+            RubyClass Set = runtime.getClass("Set");
+            RubyClass klass = (RubyClass) Set.getConstantAt(NAME, true);
+            if (klass == null) {
+                synchronized (DivideTSortHash.class) {
+                    klass = (RubyClass) Set.getConstantAt(NAME, true);
+                    if (klass == null) {
+                        klass = Set.defineClassUnder(NAME, runtime.getHash(), runtime.getHash().getAllocator());
+                        Set.setConstantVisibility(runtime, NAME, true); // private
+                        klass.includeModule(getTSort(runtime));
+                        klass.defineAnnotatedMethods(DivideTSortHash.class);
+                    }
+                }
+            }
+            return new DivideTSortHash(runtime, klass);
+        }
+
+        DivideTSortHash(final Ruby runtime, final RubyClass metaClass) {
+            super(runtime, metaClass);
+        }
+
+        /*
+         class << dig = {}         # :nodoc:
+           include TSort
+
+           alias tsort_each_node each_key
+           def tsort_each_child(node, &block)
+             fetch(node).each(&block)
+           end
+         end
+         */
+
+        @JRubyMethod
+        public IRubyObject tsort_each_node(ThreadContext context, Block block) {
+            return each_key(context, block);
+        }
+
+        @JRubyMethod
+        public IRubyObject tsort_each_child(ThreadContext context, IRubyObject node, Block block) {
+            IRubyObject set = fetch(context, node, Block.NULL_BLOCK);
+            if ( set instanceof RubySet ) {
+                return ((RubySet) set).each(context, block);
+            }
+            // some Enumerable (we do not expect this to happen)
+            return set.callMethod(context, "each", IRubyObject.NULL_ARRAY, block);
+        }
+
+    }
+
+    static RubyModule getTSort(final Ruby runtime) {
+        if ( ! runtime.getObject().hasConstant("TSort") ) {
+            runtime.getLoadService().require("tsort");
+        }
+        return runtime.getModule("TSort");
+    }
+
+    @Override
+    public final IRubyObject inspect() {
+        return inspect(getRuntime().getCurrentContext());
+    }
+
+    private static final byte[] RECURSIVE_BYTES = new byte[] { '.','.','.' };
+
+    // Returns a string containing a human-readable representation of the set.
+    // e.g. "#<Set: {element1, element2, ...}>"
+    @JRubyMethod(name = "inspect")
+    public RubyString inspect(ThreadContext context) {
+        final Ruby runtime = context.runtime;
+
+        final RubyString str;
+
+        if (size() == 0) {
+            str = RubyString.newStringLight(runtime, 16, USASCIIEncoding.INSTANCE);
+            inspectPrefix(str, getMetaClass()); str.cat('{').cat('}').cat('>'); // "#<Set: {}>"
+            return str;
+        }
+
+        if (runtime.isInspecting(this)) {
+            str = RubyString.newStringLight(runtime, 20, USASCIIEncoding.INSTANCE);
+            inspectPrefix(str, getMetaClass());
+            str.cat('{').cat(RECURSIVE_BYTES).cat('}').cat('>'); // "#<Set: {...}>"
+            return str;
+        }
+
+        str = RubyString.newStringLight(runtime, 32, USASCIIEncoding.INSTANCE);
+        inspectPrefix(str, getMetaClass());
+
+        try {
+            runtime.registerInspecting(this);
+            inspectSet(context, str);
+            return str.cat('>');
+        }
+        finally {
+            runtime.unregisterInspecting(this);
+        }
+    }
+
+    private static RubyString inspectPrefix(final RubyString str, final RubyClass metaClass) {
+        str.cat('#').cat('<').cat(metaClass.getRealClass().getName().getBytes(RubyEncoding.UTF8));
+        str.cat(':').cat(' '); return str;
+    }
+
+    private void inspectSet(final ThreadContext context, final RubyString str) {
+
+        str.cat((byte) '{');
+
+        boolean tainted = isTaint(); boolean notFirst = false;
+
+        for ( IRubyObject elem : elements() ) {
+            final RubyString s = inspect(context, elem);
+            if ( s.isTaint() ) tainted = true;
+            if ( notFirst ) str.cat((byte) ',').cat((byte) ' ');
+            else str.setEncoding( s.getEncoding() ); notFirst = true;
+            str.cat19( s );
+        }
+
+        str.cat((byte) '}');
+
+        if ( tainted ) str.setTaint(true);
+    }
+
+    //
+
+    protected final Set<IRubyObject> elements() {
+        return hash.directKeySet(); // Hash view -> no copying
+    }
+
+    protected final void modifyCheck(final Ruby runtime) {
+        if ((flags & FROZEN_F) != 0) throw runtime.newFrozenError("Set");
+    }
+
+}

--- a/core/src/main/java/org/jruby/ext/set/RubySortedSet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySortedSet.java
@@ -118,10 +118,14 @@ public class RubySortedSet extends RubySet implements SortedSet {
         order.clear();
     }
 
-    @Override
-    @JRubyMethod(name = "to_a", alias = "sort") // re-def Enumerable#sort
-    public RubyArray to_a(final ThreadContext context) {
+    @JRubyMethod(name = "sort") // re-def Enumerable#sort
+    public RubyArray sort(final ThreadContext context) {
         return RubyArray.newArray(context.runtime, order); // instead of this.hash.keys();
+    }
+
+    @Override
+    public RubyArray to_a(final ThreadContext context) {
+        return sort(context); // instead of this.hash.keys();
     }
 
     // NOTE: weirdly Set/SortedSet in Ruby do not have sort!

--- a/core/src/main/java/org/jruby/ext/set/RubySortedSet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySortedSet.java
@@ -91,11 +91,10 @@ public class RubySortedSet extends RubySet implements SortedSet {
 
     @Override
     protected void addImpl(final Ruby runtime, final IRubyObject obj) {
-
-        if ( ! obj.respondsTo("<=>") ) { // TODO site-cache
-            throw runtime.newArgumentError("value must respond to <=>");
-        }
-
+        // NOTE: we're able to function without the check - comparator will raise ArgumentError
+        //if ( ! obj.respondsTo("<=>") ) {
+        //    throw runtime.newArgumentError("value must respond to <=>");
+        //}
         super.addImpl(runtime, obj); // @hash[obj] = true
         order.add(obj);
     }

--- a/core/src/main/java/org/jruby/ext/set/RubySortedSet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySortedSet.java
@@ -81,6 +81,13 @@ public class RubySortedSet extends RubySet implements SortedSet {
         order = new TreeSet<>(new OrderComparator(runtime));
     }
 
+    @Override
+    void unmarshal() {
+        super.unmarshal();
+        IRubyObject[] elems = hash.keys().toJavaArrayMaybeUnsafe();
+        for ( int i=0; i<elems.length; i++ ) order.add( elems[i] );
+    }
+
     @JRubyMethod(name = "[]", rest = true, meta = true) // re-def Set[] for SortedSet
     public static RubySortedSet create(final ThreadContext context, IRubyObject self, IRubyObject... ary) {
         final Ruby runtime = context.runtime;

--- a/core/src/main/java/org/jruby/ext/set/RubySortedSet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySortedSet.java
@@ -116,8 +116,9 @@ public class RubySortedSet extends RubySet implements SortedSet {
 
     @Override
     protected void deleteImplIterator(final IRubyObject obj, final Iterator it) {
-        it.remove(); // super
-        order.remove(obj);
+        super.deleteImpl(obj);
+        // iterator over elementsOrdered()
+        it.remove(); // order.remove(obj)
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ext/set/RubySortedSet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySortedSet.java
@@ -81,6 +81,14 @@ public class RubySortedSet extends RubySet implements SortedSet {
         order = new TreeSet<>(new OrderComparator(runtime));
     }
 
+    @JRubyMethod(name = "[]", rest = true, meta = true) // re-def Set[] for SortedSet
+    public static RubySortedSet create(final ThreadContext context, IRubyObject self, IRubyObject... ary) {
+        final Ruby runtime = context.runtime;
+
+        RubySortedSet set = new RubySortedSet(runtime, (RubyClass) self);
+        return (RubySortedSet) set.initSet(context, ary, 0, ary.length);
+    }
+
     @Override
     protected void addImpl(final Ruby runtime, final IRubyObject obj) {
 

--- a/core/src/main/java/org/jruby/ext/set/RubySortedSet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySortedSet.java
@@ -33,9 +33,7 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.*;
 import org.jruby.runtime.builtin.IRubyObject;
 
-import java.util.Iterator;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 
 import static org.jruby.RubyArray.DefaultComparator;
 
@@ -45,7 +43,7 @@ import static org.jruby.RubyArray.DefaultComparator;
  * @author kares
  */
 @org.jruby.anno.JRubyClass(name="SortedSet", parent = "Set")
-public class RubySortedSet extends RubySet {
+public class RubySortedSet extends RubySet implements SortedSet {
 
     static RubyClass createSortedSetClass(final Ruby runtime) {
         RubyClass SortedSet = runtime.defineClass("SortedSet", runtime.getClass("Set"), ALLOCATOR);
@@ -76,11 +74,11 @@ public class RubySortedSet extends RubySet {
         }
     }
 
-    private final TreeSet order;
+    private final TreeSet<IRubyObject> order;
 
     protected RubySortedSet(Ruby runtime, RubyClass klass) {
         super(runtime, klass);
-        order = new TreeSet(new OrderComparator(runtime));
+        order = new TreeSet<>(new OrderComparator(runtime));
     }
 
     @Override
@@ -130,5 +128,81 @@ public class RubySortedSet extends RubySet {
 
     @Override
     protected Set<IRubyObject> elementsOrdered() { return order; }
+
+    @Override
+    public Iterator<Object> iterator() {
+        return new JavaIterator();
+    }
+
+    // java.util.SortedSet :
+
+    public Comparator<? super IRubyObject> comparator() {
+        return order.comparator();
+    }
+
+    public Object first() {
+        return firstValue().toJava(Object.class);
+    }
+
+    public IRubyObject firstValue() {
+        return order.first();
+    }
+
+    public Object last() {
+        return lastValue().toJava(Object.class);
+    }
+
+    public IRubyObject lastValue() {
+        return order.last();
+    }
+
+    public SortedSet headSet(Object toElement) {
+        throw new UnsupportedOperationException("NOT IMPLEMENTED");
+    }
+
+    public SortedSet subSet(Object fromElement, Object toElement) {
+        throw new UnsupportedOperationException("NOT IMPLEMENTED");
+    }
+
+    public SortedSet tailSet(Object fromElement) {
+        throw new UnsupportedOperationException("NOT IMPLEMENTED");
+    }
+
+    public SortedSet<IRubyObject> rawHeadSet(IRubyObject toElement) {
+        return order.headSet(toElement);
+    }
+
+    public SortedSet<IRubyObject> rawSubSet(IRubyObject fromElement, IRubyObject toElement) {
+        return order.subSet(fromElement, toElement);
+    }
+
+    public SortedSet<IRubyObject> rawTailSet(IRubyObject fromElement) {
+        return order.tailSet(fromElement);
+    }
+
+    private class JavaIterator implements Iterator<Object> {
+
+        private final Iterator<IRubyObject> rawIterator;
+
+        JavaIterator() {
+            rawIterator = RubySortedSet.this.order.iterator();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return rawIterator.hasNext();
+        }
+
+        @Override
+        public Object next() {
+            return rawIterator.next().toJava(Object.class);
+        }
+
+        @Override
+        public void remove() {
+            rawIterator.remove();
+        }
+
+    }
 
 }

--- a/core/src/main/java/org/jruby/ext/set/RubySortedSet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySortedSet.java
@@ -1,0 +1,72 @@
+/*
+ **** BEGIN LICENSE BLOCK *****
+ * Version: EPL 1.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 1.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2016 Karol Bucek
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.ext.set;
+
+import org.jruby.*;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.*;
+import org.jruby.runtime.builtin.IRubyObject;
+
+/**
+ * Native implementation of Ruby's SortedSet (set.rb replacement).
+ *
+ * @author kares
+ */
+@org.jruby.anno.JRubyClass(name="SortedSet", parent = "Set")
+public class RubySortedSet extends RubySet {
+
+    static RubyClass createSortedSetClass(final Ruby runtime) {
+        RubyClass SortedSet = runtime.defineClass("SortedSet", runtime.getClass("Set"), ALLOCATOR);
+
+        SortedSet.setReifiedClass(RubySortedSet.class);
+
+        SortedSet.defineAnnotatedMethods(RubySortedSet.class);
+
+        return SortedSet;
+    }
+
+    private static final ObjectAllocator ALLOCATOR = new ObjectAllocator() {
+        public RubySortedSet allocate(Ruby runtime, RubyClass klass) {
+            return new RubySortedSet(runtime, klass);
+        }
+    };
+
+    public RubySortedSet(Ruby runtime, RubyClass klass) {
+        super(runtime, klass);
+    }
+
+    @Override
+    protected void addObject(final Ruby runtime, final IRubyObject obj) {
+        if ( ! obj.respondsTo("<=>") ) { // TODO site-cache
+            throw runtime.newArgumentError("value must respond to <=>");
+        }
+        super.addObject(runtime, obj);
+    }
+
+}

--- a/core/src/main/java/org/jruby/ext/set/SetLibrary.java
+++ b/core/src/main/java/org/jruby/ext/set/SetLibrary.java
@@ -1,0 +1,45 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 1.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 1.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2016 Karol Bucek
+ * 
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.ext.set;
+
+import org.jruby.Ruby;
+import org.jruby.runtime.load.Library;
+
+public final class SetLibrary implements Library {
+
+    public void load(Ruby runtime, boolean wrap) {
+        SetLibrary.load(runtime);
+    }
+
+    public static void load(Ruby runtime) {
+        RubySet.createSetClass(runtime);
+        RubySortedSet.createSortedSetClass(runtime);
+        runtime.getModule("Enumerable").defineAnnotatedMethods(EnumerableExt.class);
+    }
+
+}

--- a/core/src/main/ruby/jruby/set.rb
+++ b/core/src/main/ruby/jruby/set.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+#
+# .rb part for JRuby's native Set impl (taken from set.rb)
+
+class Set
+
+  def pretty_print(pp)  # :nodoc:
+    pp.text sprintf('#<%s: {', self.class.name)
+    pp.nest(1) {
+      pp.seplist(self) { |o|
+        pp.pp o
+      }
+    }
+    pp.text '}>'
+  end
+
+  def pretty_print_cycle(pp)    # :nodoc:
+    pp.text sprintf('#<%s: {%s}>', self.class.name, empty? ? '' : '...')
+  end
+
+end

--- a/spec/ruby/library/set/sortedset/add_spec.rb
+++ b/spec/ruby/library/set/sortedset/add_spec.rb
@@ -7,8 +7,12 @@ describe "SortedSet#add" do
 
   it "takes only values which responds <=>" do
     obj = mock('no_comparison_operator')
-    obj.should_receive(:respond_to?).with(:<=>).and_return(false)
+    obj.stub!(:respond_to?).with(:<=>).and_return(false)
     lambda { SortedSet["hello"].add(obj) }.should raise_error(ArgumentError)
+  end
+
+  it "raises on incompatible <=> comparison" do
+    lambda { SortedSet['1', '2'].add(3) }.should raise_error(ArgumentError)
   end
 end
 

--- a/spec/ruby/library/set/sortedset/initialize_spec.rb
+++ b/spec/ruby/library/set/sortedset/initialize_spec.rb
@@ -21,4 +21,8 @@ describe "SortedSet#initialize" do
     s.should include(4)
     s.should include(9)
   end
+
+  it "raises on incompatible <=> comparison" do
+    lambda { SortedSet.new(['00', nil]) }.should raise_error(ArgumentError)
+  end
 end

--- a/spec/ruby/library/set/sortedset/to_a_spec.rb
+++ b/spec/ruby/library/set/sortedset/to_a_spec.rb
@@ -2,7 +2,16 @@ require File.expand_path('../../../../spec_helper', __FILE__)
 require 'set'
 
 describe "SortedSet#to_a" do
-  it "returns an array containing elements of self" do
-    SortedSet[1, 2, 3].to_a.sort.should == [1, 2, 3]
+  it "returns an array containing elements" do
+    set = SortedSet.new [1, 2, 3]
+    set.to_a.should == [1, 2, 3]
+  end
+
+  it "returns a sorted array containing elements" do
+    set = SortedSet[2, 3, 1]
+    set.to_a.should == [1, 2, 3]
+
+    set = SortedSet.new [5, 6, 4, 4]
+    set.to_a.should == [4, 5, 6]
   end
 end

--- a/test/jruby/test_set.rb
+++ b/test/jruby/test_set.rb
@@ -1,0 +1,121 @@
+require 'test/unit'
+require 'set.rb'
+
+# JRuby's Set impl specific or low-level details.
+class TestSet < Test::Unit::TestCase
+
+  class SubSet < Set ; end
+  class SubSortedSet < SortedSet ; end
+
+  def test_sub_set
+    set = SubSet.new
+    assert_same SubSet, set.class
+    assert set.is_a?(SubSet)
+    assert set.is_a?(Set)
+    assert hash = set.instance_variable_get(:@hash)
+    assert hash.is_a?(Hash)
+    assert_equal Hash.new, hash
+    assert_equal '#<TestSet::SubSet: {}>', set.inspect
+
+    assert_false Set.new.equal?(SubSet.new)
+    assert_true Set.new.eql?(SubSet.new)
+    assert_true ( SubSet.new == Set.new )
+
+    assert_false SortedSet.new.equal?(SubSortedSet.new)
+    assert_true SortedSet.new.eql?(SubSortedSet.new)
+    assert_true ( SubSortedSet.new == Set.new )
+    assert_true ( SubSortedSet.new == SortedSet.new )
+    assert_true ( SortedSet.new == SubSortedSet.new )
+  end
+
+  def test_allocate
+    set = Set.allocate
+    assert_same Set, set.class
+    assert_nil set.instance_variable_get(:@hash) # same on MRI
+
+    # set not really usable :
+    begin
+      set << 1 ; fail 'set << 1 did not fail!'
+    rescue # NoMethodError # JRuby: NPE
+      # NoMethodError: undefined method `[]=' for nil:NilClass
+      #   from /opt/local/rvm/rubies/ruby-2.3.3/lib/ruby/2.3.0/set.rb:313:in `add'
+    end
+  end
+
+  def test_marshal_dump
+    assert_equal "\x04\b{\x00".force_encoding('ASCII-8BIT'), Marshal.dump(Hash.new)
+
+    # MRI internally uses a @hash with a default: `Hash.new(false)'
+    #empty_set = "\x04\bo:\bSet\x06:\n@hash}\x00F".force_encoding('ASCII-8BIT')
+    #assert_equal empty_set, Marshal.dump(Set.new)
+
+    dump = Marshal.dump(Set.new)
+    assert_equal Set.new, Marshal.load(dump)
+
+    set = Marshal.load Marshal.dump(Set.new([1, 2]))
+    assert_same Set, set.class
+    assert_equal Set.new([1, 2]), set
+    set << 3
+    assert_equal 3, set.size
+
+    set = Marshal.load Marshal.dump(Set.new([1, 2]).dup)
+    assert_same Set, set.class
+    assert_equal Set.new([1, 2]), set
+  end
+
+  def test_sorted_marshal_dump
+    dump = Marshal.dump(SortedSet.new)
+    assert_equal SortedSet.new, Marshal.load(dump)
+
+    set = Marshal.load Marshal.dump(SortedSet.new([2, 1]))
+    assert_same SortedSet, set.class
+    assert_equal SortedSet.new([1, 2]), set
+    assert_equal [1, 2], set.sort
+    set << 3
+    assert_equal 3, set.size
+    assert_equal [1, 2, 3], set.sort
+
+    set = Marshal.load Marshal.dump(SortedSet.new([2, 1]).dup)
+    assert_same SortedSet, set.class
+    assert_equal SortedSet.new([1, 2]), set
+    assert_equal [1, 2], set.to_a
+
+    set = Marshal.load Marshal.dump(SortedSet.new([2, 3, 1]))
+    each = []; set.each { |e| each << e }
+    assert_equal [1, 2, 3], each
+  end
+
+  def test_dup
+    set = Set.new [1, 2]
+    assert_same Set, set.dup.class
+    assert_equal set, set.dup
+    dup = set.dup
+    set << 3
+    assert_equal 3, set.size
+    assert_equal 2, dup.size
+
+    set = SortedSet.new [1, 2]
+    assert_same SortedSet, set.dup.class
+    assert_equal set, set.dup
+    dup = set.dup
+    set << 0
+    assert_equal 3, set.size
+    assert_equal 2, dup.size
+  end
+
+  def test_to_java
+    assert set = Set.new.to_java
+    assert set.toString.start_with?('#<Set:0x')
+    assert_equal org.jruby.ext.set.RubySet, set.class
+    assert set.is_a?(java.util.Set)
+    assert_equal java.util.HashSet.new, set
+
+    assert set = SortedSet.new([2, 1]).to_java
+    assert set.toString.start_with?('#<SortedSet:0x')
+    assert_equal org.jruby.ext.set.RubySortedSet, set.class
+    assert set.is_a?(java.util.Set)
+    assert set.is_a?(java.util.SortedSet)
+    assert_equal java.util.TreeSet.new([1, 2]), set
+  end
+
+end

--- a/test/jruby/test_set.rb
+++ b/test/jruby/test_set.rb
@@ -46,8 +46,8 @@ class TestSet < Test::Unit::TestCase
     assert_equal "\x04\b{\x00".force_encoding('ASCII-8BIT'), Marshal.dump(Hash.new)
 
     # MRI internally uses a @hash with a default: `Hash.new(false)'
-    #empty_set = "\x04\bo:\bSet\x06:\n@hash}\x00F".force_encoding('ASCII-8BIT')
-    #assert_equal empty_set, Marshal.dump(Set.new)
+    empty_set = "\x04\bo:\bSet\x06:\n@hash}\x00F".force_encoding('ASCII-8BIT')
+    assert_equal empty_set, Marshal.dump(Set.new)
 
     dump = Marshal.dump(Set.new)
     assert_equal Set.new, Marshal.load(dump)
@@ -116,6 +116,6 @@ class TestSet < Test::Unit::TestCase
     assert set.is_a?(java.util.Set)
     assert set.is_a?(java.util.SortedSet)
     assert_equal java.util.TreeSet.new([1, 2]), set
-  end
+  end if defined? JRUBY_VERSION
 
 end


### PR DESCRIPTION
work towards having `Set/SortedSet` natively instead of `set.rb`

had these changes lying around for a long-time (mostly waiting to target 9.2)
primarily this has been motivated for premium Java Integration features : 
`Set implements java.util.Set` and `SortedSet implements java.util.SortedSet`

but there's also a significant gain in performance.
set.rb is rather loosely written with some ugly-ness such as patching/features-detection on `SortedSet.new`

for maximum compatibility sets are backed by a `Hash` like before (and serializes the same as before), this is important for some older versions of Sprockets when under Rails switching between MRI and JRuby.

`SortedSet` uses Java's `TreeSet` implementation for ordering as it was available and performs better than the pieces in *set.rb*

some (naive) performance numbers, also showcasing `Set` is now at Java's `HashSet` speed : 
```
Ruby Set#include? hit   0.530000   0.000000   0.530000 (  0.473302)
Ruby Set#include? miss  0.450000   0.000000   0.450000 (  0.452750)
HashSet#include? hit    0.390000   0.000000   0.390000 (  0.388358)
HashSet#include? miss   0.370000   0.000000   0.370000 (  0.364610)
     Set.new([1,2,3])    1.860000   0.010000   1.870000 (  1.847379)
SortedSet.new([1,2,3])   3.560000   0.010000   3.570000 (  3.538512)
     Set#inspect         4.180000   0.000000   4.180000 (  4.157021)
SortedSet#inspect        4.160000   0.010000   4.170000 (  4.145266)
     Set#flatten         1.510000   0.000000   1.510000 (  1.504799)
     Set#each {|e| e}    1.310000   0.000000   1.310000 (  1.306374)
```

JRuby 9.1.9
```
Ruby Set#include? hit   0.660000   0.000000   0.660000 (  0.657267)
Ruby Set#include? miss  0.810000   0.000000   0.810000 (  0.811419)
HashSet#include? hit    0.430000   0.000000   0.430000 (  0.421336)
HashSet#include? miss   0.370000   0.000000   0.370000 (  0.367006)
     Set.new([1,2,3])    8.600000   0.010000   8.610000 (  8.455883)
SortedSet.new([1,2,3])  15.920000   0.020000  15.940000 ( 15.828404)
     Set#inspect         6.710000   0.000000   6.710000 (  6.633052)
SortedSet#inspect        5.730000   0.010000   5.740000 (  5.663528)
     Set#flatten         8.960000   0.000000   8.960000 (  8.879096)
     Set#each {|e| e}    1.680000   0.000000   1.680000 (  1.663696)
```

MRI 2.3.3
```
Ruby Set#include? hit   0.960000   0.000000   0.960000 (  0.957069)
Ruby Set#include? miss  1.040000   0.000000   1.040000 (  1.043396)
     Set.new([1,2,3])   20.590000   0.010000  20.600000 ( 20.606219)
SortedSet.new([1,2,3])  30.410000   0.000000  30.410000 ( 30.411511)
     Set#inspect        10.890000   0.000000  10.890000 ( 10.889514)
SortedSet#inspect       11.010000   0.000000  11.010000 ( 11.007346)
     Set#flatten        20.050000   0.000000  20.050000 ( 20.054732)
     Set#each {|e| e}    2.680000   0.000000   2.680000 (  2.686750)
```