### PR TITLE
Revert "Fixed yielded arrays of 1 element bug when using Enumerator::…

### DIFF
--- a/core/src/main/java/org/jruby/RubyYielder.java
+++ b/core/src/main/java/org/jruby/RubyYielder.java
@@ -104,10 +104,6 @@ public class RubyYielder extends RubyObject {
 
     @JRubyMethod(name = "<<", rest = true)
     public IRubyObject op_lshift(ThreadContext context, IRubyObject[]args) {
-        if (args.length == 1 &&
-                args[0] instanceof RubyArray &&
-                ((RubyArray) args[0]).getLength() == 1)
-            args[0] = RubyArray.newArray(context.runtime, args[0]);
         yield(context, args);
         return this;
     }


### PR DESCRIPTION
This fixes: https://github.com/jruby/jruby/issues/5044

This reverts commit cb25efe8052eea9d919cdb20d13a9678614f5307.

The code reverted in this pull request comes from https://github.com/jruby/jruby/issues/2376 and the related issue https://github.com/jruby/jruby/pull/2458

The test case in 2376 still works with the code removed. 

```bash
jruby:master > bin/jruby -e "puts Enumerator.new{|y| y << [42]}.first.inspect"
[42]

```