### PR TITLE
Set original Module to definedClass of methods

### DIFF
--- a/core/src/main/java/org/jruby/PrependedModule.java
+++ b/core/src/main/java/org/jruby/PrependedModule.java
@@ -54,6 +54,12 @@ public class PrependedModule extends IncludedModule {
     }
 
     @Override
+    public void addMethod(String name, DynamicMethod method) {
+        super.addMethod(name, method);
+        method.setDefinedClass(origin);
+    }
+
+    @Override
     public boolean isPrepended() {
         return true;
     }

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1175,6 +1175,11 @@ public class RubyModule extends RubyObject {
     public void addMethod(String name, DynamicMethod method) {
         testFrozen("class/module");
 
+        if (methodLocation != this) {
+            methodLocation.addMethod(name, method);
+            return;
+        }
+
         if (this instanceof MetaClass) {
             // FIXME: Gross and not quite right. See MRI's rb_frozen_class_p logic
             RubyBasicObject attached = (RubyBasicObject)((MetaClass)this).getAttached();

--- a/test/mri/excludes/TestMethod.rb
+++ b/test/mri/excludes/TestMethod.rb
@@ -1,4 +1,3 @@
-exclude :test_alias_owner, "needs investigation"
 exclude :test_body, "fails due RubyVM constant"
 exclude :test_callee, "needs investigation"
 exclude :test_define_method_visibility, "needs investigation"


### PR DESCRIPTION
Set original Module to definedClass of methods when
new methods are defined to PrependedModule.

Before this commit, definedClass of method a
is class c but definedClass of method b
is PrependedModule:

```
M = Module.new
c = Class.new {
  def a; end
  prepend M
  def b; end
}
```

This commit will set definedClass of method b
to class c and fix `TestMethod#test_alias_owner`.