### PR TITLE
Add FrozenError class

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1543,6 +1543,7 @@ public final class Ruby implements Constantizable {
     private void initExceptions() {
         standardError = defineClassIfAllowed("StandardError", exceptionClass);
         runtimeError = defineClassIfAllowed("RuntimeError", standardError);
+        frozenError = defineClassIfAllowed("FrozenError", runtimeError);
         ioError = defineClassIfAllowed("IOError", standardError);
         scriptError = defineClassIfAllowed("ScriptError", exceptionClass);
         rangeError = defineClassIfAllowed("RangeError", standardError);
@@ -2447,6 +2448,10 @@ public final class Ruby implements Constantizable {
 
     public RubyClass getRuntimeError() {
         return runtimeError;
+    }
+
+    public RubyClass getFrozenError() {
+        return frozenError;
     }
 
     public RubyClass getIOError() {
@@ -4045,8 +4050,7 @@ public final class Ruby implements Constantizable {
     }
 
     public RaiseException newFrozenError(String objectType, boolean runtimeError) {
-        // TODO: Should frozen error have its own distinct class?  If not should more share?
-        return newRaiseException(getRuntimeError(), "can't modify frozen " + objectType);
+        return newRaiseException(getFrozenError(), "can't modify frozen " + objectType);
     }
 
     public RaiseException newSystemStackError(String message) {
@@ -4906,7 +4910,7 @@ public final class Ruby implements Constantizable {
             matchDataClass, regexpClass, timeClass, bignumClass, dirClass,
             fileClass, fileStatClass, ioClass, threadClass, threadGroupClass,
             continuationClass, structClass, tmsStruct, passwdStruct,
-            groupStruct, procStatusClass, exceptionClass, runtimeError, ioError,
+            groupStruct, procStatusClass, exceptionClass, runtimeError, frozenError, ioError,
             scriptError, nameError, nameErrorMessage, noMethodError, signalException,
             rangeError, dummyClass, systemExit, localJumpError, nativeException,
             systemCallError, fatal, interrupt, typeError, argumentError, uncaughtThrowError, indexError, stopIteration,

--- a/test/mri/-ext-/string/test_enc_associate.rb
+++ b/test/mri/-ext-/string/test_enc_associate.rb
@@ -7,8 +7,8 @@ class Test_StrEncAssociate < Test::Unit::TestCase
     s = Bug::String.new("abc")
     s.force_encoding(Encoding::US_ASCII)
     s.freeze
-    assert_raise(RuntimeError) {s.associate_encoding!(Encoding::US_ASCII)}
-    assert_raise(RuntimeError) {s.associate_encoding!(Encoding::UTF_8)}
+    assert_raise(FrozenError) {s.associate_encoding!(Encoding::US_ASCII)}
+    assert_raise(FrozenError) {s.associate_encoding!(Encoding::UTF_8)}
   end
 
   Encoding.list.select(&:dummy?).each do |enc|

--- a/test/mri/date/test_date_marshal.rb
+++ b/test/mri/date/test_date_marshal.rb
@@ -30,13 +30,13 @@ class TestDateMarshal < Test::Unit::TestCase
     a = d.marshal_dump
     d.freeze
     assert(d.frozen?)
-    assert_raise(RuntimeError){d.marshal_load(a)}
+    assert_raise(FrozenError){d.marshal_load(a)}
 
     d = DateTime.now
     a = d.marshal_dump
     d.freeze
     assert(d.frozen?)
-    assert_raise(RuntimeError){d.marshal_load(a)}
+    assert_raise(FrozenError){d.marshal_load(a)}
   end
 
 end

--- a/test/mri/dbm/test_dbm.rb
+++ b/test/mri/dbm/test_dbm.rb
@@ -625,7 +625,7 @@ if defined? DBM
     def test_freeze
       DBM.open("#{@tmproot}/a") {|d|
         d.freeze
-        assert_raise(RuntimeError) { d["k"] = "v" }
+        assert_raise(FrozenError) { d["k"] = "v" }
       }
     end
   end

--- a/test/mri/gdbm/test_gdbm.rb
+++ b/test/mri/gdbm/test_gdbm.rb
@@ -721,7 +721,7 @@ if defined? GDBM
     def test_freeze
       GDBM.open("#{@tmproot}/a.dbm") {|d|
         d.freeze
-        assert_raise(RuntimeError) { d["k"] = "v" }
+        assert_raise(FrozenError) { d["k"] = "v" }
       }
     end
   end

--- a/test/mri/pathname/test_pathname.rb
+++ b/test/mri/pathname/test_pathname.rb
@@ -633,7 +633,7 @@ class TestPathname < Test::Unit::TestCase
     obj = Pathname.new("a")
     obj.freeze
     assert_equal(false, obj.tainted?)
-    assert_raise(RuntimeError) { obj.taint }
+    assert_raise(FrozenError) { obj.taint }
 
     obj = Pathname.new("a")
     obj.taint

--- a/test/mri/ruby/test_array.rb
+++ b/test/mri/ruby/test_array.rb
@@ -571,7 +571,7 @@ class TestArray < Test::Unit::TestCase
     assert_equal([4, 5, 4, 5, 4, 5], b)
 
     assert_raise(TypeError) { [0].concat(:foo) }
-    assert_raise(RuntimeError) { [0].freeze.concat(:foo) }
+    assert_raise(FrozenError) { [0].freeze.concat(:foo) }
   end
 
   def test_count
@@ -1260,10 +1260,10 @@ class TestArray < Test::Unit::TestCase
 
     fa = a.dup.freeze
     assert_nothing_raised(RuntimeError) { a.replace(a) }
-    assert_raise(RuntimeError) { fa.replace(fa) }
+    assert_raise(FrozenError) { fa.replace(fa) }
     assert_raise(ArgumentError) { fa.replace() }
     assert_raise(TypeError) { a.replace(42) }
-    assert_raise(RuntimeError) { fa.replace(42) }
+    assert_raise(FrozenError) { fa.replace(42) }
   end
 
   def test_reverse
@@ -1491,7 +1491,7 @@ class TestArray < Test::Unit::TestCase
     o2 = o1.clone
     ary << o1 << o2
     orig = ary.dup
-    assert_raise(RuntimeError, "frozen during comparison") {ary.sort!}
+    assert_raise(FrozenError, "frozen during comparison") {ary.sort!}
     assert_equal(orig, ary, "must not be modified once frozen")
   end
 
@@ -1723,7 +1723,7 @@ class TestArray < Test::Unit::TestCase
     f = a.dup.freeze
     assert_raise(ArgumentError) { a.uniq!(1) }
     assert_raise(ArgumentError) { f.uniq!(1) }
-    assert_raise(RuntimeError) { f.uniq! }
+    assert_raise(FrozenError) { f.uniq! }
 
     assert_nothing_raised do
       a = [ {c: "b"}, {c: "r"}, {c: "w"}, {c: "g"}, {c: "g"} ]
@@ -1769,7 +1769,7 @@ class TestArray < Test::Unit::TestCase
   def test_uniq_bang_with_freeze
     ary = [1,2]
     orig = ary.dup
-    assert_raise(RuntimeError, "frozen during comparison") {
+    assert_raise(FrozenError, "frozen during comparison") {
       ary.uniq! {|v| ary.freeze; 1}
     }
     assert_equal(orig, ary, "must not be modified once frozen")
@@ -2019,7 +2019,7 @@ class TestArray < Test::Unit::TestCase
     assert_raise(ArgumentError) { [0][0, 0, 0] = 0 }
     assert_raise(ArgumentError) { [0].freeze[0, 0, 0] = 0 }
     assert_raise(TypeError) { [0][:foo] = 0 }
-    assert_raise(RuntimeError) { [0].freeze[:foo] = 0 }
+    assert_raise(FrozenError) { [0].freeze[:foo] = 0 }
   end
 
   def test_first2
@@ -2044,8 +2044,8 @@ class TestArray < Test::Unit::TestCase
   end
 
   def test_unshift_error
-    assert_raise(RuntimeError) { [].freeze.unshift('cat') }
-    assert_raise(RuntimeError) { [].freeze.unshift() }
+    assert_raise(FrozenError) { [].freeze.unshift('cat') }
+    assert_raise(FrozenError) { [].freeze.unshift() }
   end
 
   def test_aref
@@ -2104,7 +2104,7 @@ class TestArray < Test::Unit::TestCase
     assert_raise(ArgumentError) { a.insert }
     assert_equal([0, 1, 2], a.insert(-1, 2))
     assert_equal([0, 1, 3, 2], a.insert(-2, 3))
-    assert_raise(RuntimeError) { [0].freeze.insert(0)}
+    assert_raise(FrozenError) { [0].freeze.insert(0)}
     assert_raise(ArgumentError) { [0].freeze.insert }
   end
 
@@ -2285,8 +2285,8 @@ class TestArray < Test::Unit::TestCase
     assert_raise(ArgumentError) { a.flatten!(1, 2) }
     assert_raise(TypeError) { a.flatten!(:foo) }
     assert_raise(ArgumentError) { f.flatten!(1, 2) }
-    assert_raise(RuntimeError) { f.flatten! }
-    assert_raise(RuntimeError) { f.flatten!(:foo) }
+    assert_raise(FrozenError) { f.flatten! }
+    assert_raise(FrozenError) { f.flatten!(:foo) }
   end
 
   def test_shuffle
@@ -2621,7 +2621,7 @@ class TestArray < Test::Unit::TestCase
     assert_equal([], a.rotate!(13))
     assert_equal([], a.rotate!(-13))
     a = [].freeze
-    assert_raise_with_message(RuntimeError, /can\'t modify frozen/) {a.rotate!}
+    assert_raise_with_message(FrozenError, /can\'t modify frozen/) {a.rotate!}
     a = [1,2,3]
     assert_raise(ArgumentError) { a.rotate!(1, 1) }
   end

--- a/test/mri/ruby/test_class.rb
+++ b/test/mri/ruby/test_class.rb
@@ -427,14 +427,14 @@ class TestClass < Test::Unit::TestCase
     obj = Object.new
     c = obj.singleton_class
     obj.freeze
-    assert_raise_with_message(RuntimeError, /frozen object/) {
+    assert_raise_with_message(FrozenError, /frozen object/) {
       c.class_eval {def f; end}
     }
   end
 
   def test_singleton_class_message
     c = Class.new.freeze
-    assert_raise_with_message(RuntimeError, /frozen Class/) {
+    assert_raise_with_message(FrozenError, /frozen Class/) {
       def c.f; end
     }
   end

--- a/test/mri/ruby/test_enumerator.rb
+++ b/test/mri/ruby/test_enumerator.rb
@@ -79,7 +79,7 @@ class TestEnumerator < Test::Unit::TestCase
     enum = @obj.to_enum
     assert_raise(NoMethodError) { enum.each {} }
     enum.freeze
-    assert_raise(RuntimeError) {
+    assert_raise(FrozenError) {
       capture_io do
         # warning: Enumerator.new without a block is deprecated; use Object#to_enum
         enum.__send__(:initialize, @obj, :foo)
@@ -440,7 +440,7 @@ class TestEnumerator < Test::Unit::TestCase
     assert_equal([1, 2, 3], a)
 
     g.freeze
-    assert_raise(RuntimeError) {
+    assert_raise(FrozenError) {
       g.__send__ :initialize, proc { |y| y << 4 << 5 }
     }
 

--- a/test/mri/ruby/test_eval.rb
+++ b/test/mri/ruby/test_eval.rb
@@ -506,7 +506,7 @@ class TestEval < Test::Unit::TestCase
   def test_fstring_instance_eval
     bug = "[ruby-core:78116] [Bug #12930]".freeze
     assert_same bug, (bug.instance_eval {self})
-    assert_raise(RuntimeError) {
+    assert_raise(FrozenError) {
       bug.instance_eval {@ivar = true}
     }
   end

--- a/test/mri/ruby/test_hash.rb
+++ b/test/mri/ruby/test_hash.rb
@@ -969,8 +969,8 @@ class TestHash < Test::Unit::TestCase
     assert_raise(TypeError) { h2.replace(1) }
     h2.freeze
     assert_raise(ArgumentError) { h2.replace() }
-    assert_raise(RuntimeError) { h2.replace(h1) }
-    assert_raise(RuntimeError) { h2.replace(42) }
+    assert_raise(FrozenError) { h2.replace(h1) }
+    assert_raise(FrozenError) { h2.replace(42) }
   end
 
   def test_size2

--- a/test/mri/ruby/test_lazy_enumerator.rb
+++ b/test/mri/ruby/test_lazy_enumerator.rb
@@ -25,7 +25,7 @@ class TestLazyEnumerator < Test::Unit::TestCase
 
     a = [1, 2, 3].lazy
     a.freeze
-    assert_raise(RuntimeError) {
+    assert_raise(FrozenError) {
       a.__send__ :initialize, [4, 5], &->(y, *v) { y << yield(*v) }
     }
   end

--- a/test/mri/ruby/test_literal.rb
+++ b/test/mri/ruby/test_literal.rb
@@ -162,6 +162,20 @@ class TestRubyLiteral < Test::Unit::TestCase
     end
   end
 
+  if defined?(RubyVM::InstructionSequence.compile_option) and
+    RubyVM::InstructionSequence.compile_option.key?(:debug_frozen_string_literal)
+    def test_debug_frozen_string
+      src = 'n = 1; "foo#{n ? "-#{n}" : ""}"'; f = "test.rb"; n = 1
+      opt = {frozen_string_literal: true, debug_frozen_string_literal: true}
+      str = RubyVM::InstructionSequence.compile(src, f, f, n, opt).eval
+      assert_equal("foo-1", str)
+      assert_predicate(str, :frozen?)
+      assert_raise_with_message(FrozenError, /created at #{Regexp.quote(f)}:#{n}/) {
+        str << "x"
+      }
+    end
+  end
+
   def test_regexp
     assert_instance_of Regexp, //
     assert_match(//, 'a')

--- a/test/mri/ruby/test_marshal.rb
+++ b/test/mri/ruby/test_marshal.rb
@@ -568,7 +568,7 @@ class TestMarshal < Test::Unit::TestCase
     s.instance_variable_set(:@t, 42)
     t = Bug8276.new(s)
     s = Marshal.dump(t)
-    assert_raise(RuntimeError) {Marshal.load(s)}
+    assert_raise(FrozenError) {Marshal.load(s)}
   end
 
   def test_marshal_load_ivar

--- a/test/mri/ruby/test_module.rb
+++ b/test/mri/ruby/test_module.rb
@@ -636,15 +636,15 @@ class TestModule < Test::Unit::TestCase
       def bar; end
     end
     m.freeze
-    assert_raise(RuntimeError) do
+    assert_raise(FrozenError) do
       m.module_eval do
         def foo; end
       end
     end
-    assert_raise(RuntimeError) do
+    assert_raise(FrozenError) do
       m.__send__ :private, :bar
     end
-    assert_raise(RuntimeError) do
+    assert_raise(FrozenError) do
       m.private_class_method :baz
     end
   end
@@ -949,7 +949,7 @@ class TestModule < Test::Unit::TestCase
   def test_frozen_module
     m = Module.new
     m.freeze
-    assert_raise(RuntimeError) do
+    assert_raise(FrozenError) do
       m.instance_eval { undef_method(:foo) }
     end
   end
@@ -957,7 +957,7 @@ class TestModule < Test::Unit::TestCase
   def test_frozen_class
     c = Class.new
     c.freeze
-    assert_raise(RuntimeError) do
+    assert_raise(FrozenError) do
       c.instance_eval { undef_method(:foo) }
     end
   end
@@ -967,7 +967,7 @@ class TestModule < Test::Unit::TestCase
     o = klass.new
     c = class << o; self; end
     c.freeze
-    assert_raise_with_message(RuntimeError, /frozen/) do
+    assert_raise_with_message(FrozenError, /frozen/) do
       c.instance_eval { undef_method(:foo) }
     end
     klass.class_eval do
@@ -2061,17 +2061,17 @@ class TestModule < Test::Unit::TestCase
     bug11532 = '[ruby-core:70828] [Bug #11532]'
 
     c = Class.new {const_set(:A, 1)}.freeze
-    assert_raise_with_message(RuntimeError, /frozen class/, bug11532) {
+    assert_raise_with_message(FrozenError, /frozen class/, bug11532) {
       c.class_eval {private_constant :A}
     }
 
     c = Class.new {const_set(:A, 1); private_constant :A}.freeze
-    assert_raise_with_message(RuntimeError, /frozen class/, bug11532) {
+    assert_raise_with_message(FrozenError, /frozen class/, bug11532) {
       c.class_eval {public_constant :A}
     }
 
     c = Class.new {const_set(:A, 1)}.freeze
-    assert_raise_with_message(RuntimeError, /frozen class/, bug11532) {
+    assert_raise_with_message(FrozenError, /frozen class/, bug11532) {
       c.class_eval {deprecate_constant :A}
     }
   end

--- a/test/mri/ruby/test_object.rb
+++ b/test/mri/ruby/test_object.rb
@@ -95,12 +95,12 @@ class TestObject < Test::Unit::TestCase
   def test_taint_frozen_obj
     o = Object.new
     o.freeze
-    assert_raise(RuntimeError) { o.taint }
+    assert_raise(FrozenError) { o.taint }
 
     o = Object.new
     o.taint
     o.freeze
-    assert_raise(RuntimeError) { o.untaint }
+    assert_raise(FrozenError) { o.untaint }
   end
 
   def test_freeze_immediate
@@ -119,7 +119,7 @@ class TestObject < Test::Unit::TestCase
       attr_accessor :foo
     }
     obj = klass.new.freeze
-    assert_raise_with_message(RuntimeError, /#{name}/) {
+    assert_raise_with_message(FrozenError, /#{name}/) {
       obj.foo = 1
     }
   end
@@ -395,7 +395,7 @@ class TestObject < Test::Unit::TestCase
   def test_remove_method
     c = Class.new
     c.freeze
-    assert_raise(RuntimeError) do
+    assert_raise(FrozenError) do
       c.instance_eval { remove_method(:foo) }
     end
 
@@ -803,7 +803,7 @@ class TestObject < Test::Unit::TestCase
     class<<x;self;end.class_eval {define_method(:to_s) {name}}
     assert_same(name, x.to_s)
     assert_not_predicate(name, :tainted?)
-    assert_raise(RuntimeError) {name.taint}
+    assert_raise(FrozenError) {name.taint}
     assert_equal("X", [x].join(""))
     assert_not_predicate(name, :tainted?)
     assert_not_predicate(eval('"X".freeze'), :tainted?)
@@ -895,7 +895,7 @@ class TestObject < Test::Unit::TestCase
     b = yield
     assert_nothing_raised("copy") {a.instance_eval {initialize_copy(b)}}
     c = a.dup.freeze
-    assert_raise(RuntimeError, "frozen") {c.instance_eval {initialize_copy(b)}}
+    assert_raise(FrozenError, "frozen") {c.instance_eval {initialize_copy(b)}}
     d = a.dup.trust
     [a, b, c, d]
   end

--- a/test/mri/ruby/test_pack.rb
+++ b/test/mri/ruby/test_pack.rb
@@ -816,7 +816,7 @@ EXPECTED
   def test_pack_with_buffer
     buf = String.new(capacity: 100)
 
-    assert_raise_with_message(RuntimeError, /frozen/) {
+    assert_raise_with_message(FrozenError, /frozen/) {
       [0xDEAD_BEEF].pack('N', buffer: 'foo'.freeze)
     }
     assert_raise_with_message(TypeError, /must be String/) {

--- a/test/mri/ruby/test_rand.rb
+++ b/test/mri/ruby/test_rand.rb
@@ -492,7 +492,7 @@ END
   def test_initialize_frozen
     r = Random.new(0)
     r.freeze
-    assert_raise(RuntimeError, '[Bug #6540]') do
+    assert_raise(FrozenError, '[Bug #6540]') do
       r.__send__(:initialize, r)
     end
   end
@@ -501,7 +501,7 @@ END
     r = Random.new(0)
     d = r.__send__(:marshal_dump)
     r.freeze
-    assert_raise(RuntimeError, '[Bug #6540]') do
+    assert_raise(FrozenError, '[Bug #6540]') do
       r.__send__(:marshal_load, d)
     end
   end

--- a/test/mri/ruby/test_range.rb
+++ b/test/mri/ruby/test_range.rb
@@ -14,7 +14,7 @@ class TestRange < Test::Unit::TestCase
   def test_frozen_initialize
     r = Range.allocate
     r.freeze
-    assert_raise(RuntimeError){r.__send__(:initialize, 1, 2)}
+    assert_raise(FrozenError){r.__send__(:initialize, 1, 2)}
   end
 
   def test_range_string

--- a/test/mri/ruby/test_rubyoptions.rb
+++ b/test/mri/ruby/test_rubyoptions.rb
@@ -885,7 +885,7 @@ class TestRubyOptions < Test::Unit::TestCase
 
   def test_frozen_string_literal_debug
     with_debug_pat = /created at/
-    wo_debug_pat = /can\'t modify frozen String \(RuntimeError\)\n\z/
+    wo_debug_pat = /can\'t modify frozen String \(FrozenError\)\n\z/
     frozen = [
       ["--enable-frozen-string-literal", true],
       ["--disable-frozen-string-literal", false],

--- a/test/mri/ruby/test_thread.rb
+++ b/test/mri/ruby/test_thread.rb
@@ -90,7 +90,7 @@ class TestThread < Test::Unit::TestCase
   def test_thread_variable_frozen
     t = Thread.new { }.join
     t.freeze
-    assert_raise(RuntimeError) do
+    assert_raise(FrozenError) do
       t.thread_variable_set(:foo, "bar")
     end
   end
@@ -491,7 +491,7 @@ class TestThread < Test::Unit::TestCase
   end
 
   def test_thread_local_security
-    assert_raise(RuntimeError) do
+    assert_raise(FrozenError) do
       Thread.new do
         Thread.current[:foo] = :bar
         Thread.current.freeze

--- a/test/mri/ruby/test_transcode.rb
+++ b/test/mri/ruby/test_transcode.rb
@@ -13,8 +13,8 @@ class TestTranscode < Test::Unit::TestCase
     assert_raise(Encoding::UndefinedConversionError) { "\x80".encode('utf-8','ASCII-8BIT') }
     assert_raise(Encoding::InvalidByteSequenceError) { "\x80".encode('utf-8','US-ASCII') }
     assert_raise(Encoding::UndefinedConversionError) { "\xA5".encode('utf-8','iso-8859-3') }
-    assert_raise(RuntimeError) { 'hello'.freeze.encode!('iso-8859-1') }
-    assert_raise(RuntimeError) { '\u3053\u3093\u306b\u3061\u306f'.freeze.encode!('iso-8859-1') } # こんにちは
+    assert_raise(FrozenError) { 'hello'.freeze.encode!('iso-8859-1') }
+    assert_raise(FrozenError) { '\u3053\u3093\u306b\u3061\u306f'.freeze.encode!('iso-8859-1') } # こんにちは
   end
 
   def test_arguments

--- a/test/mri/ruby/test_variable.rb
+++ b/test/mri/ruby/test_variable.rb
@@ -137,14 +137,14 @@ class TestVariable < Test::Unit::TestCase
       assert_empty v.instance_variables
       msg = "can't modify frozen #{v.class}"
 
-      assert_raise_with_message(RuntimeError, msg) do
+      assert_raise_with_message(FrozenError, msg) do
         v.instance_variable_set(:@foo, :bar)
       end
 
       assert_nil EnvUtil.suppress_warning {v.instance_variable_get(:@foo)}
       assert_not_send([v, :instance_variable_defined?, :@foo])
 
-      assert_raise_with_message(RuntimeError, msg) do
+      assert_raise_with_message(FrozenError, msg) do
         v.remove_instance_variable(:@foo)
       end
     end

--- a/test/mri/stringio/test_stringio.rb
+++ b/test/mri/stringio/test_stringio.rb
@@ -701,9 +701,9 @@ class TestStringIO < Test::Unit::TestCase
     s = StringIO.new
     s.freeze
     bug = '[ruby-core:33648]'
-    assert_raise(RuntimeError, bug) {s.puts("foo")}
-    assert_raise(RuntimeError, bug) {s.string = "foo"}
-    assert_raise(RuntimeError, bug) {s.reopen("")}
+    assert_raise(FrozenError, bug) {s.puts("foo")}
+    assert_raise(FrozenError, bug) {s.string = "foo"}
+    assert_raise(FrozenError, bug) {s.reopen("")}
   end
 
   def test_frozen_string

--- a/test/mri/test_delegate.rb
+++ b/test/mri/test_delegate.rb
@@ -92,7 +92,7 @@ class TestDelegateClass < Test::Unit::TestCase
     a = [42, :hello].freeze
     d = SimpleDelegator.new(a)
     assert_nothing_raised(bug2679) {d.dup[0] += 1}
-    assert_raise(RuntimeError) {d.clone[0] += 1}
+    assert_raise(FrozenError) {d.clone[0] += 1}
     d.freeze
     assert(d.clone.frozen?)
     assert(!d.dup.frozen?)
@@ -101,7 +101,7 @@ class TestDelegateClass < Test::Unit::TestCase
   def test_frozen
     d = SimpleDelegator.new([1, :foo])
     d.freeze
-    assert_raise(RuntimeError, '[ruby-dev:40314]#1') {d.__setobj__("foo")}
+    assert_raise(FrozenError, '[ruby-dev:40314]#1') {d.__setobj__("foo")}
     assert_equal([1, :foo], d)
   end
 

--- a/test/mri/test_set.rb
+++ b/test/mri/test_set.rb
@@ -693,7 +693,7 @@ class TC_Set < Test::Unit::TestCase
     set << 4
     assert_same orig, set.freeze
     assert_equal true, set.frozen?
-    assert_raise(RuntimeError) {
+    assert_raise(FrozenError) {
       set << 5
     }
     assert_equal 4, set.size
@@ -716,7 +716,7 @@ class TC_Set < Test::Unit::TestCase
     set2 = set1.clone
 
     assert_predicate set2, :frozen?
-    assert_raise(RuntimeError) {
+    assert_raise(FrozenError) {
       set2.add 5
     }
   end
@@ -831,6 +831,34 @@ class TC_SortedSet < Test::Unit::TestCase
     assert_equal(6, e.size)
     set << 42
     assert_equal(7, e.size)
+  end
+
+  def test_freeze
+    orig = set = SortedSet[3,2,1]
+    assert_equal false, set.frozen?
+    set << 4
+    assert_same orig, set.freeze
+    assert_equal true, set.frozen?
+    assert_raise(FrozenError) {
+      set << 5
+    }
+    assert_equal 4, set.size
+
+    # https://bugs.ruby-lang.org/issues/12091
+    assert_nothing_raised {
+      assert_equal [1,2,3,4], set.to_a
+    }
+  end
+
+  def test_freeze_clone
+    set1 = SortedSet[1,2,3]
+    set1.freeze
+    set2 = set1.clone
+
+    assert_predicate set2, :frozen?
+    assert_raise(FrozenError) {
+      set2.add 5
+    }
   end
 end
 


### PR DESCRIPTION
Hi folks,

This is another feature targeting Ruby 2.5 [1]:

- Add FrozenError as a subclass of RuntimeError (feature #13224).
    
FrozenError will be used instead of RuntimeError for exceptions
raised when there is an attempt to modify a frozen object.
    
For more information, please see feature #13224

Note: The updated tests are copied from MRI.

Thanks for your review and feedback.

1. https://github.com/jruby/jruby/issues/4876
