### PR TITLE
Add support for validating Regexp in Ripper

### DIFF
--- a/core/src/main/java/org/jruby/ext/ripper/RipperLexer.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperLexer.java
@@ -418,6 +418,12 @@ public class RipperLexer extends LexingCommon {
     }
 
     @Override
+    protected void mismatchedRegexpEncodingError(Encoding optionEncoding, Encoding encoding) {
+        compile_error("regexp encoding option '" + optionsEncodingChar(optionEncoding) +
+                "' differs from source encoding '" + encoding + "'");
+    }
+
+    @Override
     protected void setTokenInfo(String name, ByteList value) {
 
     }

--- a/core/src/main/java/org/jruby/ext/ripper/RipperLexer.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperLexer.java
@@ -37,6 +37,7 @@ import org.jruby.lexer.LexerSource;
 import org.jruby.lexer.LexingCommon;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
+import org.jruby.util.RegexpOptions;
 import org.jruby.util.SafeDoubleParser;
 import org.jruby.util.StringSupport;
 import org.jruby.util.cli.Options;
@@ -403,6 +404,17 @@ public class RipperLexer extends LexingCommon {
             warning("`%s' is ignored after any tokens", name);
             return;
         }
+    }
+
+    @Override
+    protected RegexpOptions parseRegexpFlags() throws IOException {
+        StringBuilder unknownFlags = new StringBuilder(10);
+        RegexpOptions options = parseRegexpFlags(unknownFlags);
+        if (unknownFlags.length() != 0) {
+            compile_error("unknown regexp option" +
+                    (unknownFlags.length() > 1 ? "s" : "") + " - " + unknownFlags);
+        }
+        return options;
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ext/ripper/StringTerm.java
+++ b/core/src/main/java/org/jruby/ext/ripper/StringTerm.java
@@ -69,7 +69,10 @@ public class StringTerm extends StrTerm {
                 return ' ';
             }
 
-            if ((flags & STR_FUNC_REGEXP) != 0) return parseRegexpFlags(lexer);
+            if ((flags & STR_FUNC_REGEXP) != 0) {
+                lexer.parseRegexpFlags();
+                return RubyParser.tREGEXP_END;
+            }
 
             return RubyParser.tSTRING_END;
     }
