### PR TITLE
Include `#test_array_splat` to test targets

### DIFF
--- a/test/mri/excludes/TestBasicInstructions.rb
+++ b/test/mri/excludes/TestBasicInstructions.rb
@@ -1,1 +1,0 @@
-exclude :test_array_splat, "needs investigation"


### PR DESCRIPTION
Currently `#test_array_splat` does not fail.