### PR TITLE
refactor annotation-binder generated populators

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -3027,6 +3027,15 @@ public final class Ruby implements Constantizable {
         javaToRuby.put(methodName, rubyName);
     }
 
+    public void addBoundMethods(String className, String... tuples) {
+        Map<String, String> javaToRuby = boundMethods.get(className);
+        if (javaToRuby == null) boundMethods.put(className, javaToRuby = new HashMap<>(tuples.length / 2 + 1, 1));
+        for (int i = 0; i < tuples.length; i += 2) {
+            javaToRuby.put(tuples[i], tuples[i+1]);
+        }
+    }
+
+    @Deprecated // no longer used -> except for IndyBinder
     public void addBoundMethodsPacked(String className, String packedTuples) {
         List<String> names = StringSupport.split(packedTuples, ';');
         for (int i = 0; i < names.size(); i += 2) {
@@ -3034,6 +3043,7 @@ public final class Ruby implements Constantizable {
         }
     }
 
+    @Deprecated // no longer used -> except for IndyBinder
     public void addSimpleBoundMethodsPacked(String className, String packedNames) {
         List<String> names = StringSupport.split(packedNames, ';');
         for (String name : names) {

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -4509,8 +4509,7 @@ public final class Ruby implements Constantizable {
      * @param method
      */
     void addProfiledMethod(final String name, final DynamicMethod method) {
-        if (!config.isProfiling()) return;
-        if (method.isUndefined()) return;
+        if (!config.isProfiling() || method.isUndefined()) return;
 
         getProfilingService().addProfiledMethod( name, method );
     }
@@ -5014,7 +5013,7 @@ public final class Ruby implements Constantizable {
 
     private final long startTime = System.currentTimeMillis();
 
-    private final RubyInstanceConfig config;
+    final RubyInstanceConfig config;
 
     private InputStream in;
     private PrintStream out;

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -977,8 +977,8 @@ public class RubyModule extends RubyObject {
         public Map<Set<FrameField>, List<String>> writeGroups = Collections.EMPTY_MAP;
 
         @SuppressWarnings("deprecation")
-        public void clump(final Class cls) {
-            Method[] declaredMethods = Initializer.DECLARED_METHODS.get(cls);
+        public void clump(final Class klass) {
+            Method[] declaredMethods = Initializer.DECLARED_METHODS.get(klass);
             for (Method method: declaredMethods) {
                 JRubyMethod anno = method.getAnnotation(JRubyMethod.class);
 
@@ -991,7 +991,8 @@ public class RubyModule extends RubyObject {
 
                 JavaMethodDescriptor desc = new JavaMethodDescriptor(method);
 
-                String name = anno.name().length == 0 ? method.getName() : anno.name()[0];
+                final String[] names = anno.name();
+                String name = names.length == 0 ? method.getName() : names[0];
 
                 Map<String, List<JavaMethodDescriptor>> methodsHash;
                 if (desc.isStatic) {
@@ -1006,7 +1007,7 @@ public class RubyModule extends RubyObject {
 
                 List<JavaMethodDescriptor> methodDescs = methodsHash.get(name);
                 if (methodDescs == null) {
-                    methodsHash.put(name, methodDescs = new ArrayList(4));
+                    methodsHash.put(name, methodDescs = new ArrayList<>(4));
                 }
 
                 methodDescs.add(desc);
@@ -1015,7 +1016,7 @@ public class RubyModule extends RubyObject {
                 if (anno.reads().length > 0 && readGroups == Collections.EMPTY_MAP) readGroups = new HashMap<>();
                 if (anno.writes().length > 0 && writeGroups == Collections.EMPTY_MAP) writeGroups = new HashMap<>();
 
-                AnnotationHelper.groupFrameFields(readGroups, writeGroups, anno, method.getName().toString());
+                AnnotationHelper.groupFrameFields(readGroups, writeGroups, anno, method.getName());
             }
         }
 

--- a/core/src/main/java/org/jruby/anno/AnnotationBinder.java
+++ b/core/src/main/java/org/jruby/anno/AnnotationBinder.java
@@ -147,7 +147,7 @@ public class AnnotationBinder extends AbstractProcessor {
             if (!hasAnno) return;
 
             out.println("        JavaMethod javaMethod;");
-            out.println("        DynamicMethod moduleMethod;");
+            out.println("        DynamicMethod moduleMethod, aliasedMethod;");
             if (hasMeta || hasModule) out.println("        RubyClass singletonClass = cls.getSingletonClass();");
             out.println("        Ruby runtime = cls.getRuntime();");
 
@@ -516,17 +516,20 @@ public class AnnotationBinder extends AbstractProcessor {
     private void defineMethodOnClass(String methodVar, String classVar, final String[] names, final String[] aliases,
         ExecutableElement md) {
         CharSequence baseName = getBaseName(names, md);
-        if (names.length == 0) {
-            out.println("        " + classVar + ".addMethodAtBootTimeOnly(\"" + baseName + "\", " + methodVar + ");");
-        } else {
+        // aliasedMethod = type.putMethod(runtime, baseName, method);
+        out.println("        aliasedMethod = " + classVar + ".putMethod(runtime, \"" + baseName + "\", " + methodVar + ");");
+        if (names.length > 0) {
             for (String name : names) {
-                out.println("        " + classVar + ".addMethodAtBootTimeOnly(\"" + name + "\", " + methodVar + ");");
+                if (!name.contentEquals(baseName)) {
+                    out.println("        " + classVar + ".putMethod(runtime, \"" + name + "\", " + methodVar + ");");
+                }
             }
         }
 
         if (aliases.length > 0) {
             for (String alias : aliases) {
-                out.println("        " + classVar + ".defineAlias(\"" + alias + "\", \"" + baseName + "\");");
+                // type.putAlias(alias, aliasedMethod, baseName); /* baseName == method.getName() */
+                out.println("        " + classVar + ".putAlias(\"" + alias + "\", aliasedMethod, \"" + baseName + "\");");
             }
         }
     }

--- a/core/src/main/java/org/jruby/anno/AnnotationHelper.java
+++ b/core/src/main/java/org/jruby/anno/AnnotationHelper.java
@@ -1,6 +1,5 @@
 package org.jruby.anno;
 
-import javax.lang.model.element.ExecutableElement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;

--- a/core/src/main/java/org/jruby/anno/AnnotationHelper.java
+++ b/core/src/main/java/org/jruby/anno/AnnotationHelper.java
@@ -108,7 +108,7 @@ public class AnnotationHelper {
                 List<String> names = accessEntry.getValue();
 
                 int bits = FrameField.pack(reads.stream().toArray(n -> new FrameField[n]));
-                String namesJoined = names.stream().collect(Collectors.joining(";"));
+                String namesJoined = names.stream().distinct().collect(Collectors.joining(";"));
 
                 action.accept(bits, namesJoined);
             }

--- a/core/src/main/java/org/jruby/anno/JavaMethodDescriptor.java
+++ b/core/src/main/java/org/jruby/anno/JavaMethodDescriptor.java
@@ -30,7 +30,6 @@ package org.jruby.anno;
 
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
-import org.jruby.util.CodegenUtils;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -39,8 +38,10 @@ public class JavaMethodDescriptor extends MethodDescriptor<Method> {
     public final Class[] parameters;
     public final Class returnClass;
     public final Class declaringClass;
-    public final String signature;
-    public final Class[] argumentTypes;
+    @Deprecated // no longer used
+    public String signature;
+    @Deprecated // initialized on demand
+    public Class[] argumentTypes;
 
     public JavaMethodDescriptor(Method method) {
         super(method);
@@ -48,13 +49,17 @@ public class JavaMethodDescriptor extends MethodDescriptor<Method> {
         declaringClass = method.getDeclaringClass();
         parameters = method.getParameterTypes();
         returnClass = method.getReturnType();
+    }
 
-        int start = (hasContext ? 1 : 0) + (isStatic ? 1 : 0);
-        int end = parameters.length - (hasBlock ? 1 : 0);
-        argumentTypes = new Class[end - start];
-        System.arraycopy(parameters, start, argumentTypes, 0, end - start);
-
-        signature = CodegenUtils.sig(method.getReturnType(), method.getParameterTypes());
+    public final Class[] getArgumentTypes() {
+        if (argumentTypes == null) {
+            int start = (hasContext ? 1 : 0) + (isStatic ? 1 : 0);
+            int end = parameters.length - (hasBlock ? 1 : 0);
+            Class[] argumentTypes = new Class[end - start];
+            System.arraycopy(parameters, start, argumentTypes, 0, end - start);
+            return this.argumentTypes = argumentTypes;
+        }
+        return argumentTypes;
     }
 
     public Class getDeclaringClass() {

--- a/core/src/main/java/org/jruby/anno/TypePopulator.java
+++ b/core/src/main/java/org/jruby/anno/TypePopulator.java
@@ -36,11 +36,15 @@ import org.jruby.RubyModule;
 import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.internal.runtime.methods.JavaMethod;
 import org.jruby.runtime.Arity;
+import org.jruby.runtime.Block;
 import org.jruby.runtime.MethodFactory;
 import org.jruby.runtime.MethodIndex;
+import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
+import org.jruby.runtime.builtin.IRubyObject;
 
 public abstract class TypePopulator {
+
     public static void populateMethod(JavaMethod javaMethod, int arity, String simpleName, boolean isStatic, boolean notImplemented) {
         javaMethod.setIsBuiltin(true);
         javaMethod.setArity(Arity.createArity(arity));
@@ -65,7 +69,7 @@ public abstract class TypePopulator {
         moduleMethod.setVisibility(Visibility.PUBLIC);
         return moduleMethod;
     }
-    
+
     public abstract void populate(RubyModule clsmod, Class clazz);
     
     public static final TypePopulator DEFAULT = new DefaultTypePopulator();
@@ -126,4 +130,47 @@ public abstract class TypePopulator {
             }
         }
     }
+
+    // used by generated code (populators) - @see AnnorationBinder
+
+    protected static final Class[] ARG0 = new Class[] {};
+    protected static final Class[] ARG1 = new Class[] { IRubyObject.class };
+    protected static final Class[] ARG2 = new Class[] { IRubyObject.class, IRubyObject.class };
+    protected static final Class[] ARG3 = new Class[] { IRubyObject.class, IRubyObject.class, IRubyObject.class };
+    protected static final Class[] ARG4 = new Class[] { IRubyObject.class, IRubyObject.class, IRubyObject.class, IRubyObject.class };
+
+    protected static final Class[] ARG0_ARY = new Class[] { IRubyObject[].class };
+    protected static final Class[] ARG1_ARY = new Class[] { IRubyObject.class, IRubyObject[].class };
+    //protected static final Class[] ARG2_ARY = new Class[] { IRubyObject.class, IRubyObject.class, IRubyObject[].class };
+
+    protected static final Class[] CONTEXT_ARG0 = new Class[] { ThreadContext.class };
+    protected static final Class[] CONTEXT_ARG1 = new Class[] { ThreadContext.class, IRubyObject.class };
+    protected static final Class[] CONTEXT_ARG2 = new Class[] { ThreadContext.class, IRubyObject.class, IRubyObject.class };
+    protected static final Class[] CONTEXT_ARG3 = new Class[] { ThreadContext.class, IRubyObject.class, IRubyObject.class, IRubyObject.class };
+    protected static final Class[] CONTEXT_ARG4 = new Class[] { ThreadContext.class, IRubyObject.class, IRubyObject.class, IRubyObject.class, IRubyObject.class };
+
+    protected static final Class[] CONTEXT_ARG0_ARY = new Class[] { ThreadContext.class, IRubyObject[].class };
+    protected static final Class[] CONTEXT_ARG1_ARY = new Class[] { ThreadContext.class, IRubyObject.class, IRubyObject[].class };
+    //protected static final Class[] CONTEXT_ARG2_ARY = new Class[] { ThreadContext.class, IRubyObject.class, IRubyObject.class, IRubyObject[].class };
+
+    protected static final Class[] ARG0_BLOCK = new Class[] { Block.class };
+    protected static final Class[] ARG1_BLOCK = new Class[] { IRubyObject.class, Block.class };
+    protected static final Class[] ARG2_BLOCK = new Class[] { IRubyObject.class, IRubyObject.class, Block.class };
+    protected static final Class[] ARG3_BLOCK = new Class[] { IRubyObject.class, IRubyObject.class, IRubyObject.class, Block.class };
+    protected static final Class[] ARG4_BLOCK = new Class[] { IRubyObject.class, IRubyObject.class, IRubyObject.class, IRubyObject.class, Block.class };
+
+    protected static final Class[] ARG0_ARY_BLOCK = new Class[] { IRubyObject[].class, Block.class };
+    protected static final Class[] ARG1_ARY_BLOCK = new Class[] { IRubyObject.class, IRubyObject[].class, Block.class };
+    //protected static final Class[] ARG2_ARY_BLOCK = new Class[] { IRubyObject.class, IRubyObject.class, IRubyObject[].class, Block.class };
+
+    protected static final Class[] CONTEXT_ARG0_BLOCK = new Class[] { ThreadContext.class, Block.class };
+    protected static final Class[] CONTEXT_ARG1_BLOCK = new Class[] { ThreadContext.class, IRubyObject.class, Block.class };
+    protected static final Class[] CONTEXT_ARG2_BLOCK = new Class[] { ThreadContext.class, IRubyObject.class, IRubyObject.class, Block.class };
+    protected static final Class[] CONTEXT_ARG3_BLOCK = new Class[] { ThreadContext.class, IRubyObject.class, IRubyObject.class, IRubyObject.class, Block.class };
+    protected static final Class[] CONTEXT_ARG4_BLOCK = new Class[] { ThreadContext.class, IRubyObject.class, IRubyObject.class, IRubyObject.class, IRubyObject.class, Block.class };
+
+    protected static final Class[] CONTEXT_ARG0_ARY_BLOCK = new Class[] { ThreadContext.class, IRubyObject[].class, Block.class };
+    protected static final Class[] CONTEXT_ARG1_ARY_BLOCK = new Class[] { ThreadContext.class, IRubyObject.class, IRubyObject[].class, Block.class };
+    //protected static final Class[] CONTEXT_ARG2_ARY_BLOCK = new Class[] { ThreadContext.class, IRubyObject.class, IRubyObject.class, IRubyObject[].class, Block.class };
+
 }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/InvokeDynamicMethodFactory.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InvokeDynamicMethodFactory.java
@@ -83,7 +83,7 @@ public class InvokeDynamicMethodFactory extends InvocationMethodFactory {
             return super.getAnnotatedMethod(implementationClass, descs, name);
         }
 
-        if (!Modifier.isPublic(desc1.getDeclaringClass().getModifiers())) {
+        if (!Modifier.isPublic(desc1.declaringClass.getModifiers())) {
             LOG.warn("warning: binding non-public class {}; reflected handles won't work", desc1.declaringClassName);
         }
 
@@ -198,8 +198,7 @@ public class InvokeDynamicMethodFactory extends InvocationMethodFactory {
         targetBinder = SmartBinder.from(baseSignature);
 
         // unused by Java-based methods
-        targetBinder = targetBinder
-                .exclude("class", "name");
+        targetBinder = targetBinder.exclude("class", "name");
 
         if (isStatic) {
             if (hasContext) {


### PR DESCRIPTION
accounts for a slight speed-up - the populator won't execute much 'redundant' code

this isn't the main issue with boot (compared to invokers) but still deserves a hand-craft