### PR TITLE
Update File#path to raise IOError for files opened with File::Constants::TMPFILE option

### DIFF
--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -455,6 +455,9 @@ public class RubyFile extends RubyIO implements EncodingCapable {
 
     @JRubyMethod(name = {"path", "to_path"})
     public IRubyObject path(ThreadContext context) {
+        if ((openFile.getMode() & OpenFile.TMPFILE) != 0) {
+            throw context.runtime.newIOError("File is unnamed (TMPFILE?)");
+        }
         IRubyObject newPath = context.runtime.getNil();
         final String path = getPath();
         if (path != null) {

--- a/core/src/main/java/org/jruby/util/io/ModeFlags.java
+++ b/core/src/main/java/org/jruby/util/io/ModeFlags.java
@@ -73,6 +73,7 @@ public class ModeFlags implements Cloneable {
     public static final int NONBLOCK = OpenFlags.O_NONBLOCK.intValue();
     /** binary flag, to ensure no encoding changes are made while writing */
     public static final int BINARY = OpenFlags.O_BINARY.intValue();
+    public static final int TMPFILE = OpenFlags.O_TMPFILE.intValue();
     /** textmode flag, MRI has no equivalent but we use ModeFlags currently
      * to also capture what are oflags.
      */
@@ -272,6 +273,15 @@ public class ModeFlags implements Cloneable {
     }
     
     /**
+     * Whether the flags specify "unnamed temporary".
+     *
+     * @return true if unnamed temporary mode, false otherwise
+     */
+    public boolean isTemporary() {
+        return (flags & TMPFILE) != 0;
+    }
+
+    /**
      * Whether the flags specify to create nonexisting files.
      * 
      * @return true if nonexisting files should be created, false otherwise
@@ -347,6 +357,7 @@ public class ModeFlags implements Cloneable {
         if (isExclusive()) buf.append("EXCLUSIVE ");
         if (isReadOnly()) buf.append("READONLY ");
         if (isText()) buf.append("TEXT ");
+        if (isTemporary()) buf.append("TMPFILE ");
         if (isTruncate()) buf.append("TRUNCATE ");
         if (isWritable()) {
             if (isReadable()) {
@@ -395,6 +406,9 @@ public class ModeFlags implements Cloneable {
         }
         if ((flags & BINARY) == BINARY) {
             fmodeFlags |= OpenFile.BINMODE;
+        }
+        if ((flags & TMPFILE) == TMPFILE) {
+            fmodeFlags |= OpenFile.TMPFILE;
         }
 
         // This is unique to us to keep bridge betweeen mode_flags and oflags

--- a/core/src/main/java/org/jruby/util/io/OpenFile.java
+++ b/core/src/main/java/org/jruby/util/io/OpenFile.java
@@ -71,6 +71,7 @@ public class OpenFile implements Finalizable {
     public static final int TRUNC              = 0x00000800;
     public static final int TEXTMODE           = 0x00001000;
     public static final int SETENC_BY_BOM      = 0x00100000;
+    public static final int TMPFILE            = 0x00410000;
     public static final int PREP         = (1<<16);
 
     public static final int SYNCWRITE = SYNC | WRITABLE;

--- a/test/mri/ruby/test_file.rb
+++ b/test/mri/ruby/test_file.rb
@@ -468,4 +468,16 @@ class TestFile < Test::Unit::TestCase
       assert_file.not_exist?(path)
     end
   end
+
+  def test_open_tempfile_path
+    Dir.mktmpdir(__method__.to_s) do |tmpdir|
+      File.open(tmpdir, File::RDWR | File::TMPFILE) do |io|
+        io.write "foo"
+        io.flush
+        assert_equal 3, io.size
+        assert_raise(IOError) { io.path }
+      end
+    end
+  end if File::Constants.const_defined?(:TMPFILE)
+
 end


### PR DESCRIPTION
Hi folks,

This is another feature targeting Ruby 2.5 [1] on File#path method (feature #13568).

Note: The test is copied from MRI.

Thanks for your review and feedback.

1. https://github.com/jruby/jruby/issues/4876