### PR TITLE
File.symlink? fix typo

### DIFF
--- a/core/src/main/ruby/jruby/kernel/file.rb
+++ b/core/src/main/ruby/jruby/kernel/file.rb
@@ -130,7 +130,7 @@ if org.jruby.platform.Platform::IS_WINDOWS
           return false if file =~ /^(classpath:|classloader:|uri:classloader|jar:)/ || !File.exist?(file)
 
           file.slice!(5..-1) if file =~ /^file:/
-          wfile = checked.wincode
+          wfile = file.wincode
           attrib = GetFileAttributesW(wfile)
 
           if attrib == INVALID_FILE_ATTRIBUTES


### PR DESCRIPTION
introduced by
https://github.com/jruby/jruby/commit/fd5e4140fb61e361027a28990865df61143214cf

9.1.13.0 also contains this error