### PR TITLE
fix issue where expr fails on freebsd.

### DIFF
--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -244,7 +244,7 @@ do
      # Match -Xa.b.c=d to translate to -Da.b.c=d as a java option
      -X*)
         val=${1:2}
-        if expr "$val" : '.*[.]' > /dev/null; then
+        if expr -- "$val" : '.*[.]' > /dev/null; then
           java_args=("${java_args[@]}" "-Djruby.${val}")
         else
           ruby_args=("${ruby_args[@]}" "-X${val}")

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -26,9 +26,9 @@ progname=`basename "$0"`
 
 while [ -h "$PRG" ] ; do
   ls=`ls -ld "$PRG"`
-  link=`expr "$ls" : '.*-> \(.*\)$'`
-  if expr "$link" : '.*/.*' > /dev/null; then
-    if expr "$link" : '/' > /dev/null; then
+  link=`expr -- "$ls" : '.*-> \(.*\)$'`
+  if expr -- "$link" : '.*/.*' > /dev/null; then
+    if expr -- "$link" : '/' > /dev/null; then
       PRG="$link"
     else
       PRG="`dirname ${PRG}`/${link}"
@@ -202,7 +202,7 @@ do
      # Match -Xa.b.c=d to translate to -Da.b.c=d as a java option
      -X*)
      val=${1:2}
-     if expr "$val" : '.*[.]' > /dev/null; then
+     if expr -- "$val" : '.*[.]' > /dev/null; then
        java_args="${java_args} -Djruby.${val}"
      else
        ruby_args="${ruby_args} -X${val}"


### PR DESCRIPTION
These scripts produce errors when run on FreeBSD (in the context of logstash). Adding the double dash prevents interpretation of the left operand as an option to expr itself. See also https://discuss.elastic.co/t/cannot-install-multiline-filter-on-freebsd-11/106929?source_topic_id=117201.

In particular, the culprit in the logstash issue was line https://github.com/jruby/jruby/blob/4cdf882cf1a17f71620886250e3519d4ab1ef91b/bin/jruby.bash#L247 expanding to "expr -C : .[.*]".

Thanks.