### PR TITLE
Add File.lutime

### DIFF
--- a/test/mri/ruby/test_file_exhaustive.rb
+++ b/test/mri/ruby/test_file_exhaustive.rb
@@ -640,6 +640,34 @@ class TestFileExhaustive < Test::Unit::TestCase
     assert_equal(t + 2, File.mtime(zerofile))
   end
 
+  def test_utime_symlinkfile
+    return unless symlinkfile
+    t = Time.local(2000)
+    stat = File.lstat(symlinkfile)
+    assert_equal(1, File.utime(t, t, symlinkfile))
+    assert_equal(t, File.stat(regular_file).atime)
+    assert_equal(t, File.stat(regular_file).mtime)
+  end
+
+  def test_lutime
+    return unless File.respond_to?(:lutime)
+    return unless symlinkfile
+
+    r = File.stat(regular_file)
+    t = Time.local(2000)
+    File.lutime(t + 1, t + 2, symlinkfile)
+  rescue NotImplementedError => e
+    skip(e.message)
+  else
+    stat = File.stat(regular_file)
+    assert_equal(r.atime, stat.atime)
+    assert_equal(r.mtime, stat.mtime)
+
+    stat = File.lstat(symlinkfile)
+    assert_equal(t + 1, stat.atime)
+    assert_equal(t + 2, stat.mtime)
+  end
+
   def test_hardlink
     return unless hardlinkfile
     assert_equal("file", File.ftype(hardlinkfile))


### PR DESCRIPTION
Hi folks,

This is another feature targeting Ruby 2.5 [1]: File.lutime (feature #4052).

Nothing new, it's just a copy of File.utime implementation.

Note: the tests are copied from MRI.

Thanks for your review and feedback.

1. https://github.com/jruby/jruby/issues/4876