### PR TITLE
Improve compatibility with MRI's Ripper for JRuby 9.1

### DIFF
--- a/core/src/main/java/org/jruby/ext/ripper/HeredocTerm.java
+++ b/core/src/main/java/org/jruby/ext/ripper/HeredocTerm.java
@@ -200,10 +200,9 @@ public class HeredocTerm extends StrTerm {
             str = tok;
         }
         
-        lexer.dispatchHeredocEnd();
-        lexer.heredoc_restore(this);
-        lexer.setStrTerm(new StringTerm(-1, '\0', '\0'));
+        lexer.pushback(c);
         lexer.setValue(lexer.createStr(str, 0));
+        lexer.flush_string_content(lexer.getEncoding());
         return Tokens.tSTRING_CONTENT;
     }
 }

--- a/core/src/main/java/org/jruby/ext/ripper/RipperLexer.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperLexer.java
@@ -99,6 +99,11 @@ public class RipperLexer extends LexingCommon {
         parser.dispatch("on_operator_ambiguous", getRuntime().newSymbol(op), getRuntime().newString(syn));
     }
 
+    protected void onMagicComment(String name, ByteList value) {
+        super.onMagicComment(name, value);
+        parser.dispatch("on_magic_comment", getRuntime().newString(name), getRuntime().newString(value));
+    }
+
     private int getFloatToken(String number, int suffix) {
         if ((suffix & SUFFIX_R) != 0) {
             BigDecimal bd = new BigDecimal(number);

--- a/core/src/main/java/org/jruby/ext/ripper/RipperLexer.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperLexer.java
@@ -2392,18 +2392,7 @@ public class RipperLexer extends LexingCommon {
     // This is different than MRI in that we return a boolean since we only care whether it was added
     // or not.  The MRI version returns the byte supplied which is never used as a value.
     public boolean tokenAddMBC(int first_byte, ByteList buffer) {
-        int length = precise_mbclen();
-
-        if (length <= 0) {
-            compile_error("invalid multibyte char (" + getEncoding().getName() + ")");
-            return false;
-        }
-
-        tokAdd(first_byte, buffer);                  // add first byte since we have it.
-        lex_p += length - 1;                         // we already read first byte so advance pointer for remainder
-        if (length > 1) tokCopy(length - 1, buffer); // copy next n bytes over.
-
-        return true;
+        return tokadd_mbchar(first_byte, buffer);
     }
 
     // MRI: parser_tokadd_utf8 sans regexp literal parsing

--- a/core/src/main/java/org/jruby/ext/ripper/RipperLexer.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperLexer.java
@@ -96,8 +96,7 @@ public class RipperLexer extends LexingCommon {
     public boolean ignoreNextScanEvent = false;
 
     protected void ambiguousOperator(String op, String syn) {
-        warn("`" + op + "' after local variable or literal is interpreted as binary operator");
-        warn("even though it seems like " + syn);
+        parser.dispatch("on_operator_ambiguous", getRuntime().newSymbol(op), getRuntime().newString(syn));
     }
 
     private int getFloatToken(String number, int suffix) {

--- a/core/src/main/java/org/jruby/ext/ripper/RipperParser.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperParser.java
@@ -2836,6 +2836,7 @@ states[282] = new RipperParserState() {
 states[283] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
                     yyVal = Long.valueOf(p.getCmdArgumentState().getStack());
+                    p.getCmdArgumentState().begin();
     return yyVal;
   }
 };
@@ -4774,6 +4775,6 @@ states[647] = new RipperParserState() {
   }
 };
 }
-					// line 2130 "RipperParser.y"
+					// line 2131 "RipperParser.y"
 }
-					// line 9461 "-"
+					// line 9462 "-"

--- a/core/src/main/java/org/jruby/ext/ripper/RipperParser.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperParser.java
@@ -3564,7 +3564,7 @@ states[410] = new RipperParserState() {
 };
 states[411] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = null;
+                    yyVal = p.getContext().getRuntime().getFalse();
     return yyVal;
   }
 };

--- a/core/src/main/java/org/jruby/ext/ripper/RipperParser.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperParser.java
@@ -2125,7 +2125,7 @@ states[90] = new RipperParserState() {
 };
 states[91] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = ((IRubyObject)yyVals[0+yyTop]);
+                    yyVal = p.assignableIdentifier(((IRubyObject)yyVals[0+yyTop]));
     return yyVal;
   }
 };
@@ -2143,7 +2143,7 @@ states[93] = new RipperParserState() {
 };
 states[94] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.assignable(((IRubyObject)yyVals[0+yyTop]));
+                    yyVal = p.assignableConstant(((IRubyObject)yyVals[0+yyTop]));
     return yyVal;
   }
 };
@@ -2155,50 +2155,43 @@ states[95] = new RipperParserState() {
 };
 states[96] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    p.compile_error("Can't assign to nil");
-                    yyVal = null;
+                    p.yyerror("Can't assign to nil");
     return yyVal;
   }
 };
 states[97] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    p.compile_error("Can't change the value of self");
-                    yyVal = null;
+                    p.yyerror("Can't change the value of self");
     return yyVal;
   }
 };
 states[98] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    p.compile_error("Can't assign to true");
-                    yyVal = null;
+                    p.yyerror("Can't assign to true");
     return yyVal;
   }
 };
 states[99] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    p.compile_error("Can't assign to false");
-                    yyVal = null;
+                    p.yyerror("Can't assign to false");
     return yyVal;
   }
 };
 states[100] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    p.compile_error("Can't assign to __FILE__");
-                    yyVal = null;
+                    p.yyerror("Can't assign to __FILE__");
     return yyVal;
   }
 };
 states[101] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    p.compile_error("Can't assign to __LINE__");
-                    yyVal = null;
+                    p.yyerror("Can't assign to __LINE__");
     return yyVal;
   }
 };
 states[102] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    p.compile_error("Can't assign to __ENCODING__");
