### PR TITLE
correct __send__ routing of native methods when it has overloads

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -1719,19 +1719,25 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     @JRubyMethod(name = "__send__", omit = true)
     public IRubyObject send(ThreadContext context, IRubyObject arg0, Block block) {
         String name = RubySymbol.objectToSymbolString(arg0);
-
+        if (block == Block.NULL_BLOCK) {
+            return getMetaClass().finvoke(context, this, name);
+        }
         return getMetaClass().finvoke(context, this, name, block);
     }
     @JRubyMethod(name = "__send__", omit = true)
     public IRubyObject send(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Block block) {
         String name = RubySymbol.objectToSymbolString(arg0);
-
+        if (block == Block.NULL_BLOCK) {
+            return getMetaClass().finvoke(context, this, name, arg1);
+        }
         return getMetaClass().finvoke(context, this, name, arg1, block);
     }
     @JRubyMethod(name = "__send__", omit = true)
     public IRubyObject send(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
         String name = RubySymbol.objectToSymbolString(arg0);
-
+        if (block == Block.NULL_BLOCK) {
+            return getMetaClass().finvoke(context, this, name, arg1, arg2);
+        }
         return getMetaClass().finvoke(context, this, name, arg1, arg2, block);
     }
     @JRubyMethod(name = "__send__", required = 1, rest = true, omit = true)
@@ -1740,6 +1746,9 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
 
         final int length = args.length - 1;
         args = ( length == 0 ) ? IRubyObject.NULL_ARRAY : ArraySupport.newCopy(args, 1, length);
+        if (block == Block.NULL_BLOCK) {
+            return getMetaClass().finvoke(context, this, name, args);
+        }
         return getMetaClass().finvoke(context, this, name, args, block);
     }
 


### PR DESCRIPTION
> suppose a method is implemented in block-less form in native code e.g.
```
static civil(ThreadContext context, IRubyObject self)
static civil(ThreadContext context, IRubyObject self, IRubyObject[] args)
```

> doing a `Date.civil` will properly route to `civil(context, self)`
while a `Date.send(:civil)` ends up being routed through args case

managed to hit 2 issues while implementing over-loaded native method matching, the above case is simplified, the full case (date.rb -> RubyDate.java soon to land in a PR) looks as follows : 
```java
    @JRubyMethod(name = "civil", alias = "new", meta = true)
    public static RubyDate civil(ThreadContext context, IRubyObject self) {

    }

    @JRubyMethod(name = "civil", alias = "new", meta = true)
    public static RubyDate civil(ThreadContext context, IRubyObject self, IRubyObject year) {

    }

    @JRubyMethod(name = "civil", alias = "new", meta = true)
    public static RubyDate civil(ThreadContext context, IRubyObject self, IRubyObject year, IRubyObject month) {
        return new RubyDate(context.runtime, (RubyClass) self, civilImpl(context, year, month));
    }

    @JRubyMethod(name = "civil", alias = "new", meta = true)
    public static RubyDate civil(ThreadContext context, IRubyObject self, IRubyObject year, IRubyObject month, IRubyObject mday) {

    }

    @JRubyMethod(name = "civil", alias = "new", meta = true, optional = 4) // 4 args case
    public static RubyDate civil(ThreadContext context, IRubyObject self, IRubyObject[] args) {
        // IRubyObject year, IRubyObject month, IRubyObject mday, IRubyObject start

        // TODO interpreter needs a ThreeOperandArgNoBlockCallInstr otherwise routes 3 args here
        if (args.length == 3) return civil(context, self, args[0], args[1], args[2]);
  }
```


1. as mentioned in the **TODO** above compared to JRuby 1.7.x 
   9K does no longer route the (arg1, arg2, arg3) case as before
   (so far this turned out to be non-critical as we only hit it with AR-JDBC and adjusted accordingly)
   still it was quite annoying and ugly - not sure how much time it needs to have a proper IR instr

2. case addressed here is that **`Date.send(:civil)` will not take the same path as `Date.civil`**
    due (native) `send` having the `(ThreadContext, ..., Block)` version signature implemented
    the `send(:civil)` version ends up calling `civil(context, IRubyObject self, IRubyObject[] args)`
  
... this is something I would really like to address as its even more annoying than **1.**
while I do not like the additional if+check this is the simplest change-set I can come up with
could move the check down to generated invokers (would need to generate Block forms routing block-less)
... or also implement non-block versions of `Kernel.send` and `BasicObject.__send__` not sure if that will work (the populator/binding if I recall right can not handle this) but if working that should route properly


related invoker, so far, looks like this : 
```java
    public IRubyObject call(ThreadContext var1, IRubyObject var2, RubyModule var3, String var4, IRubyObject var5) {
        return RubyDate.civil(var1, var2, var5);
    }

    public IRubyObject call(ThreadContext var1, IRubyObject var2, RubyModule var3, String var4, IRubyObject var5, IRubyObject var6) {
        return RubyDate.civil(var1, var2, var5, var6);
    }

    public IRubyObject call(ThreadContext var1, IRubyObject var2, RubyModule var3, String var4, IRubyObject var5, IRubyObject var6, IRubyObject var7) {
        return RubyDate.civil(var1, var2, var5, var6, var7);
    }

    public IRubyObject call(ThreadContext var1, IRubyObject var2, RubyModule var3, String var4) {
        return RubyDate.civil(var1, var2);
    }

    public IRubyObject call(ThreadContext var1, IRubyObject var2, RubyModule var3, String var4, IRubyObject[] var5) {
        if (var5.length > 4) {
            Arity.checkArgumentCount(var1.runtime, var5, 0, 4);
        }

        return RubyDate.civil(var1, var2, var5);
    }
```
... while `JavaMethodN` (super) routes `send()` (with a NULL_BLOCK) as : 
```java
        @Override
        public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, Block block) {
            return call(context, self, clazz, name, IRubyObject.NULL_ARRAY);
        }
```


