### PR TITLE
Fix error message in Hash#fetch

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1186,7 +1186,7 @@ public class RubyHash extends RubyObject implements Map {
         if (value == null) {
             if (block.isGiven()) return block.yield(context, key);
 
-            throw runtime.newKeyError("key not found: :" + key);
+            throw runtime.newKeyError("key not found: " + key.inspect());
         }
 
         return value;


### PR DESCRIPTION
In Hash#fetch, the old error message assumed the key was a symbol. Instead we
inspect it like in MRI. This closes https://github.com/jruby/jruby/issues/4729.