### PR TITLE
Fix Hash#rehash method for duplicate keys

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -933,8 +933,17 @@ public class RubyHash extends RubyObject implements Map {
                 RubyHashEntry next = entry.next;
                 entry.hash = hashValue(entry.key); // update the hash value
                 int i = bucketIndex(entry.hash, newTable.length);
-                entry.next = newTable[i];
-                newTable[i] = entry;
+
+                if (newTable[i] != null && internalKeyExist(newTable[i], entry.hash, entry.key)) {
+                    RubyHashEntry tmpNext = entry.nextAdded;
+                    RubyHashEntry tmpPrev = entry.prevAdded;
+                    tmpPrev.nextAdded = tmpNext;
+                    tmpPrev.prevAdded = tmpPrev;
+                    size--;
+                } else {
+                    entry.next = newTable[i];
+                    newTable[i] = entry;
+                }
                 entry = next;
             }
         }

--- a/spec/ruby/core/hash/rehash_spec.rb
+++ b/spec/ruby/core/hash/rehash_spec.rb
@@ -35,6 +35,21 @@ describe "Hash#rehash" do
     h[k2].should == v2
   end
 
+  it "removes duplicate keys" do
+    a = [1,2]
+    b = [1]
+
+    h = {}
+    h[a] = true
+    h[b] = true
+    b << 2
+    h.length.should == 2
+    h.keys == [a, b]
+    h.rehash
+    h.length.should == 1
+    h.keys == [a]
+  end
+
   it "raises a #{frozen_error_class} if called on a frozen instance" do
     lambda { HashSpecs.frozen_hash.rehash  }.should raise_error(frozen_error_class)
     lambda { HashSpecs.empty_frozen_hash.rehash }.should raise_error(frozen_error_class)


### PR DESCRIPTION
Duplicate keys where just ignored before and inserted again.
Fix #4958.