### PR TITLE
Implement `Rational#coerce` with `Complex` object

### DIFF
--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -712,6 +712,13 @@ public class RubyRational extends RubyNumeric {
             return runtime.newArray(other, f_to_f(context, this));
         } else if (other instanceof RubyRational) {
             return runtime.newArray(other, this);
+        } else if (other instanceof RubyComplex) {
+            RubyComplex otherComplex = (RubyComplex)other;
+            if (k_exact_p(otherComplex.getImage()) && f_zero_p(context, otherComplex.getImage())) {
+                return runtime.newArray(RubyRational.newRationalBang(context, getMetaClass(), otherComplex.getReal()), this);
+            } else {
+                return runtime.newArray(other, RubyComplex.newComplexCanonicalize(context, this));
+            }
         }
         throw runtime.newTypeError(other.getMetaClass() + " can't be coerced into " + getMetaClass());
     }

--- a/test/mri/excludes/Rational_Test.rb
+++ b/test/mri/excludes/Rational_Test.rb
@@ -1,5 +1,4 @@
 exclude :test_cmp, "needs investigation"
-exclude :test_coerce, "needs investigation"
 exclude :test_coerce2, "needs investigation"
 exclude :test_conv, "needs investigation"
 exclude :test_marshal, "needs investigation"


### PR DESCRIPTION
In MRI

* if the argument is complex with zero imaginary part,
  converts it to ratinal
* if the argument is complex with non-zero imaginary part,
  converts self to complex

Ref: https://github.com/ruby/ruby/blob/v2_3_0/rational.c#L1171