### PR TITLE
Module#define_method, alias_method, undef_method, remove_method are now public

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1934,7 +1934,7 @@ public class RubyModule extends RubyObject {
         return newMethod;
     }
 
-    @JRubyMethod(name = "define_method", visibility = PRIVATE, reads = VISIBILITY)
+    @JRubyMethod(name = "define_method", reads = VISIBILITY)
     public IRubyObject define_method(ThreadContext context, IRubyObject arg0, Block block) {
         Visibility visibility = getCurrentVisibilityForDefineMethod(context);
 
@@ -1985,7 +1985,7 @@ public class RubyModule extends RubyObject {
         return nameSym;
     }
 
-    @JRubyMethod(name = "define_method", visibility = PRIVATE, reads = VISIBILITY)
+    @JRubyMethod(name = "define_method", reads = VISIBILITY)
     public IRubyObject define_method(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Block block) {
         Visibility visibility = getCurrentVisibilityForDefineMethod(context);
 
@@ -2837,7 +2837,7 @@ public class RubyModule extends RubyObject {
         return this;
     }
 
-    @JRubyMethod(name = "alias_method", required = 2, visibility = PRIVATE)
+    @JRubyMethod(name = "alias_method", required = 2)
     public RubyModule alias_method(ThreadContext context, IRubyObject newId, IRubyObject oldId) {
         String newName = newId.asJavaString();
         defineAlias(newName, oldId.asJavaString());
@@ -2850,7 +2850,7 @@ public class RubyModule extends RubyObject {
         return this;
     }
 
-    @JRubyMethod(name = "undef_method", rest = true, visibility = PRIVATE)
+    @JRubyMethod(name = "undef_method", rest = true)
     public RubyModule undef_method(ThreadContext context, IRubyObject[] args) {
         for (int i=0; i<args.length; i++) {
             undef(context, args[i].asJavaString());
@@ -2909,7 +2909,7 @@ public class RubyModule extends RubyObject {
         }
     }
 
-    @JRubyMethod(name = "remove_method", rest = true, visibility = PRIVATE)
+    @JRubyMethod(name = "remove_method", rest = true)
     public RubyModule remove_method(ThreadContext context, IRubyObject[] args) {
         for(int i=0;i<args.length;i++) {
             removeMethod(context, TypeConverter.checkID(args[i]).toString());

--- a/test/mri/ruby/test_module.rb
+++ b/test/mri/ruby/test_module.rb
@@ -2038,6 +2038,10 @@ class TestModule < Test::Unit::TestCase
       attr_accessor
       attr_reader
       attr_writer
+      define_method
+      alias_method
+      undef_method
+      remove_method
     ]
     assert_equal public_methods.sort, (Module.public_methods & public_methods).sort
   end
@@ -2104,9 +2108,9 @@ class TestModule < Test::Unit::TestCase
 
   def test_visibility_by_public_class_method
     bug8284 = '[ruby-core:54404] [Bug #8284]'
-    assert_raise(NoMethodError) {Object.define_method}
-    Module.new.public_class_method(:define_method)
-    assert_raise(NoMethodError, bug8284) {Object.define_method}
+    assert_raise(NoMethodError) {Object.remove_const}
+    Module.new.public_class_method(:remove_const)
+    assert_raise(NoMethodError, bug8284) {Object.remove_const}
   end
 
   def test_include_module_with_constants_does_not_invalidate_method_cache


### PR DESCRIPTION
Hi folks,

This is another feature targeting Ruby 2.5 [1]:

- Module#define_method, alias_method, undef_method, remove_method are now public (feature #14133).

Note: The tests are copied from MRI.

Thanks for your review and feedback.

1. https://github.com/jruby/jruby/issues/4876