### PR TITLE
Fix typo in a method name comment

### DIFF
--- a/core/src/main/java/org/jruby/ext/ripper/RipperLexer.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperLexer.java
@@ -923,9 +923,9 @@ public class RipperLexer extends LexingCommon {
     }
 
     /**
-     *  Returns the next token. Also sets yyVal is needed.
+     *  Returns the next token. Also sets yyVal as needed.
      *
-     *@return    Description of the Returned Value
+     * @return    the next token
      */
     private int yylex() throws IOException {
         int c;

--- a/core/src/main/java/org/jruby/ext/ripper/RipperLexer.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperLexer.java
@@ -710,7 +710,7 @@ public class RipperLexer extends LexingCommon {
         return lex_p > tokp;
     }
     
-    public void dispatchDelayedToken(int token) { //mri: rupper_dispatch_delayed_token
+    public void dispatchDelayedToken(int token) { //mri: ripper_dispatch_delayed_token
         int saved_line = ruby_sourceline;
         int saved_tokp = tokp;
         


### PR DESCRIPTION
This PR fixes a typo in a comment in the Ripper code-base: a reference to an MRI function which had a typo.