### PR TITLE
Parallel exception hierarchy for Java

### DIFF
--- a/core/src/main/java/org/jruby/AbstractRubyException.java
+++ b/core/src/main/java/org/jruby/AbstractRubyException.java
@@ -1,0 +1,363 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2002-2006 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004-2005 Charles O Nutter <headius@headius.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 David Corbin <dcorbin@users.sf.net>
+ * Copyright (C) 2006 Michael Studman <codehaus@michaelstudman.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby;
+
+import org.jruby.anno.JRubyMethod;
+import org.jruby.exceptions.JumpException.FlowControlException;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.java.proxies.ConcreteJavaProxy;
+import org.jruby.runtime.Block;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.backtrace.BacktraceData;
+import org.jruby.runtime.backtrace.RubyStackTraceElement;
+import org.jruby.runtime.backtrace.TraceType;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import java.io.PrintStream;
+
+import static org.jruby.runtime.Visibility.PRIVATE;
+
+/**
+ *
+ * @author  jpetersen
+ */
+public abstract class AbstractRubyException<T extends RaiseException> extends RubyObject {
+
+    protected AbstractRubyException(Ruby runtime, RubyClass rubyClass) {
+        this(runtime, rubyClass, null);
+    }
+
+    public AbstractRubyException(Ruby runtime, RubyClass rubyClass, String message) {
+        super(runtime, rubyClass);
+
+        this.setMessage(message == null ? runtime.getNil() : runtime.newString(message));
+        this.cause = RubyBasicObject.UNDEF;
+    }
+
+    @JRubyMethod(optional = 2, visibility = PRIVATE)
+    public IRubyObject initialize(IRubyObject[] args, Block block) {
+        if ( args.length == 1 ) setMessage(args[0]);
+        // cause filled in at RubyKernel#raise ... Exception.new does not fill-in cause!
+        return this;
+    }
+
+    @JRubyMethod
+    public IRubyObject backtrace() {
+        return getBacktrace();
+    }
+
+    @JRubyMethod(required = 1)
+    public IRubyObject set_backtrace(IRubyObject obj) {
+        setBacktrace(obj);
+        return backtrace();
+    }
+
+    private void setBacktrace(IRubyObject obj) {
+        if (obj.isNil()) {
+            backtrace = null;
+        } else if (isArrayOfStrings(obj)) {
+            backtrace = obj;
+        } else if (obj instanceof RubyString) {
+            backtrace = RubyArray.newArray(getRuntime(), obj);
+        } else {
+            throw getRuntime().newTypeError("backtrace must be Array of String");
+        }
+    }
+
+    @JRubyMethod(omit = true)
+    public IRubyObject backtrace_locations(ThreadContext context) {
+        Ruby runtime = context.runtime;
+        RubyStackTraceElement[] elements = backtraceData.getBacktrace(runtime);
+
+        return RubyThread.Location.newLocationArray(runtime, elements);
+    }
+
+    @JRubyMethod(name = "exception", optional = 1, rest = true, meta = true)
+    public static IRubyObject exception(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
+        return ((RubyClass) recv).newInstance(context, args, block);
+    }
+
+    @JRubyMethod(optional = 1)
+    public AbstractRubyException exception(IRubyObject[] args) {
+        switch (args.length) {
+            case 0 :
+                return this;
+            case 1 :
+                if (args[0] == this) return this;
+                AbstractRubyException ret = (AbstractRubyException) rbClone();
+                ret.initialize(args, Block.NULL_BLOCK); // This looks wrong, but it's the way MRI does it.
+                return ret;
+            default :
+                throw getRuntime().newArgumentError("Wrong argument count");
+        }
+    }
+
+    @JRubyMethod(name = "to_s")
+    public IRubyObject to_s(ThreadContext context) {
+        final IRubyObject msg = getMessage();
+        if ( ! msg.isNil() ) return msg.asString();
+        return context.runtime.newString(getMetaClass().getRealClass().getName());
+    }
+
+    @Deprecated
+    public IRubyObject to_s19(ThreadContext context) { return to_s(context); }
+
+    @JRubyMethod(name = "message")
+    public IRubyObject message(ThreadContext context) {
+        return callMethod(context, "to_s");
+    }
+
+    /** inspects an object and return a kind of debug information
+     *
+     *@return A RubyString containing the debug information.
+     */
+    @JRubyMethod(name = "inspect")
+    public RubyString inspect(ThreadContext context) {
+        // rb_class_name skips intermediate classes (JRUBY-6786)
+        String rubyClass = getMetaClass().getRealClass().getName();
+        RubyString exception = RubyString.objAsString(context, this);
+
+        if (exception.isEmpty()) return context.runtime.newString(rubyClass);
+
+        return RubyString.newString(context.runtime,
+                new StringBuilder(2 + rubyClass.length() + 2 + exception.size() + 1).
+                    append("#<").append(rubyClass).append(": ").append(exception.getByteList()).append('>')
+        );
+    }
+
+    @Override
+    @JRubyMethod(name = "==")
+    public RubyBoolean op_equal(ThreadContext context, IRubyObject other) {
+        if (this == other) return context.runtime.getTrue();
+
+        boolean equal = context.runtime.getException().isInstance(other) &&
+                getMetaClass().getRealClass() == other.getMetaClass().getRealClass() &&
+                callMethod(context, "message").equals(other.callMethod(context, "message")) &&
+                callMethod(context, "backtrace").equals(other.callMethod(context, "backtrace"));
+        return context.runtime.newBoolean(equal);
+    }
+
+    @JRubyMethod(name = "===", meta = true)
+    public static IRubyObject op_eqq(ThreadContext context, IRubyObject recv, IRubyObject other) {
+        Ruby runtime = context.runtime;
+        // special case non-FlowControlException Java exceptions so they'll be caught by rescue Exception
+        if (other instanceof ConcreteJavaProxy &&
+                (recv == runtime.getException() || recv == runtime.getStandardError())) {
+
+            Object object = ((ConcreteJavaProxy)other).getObject();
+            if (object instanceof Throwable && !(object instanceof FlowControlException)) {
+                if (recv == runtime.getException() || object instanceof Exception) {
+                    return context.runtime.getTrue();
+                }
+            }
+        }
+        // fall back on default logic
+        return ((RubyClass)recv).op_eqq(context, other);
+    }
+
+    @JRubyMethod(name = "cause")
+    public IRubyObject cause(ThreadContext context) {
+        assert cause != null;
+        return cause == RubyBasicObject.UNDEF ? context.nil : cause;
+    }
+
+    @Override
+    public Object toJava(Class target) {
+        if (target.isAssignableFrom(RaiseException.class)) {
+            return target.cast(raiseException);
+        }
+        return super.toJava(target);
+    }
+
+    protected abstract T constructRaiseException(String message);
+
+    public T getRaiseException() {
+        if (raiseException == null) {
+            return raiseException = constructRaiseException(message.asJavaString());
+        }
+        return raiseException;
+    }
+
+    public void setCause(IRubyObject cause) {
+        this.cause = cause;
+    }
+
+    // NOTE: can not have IRubyObject as NativeException has getCause() returning Throwable
+    public Object getCause() {
+        return cause == RubyBasicObject.UNDEF ? null : cause;
+    }
+
+    public void setBacktraceData(BacktraceData backtraceData) {
+        this.backtraceData = backtraceData;
+    }
+
+    public BacktraceData getBacktraceData() {
+        return backtraceData;
+    }
+
+    public RubyStackTraceElement[] getBacktraceElements() {
+        if (backtraceData == null) {
+            return RubyStackTraceElement.EMPTY_ARRAY;
+        }
+        return backtraceData.getBacktrace(getRuntime());
+    }
+
+    public void prepareBacktrace(ThreadContext context) {
+        // if it's null, build a backtrace
+        if (backtraceData == null) {
+            backtraceData = context.runtime.getInstanceConfig().getTraceType().getBacktrace(context);
+        }
+    }
+
+    /**
+     * Prepare an "integrated" backtrace that includes the normal Ruby trace plus non-filtered Java frames. Used by
+     * Java integration to show the Java frames for a JI-called method.
+     *
+     * @param context
+     * @param javaTrace
+     */
+    public void prepareIntegratedBacktrace(ThreadContext context, StackTraceElement[] javaTrace) {
+        // if it's null, build a backtrace
+        if (backtraceData == null) {
+            backtraceData = context.runtime.getInstanceConfig().getTraceType().getIntegratedBacktrace(context, javaTrace);
+        }
+    }
+
+    public void forceBacktrace(IRubyObject backtrace) {
+        backtraceData = (backtrace != null && backtrace.isNil()) ? null : BacktraceData.EMPTY;
+        setBacktrace(backtrace);
+    }
+
+    public IRubyObject getBacktrace() {
+        if (backtrace == null) {
+            initBacktrace();
+        }
+        return backtrace;
+    }
+
+    public void initBacktrace() {
+        Ruby runtime = getRuntime();
+        if (backtraceData == null) {
+            backtrace = runtime.getNil();
+        } else {
+            backtrace = TraceType.generateMRIBacktrace(runtime, backtraceData.getBacktrace(runtime));
+        }
+    }
+
+    @Override
+    public void copySpecialInstanceVariables(IRubyObject clone) {
+        AbstractRubyException exception = (AbstractRubyException)clone;
+        exception.backtraceData = backtraceData;
+        exception.backtrace = backtrace;
+        exception.message = message;
+    }
+
+    /**
+     * Print the Ruby exception's backtrace to the given PrintStream.
+     *
+     * @param errorStream the PrintStream to which backtrace should be printed
+     */
+    public void printBacktrace(PrintStream errorStream) {
+        printBacktrace(errorStream, 0);
+    }
+
+    /**
+     * Print the Ruby exception's backtrace to the given PrintStream. This
+     * version accepts a number of lines to skip and is primarily used
+     * internally for exception printing where the first line is treated specially.
+     *
+     * @param errorStream the PrintStream to which backtrace should be printed
+     */
+    public void printBacktrace(PrintStream errorStream, int skip) {
+        IRubyObject trace = callMethod(getRuntime().getCurrentContext(), "backtrace");
+        if ( trace.isNil() ) return;
+        if ( trace instanceof RubyArray ) {
+            IRubyObject[] elements = ((RubyArray) trace).toJavaArrayMaybeUnsafe();
+            for (int i = skip; i < elements.length; i++) {
+                IRubyObject stackTraceLine = elements[i];
+                if (stackTraceLine instanceof RubyString) {
+                    errorStream.println("\tfrom " + stackTraceLine);
+                }
+                else {
+                    errorStream.println("\t" + stackTraceLine);
+                }
+            }
+        }
+    }
+
+    private boolean isArrayOfStrings(IRubyObject backtrace) {
+        if (!(backtrace instanceof RubyArray)) return false;
+
+        final RubyArray rTrace = ((RubyArray) backtrace);
+
+        for (int i = 0 ; i < rTrace.getLength() ; i++) {
+            if (!(rTrace.eltInternal(i) instanceof RubyString)) return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return error message if provided or nil
+     */
+    public IRubyObject getMessage() {
+        return message == null ? getRuntime().getNil() : message;
+    }
+
+    /**
+     * Set the message for this NameError.
+     * @param message the message
+     */
+    public void setMessage(IRubyObject message) {
+        this.message = message;
+    }
+
+    public String getMessageAsJavaString() {
+        final IRubyObject msg = getMessage();
+        return msg.isNil() ? null : msg.toString();
+    }
+
+    private BacktraceData backtraceData;
+    private IRubyObject backtrace;
+    IRubyObject message;
+    IRubyObject cause;
+    private T raiseException;
+
+    public static final int TRACE_HEAD = 8;
+    public static final int TRACE_TAIL = 4;
+    public static final int TRACE_MAX = TRACE_HEAD + TRACE_TAIL + 6;
+}

--- a/core/src/main/java/org/jruby/AbstractRubyException.java
+++ b/core/src/main/java/org/jruby/AbstractRubyException.java
@@ -351,7 +351,7 @@ public abstract class AbstractRubyException extends RubyObject {
         return msg.isNil() ? null : msg.toString();
     }
 
-    private BacktraceData backtraceData;
+    protected BacktraceData backtraceData;
     private IRubyObject backtrace;
     IRubyObject message;
     IRubyObject cause;

--- a/core/src/main/java/org/jruby/AbstractRubyException.java
+++ b/core/src/main/java/org/jruby/AbstractRubyException.java
@@ -55,7 +55,7 @@ import static org.jruby.runtime.Visibility.PRIVATE;
  *
  * @author  jpetersen
  */
-public abstract class AbstractRubyException<T extends RaiseException> extends RubyObject {
+public abstract class AbstractRubyException extends RubyObject {
 
     protected AbstractRubyException(Ruby runtime, RubyClass rubyClass) {
         this(runtime, rubyClass, null);
@@ -203,11 +203,11 @@ public abstract class AbstractRubyException<T extends RaiseException> extends Ru
         return super.toJava(target);
     }
 
-    protected abstract T constructRaiseException(String message);
+    protected abstract RaiseException constructRaiseException(String message);
 
-    public T getRaiseException() {
+    public RaiseException getRaiseException() {
         if (raiseException == null) {
-            return raiseException = constructRaiseException(message.asJavaString());
+            return raiseException = constructRaiseException(getMessageAsJavaString());
         }
         return raiseException;
     }
@@ -355,7 +355,7 @@ public abstract class AbstractRubyException<T extends RaiseException> extends Ru
     private IRubyObject backtrace;
     IRubyObject message;
     IRubyObject cause;
-    private T raiseException;
+    private RaiseException raiseException;
 
     public static final int TRACE_HEAD = 8;
     public static final int TRACE_TAIL = 4;

--- a/core/src/main/java/org/jruby/NativeException.java
+++ b/core/src/main/java/org/jruby/NativeException.java
@@ -43,11 +43,20 @@ public class NativeException extends RubyException {
     public static final String CLASS_NAME = "NativeException";
 
     public NativeException(Ruby runtime, RubyClass rubyClass, Throwable cause) {
-        super(runtime, rubyClass);
-        this.cause = cause;
-        this.messageAsJavaString = cause.getClass().getName() + ": " + searchStackMessage(cause);
+        this(runtime, rubyClass, cause, buildMessage(cause));
     }
-    
+
+    private NativeException(Ruby runtime, RubyClass rubyClass, Throwable cause, String message) {
+        super(runtime, rubyClass, message);
+        this.cause = cause;
+        String s = buildMessage(cause);
+        this.messageAsJavaString = message;
+    }
+
+    private static String buildMessage(Throwable cause) {
+        return cause.getClass().getName() + ": " + searchStackMessage(cause);
+    }
+
     private NativeException(Ruby runtime, RubyClass rubyClass) {
         super(runtime, rubyClass, null);
         this.cause = new Throwable();
@@ -64,6 +73,7 @@ public class NativeException extends RubyException {
 
     public static RubyClass createClass(Ruby runtime, RubyClass baseClass) {
         RubyClass exceptionClass = runtime.defineClass(CLASS_NAME, baseClass, NATIVE_EXCEPTION_ALLOCATOR);
+        runtime.getObject().deprecateConstant(runtime, CLASS_NAME);
 
         exceptionClass.defineAnnotatedMethods(NativeException.class);
 

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -4001,7 +4001,7 @@ public final class Ruby implements Constantizable {
             }
         }
 
-        return new RaiseException(new RubyNameError(this, getNameError(), message, name), false);
+        return new RaiseException(new RubyNameError(this, getNameError(), message, name));
     }
 
     /**
@@ -4067,11 +4067,11 @@ public final class Ruby implements Constantizable {
      * @return a new NoMethodError
      */
     public RaiseException newNoMethodError(String message, String name, IRubyObject args) {
-        return new RaiseException(new RubyNoMethodError(this, getNoMethodError(), message, name, args), true);
+        return new RaiseException(new RubyNoMethodError(this, getNoMethodError(), message, name, args));
     }
 
     public RaiseException newLocalJumpError(RubyLocalJumpError.Reason reason, IRubyObject exitValue, String message) {
-        return new RaiseException(new RubyLocalJumpError(this, getLocalJumpError(), message, reason, exitValue), true);
+        return new RaiseException(new RubyLocalJumpError(this, getLocalJumpError(), message, reason, exitValue));
     }
 
     public RaiseException newLocalJumpErrorNoBlock() {
@@ -4200,7 +4200,7 @@ public final class Ruby implements Constantizable {
      * @return
      */
     public RaiseException newRaiseException(RubyClass exceptionClass, String message) {
-        return new RaiseException(this, exceptionClass, message, true);
+        return RubyException.newRaiseException(this, exceptionClass, message);
     }
 
     /**
@@ -4216,9 +4216,9 @@ public final class Ruby implements Constantizable {
      */
     private RaiseException newLightweightErrnoException(RubyClass exceptionClass, String message) {
         if (RubyInstanceConfig.ERRNO_BACKTRACE) {
-            return new RaiseException(this, exceptionClass, message, true);
+            return RubyException.newRaiseException(this, exceptionClass, message);
         } else {
-            return new RaiseException(this, exceptionClass, ERRNO_BACKTRACE_MESSAGE, disabledBacktrace(), true);
+            return RubyException.newRaiseException(this, exceptionClass, ERRNO_BACKTRACE_MESSAGE, disabledBacktrace());
         }
     }
 
@@ -4815,7 +4815,7 @@ public final class Ruby implements Constantizable {
     public RaiseException newNameErrorObject(String message, IRubyObject name) {
         RubyException error = new RubyNameError(this, getNameError(), message, name);
 
-        return new RaiseException(error, false);
+        return new RaiseException(error);
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1564,53 +1564,52 @@ public final class Ruby implements Constantizable {
     }
 
     private void initExceptions() {
-        ifAllowed("StandardError", (ruby) -> standardError = RubyStandardError.define(ruby, exceptionClass));
-        ifAllowed("RubyError", (ruby) -> runtimeError = RubyRuntimeError.define(ruby, standardError));
-        ifAllowed("IOError", (ruby) -> ioError = RubyIOError.define(ruby, standardError));
-        ifAllowed("ScriptError", (ruby) -> scriptError = RubyScriptError.define(ruby, exceptionClass));
-        ifAllowed("RangeError", (ruby) -> rangeError = RubyRangeError.define(ruby, standardError));
-        ifAllowed("SignalException", (ruby) -> signalException = RubySignalException.define(ruby, exceptionClass));
-        ifAllowed("NameError", (ruby) -> {
+        ifAllowed("StandardError",          (ruby) -> standardError = RubyStandardError.define(ruby, exceptionClass));
+        ifAllowed("RubyError",              (ruby) -> runtimeError = RubyRuntimeError.define(ruby, standardError));
+        ifAllowed("IOError",                (ruby) -> ioError = RubyIOError.define(ruby, standardError));
+        ifAllowed("ScriptError",            (ruby) -> scriptError = RubyScriptError.define(ruby, exceptionClass));
+        ifAllowed("RangeError",             (ruby) -> rangeError = RubyRangeError.define(ruby, standardError));
+        ifAllowed("SignalException",        (ruby) -> signalException = RubySignalException.define(ruby, exceptionClass));
+        ifAllowed("NameError",              (ruby) -> {
             nameError = RubyNameError.define(ruby, standardError);
-            nameErrorMessage = RubyNameError.defineMessage(ruby, nameError);
+            nameErrorMessage = RubyNameError.RubyNameErrorMessage.define(ruby, nameError);
         });
-        ifAllowed("NoMethodError", (ruby) -> noMethodError = RubyNoMethodError.define(ruby, nameError));
-        ifAllowed("SystemExit", (ruby) -> systemExit = RubySystemExit.define(ruby, exceptionClass));
-        ifAllowed("LocalJumpError", (ruby) -> localJumpError = RubyLocalJumpError.define(ruby, standardError));
-        ifAllowed("SystemCallError", (ruby) -> systemCallError = RubySystemCallError.define(ruby, standardError));
-
-        ifAllowed("Fatal", (ruby) -> fatal = RubyFatal.define(ruby, exceptionClass));
-        ifAllowed("Interrupt", (ruby) -> interrupt = RubyInterrupt.define(ruby, signalException));
-        ifAllowed("TypeError", (ruby) -> typeError = RubyTypeError.define(ruby, standardError));
-        ifAllowed("ArgumentError", (ruby) -> argumentError = RubyArgumentError.define(ruby, standardError));
-        ifAllowed("UncaughtThrowError", (ruby) -> uncaughtThrowError = RubyUncaughtThrowError.define(ruby, argumentError));
-        ifAllowed("IndexError", (ruby) -> indexError = RubyIndexError.define(ruby, standardError));
-        ifAllowed("StopIteration", (ruby) -> stopIteration = RubyStopIteration.define(ruby, indexError));
-        ifAllowed("SyntaxError", (ruby) -> syntaxError = RubySyntaxError.define(ruby, scriptError));
-        ifAllowed("LoadError", (ruby) -> loadError = RubyLoadError.define(ruby, scriptError));
-        ifAllowed("NotImplementedError", (ruby) -> notImplementedError = RubyNotImplementedError.define(ruby, scriptError));
-        ifAllowed("SecurityError", (ruby) -> securityError = RubySecurityError.define(ruby, exceptionClass));
-        ifAllowed("NoMemoryError", (ruby) -> noMemoryError = RubyNoMemoryError.define(ruby, exceptionClass));
-        ifAllowed("RegexpError", (ruby) -> regexpError = RubyRegexpError.define(ruby, standardError));
+        ifAllowed("NoMethodError",          (ruby) -> noMethodError = RubyNoMethodError.define(ruby, nameError));
+        ifAllowed("SystemExit",             (ruby) -> systemExit = RubySystemExit.define(ruby, exceptionClass));
+        ifAllowed("LocalJumpError",         (ruby) -> localJumpError = RubyLocalJumpError.define(ruby, standardError));
+        ifAllowed("SystemCallError",        (ruby) -> systemCallError = RubySystemCallError.define(ruby, standardError));
+        ifAllowed("Fatal",                  (ruby) -> fatal = RubyFatal.define(ruby, exceptionClass));
+        ifAllowed("Interrupt",              (ruby) -> interrupt = RubyInterrupt.define(ruby, signalException));
+        ifAllowed("TypeError",              (ruby) -> typeError = RubyTypeError.define(ruby, standardError));
+        ifAllowed("ArgumentError",          (ruby) -> argumentError = RubyArgumentError.define(ruby, standardError));
+        ifAllowed("UncaughtThrowError",     (ruby) -> uncaughtThrowError = RubyUncaughtThrowError.define(ruby, argumentError));
+        ifAllowed("IndexError",             (ruby) -> indexError = RubyIndexError.define(ruby, standardError));
+        ifAllowed("StopIteration",          (ruby) -> stopIteration = RubyStopIteration.define(ruby, indexError));
+        ifAllowed("SyntaxError",            (ruby) -> syntaxError = RubySyntaxError.define(ruby, scriptError));
+        ifAllowed("LoadError",              (ruby) -> loadError = RubyLoadError.define(ruby, scriptError));
+        ifAllowed("NotImplementedError",    (ruby) -> notImplementedError = RubyNotImplementedError.define(ruby, scriptError));
+        ifAllowed("SecurityError",          (ruby) -> securityError = RubySecurityError.define(ruby, exceptionClass));
+        ifAllowed("NoMemoryError",          (ruby) -> noMemoryError = RubyNoMemoryError.define(ruby, exceptionClass));
+        ifAllowed("RegexpError",            (ruby) -> regexpError = RubyRegexpError.define(ruby, standardError));
         // Proposal to RubyCommons for interrupting Regexps
         ifAllowed("InterruptedRegexpError", (ruby) -> interruptedRegexpError = RubyInterruptedRegexpError.define(ruby, regexpError));
-        ifAllowed("EOFError", (ruby) -> eofError = RubyEOFError.define(ruby, ioError));
-        ifAllowed("ThreadError", (ruby) -> threadError = RubyThreadError.define(ruby, standardError));
-        ifAllowed("ConcurrencyError", (ruby) -> concurrencyError = RubyConcurrencyError.define(ruby, threadError));
-        ifAllowed("SystemStackError", (ruby) -> systemStackError = RubySystemStackError.define(ruby, exceptionClass));
-        ifAllowed("ZeroDivisionError", (ruby) -> zeroDivisionError = RubyZeroDivisionError.define(ruby, standardError));
-        ifAllowed("FloatDomainError", (ruby) -> RubyFloatDomainError.define(ruby, rangeError));
-        ifAllowed("EncodingError", (ruby) -> {
+        ifAllowed("EOFError",               (ruby) -> eofError = RubyEOFError.define(ruby, ioError));
+        ifAllowed("ThreadError",            (ruby) -> threadError = RubyThreadError.define(ruby, standardError));
+        ifAllowed("ConcurrencyError",       (ruby) -> concurrencyError = RubyConcurrencyError.define(ruby, threadError));
+        ifAllowed("SystemStackError",       (ruby) -> systemStackError = RubySystemStackError.define(ruby, exceptionClass));
+        ifAllowed("ZeroDivisionError",      (ruby) -> zeroDivisionError = RubyZeroDivisionError.define(ruby, standardError));
+        ifAllowed("FloatDomainError",       (ruby) -> RubyFloatDomainError.define(ruby, rangeError));
+        ifAllowed("EncodingError",          (ruby) -> {
             encodingError = RubyEncodingError.define(ruby, standardError);
             encodingCompatibilityError = RubyEncodingError.RubyCompatibilityError.define(ruby, encodingError, encodingClass);
             invalidByteSequenceError = RubyEncodingError.RubyInvalidByteSequenceError.define(ruby, encodingError, encodingClass);
             undefinedConversionError = RubyEncodingError.RubyUndefinedConversionError.define(ruby, encodingError, encodingClass);
             converterNotFoundError = RubyEncodingError.RubyConverterNotFoundError.define(ruby, encodingError, encodingClass);
         });
-        ifAllowed("Fiber", (ruby) -> fiberError = RubyFiberError.define(ruby, standardError));
-        ifAllowed("ConcurrencyError", (ruby) -> concurrencyError = RubyConcurrencyError.define(ruby, threadError));
-        ifAllowed("KeyError", (ruby) -> keyError = RubyKeyError.define(ruby, indexError));
-        ifAllowed("DomainError", (ruby) -> mathDomainError = RubyDomainError.define(ruby, argumentError, mathModule));
+        ifAllowed("Fiber",                  (ruby) -> fiberError = RubyFiberError.define(ruby, standardError));
+        ifAllowed("ConcurrencyError",       (ruby) -> concurrencyError = RubyConcurrencyError.define(ruby, threadError));
+        ifAllowed("KeyError",               (ruby) -> keyError = RubyKeyError.define(ruby, indexError));
+        ifAllowed("DomainError",            (ruby) -> mathDomainError = RubyDomainError.define(ruby, argumentError, mathModule));
 
         initErrno();
 

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1598,7 +1598,7 @@ public final class Ruby implements Constantizable {
         ifAllowed("ConcurrencyError",       (ruby) -> concurrencyError = RubyConcurrencyError.define(ruby, threadError));
         ifAllowed("SystemStackError",       (ruby) -> systemStackError = RubySystemStackError.define(ruby, exceptionClass));
         ifAllowed("ZeroDivisionError",      (ruby) -> zeroDivisionError = RubyZeroDivisionError.define(ruby, standardError));
-        ifAllowed("FloatDomainError",       (ruby) -> RubyFloatDomainError.define(ruby, rangeError));
+        ifAllowed("FloatDomainError",       (ruby) -> floatDomainError = RubyFloatDomainError.define(ruby, rangeError));
         ifAllowed("EncodingError",          (ruby) -> {
             encodingError = RubyEncodingError.define(ruby, standardError);
             encodingCompatibilityError = RubyEncodingError.RubyCompatibilityError.define(ruby, encodingError, encodingClass);

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -3944,7 +3944,7 @@ public final class Ruby implements Constantizable {
         IRubyObject msg = new RubyNameError.RubyNameErrorMessage(this, message, recv, name);
         RubyException err = RubyNameError.newNameError(getNameError(), msg, name, privateCall);
 
-        return err.getRaiseException();
+        return err.toThrowable();
     }
 
     /**
@@ -3991,7 +3991,7 @@ public final class Ruby implements Constantizable {
             }
         }
 
-        return new RubyNameError(this, getNameError(), message, name).getRaiseException();
+        return new RubyNameError(this, getNameError(), message, name).toThrowable();
     }
 
     /**
@@ -4045,7 +4045,7 @@ public final class Ruby implements Constantizable {
         IRubyObject msg = new RubyNameError.RubyNameErrorMessage(this, message, recv, nameStr);
         RubyException err = RubyNoMethodError.newNoMethodError(getNoMethodError(), msg, nameStr, args, privateCall);
 
-        return err.getRaiseException();
+        return err.toThrowable();
     }
 
     /**
@@ -4057,11 +4057,11 @@ public final class Ruby implements Constantizable {
      * @return a new NoMethodError
      */
     public RaiseException newNoMethodError(String message, String name, IRubyObject args) {
-        return new RubyNoMethodError(this, getNoMethodError(), message, name, args).getRaiseException();
+        return new RubyNoMethodError(this, getNoMethodError(), message, name, args).toThrowable();
     }
 
     public RaiseException newLocalJumpError(RubyLocalJumpError.Reason reason, IRubyObject exitValue, String message) {
-        return new RubyLocalJumpError(this, getLocalJumpError(), message, reason, exitValue).getRaiseException();
+        return new RubyLocalJumpError(this, getLocalJumpError(), message, reason, exitValue).toThrowable();
     }
 
     public RaiseException newLocalJumpErrorNoBlock() {
@@ -4101,11 +4101,11 @@ public final class Ruby implements Constantizable {
     }
 
     public RaiseException newSystemExit(int status) {
-        return RubySystemExit.newInstance(this, status, "exit").getRaiseException();
+        return RubySystemExit.newInstance(this, status, "exit").toThrowable();
     }
 
     public RaiseException newSystemExit(int status, String message) {
-        return RubySystemExit.newInstance(this, status, message).getRaiseException();
+        return RubySystemExit.newInstance(this, status, message).toThrowable();
     }
 
     public RaiseException newIOError(String message) {
@@ -4227,7 +4227,7 @@ public final class Ruby implements Constantizable {
         final ThreadContext context = getCurrentContext();
         if (RubyInstanceConfig.STOPITERATION_BACKTRACE) {
             RubyException ex = RubyStopIteration.newInstance(context, result, message);
-            return ex.getRaiseException();
+            return ex.toThrowable();
         }
         if ( message == null ) message = STOPIERATION_BACKTRACE_MESSAGE;
         RubyException ex = RubyStopIteration.newInstance(context, result, message);
@@ -4805,7 +4805,7 @@ public final class Ruby implements Constantizable {
     public RaiseException newNameErrorObject(String message, IRubyObject name) {
         RubyException error = new RubyNameError(this, getNameError(), message, name);
 
-        return error.getRaiseException();
+        return error.toThrowable();
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1563,7 +1563,7 @@ public final class Ruby implements Constantizable {
     }
 
     private void initExceptions() {
-        standardError = defineClassIfAllowed("StandardError", exceptionClass);
+        standardError = RubyStandardError.createStandardErrorClass(this, exceptionClass);
         runtimeError = defineClassIfAllowed("RuntimeError", standardError);
         ioError = defineClassIfAllowed("IOError", standardError);
         scriptError = defineClassIfAllowed("ScriptError", exceptionClass);
@@ -3954,7 +3954,7 @@ public final class Ruby implements Constantizable {
         IRubyObject msg = new RubyNameError.RubyNameErrorMessage(this, message, recv, name);
         RubyException err = RubyNameError.newNameError(getNameError(), msg, name, privateCall);
 
-        return new RaiseException(err);
+        return err.getRaiseException();
     }
 
     /**
@@ -4001,7 +4001,7 @@ public final class Ruby implements Constantizable {
             }
         }
 
-        return new RaiseException(new RubyNameError(this, getNameError(), message, name));
+        return new RubyNameError(this, getNameError(), message, name).getRaiseException();
     }
 
     /**
@@ -4055,7 +4055,7 @@ public final class Ruby implements Constantizable {
         IRubyObject msg = new RubyNameError.RubyNameErrorMessage(this, message, recv, nameStr);
         RubyException err = RubyNoMethodError.newNoMethodError(getNoMethodError(), msg, nameStr, args, privateCall);
 
-        return new RaiseException(err);
+        return err.getRaiseException();
     }
 
     /**
@@ -4067,11 +4067,11 @@ public final class Ruby implements Constantizable {
      * @return a new NoMethodError
      */
     public RaiseException newNoMethodError(String message, String name, IRubyObject args) {
-        return new RaiseException(new RubyNoMethodError(this, getNoMethodError(), message, name, args));
+        return new RubyNoMethodError(this, getNoMethodError(), message, name, args).getRaiseException();
     }
 
     public RaiseException newLocalJumpError(RubyLocalJumpError.Reason reason, IRubyObject exitValue, String message) {
-        return new RaiseException(new RubyLocalJumpError(this, getLocalJumpError(), message, reason, exitValue));
+        return new RubyLocalJumpError(this, getLocalJumpError(), message, reason, exitValue).getRaiseException();
     }
 
     public RaiseException newLocalJumpErrorNoBlock() {
@@ -4111,11 +4111,11 @@ public final class Ruby implements Constantizable {
     }
 
     public RaiseException newSystemExit(int status) {
-        return new RaiseException(RubySystemExit.newInstance(this, status, "exit"));
+        return RubySystemExit.newInstance(this, status, "exit").getRaiseException();
     }
 
     public RaiseException newSystemExit(int status, String message) {
-        return new RaiseException(RubySystemExit.newInstance(this, status, message));
+        return RubySystemExit.newInstance(this, status, message).getRaiseException();
     }
 
     public RaiseException newIOError(String message) {
@@ -4200,7 +4200,7 @@ public final class Ruby implements Constantizable {
      * @return
      */
     public RaiseException newRaiseException(RubyClass exceptionClass, String message) {
-        return RubyException.newRaiseException(this, exceptionClass, message);
+        return RaiseException.from(this, exceptionClass, message);
     }
 
     /**
@@ -4216,9 +4216,9 @@ public final class Ruby implements Constantizable {
      */
     private RaiseException newLightweightErrnoException(RubyClass exceptionClass, String message) {
         if (RubyInstanceConfig.ERRNO_BACKTRACE) {
-            return RubyException.newRaiseException(this, exceptionClass, message);
+            return RaiseException.from(this, exceptionClass, message);
         } else {
-            return RubyException.newRaiseException(this, exceptionClass, ERRNO_BACKTRACE_MESSAGE, disabledBacktrace());
+            return RaiseException.from(this, exceptionClass, ERRNO_BACKTRACE_MESSAGE, disabledBacktrace());
         }
     }
 
@@ -4237,11 +4237,11 @@ public final class Ruby implements Constantizable {
         final ThreadContext context = getCurrentContext();
         if (RubyInstanceConfig.STOPITERATION_BACKTRACE) {
             RubyException ex = RubyStopIteration.newInstance(context, result, message);
-            return new RaiseException(ex);
+            return ex.getRaiseException();
         }
         if ( message == null ) message = STOPIERATION_BACKTRACE_MESSAGE;
         RubyException ex = RubyStopIteration.newInstance(context, result, message);
-        return new RaiseException(ex, disabledBacktrace());
+        return RaiseException.from(ex, disabledBacktrace());
     }
 
     @Deprecated
@@ -4815,7 +4815,7 @@ public final class Ruby implements Constantizable {
     public RaiseException newNameErrorObject(String message, IRubyObject name) {
         RubyException error = new RubyNameError(this, getNameError(), message, name);
 
-        return new RaiseException(error);
+        return error.getRaiseException();
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/RubyArgumentError.java
+++ b/core/src/main/java/org/jruby/RubyArgumentError.java
@@ -1,0 +1,58 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.ArgumentError;
+
+/**
+ * The Java representation of a Ruby ArgumentError.
+ *
+ * @see ArgumentError
+ */
+@JRubyClass(name="ArgumentError", parent="StandardError")
+public class RubyArgumentError extends RubyStandardError {
+    protected RubyArgumentError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    protected RubyArgumentError(Ruby runtime, RubyClass exceptionClass, String message) {
+        super(runtime, exceptionClass, message);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass argumentErrorClass = runtime.defineClass("ArgumentError", exceptionClass, (r, klass) -> new RubyArgumentError(runtime, klass));
+
+        return argumentErrorClass;
+    }
+
+    @Override
+    protected RaiseException constructRaiseException(String message) {
+        return new ArgumentError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubyArgumentError.java
+++ b/core/src/main/java/org/jruby/RubyArgumentError.java
@@ -52,7 +52,7 @@ public class RubyArgumentError extends RubyStandardError {
     }
 
     @Override
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new ArgumentError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubyConcurrencyError.java
+++ b/core/src/main/java/org/jruby/RubyConcurrencyError.java
@@ -1,0 +1,53 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.ConcurrencyError;
+
+/**
+ * The Java representation of a Ruby ConcurrencyError.
+ *
+ * @see ConcurrencyError
+ */
+@JRubyClass(name="ConcurrencyError", parent="ThreadError")
+public class RubyConcurrencyError extends RubyThreadError {
+    protected RubyConcurrencyError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass concurrencyErrorClass = runtime.defineClass("ConcurrencyError", exceptionClass, (r, klass) -> new RubyConcurrencyError(runtime, klass));
+
+        return concurrencyErrorClass;
+    }
+
+    protected RaiseException constructRaiseException(String message) {
+        return new ConcurrencyError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubyConcurrencyError.java
+++ b/core/src/main/java/org/jruby/RubyConcurrencyError.java
@@ -47,7 +47,7 @@ public class RubyConcurrencyError extends RubyThreadError {
         return concurrencyErrorClass;
     }
 
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new ConcurrencyError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubyDomainError.java
+++ b/core/src/main/java/org/jruby/RubyDomainError.java
@@ -49,7 +49,7 @@ public class RubyDomainError extends RubyArgumentError {
     }
 
     @Override
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new DomainError(message, this);
     }
 

--- a/core/src/main/java/org/jruby/RubyDomainError.java
+++ b/core/src/main/java/org/jruby/RubyDomainError.java
@@ -1,0 +1,56 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.DomainError;
+import org.jruby.exceptions.RaiseException;
+
+/**
+ /**
+ * The Java representation of a Ruby DomainError.
+ *
+ * @see DomainError
+ * @see RubyEnumerator
+ * @author kares
+ */
+@JRubyClass(name="DomainError", parent="ArgumentError")
+public class RubyDomainError extends RubyArgumentError {
+    protected RubyDomainError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass superClass, RubyModule under) {
+        return under.defineClassUnder("DomainError", superClass, (runtime1, klass) -> new RubyDomainError(runtime1, klass));
+    }
+
+    @Override
+    protected RaiseException constructRaiseException(String message) {
+        return new DomainError(message, this);
+    }
+
+}

--- a/core/src/main/java/org/jruby/RubyEOFError.java
+++ b/core/src/main/java/org/jruby/RubyEOFError.java
@@ -47,7 +47,7 @@ public class RubyEOFError extends RubyIOError {
         return eofErrorClass;
     }
 
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new EOFError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubyEOFError.java
+++ b/core/src/main/java/org/jruby/RubyEOFError.java
@@ -1,0 +1,53 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.EOFError;
+import org.jruby.exceptions.RaiseException;
+
+/**
+ * The Java representation of a Ruby EOFError.
+ *
+ * @see EOFError
+ */
+@JRubyClass(name="EOFError", parent="IOError")
+public class RubyEOFError extends RubyIOError {
+    protected RubyEOFError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass eofErrorClass = runtime.defineClass("EOFError", exceptionClass, (r, klass) -> new RubyEOFError(runtime, klass));
+
+        return eofErrorClass;
+    }
+
+    protected RaiseException constructRaiseException(String message) {
+        return new EOFError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubyEncodingError.java
+++ b/core/src/main/java/org/jruby/RubyEncodingError.java
@@ -47,7 +47,7 @@ public class RubyEncodingError extends RubyStandardError {
         return encodingErrorClass;
     }
 
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new EncodingError(message, this);
     }
 
@@ -61,7 +61,7 @@ public class RubyEncodingError extends RubyStandardError {
             return under.defineClassUnder("CompatibilityError", exceptionClass, (r, klass) -> new RubyCompatibilityError(runtime, klass));
         }
 
-        protected RaiseException constructRaiseException(String message) {
+        protected RaiseException constructThrowable(String message) {
             return new EncodingError.CompatibilityError(message, this);
         }
     }
@@ -81,7 +81,7 @@ public class RubyEncodingError extends RubyStandardError {
             return invalidByteSequenceErrorClass;
         }
 
-        protected RaiseException constructRaiseException(String message) {
+        protected RaiseException constructThrowable(String message) {
             return new EncodingError.InvalidByteSequenceError(message, this);
         }
     }
@@ -101,7 +101,7 @@ public class RubyEncodingError extends RubyStandardError {
             return undefinedConversionErrorClass;
         }
 
-        protected RaiseException constructRaiseException(String message) {
+        protected RaiseException constructThrowable(String message) {
             return new EncodingError.UndefinedConversionError(message, this);
         }
     }
@@ -118,7 +118,7 @@ public class RubyEncodingError extends RubyStandardError {
             return converterNotFoundErrorClass;
         }
 
-        protected RaiseException constructRaiseException(String message) {
+        protected RaiseException constructThrowable(String message) {
             return new EncodingError.ConverterNotFoundError(message, this);
         }
     }

--- a/core/src/main/java/org/jruby/RubyEncodingError.java
+++ b/core/src/main/java/org/jruby/RubyEncodingError.java
@@ -1,0 +1,125 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.EncodingError;
+
+/**
+ * The Java representation of a Ruby EncodingError.
+ *
+ * @see EncodingError
+ */
+@JRubyClass(name="EncodingError", parent="StandardError")
+public class RubyEncodingError extends RubyStandardError {
+    protected RubyEncodingError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass encodingErrorClass = runtime.defineClass("EncodingError", exceptionClass, (r, klass) -> new RubyEncodingError(runtime, klass));
+
+        return encodingErrorClass;
+    }
+
+    protected RaiseException constructRaiseException(String message) {
+        return new EncodingError(message, this);
+    }
+
+    @JRubyClass(name="CompatibilityError", parent="EncodingError")
+    public static class RubyCompatibilityError extends RubyEncodingError {
+        protected RubyCompatibilityError(Ruby runtime, RubyClass exceptionClass) {
+            super(runtime, exceptionClass);
+        }
+
+        static RubyClass define(Ruby runtime, RubyClass exceptionClass, RubyModule under) {
+            return under.defineClassUnder("CompatibilityError", exceptionClass, (r, klass) -> new RubyCompatibilityError(runtime, klass));
+        }
+
+        protected RaiseException constructRaiseException(String message) {
+            return new EncodingError.CompatibilityError(message, this);
+        }
+    }
+
+    @JRubyClass(name="InvalidByteSequenceError", parent="EncodingError")
+    public static class RubyInvalidByteSequenceError extends RubyEncodingError {
+        protected RubyInvalidByteSequenceError(Ruby runtime, RubyClass exceptionClass) {
+            super(runtime, exceptionClass);
+        }
+
+        static RubyClass define(Ruby runtime, RubyClass exceptionClass, RubyModule under) {
+            RubyClass invalidByteSequenceErrorClass = under.defineClassUnder("InvalidByteSequenceError", exceptionClass, (r, klass) -> new RubyInvalidByteSequenceError(runtime, klass));
+
+            invalidByteSequenceErrorClass.defineAnnotatedMethods(RubyConverter.EncodingErrorMethods.class);
+            invalidByteSequenceErrorClass.defineAnnotatedMethods(RubyConverter.InvalidByteSequenceErrorMethods.class);
+
+            return invalidByteSequenceErrorClass;
+        }
+
+        protected RaiseException constructRaiseException(String message) {
+            return new EncodingError.InvalidByteSequenceError(message, this);
+        }
+    }
+
+    @JRubyClass(name="UndefinedConversionError", parent="EncodingError")
+    public static class RubyUndefinedConversionError extends RubyEncodingError {
+        protected RubyUndefinedConversionError(Ruby runtime, RubyClass exceptionClass) {
+            super(runtime, exceptionClass);
+        }
+
+        static RubyClass define(Ruby runtime, RubyClass exceptionClass, RubyModule under) {
+            RubyClass undefinedConversionErrorClass = under.defineClassUnder("UndefinedConversionError", exceptionClass, (r, klass) -> new RubyUndefinedConversionError(runtime, klass));
+
+            undefinedConversionErrorClass.defineAnnotatedMethods(RubyConverter.EncodingErrorMethods.class);
+            undefinedConversionErrorClass.defineAnnotatedMethods(RubyConverter.UndefinedConversionErrorMethods.class);
+
+            return undefinedConversionErrorClass;
+        }
+
+        protected RaiseException constructRaiseException(String message) {
+            return new EncodingError.UndefinedConversionError(message, this);
+        }
+    }
+
+    @JRubyClass(name="ConverterNotFoundError", parent="EncodingError")
+    public static class RubyConverterNotFoundError extends RubyEncodingError {
+        protected RubyConverterNotFoundError(Ruby runtime, RubyClass exceptionClass) {
+            super(runtime, exceptionClass);
+        }
+
+        static RubyClass define(Ruby runtime, RubyClass exceptionClass, RubyModule under) {
+            RubyClass converterNotFoundErrorClass = under.defineClassUnder("ConverterNotFoundError", exceptionClass, (r, klass) -> new RubyConverterNotFoundError(runtime, klass));
+
+            return converterNotFoundErrorClass;
+        }
+
+        protected RaiseException constructRaiseException(String message) {
+            return new EncodingError.ConverterNotFoundError(message, this);
+        }
+    }
+}

--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -835,7 +835,7 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
             if (value instanceof RubyException) {
                 doneObject = value;
                 if ( silent ) return null;
-                throw ((RubyException) value).getRaiseException();
+                throw ((RubyException) value).toThrowable();
             }
 
             // otherwise, just return it

--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -835,7 +835,7 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
             if (value instanceof RubyException) {
                 doneObject = value;
                 if ( silent ) return null;
-                throw new RaiseException((RubyException) value);
+                throw ((RubyException) value).getRaiseException();
             }
 
             // otherwise, just return it

--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -73,7 +73,7 @@ public class RubyException extends AbstractRubyException {
         super(runtime, rubyClass, message);
     }
 
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new Exception(message, this);
     }
 

--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -39,6 +39,7 @@ package org.jruby;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.JumpException.FlowControlException;
+import org.jruby.exceptions.RaiseException;
 import org.jruby.java.proxies.ConcreteJavaProxy;
 import org.jruby.runtime.*;
 import org.jruby.runtime.backtrace.BacktraceData;
@@ -61,283 +62,40 @@ import static org.jruby.runtime.Visibility.PRIVATE;
  * @author  jpetersen
  */
 @JRubyClass(name="Exception")
-public class RubyException extends RubyObject {
+public class RubyException<T extends RaiseException> extends AbstractRubyException<RaiseException> {
+
+    public static RubyClass createExceptionClass(Ruby runtime) {
+        RubyClass exceptionClass = runtime.defineClass("Exception", runtime.getObject(), EXCEPTION_ALLOCATOR);
+        runtime.setException(exceptionClass);
+
+        exceptionClass.setClassIndex(ClassIndex.EXCEPTION);
+        exceptionClass.setReifiedClass(RubyException.class);
+
+        exceptionClass.setMarshal(EXCEPTION_MARSHAL);
+        exceptionClass.defineAnnotatedMethods(AbstractRubyException.class);
+
+        return exceptionClass;
+    }
 
     protected RubyException(Ruby runtime, RubyClass rubyClass) {
         super(runtime, rubyClass);
-        this.cause = RubyBasicObject.UNDEF;
     }
 
     public RubyException(Ruby runtime, RubyClass rubyClass, String message) {
-        super(runtime, rubyClass);
-
-        this.setMessage(message == null ? runtime.getNil() : runtime.newString(message));
-        this.cause = RubyBasicObject.UNDEF;
+        super(runtime, rubyClass, message);
     }
 
-    @JRubyMethod(optional = 2, visibility = PRIVATE)
-    public IRubyObject initialize(IRubyObject[] args, Block block) {
-        if ( args.length == 1 ) setMessage(args[0]);
-        // cause filled in at RubyKernel#raise ... Exception.new does not fill-in cause!
-        return this;
+    protected T constructRaiseException(String message) {
+        return (T) new RaiseException(message, this);
     }
 
-    @JRubyMethod
-    public IRubyObject backtrace() {
-        return getBacktrace();
-    }
-
-    @JRubyMethod(required = 1)
-    public IRubyObject set_backtrace(IRubyObject obj) {
-        setBacktrace(obj);
-        return backtrace();
-    }
-
-    private void setBacktrace(IRubyObject obj) {
-        if (obj.isNil()) {
-            backtrace = null;
-        } else if (isArrayOfStrings(obj)) {
-            backtrace = obj;
-        } else if (obj instanceof RubyString) {
-            backtrace = RubyArray.newArray(getRuntime(), obj);
-        } else {
-            throw getRuntime().newTypeError("backtrace must be Array of String");
-        }
-    }
-
-    @JRubyMethod(omit = true)
-    public IRubyObject backtrace_locations(ThreadContext context) {
-        Ruby runtime = context.runtime;
-        RubyStackTraceElement[] elements = backtraceData.getBacktrace(runtime);
-
-        return RubyThread.Location.newLocationArray(runtime, elements);
-    }
-
-    @JRubyMethod(name = "exception", optional = 1, rest = true, meta = true)
-    public static IRubyObject exception(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
-        return ((RubyClass) recv).newInstance(context, args, block);
-    }
-
-    @JRubyMethod(optional = 1)
-    public RubyException exception(IRubyObject[] args) {
-        switch (args.length) {
-            case 0 :
-                return this;
-            case 1 :
-                if (args[0] == this) return this;
-                RubyException ret = (RubyException) rbClone();
-                ret.initialize(args, Block.NULL_BLOCK); // This looks wrong, but it's the way MRI does it.
-                return ret;
-            default :
-                throw getRuntime().newArgumentError("Wrong argument count");
-        }
-    }
-
-    @JRubyMethod(name = "to_s")
-    public IRubyObject to_s(ThreadContext context) {
-        final IRubyObject msg = getMessage();
-        if ( ! msg.isNil() ) return msg.asString();
-        return context.runtime.newString(getMetaClass().getRealClass().getName());
-    }
-
-    @Deprecated
-    public IRubyObject to_s19(ThreadContext context) { return to_s(context); }
-
-    @JRubyMethod(name = "message")
-    public IRubyObject message(ThreadContext context) {
-        return callMethod(context, "to_s");
-    }
-
-    /** inspects an object and return a kind of debug information
-     *
-     *@return A RubyString containing the debug information.
-     */
-    @JRubyMethod(name = "inspect")
-    public RubyString inspect(ThreadContext context) {
-        // rb_class_name skips intermediate classes (JRUBY-6786)
-        String rubyClass = getMetaClass().getRealClass().getName();
-        RubyString exception = RubyString.objAsString(context, this);
-
-        if (exception.isEmpty()) return context.runtime.newString(rubyClass);
-
-        return RubyString.newString(context.runtime,
-                new StringBuilder(2 + rubyClass.length() + 2 + exception.size() + 1).
-                    append("#<").append(rubyClass).append(": ").append(exception.getByteList()).append('>')
-        );
-    }
-
-    @Override
-    @JRubyMethod(name = "==")
-    public RubyBoolean op_equal(ThreadContext context, IRubyObject other) {
-        if (this == other) return context.runtime.getTrue();
-
-        boolean equal = context.runtime.getException().isInstance(other) &&
-                getMetaClass().getRealClass() == other.getMetaClass().getRealClass() &&
-                callMethod(context, "message").equals(other.callMethod(context, "message")) &&
-                callMethod(context, "backtrace").equals(other.callMethod(context, "backtrace"));
-        return context.runtime.newBoolean(equal);
-    }
-
-    @JRubyMethod(name = "===", meta = true)
-    public static IRubyObject op_eqq(ThreadContext context, IRubyObject recv, IRubyObject other) {
-        Ruby runtime = context.runtime;
-        // special case non-FlowControlException Java exceptions so they'll be caught by rescue Exception
-        if (other instanceof ConcreteJavaProxy &&
-                (recv == runtime.getException() || recv == runtime.getStandardError())) {
-
-            Object object = ((ConcreteJavaProxy)other).getObject();
-            if (object instanceof Throwable && !(object instanceof FlowControlException)) {
-                if (recv == runtime.getException() || object instanceof Exception) {
-                    return context.runtime.getTrue();
-                }
-            }
-        }
-        // fall back on default logic
-        return ((RubyClass)recv).op_eqq(context, other);
-    }
-
-    @JRubyMethod(name = "cause")
-    public IRubyObject cause(ThreadContext context) {
-        assert cause != null;
-        return cause == RubyBasicObject.UNDEF ? context.nil : cause;
-    }
-
-    public void setCause(IRubyObject cause) {
-        this.cause = cause;
-    }
-
-    // NOTE: can not have IRubyObject as NativeException has getCause() returning Throwable
-    public Object getCause() {
-        return cause == RubyBasicObject.UNDEF ? null : cause;
-    }
-
-    public void setBacktraceData(BacktraceData backtraceData) {
-        this.backtraceData = backtraceData;
-    }
-
-    public BacktraceData getBacktraceData() {
-        return backtraceData;
-    }
-
-    public RubyStackTraceElement[] getBacktraceElements() {
-        if (backtraceData == null) {
-            return RubyStackTraceElement.EMPTY_ARRAY;
-        }
-        return backtraceData.getBacktrace(getRuntime());
-    }
-
-    public void prepareBacktrace(ThreadContext context, boolean nativeException) {
-        // if it's null, build a backtrace
-        if (backtraceData == null) {
-            backtraceData = context.runtime.getInstanceConfig().getTraceType().getBacktrace(context, nativeException);
-        }
-    }
-
-    /**
-     * Prepare an "integrated" backtrace that includes the normal Ruby trace plus non-filtered Java frames. Used by
-     * Java integration to show the Java frames for a JI-called method.
-     *
-     * @param context
-     * @param javaTrace
-     */
-    public void prepareIntegratedBacktrace(ThreadContext context, StackTraceElement[] javaTrace) {
-        // if it's null, build a backtrace
-        if (backtraceData == null) {
-            backtraceData = context.runtime.getInstanceConfig().getTraceType().getIntegratedBacktrace(context, javaTrace);
-        }
-    }
-
-    public void forceBacktrace(IRubyObject backtrace) {
-        backtraceData = (backtrace != null && backtrace.isNil()) ? null : BacktraceData.EMPTY;
-        setBacktrace(backtrace);
-    }
-
-    public IRubyObject getBacktrace() {
-        if (backtrace == null) {
-            initBacktrace();
-        }
-        return backtrace;
-    }
-
-    public void initBacktrace() {
-        Ruby runtime = getRuntime();
-        if (backtraceData == null) {
-            backtrace = runtime.getNil();
-        } else {
-            backtrace = TraceType.generateMRIBacktrace(runtime, backtraceData.getBacktrace(runtime));
-        }
-    }
-
-    @Override
-    public void copySpecialInstanceVariables(IRubyObject clone) {
-        RubyException exception = (RubyException)clone;
-        exception.backtraceData = backtraceData;
-        exception.backtrace = backtrace;
-        exception.message = message;
-    }
-
-    /**
-     * Print the Ruby exception's backtrace to the given PrintStream.
-     *
-     * @param errorStream the PrintStream to which backtrace should be printed
-     */
-    public void printBacktrace(PrintStream errorStream) {
-        printBacktrace(errorStream, 0);
-    }
-
-    /**
-     * Print the Ruby exception's backtrace to the given PrintStream. This
-     * version accepts a number of lines to skip and is primarily used
-     * internally for exception printing where the first line is treated specially.
-     *
-     * @param errorStream the PrintStream to which backtrace should be printed
-     */
-    public void printBacktrace(PrintStream errorStream, int skip) {
-        IRubyObject trace = callMethod(getRuntime().getCurrentContext(), "backtrace");
-        if ( trace.isNil() ) return;
-        if ( trace instanceof RubyArray ) {
-            IRubyObject[] elements = ((RubyArray) trace).toJavaArrayMaybeUnsafe();
-            for (int i = skip; i < elements.length; i++) {
-                IRubyObject stackTraceLine = elements[i];
-                if (stackTraceLine instanceof RubyString) {
-                    errorStream.println("\tfrom " + stackTraceLine);
-                }
-                else {
-                    errorStream.println("\t" + stackTraceLine);
-                }
-            }
-        }
-    }
-
-    private boolean isArrayOfStrings(IRubyObject backtrace) {
-        if (!(backtrace instanceof RubyArray)) return false;
-
-        final RubyArray rTrace = ((RubyArray) backtrace);
-
-        for (int i = 0 ; i < rTrace.getLength() ; i++) {
-            if (!(rTrace.eltInternal(i) instanceof RubyString)) return false;
-        }
-
-        return true;
-    }
-
-    public static ObjectAllocator EXCEPTION_ALLOCATOR = new ObjectAllocator() {
-        @Override
-        public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-            RubyException instance = new RubyException(runtime, klass);
-
-            // for future compatibility as constructors move toward not accepting metaclass?
-            instance.setMetaClass(klass);
-
-            return instance;
-        }
-    };
+    public static ObjectAllocator EXCEPTION_ALLOCATOR = (runtime, klass) -> new RubyException(runtime, klass);
 
     private static final ObjectMarshal EXCEPTION_MARSHAL = new ObjectMarshal() {
         @Override
         public void marshalTo(Ruby runtime, Object obj, RubyClass type,
                               MarshalStream marshalStream) throws IOException {
-            RubyException exc = (RubyException)obj;
+            AbstractRubyException exc = (AbstractRubyException)obj;
 
             marshalStream.registerLinkTarget(exc);
             List<Variable<Object>> attrs = exc.getVariableList();
@@ -349,7 +107,7 @@ public class RubyException extends RubyObject {
         @Override
         public Object unmarshalFrom(Ruby runtime, RubyClass type,
                                     UnmarshalStream unmarshalStream) throws IOException {
-            RubyException exc = (RubyException)type.allocate();
+            AbstractRubyException exc = (AbstractRubyException)type.allocate();
 
             unmarshalStream.registerLinkTarget(exc);
             // FIXME: Can't just pull these off the wire directly? Or maybe we should
@@ -363,55 +121,24 @@ public class RubyException extends RubyObject {
         }
     };
 
-    public static RubyClass createExceptionClass(Ruby runtime) {
-        RubyClass exceptionClass = runtime.defineClass("Exception", runtime.getObject(), EXCEPTION_ALLOCATOR);
-        runtime.setException(exceptionClass);
+    public static RaiseException newRaiseException(Ruby runtime, RubyClass excptnClass, String msg) {
+        return newException(runtime, excptnClass, msg).getRaiseException();
+    }
 
-        exceptionClass.setClassIndex(ClassIndex.EXCEPTION);
-        exceptionClass.setReifiedClass(RubyException.class);
-
-        exceptionClass.setMarshal(EXCEPTION_MARSHAL);
-        exceptionClass.defineAnnotatedMethods(RubyException.class);
-
-        return exceptionClass;
+    public static RaiseException newRaiseException(Ruby runtime, RubyClass excptnClass, String msg, IRubyObject backtrace) {
+        return newException(runtime, excptnClass, msg).getRaiseException();
     }
 
     public static RubyException newException(Ruby runtime, RubyClass excptnClass, String msg) {
+        if (msg == null) {
+            msg = "No message available";
+        }
+
         return new RubyException(runtime, excptnClass, msg);
     }
 
-    // rb_exc_new3
+    @Deprecated
     public static IRubyObject newException(ThreadContext context, RubyClass exceptionClass, IRubyObject message) {
         return exceptionClass.callMethod(context, "new", message.convertToString());
     }
-
-    /**
-     * @return error message if provided or nil
-     */
-    public IRubyObject getMessage() {
-        return message == null ? getRuntime().getNil() : message;
-    }
-
-    /**
-     * Set the message for this NameError.
-     * @param message the message
-     */
-    public void setMessage(IRubyObject message) {
-        this.message = message;
-    }
-
-    public String getMessageAsJavaString() {
-        final IRubyObject msg = getMessage();
-        return msg.isNil() ? null : msg.toString();
-    }
-
-    private BacktraceData backtraceData;
-    private IRubyObject backtrace;
-    IRubyObject message;
-    IRubyObject cause;
-
-    public static final int TRACE_HEAD = 8;
-    public static final int TRACE_TAIL = 4;
-    public static final int TRACE_MAX = TRACE_HEAD + TRACE_TAIL + 6;
-
 }

--- a/core/src/main/java/org/jruby/RubyFatal.java
+++ b/core/src/main/java/org/jruby/RubyFatal.java
@@ -1,0 +1,53 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.Fatal;
+
+/**
+ * The Java representation of a Ruby Fatal.
+ *
+ * @see Fatal
+ */
+@JRubyClass(name="Fatal", parent="Exception")
+public class RubyFatal extends RubyException {
+    protected RubyFatal(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass fatalClass = runtime.defineClass("Fatal", exceptionClass, (r, klass) -> new RubyFatal(runtime, klass));
+
+        return fatalClass;
+    }
+
+    protected RaiseException constructRaiseException(String message) {
+        return new Fatal(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubyFatal.java
+++ b/core/src/main/java/org/jruby/RubyFatal.java
@@ -47,7 +47,7 @@ public class RubyFatal extends RubyException {
         return fatalClass;
     }
 
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new Fatal(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubyFiberError.java
+++ b/core/src/main/java/org/jruby/RubyFiberError.java
@@ -45,7 +45,7 @@ public class RubyFiberError extends RubyStandardError {
         return runtime.defineClass("FiberError", exceptionClass, (r, klass) -> new RubyFiberError(runtime, klass));
     }
 
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new FiberError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubyFiberError.java
+++ b/core/src/main/java/org/jruby/RubyFiberError.java
@@ -1,0 +1,51 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.FiberError;
+
+/**
+ * The Java representation of a Ruby FiberError.
+ *
+ * @see FiberError
+ */
+@JRubyClass(name="FiberError", parent="StandardError")
+public class RubyFiberError extends RubyStandardError {
+    protected RubyFiberError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        return runtime.defineClass("FiberError", exceptionClass, (r, klass) -> new RubyFiberError(runtime, klass));
+    }
+
+    protected RaiseException constructRaiseException(String message) {
+        return new FiberError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubyFloatDomainError.java
+++ b/core/src/main/java/org/jruby/RubyFloatDomainError.java
@@ -47,7 +47,7 @@ public class RubyFloatDomainError extends RubyRangeError {
         return floatDomainErrorClass;
     }
 
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new FloatDomainError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubyFloatDomainError.java
+++ b/core/src/main/java/org/jruby/RubyFloatDomainError.java
@@ -1,0 +1,53 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.FloatDomainError;
+
+/**
+ * The Java representation of a Ruby FloatDomainError.
+ *
+ * @see FloatDomainError
+ */
+@JRubyClass(name="FloatDomainError", parent="RangeError")
+public class RubyFloatDomainError extends RubyRangeError {
+    protected RubyFloatDomainError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass floatDomainErrorClass = runtime.defineClass("FloatDomainError", exceptionClass, (r, klass) -> new RubyFloatDomainError(runtime, klass));
+
+        return floatDomainErrorClass;
+    }
+
+    protected RaiseException constructRaiseException(String message) {
+        return new FloatDomainError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubyIOError.java
+++ b/core/src/main/java/org/jruby/RubyIOError.java
@@ -47,7 +47,7 @@ public class RubyIOError extends RubyStandardError {
         return iOErrorClass;
     }
 
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new IOError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubyIOError.java
+++ b/core/src/main/java/org/jruby/RubyIOError.java
@@ -1,0 +1,53 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.IOError;
+
+/**
+ * The Java representation of a Ruby IOError.
+ *
+ * @see IOError
+ */
+@JRubyClass(name="IOError", parent="StandardError")
+public class RubyIOError extends RubyStandardError {
+    protected RubyIOError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass iOErrorClass = runtime.defineClass("IOError", exceptionClass, (r, klass) -> new RubyIOError(runtime, klass));
+
+        return iOErrorClass;
+    }
+
+    protected RaiseException constructRaiseException(String message) {
+        return new IOError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubyIndexError.java
+++ b/core/src/main/java/org/jruby/RubyIndexError.java
@@ -1,0 +1,54 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.IndexError;
+import org.jruby.exceptions.RaiseException;
+
+/**
+ * The Java representation of a Ruby IndexError.
+ *
+ * @see IndexError
+ */
+@JRubyClass(name="IndexError", parent="StandardError")
+public class RubyIndexError extends RubyStandardError {
+    protected RubyIndexError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass IndexErrorClass = runtime.defineClass("IndexError", exceptionClass, (r, klass) -> new RubyIndexError(runtime, klass));
+
+        return IndexErrorClass;
+    }
+
+    @Override
+    protected RaiseException constructRaiseException(String message) {
+        return new IndexError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubyIndexError.java
+++ b/core/src/main/java/org/jruby/RubyIndexError.java
@@ -48,7 +48,7 @@ public class RubyIndexError extends RubyStandardError {
     }
 
     @Override
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new IndexError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubyInterrupt.java
+++ b/core/src/main/java/org/jruby/RubyInterrupt.java
@@ -60,7 +60,7 @@ public class RubyInterrupt extends RubySignalException {
     }
 
     @Override
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new Interrupt(message, this);
     }
 

--- a/core/src/main/java/org/jruby/RubyInterrupt.java
+++ b/core/src/main/java/org/jruby/RubyInterrupt.java
@@ -40,12 +40,7 @@ import org.jruby.util.ArraySupport;
 
 @JRubyClass(name="Interrupt", parent="SignalException")
 public class RubyInterrupt extends RubySignalException {
-    private static final ObjectAllocator INTERRUPT_ALLOCATOR = new ObjectAllocator() {
-        @Override
-        public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-            return new RubyInterrupt(runtime, klass);
-        }
-    };
+    private static final ObjectAllocator INTERRUPT_ALLOCATOR = (runtime, klass) -> new RubyInterrupt(runtime, klass);
 
     static RubyClass createInterruptClass(Ruby runtime, RubyClass signalExceptionClass) {
         RubyClass interruptClass = runtime.defineClass("Interrupt", signalExceptionClass, INTERRUPT_ALLOCATOR);

--- a/core/src/main/java/org/jruby/RubyInterrupt.java
+++ b/core/src/main/java/org/jruby/RubyInterrupt.java
@@ -30,6 +30,8 @@ import static jnr.constants.platform.Signal.SIGINT;
 
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.Interrupt;
+import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
@@ -38,11 +40,16 @@ import org.jruby.runtime.builtin.IRubyObject;
 import static org.jruby.runtime.Visibility.PRIVATE;
 import org.jruby.util.ArraySupport;
 
+/**
+ * The Java representation of a Ruby Interrupt.
+ *
+ * @see Interrupt
+ */
 @JRubyClass(name="Interrupt", parent="SignalException")
 public class RubyInterrupt extends RubySignalException {
     private static final ObjectAllocator INTERRUPT_ALLOCATOR = (runtime, klass) -> new RubyInterrupt(runtime, klass);
 
-    static RubyClass createInterruptClass(Ruby runtime, RubyClass signalExceptionClass) {
+    static RubyClass define(Ruby runtime, RubyClass signalExceptionClass) {
         RubyClass interruptClass = runtime.defineClass("Interrupt", signalExceptionClass, INTERRUPT_ALLOCATOR);
         interruptClass.defineAnnotatedMethods(RubyInterrupt.class);
         return interruptClass;
@@ -50,6 +57,11 @@ public class RubyInterrupt extends RubySignalException {
 
     protected RubyInterrupt(Ruby runtime, RubyClass exceptionClass) {
         super(runtime, exceptionClass);
+    }
+
+    @Override
+    protected RaiseException constructRaiseException(String message) {
+        return new Interrupt(message, this);
     }
 
     @JRubyMethod(optional = 1, visibility = PRIVATE)

--- a/core/src/main/java/org/jruby/RubyInterruptedRegexpError.java
+++ b/core/src/main/java/org/jruby/RubyInterruptedRegexpError.java
@@ -1,0 +1,53 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.InterruptedRegexpError;
+
+/**
+ * The Java representation of a Ruby InterruptedRegexpError.
+ *
+ * @see InterruptedRegexpError
+ */
+@JRubyClass(name="InterruptedRegexpError", parent="RegexpError")
+public class RubyInterruptedRegexpError extends RubyRegexpError {
+    protected RubyInterruptedRegexpError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass interruptedRegexpErrorClass = runtime.defineClass("InterruptedRegexpError", exceptionClass, (r, klass) -> new RubyInterruptedRegexpError(runtime, klass));
+
+        return interruptedRegexpErrorClass;
+    }
+
+    protected RaiseException constructRaiseException(String message) {
+        return new InterruptedRegexpError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubyInterruptedRegexpError.java
+++ b/core/src/main/java/org/jruby/RubyInterruptedRegexpError.java
@@ -47,7 +47,7 @@ public class RubyInterruptedRegexpError extends RubyRegexpError {
         return interruptedRegexpErrorClass;
     }
 
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new InterruptedRegexpError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -859,24 +859,24 @@ public class RubyKernel {
             case 0:
                 IRubyObject lastException = runtime.getGlobalVariables().get("$!");
                 if (lastException.isNil()) {
-                    raise = new RaiseException(runtime, runtime.getRuntimeError(), "");
+                    raise = RaiseException.from(runtime, runtime.getRuntimeError(), "");
                 } else {
                     // non RubyException value is allowed to be assigned as $!.
-                    raise = new RaiseException((RubyException) lastException);
+                    raise = ((RubyException) lastException).getRaiseException();
                 }
                 break;
             case 1:
                 if (args[0] instanceof RubyString) {
-                    raise = new RaiseException((RubyException) runtime.getRuntimeError().newInstance(context, args, block));
+                    raise = ((RubyException) runtime.getRuntimeError().newInstance(context, args, block)).getRaiseException();
                 } else {
-                    raise = new RaiseException(convertToException(runtime, args[0], null));
+                    raise = convertToException(runtime, args[0], null).getRaiseException();
                 }
                 break;
             case 2:
-                raise = new RaiseException(convertToException(runtime, args[0], args[1]));
+                raise = convertToException(runtime, args[0], args[1]).getRaiseException();
                 break;
             default:
-                raise = new RaiseException(convertToException(runtime, args[0], args[1]), args[2]);
+                raise = RaiseException.from(convertToException(runtime, args[0], args[1]), args[2]);
                 break;
         }
 
@@ -1198,7 +1198,7 @@ public class RubyKernel {
     }
 
     private static RaiseException uncaughtThrow(Ruby runtime, IRubyObject tag, IRubyObject value, RubyString message) {
-        return new RaiseException( RubyUncaughtThrowError.newUncaughtThrowError(runtime, tag, value, message) );
+        return RubyUncaughtThrowError.newUncaughtThrowError(runtime, tag, value, message).getRaiseException();
     }
 
     @JRubyMethod(module = true, visibility = PRIVATE)

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -859,7 +859,7 @@ public class RubyKernel {
             case 0:
                 IRubyObject lastException = runtime.getGlobalVariables().get("$!");
                 if (lastException.isNil()) {
-                    raise = new RaiseException(runtime, runtime.getRuntimeError(), "", false);
+                    raise = new RaiseException(runtime, runtime.getRuntimeError(), "");
                 } else {
                     // non RubyException value is allowed to be assigned as $!.
                     raise = new RaiseException((RubyException) lastException);

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -862,18 +862,18 @@ public class RubyKernel {
                     raise = RaiseException.from(runtime, runtime.getRuntimeError(), "");
                 } else {
                     // non RubyException value is allowed to be assigned as $!.
-                    raise = ((RubyException) lastException).getRaiseException();
+                    raise = ((RubyException) lastException).toThrowable();
                 }
                 break;
             case 1:
                 if (args[0] instanceof RubyString) {
-                    raise = ((RubyException) runtime.getRuntimeError().newInstance(context, args, block)).getRaiseException();
+                    raise = ((RubyException) runtime.getRuntimeError().newInstance(context, args, block)).toThrowable();
                 } else {
-                    raise = convertToException(runtime, args[0], null).getRaiseException();
+                    raise = convertToException(runtime, args[0], null).toThrowable();
                 }
                 break;
             case 2:
-                raise = convertToException(runtime, args[0], args[1]).getRaiseException();
+                raise = convertToException(runtime, args[0], args[1]).toThrowable();
                 break;
             default:
                 raise = RaiseException.from(convertToException(runtime, args[0], args[1]), args[2]);
@@ -1198,7 +1198,7 @@ public class RubyKernel {
     }
 
     private static RaiseException uncaughtThrow(Ruby runtime, IRubyObject tag, IRubyObject value, RubyString message) {
-        return RubyUncaughtThrowError.newUncaughtThrowError(runtime, tag, value, message).getRaiseException();
+        return RubyUncaughtThrowError.newUncaughtThrowError(runtime, tag, value, message).toThrowable();
     }
 
     @JRubyMethod(module = true, visibility = PRIVATE)

--- a/core/src/main/java/org/jruby/RubyKeyError.java
+++ b/core/src/main/java/org/jruby/RubyKeyError.java
@@ -53,7 +53,7 @@ public class RubyKeyError extends RubyIndexError {
     }
 
     @Override
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new KeyError(message, this);
     }
 

--- a/core/src/main/java/org/jruby/RubyKeyError.java
+++ b/core/src/main/java/org/jruby/RubyKeyError.java
@@ -1,0 +1,60 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.KeyError;
+import org.jruby.runtime.Block;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+/**
+ /**
+ * The Java representation of a Ruby KeyError.
+ *
+ * @see KeyError
+ * @see RubyEnumerator
+ * @author kares
+ */
+@JRubyClass(name="KeyError", parent="IndexError")
+public class RubyKeyError extends RubyIndexError {
+    protected RubyKeyError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass superClass) {
+        return runtime.defineClass("KeyError", superClass, (runtime1, klass) -> new RubyKeyError(runtime1, klass));
+    }
+
+    @Override
+    protected RaiseException constructRaiseException(String message) {
+        return new KeyError(message, this);
+    }
+
+}

--- a/core/src/main/java/org/jruby/RubyLoadError.java
+++ b/core/src/main/java/org/jruby/RubyLoadError.java
@@ -48,7 +48,7 @@ public class RubyLoadError extends RubyScriptError {
     }
 
     @Override
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new LoadError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubyLoadError.java
+++ b/core/src/main/java/org/jruby/RubyLoadError.java
@@ -1,0 +1,54 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.LoadError;
+
+/**
+ * The Java representation of a Ruby LoadError.
+ *
+ * @see LoadError
+ */
+@JRubyClass(name="LoadError", parent="StandardError")
+public class RubyLoadError extends RubyScriptError {
+    protected RubyLoadError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass LoadErrorClass = runtime.defineClass("LoadError", exceptionClass, (r, klass) -> new RubyLoadError(runtime, klass));
+
+        return LoadErrorClass;
+    }
+
+    @Override
+    protected RaiseException constructRaiseException(String message) {
+        return new LoadError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubyLocalJumpError.java
+++ b/core/src/main/java/org/jruby/RubyLocalJumpError.java
@@ -75,7 +75,7 @@ public class RubyLocalJumpError extends RubyStandardError {
     }
 
     @Override
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new LocalJumpError(message, this);
     }
 

--- a/core/src/main/java/org/jruby/RubyLocalJumpError.java
+++ b/core/src/main/java/org/jruby/RubyLocalJumpError.java
@@ -30,11 +30,18 @@ package org.jruby;
 
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.LocalJumpError;
+import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.builtin.IRubyObject;
 
+/**
+ * The Java representation of a Ruby LocalJumpError.
+ *
+ * @see LocalJumpError
+ */
 @JRubyClass(name="LocalJumpError",parent="StandardError")
-public class RubyLocalJumpError extends RubyException {
+public class RubyLocalJumpError extends RubyStandardError {
     public enum Reason {
         REDO, BREAK, NEXT, RETURN, RETRY, NOREASON;
         
@@ -44,14 +51,9 @@ public class RubyLocalJumpError extends RubyException {
         }
     }
     
-    private static ObjectAllocator LOCALJUMPERROR_ALLOCATOR = new ObjectAllocator() {
-        @Override
-        public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-            return new RubyLocalJumpError(runtime, klass);
-        }
-    };
+    private static ObjectAllocator LOCALJUMPERROR_ALLOCATOR = (runtime, klass) -> new RubyLocalJumpError(runtime, klass);
 
-    public static RubyClass createLocalJumpErrorClass(Ruby runtime, RubyClass standardErrorClass) {
+    public static RubyClass define(Ruby runtime, RubyClass standardErrorClass) {
         RubyClass nameErrorClass = runtime.defineClass("LocalJumpError", standardErrorClass, LOCALJUMPERROR_ALLOCATOR);
         
         nameErrorClass.defineAnnotatedMethods(RubyLocalJumpError.class);
@@ -70,6 +72,11 @@ public class RubyLocalJumpError extends RubyException {
         this.reason = reason;
         setInternalVariable("reason", runtime.newSymbol(reason.toString()));
         setInternalVariable("exit_value", exitValue);
+    }
+
+    @Override
+    protected RaiseException constructRaiseException(String message) {
+        return new LocalJumpError(message, this);
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/RubyNameError.java
+++ b/core/src/main/java/org/jruby/RubyNameError.java
@@ -181,7 +181,7 @@ public class RubyNameError extends RubyStandardError {
     }
 
     @Override
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new NameError(message, this);
     }
 

--- a/core/src/main/java/org/jruby/RubyNameError.java
+++ b/core/src/main/java/org/jruby/RubyNameError.java
@@ -31,6 +31,8 @@ package org.jruby;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyClass;
 import org.jruby.exceptions.JumpException;
+import org.jruby.exceptions.NameError;
+import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
@@ -40,10 +42,13 @@ import org.jruby.util.ByteList;
 import org.jruby.util.Sprintf;
 
 /**
+ * The Java representation of a Ruby NameError.
+ *
+ * @see NameError
  * @author Anders Bengtsson
  */
 @JRubyClass(name="NameError", parent="StandardError")
-public class RubyNameError extends RubyException {
+public class RubyNameError extends RubyStandardError {
     private IRubyObject name;
     private IRubyObject receiver;
     protected boolean privateCall;
@@ -59,12 +64,7 @@ public class RubyNameError extends RubyException {
     @JRubyClass(name = "NameError::Message", parent = "Data")
     public static final class RubyNameErrorMessage extends RubyObject {
 
-        private static final ObjectAllocator ALLOCATOR = new ObjectAllocator() {
-            @Override
-            public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-                return new RubyNameErrorMessage(runtime);
-            }
-        };
+        private static final ObjectAllocator ALLOCATOR = (runtime, klass) -> new RubyNameErrorMessage(runtime);
 
         private final String message;
         private final IRubyObject object;
@@ -146,21 +146,16 @@ public class RubyNameError extends RubyException {
         }
     }
 
-    private static final ObjectAllocator ALLOCATOR = new ObjectAllocator() {
-        @Override
-        public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-            return new RubyNameError(runtime, klass);
-        }
-    };
+    private static final ObjectAllocator ALLOCATOR = (runtime, klass) -> new RubyNameError(runtime, klass);
 
-    static RubyClass createNameErrorClass(Ruby runtime, RubyClass StandardError) {
+    static RubyClass define(Ruby runtime, RubyClass StandardError) {
         RubyClass NameError = runtime.defineClass("NameError", StandardError, ALLOCATOR);
         NameError.defineAnnotatedMethods(RubyNameError.class);
         NameError.setReifiedClass(RubyNameError.class);
         return NameError;
     }
 
-    static RubyClass createNameErrorMessageClass(Ruby runtime, RubyClass NameError) {
+    static RubyClass defineMessage(Ruby runtime, RubyClass NameError) {
         RubyClass Message = NameError.defineClassUnder("Message", runtime.getClass("Data"), RubyNameErrorMessage.ALLOCATOR);
         NameError.setConstantVisibility(runtime, "Message", true);
         Message.defineAnnotatedMethods(RubyNameErrorMessage.class);
@@ -183,6 +178,11 @@ public class RubyNameError extends RubyException {
     public RubyNameError(Ruby runtime, RubyClass exceptionClass, String message, IRubyObject name) {
         super(runtime, exceptionClass, message);
         this.name = name;
+    }
+
+    @Override
+    protected RaiseException constructRaiseException(String message) {
+        return new NameError(message, this);
     }
 
     @JRubyMethod(name = "exception", meta = true)

--- a/core/src/main/java/org/jruby/RubyNameError.java
+++ b/core/src/main/java/org/jruby/RubyNameError.java
@@ -89,6 +89,13 @@ public class RubyNameError extends RubyStandardError {
             return arg;
         }
 
+        static RubyClass define(Ruby runtime, RubyClass NameError) {
+            RubyClass Message = NameError.defineClassUnder("Message", runtime.getClass("Data"), ALLOCATOR);
+            NameError.setConstantVisibility(runtime, "Message", true);
+            Message.defineAnnotatedMethods(RubyNameErrorMessage.class);
+            return Message;
+        }
+
         @JRubyMethod(name = "_dump")
         public IRubyObject dump(ThreadContext context, IRubyObject arg) {
             return to_str(context);
@@ -153,13 +160,6 @@ public class RubyNameError extends RubyStandardError {
         NameError.defineAnnotatedMethods(RubyNameError.class);
         NameError.setReifiedClass(RubyNameError.class);
         return NameError;
-    }
-
-    static RubyClass defineMessage(Ruby runtime, RubyClass NameError) {
-        RubyClass Message = NameError.defineClassUnder("Message", runtime.getClass("Data"), RubyNameErrorMessage.ALLOCATOR);
-        NameError.setConstantVisibility(runtime, "Message", true);
-        Message.defineAnnotatedMethods(RubyNameErrorMessage.class);
-        return Message;
     }
 
     protected RubyNameError(Ruby runtime, RubyClass exceptionClass) {

--- a/core/src/main/java/org/jruby/RubyNoMemoryError.java
+++ b/core/src/main/java/org/jruby/RubyNoMemoryError.java
@@ -1,0 +1,54 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.NoMemoryError;
+
+/**
+ * The Java representation of a Ruby NoMemoryError.
+ *
+ * @see NoMemoryError
+ */
+@JRubyClass(name="NoMemoryError", parent="StandardError")
+public class RubyNoMemoryError extends RubyStandardError {
+    protected RubyNoMemoryError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass NoMemoryErrorClass = runtime.defineClass("NoMemoryError", exceptionClass, (r, klass) -> new RubyNoMemoryError(runtime, klass));
+
+        return NoMemoryErrorClass;
+    }
+
+    @Override
+    protected RaiseException constructRaiseException(String message) {
+        return new NoMemoryError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubyNoMemoryError.java
+++ b/core/src/main/java/org/jruby/RubyNoMemoryError.java
@@ -35,8 +35,8 @@ import org.jruby.exceptions.NoMemoryError;
  *
  * @see NoMemoryError
  */
-@JRubyClass(name="NoMemoryError", parent="StandardError")
-public class RubyNoMemoryError extends RubyStandardError {
+@JRubyClass(name="NoMemoryError", parent="Exception")
+public class RubyNoMemoryError extends RubyException {
     protected RubyNoMemoryError(Ruby runtime, RubyClass exceptionClass) {
         super(runtime, exceptionClass);
     }

--- a/core/src/main/java/org/jruby/RubyNoMemoryError.java
+++ b/core/src/main/java/org/jruby/RubyNoMemoryError.java
@@ -48,7 +48,7 @@ public class RubyNoMemoryError extends RubyStandardError {
     }
 
     @Override
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new NoMemoryError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubyNoMethodError.java
+++ b/core/src/main/java/org/jruby/RubyNoMethodError.java
@@ -28,6 +28,8 @@ package org.jruby;
 
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.NoMethodError;
+import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.Visibility;
@@ -35,18 +37,18 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.Visibility;
 import org.jruby.util.ArraySupport;
 
+/**
+ * The Java representation of a Ruby NoMethodError.
+ *
+ * @see NoMethodError
+ */
 @JRubyClass(name="NoMethodError", parent="NameError")
 public class RubyNoMethodError extends RubyNameError {
     private IRubyObject args;
 
-    private static final ObjectAllocator ALLOCATOR = new ObjectAllocator() {
-        @Override
-        public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-            return new RubyNoMethodError(runtime, klass);
-        }
-    };
+    private static final ObjectAllocator ALLOCATOR = (runtime, klass) -> new RubyNoMethodError(runtime, klass);
 
-    static RubyClass createNoMethodErrorClass(Ruby runtime, RubyClass nameErrorClass) {
+    static RubyClass define(Ruby runtime, RubyClass nameErrorClass) {
         RubyClass noMethodErrorClass = runtime.defineClass("NoMethodError", nameErrorClass, ALLOCATOR);
         noMethodErrorClass.defineAnnotatedMethods(RubyNoMethodError.class);
         return noMethodErrorClass;
@@ -60,6 +62,11 @@ public class RubyNoMethodError extends RubyNameError {
     public RubyNoMethodError(Ruby runtime, RubyClass exceptionClass, String message, String name, IRubyObject args) {
         super(runtime, exceptionClass, message,  name);
         this.args = args;
+    }
+
+    @Override
+    protected RaiseException constructRaiseException(String message) {
+        return new NoMethodError(message, this);
     }
 
     public static RubyException newNoMethodError(IRubyObject recv, IRubyObject message, IRubyObject name, IRubyObject args) {

--- a/core/src/main/java/org/jruby/RubyNoMethodError.java
+++ b/core/src/main/java/org/jruby/RubyNoMethodError.java
@@ -65,7 +65,7 @@ public class RubyNoMethodError extends RubyNameError {
     }
 
     @Override
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new NoMethodError(message, this);
     }
 

--- a/core/src/main/java/org/jruby/RubyNotImplementedError.java
+++ b/core/src/main/java/org/jruby/RubyNotImplementedError.java
@@ -48,7 +48,7 @@ public class RubyNotImplementedError extends RubyScriptError {
     }
 
     @Override
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new NotImplementedError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubyNotImplementedError.java
+++ b/core/src/main/java/org/jruby/RubyNotImplementedError.java
@@ -1,0 +1,54 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.NotImplementedError;
+import org.jruby.exceptions.RaiseException;
+
+/**
+ * The Java representation of a Ruby NotImplementedError.
+ *
+ * @see NotImplementedError
+ */
+@JRubyClass(name="NotImplementedError", parent="ScriptError")
+public class RubyNotImplementedError extends RubyScriptError {
+    protected RubyNotImplementedError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass NotImplementedErrorClass = runtime.defineClass("NotImplementedError", exceptionClass, (r, klass) -> new RubyNotImplementedError(runtime, klass));
+
+        return NotImplementedErrorClass;
+    }
+
+    @Override
+    protected RaiseException constructRaiseException(String message) {
+        return new NotImplementedError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -39,6 +39,7 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.common.RubyWarnings;
 import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.StandardError;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.CallSite;
@@ -489,18 +490,15 @@ public class RubyNumeric extends RubyObject {
         final IRubyObject result;
         try {
             result = coerceBody(context, other);
-        } catch (RaiseException e) { // e.g. NoMethodError: undefined method `coerce'
-            if (context.runtime.getStandardError().isInstance( e.getException() )) {
-                context.setErrorInfo($ex); // restore $!
-                RubyWarnings warnings = context.runtime.getWarnings();
-                warnings.warn("Numerical comparison operators will no more rescue exceptions of #coerce");
-                warnings.warn("in the next release. Return nil in #coerce if the coercion is impossible.");
-                if (err) {
-                    coerceFailed(context, other);
-                }
-                return null;
+        } catch (StandardError e) { // e.g. NoMethodError: undefined method `coerce'
+            context.setErrorInfo($ex); // restore $!
+            RubyWarnings warnings = context.runtime.getWarnings();
+            warnings.warn("Numerical comparison operators will no more rescue exceptions of #coerce");
+            warnings.warn("in the next release. Return nil in #coerce if the coercion is impossible.");
+            if (err) {
+                coerceFailed(context, other);
             }
-            throw e;
+            return null;
         }
 
         return coerceResult(context, result, err);

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -483,7 +483,7 @@ public class RubyNumeric extends RubyObject {
         final IRubyObject result;
         try {
             result = coerceBody(context, other);
-        } catch (StandardError e) { // e.g. NoMethodError: undefined method `coerce'
+        } catch (StandardError e) {
             context.setErrorInfo($ex); // restore $!
             RubyWarnings warnings = context.runtime.getWarnings();
             warnings.warn("Numerical comparison operators will no more rescue exceptions of #coerce");

--- a/core/src/main/java/org/jruby/RubyRangeError.java
+++ b/core/src/main/java/org/jruby/RubyRangeError.java
@@ -47,7 +47,7 @@ public class RubyRangeError extends RubyStandardError {
         return rangeErrorClass;
     }
 
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new RangeError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubyRangeError.java
+++ b/core/src/main/java/org/jruby/RubyRangeError.java
@@ -1,0 +1,53 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RangeError;
+import org.jruby.exceptions.RaiseException;
+
+/**
+ * The Java representation of a Ruby RangeError.
+ *
+ * @see RangeError
+ */
+@JRubyClass(name="RangeError", parent="StandardError")
+public class RubyRangeError extends RubyStandardError {
+    protected RubyRangeError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass rangeErrorClass = runtime.defineClass("RangeError", exceptionClass, (r, klass) -> new RubyRangeError(runtime, klass));
+
+        return rangeErrorClass;
+    }
+
+    protected RaiseException constructRaiseException(String message) {
+        return new RangeError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubyRegexpError.java
+++ b/core/src/main/java/org/jruby/RubyRegexpError.java
@@ -47,7 +47,7 @@ public class RubyRegexpError extends RubyStandardError {
         return regexpErrorClass;
     }
 
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new RegexpError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubyRegexpError.java
+++ b/core/src/main/java/org/jruby/RubyRegexpError.java
@@ -1,0 +1,53 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.RegexpError;
+
+/**
+ * The Java representation of a Ruby RegexpError.
+ *
+ * @see RegexpError
+ */
+@JRubyClass(name="RegexpError", parent="StandardError")
+public class RubyRegexpError extends RubyStandardError {
+    protected RubyRegexpError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass regexpErrorClass = runtime.defineClass("RegexpError", exceptionClass, (r, klass) -> new RubyRegexpError(runtime, klass));
+
+        return regexpErrorClass;
+    }
+
+    protected RaiseException constructRaiseException(String message) {
+        return new RegexpError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubyRuntimeError.java
+++ b/core/src/main/java/org/jruby/RubyRuntimeError.java
@@ -1,0 +1,54 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.RuntimeError;
+import org.jruby.exceptions.StandardError;
+
+/**
+ * The Java representation of a Ruby RuntimeError.
+ *
+ * @see RuntimeError
+ */
+@JRubyClass(name="RuntimeError", parent="StandardError")
+public class RubyRuntimeError extends RubyStandardError {
+    protected RubyRuntimeError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass runtimeErrorClass = runtime.defineClass("RuntimeError", exceptionClass, (r, klass) -> new RubyRuntimeError(runtime, klass));
+
+        return runtimeErrorClass;
+    }
+
+    protected RaiseException constructRaiseException(String message) {
+        return new RuntimeError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubyRuntimeError.java
+++ b/core/src/main/java/org/jruby/RubyRuntimeError.java
@@ -48,7 +48,7 @@ public class RubyRuntimeError extends RubyStandardError {
         return runtimeErrorClass;
     }
 
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new RuntimeError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubyScriptError.java
+++ b/core/src/main/java/org/jruby/RubyScriptError.java
@@ -1,0 +1,53 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.ScriptError;
+
+/**
+ * The Java representation of a Ruby ScriptError.
+ *
+ * @see ScriptError
+ */
+@JRubyClass(name="ScriptError", parent="Exception")
+public class RubyScriptError extends RubyException {
+    protected RubyScriptError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass scriptErrorClass = runtime.defineClass("ScriptError", exceptionClass, (r, klass) -> new RubyScriptError(runtime, klass));
+
+        return scriptErrorClass;
+    }
+
+    protected RaiseException constructRaiseException(String message) {
+        return new ScriptError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubyScriptError.java
+++ b/core/src/main/java/org/jruby/RubyScriptError.java
@@ -47,7 +47,7 @@ public class RubyScriptError extends RubyException {
         return scriptErrorClass;
     }
 
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new ScriptError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubySecurityError.java
+++ b/core/src/main/java/org/jruby/RubySecurityError.java
@@ -35,8 +35,8 @@ import org.jruby.exceptions.RaiseException;
  *
  * @see SecurityError
  */
-@JRubyClass(name="SecurityError", parent="StandardError")
-public class RubySecurityError extends RubyStandardError {
+@JRubyClass(name="SecurityError", parent="Exception")
+public class RubySecurityError extends RubyException {
     protected RubySecurityError(Ruby runtime, RubyClass exceptionClass) {
         super(runtime, exceptionClass);
     }

--- a/core/src/main/java/org/jruby/RubySecurityError.java
+++ b/core/src/main/java/org/jruby/RubySecurityError.java
@@ -1,0 +1,54 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.SecurityError;
+import org.jruby.exceptions.RaiseException;
+
+/**
+ * The Java representation of a Ruby SecurityError.
+ *
+ * @see SecurityError
+ */
+@JRubyClass(name="SecurityError", parent="StandardError")
+public class RubySecurityError extends RubyStandardError {
+    protected RubySecurityError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass SecurityErrorClass = runtime.defineClass("SecurityError", exceptionClass, (r, klass) -> new RubySecurityError(runtime, klass));
+
+        return SecurityErrorClass;
+    }
+
+    @Override
+    protected RaiseException constructRaiseException(String message) {
+        return new SecurityError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubySecurityError.java
+++ b/core/src/main/java/org/jruby/RubySecurityError.java
@@ -48,7 +48,7 @@ public class RubySecurityError extends RubyStandardError {
     }
 
     @Override
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new SecurityError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubySignalException.java
+++ b/core/src/main/java/org/jruby/RubySignalException.java
@@ -42,6 +42,11 @@ import org.jruby.RubyBasicObject;
 import org.jruby.RubySignal;
 import org.jruby.util.TypeConverter;
 
+/**
+ * The Java representation of a Ruby SignalException.
+ *
+ * @see SignalException
+ */
 @JRubyClass(name="SignalException", parent="Exception")
 public class RubySignalException extends RubyException {
     private static final ObjectAllocator SIGNAL_EXCEPTION_ALLOCATOR =
@@ -51,7 +56,12 @@ public class RubySignalException extends RubyException {
         super(runtime, exceptionClass);
     }
 
-    static RubyClass createSignalExceptionClass(Ruby runtime, RubyClass exceptionClass) {
+    @Override
+    protected RaiseException constructRaiseException(String message) {
+        return new SignalException(message, this);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
         RubyClass signalExceptionClass = runtime.defineClass("SignalException", exceptionClass, SIGNAL_EXCEPTION_ALLOCATOR);
         signalExceptionClass.defineAnnotatedMethods(RubySignalException.class);
 
@@ -119,10 +129,6 @@ public class RubySignalException extends RubyException {
     @Override
     public IRubyObject message(ThreadContext context) {
         return super.message(context);
-    }
-
-    protected RaiseException constructRaiseException(String message) {
-        return new SignalException(message, this);
     }
 
     private IRubyObject signo;

--- a/core/src/main/java/org/jruby/RubySignalException.java
+++ b/core/src/main/java/org/jruby/RubySignalException.java
@@ -30,6 +30,8 @@ import static jnr.constants.platform.Signal.NSIG;
 
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.SignalException;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
@@ -42,12 +44,8 @@ import org.jruby.util.TypeConverter;
 
 @JRubyClass(name="SignalException", parent="Exception")
 public class RubySignalException extends RubyException {
-    private static final ObjectAllocator SIGNAL_EXCEPTION_ALLOCATOR = new ObjectAllocator() {
-        @Override
-        public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-            return new RubySignalException(runtime, klass);
-        }
-    };
+    private static final ObjectAllocator SIGNAL_EXCEPTION_ALLOCATOR =
+            (runtime, klass) -> new RubySignalException(runtime, klass);
 
     protected RubySignalException(Ruby runtime, RubyClass exceptionClass) {
         super(runtime, exceptionClass);
@@ -121,6 +119,10 @@ public class RubySignalException extends RubyException {
     @Override
     public IRubyObject message(ThreadContext context) {
         return super.message(context);
+    }
+
+    protected RaiseException constructRaiseException(String message) {
+        return new SignalException(message, this);
     }
 
     private IRubyObject signo;

--- a/core/src/main/java/org/jruby/RubySignalException.java
+++ b/core/src/main/java/org/jruby/RubySignalException.java
@@ -57,7 +57,7 @@ public class RubySignalException extends RubyException {
     }
 
     @Override
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new SignalException(message, this);
     }
 

--- a/core/src/main/java/org/jruby/RubyStandardError.java
+++ b/core/src/main/java/org/jruby/RubyStandardError.java
@@ -52,7 +52,7 @@ public class RubyStandardError extends RubyException {
     }
 
     @Override
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new StandardError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubyStandardError.java
+++ b/core/src/main/java/org/jruby/RubyStandardError.java
@@ -30,18 +30,28 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.StandardError;
 
+/**
+ * The Java representation of a Ruby StandardError.
+ *
+ * @see StandardError
+ */
 @JRubyClass(name="StandardError", parent="Exception")
 public class RubyStandardError extends RubyException {
     protected RubyStandardError(Ruby runtime, RubyClass exceptionClass) {
         super(runtime, exceptionClass);
     }
 
-    static RubyClass createStandardErrorClass(Ruby runtime, RubyClass exceptionClass) {
-        RubyClass signalExceptionClass = runtime.defineClass("StandardError", exceptionClass, (r, klass) -> new RubyStandardError(runtime, klass));
-
-        return signalExceptionClass;
+    protected RubyStandardError(Ruby runtime, RubyClass exceptionClass, String message) {
+        super(runtime, exceptionClass, message);
     }
 
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass standardErrorClass = runtime.defineClass("StandardError", exceptionClass, (r, klass) -> new RubyStandardError(runtime, klass));
+
+        return standardErrorClass;
+    }
+
+    @Override
     protected RaiseException constructRaiseException(String message) {
         return new StandardError(message, this);
     }

--- a/core/src/main/java/org/jruby/RubyStandardError.java
+++ b/core/src/main/java/org/jruby/RubyStandardError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.StandardError;
+
+@JRubyClass(name="StandardError", parent="Exception")
+public class RubyStandardError extends RubyException {
+    protected RubyStandardError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass createStandardErrorClass(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass signalExceptionClass = runtime.defineClass("StandardError", exceptionClass, (r, klass) -> new RubyStandardError(runtime, klass));
+
+        return signalExceptionClass;
+    }
+
+    protected RaiseException constructRaiseException(String message) {
+        return new StandardError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubyStopIteration.java
+++ b/core/src/main/java/org/jruby/RubyStopIteration.java
@@ -68,7 +68,7 @@ public class RubyStopIteration extends RubyIndexError {
     }
 
     @Override
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new StopIteration(message, this);
     }
 

--- a/core/src/main/java/org/jruby/RubyStopIteration.java
+++ b/core/src/main/java/org/jruby/RubyStopIteration.java
@@ -28,28 +28,25 @@ package org.jruby;
 
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.StopIteration;
 import org.jruby.runtime.Block;
-import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 /**
- * Ruby's StopIteration exception.
+ /**
+ * The Java representation of a Ruby StopIteration.
+ *
+ * @see StopIteration
  * @see RubyEnumerator
  * @author kares
  */
 @JRubyClass(name="StopIteration", parent="IndexError")
-public class RubyStopIteration extends RubyException {
+public class RubyStopIteration extends RubyIndexError {
 
-    private static final ObjectAllocator ALLOCATOR = new ObjectAllocator() {
-        @Override
-        public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-            return new RubyStopIteration(runtime, klass);
-        }
-    };
-
-    static RubyClass createStopIterationClass(Ruby runtime, RubyClass superClass) {
-        RubyClass StopIteration = runtime.defineClass("StopIteration", superClass, ALLOCATOR);
+    static RubyClass define(Ruby runtime, RubyClass superClass) {
+        RubyClass StopIteration = runtime.defineClass("StopIteration", superClass, (runtime1, klass) -> new RubyStopIteration(runtime1, klass));
         StopIteration.defineAnnotatedMethods(RubyStopIteration.class);
         return StopIteration;
     }
@@ -68,6 +65,11 @@ public class RubyStopIteration extends RubyException {
 
     protected RubyStopIteration(Ruby runtime, RubyClass exceptionClass) {
         super(runtime, exceptionClass);
+    }
+
+    @Override
+    protected RaiseException constructRaiseException(String message) {
+        return new StopIteration(message, this);
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/RubySyntaxError.java
+++ b/core/src/main/java/org/jruby/RubySyntaxError.java
@@ -48,7 +48,7 @@ public class RubySyntaxError extends RubyScriptError {
     }
 
     @Override
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new SyntaxError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubySyntaxError.java
+++ b/core/src/main/java/org/jruby/RubySyntaxError.java
@@ -1,0 +1,54 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.SyntaxError;
+import org.jruby.exceptions.RaiseException;
+
+/**
+ * The Java representation of a Ruby SyntaxError.
+ *
+ * @see SyntaxError
+ */
+@JRubyClass(name="SyntaxError", parent="ScriptError")
+public class RubySyntaxError extends RubyScriptError {
+    protected RubySyntaxError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass SyntaxErrorClass = runtime.defineClass("SyntaxError", exceptionClass, (r, klass) -> new RubySyntaxError(runtime, klass));
+
+        return SyntaxErrorClass;
+    }
+
+    @Override
+    protected RaiseException constructRaiseException(String message) {
+        return new SyntaxError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubySystemCallError.java
+++ b/core/src/main/java/org/jruby/RubySystemCallError.java
@@ -7,6 +7,8 @@ import java.util.HashMap;
 
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.SystemCallError;
 import org.jruby.platform.Platform;
 import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
@@ -21,8 +23,13 @@ import org.jruby.runtime.marshal.UnmarshalStream;
 
 import jnr.constants.platform.Errno;
 
+/**
+ * The Java representation of a Ruby SystemCallError.
+ *
+ * @see SystemCallError
+ */
 @JRubyClass(name="SystemCallError", parent="StandardError")
-public class RubySystemCallError extends RubyException {
+public class RubySystemCallError extends RubyStandardError {
     private IRubyObject errno = getRuntime().getNil();
 
     private final static Map<String, String> defaultMessages = new HashMap<String, String>();
@@ -121,9 +128,9 @@ public class RubySystemCallError extends RubyException {
         super(runtime, rubyClass, null);
     }
 
-    public RubySystemCallError(Ruby runtime, RubyClass rubyClass, String message, int errno) {
-        super(runtime, rubyClass, message);
-        this.errno = runtime.newFixnum(errno);
+    @Override
+    protected RaiseException constructRaiseException(String message) {
+        return new SystemCallError(message, this);
     }
 
     private static ObjectAllocator SYSTEM_CALL_ERROR_ALLOCATOR = new ObjectAllocator() {
@@ -170,7 +177,7 @@ public class RubySystemCallError extends RubyException {
         }
     };
 
-    public static RubyClass createSystemCallErrorClass(Ruby runtime, RubyClass standardError) {
+    public static RubyClass define(Ruby runtime, RubyClass standardError) {
         RubyClass exceptionClass = runtime.defineClass("SystemCallError", standardError, SYSTEM_CALL_ERROR_ALLOCATOR);
 
         exceptionClass.setMarshal(SYSTEM_CALL_ERROR_MARSHAL);

--- a/core/src/main/java/org/jruby/RubySystemCallError.java
+++ b/core/src/main/java/org/jruby/RubySystemCallError.java
@@ -129,7 +129,7 @@ public class RubySystemCallError extends RubyStandardError {
     }
 
     @Override
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new SystemCallError(message, this);
     }
 

--- a/core/src/main/java/org/jruby/RubySystemExit.java
+++ b/core/src/main/java/org/jruby/RubySystemExit.java
@@ -28,24 +28,26 @@ package org.jruby;
 
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.SystemExit;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ObjectAllocator;
 import static org.jruby.runtime.Visibility.*;
 import org.jruby.runtime.builtin.IRubyObject;
 
+/**
+ * The Java representation of a Ruby SystemExit.
+ *
+ * @see SystemExit
+ */
 @JRubyClass(name="SystemExit", parent="Exception")
 public class RubySystemExit extends RubyException {
 
     IRubyObject status;
 
-    private static final ObjectAllocator ALLOCATOR = new ObjectAllocator() {
-        @Override
-        public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-            return new RubySystemExit(runtime, klass);
-        }
-    };
+    private static final ObjectAllocator ALLOCATOR = (runtime, klass) -> new RubySystemExit(runtime, klass);
 
-    static RubyClass createSystemExitClass(Ruby runtime, RubyClass exceptionClass) {
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
         RubyClass systemExitClass = runtime.defineClass("SystemExit", exceptionClass, ALLOCATOR);
 
         systemExitClass.defineAnnotatedMethods(RubySystemExit.class);
@@ -64,6 +66,11 @@ public class RubySystemExit extends RubyException {
     protected RubySystemExit(Ruby runtime, RubyClass exceptionClass) {
         super(runtime, exceptionClass);
         status = runtime.getNil();
+    }
+
+    @Override
+    protected RaiseException constructRaiseException(String message) {
+        return new SystemExit(message, this);
     }
 
     @JRubyMethod(optional = 2, visibility = PRIVATE)

--- a/core/src/main/java/org/jruby/RubySystemExit.java
+++ b/core/src/main/java/org/jruby/RubySystemExit.java
@@ -69,7 +69,7 @@ public class RubySystemExit extends RubyException {
     }
 
     @Override
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new SystemExit(message, this);
     }
 

--- a/core/src/main/java/org/jruby/RubySystemStackError.java
+++ b/core/src/main/java/org/jruby/RubySystemStackError.java
@@ -47,7 +47,7 @@ public class RubySystemStackError extends RubyException {
         return systemStackErrorClass;
     }
 
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new SystemStackError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubySystemStackError.java
+++ b/core/src/main/java/org/jruby/RubySystemStackError.java
@@ -1,0 +1,53 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.SystemStackError;
+
+/**
+ * The Java representation of a Ruby SystemStackError.
+ *
+ * @see SystemStackError
+ */
+@JRubyClass(name="SystemStackError", parent="Exception")
+public class RubySystemStackError extends RubyException {
+    protected RubySystemStackError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass systemStackErrorClass = runtime.defineClass("SystemStackError", exceptionClass, (r, klass) -> new RubySystemStackError(runtime, klass));
+
+        return systemStackErrorClass;
+    }
+
+    protected RaiseException constructRaiseException(String message) {
+        return new SystemStackError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -1300,7 +1300,8 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     private IRubyObject prepareRaiseException(Ruby runtime, IRubyObject[] args, Block block) {
         if (args.length == 0) {
             if (errorInfo.isNil()) {
-                return new RaiseException(runtime, runtime.getRuntimeError(), "").getException();
+                // We force RaiseException here to populate backtrace
+                return RaiseException.from(runtime, runtime.getRuntimeError(), "").getException();
             }
             return errorInfo;
         }

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -59,7 +59,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 
 import org.jcodings.Encoding;
-import org.jcodings.specific.USASCIIEncoding;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.RaiseException;
@@ -1301,7 +1300,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     private IRubyObject prepareRaiseException(Ruby runtime, IRubyObject[] args, Block block) {
         if (args.length == 0) {
             if (errorInfo.isNil()) {
-                return new RaiseException(runtime, runtime.getRuntimeError(), "", false).getException();
+                return new RaiseException(runtime, runtime.getRuntimeError(), "").getException();
             }
             return errorInfo;
         }

--- a/core/src/main/java/org/jruby/RubyThreadError.java
+++ b/core/src/main/java/org/jruby/RubyThreadError.java
@@ -1,0 +1,53 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.ThreadError;
+
+/**
+ * The Java representation of a Ruby ThreadError.
+ *
+ * @see ThreadError
+ */
+@JRubyClass(name="ThreadError", parent="StandardError")
+public class RubyThreadError extends RubyStandardError {
+    protected RubyThreadError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass threadErrorClass = runtime.defineClass("ThreadError", exceptionClass, (r, klass) -> new RubyThreadError(runtime, klass));
+
+        return threadErrorClass;
+    }
+
+    protected RaiseException constructRaiseException(String message) {
+        return new ThreadError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubyThreadError.java
+++ b/core/src/main/java/org/jruby/RubyThreadError.java
@@ -47,7 +47,7 @@ public class RubyThreadError extends RubyStandardError {
         return threadErrorClass;
     }
 
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new ThreadError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubyTypeError.java
+++ b/core/src/main/java/org/jruby/RubyTypeError.java
@@ -1,0 +1,53 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.TypeError;
+
+/**
+ * The Java representation of a Ruby TypeError.
+ *
+ * @see TypeError
+ */
+@JRubyClass(name="TypeError", parent="StandardError")
+public class RubyTypeError extends RubyStandardError {
+    protected RubyTypeError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass typeErrorClass = runtime.defineClass("TypeError", exceptionClass, (r, klass) -> new RubyTypeError(runtime, klass));
+
+        return typeErrorClass;
+    }
+
+    protected RaiseException constructRaiseException(String message) {
+        return new TypeError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/RubyTypeError.java
+++ b/core/src/main/java/org/jruby/RubyTypeError.java
@@ -47,7 +47,7 @@ public class RubyTypeError extends RubyStandardError {
         return typeErrorClass;
     }
 
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new TypeError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubyUncaughtThrowError.java
+++ b/core/src/main/java/org/jruby/RubyUncaughtThrowError.java
@@ -27,36 +27,32 @@ package org.jruby;
 
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.UncaughtThrowError;
 import org.jruby.runtime.Block;
-import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 
 /**
+ * The Java representation of a Ruby UncaughtThrowError.
+ *
+ * @see UncaughtThrowError
  * @author kares
  */
 @JRubyClass(name="UncaughtThrowError", parent="ArgumentError")
-public class RubyUncaughtThrowError extends RubyException {
+public class RubyUncaughtThrowError extends RubyArgumentError {
 
     private IRubyObject tag, value;
 
-    private static final ObjectAllocator ALLOCATOR = new ObjectAllocator() {
-        @Override
-        public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-            return new RubyUncaughtThrowError(runtime, klass);
-        }
-    };
-
-    static RubyClass createUncaughtThrowErrorClass(Ruby runtime, RubyClass argumentError) {
-        RubyClass UncaughtThrowError = runtime.defineClass("UncaughtThrowError", argumentError, ALLOCATOR);
+    static RubyClass define(Ruby runtime, RubyClass argumentError) {
+        RubyClass UncaughtThrowError = runtime.defineClass("UncaughtThrowError", argumentError, (runtime1, klass) -> new RubyUncaughtThrowError(runtime1, klass));
         UncaughtThrowError.defineAnnotatedMethods(RubyUncaughtThrowError.class);
         return UncaughtThrowError;
     }
 
     protected RubyUncaughtThrowError(Ruby runtime, RubyClass exceptionClass) {
         super(runtime, exceptionClass, exceptionClass.getName());
-        // this.tag = this.value = runtime.getNil();
         this.message = runtime.getNil();
     }
 
@@ -67,6 +63,11 @@ public class RubyUncaughtThrowError extends RubyException {
         error.value = value;
         error.message = message;
         return error;
+    }
+
+    @Override
+    protected RaiseException constructRaiseException(String message) {
+        return new UncaughtThrowError(message, this);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyUncaughtThrowError.java
+++ b/core/src/main/java/org/jruby/RubyUncaughtThrowError.java
@@ -66,7 +66,7 @@ public class RubyUncaughtThrowError extends RubyArgumentError {
     }
 
     @Override
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new UncaughtThrowError(message, this);
     }
 

--- a/core/src/main/java/org/jruby/RubyZeroDivisionError.java
+++ b/core/src/main/java/org/jruby/RubyZeroDivisionError.java
@@ -47,7 +47,7 @@ public class RubyZeroDivisionError extends RubyStandardError {
         return zeroDivisionErrorClass;
     }
 
-    protected RaiseException constructRaiseException(String message) {
+    protected RaiseException constructThrowable(String message) {
         return new ZeroDivisionError(message, this);
     }
 }

--- a/core/src/main/java/org/jruby/RubyZeroDivisionError.java
+++ b/core/src/main/java/org/jruby/RubyZeroDivisionError.java
@@ -1,0 +1,53 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.exceptions.ZeroDivisionError;
+
+/**
+ * The Java representation of a Ruby ZeroDivisionError.
+ *
+ * @see ZeroDivisionError
+ */
+@JRubyClass(name="ZeroDivisionError", parent="StandardError")
+public class RubyZeroDivisionError extends RubyStandardError {
+    protected RubyZeroDivisionError(Ruby runtime, RubyClass exceptionClass) {
+        super(runtime, exceptionClass);
+    }
+
+    static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
+        RubyClass zeroDivisionErrorClass = runtime.defineClass("ZeroDivisionError", exceptionClass, (r, klass) -> new RubyZeroDivisionError(runtime, klass));
+
+        return zeroDivisionErrorClass;
+    }
+
+    protected RaiseException constructRaiseException(String message) {
+        return new ZeroDivisionError(message, this);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/ArgumentError.java
+++ b/core/src/main/java/org/jruby/exceptions/ArgumentError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyArgumentError;
+
+/**
+ * Represents a Ruby ArgumentError as a throwable Java exception.
+ *
+ * @see RubyArgumentError
+ */
+public class ArgumentError extends StandardError {
+    public ArgumentError(String message, RubyArgumentError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/ConcurrencyError.java
+++ b/core/src/main/java/org/jruby/exceptions/ConcurrencyError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyConcurrencyError;
+
+/**
+ * Represents a Ruby ConcurrencyError as a throwable Java exception.
+ *
+ * @see RubyConcurrencyError
+ */
+public class ConcurrencyError extends ThreadError {
+    public ConcurrencyError(String message, RubyConcurrencyError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/DomainError.java
+++ b/core/src/main/java/org/jruby/exceptions/DomainError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyDomainError;
+
+/**
+ * Represents a Ruby DomainError as a throwable Java exception.
+ *
+ * @see RubyDomainError
+ */
+public class DomainError extends ArgumentError {
+    public DomainError(String message, RubyDomainError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/EOFError.java
+++ b/core/src/main/java/org/jruby/exceptions/EOFError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyEOFError;
+
+/**
+ * Represents a Ruby EOFError as a throwable Java exception.
+ *
+ * @see RubyEOFError
+ */
+public class EOFError extends IOError {
+    public EOFError(String message, RubyEOFError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/EncodingError.java
+++ b/core/src/main/java/org/jruby/exceptions/EncodingError.java
@@ -1,0 +1,92 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyEncodingError;
+
+/**
+ * Represents a Ruby EncodingError as a throwable Java exception.
+ *
+ * @see RubyEncodingError
+ */
+public class EncodingError extends StandardError {
+    public EncodingError(String message, RubyEncodingError exception) {
+        super(message, exception);
+    }
+
+    /**
+     * Represents a Ruby CompatibilityError as a throwable Java exception.
+     *
+     * @see RubyEncodingError.RubyCompatibilityError
+     */
+    public static class CompatibilityError extends EncodingError {
+        public CompatibilityError(String message, RubyEncodingError.RubyCompatibilityError exception) {
+            super(message, exception);
+        }
+    }
+
+    /**
+     * Represents a Ruby InvalidByteSequenceError as a throwable Java exception.
+     *
+     * @see RubyEncodingError.RubyInvalidByteSequenceError
+     */
+    public static class InvalidByteSequenceError extends EncodingError {
+        public InvalidByteSequenceError(String message, RubyEncodingError.RubyInvalidByteSequenceError exception) {
+            super(message, exception);
+        }
+    }
+
+    /**
+     * Represents a Ruby UndefinedConversionError as a throwable Java exception.
+     *
+     * @see RubyEncodingError.RubyUndefinedConversionError
+     */
+    public static class UndefinedConversionError extends EncodingError {
+        public UndefinedConversionError(String message, RubyEncodingError.RubyUndefinedConversionError exception) {
+            super(message, exception);
+        }
+    }
+
+    /**
+     * Represents a Ruby ConverterNotFoundError as a throwable Java exception.
+     *
+     * @see RubyEncodingError.RubyConverterNotFoundError
+     */
+    public static class ConverterNotFoundError extends EncodingError {
+        public ConverterNotFoundError(String message, RubyEncodingError.RubyConverterNotFoundError exception) {
+            super(message, exception);
+        }
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/Exception.java
+++ b/core/src/main/java/org/jruby/exceptions/Exception.java
@@ -1,0 +1,43 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyException;
+
+public class Exception extends RaiseException {
+    public Exception(String message, RubyException exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/Exception.java
+++ b/core/src/main/java/org/jruby/exceptions/Exception.java
@@ -36,6 +36,11 @@ package org.jruby.exceptions;
 
 import org.jruby.RubyException;
 
+/**
+ * Represents a Ruby Exception as a throwable Java exception.
+ *
+ * @see RubyException
+ */
 public class Exception extends RaiseException {
     public Exception(String message, RubyException exception) {
         super(message, exception);

--- a/core/src/main/java/org/jruby/exceptions/Fatal.java
+++ b/core/src/main/java/org/jruby/exceptions/Fatal.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyFatal;
+
+/**
+ * Represents a RubyFatal as a throwable Java exception.
+ *
+ * @see RubyFatal
+ */
+public class Fatal extends Exception {
+    public Fatal(String message, RubyFatal exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/FiberError.java
+++ b/core/src/main/java/org/jruby/exceptions/FiberError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyFiberError;
+
+/**
+ * Represents a Ruby FiberError as a throwable Java exception.
+ *
+ * @see RubyFiberError
+ */
+public class FiberError extends StandardError {
+    public FiberError(String message, RubyFiberError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/FloatDomainError.java
+++ b/core/src/main/java/org/jruby/exceptions/FloatDomainError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyFloatDomainError;
+
+/**
+ * Represents a Ruby FloatDomainError as a throwable Java exception.
+ *
+ * @see RubyFloatDomainError
+ */
+public class FloatDomainError extends RangeError {
+    public FloatDomainError(String message, RubyFloatDomainError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/IOError.java
+++ b/core/src/main/java/org/jruby/exceptions/IOError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyIOError;
+
+/**
+ * Represents a Ruby IOError as a throwable Java exception.
+ *
+ * @see RubyIOError
+ */
+public class IOError extends StandardError {
+    public IOError(String message, RubyIOError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/IndexError.java
+++ b/core/src/main/java/org/jruby/exceptions/IndexError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyIndexError;
+
+/**
+ * Represents a Ruby IndexError as a throwable Java exception.
+ *
+ * @see RubyIndexError
+ */
+public class IndexError extends StandardError {
+    public IndexError(String message, RubyIndexError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/Interrupt.java
+++ b/core/src/main/java/org/jruby/exceptions/Interrupt.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyInterrupt;
+
+/**
+ * Represents a Ruby Interrupt as a throwable Java exception.
+ *
+ * @see RubyInterrupt
+ */
+public class Interrupt extends SignalException {
+    public Interrupt(String message, RubyInterrupt exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/InterruptedRegexpError.java
+++ b/core/src/main/java/org/jruby/exceptions/InterruptedRegexpError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyInterruptedRegexpError;
+
+/**
+ * Represents a Ruby InterruptedRegexpError as a throwable Java exception.
+ *
+ * @see RubyInterruptedRegexpError
+ */
+public class InterruptedRegexpError extends RegexpError {
+    public InterruptedRegexpError(String message, RubyInterruptedRegexpError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/KeyError.java
+++ b/core/src/main/java/org/jruby/exceptions/KeyError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyKeyError;
+
+/**
+ * Represents a Ruby KeyError as a throwable Java exception.
+ *
+ * @see RubyKeyError
+ */
+public class KeyError extends IndexError {
+    public KeyError(String message, RubyKeyError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/LoadError.java
+++ b/core/src/main/java/org/jruby/exceptions/LoadError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyLoadError;
+
+/**
+ * Represents a Ruby LoadError as a throwable Java exception.
+ *
+ * @see RubyLoadError
+ */
+public class LoadError extends ScriptError {
+    public LoadError(String message, RubyLoadError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/LocalJumpError.java
+++ b/core/src/main/java/org/jruby/exceptions/LocalJumpError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyLocalJumpError;
+
+/**
+ * Represents a Ruby LocalJumpError as a throwable Java exception.
+ *
+ * @see RubyLocalJumpError
+ */
+public class LocalJumpError extends StandardError {
+    public LocalJumpError(String message, RubyLocalJumpError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/NameError.java
+++ b/core/src/main/java/org/jruby/exceptions/NameError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyNameError;
+
+/**
+ * Represents a Ruby NameError as a throwable Java exception.
+ *
+ * @see RubyNameError
+ */
+public class NameError extends StandardError {
+    public NameError(String message, RubyNameError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/NoMemoryError.java
+++ b/core/src/main/java/org/jruby/exceptions/NoMemoryError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyNoMemoryError;
+
+/**
+ * Represents a Ruby NoMemoryError as a throwable Java exception.
+ *
+ * @see RubyNoMemoryError
+ */
+public class NoMemoryError extends StandardError {
+    public NoMemoryError(String message, RubyNoMemoryError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/NoMemoryError.java
+++ b/core/src/main/java/org/jruby/exceptions/NoMemoryError.java
@@ -41,7 +41,7 @@ import org.jruby.RubyNoMemoryError;
  *
  * @see RubyNoMemoryError
  */
-public class NoMemoryError extends StandardError {
+public class NoMemoryError extends Exception {
     public NoMemoryError(String message, RubyNoMemoryError exception) {
         super(message, exception);
     }

--- a/core/src/main/java/org/jruby/exceptions/NoMethodError.java
+++ b/core/src/main/java/org/jruby/exceptions/NoMethodError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyNoMethodError;
+
+/**
+ * Represents a Ruby NoMethodError as a throwable Java exception.
+ *
+ * @see RubyNoMethodError
+ */
+public class NoMethodError extends NameError {
+    public NoMethodError(String message, RubyNoMethodError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/NotImplementedError.java
+++ b/core/src/main/java/org/jruby/exceptions/NotImplementedError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyNotImplementedError;
+
+/**
+ * Represents a Ruby NotImplementedError as a throwable Java exception.
+ *
+ * @see RubyNotImplementedError
+ */
+public class NotImplementedError extends ScriptError {
+    public NotImplementedError(String message, RubyNotImplementedError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/RaiseException.java
+++ b/core/src/main/java/org/jruby/exceptions/RaiseException.java
@@ -186,6 +186,11 @@ public class RaiseException extends JumpException {
     }
 
     @Deprecated
+    public RaiseException(RubyException exception, boolean unused) {
+        this(exception.getMessageAsJavaString(), exception);
+    }
+
+    @Deprecated
     public RaiseException(RubyException exception, IRubyObject backtrace) {
         this(exception.getMessageAsJavaString(), exception);
         preRaise(exception.getRuntime().getCurrentContext(), backtrace);
@@ -193,6 +198,11 @@ public class RaiseException extends JumpException {
 
     @Deprecated
     public RaiseException(Ruby runtime, RubyClass excptnClass, String msg) {
+        this(runtime, excptnClass, msg, null);
+    }
+
+    @Deprecated
+    public RaiseException(Ruby runtime, RubyClass excptnClass, String msg, boolean unused) {
         this(runtime, excptnClass, msg, null);
     }
 
@@ -211,4 +221,13 @@ public class RaiseException extends JumpException {
         preRaise(context, backtrace);
     }
 
+    @Deprecated
+    public RaiseException(Ruby runtime, RubyClass excptnClass, String msg, IRubyObject backtrace, boolean unused) {
+        this(runtime, excptnClass, msg, backtrace);
+    }
+
+    @Deprecated
+    protected final void setException(RubyException newException, boolean unused) {
+        this.exception = newException;
+    }
 }

--- a/core/src/main/java/org/jruby/exceptions/RaiseException.java
+++ b/core/src/main/java/org/jruby/exceptions/RaiseException.java
@@ -35,7 +35,6 @@
 package org.jruby.exceptions;
 
 import java.lang.reflect.Member;
-import org.jruby.NativeException;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyException;
@@ -130,14 +129,7 @@ public class RaiseException extends JumpException {
                 if ( backtrace.isNil() ) return;
             }
 
-            // call Throwable.setStackTrace so that when RaiseException appears nested inside another exception,
-            // Ruby stack trace gets displayed
-            // JRUBY-2673: if wrapping a NativeException, use the actual Java exception's trace as our Java trace
-            if (exception instanceof NativeException) {
-                setStackTrace(((NativeException) exception).getCause().getStackTrace());
-            } else {
-                setStackTrace(RaiseException.javaTraceFromRubyTrace(exception.getBacktraceElements()));
-            }
+            setStackTrace(RaiseException.javaTraceFromRubyTrace(exception.getBacktraceElements()));
         }
     }
 
@@ -174,13 +166,13 @@ public class RaiseException extends JumpException {
 
     @Deprecated
     public static RaiseException createNativeRaiseException(Ruby runtime, Throwable cause, Member target) {
-        NativeException nativeException = new NativeException(runtime, runtime.getNativeException(), cause);
+        org.jruby.NativeException nativeException = new org.jruby.NativeException(runtime, runtime.getNativeException(), cause);
 
         return new RaiseException(cause, nativeException);
     }
 
     @Deprecated
-    public RaiseException(Throwable cause, NativeException nativeException) {
+    public RaiseException(Throwable cause, org.jruby.NativeException nativeException) {
         super(nativeException.getMessageAsJavaString(), cause);
         providedMessage = super.getMessage(); // cause.getClass().getName() + ": " + message
         setException(nativeException);

--- a/core/src/main/java/org/jruby/exceptions/RaiseException.java
+++ b/core/src/main/java/org/jruby/exceptions/RaiseException.java
@@ -66,11 +66,11 @@ public class RaiseException extends JumpException {
     }
 
     public static RaiseException from(Ruby runtime, RubyClass excptnClass, String msg) {
-        return RubyException.newException(runtime, excptnClass, msg).getRaiseException();
+        return RubyException.newException(runtime, excptnClass, msg).toThrowable();
     }
 
     public static RaiseException from(Ruby runtime, RubyClass excptnClass, String msg, IRubyObject backtrace) {
-        return RubyException.newException(runtime, excptnClass, msg).getRaiseException();
+        return RubyException.newException(runtime, excptnClass, msg).toThrowable();
     }
 
     @Override

--- a/core/src/main/java/org/jruby/exceptions/RangeError.java
+++ b/core/src/main/java/org/jruby/exceptions/RangeError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyRangeError;
+
+/**
+ * Represents a Ruby RangeError as a throwable Java exception.
+ *
+ * @see RubyRangeError
+ */
+public class RangeError extends StandardError {
+    public RangeError(String message, RubyRangeError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/RegexpError.java
+++ b/core/src/main/java/org/jruby/exceptions/RegexpError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyRegexpError;
+
+/**
+ * Represents a Ruby RegexpError as a throwable Java exception.
+ *
+ * @see RubyRegexpError
+ */
+public class RegexpError extends StandardError {
+    public RegexpError(String message, RubyRegexpError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/RuntimeError.java
+++ b/core/src/main/java/org/jruby/exceptions/RuntimeError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyRuntimeError;
+
+/**
+ * Represents a Ruby RuntimeError as a throwable Java exception.
+ *
+ * @see RubyRuntimeError
+ */
+public class RuntimeError extends StandardError {
+    public RuntimeError(String message, RubyRuntimeError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/ScriptError.java
+++ b/core/src/main/java/org/jruby/exceptions/ScriptError.java
@@ -1,0 +1,43 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyScriptError;
+
+public class ScriptError extends Exception {
+    public ScriptError(String message, RubyScriptError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/SecurityError.java
+++ b/core/src/main/java/org/jruby/exceptions/SecurityError.java
@@ -41,7 +41,7 @@ import org.jruby.RubySecurityError;
  *
  * @see RubySecurityError
  */
-public class SecurityError extends StandardError {
+public class SecurityError extends Exception {
     public SecurityError(String message, RubySecurityError exception) {
         super(message, exception);
     }

--- a/core/src/main/java/org/jruby/exceptions/SecurityError.java
+++ b/core/src/main/java/org/jruby/exceptions/SecurityError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubySecurityError;
+
+/**
+ * Represents a Ruby SecurityError as a throwable Java exception.
+ *
+ * @see RubySecurityError
+ */
+public class SecurityError extends StandardError {
+    public SecurityError(String message, RubySecurityError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/SignalException.java
+++ b/core/src/main/java/org/jruby/exceptions/SignalException.java
@@ -1,0 +1,43 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyException;
+
+public class SignalException extends Exception {
+    public SignalException(String message, RubyException exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/SignalException.java
+++ b/core/src/main/java/org/jruby/exceptions/SignalException.java
@@ -34,10 +34,15 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby.exceptions;
 
-import org.jruby.RubyException;
+import org.jruby.RubySignalException;
 
+/**
+ * Represents a Ruby SignalException as a throwable Java exception.
+ *
+ * @see RubySignalException
+ */
 public class SignalException extends Exception {
-    public SignalException(String message, RubyException exception) {
+    public SignalException(String message, RubySignalException exception) {
         super(message, exception);
     }
 }

--- a/core/src/main/java/org/jruby/exceptions/StandardError.java
+++ b/core/src/main/java/org/jruby/exceptions/StandardError.java
@@ -1,0 +1,43 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyException;
+
+public class StandardError extends Exception {
+    public StandardError(String message, RubyException exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/StandardError.java
+++ b/core/src/main/java/org/jruby/exceptions/StandardError.java
@@ -34,10 +34,15 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby.exceptions;
 
-import org.jruby.RubyException;
+import org.jruby.RubyStandardError;
 
+/**
+ * Represents a RubyStandardError as a throwable Java exception.
+ *
+ * @see RubyStandardError
+ */
 public class StandardError extends Exception {
-    public StandardError(String message, RubyException exception) {
+    public StandardError(String message, RubyStandardError exception) {
         super(message, exception);
     }
 }

--- a/core/src/main/java/org/jruby/exceptions/StopIteration.java
+++ b/core/src/main/java/org/jruby/exceptions/StopIteration.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyStopIteration;
+
+/**
+ * Represents a Ruby StopIteration as a throwable Java exception.
+ *
+ * @see RubyStopIteration
+ */
+public class StopIteration extends IndexError {
+    public StopIteration(String message, RubyStopIteration exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/SyntaxError.java
+++ b/core/src/main/java/org/jruby/exceptions/SyntaxError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubySyntaxError;
+
+/**
+ * Represents a Ruby SyntaxError as a throwable Java exception.
+ *
+ * @see RubySyntaxError
+ */
+public class SyntaxError extends ScriptError {
+    public SyntaxError(String message, RubySyntaxError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/SystemCallError.java
+++ b/core/src/main/java/org/jruby/exceptions/SystemCallError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubySystemCallError;
+
+/**
+ * Represents a Ruby SystemCallError as a throwable Java exception.
+ *
+ * @see RubySystemCallError
+ */
+public class SystemCallError extends StandardError {
+    public SystemCallError(String message, RubySystemCallError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/SystemExit.java
+++ b/core/src/main/java/org/jruby/exceptions/SystemExit.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubySystemExit;
+
+/**
+ * Represents a RubySystemExit as a throwable Java exception.
+ *
+ * @see RubySystemExit
+ */
+public class SystemExit extends Exception {
+    public SystemExit(String message, RubySystemExit exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/SystemStackError.java
+++ b/core/src/main/java/org/jruby/exceptions/SystemStackError.java
@@ -1,0 +1,43 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubySystemStackError;
+
+public class SystemStackError extends Exception {
+    public SystemStackError(String message, RubySystemStackError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/ThreadError.java
+++ b/core/src/main/java/org/jruby/exceptions/ThreadError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyThreadError;
+
+/**
+ * Represents a Ruby ThreadError as a throwable Java exception.
+ *
+ * @see RubyThreadError
+ */
+public class ThreadError extends StandardError {
+    public ThreadError(String message, RubyThreadError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/TypeError.java
+++ b/core/src/main/java/org/jruby/exceptions/TypeError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyTypeError;
+
+/**
+ * Represents a Ruby TypeError as a throwable Java exception.
+ *
+ * @see RubyTypeError
+ */
+public class TypeError extends StandardError {
+    public TypeError(String message, RubyTypeError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/UncaughtThrowError.java
+++ b/core/src/main/java/org/jruby/exceptions/UncaughtThrowError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyUncaughtThrowError;
+
+/**
+ * Represents a Ruby UncaughtThrowError as a throwable Java exception.
+ *
+ * @see RubyUncaughtThrowError
+ */
+public class UncaughtThrowError extends ArgumentError {
+    public UncaughtThrowError(String message, RubyUncaughtThrowError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/exceptions/ZeroDivisionError.java
+++ b/core/src/main/java/org/jruby/exceptions/ZeroDivisionError.java
@@ -1,0 +1,48 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Joey Gibson <joey@joeygibson.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2005 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.exceptions;
+
+import org.jruby.RubyZeroDivisionError;
+
+/**
+ * Represents a Ruby ZeroDivisionError as a throwable Java exception.
+ *
+ * @see RubyZeroDivisionError
+ */
+public class ZeroDivisionError extends StandardError {
+    public ZeroDivisionError(String message, RubyZeroDivisionError exception) {
+        super(message, exception);
+    }
+}

--- a/core/src/main/java/org/jruby/ext/JRubyPOSIXHelper.java
+++ b/core/src/main/java/org/jruby/ext/JRubyPOSIXHelper.java
@@ -24,7 +24,7 @@ public class JRubyPOSIXHelper {
             String msg  = errno.toString();
             RubyClass errnoClass = runtime.getErrno().getClass(name);
             if (errnoClass != null) {
-                throw new RaiseException(runtime, errnoClass, msg, true);
+                throw new RaiseException(runtime, errnoClass, msg);
             }
         }
     }

--- a/core/src/main/java/org/jruby/ext/JRubyPOSIXHelper.java
+++ b/core/src/main/java/org/jruby/ext/JRubyPOSIXHelper.java
@@ -24,7 +24,7 @@ public class JRubyPOSIXHelper {
             String msg  = errno.toString();
             RubyClass errnoClass = runtime.getErrno().getClass(name);
             if (errnoClass != null) {
-                throw new RaiseException(runtime, errnoClass, msg);
+                throw RaiseException.from(runtime, errnoClass, msg);
             }
         }
     }

--- a/core/src/main/java/org/jruby/ext/ffi/InvalidMemoryIO.java
+++ b/core/src/main/java/org/jruby/ext/ffi/InvalidMemoryIO.java
@@ -25,7 +25,7 @@ public abstract class InvalidMemoryIO extends MemoryIO {
     }
 
     protected RaiseException ex() {
-        return new RaiseException(runtime, getErrorClass(runtime), message, true);
+        return new RaiseException(runtime, getErrorClass(runtime), message);
     }
 
     public ByteOrder order() {

--- a/core/src/main/java/org/jruby/ext/ffi/InvalidMemoryIO.java
+++ b/core/src/main/java/org/jruby/ext/ffi/InvalidMemoryIO.java
@@ -25,7 +25,7 @@ public abstract class InvalidMemoryIO extends MemoryIO {
     }
 
     protected RaiseException ex() {
-        return new RaiseException(runtime, getErrorClass(runtime), message);
+        return RaiseException.from(runtime, getErrorClass(runtime), message);
     }
 
     public ByteOrder order() {

--- a/core/src/main/java/org/jruby/ext/ffi/MemoryPointer.java
+++ b/core/src/main/java/org/jruby/ext/ffi/MemoryPointer.java
@@ -62,7 +62,7 @@ public class MemoryPointer extends Pointer {
         if (getMemoryIO() == null) {
             Ruby runtime = context.runtime;
             throw new RaiseException(runtime, runtime.getNoMemoryError(),
-                    String.format("Failed to allocate %d objects of %d bytes", typeSize, count), true);
+                    String.format("Failed to allocate %d objects of %d bytes", typeSize, count));
         }
         
         if (block.isGiven()) {
@@ -82,7 +82,7 @@ public class MemoryPointer extends Pointer {
         MemoryIO io = Factory.getInstance().allocateDirectMemory(runtime, total > 0 ? total : 1, clear);
         if (io == null) {
             throw new RaiseException(runtime, runtime.getNoMemoryError(),
-                    String.format("Failed to allocate %d objects of %d bytes", count, typeSize), true);
+                    String.format("Failed to allocate %d objects of %d bytes", count, typeSize));
         }
 
         return new MemoryPointer(runtime, runtime.getFFI().memptrClass, io, total, typeSize);

--- a/core/src/main/java/org/jruby/ext/ffi/MemoryPointer.java
+++ b/core/src/main/java/org/jruby/ext/ffi/MemoryPointer.java
@@ -61,7 +61,7 @@ public class MemoryPointer extends Pointer {
                 size > 0 ? (int) size : 1, align, clear));
         if (getMemoryIO() == null) {
             Ruby runtime = context.runtime;
-            throw new RaiseException(runtime, runtime.getNoMemoryError(),
+            throw RaiseException.from(runtime, runtime.getNoMemoryError(),
                     String.format("Failed to allocate %d objects of %d bytes", typeSize, count));
         }
         
@@ -81,7 +81,7 @@ public class MemoryPointer extends Pointer {
         final int total = typeSize * count;
         MemoryIO io = Factory.getInstance().allocateDirectMemory(runtime, total > 0 ? total : 1, clear);
         if (io == null) {
-            throw new RaiseException(runtime, runtime.getNoMemoryError(),
+            throw RaiseException.from(runtime, runtime.getNoMemoryError(),
                     String.format("Failed to allocate %d objects of %d bytes", count, typeSize));
         }
 

--- a/core/src/main/java/org/jruby/ext/fiber/FiberQueue.java
+++ b/core/src/main/java/org/jruby/ext/fiber/FiberQueue.java
@@ -98,7 +98,7 @@ public class FiberQueue {
 
     public synchronized void checkShutdown() {
         if (queue == null) {
-            throw new RaiseException(runtime, runtime.getThreadError(), "queue shut down", false);
+            throw new RaiseException(runtime, runtime.getThreadError(), "queue shut down");
         }
     }
 
@@ -122,7 +122,7 @@ public class FiberQueue {
     private IRubyObject pop(ThreadContext context, boolean should_block) {
         final BlockingQueue<IRubyObject> queue = getQueueSafe();
         if (!should_block && queue.size() == 0) {
-            throw new RaiseException(context.runtime, context.runtime.getThreadError(), "queue empty", false);
+            throw new RaiseException(context.runtime, context.runtime.getThreadError(), "queue empty");
         }
         try {
             return context.getThread().executeTask(context, this, takeTask);

--- a/core/src/main/java/org/jruby/ext/fiber/FiberQueue.java
+++ b/core/src/main/java/org/jruby/ext/fiber/FiberQueue.java
@@ -98,7 +98,7 @@ public class FiberQueue {
 
     public synchronized void checkShutdown() {
         if (queue == null) {
-            throw new RaiseException(runtime, runtime.getThreadError(), "queue shut down");
+            throw RaiseException.from(runtime, runtime.getThreadError(), "queue shut down");
         }
     }
 
@@ -122,7 +122,7 @@ public class FiberQueue {
     private IRubyObject pop(ThreadContext context, boolean should_block) {
         final BlockingQueue<IRubyObject> queue = getQueueSafe();
         if (!should_block && queue.size() == 0) {
-            throw new RaiseException(context.runtime, context.runtime.getThreadError(), "queue empty");
+            throw RaiseException.from(context.runtime, context.runtime.getThreadError(), "queue empty");
         }
         try {
             return context.getThread().executeTask(context, this, takeTask);

--- a/core/src/main/java/org/jruby/ext/net/protocol/NetProtocolBufferedIO.java
+++ b/core/src/main/java/org/jruby/ext/net/protocol/NetProtocolBufferedIO.java
@@ -111,21 +111,22 @@ public class NetProtocolBufferedIO {
             synchronized (nim.channel.blockingLock()) {
                 boolean oldBlocking = nim.channel.isBlocking();
 
+                Ruby runtime = recv.getRuntime();
                 try {
-                    selector = SelectorFactory.openWithRetryFrom(recv.getRuntime(), SelectorProvider.provider());
+                    selector = SelectorFactory.openWithRetryFrom(runtime, SelectorProvider.provider());
                     nim.channel.configureBlocking(false);
                     SelectionKey key = nim.channel.register(selector, SelectionKey.OP_READ);
                     int n = selector.select(timeout);
 
                     if(n > 0) {
-                        IRubyObject readItems = io.read(new IRubyObject[]{recv.getRuntime().newFixnum(1024*16)});
+                        IRubyObject readItems = io.read(new IRubyObject[]{runtime.newFixnum(1024*16)});
                         return buf.concat(readItems);
                     } else {
-                        RubyClass exc = (RubyClass)(recv.getRuntime().getModule("Timeout").getConstant("Error"));
-                        throw new RaiseException(RubyException.newException(recv.getRuntime(), exc, "execution expired"),false);
+                        RubyClass exc = (RubyClass)(runtime.getModule("Timeout").getConstant("Error"));
+                        throw RubyException.newRaiseException(runtime, exc, "execution expired");
                     }
                 } catch(IOException exception) {
-                    throw recv.getRuntime().newIOErrorFromException(exception);
+                    throw runtime.newIOErrorFromException(exception);
                 } finally {
                     if (selector != null) {
                         try {

--- a/core/src/main/java/org/jruby/ext/net/protocol/NetProtocolBufferedIO.java
+++ b/core/src/main/java/org/jruby/ext/net/protocol/NetProtocolBufferedIO.java
@@ -41,7 +41,6 @@ import org.jruby.RubyObject;
 import org.jruby.RubyNumeric;
 import org.jruby.RubyIO;
 import org.jruby.Ruby;
-import org.jruby.RubyException;
 import org.jruby.RubyModule;
 import org.jruby.RubyClass;
 import org.jruby.RubyString;
@@ -123,7 +122,7 @@ public class NetProtocolBufferedIO {
                         return buf.concat(readItems);
                     } else {
                         RubyClass exc = (RubyClass)(runtime.getModule("Timeout").getConstant("Error"));
-                        throw RubyException.newRaiseException(runtime, exc, "execution expired");
+                        throw RaiseException.from(runtime, exc, "execution expired");
                     }
                 } catch(IOException exception) {
                     throw runtime.newIOErrorFromException(exception);

--- a/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
+++ b/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
@@ -35,9 +35,7 @@ import jnr.netdb.Protocol;
 import jnr.netdb.Service;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
-import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
-import org.jruby.RubyFixnum;
 import org.jruby.RubyInteger;
 import org.jruby.RubyNumeric;
 import org.jruby.RubyString;
@@ -468,7 +466,7 @@ public class SocketUtils {
     }
 
     public static RuntimeException sockerr(Ruby runtime, String msg) {
-        return new RaiseException(runtime, runtime.getClass("SocketError"), msg, true);
+        return new RaiseException(runtime, runtime.getClass("SocketError"), msg);
     }
 
     public static RuntimeException sockerr_with_trace(Ruby runtime, String msg, StackTraceElement[] trace) {
@@ -478,7 +476,7 @@ public class SocketUtils {
         for (int i = 0, il = trace.length; i < il; i++) {
             sb.append(eol).append(trace[i].toString());
         }
-        return new RaiseException(runtime, runtime.getClass("SocketError"), sb.toString(), true);
+        return new RaiseException(runtime, runtime.getClass("SocketError"), sb.toString());
     }
 
     public static int getPortFrom(ThreadContext context, IRubyObject _port) {

--- a/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
+++ b/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
@@ -466,7 +466,7 @@ public class SocketUtils {
     }
 
     public static RuntimeException sockerr(Ruby runtime, String msg) {
-        return new RaiseException(runtime, runtime.getClass("SocketError"), msg);
+        return RaiseException.from(runtime, runtime.getClass("SocketError"), msg);
     }
 
     public static RuntimeException sockerr_with_trace(Ruby runtime, String msg, StackTraceElement[] trace) {
@@ -476,7 +476,7 @@ public class SocketUtils {
         for (int i = 0, il = trace.length; i < il; i++) {
             sb.append(eol).append(trace[i].toString());
         }
-        return new RaiseException(runtime, runtime.getClass("SocketError"), sb.toString());
+        return RaiseException.from(runtime, runtime.getClass("SocketError"), sb.toString());
     }
 
     public static int getPortFrom(ThreadContext context, IRubyObject _port) {

--- a/core/src/main/java/org/jruby/ext/strscan/RubyStringScanner.java
+++ b/core/src/main/java/org/jruby/ext/strscan/RubyStringScanner.java
@@ -34,7 +34,6 @@ import org.joni.Region;
 import org.jruby.Ruby;
 import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
-import org.jruby.RubyException;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyMatchData;
 import org.jruby.RubyNumeric;
@@ -53,7 +52,6 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 import org.jruby.util.StringSupport;
-import org.jruby.util.TypeConverter;
 
 import static org.jruby.runtime.Visibility.PRIVATE;
 
@@ -445,7 +443,7 @@ public class RubyStringScanner extends RubyObject {
 
         if (!isMatched()) {
             RubyClass errorClass = runtime.getClass("StringScanner").getClass("Error");
-            throw RubyException.newRaiseException(runtime, errorClass, "unscan failed: previous match had failed");
+            throw RaiseException.from(runtime, errorClass, "unscan failed: previous match had failed");
         }
         pos = lastPos;
         clearMatched();

--- a/core/src/main/java/org/jruby/ext/strscan/RubyStringScanner.java
+++ b/core/src/main/java/org/jruby/ext/strscan/RubyStringScanner.java
@@ -445,8 +445,7 @@ public class RubyStringScanner extends RubyObject {
 
         if (!isMatched()) {
             RubyClass errorClass = runtime.getClass("StringScanner").getClass("Error");
-            throw new RaiseException(RubyException.newException(
-                    runtime, errorClass, "unscan failed: previous match had failed"));
+            throw RubyException.newRaiseException(runtime, errorClass, "unscan failed: previous match had failed");
         }
         pos = lastPos;
         clearMatched();

--- a/core/src/main/java/org/jruby/ext/thread/Queue.java
+++ b/core/src/main/java/org/jruby/ext/thread/Queue.java
@@ -494,7 +494,7 @@ public class Queue extends RubyObject implements DataType {
     public synchronized void checkShutdown() {
         if (isShutdown()) {
             Ruby runtime = getRuntime();
-            throw new RaiseException(runtime, runtime.getThreadError(), "queue shut down", false);
+            throw new RaiseException(runtime, runtime.getThreadError(), "queue shut down");
         }
     }
 

--- a/core/src/main/java/org/jruby/ext/thread/Queue.java
+++ b/core/src/main/java/org/jruby/ext/thread/Queue.java
@@ -494,7 +494,7 @@ public class Queue extends RubyObject implements DataType {
     public synchronized void checkShutdown() {
         if (isShutdown()) {
             Ruby runtime = getRuntime();
-            throw new RaiseException(runtime, runtime.getThreadError(), "queue shut down");
+            throw RaiseException.from(runtime, runtime.getThreadError(), "queue shut down");
         }
     }
 

--- a/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
+++ b/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
@@ -339,7 +339,7 @@ public class RubyZlib {
         RubyException excn = RubyException.newException(runtime, errorClass, message);
         // TODO: not yet supported. rewrite GzipReader/Writer with Inflate/Deflate?
         excn.setInstanceVariable("@input", runtime.getNil());
-        return excn.getRaiseException();
+        return excn.toThrowable();
     }
     
     static int FIXNUMARG(IRubyObject obj, int ifnil) {

--- a/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
+++ b/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
@@ -34,9 +34,6 @@ package org.jruby.ext.zlib;
 
 import java.lang.reflect.Field;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import java.util.zip.CRC32;
 import java.util.zip.Adler32;
 
@@ -52,11 +49,9 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyModule;
 
-import org.jruby.ast.util.ArgsUtil;
 import org.jruby.exceptions.RaiseException;
 
 import org.jruby.runtime.Arity;
-import org.jruby.runtime.Block;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import static org.jruby.runtime.Visibility.*;
@@ -320,7 +315,7 @@ public class RubyZlib {
 
     static RaiseException newZlibError(Ruby runtime, String klass, String message) {
         RubyClass errorClass = runtime.getModule("Zlib").getClass(klass);
-        return new RaiseException(RubyException.newException(runtime, errorClass, message), true);
+        return RubyException.newRaiseException(runtime, errorClass, message);
     }
 
     static RaiseException newGzipFileError(Ruby runtime, String message) {
@@ -344,7 +339,7 @@ public class RubyZlib {
         RubyException excn = RubyException.newException(runtime, errorClass, message);
         // TODO: not yet supported. rewrite GzipReader/Writer with Inflate/Deflate?
         excn.setInstanceVariable("@input", runtime.getNil());
-        return new RaiseException(excn, true);
+        return excn.getRaiseException();
     }
     
     static int FIXNUMARG(IRubyObject obj, int ifnil) {

--- a/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
+++ b/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
@@ -315,7 +315,7 @@ public class RubyZlib {
 
     static RaiseException newZlibError(Ruby runtime, String klass, String message) {
         RubyClass errorClass = runtime.getModule("Zlib").getClass(klass);
-        return RubyException.newRaiseException(runtime, errorClass, message);
+        return RaiseException.from(runtime, errorClass, message);
     }
 
     static RaiseException newGzipFileError(Ruby runtime, String message) {

--- a/core/src/main/java/org/jruby/internal/runtime/GlobalVariables.java
+++ b/core/src/main/java/org/jruby/internal/runtime/GlobalVariables.java
@@ -93,7 +93,7 @@ public class GlobalVariables {
         GlobalVariable variable = globalVariables.get(name);
 
         if (variable != null && oldVariable != variable && variable.isTracing()) {
-            throw new RaiseException(runtime, runtime.getRuntimeError(), "can't alias in tracer", false);
+            throw new RaiseException(runtime, runtime.getRuntimeError(), "can't alias in tracer");
         }
 
         globalVariables.put(name, oldVariable);

--- a/core/src/main/java/org/jruby/internal/runtime/GlobalVariables.java
+++ b/core/src/main/java/org/jruby/internal/runtime/GlobalVariables.java
@@ -93,7 +93,7 @@ public class GlobalVariables {
         GlobalVariable variable = globalVariables.get(name);
 
         if (variable != null && oldVariable != variable && variable.isTracing()) {
-            throw new RaiseException(runtime, runtime.getRuntimeError(), "can't alias in tracer");
+            throw RaiseException.from(runtime, runtime.getRuntimeError(), "can't alias in tracer");
         }
 
         globalVariables.put(name, oldVariable);

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import org.jcodings.Encoding;
 import org.jruby.EvalType;
 import org.jruby.MetaClass;
-import org.jruby.NativeException;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyBasicObject;
@@ -377,12 +376,18 @@ public class IRRuntimeHelpers {
 
     private static IRubyObject wrapJavaException(final ThreadContext context, final IRubyObject excType, final Throwable throwable) {
         final Ruby runtime = context.runtime;
-        if (excType == runtime.getNativeException()) { // wrap Throwable in a NativeException object
-            NativeException exception = new NativeException(runtime, runtime.getNativeException(), throwable);
-            exception.prepareIntegratedBacktrace(context, throwable.getStackTrace());
-            return exception;
+        if (excType == runtime.getNativeException()) {
+            return wrapWithNativeException(context, throwable, runtime);
         }
         return Helpers.wrapJavaException(runtime, throwable); // wrap as normal JI object
+    }
+
+    @SuppressWarnings("deprecation")
+    private static IRubyObject wrapWithNativeException(ThreadContext context, Throwable throwable, Ruby runtime) {
+        // wrap Throwable in a NativeException object
+        org.jruby.NativeException exception = new org.jruby.NativeException(runtime, runtime.getNativeException(), throwable);
+        exception.prepareIntegratedBacktrace(context, throwable.getStackTrace());
+        return exception;
     }
 
     private static boolean isRubyExceptionHandled(ThreadContext context, IRubyObject excType, Object excObj) {

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -256,13 +256,21 @@ public abstract class JavaLang {
 
         @JRubyMethod(name = "===", meta = true)
         public static IRubyObject eqq(final ThreadContext context, final IRubyObject self, IRubyObject other) {
+            if (checkNativeException(self, other)) {
+                return context.tru;
+            }
+            return self.op_eqq(context, other);
+        }
+
+        @SuppressWarnings("deprecation")
+        private static boolean checkNativeException(IRubyObject self, IRubyObject other) {
             if ( other instanceof NativeException ) {
                 final java.lang.Class java_class = (java.lang.Class) self.dataGetStruct();
                 if ( java_class.isAssignableFrom( ((NativeException) other).getCause().getClass() ) ) {
-                    return context.runtime.getTrue();
+                    return true;
                 }
             }
-            return self.op_eqq(context, other);
+            return false;
         }
 
     }

--- a/core/src/main/java/org/jruby/management/Runtime.java
+++ b/core/src/main/java/org/jruby/management/Runtime.java
@@ -28,7 +28,6 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby.management;
 
-import java.io.FileDescriptor;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.ref.SoftReference;
@@ -104,7 +103,7 @@ public class Runtime implements RuntimeMBean {
         ThreadContext tc = th.getContext();
         if (tc != null) {
             RubyException exc = new RubyException(ruby, ruby.getRuntimeError(), "thread dump");
-            exc.setBacktraceData(gather.getBacktraceData(tc, th.getNativeThread().getStackTrace(), true));
+            exc.setBacktraceData(gather.getBacktraceData(tc, th.getNativeThread().getStackTrace()));
             pw.println(Format.MRI.printBacktrace(exc, false));
         } else {
             pw.println("    [no longer alive]");

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -875,6 +875,7 @@ public class Helpers {
         }
     }
 
+    @Deprecated
     public static void storeExceptionInErrorInfo(Throwable currentThrowable, ThreadContext context) {
         IRubyObject exception;
         if (currentThrowable instanceof RaiseException) {
@@ -885,6 +886,7 @@ public class Helpers {
         context.setErrorInfo(exception);
     }
 
+    @Deprecated
     public static void storeNativeExceptionInErrorInfo(Throwable currentThrowable, ThreadContext context) {
         IRubyObject exception;
         if (currentThrowable instanceof RaiseException) {

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -744,7 +744,7 @@ public final class ThreadContext {
      */
     public void renderCurrentBacktrace(StringBuilder sb) {
         TraceType traceType = runtime.getInstanceConfig().getTraceType();
-        BacktraceData backtraceData = traceType.getBacktrace(this, false);
+        BacktraceData backtraceData = traceType.getBacktrace(this);
         traceType.getFormat().renderBacktrace(backtraceData.getBacktrace(runtime), sb, false);
     }
 
@@ -801,7 +801,7 @@ public final class ThreadContext {
 
     private RubyStackTraceElement[] getFullTrace(Integer length, StackTraceElement[] stacktrace) {
         if (length != null && length == 0) return RubyStackTraceElement.EMPTY_ARRAY;
-        return TraceType.Gather.CALLER.getBacktraceData(this, stacktrace, false).getBacktrace(runtime);
+        return TraceType.Gather.CALLER.getBacktraceData(this, stacktrace).getBacktrace(runtime);
     }
 
     private static int safeLength(int level, Integer length, RubyStackTraceElement[] trace) {
@@ -825,7 +825,7 @@ public final class ThreadContext {
     }
 
     public RubyStackTraceElement[] gatherCallerBacktrace() {
-        return Gather.CALLER.getBacktraceData(this, false).getBacktrace(runtime);
+        return Gather.CALLER.getBacktraceData(this).getBacktrace(runtime);
     }
 
     public boolean isEventHooksEnabled() {

--- a/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
@@ -3,7 +3,6 @@ package org.jruby.runtime.backtrace;
 import java.io.ByteArrayOutputStream;
 import java.io.FileDescriptor;
 import java.io.PrintStream;
-import java.util.Arrays;
 
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
@@ -40,11 +39,10 @@ public class TraceType {
      * Get a normal Ruby backtrace, using the current Gather type.
      *
      * @param context
-     * @param nativeException
      * @return
      */
-    public BacktraceData getBacktrace(ThreadContext context, boolean nativeException) {
-        return gather.getBacktraceData(context, nativeException);
+    public BacktraceData getBacktrace(ThreadContext context) {
+        return gather.getBacktraceData(context);
     }
 
     /**
@@ -167,7 +165,7 @@ public class TraceType {
          * Full raw backtraces with all Java frames included.
          */
         RAW {
-            public BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace, boolean nativeException) {
+            public BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace) {
                 return new BacktraceData(
                         javaTrace,
                         BacktraceElement.EMPTY_ARRAY,
@@ -181,7 +179,7 @@ public class TraceType {
          * A backtrace with interpreted frames intact, but don't remove Java frames.
          */
         FULL {
-            public BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace, boolean nativeException) {
+            public BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace) {
                 return new BacktraceData(
                         javaTrace,
                         context.getBacktrace(),
@@ -195,7 +193,7 @@ public class TraceType {
          * A normal Ruby-style backtrace, but which includes any non-org.jruby frames
          */
         INTEGRATED {
-            public BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace, boolean nativeException) {
+            public BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace) {
                 return new BacktraceData(
                         javaTrace,
                         context.getBacktrace(),
@@ -209,7 +207,7 @@ public class TraceType {
          * Normal Ruby-style backtrace, showing only Ruby and core class methods.
          */
         NORMAL {
-            public BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace, boolean nativeException) {
+            public BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace) {
                 return new BacktraceData(
                         javaTrace,
                         context.getBacktrace(),
@@ -223,7 +221,7 @@ public class TraceType {
          * Normal Ruby-style backtrace, showing only Ruby and core class methods.
          */
         CALLER {
-            public BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace, boolean nativeException) {
+            public BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace) {
                 return new BacktraceData(
                         javaTrace,
                         context.getBacktrace(),
@@ -237,11 +235,10 @@ public class TraceType {
          * Gather backtrace data for a normal Ruby trace.
          *
          * @param context
-         * @param nativeException
          * @return
          */
-        public BacktraceData getBacktraceData(ThreadContext context, boolean nativeException) {
-            BacktraceData data = getBacktraceData(context, Thread.currentThread().getStackTrace(), nativeException);
+        public BacktraceData getBacktraceData(ThreadContext context) {
+            BacktraceData data = getBacktraceData(context, Thread.currentThread().getStackTrace());
 
             context.runtime.incrementBacktraceCount();
             if (RubyInstanceConfig.LOG_BACKTRACES) logBacktrace(data.getBacktrace(context.runtime));
@@ -264,7 +261,7 @@ public class TraceType {
                 useGather = INTEGRATED;
             }
 
-            BacktraceData data = useGather.getBacktraceData(context, javaTrace, false);
+            BacktraceData data = useGather.getBacktraceData(context, javaTrace);
 
             context.runtime.incrementBacktraceCount();
             if (RubyInstanceConfig.LOG_BACKTRACES) logBacktrace(data.getBacktrace(context.runtime));
@@ -272,7 +269,7 @@ public class TraceType {
             return data;
         }
 
-        public abstract BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace, boolean nativeException);
+        public abstract BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace);
     }
 
     public enum Format {

--- a/core/src/main/java/org/jruby/util/io/OpenFile.java
+++ b/core/src/main/java/org/jruby/util/io/OpenFile.java
@@ -1,7 +1,6 @@
 package org.jruby.util.io;
 
 import jnr.constants.platform.Errno;
-import jnr.constants.platform.Fcntl;
 import jnr.constants.platform.OpenFlags;
 import org.jcodings.Encoding;
 import org.jcodings.Ptr;
@@ -903,7 +902,7 @@ public class OpenFile implements Finalizable {
                 posix.errno = Errno.valueOf(RubyNumeric.num2int(err));
                 throw runtime.newErrnoFromErrno(posix.errno, pathv);
             } else {
-                throw ((RubyException)err).getRaiseException();
+                throw ((RubyException)err).toThrowable();
             }
         }
     }

--- a/core/src/main/java/org/jruby/util/io/OpenFile.java
+++ b/core/src/main/java/org/jruby/util/io/OpenFile.java
@@ -903,7 +903,7 @@ public class OpenFile implements Finalizable {
                 posix.errno = Errno.valueOf(RubyNumeric.num2int(err));
                 throw runtime.newErrnoFromErrno(posix.errno, pathv);
             } else {
-                throw new RaiseException((RubyException)err);
+                throw ((RubyException)err).getRaiseException();
             }
         }
     }

--- a/core/src/main/java/org/jruby/util/io/Sockaddr.java
+++ b/core/src/main/java/org/jruby/util/io/Sockaddr.java
@@ -8,7 +8,6 @@ import org.jruby.RubyNumeric;
 import org.jruby.RubyBoolean;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.ext.socket.Addrinfo;
-import org.jruby.platform.Platform;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
@@ -24,9 +23,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
-import java.nio.ByteBuffer;
-import java.nio.IntBuffer;
-import java.util.Arrays;
 
 import org.jruby.RubyString;
 import org.jruby.ext.socket.SocketUtils;
@@ -349,7 +345,7 @@ public class Sockaddr {
     }
 
     private static RuntimeException sockerr(Ruby runtime, String msg) {
-        return new RaiseException(runtime, runtime.getClass("SocketError"), msg, true);
+        return new RaiseException(runtime, runtime.getClass("SocketError"), msg);
     }
 
     public static SocketAddress sockaddrFromBytes(Ruby runtime, byte[] val) throws IOException {

--- a/core/src/main/java/org/jruby/util/io/Sockaddr.java
+++ b/core/src/main/java/org/jruby/util/io/Sockaddr.java
@@ -345,7 +345,7 @@ public class Sockaddr {
     }
 
     private static RuntimeException sockerr(Ruby runtime, String msg) {
-        return new RaiseException(runtime, runtime.getClass("SocketError"), msg);
+        return RaiseException.from(runtime, runtime.getClass("SocketError"), msg);
     }
 
     public static SocketAddress sockaddrFromBytes(Ruby runtime, byte[] val) throws IOException {

--- a/core/src/test/java/org/jruby/exceptions/TestRaiseException.java
+++ b/core/src/test/java/org/jruby/exceptions/TestRaiseException.java
@@ -63,7 +63,7 @@ public class TestRaiseException extends TestRubyBase {
         final int count = runtime.getBacktraceCount();
 
         final RubyClass RuntimeError = runtime.getRuntimeError();
-        RaiseException re = new RaiseException(runtime, RuntimeError, "", false);
+        RaiseException re = new RaiseException(runtime, RuntimeError, "");
         IRubyObject backtrace = re.getException().backtrace();
         assertNotNil( backtrace );
         assertTrue( ((RubyArray) backtrace).isEmpty() );
@@ -78,7 +78,7 @@ public class TestRaiseException extends TestRubyBase {
         IRubyObject backtrace = runtime.getNil();
 
         final RubyClass RuntimeError = runtime.getRuntimeError();
-        RaiseException re = new RaiseException(runtime, RuntimeError, "", backtrace, false);
+        RaiseException re = new RaiseException(runtime, RuntimeError, "", backtrace);
         backtrace = re.getException().backtrace();
         assertNil( backtrace );
 

--- a/core/src/test/java/org/jruby/exceptions/TestRaiseException.java
+++ b/core/src/test/java/org/jruby/exceptions/TestRaiseException.java
@@ -63,7 +63,7 @@ public class TestRaiseException extends TestRubyBase {
         final int count = runtime.getBacktraceCount();
 
         final RubyClass RuntimeError = runtime.getRuntimeError();
-        RaiseException re = new RaiseException(runtime, RuntimeError, "");
+        RaiseException re = RaiseException.from(runtime, RuntimeError, "");
         IRubyObject backtrace = re.getException().backtrace();
         assertNotNil( backtrace );
         assertTrue( ((RubyArray) backtrace).isEmpty() );
@@ -78,7 +78,7 @@ public class TestRaiseException extends TestRubyBase {
         IRubyObject backtrace = runtime.getNil();
 
         final RubyClass RuntimeError = runtime.getRuntimeError();
-        RaiseException re = new RaiseException(runtime, RuntimeError, "", backtrace);
+        RaiseException re = RaiseException.from(runtime, RuntimeError, "", backtrace);
         backtrace = re.getException().backtrace();
         assertNil( backtrace );
 

--- a/core/src/test/java/org/jruby/test/TestJavaReentrantExceptions.java
+++ b/core/src/test/java/org/jruby/test/TestJavaReentrantExceptions.java
@@ -1,8 +1,6 @@
 package org.jruby.test;
 import junit.framework.TestCase;
-import org.jruby.NativeException;
 import org.jruby.Ruby;
-import org.jruby.exceptions.RaiseException;
 import org.jruby.javasupport.JavaEmbedUtils;
 import org.jruby.runtime.builtin.IRubyObject;
 

--- a/core/src/test/java/org/jruby/test/TestLoadService.java
+++ b/core/src/test/java/org/jruby/test/TestLoadService.java
@@ -57,7 +57,7 @@ public class TestLoadService extends TestRubyBase {
         try{
             runtime.evalScriptlet("require ''");
         } catch (RaiseException e){
-            assertEquals("Empty library is not valid, exception should have been raised", RaiseException.class, e.getClass());
+            assertTrue("Empty library is not valid, exception should have been raised", RaiseException.class.isAssignableFrom(e.getClass()));
             assertNull("Empty library is not valid, exception should only be RaiseException with no root cause", e.getCause());
         }
     }
@@ -67,7 +67,7 @@ public class TestLoadService extends TestRubyBase {
             // presumably this require should fail
             runtime.evalScriptlet("require 'somethingthatdoesnotexist'");
         } catch (RaiseException e){
-            assertEquals("Require of non-existent library should fail", RaiseException.class, e.getClass());
+            assertTrue("Require of non-existent library should fail", RaiseException.class.isAssignableFrom(e.getClass()));
             assertNull("Require of non-existent library should , exception should only be RaiseException with no root cause", e.getCause());
         }
     }
@@ -78,7 +78,7 @@ public class TestLoadService extends TestRubyBase {
             // presumably this require should fail
             runtime.evalScriptlet("require 'rubygems'; require 'somethingthatdoesnotexist'");
         } catch (RaiseException e){
-            assertEquals("Require of non-existent library should fail", RaiseException.class, e.getClass());
+            assertTrue("Require of non-existent library should fail", RaiseException.class.isAssignableFrom(e.getClass()));
             assertNull("Require of non-existent library should , exception should only be RaiseException with no root cause", e.getCause());
         }
     }


### PR DESCRIPTION
This is to address problems related to #4781.

No Ruby exception types have a real exception type in Java, which means in order to capture any of them you must catch all of them (`catch (RaiseException)`) and inspect or rethrow. This is inefficient and ugly.

This PR introduces a parallel Java exception hierarchy that maps 1:1 to the base Ruby exception hierarchy.

* All RubyException objects now know how to construct their appropriate Throwable.
* All base exception types will have their own java.lang.Throwable (subclass of RaiseException).

In addition, this makes it possible for JRuby ext authors to create the same parallel Throwable+RubyException within their libraries to improve exception handling from Java (think `catch (ParserError)` in the Psych extension).