### PR TITLE
Add `#test_slice_before` to test targets

### DIFF
--- a/test/mri/excludes/TestEnumerable.rb
+++ b/test/mri/excludes/TestEnumerable.rb
@@ -1,4 +1,3 @@
-exclude :test_slice_before, "needs investigation"
 exclude :test_callcc, "Continuations are not supported"
 exclude :test_zip, "needs investigation"
 exclude :test_first, "works - but output is not exactly 'unexpected break' as in MRI"


### PR DESCRIPTION
Currently `#test_slice_before` does not fail.