### PR TITLE
Implement KeyError#receiver and KeyError#key

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1610,7 +1610,9 @@ public final class Ruby implements Constantizable {
             fiberError = defineClass("FiberError", standardError, standardError.getAllocator());
         }
         concurrencyError = defineClassIfAllowed("ConcurrencyError", threadError);
-        keyError = defineClassIfAllowed("KeyError", indexError);
+        if (profile.allowClass("KeyError")) {
+            keyError = RubyKeyError.createKeyErrorClass(this, indexError);
+        }
 
         mathDomainError = defineClassUnder("DomainError", argumentError, argumentError.getAllocator(), mathModule);
 
@@ -3747,8 +3749,9 @@ public final class Ruby implements Constantizable {
         return newRaiseException(getSystemCallError(), message);
     }
 
-    public RaiseException newKeyError(String message) {
-        return newRaiseException(getKeyError(), message);
+    public RaiseException newKeyError(String message, IRubyObject recv, IRubyObject key) {
+        RubyException err = new RubyKeyError(this, getKeyError(), message, recv, key);
+        return new RaiseException(err);
     }
 
     public RaiseException newErrnoEINTRError() {

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1211,7 +1211,7 @@ public class RubyHash extends RubyObject implements Map {
         if (value == null) {
             if (block.isGiven()) return block.yield(context, key);
 
-            throw runtime.newKeyError("key not found: " + key.inspect());
+            throw runtime.newKeyError("key not found: " + key.inspect(), this, key);
         }
 
         return value;

--- a/core/src/main/java/org/jruby/RubyKeyError.java
+++ b/core/src/main/java/org/jruby/RubyKeyError.java
@@ -1,0 +1,81 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2017 Miguel Landaeta <miguel@miguel.cc>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyMethod;
+import org.jruby.anno.JRubyClass;
+import org.jruby.runtime.ObjectAllocator;
+import org.jruby.runtime.builtin.IRubyObject;
+
+/**
+ * @author Miguel Landaeta
+ */
+@JRubyClass(name="KeyError", parent="IndexError")
+public class RubyKeyError extends RubyException {
+    private IRubyObject receiver;
+    private IRubyObject key;
+
+    private static final ObjectAllocator ALLOCATOR = new ObjectAllocator() {
+        @Override
+        public IRubyObject allocate(Ruby runtime, RubyClass klass) {
+            return new RubyKeyError(runtime, klass);
+        }
+    };
+
+    static RubyClass createKeyErrorClass(Ruby runtime, RubyClass IndexError) {
+        RubyClass KeyError = runtime.defineClass("KeyError", IndexError, ALLOCATOR);
+        KeyError.defineAnnotatedMethods(RubyKeyError.class);
+        KeyError.setReifiedClass(RubyKeyError.class);
+        return KeyError;
+    }
+
+    protected RubyKeyError(Ruby runtime, RubyClass exceptionClass) {
+        this(runtime, exceptionClass, exceptionClass.getName());
+    }
+
+    public RubyKeyError(Ruby runtime, RubyClass exceptionClass, String message) {
+        this(runtime, exceptionClass, message, runtime.getNil(), runtime.getNil());
+    }
+
+    public RubyKeyError(Ruby runtime, RubyClass exceptionClass, String message, IRubyObject recv, IRubyObject key) {
+        super(runtime, exceptionClass, message);
+        this.receiver = recv;
+        this.key = key;
+    }
+
+    @JRubyMethod
+    public IRubyObject receiver() {
+        return receiver;
+    }
+
+    @JRubyMethod
+    public IRubyObject key() {
+        return key;
+    }
+}

--- a/core/src/main/java/org/jruby/util/Sprintf.java
+++ b/core/src/main/java/org/jruby/util/Sprintf.java
@@ -151,8 +151,8 @@ public class Sprintf {
             throw runtime.newArgumentError(message);
         }
 
-        void raiseKeyError(String message) {
-            throw runtime.newKeyError(message);
+        void raiseKeyError(String message, IRubyObject recv, IRubyObject key) {
+            throw runtime.newKeyError(message, recv, key);
         }
 
         void warn(ID id, String message) {
@@ -179,12 +179,13 @@ public class Sprintf {
             if (object == null) {
                 object = rubyHash.getIfNone();
                 if (object == RubyBasicObject.UNDEF) {
-                    raiseKeyError("key" + startDelim + RubyString.newString(runtime, name) + endDelim + " not found");
+                    RubyString nameStr = RubyString.newString(runtime, name);
+                    raiseKeyError("key" + startDelim + nameStr + endDelim + " not found", rubyHash, nameStr);
                 } else if (rubyHash.hasDefaultProc()) {
                     object = object.callMethod(runtime.getCurrentContext(), "call", nameSym);
                 }
 
-                if (object.isNil()) throw runtime.newKeyError("key" + startDelim + nameSym + endDelim + " not found");
+                if (object.isNil()) throw runtime.newKeyError("key" + startDelim + nameSym + endDelim + " not found", rubyHash, nameSym);
             }
 
             return object;
@@ -265,13 +266,14 @@ public class Sprintf {
                 if (object == null) {
                     object = rubyHash.getIfNone();
                     if (object == RubyBasicObject.UNDEF) {
-                        raiseKeyError("key<" + name + "> not found");
+                        RubyString nameStr = RubyString.newString(runtime, name);
+                        raiseKeyError("key<" + name + "> not found", rubyHash, nameStr);
                     } else if (rubyHash.hasDefaultProc()) {
                         object = object.callMethod(runtime.getCurrentContext(), "call", nameSym);
                     }
 
                     if (object.isNil()) {
-                        throw runtime.newKeyError("key " + nameSym + " not found");
+                        throw runtime.newKeyError("key " + nameSym + " not found", rubyHash, nameSym);
                     }
                 }
 

--- a/test/mri/ruby/test_hash.rb
+++ b/test/mri/ruby/test_hash.rb
@@ -477,6 +477,8 @@ class TestHash < Test::Unit::TestCase
     e = assert_raise(KeyError) { @h.fetch('gumby'*20) }
     assert_match(/key not found: "gumbygumby/, e.message)
     assert_match(/\.\.\.\z/, e.message)
+    assert_same(@h, e.receiver)
+    assert_equal('gumby'*20, e.key)
   end
 
   def test_key2?
@@ -537,9 +539,11 @@ class TestHash < Test::Unit::TestCase
     assert_equal(4, res.length)
     assert_equal %w( three two one nil ), res
 
-    assert_raise KeyError do
+    e = assert_raise KeyError do
       @h.fetch_values(3, 'invalid')
     end
+    assert_same(@h, e.receiver)
+    assert_equal('invalid', e.key)
 
     res = @h.fetch_values(3, 'invalid') { |k| k.upcase }
     assert_equal %w( three INVALID ), res


### PR DESCRIPTION
Hi,

This is another feature targeting Ruby 2.5 [1]: KeyError#receiver and KeyError#key (feature #12063).

Note: the tests are copied from MRI.

To implement this I followed the approach used with NameError class, since it has a similar behaviour. If this is not the right approach, just let me know.

Thanks for your review and feedback.

1. https://github.com/jruby/jruby/issues/4876