### PR TITLE
[ji] make RubyIOs Java Closeable/Flushable + to_java to return stream

### DIFF
--- a/core/src/main/java/org/jruby/RubyArgsFile.java
+++ b/core/src/main/java/org/jruby/RubyArgsFile.java
@@ -506,7 +506,7 @@ public class RubyArgsFile extends RubyObject {
 
     public static void argf_close(ThreadContext context, IRubyObject file) {
         if(file instanceof RubyIO) {
-            ((RubyIO)file).rbIoClose(context.runtime);
+            ((RubyIO) file).rbIoClose(context);
         } else {
             file.callMethod(context, "close");
         }

--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -282,16 +282,16 @@ public class RubyFile extends RubyIO implements EncodingCapable {
     }
 
     @Override
-    protected IRubyObject rbIoClose(Ruby runtime) {
+    protected IRubyObject rbIoClose(ThreadContext context) {
         // Make sure any existing lock is released before we try and close the file
         if (openFile.currentLock != null) {
             try {
                 openFile.currentLock.release();
             } catch (IOException e) {
-                throw getRuntime().newIOError(e.getMessage());
+                throw context.runtime.newIOError(e.getMessage());
             }
         }
-        return super.rbIoClose(runtime);
+        return super.rbIoClose(context);
     }
 
     @JRubyMethod(required = 1)

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1460,7 +1460,7 @@ public class RubyKernel {
 
             fptr = ((RubyIO)port).getOpenFileChecked();
             result = fptr.readAll(context, fptr.remainSize(), context.nil);
-            ((RubyIO)port).rbIoClose(runtime);
+            ((RubyIO)port).rbIoClose(context);
 
             return result;
         }

--- a/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
@@ -444,7 +444,6 @@ public class RubyBasicSocket extends RubyIO {
     }
 
     private IRubyObject closeHalf(ThreadContext context, int closeHalf) {
-        Ruby runtime = context.runtime;
         OpenFile fptr;
 
         int otherHalf = closeHalf == OpenFile.READABLE ? OpenFile.WRITABLE : OpenFile.READABLE;
@@ -452,7 +451,7 @@ public class RubyBasicSocket extends RubyIO {
         fptr = getOpenFileChecked();
         if ((fptr.getMode() & otherHalf) == 0) {
             // shutdown fully
-            return rbIoClose(runtime);
+            return rbIoClose(context);
         }
 
         // shutdown half

--- a/core/src/main/java/org/jruby/ext/socket/RubySocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubySocket.java
@@ -696,17 +696,15 @@ public class RubySocket extends RubyBasicSocket {
         return new Addrinfo(runtime, runtime.getClass("Addrinfo"), addr.getAddress(), addr.getPort(), Sock.SOCK_DGRAM);
     }
 
+    @Override
     @JRubyMethod
-    public IRubyObject close() {
+    public IRubyObject close(final ThreadContext context) {
         if (getOpenFile() != null) {
-            Ruby runtime = getRuntime();
-            if (isClosed()) {
-                return runtime.getNil();
-            }
+            if (isClosed()) return context.nil;
             openFile.checkClosed();
-            return rbIoClose(runtime);
+            return rbIoClose(context);
         }
-        return getRuntime().getNil();
+        return context.nil;
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ext/tempfile/Tempfile.java
+++ b/core/src/main/java/org/jruby/ext/tempfile/Tempfile.java
@@ -169,8 +169,7 @@ public class Tempfile extends RubyFile implements Finalizable {
 
     @JRubyMethod(visibility = PUBLIC)
     public IRubyObject open(ThreadContext context) {
-        Ruby runtime = context.runtime;
-        if (!isClosed()) rbIoClose(runtime);
+        if (!isClosed()) rbIoClose(context);
 
         // MRI doesn't do this, but we need to reset to blank slate
         openFile = null;
@@ -182,7 +181,7 @@ public class Tempfile extends RubyFile implements Finalizable {
 
     @JRubyMethod(visibility = PROTECTED)
     public IRubyObject _close(ThreadContext context) {
-        return !isClosed() ? super.close() : context.nil;
+        return !isClosed() ? super.close(context) : context.nil;
     }
 
     @JRubyMethod(optional = 1, visibility = PUBLIC)
@@ -252,12 +251,13 @@ public class Tempfile extends RubyFile implements Finalizable {
         }
     }
 
-    public static IRubyObject open(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
-        return open19(context, recv, args, block);
+    @Deprecated
+    public static IRubyObject open19(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
+        return open(context, recv, args, block);
     }
 
     @JRubyMethod(required = 1, optional = 1, meta = true)
-    public static IRubyObject open19(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
+    public static IRubyObject open(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         RubyClass klass = (RubyClass) recv;
         Tempfile tempfile = (Tempfile) klass.newInstance(context, args, block);
 
@@ -277,10 +277,10 @@ public class Tempfile extends RubyFile implements Finalizable {
     public IRubyObject inspect() {
         StringBuilder val = new StringBuilder();
         val.append("#<Tempfile:").append(openFile.getPath());
-        if(!openFile.isOpen()) {
+        if (!openFile.isOpen()) {
             val.append(" (closed)");
         }
-        val.append(">");
+        val.append('>');
         return getRuntime().newString(val.toString());
     }
 

--- a/spec/java_integration/addons/io_spec.rb
+++ b/spec/java_integration/addons/io_spec.rb
@@ -57,6 +57,18 @@ describe "Ruby IO" do
     expect(java.io.InputStream).to be === file.to_inputstream # old-naming
   end
 
+  it "is coercible using to_java to java.io.InputStream" do
+    file = File.open(__FILE__)
+    first_ten = file.read(10)
+    file.seek(0)
+    stream = file.to_java java.io.InputStream
+    expect(java.io.InputStream).to be === stream
+
+    bytes = "0000000000".to_java_bytes
+    expect(stream.read(bytes)).to eq(10)
+    expect(String.from_java_bytes(bytes)).to eq(first_ten)
+  end
+
   it "is coercible to java.io.OutputStream with IO#to_output_stream" do
     file = Tempfile.new("io_spec")
     stream = file.to_output_stream
@@ -70,6 +82,20 @@ describe "Ruby IO" do
     expect(str).to eq(String.from_java_bytes(bytes))
 
     expect(java.io.OutputStream).to be === file.to_outputstream # old-naming
+  end
+
+
+  it "is coercible using to_java to java.io.OutputStream" do
+    file = Tempfile.new("io_spec")
+    stream = file.to_java 'java.io.OutputStream'
+    expect(java.io.OutputStream).to be === stream
+
+    bytes = input_number.to_java_bytes
+    stream.write(bytes)
+    stream.flush
+    file.seek(0)
+    str = file.read(10)
+    expect(str).to eq(String.from_java_bytes(bytes))
   end
 
   it "gets an IO from a java.nio.channels.Channel" do


### PR DESCRIPTION
... also some minor improvements -> avoid converting to Java string

`to_java(java.io.InputStream)` returns the very same as the existing `io.to_input_stream` does

it just seems to make sense for the Java side of RubyIO to use it like a Closeable/Flushable object