### PR TITLE
Fix `Hash#reject`

### DIFF
--- a/test/mri/excludes/TestHash.rb
+++ b/test/mri/excludes/TestHash.rb
@@ -11,7 +11,6 @@ exclude :test_hash2, "[ruby-core:58993] [Bug #9231]"
 exclude :test_inverse_hash, "needs investigation"
 exclude :test_NEWHASH_fstring_key, "needs investigation"
 exclude :test_recursive_hash_value_struct, "needs investigation"
-exclude :test_reject, "needs investigation"
 exclude :test_AREF_fstring_key, "Depends on MRI-specific GC.stat key"
 exclude :test_ASET_fstring_key, "due https://github.com/jruby/jruby/commit/f3f0091da7d98c5df285"
 


### PR DESCRIPTION
In MRI, `Hash#reject`

* creates new hash
* sets keys & values if block returns false

This commit will fix `#test_reject`.

Ref: https://github.com/ruby/ruby/blob/v2_4_0/hash.c#L1328