### PR TITLE
Do not leak DNS Request IDs

### DIFF
--- a/lib/ruby/stdlib/resolv.rb
+++ b/lib/ruby/stdlib/resolv.rb
@@ -772,7 +772,7 @@ class Resolv
           sock = @socks_hash[host.index(':') ? "::" : "0.0.0.0"]
           return nil if !sock
           service = [IPAddr.new(host), port]
-          id = DNS.allocate_request_id(host, port)
+          id = DNS.allocate_request_id(service[0], service[1])
           request = msg.encode
           request[0,2] = [id].pack('n')
           return @senders[[service, id]] =


### PR DESCRIPTION
While https://github.com/jruby/jruby/commit/d1a760e066343e7a4956bbdd7be7975b1eda04cd fixed handling of compressed IPv6 addresses,
it also broke the "freeing" part of it.

Currently every DNS request leaks single request id:
```
require 'resolv'

Resolv::DNS::RequestID.values.map(&:length)
# => []

Resolv::DNS.new.getaddress('example.com')

Resolv::DNS::RequestID.values.map(&:length)
# => [1]
```

Given the fact that request ids are chosen from `0x0000..0xffff` range - the app can issue 65535 requests and then will be blocked forever trying to allocate another one.

This commit makes request id caching work by using same data for allocation and freeing.