### PR TITLE
PERFORMANCE: Intern Multiple String Constants

### DIFF
--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -30,21 +30,6 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby;
 
-import org.jruby.javasupport.JavaClass;
-import org.jruby.runtime.Arity;
-import org.jruby.runtime.JavaSites;
-import org.jruby.runtime.callsite.CachingCallSite;
-import org.jruby.runtime.callsite.RespondToCallSite;
-import org.jruby.runtime.ivars.VariableAccessor;
-import static org.jruby.util.CodegenUtils.ci;
-import static org.jruby.util.CodegenUtils.p;
-import static org.jruby.util.CodegenUtils.sig;
-import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
-import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
-import static org.objectweb.asm.Opcodes.ACC_STATIC;
-import static org.objectweb.asm.Opcodes.ACC_SUPER;
-import static org.objectweb.asm.Opcodes.ACC_VARARGS;
-
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -60,7 +45,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.compiler.impl.SkinnyMethodAdapter;
@@ -69,34 +53,49 @@ import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.java.codegen.RealClassGenerator;
 import org.jruby.java.codegen.Reified;
 import org.jruby.javasupport.Java;
-import org.jruby.runtime.Helpers;
+import org.jruby.javasupport.JavaClass;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.CallSite;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.ClassIndex;
+import org.jruby.runtime.Helpers;
+import org.jruby.runtime.JavaSites;
 import org.jruby.runtime.MethodIndex;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ObjectMarshal;
 import org.jruby.runtime.ThreadContext;
-import static org.jruby.runtime.Visibility.*;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.callsite.CacheEntry;
+import org.jruby.runtime.callsite.CachingCallSite;
+import org.jruby.runtime.callsite.RespondToCallSite;
+import org.jruby.runtime.ivars.VariableAccessor;
 import org.jruby.runtime.ivars.VariableAccessorField;
 import org.jruby.runtime.ivars.VariableTableManager;
 import org.jruby.runtime.marshal.MarshalStream;
 import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.runtime.opto.Invalidator;
 import org.jruby.util.ArraySupport;
-import org.jruby.util.OneShotClassLoader;
 import org.jruby.util.ClassDefiningClassLoader;
 import org.jruby.util.CodegenUtils;
 import org.jruby.util.JavaNameMangler;
+import org.jruby.util.OneShotClassLoader;
 import org.jruby.util.collections.WeakHashSet;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.FieldVisitor;
+
+import static org.jruby.runtime.Visibility.PRIVATE;
+import static org.jruby.util.CodegenUtils.ci;
+import static org.jruby.util.CodegenUtils.p;
+import static org.jruby.util.CodegenUtils.sig;
+import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_STATIC;
+import static org.objectweb.asm.Opcodes.ACC_SUPER;
+import static org.objectweb.asm.Opcodes.ACC_VARARGS;
 
 /**
  *
@@ -319,7 +318,7 @@ public class RubyClass extends RubyModule {
     }
 
     public Map<String, VariableAccessor> getVariableTableCopy() {
-        return new HashMap<String, VariableAccessor>(getVariableAccessorsForRead());
+        return new HashMap<>(getVariableAccessorsForRead());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -519,7 +519,7 @@ public class RubyModule extends RubyObject {
      * @param name the new base name of the class
      */
     public void setBaseName(String name) {
-        baseName = name;
+        baseName = name.intern();
         cachedName = null;
     }
 
