### PR TITLE
Deprecate Data class

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1381,6 +1381,7 @@ public final class Ruby implements Constantizable {
     private void initCore() {
         if (profile.allowClass("Data")) {
             defineClass("Data", objectClass, ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR);
+            getObject().deprecateConstant(this, "Data");
         }
 
         RubyComparable.createComparable(this);


### PR DESCRIPTION
Hi folks,

This is another feature targeting Ruby 2.5 [1]: Deprecate Data class (feature #3072).

Thanks for your review and feedback.

1. https://github.com/jruby/jruby/issues/4876