### PR TITLE
Add modification check on String#chomp! method with default separator

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -4282,6 +4282,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
 
     @JRubyMethod(name = "chomp!")
     public IRubyObject chomp_bang19(ThreadContext context) {
+        modifyCheck();
         Ruby runtime = context.runtime;
         if (value.getRealSize() == 0) return runtime.getNil();
 


### PR DESCRIPTION
When working on https://github.com/jruby/jruby/pull/5039 I noticed one of String tests on #chomp! method was not passing:

```ruby
s = S("").freeze
assert_raise_with_message(FrozenError, /frozen/) {s.chomp!}
```
https://github.com/jruby/jruby/blob/ruby-2.5/test/mri/ruby/test_string.rb#L445

After looking closely, I learned that MRI folks introduced this test on https://github.com/ruby/ruby/commit/80aa1e6218305b2f75c47af368506a7f930f1214.

I'm proposing this change since this is a difference between MRI and JRuby.

Behavior before applying this change:

```
miguel@alice:~/jruby/upstream/jruby$ PATH=$PWD/bin:$PATH jirb
irb(main):001:0> s = String.new("").freeze
=> ""
irb(main):002:0> s.chomp!
=> nil
irb(main):003:0>
```

Behavior after applying this change:

```
miguel@alice:~/jruby/upstream/jruby$ PATH=$PWD/bin:$PATH jirb
irb(main):001:0> s = String.new("").freeze
=> ""
irb(main):002:0> s.chomp!
RuntimeError: can't modify frozen String
        from org/jruby/RubyString.java:4286:in `chomp!'
        from (irb):2:in `<eval>'
        from org/jruby/RubyKernel.java:995:in `eval'
        from org/jruby/RubyKernel.java:1316:in `loop'
        from org/jruby/RubyKernel.java:1138:in `catch'
        from org/jruby/RubyKernel.java:1138:in `catch'
        from /home/miguel/jruby/upstream/jruby/bin/jirb:13:in `<main>'
irb(main):003:0> 
```

MRI behavior:

```
miguel@alice:~/jruby/upstream/jruby$ irb2.5
irb(main):001:0> s = String.new("").freeze
=> ""
irb(main):002:0> s.chomp!
Traceback (most recent call last):
        3: from /usr/bin/irb2.5:11:in `<main>'
        2: from (irb):2
        1: from (irb):2:in `chomp!'
FrozenError (can't modify frozen String)
irb(main):003:0> 
```

This change should be applied to master as well.




