### PR TITLE
Make Kernel#pp available by default

### DIFF
--- a/core/src/main/ruby/jruby/kernel.rb
+++ b/core/src/main/ruby/jruby/kernel.rb
@@ -31,5 +31,6 @@ load 'jruby/kernel/file.rb'
 load 'jruby/kernel/basicobject.rb'
 load 'jruby/kernel/hash.rb'
 load 'jruby/kernel/string.rb'
+load 'jruby/kernel/pp.rb'
 
 $" << 'thread.rb'

--- a/core/src/main/ruby/jruby/kernel/pp.rb
+++ b/core/src/main/ruby/jruby/kernel/pp.rb
@@ -1,0 +1,9 @@
+module Kernel
+  def pp(*objs)
+    require 'pp'
+    pp(*objs)
+  end
+
+  # suppress redefinition warning
+  alias pp pp # :nodoc:
+end


### PR DESCRIPTION
Hi folks,

This is another feature targeting Ruby 2.5 [1]: Kernel#pp by default (feature #14123).

~~Note: the tests are copied from MRI.~~

Thanks for your review and feedback.

1. https://github.com/jruby/jruby/issues/4876