### PR TITLE
Set MetaClass of cloned object

### DIFF
--- a/core/src/main/java/org/jruby/RubyMethod.java
+++ b/core/src/main/java/org/jruby/RubyMethod.java
@@ -193,7 +193,9 @@ public class RubyMethod extends AbstractRubyMethod {
     @JRubyMethod(name = "clone")
     @Override
     public RubyMethod rbClone() {
-        return newMethod(implementationModule, methodName, originModule, originName, method, receiver);
+        RubyMethod newMethod = newMethod(implementationModule, methodName, originModule, originName, method, receiver);
+        newMethod.setMetaClass(getMetaClass());
+        return newMethod;
     }
 
     /** Create a Proc object.

--- a/test/mri/excludes/TestMethod.rb
+++ b/test/mri/excludes/TestMethod.rb
@@ -1,7 +1,6 @@
 exclude :test_alias_owner, "needs investigation"
 exclude :test_body, "fails due RubyVM constant"
 exclude :test_callee, "needs investigation"
-exclude :test_clone, "needs investigation"
 exclude :test_define_method_visibility, "needs investigation"
 exclude :test_define_method_with_symbol, "scope changes in define_method methods?"
 exclude :test_eq, "weird logic for != when patching an object retuned from o.method, likely irrelevant"


### PR DESCRIPTION
In MRI, `method_clone` uses CLASS_OF method objects

```
clone = TypedData_Make_Struct(CLASS_OF(self), struct METHOD, &method_data_type, data);
```

By this change, `TestMethod#test_clone` will be passed.