@@ -1599,25 +1599,13 @@ public class RubyModule extends RubyObject {
      */
     public synchronized void defineAlias(String name, String oldName) {
         testFrozen("module");
+        name = name.intern();
+        oldName = oldName.intern();
         if (oldName.equals(name)) return;
 
         DynamicMethod method = searchForAliasMethod(getRuntime(), oldName);
 
         putMethod(name, new AliasMethod(this, method, oldName));
-
-        methodLocation.invalidateCoreClasses();
-        methodLocation.invalidateCacheDescendants();
-    }
-
-    public synchronized void defineAliases(List<String> aliases, String oldName) {
-        testFrozen("module");
-        DynamicMethod method = searchForAliasMethod(getRuntime(), oldName);
-
-        for (String name: aliases) {
-            if (oldName.equals(name)) continue;
-
-            putMethod(name, new AliasMethod(this, method, oldName));
-        }
 
         methodLocation.invalidateCoreClasses();
         methodLocation.invalidateCacheDescendants();
@@ -3848,6 +3836,7 @@ public class RubyModule extends RubyObject {
      * @return The result of setting the variable.
      */
     private IRubyObject setConstantCommon(String name, IRubyObject value, boolean hidden, boolean warn) {
+        name = name.intern();
         IRubyObject oldValue = fetchConstant(name);
 
         setParentForModule(name, value);

--- a/core/src/main/java/org/jruby/ast/ArgumentNode.java
+++ b/core/src/main/java/org/jruby/ast/ArgumentNode.java
@@ -93,7 +93,7 @@ public class ArgumentNode extends Node implements INameNode {
     }
 
     public String getName() {
-        return StringSupport.byteListAsString(identifier);
+        return StringSupport.byteListAsString(identifier).intern();
     }
 
     public ByteList getByteName() {

--- a/core/src/main/java/org/jruby/ast/AttrAssignNode.java
+++ b/core/src/main/java/org/jruby/ast/AttrAssignNode.java
@@ -83,7 +83,7 @@ public class AttrAssignNode extends Node implements INameNode, IArgumentNode {
      * @return name
      */
     public String getName() {
-        return StringSupport.byteListAsString(name);
+        return StringSupport.byteListAsString(name).intern();
     }
 
     public ByteList getByteName() {

--- a/core/src/main/java/org/jruby/ast/BlockArgNode.java
+++ b/core/src/main/java/org/jruby/ast/BlockArgNode.java
@@ -88,7 +88,7 @@ public class BlockArgNode extends Node implements INameNode {
      * @return it's name
      */
     public String getName() {
-        return StringSupport.byteListAsString(name);
+        return StringSupport.byteListAsString(name).intern();
     }
 
     public ByteList getByteName() {

--- a/core/src/main/java/org/jruby/ast/CallNode.java
+++ b/core/src/main/java/org/jruby/ast/CallNode.java
@@ -124,7 +124,7 @@ public class CallNode extends Node implements INameNode, IArgumentNode, BlockAcc
      * @return name
      */
     public String getName() {
-        return StringSupport.byteListAsString(name);
+        return StringSupport.byteListAsString(name).intern();
     }
 
     public ByteList getByteName() {

--- a/core/src/main/java/org/jruby/ast/ClassVarAsgnNode.java
+++ b/core/src/main/java/org/jruby/ast/ClassVarAsgnNode.java
@@ -77,7 +77,7 @@ public class ClassVarAsgnNode extends AssignableNode implements INameNode {
      * @return Returns a String
      */
     public String getName() {
-        return StringSupport.byteListAsString(name);
+        return StringSupport.byteListAsString(name).intern();
     }
 
     public ByteList getByteName() {

--- a/core/src/main/java/org/jruby/ast/ClassVarDeclNode.java
+++ b/core/src/main/java/org/jruby/ast/ClassVarDeclNode.java
@@ -75,7 +75,7 @@ public class ClassVarDeclNode extends AssignableNode implements INameNode {
      * @return Returns a String
      */
     public String getName() {
-        return StringSupport.byteListAsString(name);
+        return StringSupport.byteListAsString(name).intern();
     }
 
     public ByteList getByteName() {

--- a/core/src/main/java/org/jruby/ast/ClassVarNode.java
+++ b/core/src/main/java/org/jruby/ast/ClassVarNode.java
@@ -72,7 +72,7 @@ public class ClassVarNode extends Node implements INameNode, SideEffectFree {
      * @return Returns a String
      */
     public String getName() {
-        return StringSupport.byteListAsString(name);
+        return StringSupport.byteListAsString(name).intern();
     }
 
     public ByteList getByteName() {

--- a/core/src/main/java/org/jruby/ast/Colon3Node.java
+++ b/core/src/main/java/org/jruby/ast/Colon3Node.java
@@ -77,7 +77,7 @@ public class Colon3Node extends Node implements INameNode {
      * @return Returns a String
      */
     public String getName() {
-        return StringSupport.byteListAsString(name);
+        return StringSupport.byteListAsString(name).intern();
     }
 
     public ByteList getByteName() {

--- a/core/src/main/java/org/jruby/ast/ConstDeclNode.java
+++ b/core/src/main/java/org/jruby/ast/ConstDeclNode.java
@@ -77,7 +77,7 @@ public class ConstDeclNode extends AssignableNode implements INameNode {
      * @return name
      */
     public String getName() {
-    	return name == null ? constNode.getName() : StringSupport.byteListAsString(name);
+        return name == null ? constNode.getName() : StringSupport.byteListAsString(name).intern();
     }
 
     public ByteList getByteName() {

--- a/core/src/main/java/org/jruby/ast/ConstNode.java
+++ b/core/src/main/java/org/jruby/ast/ConstNode.java
@@ -42,7 +42,7 @@ import org.jruby.util.StringSupport;
 /**
  * The access to a Constant.
  */
-public class ConstNode extends Node implements INameNode {
+public final class ConstNode extends Node implements INameNode {
     private ByteList name;
 
     public ConstNode(ISourcePosition position, ByteList name) {
@@ -72,7 +72,7 @@ public class ConstNode extends Node implements INameNode {
      * @return Returns a String
      */
     public String getName() {
-        return StringSupport.byteListAsString(name);
+        return StringSupport.byteListAsString(name).intern();
     }
 
     public ByteList getByteName() {

--- a/core/src/main/java/org/jruby/ast/DAsgnNode.java
+++ b/core/src/main/java/org/jruby/ast/DAsgnNode.java
@@ -78,7 +78,7 @@ public class DAsgnNode extends AssignableNode implements INameNode, IScopedNode 
      * @return Returns a String
      */
     public String getName() {
-        return StringSupport.byteListAsString(name);
+        return StringSupport.byteListAsString(name).intern();
     }
 
     public ByteList getByteName() {

--- a/core/src/main/java/org/jruby/ast/DVarNode.java
+++ b/core/src/main/java/org/jruby/ast/DVarNode.java
@@ -97,7 +97,7 @@ public class DVarNode extends Node implements INameNode, IScopedNode, SideEffect
      * @return Returns a String
      */
     public String getName() {
-        return StringSupport.byteListAsString(name);
+        return StringSupport.byteListAsString(name).intern();
     }
 
     public ByteList getByteName() {

--- a/core/src/main/java/org/jruby/ast/FCallNode.java
+++ b/core/src/main/java/org/jruby/ast/FCallNode.java
@@ -119,7 +119,7 @@ public class FCallNode extends Node implements INameNode, IArgumentNode, BlockAc
      * @return Returns a String
      */
     public String getName() {
-        return StringSupport.byteListAsString(name);
+        return StringSupport.byteListAsString(name).intern();
     }
 
     public ByteList getByteName() {

--- a/core/src/main/java/org/jruby/ast/GlobalAsgnNode.java
+++ b/core/src/main/java/org/jruby/ast/GlobalAsgnNode.java
@@ -75,7 +75,7 @@ public class GlobalAsgnNode extends AssignableNode implements INameNode {
      * @return Returns a String
      */
     public String getName() {
-        return StringSupport.byteListAsString(name);
+        return StringSupport.byteListAsString(name).intern();
     }
 
     public ByteList getByteName() {

--- a/core/src/main/java/org/jruby/ast/InstAsgnNode.java
+++ b/core/src/main/java/org/jruby/ast/InstAsgnNode.java
@@ -78,7 +78,7 @@ public class InstAsgnNode extends AssignableNode implements INameNode {
      * @return Returns a String
      */
     public String getName() {
-        return StringSupport.byteListAsString(name);
+        return StringSupport.byteListAsString(name).intern();
     }
 
     public ByteList getByteName() {

--- a/core/src/main/java/org/jruby/ast/LocalAsgnNode.java
+++ b/core/src/main/java/org/jruby/ast/LocalAsgnNode.java
@@ -78,7 +78,7 @@ public class LocalAsgnNode extends AssignableNode implements INameNode, IScopedN
      * Name of the local assignment.
      **/
     public String getName() {
-        return StringSupport.byteListAsString(name);
+        return StringSupport.byteListAsString(name).intern();
     }
 
     public ByteList getByteName() {

--- a/core/src/main/java/org/jruby/ast/MethodDefNode.java
+++ b/core/src/main/java/org/jruby/ast/MethodDefNode.java
@@ -89,7 +89,7 @@ public abstract class MethodDefNode extends Node implements INameNode, DefNode {
      * @return Returns a String
      */
     public String getName() {
-        return StringSupport.byteListAsString(name);
+        return StringSupport.byteListAsString(name).intern();
     }
 
     public ByteList getByteName() {

--- a/core/src/main/java/org/jruby/internal/runtime/methods/DynamicMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/DynamicMethod.java
@@ -31,7 +31,6 @@
 package org.jruby.internal.runtime.methods;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import org.jruby.MetaClass;
 import org.jruby.PrependedModule;
 import org.jruby.RubyModule;
@@ -497,7 +496,7 @@ public abstract class DynamicMethod {
      * @param name the name to set
      */
     public void setName(String name) {
-        this.name = name;
+        this.name = name.intern();
     }
 
     /**

--- a/core/src/main/java/org/jruby/ir/IRScope.java
+++ b/core/src/main/java/org/jruby/ir/IRScope.java
@@ -340,7 +340,7 @@ public abstract class IRScope implements ParseResult {
     }
 
     public void setName(String name) { // This is for IRClosure and IRMethod ;(
-        this.name = name;
+        this.name = name.intern();
     }
 
     public void setFileName(String filename) {
@@ -1101,6 +1101,7 @@ public abstract class IRScope implements ParseResult {
 
     // Enebo: We should just make n primitive int and not take the hash hit
     protected int allocateNextPrefixedName(String prefix) {
+        prefix = prefix.intern();
         int index = getPrefixCountSize(prefix);
 
         nextVarIndex.put(prefix, index + 1);

--- a/core/src/main/java/org/jruby/ir/instructions/CallBase.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CallBase.java
@@ -43,7 +43,7 @@ public abstract class CallBase extends NOperandInstr implements ClosureAccepting
         this.callSiteId = callSiteCounter++;
         argsCount = args.length;
         hasClosure = closure != null;
-        this.name = name;
+        this.name = name.intern();
         this.callType = callType;
         this.callSite = getCallSiteFor(callType, name, potentiallyRefined);
         splatMap = IRRuntimeHelpers.buildSplatMap(args);

--- a/core/src/main/java/org/jruby/ir/instructions/SearchConstInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/SearchConstInstr.java
@@ -20,7 +20,7 @@ import org.jruby.runtime.opto.Invalidator;
 // - looks up lexical scopes
 // - then inheritance hierarchy if lexical search fails
 // - then invokes const_missing if inheritance search fails
-public class SearchConstInstr extends OneOperandResultBaseInstr implements FixedArityInstr {
+public final class SearchConstInstr extends OneOperandResultBaseInstr implements FixedArityInstr {
     private final String   constName;
     private final boolean  noPrivateConsts;
 
@@ -57,9 +57,9 @@ public class SearchConstInstr extends OneOperandResultBaseInstr implements Fixed
     @Override
     public void encode(IRWriterEncoder e) {
         super.encode(e);
-        e.encode(getConstName());
+        e.encode(constName);
         e.encode(getStartingScope());
-        e.encode(isNoPrivateConsts());
+        e.encode(noPrivateConsts);
     }
 
     public static SearchConstInstr decode(IRReaderDecoder d) {

--- a/core/src/main/java/org/jruby/ir/operands/Label.java
+++ b/core/src/main/java/org/jruby/ir/operands/Label.java
@@ -27,7 +27,7 @@ public class Label extends Operand {
     public Label(String prefix, int id) {
         super();
 
-        this.prefix = prefix;
+        this.prefix = prefix.intern();
         this.id = id;
     }
 
@@ -101,7 +101,7 @@ public class Label extends Operand {
         // Check if this label was already created
         // Important! Program would not be interpreted correctly
         // if new name will be created every time
-        String fullLabel = prefix + '_' + id;
+        final String fullLabel = (prefix + '_' + id).intern();
         if (d.getVars().containsKey(fullLabel)) {
             return (Label) d.getVars().get(fullLabel);
         }

--- a/core/src/main/java/org/jruby/ir/operands/Reference.java
+++ b/core/src/main/java/org/jruby/ir/operands/Reference.java
@@ -13,7 +13,7 @@ public abstract class Reference extends Operand {
     public Reference(String name) {
         super();
 
-        this.name = name;
+        this.name = name.intern();
     }
 
     public String getName() {

--- a/core/src/main/java/org/jruby/java/addons/KernelJavaAddons.java
+++ b/core/src/main/java/org/jruby/java/addons/KernelJavaAddons.java
@@ -71,7 +71,7 @@ public class KernelJavaAddons {
         return recv.getRuntime().getNil();
     }
 
-    static JavaClass resolveTargetType(ThreadContext context, IRubyObject type) {
+    private static JavaClass resolveTargetType(ThreadContext context, IRubyObject type) {
         JavaClass javaType = JavaClass.resolveType(context, type);
         if ( javaType == null ) throw context.runtime.newTypeError("unable to convert to type: " + type);
         return javaType;

--- a/core/src/main/java/org/jruby/javasupport/binding/ClassInitializer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/ClassInitializer.java
@@ -121,7 +121,7 @@ final class ClassInitializer extends Initializer {
                 // we need to collect all methods, though we'll only
                 // install the ones that are named in this class
                 Method method = methods.get(i);
-                String name = method.getName();
+                String name = method.getName().intern();
 
                 if (Modifier.isStatic(method.getModifiers())) {
                     prepareStaticMethod(javaClass, state, method, name);

--- a/core/src/main/java/org/jruby/javasupport/binding/Initializer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/Initializer.java
@@ -405,7 +405,7 @@ public abstract class Initializer {
             // no non-public inner classes
             if ( ! Modifier.isPublic(clazz.getModifiers()) ) continue;
 
-            final String simpleName = JavaClass.getSimpleName(clazz);
+            final String simpleName = JavaClass.getSimpleName(clazz).intern();
             if ( simpleName.length() == 0 ) continue;
 
             final RubyModule innerProxy = Java.getProxyClass(runtime, JavaClass.get(runtime, clazz));
@@ -555,7 +555,7 @@ public abstract class Initializer {
                 // first method of this name, add a collection for it
                 childMethods = new ArrayList<>(4);
                 childMethods.add(method); added++;
-                nameMethods.put(method.getName(), childMethods);
+                nameMethods.put(method.getName().intern(), childMethods);
             }
             else {
                 // we have seen other methods; check if we already have an equivalent one

--- a/core/src/main/java/org/jruby/javasupport/bsf/JRubyEngine.java
+++ b/core/src/main/java/org/jruby/javasupport/bsf/JRubyEngine.java
@@ -35,7 +35,6 @@ package org.jruby.javasupport.bsf;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Vector;
-
 import org.apache.bsf.BSFDeclaredBean;
 import org.apache.bsf.BSFException;
 import org.apache.bsf.BSFManager;
@@ -43,7 +42,6 @@ import org.apache.bsf.util.BSFEngineImpl;
 import org.apache.bsf.util.BSFFunctions;
 import org.jruby.Ruby;
 import org.jruby.RubyRuntimeAdapter;
-import org.jruby.exceptions.JumpException;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.javasupport.Java;
 import org.jruby.javasupport.JavaEmbedUtils;
@@ -54,6 +52,7 @@ import org.jruby.runtime.GlobalVariable;
 import org.jruby.runtime.IAccessor;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.StringSupport;
 
 /** 
  * An implementation of a JRuby BSF implementation.
@@ -67,8 +66,10 @@ public class JRubyEngine extends BSFEngineImpl {
         ThreadContext context = runtime.getCurrentContext();
         try {
             // Construct local variables based on parameter names passed in
-            String[] names = new String[paramNames.size()];
-            paramNames.toArray(names);
+            final String[] names = (String[]) paramNames.toArray(StringSupport.EMPTY_STRING_ARRAY);
+            for (int i = 0; i < names.length; ++i) {
+                names[i] = names[i].intern();
+            }
             context.preBsfApply(names);
 
             // Populate values for the parameter names

--- a/core/src/main/java/org/jruby/runtime/CallSite.java
+++ b/core/src/main/java/org/jruby/runtime/CallSite.java
@@ -47,7 +47,7 @@ public abstract class CallSite {
      * @see org.jruby.runtime.CallType
      */
     public CallSite(String methodName, CallType callType) {
-        this.methodName = methodName;
+        this.methodName = methodName.intern();
         this.callType = callType;
     }
 

--- a/core/src/main/java/org/jruby/runtime/callsite/SuperCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/SuperCallSite.java
@@ -21,7 +21,7 @@ public class SuperCallSite extends CallSite {
         public final CacheEntry cache;
 
         public SuperTuple(String name, CacheEntry cache) {
-            this.name = name;
+            this.name = name.intern();
             this.cache = cache;
         }
 


### PR DESCRIPTION
JRuby `intern`s most `String`s that come up in Ruby code just fine in `org.jruby.ir.persistence.IRReaderStream#decodeString`:

```java
    public String decodeString() {
        int strLength = decodeInt();

        if (strLength == NULL_STRING) return null;

        byte[] bytes = new byte[strLength]; // FIXME: This seems really innefficient
        buf.get(bytes);

        String newString = new String(bytes).intern();

        if (RubyInstanceConfig.IR_READING_DEBUG) System.out.println("STR<" + newString + ">");

        return newString;
    }
````

, but a few duplicates from more dynamic contexts are not caught. In the red-black benchmark, this adds up to ~200kb of wasted memory (memory wise this is irrelevant obviously, but duplicates make call site cache lookups slower and waste CPU cache => fixing all these spots resulted in a visible ~2% speedup in the red-black benchmark for me over very large sample sizes 2k+ runs).

So I:

* Tracked down spots generating duplicate constants for `AST`ish code paths
* Did my best to not introduce duplicate calls to `intern` by `intern`ing in constructors wherever possible instead of further upstream
* Made sure not `intern` calls made it into the hot path by checking that the method isn't called in the hot path (checked  red-black benchmark and Logstash after warm up and `intern` was never called in either => I have a bit of confidence) 


Also:
* Removed `public synchronized void defineAliases(List<String> aliases, String oldName)` since it was one of the cases that looked like they would create duplicate `String` constants but then realized that it's never used (checked for dynamic invocations too)
* Reduced visibility of ` public static JavaCallable getMatchingCallable(Ruby runtime, Class<?> javaClass, String methodName, Class<?>[] argumentTypes)` since this method was in a path affected by the added `intern` calls and only used `privately` => I didn't want to add redundant calls to `intern` to it, when I can be sure that its only caller `intern`s `String`s just fine already