-                    yyVal = null;
+                    p.yyerror("Can't assign to __ENCODING__");
     return yyVal;
   }
 };
@@ -2258,73 +2251,73 @@ states[109] = new RipperParserState() {
 };
 states[110] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    yyVal = p.dispatch("on_var_field", p.assignableIdentifier(((IRubyObject)yyVals[0+yyTop])));
     return yyVal;
   }
 };
 states[111] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    yyVal = p.dispatch("on_var_field", ((IRubyObject)yyVals[0+yyTop]));
     return yyVal;
   }
 };
 states[112] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    yyVal = p.dispatch("on_var_field", ((IRubyObject)yyVals[0+yyTop]));
     return yyVal;
   }
 };
 states[113] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    yyVal = p.dispatch("on_var_field", p.assignableConstant(((IRubyObject)yyVals[0+yyTop])));
     return yyVal;
   }
 };
 states[114] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    yyVal = p.dispatch("on_var_field", ((IRubyObject)yyVals[0+yyTop]));
     return yyVal;
   }
 };
 states[115] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    p.yyerror("Can't assign to nil");
     return yyVal;
   }
 };
 states[116] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    p.yyerror("Can't change the value of self");
     return yyVal;
   }
 };
 states[117] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    p.yyerror("Can't assign to true");
     return yyVal;
   }
 };
 states[118] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    p.yyerror("Can't assign to false");
     return yyVal;
   }
 };
 states[119] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    p.yyerror("Can't assign to __FILE__");
     return yyVal;
   }
 };
 states[120] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    p.yyerror("Can't assign to __LINE__");
     return yyVal;
   }
 };
 states[121] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    p.yyerror("Can't assign to __ENCODING__");
     return yyVal;
   }
 };
@@ -3329,7 +3322,7 @@ states[371] = new RipperParserState() {
 };
 states[372] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_mlhs_paren", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    yyVal = p.dispatch("on_mlhs_paren", ((IRubyObject)yyVals[0+yyTop]));
     return yyVal;
   }
 };
@@ -3359,13 +3352,13 @@ states[376] = new RipperParserState() {
 };
 states[377] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_mlhs_add_star", ((IRubyObject)yyVals[-3+yyTop]), p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    yyVal = p.dispatch("on_mlhs_add_star", ((IRubyObject)yyVals[-3+yyTop]), ((IRubyObject)yyVals[0+yyTop]));
     return yyVal;
   }
 };
 states[378] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_mlhs_add_star", ((IRubyObject)yyVals[-5+yyTop]), p.assignable(((IRubyObject)yyVals[-2+yyTop])));
+                    yyVal = p.dispatch("on_mlhs_add_star", ((IRubyObject)yyVals[-5+yyTop]), ((IRubyObject)yyVals[-2+yyTop]));
     return yyVal;
   }
 };
@@ -3383,13 +3376,13 @@ states[380] = new RipperParserState() {
 };
 states[381] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_mlhs_add_star", p.dispatch("on_mlhs_new"), p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    yyVal = p.dispatch("on_mlhs_add_star", p.dispatch("on_mlhs_new"), ((IRubyObject)yyVals[0+yyTop]));
     return yyVal;
   }
 };
 states[382] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_mlhs_add_star", p.assignable(((IRubyObject)yyVals[-2+yyTop])), ((IRubyObject)yyVals[0+yyTop]));
+                    yyVal = p.dispatch("on_mlhs_add_star", ((IRubyObject)yyVals[-2+yyTop]), ((IRubyObject)yyVals[0+yyTop]));
     return yyVal;
   }
 };
@@ -4124,7 +4117,7 @@ states[513] = new RipperParserState() {
 };
 states[514] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    if (p.is_id_var(((IRubyObject)yyVals[0+yyTop]))) {
+                    if (p.is_id_var()) {
                         yyVal = p.dispatch("on_var_ref", ((IRubyObject)yyVals[0+yyTop]));
                     } else {
                         yyVal = p.dispatch("on_vcall", ((IRubyObject)yyVals[0+yyTop]));
@@ -4134,41 +4127,25 @@ states[514] = new RipperParserState() {
 };
 states[515] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    if (p.is_id_var(((IRubyObject)yyVals[0+yyTop]))) {
-                        yyVal = p.dispatch("on_var_ref", ((IRubyObject)yyVals[0+yyTop]));
-                    } else {
-                        yyVal = p.dispatch("on_vcall", ((IRubyObject)yyVals[0+yyTop]));
-                    }
+                    yyVal = p.dispatch("on_var_ref", ((IRubyObject)yyVals[0+yyTop]));
     return yyVal;
   }
 };
 states[516] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    if (p.is_id_var(((IRubyObject)yyVals[0+yyTop]))) {
-                        yyVal = p.dispatch("on_var_ref", ((IRubyObject)yyVals[0+yyTop]));
-                    } else {
-                        yyVal = p.dispatch("on_vcall", ((IRubyObject)yyVals[0+yyTop]));
-                    }
+                    yyVal = p.dispatch("on_var_ref", ((IRubyObject)yyVals[0+yyTop]));
     return yyVal;
   }
 };
 states[517] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    if (p.is_id_var(((IRubyObject)yyVals[0+yyTop]))) {
-                        yyVal = p.dispatch("on_var_ref", p.assignable(((IRubyObject)yyVals[0+yyTop])));
-                    } else {
-                        yyVal = p.dispatch("on_vcall", p.assignable(((IRubyObject)yyVals[0+yyTop])));
-                    }
+                    yyVal = p.dispatch("on_var_ref", ((IRubyObject)yyVals[0+yyTop]));
     return yyVal;
   }
 };
 states[518] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    if (p.is_id_var(((IRubyObject)yyVals[0+yyTop]))) {
-                        yyVal = p.dispatch("on_var_ref", ((IRubyObject)yyVals[0+yyTop]));
-                    } else {
-                        yyVal = p.dispatch("on_vcall", ((IRubyObject)yyVals[0+yyTop]));
-                    }
+                    yyVal = p.dispatch("on_var_ref", ((IRubyObject)yyVals[0+yyTop]));
     return yyVal;
   }
 };
