### PR TITLE
Fix Broken Compilation

### DIFF
--- a/core/src/main/java/org/jruby/ast/ListNode.java
+++ b/core/src/main/java/org/jruby/ast/ListNode.java
@@ -188,8 +188,13 @@ public class ListNode extends Node implements Iterable<Node> {
 
             @Override
             public Node next() {
-                if (i >= list.length) throw new IndexOutOfBoundsException(i);
+                if (i >= list.length) throw new IndexOutOfBoundsException(String.valueOf(i));
                 return list[i++];
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException("remove");
             }
         };
     }


### PR DESCRIPTION
`master` doesn't compile right now:
* JDK 7 needs `remove` implemented since it doesn't have the `default` here
* `java.lang.IndexOutOfBoundsException` needs a `String` input to the constructor