### PR TITLE
Set encoding for character literal

### DIFF
--- a/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
@@ -1883,6 +1883,7 @@ public class RubyLexer extends LexingCommon {
         }
 
         ByteList oneCharBL = new ByteList(1);
+        oneCharBL.setEncoding(getEncoding());
         oneCharBL.append(c);
         yaccValue = new StrNode(getPosition(), oneCharBL);
         setState(EXPR_END);

--- a/test/mri/excludes/TestStringchar.rb
+++ b/test/mri/excludes/TestStringchar.rb
@@ -1,1 +1,0 @@
-exclude :test_char, "needs investigation"


### PR DESCRIPTION
MRI sets source encoding to character literal.
This commit will fix `#test_char`.

```ruby
p "a".encoding
p ?a.encoding
p ?\M-a.encoding
```

```shell
$ ruby -v /tmp/enc.rb
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin14]
#<Encoding:UTF-8>
#<Encoding:UTF-8>
#<Encoding:UTF-8>
```