### PR TITLE
Check third argument type for Dir.glob

### DIFF
--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -216,8 +216,13 @@ public class RubyDir extends RubyObject {
 
         if(args.length == 3) {
             flags = RubyNumeric.num2int(args[1]);
-            IRubyObject[] rets = ArgsUtil.extractKeywordArgs(context, (RubyHash) args[2], "base");
-            base = rets[0].convertToString().toString();
+            IRubyObject tmp = TypeConverter.checkHashType(runtime, args[2]);
+            if (tmp.isNil()){
+                throw runtime.newArgumentError("wrong number of arguments (" + args.length + " for 1..2)");
+            } else {
+                IRubyObject[] rets = ArgsUtil.extractKeywordArgs(context, (RubyHash) args[2], "base");
+                base = rets[0].convertToString().toString();
+            }
         } else if(args.length == 2) {
             IRubyObject tmp = TypeConverter.checkHashType(runtime, args[1]);
             if(tmp.isNil()){


### PR DESCRIPTION
to fix type cast error when last argument is not a hash.