### PR TITLE
Fix test coerce2 for master branch

### DIFF
--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -799,7 +799,7 @@ public class RubyNumeric extends RubyObject {
     /** num_modulo
      *
      */
-    @JRubyMethod(name = "modulo")
+    @JRubyMethod(name = {"modulo", "%"})
     public IRubyObject modulo(ThreadContext context, IRubyObject other) {
         IRubyObject div = numFuncall(context, this, sites(context).div, other);
         IRubyObject product = sites(context).op_times.call(context, other, other, div);

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -818,10 +818,6 @@ public class RubyRational extends RubyNumeric {
         throw runtime.newTypeError(other.getMetaClass() + " can't be coerced into " + getMetaClass());
     }
 
-    /** nurat_idiv
-     * 
-     */
-    @JRubyMethod(name = "div")
     @Override
     public IRubyObject idiv(ThreadContext context, IRubyObject other) {
         if (num2dbl(other) == 0.0) throw context.runtime.newZeroDivisionError();

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -829,10 +829,6 @@ public class RubyRational extends RubyNumeric {
         return f_floor(context, f_div(context, this, other));
     }
 
-    /** nurat_mod
-     * 
-     */
-    @JRubyMethod(name = {"modulo", "%"})
     public IRubyObject op_mod(ThreadContext context, IRubyObject other) {
         if (num2dbl(other) == 0.0) throw context.runtime.newZeroDivisionError();
 


### PR DESCRIPTION
This PR is porting of https://github.com/jruby/jruby/pull/5006.
Method names modulo19, op_idiv19 and op_mod19 have been changed on master branch.
So we should porting the commit manually.
I hope this PR fix "test:mri*".