### PR TITLE
Update openjdk on travis to 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - echo $MAVEN_OPTS
 
 jdk:
-  - openjdk7
+  - openjdk8
 
 os:
   - linux
@@ -60,13 +60,13 @@ matrix:
     - env: PHASE='-Pdist'
       jdk: oraclejdk8
     - env: PHASE='-Pjruby-jars'
-      jdk: openjdk7
+      jdk: openjdk8
     - env: PHASE='-Pmain'
       jdk: oraclejdk8
     - env: PHASE='-Pcomplete'
       jdk: oraclejdk8
     - env: PHASE='-Posgi'
-      jdk: openjdk7
+      jdk: openjdk8
     - env: PHASE='-Pj2ee'
       jdk: oraclejdk8
     - env: PHASE='-Prake -Dtask=test:mri'


### PR DESCRIPTION
23783ceb3bf started to use `java.util.function`, but this
package was introduced from 1.8. Update jdk to keep build passed.