### PR TITLE
Fix memory/disk usage leak when creating many ScriptingContaiers

### DIFF
--- a/core/src/main/java/org/jruby/embed/internal/SingleThreadLocalContextProvider.java
+++ b/core/src/main/java/org/jruby/embed/internal/SingleThreadLocalContextProvider.java
@@ -29,9 +29,13 @@
  */
 package org.jruby.embed.internal;
 
-import java.util.Map;
 import org.jruby.Ruby;
 import org.jruby.embed.LocalVariableBehavior;
+import org.jruby.util.JarResource;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Map;
 
 /**
  *
@@ -54,6 +58,18 @@ public class SingleThreadLocalContextProvider extends AbstractLocalContextProvid
 
     private LocalContext getLocalContext() {
         return instance;
+    }
+
+    private void terminateJarIndexCacheEntries() {
+        for (URL url : getRuntime().getJRubyClassLoader().getTempUrls()){
+            // Remove reference from jar cache
+            String jarPath = url.getPath();
+            JarResource.removeJarResource(jarPath);
+
+            // Delete temp jar on disk
+            File jarFile = new File(jarPath);
+            jarFile.delete();
+        }
     }
 
     @Override
@@ -79,6 +95,8 @@ public class SingleThreadLocalContextProvider extends AbstractLocalContextProvid
     @Override
     public void terminate() {
         getLocalContext().remove();
+
+        terminateJarIndexCacheEntries();
     }
 
 }

--- a/core/src/main/java/org/jruby/embed/internal/SingleThreadLocalContextProvider.java
+++ b/core/src/main/java/org/jruby/embed/internal/SingleThreadLocalContextProvider.java
@@ -35,6 +35,7 @@ import org.jruby.util.JarResource;
 
 import java.io.File;
 import java.net.URL;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -61,9 +62,10 @@ public class SingleThreadLocalContextProvider extends AbstractLocalContextProvid
     }
 
     private void terminateJarIndexCacheEntries() {
-        for (URL url : getRuntime().getJRubyClassLoader().getTempUrls()){
+        List<String> cachedJarPaths = getRuntime().getJRubyClassLoader().getCachedJarPaths();
+
+        for (String jarPath : cachedJarPaths){
             // Remove reference from jar cache
-            String jarPath = url.getPath();
             JarResource.removeJarResource(jarPath);
 
             // Delete temp jar on disk

--- a/core/src/main/java/org/jruby/util/JRubyClassLoader.java
+++ b/core/src/main/java/org/jruby/util/JRubyClassLoader.java
@@ -64,7 +64,7 @@ public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
 
     private static volatile File tempDir;
 
-    private List<URL> tempUrls = new ArrayList<URL>();
+    private List<String> cachedJarPaths = new ArrayList<String>();
 
     public JRubyClassLoader(ClassLoader parent) {
         super(parent);
@@ -91,7 +91,7 @@ public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
                 in.close();
                 url = f.toURI().toURL();
 
-                tempUrls.add(url);
+                cachedJarPaths.add(url.getPath());
             }
             catch (IOException e) {
                 throw new RuntimeException("BUG: we can not copy embedded jar to temp directory", e);
@@ -166,8 +166,8 @@ public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
         return "";
     }
 
-    public List<URL> getTempUrls(){
-        return tempUrls;
+    public List<String> getCachedJarPaths(){
+        return cachedJarPaths;
     }
 
     /**

--- a/core/src/main/java/org/jruby/util/JRubyClassLoader.java
+++ b/core/src/main/java/org/jruby/util/JRubyClassLoader.java
@@ -37,6 +37,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
@@ -62,6 +64,8 @@ public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
 
     private static volatile File tempDir;
 
+    private List<URL> tempUrls = new ArrayList<URL>();
+
     public JRubyClassLoader(ClassLoader parent) {
         super(parent);
     }
@@ -86,6 +90,8 @@ public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
                 out.close();
                 in.close();
                 url = f.toURI().toURL();
+
+                tempUrls.add(url);
             }
             catch (IOException e) {
                 throw new RuntimeException("BUG: we can not copy embedded jar to temp directory", e);
@@ -158,6 +164,10 @@ public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
             LOG.warn("could not access 'java.io.tmpdir' will use working directory", ex);
         }
         return "";
+    }
+
+    public List<URL> getTempUrls(){
+        return tempUrls;
     }
 
     /**

--- a/core/src/main/java/org/jruby/util/JRubyClassLoader.java
+++ b/core/src/main/java/org/jruby/util/JRubyClassLoader.java
@@ -91,7 +91,7 @@ public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
                 in.close();
                 url = f.toURI().toURL();
 
-                cachedJarPaths.add(url.getPath());
+                cachedJarPaths.add(URLUtil.getPath(url));
             }
             catch (IOException e) {
                 throw new RuntimeException("BUG: we can not copy embedded jar to temp directory", e);

--- a/core/src/main/java/org/jruby/util/JarCache.java
+++ b/core/src/main/java/org/jruby/util/JarCache.java
@@ -157,4 +157,20 @@ class JarCache {
             return index;
         }
     }
+
+    public boolean remove(String jarPath){
+        String cacheKey = jarPath;
+
+        synchronized (indexCache) {
+            JarIndex index = indexCache.get(cacheKey);
+            if (index == null){
+                return false;
+            }
+            else{
+                index.release();
+                indexCache.remove(cacheKey);
+                return true;
+            }
+        }
+    }
 }

--- a/core/src/main/java/org/jruby/util/JarResource.java
+++ b/core/src/main/java/org/jruby/util/JarResource.java
@@ -8,7 +8,7 @@ import java.util.jar.JarEntry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-abstract class JarResource extends AbstractFileResource {
+public abstract class JarResource extends AbstractFileResource {
     private static Pattern PREFIX_MATCH = Pattern.compile("^(?:jar:)?(?:file:)?(.*)$");
 
     private static final JarCache jarCache = new JarCache();
@@ -77,6 +77,10 @@ abstract class JarResource extends AbstractFileResource {
         }
 
         return null;
+    }
+
+    public static boolean removeJarResource(String jarPath){
+        return jarCache.remove(jarPath);
     }
 
     private final String jarPrefix;


### PR DESCRIPTION
This PR is to resolve https://github.com/jruby/jruby/issues/3928, **File descriptors from stdlib jars are leaked when ScriptingContainers are terminated**

It's very much a work in progress, and I was hoping to get some feedback on
1. If this is close to a reasonable approach
2. What we would need to do to move this closer to a good solution
3. What kind of testing/validation you'd like to see to be comfortable with this change
4. Is cleaning up these files even possible/desirable when the scripting container isn't using a single threaded scope. i.e. threadsafe/concurrent/singleton. They seem to share references and I'm not sure how or if their use cases should be handled.

This biggest problem I currently see with it is that I was unable to find a way to cleanup the jars and references without making the `JarResource` class public. Since I'm not very experienced with this codebase, I'm especially interested in your opinions on how to clean up the jars in a cleaner way. 

---

The basic strategy here is:
1. In `JRubyClassLoader`: When jars are extracted to a temporary folder, keep track of their paths
2. When a single threaded scripting container is terminated, its `SingleThreadLocalContextProvider` based context provider goes through each of the temp jars, and cleans up the `jarCache` references and deletes the jars from disk

In the case of a single threaded container, this should be safe. My understanding is that each single threaded container has its own class loader and context provider. Additionally, each time a container causes the class loader to extract a stdlib jar into a temp directory, it creates a uniquely named file for that class loader. So, removing these references will not affect any other scripting containers.

Since our use case in https://github.com/jruby/jruby/issues/3928 primarily involves using the single threaded local context scope, I've focused on that. But if this work should involve improvements to the other context providers we'd be happy to implement that as well.

So far I've been testing this manually by just creating scripting containers in a loop, giving them a script that requires a few stdlib jars, and verifying that the jars are created and destroyed on disk as expected. I've also been using yourkit to verify that the jar cache doesn't leak references