### PR TITLE
Adding flag to skip calling File.getCanonicalPath() on argv[0] during exec()

### DIFF
--- a/core/src/main/java/org/jruby/util/ShellLauncher.java
+++ b/core/src/main/java/org/jruby/util/ShellLauncher.java
@@ -66,6 +66,7 @@ import org.jruby.runtime.Helpers;
 import org.jruby.ext.rbconfig.RbConfigLibrary;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.cli.Options;
 import org.jruby.util.io.ChannelHelper;
 import org.jruby.util.io.IOOptions;
 import org.jruby.util.io.ModeFlags;
@@ -1200,10 +1201,16 @@ public class ShellLauncher {
             } else {
                 verifyExecutable();
                 execArgs = args;
+                boolean nativeExecCanonicalizeSymlinks = Options.NATIVE_EXEC_CANONICALIZESYMLINKS.load();
+
                 try {
-                    execArgs[0] = executableFile.getCanonicalPath();
+                    if (nativeExecCanonicalizeSymlinks) {
+                        execArgs[0] = executableFile.getCanonicalPath();
+                    } else {
+                        execArgs[0] = executableFile.getAbsolutePath();
+                    }
                 } catch (IOException ioe) {
-                    // can't get the canonical path, will use as-is
+                    // can't get the canonical or absolute path, will use as-is
                 }
             }
         }

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -161,6 +161,7 @@ public class Options {
     public static final Option<Boolean> FIBER_COROUTINES = bool(MISCELLANEOUS, "fiber.coroutines", false, "Use JVM coroutines for Fiber.");
     public static final Option<Boolean> GLOBAL_REQUIRE_LOCK = bool(MISCELLANEOUS, "global.require.lock", false, "Use a single global lock for requires.");
     public static final Option<Boolean> NATIVE_EXEC = bool(MISCELLANEOUS, "native.exec", true, "Do a true process-obliterating native exec for Kernel#exec.");
+    public static final Option<Boolean> NATIVE_EXEC_CANONICALIZESYMLINKS = bool(MISCELLANEOUS, "native.exec.canonicalizesymlinks", true, "When argv[0] to Kernel#exec is a symlink, canonicalize it before exec-ing.");
     public static final Option<Boolean> ENUMERATOR_LIGHTWEIGHT = bool(MISCELLANEOUS, "enumerator.lightweight", true, "Use lightweight Enumerator#next logic when possible.");
     public static final Option<Boolean> CONSISTENT_HASHING = bool(MISCELLANEOUS, "consistent.hashing", false, "Generate consistent object hashes across JVMs");
     public static final Option<Boolean> REIFY_VARIABLES = bool(MISCELLANEOUS, "reify.variables", true, "Attempt to expand instance vars into Java fields");


### PR DESCRIPTION
We are running into an issue with JRuby due to the way ShellLauncher.java calls File.getCanonicalPath() on argv[0] during a call to Kernel#exec. Our company uses an in-house build-and-deploy framework that works by building a "symlink tree" that merges all of an application's dependencies (JRuby, gems, and many other things including non-Ruby dependencies) that make it look to the application as if all of its dependencies exist in a single directory structure, even though it is comprised of many packages located in separate folders on disk. We then use a custom executable in our shebang lines that walk up this tree in order to find their "environment root" in order to properly set LD_LIBRARY_PATH and many other environment variables needed at runtime.

The problem is that when our JRuby code needs to exec() another process (could be another JRuby script, or even something in a completely different language), calling File.getCanonicalPath() follows the symlinks in argv[0] to the actual location of the interpreter as opposed to its location in the symlink tree, and it is unable to find the environment root.

Here's a rough example to illustrate the issue (where `/apps/foobar` is the "environment root" for the application):
`/apps/foobar/bin/jruby` -> `/packages/JRuby-x.x.x.x/bin/jruby`
`/apps/foobar/something/some-script.rb` -> `/packages/SomePackage-x.x.x.x/something/some-script.rb`
`/apps/foobar/lib/jruby.jar` -> `/packages/JRuby-x.x.x.x/lib/jruby.jar`
`/apps/foobar/lib/some-other-lib.jar` -> `/packages/SomeLibrary-x.x.x.x/lib/some-other-lib.jar`
`/apps/foobar/bin/python` -> `/packages/Python-x.x.x.x/bin/python`
`...etc...`
`/apps/foobar/.envroot` is a special marker file that indicates an "environment root"

The shebang line for `some-script.rb` will use our special executable that will take argv[0] and keep walking up the tree until it finds the `.envroot` marker file, then will set some environment variables and then invoke JRuby (or whatever arguments are in the shebang line).

This works if argv[0] is `/apps/foobar/something/some-script.rb` because it will walk up the tree until it finds that `/apps/foobar` contains the marker file. However, if argv[0] is actually `/packages/SomePackage/something/some-script.rb` as a result of JRuby calling File.getCanonicalPath(), then our launcher can't find the environment root and fails to setup the environment properly.

This patch is an initial attempt to provide a configuration value that would let us disable this behavior without affecting the default behavior in JRuby. Of course I'm open to alternative ideas on how to implement this if anyone has a better idea.
