### PR TITLE
Fix `convertCommon`

### DIFF
--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -1184,7 +1184,7 @@ public class RubyNumeric extends RubyObject {
         return sites(context).op_equals.call(context, other, other, this);
     }
 
-    /** num_numerator
+    /** numeric_numerator
      *
      */
     @JRubyMethod(name = "numerator")
@@ -1193,7 +1193,7 @@ public class RubyNumeric extends RubyObject {
         return sites(context).numerator.call(context, rational, rational);
     }
 
-    /** num_denominator
+    /** numeric_denominator
      *
      */
     @JRubyMethod(name = "denominator")

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -61,6 +61,7 @@ import static org.jruby.util.Numeric.f_abs;
 import static org.jruby.util.Numeric.f_arg;
 import static org.jruby.util.Numeric.f_mul;
 import static org.jruby.util.Numeric.f_negative_p;
+import static org.jruby.util.Numeric.f_to_r;
 
 /**
  * Base class for all numerical types in ruby.
@@ -1188,7 +1189,7 @@ public class RubyNumeric extends RubyObject {
      */
     @JRubyMethod(name = "numerator")
     public IRubyObject numerator(ThreadContext context) {
-        IRubyObject rational = RubyRational.newRationalConvert(context, this);
+        IRubyObject rational = f_to_r(context, this);
         return sites(context).numerator.call(context, rational, rational);
     }
 
@@ -1197,7 +1198,7 @@ public class RubyNumeric extends RubyObject {
      */
     @JRubyMethod(name = "denominator")
     public IRubyObject denominator(ThreadContext context) {
-        IRubyObject rational = RubyRational.newRationalConvert(context, this);
+        IRubyObject rational = f_to_r(context, this);
         return sites(context).denominator.call(context, rational, rational);
     }
 

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -365,10 +365,6 @@ public class RubyRational extends RubyNumeric {
             a1 = f_to_r(context, a1);
         } else if (a1 instanceof RubyString) {
             a1 = str_to_r_strict(context, a1);
-        } else {
-            if (a1 instanceof RubyObject && responds_to_to_r(context, a1)) {
-                a1 = f_to_r(context, a1);
-            }
         }
         
         if (a2 instanceof RubyFloat) {
@@ -382,7 +378,9 @@ public class RubyRational extends RubyNumeric {
         }
 
         if (a2.isNil()) {
-            if (a1 instanceof RubyNumeric && !f_integer_p(context, a1).isTrue()) return a1;
+            if (!(a1 instanceof RubyNumeric && f_integer_p(context, a1).isTrue())) {
+                return TypeConverter.convertToType(a1, context.getRuntime().getRational(), "to_r");
+            }
             return newInstance(context, recv, a1);
         } else {
             if (a1 instanceof RubyNumeric && a2 instanceof RubyNumeric &&


### PR DESCRIPTION
1. Remove f_to_r call
  MRI does not call `to_r` when `a1` is not a float nor a string.
  Ref: https://github.com/ruby/ruby/blob/v2_3_0/rational.c#L2423-L2428

2. Call `#to_r` when `a1` is an integer
  Ref: https://github.com/ruby/ruby/blob/v2_3_0/rational.c#L2445-L2446