### PR TITLE
Raise `TypeError` if `#extend_object` is called for no module objects

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2583,6 +2583,9 @@ public class RubyModule extends RubyObject {
      */
     @JRubyMethod(name = "extend_object", required = 1, visibility = PRIVATE)
     public IRubyObject extend_object(IRubyObject obj) {
+        if (!isModule()) {
+            throw getRuntime().newTypeError(this, getRuntime().getModule());
+        }
         obj.getSingletonClass().includeModule(this);
         return obj;
     }

--- a/test/mri/excludes/TestClass.rb
+++ b/test/mri/excludes/TestClass.rb
@@ -1,6 +1,5 @@
 exclude :test_cannot_reinitialize_class_with_initialize_copy, "broken subprocess logic in setup"
 exclude :test_check_inheritable, "needs investigation"
-exclude :test_extend_object, "needs investigation"
 exclude :test_invalid_jump_from_class_definition, "needs investigation"
 exclude :test_method_redefinition, "needs investigation"
 exclude :test_module_function, "needs investigation"


### PR DESCRIPTION
This commit will fix `TestClass#test_extend_object`.