### PR TITLE
Accept `nil` as an argument of `Rational#<=>`

### DIFF
--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -674,7 +674,7 @@ public class RubyRational extends RubyNumeric {
             }
             return f_cmp(context, f_sub(context, num1, num2), RubyFixnum.zero(context.runtime));
         }
-        return coerceBin(context, sites(context).op_cmp, other);
+        return coerceCmp(context, sites(context).op_cmp, other);
     }
 
     /** nurat_equal_p

--- a/test/mri/excludes/Rational_Test.rb
+++ b/test/mri/excludes/Rational_Test.rb
@@ -1,4 +1,3 @@
-exclude :test_cmp, "needs investigation"
 exclude :test_coerce, "needs investigation"
 exclude :test_coerce2, "needs investigation"
 exclude :test_conv, "needs investigation"


### PR DESCRIPTION
Ref: https://github.com/ruby/ruby/blob/v2_3_0/rational.c#L1104