### PR TITLE
Implement Hash#transform_keys and Hash#transform_keys!

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1430,9 +1430,29 @@ public class RubyHash extends RubyObject implements Map {
         return block.isGiven() ? each_keyCommon(context, block) : enumeratorizeWithSize(context, this, "each_key", enumSizeFn());
     }
 
+    @JRubyMethod(name = "transform_keys")
+    public IRubyObject transform_keys(final ThreadContext context, final Block block) {
+        return ((RubyHash)dup()).transform_keys_bang(context, block);
+    }
+
     @JRubyMethod(name = "transform_values")
     public IRubyObject transform_values(final ThreadContext context, final Block block) {
         return ((RubyHash)dup()).transform_values_bang(context, block);
+    }
+
+    @JRubyMethod(name = "transform_keys!")
+    public IRubyObject transform_keys_bang(final ThreadContext context, final Block block) {
+        if (block.isGiven()) {
+            testFrozen("Hash");
+            RubyHash bak = (RubyHash)dup();
+            rb_clear();
+            bak.keys().forEach((k) -> {
+                op_aset(context, block.yield(context, (IRubyObject)k), bak.op_aref(context, (IRubyObject)k));
+            });
+            return this;
+        }
+
+        return enumeratorizeWithSize(context, this, "transform_keys!", enumSizeFn());
     }
 
     @JRubyMethod(name = "transform_values!")

--- a/test/mri/ruby/test_hash.rb
+++ b/test/mri/ruby/test_hash.rb
@@ -1480,6 +1480,34 @@ class TestHash < Test::Unit::TestCase
     assert_equal([10, 20, 30], [1, 2, 3].map(&h))
   end
 
+  def test_transform_keys
+    x = @cls[a: 1, b: 2, c: 3]
+    y = x.transform_keys {|k| :"#{k}!" }
+    assert_equal({a: 1, b: 2, c: 3}, x)
+    assert_equal({a!: 1, b!: 2, c!: 3}, y)
+
+    enum = x.transform_keys
+    assert_equal(x.size, enum.size)
+    assert_instance_of(Enumerator, enum)
+
+    y = x.transform_keys.with_index {|k, i| "#{k}.#{i}" }
+    assert_equal(%w(a.0 b.1 c.2), y.keys)
+  end
+
+  def test_transform_keys_bang
+    x = @cls[a: 1, b: 2, c: 3]
+    y = x.transform_keys! {|k| :"#{k}!" }
+    assert_equal({a!: 1, b!: 2, c!: 3}, x)
+    assert_same(x, y)
+
+    enum = x.transform_keys!
+    assert_equal(x.size, enum.size)
+    assert_instance_of(Enumerator, enum)
+
+    x.transform_keys!.with_index {|k, i| "#{k}.#{i}" }
+    assert_equal(%w(a!.0 b!.1 c!.2), x.keys)
+  end
+
   def test_transform_values
     x = @cls[a: 1, b: 2, c: 3]
     y = x.transform_values {|v| v ** 2 }


### PR DESCRIPTION
Hi folks,

This is another feature targeting Ruby 2.5 [1]: Hash#transform_keys and Hash#transform_keys! (feature #13583).

Note: the tests are copied from MRI.

Thanks for your review and feedback.

1. https://github.com/jruby/jruby/issues/4876