### PR TITLE
Generify IRubyObject.toJava to make it more pleasant to use.

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -4969,7 +4969,7 @@ float_loop:
     }
 
     @Override
-    public Object toJava(Class target) {
+    public <T> T toJava(Class<T> target) {
         if (target.isArray()) {
             Class type = target.getComponentType();
             Object rawJavaArray = Array.newInstance(type, realLength);
@@ -4978,7 +4978,7 @@ float_loop:
             } catch (ArrayIndexOutOfBoundsException ex) {
                 throw concurrentModification(getRuntime(), ex);
             }
-            return rawJavaArray;
+            return target.cast(rawJavaArray);
         } else {
             return super.toJava(target);
         }

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -856,7 +856,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      * @see IRubyObject#toJava
      */
     @Override
-    public Object toJava(Class target) {
+    public <T> T toJava(Class<T> target) {
         return defaultToJava(target);
     }
 

--- a/core/src/main/java/org/jruby/RubyBoolean.java
+++ b/core/src/main/java/org/jruby/RubyBoolean.java
@@ -162,17 +162,12 @@ public class RubyBoolean extends RubyObject implements Constantizable {
             return RubyString.newStringShared(f.getRuntime(), FALSE_BYTES);
         }
 
-        /*
-        Because Boolean objects can't cast to boolean via Class.cast, and you can't return
-        a primitive from a generified method, this impl remains ungenerified.
-         */
         @Override
-        public Object toJava(Class target) {
-            if (target.isAssignableFrom(Boolean.class) | target.equals(boolean.class)) {
-                return Boolean.FALSE;
-            } else {
-                return super.toJava(target);
+        public <T> T toJava(Class<T> target) {
+            if (target.isAssignableFrom(Boolean.class) || target == boolean.class) {
+                return (T) Boolean.FALSE;
             }
+            return super.toJava(target);
         }
     }
 
@@ -206,17 +201,12 @@ public class RubyBoolean extends RubyObject implements Constantizable {
             return RubyString.newStringShared(t.getRuntime(), TRUE_BYTES);
         }
 
-        /*
-        Because Boolean objects can't cast to boolean via Class.cast, and you can't return
-        a primitive from a generified method, this impl remains ungenerified.
-         */
         @Override
-        public Object toJava(Class target) {
-            if (target.isAssignableFrom(Boolean.class) | target.equals(boolean.class)) {
-                return Boolean.TRUE;
-            } else {
-                return super.toJava(target);
+        public <T> T toJava(Class<T> target) {
+            if (target.isAssignableFrom(Boolean.class) || target == boolean.class) {
+                return (T) Boolean.TRUE;
             }
+            return super.toJava(target);
         }
     }
     

--- a/core/src/main/java/org/jruby/RubyBoolean.java
+++ b/core/src/main/java/org/jruby/RubyBoolean.java
@@ -161,6 +161,19 @@ public class RubyBoolean extends RubyObject implements Constantizable {
         public static RubyString false_to_s(IRubyObject f) {
             return RubyString.newStringShared(f.getRuntime(), FALSE_BYTES);
         }
+
+        /*
+        Because Boolean objects can't cast to boolean via Class.cast, and you can't return
+        a primitive from a generified method, this impl remains ungenerified.
+         */
+        @Override
+        public Object toJava(Class target) {
+            if (target.isAssignableFrom(Boolean.class) | target.equals(boolean.class)) {
+                return Boolean.FALSE;
+            } else {
+                return super.toJava(target);
+            }
+        }
     }
 
     static final ByteList TRUE_BYTES = new ByteList(new byte[] { 't','r','u','e' }, USASCIIEncoding.INSTANCE);
@@ -192,6 +205,19 @@ public class RubyBoolean extends RubyObject implements Constantizable {
         public static RubyString true_to_s(IRubyObject t) {
             return RubyString.newStringShared(t.getRuntime(), TRUE_BYTES);
         }
+
+        /*
+        Because Boolean objects can't cast to boolean via Class.cast, and you can't return
+        a primitive from a generified method, this impl remains ungenerified.
+         */
+        @Override
+        public Object toJava(Class target) {
+            if (target.isAssignableFrom(Boolean.class) | target.equals(boolean.class)) {
+                return Boolean.TRUE;
+            } else {
+                return super.toJava(target);
+            }
+        }
     }
     
     @JRubyMethod(name = "hash")
@@ -220,17 +246,6 @@ public class RubyBoolean extends RubyObject implements Constantizable {
 
     public void marshalTo(MarshalStream output) throws java.io.IOException {
         output.write(isTrue() ? 'T' : 'F');
-    }
-
-    @Override
-    public Object toJava(Class target) {
-        if (target.isAssignableFrom(Boolean.class) || target.equals(boolean.class)) {
-            if (isFalse()) return Boolean.FALSE;
-
-            return Boolean.TRUE;
-        } else {
-            return super.toJava(target);
-        }
     }
 }
 

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -1886,7 +1886,7 @@ public class RubyClass extends RubyModule {
     }
 
     @Override
-    public Object toJava(final Class target) {
+    public <T> T toJava(Class<T> target) {
         if (target == Class.class) {
             if (reifiedClass == null) reifyWithAncestors(); // possibly auto-reify
             // Class requested; try java_class or else return nearest reified class
@@ -1895,13 +1895,13 @@ public class RubyClass extends RubyModule {
             if ( ! javaClass.isNil() ) return javaClass.toJava(target);
 
             Class reifiedClass = nearestReifiedClass(this);
-            if ( reifiedClass != null ) return reifiedClass;
+            if ( reifiedClass != null ) return target.cast(reifiedClass);
             // should never fall through, since RubyObject has a reified class
         }
 
         if (target.isAssignableFrom(RubyClass.class)) {
             // they're asking for something RubyClass extends, give them that
-            return this;
+            return target.cast(this);
         }
 
         return defaultToJava(target);

--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -2028,10 +2028,10 @@ public class RubyFile extends RubyIO implements EncodingCapable {
     }
 
     @Override
-    public Object toJava(Class target) {
-        if (target == java.io.File.class) {
+    public <T> T toJava(Class<T> target) {
+        if (target == File.class) {
             final String path = getPath();
-            return path == null ? null : new java.io.File(path);
+            return path == null ? null : target.cast(new File(path));
         }
         return super.toJava(target);
     }

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -4752,14 +4752,14 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     }
 
     @Override
-    public Object toJava(Class target) {
+    public <T> T toJava(Class<T> target) {
         if (target == java.io.InputStream.class) {
             getOpenFile().checkReadable(getRuntime().getCurrentContext());
-            return getInStream();
+            return target.cast(getInStream());
         }
         if (target == java.io.OutputStream.class) {
             getOpenFile().checkWritable(getRuntime().getCurrentContext());
-            return getOutStream();
+            return target.cast(getOutStream());
         }
         return super.toJava(target);
     }

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -4718,7 +4718,7 @@ public class RubyModule extends RubyObject {
     }
 
     @Override
-    public Object toJava(final Class target) {
+    public <T> T toJava(Class<T> target) {
         if (target == Class.class) { // try java_class for proxy modules
             final ThreadContext context = getRuntime().getCurrentContext();
             IRubyObject javaClass = JavaClass.java_class(context, this);

--- a/core/src/main/java/org/jruby/RubyNil.java
+++ b/core/src/main/java/org/jruby/RubyNil.java
@@ -251,22 +251,19 @@ public class RubyNil extends RubyObject implements Constantizable {
     @Override
     public <T> T toJava(Class<T> target) {
         if (target.isPrimitive()) {
-            if (target == Boolean.TYPE) {
-                return target.cast(false);
-            } else if (target == Byte.TYPE) {
-                return target.cast((byte)0);
-            } else if (target == Short.TYPE) {
-                return target.cast((short)0);
-            } else if (target == Character.TYPE) {
-                return target.cast((char)0);
-            } else if (target == Integer.TYPE) {
-                return target.cast(0);
-            } else if (target == Long.TYPE) {
-                return target.cast(0L);
-            } else if (target == Float.TYPE) {
-                return target.cast(0F);
-            } else if (target == Double.TYPE) {
-                return target.cast(0.0);
+            if (target == boolean.class) {
+                return (T) Boolean.FALSE;
+            } else if (target == char.class) {
+                return (T) (Character) '\0';
+            } else {
+                switch (target.getSimpleName().charAt(0)) {
+                    case 'b': return (T) (Byte) (byte) 0;
+                    case 's': return (T) (Short) (short) 0;
+                    case 'i': return (T) (Integer) 0;
+                    case 'l': return (T) (Long) 0L;
+                    case 'f': return (T) (Float) 0.0F;
+                    case 'd': return (T) (Double) 0.0;
+                }
             }
         }
         return null;

--- a/core/src/main/java/org/jruby/RubyNil.java
+++ b/core/src/main/java/org/jruby/RubyNil.java
@@ -249,24 +249,24 @@ public class RubyNil extends RubyObject implements Constantizable {
     }
 
     @Override
-    public Object toJava(Class target) {
+    public <T> T toJava(Class<T> target) {
         if (target.isPrimitive()) {
             if (target == Boolean.TYPE) {
-                return Boolean.FALSE;
+                return target.cast(false);
             } else if (target == Byte.TYPE) {
-                return (byte)0;
+                return target.cast((byte)0);
             } else if (target == Short.TYPE) {
-                return (short)0;
+                return target.cast((short)0);
             } else if (target == Character.TYPE) {
-                return (char)0;
+                return target.cast((char)0);
             } else if (target == Integer.TYPE) {
-                return 0;
+                return target.cast(0);
             } else if (target == Long.TYPE) {
-                return (long)0;
+                return target.cast(0L);
             } else if (target == Float.TYPE) {
-                return (float)0;
+                return target.cast(0F);
             } else if (target == Double.TYPE) {
-                return (double)0;
+                return target.cast(0.0);
             }
         }
         return null;

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -1337,7 +1337,7 @@ public class RubyNumeric extends RubyObject {
     }
 
     @Override
-    public Object toJava(Class target) {
+    public <T> T toJava(Class<T> target) {
         return JavaUtil.getNumericConverter(target).coerce(this, target);
     }
 

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -5635,7 +5635,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
             if ( strLength() != 1 ) {
                 throw getRuntime().newArgumentError("could not coerce string of length " + strLength() + " (!= 1) into a char");
             }
-            return target.cast(decodeString().charAt(0));
+            return (T) (Character) decodeString().charAt(0);
         }
         return super.toJava(target);
     }

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -5624,18 +5624,18 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     }
 
     @Override
-    public Object toJava(Class target) {
+    public <T> T toJava(Class<T> target) {
         if (target.isAssignableFrom(String.class)) {
-            return decodeString();
+            return target.cast(decodeString());
         }
         if (target.isAssignableFrom(ByteList.class)) {
-            return value;
+            return target.cast(value);
         }
         if (target == Character.class || target == Character.TYPE) {
             if ( strLength() != 1 ) {
                 throw getRuntime().newArgumentError("could not coerce string of length " + strLength() + " (!= 1) into a char");
             }
-            return decodeString().charAt(0);
+            return target.cast(decodeString().charAt(0));
         }
         return super.toJava(target);
     }

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -646,8 +646,8 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
     }
 
     @Override
-    public Object toJava(Class target) {
-        if (target == String.class || target == CharSequence.class) return symbol;
+    public <T> T toJava(Class<T> target) {
+        if (target == String.class || target == CharSequence.class) return target.cast(symbol);
 
         return super.toJava(target);
     }

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -647,7 +647,9 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
 
     @Override
     public <T> T toJava(Class<T> target) {
-        if (target == String.class || target == CharSequence.class) return target.cast(symbol);
+        if (target == String.class || target == CharSequence.class) {
+            return target.cast(symbol);
+        }
 
         return super.toJava(target);
     }

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -1285,27 +1285,27 @@ public class RubyTime extends RubyObject {
     }
 
     @Override
-    public Object toJava(Class target) {
+    public <T> T toJava(Class<T> target) {
         if (target == Date.class) {
-            return getJavaDate();
+            return target.cast(getJavaDate());
         }
         if (target == Calendar.class || target == GregorianCalendar.class) {
-            return dt.toGregorianCalendar();
+            return target.cast(dt.toGregorianCalendar());
         }
         if (target == DateTime.class) {
-            return this.dt;
+            return target.cast(this.dt);
         }
         if (target == java.sql.Date.class) {
-            return new java.sql.Date(dt.getMillis());
+            return target.cast(new java.sql.Date(dt.getMillis()));
         }
         if (target == java.sql.Time.class) {
-            return new java.sql.Time(dt.getMillis());
+            return target.cast(new java.sql.Time(dt.getMillis()));
         }
         if (target == java.sql.Timestamp.class) {
-            return new java.sql.Timestamp(dt.getMillis());
+            return target.cast(new java.sql.Timestamp(dt.getMillis()));
         }
         if (target.isAssignableFrom(Date.class)) {
-            return getJavaDate();
+            return target.cast(getJavaDate());
         }
         return super.toJava(target);
     }

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -1836,6 +1836,14 @@ public class RubyBigDecimal extends RubyNumeric {
          return getRuntime().newBoolean(isZero());
     }
 
+    @Override
+    public <T> T toJava(Class<T> target) {
+        if (target == BigDecimal.class) {
+            return (T) value;
+        }
+        return super.toJava(target);
+    }
+
     /**
      * Returns the correctly rounded square root of a positive
      * BigDecimal. This method performs the fast <i>Square Root by

--- a/core/src/main/java/org/jruby/java/proxies/ConcreteJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ConcreteJavaProxy.java
@@ -210,7 +210,7 @@ public class ConcreteJavaProxy extends JavaProxy {
 
     @Override
     @SuppressWarnings("unchecked")
-    public Object toJava(final Class type) {
+    public <T> T toJava(Class<T> type) {
         final Object object = getObject();
         final Class clazz = object.getClass();
 
@@ -222,16 +222,16 @@ public class ConcreteJavaProxy extends JavaProxy {
                  object instanceof Boolean && type == Boolean.TYPE ) {
                 // FIXME in more permissive call paths, like invokedynamic, this can allow
                 // precision-loading downcasts to happen silently
-                return object;
+                return (T) object;
             }
         }
         else if ( type.isAssignableFrom(clazz) ) {
             if ( Java.OBJECT_PROXY_CACHE || metaClass.getCacheProxy() ) {
                 getRuntime().getJavaSupport().getObjectProxyCache().put(object, this);
             }
-            return object;
+            return type.cast(object);
         }
-        else if ( type.isAssignableFrom(getClass()) ) return this; // e.g. IRubyObject.class
+        else if ( type.isAssignableFrom(getClass()) ) return type.cast(this); // e.g. IRubyObject.class
 
         throw getRuntime().newTypeError("failed to coerce " + clazz.getName() + " to " + type.getName());
     }

--- a/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
@@ -462,12 +462,12 @@ public class JavaProxy extends RubyObject {
 
     @Override
     @SuppressWarnings("unchecked")
-    public Object toJava(final Class type) {
+    public <T> T toJava(Class<T> type) {
         final Object object = getObject();
         final Class<?> clazz = object.getClass();
 
-        if ( type.isAssignableFrom(clazz) ) return object;
-        if ( type.isAssignableFrom(getClass()) ) return this; // e.g. IRubyObject.class
+        if ( type.isAssignableFrom(clazz) ) return type.cast(object);
+        if ( type.isAssignableFrom(getClass()) ) return type.cast(this); // e.g. IRubyObject.class
 
         throw getRuntime().newTypeError("failed to coerce " + clazz.getName() + " to " + type.getName());
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaAccessibleObject.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaAccessibleObject.java
@@ -169,9 +169,10 @@ public abstract class JavaAccessibleObject extends RubyObject {
     }
 
     @Override
-    public Object toJava(Class target) {
-        if ( AccessibleObject.class.isAssignableFrom(target) ) {
-            return accessibleObject();
+    public <T> T toJava(Class<T> target) {
+        AccessibleObject accessibleObject = accessibleObject();
+        if (target.isAssignableFrom(accessibleObject.getClass())) {
+            return target.cast(accessibleObject);
         }
         return super.toJava(target);
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaObject.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaObject.java
@@ -301,12 +301,12 @@ public class JavaObject extends RubyObject {
 
     @Override
     @SuppressWarnings("unchecked")
-    public Object toJava(final Class target) {
+    public <T> T toJava(Class<T> target) {
         final Object value = getValue();
         if ( value == null ) return null;
 
         if ( target.isAssignableFrom( value.getClass() ) ) {
-            return value;
+            return target.cast(value);
         }
         return super.toJava(target);
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaPackage.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaPackage.java
@@ -295,9 +295,9 @@ public class JavaPackage extends RubyModule {
 
     @Override
     @SuppressWarnings("unchecked")
-    public Object toJava(final Class target) {
+    public <T> T toJava(Class<T> target) {
         if ( target.isAssignableFrom( Package.class ) ) {
-            return Package.getPackage(packageName);
+            return target.cast(Package.getPackage(packageName));
         }
         return super.toJava(target);
     }

--- a/core/src/main/java/org/jruby/runtime/builtin/IRubyObject.java
+++ b/core/src/main/java/org/jruby/runtime/builtin/IRubyObject.java
@@ -275,7 +275,7 @@ public interface IRubyObject {
      *
      * @param type The target type to which the object should be converted.
      */
-    Object toJava(Class type);
+    <T> T toJava(Class<T> type);
 
     /**
      * RubyMethod dup.

--- a/core/src/test/java/org/jruby/embed/ScriptingContainerTest.java
+++ b/core/src/test/java/org/jruby/embed/ScriptingContainerTest.java
@@ -596,7 +596,7 @@ public class ScriptingContainerTest {
         filename = basedir + "/core/src/test/ruby/org/jruby/embed/ruby/next_year.rb";
         result = instance.parse(PathType.ABSOLUTE, filename);
         IRubyObject ret = result.run();
-        assertEquals(getNextYear(), ret.toJava(Integer.class));
+        assertEquals(getNextYear(), (int) ret.toJava(Integer.class));
 
         StringWriter sw = new StringWriter();
         instance.setWriter(sw);


### PR DESCRIPTION
This change allow callers to skip the cast when calling toJava
on a Ruby object. It was initially done to assist work on #4781
by allowing a simple "throw rubyException.toJava(Throwable.class).

I tested binary compatibility in two ways:

* A full recompile with all generification in place plus testing
  standard JRuby commands. This confirms that classes recompiled
  against the API but without other use of generics still function
  properly.
* A partial recompile with only the generified classes rebuilt.
  This tests that classes not compiled against the API still
  function properly.

Of course any external JRuby extensions (readline, openssl) will
have been tested by running those standard commands (e.g. irb,
gem install).