### PR TITLE
Fix DEPENDENCY constant missing getter on LiveVariableAnalysis

### DIFF
--- a/core/src/main/java/org/jruby/ir/passes/CompilerPass.java
+++ b/core/src/main/java/org/jruby/ir/passes/CompilerPass.java
@@ -27,9 +27,7 @@ public abstract class CompilerPass {
 
     static final Logger LOG = LoggerFactory.getLogger(CompilerPass.class);
 
-    protected static final List<Class<? extends CompilerPass>> NO_DEPENDENCIES = Collections.emptyList();
-
-    private List<CompilerPassListener> listeners = new ArrayList<CompilerPassListener>();
+    private static final List<Class<? extends CompilerPass>> NO_DEPENDENCIES = Collections.emptyList();
 
     /**
      * What is the user-friendly name of this compiler pass

--- a/core/src/main/java/org/jruby/ir/passes/LiveVariableAnalysis.java
+++ b/core/src/main/java/org/jruby/ir/passes/LiveVariableAnalysis.java
@@ -1,9 +1,14 @@
 package org.jruby.ir.passes;
 
+import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.jruby.ir.IRClosure;
 import org.jruby.ir.IRFlags;
 import org.jruby.ir.IRScope;
+import org.jruby.ir.dataflow.analyses.LiveVariablesProblem;
 import org.jruby.ir.instructions.ClosureAcceptingInstr;
 import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.instructions.ResultInstr;
@@ -12,15 +17,16 @@ import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.operands.WrappedIRClosure;
 import org.jruby.ir.representations.BasicBlock;
-import org.jruby.ir.dataflow.analyses.LiveVariablesProblem;
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.List;
 
 public class LiveVariableAnalysis extends CompilerPass {
-    public static List<Class<? extends CompilerPass>> DEPENDENCIES = Arrays.<Class<? extends CompilerPass>>asList(OptimizeDynScopesPass.class);
+
+    private static final List<Class<? extends CompilerPass>> DEPENDENCIES =
+        Collections.<Class<? extends CompilerPass>>singletonList(OptimizeDynScopesPass.class);
+
+    @Override
+    public List<Class<? extends CompilerPass>> getDependencies() {
+        return DEPENDENCIES;
+    }
 
     @Override
     public String getLabel() {

--- a/core/src/main/java/org/jruby/ir/passes/OptimizeDynScopesPass.java
+++ b/core/src/main/java/org/jruby/ir/passes/OptimizeDynScopesPass.java
@@ -38,7 +38,7 @@ public class OptimizeDynScopesPass extends CompilerPass {
     public void eliminateLocalVars(IRScope s) {
         assert s.getClosures().isEmpty() : "We assume that if a scope has nested closures, it uses a dynamic scoope.";
 
-        Map<Operand, Operand> varRenameMap = new HashMap<Operand, Operand>();
+        Map<Operand, Operand> varRenameMap = new HashMap<>();
         EnumSet<IRFlags> flags = s.getExecutionContext().getFlags();
 
         flags.add(IRFlags.DYNSCOPE_ELIMINATED); // Record the fact that we eliminated the scope


### PR DESCRIPTION
`LiveVariableAnalysis` didn't have a `getDependencies` method => the `DEPENDENCIES` constant was never used and `OptimizeDynScopesPass` not returned as a dependency:

* Added the `getDependencies` method
* Made `DEPENDENCIES` `private` here and in the parent to make this a little less confusing (other children of `CompilerPass` use the same approach => `private` rules out any inheritance weirdness imo :))

Also:
* Removed dead field `listeners` from `CompilerPass`
* Made `NO_DEPENDENCIES` in `CompilerPass` private since none of the child compiler passes use it (if they don't override `getDependencies` they get no dependencies => no need to use the constant in children)