@@ -4216,73 +4193,73 @@ states[525] = new RipperParserState() {
 };
 states[526] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    yyVal = p.dispatch("on_var_field", p.assignableIdentifier(((IRubyObject)yyVals[0+yyTop])));
     return yyVal;
   }
 };
 states[527] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    yyVal = p.dispatch("on_var_field", ((IRubyObject)yyVals[0+yyTop]));
     return yyVal;
   }
 };
 states[528] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    yyVal = p.dispatch("on_var_field", ((IRubyObject)yyVals[0+yyTop]));
     return yyVal;
   }
 };
 states[529] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    yyVal = p.dispatch("on_var_field", p.assignableConstant(((IRubyObject)yyVals[0+yyTop])));
     return yyVal;
   }
 };
 states[530] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    yyVal = p.dispatch("on_var_field", ((IRubyObject)yyVals[0+yyTop]));
     return yyVal;
   }
 };
 states[531] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    p.yyerror("Can't assign to nil");
     return yyVal;
   }
 };
 states[532] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    p.yyerror("Can't change the value of self");
     return yyVal;
   }
 };
 states[533] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    p.yyerror("Can't assign to true");
     return yyVal;
   }
 };
 states[534] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    p.yyerror("Can't assign to false");
     return yyVal;
   }
 };
 states[535] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    p.yyerror("Can't assign to __FILE__");
     return yyVal;
   }
 };
 states[536] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    p.yyerror("Can't assign to __LINE__");
     return yyVal;
   }
 };
 states[537] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.dispatch("on_var_field", p.assignable(((IRubyObject)yyVals[0+yyTop])));
+                    p.yyerror("Can't assign to __ENCODING__");
     return yyVal;
   }
 };
@@ -4486,14 +4463,14 @@ states[570] = new RipperParserState() {
 };
 states[572] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = p.formal_argument(((IRubyObject)yyVals[0+yyTop]));
+                    yyVal = p.arg_var(p.formal_argument(((IRubyObject)yyVals[0+yyTop])));
     return yyVal;
   }
 };
 states[573] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
                     p.setCurrentArg(((IRubyObject)yyVals[0+yyTop]));
-                    yyVal = p.arg_var(((IRubyObject)yyVals[0+yyTop]));
+                    yyVal = ((IRubyObject)yyVals[0+yyTop]);
     return yyVal;
   }
 };
@@ -4608,7 +4585,7 @@ states[590] = new RipperParserState() {
 states[591] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
                     p.setCurrentArg(null);
-                    yyVal = p.new_assoc(p.assignable(((IRubyObject)yyVals[-2+yyTop])), ((IRubyObject)yyVals[0+yyTop]));
+                    yyVal = p.new_assoc(((IRubyObject)yyVals[-2+yyTop]), ((IRubyObject)yyVals[0+yyTop]));
 
     return yyVal;
   }
@@ -4616,7 +4593,7 @@ states[591] = new RipperParserState() {
 states[592] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
                     p.setCurrentArg(null);
-                    yyVal = p.new_assoc(p.assignable(((IRubyObject)yyVals[-2+yyTop])), ((IRubyObject)yyVals[0+yyTop]));
+                    yyVal = p.new_assoc(((IRubyObject)yyVals[-2+yyTop]), ((IRubyObject)yyVals[0+yyTop]));
     return yyVal;
   }
 };
@@ -4797,6 +4774,6 @@ states[647] = new RipperParserState() {
   }
 };
 }
-					// line 2153 "RipperParser.y"
+					// line 2130 "RipperParser.y"
 }
-					// line 9484 "-"
+					// line 9461 "-"

--- a/core/src/main/java/org/jruby/ext/ripper/RipperParser.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperParser.java
@@ -1931,12 +1931,15 @@ states[56] = new RipperParserState() {
 states[57] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
                     p.pushBlockScope();
+                    yyVal = Long.valueOf(p.getCmdArgumentState().getStack());
+                    p.getCmdArgumentState().reset();
     return yyVal;
   }
 };
 states[58] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
                     yyVal = p.dispatch("on_brace_block", ((IRubyObject)yyVals[-2+yyTop]), ((IRubyObject)yyVals[-1+yyTop]));
+                    p.getCmdArgumentState().reset(((Long)yyVals[-3+yyTop]).longValue());
                     p.popCurrentScope();
     return yyVal;
   }
@@ -3735,12 +3738,15 @@ states[438] = new RipperParserState() {
 states[439] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
                     p.pushBlockScope();
+                    yyVal = Long.valueOf(p.getCmdArgumentState().getStack());
+                    p.getCmdArgumentState().reset();
     return yyVal;
   }
 };
 states[440] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
                     yyVal = p.dispatch("on_brace_block", ((IRubyObject)yyVals[-2+yyTop]), ((IRubyObject)yyVals[-1+yyTop]));
+                    p.getCmdArgumentState().reset(((Long)yyVals[-3+yyTop]).longValue());
                     p.popCurrentScope();
     return yyVal;
   }
@@ -3748,12 +3754,15 @@ states[440] = new RipperParserState() {
 states[441] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
                     p.pushBlockScope();
+                    yyVal = Long.valueOf(p.getCmdArgumentState().getStack());
+                    p.getCmdArgumentState().reset();
     return yyVal;
   }
 };
 states[442] = new RipperParserState() {
   @Override public Object execute(RipperParser p, Object yyVal, Object[] yyVals, int yyTop) {
                     yyVal = p.dispatch("on_do_block", ((IRubyObject)yyVals[-2+yyTop]), ((IRubyObject)yyVals[-1+yyTop]));
+                    p.getCmdArgumentState().reset(((Long)yyVals[-3+yyTop]).longValue());
                     p.popCurrentScope();
     return yyVal;
   }
@@ -4775,6 +4784,6 @@ states[647] = new RipperParserState() {
   }
 };
 }
