### PR TITLE
Feature/string casecmp

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1504,7 +1504,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
                 }
                 value.setUnsafeBytes(obytes);
             }
-            
+
             setCodeRange(cr);
         }
         return this;
@@ -1584,7 +1584,11 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     @JRubyMethod(name = "casecmp")
     public IRubyObject casecmp19(ThreadContext context, IRubyObject other) {
         Ruby runtime = context.runtime;
-        RubyString otherStr = other.convertToString();
+
+        IRubyObject tmp = other.checkStringType();
+        if (tmp.isNil()) return runtime.getNil();
+
+        RubyString otherStr = (RubyString) tmp;
         Encoding enc = StringSupport.areCompatible(this, otherStr);
         if (enc == null) return runtime.getNil();
 
@@ -1608,7 +1612,10 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     @JRubyMethod(name = "casecmp?")
     public IRubyObject casecmp_p(ThreadContext context, IRubyObject other) {
         Ruby runtime = context.runtime;
-        RubyString otherStr = other.convertToString();
+
+        IRubyObject tmp = other.checkStringType();
+        if (tmp.isNil()) return runtime.getNil();
+        RubyString otherStr = (RubyString) tmp;
 
         Encoding enc = StringSupport.areCompatible(this, otherStr);
         if (enc == null) return runtime.getNil();

--- a/test/mri/ruby/test_string.rb
+++ b/test/mri/ruby/test_string.rb
@@ -2296,7 +2296,17 @@ CODE
 =end
 
   def test_casecmp
-    assert_equal(1, "\u3042B".casecmp("\u3042a"))
+     assert_equal(0, "FoO".casecmp("fOO"))
+     assert_equal(1, "FoO".casecmp("BaR"))
+     assert_equal(-1, "baR".casecmp("FoO"))
+     assert_equal(1, "\u3042B".casecmp("\u3042a"))
+
+     assert_nil("foo".casecmp(:foo))
+     assert_nil("foo".casecmp(Object.new))
+
+     o = Object.new
+     def o.to_str; "fOO"; end
+     assert_equal(0, "FoO".casecmp(o))
   end
 
   def test_casecmp?
@@ -2304,6 +2314,13 @@ CODE
     assert_equal(false, 'FoO'.casecmp?('BaR'))
     assert_equal(false, 'baR'.casecmp?('FoO'))
     assert_equal(true, 'äöü'.casecmp?('ÄÖÜ'))
+
+    assert_nil("foo".casecmp?(:foo))
+    assert_nil("foo".casecmp?(Object.new))
+
+    o = Object.new
+    def o.to_str; "fOO"; end
+    assert_equal(true, "FoO".casecmp?(o))
   end
 
   def test_upcase2


### PR DESCRIPTION
to return nil for incompatible types instead of raising exception.
Support for Ruby 2.5

See feature https://bugs.ruby-lang.org/issues/13312.