### PR TITLE
Fix an infinite loop when attempting to read from a directory

### DIFF
--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -213,6 +213,8 @@ public class Helpers {
                 case "Message too large": // Alpine Linux
                 case "Message too long":
                     return Errno.EMSGSIZE;
+                case "Is a directory":
+                    return Errno.EISDIR;
             }
         }
         return null;

--- a/core/src/main/java/org/jruby/util/io/OpenFile.java
+++ b/core/src/main/java/org/jruby/util/io/OpenFile.java
@@ -1407,6 +1407,12 @@ public class OpenFile implements Finalizable {
                 return false;
             }
 
+            if (posix.errno != null && posix.errno != Errno.EAGAIN
+                    && posix.errno != Errno.EWOULDBLOCK && posix.errno != Errno.EINTR) {
+                // Encountered a permanent error. Don't read again.
+                return false;
+            }
+
             if (fd.chSelect != null) {
                 unlock();
                 try {

--- a/test/jruby/test_io.rb
+++ b/test/jruby/test_io.rb
@@ -379,6 +379,21 @@ class TestIO < Test::Unit::TestCase
     assert(a)
   end
 
+  unless WINDOWS
+    # On Windows an error is raised when opening a directory instead of when reading.
+    def test_read_directory
+      File.open('.', 'r') do |f|
+        assert_raise(Errno::EISDIR) { f.read }
+      end
+    end
+
+    def test_gets_directory
+      File.open('.', 'r') do |f|
+        assert_raise(Errno::EISDIR) { f.gets }
+      end
+    end
+  end
+
   if (WINDOWS)
     #JRUBY-2158
     def test_null_open_windows


### PR DESCRIPTION
When attempting to open a directory with `File.open` and then read from it, JRuby 9.1.13.0 (on platforms other than Windows) will enter an infinite loop and hang:

```ruby
> Timeout::timeout(10) { File.open('.') {|f| f.read } }
Timeout::Error: execution expired
        from org/jruby/RubyIO.java:3009:in `read'
        from org/jruby/RubyIO.java:2987:in `read'
        from (irb):1:in `block in evaluate'
        from org/jruby/RubyIO.java:1156:in `open'
        from (irb):1:in `block in evaluate'
        from org/jruby/ext/timeout/Timeout.java:117:in `timeout'
        from (irb):1:in `<eval>'
```

When attempting to do the same with MRI (tested with versions 1.9.3 through to 2.4.2) an `Errno::EISDIR` exception is raised:

```ruby
> File.open('.') {|f| f.read }
Errno::EISDIR: Is a directory @ io_fread - .
        from (irb):1:in `read'
        from (irb):1:in `block in irb_binding'
        from (irb):1:in `open'
        from (irb):1
```

The hang occurs because `OpenFile.fillbuf()` and `OpenFile.ioBufread()` loop to retry on errors. This is desirable for temporary errors like `EAGAIN`, but not for permanent errors like `EISDIR`.

This pull request modifies `OpenFile.waitReadable()` to abort retries when a permanent error is encountered. It also changes `Helpers.errnoFromException()` to map the `"Is a directory"` `IOException` message to `EISDIR`.

This change only applies to non-Windows platforms. On Windows, `File.open` raises an exception instead.