### PR TITLE
Add Method#=== that invokes #call

### DIFF
--- a/core/src/main/java/org/jruby/RubyMethod.java
+++ b/core/src/main/java/org/jruby/RubyMethod.java
@@ -156,6 +156,12 @@ public class RubyMethod extends AbstractRubyMethod {
     }
 
     @Override
+    @JRubyMethod(name = "===", required = 1)
+    public IRubyObject op_eqq(ThreadContext context, IRubyObject other) {
+        return method.call(context, receiver, implementationModule, methodName, other, Block.NULL_BLOCK);
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (!(other instanceof RubyMethod)) {
             return false;


### PR DESCRIPTION
Hi folks,

This is another feature targeting Ruby 2.5 [1]: Add Method#=== that invokes #call (feature #14142).

The associated MRI test to the feature work as expected:

```ruby
  def test_eqq
    assert_operator(0.method(:<), :===, 5)
    assert_not_operator(0.method(:<), :===, -5)
  end
```

```
miguel@alice:~/jruby$ PATH=$PWD/bin:$PATH jruby test/mri/runner.rb -v --color=never --tty=no --excludes=test/mri/excludes -q -n test_eqq -- ruby/test_method.rb
Run options: -v --color=never --tty=no --excludes=test/mri/excludes -q -n test_eqq --

# Running tests:

[1/1] TestMethod#test_eqq = 0.02 s
Finished tests in 0.260273s, 3.8421 tests/s, 15.3685 assertions/s.
1 tests, 4 assertions, 0 failures, 0 errors, 0 skips

ruby -v: jruby 9.3.0.0-SNAPSHOT (2.5.0) 2018-03-04 96b264b Java HotSpot(TM) 64-Bit Server VM 25.102-b14 on 1.8.0_102-b14 +jit [darwin-x86_64]
```

Thanks for your review and feedback.

1. https://github.com/jruby/jruby/issues/4876