### PR TITLE
Better use of ThreadContext constants

### DIFF
--- a/core/src/main/java/org/jruby/AbstractRubyMethod.java
+++ b/core/src/main/java/org/jruby/AbstractRubyMethod.java
@@ -145,10 +145,10 @@ public abstract class AbstractRubyMethod extends RubyObject implements DataType 
     }
 
     protected IRubyObject super_method(ThreadContext context, IRubyObject receiver, RubyModule superClass) {
-        if (superClass == null) return context.runtime.getNil();
+        if (superClass == null) return context.nil;
 
         DynamicMethod newMethod = superClass.searchMethod(methodName);
-        if (newMethod == UndefinedMethod.INSTANCE) return context.runtime.getNil();
+        if (newMethod == UndefinedMethod.INSTANCE) return context.nil;
 
         if (receiver == null) {
             return RubyUnboundMethod.newUnboundMethod(superClass, methodName, superClass, originName, newMethod);

--- a/core/src/main/java/org/jruby/RubyArgsFile.java
+++ b/core/src/main/java/org/jruby/RubyArgsFile.java
@@ -476,7 +476,7 @@ public class RubyArgsFile extends RubyObject {
         if (!block.isGiven()) return RubyEnumerator.enumeratorize(context.runtime, recv, "each_line");
         ArgsFileData data = ArgsFileData.getArgsFileData(context.runtime);
 
-        if (!data.next_argv(context)) return context.runtime.getNil();
+        if (!data.next_argv(context)) return context.nil;
 
         if (!(data.currentFile instanceof RubyIO)) {
             if (!data.next_argv(context)) return recv;
@@ -615,7 +615,7 @@ public class RubyArgsFile extends RubyObject {
     public static IRubyObject eof(ThreadContext context, IRubyObject recv) {
         ArgsFileData data = ArgsFileData.getArgsFileData(context.runtime);
 
-        if (!data.inited) return context.runtime.getTrue();
+        if (!data.inited) return context.tru;
 
         if (!(data.currentFile instanceof RubyIO)) {
             return data.currentFile.callMethod(context, "eof");
@@ -628,7 +628,7 @@ public class RubyArgsFile extends RubyObject {
     public static IRubyObject eof_p(ThreadContext context, IRubyObject recv) {
         ArgsFileData data = ArgsFileData.getArgsFileData(context.runtime);
 
-        if (!data.inited) return context.runtime.getTrue();
+        if (!data.inited) return context.tru;
 
         if (!(data.currentFile instanceof RubyIO)) {
             return data.currentFile.callMethod(context, "eof?");
@@ -661,7 +661,7 @@ public class RubyArgsFile extends RubyObject {
         ArgsFileData data = ArgsFileData.getArgsFileData(context.runtime);
 
         while(true) {
-            if (!data.next_argv(context)) return context.runtime.getNil();
+            if (!data.next_argv(context)) return context.nil;
 
             IRubyObject bt;
             if (!(data.currentFile instanceof RubyFile)) {
@@ -743,7 +743,7 @@ public class RubyArgsFile extends RubyObject {
         ArgsFileData data = ArgsFileData.getArgsFileData(context.runtime);
 
         while(true) {
-            if (!data.next_argv(context)) return context.runtime.getNil();
+            if (!data.next_argv(context)) return context.nil;
 
             IRubyObject bt;
             if (!(data.currentFile instanceof RubyFile)) {

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -2026,13 +2026,13 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     @JRubyMethod(name = "==", required = 1)
     @Override
     public IRubyObject op_equal(ThreadContext context, IRubyObject obj) {
-        if (this == obj) return context.runtime.getTrue();
+        if (this == obj) return context.tru;
 
         if (!(obj instanceof RubyArray)) {
-            if (obj == context.nil) return context.runtime.getFalse();
+            if (obj == context.nil) return context.fals;
 
             if (!sites(context).respond_to_to_ary.respondsTo(context, obj, obj)) {
-                return context.runtime.getFalse();
+                return context.fals;
             }
             return Helpers.rbEqual(context, obj, this);
         }
@@ -2041,14 +2041,14 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     public RubyBoolean compare(ThreadContext context, CallSite site, IRubyObject other) {
         if (!(other instanceof RubyArray)) {
-            if (!sites(context).respond_to_to_ary.respondsTo(context, other, other)) return context.runtime.getFalse();
+            if (!sites(context).respond_to_to_ary.respondsTo(context, other, other)) return context.fals;
 
             return Helpers.rbEqual(context, other, this);
         }
 
         RubyArray ary = (RubyArray) other;
 
-        if (realLength != ary.realLength) return context.runtime.getFalse();
+        if (realLength != ary.realLength) return context.fals;
 
         for (int i = 0; i < realLength; i++) {
             IRubyObject a = elt(i);
@@ -2056,10 +2056,10 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
             if (a == b) continue; // matching MRI opt. mock frameworks can throw errors if we don't
 
-            if (!site.call(context, a, a, b).isTrue()) return context.runtime.getFalse();
+            if (!site.call(context, a, a, b).isTrue()) return context.fals;
         }
 
-        return context.runtime.getTrue();
+        return context.tru;
     }
 
     /** rb_ary_eql
@@ -2068,7 +2068,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     @JRubyMethod(name = "eql?", required = 1)
     public IRubyObject eql(ThreadContext context, IRubyObject obj) {
         if(!(obj instanceof RubyArray)) {
-            return context.runtime.getFalse();
+            return context.fals;
         }
         return RecursiveComparator.compare(context, sites(context).eql, this, obj);
     }
@@ -3321,7 +3321,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      */
     public IRubyObject uniq_bang(ThreadContext context) {
         RubyHash hash = makeHash();
-        if (realLength == hash.size()) return context.runtime.getNil();
+        if (realLength == hash.size()) return context.nil;
 
         // TODO: (CON) This could be a no-op for packed arrays if size does not change
         unpack();
@@ -3341,7 +3341,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
         if (!block.isGiven()) return uniq_bang(context);
         RubyHash hash = makeHash(context, block);
-        if (realLength == hash.size()) return context.runtime.getNil();
+        if (realLength == hash.size()) return context.nil;
 
         // after evaluating the block, a new modify check is needed
         modifyCheck();
@@ -3746,7 +3746,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         if (!block.isGiven()) return enumeratorizeWithSize(context, this, "cycle", new IRubyObject[] {arg}, cycleSizeFn(context));
 
         long times = RubyNumeric.num2long(arg);
-        if (times <= 0) return context.runtime.getNil();
+        if (times <= 0) return context.nil;
 
         return cycleCommon(context, times, block);
     }
@@ -3757,7 +3757,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
                 block.yield(context, eltOk(i));
             }
         }
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     private SizeFn cycleSizeFn(final ThreadContext context) {
@@ -4380,47 +4380,47 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         if (!block.isGiven()) return all_pBlockless(context);
 
         for (int i = 0; i < realLength; i++) {
-            if (!block.yield(context, eltOk(i)).isTrue()) return context.runtime.getFalse();
+            if (!block.yield(context, eltOk(i)).isTrue()) return context.fals;
         }
 
-        return context.runtime.getTrue();
+        return context.tru;
     }
 
     private IRubyObject all_pBlockless(ThreadContext context) {
         for (int i = 0; i < realLength; i++) {
-            if (!eltOk(i).isTrue()) return context.runtime.getFalse();
+            if (!eltOk(i).isTrue()) return context.fals;
         }
 
-        return context.runtime.getTrue();
+        return context.tru;
     }
 
     @JRubyMethod(name = "any?", optional = 1)
     public IRubyObject any_p(ThreadContext context, IRubyObject[] args, Block block) {
-        if (isEmpty()) return context.runtime.getFalse();
+        if (isEmpty()) return context.fals;
         if (!isBuiltin("each")) return RubyEnumerable.any_pCommon(context, this, args, block);
         boolean patternGiven = args.length > 0;
         if (!block.isGiven() || patternGiven) return any_pBlockless(context, args);
 
         for (int i = 0; i < realLength; i++) {
-            if (block.yield(context, eltOk(i)).isTrue()) return context.runtime.getTrue();
+            if (block.yield(context, eltOk(i)).isTrue()) return context.tru;
         }
 
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     private IRubyObject any_pBlockless(ThreadContext context, IRubyObject[] args) {
         IRubyObject pattern = args.length > 0 ? args[0] : null;
         if (pattern == null) {
             for (int i = 0; i < realLength; i++) {
-                if (eltOk(i).isTrue()) return context.runtime.getTrue();
+                if (eltOk(i).isTrue()) return context.tru;
             }
         } else {
             for (int i = 0; i < realLength; i++) {
-                if (pattern.callMethod(context, "===", eltOk(i)).isTrue()) return context.runtime.getTrue();
+                if (pattern.callMethod(context, "===", eltOk(i)).isTrue()) return context.tru;
             }
         }
 
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -1294,7 +1294,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     @Override
     @JRubyMethod(name = "==")
     public IRubyObject op_equal(ThreadContext context, IRubyObject obj) {
-        return this == obj ? context.runtime.getTrue() : context.runtime.getFalse();
+        return this == obj ? context.tru : context.fals;
     }
 
     @Deprecated
@@ -1995,7 +1995,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      */
     @JRubyMethod(name = "equal?", required = 1)
     public IRubyObject equal_p(ThreadContext context, IRubyObject other) {
-        return this == other ? context.runtime.getTrue() : context.runtime.getFalse();
+        return this == other ? context.tru : context.fals;
     }
 
     @Deprecated
@@ -2155,7 +2155,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
 
         port.callMethod(context, "write", this);
 
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     /** rb_obj_tainted
@@ -2253,11 +2253,11 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      */
     public RubyBoolean instance_of_p(ThreadContext context, IRubyObject type) {
         if (type() == type) {
-            return context.runtime.getTrue();
+            return context.tru;
         } else if (!(type instanceof RubyModule)) {
             throw context.runtime.newTypeError("class or module required");
         } else {
-            return context.runtime.getFalse();
+            return context.fals;
         }
     }
 
@@ -2768,7 +2768,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      * Only the object <i>nil</i> responds <code>true</code> to <code>nil?</code>.
      */
     public IRubyObject nil_p(ThreadContext context) {
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     /** rb_obj_pattern_match
@@ -2781,11 +2781,11 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      *  pattern-match semantics.
      */
     public IRubyObject op_match(ThreadContext context, IRubyObject arg) {
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     public IRubyObject op_match19(ThreadContext context, IRubyObject arg) {
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     /**
@@ -2825,9 +2825,9 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      */
     public IRubyObject instance_variable_defined_p(ThreadContext context, IRubyObject name) {
         if (variableTableContains(validateInstanceVariable(name, name.asJavaString()))) {
-            return context.runtime.getTrue();
+            return context.tru;
         }
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     /** rb_obj_ivar_get
@@ -2855,7 +2855,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         if ((value = variableTableFetch(validateInstanceVariable(name, name.asJavaString()))) != null) {
             return (IRubyObject)value;
         }
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     /** rb_obj_ivar_set

--- a/core/src/main/java/org/jruby/RubyBignum.java
+++ b/core/src/main/java/org/jruby/RubyBignum.java
@@ -999,7 +999,7 @@ public class RubyBignum extends RubyInteger {
         } else if (other instanceof RubyFloat) {
             double a = ((RubyFloat) other).getDoubleValue();
             if (Double.isNaN(a)) {
-                return context.runtime.getFalse();
+                return context.fals;
             }
             return RubyBoolean.newBoolean(context.runtime, a == big2dbl(this));
         } else {

--- a/core/src/main/java/org/jruby/RubyComparable.java
+++ b/core/src/main/java/org/jruby/RubyComparable.java
@@ -129,7 +129,7 @@ public class RubyComparable {
     private static final ThreadContext.RecursiveFunctionEx DEFAULT_INVCMP = new ThreadContext.RecursiveFunctionEx<IRubyObject>() {
         @Override
         public IRubyObject call(ThreadContext context, IRubyObject recv, IRubyObject other, boolean recur) {
-            if (recur || !sites(context).respond_to_op_cmp.respondsTo(context, other, other)) return context.runtime.getNil();
+            if (recur || !sites(context).respond_to_op_cmp.respondsTo(context, other, other)) return context.nil;
             return sites(context).op_cmp.call(context, other, other, recv);
         }
     };
@@ -154,7 +154,7 @@ public class RubyComparable {
      */
     @JRubyMethod(name = "==", required = 1)
     public static IRubyObject op_equal(ThreadContext context, IRubyObject recv, IRubyObject other) {
-        return callCmpMethod(context, recv, other, context.runtime.getFalse());
+        return callCmpMethod(context, recv, other, context.fals);
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/RubyComplex.java
+++ b/core/src/main/java/org/jruby/RubyComplex.java
@@ -769,7 +769,7 @@ public class RubyComplex extends RubyNumeric {
     @JRubyMethod(name = "real?")
     @Override
     public IRubyObject real_p(ThreadContext context) {
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     @Override
@@ -780,7 +780,7 @@ public class RubyComplex extends RubyNumeric {
      */
     // @JRubyMethod(name = "complex?")
     public IRubyObject complex_p(ThreadContext context) {
-        return context.runtime.getTrue();
+        return context.tru;
     }
 
     /** nucomp_exact_p

--- a/core/src/main/java/org/jruby/RubyContinuation.java
+++ b/core/src/main/java/org/jruby/RubyContinuation.java
@@ -109,7 +109,7 @@ public class RubyContinuation extends RubyObject {
         } catch (Continuation c) {
             if (c == continuation) {
                 if (continuation.args.length == 0) {
-                    return context.runtime.getNil();
+                    return context.nil;
                 } else if (continuation.args.length == 1) {
                     return continuation.args[0];
                 } else {

--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -757,7 +757,7 @@ public class RubyDir extends RubyObject {
 
     @JRubyMethod(name = {"path", "to_path"})
     public IRubyObject path(ThreadContext context) {
-        return path == null ? context.runtime.getNil() : path.strDup(context.runtime);
+        return path == null ? context.nil : path.strDup(context.runtime);
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -103,7 +103,7 @@ public class RubyException extends RubyObject {
             Object object = ((ConcreteJavaProxy)other).getObject();
             if (object instanceof Throwable && !(object instanceof FlowControlException)) {
                 if (recv == runtime.getException() || object instanceof java.lang.Exception) {
-                    return context.runtime.getTrue();
+                    return context.tru;
                 }
             }
         }
@@ -273,7 +273,7 @@ public class RubyException extends RubyObject {
     @Override
     @JRubyMethod(name = "==")
     public RubyBoolean op_equal(ThreadContext context, IRubyObject other) {
-        if (this == other) return context.runtime.getTrue();
+        if (this == other) return context.tru;
 
         boolean equal = context.runtime.getException().isInstance(other) &&
                 getMetaClass().getRealClass() == other.getMetaClass().getRealClass() &&

--- a/core/src/main/java/org/jruby/RubyFileStat.java
+++ b/core/src/main/java/org/jruby/RubyFileStat.java
@@ -565,6 +565,6 @@ public class RubyFileStat extends RubyObject {
             return RubyNumeric.int2fix(context.runtime,
                     (stat.mode() & (S_IRUGO | S_IWUGO | S_IXUGO) ));
         }
-        return context.runtime.getNil();
+        return context.nil;
     }
 }

--- a/core/src/main/java/org/jruby/RubyFileTest.java
+++ b/core/src/main/java/org/jruby/RubyFileTest.java
@@ -319,14 +319,14 @@ public class RubyFileTest {
     public static IRubyObject worldReadable(ThreadContext context, IRubyObject recv, IRubyObject filename) {
         RubyFileStat stat = getRubyFileStat(context, filename);
 
-        return stat == null ? context.runtime.getNil() : stat.worldReadable(context);
+        return stat == null ? context.nil : stat.worldReadable(context);
     }
 
     @JRubyMethod(name = "world_writable?", required = 1, module = true)
     public static IRubyObject worldWritable(ThreadContext context, IRubyObject recv, IRubyObject filename) {
         RubyFileStat stat = getRubyFileStat(context, filename);
 
-        return stat == null ? context.runtime.getNil() : stat.worldWritable(context);
+        return stat == null ? context.nil : stat.worldWritable(context);
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyFloat.java
+++ b/core/src/main/java/org/jruby/RubyFloat.java
@@ -491,7 +491,7 @@ public class RubyFloat extends RubyNumeric {
     @Override
     public IRubyObject op_equal(ThreadContext context, IRubyObject other) {
         if (Double.isNaN(value)) {
-            return context.runtime.getFalse();
+            return context.fals;
         }
         switch (other.getMetaClass().getClassIndex()) {
         case INTEGER:
@@ -505,7 +505,7 @@ public class RubyFloat extends RubyNumeric {
 
     public IRubyObject op_equal(ThreadContext context, double other) {
         if (Double.isNaN(value)) {
-            return context.runtime.getFalse();
+            return context.fals;
         }
         return RubyBoolean.newBoolean(context.runtime, value == other);
     }

--- a/core/src/main/java/org/jruby/RubyGC.java
+++ b/core/src/main/java/org/jruby/RubyGC.java
@@ -67,12 +67,12 @@ public class RubyGC {
 
     @JRubyMethod(module = true, visibility = PRIVATE)
     public static IRubyObject start(ThreadContext context, IRubyObject recv) {
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     @JRubyMethod
     public static IRubyObject garbage_collect(ThreadContext context, IRubyObject recv) {
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     @JRubyMethod(module = true, visibility = PRIVATE)

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1160,7 +1160,7 @@ public class RubyHash extends RubyObject implements Map {
     @JRubyMethod(name = "<", required = 1)
     public IRubyObject op_lt(ThreadContext context, IRubyObject other) {
         final RubyHash otherHash = ((RubyBasicObject) other).convertToHash();
-        if (size() >= otherHash.size()) return context.runtime.getFalse();
+        if (size() >= otherHash.size()) return context.fals;
 
         return RubyBoolean.newBoolean(context.runtime, hash_le(otherHash));
     }
@@ -1168,7 +1168,7 @@ public class RubyHash extends RubyObject implements Map {
     @JRubyMethod(name = "<=", required = 1)
     public IRubyObject op_le(ThreadContext context, IRubyObject other) {
         final RubyHash otherHash = other.convertToHash();
-        if (size() > otherHash.size()) return context.runtime.getFalse();
+        if (size() > otherHash.size()) return context.fals;
 
         return RubyBoolean.newBoolean(context.runtime, hash_le(otherHash));
     }
@@ -1524,7 +1524,7 @@ public class RubyHash extends RubyObject implements Map {
 
     @JRubyMethod(name = "select!")
     public IRubyObject select_bang(final ThreadContext context, final Block block) {
-        if (block.isGiven()) return keep_ifCommon(context, block) ? this : context.runtime.getNil();
+        if (block.isGiven()) return keep_ifCommon(context, block) ? this : context.nil;
 
         return enumeratorizeWithSize(context, this, "select!", enumSizeFn());
     }
@@ -1579,7 +1579,7 @@ public class RubyHash extends RubyObject implements Map {
     @JRubyMethod
     public IRubyObject key(ThreadContext context, IRubyObject expected) {
         IRubyObject key = internalIndex(context, expected);
-        return key != null ? key : context.runtime.getNil();
+        return key != null ? key : context.nil;
     }
 
     private IRubyObject internalIndex(final ThreadContext context, final IRubyObject expected) {
@@ -2085,9 +2085,9 @@ public class RubyHash extends RubyObject implements Map {
         IRubyObject pattern = args.length > 0 ? args[0] : null;
         boolean patternGiven = pattern != null;
 
-        if (isEmpty()) return context.runtime.getFalse();
+        if (isEmpty()) return context.fals;
 
-        if (!block.isGiven() && !patternGiven) return context.runtime.getTrue();
+        if (!block.isGiven() && !patternGiven) return context.tru;
         if (patternGiven) return any_p_p(context, pattern);
 
         if (block.getSignature().arityValue() > 1) {
@@ -2102,9 +2102,9 @@ public class RubyHash extends RubyObject implements Map {
             for (RubyHashEntry entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
                 IRubyObject newAssoc = RubyArray.newArray(context.runtime, entry.key, entry.value);
                 if (block.yield(context, newAssoc).isTrue())
-                    return context.runtime.getTrue();
+                    return context.tru;
             }
-            return context.runtime.getFalse();
+            return context.fals;
         } finally {
             iteratorExit();
         }
@@ -2115,9 +2115,9 @@ public class RubyHash extends RubyObject implements Map {
         try {
             for (RubyHashEntry entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
                 if (block.yieldArray(context, context.runtime.newArray(entry.key, entry.value), null).isTrue())
-                    return context.runtime.getTrue();
+                    return context.tru;
             }
-            return context.runtime.getFalse();
+            return context.fals;
         } finally {
             iteratorExit();
         }

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1059,7 +1059,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         if (openFile.encs.enc2 != null) return encodingService.getEncoding(openFile.encs.enc2);
 
         if (openFile.isWritable()) {
-            return openFile.encs.enc == null ? context.runtime.getNil() : encodingService.getEncoding(openFile.encs.enc);
+            return openFile.encs.enc == null ? context.nil : encodingService.getEncoding(openFile.encs.enc);
         }
 
         return encodingService.getEncoding(getReadEncoding());
@@ -1564,7 +1564,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         OpenFile myOpenFile = getOpenFileChecked();
 
         if (myOpenFile.getProcess() == null) {
-            return context.runtime.getNil();
+            return context.nil;
         }
 
         // Of course this isn't particularly useful.
@@ -2436,7 +2436,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         if (args.length == 2) {
             arg = args[1];
         } else {
-            arg = context.runtime.getNil();
+            arg = context.nil;
         }
 
         return ctl(context, cmd, arg);

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -629,12 +629,12 @@ public class RubyKernel {
 
     @JRubyMethod(name = "respond_to_missing?", visibility = PRIVATE)
     public static IRubyObject respond_to_missing_p(ThreadContext context, IRubyObject recv, IRubyObject symbol) {
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     @JRubyMethod(name = "respond_to_missing?", visibility = PRIVATE)
     public static IRubyObject respond_to_missing_p(ThreadContext context, IRubyObject recv, IRubyObject symbol, IRubyObject isPrivate) {
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     /** Returns value of $_.

--- a/core/src/main/java/org/jruby/RubyMethod.java
+++ b/core/src/main/java/org/jruby/RubyMethod.java
@@ -326,7 +326,7 @@ public class RubyMethod extends AbstractRubyMethod {
             return runtime.newArray(runtime.newString(filename), runtime.newFixnum(getLine()));
         }
 
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     public String getFilename() {

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1176,11 +1176,11 @@ public class RubyModule extends RubyObject {
         // See if module is in chain...Cannot match against itself so start at superClass.
         for (RubyModule p = getSuperClass(); p != null; p = p.getSuperClass()) {
             if (p.isSame(moduleToCompare)) {
-                return context.runtime.getTrue();
+                return context.tru;
             }
         }
 
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     @JRubyMethod(name = "singleton_class?")
@@ -2276,7 +2276,7 @@ public class RubyModule extends RubyObject {
     @JRubyMethod(name = "==", required = 1)
     @Override
     public IRubyObject op_equal(ThreadContext context, IRubyObject other) {
-        if(!(other instanceof RubyModule)) return context.runtime.getFalse();
+        if(!(other instanceof RubyModule)) return context.fals;
 
         RubyModule otherModule = (RubyModule) other;
         if(otherModule.isIncluded()) {
@@ -2678,12 +2678,12 @@ public class RubyModule extends RubyObject {
 
     @JRubyMethod(name = "included", required = 1, visibility = PRIVATE)
     public IRubyObject included(ThreadContext context, IRubyObject other) {
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     @JRubyMethod(name = "extended", required = 1, visibility = PRIVATE)
     public IRubyObject extended(ThreadContext context, IRubyObject other, Block block) {
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     @JRubyMethod(name = "mix", visibility = PRIVATE)
@@ -2823,22 +2823,22 @@ public class RubyModule extends RubyObject {
 
     @JRubyMethod(name = "method_added", required = 1, visibility = PRIVATE)
     public IRubyObject method_added(ThreadContext context, IRubyObject nothing) {
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     @JRubyMethod(name = "method_removed", required = 1, visibility = PRIVATE)
     public IRubyObject method_removed(ThreadContext context, IRubyObject nothing) {
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     @JRubyMethod(name = "method_undefined", required = 1, visibility = PRIVATE)
     public IRubyObject method_undefined(ThreadContext context, IRubyObject nothing) {
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     @JRubyMethod(name = "method_defined?", required = 1)
     public RubyBoolean method_defined_p(ThreadContext context, IRubyObject symbol) {
-        return isMethodBound(symbol.asJavaString(), true) ? context.runtime.getTrue() : context.runtime.getFalse();
+        return isMethodBound(symbol.asJavaString(), true) ? context.tru : context.fals;
     }
 
     @JRubyMethod(name = "public_method_defined?", required = 1)
@@ -3163,11 +3163,11 @@ public class RubyModule extends RubyObject {
         RubyModule module = this;
         do {
             if (module.hasClassVariable(internedName)) {
-                return context.runtime.getTrue();
+                return context.tru;
             }
         } while ((module = module.getSuperClass()) != null);
 
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     /** rb_mod_cvar_get
@@ -3376,7 +3376,7 @@ public class RubyModule extends RubyObject {
             removeAutoload(name);
             // FIXME: I'm not sure this is right, but the old code returned
             // the undef, which definitely isn't right...
-            return context.runtime.getNil();
+            return context.nil;
         }
 
         if (hasConstantInHierarchy(name)) {

--- a/core/src/main/java/org/jruby/RubyNil.java
+++ b/core/src/main/java/org/jruby/RubyNil.java
@@ -181,7 +181,7 @@ public class RubyNil extends RubyObject implements Constantizable {
      */
     @JRubyMethod(name = "&", required = 1)
     public static RubyBoolean op_and(ThreadContext context, IRubyObject recv, IRubyObject obj) {
-        return context.runtime.getFalse();
+        return context.fals;
     }
     
     /** nil_or

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -720,8 +720,8 @@ public class RubyNumeric extends RubyObject {
      */
     @JRubyMethod(name = "eql?")
     public IRubyObject eql_p(ThreadContext context, IRubyObject other) {
-        if (getClass() != other.getClass()) return context.runtime.getFalse();
-        return equalInternal(context, this, other) ? context.runtime.getTrue() : context.runtime.getFalse();
+        if (getClass() != other.getClass()) return context.fals;
+        return equalInternal(context, this, other) ? context.tru : context.fals;
     }
 
     /** num_quo
@@ -1225,7 +1225,7 @@ public class RubyNumeric extends RubyObject {
      */
     protected final IRubyObject op_num_equal(ThreadContext context, IRubyObject other) {
         // it won't hurt fixnums
-        if (this == other)  return context.runtime.getTrue();
+        if (this == other)  return context.tru;
 
         return numFuncall(context, other, sites(context).op_equals, this);
     }
@@ -1396,12 +1396,12 @@ public class RubyNumeric extends RubyObject {
 
     @JRubyMethod(name = "finite?")
     public IRubyObject finite_p(ThreadContext context) {
-        return context.runtime.getTrue();
+        return context.tru;
     }
 
     @JRubyMethod(name = "infinite?")
     public IRubyObject infinite_p(ThreadContext context) {
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     @JRubyMethod(name = "clone", required = 0, optional = 1)

--- a/core/src/main/java/org/jruby/RubyRandom.java
+++ b/core/src/main/java/org/jruby/RubyRandom.java
@@ -619,7 +619,7 @@ public class RubyRandom extends RubyObject {
     @JRubyMethod(name = "==", required = 1)
     public IRubyObject op_equal(ThreadContext context, IRubyObject obj) {
         if (!getType().equals(obj.getType())) {
-            return context.runtime.getFalse();
+            return context.fals;
         }
         return context.runtime.newBoolean(random.equals(((RubyRandom) obj).random));
     }

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -383,8 +383,8 @@ public class RubyRange extends RubyObject {
     }
 
     private IRubyObject equalityInner(ThreadContext context, IRubyObject other, MethodNames equalityCheck) {
-        if (this == other) return context.runtime.getTrue();
-        if (!(other instanceof RubyRange)) return context.runtime.getFalse();
+        if (this == other) return context.tru;
+        if (!(other instanceof RubyRange)) return context.fals;
 
         RubyRange otherRange = (RubyRange) other;
 
@@ -435,7 +435,7 @@ public class RubyRange extends RubyObject {
         if (result.isNil()) {
             return null;
         }
-        return RubyComparable.cmpint(context, result, a, b) < 0 ? context.runtime.getTrue() : null;
+        return RubyComparable.cmpint(context, result, a, b) < 0 ? context.tru : null;
     }
 
     private static IRubyObject rangeLe(ThreadContext context, IRubyObject a, IRubyObject b) {
@@ -447,7 +447,7 @@ public class RubyRange extends RubyObject {
         if (c == 0) {
             return RubyFixnum.zero(context.runtime);
         }
-        return c < 0 ? context.runtime.getTrue() : null;
+        return c < 0 ? context.tru : null;
     }
 
     private void rangeEach(ThreadContext context, RangeCallBack callback) {
@@ -747,7 +747,7 @@ public class RubyRange extends RubyObject {
     @JRubyMethod(name = "cover?")
     public RubyBoolean cover_p(ThreadContext context, IRubyObject obj) {
         if (rangeLe(context, begin, obj) == null) {
-            return context.runtime.getFalse(); // obj < start...end
+            return context.fals; // obj < start...end
         }
         return context.runtime.newBoolean(isExclusive
                 ? // begin <= obj < end || begin <= obj <= end

--- a/core/src/main/java/org/jruby/RubyRegexp.java
+++ b/core/src/main/java/org/jruby/RubyRegexp.java
@@ -1033,10 +1033,10 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
     @Override
     public IRubyObject op_equal(ThreadContext context, IRubyObject other) {
         if (this == other) {
-            return context.runtime.getTrue();
+            return context.tru;
         }
         if (!(other instanceof RubyRegexp)) {
-            return context.runtime.getFalse();
+            return context.fals;
         }
         RubyRegexp otherRegex = (RubyRegexp) other;
 

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1638,7 +1638,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         IRubyObject[] args = new IRubyObject[] {runtime.newSymbol("fold")};
         RubyString downcasedString = this.downcase(context, args);
         RubyString otherDowncasedString = otherStr.downcase(context, args);
-        return downcasedString.equals(otherDowncasedString) ? runtime.getTrue() : runtime.getFalse();
+        return downcasedString.equals(otherDowncasedString) ? context.tru : context.fals;
     }
 
     /** rb_str_match
@@ -2483,7 +2483,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
      */
     @JRubyMethod(name = "empty?")
     public RubyBoolean empty_p(ThreadContext context) {
-        return isEmpty() ? context.runtime.getTrue() : context.runtime.getFalse();
+        return isEmpty() ? context.tru : context.fals;
     }
 
     public boolean isEmpty() {
@@ -4313,20 +4313,20 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
 
     @JRubyMethod(name = "end_with?")
     public IRubyObject end_with_p(ThreadContext context) {
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     @JRubyMethod(name = "end_with?")
     public IRubyObject end_with_p(ThreadContext context, IRubyObject arg) {
-        return end_with_pCommon(arg) ? context.runtime.getTrue() : context.runtime.getFalse();
+        return end_with_pCommon(arg) ? context.tru : context.fals;
     }
 
     @JRubyMethod(name = "end_with?", rest = true)
     public IRubyObject end_with_p(ThreadContext context, IRubyObject[]args) {
         for (int i = 0; i < args.length; i++) {
-            if (end_with_pCommon(args[i])) return context.runtime.getTrue();
+            if (end_with_pCommon(args[i])) return context.tru;
         }
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     // MRI: rb_str_end_with, loop body

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -766,7 +766,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     @JRubyMethod(name = "pending_interrupt?", optional = 1)
     public IRubyObject pending_interrupt_p(ThreadContext context, IRubyObject[] args) {
         if (pendingInterruptQueue.isEmpty()) {
-            return context.runtime.getFalse();
+            return context.fals;
         } else {
             if (args.length == 1) {
                 IRubyObject err = args[0];
@@ -774,12 +774,12 @@ public class RubyThread extends RubyObject implements ExecutionContext {
                     throw context.runtime.newTypeError("class or module required for rescue clause");
                 }
                 if (pendingInterruptInclude(err)) {
-                    return context.runtime.getTrue();
+                    return context.tru;
                 } else {
-                    return context.runtime.getFalse();
+                    return context.fals;
                 }
             } else {
-                return context.runtime.getTrue();
+                return context.tru;
             }
         }
     }

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -614,7 +614,7 @@ public class RubyTime extends RubyObject {
             return context.runtime.newBoolean(cmp((RubyTime) other) == 0);
         }
         if (other == context.nil) {
-            return context.runtime.getFalse();
+            return context.fals;
         }
 
         return RubyComparable.op_equal(context, this, other);
@@ -763,7 +763,7 @@ public class RubyTime extends RubyObject {
             return context.runtime.newBoolean(RubyNumeric.fix2int(invokedynamic(context, this, OP_CMP, other)) == 0);
         }
 
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     @JRubyMethod(name = "<=>", required = 1)

--- a/core/src/main/java/org/jruby/ast/util/ArgsUtil.java
+++ b/core/src/main/java/org/jruby/ast/util/ArgsUtil.java
@@ -119,7 +119,7 @@ public final class ArgsUtil {
             if (options.containsKey(keySym)) {
                 ret[index] = options.fastARef(keySym);
             } else {
-                ret[index] = context.runtime.getNil();
+                ret[index] = context.nil;
             }
             index++;
             validKeySet.add(keySym);

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -1316,12 +1316,12 @@ public class RubyBigDecimal extends RubyNumeric {
             IRubyObject cmp = callCoerced(context, sites(context).op_cmp, arg, false);
             if ( cmp.isNil() ) { // arg.coerce failed
                 if (op == '*') return context.nil;
-                if (op == '=' || isNaN()) return context.runtime.getFalse();
+                if (op == '=' || isNaN()) return context.fals;
                 throw context.runtime.newArgumentError("comparison of BigDecimal with "+ errMessageType(context, arg) +" failed");
             }
             e = RubyNumeric.fix2int(cmp);
         } else {
-            if (isNaN() || rb.isNaN()) return (op == '*') ? context.nil : context.runtime.getFalse();
+            if (isNaN() || rb.isNaN()) return (op == '*') ? context.nil : context.fals;
 
             e = infinitySign != 0 || rb.infinitySign != 0 ? infinitySign - rb.infinitySign : value.compareTo(rb.value);
         }

--- a/core/src/main/java/org/jruby/ext/digest/RubyDigest.java
+++ b/core/src/main/java/org/jruby/ext/digest/RubyDigest.java
@@ -286,7 +286,7 @@ public class RubyDigest {
         /* instance methods that may be overridden */
         @JRubyMethod(name = "==", required = 1)
         public static IRubyObject op_equal(ThreadContext context, IRubyObject self, IRubyObject oth) {
-            if(oth.isNil()) return context.runtime.getFalse();
+            if(oth.isNil()) return context.fals;
 
             RubyString str1, str2;
             RubyModule instance = (RubyModule)context.runtime.getModule("Digest").getConstantAt("Instance");
@@ -298,7 +298,7 @@ public class RubyDigest {
                 str2 = oth.convertToString();
             }
             boolean ret = str1.bytesize().eql(str2.bytesize()) && (str1.eql(str2));
-            return ret ? context.runtime.getTrue() : context.runtime.getFalse();
+            return ret ? context.tru : context.fals;
         }
 
         @JRubyMethod()

--- a/core/src/main/java/org/jruby/ext/ffi/AutoPointer.java
+++ b/core/src/main/java/org/jruby/ext/ffi/AutoPointer.java
@@ -157,7 +157,7 @@ public class AutoPointer extends Pointer {
         reaper = null;
         referent = null;
 
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     @JRubyMethod(name = "autorelease=")
@@ -170,7 +170,7 @@ public class AutoPointer extends Pointer {
 
         r.autorelease(autorelease.isTrue());
 
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     @JRubyMethod(name = "autorelease?")

--- a/core/src/main/java/org/jruby/ext/ffi/CallbackInfo.java
+++ b/core/src/main/java/org/jruby/ext/ffi/CallbackInfo.java
@@ -143,7 +143,7 @@ public class CallbackInfo extends Type {
             return new CallbackInfo(context.runtime, (RubyClass) klass,
                     (Type) returnType, nativeParamTypes, stdcall);
         } catch (UnsatisfiedLinkError ex) {
-            return context.runtime.getNil();
+            return context.nil;
         }
     }
     

--- a/core/src/main/java/org/jruby/ext/ffi/Enum.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Enum.java
@@ -162,14 +162,14 @@ public final class Enum extends RubyObject {
     public final IRubyObject find(ThreadContext context, IRubyObject query) {
         if (query instanceof RubySymbol) {
             IRubyObject value = kv_map.fastARef(query);
-            return value != null ? value : context.runtime.getNil();
+            return value != null ? value : context.nil;
 
         } else if (query instanceof RubyInteger) {
             RubySymbol symbol = valueToSymbol.get((Long)((RubyInteger) query).getLongValue());
-            return symbol != null ? symbol : context.runtime.getNil();
+            return symbol != null ? symbol : context.nil;
 
         } else {
-            return context.runtime.getNil();
+            return context.nil;
         }
     }
 
@@ -229,6 +229,6 @@ public final class Enum extends RubyObject {
 
     @JRubyMethod(name = "reference_required?")
     public IRubyObject reference_required_p(ThreadContext context) {
-        return context.runtime.getFalse();
+        return context.fals;
     }
 }

--- a/core/src/main/java/org/jruby/ext/ffi/Enums.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Enums.java
@@ -121,7 +121,7 @@ public final class Enums extends RubyObject {
                 return item;
             }
         }
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     @JRubyMethod(name = "__map_symbol")

--- a/core/src/main/java/org/jruby/ext/ffi/MappedType.java
+++ b/core/src/main/java/org/jruby/ext/ffi/MappedType.java
@@ -117,10 +117,10 @@ public final class MappedType extends Type {
     }
 
     public final IRubyObject fromNative(ThreadContext context, IRubyObject value) {
-        return fromNativeCallSite.call(context, this, converter, value, context.runtime.getNil());
+        return fromNativeCallSite.call(context, this, converter, value, context.nil);
     }
 
     public final IRubyObject toNative(ThreadContext context, IRubyObject value) {
-        return toNativeCallSite.call(context, this, converter, value, context.runtime.getNil());
+        return toNativeCallSite.call(context, this, converter, value, context.nil);
     }
 }

--- a/core/src/main/java/org/jruby/ext/ffi/MemoryPointer.java
+++ b/core/src/main/java/org/jruby/ext/ffi/MemoryPointer.java
@@ -135,13 +135,13 @@ public class MemoryPointer extends Pointer {
         ((AllocatedDirectMemoryIO) getMemoryIO()).free();
         // Replace memory object with one that throws an exception on any access
         setMemoryIO(new FreedMemoryIO(context.runtime));
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     @JRubyMethod(name = "autorelease=", required = 1)
     public final IRubyObject autorelease(ThreadContext context, IRubyObject release) {
         ((AllocatedDirectMemoryIO) getMemoryIO()).setAutoRelease(release.isTrue());
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     @JRubyMethod(name = "autorelease?")

--- a/core/src/main/java/org/jruby/ext/ffi/StructByReference.java
+++ b/core/src/main/java/org/jruby/ext/ffi/StructByReference.java
@@ -108,7 +108,7 @@ public final class StructByReference extends RubyObject {
 
     @JRubyMethod(name = "reference_required?")
     public IRubyObject reference_required_p(ThreadContext context) {
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     public final StructLayout getStructLayout() {

--- a/core/src/main/java/org/jruby/ext/ffi/StructLayout.java
+++ b/core/src/main/java/org/jruby/ext/ffi/StructLayout.java
@@ -1187,7 +1187,7 @@ public final class StructLayout extends Type {
         public IRubyObject get(ThreadContext context, StructLayout.Storage cache, Member m, AbstractMemory ptr) {
             MemoryIO io = ptr.getMemoryIO().getMemoryIO(m.getOffset(ptr));
             if (io == null || io.isNull()) {
-                return context.runtime.getNil();
+                return context.nil;
             }
 
             return RubyString.newStringNoCopy(context.runtime, io.getZeroTerminatedByteArray(0));

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/DataConverters.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/DataConverters.java
@@ -222,7 +222,7 @@ public class DataConverters {
             }
             Pointer ptr = (Pointer) obj;
             if (ptr.getAddress() == 0) {
-                return context.runtime.getNil();
+                return context.nil;
             }
             return new org.jruby.ext.ffi.jffi.Function(context.runtime,
                     context.runtime.getModule("FFI").getClass("Function"),

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/DefaultMethodFactory.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/DefaultMethodFactory.java
@@ -260,7 +260,7 @@ public final class DefaultMethodFactory extends MethodFactory {
         public static final FunctionInvoker INSTANCE = new VoidInvoker();
         public final IRubyObject invoke(ThreadContext context, Function function, HeapInvocationBuffer args) {
             invoker.invokeInt(function, args);
-            return context.runtime.getNil();
+            return context.nil;
         }
     }
 

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/DynamicLibrary.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/DynamicLibrary.java
@@ -77,7 +77,7 @@ public class DynamicLibrary extends RubyObject {
         final String sym = symbolName.toString();
         final long address = library.getSymbolAddress(sym);
         if (address == 0L) {
-            return context.runtime.getNil();
+            return context.nil;
         }
 
         return new Symbol(context.runtime, this, sym, new DataSymbolMemoryIO(context.runtime, this, address));
@@ -88,14 +88,14 @@ public class DynamicLibrary extends RubyObject {
         final String sym = symbolName.toString();
         final long address = library.getSymbolAddress(sym);
         if (address == 0L) {
-            return context.runtime.getNil();
+            return context.nil;
         }
         return new Symbol(context.runtime, this, sym,
                 new TextSymbolMemoryIO(context.runtime, this, address));
     }
     @JRubyMethod(name = "name")
     public IRubyObject name(ThreadContext context) {
-        return name != null ? RubyString.newString(context.runtime, name) : context.runtime.getNil();
+        return name != null ? RubyString.newString(context.runtime, name) : context.nil;
     }
     public static final class Symbol extends Pointer {
         private final DynamicLibrary library;

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/Function.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/Function.java
@@ -146,7 +146,7 @@ public final class Function extends org.jruby.ext.ffi.AbstractInvoker {
         
         // Replace memory object with one that throws an exception on any access
         setMemoryIO(new FreedMemoryIO(context.runtime));
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     @JRubyMethod(name = "autorelease=", required = 1)
@@ -155,7 +155,7 @@ public final class Function extends org.jruby.ext.ffi.AbstractInvoker {
             ((AllocatedDirectMemoryIO) getMemoryIO()).setAutoRelease(autorelease = release.isTrue());
         }
 
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     @JRubyMethod(name = { "autorelease?", "autorelease" })

--- a/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
+++ b/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
@@ -241,7 +241,7 @@ public class RubyPathname extends RubyObject {
         if (other instanceof RubyPathname) {
             return Helpers.rbEqual(context, getPath(), ((RubyPathname) other).getPath());
         } else {
-            return context.runtime.getFalse();
+            return context.fals;
         }
     }
 

--- a/core/src/main/java/org/jruby/ext/ripper/RipperParserBase.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperParserBase.java
@@ -152,7 +152,7 @@ public class RipperParserBase {
     }
 
     public IRubyObject escape(IRubyObject arg) {
-        return arg == null ? context.runtime.getNil() : arg;
+        return arg == null ? context.nil : arg;
     }
     
     public IRubyObject formal_argument(IRubyObject identifier) {

--- a/core/src/main/java/org/jruby/ext/ripper/RubyRipper.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RubyRipper.java
@@ -288,14 +288,14 @@ public class RubyRipper extends RubyObject {
         filename = filenameAsString(context, file).dup();
         parser = new RipperParser(context, this, source(context, src, filename.asJavaString(), lineAsInt(context, line)));
          
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     @JRubyMethod
     public IRubyObject column(ThreadContext context) {
         if (!parser.hasStarted()) throw context.runtime.newArgumentError("method called for uninitialized object");
             
-        if (!parseStarted) return context.runtime.getNil();
+        if (!parseStarted) return context.nil;
         
         return context.runtime.newFixnum(parser.getColumn());
     }
@@ -346,7 +346,7 @@ public class RubyRipper extends RubyObject {
         } catch (SyntaxException e) {
             
         }
-        return context.runtime.getNil();
+        return context.nil;
     }    
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -860,7 +860,7 @@ public class RubySet extends RubyObject implements Set {
     @Override
     @JRubyMethod(name = "==")
     public IRubyObject op_equal(ThreadContext context, IRubyObject other) {
-        if ( this == other ) return context.runtime.getTrue();
+        if ( this == other ) return context.tru;
         if ( getMetaClass().isInstance(other) ) {
             return this.hash.op_equal(context, ((RubySet) other).hash); // @hash == ...
         }
@@ -868,12 +868,12 @@ public class RubySet extends RubyObject implements Set {
             RubySet that = (RubySet) other;
             if ( this.size() == that.size() ) { // && includes all of our elements :
                 for ( IRubyObject obj : elementsOrdered() ) {
-                    if ( ! that.containsImpl(obj) ) return context.runtime.getFalse();
+                    if ( ! that.containsImpl(obj) ) return context.fals;
                 }
-                return context.runtime.getTrue();
+                return context.tru;
             }
         }
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     @JRubyMethod(name = "reset")
@@ -887,7 +887,7 @@ public class RubySet extends RubyObject implements Set {
         if ( other instanceof RubySet ) {
             return this.hash.op_eql(context, ((RubySet) other).hash);
         }
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
+++ b/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
@@ -467,7 +467,7 @@ public class Addrinfo extends RubyObject {
         if (getAddressFamily() == AF_INET) {
             return context.runtime.newBoolean(getInet4Address().isMulticastAddress());
         }
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     @JRubyMethod(name = "ipv6_unspecified?")
@@ -475,7 +475,7 @@ public class Addrinfo extends RubyObject {
         if (getAddressFamily() == AF_INET6) {
             return context.runtime.newBoolean(getInet6Address().getHostAddress().equals("::"));
         }
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     @JRubyMethod(name = "ipv6_loopback?")
@@ -491,7 +491,7 @@ public class Addrinfo extends RubyObject {
         if (getAddressFamily() == AF_INET6) {
             return context.runtime.newBoolean(getInet6Address().isMulticastAddress());
         }
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     @JRubyMethod(name = "ipv6_linklocal?")

--- a/core/src/main/java/org/jruby/ext/socket/RubyServerSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyServerSocket.java
@@ -131,7 +131,7 @@ public class RubyServerSocket extends RubySocket {
 
     @JRubyMethod()
     public IRubyObject accept_nonblock(ThreadContext context, IRubyObject opts) {
-        return doAcceptNonblock(this, context, ArgsUtil.extractKeywordArg(context, "exception", opts) != context.runtime.getFalse());
+        return doAcceptNonblock(this, context, ArgsUtil.extractKeywordArg(context, "exception", opts) != context.fals);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ext/socket/RubySocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubySocket.java
@@ -712,7 +712,7 @@ public class RubySocket extends RubyBasicSocket {
 
     @Override
     public RubyBoolean closed_p(ThreadContext context) {
-        if (getOpenFile() == null) return context.runtime.getFalse();
+        if (getOpenFile() == null) return context.fals;
 
         return super.closed_p(context);
     }

--- a/core/src/main/java/org/jruby/ext/stringio/StringIO.java
+++ b/core/src/main/java/org/jruby/ext/stringio/StringIO.java
@@ -252,7 +252,7 @@ public class StringIO extends RubyObject implements EncodingCapable {
 
     @JRubyMethod(name = {"isatty", "tty?"})
     public IRubyObject strioFalse(ThreadContext context) {
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     @JRubyMethod(name = {"pid", "fileno"})
@@ -471,7 +471,7 @@ public class StringIO extends RubyObject implements EncodingCapable {
     public IRubyObject getc(ThreadContext context) {
         checkReadable();
 
-        if (isEndOfString()) return context.runtime.getNil();
+        if (isEndOfString()) return context.nil;
 
         StringIOData ptr = this.ptr;
 
@@ -489,7 +489,7 @@ public class StringIO extends RubyObject implements EncodingCapable {
     public IRubyObject getbyte(ThreadContext context) {
         checkReadable();
 
-        if (isEndOfString()) return context.runtime.getNil();
+        if (isEndOfString()) return context.nil;
 
         int c;
         StringIOData ptr = this.ptr;
@@ -1029,7 +1029,7 @@ public class StringIO extends RubyObject implements EncodingCapable {
     @JRubyMethod(name = "sync")
     public IRubyObject sync(ThreadContext context) {
         checkInitialized();
-        return context.runtime.getTrue();
+        return context.tru;
     }
 
     // only here for the fake-out class in org.jruby

--- a/core/src/main/java/org/jruby/ext/strscan/RubyStringScanner.java
+++ b/core/src/main/java/org/jruby/ext/strscan/RubyStringScanner.java
@@ -467,7 +467,7 @@ public class RubyStringScanner extends RubyObject {
     @JRubyMethod(name = "eos?")
     public RubyBoolean eos_p(ThreadContext context) {
         check();
-        return pos >= str.getByteList().getRealSize() ? context.runtime.getTrue() : context.runtime.getFalse();
+        return pos >= str.getByteList().getRealSize() ? context.tru : context.fals;
     }
 
     @JRubyMethod(name = "empty?")
@@ -482,13 +482,13 @@ public class RubyStringScanner extends RubyObject {
     @JRubyMethod(name = "rest?")
     public RubyBoolean rest_p(ThreadContext context) {
         check();
-        return pos >= str.getByteList().getRealSize() ? context.runtime.getFalse() : context.runtime.getTrue();
+        return pos >= str.getByteList().getRealSize() ? context.fals : context.tru;
     }
 
     @JRubyMethod(name = "matched?")
     public RubyBoolean matched_p(ThreadContext context) {
         check();
-        return isMatched() ? context.runtime.getTrue() : context.runtime.getFalse();
+        return isMatched() ? context.tru : context.fals;
     }
 
     @JRubyMethod(name = "matched")
@@ -547,7 +547,7 @@ public class RubyStringScanner extends RubyObject {
     public IRubyObject pre_match(ThreadContext context) {
         check();
         if (!isMatched()) {
-            return context.runtime.getNil();
+            return context.nil;
         }
         return extractRange(context.runtime, 0, lastPos + beg);
     }

--- a/core/src/main/java/org/jruby/ext/thread/Mutex.java
+++ b/core/src/main/java/org/jruby/ext/thread/Mutex.java
@@ -80,7 +80,7 @@ public class Mutex extends RubyObject {
     @JRubyMethod
     public RubyBoolean try_lock(ThreadContext context) {
         if (lock.isHeldByCurrentThread()) {
-            return context.runtime.getFalse();
+            return context.fals;
         }
         return context.runtime.newBoolean(context.getThread().tryLock(lock));
     }

--- a/core/src/main/java/org/jruby/ext/tracepoint/TracePoint.java
+++ b/core/src/main/java/org/jruby/ext/tracepoint/TracePoint.java
@@ -93,7 +93,7 @@ public class TracePoint extends RubyObject {
                 inside = true;
 
                 if (file == null) file = "(ruby)";
-                if (type == null) type = context.runtime.getFalse();
+                if (type == null) type = context.fals;
 
                 IRubyObject binding;
                 if (event == RubyEvent.THREAD_BEGIN || event == RubyEvent.THREAD_END) {

--- a/core/src/main/java/org/jruby/ir/instructions/UndefMethodInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/UndefMethodInstr.java
@@ -53,7 +53,7 @@ public class UndefMethodInstr extends OneOperandResultBaseInstr implements Fixed
         Object nameArg = getMethodName().retrieve(context, self, currScope, currDynScope, temp);
         String name = (nameArg instanceof String) ? (String) nameArg : nameArg.toString();
         module.undef(context, name);
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/operands/SValue.java
+++ b/core/src/main/java/org/jruby/ir/operands/SValue.java
@@ -77,7 +77,7 @@ public class SValue extends Operand {
     public Object retrieve(ThreadContext context, IRubyObject self, StaticScope currScope, DynamicScope currDynScope, Object[] temp) {
         Object val = array.retrieve(context, self, currScope, currDynScope, temp);
 
-        return (val instanceof RubyArray) ? val : context.runtime.getNil();
+        return (val instanceof RubyArray) ? val : context.nil;
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -439,7 +439,7 @@ public class IRRuntimeHelpers {
                 IRubyObject eqqVal = isUndefValue ? v : callSite.call(context, v, v, value);
                 if (eqqVal.isTrue()) return eqqVal;
             }
-            return context.runtime.getFalse();
+            return context.fals;
         }
         return isUndefValue ? receiver : callSite.call(context, receiver, receiver, value);
     }

--- a/core/src/main/java/org/jruby/ir/targets/Bootstrap.java
+++ b/core/src/main/java/org/jruby/ir/targets/Bootstrap.java
@@ -294,21 +294,21 @@ public class Bootstrap {
     }
 
     public static IRubyObject True(ThreadContext context, MutableCallSite site) {
-        MethodHandle constant = (MethodHandle)context.runtime.getTrue().constant();
-        if (constant == null) constant = (MethodHandle)OptoFactory.newConstantWrapper(IRubyObject.class, context.runtime.getTrue());
+        MethodHandle constant = (MethodHandle)context.tru.constant();
+        if (constant == null) constant = (MethodHandle)OptoFactory.newConstantWrapper(IRubyObject.class, context.tru);
 
         site.setTarget(constant);
 
-        return context.runtime.getTrue();
+        return context.tru;
     }
 
     public static IRubyObject False(ThreadContext context, MutableCallSite site) {
-        MethodHandle constant = (MethodHandle)context.runtime.getFalse().constant();
-        if (constant == null) constant = (MethodHandle)OptoFactory.newConstantWrapper(IRubyObject.class, context.runtime.getFalse());
+        MethodHandle constant = (MethodHandle)context.fals.constant();
+        if (constant == null) constant = (MethodHandle)OptoFactory.newConstantWrapper(IRubyObject.class, context.fals);
 
         site.setTarget(constant);
 
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     public static Ruby runtime(ThreadContext context, MutableCallSite site) {

--- a/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
@@ -309,7 +309,7 @@ public class JavaProxy extends RubyObject {
             boolean equal = getObject() == ((JavaProxy) other).getObject();
             return context.runtime.newBoolean(equal);
         }
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
@@ -311,9 +311,9 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         public IRubyObject any_p(ThreadContext context, IRubyObject[] args, Block block) {
             boolean patternGiven = args.length > 0;
 
-            if (isEmpty()) return context.runtime.getFalse();
+            if (isEmpty()) return context.fals;
 
-            if (!block.isGiven() && !patternGiven) return context.runtime.getTrue();
+            if (!block.isGiven() && !patternGiven) return context.tru;
             if (patternGiven) return any_p_p(context, args[0]);
 
             if (block.getSignature().arityValue() > 1) {

--- a/core/src/main/java/org/jruby/javasupport/JavaPackage.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaPackage.java
@@ -208,12 +208,12 @@ public class JavaPackage extends RubyModule {
     private IRubyObject respond_to(final ThreadContext context, IRubyObject mname, final boolean includePrivate) {
         String name = mname.asJavaString();
 
-        if (getMetaClass().respondsToMethod(name, !includePrivate)) return context.runtime.getTrue();
+        if (getMetaClass().respondsToMethod(name, !includePrivate)) return context.tru;
         /*
         if ( ( name = BlankSlateWrapper.handlesMethod(name) ) != null ) {
             RubyBoolean bound = checkMetaClassBoundMethod(context, name, includePrivate);
             if ( bound != null ) return bound;
-            return context.runtime.getFalse(); // un-bound (removed) method
+            return context.fals; // un-bound (removed) method
         }
         */
 
@@ -229,9 +229,9 @@ public class JavaPackage extends RubyModule {
         DynamicMethod method = getMetaClass().searchMethod(name);
         if ( ! method.isUndefined() && ! method.isNotImplemented() ) {
             if ( ! includePrivate && method.getVisibility() == PRIVATE ) {
-                return context.runtime.getFalse();
+                return context.fals;
             }
-            return context.runtime.getTrue();
+            return context.tru;
         }
         return null;
     }
@@ -249,9 +249,9 @@ public class JavaPackage extends RubyModule {
     private RubyBoolean respond_to_missing(final ThreadContext context, IRubyObject mname, final boolean includePrivate) {
         final String name = mname.asJavaString();
         if ( BlankSlateWrapper.handlesMethod(name) != null ) {
-            return context.runtime.getFalse(); // not missing!
+            return context.fals; // not missing!
         }
-        return context.runtime.getTrue();
+        return context.tru;
     }
 
     @JRubyMethod(name = "method_missing", visibility = Visibility.PRIVATE)

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyReflectionObject.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyReflectionObject.java
@@ -65,7 +65,7 @@ public class JavaProxyReflectionObject extends RubyObject {
         if ( ! ( obj instanceof JavaProxyReflectionObject ) ) {
             final Object wrappedObj = obj.dataGetStruct();
             if ( ! ( wrappedObj instanceof JavaObject ) ) {
-                return context.runtime.getFalse();
+                return context.fals;
             }
             obj = (IRubyObject) wrappedObj;
         }
@@ -80,12 +80,12 @@ public class JavaProxyReflectionObject extends RubyObject {
     @Override
     @JRubyMethod(name = "equal?")
     public RubyBoolean op_equal(final ThreadContext context, IRubyObject obj) {
-        if ( this == obj ) return context.runtime.getTrue();
+        if ( this == obj ) return context.tru;
 
         if ( ! ( obj instanceof JavaProxyReflectionObject ) ) {
             final Object wrappedObj = obj.dataGetStruct();
             if ( ! ( wrappedObj instanceof JavaObject ) ) {
-                return context.runtime.getFalse();
+                return context.fals;
             }
             obj = (IRubyObject) wrappedObj;
         }

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -711,7 +711,7 @@ public class Helpers {
             IRubyObject result = isExceptionHandled(currentException, exceptions[i], context);
             if (result.isTrue()) return result;
         }
-        return context.runtime.getFalse();
+        return context.fals;
     }
 
     public static IRubyObject isExceptionHandled(RubyException currentException, IRubyObject exception, ThreadContext context) {
@@ -802,16 +802,16 @@ public class Helpers {
         } else {
             if (throwables.length == 0) {
                 // no rescue means StandardError, which rescues Java exceptions
-                return context.runtime.getTrue();
+                return context.tru;
             } else {
                 for (int i = 0; i < throwables.length; i++) {
                     if (checkJavaException(currentThrowable, throwables[i], context)) {
-                        return context.runtime.getTrue();
+                        return context.tru;
                     }
                 }
             }
 
-            return context.runtime.getFalse();
+            return context.fals;
         }
     }
 
@@ -825,10 +825,10 @@ public class Helpers {
             return isExceptionHandled(((RaiseException) currentThrowable).getException(), throwable, context);
         } else {
             if (checkJavaException(currentThrowable, throwable, context)) {
-                return context.runtime.getTrue();
+                return context.tru;
             }
 
-            return context.runtime.getFalse();
+            return context.fals;
         }
     }
 
@@ -842,13 +842,13 @@ public class Helpers {
             return isExceptionHandled(((RaiseException)currentThrowable).getException(), throwable0, throwable1, context);
         } else {
             if (checkJavaException(currentThrowable, throwable0, context)) {
-                return context.runtime.getTrue();
+                return context.tru;
             }
             if (checkJavaException(currentThrowable, throwable1, context)) {
-                return context.runtime.getTrue();
+                return context.tru;
             }
 
-            return context.runtime.getFalse();
+            return context.fals;
         }
     }
 
@@ -862,16 +862,16 @@ public class Helpers {
             return isExceptionHandled(((RaiseException)currentThrowable).getException(), throwable0, throwable1, throwable2, context);
         } else {
             if (checkJavaException(currentThrowable, throwable0, context)) {
-                return context.runtime.getTrue();
+                return context.tru;
             }
             if (checkJavaException(currentThrowable, throwable1, context)) {
-                return context.runtime.getTrue();
+                return context.tru;
             }
             if (checkJavaException(currentThrowable, throwable2, context)) {
-                return context.runtime.getTrue();
+                return context.tru;
             }
 
-            return context.runtime.getFalse();
+            return context.fals;
         }
     }
 
@@ -902,7 +902,7 @@ public class Helpers {
     }
 
     public static void clearErrorInfo(ThreadContext context) {
-        context.setErrorInfo(context.runtime.getNil());
+        context.setErrorInfo(context.nil);
     }
 
     public static void checkSuperDisabledOrOutOfMethod(ThreadContext context) {
@@ -2227,7 +2227,7 @@ public class Helpers {
         }
 
         if (receiver.callMethod(context, "respond_to_missing?",
-            new IRubyObject[]{context.runtime.newSymbol(name), context.runtime.getFalse()}).isTrue()) {
+            new IRubyObject[]{context.runtime.newSymbol(name), context.fals}).isTrue()) {
             return definedMessage;
         }
         return null;

--- a/core/src/main/java/org/jruby/runtime/NullBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/NullBlockBody.java
@@ -21,7 +21,7 @@ public class NullBlockBody extends BlockBody {
     }
     @Override
     public IRubyObject yieldSpecific(ThreadContext context, Block block) {
-        throw context.runtime.newLocalJumpError(RubyLocalJumpError.Reason.NOREASON, context.runtime.getNil(), "yield called out of block");
+        throw context.runtime.newLocalJumpError(RubyLocalJumpError.Reason.NOREASON, context.nil, "yield called out of block");
     }
     @Override
     public IRubyObject call(ThreadContext context, Block block, IRubyObject arg0) {
@@ -29,7 +29,7 @@ public class NullBlockBody extends BlockBody {
     }
     @Override
     public IRubyObject yieldSpecific(ThreadContext context, Block block, IRubyObject arg0) {
-        throw context.runtime.newLocalJumpError(RubyLocalJumpError.Reason.NOREASON, context.runtime.getNil(), "yield called out of block");
+        throw context.runtime.newLocalJumpError(RubyLocalJumpError.Reason.NOREASON, context.nil, "yield called out of block");
     }
     @Override
     public IRubyObject call(ThreadContext context, Block block, IRubyObject arg0, IRubyObject arg1) {
@@ -37,7 +37,7 @@ public class NullBlockBody extends BlockBody {
     }
     @Override
     public IRubyObject yieldSpecific(ThreadContext context, Block block, IRubyObject arg0, IRubyObject arg1) {
-        throw context.runtime.newLocalJumpError(RubyLocalJumpError.Reason.NOREASON, context.runtime.getNil(), "yield called out of block");
+        throw context.runtime.newLocalJumpError(RubyLocalJumpError.Reason.NOREASON, context.nil, "yield called out of block");
     }
     @Override
     public IRubyObject call(ThreadContext context, Block block, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
@@ -45,7 +45,7 @@ public class NullBlockBody extends BlockBody {
     }
     @Override
     public IRubyObject yieldSpecific(ThreadContext context, Block block, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
-        throw context.runtime.newLocalJumpError(RubyLocalJumpError.Reason.NOREASON, context.runtime.getNil(), "yield called out of block");
+        throw context.runtime.newLocalJumpError(RubyLocalJumpError.Reason.NOREASON, context.nil, "yield called out of block");
     }
 
     @Override

--- a/core/src/main/java/org/jruby/specialized/RubyArrayOneObject.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArrayOneObject.java
@@ -163,7 +163,7 @@ public class RubyArrayOneObject extends RubyArraySpecialized {
 
         modifyCheck();
 
-        return context.runtime.getNil();
+        return context.nil;
     }
 
     @Override

--- a/core/src/main/java/org/jruby/util/RecursiveComparator.java
+++ b/core/src/main/java/org/jruby/util/RecursiveComparator.java
@@ -17,7 +17,7 @@ public class RecursiveComparator {
     public static <T> IRubyObject compare(ThreadContext context, T invokable, IRubyObject a, IRubyObject b) {
 
         if (a == b) {
-            return context.runtime.getTrue();
+            return context.tru;
         }
         
         boolean clear = false; // whether to clear thread-local set (at top comparison)
@@ -37,7 +37,7 @@ public class RecursiveComparator {
                     clear = true;
                 }
                 else if (seen.contains(pair)) { // are we recursing?
-                    return context.runtime.getTrue();
+                    return context.tru;
                 }
 
                 seen.add(pair);


### PR DESCRIPTION
There are two changes here:

* A global search and replace for the `context.runtime.getTrue()` for true, false, and nil and replacing them with the `context.tru` pattern.
* ~~Retyping the `tru`, `fals`, and `nil` fields on ThreadContext to be the most specific type.~~

~~The latter change is binary incompatible if any third-party libraries have started to use these fields directly. However these fields were introduced fairly recently.~~

The second change has been removed because of additional internal compatibility problems. There are many places in code generation, and likely in any AOT code in the wild, that try to access the `nil` field using `IRubyObject`.