### PR TITLE
Fix String#rpartition for RegEx on Strings with multibyte chars

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1509,7 +1509,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
                 }
                 value.setUnsafeBytes(obytes);
             }
-            
+
             setCodeRange(cr);
         }
         return this;
@@ -4278,11 +4278,9 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         final int pos;
         final RubyString sep;
         if (arg instanceof RubyRegexp) {
-            RubyRegexp regex = (RubyRegexp)arg;
-
-            pos = regex.search(context, this, value.getRealSize(), true);
-
-            if (pos < 0) return rpartitionMismatch(runtime);
+            IRubyObject tmp = rindex(context, arg);
+            if (tmp.isNil()) return rpartitionMismatch(runtime);
+            pos = (int)tmp.convertToInteger().getIntValue();
             sep = (RubyString)RubyRegexp.nth_match(0, context.getBackRef());
         } else {
             IRubyObject tmp = arg.checkStringType();

--- a/test/mri/excludes/TestString.rb
+++ b/test/mri/excludes/TestString.rb
@@ -1,4 +1,3 @@
 exclude :test_casecmp?, "missing 2.4 case-folding logic (#4731)"
 exclude :test_crypt, "does not raise as expected"
-exclude :test_rpartition, "needs investigation"
 exclude :test_setter, "does not raise as expected"


### PR DESCRIPTION
because before it used the wrong index when there was a mulitbyte character in the string.
We now let handle rindex function the index detection.