### PR TITLE
Allow "-" for directory name in `TestThread`

### DIFF
--- a/test/jruby/test_thread.rb
+++ b/test/jruby/test_thread.rb
@@ -360,22 +360,22 @@ class TestThread < Test::Unit::TestCase
 
   def test_thread_name
     Thread.new do
-      assert_match(/\#\<Thread\:0x\h+(@[\w\/\._]+\:\d+)?\srun\>/, Thread.current.inspect)
+      assert_match(/\#\<Thread\:0x\h+(@[\w\/\.\-_]+\:\d+)?\srun\>/, Thread.current.inspect)
       # TODO? currently in JIT file comes as "" and line as 0
       assert_match(/Ruby\-\d+\-Thread\-\d+\:\s(.*\.rb)?\:\d+/, native_thread_name(Thread.current)) if defined? JRUBY_VERSION
     end.join
 
     Thread.new do
       Thread.current.name = 'foo'
-      assert_match(/\#\<Thread\:0x\h+@foo(@[\w\/\._]+\:\d+)?\srun\>/, Thread.current.inspect)
+      assert_match(/\#\<Thread\:0x\h+@foo(@[\w\/\.\-_]+\:\d+)?\srun\>/, Thread.current.inspect)
       assert_match(/Ruby\-\d+\-Thread\-\d+\@foo:\s(.*\.rb)?\:\d+/, native_thread_name(Thread.current)) if defined? JRUBY_VERSION
 
       Thread.current.name = 'bar'
-      assert_match(/\#\<Thread\:0x\h+@bar(@[\w\/\._]+\:\d+)?\srun\>/, Thread.current.inspect)
+      assert_match(/\#\<Thread\:0x\h+@bar(@[\w\/\.\-_]+\:\d+)?\srun\>/, Thread.current.inspect)
       assert_match(/Ruby\-\d+\-Thread\-\d+\@bar:\s(.*\.rb)?\:\d+/, native_thread_name(Thread.current)) if defined? JRUBY_VERSION
 
       Thread.current.name = nil
-      assert_match(/\#\<Thread\:0x\h+(@[\w\/\._]+\:\d+)?\srun\>/, Thread.current.inspect)
+      assert_match(/\#\<Thread\:0x\h+(@[\w\/\.\-_]+\:\d+)?\srun\>/, Thread.current.inspect)
       assert_match(/Ruby\-\d+\-Thread\-\d+\:\s(.*\.rb)?\:\d+/, native_thread_name(Thread.current)) if defined? JRUBY_VERSION
     end.join
 


### PR DESCRIPTION
When I run this test class on Travis CI,
some tests fail because on Travis CI
directrory name includes my account name,
so inspected result becomes:

```
<"#<Thread:0x7cf50001@foo@/home/travis/build/yui-knk/jruby/test/jruby/test_thread.rb:368 run>">
```

which does not match `</\#\<Thread\:0x\h+@foo(@[\w\/\._]+\:\d+)?\srun\>/>`.