### PR TITLE
Fix issues discovered using Error Prone

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -1177,7 +1177,7 @@ public class RubyEnumerable {
 
     @Deprecated @SuppressWarnings("deprecation")
     public static IRubyObject each_with_index19(ThreadContext context, IRubyObject self, IRubyObject[] args, Block block) {
-        return each_with_index19(context, self, args, block);
+        return each_with_index(context, self, args, block);
     }
 
     @JRubyMethod(required = 1)

--- a/core/src/main/java/org/jruby/ext/ffi/StructLayout.java
+++ b/core/src/main/java/org/jruby/ext/ffi/StructLayout.java
@@ -658,7 +658,10 @@ public final class StructLayout extends Type {
 
         @Override
         public int hashCode() {
-            return 53 * 5 + (int) (this.offset ^ (this.offset >>> 32)) ^ type.hashCode();
+            int result = super.hashCode();
+            result = 31 * result + type.hashCode();
+            result = 31 * result + offset;
+            return result;
         }
 
         /**

--- a/core/src/main/java/org/jruby/ext/ripper/RipperLexer.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperLexer.java
@@ -2349,7 +2349,7 @@ public class RipperLexer extends LexingCommon {
         int length = precise_mbclen();
 
         if (length <= 0) {
-            compile_error("invalid multibyte char (" + getEncoding().getName() + ")");
+            compile_error("invalid multibyte char (" + getEncoding() + ")");
             return false;
         }
 

--- a/core/src/main/java/org/jruby/ir/interpreter/FullInterpreterContext.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/FullInterpreterContext.java
@@ -188,6 +188,6 @@ public class FullInterpreterContext extends InterpreterContext {
             if (ipc <= rescueIPCs[i]) return rescueIPCs[i + 1];
         }
 
-        throw new RuntimeException("BUG: no RPC found for " + getFileName() + ":" + getName() + ":" + ipc + getInstructions());
+        throw new RuntimeException("BUG: no RPC found for " + getFileName() + ":" + getName() + ":" + ipc);
     }
 }

--- a/core/src/main/java/org/jruby/ir/operands/SymbolProc.java
+++ b/core/src/main/java/org/jruby/ir/operands/SymbolProc.java
@@ -34,7 +34,10 @@ public class SymbolProc extends ImmutableLiteral {
 
     @Override
     public int hashCode() {
-        return 47 * 7 + (int) (this.name.hashCode() ^ (this.encoding.hashCode() >>> 32));
+        int result = super.hashCode();
+        result = 31 * result + name.hashCode();
+        result = 31 * result + encoding.hashCode();
+        return result;
     }
 
     @Override

--- a/core/src/main/java/org/jruby/util/Pack.java
+++ b/core/src/main/java/org/jruby/util/Pack.java
@@ -1320,7 +1320,7 @@ public class Pack {
                     }
 
                     long ul = 0;
-                    long ulmask = (0xfe << 56) & 0xffffffff;
+                    long ulmask = (0xfeL << 56) & 0xffffffff;
                     RubyBignum big128 = RubyBignum.newBignum(runtime, 128);
                     int pos = encode.position();
 

--- a/core/src/main/java/org/jruby/util/io/ChannelStream.java
+++ b/core/src/main/java/org/jruby/util/io/ChannelStream.java
@@ -561,7 +561,7 @@ public class ChannelStream implements Stream, Finalizable {
 
         dst.ensure(Math.min(len, bufferedInputBytesRemaining()));
 
-        if (hasUngotChars() && hasUngotChars()) {
+        if (hasUngotChars()) {
             for(int i = 0; i < ungotChars.length(); i++){
                 byte ungotc = (byte) ungotChars.get(i);
                 ++bytesCopied;


### PR DESCRIPTION
Hello!

As part of the investigation that led to #4844, I integrated Error Prone (http://errorprone.info) into the JRuby compiler. (See configuration in https://github.com/nglorioso/jruby/commit/ae3a5cb605b2b8b31ba0fae66332086ce01730f9).

This found a number of bugs (ranging in severity/nagginess). I'm happy to revert or change any of these, but all of them represent real defects:

RubyEnumerable - each_with_index19 is trivially infinitely-recursive. I assumed that each_with_index is appropriate
StructLayout/SymbolProc - `hashCode()` ends up RSHIFT'ing an int value by 32 bits, which always ends up resulting in 0. I changed to 16 bits, but if you needed a stable hash code, I can change to XOR 0
RipperContext/FullInterpreterContext - Array.toString() is unhelpful for error messages. Manually unrolled them with Arrays.toString.
RealClassGenerator - an exception was created and thrown on the floor in an exceptional condition. I threw it instead.
Pack - ulMask was an int constant left shifted by 56, but since it was an int, it shifts out to 0 instead of 0xfe000000.
SelectExecutor - Here, I don't have enough context to make the right changes, but the errorKeyList.contains() calls will never return true, since the file descriptor objects can't be contained in `errorKeyList`