### PR TITLE
Implement Dir.children

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -167,8 +167,8 @@ project 'JRuby Core' do
           'compilerArgs' => { 'arg' => '-J-Xmx1G' },
           'showWarnings' => 'true',
           'showDeprecation' => 'true',
-          'source' => [ '${base.java.version}', '1.7' ],
-          'target' => [ '${base.javac.version}', '1.7' ],
+          'source' => [ '${base.java.version}', '1.8' ],
+          'target' => [ '${base.javac.version}', '1.8' ],
           'useIncrementalCompilation' =>  'false' ) do
     execute_goals( 'compile',
                    :id => 'anno',

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -536,9 +536,9 @@ DO NOT MODIFIY - GENERATED CODE
           <showWarnings>true</showWarnings>
           <showDeprecation>true</showDeprecation>
           <source>${base.java.version}</source>
-          <source>1.7</source>
+          <source>1.8</source>
           <target>${base.javac.version}</target>
-          <target>1.7</target>
+          <target>1.8</target>
           <useIncrementalCompilation>false</useIncrementalCompilation>
         </configuration>
       </plugin>

--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -355,6 +355,17 @@ public class RubyDir extends RubyObject {
     }
 
     /**
+     * Returns an array containing all of the filenames except for "." and ".."
+     * in the given directory.
+     */
+    @JRubyMethod(name = "children", meta = true)
+    public static RubyArray children(ThreadContext context, IRubyObject recv, IRubyObject arg) {
+        RubyArray entries = entries19(context, recv, arg);
+        entries.removeIf(f -> f.equals(".") || f.equals(".."));
+        return entries;
+    }
+
+    /**
      * Deletes the directory specified by <code>path</code>.  The directory must
      * be empty.
      */

--- a/test/mri/ruby/test_dir.rb
+++ b/test/mri/ruby/test_dir.rb
@@ -184,17 +184,24 @@ class TestDir < Test::Unit::TestCase
     end
   end
 
-  def assert_entries(entries)
+  def assert_entries(entries, children_only = false)
     entries.sort!
-    assert_equal(%w(. ..) + ("a".."z").to_a, entries)
+    expected = ("a".."z").to_a
+    expected = %w(. ..) + expected unless children_only
+    assert_equal(expected, entries)
   end
 
   def test_entries
     assert_entries(Dir.open(@root) {|dir| dir.entries})
+    assert_entries(Dir.entries(@root).to_a)
   end
 
   def test_foreach
     assert_entries(Dir.foreach(@root).to_a)
+  end
+
+  def test_children
+    assert_entries(Dir.children(@root), true)
   end
 
   def test_dir_enc


### PR DESCRIPTION
Hi folks,

This is another feature targeting Ruby 2.5 [1]: Dir.children (feature #11302).

Notes:
* The tests are copied from MRI.
* I also cherry-picked a commit [2] from master to be able to use Java8 lambda expressions. If that's not OK, this PR could wait until that change is merged in ruby-2.5 branch; if this is the right approach, of course.

Thanks for your review and feedback.

1. https://github.com/jruby/jruby/issues/4876
2. https://github.com/jruby/jruby/commit/12b9f0f7ee33d88c0ab38b0333ecc4f674a35502