### PR TITLE
redo date.rb (most) parts in native

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -5251,6 +5251,8 @@ public final class Ruby implements Constantizable {
     // I know of use very few of them.  Even if there are many the size of these lists are modest.
     private final Map<String, List<StrptimeToken>> strptimeFormatCache = new ConcurrentHashMap<>();
 
+    transient RubyString tzVar;
+
     @Deprecated
     private void setNetworkStack() {
         deprecatedNetworkStackProperty();

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -345,8 +345,8 @@ public class RubyHash extends RubyObject implements Map {
     { head.prevAdded = head.nextAdded = head; }
 
     public static final class RubyHashEntry implements Map.Entry {
-        private IRubyObject key;
-        private IRubyObject value;
+        IRubyObject key;
+        IRubyObject value;
         private RubyHashEntry next;
         private RubyHashEntry prevAdded;
         private RubyHashEntry nextAdded;
@@ -578,6 +578,10 @@ public class RubyHash extends RubyObject implements Map {
             }
         }
         return NO_ENTRY;
+    }
+
+    final RubyHashEntry getEntry(IRubyObject key) {
+        return internalGetEntry(key);
     }
 
     private boolean internalKeyExist(RubyHashEntry entry, int hash, IRubyObject key) {

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -179,20 +179,29 @@ public class RubyNumeric extends RubyObject {
     /** check_int
      *
      */
+    public static int checkInt(final Ruby runtime, long num){
+        if (num < Integer.MIN_VALUE) {
+            tooSmall(runtime, num);
+        } else if (num > Integer.MAX_VALUE) {
+            tooBig(runtime, num);
+        }
+        return (int) num;
+    }
+
     public static void checkInt(IRubyObject arg, long num){
         if (num < Integer.MIN_VALUE) {
-            tooSmall(arg, num);
+            tooSmall(arg.getRuntime(), num);
         } else if (num > Integer.MAX_VALUE) {
-            tooBig(arg, num);
+            tooBig(arg.getRuntime(), num);
         }
     }
 
-    private static void tooSmall(IRubyObject arg, long num) {
-        throw arg.getRuntime().newRangeError("integer " + num + " too small to convert to `int'");
+    private static void tooSmall(Ruby runtime, long num) {
+        throw runtime.newRangeError("integer " + num + " too small to convert to `int'");
     }
 
-    private static void tooBig(IRubyObject arg, long num) {
-        throw arg.getRuntime().newRangeError("integer " + num + " too big to convert to `int'");
+    private static void tooBig(Ruby runtime, long num) {
+        throw runtime.newRangeError("integer " + num + " too big to convert to `int'");
     }
 
     /**

--- a/core/src/main/java/org/jruby/ext/date/DateLibrary.java
+++ b/core/src/main/java/org/jruby/ext/date/DateLibrary.java
@@ -11,6 +11,7 @@ public class DateLibrary implements Library {
     public static void load(Ruby runtime) {
         RubyClass Date = RubyDate.createDateClass(runtime);
         RubyDateTime.createDateTimeClass(runtime, Date);
+        TimeExt.load(runtime);
     }
 
     public void load(final Ruby runtime, boolean wrap) throws IOException {

--- a/core/src/main/java/org/jruby/ext/date/DateUtils.java
+++ b/core/src/main/java/org/jruby/ext/date/DateUtils.java
@@ -104,10 +104,10 @@ abstract class DateUtils {
     static int offset_to_sec(ThreadContext context, IRubyObject of) {
         long n; IRubyObject vs;
         switch (of.getMetaClass().getClassIndex()) {
-            case FIXNUM:
-                int i = ((RubyFixnum) of).getIntValue();
+            case INTEGER:
+                long i = ((RubyInteger) of).getLongValue();
                 if (i != -1 && i != 0 && i != 1) return INVALID_OFFSET;
-	            return i * DAY_IN_SECONDS;
+	            return (int) i * DAY_IN_SECONDS;
             case FLOAT:
                 double d = ((RubyFloat) of).getDoubleValue();
 

--- a/core/src/main/java/org/jruby/ext/date/DateUtils.java
+++ b/core/src/main/java/org/jruby/ext/date/DateUtils.java
@@ -89,7 +89,7 @@ abstract class DateUtils {
      *
      * Returns the corresponding Julian Day Number.
      */
-    static long ordinal_to_jd(int y, int d, final int sg) {
+    static long ordinal_to_jd(int y, int d, final long sg) {
         return find_fdoy(y, sg) + d - 1;
     }
 
@@ -115,7 +115,7 @@ abstract class DateUtils {
      # and day of the week of the Commercial Date to convert.
      # +sg+ specifies the Day of Calendar Reform.
      */
-    static long commercial_to_jd(int y, int w, int d, final int sg) {
+    static long commercial_to_jd(int y, int w, int d, final long sg) {
         long j = find_fdoy(y, sg) + 3;
         return (j - (((j - 1) + 1) % 7)) + 7 * (w - 1) + (d - 1);
     }
@@ -129,7 +129,7 @@ abstract class DateUtils {
      # Returns the corresponding Commercial Date as
      # [commercial_year, week_of_year, day_of_week]
      */
-    static int[] jd_to_commercial(long jd, final int sg) {
+    static int[] jd_to_commercial(long jd, final long sg) {
         int a = jd_to_civil(jd - 3, sg)[0];
         final int y;
         if (jd >= commercial_to_jd(a + 1, 1, 1, sg)) {
@@ -144,12 +144,12 @@ abstract class DateUtils {
         return new int[] { y, w, d };
     }
 
-    private static long weeknum_to_jd(int y, int w, int d, int f, final int sg) {
+    private static long weeknum_to_jd(int y, int w, int d, int f, final long sg) {
         long a = find_fdoy(y, sg) + 6;
         return (a - ((a - f) + 1) % 7 - 7) + 7 * w + d;
     }
 
-    private static int[] jd_to_weeknum(long jd, int f, final int sg) {
+    private static int[] jd_to_weeknum(long jd, int f, final long sg) {
         final int y = jd_to_civil(jd, sg)[0];
         long a = find_fdoy(y, sg) + 6;
 
@@ -159,7 +159,7 @@ abstract class DateUtils {
         return new int[] { y, w, d };
     }
 
-    private static long nth_kday_to_jd(int y, int m, int n, int k, final int sg) {
+    private static long nth_kday_to_jd(int y, int m, int n, int k, final long sg) {
         final long j;
         if (n > 0) {
             j = find_fdom(y, m, sg) - 1;
@@ -170,7 +170,7 @@ abstract class DateUtils {
         return (j - (((j - k) + 1) % 7)) + 7 * n;
     }
 
-    private static int[] jd_to_nth_kday(long jd, final int sg) {
+    private static int[] jd_to_nth_kday(long jd, final long sg) {
         final int[] y_m_d = jd_to_civil(jd, sg);
         final int y = y_m_d[0];
         final int m = y_m_d[1];
@@ -271,7 +271,7 @@ abstract class DateUtils {
         return INVALID_OFFSET; // 0
     }
 
-    static Long find_ldom(int y, int m, final int sg) {
+    static Long find_ldom(int y, int m, final long sg) {
         Long j = null;
         for (int d = 31; d >= 1; d--) {
             j = _valid_civil_p(y, m, d, sg);
@@ -280,7 +280,7 @@ abstract class DateUtils {
         return j;
     }
 
-    static Long find_fdom(int y, int m, final int sg) {
+    static Long find_fdom(int y, int m, final long sg) {
         Long j = null;
         for (int d = 1; d <= 31; d++) {
             j = _valid_civil_p(y, m, d, sg);
@@ -289,7 +289,7 @@ abstract class DateUtils {
         return j;
     }
 
-    static Long find_fdoy(int y, final int sg) {
+    static Long find_fdoy(int y, final long sg) {
         Long j = null;
         for (int d = 1; d <= 31; d++) {
             j = _valid_civil_p(y, 1, d, sg);
@@ -298,7 +298,7 @@ abstract class DateUtils {
         return j;
     }
 
-    static Long find_ldoy(int y, final int sg) {
+    static Long find_ldoy(int y, final long sg) {
         Long j = null;
         for (int d = 31; d >= 1; d--) {
             j = _valid_civil_p(y, 12, d, sg);
@@ -307,7 +307,7 @@ abstract class DateUtils {
         return j;
     }
 
-    static Long _valid_civil_p(int y, int m, int d, final int sg) {
+    static Long _valid_civil_p(int y, int m, int d, final long sg) {
         if (d < 0) {
             Long j = find_ldom(y, m, sg);
             if (j == null) return null;
@@ -323,7 +323,7 @@ abstract class DateUtils {
         return jd;
     }
 
-    static Long _valid_ordinal_p(int y, int d, final int sg) {
+    static Long _valid_ordinal_p(int y, int d, final long sg) {
         if (d < 0) {
             Long j = find_ldoy(y, sg);
             if (j == null) return null;
@@ -340,7 +340,7 @@ abstract class DateUtils {
         return jd;
     }
 
-    static Long _valid_commercial_p(int y, int w, int d, final int sg) {
+    static Long _valid_commercial_p(int y, int w, int d, final long sg) {
         if (d < 0) d += 8;
 
         if (w < 0) {
@@ -356,7 +356,7 @@ abstract class DateUtils {
         return jd;
     }
 
-    static Long _valid_weeknum_p(int y, int w, int d, int f, final int sg) {
+    static Long _valid_weeknum_p(int y, int w, int d, int f, final long sg) {
         if (d < 0) d += 7;
 
         if (w < 0) {
@@ -373,7 +373,7 @@ abstract class DateUtils {
         return jd;
     }
 
-    static Long _valid_nth_kday_p(int y, int m, int n, int k, final int sg) {
+    static Long _valid_nth_kday_p(int y, int m, int n, int k, final long sg) {
         if (k < 0) k += 7;
 
         if (n < 0) {
@@ -419,8 +419,8 @@ abstract class DateUtils {
         return t.convertToInteger().getIntValue() - 4712; /* unshift */
     }
 
-    static int guess_style(ThreadContext context, IRubyObject y, double sg) { /* -/+oo or zero */
-        int style = 0;
+    static long guess_style(ThreadContext context, IRubyObject y, double sg) { /* -/+oo or zero */
+        long style = 0;
 
         if (sg == Double.POSITIVE_INFINITY) { // Double.isInfinite
             style = JULIAN;

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -100,9 +100,9 @@ public class RubyDate extends RubyObject {
         super(runtime, klass);
     }
 
-    private DateTime dt;
-    private int off; // @of
-    private int start = ITALY; // @sg
+    DateTime dt;
+    int off; // @of
+    int start = ITALY; // @sg
     private float subMillis; // @sub_millis
 
     static RubyClass createDateClass(Ruby runtime) {
@@ -396,6 +396,23 @@ public class RubyDate extends RubyObject {
         final int d = args[2].convertToInteger().getIntValue();
 
         return DateUtils._valid_civil_p(y, m, d, sg);
+    }
+
+    /**
+     # Create a new Date object representing today.
+     #
+     # +sg+ specifies the Day of Calendar Reform.
+     **/
+
+    @JRubyMethod(meta = true)
+    public static RubyDate today(ThreadContext context, IRubyObject self) { // sg=ITALY
+        return new RubyDate(context.runtime, new DateTime(CHRONO_ITALY_UTC).withTimeAtStartOfDay());
+    }
+
+    @JRubyMethod(meta = true)
+    public static RubyDate today(ThreadContext context, IRubyObject self, IRubyObject sg) {
+        final int start = val2sg(context, sg);
+        return new RubyDate(context.runtime, new DateTime(getChronology(start, 0)).withTimeAtStartOfDay(), 0, start, 0);
     }
 
     @Deprecated // NOTE: should go away once no date.rb is using it
@@ -908,7 +925,7 @@ public class RubyDate extends RubyObject {
     // def jd_to_ajd(jd, fr, of=0) jd + fr - of - Rational(1, 2) end
     private static double jd_to_ajd(long jd, int fr, int of) { return jd + fr - of - 0.5; }
 
-    private static Chronology getChronology(final int sg, final int off) {
+    static Chronology getChronology(final int sg, final int off) {
         final DateTimeZone zone;
         if (off == 0) {
             if (sg == ITALY) return CHRONO_ITALY_UTC;
@@ -932,7 +949,7 @@ public class RubyDate extends RubyObject {
     }
 
     // MRI: #define val2sg(vsg,dsg)
-    private static int val2sg(ThreadContext context, IRubyObject sg) {
+    static int val2sg(ThreadContext context, IRubyObject sg) {
         return getValidStart(context, sg.convertToFloat().getDoubleValue(), ITALY);
     }
 

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -541,6 +541,46 @@ public class RubyDate extends RubyObject {
         return RubyDate._valid_ordinal_p(context, null, args);
     }
 
+    @JRubyMethod(name = "commercial", meta = true, optional = 4)
+    public static RubyDate commercial(ThreadContext context, IRubyObject self, IRubyObject[] args) {
+        // commercial(y=-4712, w=1, d=1, sg=ITALY)
+
+        final int len = args.length;
+
+        final int sg = len > 3 ? val2sg(context, args[3]) : ITALY;
+        IRubyObject year = (len > 0) ? args[0] : RubyFixnum.newFixnum(context.runtime, -4712);
+        IRubyObject week = (len > 1) ? args[1] : RubyFixnum.newFixnum(context.runtime, 1);
+        IRubyObject day = (len > 2) ? args[2] : RubyFixnum.newFixnum(context.runtime, 1);
+
+        Long jd = validCommercialImpl(year, week, day, sg);
+        if (jd == null) {
+            throw context.runtime.newArgumentError("invalid date");
+        }
+        return new RubyDate(context, (RubyClass) self, jd_to_ajd(context, jd, 0, 0), 0, sg);
+    }
+
+    @JRubyMethod(name = "valid_commercial?", meta = true, required = 3, optional = 1)
+    public static IRubyObject valid_commercial_p(ThreadContext context, IRubyObject self, IRubyObject[] args) {
+        final int sg = args.length > 3 ? val2sg(context, args[3]) : ITALY;
+        final Long jd = validCommercialImpl(args[0], args[1], args[2], sg);
+        return jd == null ? context.fals : context.tru;
+    }
+
+    static Long validCommercialImpl(IRubyObject year, IRubyObject week, IRubyObject day, final int sg) {
+        final int y = year.convertToInteger().getIntValue();
+        int w = week.convertToInteger().getIntValue();
+        int d = day.convertToInteger().getIntValue();
+        return DateUtils._valid_commercial_p(y, w, d, sg);
+    }
+
+    @Deprecated // NOTE: should go away once no date.rb is using it
+    @JRubyMethod(name = "_valid_commercial?", meta = true, required = 3, optional = 1, visibility = Visibility.PRIVATE)
+    public static IRubyObject _valid_commercial_p(ThreadContext context, IRubyObject self, IRubyObject[] args) {
+        final int sg = args.length > 3 ? val2sg(context, args[3]) : GREGORIAN;
+        final Long jd = validCommercialImpl(args[0], args[1], args[2], sg);
+        return jd == null ? context.nil : RubyFixnum.newFixnum(context.runtime, jd);
+    }
+
     /**
      # Create a new Date object representing today.
      #

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -201,7 +201,7 @@ public class RubyDate extends RubyObject {
     }
 
     private void initialize(final ThreadContext context, IRubyObject arg, IRubyObject of, final int start) {
-        final int off = of.convertToInteger().getIntValue();
+        final int off = val2off(context, of);
 
         this.off = off; this.start = start;
 

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -460,6 +460,14 @@ public class RubyDate extends RubyObject {
         return (RubyNumeric) RubyRational.newRationalCanonicalize(context, hour * 3600 + min * 60 + sec, DAY_IN_SECONDS);
     }
 
+    @JRubyMethod(name = "_valid_jd?", meta = true, visibility = Visibility.PRIVATE)
+    public static IRubyObject _valid_jd_p(IRubyObject self, IRubyObject jd, IRubyObject sg) {
+        // Is +jd+ a valid Julian Day Number?
+        //
+        // If it is, returns it.  In fact, any value is treated as a valid Julian Day Number.
+        return jd;
+    }
+
     /**
      # Create a new Date object representing today.
      #

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -934,7 +934,10 @@ public class RubyDate extends RubyObject {
         else {
             zone = DateTimeZone.forOffsetMillis(off * 1000); // off in seconds
         }
+        return getChronology(sg, zone);
+    }
 
+    static Chronology getChronology(final int sg, final DateTimeZone zone) {
         switch (sg) {
             case ITALY:
                 return GJChronology.getInstance(zone);

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -1043,6 +1043,11 @@ public class RubyDate extends RubyObject {
         return (RubyString) RubyKernel.sprintf(context, this, args);
     }
 
+    @JRubyMethod
+    public RubyDateTime to_datetime(ThreadContext context) {
+        return new RubyDateTime(context.runtime, dt.withTimeAtStartOfDay(), off, start);
+    }
+
     // date/format.rb
 
     @JRubyMethod // def strftime(fmt='%F')

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -77,7 +77,7 @@ public class RubyDate extends RubyObject {
 
     //private static final GJChronology CHRONO_ITALY_DEFAULT_DTZ = GJChronology.getInstance(DEFAULT_DTZ);
 
-    private static final GJChronology CHRONO_ITALY_UTC = GJChronology.getInstance(DateTimeZone.UTC);
+    static final GJChronology CHRONO_ITALY_UTC = GJChronology.getInstance(DateTimeZone.UTC);
 
     // The Julian Day Number of the Day of Calendar Reform for Italy
     // and the Catholic countries.

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -123,12 +123,12 @@ public class RubyDate extends RubyObject {
         }
     };
 
-    private static RubyClass getDate(final Ruby runtime) {
+    static RubyClass getDate(final Ruby runtime) {
         return (RubyClass) runtime.getObject().getConstantAt("Date");
     }
 
-    private RubyDate(Ruby runtime) {
-        super(runtime, getDate(runtime));
+    static RubyClass getDateTime(final Ruby runtime) {
+        return (RubyClass) runtime.getObject().getConstantAt("DateTime");
     }
 
     public RubyDate(Ruby runtime, RubyClass klass, DateTime dt) {
@@ -251,6 +251,9 @@ public class RubyDate extends RubyObject {
      */
     @JRubyMethod(name = "new!", meta = true)
     public static RubyDate new_(ThreadContext context, IRubyObject self) {
+        if (self == getDateTime(context.runtime)) {
+            return new RubyDateTime(context.runtime, 0, CHRONO_ITALY_UTC);
+        }
         return new RubyDate(context.runtime, 0, CHRONO_ITALY_UTC);
     }
 
@@ -260,7 +263,13 @@ public class RubyDate extends RubyObject {
     @JRubyMethod(name = "new!", meta = true)
     public static RubyDate new_(ThreadContext context, IRubyObject self, IRubyObject ajd) {
         if (ajd instanceof JavaProxy) { // backwards - compatibility with JRuby's date.rb
+            if (self == getDateTime(context.runtime)) {
+                return new RubyDateTime(context.runtime, (DateTime) JavaUtil.unwrapJavaValue(ajd));
+            }
             return new RubyDate(context.runtime, (DateTime) JavaUtil.unwrapJavaValue(ajd));
+        }
+        if (self == getDateTime(context.runtime)) {
+            return new RubyDateTime(context, ajd, CHRONO_ITALY_UTC, ITALY);
         }
         return new RubyDate(context, ajd, CHRONO_ITALY_UTC, ITALY);
     }
@@ -270,7 +279,10 @@ public class RubyDate extends RubyObject {
      */
     @JRubyMethod(name = "new!", meta = true)
     public static RubyDate new_(ThreadContext context, IRubyObject self, IRubyObject ajd, IRubyObject of) {
-        return new RubyDate(context.runtime).initialize(context, ajd, of);
+        if (self == getDateTime(context.runtime)) {
+            return new RubyDateTime(context.runtime, (RubyClass) self).initialize(context, ajd, of);
+        }
+        return new RubyDate(context.runtime, (RubyClass) self).initialize(context, ajd, of);
     }
 
     /**
@@ -278,7 +290,10 @@ public class RubyDate extends RubyObject {
      */
     @JRubyMethod(name = "new!", meta = true)
     public static RubyDate new_(ThreadContext context, IRubyObject self, IRubyObject ajd, IRubyObject of, IRubyObject sg) {
-        return new RubyDate(context.runtime).initialize(context, ajd, of, sg);
+        if (self == getDateTime(context.runtime)) {
+            return new RubyDateTime(context.runtime, (RubyClass) self).initialize(context, ajd, of, sg);
+        }
+        return new RubyDate(context.runtime, (RubyClass) self).initialize(context, ajd, of, sg);
     }
 
     /**

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -54,6 +54,7 @@ import org.jruby.util.ByteList;
 import org.jruby.util.ConvertBytes;
 import org.jruby.util.Numeric;
 import org.jruby.util.RubyDateParser;
+import org.jruby.util.TimeZoneConverter;
 import org.jruby.util.TypeConverter;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
@@ -1612,6 +1613,13 @@ public class RubyDate extends RubyObject {
             default:
                 throw context.runtime.newArgumentError(args.length, 1);
         }
+    }
+
+    @JRubyMethod(name = "zone_to_diff", meta = true, visibility = Visibility.PRIVATE)
+    public static IRubyObject zone_to_diff(ThreadContext context, IRubyObject self, IRubyObject zone) {
+        final int offset = TimeZoneConverter.dateZoneToDiff(zone.asJavaString());
+        if (offset == TimeZoneConverter.INVALID_ZONE) return context.nil;
+        return RubyFixnum.newFixnum(context.runtime, offset);
     }
 
     @JRubyMethod(name = "i", meta = true, visibility = Visibility.PRIVATE)

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -403,7 +403,7 @@ public class RubyDate extends RubyObject {
     static DateTime civilImpl(ThreadContext context, IRubyObject year, IRubyObject month, IRubyObject mday, final long sg) {
         final int y = (sg > 0) ? getYear(year) : year.convertToInteger().getIntValue();
         final int m = getMonth(month);
-        final int[] rest = new int[] { 0, 1 };
+        final long[] rest = new long[] { 0, 1 };
         final int d = (int) getDay(context, mday, rest);
 
         DateTime dt = civilDate(context, y, m ,d, getChronology(context, sg, 0));
@@ -533,7 +533,7 @@ public class RubyDate extends RubyObject {
     }
 
     private static RubyDate jdImpl(ThreadContext context, IRubyObject self, IRubyObject jd, final long sg) {
-        final int[] rest = new int[] { 0, 1 };
+        final long[] rest = new long[] { 0, 1 };
         long jdi = getDay(context, jd, rest);
         RubyNumeric ajd = jd_to_ajd(context, jdi);
 
@@ -542,7 +542,7 @@ public class RubyDate extends RubyObject {
         return date;
     }
 
-    static DateTime adjustWithDayFraction(ThreadContext context, DateTime dt, final int[] rest) {
+    static DateTime adjustWithDayFraction(ThreadContext context, DateTime dt, final long[] rest) {
         final RubyFixnum zero = RubyFixnum.zero(context.runtime);
         int ival = getHour(context, zero, rest);
         dt = dt.plusHours(ival);

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -226,7 +226,7 @@ public class RubyDate extends RubyObject {
     }
 
     static final int DAY_IN_SECONDS = 86_400; // 24 * 60 * 60
-    private static final int DAY_MS = 86_400_000; // 24 * 60 * 60 * 1000
+    static final int DAY_MS = 86_400_000; // 24 * 60 * 60 * 1000
     private static RubyFixnum DAY_MS_CACHE;
 
     private long initMillis(final ThreadContext context, IRubyObject ajd) {

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -581,6 +581,18 @@ public class RubyDate extends RubyObject {
         return jd == null ? context.nil : RubyFixnum.newFixnum(context.runtime, jd);
     }
 
+    @Deprecated // NOTE: should go away once no date.rb is using it
+    @JRubyMethod(name = "_valid_weeknum?", meta = true, required = 4, optional = 1, visibility = Visibility.PRIVATE)
+    public static IRubyObject _valid_weeknum_p(ThreadContext context, IRubyObject self, IRubyObject[] args) {
+        final int sg = args.length > 4 ? val2sg(context, args[4]) : GREGORIAN;
+        final int y = args[0].convertToInteger().getIntValue();
+        final int w = args[1].convertToInteger().getIntValue();
+        final int d = args[2].convertToInteger().getIntValue();
+        final int f = args[3].convertToInteger().getIntValue();
+        final Long jd = DateUtils._valid_weeknum_p(y, w, d, f, sg);
+        return jd == null ? context.nil : RubyFixnum.newFixnum(context.runtime, jd);
+    }
+
     /**
      # Create a new Date object representing today.
      #

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -1551,6 +1551,18 @@ public class RubyDate extends RubyObject {
         return new RubyDateTime(context.runtime, getDateTime(context.runtime), dt.withTimeAtStartOfDay(), off, start);
     }
 
+    @JRubyMethod // Time.local(year, mon, mday)
+    public RubyTime to_time(ThreadContext context) {
+        final Ruby runtime = context.runtime;
+        DateTime dt = this.dt;
+
+        dt = new DateTime(dt.getYear(), dt.getMonthOfYear(), dt.getDayOfMonth(),
+                0, 0, 0,
+                RubyTime.getLocalTimeZone(runtime)
+        );
+        return new RubyTime(runtime, runtime.getTime(), dt);
+    }
+
     // date/format.rb
 
     @JRubyMethod // def strftime(fmt='%F')

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -1157,7 +1157,7 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod
     public IRubyObject next_year(ThreadContext context, IRubyObject n) {
-        return newInstance(context, dt.plusMonths(+timesIntDiff(context, n, 12)), off, start);
+        return prevNextYear(context, n, false);
     }
 
     @JRubyMethod
@@ -1167,12 +1167,19 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod
     public IRubyObject prev_year(ThreadContext context, IRubyObject n) {
-        return newInstance(context, dt.plusMonths(-timesIntDiff(context, n, 12)), off, start);
+        return prevNextYear(context, n, true);
     }
 
-    private static int timesIntDiff(final ThreadContext context, IRubyObject n, final int times) {
+    private RubyDate prevNextYear(ThreadContext context, IRubyObject n, final boolean negate) {
+        long months = timesIntDiff(context, n, 12);
+        if (negate) months = -months; // prev_year
+        final int years = RubyNumeric.checkInt(context.runtime, months / 12);
+        return newInstance(context, this.dt.plusYears(years).plusMonths((int) (months % 12)), off, start);
+    }
+
+    static long timesIntDiff(final ThreadContext context, IRubyObject n, final int times) {
         IRubyObject mul = RubyFixnum.newFixnum(context.runtime, times).op_mul(context, n);
-        return ((RubyNumeric) mul).round(context).convertToInteger().getIntValue();
+        return ((RubyNumeric) mul).round(context).convertToInteger().getLongValue();
     }
 
     @JRubyMethod // [ ajd, @of, @sg ]

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -524,11 +524,17 @@ public class RubyDate extends RubyObject {
         return context.tru; // @see _valid_jd_p
     }
 
+    // Is +jd+ a valid Julian Day Number?
+    //
+    // If it is, returns it.  In fact, any value is treated as a valid Julian Day Number.
+
+    @JRubyMethod(name = "_valid_jd?", meta = true, visibility = Visibility.PRIVATE)
+    public static IRubyObject _valid_jd_p(IRubyObject self, IRubyObject jd) {
+        return jd;
+    }
+
     @JRubyMethod(name = "_valid_jd?", meta = true, visibility = Visibility.PRIVATE)
     public static IRubyObject _valid_jd_p(IRubyObject self, IRubyObject jd, IRubyObject sg) {
-        // Is +jd+ a valid Julian Day Number?
-        //
-        // If it is, returns it.  In fact, any value is treated as a valid Julian Day Number.
         return jd;
     }
 

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -1436,8 +1436,8 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod
     public RubyString inspect(ThreadContext context) {
-        long off = this.off * 86_400;
-        long s = (dt.getHourOfDay() * 60 + dt.getMinuteOfHour()) * 60 + dt.getSecondOfMinute() - off;
+        int off = this.off;
+        int s = (dt.getHourOfDay() * 60 + dt.getMinuteOfHour()) * 60 + dt.getSecondOfMinute() - off;
         long ns = (dt.getMillisOfSecond() * 1_000_000) + (subMillisNum * 1_000_000) / subMillisDen;
         ByteList str = new ByteList(54); // e.g. #<Date: 2018-01-15 ((2458134j,0s,0n),+0s,2299161j)>
         str.append('#').append('<');

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -560,12 +560,12 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod(name = "valid_jd?", meta = true)
     public static IRubyObject valid_jd_p(ThreadContext context, IRubyObject self, IRubyObject jd) {
-        return context.tru; // @see _valid_jd_p
+        return jd == context.nil ? context.fals : context.tru; // @see _valid_jd_p
     }
 
     @JRubyMethod(name = "valid_jd?", meta = true)
     public static IRubyObject valid_jd_p(ThreadContext context, IRubyObject self, IRubyObject jd, IRubyObject sg) {
-        return context.tru; // @see _valid_jd_p
+        return jd == context.nil ? context.fals : context.tru; // @see _valid_jd_p
     }
 
     // Is +jd+ a valid Julian Day Number?

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -142,8 +142,8 @@ public class RubyDate extends RubyObject {
         this(runtime, getDate(runtime), dt);
     }
 
-    RubyDate(Ruby runtime, DateTime dt, int off, int start) {
-        super(runtime, getDate(runtime));
+    RubyDate(Ruby runtime, RubyClass klass, DateTime dt, int off, int start) {
+        super(runtime, klass);
 
         this.dt = dt;
         this.off = off; this.start = start;
@@ -384,7 +384,7 @@ public class RubyDate extends RubyObject {
     @JRubyMethod(name = "civil", alias = "new", meta = true)
     public static RubyDate civil(ThreadContext context, IRubyObject self, IRubyObject year, IRubyObject month, IRubyObject mday) {
         // return civil(context, self, new IRubyObject[] { year, month, mday, RubyFixnum.newFixnum(context.runtime, ITALY) });
-        return new RubyDate(context.runtime, civilImpl(context, year, month, mday));
+        return new RubyDate(context.runtime, (RubyClass) self, civilImpl(context, year, month, mday));
     }
 
     static DateTime civilImpl(ThreadContext context, IRubyObject year, IRubyObject month, IRubyObject mday) {
@@ -406,7 +406,7 @@ public class RubyDate extends RubyObject {
         final int m = getMonth(args[1]);
         final int d = args[2].convertToInteger().getIntValue();
 
-        RubyDate date = new RubyDate(context.runtime, civilDate(context, y, m, d, getChronology(context, sg, 0)));
+        RubyDate date = new RubyDate(context.runtime, (RubyClass) self, civilDate(context, y, m, d, getChronology(context, sg, 0)));
         date.start = sg;
         return date;
     }
@@ -642,13 +642,13 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod(meta = true)
     public static RubyDate today(ThreadContext context, IRubyObject self) { // sg=ITALY
-        return new RubyDate(context.runtime, new DateTime(CHRONO_ITALY_UTC).withTimeAtStartOfDay());
+        return new RubyDate(context.runtime, (RubyClass) self, new DateTime(CHRONO_ITALY_UTC).withTimeAtStartOfDay());
     }
 
     @JRubyMethod(meta = true)
     public static RubyDate today(ThreadContext context, IRubyObject self, IRubyObject sg) {
         final int start = val2sg(context, sg);
-        return new RubyDate(context.runtime, new DateTime(getChronology(context, start, 0)).withTimeAtStartOfDay(), 0, start);
+        return new RubyDate(context.runtime, (RubyClass) self, new DateTime(getChronology(context, start, 0)).withTimeAtStartOfDay(), 0, start);
     }
 
     @Deprecated // NOTE: should go away once no date.rb is using it
@@ -1353,7 +1353,7 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod
     public RubyDateTime to_datetime(ThreadContext context) {
-        return new RubyDateTime(context.runtime, dt.withTimeAtStartOfDay(), off, start);
+        return new RubyDateTime(context.runtime, getDateTime(context.runtime), dt.withTimeAtStartOfDay(), off, start);
     }
 
     // date/format.rb

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -1215,7 +1215,6 @@ public class RubyDate extends RubyObject {
         RubyNumeric tmp = (RubyNumeric)
                 jd.op_minus(context, RubyRational.newRationalCanonicalize(context, of_sec, 86400));
         final RubyRational MINUS_HALF = RubyRational.newRational(context.runtime, -1, 2);
-        // RubyInteger tmp = (RubyInteger) jd.op_minus(context, of);
         return (RubyNumeric) ((RubyNumeric) tmp.op_plus(context, fr)).op_plus(context, MINUS_HALF);
     }
 
@@ -1349,6 +1348,9 @@ public class RubyDate extends RubyObject {
         };
         return (RubyString) RubyKernel.sprintf(context, this, args);
     }
+
+    @JRubyMethod
+    public RubyDate to_date() { return this; }
 
     @JRubyMethod
     public RubyDateTime to_datetime(ThreadContext context) {

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -272,6 +272,16 @@ public class RubyDate extends RubyObject {
         return v;
     }
 
+    @Override
+    public IRubyObject initialize_copy(IRubyObject original) {
+        final RubyDate from = (RubyDate) original;
+
+        this.dt = from.dt; this.off = from.off; this.start = from.start;
+        this.subMillisNum = from.subMillisNum; this.subMillisDen = from.subMillisDen;
+
+        return this;
+    }
+
     // Date.new!(dt_or_ajd=0, of=0, sg=ITALY, sub_millis=0)
 
     /**

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -414,9 +414,15 @@ public class RubyDate extends RubyObject {
     @JRubyMethod(name = "civil", alias = "new", meta = true, optional = 4) // 4 args case
     public static RubyDate civil(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         // IRubyObject year, IRubyObject month, IRubyObject mday, IRubyObject start
-
-        // TODO interpreter needs a ThreeOperandArgNoBlockCallInstr otherwise routes 3 args here
-        if (args.length == 3) return civil(context, self, args[0], args[1], args[2]);
+        switch (args.length) {
+            // NOTE: slightly annoying but send might route its Date.send(:civil, *args) here
+            case 0: return civil(context, self);
+            case 1: return civil(context, self, args[0]);
+            case 2: return civil(context, self, args[0], args[1]);
+            // besides the above note on send ^^
+            // interpreter does not have a ThreeOperandArgNoBlockCallInstr thus routes 3 args as args[] here
+            case 3: return civil(context, self, args[0], args[1], args[2]);
+        }
 
         final long sg = val2sg(context, args[3]);
 

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -771,8 +771,7 @@ public class RubyDate extends RubyObject {
     }
 
     private long getJulianDayNumber() {
-        double day = DateTimeUtils.toJulianDay(dt.getMillis()) + off;
-        return (long) Math.floor(day + 0.5);
+        return DateTimeUtils.toJulianDayNumber(dt.getMillis() + off * 1000);
     }
 
     @JRubyMethod(name = "julian?")
@@ -786,11 +785,6 @@ public class RubyDate extends RubyObject {
     }
 
     public final boolean isJulian() {
-        // JULIAN.<=>(numeric)     => +1
-        //if (start == JULIAN) return true;
-        // GREGORIAN.<=>(numeric)  => -1
-        //if (start == GREGORIAN) return false;
-
         return getJulianDayNumber() < start;
     }
 

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -719,7 +719,7 @@ public class RubyDate extends RubyObject {
         if (cmp == 0) {
             if (this.subMillisDen == 1 && that.subMillisDen == 1) {
                 int diff = this.subMillisNum - that.subMillisNum;
-                return diff < 0 ? 1 : ( diff == 0 ? 0 : -1 );
+                return diff < 0 ? -1 : ( diff == 0 ? 0 : +1 );
             }
             return cmpSubMillis(that);
         }
@@ -730,8 +730,7 @@ public class RubyDate extends RubyObject {
     private int cmpSubMillis(final RubyDate that) {
         ThreadContext context = getRuntime().getCurrentContext();
         RubyNumeric diff = subMillisDiff(context, that);
-        if (diff.isZero()) return 0;
-        return Numeric.f_negative_p(context, diff) ? 1 : -1;
+        return diff.isZero() ? 0 : ( Numeric.f_negative_p(context, diff) ? -1 : +1 );
     }
 
     private IRubyObject fallback_cmp(ThreadContext context, IRubyObject other) {

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -28,6 +28,7 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby.ext.date;
 
+import org.jcodings.specific.USASCIIEncoding;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
@@ -1471,10 +1472,11 @@ public class RubyDate extends RubyObject {
         }
         str.append('j').append(')').append('>');
 
-        return RubyString.newStringLight(context.runtime, str);
+        return RubyString.newUsAsciiStringNoCopy(context.runtime, str);
     }
 
     private static final ByteList TO_S_FORMAT = new ByteList(ByteList.plain("%.4d-%02d-%02d"), false);
+    static { TO_S_FORMAT.setEncoding(USASCIIEncoding.INSTANCE); }
 
     @Override
     public final IRubyObject to_s() {
@@ -1519,6 +1521,7 @@ public class RubyDate extends RubyObject {
 
     private static final String DEFAULT_FORMAT = "%F";
     private static final ByteList DEFAULT_FORMAT_BYTES = ByteList.create(DEFAULT_FORMAT);
+    static { DEFAULT_FORMAT_BYTES.setEncoding(USASCIIEncoding.INSTANCE); }
 
     @JRubyMethod(meta = true)
     public static IRubyObject _strptime(ThreadContext context, IRubyObject self, IRubyObject string) {

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -1097,8 +1097,7 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod
     public IRubyObject next_day(ThreadContext context, IRubyObject n) {
-        int days = n.convertToInteger().getIntValue();
-        return newInstance(context, dt.plusDays(+days), off, start);
+        return newInstance(context, dt.plusDays(+simpleIntDiff(n)), off, start);
     }
 
     @JRubyMethod
@@ -1108,8 +1107,7 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod
     public IRubyObject prev_day(ThreadContext context, IRubyObject n) {
-        int days = n.convertToInteger().getIntValue();
-        return newInstance(context, dt.plusDays(-days), off, start);
+        return newInstance(context, dt.plusDays(-simpleIntDiff(n)), off, start);
     }
 
     @JRubyMethod
@@ -1119,8 +1117,7 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod
     public IRubyObject next_month(ThreadContext context, IRubyObject n) {
-        int months = n.convertToInteger().getIntValue();
-        return newInstance(context, dt.plusMonths(+months), off, start);
+        return newInstance(context, dt.plusMonths(+simpleIntDiff(n)), off, start);
     }
 
     @JRubyMethod
@@ -1130,8 +1127,17 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod
     public IRubyObject prev_month(ThreadContext context, IRubyObject n) {
-        int months = n.convertToInteger().getIntValue();
-        return newInstance(context, dt.plusMonths(-months), off, start);
+        return newInstance(context, dt.plusMonths(-simpleIntDiff(n)), off, start);
+    }
+
+    private static int simpleIntDiff(IRubyObject n) {
+        final int days = n.convertToInteger().getIntValue();
+        if (n instanceof RubyRational) {
+            if (((RubyRational) n).getDenominator().getLongValue() != 1) {
+                return days + 1; // MRI rulez: 1/2 -> 1 (but 0.5 -> 0)
+            }
+        }
+        return days;
     }
 
     @JRubyMethod(name = ">>")
@@ -1151,8 +1157,7 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod
     public IRubyObject next_year(ThreadContext context, IRubyObject n) {
-        int years = n.convertToInteger().getIntValue();
-        return newInstance(context, dt.plusYears(+years), off, start);
+        return newInstance(context, dt.plusMonths(+timesIntDiff(context, n, 12)), off, start);
     }
 
     @JRubyMethod
@@ -1162,8 +1167,12 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod
     public IRubyObject prev_year(ThreadContext context, IRubyObject n) {
-        int years = n.convertToInteger().getIntValue();
-        return newInstance(context, dt.plusYears(-years), off, start);
+        return newInstance(context, dt.plusMonths(-timesIntDiff(context, n, 12)), off, start);
+    }
+
+    private static int timesIntDiff(final ThreadContext context, IRubyObject n, final int times) {
+        IRubyObject mul = RubyFixnum.newFixnum(context.runtime, times).op_mul(context, n);
+        return ((RubyNumeric) mul).round(context).convertToInteger().getIntValue();
     }
 
     @JRubyMethod // [ ajd, @of, @sg ]

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -1383,7 +1383,7 @@ public class RubyDate extends RubyObject {
     private static double jd_to_ajd(long jd) { return jd - 0.5; }
 
     static RubyNumeric jd_to_ajd(ThreadContext context, long jd) {
-        return (RubyNumeric) RubyRational.newRationalCanonicalize(context, (jd * 2) - 1, 2);
+        return RubyRational.newRational(context.runtime, (jd * 2) - 1, 2);
     }
 
     static RubyNumeric jd_to_ajd(ThreadContext context, long jd, RubyNumeric fr, int of_sec) {

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -30,6 +30,8 @@ package org.jruby.ext.date;
 
 import org.joda.time.Chronology;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.chrono.GJChronology;
 
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
@@ -101,13 +103,18 @@ public class RubyDateTime extends RubyDate {
 
     @JRubyMethod(meta = true)
     public static RubyDateTime now(ThreadContext context, IRubyObject self) { // sg=ITALY
-        return new RubyDateTime(context.runtime, new DateTime(CHRONO_ITALY_UTC));
+        final DateTimeZone zone = RubyTime.getLocalTimeZone(context.runtime);
+        if (zone == DateTimeZone.UTC) {
+            return new RubyDateTime(context.runtime, new DateTime(CHRONO_ITALY_UTC));
+        }
+        return new RubyDateTime(context.runtime, new DateTime(GJChronology.getInstance(zone)));
     }
 
     @JRubyMethod(meta = true)
     public static RubyDateTime now(ThreadContext context, IRubyObject self, IRubyObject sg) {
         final int start = val2sg(context, sg);
-        return new RubyDateTime(context.runtime, new DateTime(getChronology(start, 0)), 0, start);
+        final DateTimeZone zone = RubyTime.getLocalTimeZone(context.runtime);
+        return new RubyDateTime(context.runtime, new DateTime(getChronology(start, zone)), 0, start);
     }
 
     @JRubyMethod // Date.civil(year, mon, mday, @sg)

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -99,8 +99,8 @@ public class RubyDateTime extends RubyDate {
         this.off = off; this.start = start;
     }
 
-    RubyDateTime(ThreadContext context, IRubyObject ajd, Chronology chronology, int off) {
-        super(context, ajd, chronology, off);
+    RubyDateTime(ThreadContext context, RubyClass klass, IRubyObject ajd, Chronology chronology, int off) {
+        super(context, klass, ajd, chronology, off);
     }
 
     /**

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -49,6 +49,8 @@ import org.jruby.runtime.builtin.IRubyObject;
  * JRuby's <code>DateTime</code> implementation - 'native' parts.
  * In MRI, since 2.x, all of date.rb has been moved to native (C) code.
  *
+ * NOTE: There's still date.rb, where this gets bootstrapped from.
+ *
  * @see RubyDate
  *
  * @author kares
@@ -87,7 +89,11 @@ public class RubyDateTime extends RubyDate {
     }
 
     RubyDateTime(Ruby runtime, DateTime dt, int off, int start) {
-        super(runtime, getDateTime(runtime));
+        this(runtime, getDateTime(runtime), dt, off, start);
+    }
+
+    private RubyDateTime(Ruby runtime, RubyClass klass, DateTime dt, int off, int start) {
+        super(runtime, klass);
 
         this.dt = dt;
         this.off = off; this.start = start;
@@ -131,41 +137,58 @@ public class RubyDateTime extends RubyDate {
         return new RubyDateTime(context.runtime, civilImpl(context, year, month));
     }
 
-    @JRubyMethod(name = "civil", alias = "new", meta = true)
-    public static RubyDateTime civil(ThreadContext context, IRubyObject self, IRubyObject year, IRubyObject month, IRubyObject mday) {
-        return new RubyDateTime(context.runtime, civilImpl(context, year, month, mday));
-    }
+    //@JRubyMethod(name = "civil", alias = "new", meta = true)
+    //public static RubyDateTime civil(ThreadContext context, IRubyObject self, IRubyObject year, IRubyObject month, IRubyObject mday) {
+    //    return new RubyDateTime(context.runtime, civilImpl(context, year, month, mday));
+    //}
 
     @JRubyMethod(name = "civil", alias = "new", meta = true, optional = 8)
     public static RubyDateTime civil(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         // year=-4712, month=1, mday=1,
         //  hour=0, minute=0, second=0, offset=0, start=Date::ITALY
 
-        int hour = 0, minute = 0, second = 0; long millis = 0; int off = 0, sg = ITALY;
+        final int len = args.length;
 
-        switch (args.length) {
-            case 8: sg = val2sg(context, args[7]);
-            case 7: off = val2off(context, args[6]);
-            case 6:
-                long sec = args[5].convertToInteger().getLongValue();
-                if (args[5] instanceof RubyRational) {
-                    millis = secMillis(context, (RubyRational) args[5]);
-                }
-                second = (int) (sec < 0 ? sec + 60 : sec); // JODA will handle invalid value
-            case 5: minute = getMinute(context, args[4]);
-            case 4: hour = getHour(context, args[3]);
-                break;
+        int hour = 0, minute = 0, second = 0; long millis = 0; int subMillisNum = 0, subMillisDen = 1;
+        int off = 0, sg = ITALY;
 
-            // TODO interpreter needs a ThreeOperandArgNoBlockCallInstr otherwise routes 3 args via []
-            case 3: return civil(context, self, args[0], args[1], args[2]);
-        }
+        if (len == 8) sg = val2sg(context, args[7]);
+        if (len >= 7) off = val2off(context, args[6]);
 
         final int year = (sg > 0) ? getYear(args[0]) : args[0].convertToInteger().getIntValue();
         final int month = getMonth(args[1]);
-        final int day = args[2].convertToInteger().getIntValue();
+        final int[] rest = new int[] { 0, 1 };
+        final int day = getDay(context, args[2], rest);
 
         final Chronology chronology = getChronology(context, sg, off);
         DateTime dt = civilDate(context, year, month, day, chronology); // hour: 0, minute: 0, second: 0
+
+        //System.out.println(" 1.day " + day + " rest = " + rest[0] + " / " + rest[1]);
+
+        if (len >= 4 || rest[0] != 0) {
+            hour = getHour(context, len >= 4 ? args[3] : RubyFixnum.zero(context.runtime), rest);
+        }
+
+        //System.out.println(" 2.hour " + hour + " rest = " + rest[0] + " / " + rest[1]);
+
+        if (len >= 5 || rest[0] != 0) {
+            minute = getMinute(context, len >= 5 ? args[4] : RubyFixnum.zero(context.runtime), rest);
+        }
+
+        //System.out.println(" 3.minu " + minute + " rest = " + rest[0] + " / " + rest[1]);
+
+        if (len >= 6 || rest[0] != 0) {
+            IRubyObject sec = len >= 6 ? args[5] : RubyFixnum.zero(context.runtime);
+            second = getSecond(context, sec, rest);
+            final int r0 = rest[0], r1 = rest[1];
+            if (r0 != 0) {
+                millis = ( 1000 * r0 ) / r1;
+                subMillisNum = (int) ((1000 * r0) - (millis * r1)); subMillisDen = r1;
+            }
+        }
+
+        //System.out.println(" 4.seco " + second + " rest = " + rest[0] + " / " + rest[1] + "\n  millis = " + millis);
+
         try {
             long ms = dt.getMillis();
             ms = chronology.hourOfDay().set(ms, hour);
@@ -178,25 +201,89 @@ public class RubyDateTime extends RubyDate {
             throw context.runtime.newArgumentError("invalid date");
         }
 
-        return new RubyDateTime(context.runtime, dt, off, sg);
+        RubyDateTime dateTime = new RubyDateTime(context.runtime, (RubyClass) self, dt, off, sg);
+        dateTime.subMillisNum = subMillisNum; dateTime.subMillisDen = subMillisDen;
+        return dateTime;
     }
 
-    private static long secMillis(ThreadContext context, RubyRational sec) {
+    private static int getDay(ThreadContext context, IRubyObject day, final int[] rest) {
+        long d = day.convertToInteger().getLongValue();
+
+        if (day instanceof RubyRational) {
+            long num = ((RubyRational) day).getNumerator().getLongValue();
+            int den = ((RubyRational) day).getDenominator().getIntValue();
+            rest[0] = (int) (num - d * den); rest[1] = den;
+        }
+
+        return (int) d;
+    }
+
+    private static int getHour(ThreadContext context, IRubyObject hour, final int[] rest) {
+        long h = hour.convertToInteger().getLongValue();
+        int i = 0;
+        final int r0 = rest[0], r1 = rest[1];
+        if (r0 != 0) {
+            i = (24 * r0) / r1;
+            rest[0] = (24 * r0) - (i * r1);
+        }
+        addRationalModToRest(context, hour, h, rest);
+
+        h += i;
+        return (int) (h < 0 ? h + 24 : h); // JODA will handle invalid value
+    }
+
+    private static int getMinute(ThreadContext context, IRubyObject val, final int[] rest) {
+        long v = val.convertToInteger().getLongValue();
+        int i = 0;
+        final int r0 = rest[0], r1 = rest[1];
+        if (r0 != 0) {
+            i = (60 * r0) / r1;
+            rest[0] = (60 * r0) - (i * r1);
+        }
+        addRationalModToRest(context, val, v, rest);
+
+        v += i;
+        return (int) (v < 0 ? v + 60 : v); // JODA will handle invalid value
+    }
+
+    private static int getSecond(ThreadContext context, IRubyObject sec, final int[] rest) {
+        return getMinute(context, sec, rest);
+    }
+
+    private long getMillisAndSetSubMillis(final int[] rest) {
+        long millis = 0;
+        final int r0 = rest[0], r1 = rest[1];
+        if (r0 != 0) {
+            millis = (1000 * r0) / r1;
+            this.subMillisNum = (int) ((1000 * r0) - (millis * r1));
+            this.subMillisDen = r1;
+        }
+        return millis;
+    }
+
+    private static long secMillis(ThreadContext context, RubyRational sec) { // (sec * 1000) % 100
         RubyInteger val = (RubyInteger) sec.getNumerator().op_mul(context, 1000);
         val = (RubyInteger) val.idiv(context, sec.getDenominator());
         return ((RubyInteger) val.op_mod(context, 1000)).getLongValue();
     }
 
-    private static int getHour(ThreadContext context, IRubyObject hour) {
-        long h = hour.convertToInteger().getLongValue();
-        assertValidFraction(context, hour, h);
-        return (int) (h < 0 ? h + 24 : h); // JODA will handle invalid value
-    }
-
-    private static int getMinute(ThreadContext context, IRubyObject min) {
-        long m = min.convertToInteger().getLongValue();
-        assertValidFraction(context, min, m);
-        return (int) (m < 0 ? m + 60 : m); // JODA will handle invalid value
+    private static void addRationalModToRest(ThreadContext context, IRubyObject val, long ival, final int[] rest) {
+        if (val instanceof RubyRational) {
+            long num = ((RubyRational) val).getNumerator().getLongValue();
+            int den = ((RubyRational) val).getDenominator().getIntValue();
+            num -= ival * den;
+            if (num != 0) {
+                IRubyObject res = RubyRational.newRational(context.runtime, rest[0], rest[1]).
+                        op_add(context, RubyRational.newRationalCanonicalize(context, num, den));
+                if (res instanceof RubyRational) {
+                    rest[0] = ((RubyRational) res).getNumerator().getIntValue();
+                    rest[1] = ((RubyRational) res).getDenominator().getIntValue();
+                } else {
+                    rest[0] = res.convertToInteger().getIntValue();
+                    rest[1] = 1;
+                }
+            }
+        }
     }
 
     private static void assertValidFraction(ThreadContext context, IRubyObject val, long ival) {
@@ -225,12 +312,21 @@ public class RubyDateTime extends RubyDate {
     public static RubyDateTime now(ThreadContext context, IRubyObject self, IRubyObject sg) {
         final int start = val2sg(context, sg);
         final DateTimeZone zone = RubyTime.getLocalTimeZone(context.runtime);
-        return new RubyDateTime(context.runtime, new DateTime(getChronology(context, start, zone)), 0, start);
+        return new RubyDateTime(context.runtime, (RubyClass) self, new DateTime(getChronology(context, start, zone)), 0, start);
     }
 
-    @JRubyMethod // Date.civil(year, mon, mday, @sg)
+    @JRubyMethod // Date.civil(year, mon, mday, @sg) TODO dble-check
     public RubyDate to_date(ThreadContext context) {
-        return new RubyDate(context.runtime, dt.withTimeAtStartOfDay(), 0, start, 0);
+        return new RubyDate(context.runtime, dt.withTimeAtStartOfDay(), 0, start);
+    }
+
+    @JRubyMethod // Time.new(year, mon, mday, hour, min, sec + sec_fraction, (@of * 86400.0))
+    public RubyTime to_time(ThreadContext context) {
+        final Ruby runtime = context.runtime;
+        RubyTime time = new RubyTime(runtime, runtime.getTime(), dt);
+        // sec_fraction: Rational(context, dt.getMillisOfSecond() + (long) subMillis, 1000);
+        time.setUSec(0);
+        return time;
     }
 
 }

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -70,8 +70,8 @@ public class RubyDateTime extends RubyDate {
         }
     };
 
-    private static RubyClass getDateTime(final Ruby runtime) {
-        return (RubyClass) runtime.getObject().getConstantAt("DateTime");
+    protected RubyDateTime(Ruby runtime, RubyClass klass) {
+        super(runtime, klass);
     }
 
     public RubyDateTime(Ruby runtime, RubyClass klass, DateTime dt) {
@@ -91,6 +91,10 @@ public class RubyDateTime extends RubyDate {
 
         this.dt = dt;
         this.off = off; this.start = start;
+    }
+
+    RubyDateTime(ThreadContext context, IRubyObject ajd, Chronology chronology, int off) {
+        super(context, ajd, chronology, off);
     }
 
     /**

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -28,6 +28,7 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby.ext.date;
 
+import org.joda.time.Chronology;
 import org.joda.time.DateTime;
 
 import org.jruby.Ruby;
@@ -35,6 +36,8 @@ import org.jruby.RubyClass;
 import org.jruby.anno.JRubyClass;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.log.Logger;
+import org.jruby.util.log.LoggerFactory;
 
 /**
  * JRuby's <code>DateTime</code> implementation - 'native' parts.
@@ -46,6 +49,8 @@ import org.jruby.runtime.builtin.IRubyObject;
  */
 @JRubyClass(name = "DateTime")
 public class RubyDateTime extends RubyDate {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RubyDateTime.class);
 
     static RubyClass createDateTimeClass(Ruby runtime, RubyClass Date) {
         RubyClass DateTime = runtime.defineClass("DateTime", Date, ALLOCATOR);
@@ -71,6 +76,17 @@ public class RubyDateTime extends RubyDate {
 
     public RubyDateTime(Ruby runtime, DateTime dt) {
         super(runtime, getDateTime(runtime), dt);
+    }
+
+    public RubyDateTime(Ruby runtime, long millis, Chronology chronology) {
+        super(runtime, getDateTime(runtime), new DateTime(millis, chronology));
+    }
+
+    RubyDateTime(Ruby runtime, DateTime dt, int off, int start) {
+        super(runtime, getDateTime(runtime));
+
+        this.dt = dt;
+        this.off = off; this.start = start;
     }
 
 }

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -33,8 +33,11 @@ import org.joda.time.DateTime;
 
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
+import org.jruby.RubyTime;
 import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ObjectAllocator;
+import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
@@ -87,6 +90,29 @@ public class RubyDateTime extends RubyDate {
 
         this.dt = dt;
         this.off = off; this.start = start;
+    }
+    
+
+    /**
+     # Create a new DateTime object representing the current time.
+     #
+     # +sg+ specifies the Day of Calendar Reform.
+     **/
+
+    @JRubyMethod(meta = true)
+    public static RubyDateTime now(ThreadContext context, IRubyObject self) { // sg=ITALY
+        return new RubyDateTime(context.runtime, new DateTime(CHRONO_ITALY_UTC));
+    }
+
+    @JRubyMethod(meta = true)
+    public static RubyDateTime now(ThreadContext context, IRubyObject self, IRubyObject sg) {
+        final int start = val2sg(context, sg);
+        return new RubyDateTime(context.runtime, new DateTime(getChronology(start, 0)), 0, start);
+    }
+
+    @JRubyMethod // Date.civil(year, mon, mday, @sg)
+    public RubyDate to_date(ThreadContext context) {
+        return new RubyDate(context.runtime, dt.withTimeAtStartOfDay(), 0, start, 0);
     }
 
 }

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -170,7 +170,7 @@ public class RubyDateTime extends RubyDate {
 
         final int len = args.length;
 
-        int hour = 0, minute = 0, second = 0; long millis = 0; int subMillisNum = 0, subMillisDen = 1;
+        int hour = 0, minute = 0, second = 0; long millis = 0; long subMillisNum = 0, subMillisDen = 1;
         int off = 0; long sg = ITALY;
 
         if (len == 8) sg = val2sg(context, args[7]);
@@ -178,7 +178,7 @@ public class RubyDateTime extends RubyDate {
 
         final int year = (sg > 0) ? getYear(args[0]) : args[0].convertToInteger().getIntValue();
         final int month = getMonth(args[1]);
-        final int[] rest = new int[] { 0, 1 };
+        final long[] rest = new long[] { 0, 1 };
         final int day = (int) getDay(context, args[2], rest);
 
         if (len >= 4 || rest[0] != 0) {
@@ -192,10 +192,10 @@ public class RubyDateTime extends RubyDate {
         if (len >= 6 || rest[0] != 0) {
             IRubyObject sec = len >= 6 ? args[5] : RubyFixnum.zero(context.runtime);
             second = getSecond(context, sec, rest);
-            final int r0 = rest[0], r1 = rest[1];
+            final long r0 = rest[0], r1 = rest[1];
             if (r0 != 0) {
                 millis = ( 1000 * r0 ) / r1;
-                subMillisNum = (int) ((1000 * r0) - (millis * r1)); subMillisDen = r1;
+                subMillisNum = ((1000 * r0) - (millis * r1)); subMillisDen = r1;
             }
         }
 
@@ -222,23 +222,23 @@ public class RubyDateTime extends RubyDate {
         return new RubyDateTime(context.runtime, (RubyClass) self, dt, off, sg, subMillisNum, subMillisDen);
     }
 
-    static long getDay(ThreadContext context, IRubyObject day, final int[] rest) {
+    static long getDay(ThreadContext context, IRubyObject day, final long[] rest) {
         long d = day.convertToInteger().getLongValue();
 
         if (!(day instanceof RubyInteger) && day instanceof RubyNumeric) { // Rational|Float
             RubyRational rat = ((RubyNumeric) day).convertToRational();
             long num = rat.getNumerator().getLongValue();
             int den = rat.getDenominator().getIntValue();
-            rest[0] = (int) (num - d * den); rest[1] = den;
+            rest[0] = (num - d * den); rest[1] = den;
         }
 
         return d;
     }
 
-    static int getHour(ThreadContext context, IRubyObject hour, final int[] rest) {
+    static int getHour(ThreadContext context, IRubyObject hour, final long[] rest) {
         long h = hour.convertToInteger().getLongValue();
-        int i = 0;
-        final int r0 = rest[0], r1 = rest[1];
+        long i = 0;
+        final long r0 = rest[0], r1 = rest[1];
         if (r0 != 0) {
             i = (24 * r0) / r1;
             rest[0] = (24 * r0) - (i * r1);
@@ -249,10 +249,10 @@ public class RubyDateTime extends RubyDate {
         return (int) (h < 0 ? h + 24 : h); // JODA will handle invalid value
     }
 
-    static int getMinute(ThreadContext context, IRubyObject val, final int[] rest) {
+    static int getMinute(ThreadContext context, IRubyObject val, final long[] rest) {
         long v = val.convertToInteger().getLongValue();
-        int i = 0;
-        final int r0 = rest[0], r1 = rest[1];
+        long i = 0;
+        final long r0 = rest[0], r1 = rest[1];
         if (r0 != 0) {
             i = (60 * r0) / r1;
             rest[0] = (60 * r0) - (i * r1);
@@ -263,24 +263,24 @@ public class RubyDateTime extends RubyDate {
         return (int) (v < 0 ? v + 60 : v); // JODA will handle invalid value
     }
 
-    static int getSecond(ThreadContext context, IRubyObject sec, final int[] rest) {
+    static int getSecond(ThreadContext context, IRubyObject sec, final long[] rest) {
         return getMinute(context, sec, rest);
     }
 
-    private static void addRationalModToRest(ThreadContext context, IRubyObject val, long ival, final int[] rest) {
+    private static void addRationalModToRest(ThreadContext context, IRubyObject val, long ival, final long[] rest) {
         if (!(val instanceof RubyInteger) && val instanceof RubyNumeric) { // Rational|Float
             RubyRational rat = ((RubyNumeric) val).convertToRational();
             long num = rat.getNumerator().getLongValue();
-            int den = rat.getDenominator().getIntValue();
+            long den = rat.getDenominator().getLongValue();
             num -= ival * den;
             if (num != 0) {
                 IRubyObject res = RubyRational.newRational(context.runtime, rest[0], rest[1]).
                         op_plus(context, RubyRational.newRationalCanonicalize(context, num, den));
                 if (res instanceof RubyRational) {
-                    rest[0] = ((RubyRational) res).getNumerator().getIntValue();
-                    rest[1] = ((RubyRational) res).getDenominator().getIntValue();
+                    rest[0] = ((RubyRational) res).getNumerator().getLongValue();
+                    rest[1] = ((RubyRational) res).getDenominator().getLongValue();
                 } else {
-                    rest[0] = res.convertToInteger().getIntValue();
+                    rest[0] = res.convertToInteger().getLongValue();
                     rest[1] = 1;
                 }
             }
@@ -320,7 +320,7 @@ public class RubyDateTime extends RubyDate {
         final int len = args.length;
         final RubyFixnum zero = RubyFixnum.zero(context.runtime);
 
-        final int[] rest = new int[] { 0, 1 };
+        final long[] rest = new long[] { 0, 1 };
         final long jd = getDay(context, args[0], rest);
 
         final IRubyObject hour = (len > 1) ? args[1] : zero;

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -94,7 +94,7 @@ public class RubyDateTime extends RubyDate {
         super(runtime, getDateTime(runtime), new DateTime(millis, chronology));
     }
 
-    private RubyDateTime(ThreadContext context, RubyClass klass, IRubyObject ajd, int off, long start) {
+    RubyDateTime(ThreadContext context, RubyClass klass, IRubyObject ajd, int off, long start) {
         super(context, klass, ajd, off, start);
     }
 

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -94,7 +94,7 @@ public class RubyDateTime extends RubyDate {
         super(runtime, getDateTime(runtime), new DateTime(millis, chronology));
     }
 
-    private RubyDateTime(ThreadContext context, RubyClass klass, IRubyObject ajd, int off, int start) {
+    private RubyDateTime(ThreadContext context, RubyClass klass, IRubyObject ajd, int off, long start) {
         super(context, klass, ajd, off, start);
     }
 
@@ -105,14 +105,14 @@ public class RubyDateTime extends RubyDate {
         this.off = off;
     }
 
-    RubyDateTime(Ruby runtime, RubyClass klass, DateTime dt, int off, int start) {
+    RubyDateTime(Ruby runtime, RubyClass klass, DateTime dt, int off, long start) {
         super(runtime, klass);
 
         this.dt = dt;
         this.off = off; this.start = start;
     }
 
-    RubyDateTime(Ruby runtime, RubyClass klass, DateTime dt, int off, int start, int subMillisNum, int subMillisDen) {
+    RubyDateTime(Ruby runtime, RubyClass klass, DateTime dt, int off, long start, int subMillisNum, int subMillisDen) {
         super(runtime, klass);
 
         this.dt = dt;
@@ -125,7 +125,7 @@ public class RubyDateTime extends RubyDate {
     }
 
     @Override
-    RubyDate newInstance(final ThreadContext context, final DateTime dt, int off, int start, int subNum, int subDen) {
+    RubyDate newInstance(final ThreadContext context, final DateTime dt, int off, long start, int subNum, int subDen) {
         return new RubyDateTime(context.runtime, getMetaClass(), dt, off, start, subNum, subDen);
     }
 
@@ -171,7 +171,7 @@ public class RubyDateTime extends RubyDate {
         final int len = args.length;
 
         int hour = 0, minute = 0, second = 0; long millis = 0; int subMillisNum = 0, subMillisDen = 1;
-        int off = 0, sg = ITALY;
+        int off = 0; long sg = ITALY;
 
         if (len == 8) sg = val2sg(context, args[7]);
         if (len >= 7) off = val2off(context, args[6]);
@@ -337,7 +337,7 @@ public class RubyDateTime extends RubyDate {
             fr = zero;
         }
 
-        int off = 0, sg = ITALY;
+        int off = 0; long sg = ITALY;
         if (len > 4) off = val2off(context, args[4]);
         if (len > 5) sg = val2sg(context, args[5]);
 
@@ -365,7 +365,7 @@ public class RubyDateTime extends RubyDate {
 
     @JRubyMethod(meta = true)
     public static RubyDateTime now(ThreadContext context, IRubyObject self, IRubyObject sg) {
-        final int start = val2sg(context, sg);
+        final long start = val2sg(context, sg);
         final DateTimeZone zone = RubyTime.getLocalTimeZone(context.runtime);
         final DateTime dt = new DateTime(getChronology(context, start, zone));
         final int off = zone.getOffset(dt.getMillis()) / 1000;

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -409,7 +409,15 @@ public class RubyDateTime extends RubyDate {
 
     @JRubyMethod // Date.civil(year, mon, mday, @sg)
     public RubyDate to_date(ThreadContext context) {
-        return new RubyDate(context.runtime, getDate(context.runtime), dt.withTimeAtStartOfDay(), 0, start);
+        final Ruby runtime = context.runtime;
+        return new RubyDate(runtime, getDate(runtime), withTimeAt0InZone(dt, DateTimeZone.UTC), 0, start);
+    }
+
+    static DateTime withTimeAt0InZone(DateTime dt, DateTimeZone zone) {
+        long millis = dt.getZone().getMillisKeepLocal(zone, dt.getMillis());
+        final Chronology chronology = dt.getChronology().withZone(zone);
+        millis = chronology.millisOfDay().set(millis, 0);
+        return new DateTime(millis, chronology);
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -112,7 +112,7 @@ public class RubyDateTime extends RubyDate {
         this.off = off; this.start = start;
     }
 
-    RubyDateTime(Ruby runtime, RubyClass klass, DateTime dt, int off, long start, int subMillisNum, int subMillisDen) {
+    RubyDateTime(Ruby runtime, RubyClass klass, DateTime dt, int off, long start, long subMillisNum, long subMillisDen) {
         super(runtime, klass);
 
         this.dt = dt;
@@ -125,7 +125,7 @@ public class RubyDateTime extends RubyDate {
     }
 
     @Override
-    RubyDate newInstance(final ThreadContext context, final DateTime dt, int off, long start, int subNum, int subDen) {
+    RubyDate newInstance(final ThreadContext context, final DateTime dt, int off, long start, long subNum, long subDen) {
         return new RubyDateTime(context.runtime, getMetaClass(), dt, off, start, subNum, subDen);
     }
 
@@ -341,7 +341,8 @@ public class RubyDateTime extends RubyDate {
         if (len > 4) off = val2off(context, args[4]);
         if (len > 5) sg = val2sg(context, args[5]);
 
-        RubyDateTime dateTime = new RubyDateTime(context, (RubyClass) self, jd_to_ajd(context, jd, fr, off), off, sg);
+        RubyNumeric ajd = jd_to_ajd(context, jd, fr, off);
+        RubyDateTime dateTime = new RubyDateTime(context, (RubyClass) self, ajd, off, sg);
         if (rest[0] != 0) dateTime.dt = adjustWithDayFraction(context, dateTime.dt, rest);
         return dateTime;
     }

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -39,12 +39,14 @@ import org.jruby.RubyFixnum;
 import org.jruby.RubyInteger;
 import org.jruby.RubyNumeric;
 import org.jruby.RubyRational;
+import org.jruby.RubyString;
 import org.jruby.RubyTime;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.ByteList;
 
 /**
  * JRuby's <code>DateTime</code> implementation - 'native' parts.
@@ -392,6 +394,32 @@ public class RubyDateTime extends RubyDate {
         // sec_fraction: Rational(context, dt.getMillisOfSecond() + (long) subMillis, 1000);
         time.setUSec(0);
         return time;
+    }
+
+    // date/format.rb
+
+    private static final ByteList STRF_FORMAT_BYTES = ByteList.create("%FT%T%:z");
+
+    @JRubyMethod // def strftime(fmt='%FT%T%:z')
+    public RubyString strftime(ThreadContext context) {
+        return super.strftime(context, RubyString.newStringLight(context.runtime, STRF_FORMAT_BYTES));
+    }
+
+    @JRubyMethod // alias_method :format, :strftime
+    public RubyString strftime(ThreadContext context, IRubyObject fmt) {
+        return super.strftime(context, fmt);
+    }
+
+    private static final String DEFAULT_FORMAT = "%FT%T%z";
+
+    @JRubyMethod(meta = true)
+    public static IRubyObject _strptime(ThreadContext context, IRubyObject self, IRubyObject string) {
+        return parse(context, string, DEFAULT_FORMAT);
+    }
+
+    @JRubyMethod(meta = true)
+    public static IRubyObject _strptime(ThreadContext context, IRubyObject self, IRubyObject string, IRubyObject format) {
+        return RubyDate._strptime(context, self, string, format);
     }
 
 }

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -379,6 +379,22 @@ public class RubyDateTime extends RubyDate {
         return newInstance(context, this.dt.plusDays(days).plusSeconds((int) (seconds % DAY_IN_SECONDS)), off, start);
     }
 
+    private static final ByteList TO_S_FORMAT = new ByteList(ByteList.plain("%.4d-%02d-%02dT%02d:%02d:%02d%s"), false);
+
+    @JRubyMethod
+    public RubyString to_s(ThreadContext context) {
+        // format('%.4d-%02d-%02dT%02d:%02d:%02d%s', year, mon, mday, hour, min, sec, zone)
+        return format(context, TO_S_FORMAT,
+                year(context),
+                mon(context),
+                mday(context),
+                hour(context),
+                minute(context),
+                second(context),
+                zone(context)
+        );
+    }
+
     @JRubyMethod // Date.civil(year, mon, mday, @sg)
     public RubyDate to_date(ThreadContext context) {
         return new RubyDate(context.runtime, getDate(context.runtime), dt.withTimeAtStartOfDay(), 0, start);

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -89,15 +89,11 @@ public class RubyDateTime extends RubyDate {
         super(runtime, getDateTime(runtime), new DateTime(millis, chronology));
     }
 
-    RubyDateTime(Ruby runtime, DateTime dt, int off, int start) {
-        this(runtime, getDateTime(runtime), dt, off, start);
-    }
-
     private RubyDateTime(ThreadContext context, RubyClass klass, IRubyObject ajd, int off, int start) {
         super(context, klass, ajd, off, start);
     }
 
-    private RubyDateTime(Ruby runtime, RubyClass klass, DateTime dt, int off, int start) {
+    RubyDateTime(Ruby runtime, RubyClass klass, DateTime dt, int off, int start) {
         super(runtime, klass);
 
         this.dt = dt;
@@ -142,22 +138,22 @@ public class RubyDateTime extends RubyDate {
 
     @JRubyMethod(name = "civil", alias = "new", meta = true)
     public static RubyDateTime civil(ThreadContext context, IRubyObject self) {
-        return new RubyDateTime(context.runtime, defaultDateTime);
+        return new RubyDateTime(context.runtime, (RubyClass) self, defaultDateTime);
     }
 
     @JRubyMethod(name = "civil", alias = "new", meta = true)
     public static RubyDateTime civil(ThreadContext context, IRubyObject self, IRubyObject year) {
-        return new RubyDateTime(context.runtime, civilImpl(context, year));
+        return new RubyDateTime(context.runtime, (RubyClass) self, civilImpl(context, year));
     }
 
     @JRubyMethod(name = "civil", alias = "new", meta = true)
     public static RubyDateTime civil(ThreadContext context, IRubyObject self, IRubyObject year, IRubyObject month) {
-        return new RubyDateTime(context.runtime, civilImpl(context, year, month));
+        return new RubyDateTime(context.runtime, (RubyClass) self, civilImpl(context, year, month));
     }
 
     //@JRubyMethod(name = "civil", alias = "new", meta = true)
     //public static RubyDateTime civil(ThreadContext context, IRubyObject self, IRubyObject year, IRubyObject month, IRubyObject mday) {
-    //    return new RubyDateTime(context.runtime, civilImpl(context, year, month, mday));
+    //    return new RubyDateTime(context.runtime, (RubyClass) self, civilImpl(context, year, month, mday));
     //}
 
     @JRubyMethod(name = "civil", alias = "new", meta = true, optional = 8)
@@ -352,9 +348,9 @@ public class RubyDateTime extends RubyDate {
     public static RubyDateTime now(ThreadContext context, IRubyObject self) { // sg=ITALY
         final DateTimeZone zone = RubyTime.getLocalTimeZone(context.runtime);
         if (zone == DateTimeZone.UTC) {
-            return new RubyDateTime(context.runtime, new DateTime(CHRONO_ITALY_UTC));
+            return new RubyDateTime(context.runtime, (RubyClass) self, new DateTime(CHRONO_ITALY_UTC));
         }
-        return new RubyDateTime(context.runtime, new DateTime(GJChronology.getInstance(zone)));
+        return new RubyDateTime(context.runtime, (RubyClass) self, new DateTime(GJChronology.getInstance(zone)));
     }
 
     @JRubyMethod(meta = true)
@@ -381,9 +377,9 @@ public class RubyDateTime extends RubyDate {
         return newInstance(context, this.dt.plusDays(days).plusSeconds((int) (seconds % DAY_IN_SECONDS)), off, start);
     }
 
-    @JRubyMethod // Date.civil(year, mon, mday, @sg) TODO dble-check
+    @JRubyMethod // Date.civil(year, mon, mday, @sg)
     public RubyDate to_date(ThreadContext context) {
-        return new RubyDate(context.runtime, dt.withTimeAtStartOfDay(), 0, start);
+        return new RubyDate(context.runtime, getDate(context.runtime), dt.withTimeAtStartOfDay(), 0, start);
     }
 
     @JRubyMethod // Time.new(year, mon, mday, hour, min, sec + sec_fraction, (@of * 86400.0))

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -104,8 +104,21 @@ public class RubyDateTime extends RubyDate {
         this.off = off; this.start = start;
     }
 
+    RubyDateTime(Ruby runtime, RubyClass klass, DateTime dt, int off, int start, int subMillisNum, int subMillisDen) {
+        super(runtime, klass);
+
+        this.dt = dt;
+        this.off = off; this.start = start;
+        this.subMillisNum = subMillisNum; this.subMillisDen = subMillisDen;
+    }
+
     RubyDateTime(ThreadContext context, RubyClass klass, IRubyObject ajd, Chronology chronology, int off) {
         super(context, klass, ajd, chronology, off);
+    }
+
+    @Override
+    RubyDate newInstance(final ThreadContext context, final DateTime dt, int off, int start, int subNum, int subDen) {
+        return new RubyDateTime(context.runtime, getMetaClass(), dt, off, start, subNum, subDen);
     }
 
     /**

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -28,6 +28,7 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby.ext.date;
 
+import org.jcodings.specific.USASCIIEncoding;
 import org.joda.time.Chronology;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -179,19 +180,13 @@ public class RubyDateTime extends RubyDate {
         final Chronology chronology = getChronology(context, sg, off);
         DateTime dt = civilDate(context, year, month, day, chronology); // hour: 0, minute: 0, second: 0
 
-        //System.out.println(" 1.day " + day + " rest = " + rest[0] + " / " + rest[1]);
-
         if (len >= 4 || rest[0] != 0) {
             hour = getHour(context, len >= 4 ? args[3] : RubyFixnum.zero(context.runtime), rest);
         }
 
-        //System.out.println(" 2.hour " + hour + " rest = " + rest[0] + " / " + rest[1]);
-
         if (len >= 5 || rest[0] != 0) {
             minute = getMinute(context, len >= 5 ? args[4] : RubyFixnum.zero(context.runtime), rest);
         }
-
-        //System.out.println(" 3.minu " + minute + " rest = " + rest[0] + " / " + rest[1]);
 
         if (len >= 6 || rest[0] != 0) {
             IRubyObject sec = len >= 6 ? args[5] : RubyFixnum.zero(context.runtime);
@@ -202,8 +197,6 @@ public class RubyDateTime extends RubyDate {
                 subMillisNum = (int) ((1000 * r0) - (millis * r1)); subMillisDen = r1;
             }
         }
-
-        //System.out.println(" 4.seco " + second + " rest = " + rest[0] + " / " + rest[1] + "\n  millis = " + millis);
 
         try {
             long ms = dt.getMillis();
@@ -384,6 +377,7 @@ public class RubyDateTime extends RubyDate {
     }
 
     private static final ByteList TO_S_FORMAT = new ByteList(ByteList.plain("%.4d-%02d-%02dT%02d:%02d:%02d%s"), false);
+    static { TO_S_FORMAT.setEncoding(USASCIIEncoding.INSTANCE); }
 
     @JRubyMethod
     public RubyString to_s(ThreadContext context) {
@@ -422,6 +416,7 @@ public class RubyDateTime extends RubyDate {
     // date/format.rb
 
     private static final ByteList STRF_FORMAT_BYTES = ByteList.create("%FT%T%:z");
+    static { STRF_FORMAT_BYTES.setEncoding(USASCIIEncoding.INSTANCE); }
 
     @JRubyMethod // def strftime(fmt='%FT%T%:z')
     public RubyString strftime(ThreadContext context) {

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -427,9 +427,13 @@ public class RubyDateTime extends RubyDate {
     public RubyTime to_time(ThreadContext context) {
         final Ruby runtime = context.runtime;
         DateTime dt = this.dt;
-        dt = dt.withZoneRetainFields(RubyTime.getTimeZone(runtime, this.off));
 
-        //DateTime dt = new DateTime(this.dt.getMillis(), RubyTime.getTimeZone(runtime, this.off));
+        dt = new DateTime(
+                dt.getYear(), dt.getMonthOfYear(), dt.getDayOfMonth(),
+                dt.getHourOfDay(), dt.getMinuteOfHour(), dt.getSecondOfMinute(),
+                dt.getMillisOfSecond(), RubyTime.getTimeZone(runtime, this.off)
+        );
+
         RubyTime time = new RubyTime(runtime, runtime.getTime(), dt);
         if (subMillisNum != 0) {
             RubyNumeric usec = (RubyNumeric)

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -382,6 +382,9 @@ public class RubyDateTime extends RubyDate {
         return new RubyDate(context.runtime, getDate(context.runtime), dt.withTimeAtStartOfDay(), 0, start);
     }
 
+    @JRubyMethod
+    public RubyDateTime to_datetime() { return this; }
+
     @JRubyMethod // Time.new(year, mon, mday, hour, min, sec + sec_fraction, (@of * 86400.0))
     public RubyTime to_time(ThreadContext context) {
         final Ruby runtime = context.runtime;

--- a/core/src/main/java/org/jruby/ext/date/TimeExt.java
+++ b/core/src/main/java/org/jruby/ext/date/TimeExt.java
@@ -67,8 +67,9 @@ public abstract class TimeExt {
 
         final int off = dt.getZone().getOffset(dt.getMillis()) / 1000;
 
+        int year = dt.getYear(); if (year <= 0) year--; // JODA's Julian chronology (no year 0)
         dt = new DateTime(
-                dt.getYear(), dt.getMonthOfYear(), dt.getDayOfMonth(),
+                year, dt.getMonthOfYear(), dt.getDayOfMonth(),
                 dt.getHourOfDay(), dt.getMinuteOfHour(), dt.getSecondOfMinute(),
                 dt.getMillisOfSecond(), getChronology(context, ITALY, dt.getZone())
         );

--- a/core/src/main/java/org/jruby/ext/date/TimeExt.java
+++ b/core/src/main/java/org/jruby/ext/date/TimeExt.java
@@ -1,0 +1,83 @@
+/*
+ **** BEGIN LICENSE BLOCK *****
+ * Version: EPL 1.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 1.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2018 The JRuby Team
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.ext.date;
+
+import org.joda.time.Chronology;
+import org.joda.time.DateTime;
+import org.jruby.*;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import static org.jruby.ext.date.DateUtils.*;
+import static org.jruby.ext.date.RubyDate.*;
+
+/**
+ * Time's extensions from `require 'date'`
+ *
+ * @author kares
+ */
+public abstract class TimeExt {
+
+    private TimeExt() { /* no instances */ }
+
+    static void load(Ruby runtime) {
+        runtime.getTime().defineAnnotatedMethods(TimeExt.class);
+    }
+
+    @JRubyMethod
+    public static RubyTime to_time(IRubyObject self) { return (RubyTime) self; }
+
+    @JRubyMethod(name = "to_date")
+    public static RubyDate to_date(ThreadContext context, IRubyObject self) {
+        final DateTime dt = ((RubyTime) self).getDateTime();
+        long jd = civil_to_jd(dt.getYear(), dt.getMonthOfYear(), dt.getDayOfMonth(), GREGORIAN);
+        return new RubyDate(context, getDate(context.runtime), jd_to_ajd(context, jd), CHRONO_ITALY_UTC, ITALY);
+    }
+
+    @JRubyMethod(name = "to_datetime")
+    public static RubyDateTime to_datetime(ThreadContext context, IRubyObject self) {
+        final Ruby runtime = context.runtime;
+
+        final DateTime dt = ((RubyTime) self).getDateTime();
+        RubyFixnum jd = RubyFixnum.newFixnum(runtime, civil_to_jd(dt.getYear(), dt.getMonthOfYear(), dt.getDayOfMonth(), ITALY));
+
+        final RubyFixnum DAY_IN_SECS = RubyFixnum.newFixnum(runtime, DAY_IN_SECONDS);
+
+        int sec = dt.getSecondOfMinute(); // if (sec > 59) sec = 59;
+        IRubyObject subsec = RubyRational.newRationalConvert(context, ((RubyTime) self).subsec(), DAY_IN_SECS);
+        RubyNumeric fr = timeToDayFraction(context, dt.getHourOfDay(), dt.getMinuteOfHour(), sec);
+        fr = (RubyNumeric) ((RubyNumeric) subsec).op_plus(context, fr);
+
+        final int off = dt.getZone().getOffset(dt.getMillis()) / 1000;
+        final Chronology chronology = getChronology(context, ITALY, off);
+        return new RubyDateTime(context, getDateTime(context.runtime), jd_to_ajd(context, jd, fr, off), chronology, ITALY);
+    }
+
+}

--- a/core/src/main/java/org/jruby/ext/date/TimeExt.java
+++ b/core/src/main/java/org/jruby/ext/date/TimeExt.java
@@ -63,13 +63,14 @@ public abstract class TimeExt {
     @JRubyMethod(name = "to_datetime")
     public static RubyDateTime to_datetime(ThreadContext context, IRubyObject self) {
         final RubyTime time = (RubyTime) self;
-        final DateTime dt = ((RubyTime) self).getDateTime();
+        DateTime dt = ((RubyTime) self).getDateTime();
 
         final int off = dt.getZone().getOffset(dt.getMillis()) / 1000;
-        final DateTime val = new DateTime(
+
+        dt = new DateTime(
                 dt.getYear(), dt.getMonthOfYear(), dt.getDayOfMonth(),
                 dt.getHourOfDay(), dt.getMinuteOfHour(), dt.getSecondOfMinute(),
-                dt.getMillisOfSecond(), dt.getZone() // will use ISO chronology
+                dt.getMillisOfSecond(), getChronology(context, ITALY, dt.getZone())
         );
 
         long subMillisNum = 0, subMillisDen = 1;
@@ -84,7 +85,7 @@ public abstract class TimeExt {
             }
         }
 
-        return new RubyDateTime(context.runtime, getDateTime(context.runtime), val, off, ITALY, subMillisNum, subMillisDen);
+        return new RubyDateTime(context.runtime, getDateTime(context.runtime), dt, off, ITALY, subMillisNum, subMillisDen);
     }
 
 }

--- a/core/src/main/java/org/jruby/ext/date/TimeExt.java
+++ b/core/src/main/java/org/jruby/ext/date/TimeExt.java
@@ -58,7 +58,7 @@ public abstract class TimeExt {
     public static RubyDate to_date(ThreadContext context, IRubyObject self) {
         final DateTime dt = ((RubyTime) self).getDateTime();
         long jd = civil_to_jd(dt.getYear(), dt.getMonthOfYear(), dt.getDayOfMonth(), GREGORIAN);
-        return new RubyDate(context, getDate(context.runtime), jd_to_ajd(context, jd), CHRONO_ITALY_UTC, ITALY);
+        return new RubyDate(context, getDate(context.runtime), jd_to_ajd(context, jd), CHRONO_ITALY_UTC, 0);
     }
 
     @JRubyMethod(name = "to_datetime")
@@ -77,7 +77,7 @@ public abstract class TimeExt {
 
         final int off = dt.getZone().getOffset(dt.getMillis()) / 1000;
         final Chronology chronology = getChronology(context, ITALY, off);
-        return new RubyDateTime(context, getDateTime(context.runtime), jd_to_ajd(context, jd, fr, off), chronology, ITALY);
+        return new RubyDateTime(context, getDateTime(context.runtime), jd_to_ajd(context, jd, fr, off), chronology, off);
     }
 
 }

--- a/core/src/main/java/org/jruby/ext/date/TimeExt.java
+++ b/core/src/main/java/org/jruby/ext/date/TimeExt.java
@@ -62,11 +62,11 @@ public abstract class TimeExt {
     }
 
     @JRubyMethod(name = "to_datetime")
-    public static RubyDateTime to_datetime(ThreadContext context, IRubyObject self) {
+    public static RubyDateTime to_datetime1(ThreadContext context, IRubyObject self) {
         final Ruby runtime = context.runtime;
 
         final DateTime dt = ((RubyTime) self).getDateTime();
-        RubyFixnum jd = RubyFixnum.newFixnum(runtime, civil_to_jd(dt.getYear(), dt.getMonthOfYear(), dt.getDayOfMonth(), ITALY));
+        final long jd = civil_to_jd(dt.getYear(), dt.getMonthOfYear(), dt.getDayOfMonth(), ITALY);
 
         final RubyFixnum DAY_IN_SECS = RubyFixnum.newFixnum(runtime, DAY_IN_SECONDS);
 

--- a/core/src/main/java/org/jruby/util/RubyDateFormatter.java
+++ b/core/src/main/java/org/jruby/util/RubyDateFormatter.java
@@ -51,6 +51,7 @@ import org.joda.time.DateTime;
 import org.joda.time.chrono.GJChronology;
 import org.joda.time.chrono.JulianChronology;
 import org.jruby.Ruby;
+import org.jruby.RubyNumeric;
 import org.jruby.RubyString;
 import org.jruby.RubyTime;
 import org.jruby.lexer.StrftimeLexer;
@@ -356,7 +357,7 @@ public class RubyDateFormatter {
     }
 
     /** Convenience method when using no pattern caching */
-    public RubyString compileAndFormat(RubyString pattern, boolean dateLibrary, DateTime dt, long nsec, IRubyObject sub_millis) {
+    public RubyString compileAndFormat(RubyString pattern, boolean dateLibrary, DateTime dt, long nsec, RubyNumeric sub_millis) {
         RubyString out = format(compilePattern(pattern, dateLibrary), dt, nsec, sub_millis);
         if (pattern.isTaint()) {
             out.setTaint(true);
@@ -364,13 +365,13 @@ public class RubyDateFormatter {
         return out;
     }
 
-    public RubyString format(List<Token> compiledPattern, DateTime dt, long nsec, IRubyObject sub_millis) {
+    public RubyString format(List<Token> compiledPattern, DateTime dt, long nsec, RubyNumeric sub_millis) {
         return runtime.newString(formatToByteList(compiledPattern, dt, nsec, sub_millis));
     }
 
-    public ByteList formatToByteList(List<Token> compiledPattern, DateTime dt, long nsec, IRubyObject sub_millis) {
+    private ByteList formatToByteList(List<Token> compiledPattern, DateTime dt, long nsec, RubyNumeric sub_millis) {
         RubyTimeOutputFormatter formatter = RubyTimeOutputFormatter.DEFAULT_FORMATTER;
-        ByteList toAppendTo = new ByteList();
+        final ByteList toAppendTo = new ByteList(24);
 
         for (Token token: compiledPattern) {
             CharSequence output = null;
@@ -512,16 +513,10 @@ public class RubyDateFormatter {
                     output = RubyTimeOutputFormatter.formatNumber(dt.getMillisOfSecond(), 3, '0');
                     if (width > 3) {
                         StringBuilder buff = new StringBuilder(output.length() + 6).append(output);
-                        if (sub_millis == null || sub_millis.isNil()) { // Time
+                        if (sub_millis == null) { // Time
                             buff.append(RubyTimeOutputFormatter.formatNumber(nsec, 6, '0'));
                         } else { // Date, DateTime
-                            int prec = width - 3;
-                            final ThreadContext context = runtime.getCurrentContext(); // TODO really need the dynamic nature here?
-                            IRubyObject power = runtime.newFixnum(10).op_pow(context, prec);
-                            IRubyObject truncated = sub_millis.callMethod(context, "numerator").callMethod(context, "*", power);
-                            truncated = truncated.callMethod(context, "/", sub_millis.callMethod(context, "denominator"));
-                            long decimals = truncated.convertToInteger().getLongValue();
-                            buff.append(RubyTimeOutputFormatter.formatNumber(decimals, prec, '0'));
+                            formatSubMillisGt3(runtime, buff, width, sub_millis);
                         }
                         output = buff;
                     }
@@ -569,6 +564,18 @@ public class RubyDateFormatter {
         return toAppendTo;
     }
 
+    private static void formatSubMillisGt3(final Ruby runtime, final StringBuilder buff,
+                                           final int width, RubyNumeric sub_millis) {
+        final int prec = width - 3;
+        final ThreadContext context = runtime.getCurrentContext();
+        RubyNumeric power = (RubyNumeric) runtime.newFixnum(10).op_pow(context, prec);
+        RubyNumeric truncated = (RubyNumeric) sub_millis.numerator(context).
+                convertToInteger().op_mul(context, power);
+        truncated = (RubyNumeric) truncated.idiv(context, sub_millis.denominator(context));
+        long decimals = truncated.convertToInteger().getLongValue();
+        buff.append(RubyTimeOutputFormatter.formatNumber(decimals, prec, '0'));
+    }
+
     /**
      * Ruby always follows Astronomical year numbering,
      * that is BC x is -x+1 and there is a year 0 (BC 1)
@@ -587,8 +594,7 @@ public class RubyDateFormatter {
         dtCalendar.setFirstDayOfWeek(firstDayOfWeek);
         dtCalendar.setMinimalDaysInFirstWeek(7);
         int value = dtCalendar.get(java.util.Calendar.WEEK_OF_YEAR);
-        if ((value == 52 || value == 53) &&
-                (dtCalendar.get(Calendar.MONTH) == Calendar.JANUARY )) {
+        if ((value == 52 || value == 53) && (dtCalendar.get(Calendar.MONTH) == Calendar.JANUARY )) {
             // MRI behavior: Week values are monotonous.
             // So, weeks that effectively belong to previous year,
             // will get the value of 0, not 52 or 53, as in Java.
@@ -608,8 +614,8 @@ public class RubyDateFormatter {
             hours = -hours;
         }
 
-        String mm = RubyTimeOutputFormatter.formatNumber(minutes, 2, '0');
-        String ss = RubyTimeOutputFormatter.formatNumber(seconds, 2, '0');
+        CharSequence mm = RubyTimeOutputFormatter.formatNumber(minutes, 2, '0');
+        CharSequence ss = RubyTimeOutputFormatter.formatNumber(seconds, 2, '0');
 
         char padder = formatter.getPadder('0');
         int defaultWidth = -1;
@@ -643,10 +649,12 @@ public class RubyDateFormatter {
             width = minWidth;
         }
         width -= after.length();
-        CharSequence before = RubyTimeOutputFormatter.formatSignedNumber(hours, width, padder);
+        StringBuilder before = RubyTimeOutputFormatter.formatSignedNumber(hours, width, padder);
 
         if (value < 0 && hours == 0) { // the formatter could not handle this case
-            before = before.toString().replace('+', '-');
+            for (int i=0; i<before.length(); i++) { // replace('+', '-')
+                if (before.charAt(i) == '+') before.setCharAt(i, '-');
+            }
         }
         return new StringBuilder(before.length() + after.length()).append(before).append(after); // before + after
     }

--- a/core/src/main/java/org/jruby/util/RubyDateParser.java
+++ b/core/src/main/java/org/jruby/util/RubyDateParser.java
@@ -25,6 +25,7 @@
  ***** END LICENSE BLOCK *****/
 package org.jruby.util;
 
+import org.jcodings.Encoding;
 import org.jruby.Ruby;
 import org.jruby.RubyBignum;
 import org.jruby.RubyFixnum;
@@ -61,10 +62,11 @@ public class RubyDateParser {
         final List<StrptimeToken> compiledPattern = context.runtime.getCachedStrptimePattern(format);
         final StrptimeParser.FormatBag bag = new StrptimeParser().parse(compiledPattern, text.asJavaString());
 
-        return bag == null ? context.nil :  convertFormatBagToHash(context, bag, text.isTaint());
+        return bag == null ? context.nil : convertFormatBagToHash(context, bag, text.getEncoding(), text.isTaint());
     }
 
-    private IRubyObject convertFormatBagToHash(ThreadContext context, StrptimeParser.FormatBag bag, boolean tainted) {
+    static IRubyObject convertFormatBagToHash(ThreadContext context, StrptimeParser.FormatBag bag,
+                                              Encoding encoding, boolean tainted) {
         Ruby runtime = context.runtime;
         RubyHash hash = RubyHash.newHash(runtime);
 
@@ -84,7 +86,7 @@ public class RubyDateParser {
         if (has(bag.getWNum1())) hash.op_aset(context, RubySymbol.newSymbol(runtime, "wnum1"), runtime.newFixnum(bag.getWNum1()));
 
         if (bag.getZone() != null) {
-            final RubyString zone = RubyString.newString(runtime, bag.getZone());
+            final RubyString zone = RubyString.newString(runtime, bag.getZone(), encoding);
             if (tainted) zone.taint(context);
 
             hash.op_aset(context, RubySymbol.newSymbol(runtime, "zone"), zone);
@@ -115,7 +117,7 @@ public class RubyDateParser {
             hash.op_aset(context, RubySymbol.newSymbol(runtime, "_cent"), RubyBignum.newBignum(runtime, bag.getCent()));
         }
         if (bag.getLeftover() != null) {
-            final RubyString leftover = RubyString.newString(runtime, bag.getLeftover());
+            final RubyString leftover = RubyString.newString(runtime, bag.getLeftover(), encoding);
             if (tainted) leftover.taint(context);
 
             hash.op_aset(context, RubySymbol.newSymbol(runtime, "leftover"), leftover);

--- a/core/src/main/java/org/jruby/util/RubyDateParser.java
+++ b/core/src/main/java/org/jruby/util/RubyDateParser.java
@@ -43,6 +43,7 @@ import static org.jruby.util.StrptimeParser.FormatBag.has;
  * This class has {@code StrptimeParser} and provides methods that are calls from JRuby.
  */
 public class RubyDateParser {
+
     /**
      * Date._strptime method in JRuby 9.1.5.0's lib/ruby/stdlib/date/format.rb is replaced
      * with this method. This is Java implementation of date__strptime method in MRI 2.3.1's
@@ -53,7 +54,11 @@ public class RubyDateParser {
      */
 
     public IRubyObject parse(ThreadContext context, final RubyString format, final RubyString text) {
-        final List<StrptimeToken> compiledPattern = context.runtime.getCachedStrptimePattern(format.asJavaString());
+        return parse(context, format.asJavaString(), text);
+    }
+
+    public IRubyObject parse(ThreadContext context, final String format, final RubyString text) {
+        final List<StrptimeToken> compiledPattern = context.runtime.getCachedStrptimePattern(format);
         final StrptimeParser.FormatBag bag = new StrptimeParser().parse(compiledPattern, text.asJavaString());
 
         return bag == null ? context.nil :  convertFormatBagToHash(context, bag, text.isTaint());

--- a/core/src/main/java/org/jruby/util/RubyTimeOutputFormatter.java
+++ b/core/src/main/java/org/jruby/util/RubyTimeOutputFormatter.java
@@ -95,25 +95,27 @@ public class RubyTimeOutputFormatter {
         return sequence.toString();
     }
 
-    static String formatNumber(long value, int width, char padder) {
+    static CharSequence formatNumber(long value, int width, char padder) {
         if (value >= 0 || padder != '0') {
-            return padding(Long.toString(value), width, padder).toString();
+            return padding(Long.toString(value), width, padder);
         }
-        return "-" + padding(Long.toString(-value), width - 1, padder);
+        return padding(new StringBuilder().append('-'), Long.toString(-value), width - 1, padder);
     }
 
-    static CharSequence formatSignedNumber(long value, int width, char padder) {
+    static StringBuilder formatSignedNumber(long value, int width, char padder) {
+        StringBuilder out = new StringBuilder();
         if (padder == '0') {
             if (value >= 0) {
-                return "+" + padding(Long.toString(value), width - 1, padder);
+                return padding(out.append('+'), Long.toString(value), width - 1, padder);
             } else {
-                return "-" + padding(Long.toString(-value), width - 1, padder);
+                return padding(out.append('-'), Long.toString(-value), width - 1, padder);
             }
         } else {
             if (value >= 0) {
-                return padding('+' + Long.toString(value), width, padder);
+                final StringBuilder str = new StringBuilder().append('+').append(Long.toString(value));
+                return padding(out, str, width, padder);
             } else {
-                return padding(Long.toString(value), width, padder);
+                return padding(out, Long.toString(value), width, padder);
             }
         }
     }
@@ -121,15 +123,27 @@ public class RubyTimeOutputFormatter {
     private static final int SMALLBUF = 100;
 
     private static CharSequence padding(CharSequence sequence, int width, char padder) {
-        if (sequence.length() >= width) return sequence;
+        final int len = sequence.length();
+        if (len >= width) return sequence;
 
         if (width > SMALLBUF) throw new IndexOutOfBoundsException("padding width " + width + " too large");
 
-        StringBuilder buf = new StringBuilder(width + sequence.length());
-        for (int i = sequence.length(); i < width; i++) {
-            buf.append(padder);
-        }
-        buf.append(sequence);
-        return buf;
+        StringBuilder out = new StringBuilder(width + len);
+        for (int i = len; i < width; i++) out.append(padder);
+        out.append(sequence);
+        return out;
     }
+
+    private static StringBuilder padding(final StringBuilder out, CharSequence sequence,
+                                         final int width, final char padder) {
+        final int len = sequence.length();
+        if (len >= width) return out.append(sequence);
+
+        if (width > SMALLBUF) throw new IndexOutOfBoundsException("padding width " + width + " too large");
+
+        out.ensureCapacity(width + len);
+        for (int i = len; i < width; i++) out.append(padder);
+        return out.append(sequence);
+    }
+
 }

--- a/core/src/main/java/org/jruby/util/TimeZoneConverter.java
+++ b/core/src/main/java/org/jruby/util/TimeZoneConverter.java
@@ -381,6 +381,8 @@ public class TimeZoneConverter {
         }
     }
 
+    public static final int INVALID_ZONE = Integer.MIN_VALUE;
+
     /**
      * Ports date_zone_to_diff from ext/date/date_parse.c in MRI 2.3.1 under BSDL.
      */
@@ -420,7 +422,7 @@ public class TimeZoneConverter {
             sign = false;
         } else {
             // if z doesn't start with "+" or "-", invalid
-            return Integer.MIN_VALUE;
+            return INVALID_ZONE;
         }
         z = z.substring(1);
 

--- a/lib/ruby/stdlib/date.rb
+++ b/lib/ruby/stdlib/date.rb
@@ -655,28 +655,6 @@ class Date
       jd
     end
 
-    # Do hour +h+, minute +min+, and second +s+ constitute a valid time?
-    #
-    # If they do, returns their value as a fraction of a day.  If not,
-    # returns nil.
-    #
-    # The 24-hour clock is used.  Negative values of +h+, +min+, and
-    # +sec+ are treating as counting backwards from the end of the
-    # next larger unit (e.g. a +min+ of -2 is treated as 58).  No
-    # wraparound is performed.
-    def _valid_time? (h, min, s) # :nodoc:
-      h   += 24 if h   < 0
-      min += 60 if min < 0
-      s   += 60 if s   < 0
-      return unless ((0...24) === h &&
-                     (0...60) === min &&
-                     (0...60) === s) ||
-                     (24 == h &&
-                       0 == min &&
-                       0 == s)
-      time_to_day_fraction(h, min, s)
-    end
-
   end
 
   extend  t
@@ -703,11 +681,6 @@ class Date
     !!_valid_nth_kday?(y, m, n, k, sg)
   end
   private_class_method :valid_nth_kday?
-
-  def self.valid_time? (h, min, s) # :nodoc:
-    !!_valid_time?(h, min, s)
-  end
-  private_class_method :valid_time?
 
   # Create a new Date object from a Julian Day Number.
   #

--- a/lib/ruby/stdlib/date.rb
+++ b/lib/ruby/stdlib/date.rb
@@ -528,9 +528,6 @@ class Date
     new_by_frags(elem, sg)
   end
 
-  def zone() strftime('%:z') end
-  private :zone
-
   DAYNAMES.each_with_index do |n, i|
     define_method(n.downcase + '?') { wday == i }
   end
@@ -590,11 +587,6 @@ class Date
   def downto(min, &block) # :yield: date
     step(min, -1, &block)
   end
-
-  # Return the date as a human-readable string.
-  #
-  # The format used is YYYY-MM-DD.
-  def to_s() format('%.4d-%02d-%02d', year, mon, mday) end # 4p
 
 end
 
@@ -784,11 +776,6 @@ class DateTime < Date
   def self.jisx0301(str='-4712-01-01T00:00:00+00:00', sg=ITALY) # :nodoc:
     elem = _jisx0301(str)
     new_by_frags(elem, sg)
-  end
-
-  def to_s # 4p
-    format('%.4d-%02d-%02dT%02d:%02d:%02d%s',
-           year, mon, mday, hour, min, sec, zone)
   end
 
 end

--- a/lib/ruby/stdlib/date.rb
+++ b/lib/ruby/stdlib/date.rb
@@ -218,7 +218,7 @@ class Date
   ABBR_DAYNAMES = %w(Sun Mon Tue Wed Thu Fri Sat)
 
   [MONTHNAMES, DAYNAMES, ABBR_MONTHNAMES, ABBR_DAYNAMES].each do |xs|
-    xs.each{|x| x.freeze unless x.nil?}.freeze
+    xs.each { |x| x.freeze unless x.nil? }.freeze
   end
 
   class Infinity < Numeric # :nodoc:
@@ -291,7 +291,6 @@ class Date
   GREGORIAN = -Infinity.new
 
   def self.rewrite_frags(elem) # :nodoc:
-    elem ||= {}
     if seconds = elem[:seconds]
       d,   fr = seconds.divmod(86400)
       h,   fr = fr.divmod(3600)
@@ -322,15 +321,14 @@ class Date
     [nil,         [:cwyear, :cweek, :wday]],
     [nil,         [:year, :wnum0, :cwday]],
     [nil,         [:year, :wnum1, :cwday]]
-  ]
+  ].freeze
+  private_constant :COMPLETE_FRAGS
 
   def self.complete_frags(elem) # :nodoc:
-    g = COMPLETE_FRAGS.max_by { |kind, fields|
-      fields.count { |field| elem.key? field }
-    }
+    g = COMPLETE_FRAGS.max_by { |_, fields| fields.count { |field| elem.key? field } }
     c = g[1].count { |field| elem.key? field }
 
-    if c == 0 and [:hour, :min, :sec].none? { |field| elem.key? field }
+    if c == 0 && [:hour, :min, :sec].none? { |field| elem.key? field }
       g = nil
     end
 
@@ -398,7 +396,6 @@ class Date
     end
 
     year = elem[:year]
-
     if year and yday = elem[:yday] and
         jd = _valid_ordinal?(year, yday, sg)
       return jd
@@ -435,9 +432,11 @@ class Date
   private_class_method :valid_time_frags?
 
   def self.new_by_frags(elem, sg) # :nodoc:
+    raise ArgumentError, 'invalid date' unless elem
+
     # fast path
-    if elem and !elem.key?(:jd) and !elem.key?(:yday) and
-        year = elem[:year] and mon = elem[:mon] and mday = elem[:mday]
+    if !elem.key?(:jd) && !elem.key?(:yday) &&
+        (year = elem[:year]) && (mon = elem[:mon]) && (mday = elem[:mday])
       return Date.civil(year, mon, mday, sg)
     end
 
@@ -466,8 +465,7 @@ class Date
   # An ArgumentError will be raised if +str+ cannot be
   # parsed.
   def self.strptime(str='-4712-01-01', fmt='%F', sg=ITALY)
-    elem = _strptime(str, fmt)
-    new_by_frags(elem, sg)
+    new_by_frags(_strptime(str, fmt), sg)
   end
 
   # Create a new Date object by parsing from a String,
@@ -685,6 +683,8 @@ class DateTime < Date
   end
 
   def self.new_by_frags(elem, sg) # :nodoc:
+    raise ArgumentError, 'invalid date' unless elem
+    
     elem = rewrite_frags(elem)
     elem = complete_frags(elem)
     unless (jd = valid_date_frags?(elem, sg)) &&
@@ -771,17 +771,7 @@ class DateTime < Date
     new_by_frags(elem, sg)
   end
 
-end
-
-class Date
-
-  def to_time
-    Time.local(year, mon, mday)
-  end
-
-end
-
-class DateTime < Date
+  # adjust superclass (Date) methods :
 
   public :hour, :min, :sec, :sec_fraction, :zone, :offset, :new_offset,
          :minute, :second, :second_fraction

--- a/lib/ruby/stdlib/date.rb
+++ b/lib/ruby/stdlib/date.rb
@@ -1449,37 +1449,6 @@ class Date
     self
   end
 
-  def to_datetime
-    DateTime.new!(@dt.withTimeAtStartOfDay, @of, @sg)
-  end
-
-  # Create a new Date object representing today.
-  #
-  # +sg+ specifies the Day of Calendar Reform.
-  def self.today(sg=ITALY)
-    t = Time.now
-    civil(t.year, t.mon, t.mday, sg)
-  end
-
-  DEFAULT_TZ = ENV['TZ']
-  DEFAULT_DTZ = JODA::DateTimeZone.getDefault
-  CHRONO_ITALY_DEFAULT_DTZ = chronology(ITALY, DEFAULT_DTZ)
-  CHRONO_ITALY_UTC = JODA.chrono::GJChronology.getInstance(JODA::DateTimeZone::UTC)
-
-  # Create a new DateTime object representing the current time.
-  #
-  # +sg+ specifies the Day of Calendar Reform.
-  def self.now(sg=ITALY)
-    dtz = (ENV['TZ'] == DEFAULT_TZ) ? DEFAULT_DTZ : org.jruby::RubyTime.getLocalTimeZone(JRuby.runtime)
-
-    if dtz == DEFAULT_DTZ and sg == ITALY
-      new!(JODA::DateTime.new(CHRONO_ITALY_DEFAULT_DTZ), nil, sg)
-    else
-      new!(JODA::DateTime.new(chronology(sg, dtz)), nil, sg)
-    end
-  end
-  private_class_method :now
-
 end
 
 class DateTime < Date
@@ -1499,6 +1468,4 @@ class DateTime < Date
     self
   end
 
-  private_class_method :today
-  public_class_method  :now
 end

--- a/lib/ruby/stdlib/date.rb
+++ b/lib/ruby/stdlib/date.rb
@@ -596,15 +596,6 @@ class Date
   # The format used is YYYY-MM-DD.
   def to_s() format('%.4d-%02d-%02d', year, mon, mday) end # 4p
 
-  # @private
-  def self._load(str)
-    ary = Marshal.load(str)
-    raise TypeError, "expected an array" unless ary.is_a?(Array)
-    obj = allocate
-    obj.marshal_load(ary)
-    obj
-  end
-
 end
 
 # Class representing a date and time.

--- a/lib/ruby/stdlib/date.rb
+++ b/lib/ruby/stdlib/date.rb
@@ -334,44 +334,6 @@ class Date
       jd
     end
 
-    # Convert a Julian Day Number to a Civil Date.  +jd+ is
-    # the Julian Day Number. +sg+ specifies the Day of
-    # Calendar Reform.
-    #
-    # Returns the corresponding [year, month, day_of_month]
-    # as a three-element array.
-    def jd_to_civil(jd, sg=GREGORIAN) # :nodoc:
-      if jd < sg
-        a = jd
-      else
-        x = ((jd - 1867216.25) / 36524.25).floor
-        a = jd + 1 + x - (x / 4.0).floor
-      end
-      b = a + 1524
-      c = ((b - 122.1) / 365.25).floor
-      d = (365.25 * c).floor
-      e = ((b - d) / 30.6001).floor
-      dom = b - d - (30.6001 * e).floor
-      if e <= 13
-        m = e - 1
-        y = c - 4716
-      else
-        m = e - 13
-        y = c - 4715
-      end
-      return y, m, dom
-    end
-
-    # Convert an Astronomical Julian Day Number to a (civil) Julian
-    # Day Number.
-    #
-    # +ajd+ is the Astronomical Julian Day Number to convert.
-    # +of+ is the offset from UTC as a fraction of a day (defaults to 0).
-    #
-    # Returns the (civil) Julian Day Number as [day_number,
-    # fraction] where +fraction+ is always 1/2.
-    def ajd_to_jd(ajd, of=0) (ajd + of + HALF_DAYS_IN_DAY).divmod(1) end # :nodoc:
-
     # Convert a (civil) Julian Day Number to an Astronomical Julian
     # Day Number.
     #
@@ -381,62 +343,15 @@ class Date
     #
     # Returns the Astronomical Julian Day Number as a single
     # numeric value.
-    def jd_to_ajd(jd, fr, of=0) jd + fr - of - HALF_DAYS_IN_DAY end # :nodoc:
-
-    # Convert a fractional day +fr+ to [hours, minutes, seconds,
-    # fraction_of_a_second]
-    # def day_fraction_to_time(fr) # :nodoc:
-    #   ss,  fr = fr.divmod(SECONDS_IN_DAY) # 4p
-    #   h,   ss = ss.divmod(3600)
-    #   min, s  = ss.divmod(60)
-    #   return h, min, s, fr * 86400
-    # end
+    def jd_to_ajd(jd, fr, of=0) jd + fr - of - HALF_DAYS_IN_DAY end # :nodoc: TODO to be removed after Time#to_date/date_time
 
     # Convert an +h+ hour, +min+ minutes, +s+ seconds period to a fractional day.
     def time_to_day_fraction(h, min, s) Rational(h * 3600 + min * 60 + s, 86400) end
-
-    # Convert an Astronomical Modified Julian Day Number to an
-    # Astronomical Julian Day Number.
-    def amjd_to_ajd(amjd) amjd + MJD_EPOCH_IN_AJD end # :nodoc:
-
-    # Convert an Astronomical Julian Day Number to an
-    # Astronomical Modified Julian Day Number.
-    # def ajd_to_amjd(ajd) ajd - MJD_EPOCH_IN_AJD end # :nodoc:
-
-    # Convert a Modified Julian Day Number to a Julian
-    # Day Number.
-    # def mjd_to_jd(mjd) mjd + MJD_EPOCH_IN_CJD end # :nodoc:
-
-    # Convert a Julian Day Number to a Modified Julian Day
-    # Number.
-    # def jd_to_mjd(jd) jd - MJD_EPOCH_IN_CJD end # :nodoc:
-
-    # Convert a count of the number of days since the adoption
-    # of the Gregorian Calendar (in Italy) to a Julian Day Number.
-    # def ld_to_jd(ld) ld +  LD_EPOCH_IN_CJD end # :nodoc:
-
-    # Convert a Julian Day Number to the number of days since
-    # the adoption of the Gregorian Calendar (in Italy).
-    # def jd_to_ld(jd) jd -  LD_EPOCH_IN_CJD end # :nodoc:
 
   end
 
   extend  t
   include t
-
-  def self.valid_jd? (jd, sg=ITALY)
-    !!_valid_jd?(jd, sg)
-  end
-
-  # Create a new Date object from a Julian Day Number.
-  #
-  # +jd+ is the Julian Day Number; if not specified, it defaults to
-  # 0.
-  # +sg+ specifies the Day of Calendar Reform.
-  def self.jd(jd=0, sg=ITALY)
-    jd = _valid_jd?(jd, sg)
-    new!(jd_to_ajd(jd, 0, 0), 0, sg)
-  end
 
   def self.rewrite_frags(elem) # :nodoc:
     elem ||= {}
@@ -873,30 +788,6 @@ end
 # UTC as a fraction of a day.
 #
 class DateTime < Date
-
-  # Create a new DateTime object corresponding to the specified
-  # Julian Day Number +jd+ and hour +h+, minute +min+, second +s+.
-  #
-  # The 24-hour clock is used.  Negative values of +h+, +min+, and
-  # +sec+ are treating as counting backwards from the end of the
-  # next larger unit (e.g. a +min+ of -2 is treated as 58).  No
-  # wraparound is performed.  If an invalid time portion is specified,
-  # an ArgumentError is raised.
-  #
-  # +of+ is the offset from UTC as a fraction of a day (defaults to 0).
-  # +sg+ specifies the Day of Calendar Reform.
-  #
-  # All day/time values default to 0.
-  def self.jd(jd=0, h=0, min=0, s=0, of=0, sg=ITALY)
-    unless (jd = _valid_jd?(jd, sg)) &&
-           (fr = _valid_time?(h, min, s))
-      raise ArgumentError, 'invalid date'
-    end
-    if String === of
-      of = Rational(zone_to_diff(of) || 0, 86400)
-    end
-    new!(jd_to_ajd(jd, fr, of), of, sg)
-  end
 
   # Create a new DateTime object corresponding to the specified
   # Ordinal Date and hour +h+, minute +min+, second +s+.

--- a/lib/ruby/stdlib/date.rb
+++ b/lib/ruby/stdlib/date.rb
@@ -321,14 +321,6 @@ class Date
       j
     end
 
-    def find_ldoy(y, sg) # :nodoc:
-      j = nil
-      31.downto(1) do |d|
-        break if j = _valid_civil?(y, 12, d, sg)
-      end
-      j
-    end
-
     def find_fdom(y, m, sg) # :nodoc:
       j = nil
       1.upto(31) do |d|
@@ -343,30 +335,6 @@ class Date
         break if j = _valid_civil?(y, m, d, sg)
       end
       j
-    end
-
-    # Convert an Ordinal Date to a Julian Day Number.
-    #
-    # +y+ and +d+ are the year and day-of-year to convert.
-    # +sg+ specifies the Day of Calendar Reform.
-    #
-    # Returns the corresponding Julian Day Number.
-    def ordinal_to_jd(y, d, sg=GREGORIAN) # :nodoc:
-      find_fdoy(y, sg) + d - 1
-    end
-
-    # Convert a Julian Day Number to an Ordinal Date.
-    #
-    # +jd+ is the Julian Day Number to convert.
-    # +sg+ specifies the Day of Calendar Reform.
-    #
-    # Returns the corresponding Ordinal Date as
-    # [year, day_of_year]
-    def jd_to_ordinal(jd, sg=GREGORIAN) # :nodoc:
-      y = jd_to_civil(jd, sg)[0]
-      j = find_fdoy(y, sg)
-      doy = jd - j + 1
-      return y, doy
     end
 
     # Convert a Civil Date to a Julian Day Number.
@@ -532,31 +500,6 @@ class Date
     # the adoption of the Gregorian Calendar (in Italy).
     # def jd_to_ld(jd) jd -  LD_EPOCH_IN_CJD end # :nodoc:
 
-    # Do the year +y+ and day-of-year +d+ make a valid Ordinal Date?
-    # Returns the corresponding Julian Day Number if they do, or
-    # nil if they don't.
-    #
-    # +d+ can be a negative number, in which case it counts backwards
-    # from the end of the year (-1 being the last day of the year).
-    # No year wraparound is performed, however, so valid values of
-    # +d+ are -365 .. -1, 1 .. 365 on a non-leap-year,
-    # -366 .. -1, 1 .. 366 on a leap year.
-    # A date falling in the period skipped in the Day of Calendar Reform
-    # adjustment is not valid.
-    #
-    # +sg+ specifies the Day of Calendar Reform.
-    def _valid_ordinal? (y, d, sg=GREGORIAN) # :nodoc:
-      if d < 0
-        return unless j = find_ldoy(y, sg)
-        ny, nd = jd_to_ordinal(j + d + 1, sg)
-        return unless ny == y
-        d = nd
-      end
-      jd = ordinal_to_jd(y, d, sg)
-      return unless [y, d] == jd_to_ordinal(jd, sg)
-      jd
-    end
-
     # Do year +y+, week-of-year +w+, and day-of-week +d+ make a
     # valid Commercial Date?  Returns the corresponding Julian
     # Day Number if they do, nil if they don't.
@@ -627,10 +570,6 @@ class Date
     !!_valid_jd?(jd, sg)
   end
 
-  def self.valid_ordinal? (y, d, sg=ITALY)
-    !!_valid_ordinal?(y, d, sg)
-  end
-
   def self.valid_commercial? (y, w, d, sg=ITALY)
     !!_valid_commercial?(y, w, d, sg)
   end
@@ -652,23 +591,6 @@ class Date
   # +sg+ specifies the Day of Calendar Reform.
   def self.jd(jd=0, sg=ITALY)
     jd = _valid_jd?(jd, sg)
-    new!(jd_to_ajd(jd, 0, 0), 0, sg)
-  end
-
-  # Create a new Date object from an Ordinal Date, specified
-  # by year +y+ and day-of-year +d+. +d+ can be negative,
-  # in which it counts backwards from the end of the year.
-  # No year wraparound is performed, however.  An invalid
-  # value for +d+ results in an ArgumentError being raised.
-  #
-  # +y+ defaults to -4712, and +d+ to 1; this is Julian Day
-  # Number day 0.
-  #
-  # +sg+ specifies the Day of Calendar Reform.
-  def self.ordinal(y=-4712, d=1, sg=ITALY)
-    unless jd = _valid_ordinal?(y, d, sg)
-      raise ArgumentError, 'invalid date'
-    end
     new!(jd_to_ajd(jd, 0, 0), 0, sg)
   end
 

--- a/lib/ruby/stdlib/date.rb
+++ b/lib/ruby/stdlib/date.rb
@@ -596,37 +596,10 @@ class Date
   # The format used is YYYY-MM-DD.
   def to_s() format('%.4d-%02d-%02d', year, mon, mday) end # 4p
 
-  HALF_DAYS_IN_DAY = Rational(1, 2) # :nodoc:
-  private_constant :HALF_DAYS_IN_DAY
-
-  # Load from Marshal format.
   # @private
-  # @note marshal_dump differs from MRI, implemented as [ ajd, @of, @sg ]
-  def marshal_load(a)
-    case a.size
-    when 2 # 1.6.x
-      ajd = a[0] - HALF_DAYS_IN_DAY
-      of = 0
-      sg = a[1]
-      sg = sg ? GREGORIAN : JULIAN unless Numeric === sg
-    when 3 # 1.8.x, 1.9.2
-      ajd, of, sg = a
-    when 6
-      _, jd, df, sf, of, sg = a
-      of = Rational(of, 86_400)
-      ajd = jd - HALF_DAYS_IN_DAY
-      ajd += Rational(df, 86_400) if df != 0
-      ajd += Rational(sf, 86_400_000_000_000) if sf != 0
-    else
-      raise TypeError, "invalid size"
-    end
-
-    initialize(ajd, of, sg)
-  end
-
   def self._load(str)
     ary = Marshal.load(str)
-    raise TypeError, "expected an array" unless Array === ary
+    raise TypeError, "expected an array" unless ary.is_a?(Array)
     obj = allocate
     obj.marshal_load(ary)
     obj

--- a/lib/ruby/stdlib/date.rb
+++ b/lib/ruby/stdlib/date.rb
@@ -1,14 +1,7 @@
-#
-# date.rb - date and time library
-#
-# Author: Tadayoshi Funaba 1998-2011
-#
-# Documentation: William Webber <william@williamwebber.com>
-#
-#--
-# $Id: date.rb,v 2.37 2008-01-17 20:16:31+09 tadf Exp $
-#++
-#
+# encoding: US-ASCII
+# frozen_string_literal: false
+# date.rb: Written by Tadayoshi Funaba 1998-2011
+
 # == Overview
 #
 # This file provides two classes for working with

--- a/lib/ruby/stdlib/date.rb
+++ b/lib/ruby/stdlib/date.rb
@@ -386,34 +386,6 @@ class Date
       return y, m, dom
     end
 
-    # Convert a Commercial Date to a Julian Day Number.
-    #
-    # +y+, +w+, and +d+ are the (commercial) year, week of the year,
-    # and day of the week of the Commercial Date to convert.
-    # +sg+ specifies the Day of Calendar Reform.
-    def commercial_to_jd(y, w, d, sg=GREGORIAN) # :nodoc:
-      j = find_fdoy(y, sg) + 3
-      (j - (((j - 1) + 1) % 7)) +
-        7 * (w - 1) +
-        (d - 1)
-    end
-
-    # Convert a Julian Day Number to a Commercial Date
-    #
-    # +jd+ is the Julian Day Number to convert.
-    # +sg+ specifies the Day of Calendar Reform.
-    #
-    # Returns the corresponding Commercial Date as
-    # [commercial_year, week_of_year, day_of_week]
-    def jd_to_commercial(jd, sg=GREGORIAN) # :nodoc:
-      a = jd_to_civil(jd - 3, sg)[0]
-      y = if jd >= commercial_to_jd(a + 1, 1, 1, sg) then a + 1 else a end
-      w = 1 + ((jd - commercial_to_jd(y, 1, 1, sg)) / 7).floor
-      d = (jd + 1) % 7
-      d = 7 if d == 0
-      return y, w, d
-    end
-
     def weeknum_to_jd(y, w, d, f=0, sg=GREGORIAN) # :nodoc:
       a = find_fdoy(y, sg) + 6
       (a - ((a - f) + 1) % 7 - 7) + 7 * w + d
@@ -500,35 +472,6 @@ class Date
     # the adoption of the Gregorian Calendar (in Italy).
     # def jd_to_ld(jd) jd -  LD_EPOCH_IN_CJD end # :nodoc:
 
-    # Do year +y+, week-of-year +w+, and day-of-week +d+ make a
-    # valid Commercial Date?  Returns the corresponding Julian
-    # Day Number if they do, nil if they don't.
-    #
-    # Monday is day-of-week 1; Sunday is day-of-week 7.
-    #
-    # +w+ and +d+ can be negative, in which case they count
-    # backwards from the end of the year and the end of the
-    # week respectively.  No wraparound is performed, however,
-    # and invalid values cause an ArgumentError to be raised.
-    # A date falling in the period skipped in the Day of Calendar
-    # Reform adjustment is not valid.
-    #
-    # +sg+ specifies the Day of Calendar Reform.
-    def _valid_commercial? (y, w, d, sg=GREGORIAN) # :nodoc:
-      if d < 0
-        d += 8
-      end
-      if w < 0
-        ny, nw, nd =
-          jd_to_commercial(commercial_to_jd(y + 1, 1, 1, sg) + w * 7, sg)
-        return unless ny == y
-        w = nw
-      end
-      jd = commercial_to_jd(y, w, d, sg)
-      return unless [y, w, d] == jd_to_commercial(jd, sg)
-      jd
-    end
-
     def _valid_weeknum? (y, w, d, f, sg=GREGORIAN) # :nodoc:
       if d < 0
         d += 7
@@ -570,10 +513,6 @@ class Date
     !!_valid_jd?(jd, sg)
   end
 
-  def self.valid_commercial? (y, w, d, sg=ITALY)
-    !!_valid_commercial?(y, w, d, sg)
-  end
-
   def self.valid_weeknum? (y, w, d, f, sg=ITALY) # :nodoc:
     !!_valid_weeknum?(y, w, d, f, sg)
   end
@@ -591,27 +530,6 @@ class Date
   # +sg+ specifies the Day of Calendar Reform.
   def self.jd(jd=0, sg=ITALY)
     jd = _valid_jd?(jd, sg)
-    new!(jd_to_ajd(jd, 0, 0), 0, sg)
-  end
-
-  # Create a new Date object for the Commercial Date specified by
-  # year +y+, week-of-year +w+, and day-of-week +d+.
-  #
-  # Monday is day-of-week 1; Sunday is day-of-week 7.
-  #
-  # +w+ and +d+ can be negative, in which case they count
-  # backwards from the end of the year and the end of the
-  # week respectively.  No wraparound is performed, however,
-  # and invalid values cause an ArgumentError to be raised.
-  #
-  # +y+ defaults to -4712, +w+ to 1, and +d+ to 1; this is
-  # Julian Day Number day 0.
-  #
-  # +sg+ specifies the Day of Calendar Reform.
-  def self.commercial(y=-4712, w=1, d=1, sg=ITALY)
-    unless jd = _valid_commercial?(y, w, d, sg)
-      raise ArgumentError, 'invalid date'
-    end
     new!(jd_to_ajd(jd, 0, 0), 0, sg)
   end
 

--- a/lib/ruby/stdlib/date/format.rb
+++ b/lib/ruby/stdlib/date/format.rb
@@ -877,42 +877,6 @@ class Date
     end
   end
 
-  # @private native code at MRI's (~ date_zone_to_diff)
-  def self.zone_to_diff(zone) # :nodoc:
-    zone = zone.downcase
-    if zone.sub!(/\s+(standard|daylight)\s+time\z/, '')
-      dst = $1 == 'daylight'
-    else
-      dst = zone.sub!(/\s+dst\z/, '')
-    end
-    if Format::ZONES.include?(zone)
-      offset = Format::ZONES[zone]
-      offset += 3600 if dst
-    elsif zone.sub!(/\A(?:gmt|utc?)?([-+])/, '')
-      sign = $1
-      if zone.include?(':')
-        hour, min, sec, = zone.split(':')
-      elsif zone.include?(',') || zone.include?('.')
-        hour, fr, = zone.split(/[,.]/)
-        min = Rational(fr.to_i, 10**fr.size) * 60
-      else
-        case zone.size
-          when 3
-            hour = zone[0,1]
-            min = zone[1,2]
-          else
-            hour = zone[0,2]
-            min = zone[2,2]
-            sec = zone[4,2]
-        end
-      end
-      offset = hour.to_i * 3600 + min.to_i * 60 + sec.to_i
-      offset = -offset if sign == '-'
-    end
-    offset
-  end
-  private_class_method :zone_to_diff
-
   def self.set_zone(h, zone) # :nodoc:
     h[:zone] = zone
     h[:offset] = zone_to_diff(zone)

--- a/lib/ruby/stdlib/date/format.rb
+++ b/lib/ruby/stdlib/date/format.rb
@@ -9,23 +9,23 @@ class Date
       'january'  => 1, 'february' => 2, 'march'    => 3, 'april'    => 4,
       'may'      => 5, 'june'     => 6, 'july'     => 7, 'august'   => 8,
       'september'=> 9, 'october'  =>10, 'november' =>11, 'december' =>12
-    }
+    }.freeze
 
     DAYS = {
       'sunday'   => 0, 'monday'   => 1, 'tuesday'  => 2, 'wednesday'=> 3,
       'thursday' => 4, 'friday'   => 5, 'saturday' => 6
-    }
+    }.freeze
 
     ABBR_MONTHS = {
       'jan'      => 1, 'feb'      => 2, 'mar'      => 3, 'apr'      => 4,
       'may'      => 5, 'jun'      => 6, 'jul'      => 7, 'aug'      => 8,
       'sep'      => 9, 'oct'      =>10, 'nov'      =>11, 'dec'      =>12
-    }
+    }.freeze
 
     ABBR_DAYS = {
       'sun'      => 0, 'mon'      => 1, 'tue'      => 2, 'wed'      => 3,
       'thu'      => 4, 'fri'      => 5, 'sat'      => 6
-    }
+    }.freeze
 
     ZONES = {
       'ut'  =>  0*3600, 'gmt' =>  0*3600, 'est' => -5*3600, 'edt' => -4*3600,
@@ -103,11 +103,7 @@ class Date
       'w. central africa'     =>    3600, 'w. europe'             =>    3600,
       'west asia'             =>   18000, 'west pacific'          =>   36000,
       'yakutsk'               =>   32400
-    }
-
-    [MONTHS, DAYS, ABBR_MONTHS, ABBR_DAYS, ZONES].each do |x|
-      x.freeze
-    end
+    }.freeze
 
     class Bag # :nodoc:
 
@@ -133,14 +129,6 @@ class Date
     end
 
   end
-
-  def strftime(fmt='%F')
-    out = JRuby.runtime.current_context.getRubyDateFormatter.compileAndFormat(fmt, true, @dt, 0, @sub_millis.nonzero?)
-    out.taint if fmt.tainted?
-    out
-  end
-
-# alias_method :format, :strftime
 
   def asctime() strftime('%c') end
 
@@ -175,205 +163,6 @@ class Date
       g + strftime('.%m.%d')
     end
   end
-
-=begin
-  def beat(n=0)
-    i, f = (new_offset(HOURS_IN_DAY).day_fraction * 1000).divmod(1)
-    ('@%03d' % i) +
-      if n < 1
-        ''
-      else
-        '.%0*d' % [n, (f / Rational(1, 10**n)).round]
-      end
-  end
-=end
-
-  def self.num_pattern? (s) # :nodoc:
-    /\A%[EO]?[CDdeFGgHIjkLlMmNQRrSsTUuVvWwXxYy\d]/ =~ s || /\A\d/ =~ s
-  end
-
-  private_class_method :num_pattern?
-
-  def self._strptime_i(str, fmt, e) # :nodoc:
-    fmt.scan(/%([EO]?(?::{1,3}z|.))|(.)/m) do |s, c|
-      a = $&
-      if s
-        case s
-        when 'A', 'a'
-          return unless str.sub!(/\A(#{Format::DAYS.keys.join('|')})/io, '') ||
-                        str.sub!(/\A(#{Format::ABBR_DAYS.keys.join('|')})/io, '')
-          val = Format::DAYS[$1.downcase] || Format::ABBR_DAYS[$1.downcase]
-          return unless val
-          e.wday = val
-        when 'B', 'b', 'h'
-          return unless str.sub!(/\A(#{Format::MONTHS.keys.join('|')})/io, '') ||
-                        str.sub!(/\A(#{Format::ABBR_MONTHS.keys.join('|')})/io, '')
-          val = Format::MONTHS[$1.downcase] || Format::ABBR_MONTHS[$1.downcase]
-          return unless val
-          e.mon = val
-        when 'C', 'EC'
-          return unless str.sub!(if num_pattern?($')
-                                 then /\A([-+]?\d{1,2})/
-                                 else /\A([-+]?\d{1,})/
-                                 end, '')
-          val = $1.to_i
-          e._cent = val
-        when 'c', 'Ec'
-          return unless _strptime_i(str, '%a %b %e %H:%M:%S %Y', e)
-        when 'D'
-          return unless _strptime_i(str, '%m/%d/%y', e)
-        when 'd', 'e', 'Od', 'Oe'
-          return unless str.sub!(/\A( \d|\d{1,2})/, '')
-          val = $1.to_i
-          return unless (1..31) === val
-          e.mday = val
-        when 'F'
-          return unless _strptime_i(str, '%Y-%m-%d', e)
-        when 'G'
-          return unless str.sub!(if num_pattern?($')
-                                 then /\A([-+]?\d{1,4})/
-                                 else /\A([-+]?\d{1,})/
-                                 end, '')
-          val = $1.to_i
-          e.cwyear = val
-        when 'g'
-          return unless str.sub!(/\A(\d{1,2})/, '')
-          val = $1.to_i
-          return unless (0..99) === val
-          e.cwyear = val
-          e._cent ||= if val >= 69 then 19 else 20 end
-        when 'H', 'k', 'OH'
-          return unless str.sub!(/\A( \d|\d{1,2})/, '')
-          val = $1.to_i
-          return unless (0..24) === val
-          e.hour = val
-        when 'I', 'l', 'OI'
-          return unless str.sub!(/\A( \d|\d{1,2})/, '')
-          val = $1.to_i
-          return unless (1..12) === val
-          e.hour = val
-        when 'j'
-          return unless str.sub!(/\A(\d{1,3})/, '')
-          val = $1.to_i
-          return unless (1..366) === val
-          e.yday = val
-        when 'L'
-          return unless str.sub!(if num_pattern?($')
-                                 then /\A([-+]?\d{1,3})/
-                                 else /\A([-+]?\d{1,})/
-                                 end, '')
-#         val = Rational($1.to_i, 10**3)
-          val = Rational($1.to_i, 10**$1.size)
-          e.sec_fraction = val
-        when 'M', 'OM'
-          return unless str.sub!(/\A(\d{1,2})/, '')
-          val = $1.to_i
-          return unless (0..59) === val
-          e.min = val
-        when 'm', 'Om'
-          return unless str.sub!(/\A(\d{1,2})/, '')
-          val = $1.to_i
-          return unless (1..12) === val
-          e.mon = val
-        when 'N'
-          return unless str.sub!(if num_pattern?($')
-                                 then /\A([-+]?\d{1,9})/
-                                 else /\A([-+]?\d{1,})/
-                                 end, '')
-#         val = Rational($1.to_i, 10**9)
-          val = Rational($1.to_i, 10**$1.size)
-          e.sec_fraction = val
-        when 'n', 't'
-          return unless _strptime_i(str, "\s", e)
-        when 'P', 'p'
-          return unless str.sub!(/\A([ap])(?:m\b|\.m\.)/i, '')
-          e._merid = if $1.downcase == 'a' then 0 else 12 end
-        when 'Q'
-          return unless str.sub!(/\A(-?\d{1,})/, '')
-          val = Rational($1.to_i, 10**3)
-          e.seconds = val
-        when 'R'
-          return unless _strptime_i(str, '%H:%M', e)
-        when 'r'
-          return unless _strptime_i(str, '%I:%M:%S %p', e)
-        when 'S', 'OS'
-          return unless str.sub!(/\A(\d{1,2})/, '')
-          val = $1.to_i
-          return unless (0..60) === val
-          e.sec = val
-        when 's'
-          return unless str.sub!(/\A(-?\d{1,})/, '')
-          val = $1.to_i
-          e.seconds = val
-        when 'T'
-          return unless _strptime_i(str, '%H:%M:%S', e)
-        when 'U', 'W', 'OU', 'OW'
-          return unless str.sub!(/\A(\d{1,2})/, '')
-          val = $1.to_i
-          return unless (0..53) === val
-          e.__send__(if s[-1,1] == 'U' then :wnum0= else :wnum1= end, val)
-        when 'u', 'Ou'
-          return unless str.sub!(/\A(\d{1})/, '')
-          val = $1.to_i
-          return unless (1..7) === val
-          e.cwday = val
-        when 'V', 'OV'
-          return unless str.sub!(/\A(\d{1,2})/, '')
-          val = $1.to_i
-          return unless (1..53) === val
-          e.cweek = val
-        when 'v'
-          return unless _strptime_i(str, '%e-%b-%Y', e)
-        when 'w'
-          return unless str.sub!(/\A(\d{1})/, '')
-          val = $1.to_i
-          return unless (0..6) === val
-          e.wday = val
-        when 'X', 'EX'
-          return unless _strptime_i(str, '%H:%M:%S', e)
-        when 'x', 'Ex'
-          return unless _strptime_i(str, '%m/%d/%y', e)
-        when 'Y', 'EY'
-          return unless str.sub!(if num_pattern?($')
-                                 then /\A([-+]?\d{1,4})/
-                                 else /\A([-+]?\d{1,})/
-                                 end, '')
-          val = $1.to_i
-          e.year = val
-        when 'y', 'Ey', 'Oy'
-          return unless str.sub!(/\A(\d{1,2})/, '')
-          val = $1.to_i
-          return unless (0..99) === val
-          e.year = val
-          e._cent ||= if val >= 69 then 19 else 20 end
-        when 'Z', /\A:{0,3}z/
-          return unless str.sub!(/\A((?:gmt|utc?)?[-+]\d+(?:[,.:]\d+(?::\d+)?)?
-                                    |[[:alpha:].\s]+(?:standard|daylight)\s+time\b
-                                    |[[:alpha:]]+(?:\s+dst)?\b
-                                    )/ix, '')
-          val = $1
-          e.zone = val
-          offset = zone_to_diff(val)
-          e.offset = offset
-        when '%'
-          return unless str.sub!(/\A%/, '')
-        when '+'
-          return unless _strptime_i(str, '%a %b %e %H:%M:%S %Z %Y', e)
-        else
-          return unless str.sub!(Regexp.new('\\A' + Regexp.quote(a)), '')
-        end
-      else
-        case c
-        when /\A\s/
-          str.sub!(/\A\s+/, '')
-        else
-          return unless str.sub!(Regexp.new('\\A' + Regexp.quote(a)), '')
-        end
-      end
-    end
-  end
-
-  private_class_method :_strptime_i
 
   def self.s3e(e, y, m, d, bc=false)
     unless String === m
@@ -441,7 +230,6 @@ class Date
     end
 
   end
-
   private_class_method :s3e
 
   def self._parse_day(str, e) # :nodoc:
@@ -512,23 +300,6 @@ class Date
       true
     end
   end
-
-=begin
-  def self._parse_beat(str, e) # :nodoc:
-    if str.sub!(/@\s*(\d+)(?:[,.](\d*))?/, ' ')
-      beat = Rational($1.to_i)
-      beat += Rational($2.to_i, 10**$2.size) if $2
-      secs = Rational(beat, 1000)
-      h, min, s, fr = self.day_fraction_to_time(secs)
-      e.hour = h
-      e.min = min
-      e.sec = s
-      e.sec_fraction = fr * 86400
-      e.zone = '+01:00'
-      true
-    end
-  end
-=end
 
   def self._parse_eu(str, e) # :nodoc:
     if str.sub!(
@@ -798,7 +569,7 @@ class Date
     end
   end
 
-  private_class_method :_parse_day, :_parse_time, # :_parse_beat,
+  private_class_method :_parse_day, :_parse_time,
         :_parse_eu, :_parse_us, :_parse_iso, :_parse_iso2,
         :_parse_jis, :_parse_vms, :_parse_sla, :_parse_dot,
         :_parse_year, :_parse_mon, :_parse_mday, :_parse_ddd
@@ -915,7 +686,7 @@ class Date
       end
 
       h[:sec_fraction] = Rational(sec_fraction.to_i, 10**sec_fraction.size) if sec_fraction # JRuby bug fix!
-      set_zone(h, zone)
+      set_zone(h, zone) if zone
 
     elsif /\A\s*
       (?:
@@ -957,7 +728,7 @@ class Date
       end
 
       h[:sec_fraction] = Rational(sec_fraction.to_i, 10**sec_fraction.size) if sec_fraction # JRuby bug fix!
-      set_zone(h, zone)
+      set_zone(h, zone) if zone
 
     elsif /\A\s*
       (?<hour>\d{2})
@@ -980,7 +751,7 @@ class Date
       h[:min] = i min
       h[:sec] = i sec if sec
       h[:sec_fraction] = Rational(sec_fraction.to_i, 10**sec_fraction.size) if sec_fraction # JRuby bug fix!
-      set_zone(h, zone)
+      set_zone(h, zone) if zone
     end
     h
   end
@@ -1106,29 +877,26 @@ class Date
     end
   end
 
-  t = Module.new do
-
-    private
-
-    def zone_to_diff(zone) # :nodoc:
-      zone = zone.downcase
-      if zone.sub!(/\s+(standard|daylight)\s+time\z/, '')
-        dst = $1 == 'daylight'
+  # @private native code at MRI's (~ date_zone_to_diff)
+  def self.zone_to_diff(zone) # :nodoc:
+    zone = zone.downcase
+    if zone.sub!(/\s+(standard|daylight)\s+time\z/, '')
+      dst = $1 == 'daylight'
+    else
+      dst = zone.sub!(/\s+dst\z/, '')
+    end
+    if Format::ZONES.include?(zone)
+      offset = Format::ZONES[zone]
+      offset += 3600 if dst
+    elsif zone.sub!(/\A(?:gmt|utc?)?([-+])/, '')
+      sign = $1
+      if zone.include?(':')
+        hour, min, sec, = zone.split(':')
+      elsif zone.include?(',') || zone.include?('.')
+        hour, fr, = zone.split(/[,.]/)
+        min = Rational(fr.to_i, 10**fr.size) * 60
       else
-        dst = zone.sub!(/\s+dst\z/, '')
-      end
-      if Format::ZONES.include?(zone)
-        offset = Format::ZONES[zone]
-        offset += 3600 if dst
-      elsif zone.sub!(/\A(?:gmt|utc?)?([-+])/, '')
-        sign = $1
-        if zone.include?(':')
-          hour, min, sec, = zone.split(':')
-        elsif zone.include?(',') || zone.include?('.')
-          hour, fr, = zone.split(/[,.]/)
-          min = Rational(fr.to_i, 10**fr.size) * 60
-        else
-          case zone.size
+        case zone.size
           when 3
             hour = zone[0,1]
             min = zone[1,2]
@@ -1136,56 +904,24 @@ class Date
             hour = zone[0,2]
             min = zone[2,2]
             sec = zone[4,2]
-          end
         end
-        offset = hour.to_i * 3600 + min.to_i * 60 + sec.to_i
-        offset *= -1 if sign == '-'
       end
-      offset
+      offset = hour.to_i * 3600 + min.to_i * 60 + sec.to_i
+      offset = -offset if sign == '-'
     end
-
+    offset
   end
+  private_class_method :zone_to_diff
 
-  extend  t
-  include t
+  def self.set_zone(h, zone) # :nodoc:
+    h[:zone] = zone
+    h[:offset] = zone_to_diff(zone)
+  end
+  private_class_method :set_zone
 
-  extend Module.new {
-    private
-    def set_zone(h, zone)
-      if zone
-        h[:zone] = zone
-        h[:offset] = zone_to_diff(zone)
-      end
-    end
-
-    def comp_year69(year)
-      y = i year
-      if year.length < 4
-        if y >= 69
-          y + 1900
-        else
-          y + 2000
-        end
-      else
-        y
-      end
-    end
-
-    def i(str)
-      Integer(str, 10)
-    end
-  }
 end
 
 class DateTime < Date
-
-  def strftime(fmt='%FT%T%:z')
-    super(fmt)
-  end
-
-  def self._strptime(str, fmt='%FT%T%z')
-    super(str, fmt)
-  end
 
   def iso8601_timediv(n) # :nodoc:
     n = n.to_i
@@ -1197,7 +933,6 @@ class DateTime < Date
              end +
              '%:z')
   end
-
   private :iso8601_timediv
 
   def iso8601(n=0)

--- a/spec/tags/ruby/library/date/minus_month_tags.txt
+++ b/spec/tags/ruby/library/date/minus_month_tags.txt
@@ -1,1 +1,0 @@
-fails:Date#<< raises an error on non numeric parameters

--- a/spec/tags/ruby/library/date/valid_jd_tags.txt
+++ b/spec/tags/ruby/library/date/valid_jd_tags.txt
@@ -1,1 +1,0 @@
-fails:Date.valid_jd? returns true if passed false

--- a/spec/tags/ruby/library/datetime/hour_tags.txt
+++ b/spec/tags/ruby/library/datetime/hour_tags.txt
@@ -1,2 +1,3 @@
 fails:DateTime#hour raises an error for Rational
 fails:DateTime#hour raises an error for Float
+fails:DateTime#hour raises an error for hour fractions smaller than -24

--- a/spec/tags/ruby/library/datetime/min_tags.txt
+++ b/spec/tags/ruby/library/datetime/min_tags.txt
@@ -1,2 +1,3 @@
 fails:DateTime.min raises an error for Rational
 fails:DateTime.min raises an error for Float
+fails:DateTime.min raises an error for minute fractions smaller than -60

--- a/spec/tags/ruby/library/datetime/minute_tags.txt
+++ b/spec/tags/ruby/library/datetime/minute_tags.txt
@@ -1,2 +1,3 @@
 fails:DateTime.minute raises an error for Rational
 fails:DateTime.minute raises an error for Float
+fails:DateTime.minute raises an error for minute fractions smaller than -60

--- a/spec/tags/ruby/library/datetime/sec_tags.txt
+++ b/spec/tags/ruby/library/datetime/sec_tags.txt
@@ -1,1 +1,2 @@
 fails:DateTime.sec raises an error when minute is given as a rational
+fails:DateTime.sec raises an error for second fractions smaller than -60

--- a/spec/tags/ruby/library/datetime/second_tags.txt
+++ b/spec/tags/ruby/library/datetime/second_tags.txt
@@ -1,1 +1,2 @@
 fails:DateTime#second raises an error when minute is given as a rational
+fails:DateTime#second raises an error for second fractions smaller than -60

--- a/test/jruby.index
+++ b/test/jruby.index
@@ -17,7 +17,7 @@ jruby/test_comparable
 jruby/test_core_arities
 jruby/test_custom_enumerable
 jruby/test_cvars_in_odd_scopes
-jruby/test_date_joda_time
+jruby/test_date
 jruby/test_defined
 jruby/test_default_constants
 jruby/test_delegated_array_equals

--- a/test/jruby/test_date.rb
+++ b/test/jruby/test_date.rb
@@ -256,4 +256,23 @@ class TestDate < Test::Unit::TestCase
     assert_equal 1, date.day
   end
 
+  def test_now_zone
+    begin
+      old_tz, ENV['TZ'] = ENV['TZ'], 'UTC+9:45'
+      time = DateTime.now
+      strf = time.strftime('%FT%T%z')
+      assert strf.end_with?('-0945'), "invalid zone for: #{strf} (expected '-0945')"
+      date = Time.now.strftime('%F')
+      assert strf.start_with?(date), "DateTime '#{strf}' does not start with: '#{date}'"
+    ensure
+      ENV['TZ'] = old_tz
+    end
+  end
+
+  def test_now_local
+    time = DateTime.now
+    zone = Time.new.strftime('%:z')
+    assert time.to_s.end_with?(zone), "invalid zone for: #{time.to_s} (expected '#{zone}')"
+  end
+
 end

--- a/test/jruby/test_date.rb
+++ b/test/jruby/test_date.rb
@@ -17,6 +17,68 @@ class TestDate < Test::Unit::TestCase
     end
   end
 
+  def test_new_civil
+    date = Date.new
+    assert_equal -4712, date.year
+    assert_equal 1, date.month
+    assert_equal 1, date.day
+
+    date = Date.new -4712
+    assert_equal -4712, date.year
+    assert_equal 1, date.month
+    assert_equal 1, date.day
+
+    date = Date.new 0
+    assert_equal 0, date.year
+    assert_equal 1, date.month
+    assert_equal 1, date.day
+
+    date = Date.new 1
+    assert_equal 1, date.year
+    assert_equal 1, date.month
+    assert_equal 1, date.day
+
+    date = Date.new -1
+    assert_equal -1, date.year
+    assert_equal 1, date.month
+    assert_equal 1, date.day
+
+    date = Date.new -2, 10
+    assert_equal -2, date.year
+    assert_equal 10, date.month
+    assert_equal 1, date.day
+
+    date = Date.new 1492, -3, -3
+    assert_equal 1492, date.year
+    assert_equal 10, date.month
+    assert_equal 29, date.day
+
+    date = Date.new -6, -6, -6
+    assert_equal -6, date.year
+    assert_equal 7, date.month
+    assert_equal 26, date.day
+
+    date = Date.new -9, -11, -20
+    assert_equal -9, date.year
+    assert_equal 2, date.month
+    assert_equal 9, date.day
+
+    date = Date.new -9999, -12, -31
+    assert_equal -9999, date.year
+    assert_equal 1, date.month
+    assert_equal 1, date.day
+
+    date = Date.new -6, -6, -6, Date::ITALY
+    assert_equal -6, date.year
+    assert_equal 7, date.month
+    assert_equal 26, date.day
+
+    date = Date.new -6, -6, -6, Date::GREGORIAN
+    assert_equal -6, date.year
+    assert_equal 7, date.month
+    assert_equal 26, date.day
+  end
+
   def test_date_time_methods
     date = Date.new(1, 2, 3)
     assert_equal 1, date.year
@@ -33,6 +95,18 @@ class TestDate < Test::Unit::TestCase
     assert_equal 2001, date.year
     assert_equal 3, date.month
     assert_equal 31, date.day
+
+    date = Date.new(1001, 2, -10)
+    assert_equal 1001, date.year
+    assert_equal 2, date.month
+    assert_equal 19, date.day
+
+    begin
+      Date.new(1900, 1, 0)
+      fail 'expected to fail'
+    rescue ArgumentError => e
+      assert_equal 'invalid date', e.message
+    end
   end
 
   def test_new_start
@@ -116,11 +190,17 @@ class TestDate < Test::Unit::TestCase
 
     date = Date.new(-111, 10, 11)
     assert_equal '-0111-10-11', date.to_s
+
+    date = Date.new(-1111, 11)
+    assert_equal '-1111-11-01', date.strftime
   end
 
   def test_inspect
     date = Date.new(2000, 12, 31)
     assert_equal '#<Date: 2000-12-31 ((2451910j,0s,0n),+0s,2299161j)>', date.inspect
+
+    date = Date.new(-2, 2)
+    assert_equal '#<Date: -0002-02-01 ((1720359j,0s,0n),+0s,2299161j)>', date.inspect
 
     date = Date.today
     assert_match /#<Date: 20\d\d\-\d\d\-\d\d \(\(\d+j,0s,0n\),\+0s,2299161j\)>/, date.inspect
@@ -162,6 +242,18 @@ class TestDate < Test::Unit::TestCase
 
     date = DateTime.new(2000, 10, 10, 12, 24, 36, 48)
     assert_equal Rational(1241, 2400), date.day_fraction
+  end
+
+  def test_civil_invalid_sg
+    date = Date.civil(2000, 1, 1, sg = 2426355 + 1_000_000)
+    assert_equal 2000, date.year
+    assert_equal 1, date.month
+    assert_equal 1, date.day
+
+    date = Date.civil(2000, 1, 1, sg = Date::JULIAN)
+    assert_equal 2000, date.year
+    assert_equal 1, date.month
+    assert_equal 1, date.day
   end
 
 end

--- a/test/jruby/test_date.rb
+++ b/test/jruby/test_date.rb
@@ -590,6 +590,20 @@ class TestDate < Test::Unit::TestCase
     assert_equal dt, time.to_datetime
   end
 
+  def test_to_datetime_reform
+    time = Time.utc(1582, 10, 15, 1, 2, 3)
+    dt = time.to_datetime
+    assert_equal [1582, 10, 15, 1, 2, 3], [ dt.year, dt.month, dt.day, dt.hour, dt.min, dt.sec ]
+
+    utc_time = Time.utc(1582, 10, 14, 1, 2, 3, 45 + Rational(6789, 10_000))
+    dt = utc_time.to_datetime
+    assert_equal DateTime::ITALY, dt.start
+    assert_equal [1582, 10, 24, 1, 2, 3], [ dt.year, dt.month, dt.day, dt.hour, dt.min, dt.sec ]
+    time = dt.to_time
+    assert_equal [1582, 10, 24], [ time.year, time.month, time.day ]
+    assert utc_time != time # no round-trip possible
+  end
+
   def test_to_time_roundtrip # based on AR-JDBC testing
     time = Time.utc(3, 12, 31, 23, 58, 59)
     time2 = time.to_datetime.to_time # '0004-01-01 00:56:43 +0057' in < 9.2
@@ -610,6 +624,7 @@ class TestDate < Test::Unit::TestCase
     assert_equal 0, date.send(:hour)
     assert_equal 0, date.send(:minute)
     assert_equal 0, date.send(:second)
+    assert_equal Date::ITALY, date.start
 
     date = dt.to_time.to_date
     assert_equal 2012, date.year
@@ -618,6 +633,7 @@ class TestDate < Test::Unit::TestCase
     assert_equal 0, date.send(:hour)
     assert_equal 0, date.send(:minute)
     assert_equal 0, date.send(:second)
+    assert_equal Date::ITALY, date.start
 
     dt = DateTime.new(1008, 12, 9, 10, 40, 00, '+11:00')
     date = dt.to_date

--- a/test/jruby/test_date.rb
+++ b/test/jruby/test_date.rb
@@ -555,6 +555,16 @@ class TestDate < Test::Unit::TestCase
 
     assert_equal time, datetime.to_time.utc
     assert_equal time, datetime.to_time
+
+    time = Time.new(-8, 1, 2, 23, 54, 0, '+11:00')
+    dt = DateTime.new(-8, 1, 2, 23, 54, 0, '+11:00')
+    assert_equal '#<DateTime: -0008-01-02T23:54:00+11:00 ((1718137j,46440s,0n),+39600s,2299161j)>', time.to_datetime.inspect
+    assert_equal dt, time.to_datetime
+
+    time = Time.new(0, 1, 1, 11, 00, 0, '+11:00')
+    dt = DateTime.new(0, 1, 1, 11, 00, 0, '+11:00')
+    assert_equal '#<DateTime: 0000-01-01T11:00:00+11:00 ((1721058j,0s,0n),+39600s,2299161j)>', time.to_datetime.inspect
+    assert_equal dt, time.to_datetime
   end
 
   def test_to_date

--- a/test/jruby/test_date.rb
+++ b/test/jruby/test_date.rb
@@ -1,3 +1,4 @@
+# encoding: US-ASCII
 require 'test/unit'
 
 class TestDate < Test::Unit::TestCase
@@ -543,6 +544,19 @@ class TestDate < Test::Unit::TestCase
     assert_equal time, time2
   end
 
+  def test_to_datetime
+    time = Time.new(1008, 12, 25, 10, 44, 36, '-11:00')
+    dt = DateTime.new(1008, 12, 25, 10, 44, 36, '-11:00')
+    assert_equal '#<DateTime: 1008-12-25T10:44:36-11:00 ((2089589j,78276s,0n),-39600s,2299161j)>', time.to_datetime.inspect
+    assert_equal dt, time.to_datetime
+
+    time = Time.utc(3, 12, 31, 23, 58, 59)
+    datetime = time.to_datetime
+
+    assert_equal time, datetime.to_time.utc
+    assert_equal time, datetime.to_time
+  end
+
   def test_to_date
     dt = DateTime.new(2012, 12, 31, 12, 23, 00, '+05:00')
     date = dt.to_date
@@ -553,11 +567,27 @@ class TestDate < Test::Unit::TestCase
     assert_equal 0, date.send(:minute)
     assert_equal 0, date.send(:second)
 
-    dt = DateTime.new(1008, 12, 31, 10, 40, 00, '+11:00')
+    date = dt.to_time.to_date
+    assert_equal 2012, date.year
+    assert_equal 12, date.month
+    assert_equal 31, date.day
+    assert_equal 0, date.send(:hour)
+    assert_equal 0, date.send(:minute)
+    assert_equal 0, date.send(:second)
+
+    dt = DateTime.new(1008, 12, 9, 10, 40, 00, '+11:00')
     date = dt.to_date
     assert_equal 1008, date.year
     assert_equal 12, date.month
-    assert_equal 31, date.day
+    assert_equal 9, date.day
+    assert_equal 0, date.send(:hour)
+    assert_equal 0, date.send(:minute)
+    assert_equal 0, date.send(:second)
+
+    date = dt.to_time.to_date
+    assert_equal 1008, date.year
+    assert_equal 12, date.month
+    assert_equal 3, date.day
     assert_equal 0, date.send(:hour)
     assert_equal 0, date.send(:minute)
     assert_equal 0, date.send(:second)

--- a/test/jruby/test_date.rb
+++ b/test/jruby/test_date.rb
@@ -363,6 +363,28 @@ class TestDate < Test::Unit::TestCase
 
     date = Date.new(1000, 1, 1)
     assert_equal true, date.julian?
+
+    date = Date.new(1582, 10, 15)
+    assert_equal false, date.julian?
+    assert_equal true, (date - 1).julian?
+
+    date = DateTime.new(1582, 10, 15)
+    assert_equal false, date.julian?
+    assert_equal true, (date - 1).julian?
+
+    date = DateTime.new(1582, 10, 15, 0, 0, 0)
+    assert_equal '#<DateTime: 1582-10-15T00:00:00+00:00 ((2299161j,0s,0n),+0s,2299161j)>', date.inspect
+    assert_equal false, date.julian?
+    date = DateTime.new(1582, 10, 15, 1, 0, 0)
+    assert_equal false, date.julian?
+    # NOTE: MRI's crazy-bits - NOT IMPLEMENTED seems like a bug
+    #date = DateTime.new(1582, 10, 15, 0, 0, 0, '+01:00')
+    #assert_equal true, date.julian?
+    #date = DateTime.new(1582, 10, 15, 0, 59, 59, '+01:00')
+    #assert_equal true, date.julian?
+    date = DateTime.new(1582, 10, 15, 1, 0, 0, '+01:00')
+    assert_equal '#<DateTime: 1582-10-15T01:00:00+01:00 ((2299161j,0s,0n),+3600s,2299161j)>', date.inspect
+    assert_equal false, date.julian?
   end
 
   def test_to_s_strftime
@@ -432,7 +454,7 @@ class TestDate < Test::Unit::TestCase
   end
 
   def test_civil_invalid_offset
-    if defined? JRUBY_VERSION # non-compatibility - this is how all JRubies (< 9.2) worked
+    if defined? JRUBY_VERSION # this is how all JRubies (< 9.2) worked
       assert_raise(ArgumentError) do
         DateTime.new(2000, 10, 10, 12, 24, 36, Rational(25, 24))
       end

--- a/test/jruby/test_date.rb
+++ b/test/jruby/test_date.rb
@@ -532,6 +532,26 @@ class TestDate < Test::Unit::TestCase
     assert_equal time, time2
   end
 
+  def test_parse_strftime
+    d = DateTime.parse('2001-02-03T04:05:06+09:00')
+    assert_equal('Sat Feb  3 04:05:06 2001', d.strftime('%-100c'))
+    #assert_equal('Sat Feb  3 04:05:06 2001'.rjust(26), d.strftime('%26c'))
+    assert_equal('00000020010000000006', d.strftime('%10Y%10w'))
+
+    s = '2006-08-08T23:15:33.123456789'; f = '%FT%T.%N'
+
+    d = DateTime.parse(s)
+    assert_equal Rational(123456789, 1000000000), d.sec_fraction
+    assert_equal(s, d.strftime(f))
+    d = DateTime.strptime(s, f)
+    assert_equal(s, d.strftime(f))
+
+    d = DateTime.parse(s + '1234')
+    assert_equal Rational(617283945617, 5000000000000), d.sec_fraction
+    assert_equal(s, d.strftime(f))
+  end
+
+
   def test_24_hours
     d = DateTime.new(2025, 12, 31, 24)
     assert_equal [2026, 1, 1, 0, 0, 0, 0], [d.year, d.mon, d.mday, d.hour, d.min, d.sec, d.offset]
@@ -542,7 +562,7 @@ class TestDate < Test::Unit::TestCase
     DateTime.new(2025, 11, 30, 24, 0, 0)
   end
 
-  # from MRI's test @see test_switch_hitter.rb
+  # from MRI's test @see test/mri/date/test_switch_hitter.rb
   def test_period2 # except big dates (years) - not supported
     cm_period0 = 71149239
     cm_period = 0xfffffff.div(cm_period0) * cm_period0
@@ -575,6 +595,19 @@ class TestDate < Test::Unit::TestCase
     period2_iter2(from, to, Date::ITALY)
     period2_iter2(from, to, Date::ENGLAND)
     period2_iter2(from, to, Date::JULIAN)
+  end
+
+  # from MRI's test @see test/mri/date/test_date_strftime.rb
+  def test_strftime__offset
+    s = '2006-08-08T23:15:33'
+    (-23..23).collect { |x| '%+.2d' % x }.each do |hh| # (-24..24)
+      %w(00 30).each do |mm|
+        r = hh + mm
+        r = '+0000' if r[-4,4] == '2430'
+        d = DateTime.parse(s + hh + mm)
+        assert_equal(r, d.strftime('%z'))
+      end
+    end
   end
 
 end

--- a/test/jruby/test_date.rb
+++ b/test/jruby/test_date.rb
@@ -285,8 +285,24 @@ class TestDate < Test::Unit::TestCase
     d = DateTime.new(2000, 3, 1).prev_day(2)
     assert_equal [2000, 2, 28, 00, 0, 0], [d.year, d.mon, d.mday, d.hour, d.min, d.sec]
 
-    #d = DateTime.new(2000,3,1).prev_day(1.to_r/2)
-    #assert_equal [2000, 2, 29, 12, 0, 0], [d.year, d.mon, d.mday, d.hour, d.min, d.sec]
+    d = DateTime.new(2000,3,1).prev_day(1.to_r/2)
+    assert_equal [2000, 2, 29, 12, 0, 0], [d.year, d.mon, d.mday, d.hour, d.min, d.sec]
+
+    d = DateTime.new(2000,3,1).prev_day(3.to_r/5)
+    assert_equal [2000, 2, 29, 9, 36, 0], [d.year, d.mon, d.mday, d.hour, d.min, d.sec]
+
+    d = DateTime.new(2000,3,1).next_day(0.5)
+    assert_equal [2000, 3, 1, 12, 0, 0], [d.year, d.mon, d.mday, d.hour, d.min, d.sec]
+
+    d = DateTime.new(2000,3,1).next_day(0.4444)
+    assert_equal [2000, 3, 1, 10, 39, 56], [d.year, d.mon, d.mday, d.hour, d.min, d.sec]
+
+    d = DateTime.new(2000,3,1).next_day(0.55555)
+    # NOTE: likely a (minor) rounding issue - JRuby gets time: 13:20:00
+    #assert_equal [2000, 3, 1, 13, 19, 59], [d.year, d.mon, d.mday, d.hour, d.min, d.sec]
+
+    d = DateTime.new(2000,3,1).next_day(-0.1)
+    assert_equal [2000, 2, 29, 21, 36, 0], [d.year, d.mon, d.mday, d.hour, d.min, d.sec]
 
     d = Date.new(2000,3,1).prev_day(1.to_r/2)
     assert_equal [2000, 2, 29], [d.year, d.mon, d.mday]
@@ -302,9 +318,6 @@ class TestDate < Test::Unit::TestCase
 
     d = Date.new(2000,3,1).prev_day(Rational(0, 1))
     assert_equal [2000, 3, 1], [d.year, d.mon, d.mday]
-
-    #d = DateTime.new(2000,3,1).next_day(0.5)
-    #assert_equal [2000, 3, 1, 12, 0, 0], [d.year, d.mon, d.mday, d.hour, d.min, d.sec]
 
     d = Date.new(2000,3,1).next_day(0.7)
     assert_equal [2000, 3, 1], [d.year, d.mon, d.mday]
@@ -458,6 +471,36 @@ class TestDate < Test::Unit::TestCase
     time = DateTime.now
     zone = Time.new.strftime('%:z')
     assert time.to_s.end_with?(zone), "invalid zone for: #{time.to_s} (expected '#{zone}')"
+  end
+
+  def test_time_conv
+    today = Date.today
+    assert_equal today.to_s, Date.today.to_time.strftime('%F')
+    assert_equal today, Date.today.to_time.to_date
+
+    time = DateTime.now
+    #assert_equal nil, time.to_time.zone
+    assert_equal time.to_s, time.to_time.strftime('%FT%T%:z')
+    assert_equal time, time.to_time.to_datetime
+
+    time = Time.now
+    assert_equal time.nsec.to_r / 1_000_000_000, time.to_datetime.sec_fraction
+
+    time2 = time.to_time.to_datetime.to_time
+    assert_equal time.nsec, time2.nsec
+    assert_equal time.usec, time2.usec
+    assert_equal time, time2
+
+    time = Time.new(2018, 2, 25, 12, 21, 33 + Rational(999_999_999, 1_000_000_000), '+10:30')
+    assert_equal time.nsec.to_r / 1_000_000_000, time.to_datetime.sec_fraction
+
+    assert_equal '+10:30', time.to_datetime.zone
+    assert_equal time.to_s, time.to_datetime.strftime('%F %T %z')
+
+    time2 = time.to_time.to_datetime.to_time
+    assert_equal time.nsec, time2.nsec
+    assert_equal time.usec, time2.usec
+    assert_equal time, time2
   end
 
 end

--- a/test/jruby/test_date.rb
+++ b/test/jruby/test_date.rb
@@ -246,6 +246,101 @@ class TestDate < Test::Unit::TestCase
   def test_jd
     assert Date.jd.is_a?(Date)
     assert DateTime.jd.is_a?(DateTime)
+
+    d = DateTime.jd(0, 0,0,0, '+0900')
+    assert_equal([-4712, 1, 1, 0, 0, 0, 9.to_r/24], [d.year, d.mon, d.mday, d.hour, d.min, d.sec, d.offset])
+  end
+
+  def test_ordinal
+    d = Date.ordinal
+    dt = DateTime.ordinal
+    assert_equal [-4712, 1, 1], [ d.year, d.mon, d.mday ]
+    assert_equal [-4712, 1, 1], [ dt.year, dt.mon, dt.mday ]
+    assert_equal [0, 0, 0], [ dt.hour, dt.min, dt.sec ]
+    assert dt.is_a?(DateTime)
+
+    assert_equal Date.ordinal(-4712, 1), d
+    assert_equal DateTime.ordinal(-4712, 1), dt
+
+    d = Date.ordinal(2500, -10)
+    assert_equal [2500, 12, 22], [ d.year, d.mon, d.mday ]
+  end
+
+  def test__plus
+    d = Date.new(2000,2,29) + (-1)
+    assert_equal [2000, 2, 28], [d.year, d.mon, d.mday]
+    d = Date.new(2000,2,29) + 1.1
+    assert_equal [2000, 3, 1], [d.year, d.mon, d.mday]
+    d = Date.new(1999,12,31) + Rational(4, 3)
+    assert_equal [2000, 1, 1], [d.year, d.mon, d.mday]
+    d = Date.new(1999,12,31) + Rational(3, 4)
+    assert_equal [1999, 12, 31], [d.year, d.mon, d.mday]
+
+    d = DateTime.new(2000,2,29) + Rational(1, 2)
+    assert_equal DateTime, d.class
+    assert_equal [2000, 2, 29, 12, 0, 0], [d.year, d.mon, d.mday, d.hour, d.min, d.sec]
+  end
+
+  def test_prev_next
+    d = DateTime.new(2000, 3, 1).prev_day(2)
+    assert_equal [2000, 2, 28, 00, 0, 0], [d.year, d.mon, d.mday, d.hour, d.min, d.sec]
+
+    #d = DateTime.new(2000,3,1).prev_day(1.to_r/2)
+    #assert_equal [2000, 2, 29, 12, 0, 0], [d.year, d.mon, d.mday, d.hour, d.min, d.sec]
+
+    d = Date.new(2000,3,1).prev_day(1.to_r/2)
+    assert_equal [2000, 2, 29], [d.year, d.mon, d.mday]
+
+    d = Date.new(2000,3,1).prev_day(Rational(8, 9))
+    assert_equal [2000, 2, 29], [d.year, d.mon, d.mday]
+
+    d = Date.new(2000,3,1).prev_day(Rational(1, 10))
+    assert_equal [2000, 2, 29], [d.year, d.mon, d.mday]
+
+    d = Date.new(2000,3,1).prev_day(Rational(1, 1))
+    assert_equal [2000, 2, 29], [d.year, d.mon, d.mday]
+
+    d = Date.new(2000,3,1).prev_day(Rational(0, 1))
+    assert_equal [2000, 3, 1], [d.year, d.mon, d.mday]
+
+    #d = DateTime.new(2000,3,1).next_day(0.5)
+    #assert_equal [2000, 3, 1, 12, 0, 0], [d.year, d.mon, d.mday, d.hour, d.min, d.sec]
+
+    d = Date.new(2000,3,1).next_day(0.7)
+    assert_equal [2000, 3, 1], [d.year, d.mon, d.mday]
+
+    d = Date.new(2000,3,1).next_day(1.7)
+    assert_equal [2000, 3, 2], [d.year, d.mon, d.mday]
+
+    d = DateTime.new(2000,3,1).next_month(1)
+    assert_equal [2000, 4, 1, 0, 0, 0], [d.year, d.mon, d.mday, d.hour, d.min, d.sec]
+
+    d = DateTime.new(2000,3,1).next_month(1.5)
+    assert_equal [2000, 4, 1, 0, 0, 0], [d.year, d.mon, d.mday, d.hour, d.min, d.sec]
+
+    d = Date.new(2000,3,1).prev_month(Rational(1, 4))
+    assert_equal [2000, 2, 1], [d.year, d.mon, d.mday]
+
+    d = Date.new(2000,3,1).next_month(1.9)
+    assert_equal [2000, 4, 1], [d.year, d.mon, d.mday]
+
+    d = DateTime.new(2000,3,1).prev_month(Rational(1, 3))
+    assert_equal [2000, 2, 1, 0, 0, 0], [d.year, d.mon, d.mday, d.hour, d.min, d.sec]
+
+    d = DateTime.new(2000,3,1).prev_month(Rational(4, 3))
+    assert_equal [2000, 1, 1, 0, 0, 0], [d.year, d.mon, d.mday, d.hour, d.min, d.sec]
+
+    d = Date.new(2000, 3, 1).next_year(-1)
+    assert_equal [1999, 3, 1], [d.year, d.mon, d.mday]
+
+    d = Date.new(2000, 3, 1).next_year(Rational(-1, 2))
+    assert_equal [1999, 9, 1], [d.year, d.mon, d.mday]
+
+    d = Date.new(2000, 3, 1).next_year(-1.9)
+    assert_equal [1998, 4, 1], [d.year, d.mon, d.mday]
+
+    d = Date.new(2000, 3, 1).prev_year(+1.5)
+    assert_equal [1998, 9, 1], [d.year, d.mon, d.mday]
   end
 
   def test_julian

--- a/test/jruby/test_date.rb
+++ b/test/jruby/test_date.rb
@@ -23,6 +23,9 @@ class TestDate < Test::Unit::TestCase
     assert_equal 1, date.month
     assert_equal 1, date.day
 
+    assert_equal date, Date.send(:civil)
+    assert_equal date, Date.send(:new)
+
     date = Date.new -4712
     assert_equal -4712, date.year
     assert_equal 1, date.month
@@ -33,12 +36,12 @@ class TestDate < Test::Unit::TestCase
     assert_equal 1, date.month
     assert_equal 1, date.day
 
-    date = Date.new 1
+    date = Date.civil 1
     assert_equal 1, date.year
     assert_equal 1, date.month
     assert_equal 1, date.day
 
-    date = Date.new -1
+    date = Date.send :civil, -1
     assert_equal -1, date.year
     assert_equal 1, date.month
     assert_equal 1, date.day
@@ -53,12 +56,12 @@ class TestDate < Test::Unit::TestCase
     assert_equal 10, date.month
     assert_equal 29, date.day
 
-    date = Date.new -6, -6, -6
+    date = Date.send(:civil, -6, -6, -6)
     assert_equal -6, date.year
     assert_equal 7, date.month
     assert_equal 26, date.day
 
-    date = Date.new -9, -11, -20
+    date = Date.send(:new, -9, -11, -20)
     assert_equal -9, date.year
     assert_equal 2, date.month
     assert_equal 9, date.day
@@ -249,6 +252,14 @@ class TestDate < Test::Unit::TestCase
 
     d = DateTime.jd(0, 0,0,0, '+0900')
     assert_equal([-4712, 1, 1, 0, 0, 0, 9.to_r/24], [d.year, d.mon, d.mday, d.hour, d.min, d.sec, d.offset])
+
+    dt = DateTime.new(2012, 12, 24, 12, 23, 00, '+05:00')
+    assert_equal 2456286, dt.jd
+    assert_equal 2456286, dt.to_date.jd
+
+    assert_equal 0, dt.to_date.send(:hour)
+    assert_equal 0, dt.to_date.send(:minute)
+    assert_equal 0, dt.to_date.send(:second)
   end
 
   def test_ordinal
@@ -530,6 +541,26 @@ class TestDate < Test::Unit::TestCase
     assert_equal time.nsec, time2.nsec
     assert_equal time.usec, time2.usec
     assert_equal time, time2
+  end
+
+  def test_to_date
+    dt = DateTime.new(2012, 12, 31, 12, 23, 00, '+05:00')
+    date = dt.to_date
+    assert_equal 2012, date.year
+    assert_equal 12, date.month
+    assert_equal 31, date.day
+    assert_equal 0, date.send(:hour)
+    assert_equal 0, date.send(:minute)
+    assert_equal 0, date.send(:second)
+
+    dt = DateTime.new(1008, 12, 31, 10, 40, 00, '+11:00')
+    date = dt.to_date
+    assert_equal 1008, date.year
+    assert_equal 12, date.month
+    assert_equal 31, date.day
+    assert_equal 0, date.send(:hour)
+    assert_equal 0, date.send(:minute)
+    assert_equal 0, date.send(:second)
   end
 
   def test_parse_strftime

--- a/test/mri/excludes/TestDateStrftime.rb
+++ b/test/mri/excludes/TestDateStrftime.rb
@@ -1,2 +1,2 @@
 exclude :test_strftime__gnuext_complex, "need important implem changes and almost useless feature"
-exclude :test_strftime__offset, ""
+exclude :test_strftime__offset, "works with (-23..23) +24:00 and -24:00 'virtual' offsets not supported"

--- a/test/mri/excludes/TestSH.rb
+++ b/test/mri/excludes/TestSH.rb
@@ -1,6 +1,2 @@
-exclude :test_enc, "depending on MRI buffer sizes, not useful"
-exclude :test_inspect, "depending on MRI buffer sizes, not useful"
 exclude :test_period2, ""
 exclude :test_strftime, "depending on MRI buffer sizes, not useful"
-exclude :test_to_s, "depending on MRI buffer sizes, not useful"
-exclude :test_zone, "depending on MRI buffer sizes, not useful"

--- a/test/mri/excludes/TestSH.rb
+++ b/test/mri/excludes/TestSH.rb
@@ -1,2 +1,2 @@
-exclude :test_period2, ""
+exclude :test_period2, "bignum too big to convert into `long'" # not relevant - JODA doesn't handle huge years anyway
 exclude :test_strftime, "depending on MRI buffer sizes, not useful"


### PR DESCRIPTION
still using JODA but all of the JI stuff in date.rb is gone behind ext classes, motivation : 

- for a while its 'hard' to create `Date` instances in AR-JDBC
- some near era conversion had a nasty bug in all 9K which constantly pops up in AR-JDBC
- some isolated AR benchmarks showed its slower than MRI
- there's going to be some nice JI bonuses - `toJava` working as with `RubyTime` etc.

some parts were already in native (formatting) so the base setup was already there.

NOTE: in MRI pretty much all of the date.rb is in native - so there's still space for improvement.
e.g. `_parse` would make sense to end up in .java maybe someone will attempt it afterwards.

p.s. left behind one minor suite failure (argument validation `hour: 24+1.to_r/2`)
while its simple the bigger picture (of MRI argument handling) feels a bit weird. 
some parts handle the overflow some not, smt Float do not work while Rational is ok - clunky.
would eventually circle back as I feel like that might end up as a MRI report/feature request. 

needs rebase (waiting for tests) but would like to get this in so I can spent time testing + adding JI stuff.