### PR TITLE
MINOR: Add missing `final`s and cleanup dead imports in `org.jruby.irinstructions.CallBase`

### DIFF
--- a/core/src/main/java/org/jruby/ir/instructions/CallBase.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CallBase.java
@@ -1,6 +1,5 @@
 package org.jruby.ir.instructions;
 
-import org.jruby.RubyArray;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.Operation;
 import org.jruby.ir.operands.*;
@@ -14,8 +13,6 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.callsite.RefinedCachingCallSite;
 import org.jruby.util.ArraySupport;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import static org.jruby.ir.IRFlags.*;
@@ -26,9 +23,9 @@ public abstract class CallBase extends NOperandInstr implements ClosureAccepting
     public transient final long callSiteId;
     private final CallType callType;
     protected String name;
-    protected transient CallSite callSite;
-    protected transient int argsCount;
-    protected transient boolean hasClosure;
+    protected final transient CallSite callSite;
+    protected final transient int argsCount;
+    protected final transient boolean hasClosure;
 
     private transient boolean flagsComputed;
     private transient boolean canBeEval;


### PR DESCRIPTION
Just two trivial things I found while researching something else:

* Removed some dead imports
* Added `final` to three fields that are never mutated anywhere to make this class a little easier to follow when trying to debug concurreny issues like #4739 :)