### PR TITLE
MINOR: cleanup setting callcounts for JIT

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
@@ -288,7 +288,7 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
 
     // Unlike JIT in MixedMode this will always successfully build but if using executor pool it may take a while
     // and replace interpreterContext asynchronously.
-    protected void promoteToFullBuild(ThreadContext context) {
+    private void promoteToFullBuild(ThreadContext context) {
         Ruby runtime = context.runtime;
 
         if (runtime.isBooting() && !Options.JIT_KERNEL.load()) return;   // don't Promote to full build during runtime boot

--- a/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
@@ -285,7 +285,6 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
         synchronized (this) {
             if (box.callCount >= 0) {
                 if (box.callCount++ >= Options.JIT_THRESHOLD.load()) {
-                    box.callCount = -1;
                     context.runtime.getJITCompiler().buildThresholdReached(context, this);
                 }
             }

--- a/core/src/main/java/org/jruby/runtime/InterpretedIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/InterpretedIRBlockBody.java
@@ -1,7 +1,7 @@
 package org.jruby.runtime;
 
+import java.io.ByteArrayOutputStream;
 import org.jruby.RubyModule;
-import org.jruby.EvalType;
 import org.jruby.compiler.Compilable;
 import org.jruby.ir.IRClosure;
 import org.jruby.ir.IRScope;
@@ -13,8 +13,6 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.cli.Options;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
-
-import java.io.ByteArrayOutputStream;
 
 public class InterpretedIRBlockBody extends IRBlockBody implements Compilable<InterpreterContext> {
     private static final Logger LOG = LoggerFactory.getLogger(InterpretedIRBlockBody.class);
@@ -155,7 +153,7 @@ public class InterpretedIRBlockBody extends IRBlockBody implements Compilable<In
 
     // Unlike JIT in MixedMode this will always successfully build but if using executor pool it may take a while
     // and replace interpreterContext asynchronously.
-    protected void promoteToFullBuild(ThreadContext context) {
+    private void promoteToFullBuild(ThreadContext context) {
         if (context.runtime.isBooting() && !Options.JIT_KERNEL.load()) return; // don't Promote to full build during runtime boot
 
         if (callCount++ >= Options.JIT_THRESHOLD.load()) context.runtime.getJITCompiler().buildThresholdReached(context, this);

--- a/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
@@ -17,7 +17,7 @@ import org.jruby.util.log.LoggerFactory;
 import java.io.ByteArrayOutputStream;
 
 public class MixedModeIRBlockBody extends IRBlockBody implements Compilable<CompiledIRBlockBody> {
-    private static final Logger LOG = LoggerFactory.getLogger(InterpretedIRBlockBody.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MixedModeIRBlockBody.class);
     protected boolean pushScope;
     protected boolean reuseParentScope;
     private boolean displayedCFG = false; // FIXME: Remove when we find nicer way of logging CFG
@@ -160,7 +160,7 @@ public class MixedModeIRBlockBody extends IRBlockBody implements Compilable<Comp
         }
     }
 
-    protected void promoteToFullBuild(ThreadContext context) {
+    private void promoteToFullBuild(ThreadContext context) {
         if (context.runtime.isBooting() && !Options.JIT_KERNEL.load()) return; // don't JIT during runtime boot
 
         if (callCount >= 0) {
@@ -182,7 +182,6 @@ public class MixedModeIRBlockBody extends IRBlockBody implements Compilable<Comp
                 if (callCount < 0) return;
 
                 if (callCount++ >= Options.JIT_THRESHOLD.load()) {
-                    callCount = -1;
                     context.runtime.getJITCompiler().buildThresholdReached(context, this);
                 }
             }


### PR DESCRIPTION
Just some trivial spots I found recently:

* Some of those `promoteToFullBuild` (and analogously named) methods can be made `private` since they aren't used in child classes
* Removed dead import `import org.jruby.EvalType;`
* Fixed logger for `MixedModeIRBlockBody` (it was using the wrong class to bind to)
* Removed two redundant sets of the callcount to `-1` (`callCount = -1;` is not necessary since `context.runtime.getJITCompiler().buildThresholdReached(context, this);` will do this:

```java

    public void buildThresholdReached(ThreadContext context, final Compilable method) {
        final RubyInstanceConfig config = context.runtime.getInstanceConfig();

        // Disable any other jit tasks from entering queue
        method.setCallCount(-1);
```

=> sets the `-1` here either way.