### PR TITLE
Fix break not turning into LocalJumpError soon enough

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -57,7 +57,7 @@ project 'JRuby Core' do
   jar 'org.jruby.jcodings:jcodings:1.0.18'
   jar 'org.jruby:dirgra:0.3'
 
-  jar 'com.headius:invokebinder:1.7'
+  jar 'com.headius:invokebinder:1.8-SNAPSHOT'
   jar 'com.headius:options:1.4'
   jar 'com.headius:unsafe-fences:1.0'
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -193,7 +193,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>com.headius</groupId>
       <artifactId>invokebinder</artifactId>
-      <version>1.7</version>
+      <version>1.8-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.headius</groupId>

--- a/core/src/main/java/org/jruby/ir/instructions/BuildLambdaInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/BuildLambdaInstr.java
@@ -56,6 +56,8 @@ public class BuildLambdaInstr extends OneOperandResultBaseInstr implements Fixed
         return getOperand1();
     }
 
+    public boolean hasLiteralClosure() { return getClosureArg() instanceof WrappedIRClosure; }
+
     @Override
     public void encode(IRWriterEncoder e) {
         super.encode(e);

--- a/core/src/main/java/org/jruby/ir/instructions/CallBase.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CallBase.java
@@ -425,6 +425,14 @@ public abstract class CallBase extends NOperandInstr implements ClosureAccepting
         IRubyObject[] values = prepareArguments(context, self, currScope, dynamicScope, temp);
         Block preparedBlock = prepareBlock(context, self, currScope, dynamicScope, temp);
 
+        if (getClosureArg() != null) {
+            try {
+                return callSite.call(context, self, object, values, preparedBlock);
+            } finally {
+                preparedBlock.escape();
+            }
+        }
+
         return callSite.call(context, self, object, values, preparedBlock);
     }
 

--- a/core/src/main/java/org/jruby/ir/instructions/CallBase.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CallBase.java
@@ -425,7 +425,7 @@ public abstract class CallBase extends NOperandInstr implements ClosureAccepting
         IRubyObject[] values = prepareArguments(context, self, currScope, dynamicScope, temp);
         Block preparedBlock = prepareBlock(context, self, currScope, dynamicScope, temp);
 