@@ -131,29 +134,6 @@ public class StringTerm extends StrTerm {
         lexer.setValue(lexer.createStr(buffer, flags));
         lexer.flush_string_content(enc[0]);
         return RubyParser.tSTRING_CONTENT;
-    }
-
-    private int parseRegexpFlags(RipperLexer lexer) throws IOException {
-        int c;
-        StringBuilder unknownFlags = new StringBuilder(10);
-
-        for (c = lexer.nextc(); c != EOF
-                && Character.isLetter(c); c = lexer.nextc()) {
-            switch (c) {
-                case 'i': case 'x': case 'm': case 'o': case 'n':
-                case 'e': case 's': case 'u':
-                break;
-            default:
-                unknownFlags.append((char) c);
-                break;
-            }
-        }
-        lexer.pushback(c);
-        if (unknownFlags.length() != 0) {
-            lexer.compile_error("unknown regexp option" + (unknownFlags.length() > 1 ? "s" : "") + " - " + unknownFlags.toString());
-        }
-
-        return RubyParser.tREGEXP_END;
     }
 
     private void mixedEscape(RipperLexer lexer, Encoding foundEncoding, Encoding parserEncoding) {

--- a/core/src/main/java/org/jruby/lexer/LexingCommon.java
+++ b/core/src/main/java/org/jruby/lexer/LexingCommon.java
@@ -1174,7 +1174,7 @@ public abstract class LexingCommon {
 
             value.setEncoding(optionsEncoding);
         } else if (options.isEncodingNone()) {
-            if (value.getEncoding() == ASCII8BIT_ENCODING && !is7BitASCII(value)) {
+            if (value.getEncoding() != ASCII8BIT_ENCODING && !is7BitASCII(value)) {
                 mismatchedRegexpEncodingError(optionsEncoding, value.getEncoding());
             }
             value.setEncoding(ASCII8BIT_ENCODING);

--- a/core/src/main/java/org/jruby/lexer/LexingCommon.java
+++ b/core/src/main/java/org/jruby/lexer/LexingCommon.java
@@ -18,6 +18,8 @@ import org.jruby.lexer.yacc.ISourcePosition;
 import org.jruby.lexer.yacc.SimpleSourcePosition;
 import org.jruby.lexer.yacc.StackState;
 import org.jruby.util.ByteList;
+import org.jruby.util.KCode;
+import org.jruby.util.RegexpOptions;
 import org.jruby.util.StringSupport;
 import org.jruby.util.io.EncodingUtils;
 
@@ -1086,5 +1088,51 @@ public abstract class LexingCommon {
             return true;
         }
         return false;
+    }
+
+    protected abstract RegexpOptions parseRegexpFlags() throws IOException;
+
+    protected RegexpOptions parseRegexpFlags(StringBuilder unknownFlags) throws IOException {
+        RegexpOptions options = new RegexpOptions();
+        int c;
+
+        newtok(true);
+        for (c = nextc(); c != EOF && Character.isLetter(c); c = nextc()) {
+            switch (c) {
+            case 'i':
+                options.setIgnorecase(true);
+                break;
+            case 'x':
+                options.setExtended(true);
+                break;
+            case 'm':
+                options.setMultiline(true);
+                break;
+            case 'o':
+                options.setOnce(true);
+                break;
+            case 'n':
+                options.setExplicitKCode(KCode.NONE);
+                break;
+            case 'e':
+                options.setExplicitKCode(KCode.EUC);
+                break;
+            case 's':
+                options.setExplicitKCode(KCode.SJIS);
+                break;
+            case 'u':
+                options.setExplicitKCode(KCode.UTF8);
+                break;
+            case 'j':
+                options.setJava(true);
+                break;
+            default:
+                unknownFlags.append((char) c);
+                break;
+            }
+        }
+        pushback(c);
+
+        return options;
     }
 }

--- a/core/src/main/java/org/jruby/lexer/LexingCommon.java
+++ b/core/src/main/java/org/jruby/lexer/LexingCommon.java
@@ -18,6 +18,8 @@ import org.jruby.javasupport.ext.JavaLang;
 import org.jruby.lexer.yacc.ISourcePosition;
 import org.jruby.lexer.yacc.SimpleSourcePosition;
 import org.jruby.lexer.yacc.StackState;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 import org.jruby.util.KCode;
 import org.jruby.util.RegexpOptions;
@@ -1139,9 +1141,12 @@ public abstract class LexingCommon {
 
     public void checkRegexpFragment(Ruby runtime, ByteList value, RegexpOptions options) {
         setRegexpEncoding(runtime, value, options);
+        ThreadContext context = runtime.getCurrentContext();
+        IRubyObject $ex = context.getErrorInfo();
         try {
             RubyRegexp.preprocessCheck(runtime, value);
         } catch (RaiseException re) {
+            context.setErrorInfo($ex);
             compile_error(re.getMessage());
         }
     }
@@ -1152,10 +1157,13 @@ public abstract class LexingCommon {
         if (stringValue.startsWith("(?u)") || stringValue.startsWith("(?a)") || stringValue.startsWith("(?d)"))
             return;
 
+        ThreadContext context = runtime.getCurrentContext();
+        IRubyObject $ex = context.getErrorInfo();
         try {
             // This is only for syntax checking but this will as a side-effect create an entry in the regexp cache.
             RubyRegexp.newRegexpParser(runtime, value, (RegexpOptions)options.clone());
         } catch (RaiseException re) {
+            context.setErrorInfo($ex);
             compile_error(re.getMessage());
         }
     }

--- a/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
@@ -62,6 +62,7 @@ import org.jruby.lexer.yacc.SyntaxException.PID;
 import org.jruby.parser.ParserSupport;
 import org.jruby.parser.RubyParser;
 import org.jruby.util.ByteList;
+import org.jruby.util.RegexpOptions;
 import org.jruby.util.SafeDoubleParser;
 import org.jruby.util.StringSupport;
 import org.jruby.util.cli.Options;
@@ -436,6 +437,17 @@ public class RubyLexer extends LexingCommon {
         // Enebo: This is a hash in MRI for multiple potential compile options but we currently only support one.
         // I am just going to set it and when a second is done we will reevaluate how they are populated.
         parserSupport.getConfiguration().setFrozenStringLiteral(b == 1);
+    }
+
+    @Override
+    protected RegexpOptions parseRegexpFlags() throws IOException {
+        StringBuilder unknownFlags = new StringBuilder(10);
+        RegexpOptions options = parseRegexpFlags(unknownFlags);
+        if (unknownFlags.length() != 0) {
+            compile_error(PID.REGEXP_UNKNOWN_OPTION, "unknown regexp option" +
+                    (unknownFlags.length() > 1 ? "s" : "") + " - " + unknownFlags);
+        }
+        return options;
     }
 
     private final ByteList TRUE = new ByteList(new byte[] {'t', 'r', 'u', 'e'});

--- a/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
@@ -450,6 +450,12 @@ public class RubyLexer extends LexingCommon {
         return options;
     }
 
+    @Override
+    protected void mismatchedRegexpEncodingError(Encoding optionEncoding, Encoding encoding) {
+        compile_error(PID.REGEXP_ENCODING_MISMATCH, "regexp encoding option '" + optionsEncodingChar(optionEncoding) +
+                "' differs from source encoding '" + encoding + "'");
+    }
+
     private final ByteList TRUE = new ByteList(new byte[] {'t', 'r', 'u', 'e'});
     private final ByteList FALSE = new ByteList(new byte[] {'f', 'a', 'l', 's', 'e'});
     protected int asTruth(String name, ByteList value) {

--- a/core/src/main/java/org/jruby/lexer/yacc/StringTerm.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/StringTerm.java
@@ -33,7 +33,6 @@ import org.jruby.ast.RegexpNode;
 import org.jruby.lexer.yacc.SyntaxException.PID;
 import org.jruby.parser.RubyParser;
 import org.jruby.util.ByteList;
-import org.jruby.util.KCode;
 import org.jruby.util.RegexpOptions;
 
 import static org.jruby.lexer.LexingCommon.*;
@@ -80,7 +79,7 @@ public class StringTerm extends StrTerm {
             }
 
             if ((flags & STR_FUNC_REGEXP) != 0) {
-                RegexpOptions options = parseRegexpFlags(lexer);
+                RegexpOptions options = lexer.parseRegexpFlags();
                 ByteList regexpBytelist = ByteList.create("");
 
                 lexer.setValue(new RegexpNode(lexer.getPosition(), regexpBytelist, options));
@@ -138,55 +137,6 @@ public class StringTerm extends StrTerm {
 
         lexer.setValue(lexer.createStr(buffer, flags));
         return RubyParser.tSTRING_CONTENT;
-    }
-
-    private RegexpOptions parseRegexpFlags(RubyLexer lexer) throws IOException {
-        RegexpOptions options = new RegexpOptions();
-        int c;
-        StringBuilder unknownFlags = new StringBuilder(10);
-
-        lexer.newtok(true);
-        for (c = lexer.nextc(); c != EOF
-                && Character.isLetter(c); c = lexer.nextc()) {
-            switch (c) {
-            case 'i':
-                options.setIgnorecase(true);
-                break;
-            case 'x':
-                options.setExtended(true);
-                break;
-            case 'm':
-                options.setMultiline(true);
-                break;
-            case 'o':
-                options.setOnce(true);
-                break;
-            case 'n':
-                options.setExplicitKCode(KCode.NONE);
-                break;
-            case 'e':
-                options.setExplicitKCode(KCode.EUC);
-                break;
-            case 's':
-                options.setExplicitKCode(KCode.SJIS);
-                break;
-            case 'u':
-                options.setExplicitKCode(KCode.UTF8);
-                break;
-            case 'j':
-                options.setJava(true);
-                break;
-            default:
-                unknownFlags.append((char) c);
-                break;
-            }
-        }
-        lexer.pushback(c);
-        if (unknownFlags.length() != 0) {
-            lexer.compile_error(PID.REGEXP_UNKNOWN_OPTION, "unknown regexp option" +
-                    (unknownFlags.length() > 1 ? "s" : "") + " - " + unknownFlags);
-        }
-        return options;
     }
 
     private void mixedEscape(RubyLexer lexer, Encoding foundEncoding, Encoding parserEncoding) {

--- a/core/src/main/java/org/jruby/parser/ParserSupport.java
+++ b/core/src/main/java/org/jruby/parser/ParserSupport.java
@@ -1453,13 +1453,8 @@ public class ParserSupport {
 
     // MRI: reg_fragment_check
     public void regexpFragmentCheck(RegexpNode end, ByteList value) {
-        setRegexpEncoding(end, value);
-        try {
-            RubyRegexp.preprocessCheck(configuration.getRuntime(), value);
-        } catch (RaiseException re) {
-            compile_error(re.getMessage());
-        }
-    }        // 1.9 mode overrides to do extra checking...
+        lexer.checkRegexpFragment(configuration.getRuntime(), value, end.getOptions());
+    }
 
     private List<Integer> allocateNamedLocals(RegexpNode regexpNode) {
         RubyRegexp pattern = RubyRegexp.newRegexp(configuration.getRuntime(), regexpNode.getValue(), regexpNode.getOptions());
@@ -1487,20 +1482,6 @@ public class ParserSupport {
         return locals;
     }
 
-    private boolean is7BitASCII(ByteList value) {
-        return StringSupport.codeRangeScan(value.getEncoding(), value) == StringSupport.CR_7BIT;
-    }
-
-    // TODO: Put somewhere more consolidated (similiar
-    private char optionsEncodingChar(Encoding optionEncoding) {
-        if (optionEncoding == USASCII_ENCODING) return 'n';
-        if (optionEncoding == org.jcodings.specific.EUCJPEncoding.INSTANCE) return 'e';
-        if (optionEncoding == org.jcodings.specific.SJISEncoding.INSTANCE) return 's';
-        if (optionEncoding == UTF8_ENCODING) return 'u';
-
-        return ' ';
-    }
-
     public void compile_error(String message) { // mri: rb_compile_error_with_enc
         String line = lexer.getCurrentLine();
         ISourcePosition position = lexer.getPosition();
@@ -1515,49 +1496,8 @@ public class ParserSupport {
         throw getConfiguration().getRuntime().newSyntaxError(errorMessage + message);
     }
 
-    protected void compileError(Encoding optionEncoding, Encoding encoding) {
-        lexer.compile_error(PID.REGEXP_ENCODING_MISMATCH, "regexp encoding option '" + optionsEncodingChar(optionEncoding) +
-                "' differs from source encoding '" + encoding + "'");
-    }
-    
-    // MRI: reg_fragment_setenc_gen
-    public void setRegexpEncoding(RegexpNode end, ByteList value) {
-        RegexpOptions options = end.getOptions();
-        Encoding optionsEncoding = options.setup(configuration.getRuntime()) ;
-
-        // Change encoding to one specified by regexp options as long as the string is compatible.
-        if (optionsEncoding != null) {
-            if (optionsEncoding != value.getEncoding() && !is7BitASCII(value)) {
-                compileError(optionsEncoding, value.getEncoding());
-            }
-
-            value.setEncoding(optionsEncoding);
-        } else if (options.isEncodingNone()) {
-            if (value.getEncoding() == ASCII8BIT_ENCODING && !is7BitASCII(value)) {
-                compileError(optionsEncoding, value.getEncoding());
-            }
-            value.setEncoding(ASCII8BIT_ENCODING);
-        } else if (lexer.getEncoding() == USASCII_ENCODING) {
-            if (!is7BitASCII(value)) {
-                value.setEncoding(USASCII_ENCODING); // This will raise later
-            } else {
-                value.setEncoding(ASCII8BIT_ENCODING);
-            }
-        }
-    }    
-
     protected void checkRegexpSyntax(ByteList value, RegexpOptions options) {
-        final String stringValue = value.toString();
-        // Joni doesn't support these modifiers - but we can fix up in some cases - let the error delay until we try that
-        if (stringValue.startsWith("(?u)") || stringValue.startsWith("(?a)") || stringValue.startsWith("(?d)"))
-            return;
-
-        try {
-            // This is only for syntax checking but this will as a side-effect create an entry in the regexp cache.
-            RubyRegexp.newRegexpParser(getConfiguration().getRuntime(), value, (RegexpOptions)options.clone());
-        } catch (RaiseException re) {
-            compile_error(re.getMessage());
-        }
+        lexer.checkRegexpSyntax(configuration.getRuntime(), value, options);
     }
 
     public Node newRegexpNode(ISourcePosition position, Node contents, RegexpNode end) {

--- a/test/mri/excludes/TestRipper/Ripper.rb
+++ b/test/mri/excludes/TestRipper/Ripper.rb
@@ -1,1 +1,0 @@
-exclude :test_regexp_with_option, 'needs regexp validation'

--- a/test/mri/excludes/TestRipper/Sexp.rb
+++ b/test/mri/excludes/TestRipper/Sexp.rb
@@ -1,1 +1,0 @@
-exclude :test_compile_error, 'needs regexp validation'


### PR DESCRIPTION
This represents a stab at implementing the remaining Ripper compatibility as mentioned in #4898.

This uses the fact that Regexp tokenization is handled by a single StringTerm, and thus all tSTRING_CONTENT fragments are easily collectable until the tREGEXP_END comes with the options that we need for validation.

The validation itself is a copied/simplified version of what is performed by the main parser, as large parts the validation depended on the AST structure, which we do not have here.

Technically, this doesn't perform the validation at the same point in time as the main parser, as it performs the validation when encountering the tREGEXP_END token rather than when processing the regexp rule.

I speculate that the difference doesn't really matter given that the only thing we could do with the tREGEXP_END token is to apply the regexp rule.

In order to reduce copy-paste between the main parser and Ripper, I opted to shift some Regexp-related code into the Lexer. In theory, the code doesn't belong in the lexer, but putting it in the Lexer has some benefits. First, it is a component that is shared in a reasonable way between the two parsers. Second, it is essentially required by the proposed implementation, as the new validation takes place effectively inside the Lexer.

Unsurprisingly, it turns out that the coverage for Ripper parsing of Regexp isn't very extensive, and I haven't had time to put the code through any additional tests.