### PR TITLE
MINOR: Cache required arg count in CompiledMethodIR

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
@@ -23,7 +23,7 @@ import org.jruby.util.cli.Options;
 
 public abstract class AbstractIRMethod extends DynamicMethod implements IRMethodArgs, PositionAware, Cloneable {
 
-    private final Signature signature;
+    protected final Signature signature;
     protected final IRScope method;
     protected final StaticScope staticScope;
     protected InterpreterContext interpreterContext = null;

--- a/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
@@ -1,42 +1,29 @@
 package org.jruby.internal.runtime;
 
-import org.jruby.Ruby;
+import java.util.ArrayList;
+import java.util.List;
 import org.jruby.RubyModule;
-import org.jruby.anno.MethodDescriptor;
-import org.jruby.compiler.Compilable;
 import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.internal.runtime.methods.IRMethodArgs;
 import org.jruby.ir.IRMethod;
 import org.jruby.ir.IRScope;
-import org.jruby.ir.Interp;
 import org.jruby.ir.instructions.GetFieldInstr;
 import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.instructions.PutFieldInstr;
 import org.jruby.ir.interpreter.InterpreterContext;
-import org.jruby.ir.persistence.IRDumper;
-import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.ArgumentDescriptor;
 import org.jruby.runtime.Arity;
-import org.jruby.runtime.Block;
-import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.PositionAware;
 import org.jruby.runtime.Signature;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
-import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.ivars.MethodData;
 import org.jruby.util.cli.Options;
-import org.jruby.util.log.Logger;
-import org.jruby.util.log.LoggerFactory;
-
-import java.io.ByteArrayOutputStream;
-import java.util.ArrayList;
-import java.util.List;
 
 public abstract class AbstractIRMethod extends DynamicMethod implements IRMethodArgs, PositionAware, Cloneable {
 
-    private Signature signature;
+    private final Signature signature;
     protected final IRScope method;
     protected final StaticScope staticScope;
     protected InterpreterContext interpreterContext = null;
@@ -78,7 +65,7 @@ public abstract class AbstractIRMethod extends DynamicMethod implements IRMethod
 
     public abstract InterpreterContext ensureInstrsReady();
 
-    public Signature getSignature() {
+    public final Signature getSignature() {
         return signature;
     }
 

--- a/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
@@ -10,7 +10,6 @@ import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.runtime.ArgumentDescriptor;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.Helpers;
-import org.jruby.runtime.Signature;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -20,8 +19,6 @@ public final class CompiledIRMethod extends AbstractIRMethod {
 
     private final MethodHandle specific;
     private final int specificArity;
-
-    private final int required;
 
     private final boolean hasKwargs;
 
@@ -44,12 +41,6 @@ public final class CompiledIRMethod extends AbstractIRMethod {
         assert method.hasExplicitCallProtocol();
 
         setHandle(variable);
-        final Signature sig = getSignature();
-        if (sig != null) {
-            required = sig.required();
-        } else {
-            required = -1;
-        }
     }
 
     public MethodHandle getHandleFor(int arity) {
@@ -78,7 +69,7 @@ public final class CompiledIRMethod extends AbstractIRMethod {
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject[] args, Block block) {
-        if (hasKwargs) args = IRRuntimeHelpers.frobnicateKwargsArgument(context, args, required);
+        if (hasKwargs) args = IRRuntimeHelpers.frobnicateKwargsArgument(context, args, signature);
 
         try {
             return (IRubyObject) this.variable.invokeExact(context, staticScope, self, args, block, implementationClass, name);
@@ -143,7 +134,7 @@ public final class CompiledIRMethod extends AbstractIRMethod {
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject[] args) {
-        if (hasKwargs) args = IRRuntimeHelpers.frobnicateKwargsArgument(context, args, required);
+        if (hasKwargs) args = IRRuntimeHelpers.frobnicateKwargsArgument(context, args, signature);
 
         try {
             return (IRubyObject) this.variable.invokeExact(context, staticScope, self, args, Block.NULL_BLOCK, implementationClass, name);

--- a/core/src/main/java/org/jruby/runtime/Signature.java
+++ b/core/src/main/java/org/jruby/runtime/Signature.java
@@ -17,7 +17,7 @@ import org.jruby.util.TypeConverter;
 /**
  * A representation of a Ruby method signature (argument layout, min/max, keyword layout, rest args).
  */
-public class Signature {
+public final class Signature {
     public enum Rest {
         NONE, NORM, ANON, STAR;
 


### PR DESCRIPTION
The required arg count is constant for a compiled method:
* Made all steps of getting this number `final` (they obviously are final already in the execution)
* cached the `required` count
   * Had to work around the fact that the `Signature` is `null` at times (in which case the `required` number isn't used down the line)

Saves us `3` bytes on this method, which can't hurt here? :)

<img width="1996" alt="screen shot 2017-08-29 at 12 58 27" src="https://user-images.githubusercontent.com/6490959/29817836-dd31c6e6-8cb9-11e7-89dd-ee646ac67836.png">
 
left is this version, right is `master`