-        if (getClosureArg() != null) {
+        if (hasLiteralClosure()) {
             try {
                 return callSite.call(context, self, object, values, preparedBlock);
             } finally {

--- a/core/src/main/java/org/jruby/ir/instructions/ClosureAcceptingInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ClosureAcceptingInstr.java
@@ -8,4 +8,5 @@ import org.jruby.ir.operands.Operand;
  */
 public interface ClosureAcceptingInstr {
     public Operand getClosureArg();
+    public boolean hasLiteralClosure();
 }

--- a/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
@@ -419,7 +419,6 @@ public class InterpreterEngine {
     protected static IRubyObject processReturnOp(ThreadContext context, Block block, Instr instr, Operation operation,
                                                  DynamicScope currDynScope, Object[] temp, IRubyObject self,
                                                  StaticScope currScope) {
-        Block.Type blockType = block == null ? null : block.type;
         switch(operation) {
             // --------- Return flavored instructions --------
             case RETURN: {
@@ -433,12 +432,12 @@ public class InterpreterEngine {
                 // This assumes that scopes with break instr. have a frame / dynamic scope
                 // pushed so that we can get to its static scope. For-loops now always have
                 // a dyn-scope pushed onto stack which makes this work in all scenarios.
-                return IRRuntimeHelpers.initiateBreak(context, currDynScope, rv, block, blockType);
+                return IRRuntimeHelpers.initiateBreak(context, currDynScope, rv, block);
             }
             case NONLOCAL_RETURN: {
                 NonlocalReturnInstr ri = (NonlocalReturnInstr)instr;
                 IRubyObject rv = (IRubyObject)retrieveOp(ri.getReturnValue(), context, self, currDynScope, currScope, temp);
-                return IRRuntimeHelpers.initiateNonLocalReturn(context, currDynScope, blockType, rv);
+                return IRRuntimeHelpers.initiateNonLocalReturn(context, currDynScope, block, rv);
             }
             case RETURN_OR_RETHROW_SAVED_EXC: {
                 IRubyObject retVal = (IRubyObject) retrieveOp(((ReturnBase) instr).getReturnValue(), context, self, currDynScope, currScope, temp);

--- a/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
@@ -433,7 +433,7 @@ public class InterpreterEngine {
                 // This assumes that scopes with break instr. have a frame / dynamic scope
                 // pushed so that we can get to its static scope. For-loops now always have
                 // a dyn-scope pushed onto stack which makes this work in all scenarios.
-                return IRRuntimeHelpers.initiateBreak(context, currDynScope, rv, blockType);
+                return IRRuntimeHelpers.initiateBreak(context, currDynScope, rv, block, blockType);
             }
             case NONLOCAL_RETURN: {
                 NonlocalReturnInstr ri = (NonlocalReturnInstr)instr;

--- a/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
@@ -329,7 +329,7 @@ public class InterpreterEngine {
                 IRubyObject r = (IRubyObject)retrieveOp(call.getReceiver(), context, self, currDynScope, currScope, temp);
                 IRubyObject o = (IRubyObject)call.getArg1().retrieve(context, self, currScope, currDynScope, temp);
                 Block preparedBlock = call.prepareBlock(context, self, currScope, currDynScope, temp);
-                result = call.getCallSite().call(context, self, r, o, preparedBlock);
+                result = call.getCallSite().callIter(context, self, r, o, preparedBlock);
                 setResult(temp, currDynScope, call.getResult(), result);
                 break;
             }

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -95,8 +95,8 @@ public class IRRuntimeHelpers {
     }
 
     // Create a jump for a non-local return which will return from nearest lambda (which may be itself) or method.
-    public static IRubyObject initiateNonLocalReturn(ThreadContext context, DynamicScope dynScope, Block.Type blockType, IRubyObject returnValue) {
-        if (IRRuntimeHelpers.inLambda(blockType)) throw new IRWrappedLambdaReturnValue(returnValue);
+    public static IRubyObject initiateNonLocalReturn(ThreadContext context, DynamicScope dynScope, Block block, IRubyObject returnValue) {
+        if (IRRuntimeHelpers.inLambda(block.type)) throw new IRWrappedLambdaReturnValue(returnValue);
 
         throw IRReturnJump.create(getContainingMethodOrLambdasDynamicScope(dynScope), returnValue);
     }
@@ -159,10 +159,10 @@ public class IRRuntimeHelpers {
     }
 
     // FIXME: When we recompile lambdas we can eliminate this binary code path and we can emit as a NONLOCALRETURN directly.
-    public static IRubyObject initiateBreak(ThreadContext context, DynamicScope dynScope, IRubyObject breakValue, Block block, Block.Type blockType) throws RuntimeException {
+    public static IRubyObject initiateBreak(ThreadContext context, DynamicScope dynScope, IRubyObject breakValue, Block block) throws RuntimeException {
         // Wrap the return value in an exception object and push it through the break exception
         // paths so that ensures are run, frames/scopes are popped from runtime stacks, etc.
-        if (inLambda(blockType)) throw new IRWrappedLambdaReturnValue(breakValue);
+        if (inLambda(block.type)) throw new IRWrappedLambdaReturnValue(breakValue);
 
         IRScopeType scopeType = ensureScopeIsClosure(context, dynScope);
 

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -96,7 +96,7 @@ public class IRRuntimeHelpers {
 
     // Create a jump for a non-local return which will return from nearest lambda (which may be itself) or method.
     public static IRubyObject initiateNonLocalReturn(ThreadContext context, DynamicScope dynScope, Block block, IRubyObject returnValue) {
-        if (IRRuntimeHelpers.inLambda(block.type)) throw new IRWrappedLambdaReturnValue(returnValue);
+        if (block != null && IRRuntimeHelpers.inLambda(block.type)) throw new IRWrappedLambdaReturnValue(returnValue);
 
         throw IRReturnJump.create(getContainingMethodOrLambdasDynamicScope(dynScope), returnValue);
     }

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -159,15 +159,21 @@ public class IRRuntimeHelpers {
     }
 
     // FIXME: When we recompile lambdas we can eliminate this binary code path and we can emit as a NONLOCALRETURN directly.
-    public static IRubyObject initiateBreak(ThreadContext context, DynamicScope dynScope, IRubyObject breakValue, Block.Type blockType) throws RuntimeException {
+    public static IRubyObject initiateBreak(ThreadContext context, DynamicScope dynScope, IRubyObject breakValue, Block block, Block.Type blockType) throws RuntimeException {
         // Wrap the return value in an exception object and push it through the break exception
         // paths so that ensures are run, frames/scopes are popped from runtime stacks, etc.
         if (inLambda(blockType)) throw new IRWrappedLambdaReturnValue(breakValue);
 
         IRScopeType scopeType = ensureScopeIsClosure(context, dynScope);
 
+        DynamicScope parentScope = dynScope.getParentScope();
+
+        if (block.isEscaped()) {
+            throw context.runtime.newLocalJumpError(RubyLocalJumpError.Reason.BREAK, breakValue, "unexpected break");
+        }
+
         // Raise a break jump so we can bubble back down the stack to the appropriate place to break from.
-        throw IRBreakJump.create(dynScope.getParentScope(), breakValue, scopeType.isEval()); // weirdly evals are impld as closures...yes yes.
+        throw IRBreakJump.create(parentScope, breakValue, scopeType.isEval()); // weirdly evals are impld as closures...yes yes.
     }
 
     // Are we within the scope where we want to return the value we are passing down the stack?

--- a/core/src/main/java/org/jruby/ir/targets/ArrayDerefInvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/ArrayDerefInvokeSite.java
@@ -31,7 +31,7 @@ import static org.jruby.util.CodegenUtils.sig;
 */
 public class ArrayDerefInvokeSite extends NormalInvokeSite {
     public ArrayDerefInvokeSite(MethodType type, String file, int line) {
-        super(type, "[]", file, line);
+        super(type, "[]", false, file, line);
     }
 
     public static final Handle BOOTSTRAP = new Handle(Opcodes.H_INVOKESTATIC, p(ArrayDerefInvokeSite.class), "bootstrap", sig(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class, String.class, int.class));

--- a/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter.java
+++ b/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter.java
@@ -361,9 +361,10 @@ public abstract class IRBytecodeAdapter {
      *
      * @param name name of the method to invoke
      * @param arity arity of the call
-     * @param hasClosure whether a closure will be on the stack for passing
+     * @param receivesClosure whether a closure will be on the stack for passing
+     * @param literalClosure whether the closure is passed directly as a literal block
      */
-    public abstract void invokeOther(String file, int line, String name, int arity, boolean hasClosure, boolean isPotentiallyRefined);
+    public abstract void invokeOther(String file, int line, String name, int arity, boolean receivesClosure, boolean literalClosure, boolean isPotentiallyRefined);
 
     /**
      * Invoke the array dereferencing method ([]) on an object other than self.
@@ -405,9 +406,10 @@ public abstract class IRBytecodeAdapter {
      * @param name name of the method to invoke
      * @param arity arity of the call
      * @param hasClosure whether a closure will be on the stack for passing
+     * @param literalClosure whether the passed closure is a literal block
      * @param callType
      */
-    public abstract void invokeSelf(String file, int line, String name, int arity, boolean hasClosure, CallType callType, boolean isPotentiallyRefined);
+    public abstract void invokeSelf(String file, int line, String name, int arity, boolean hasClosure, boolean literalClosure, CallType callType, boolean isPotentiallyRefined);
 
     /**
      * Invoke a superclass method from an instance context.

--- a/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter.java
+++ b/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter.java
@@ -9,6 +9,8 @@ import org.jcodings.Encoding;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.compiler.impl.SkinnyMethodAdapter;
+import org.jruby.ir.instructions.ClosureAcceptingInstr;
+import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.UndefinedValue;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.runtime.CallType;
@@ -361,10 +363,9 @@ public abstract class IRBytecodeAdapter {
      *
      * @param name name of the method to invoke
      * @param arity arity of the call
-     * @param receivesClosure whether a closure will be on the stack for passing
-     * @param literalClosure whether the closure is passed directly as a literal block
+     * @param blockPassType what type of closure is passed
      */
-    public abstract void invokeOther(String file, int line, String name, int arity, boolean receivesClosure, boolean literalClosure, boolean isPotentiallyRefined);
+    public abstract void invokeOther(String file, int line, String name, int arity, BlockPassType blockPassType, boolean isPotentiallyRefined);
 
     /**
      * Invoke the array dereferencing method ([]) on an object other than self.
@@ -395,6 +396,30 @@ public abstract class IRBytecodeAdapter {
      */
     public abstract void invokeOtherOneFloat(String file, int line, String name, double flote, CallType callType);
 
+    public enum BlockPassType {
+        NONE(false, false),
+        GIVEN(true, false),
+        LITERAL(true, true);
+
+        private final boolean given;
+        private final boolean literal;
+
+        BlockPassType(boolean given, boolean literal) {
+            this.given = given;
+            this.literal = literal;
+        }
+
+        public boolean given() {
+            return given;
+        }
+        public boolean literal() {
+            return literal;
+        }
+        public static BlockPassType fromIR(ClosureAcceptingInstr callInstr) {
+            Operand closure = callInstr.getClosureArg();
+            return closure != null ? ( callInstr.hasLiteralClosure() ? BlockPassType.LITERAL : BlockPassType.GIVEN) : BlockPassType.NONE;
+        }
+    }
 
     /**
      * Invoke a method on self.
@@ -405,11 +430,10 @@ public abstract class IRBytecodeAdapter {
      * @param line the line number where this call appears
      * @param name name of the method to invoke
      * @param arity arity of the call
-     * @param hasClosure whether a closure will be on the stack for passing
-     * @param literalClosure whether the passed closure is a literal block
+     * @param blockPassType what type of closure is passed
      * @param callType
      */
-    public abstract void invokeSelf(String file, int line, String name, int arity, boolean hasClosure, boolean literalClosure, CallType callType, boolean isPotentiallyRefined);
+    public abstract void invokeSelf(String file, int line, String name, int arity, BlockPassType blockPassType, CallType callType, boolean isPotentiallyRefined);
 
     /**
      * Invoke a superclass method from an instance context.

--- a/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter6.java
+++ b/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter6.java
@@ -382,8 +382,8 @@ public class IRBytecodeAdapter6 extends IRBytecodeAdapter{
         });
     }
 
-    public void invokeOther(String file, int line, String name, int arity, boolean hasClosure, boolean isPotentiallyRefined) {
-        invoke(file, line, name, arity, hasClosure, CallType.NORMAL, isPotentiallyRefined);
+    public void invokeOther(String file, int line, String name, int arity, boolean receivesClosure, boolean literalClosure, boolean isPotentiallyRefined) {
+        invoke(file, line, name, arity, receivesClosure, literalClosure, CallType.NORMAL, isPotentiallyRefined);
     }
 
     public void invokeArrayDeref(String file, int line) {
@@ -410,14 +410,14 @@ public class IRBytecodeAdapter6 extends IRBytecodeAdapter{
         adapter.invokestatic(getClassData().clsName, methodName, incomingSig);
     }
 
-    public void invoke(String file, int lineNumber, String name, int arity, boolean hasClosure, CallType callType, boolean isPotentiallyRefined) {
+    public void invoke(String file, int lineNumber, String name, int arity, boolean receivesClosure, boolean literalClosure, CallType callType, boolean isPotentiallyRefined) {
         if (arity > MAX_ARGUMENTS) throw new NotCompilableException("call to `" + name + "' has more than " + MAX_ARGUMENTS + " arguments");
 
         SkinnyMethodAdapter adapter2;
         String incomingSig;
         String outgoingSig;
 
-        if (hasClosure) {
+        if (receivesClosure) {
             switch (arity) {
                 case -1:
                     incomingSig = sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY, Block.class));
@@ -478,29 +478,29 @@ public class IRBytecodeAdapter6 extends IRBytecodeAdapter{
             case -1:
             case 1:
                 adapter2.aload(3);
-                if (hasClosure) adapter2.aload(4);
+                if (receivesClosure) adapter2.aload(4);
                 break;
             case 0:
-                if (hasClosure) adapter2.aload(3);
+                if (receivesClosure) adapter2.aload(3);
                 break;
             case 2:
                 adapter2.aload(3);
                 adapter2.aload(4);
-                if (hasClosure) adapter2.aload(5);
+                if (receivesClosure) adapter2.aload(5);
                 break;
             case 3:
                 adapter2.aload(3);
                 adapter2.aload(4);
                 adapter2.aload(5);
-                if (hasClosure) adapter2.aload(6);
+                if (receivesClosure) adapter2.aload(6);
                 break;
             default:
                 buildArrayFromLocals(adapter2, 3, arity);
-                if (hasClosure) adapter2.aload(3 + arity);
+                if (receivesClosure) adapter2.aload(3 + arity);
                 break;
         }
 
-        adapter2.invokevirtual(p(CachingCallSite.class), hasClosure ? "callIter" : "call", outgoingSig);
+        adapter2.invokevirtual(p(CachingCallSite.class), literalClosure ? "callIter" : "call", outgoingSig);
         adapter2.areturn();
         adapter2.end();
 
@@ -533,9 +533,9 @@ public class IRBytecodeAdapter6 extends IRBytecodeAdapter{
         if (!MethodIndex.hasFastFixnumOps(name)) {
             pushFixnum(fixnum);
             if (callType == CallType.NORMAL) {
-                invokeOther(file, line, name, 1, false, false);
+                invokeOther(file, line, name, 1, false, false,false);
             } else {
-                invokeSelf(file, line, name, 1, false, callType, false);
+                invokeSelf(file, line, name, 1, false, false, callType, false);
             }
             return;
         }
@@ -589,9 +589,9 @@ public class IRBytecodeAdapter6 extends IRBytecodeAdapter{
         if (!MethodIndex.hasFastFloatOps(name)) {
             pushFloat(flote);
             if (callType == CallType.NORMAL) {
-                invokeOther(file, line, name, 1, false, false);
+                invokeOther(file, line, name, 1, false, false, false);
             } else {
-                invokeSelf(file, line, name, 1, false, callType, false);
+                invokeSelf(file, line, name, 1, false, false, callType, false);
             }
             return;
         }
@@ -641,10 +641,10 @@ public class IRBytecodeAdapter6 extends IRBytecodeAdapter{
         adapter.invokestatic(getClassData().clsName, methodName, incomingSig);
     }
 
-    public void invokeSelf(String file, int line, String name, int arity, boolean hasClosure, CallType callType, boolean isPotentiallyRefined) {
+    public void invokeSelf(String file, int line, String name, int arity, boolean receivesClosure, boolean literalClosure, CallType callType, boolean isPotentiallyRefined) {
         if (arity > MAX_ARGUMENTS) throw new NotCompilableException("call to `" + name + "' has more than " + MAX_ARGUMENTS + " arguments");
 
-        invoke(file, line, name, arity, hasClosure, callType, isPotentiallyRefined);
+        invoke(file, line, name, arity, receivesClosure, literalClosure, callType, isPotentiallyRefined);
     }
 
     public void invokeInstanceSuper(String file, int line, String name, int arity, boolean hasClosure, boolean[] splatmap) {

--- a/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter6.java
+++ b/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter6.java
@@ -500,7 +500,7 @@ public class IRBytecodeAdapter6 extends IRBytecodeAdapter{
                 break;
         }
 
-        adapter2.invokevirtual(p(CachingCallSite.class), "call", outgoingSig);
+        adapter2.invokevirtual(p(CachingCallSite.class), hasClosure ? "callIter" : "call", outgoingSig);
         adapter2.areturn();
         adapter2.end();
 

--- a/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter6.java
+++ b/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter6.java
@@ -382,8 +382,9 @@ public class IRBytecodeAdapter6 extends IRBytecodeAdapter{
         });
     }
 
-    public void invokeOther(String file, int line, String name, int arity, boolean receivesClosure, boolean literalClosure, boolean isPotentiallyRefined) {
-        invoke(file, line, name, arity, receivesClosure, literalClosure, CallType.NORMAL, isPotentiallyRefined);
+    @Override
+    public void invokeOther(String file, int line, String name, int arity, BlockPassType blockPassType, boolean isPotentiallyRefined) {
+        invoke(file, line, name, arity, blockPassType, CallType.NORMAL, isPotentiallyRefined);
     }
 
     public void invokeArrayDeref(String file, int line) {
@@ -410,14 +411,15 @@ public class IRBytecodeAdapter6 extends IRBytecodeAdapter{
         adapter.invokestatic(getClassData().clsName, methodName, incomingSig);
     }
 
-    public void invoke(String file, int lineNumber, String name, int arity, boolean receivesClosure, boolean literalClosure, CallType callType, boolean isPotentiallyRefined) {
+    public void invoke(String file, int lineNumber, String name, int arity, BlockPassType blockPassType, CallType callType, boolean isPotentiallyRefined) {
         if (arity > MAX_ARGUMENTS) throw new NotCompilableException("call to `" + name + "' has more than " + MAX_ARGUMENTS + " arguments");
 
         SkinnyMethodAdapter adapter2;
         String incomingSig;
         String outgoingSig;
 
-        if (receivesClosure) {
+        boolean blockGiven = blockPassType.given();
+        if (blockGiven) {
             switch (arity) {
                 case -1:
                     incomingSig = sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY, Block.class));
@@ -478,29 +480,29 @@ public class IRBytecodeAdapter6 extends IRBytecodeAdapter{
             case -1:
             case 1:
                 adapter2.aload(3);
-                if (receivesClosure) adapter2.aload(4);
+                if (blockGiven) adapter2.aload(4);
                 break;
             case 0:
-                if (receivesClosure) adapter2.aload(3);
+                if (blockGiven) adapter2.aload(3);
                 break;
             case 2:
                 adapter2.aload(3);
                 adapter2.aload(4);
-                if (receivesClosure) adapter2.aload(5);
+                if (blockGiven) adapter2.aload(5);
                 break;
             case 3:
                 adapter2.aload(3);
                 adapter2.aload(4);
                 adapter2.aload(5);
-                if (receivesClosure) adapter2.aload(6);
+                if (blockGiven) adapter2.aload(6);
                 break;
             default:
                 buildArrayFromLocals(adapter2, 3, arity);
-                if (receivesClosure) adapter2.aload(3 + arity);
+                if (blockGiven) adapter2.aload(3 + arity);
                 break;
         }
 
-        adapter2.invokevirtual(p(CachingCallSite.class), literalClosure ? "callIter" : "call", outgoingSig);
+        adapter2.invokevirtual(p(CachingCallSite.class), blockPassType.literal() ? "callIter" : "call", outgoingSig);
         adapter2.areturn();
         adapter2.end();
 
@@ -533,9 +535,9 @@ public class IRBytecodeAdapter6 extends IRBytecodeAdapter{
         if (!MethodIndex.hasFastFixnumOps(name)) {
             pushFixnum(fixnum);
             if (callType == CallType.NORMAL) {
-                invokeOther(file, line, name, 1, false, false,false);
+                invokeOther(file, line, name, 1, BlockPassType.NONE, false);
             } else {
-                invokeSelf(file, line, name, 1, false, false, callType, false);
+                invokeSelf(file, line, name, 1, BlockPassType.NONE, callType, false);
             }
             return;
         }
@@ -589,9 +591,9 @@ public class IRBytecodeAdapter6 extends IRBytecodeAdapter{
         if (!MethodIndex.hasFastFloatOps(name)) {
             pushFloat(flote);
             if (callType == CallType.NORMAL) {
-                invokeOther(file, line, name, 1, false, false, false);
+                invokeOther(file, line, name, 1, BlockPassType.NONE, false);
             } else {
-                invokeSelf(file, line, name, 1, false, false, callType, false);
+                invokeSelf(file, line, name, 1, BlockPassType.NONE, callType, false);
             }
             return;
         }
@@ -641,10 +643,10 @@ public class IRBytecodeAdapter6 extends IRBytecodeAdapter{
         adapter.invokestatic(getClassData().clsName, methodName, incomingSig);
     }
 
-    public void invokeSelf(String file, int line, String name, int arity, boolean receivesClosure, boolean literalClosure, CallType callType, boolean isPotentiallyRefined) {
+    public void invokeSelf(String file, int line, String name, int arity, BlockPassType blockPassType, CallType callType, boolean isPotentiallyRefined) {
         if (arity > MAX_ARGUMENTS) throw new NotCompilableException("call to `" + name + "' has more than " + MAX_ARGUMENTS + " arguments");
 
-        invoke(file, line, name, arity, receivesClosure, literalClosure, callType, isPotentiallyRefined);
+        invoke(file, line, name, arity, blockPassType, callType, isPotentiallyRefined);
     }
 
     public void invokeInstanceSuper(String file, int line, String name, int arity, boolean hasClosure, boolean[] splatmap) {

--- a/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter7.java
+++ b/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter7.java
@@ -125,24 +125,24 @@ public class IRBytecodeAdapter7 extends IRBytecodeAdapter6 {
         adapter.invokedynamic("encoding", sig(RubyEncoding.class, ThreadContext.class), Bootstrap.contextValueString(), new String(encoding.getName()));
     }
 
-    public void invokeOther(String file, int line, String name, int arity, boolean hasClosure, boolean isPotentiallyRefined) {
+    public void invokeOther(String file, int line, String name, int arity, boolean receivesClosure, boolean literalClosure, boolean isPotentiallyRefined) {
         if (arity > MAX_ARGUMENTS) throw new NotCompilableException("call to `" + name + "' has more than " + MAX_ARGUMENTS + " arguments");
         if (isPotentiallyRefined) {
-            super.invokeOther(file, line, name, arity, hasClosure, isPotentiallyRefined);
+            super.invokeOther(file, line, name, arity, receivesClosure, literalClosure, isPotentiallyRefined);
             return;
         }
 
-        if (hasClosure) {
+        if (receivesClosure) {
             if (arity == -1) {
-                adapter.invokedynamic("invoke:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY, Block.class)), NormalInvokeSite.BOOTSTRAP, file, line);
+                adapter.invokedynamic("invoke:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY, Block.class)), NormalInvokeSite.BOOTSTRAP, literalClosure, file, line);
             } else {
-                adapter.invokedynamic("invoke:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, arity + 2, Block.class)), NormalInvokeSite.BOOTSTRAP, file, line);
+                adapter.invokedynamic("invoke:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, arity + 2, Block.class)), NormalInvokeSite.BOOTSTRAP, literalClosure, file, line);
             }
         } else {
             if (arity == -1) {
-                adapter.invokedynamic("invoke:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY)), NormalInvokeSite.BOOTSTRAP, file, line);
+                adapter.invokedynamic("invoke:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY)), NormalInvokeSite.BOOTSTRAP, literalClosure, file, line);
             } else {
-                adapter.invokedynamic("invoke:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT, arity)), NormalInvokeSite.BOOTSTRAP, file, line);
+                adapter.invokedynamic("invoke:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT, arity)), NormalInvokeSite.BOOTSTRAP, literalClosure, file, line);
             }
         }
     }
@@ -156,9 +156,9 @@ public class IRBytecodeAdapter7 extends IRBytecodeAdapter6 {
         if (!MethodIndex.hasFastFixnumOps(name)) {
             pushFixnum(fixnum);
             if (callType == CallType.NORMAL) {
-                invokeOther(file, line, name, 1, false, false);
+                invokeOther(file, line, name, 1, false, false,false);
             } else {
-                invokeSelf(file, line, name, 1, false, callType, false);
+                invokeSelf(file, line, name, 1, false, false, callType, false);
             }
             return;
         }
@@ -179,9 +179,9 @@ public class IRBytecodeAdapter7 extends IRBytecodeAdapter6 {
         if (!MethodIndex.hasFastFloatOps(name)) {
             pushFloat(flote);
             if (callType == CallType.NORMAL) {
-                invokeOther(file, line, name, 1, false, false);
+                invokeOther(file, line, name, 1, false, false, false);
             } else {
-                invokeSelf(file, line, name, 1, false, callType, false);
+                invokeSelf(file, line, name, 1, false, false, callType, false);
             }
             return;
         }
@@ -198,25 +198,25 @@ public class IRBytecodeAdapter7 extends IRBytecodeAdapter6 {
             0);
     }
 
-    public void invokeSelf(String file, int line, String name, int arity, boolean hasClosure, CallType callType, boolean isPotentiallyRefined) {
+    public void invokeSelf(String file, int line, String name, int arity, boolean receivesClosure, boolean literalClosure, CallType callType, boolean isPotentiallyRefined) {
         if (arity > MAX_ARGUMENTS) throw new NotCompilableException("call to `" + name + "' has more than " + MAX_ARGUMENTS + " arguments");
         if (isPotentiallyRefined) {
-            super.invokeSelf(file, line, name, arity, hasClosure, callType, isPotentiallyRefined);
+            super.invokeSelf(file, line, name, arity, receivesClosure, literalClosure, callType, isPotentiallyRefined);
             return;
         }
 
         String action = callType == CallType.FUNCTIONAL ? "callFunctional" : "callVariable";
-        if (hasClosure) {
+        if (receivesClosure) {
             if (arity == -1) {
-                adapter.invokedynamic(action + ":" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY, Block.class)), SelfInvokeSite.BOOTSTRAP, file, line);
+                adapter.invokedynamic(action + ":" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY, Block.class)), SelfInvokeSite.BOOTSTRAP, literalClosure, file, line);
             } else {
-                adapter.invokedynamic(action + ":" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, arity + 2, Block.class)), SelfInvokeSite.BOOTSTRAP, file, line);
+                adapter.invokedynamic(action + ":" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, arity + 2, Block.class)), SelfInvokeSite.BOOTSTRAP, literalClosure, file, line);
             }
         } else {
             if (arity == -1) {
-                adapter.invokedynamic(action + ":" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY)), SelfInvokeSite.BOOTSTRAP, file, line);
+                adapter.invokedynamic(action + ":" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY)), SelfInvokeSite.BOOTSTRAP, literalClosure, file, line);
             } else {
-                adapter.invokedynamic(action + ":" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT, arity)), SelfInvokeSite.BOOTSTRAP, file, line);
+                adapter.invokedynamic(action + ":" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT, arity)), SelfInvokeSite.BOOTSTRAP, literalClosure, file, line);
             }
         }
     }

--- a/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter7.java
+++ b/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter7.java
@@ -125,24 +125,24 @@ public class IRBytecodeAdapter7 extends IRBytecodeAdapter6 {
         adapter.invokedynamic("encoding", sig(RubyEncoding.class, ThreadContext.class), Bootstrap.contextValueString(), new String(encoding.getName()));
     }
 
-    public void invokeOther(String file, int line, String name, int arity, boolean receivesClosure, boolean literalClosure, boolean isPotentiallyRefined) {
+    public void invokeOther(String file, int line, String name, int arity, BlockPassType blockPassType, boolean isPotentiallyRefined) {
         if (arity > MAX_ARGUMENTS) throw new NotCompilableException("call to `" + name + "' has more than " + MAX_ARGUMENTS + " arguments");
         if (isPotentiallyRefined) {
-            super.invokeOther(file, line, name, arity, receivesClosure, literalClosure, isPotentiallyRefined);
+            super.invokeOther(file, line, name, arity, blockPassType, isPotentiallyRefined);
             return;
         }
 
-        if (receivesClosure) {
+        if (blockPassType.given()) {
             if (arity == -1) {
-                adapter.invokedynamic("invoke:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY, Block.class)), NormalInvokeSite.BOOTSTRAP, literalClosure, file, line);
+                adapter.invokedynamic("invoke:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY, Block.class)), NormalInvokeSite.BOOTSTRAP, blockPassType.literal(), file, line);
             } else {
-                adapter.invokedynamic("invoke:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, arity + 2, Block.class)), NormalInvokeSite.BOOTSTRAP, literalClosure, file, line);
+                adapter.invokedynamic("invoke:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, arity + 2, Block.class)), NormalInvokeSite.BOOTSTRAP, blockPassType.literal(), file, line);
             }
         } else {
             if (arity == -1) {
-                adapter.invokedynamic("invoke:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY)), NormalInvokeSite.BOOTSTRAP, literalClosure, file, line);
+                adapter.invokedynamic("invoke:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY)), NormalInvokeSite.BOOTSTRAP, false, file, line);
             } else {
-                adapter.invokedynamic("invoke:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT, arity)), NormalInvokeSite.BOOTSTRAP, literalClosure, file, line);
+                adapter.invokedynamic("invoke:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT, arity)), NormalInvokeSite.BOOTSTRAP, false, file, line);
             }
         }
     }
@@ -156,9 +156,9 @@ public class IRBytecodeAdapter7 extends IRBytecodeAdapter6 {
         if (!MethodIndex.hasFastFixnumOps(name)) {
             pushFixnum(fixnum);
             if (callType == CallType.NORMAL) {
-                invokeOther(file, line, name, 1, false, false,false);
+                invokeOther(file, line, name, 1, BlockPassType.NONE,false);
             } else {
-                invokeSelf(file, line, name, 1, false, false, callType, false);
+                invokeSelf(file, line, name, 1, BlockPassType.NONE, callType, false);
             }
             return;
         }
@@ -179,9 +179,9 @@ public class IRBytecodeAdapter7 extends IRBytecodeAdapter6 {
         if (!MethodIndex.hasFastFloatOps(name)) {
             pushFloat(flote);
             if (callType == CallType.NORMAL) {
-                invokeOther(file, line, name, 1, false, false, false);
+                invokeOther(file, line, name, 1, BlockPassType.NONE, false);
             } else {
-                invokeSelf(file, line, name, 1, false, false, callType, false);
+                invokeSelf(file, line, name, 1, BlockPassType.NONE, callType, false);
             }
             return;
         }
@@ -198,25 +198,25 @@ public class IRBytecodeAdapter7 extends IRBytecodeAdapter6 {
             0);
     }
 
-    public void invokeSelf(String file, int line, String name, int arity, boolean receivesClosure, boolean literalClosure, CallType callType, boolean isPotentiallyRefined) {
+    public void invokeSelf(String file, int line, String name, int arity, BlockPassType blockPassType, CallType callType, boolean isPotentiallyRefined) {
         if (arity > MAX_ARGUMENTS) throw new NotCompilableException("call to `" + name + "' has more than " + MAX_ARGUMENTS + " arguments");
         if (isPotentiallyRefined) {
-            super.invokeSelf(file, line, name, arity, receivesClosure, literalClosure, callType, isPotentiallyRefined);
+            super.invokeSelf(file, line, name, arity, blockPassType, callType, isPotentiallyRefined);
             return;
         }
 
         String action = callType == CallType.FUNCTIONAL ? "callFunctional" : "callVariable";
-        if (receivesClosure) {
+        if (blockPassType != BlockPassType.NONE) {
             if (arity == -1) {
-                adapter.invokedynamic(action + ":" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY, Block.class)), SelfInvokeSite.BOOTSTRAP, literalClosure, file, line);
+                adapter.invokedynamic(action + ":" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY, Block.class)), SelfInvokeSite.BOOTSTRAP, blockPassType.literal(), file, line);
             } else {
-                adapter.invokedynamic(action + ":" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, arity + 2, Block.class)), SelfInvokeSite.BOOTSTRAP, literalClosure, file, line);
+                adapter.invokedynamic(action + ":" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, arity + 2, Block.class)), SelfInvokeSite.BOOTSTRAP, blockPassType.literal(), file, line);
             }
         } else {
             if (arity == -1) {
-                adapter.invokedynamic(action + ":" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY)), SelfInvokeSite.BOOTSTRAP, literalClosure, file, line);
+                adapter.invokedynamic(action + ":" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY)), SelfInvokeSite.BOOTSTRAP, false, file, line);
             } else {
-                adapter.invokedynamic(action + ":" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT, arity)), SelfInvokeSite.BOOTSTRAP, literalClosure, file, line);
+                adapter.invokedynamic(action + ":" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT, arity)), SelfInvokeSite.BOOTSTRAP, false, file, line);
             }
         }
     }

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -854,8 +854,9 @@ public class JVMVisitor extends IRVisitor {
         jvmMethod().loadContext();
         jvmLoadLocal(DYNAMIC_SCOPE);
         visit(breakInstr.getReturnValue());
+        jvmMethod().loadSelfBlock();
         jvmMethod().loadBlockType();
-        jvmAdapter().invokestatic(p(IRRuntimeHelpers.class), "initiateBreak", sig(IRubyObject.class, ThreadContext.class, DynamicScope.class, IRubyObject.class, Block.Type.class));
+        jvmAdapter().invokestatic(p(IRRuntimeHelpers.class), "initiateBreak", sig(IRubyObject.class, ThreadContext.class, DynamicScope.class, IRubyObject.class, Block.class, Block.Type.class));
         jvmMethod().returnValue();
 
     }

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -856,8 +856,7 @@ public class JVMVisitor extends IRVisitor {
         jvmLoadLocal(DYNAMIC_SCOPE);
         visit(breakInstr.getReturnValue());
         jvmMethod().loadSelfBlock();
-        jvmMethod().loadBlockType();
-        jvmAdapter().invokestatic(p(IRRuntimeHelpers.class), "initiateBreak", sig(IRubyObject.class, ThreadContext.class, DynamicScope.class, IRubyObject.class, Block.class, Block.Type.class));
+        jvmAdapter().invokestatic(p(IRRuntimeHelpers.class), "initiateBreak", sig(IRubyObject.class, ThreadContext.class, DynamicScope.class, IRubyObject.class, Block.class));
         jvmMethod().returnValue();
 
     }
@@ -2063,10 +2062,10 @@ public class JVMVisitor extends IRVisitor {
     public void NonlocalReturnInstr(NonlocalReturnInstr returninstr) {
         jvmMethod().loadContext();
         jvmLoadLocal(DYNAMIC_SCOPE);
-        jvmMethod().loadBlockType();
+        jvmMethod().loadSelfBlock();
         visit(returninstr.getReturnValue());
 
-        jvmMethod().invokeIRHelper("initiateNonLocalReturn", sig(IRubyObject.class, ThreadContext.class, DynamicScope.class, Block.Type.class, IRubyObject.class));
+        jvmMethod().invokeIRHelper("initiateNonLocalReturn", sig(IRubyObject.class, ThreadContext.class, DynamicScope.class, Block.class, IRubyObject.class));
         jvmMethod().returnValue();
     }
 

--- a/core/src/main/java/org/jruby/ir/targets/NormalInvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/NormalInvokeSite.java
@@ -24,15 +24,16 @@ import static org.jruby.util.CodegenUtils.sig;
 public class NormalInvokeSite extends InvokeSite {
     CacheEntry cache;
 
-    public NormalInvokeSite(MethodType type, String name, String file, int line) {
-        super(type, name, CallType.NORMAL, file, line);
+    public NormalInvokeSite(MethodType type, String name, boolean literalClosure, String file, int line) {
+        super(type, name, CallType.NORMAL, literalClosure, file, line);
     }
 
-    public static Handle BOOTSTRAP = new Handle(Opcodes.H_INVOKESTATIC, p(NormalInvokeSite.class), "bootstrap", sig(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class, String.class, int.class));
+    public static Handle BOOTSTRAP = new Handle(Opcodes.H_INVOKESTATIC, p(NormalInvokeSite.class), "bootstrap", sig(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class, int.class, String.class, int.class));
 
-    public static CallSite bootstrap(MethodHandles.Lookup lookup, String name, MethodType type, String file, int line) {
+    public static CallSite bootstrap(MethodHandles.Lookup lookup, String name, MethodType type, int closureInt, String file, int line) {
+        boolean literalClosure = closureInt != 0;
         String methodName = StringSupport.split(name, ':').get(1);
-        InvokeSite site = new NormalInvokeSite(type, JavaNameMangler.demangleMethodName(methodName), file, line);
+        InvokeSite site = new NormalInvokeSite(type, JavaNameMangler.demangleMethodName(methodName), literalClosure, file, line);
 
         return InvokeSite.bootstrap(site, lookup);
     }

--- a/core/src/main/java/org/jruby/ir/targets/SelfInvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/SelfInvokeSite.java
@@ -23,17 +23,22 @@ import static org.jruby.util.CodegenUtils.sig;
 * Created by headius on 10/23/14.
 */
 public class SelfInvokeSite extends InvokeSite {
-    public SelfInvokeSite(MethodType type, String name, CallType callType, String file, int line) {
-        super(type, name, callType, file, line);
+    public SelfInvokeSite(MethodType type, String name, CallType callType, boolean literalClosure, String file, int line) {
+        super(type, name, callType, literalClosure, file, line);
     }
 
-    public static Handle BOOTSTRAP = new Handle(Opcodes.H_INVOKESTATIC, p(SelfInvokeSite.class), "bootstrap", sig(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class, String.class, int.class));
+    public SelfInvokeSite(MethodType type, String name, CallType callType, String file, int line) {
+        this(type, name, callType, false, file, line);
+    }
 
-    public static CallSite bootstrap(MethodHandles.Lookup lookup, String name, MethodType type, String file, int line) {
+    public static Handle BOOTSTRAP = new Handle(Opcodes.H_INVOKESTATIC, p(SelfInvokeSite.class), "bootstrap", sig(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class, int.class, String.class, int.class));
+
+    public static CallSite bootstrap(MethodHandles.Lookup lookup, String name, MethodType type, int closureInt, String file, int line) {
+        boolean literalClosure = closureInt != 0;
         List<String> nameComponents = StringSupport.split(name, ':');
         String methodName = JavaNameMangler.demangleMethodName(nameComponents.get(1));
         CallType callType = nameComponents.get(0).equals("callFunctional") ? CallType.FUNCTIONAL : CallType.VARIABLE;
-        InvokeSite site = new SelfInvokeSite(type, methodName, callType, file, line);
+        InvokeSite site = new SelfInvokeSite(type, methodName, callType, literalClosure, file, line);
 
         return InvokeSite.bootstrap(site, lookup);
     }


### PR DESCRIPTION
For #4686 and #4577.

The strategy here is as it was in 1.7: mark literal blocks as "escaped" when the call they were originally passed to returns. Break operations can then immediately trigger a LocalJumpError and be rescued in all the various ways reported in #4686 and #4577.

This does not fix super calls because the additional work is nontrivial (pushing literal-closure param through a lot of code in interpreter and JIT) and the exposure surface is pretty small for super PLUS literal closure PLUS break PLUS escaping of that block.