### PR TITLE
Add Ruby part of TracePoint impl

### DIFF
--- a/core/src/main/ruby/jruby/vm_trace.rb
+++ b/core/src/main/ruby/jruby/vm_trace.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+#
+# .rb part for JRuby's native TracePoint impl
+
+class TracePoint
+
+  def self.trace(*events, &blk)  # :nodoc:
+    tp = new(*events, &blk)
+    tp.enable
+    tp
+  end
+
+end


### PR DESCRIPTION
This PR adds a Ruby implementation of the class method `.trace` to TracePoint.

The file is named after C impl file in MRI.

Fixes #4800

Questions for reviewer:

- Do we want to have a full implementation of each of TracePoint methods?
- Are there tests that I can re-enable, now?