### PR TITLE
Fix `Symbol#inspect` of UTF_16/UTF_32

### DIFF
--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -256,27 +256,22 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
     }
 
     final RubyString inspect(final Ruby runtime) {
-        ByteList result = new ByteList(symbolBytes.getRealSize() + 1);
-        result.setEncoding(symbolBytes.getEncoding());
-        result.append((byte)':');
-        result.append(symbolBytes);
-
         // TODO: 1.9 rb_enc_symname_p
         Encoding resenc = runtime.getDefaultInternalEncoding();
         if (resenc == null) resenc = runtime.getDefaultExternalEncoding();
 
-        RubyString str = RubyString.newString(runtime, result);
+        RubyString str = RubyString.newString(runtime, symbolBytes);
 
-        if (isPrintable() && (resenc.equals(symbolBytes.getEncoding()) || str.isAsciiOnly()) && isSymbolName19(symbol)) {
-            return str;
+        if (!(isPrintable() && (resenc.equals(symbolBytes.getEncoding()) || str.isAsciiOnly()) && isSymbolName19(symbol))) {
+            str = str.inspect(runtime);
         }
 
-        str = str.inspect(runtime);
-        ByteList bytes = str.getByteList();
-        bytes.set(0, ':');
-        bytes.set(1, '"');
+        ByteList result = new ByteList(str.getByteList().getRealSize() + 1);
+        result.setEncoding(str.getEncoding());
+        result.append((byte)':');
+        result.append(str.getBytes());
 
-        return str;
+        return RubyString.newString(runtime, result);
     }
 
     @Deprecated

--- a/test/mri/excludes/TestSymbol.rb
+++ b/test/mri/excludes/TestSymbol.rb
@@ -1,4 +1,3 @@
-exclude :test_ascii_incomat_inspect, "needs investigation"
 exclude :test_inspect, "needs investigation"
 exclude :test_to_proc_arg, "we have plans to do different caching here, see 69662ab8cd1616a2ee076488226a473648fc6267"
 exclude :test_to_proc_binding, "needs investigation #4303"


### PR DESCRIPTION
Stop to append byte before inspect string.
For example, when an encoding of `symbolBytes` is UTF_16LE, "a" is
`[0x61, 0x00]`. If we append `":"` (0x3A) to `symbolBytes` before
inspect it, bytes are `[0x3A, 0x61, 0x00]` with UTF_16LE encoding.
This is not what we want to get. This commit chnages the order of
inspecting and appending to avoid this.

Ref: https://github.com/ruby/ruby/blob/v2_5_0/string.c#L10402