### PR TITLE
Fix file descriptor leak in resolv.rb

### DIFF
--- a/lib/ruby/stdlib/resolv.rb
+++ b/lib/ruby/stdlib/resolv.rb
@@ -745,49 +745,74 @@ class Resolv
         def initialize(*nameserver_port)
           super()
           @nameserver_port = nameserver_port
-          @socks_hash = {}
-          @socks = []
-          nameserver_port.each {|host, port|
-            if host.index(':')
-              bind_host = "::"
-              af = Socket::AF_INET6
-            else
-              bind_host = "0.0.0.0"
-              af = Socket::AF_INET
-            end
-            next if @socks_hash[bind_host]
-            begin
-              sock = UDPSocket.new(af)
-            rescue Errno::EAFNOSUPPORT
-              next # The kernel doesn't support the address family.
-            end
-            sock.do_not_reverse_lookup = true
-            DNS.bind_random_port(sock, bind_host)
-            @socks << sock
-            @socks_hash[bind_host] = sock
+          @mutex = Thread::Mutex.new
+          @initialized = false
+        end
+
+        def lazy_initialize
+          @mutex.synchronize {
+            next if @initialized
+            @initialized = true
+            @socks_hash = {}
+            @socks = []
+            @nameserver_port.each {|host, port|
+              if host.index(':')
+                bind_host = "::"
+                af = Socket::AF_INET6
+              else
+                bind_host = "0.0.0.0"
+                af = Socket::AF_INET
+              end
+              next if @socks_hash[bind_host]
+              begin
+                sock = UDPSocket.new(af)
+              rescue Errno::EAFNOSUPPORT
+                next # The kernel doesn't support the address family.
+              end
+              @socks << sock
+              @socks_hash[bind_host] = sock
+              sock.do_not_reverse_lookup = true
+              DNS.bind_random_port(sock, bind_host)
+            }
           }
+          self
         end
 
         def recv_reply(readable_socks)
-          reply, from = readable_socks[0].recvfrom(UDPSize)
-          return reply, [IPAddr.new(from[3]),from[1]]
+          @mutex.synchronize {
+            unless @initialized
+              raise ResolvError.new("recv_reply called on uninitialized requester.")
+            end
+            reply, from = readable_socks[0].recvfrom(UDPSize)
+            return reply, [IPAddr.new(from[3]),from[1]]
+          }
         end
 
         def sender(msg, data, host, port=Port)
-          sock = @socks_hash[host.index(':') ? "::" : "0.0.0.0"]
-          return nil if !sock
-          service = [IPAddr.new(host), port]
-          id = DNS.allocate_request_id(service[0], service[1])
-          request = msg.encode
-          request[0,2] = [id].pack('n')
-          return @senders[[service, id]] =
-            Sender.new(request, data, sock, host, port)
+          @mutex.synchronize {
+            unless @initialized
+              raise ResolvError.new("sender called on uninitialized requester.")
+            end
+            sock = @socks_hash[host.index(':') ? "::" : "0.0.0.0"]
+            return nil if !sock
+            service = [IPAddr.new(host), port]
+            id = DNS.allocate_request_id(service[0], service[1])
+            request = msg.encode
+            request[0,2] = [id].pack('n')
+            return @senders[[service, id]] =
+              Sender.new(request, data, sock, host, port)
+          }
         end
 
         def close
-          super
-          @senders.each_key {|service, id|
-            DNS.free_request_id(service[0], service[1], id)
+          @mutex.synchronize {
+            if @initialized
+              super
+              @senders.each_key {|service, id|
+                DNS.free_request_id(service[0], service[1], id)
+              }
+              @initialized = false
+            end
           }
         end
 

--- a/test/mri/resolv/test_dns.rb
+++ b/test/mri/resolv/test_dns.rb
@@ -3,6 +3,8 @@ require 'test/unit'
 require 'resolv'
 require 'socket'
 require 'tempfile'
+require 'timeout'
+require 'minitest/mock'
 
 class TestResolvDNS < Test::Unit::TestCase
   def setup
@@ -220,5 +222,23 @@ class TestResolvDNS < Test::Unit::TestCase
       }
     }
     assert_operator(2**14, :<, m.to_s.length)
+  end
+
+  def test_timeout_without_leaking_file_descriptors_connected
+    socket = nil
+    bind_random_port = lambda do |udpsock, bind_host="0.0.0.0"|
+      socket = udpsock
+      sleep 3
+    end
+
+    Resolv::DNS.stub(:bind_random_port, bind_random_port) do
+      r = Resolv::DNS.new(nameserver_port: [['127.0.0.1', 53]])
+      begin
+        Timeout.timeout(0.5) { r.getname("8.8.8.8") }
+      rescue Timeout::Error
+      end
+    end
+
+    assert(socket.closed?, "file descriptor leaked")
   end
 end


### PR DESCRIPTION
There's an edge case in resolv.rb that can lead to file descriptor leaks on a highly saturated system (logstash in our case).

![file-descriptor-leak](https://user-images.githubusercontent.com/63675/36873892-3507d282-1d67-11e8-9912-3ba58a287b5b.png)

(the cliff at the end is from a restart of logstash)

We're using the logstash-filter-dns plugin which [uses timeout](https://github.com/logstash-plugins/logstash-filter-dns/blob/v3.0.7/lib/logstash/filters/dns.rb#L250-L252).

When a timeout fires while [waiting](https://github.com/jruby/jruby/blob/9.1.13.0/lib/ruby/stdlib/resolv.rb#L659-L668) for a [random](https://github.com/jruby/jruby/blob/9.1.13.0/lib/ruby/stdlib/resolv.rb#L817) [port](https://github.com/jruby/jruby/blob/9.1.13.0/lib/ruby/stdlib/resolv.rb#L764), the new object is never returned to the caller. Instead `requester` is [set to nil](https://github.com/jruby/jruby/blob/9.1.13.0/lib/ruby/stdlib/resolv.rb#L524). There's no handle to any sockets that were created in the initializer, so they can't be closed, and one ore more file descriptors is leaked.