### PR TITLE
[ji] (auto) convert java numbers

### DIFF
--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -352,7 +352,7 @@ public abstract class RubyInteger extends RubyNumeric {
             enc =  arg.convertToString().toEncoding(runtime);
         }
         if (enc == ASCIIEncoding.INSTANCE && value >= 0x80) {
-            return chr19(context);
+            return chr(context);
         }
         return RubyString.newStringNoCopy(runtime, fromEncodedBytes(runtime, enc, value), enc, 0);
     }
@@ -505,8 +505,7 @@ public abstract class RubyInteger extends RubyNumeric {
      */
     @JRubyMethod(name = "gcd")
     public IRubyObject gcd(ThreadContext context, IRubyObject other) {
-        checkInteger(context, other);
-        return f_gcd(context, this, RubyRational.intValue(context, other));
+        return f_gcd(context, this, toInteger(context, other));
     }
 
     /** rb_lcm
@@ -514,8 +513,7 @@ public abstract class RubyInteger extends RubyNumeric {
      */
     @JRubyMethod(name = "lcm")
     public IRubyObject lcm(ThreadContext context, IRubyObject other) {
-        checkInteger(context, other);
-        return f_lcm(context, this, RubyRational.intValue(context, other));
+        return f_lcm(context, this, toInteger(context, other));
     }
 
     /** rb_gcdlcm
@@ -523,9 +521,16 @@ public abstract class RubyInteger extends RubyNumeric {
      */
     @JRubyMethod(name = "gcdlcm")
     public IRubyObject gcdlcm(ThreadContext context, IRubyObject other) {
-        checkInteger(context, other);
-        other = RubyRational.intValue(context, other);
+        other = toInteger(context, other);
         return context.runtime.newArray(f_gcd(context, this, other), f_lcm(context, this, other));
+    }
+
+    static IRubyObject toInteger(ThreadContext context, IRubyObject num) {
+        if (num instanceof RubyInteger) return num;
+        if (num instanceof RubyNumeric && !num.callMethod(context, "integer?").isTrue()) {
+            throw context.runtime.newTypeError("not an integer");
+        }
+        return num.callMethod(context, "to_i");
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyRandom.java
+++ b/core/src/main/java/org/jruby/RubyRandom.java
@@ -38,6 +38,8 @@ import org.jruby.util.ByteList;
 import org.jruby.util.Random;
 import org.jruby.util.TypeConverter;
 
+import static org.jruby.util.TypeConverter.toFloat;
+
 /**
  * Implementation of the Random class.
  */
@@ -487,8 +489,8 @@ public class RubyRandom extends RubyObject {
                 double mid = 0.5;
                 double r;
                 if (Double.isInfinite(max)) {
-                    double min = floatValue(context, range.begin) / 2.0;
-                    max = floatValue(context, range.end) / 2.0;
+                    double min = floatValue(context, toFloat(context.runtime, range.begin)) / 2.0;
+                    max = floatValue(context, toFloat(context.runtime, range.end)) / 2.0;
                     scale = 2;
                     mid = max + min;
                     max -= min;
@@ -533,15 +535,8 @@ public class RubyRandom extends RubyObject {
     }
 
     // c: float_value
-    private static double floatValue(ThreadContext context, IRubyObject v) {
-        final double x;
-        if (v instanceof RubyFloat) {
-            x = ((RubyFloat) v).getDoubleValue();
-        } else if (v instanceof RubyNumeric) {
-            x = ((RubyNumeric) v).convertToFloat().getDoubleValue();
-        } else {
-            throw context.runtime.newTypeError(v, context.runtime.getFloat());
-        }
+    private static double floatValue(ThreadContext context, RubyFloat v) {
+        final double x = v.getDoubleValue();
         checkFloatValue(context, x);
         return x;
     }

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -808,10 +808,8 @@ public class RubyRational extends RubyNumeric {
         return f_negate(context, this);
     }
 
-    private IRubyObject op_roundCommonPre(ThreadContext context, IRubyObject n) {
-        checkInteger(context, n);
-        Ruby runtime = context.runtime;
-        return f_expt(context, RubyFixnum.newFixnum(runtime, 10), n);
+    private static IRubyObject op_roundCommonPre(ThreadContext context, IRubyObject n) {
+        return f_expt(context, RubyFixnum.newFixnum(context.runtime, 10), RubyInteger.toInteger(context, n));
     }
 
     private IRubyObject op_roundCommonPost(ThreadContext context, IRubyObject s, IRubyObject n, IRubyObject b) {
@@ -1043,8 +1041,8 @@ public class RubyRational extends RubyNumeric {
     @JRubyMethod(name = "marshal_load")
     public IRubyObject marshal_load(ThreadContext context, IRubyObject arg) {
         RubyArray load = arg.convertToArray();
-        num = load.size() > 0 ? load.eltInternal(0) : context.runtime.getNil();
-        den = load.size() > 1 ? load.eltInternal(1) : context.runtime.getNil();
+        num = load.size() > 0 ? load.eltInternal(0) : context.nil;
+        den = load.size() > 1 ? load.eltInternal(1) : context.nil;
 
         if (f_zero_p(context, den)) {
             throw context.runtime.newZeroDivisionError();

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -320,7 +320,7 @@ public class RubyRational extends RubyNumeric {
      */
     @JRubyMethod(name = "convert", meta = true, visibility = Visibility.PRIVATE)
     public static IRubyObject convert(ThreadContext context, IRubyObject recv, IRubyObject a1) {
-        if (a1.isNil()) {
+        if (a1 == context.nil) {
             throw context.runtime.newTypeError("can't convert nil into Rational");
         }
 
@@ -332,7 +332,7 @@ public class RubyRational extends RubyNumeric {
      */
     @JRubyMethod(name = "convert", meta = true, visibility = Visibility.PRIVATE)
     public static IRubyObject convert(ThreadContext context, IRubyObject recv, IRubyObject a1, IRubyObject a2) {
-        if (a1.isNil() || a2.isNil()) {
+        if (a1 == context.nil || a2 == context.nil) {
             throw context.runtime.newTypeError("can't convert nil into Rational");
         }
         
@@ -354,7 +354,7 @@ public class RubyRational extends RubyNumeric {
         } else if (a1 instanceof RubyString) {
             a1 = str_to_r_strict(context, a1);
         } else {
-            if (a1 instanceof RubyObject && responds_to_to_r(context, a1)) {
+            if (a1 instanceof RubyObject && sites(context).respond_to_to_r.respondsTo(context, a1, a1)) {
                 a1 = f_to_r(context, a1);
             }
         }
@@ -366,27 +366,22 @@ public class RubyRational extends RubyNumeric {
         }
 
         if (a1 instanceof RubyRational) {
-            if (a2.isNil() || (k_exact_p(a2) && f_one_p(context, a2))) return a1;
+            if (a2 == context.nil || (k_exact_p(a2) && f_one_p(context, a2))) return a1;
         }
 
-        if (a2.isNil()) {
-            if (a1 instanceof RubyNumeric && !f_integer_p(context, a1).isTrue()) return a1;
+        if (a2 == context.nil) {
+            if (!(a1 instanceof RubyNumeric && f_integer_p(context, a1).isTrue())) {
+                return TypeConverter.convertToType(a1, context.runtime.getRational(), "to_r");
+            }
             return newInstance(context, recv, a1);
         } else {
-            if (a1 instanceof RubyNumeric && a2 instanceof RubyNumeric &&
+            if ((a1 instanceof RubyNumeric && a2 instanceof RubyNumeric) &&
                 (!f_integer_p(context, a1).isTrue() || !f_integer_p(context, a2).isTrue())) {
                 return f_div(context, a1, a2);
             }
             return newInstance(context, recv, a1, a2);
         }
     }
-
-    private static boolean responds_to_to_r(ThreadContext context, IRubyObject obj) {
-        return respond_to_to_r.respondsTo(context, obj, obj);
-    }
-
-    // TODO: wasn't sure whether to put this on NumericSites, here for now - should move
-    static final RespondToCallSite respond_to_to_r = new RespondToCallSite("to_r");
 
     /** nurat_numerator
      * 

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -371,7 +371,7 @@ public class RubyRational extends RubyNumeric {
 
         if (a2 == context.nil) {
             if (!(a1 instanceof RubyNumeric && f_integer_p(context, a1).isTrue())) {
-                return TypeConverter.convertToType(a1, context.runtime.getRational(), "to_r");
+                return TypeConverter.convertToType(context, a1, context.runtime.getRational(), sites(context).to_r_checked);
             }
             return newInstance(context, recv, a1);
         } else {

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -25,7 +25,6 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby;
 
-import static org.jruby.util.Numeric.checkInteger;
 import static org.jruby.util.Numeric.f_abs;
 import static org.jruby.util.Numeric.f_add;
 import static org.jruby.util.Numeric.f_cmp;
@@ -68,7 +67,6 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.common.IRubyWarnings;
 import org.jruby.runtime.Arity;
-import org.jruby.runtime.Block;
 import org.jruby.runtime.ClassIndex;
 import org.jruby.runtime.JavaSites;
 import org.jruby.runtime.ObjectAllocator;
@@ -208,25 +206,15 @@ public class RubyRational extends RubyNumeric {
         canonicalization = canonical;
     }
 
-    /** nurat_int_check
-     * 
-     */
-    static void intCheck(ThreadContext context, IRubyObject num) {
-        if (num instanceof RubyFixnum || num instanceof RubyBignum) return;
-        if (!(num instanceof RubyNumeric) || !num.callMethod(context, "integer?").isTrue()) {
-            Ruby runtime = num.getRuntime();
-            throw runtime.newTypeError("can't convert "
-                    + num.getMetaClass().getName() + " into Rational");
-        }
-    }
-
     /** nurat_int_value
      * 
      */
     static IRubyObject intValue(ThreadContext context, IRubyObject num) {
-        intCheck(context, num);
-        if (!(num instanceof RubyInteger)) num = num.callMethod(context, "to_f");
-        return num;
+        IRubyObject i;
+        if (( i = RubyInteger.toInteger(context, num) ) == null) {
+            throw context.runtime.newTypeError("can't convert " + num.getMetaClass().getName() + " into Rational");
+        }
+        return i;
     }
     
     /** nurat_s_canonicalize_internal
@@ -809,7 +797,7 @@ public class RubyRational extends RubyNumeric {
     }
 
     private static IRubyObject op_roundCommonPre(ThreadContext context, IRubyObject n) {
-        return f_expt(context, RubyFixnum.newFixnum(context.runtime, 10), RubyInteger.toInteger(context, n));
+        return f_expt(context, RubyFixnum.newFixnum(context.runtime, 10), intValue(context, n));
     }
 
     private IRubyObject op_roundCommonPost(ThreadContext context, IRubyObject s, IRubyObject n, IRubyObject b) {

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -31,6 +31,7 @@ import org.jruby.*;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyModule;
+import org.jruby.ext.bigdecimal.RubyBigDecimal;
 import org.jruby.internal.runtime.methods.JavaMethod;
 import org.jruby.javasupport.Java;
 import org.jruby.javasupport.JavaClass;
@@ -329,6 +330,9 @@ public abstract class JavaLang {
             if (val instanceof java.math.BigInteger) { // NOTE: should be moved into its own?
                 return RubyBignum.newBignum(context.runtime, (java.math.BigInteger) val);
             }
+            if (val instanceof java.math.BigDecimal) { // NOTE: should be moved into its own?
+                return RubyBignum.newBignum(context.runtime, ((java.math.BigDecimal) val).toBigInteger());
+            }
             return context.runtime.newFixnum(val.longValue());
         }
 
@@ -338,6 +342,26 @@ public abstract class JavaLang {
             return context.runtime.newBoolean(val instanceof Integer || val instanceof Long ||
                                                     val instanceof Short || val instanceof Byte ||
                                                     val instanceof java.math.BigInteger);
+        }
+
+        @JRubyMethod(name = "coerce")
+        public static IRubyObject coerce(final ThreadContext context, final IRubyObject self, final IRubyObject type) {
+            java.lang.Number val = (java.lang.Number) self.toJava(java.lang.Number.class);
+
+            // NOTE: a basic stub that always coverts Java numbers to Ruby ones (for simplicity)
+            // gist being this is not expected to be used heavily, if so should get special care
+            final IRubyObject value;
+            if (val instanceof java.math.BigDecimal) {
+                final RubyClass klass = context.runtime.getClass("BigDecimal");
+                if (klass == null) { // user should require 'bigdecimal'
+                    throw context.runtime.newNameError("uninitialized constant BigDecimal", "BigDecimal");
+                }
+                value = new RubyBigDecimal(context.runtime, klass, (java.math.BigDecimal) val);
+            }
+            else {
+                value = convertJavaToUsableRubyObject(context.runtime, val);
+            }
+            return context.runtime.newArray(type, value);
         }
 
     }

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -62,6 +62,7 @@ public abstract class JavaLang {
         Throwable.define(runtime);
         Runnable.define(runtime);
         Character.define(runtime);
+        Number.define(runtime);
         Class.define(runtime);
         ClassLoader.define(runtime);
         // Java::byte[].class_eval ...
@@ -307,6 +308,40 @@ public abstract class JavaLang {
 
     }
 
+    @JRubyClass(name = "Java::JavaLang::Number")
+    public static class Number {
+
+        static RubyClass define(final Ruby runtime) {
+            final RubyModule Number = Java.getProxyClass(runtime, java.lang.Number.class);
+            Number.defineAnnotatedMethods(Number.class);
+            return (RubyClass) Number;
+        }
+
+        @JRubyMethod(name = "to_f")
+        public static IRubyObject to_f(final ThreadContext context, final IRubyObject self) {
+            java.lang.Number val = (java.lang.Number) self.toJava(java.lang.Number.class);
+            return context.runtime.newFloat(val.doubleValue());
+        }
+
+        @JRubyMethod(name = { "to_i", "to_int" })
+        public static IRubyObject to_i(final ThreadContext context, final IRubyObject self) {
+            java.lang.Number val = (java.lang.Number) self.toJava(java.lang.Number.class);
+            if (val instanceof java.math.BigInteger) { // NOTE: should be moved into its own?
+                return RubyBignum.newBignum(context.runtime, (java.math.BigInteger) val);
+            }
+            return context.runtime.newFixnum(val.longValue());
+        }
+
+        @JRubyMethod(name = "integer?")
+        public static IRubyObject integer_p(final ThreadContext context, final IRubyObject self) {
+            java.lang.Number val = (java.lang.Number) self.toJava(java.lang.Number.class);
+            return context.runtime.newBoolean(val instanceof Integer || val instanceof Long ||
+                                                    val instanceof Short || val instanceof Byte ||
+                                                    val instanceof java.math.BigInteger);
+        }
+
+    }
+
     @JRubyClass(name = "Java::JavaLang::Character")
     public static class Character {
 
@@ -328,6 +363,12 @@ public abstract class JavaLang {
 
         private static char to_char(final IRubyObject num) {
             return (java.lang.Character) num.toJava(java.lang.Character.TYPE);
+        }
+
+        @JRubyMethod(name = "to_i")
+        public static IRubyObject to_i(final ThreadContext context, final IRubyObject self) {
+            java.lang.Character c = (java.lang.Character) self.toJava(java.lang.Character.class);
+            return context.runtime.newFixnum(c);
         }
 
     }

--- a/core/src/main/java/org/jruby/runtime/JavaSites.java
+++ b/core/src/main/java/org/jruby/runtime/JavaSites.java
@@ -363,6 +363,7 @@ public class JavaSites {
         public final CallSite remainder = new FunctionalCachingCallSite("remainder");
         public final CallSite op_cmp = new FunctionalCachingCallSite("<=>");
         public final CheckedSites to_r_checked = new CheckedSites("to_r");
+        public final RespondToCallSite respond_to_to_r = new RespondToCallSite("to_r");
     }
 
     public static class RangeSites {

--- a/core/src/main/java/org/jruby/util/Pack.java
+++ b/core/src/main/java/org/jruby/util/Pack.java
@@ -38,7 +38,6 @@ package org.jruby.util;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import org.jcodings.Encoding;
 
 import org.jcodings.specific.ASCIIEncoding;
 import org.jcodings.specific.USASCIIEncoding;
@@ -50,10 +49,11 @@ import org.jruby.RubyBignum;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
 import org.jruby.RubyNumeric;
-import org.jruby.RubyObject;
 import org.jruby.RubyString;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+
+import static org.jruby.util.TypeConverter.toFloat;
 
 public class Pack {
     private static final byte[] sSp10 = "          ".getBytes();
@@ -97,17 +97,6 @@ public class Pack {
 
     private static double obj2dbl(Ruby runtime, IRubyObject o) {
         return toFloat(runtime, o).getDoubleValue();
-    }
-
-    // MRI: rb_to_float 1.9
-    private static RubyFloat toFloat(Ruby runtime, IRubyObject obj) {
-        if (obj instanceof RubyNumeric) {
-            return ((RubyNumeric) obj).convertToFloat();
-        }
-        if (obj instanceof RubyString || obj.isNil()) {
-            throw runtime.newTypeError(obj, "Float");
-        }
-        return (RubyFloat) TypeConverter.convertToType(obj, runtime.getFloat(), "to_f", true);
     }
 
     static {

--- a/core/src/main/java/org/jruby/util/Pack.java
+++ b/core/src/main/java/org/jruby/util/Pack.java
@@ -83,23 +83,32 @@ public class Pack {
     private static final Converter[] converters = new Converter[256];
 
     private static long num2quad(IRubyObject arg) {
-        if (arg == arg.getRuntime().getNil()) {
-            return 0L;
-        }
-        else if (arg instanceof RubyBignum) {
-            BigInteger big = ((RubyBignum)arg).getValue();
+        if (arg.isNil()) return 0L;
+        if (arg instanceof RubyBignum) {
+            BigInteger big = ((RubyBignum) arg).getValue();
             return big.longValue();
         }
         return RubyNumeric.num2long(arg);
     }
 
     private static float obj2flt(Ruby runtime, IRubyObject o) {
-        return (float) TypeConverter.toFloat(runtime, o).getDoubleValue();        
+        return (float) toFloat(runtime, o).getDoubleValue();
     }
 
     private static double obj2dbl(Ruby runtime, IRubyObject o) {
-        return TypeConverter.toFloat(runtime, o).getDoubleValue();        
-    }    
+        return toFloat(runtime, o).getDoubleValue();
+    }
+
+    // MRI: rb_to_float 1.9
+    private static RubyFloat toFloat(Ruby runtime, IRubyObject obj) {
+        if (obj instanceof RubyNumeric) {
+            return ((RubyNumeric) obj).convertToFloat();
+        }
+        if (obj instanceof RubyString || obj.isNil()) {
+            throw runtime.newTypeError(obj, "Float");
+        }
+        return (RubyFloat) TypeConverter.convertToType(obj, runtime.getFloat(), "to_f", true);
+    }
 
     static {
         uu_table =

--- a/core/src/main/java/org/jruby/util/TypeConverter.java
+++ b/core/src/main/java/org/jruby/util/TypeConverter.java
@@ -131,12 +131,13 @@ public class TypeConverter {
         return convertToType(context, obj, target, sites);
     }
 
-    // MRI: rb_to_float 1.9
+    // NOTE: no longer used, pack has specific conversion rules (e.g. String#to_f should not happen)
+    // thus has been moved and re-implemented directly in org.jruby.util.Pack (MRI: rb_to_float 1.9)
     public static RubyNumeric toFloat(Ruby runtime, IRubyObject obj) {
         if (obj instanceof RubyFloat) return (RubyNumeric) obj;
-        
         return (RubyNumeric) convertToType(obj, runtime.getFloat(), "to_f", true);
     }
+
     /**
      * Checks that this object is of type DATA and then returns it, otherwise raises failure (MRI: Check_Type(obj, T_DATA))
      *

--- a/core/src/main/java/org/jruby/util/TypeConverter.java
+++ b/core/src/main/java/org/jruby/util/TypeConverter.java
@@ -134,8 +134,7 @@ public class TypeConverter {
     // MRI: rb_to_float 1.9
     public static RubyNumeric toFloat(Ruby runtime, IRubyObject obj) {
         if (obj instanceof RubyFloat) return (RubyNumeric) obj;
-        if (!runtime.getNumeric().isInstance(obj)) throw runtime.newTypeError(obj, "Float");
-
+        
         return (RubyNumeric) convertToType(obj, runtime.getFloat(), "to_f", true);
     }
     /**
@@ -262,9 +261,10 @@ public class TypeConverter {
 
     // rb_check_to_integer
     public static IRubyObject checkIntegerType(Ruby runtime, IRubyObject obj, String method) {
+        if (method.equals("to_int")) return checkIntegerType(runtime.getCurrentContext(), obj);
+
         if (obj instanceof RubyFixnum) return obj;
 
-        if (method.equals("to_int")) return checkIntegerType(runtime.getCurrentContext(), obj);
         if (method.equals("to_i")) {
             ThreadContext context = runtime.getCurrentContext();
             TypeConverterSites sites = sites(context);
@@ -280,7 +280,6 @@ public class TypeConverter {
     // rb_check_to_float
     public static IRubyObject checkFloatType(Ruby runtime, IRubyObject obj) {
         if (obj instanceof RubyFloat) return obj;
-        if (!(obj instanceof RubyNumeric)) return runtime.getNil();
 
         ThreadContext context = runtime.getCurrentContext();
         TypeConverterSites sites = sites(context);

--- a/core/src/main/java/org/jruby/util/TypeConverter.java
+++ b/core/src/main/java/org/jruby/util/TypeConverter.java
@@ -131,11 +131,15 @@ public class TypeConverter {
         return convertToType(context, obj, target, sites);
     }
 
-    // NOTE: no longer used, pack has specific conversion rules (e.g. String#to_f should not happen)
-    // thus has been moved and re-implemented directly in org.jruby.util.Pack (MRI: rb_to_float 1.9)
-    public static RubyNumeric toFloat(Ruby runtime, IRubyObject obj) {
-        if (obj instanceof RubyFloat) return (RubyNumeric) obj;
-        return (RubyNumeric) convertToType(obj, runtime.getFloat(), "to_f", true);
+    // MRI: rb_to_float - adjusted to handle also Java numbers (non RubyNumeric types)
+    public static RubyFloat toFloat(Ruby runtime, IRubyObject obj) {
+        if (obj instanceof RubyNumeric) {
+            return ((RubyNumeric) obj).convertToFloat();
+        }
+        if (obj instanceof RubyString || obj.isNil()) {
+            throw runtime.newTypeError(obj, "Float");
+        }
+        return (RubyFloat) TypeConverter.convertToType(obj, runtime.getFloat(), "to_f", true);
     }
 
     /**

--- a/spec/ruby/core/rational/to_r_spec.rb
+++ b/spec/ruby/core/rational/to_r_spec.rb
@@ -7,4 +7,14 @@ describe "Rational#to_r" do
     obj = BasicObject.new
     lambda { Rational(obj) }.should raise_error(TypeError)
   end
+
+  it "works when a BasicObject has to_r" do
+    obj = BasicObject.new; def obj.to_r; 1 / 2.to_r end
+    Rational(obj).should == Rational('1/2')
+  end
+
+  it "fails when a BasicObject's to_r does not return a Rational" do
+    obj = BasicObject.new; def obj.to_r; 1 end
+    lambda { Rational(obj) }.should raise_error(TypeError)
+  end
 end

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -1599,6 +1599,23 @@ CLASSDEF
     end
   end
 
+  def test_java_numbers_with_array
+    num1 = 0.5; num2 = 111
+    if defined?(JRUBY_VERSION)
+      num1 = java.lang.Float.new(num1)
+      num2 = java.lang.Short.new(num2)
+    end
+    pack = [ num1, num2 ].pack('D')
+    assert_equal "\x00\x00\x00\x00\x00\x00\xE0?".force_encoding('ASCII-8BIT'), pack
+
+    i = java.lang.Integer.new(1)
+    arr = []; arr[i] = 'one'
+    assert_equal 'one', arr.at(i)
+    assert_equal 'one', arr[1]
+    i = java.lang.Long.new(1)
+    assert_equal 'one', arr[i]
+  end
+
   def test_java_numbers_treated_like_ruby_ones
     i = java.lang.Integer.new(3)
     assert_equal 3.0, i.to_f
@@ -1608,10 +1625,14 @@ CLASSDEF
     assert_equal 4, java.lang.Byte.new(4).to_i
     assert_equal 5, java.lang.Byte.new(5).to_int
 
+    assert_equal 1, 10.gcd(i)
+
     i = java.math.BigInteger.new('3')
     assert_equal 3.0, i.to_f
     assert_equal 3, i.to_i
     assert_equal true, i.integer?
+
+    assert_equal 30, 10.lcm(i)
 
     f = java.lang.Float.new(3)
     assert_equal 3.0, f.to_f

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -1616,6 +1616,40 @@ CLASSDEF
     assert_equal 'one', arr[i]
   end
 
+  def test_java_numbers_coercing
+    num1 = 1; num2 = 2
+    if defined?(JRUBY_VERSION)
+      num1 = java.lang.Integer.new(num1)
+      num2 = java.lang.Byte.new(num2)
+    end
+    assert_equal 2, 2 / num1
+    assert_equal 1, 2.div(num2)
+
+    assert_equal 4, 2 * num2
+    big = 1_000_000_000_000_000_000_000_000
+    assert_equal 2 * big, big * num2
+
+    assert_equal 1, 5 % num2
+    assert_equal 0, big % num1
+    assert_equal 100, 10 ** num2
+
+    require 'bigdecimal'
+    dec = BigDecimal('4444.1234')
+    assert_equal BigDecimal('8888.2468'), dec * num2
+    assert_equal BigDecimal('4445.1234'), dec + num1
+  end
+
+  def test_java_numbers_with_rational
+    num1 = 0.5; num2 = 2
+    if defined?(JRUBY_VERSION)
+      num1 = java.lang.Double.new(num1)
+      num2 = java.lang.Integer.new(num2)
+    end
+    half = Rational('1/2')
+    assert_equal 1, half.div(num1)
+    assert_equal Rational('1/4'), half / num2
+  end
+
   def test_java_numbers_treated_like_ruby_ones
     i = java.lang.Integer.new(3)
     assert_equal 3.0, i.to_f

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -1599,6 +1599,36 @@ CLASSDEF
     end
   end
 
+  def test_java_numbers_treated_like_ruby_ones
+    i = java.lang.Integer.new(3)
+    assert_equal 3.0, i.to_f
+    assert_equal 3, i.to_i
+    assert_equal true, i.integer?
+
+    assert_equal 4, java.lang.Byte.new(4).to_i
+    assert_equal 5, java.lang.Byte.new(5).to_int
+
+    i = java.math.BigInteger.new('3')
+    assert_equal 3.0, i.to_f
+    assert_equal 3, i.to_i
+    assert_equal true, i.integer?
+
+    f = java.lang.Float.new(3)
+    assert_equal 3.0, f.to_f
+    assert_equal 3, f.to_i
+    assert_equal false, f.integer?
+
+    f = java.math.BigDecimal.new('3.0')
+    assert_equal 3.0, f.to_f
+    assert_equal 3, f.to_i
+    assert_equal false, f.integer?
+  end
+
+  def test_java_character_converts_to_i
+    c = '0'.to_java(:char)
+    assert_equal 48, c.to_i
+  end
+
   # GH-3262
   def test_indexed_bean_style_accessors_are_not_aliased
     # ArgumentError: wrong number of arguments (0 for 1)


### PR DESCRIPTION
Java Integration does not fully handle Java's `Number` type system (primitives as well as java.math classes).

mostly Java numeric values are converted back and forth as needed, however there's still a fay to explicitly instanciate Java types (`java.lang.Integer.new(10)` etc).

improvements presented here try to fix those Java value proxies to seamlessly work with Ruby's conversion rules (e.g. `to_int`). there has been requests on these already, added test demonstrate what's now possible.