### PR TITLE
Add Process::last_status method

### DIFF
--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -603,6 +603,11 @@ public class RubyProcess {
         return ary;
     }
 
+    @JRubyMethod(name = "last_status", module = true, visibility = PRIVATE)
+    public static IRubyObject last_status(ThreadContext context, IRubyObject recv) {
+        return context.getLastExitStatus();
+    }
+
     @JRubyMethod(name = "setrlimit", module = true, visibility = PRIVATE)
     public static IRubyObject setrlimit(ThreadContext context, IRubyObject recv, IRubyObject resource, IRubyObject rlimCur) {
         return setrlimit(context, recv, resource, rlimCur, context.nil);

--- a/test/mri/ruby/test_process.rb
+++ b/test/mri/ruby/test_process.rb
@@ -2312,4 +2312,9 @@ EOS
       end
     end
   end
+
+  def test_last_status
+    Process.wait spawn(RUBY, "-e", "exit 13")
+    assert_same(Process.last_status, $?)
+  end
 end


### PR DESCRIPTION
Hi folks,

This is another feature targeting Ruby 2.5 [1]: Process::last_status method (feature #14043).

Note: The tests are copied from MRI.

Thanks for your review and feedback.

1. https://github.com/jruby/jruby/issues/4876