### PR TITLE
[#4710] nanosecond precision in utime using libc futimens

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -46,7 +46,7 @@ project 'JRuby Core' do
   jar 'com.github.jnr:jnr-enxio:0.16', :exclusions => ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-x86asm:1.0.2', :exclusions => ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-unixsocket:0.17', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-posix:3.0.43', :exclusions => ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-posix:3.0.44', :exclusions => ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-constants:0.9.9', :exclusions => ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-ffi:2.1.7'
   jar 'com.github.jnr:jffi:${jffi.version}'

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -135,7 +135,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
-      <version>3.0.43</version>
+      <version>3.0.44</version>
       <exclusions>
         <exclusion>
           <artifactId>jnr-ffi</artifactId>


### PR DESCRIPTION
timeval & ufiles only provide microsecond precision. Use timespec & futimens from libc to implement [File.ufile](https://ruby-doc.org/core-2.2.0/File.html#method-c-utime), to provide nanosecond precision.

This PR is required https://github.com/jnr/jnr-posix/pull/107 to be able to use the native function.

## Testing
### test/utime.rb
```ruby
F = '/tmp/test'
mtime = File.mtime(F)

File.utime(Time.now, mtime, F)
File.mtime(F) == mtime or raise "File.mtime should be == mtime"
```
### JRuby error
```
$ touch /tmp/test
$ stat /tmp/test 
  File: /tmp/test
  Size: 0               Blocks: 0          IO Block: 4096   regular empty file
Device: 802h/2050d      Inode: 430953      Links: 1
Access: (0644/-rw-r--r--)  Uid: ( 1000/  alexis)   Gid: ( 1000/  alexis)
Access: 2017-09-23 15:50:57.974453385 -0700
Modify: 2017-09-23 15:50:57.974453385 -0700
Change: 2017-09-23 15:50:57.974453385 -0700
 Birth: -
$ ruby -v
jruby 9.1.12.0 (2.3.3) 2017-06-15 33c6439 OpenJDK 64-Bit Server VM 25.144-b01 on 1.8.0_144-8u144-b01-1-b01 +jit [linux-x86_64]
$ ruby test/utime.rb
RuntimeError: File.mtime should be == mtime
  <main> at test/utime.rb:6
$ stat /tmp/test 
  File: /tmp/test
  Size: 0               Blocks: 0          IO Block: 4096   regular empty file
Device: 802h/2050d      Inode: 430953      Links: 1
Access: (0644/-rw-r--r--)  Uid: ( 1000/  alexis)   Gid: ( 1000/  alexis)
Access: 2017-09-23 15:51:12.058870000 -0700
Modify: 2017-09-23 15:50:57.974453000 -0700
Change: 2017-09-23 15:51:12.062198429 -0700
 Birth: -
```

### PR fix
```
$ bin/ruby -v
jruby 9.2.0.0-SNAPSHOT (2.4.1) 2017-09-23 0f9c2a3 OpenJDK 64-Bit Server VM 25.144-b01 on 1.8.0_144-8u144-b01-1-b01 +jit [linux-x86_64]
$ ruby test/utime.rb
$
```