### PR TITLE
Raise Errno::ENOTDIR if the parent of an opened file is not a directory

### DIFF
--- a/core/src/main/java/org/jruby/util/RegularFileResource.java
+++ b/core/src/main/java/org/jruby/util/RegularFileResource.java
@@ -173,6 +173,8 @@ class RegularFileResource extends AbstractFileResource {
                         throw new ResourceException.TooManySymlinks(absolutePath());
                     case EISDIR:
                         throw new ResourceException.FileIsDirectory(absolutePath());
+                    case ENOTDIR:
+                        throw new ResourceException.FileIsNotDirectory(absolutePath());
                     default:
                         throw new ResourceException.IOError(new IOException("unhandled errno: " + errno));
 

--- a/core/src/main/java/org/jruby/util/ResourceException.java
+++ b/core/src/main/java/org/jruby/util/ResourceException.java
@@ -32,6 +32,10 @@ public abstract class ResourceException extends IOException {
         public FileIsDirectory(String path) { super("EISDIR", path); }
     }
 
+    public static class FileIsNotDirectory extends ErrnoException {
+        public FileIsNotDirectory(String path) { super ("ENOTDIR", path); }
+    }
+
     public static class FileExists extends ErrnoException {
         public FileExists(String path) { super("EEXIST", path); }
     }

--- a/core/src/main/java/org/jruby/util/io/PosixShim.java
+++ b/core/src/main/java/org/jruby/util/io/PosixShim.java
@@ -416,6 +416,8 @@ public class PosixShim {
             errno = Errno.EEXIST;
         } catch (ResourceException.FileIsDirectory e) {
             errno = Errno.EISDIR;
+        } catch (ResourceException.FileIsNotDirectory e) {
+            errno = Errno.ENOTDIR;
         } catch (ResourceException.NotFound e) {
             errno = Errno.ENOENT;
         } catch (ResourceException.PermissionDenied e) {

--- a/test/jruby/test_io.rb
+++ b/test/jruby/test_io.rb
@@ -205,6 +205,11 @@ class TestIO < Test::Unit::TestCase
     assert_raises(Errno::EBADF) { f.close }
   end
 
+  def test_open_child_of_file
+    ensure_files @file
+    assert_raises(WINDOWS ? Errno::ENOENT : Errno::ENOTDIR) { File.open(File.join(@file, 'child')) }
+  end
+
   unless WINDOWS # Windows doesn't take kindly to perm mode tests
     def test_sysopen
       ensure_files @file


### PR DESCRIPTION
MRI 2.4.2 raises `Errno::ENOTDIR` when attempting to open a path where the parent entry is not a directory. For example, supposing `/tmp/file1` is a regular file:

```ruby
> File.open('/tmp/file1/file2')
Errno::ENOTDIR: Not a directory @ rb_sysopen - /tmp/file1/file2
        from (irb):1:in `initialize'
        from (irb):1:in `open'
        from (irb):1
```

However, JRuby 9.1.13.0 (on platforms other than Windows) raises `Java::JavaLang::RuntimeException` instead:

```ruby
> File.open('/tmp/file1/file2')
Java::JavaLang::RuntimeException: Unhandled IOException: java.io.IOException: unhandled errno: Not a directory
        from org.jruby.util.io.PosixShim.open(PosixShim.java:426)
        from org.jruby.RubyIO.cloexecOpen(RubyIO.java:1266)
        from org.jruby.RubyIO.sysopenFunc(RubyIO.java:1252)
        from org.jruby.RubyIO.sysopenInternal(RubyIO.java:1244)
        from org.jruby.RubyIO.sysopen(RubyIO.java:1229)
        from org.jruby.RubyFile.fileOpenGeneric(RubyFile.java:1373)
        from org.jruby.RubyFile.openFile(RubyFile.java:1350)
        from org.jruby.RubyFile.initialize(RubyFile.java:366)
        from org.jruby.RubyFile$INVOKER$i$0$3$initialize.call(RubyFile$INVOKER$i$0$3$initialize.gen)
        from org.jruby.runtime.callsite.CachingCallSite.callBlock(CachingCallSite.java:77)
        from org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:83)
        from org.jruby.RubyClass.newInstance(RubyClass.java:1022)
        from org.jruby.RubyIO.open(RubyIO.java:1154)
        from org.jruby.RubyIO$INVOKER$s$0$0$open.call(RubyIO$INVOKER$s$0$0$open.gen)
```

This pull request changes `RegularFileResource.openChannel()` and `PosixShim.open()` so that they handle the `ENOTDIR` case, making `File.open` raise the correct exception.

The change only applies to platforms other than Windows. On Windows, both JRuby and MRI raise `Errno::ENOENT` for such paths.