### PR TITLE
Implement Kernel.yield_self

### DIFF
--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1192,6 +1192,16 @@ public class RubyKernel {
         return context.nil;
     }
 
+    @JRubyMethod(module = true)
+    public static IRubyObject yield_self(ThreadContext context, IRubyObject recv, Block block) {
+        if (block.isGiven()) {
+            return block.yield(context, recv);
+        } else {
+            SizeFn enumSizeFn = RubyArray.newArray(context.runtime, context.nil).enumLengthFn();
+            return RubyEnumerator.enumeratorizeWithSize(context, recv, "yield_self", enumSizeFn);
+        }
+    }
+
     @JRubyMethod(module = true, visibility = PRIVATE)
     public static IRubyObject set_trace_func(ThreadContext context, IRubyObject recv, IRubyObject trace_func, Block block) {
         if (trace_func.isNil()) {

--- a/test/mri/ruby/test_object.rb
+++ b/test/mri/ruby/test_object.rb
@@ -18,6 +18,16 @@ class TestObject < Test::Unit::TestCase
     assert_same(object, object.itself, feature6373)
   end
 
+  def test_yield_self
+    feature = '[ruby-core:46320] [Feature #6721]'
+    object = Object.new
+    assert_same(self, object.yield_self {self}, feature)
+    assert_same(object, object.yield_self {|x| break x}, feature)
+    enum = object.yield_self
+    assert_instance_of(Enumerator, enum)
+    assert_equal(1, enum.size)
+  end
+
   def test_dup
     assert_equal 1, 1.dup
     assert_equal true, true.dup


### PR DESCRIPTION
Hi folks,

This is another feature targeting Ruby 2.5: Kernel.yield_self (feature #6721).

Note: the tests are copied from MRI.

Thanks for your review and feedback.