### PR TITLE
Miscellaneous parsing fixes

### DIFF
--- a/core/src/main/java/org/jruby/ext/ripper/HeredocTerm.java
+++ b/core/src/main/java/org/jruby/ext/ripper/HeredocTerm.java
@@ -172,6 +172,7 @@ public class HeredocTerm extends StrTerm {
                     return token;
                 } else {
                     tok.append(c);
+                    c = lexer.nextc();
                 }
             }
 

--- a/core/src/main/java/org/jruby/ext/ripper/HeredocTerm.java
+++ b/core/src/main/java/org/jruby/ext/ripper/HeredocTerm.java
@@ -193,7 +193,14 @@ public class HeredocTerm extends StrTerm {
                     return RubyParser.tSTRING_CONTENT;
                 }
                 tok.append(lexer.nextc());
-                
+
+                if (lexer.getHeredocIndent() > 0) {
+                    lexer.lex_goto_eol();
+                    lexer.setValue(lexer.createStr(tok, 0));
+                    lexer.flush_string_content(enc[0]);
+                    return RubyParser.tSTRING_CONTENT;
+                }
+
                 if ((c = lexer.nextc()) == EOF) return error(lexer, len, str, eos);
             } while (!lexer.whole_match_p(eos, indent));
             str = tok;

