### PR TITLE
IO#set_encoding should return self (fixes #4712)

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1058,7 +1058,7 @@ public class RubyIO extends RubyObject implements IOEncodable {
     public IRubyObject set_encoding(ThreadContext context, IRubyObject encodingObj) {
         setEncoding(context, encodingObj, context.nil, context.nil);
 
-        return context.nil;
+        return this;
     }
 
     @JRubyMethod
@@ -1070,14 +1070,14 @@ public class RubyIO extends RubyObject implements IOEncodable {
             setEncoding(context, encodingString, internalEncoding, context.nil);
         }
 
-        return context.nil;
+        return this;
     }
 
     @JRubyMethod
     public IRubyObject set_encoding(ThreadContext context, IRubyObject encodingString, IRubyObject internalEncoding, IRubyObject options) {
         setEncoding(context, encodingString, internalEncoding, options);
 
-        return context.nil;
+        return this;
     }
 
     // mri: io_encoding_set

--- a/spec/tags/ruby/core/io/set_encoding_tags.txt
+++ b/spec/tags/ruby/core/io/set_encoding_tags.txt
@@ -1,1 +1,0 @@
-fails:IO#set_encoding returns self


### PR DESCRIPTION
Also untagged the now passing corresponding spec and checked if StringIO does the right thing (it does).