### PR TITLE
MINOR: Dry up RubyArray and improve performance in a few spots

### DIFF
--- a/core/src/main/java/org/jruby/specialized/RubyArrayOneObject.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArrayOneObject.java
@@ -4,16 +4,12 @@ import org.jcodings.specific.USASCIIEncoding;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyClass;
-import org.jruby.RubyFixnum;
 import org.jruby.RubyString;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.Block;
-import org.jruby.runtime.Constants;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.util.io.EncodingUtils;
 
-import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
 import static org.jruby.runtime.Helpers.arrayOf;
 
 /**

--- a/core/src/main/java/org/jruby/specialized/RubyArrayTwoObject.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArrayTwoObject.java
@@ -9,14 +9,11 @@ import org.jruby.RubyFixnum;
 import org.jruby.RubyString;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.Block;
-import org.jruby.runtime.Constants;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.invokedynamic.MethodNames;
 import org.jruby.util.ByteList;
-import org.jruby.util.io.EncodingUtils;
 
-import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
 import static org.jruby.runtime.Helpers.arrayOf;
 import static org.jruby.runtime.Helpers.invokedynamic;
 


### PR DESCRIPTION
Some cleanups I came across debugging `RubyArray` performance recently :)

* remove dead imports from `RubyArray`
* Extract the `USE_PACKED_ARRAYS == true` paths to a single `if` branch to be more JIT friendly here
   * especially `isPackedArray` will be nicely dead code eliminated now for the `Collection` case and we save an expensive `size` call here and there (+ bytecode becomes smaller :))
* Make 2 methods `static` that had no instance reference anywhere
* Remove dead cast
* Removed redundant array creation for varargs method with one arguement
* Remove dead imports from packed array types
* Replaced slower collection to array conversion `list.toArray(new IRubyObject[list.size()]))` with the faster version `collection.toArray(IRubyObject.NULL_ARRAY)`
   * https://shipilev.net/blog/2016/arrays-wisdom-ancients/#_conclusion (as one example)

Just a few suggestions, let me know what you think :)