### PR TITLE
PERFORMANCE: Smaller bytecode for interface impl returns

### DIFF
--- a/core/src/main/java/org/jruby/java/codegen/RealClassGenerator.java
+++ b/core/src/main/java/org/jruby/java/codegen/RealClassGenerator.java
@@ -817,9 +817,12 @@ public abstract class RealClassGenerator {
                     }
                 }
             } else {
-                mv.ldc(Type.getType(returnType));
-                mv.invokeinterface(p(IRubyObject.class), "toJava", sig(Object.class, Class.class));
-                mv.checkcast(p(returnType));
+                if (!IRubyObject.class.isAssignableFrom(returnType)) {
+                    mv.ldc(Type.getType(returnType));
+                    mv.invokeinterface(
+                        p(IRubyObject.class), "toJava", sig(Object.class, Class.class));
+                    mv.checkcast(p(returnType));
+                }
                 mv.areturn();
             }
         } else {


### PR DESCRIPTION
Same as #4777 but for the return type.
There is no point in running the typecast if the return type is an `IRubyObject` :)

That said ... small disclaimer:

I'm a little unsure I didn't make a mistake here, functionally this seems fine in my testing (and is fairly straightforward imo) but the performance gain is much bigger than that from #4777.
The `org.jruby.benchmark.JavaInterfaceBenchmark#benchHalfRubyVersion` benchmark goes from `0.036ops/ns` to `0.045ops/ns` for me, which seems like an unexpectedly huge increase.