-					// line 2131 "RipperParser.y"
+					// line 2140 "RipperParser.y"
 }
-					// line 9462 "-"
+					// line 9471 "-"

--- a/core/src/main/java/org/jruby/ext/ripper/RipperParser.y
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperParser.y
@@ -1378,7 +1378,7 @@ block_param_def : tPIPE opt_bv_decl tPIPE {
 
 // shadowed block variables....
 opt_bv_decl     : opt_nl {
-                    $$ = null;
+                    $$ = p.getContext().getRuntime().getFalse();
                 }
                 | opt_nl ';' bv_decls opt_nl {
                     $$ = $3;

--- a/core/src/main/java/org/jruby/ext/ripper/RipperParser.y
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperParser.y
@@ -535,7 +535,7 @@ mlhs_post       : mlhs_item {
                 }
 
 mlhs_node       : /*mri:user_variable*/ tIDENTIFIER {
-                    $$ = $1;
+                    $$ = p.assignableIdentifier($1);
                 }
                 | tIVAR {
                     $$ = $1;
@@ -544,38 +544,31 @@ mlhs_node       : /*mri:user_variable*/ tIDENTIFIER {
                     $$ = $1;
                 }
                 | tCONSTANT {
-                    $$ = p.assignable($1);
+                    $$ = p.assignableConstant($1);
                 }
                 | tCVAR {
                     $$ = $1;
                 } /*mri:user_variable*/
                 | /*mri:keyword_variable*/ kNIL {
-                    p.compile_error("Can't assign to nil");
-                    $$ = null;
+                    p.yyerror("Can't assign to nil");
                 }
                 | kSELF {
-                    p.compile_error("Can't change the value of self");
-                    $$ = null;
+                    p.yyerror("Can't change the value of self");
                 }
                 | kTRUE {
-                    p.compile_error("Can't assign to true");
-                    $$ = null;
+                    p.yyerror("Can't assign to true");
                 }
                 | kFALSE {
-                    p.compile_error("Can't assign to false");
-                    $$ = null;
+                    p.yyerror("Can't assign to false");
                 }
                 | k__FILE__ {
-                    p.compile_error("Can't assign to __FILE__");
-                    $$ = null;
+                    p.yyerror("Can't assign to __FILE__");
                 }
                 | k__LINE__ {
-                    p.compile_error("Can't assign to __LINE__");
-                    $$ = null;
+                    p.yyerror("Can't assign to __LINE__");
                 }
                 | k__ENCODING__ {
-                    p.compile_error("Can't assign to __ENCODING__");
-                    $$ = null;
+                    p.yyerror("Can't assign to __ENCODING__");
                 } /*mri:keyword_variable*/
                 | primary_value '[' opt_call_args rbracket {
                     $$ = p.dispatch("on_aref_field", $1, $3);
@@ -612,40 +605,40 @@ mlhs_node       : /*mri:user_variable*/ tIDENTIFIER {
                 }
 
 lhs             : /*mri:user_variable*/ tIDENTIFIER {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    $$ = p.dispatch("on_var_field", p.assignableIdentifier($1));
                 }
                 | tIVAR {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    $$ = p.dispatch("on_var_field", $1);
                 }
                 | tGVAR {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    $$ = p.dispatch("on_var_field", $1);
                 }
                 | tCONSTANT {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    $$ = p.dispatch("on_var_field", p.assignableConstant($1));
                 }
                 | tCVAR {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    $$ = p.dispatch("on_var_field", $1);
                 } /*mri:user_variable*/
                 | /*mri:keyword_variable*/ kNIL {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    p.yyerror("Can't assign to nil");
                 }
                 | kSELF {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    p.yyerror("Can't change the value of self");
                 }
                 | kTRUE {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    p.yyerror("Can't assign to true");
                 }
                 | kFALSE {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    p.yyerror("Can't assign to false");
                 }
                 | k__FILE__ {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    p.yyerror("Can't assign to __FILE__");
                 }
                 | k__LINE__ {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    p.yyerror("Can't assign to __LINE__");
                 }
                 | k__ENCODING__ {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    p.yyerror("Can't assign to __ENCODING__");
                 } /*mri:keyword_variable*/
                 | primary_value '[' opt_call_args rbracket {
                     $$ = p.dispatch("on_aref_field", $1, $3);
@@ -1244,7 +1237,7 @@ for_var         : lhs
                 }
 
 f_marg          : f_norm_arg {
-                    $$ = p.dispatch("on_mlhs_paren", p.assignable($1));
+                    $$ = p.dispatch("on_mlhs_paren", $1);
                 }
                 | tLPAREN f_margs rparen {
                     $$ = p.dispatch("on_mlhs_paren", $2);
@@ -1262,10 +1255,10 @@ f_margs         : f_marg_list {
                     $$ = $1;
                 }
                 | f_marg_list ',' tSTAR f_norm_arg {
-                    $$ = p.dispatch("on_mlhs_add_star", $1, p.assignable($4));
+                    $$ = p.dispatch("on_mlhs_add_star", $1, $4);
                 }
                 | f_marg_list ',' tSTAR f_norm_arg ',' f_marg_list {
-                    $$ = p.dispatch("on_mlhs_add_star", $1, p.assignable($4));
+                    $$ = p.dispatch("on_mlhs_add_star", $1, $4);
                 }
                 | f_marg_list ',' tSTAR {
                     $$ = p.dispatch("on_mlhs_add_star", $1, null);
@@ -1274,10 +1267,10 @@ f_margs         : f_marg_list {
                     $$ = p.dispatch("on_mlhs_add_star", $1, $5);
                 }
                 | tSTAR f_norm_arg {
-                    $$ = p.dispatch("on_mlhs_add_star", p.dispatch("on_mlhs_new"), p.assignable($2));
+                    $$ = p.dispatch("on_mlhs_add_star", p.dispatch("on_mlhs_new"), $2);
                 }
                 | tSTAR f_norm_arg ',' f_marg_list {
-                    $$ = p.dispatch("on_mlhs_add_star", p.assignable($2), $4);
+                    $$ = p.dispatch("on_mlhs_add_star", $2, $4);
                 }
                 | tSTAR {
                     $$ = p.dispatch("on_mlhs_add_star", p.dispatch("on_mlhs_new"), null);
@@ -1721,39 +1714,23 @@ simple_numeric  : tINTEGER {
  
 // [!null]
 var_ref         : /*mri:user_variable*/ tIDENTIFIER {
-                    if (p.is_id_var($1)) {
+                    if (p.is_id_var()) {
                         $$ = p.dispatch("on_var_ref", $1);
                     } else {
                         $$ = p.dispatch("on_vcall", $1);
                     }
                 }
                 | tIVAR {
-                    if (p.is_id_var($1)) {
-                        $$ = p.dispatch("on_var_ref", $1);
-                    } else {
-                        $$ = p.dispatch("on_vcall", $1);
-                    }
+                    $$ = p.dispatch("on_var_ref", $1);
                 }
                 | tGVAR {
-                    if (p.is_id_var($1)) {
-                        $$ = p.dispatch("on_var_ref", $1);
-                    } else {
-                        $$ = p.dispatch("on_vcall", $1);
-                    }
+                    $$ = p.dispatch("on_var_ref", $1);
                 }
                 | tCONSTANT {
-                    if (p.is_id_var($1)) {
-                        $$ = p.dispatch("on_var_ref", p.assignable($1));
-                    } else {
-                        $$ = p.dispatch("on_vcall", p.assignable($1));
-                    }
+                    $$ = p.dispatch("on_var_ref", $1);
                 }
                 | tCVAR {
-                    if (p.is_id_var($1)) {
-                        $$ = p.dispatch("on_var_ref", $1);
-                    } else {
-                        $$ = p.dispatch("on_vcall", $1);
-                    }
+                    $$ = p.dispatch("on_var_ref", $1);
                 } /*mri:user_variable*/
                 | /*mri:keyword_variable*/ kNIL {
                     $$ = p.dispatch("on_var_ref", $1);
@@ -1779,40 +1756,40 @@ var_ref         : /*mri:user_variable*/ tIDENTIFIER {
 
 // [!null]
 var_lhs         : /*mri:user_variable*/ tIDENTIFIER {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    $$ = p.dispatch("on_var_field", p.assignableIdentifier($1));
                 }
                 | tIVAR {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    $$ = p.dispatch("on_var_field", $1);
                 }
                 | tGVAR {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    $$ = p.dispatch("on_var_field", $1);
                 }
                 | tCONSTANT {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    $$ = p.dispatch("on_var_field", p.assignableConstant($1));
                 }
                 | tCVAR {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    $$ = p.dispatch("on_var_field", $1);
                 } /*mri:user_variable*/
                 | /*mri:keyword_variable*/ kNIL {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    p.yyerror("Can't assign to nil");
                 }
                 | kSELF {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    p.yyerror("Can't change the value of self");
                 }
                 | kTRUE {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    p.yyerror("Can't assign to true");
                 }
                 | kFALSE {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    p.yyerror("Can't assign to false");
                 }
                 | k__FILE__ {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    p.yyerror("Can't assign to __FILE__");
                 }
                 | k__LINE__ {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    p.yyerror("Can't assign to __LINE__");
                 }
                 | k__ENCODING__ {
-                    $$ = p.dispatch("on_var_field", p.assignable($1));
+                    p.yyerror("Can't assign to __ENCODING__");
                 } /*mri:keyword_variable*/
  
 
@@ -1935,12 +1912,12 @@ f_bad_arg       : tCONSTANT {
 // Token:f_norm_arg [!null]
 f_norm_arg      : f_bad_arg
                 | tIDENTIFIER {
-                    $$ = p.formal_argument($1);
+                    $$ = p.arg_var(p.formal_argument($1));
                 }
 
 f_arg_asgn      : f_norm_arg {
                     p.setCurrentArg($1);
-                    $$ = p.arg_var($1);
+                    $$ = $1;
                 }
 
 f_arg_item      : f_arg_asgn {
@@ -2012,13 +1989,13 @@ f_kwrest        : kwrest_mark tIDENTIFIER {
 
 f_opt           : f_arg_asgn '=' arg_value {
                     p.setCurrentArg(null);
-                    $$ = p.new_assoc(p.assignable($1), $3);
+                    $$ = p.new_assoc($1, $3);
 
                 }
 
 f_block_opt     : f_arg_asgn '=' primary_value {
                     p.setCurrentArg(null);
-                    $$ = p.new_assoc(p.assignable($1), $3);
+                    $$ = p.new_assoc($1, $3);
                 }
 
 f_block_optarg  : f_block_opt {

--- a/core/src/main/java/org/jruby/ext/ripper/RipperParser.y
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperParser.y
@@ -411,8 +411,11 @@ block_command   : block_call
 // :brace_block - [!null]
 cmd_brace_block : tLBRACE_ARG {
                     p.pushBlockScope();
+                    $$ = Long.valueOf(p.getCmdArgumentState().getStack());
+                    p.getCmdArgumentState().reset();
                 } opt_block_param compstmt tRCURLY {
                     $$ = p.dispatch("on_brace_block", $3, $4);
+                    p.getCmdArgumentState().reset($<Long>2.longValue());
                     p.popCurrentScope();
                 }
 
@@ -1473,14 +1476,20 @@ method_call     : fcall paren_args {
 
 brace_block     : tLCURLY {
                     p.pushBlockScope();
+                    $$ = Long.valueOf(p.getCmdArgumentState().getStack());
+                    p.getCmdArgumentState().reset();
                 } opt_block_param compstmt tRCURLY {
                     $$ = p.dispatch("on_brace_block", $3, $4);
+                    p.getCmdArgumentState().reset($<Long>2.longValue());
                     p.popCurrentScope();
                 }
                 | kDO {
                     p.pushBlockScope();
+                    $$ = Long.valueOf(p.getCmdArgumentState().getStack());
+                    p.getCmdArgumentState().reset();
                 } opt_block_param compstmt kEND {
                     $$ = p.dispatch("on_do_block", $3, $4);
+                    p.getCmdArgumentState().reset($<Long>2.longValue());
                     p.popCurrentScope();
                 }
 

--- a/core/src/main/java/org/jruby/ext/ripper/RipperParser.y
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperParser.y
@@ -962,6 +962,7 @@ call_args       : command {
 
 command_args    : /* none */ {
                     $$ = Long.valueOf(p.getCmdArgumentState().getStack());
+                    p.getCmdArgumentState().begin();
                 } call_args {
                     p.getCmdArgumentState().reset($<Long>1.longValue());
                     $$ = $2;

--- a/core/src/main/java/org/jruby/ext/ripper/RipperParserBase.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperParserBase.java
@@ -108,44 +108,21 @@ public class RipperParserBase {
                 
         return identifier;
     }
-    
-    public IRubyObject assignable(IRubyObject name) {
-        // MRI calls get_id(name), but we differ quite a bit and we only need to worry about strings
-        // for anything we care about.  Possibly this should return nil and not original value?
-        if (!(name instanceof RubyString)) return name;
-        
-        String javaName = name.asJavaString();
-        
-        if (javaName.equals("self")) {
-            yyerror("Can't change the value of self");
-        } else if (javaName.equals("nil")) {
-            yyerror("Can't assign to nil");
-        } else if (javaName.equals("true")) {
-            yyerror("Can't assign to true");
-        } else if (javaName.equals("false")) {
-            yyerror("Can't assign to false");
-        } else if (javaName.equals("__FILE__")) {
-            yyerror("Can't assign to __FILE__");
-        } else if (javaName.equals("__LINE__")) {
-            yyerror("Can't assign to __LINE__");
-        } else if (Character.isUpperCase(javaName.charAt(0))) { // MRI: ID_CONST
-            if (isInDef() || isInSingle()) dispatch("on_assign_error", name);
-            return name;
-        } else if (javaName.charAt(0) == '@') { // MRI: ID_CLASS & ID_INSTANCE
-            if (javaName.charAt(1) == '@') {
-                return name;
-            } else {
-                return name;
-            }
-        } else if (javaName.charAt(0) == '$') { // MRI: ID_GLOBAL
-            return name;
-        }
 
-        currentScope.assign(lexer.getPosition(), javaName.intern(), null);
-        
-        return name;
+    public IRubyObject assignableConstant(IRubyObject value) {
+        if (isInDef() || isInSingle()) {
+            return dispatch("on_assign_error", value);
+        } else {
+            return value;
+        }
     }
-    
+
+    public IRubyObject assignableIdentifier(IRubyObject value) {
+        String ident = lexer.getIdent().intern();
+        getCurrentScope().assign(lexer.getPosition(), ident, null);
+        return value;
+    }
+
     public IRubyObject dispatch(String method_name) {
         return Helpers.invoke(context, ripper, method_name);
     }
@@ -186,12 +163,8 @@ public class RipperParserBase {
         throw new SyntaxException("identifier " + identifier + " is not valid", identifier);
     }    
     
-    // FIXME: Consider removing identifier.
-    public boolean is_id_var(IRubyObject identifier) {
+    public boolean is_id_var() {
         String ident = lexer.getIdent().intern();
-        char c = ident.charAt(0);
-        
-        if (c == '$' || c == '@' || Character.toUpperCase(c) == c) return true;
 
         return getCurrentScope().isDefined(ident) >= 0;
     }

--- a/core/src/main/java/org/jruby/ext/ripper/RipperParserBase.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperParserBase.java
@@ -193,7 +193,7 @@ public class RipperParserBase {
         
         if (c == '$' || c == '@' || Character.toUpperCase(c) == c) return true;
 
-        return getCurrentScope().getLocalScope().isDefined(ident) >= 0;
+        return getCurrentScope().isDefined(ident) >= 0;
     }
     
     public boolean is_local_id(String identifier) {

--- a/core/src/main/java/org/jruby/ext/ripper/RipperParserBase.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperParserBase.java
@@ -242,6 +242,7 @@ public class RipperParserBase {
     
     public void pushLocalScope() {
         currentScope = getRuntime().getStaticScopeFactory().newLocalScope(currentScope);
+        getCmdArgumentState().reset();
     }
 
     public int getHeredocIndent() {

--- a/core/src/main/java/org/jruby/ext/ripper/StringTerm.java
+++ b/core/src/main/java/org/jruby/ext/ripper/StringTerm.java
@@ -78,8 +78,6 @@ public class StringTerm extends StrTerm {
         boolean spaceSeen = false;
         int c;
 
-        // FIXME: How much more obtuse can this be?
-        // Heredoc already parsed this and saved string...Do not parse..just return
         if (flags == -1) {
             lexer.ignoreNextScanEvent = true;
             return Tokens.tSTRING_END;

--- a/core/src/main/java/org/jruby/lexer/LexingCommon.java
+++ b/core/src/main/java/org/jruby/lexer/LexingCommon.java
@@ -907,17 +907,19 @@ public abstract class LexingCommon {
             String name = magicLine.subSequence(beg, end).toString().replace('-', '_');
             ByteList value = magicLine.makeShared(vbeg, vend - vbeg);
 
-            if ("coding".equals(name) || "encoding".equals(name)) {
-                magicCommentEncoding(value);
-            } else if ("frozen_string_literal".equals(name)) {
-                setCompileOptionFlag(name, value);
-            } else if ("warn_indent".equals(name)) {
-                setTokenInfo(name, value);
-            } else {
-                return false;
-            }
+            onMagicComment(name, value);
         }
 
         return true;
+    }
+
+    protected void onMagicComment(String name, ByteList value) {
+        if ("coding".equals(name) || "encoding".equals(name)) {
+            magicCommentEncoding(value);
+        } else if ("frozen_string_literal".equals(name)) {
+            setCompileOptionFlag(name, value);
+        } else if ("warn_indent".equals(name)) {
+            setTokenInfo(name, value);
+        }
     }
 }

--- a/core/src/main/java/org/jruby/lexer/LexingCommon.java
+++ b/core/src/main/java/org/jruby/lexer/LexingCommon.java
@@ -547,6 +547,7 @@ public abstract class LexingCommon {
 
         if (length <= 0) {
             compile_error("invalid multibyte char (" + getEncoding() + ")");
+            return false;
         } else if (length > 1) {
             tokenCR = StringSupport.CR_VALID;
         }
@@ -560,7 +561,10 @@ public abstract class LexingCommon {
     public boolean tokadd_mbchar(int first_byte, ByteList buffer) {
         int length = precise_mbclen();
 
-        if (length <= 0) compile_error("invalid multibyte char (" + getEncoding() + ")");
+        if (length <= 0) {
+            compile_error("invalid multibyte char (" + getEncoding() + ")");
+            return false;
+        }
 
         tokAdd(first_byte, buffer);                  // add first byte since we have it.
         lex_p += length - 1;                         // we already read first byte so advance pointer for remainder

--- a/core/src/main/java/org/jruby/lexer/yacc/HeredocTerm.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/HeredocTerm.java
@@ -188,8 +188,7 @@ public class HeredocTerm extends StrTerm {
             str = tok;
         }
 
-        lexer.heredoc_restore(this);
-        lexer.setStrTerm(new StringTerm(-1, '\0', '\0', lexer.getRubySourceline()));
+        lexer.pushback(c);
         lexer.setValue(lexer.createStr(str, 0));
         return Tokens.tSTRING_CONTENT;
     }

--- a/core/src/main/java/org/jruby/lexer/yacc/StringTerm.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/StringTerm.java
@@ -166,8 +166,6 @@ public class StringTerm extends StrTerm {
         boolean spaceSeen = false;
         int c;
 
-        // FIXME: How much more obtuse can this be?
-        // Heredoc already parsed this and saved string...Do not parse..just return
         if (flags == -1) {
             lexer.setValue("" + end);
             return Tokens.tSTRING_END;

--- a/test/jruby/test_ripper.rb
+++ b/test/jruby/test_ripper.rb
@@ -33,4 +33,8 @@ class TestJRubyRipper < Test::Unit::TestCase
     assert_equal nil, extract("p{||}", :on_block_var).last
     assert_equal false, extract("p{|a|}", :on_block_var).last
   end
+
+  def test_block_local_var_ref
+    assert_equal [:on_var_ref, [:@ident, "a", [1, 5]]], extract("p{|a|a}", :on_var_ref)
+  end
 end

--- a/test/jruby/test_ripper.rb
+++ b/test/jruby/test_ripper.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+
+require 'test/unit'
+require 'ripper'
+
+class TestJRubyRipper < Test::Unit::TestCase
+  def test_invalid_bytecode
+    assert_equal nil, Ripper.sexp("\xae")
+    assert_equal nil, Ripper.sexp("\xaeb")
+    assert_equal nil, Ripper.sexp("a\xae")
+    assert_equal nil, Ripper.sexp("a\xae = 0")
+  end
+end

--- a/test/jruby/test_ripper.rb
+++ b/test/jruby/test_ripper.rb
@@ -4,10 +4,33 @@ require 'test/unit'
 require 'ripper'
 
 class TestJRubyRipper < Test::Unit::TestCase
+  class ExtractRipper < Ripper::SexpBuilderPP
+    def attach(method, &block)
+      class << self; self; end.class_eval do
+        m = method
+        define_method(m) do |*args|
+          yield(m, *args)
+        end
+      end
+      self
+    end
+  end
+
+  def extract(source, method)
+    ret = nil
+    ExtractRipper.new(source).attach(method) { |*args| ret ||= args }.parse
+    ret
+  end
+
   def test_invalid_bytecode
     assert_equal nil, Ripper.sexp("\xae")
     assert_equal nil, Ripper.sexp("\xaeb")
     assert_equal nil, Ripper.sexp("a\xae")
     assert_equal nil, Ripper.sexp("a\xae = 0")
+  end
+
+  def test_opt_bv_decl
+    assert_equal nil, extract("p{||}", :on_block_var).last
+    assert_equal false, extract("p{|a|}", :on_block_var).last
   end
 end

--- a/test/jruby/test_ripper.rb
+++ b/test/jruby/test_ripper.rb
@@ -45,4 +45,8 @@ class TestJRubyRipper < Test::Unit::TestCase
     assert_equal [:on_var_ref, [:@ident, "a", [1, 6]]], extract("p{a=1;a}", :on_var_ref)
     assert_equal [:on_var_ref, [:@ident, "a", [1, 6]]], extract("p{|&a|a}", :on_var_ref)
   end
+
+  def test_command_args
+    assert_equal :command, extract("p m do; end", :on_method_add_block).dig(1, 0)
+  end
 end

--- a/test/jruby/test_ripper.rb
+++ b/test/jruby/test_ripper.rb
@@ -49,4 +49,9 @@ class TestJRubyRipper < Test::Unit::TestCase
   def test_command_args
     assert_equal :command, extract("p m do; end", :on_method_add_block).dig(1, 0)
   end
+
+  def test_heredoc
+    assert_equal [:on_string_content, [:@tstring_content, "x\n", [2, 0]]], extract("<<EOS\nx\nEOS\n", :on_string_content)
+    assert_equal [:on_string_content, [:string_embexpr, [[:vcall, [:@ident, "o", [2, 2]]]]], [:@tstring_content, "x\n", [2, 4]]], extract("<<EOS\n\#{o}x\nEOS\n", :on_string_content)
+  end
 end

--- a/test/jruby/test_ripper.rb
+++ b/test/jruby/test_ripper.rb
@@ -37,4 +37,12 @@ class TestJRubyRipper < Test::Unit::TestCase
   def test_block_local_var_ref
     assert_equal [:on_var_ref, [:@ident, "a", [1, 5]]], extract("p{|a|a}", :on_var_ref)
   end
+
+  def test_var_ref
+    assert_equal [:on_var_ref, [:@ident, "a", [1, 9]]], extract("p{|(a,b)|a}", :on_var_ref)
+    assert_equal [:on_var_ref, [:@ident, "a", [1, 7]]], extract("p{|a=1|a}", :on_var_ref)
+    assert_equal [:on_var_ref, [:@ident, "a", [1, 9]]], extract("p{|a=1+1|a}", :on_var_ref)
+    assert_equal [:on_var_ref, [:@ident, "a", [1, 6]]], extract("p{a=1;a}", :on_var_ref)
+    assert_equal [:on_var_ref, [:@ident, "a", [1, 6]]], extract("p{|&a|a}", :on_var_ref)
+  end
 end

--- a/test/mri.index
+++ b/test/mri.index
@@ -327,11 +327,13 @@ psych/visitors/test_emitter.rb
 psych/visitors/test_to_ruby.rb
 psych/visitors/test_yaml_tree.rb
 
-ripper/test_files.rb
+# Assumes MRI source layout to randomly rip .rb files
+# ripper/test_files.rb
 ripper/test_filter.rb
 ripper/test_parser_events.rb
 ripper/test_ripper.rb
 ripper/test_scanner_events.rb
+ripper/test_sexp.rb
 
 scanf/test_scanf.rb
 scanf/test_scanfblocks.rb

--- a/test/mri/excludes/TestRipper/Filter.rb
+++ b/test/mri/excludes/TestRipper/Filter.rb
@@ -1,3 +1,0 @@
-exclude :test_filter_lineno, "needs investigation"
-exclude :test_filter_lineno_set, "needs investigation"
-

--- a/test/mri/excludes/TestRipper/Generic.rb
+++ b/test/mri/excludes/TestRipper/Generic.rb
@@ -1,1 +1,0 @@
-exclude :test_parse_files, "assumes MRI source layout to randomly rip .rb files"

--- a/test/mri/excludes/TestRipper/ParserEvents.rb
+++ b/test/mri/excludes/TestRipper/ParserEvents.rb
@@ -1,4 +1,3 @@
-exclude :test_block_variables, "missing rlimit used in this test; related to #2776"
 exclude :test_event_coverage, "needs investigation"
 exclude :test_local_variables, "needs investigation"
 exclude :test_magic_comment, "needs investigation"

--- a/test/mri/excludes/TestRipper/ParserEvents.rb
+++ b/test/mri/excludes/TestRipper/ParserEvents.rb
@@ -1,4 +1,3 @@
 exclude :test_event_coverage, "needs investigation"
-exclude :test_local_variables, "needs investigation"
 exclude :test_magic_comment, "needs investigation"
 exclude :test_operator_ambiguous, "needs investigation"

--- a/test/mri/excludes/TestRipper/ParserEvents.rb
+++ b/test/mri/excludes/TestRipper/ParserEvents.rb
@@ -1,2 +1,0 @@
-exclude :test_event_coverage, "needs investigation"
-exclude :test_magic_comment, "needs investigation"

--- a/test/mri/excludes/TestRipper/ParserEvents.rb
+++ b/test/mri/excludes/TestRipper/ParserEvents.rb
@@ -1,3 +1,2 @@
 exclude :test_event_coverage, "needs investigation"
 exclude :test_magic_comment, "needs investigation"
-exclude :test_operator_ambiguous, "needs investigation"

--- a/test/mri/excludes/TestRipper/Ripper.rb
+++ b/test/mri/excludes/TestRipper/Ripper.rb
@@ -1,1 +1,1 @@
-exclude :test_regexp_with_option, "needs investigation #4308"
+exclude :test_regexp_with_option, 'needs regexp validation'

--- a/test/mri/excludes/TestRipper/Sexp.rb
+++ b/test/mri/excludes/TestRipper/Sexp.rb
@@ -1,0 +1,3 @@
+exclude :test_compile_error, 'needs regexp validation'
+exclude :test_heredoc_content, 'last string_token broken'
+exclude :test_squiggly_heredoc, 'last string_token broken'

--- a/test/mri/excludes/TestRipper/Sexp.rb
+++ b/test/mri/excludes/TestRipper/Sexp.rb
@@ -1,3 +1,1 @@
 exclude :test_compile_error, 'needs regexp validation'
-exclude :test_heredoc_content, 'last string_token broken'
-exclude :test_squiggly_heredoc, 'last string_token broken'


### PR DESCRIPTION
Same as #4898, but targeted on jruby-9.1 branch instead.

The main difference is that it skips https://github.com/jruby/jruby/pull/4898/commits/1763e4e3c1a5d121cec042663d60bc5309c6d379 that aligned the main parser and Ripper parser, as it seems the misalignment doesn't exist on this branch.