### PR TITLE
Alias Set#to_s to inspect

### DIFF
--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -1080,7 +1080,7 @@ public class RubySet extends RubyObject implements Set {
 
     // Returns a string containing a human-readable representation of the set.
     // e.g. "#<Set: {element1, element2, ...}>"
-    @JRubyMethod(name = "inspect")
+    @JRubyMethod(name = "inspect", alias = "to_s")
     public RubyString inspect(ThreadContext context) {
         final Ruby runtime = context.runtime;
 

--- a/spec/ruby/core/set/to_s_spec.rb
+++ b/spec/ruby/core/set/to_s_spec.rb
@@ -1,0 +1,13 @@
+require File.expand_path('../shared/inspect', __FILE__)
+require 'set'
+
+ruby_version_is "2.5" do
+  describe "Set#to_s" do
+    it_behaves_like :set_inspect, :to_s
+
+    it "is an alias of inspect" do
+      set = Set.new
+      set.method(:to_s).should == set.method(:inspect)
+    end
+  end
+end


### PR DESCRIPTION
to support Ruby 2.5 and stated in this feature https://bugs.ruby-lang.org/issues/13676.
https://github.com/ruby/ruby/commit/d893c123f6b021254b21c920e182d3c64967f5d5.
#4876.