--- a/core/src/main/java/org/jruby/ext/ripper/HeredocTerm.java
+++ b/core/src/main/java/org/jruby/ext/ripper/HeredocTerm.java
@@ -166,16 +166,13 @@ public class HeredocTerm extends StrTerm {
             ByteList tok = new ByteList();
             tok.setEncoding(lexer.getEncoding());
             if (c == '#') {
-                switch (c = lexer.nextc()) {
-                case '$':
-                case '@':
-                    lexer.pushback(c);
-                    return RubyParser.tSTRING_DVAR;
-                case '{':
-                    lexer.commandStart = true;
-                    return RubyParser.tSTRING_DBEG;
+                int token = lexer.peekVariableName(RipperParser.tSTRING_DVAR, RipperParser.tSTRING_DBEG);
+
+                if (token != 0) {
+                    return token;
+                } else {
+                    tok.append(c);
                 }
-                tok.append('#');
             }
 
             // MRI has extra pointer which makes our code look a little bit more strange in comparison

--- a/core/src/main/java/org/jruby/ext/ripper/RipperLexer.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperLexer.java
@@ -491,14 +491,6 @@ public class RipperLexer extends LexingCommon {
             begin = '\0';
         }
 
-        // consume spaces here to record them as part of token
-        int w = nextc();
-        while (Character.isWhitespace(w)) {
-            value = value + (char) w;
-            w = nextc();
-        }
-        pushback(w);
-        
         switch (c) {
         case 'Q':
             lex_strterm = new StringTerm(str_dquote, begin ,end);

--- a/core/src/main/java/org/jruby/ext/ripper/RipperParserBase.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperParserBase.java
@@ -111,10 +111,10 @@ public class RipperParserBase {
 
     public IRubyObject assignableConstant(IRubyObject value) {
         if (isInDef() || isInSingle()) {
-            return dispatch("on_assign_error", value);
-        } else {
-            return value;
+            value = dispatch("on_assign_error", value);
+            error();
         }
+        return value;
     }
 
     public IRubyObject assignableIdentifier(IRubyObject value) {

--- a/core/src/main/java/org/jruby/ext/ripper/StringTerm.java
+++ b/core/src/main/java/org/jruby/ext/ripper/StringTerm.java
@@ -105,16 +105,13 @@ public class StringTerm extends StrTerm {
         }        
 
         if ((flags & STR_FUNC_EXPAND) != 0 && c == '#') {
-            c = lexer.nextc();
-            switch (c) {
-            case '$':
-            case '@':
-                lexer.pushback(c);
-                return RubyParser.tSTRING_DVAR;
-            case '{':
-                return RubyParser.tSTRING_DBEG;
+            int token = lexer.peekVariableName(RubyParser.tSTRING_DVAR, RubyParser.tSTRING_DBEG);
+
+            if (token != 0) {
+                return token;
+            } else {
+                buffer.append(c);
             }
-            buffer.append((byte) '#');
         }
         lexer.pushback(c);
         

--- a/core/src/main/java/org/jruby/ext/ripper/StringTerm.java
+++ b/core/src/main/java/org/jruby/ext/ripper/StringTerm.java
@@ -112,9 +112,9 @@ public class StringTerm extends StrTerm {
             } else {
                 buffer.append(c);
             }
+        } else {
+            lexer.pushback(c);
         }
-        lexer.pushback(c);
-        
         Encoding enc[] = new Encoding[1];
         enc[0] = lexer.getEncoding();
 

--- a/core/src/main/java/org/jruby/lexer/LexingCommon.java
+++ b/core/src/main/java/org/jruby/lexer/LexingCommon.java
@@ -353,8 +353,9 @@ public abstract class LexingCommon {
                 return 0;
         }
 
+        pushback(c);
+
         if (significant != -1 && Character.isAlphabetic(significant) || significant == '_') {
-            pushback(c);
             setValue("#" + significant);
             return tSTRING_DVAR;
         }

--- a/core/src/main/java/org/jruby/lexer/LexingCommon.java
+++ b/core/src/main/java/org/jruby/lexer/LexingCommon.java
@@ -291,6 +291,77 @@ public abstract class LexingCommon {
         return Encoding.isMbcAscii((byte) c);
     }
 
+    // Return of 0 means failed to find anything.  Non-zero means return that from lexer.
+    public int peekVariableName(int tSTRING_DVAR, int tSTRING_DBEG) throws IOException {
+        int c = nextc(); // byte right after #
+        int significant = -1;
+        switch (c) {
+            case '$': {  // we unread back to before the $ so next lex can read $foo
+                int c2 = nextc();
+
+                if (c2 == '-') {
+                    int c3 = nextc();
+
+                    if (c3 == EOF) {
+                        pushback(c3); pushback(c2);
+                        return 0;
+                    }
+
+                    significant = c3;                              // $-0 potentially
+                    pushback(c3); pushback(c2);
+                    break;
+                } else if (isGlobalCharPunct(c2)) {          // $_ potentially
+                    setValue("#" + (char) c2);
+
+                    pushback(c2); pushback(c);
+                    return tSTRING_DVAR;
+                }
+
+                significant = c2;                                  // $FOO potentially
+                pushback(c2);
+                break;
+            }
+            case '@': {  // we unread back to before the @ so next lex can read @foo
+                int c2 = nextc();
+
+                if (c2 == '@') {
+                    int c3 = nextc();
+
+                    if (c3 == EOF) {
+                        pushback(c3); pushback(c2);
+                        return 0;
+                    }
+
+                    significant = c3;                                // #@@foo potentially
+                    pushback(c3); pushback(c2);
+                    break;
+                }
+
+                significant = c2;                                    // #@foo potentially
+                pushback(c2);
+                break;
+            }
+            case '{':
+                //setBraceNest(getBraceNest() + 1);
+                setValue("#" + (char) c);
+                commandStart = true;
+                return tSTRING_DBEG;
+            default:
+                // We did not find significant char after # so push it back to
+                // be processed as an ordinary string.
+                pushback(c);
+                return 0;
+        }
+
+        if (significant != -1 && Character.isAlphabetic(significant) || significant == '_') {
+            pushback(c);
+            setValue("#" + significant);
+            return tSTRING_DVAR;
+        }
+
+        return 0;
+    }
+
     // FIXME: I added number gvars here and they did not.
     public boolean isGlobalCharPunct(int c) {
         switch (c) {

--- a/core/src/main/java/org/jruby/lexer/yacc/HeredocTerm.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/HeredocTerm.java
@@ -154,6 +154,7 @@ public class HeredocTerm extends StrTerm {
                     return token;
                 } else {
                     tok.append(c);
+                    c = lexer.nextc();
                 }
             }
 

--- a/core/src/main/java/org/jruby/lexer/yacc/HeredocTerm.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/HeredocTerm.java
@@ -148,16 +148,13 @@ public class HeredocTerm extends StrTerm {
             ByteList tok = new ByteList();
             tok.setEncoding(lexer.getEncoding());
             if (c == '#') {
-                switch (c = lexer.nextc()) {
-                    case '$':
-                    case '@':
-                        lexer.pushback(c);
-                        return RubyParser.tSTRING_DVAR;
-                    case '{':
-                        lexer.commandStart = true;
-                        return RubyParser.tSTRING_DBEG;
+                int token = lexer.peekVariableName(RubyParser.tSTRING_DVAR, RubyParser.tSTRING_DBEG);
+
+                if (token != 0) {
+                    return token;
+                } else {
+                    tok.append(c);
                 }
-                tok.append('#');
             }
 
             // MRI has extra pointer which makes our code look a little bit more strange in comparison

--- a/core/src/main/java/org/jruby/lexer/yacc/StringTerm.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/StringTerm.java
@@ -119,7 +119,11 @@ public class StringTerm extends StrTerm {
         if ((flags & STR_FUNC_EXPAND) != 0 && c == '#') {
             int token = lexer.peekVariableName(RubyParser.tSTRING_DVAR, RubyParser.tSTRING_DBEG);
 
-            if (token != 0) return token;
+            if (token != 0) {
+                return token;
+            } else {
+                buffer.append(c);
+            }
         }
         lexer.pushback(c);
 

--- a/core/src/main/java/org/jruby/lexer/yacc/StringTerm.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/StringTerm.java
@@ -91,77 +91,6 @@ public class StringTerm extends StrTerm {
             return RubyParser.tSTRING_END;
     }
 
-    // Return of 0 means failed to find anything.  Non-zero means return that from lexer.
-    private int parsePeekVariableName(RubyLexer lexer) throws IOException {
-        int c = lexer.nextc(); // byte right after #
-        int significant = -1;
-        switch (c) {
-            case '$': {  // we unread back to before the $ so next lex can read $foo
-                int c2 = lexer.nextc();
-
-                if (c2 == '-') {
-                    int c3 = lexer.nextc();
-
-                    if (c3 == EOF) {
-                        lexer.pushback(c3); lexer.pushback(c2);
-                        return 0;
-                    }
-
-                    significant = c3;                              // $-0 potentially
-                    lexer.pushback(c3); lexer.pushback(c2);
-                    break;
-                } else if (lexer.isGlobalCharPunct(c2)) {          // $_ potentially
-                    lexer.setValue("#" + (char) c2);
-
-                    lexer.pushback(c2); lexer.pushback(c);
-                    return RubyParser.tSTRING_DVAR;
-                }
-
-                significant = c2;                                  // $FOO potentially
-                lexer.pushback(c2);
-                break;
-            }
-            case '@': {  // we unread back to before the @ so next lex can read @foo
-                int c2 = lexer.nextc();
-
-                if (c2 == '@') {
-                    int c3 = lexer.nextc();
-
-                    if (c3 == EOF) {
-                        lexer.pushback(c3); lexer.pushback(c2);
-                        return 0;
-                    }
-
-                    significant = c3;                                // #@@foo potentially
-                    lexer.pushback(c3); lexer.pushback(c2);
-                    break;
-                }
-
-                significant = c2;                                    // #@foo potentially
-                lexer.pushback(c2);
-                break;
-            }
-            case '{':
-                //lexer.setBraceNest(lexer.getBraceNest() + 1);
-                lexer.setValue("#" + (char) c);
-                lexer.commandStart = true;
-                return RubyParser.tSTRING_DBEG;
-            default:
-                // We did not find significant char after # so push it back to
-                // be processed as an ordinary string.
-                lexer.pushback(c);
-                return 0;
-        }
-
-        if (significant != -1 && Character.isAlphabetic(significant) || significant == '_') {
-            lexer.pushback(c);
-            lexer.setValue("#" + significant);
-            return RubyParser.tSTRING_DVAR;
-        }
-
-        return 0;
-    }
-
     public int parseString(RubyLexer lexer) throws IOException {
         boolean spaceSeen = false;
         int c;
@@ -188,7 +117,7 @@ public class StringTerm extends StrTerm {
         ByteList buffer = createByteList(lexer);
         lexer.newtok(true);
         if ((flags & STR_FUNC_EXPAND) != 0 && c == '#') {
-            int token = parsePeekVariableName(lexer);
+            int token = lexer.peekVariableName(RubyParser.tSTRING_DVAR, RubyParser.tSTRING_DBEG);
 
             if (token != 0) return token;
         }

--- a/core/src/main/java/org/jruby/lexer/yacc/StringTerm.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/StringTerm.java
@@ -124,8 +124,9 @@ public class StringTerm extends StrTerm {
             } else {
                 buffer.append(c);
             }
+        } else {
+            lexer.pushback(c);
         }
-        lexer.pushback(c);
 
         Encoding enc[] = new Encoding[1];
         enc[0] = lexer.getEncoding();

--- a/test/jruby/test_parsing.rb
+++ b/test/jruby/test_parsing.rb
@@ -37,9 +37,13 @@ class TestParsing < Test::Unit::TestCase
   end
 
   def test_parse_invalid_gvar
+    assert_equal '# comment', eval('"# comment"')
     assert_equal '#$', eval('%{#$}')
+    assert_equal '##$', eval('%{##$}')
     assert_equal '#${', eval('"#${"')
     assert_equal ' #${', eval('" #${"')
+    assert_equal ' # ##${', eval('" # ##${"')
     assert_equal " \#${\n", eval("<<E\n \#$\{\nE\n")
+    assert_equal " # #\#${\n", eval("<<E\n \# \#\#$\{\nE\n")
   end
 end

--- a/test/jruby/test_parsing.rb
+++ b/test/jruby/test_parsing.rb
@@ -35,4 +35,10 @@ class TestParsing < Test::Unit::TestCase
   
   def foo(*args)
   end
+
+  def test_parse_invalid_gvar
+    assert_equal '#$', eval('%{#$}')
+    assert_equal '#${', eval('"#${"')
+    assert_equal ' #${', eval('" #${"')
+  end
 end

--- a/test/jruby/test_parsing.rb
+++ b/test/jruby/test_parsing.rb
@@ -40,5 +40,6 @@ class TestParsing < Test::Unit::TestCase
     assert_equal '#$', eval('%{#$}')
     assert_equal '#${', eval('"#${"')
     assert_equal ' #${', eval('" #${"')
+    assert_equal " \#${\n", eval("<<E\n \#$\{\nE\n")
   end
 end

--- a/test/jruby/test_ripper.rb
+++ b/test/jruby/test_ripper.rb
@@ -58,4 +58,11 @@ class TestJRubyRipper < Test::Unit::TestCase
   def test_dyn_const_lhs
     assert_equal nil, Ripper.sexp("def m;C=s;end")
   end
+
+  def test_literal_whitespace
+    assert_equal [:on_string_content, [:@tstring_content, "\n", [1, 2]]], extract("%{\n}", :on_string_content)
+    assert_equal [:on_string_content, [:@tstring_content, " ", [1, 2]]], extract("%[ ]", :on_string_content)
+    assert_equal [:on_string_content, [:@tstring_content, "\t", [1, 2]]], extract("%(\t)", :on_string_content)
+    assert_equal [:on_string_content, [:@tstring_content, "\r", [1, 2]]], extract("%|\r|", :on_string_content)
+  end
 end

--- a/test/jruby/test_ripper.rb
+++ b/test/jruby/test_ripper.rb
@@ -54,4 +54,8 @@ class TestJRubyRipper < Test::Unit::TestCase
     assert_equal [:on_string_content, [:@tstring_content, "x\n", [2, 0]]], extract("<<EOS\nx\nEOS\n", :on_string_content)
     assert_equal [:on_string_content, [:string_embexpr, [[:vcall, [:@ident, "o", [2, 2]]]]], [:@tstring_content, "x\n", [2, 4]]], extract("<<EOS\n\#{o}x\nEOS\n", :on_string_content)
   end
+
+  def test_dyn_const_lhs
+    assert_equal nil, Ripper.sexp("def m;C=s;end")
+  end
 end

--- a/test/jruby/test_ripper.rb
+++ b/test/jruby/test_ripper.rb
@@ -53,6 +53,7 @@ class TestJRubyRipper < Test::Unit::TestCase
   def test_heredoc
     assert_equal [:on_string_content, [:@tstring_content, "x\n", [2, 0]]], extract("<<EOS\nx\nEOS\n", :on_string_content)
     assert_equal [:on_string_content, [:string_embexpr, [[:vcall, [:@ident, "o", [2, 2]]]]], [:@tstring_content, "x\n", [2, 4]]], extract("<<EOS\n\#{o}x\nEOS\n", :on_string_content)
+    assert_equal [:on_string_content, [:@tstring_content, "A ", [2, 2]], [:string_embexpr, [[:vcall, [:@ident, "a", [2, 6]]]]], [:@tstring_content, "\n", [2, 8]], [:@tstring_content, "", [3, 2]], [:string_embexpr, [[:vcall, [:@ident, "b", [3, 4]]]]], [:@tstring_content, "\n", [3, 6]]], extract("<<~EOS\n  A \#{a}\n  \#{b}\nEOS\n", :on_string_content)
   end
 
   def test_dyn_const_lhs

--- a/test/jruby/test_ripper.rb
+++ b/test/jruby/test_ripper.rb
@@ -67,11 +67,15 @@ class TestJRubyRipper < Test::Unit::TestCase
   end
 
   def test_invalid_gvar
+    assert_equal [:on_string_content, [:@tstring_content, '# comment', [1, 1]]], extract('"# comment"', :on_string_content)
     assert_equal [:on_string_content, [:@tstring_content, '#', [1, 1]]], extract('"#"', :on_string_content)
-    assert_equal [:on_string_content, [:@tstring_content, '#$', [1, 2]]], extract('%{#$}', :on_string_content)
+    assert_equal [:on_string_content, [:@tstring_content, '##', [1, 1]]], extract('"##"', :on_string_content)
     assert_equal [:on_string_content, [:@tstring_content, '#${', [1, 1]]], extract('"#${"', :on_string_content)
+    assert_equal [:on_string_content, [:@tstring_content, '#', [1, 1]], [:@tstring_content, '#${', [1, 2]]], extract('"##${"', :on_string_content)
     assert_equal [:on_string_content, [:@tstring_content, ' ', [1, 1]], [:@tstring_content, '#${', [1, 2]]], extract('" #${"', :on_string_content)
     assert_equal [:on_string_content, [:@tstring_content, '#${ ', [1, 1]]], extract('"#${ "', :on_string_content)
+    assert_equal [:on_string_content, [:@tstring_content, '# #', [1, 1]], [:@tstring_content, '#${', [1, 4]]], extract('"# ##${"', :on_string_content)
     assert_equal [:on_string_content, [:@tstring_content, "\#$}\n", [2, 0]]], extract("<<E\n\#$}\nE\n", :on_string_content)
+    assert_equal [:on_string_content, [:@tstring_content, '# #', [2, 0]], [:@tstring_content, "\#${\n", [2, 3]]], extract("<<E\n\# \#\#${\nE\n", :on_string_content)
   end
 end

--- a/test/jruby/test_ripper.rb
+++ b/test/jruby/test_ripper.rb
@@ -72,5 +72,6 @@ class TestJRubyRipper < Test::Unit::TestCase
     assert_equal [:on_string_content, [:@tstring_content, '#${', [1, 1]]], extract('"#${"', :on_string_content)
     assert_equal [:on_string_content, [:@tstring_content, ' ', [1, 1]], [:@tstring_content, '#${', [1, 2]]], extract('" #${"', :on_string_content)
     assert_equal [:on_string_content, [:@tstring_content, '#${ ', [1, 1]]], extract('"#${ "', :on_string_content)
+    assert_equal [:on_string_content, [:@tstring_content, "\#$}\n", [2, 0]]], extract("<<E\n\#$}\nE\n", :on_string_content)
   end
 end

--- a/test/jruby/test_ripper.rb
+++ b/test/jruby/test_ripper.rb
@@ -65,4 +65,12 @@ class TestJRubyRipper < Test::Unit::TestCase
     assert_equal [:on_string_content, [:@tstring_content, "\t", [1, 2]]], extract("%(\t)", :on_string_content)
     assert_equal [:on_string_content, [:@tstring_content, "\r", [1, 2]]], extract("%|\r|", :on_string_content)
   end
+
+  def test_invalid_gvar
+    assert_equal [:on_string_content, [:@tstring_content, '#', [1, 1]]], extract('"#"', :on_string_content)
+    assert_equal [:on_string_content, [:@tstring_content, '#$', [1, 2]]], extract('%{#$}', :on_string_content)
+    assert_equal [:on_string_content, [:@tstring_content, '#${', [1, 1]]], extract('"#${"', :on_string_content)
+    assert_equal [:on_string_content, [:@tstring_content, ' ', [1, 1]], [:@tstring_content, '#${', [1, 2]]], extract('" #${"', :on_string_content)
+    assert_equal [:on_string_content, [:@tstring_content, '#${ ', [1, 1]]], extract('"#${ "', :on_string_content)
+  end
 end


### PR DESCRIPTION
This addresses additional (beyond #4898) parsing inconsistencies between MRI and JRuby (and JRuby's main Ruby parser and Ripper parser).

The additional tests introduced did not pass in the original JRuby version(s), but did pass when running through MRI.