### PR TITLE
Make Integer#{round,floor,ceil,truncate} always return integer

### DIFF
--- a/core/src/main/java/org/jruby/RubyBignum.java
+++ b/core/src/main/java/org/jruby/RubyBignum.java
@@ -270,9 +270,7 @@ public class RubyBignum extends RubyInteger {
     public IRubyObject ceil(ThreadContext context, IRubyObject arg){
         int ndigits = arg.convertToInteger().getIntValue();
         BigInteger self = value;
-        if (ndigits > 0){
-            return convertToFloat();
-        } else if (ndigits == 0){
+        if (ndigits >= 0){
             return this;
         } else {
             int posdigits = Math.abs(ndigits);
@@ -293,9 +291,7 @@ public class RubyBignum extends RubyInteger {
     public IRubyObject floor(ThreadContext context, IRubyObject arg){
         int ndigits = arg.convertToInteger().getIntValue();
         BigInteger self = value;
-        if (ndigits > 0){
-            return convertToFloat();
-        } else if (ndigits == 0){
+        if (ndigits >= 0){
             return this;
         } else {
             int posdigits = Math.abs(ndigits);

--- a/core/src/main/java/org/jruby/RubyFixnum.java
+++ b/core/src/main/java/org/jruby/RubyFixnum.java
@@ -305,9 +305,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
     public IRubyObject ceil(ThreadContext context, IRubyObject arg){
         long ndigits = arg.convertToInteger().getLongValue();
         long self = getLongValue();
-        if (ndigits > 0) {
-            return convertToFloat();
-        } else if (ndigits == 0){
+        if (ndigits >= 0) {
             return this;
         } else {
             long posdigits = Math.abs(ndigits);
@@ -328,9 +326,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
     public IRubyObject floor(ThreadContext context, IRubyObject arg){
         long ndigits = (arg).convertToInteger().getLongValue();
         long self = getLongValue();
-        if (ndigits > 0) {
-            return convertToFloat();
-        } else if (ndigits == 0){
+        if (ndigits >= 0) {
             return this;
         } else {
             long posdigits = Math.abs(ndigits);

--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -457,11 +457,7 @@ public abstract class RubyInteger extends RubyNumeric {
         int ndigits = num2int(digits);
 
         RoundingMode roundingMode = getRoundingMode(context, opts);
-
-        if (ndigits > 0) {
-            return RubyKernel.new_float(runtime, this);
-        }
-        if (ndigits == 0) {
+        if (ndigits >= 0) {
             return this;
         }
 

--- a/test/mri/ruby/test_integer.rb
+++ b/test/mri/ruby/test_integer.rb
@@ -181,8 +181,8 @@ class TestInteger < Test::Unit::TestCase
     assert_int_equal(11111, 11111.round)
     assert_int_equal(11111, 11111.round(0))
 
-    assert_float_equal(11111.0, 11111.round(1))
-    assert_float_equal(11111.0, 11111.round(2))
+    assert_int_equal(11111, 11111.round(1))
+    assert_int_equal(11111, 11111.round(2))
 
     assert_int_equal(11110, 11111.round(-1))
     assert_int_equal(11100, 11111.round(-2))
@@ -255,8 +255,8 @@ class TestInteger < Test::Unit::TestCase
     assert_int_equal(11111, 11111.floor)
     assert_int_equal(11111, 11111.floor(0))
 
-    assert_float_equal(11111.0, 11111.floor(1))
-    assert_float_equal(11111.0, 11111.floor(2))
+    assert_int_equal(11111, 11111.floor(1))
+    assert_int_equal(11111, 11111.floor(2))
 
     assert_int_equal(11110, 11110.floor(-1))
     assert_int_equal(11110, 11119.floor(-1))
@@ -280,8 +280,8 @@ class TestInteger < Test::Unit::TestCase
     assert_int_equal(11111, 11111.ceil)
     assert_int_equal(11111, 11111.ceil(0))
 
-    assert_float_equal(11111.0, 11111.ceil(1))
-    assert_float_equal(11111.0, 11111.ceil(2))
+    assert_int_equal(11111, 11111.ceil(1))
+    assert_int_equal(11111, 11111.ceil(2))
 
     assert_int_equal(11110, 11110.ceil(-1))
     assert_int_equal(11120, 11119.ceil(-1))
@@ -299,14 +299,17 @@ class TestInteger < Test::Unit::TestCase
 
     assert_int_equal(1111_1111_1111_1111_1111_1111_1111_1120, 1111_1111_1111_1111_1111_1111_1111_1111.ceil(-1))
     assert_int_equal(-1111_1111_1111_1111_1111_1111_1111_1110, (-1111_1111_1111_1111_1111_1111_1111_1111).ceil(-1))
+
+    assert_int_equal(1111_1111_1111_1111_1111_1111_1111_1111, 1111_1111_1111_1111_1111_1111_1111_1111.ceil(1))
+    assert_int_equal(10**400, (10**400).ceil(1))
   end
 
   def test_truncate
     assert_int_equal(11111, 11111.truncate)
     assert_int_equal(11111, 11111.truncate(0))
 
-    assert_float_equal(11111.0, 11111.truncate(1))
-    assert_float_equal(11111.0, 11111.truncate(2))
+    assert_int_equal(11111, 11111.truncate(1))
+    assert_int_equal(11111, 11111.truncate(2))
 
     assert_int_equal(11110, 11110.truncate(-1))
     assert_int_equal(11110, 11119.truncate(-1))
@@ -324,6 +327,8 @@ class TestInteger < Test::Unit::TestCase
 
     assert_int_equal(1111_1111_1111_1111_1111_1111_1111_1110, 1111_1111_1111_1111_1111_1111_1111_1111.truncate(-1))
     assert_int_equal(-1111_1111_1111_1111_1111_1111_1111_1110, (-1111_1111_1111_1111_1111_1111_1111_1111).truncate(-1))
+    assert_int_equal(1111_1111_1111_1111_1111_1111_1111_1111, 1111_1111_1111_1111_1111_1111_1111_1111.truncate(1))
+    assert_int_equal(10**400, (10**400).truncate(1))
   end
 
   MimicInteger = Struct.new(:to_int)


### PR DESCRIPTION
Support for Ruby 2.5

See feature https://bugs.ruby-lang.org/issues/4052