### PR TITLE
No longer hide exceptions from coerce method

### DIFF
--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -953,16 +953,7 @@ public class RubyNumeric extends RubyObject {
             }
         }
         IRubyObject r = UNDEF;
-        try {
-            context.setExceptionRequiresBacktrace(false);
-            r = stepCompareWithZero(context, num);
-        } catch (RaiseException re) {
-        } finally {
-            context.setExceptionRequiresBacktrace(true);
-        }
-        if (r == UNDEF) {
-            coerceFailed(context, num);
-        }
+        r = stepCompareWithZero(context, num);
         return !r.isTrue();
     }
 

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -474,35 +474,14 @@ public class RubyNumeric extends RubyObject {
         }
         final IRubyObject $ex = context.getErrorInfo();
         final IRubyObject result;
-        try {
-            result = coerceBody(context, other);
-        }
-        catch (RaiseException e) { // e.g. NoMethodError: undefined method `coerce'
-            if (context.runtime.getStandardError().isInstance( e.getException() )) {
-                context.setErrorInfo($ex); // restore $!
-                RubyWarnings warnings = context.runtime.getWarnings();
-                warnings.warn("Numerical comparison operators will no more rescue exceptions of #coerce");
-                warnings.warn("in the next release. Return nil in #coerce if the coercion is impossible.");
-                if (err) {
-                    coerceFailed(context, other);
-                }
-                return null;
-            }
-            throw e;
-        }
 
+        result = coerceBody(context, other);
         return coerceResult(context.runtime, result, err);
     }
 
     private static RubyArray coerceResult(final Ruby runtime, final IRubyObject result, final boolean err) {
         if (!(result instanceof RubyArray) || ((RubyArray) result).getLength() != 2 ) {
-            if (err) throw runtime.newTypeError("coerce must return [x, y]");
-
-            if (!result.isNil()) {
-                RubyWarnings warnings = runtime.getWarnings();
-                warnings.warn("Bad return value for #coerce, called by numerical comparison operators.");
-                warnings.warn("#coerce must return [x, y]. The next release will raise an error for this.");
-            }
+            if (err || !result.isNil()) throw runtime.newTypeError("coerce must return [x, y]");
             return null;
         }
 

--- a/test/mri/ruby/test_float.rb
+++ b/test/mri/ruby/test_float.rb
@@ -782,7 +782,7 @@ class TestFloat < Test::Unit::TestCase
   end
 
   def test_num2dbl
-    assert_raise(TypeError) do
+    assert_raise(ArgumentError, "comparison of String with 0 failed") do
       1.0.step(2.0, "0.5") {}
     end
     assert_raise(TypeError) do


### PR DESCRIPTION
Hi folks,

This is another feature targeting Ruby 2.5 [1]:

- Numerical comparison operators (< ,<=, >=, >) no longer rescue exceptions of #coerce. Return nil in #coerce if the coercion is impossible.

-  Integer#step does no longer rescue exceptions when given a step value which cannot be compared with #> to 0.

- Range#initialize no longer rescue exceptions when comparing begin and end with #<=> and raise a "bad value for range" ArgumentError but instead let the exception from the #<=> call go through.

All of these from feature #7688 [2].

Note: The tests are copied from MRI.

Thanks for your review and feedback.

1. https://github.com/jruby/jruby/issues/4876
2. https://bugs.ruby-lang.org/issues/7688