### PR TITLE
switch ShellLauncher to use getAbsolutePath

### DIFF
--- a/core/src/main/java/org/jruby/util/ShellLauncher.java
+++ b/core/src/main/java/org/jruby/util/ShellLauncher.java
@@ -1200,11 +1200,7 @@ public class ShellLauncher {
             } else {
                 verifyExecutable();
                 execArgs = args;
-                try {
-                    execArgs[0] = executableFile.getCanonicalPath();
-                } catch (IOException ioe) {
-                    // can't get the canonical path, will use as-is
-                }
+                execArgs[0] = executableFile.getAbsolutePath();
             }
         }
 


### PR DESCRIPTION
I ran into some issues with using JRuby on a system that uses busybox as it's userland, and without this patch things won't work.

For a bit of background: busybox's goal is to be a tiny userland (commands like ls and mv) for space-constrained devices. One of the ways it does this is by being a multi-call binary. You symlink it with names such as ls and cp, and it uses $0 to determine how it's called and thus what it should do. JRuby resolves the symlink before it execs, so busybox loses $0 and thus doesn't know what the user originally called. This patch fixes that.