### PR TITLE
Improvements to subclass management and method cache invalidation

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -107,6 +107,7 @@ import org.jruby.runtime.callsite.FunctionalCachingCallSite;
 import org.jruby.runtime.ivars.MethodData;
 import org.jruby.runtime.marshal.MarshalStream;
 import org.jruby.runtime.marshal.UnmarshalStream;
+import org.jruby.runtime.opto.ConstantInvalidator;
 import org.jruby.runtime.opto.Invalidator;
 import org.jruby.runtime.opto.OptoFactory;
 import org.jruby.runtime.profile.MethodEnhancer;
@@ -1351,12 +1352,17 @@ public class RubyModule extends RubyObject {
         return null;
     }
 
-    private void invalidateConstantCacheForModuleInclusion(RubyModule module)
-    {
+    private void invalidateConstantCacheForModuleInclusion(RubyModule module) {
+        Map<String, Invalidator> invalidators = null;
         for (RubyModule mod : gatherModules(module)) {
-            for (String key : mod.getConstantMap().keySet()) {
-                invalidateConstantCache(key);
+            for (String name : mod.getConstantMap().keySet()) {
+                if (invalidators == null) invalidators = new HashMap<>();
+                invalidators.put(name, getRuntime().getConstantInvalidator(name));
             }
+        }
+        if (invalidators != null) {
+            List<Invalidator> values = new ArrayList(invalidators.values());
+            values.get(0).invalidateAll(values);
         }
     }
 
@@ -1552,6 +1558,19 @@ public class RubyModule extends RubyObject {
 
     protected void invalidateConstantCache(String constantName) {
         getRuntime().getConstantInvalidator(constantName).invalidate();
+    }
+
+    protected void invalidateConstantCaches(Set<String> constantNames) {
+        if (constantNames.size() > 0) {
+            Ruby runtime = getRuntime();
+
+            List<Invalidator> constantInvalidators = new ArrayList<>(constantNames.size());
+            for (String name : constantNames) {
+                constantInvalidators.add(runtime.getConstantInvalidator(name));
+            }
+
+            constantInvalidators.get(0).invalidateAll(constantInvalidators);
+        }
     }
 
     /**


### PR DESCRIPTION
In #4879, we got a report of heavy thread contention on the `addSubclasses` method of RubyClass. After investigating the locking involved (at @kares's recommendation), it seems as though much of this locking is excessively restrictive, using a runtime-global lock to prevent multiple threads from modifying any class's list of subclasses at the same time.

The subclasses list is also used heavily by method invalidation, and exploring that end of things showed me many places where we could improve performance.

* The global synchronization may be unnecessary most of these places, so long as the collections being modified are themselves thread-safe.
  I have removed most of this but we need much more testing, review, analysis to confirm it's safe.
* The subclass aggregation logic creates many intermediate lists, which can be reduced to a single list.
  I do not believe this code is used in any hot paths (it's mainly there for ObjectSpace) but I modified the logic to only create a single list for all subclasses and descendants in a given subhierarchy.
* The invalidation logic must aggregate invalidators from all subclasses.
  It does this by creating a list of invalidators and adding every invalidator from that class on down, recursively. However, this list is usually all GenerationAndSwitchPointInvalidator, and the SwitchPoints are later reprocessed into another array for bulk invalidation. These collection could be cached, thrown out when any descendant is added or removed by calling up-hierarchy. This would reduce the cost of invalidation, but have a higher in-memory cost. It would also provide no benefits (but no detriments) running on a system that creates many classes.
  This work has yet to be done, and I have not investigated the actual cost of the invalidator gathering.