### PR TITLE
Implement Hash#slice method

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1644,6 +1644,23 @@ public class RubyHash extends RubyObject implements Map {
         return result;
     }
 
+
+    /** rb_hash_slice
+     *
+     */
+    @JRubyMethod(name = "slice", rest = true)
+    public RubyHash slice(final ThreadContext context, final IRubyObject[] args) {
+        RubyHash result = newHash(context.runtime);
+
+        for (int i = 0; i < args.length; i++) {
+            IRubyObject key = args[i];
+            IRubyObject value = this.internalGet(key);
+            if (value != null) result.op_aset(key, value);
+        }
+
+        return result;
+    }
+
     private static class SelectVisitor extends VisitorWithState<Block> {
         final RubyHash result;
         SelectVisitor(RubyHash result) {


### PR DESCRIPTION
for Ruby 2.5 support as in https://bugs.ruby-lang.org/issues/8499 stated.
#4876

Tests are already in master, https://github.com/jruby/jruby/blob/7bd10a61c70d7ab271f5a1403b64ef37eaaf036a/spec/ruby/core/hash/slice_spec.rb
Commit: https://github.com/jruby/jruby/commit/75e45222cc109002dbf222f3f7032c40325b75f6#diff-a265476d146c86ed0f4352a5735b7e4b

Do we want to cherry-pick the tests to ruby-2.5 branch?