### PR TITLE
 Generate smaller bytecode when using Ruby type on implemented Java Interface + Benchmark

### DIFF
--- a/bench/src/main/java/org/jruby/benchmark/JavaInterfaceBenchmark.java
+++ b/bench/src/main/java/org/jruby/benchmark/JavaInterfaceBenchmark.java
@@ -1,0 +1,90 @@
+package org.jruby.benchmark;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import org.jruby.Ruby;
+import org.jruby.RubyFixnum;
+import org.jruby.RubyInstanceConfig;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@Warmup(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+public class JavaInterfaceBenchmark {
+
+    private static final int INVOCATIONS = 200_000_000;
+
+    private static final Ruby RUBY = initRuby();
+
+    private static final RubyFixnum LEFT = RUBY.newFixnum(ThreadLocalRandom.current().nextInt());
+
+    private static final RubyFixnum RIGHT = RUBY.newFixnum(ThreadLocalRandom.current().nextInt());
+
+    private static final JavaInterfaceBenchmark.Summation JAVA_SUMMER =
+        new JavaInterfaceBenchmark.Summation() {
+            @Override
+            public IRubyObject sum(final RubyFixnum left, final RubyFixnum right) {
+                return left.op_plus(RUBY.getCurrentContext(), right);
+            }
+        };
+
+    public interface Summation {
+        IRubyObject sum(RubyFixnum left, RubyFixnum right);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void benchHalfRubyVersion(final Blackhole blackhole) {
+        blackhole.consume(
+            RUBY.executeScript(
+                "org.jruby.benchmark.JavaInterfaceBenchmark.doRun(RubySummation.new)"
+            ,"benchHalfRubyVersion")
+        );
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void benchJavaVersion(final Blackhole blackhole) {
+        blackhole.consume(doRun(JAVA_SUMMER));
+    }
+
+    public static IRubyObject doRun(final JavaInterfaceBenchmark.Summation summer) {
+        IRubyObject sum = null;
+        for (int i = 0; i < INVOCATIONS; ++i) {
+            sum = summer.sum(LEFT, RIGHT);
+        }
+        return sum;
+    }
+
+    private static Ruby initRuby() {
+        final RubyInstanceConfig config = new RubyInstanceConfig();
+        config.setCompileMode(RubyInstanceConfig.CompileMode.FORCE);
+        final Ruby ruby = Ruby.newInstance(config);
+        ruby.executeScript(
+            new StringBuilder()
+                .append("class RubySummation\n")
+                .append("\tinclude org.jruby.benchmark.JavaInterfaceBenchmark::Summation\n")
+                .append('\n')
+                .append("\tdef sum(a, b)\n")
+                .append("\t\ta + b\n")
+                .append("\tend\n")
+                .append("end")
+                .toString(), "initRuby"
+        );
+        return ruby;
+    }
+}

--- a/core/src/main/java/org/jruby/ir/passes/LocalOptimizationPass.java
+++ b/core/src/main/java/org/jruby/ir/passes/LocalOptimizationPass.java
@@ -48,12 +48,12 @@ public class LocalOptimizationPass extends CompilerPass {
 
         // For all variables used by val, record a reverse mapping to let us track
         // Read-After-Write scenarios when any of these variables are modified.
-        List<Variable> valVars = new ArrayList<Variable>();
+        List<Variable> valVars = new ArrayList<>();
         val.addUsedVariables(valVars);
         for (Variable v: valVars) {
            List<Variable> x = simplificationMap.get(v);
            if (x == null) {
-              x = new ArrayList<Variable>();
+              x = new ArrayList<>();
               simplificationMap.put(v, x);
            }
            x.add(res);


### PR DESCRIPTION
It seems when compiling Ruby implementations of Java interfaces, we were generating bytecode that runs any non-primitive type through `convertJavaToUsableRubyObject`.
This seems unnecessary to me if we know that we're dealing with an `IRubyObject` type of argument => we can save that call and the loading of the `Ruby` runtime argument, right?

I included the benchmark I used to verify that this comes with a positive performance impact (for me it showed about a `5%` speed-up).