### PR TITLE
Fix "Complex#finite? returns false for NaN FAILED"

### DIFF
--- a/core/src/main/java/org/jruby/RubyComplex.java
+++ b/core/src/main/java/org/jruby/RubyComplex.java
@@ -995,7 +995,7 @@ public class RubyComplex extends RubyNumeric {
         }
 
         if (magnitude instanceof RubyFloat) {
-            return context.runtime.newBoolean(!((RubyFloat) magnitude).infinite_p().isTrue());
+            return context.runtime.newBoolean(((RubyFloat) magnitude).finite_p().isTrue());
         }
 
         return sites(context).finite.call(context, magnitude, magnitude);


### PR DESCRIPTION
The behavior of `Complex#finite?` for NaN was fixed on
Ruby 2.5.

```
$ ruby -ve "p Complex(Float::NAN, Float::NAN).finite?"
ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-darwin14]
false

$ ruby -ve "p Complex(Float::NAN, Float::NAN).finite?"
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-darwin14]
true
```

Ref: https://github.com/ruby/ruby/blob/v2_5_0/complex.c#L248
     https://github.com/ruby/ruby/blob/v2_5_0/numeric.c#L1731