### PR TITLE
IO#write accepts multiple arguments

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1450,6 +1450,15 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return write(context, str, false);
     }
 
+    @JRubyMethod(name = "write", rest = true)
+    public IRubyObject write(ThreadContext context, IRubyObject[] args) {
+        long bytes = Arrays.stream(args)
+            .map(s -> write(context, s, false))
+            .map(n -> RubyNumeric.num2long(n))
+            .reduce(0l, (x, y) -> x + y);
+        return RubyFixnum.newFixnum(context.runtime, bytes);
+    }
+
     // io_write
     public IRubyObject write(ThreadContext context, IRubyObject str, boolean nosync) {
         Ruby runtime = context.runtime;


### PR DESCRIPTION
Hi folks,

This is another feature targeting Ruby 2.5 [1] on IO#write method (feature #9329).

Note: The tests are copied from MRI.

Thanks for your review and feedback.

1. https://github.com/jruby/jruby/issues/4876