### PR TITLE
MINOR: Dry up RubyRange#fixnumEach

### DIFF
--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -153,7 +153,7 @@ public abstract class RubyInteger extends RubyNumeric {
         }
     }
 
-    private static void fixnumUpto(ThreadContext context, long from, long to, Block block) {
+    static void fixnumUpto(ThreadContext context, long from, long to, Block block) {
         // We must avoid "i++" integer overflow when (to == Long.MAX_VALUE).
         if (block.getSignature() == Signature.NO_ARGUMENTS) {
             IRubyObject nil = context.nil;

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -38,41 +38,37 @@ package org.jruby;
 
 import java.io.IOException;
 import java.util.List;
-
 import org.jcodings.Encoding;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.JumpException;
 import org.jruby.exceptions.RaiseException;
-import org.jruby.runtime.CallSite;
-import org.jruby.runtime.Helpers;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.BlockCallback;
 import org.jruby.runtime.CallBlock;
+import org.jruby.runtime.CallSite;
 import org.jruby.runtime.ClassIndex;
+import org.jruby.runtime.Helpers;
 import org.jruby.runtime.JavaSites;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ObjectMarshal;
 import org.jruby.runtime.Signature;
 import org.jruby.runtime.ThreadContext;
-
-import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
-import static org.jruby.runtime.Visibility.*;
-
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.builtin.Variable;
 import org.jruby.runtime.callsite.RespondToCallSite;
 import org.jruby.runtime.component.VariableEntry;
+import org.jruby.runtime.invokedynamic.MethodNames;
 import org.jruby.runtime.marshal.MarshalStream;
 import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.util.ByteList;
 import org.jruby.util.TypeConverter;
 
-import static org.jruby.runtime.Helpers.invokedynamic;
 import static org.jruby.RubyEnumerator.SizeFn;
+import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
 import static org.jruby.RubyNumeric.intervalStepSize;
-
-import org.jruby.runtime.invokedynamic.MethodNames;
+import static org.jruby.runtime.Helpers.invokedynamic;
+import static org.jruby.runtime.Visibility.PRIVATE;
 
 /**
  * @author jpetersen
@@ -528,26 +524,7 @@ public class RubyRange extends RubyObject {
             }
             to--;
         }
-        long from = ((RubyFixnum) begin).getLongValue();
-        if (block.getSignature() == Signature.NO_ARGUMENTS) {
-            final IRubyObject nil = context.nil;
-            long i;
-            for (i = from; i < to; i++) {
-                block.yield(context, nil);
-            }
-            if (i <= to) {
-                block.yield(context, nil);
-            }
-        } else {
-            final Ruby runtime = context.runtime;
-            long i;
-            for (i = from; i < to; i++) {
-                block.yield(context, RubyFixnum.newFixnum(runtime, i));
-            }
-            if (i <= to) {
-                block.yield(context, RubyFixnum.newFixnum(runtime, i));
-            }
-        }
+        RubyInteger.fixnumUpto(context, ((RubyFixnum) begin).getLongValue(), to, block);
     }
 
     @Deprecated


### PR DESCRIPTION
Just a random spot that can be dried up I found during profiling :)
The method has exactly the same code as the removed block (apart from two `final`s).