### PR TITLE
Use com.jcraft.jzlib.JZlib instead of hacking the internals of java.util.zip.CRC32

### DIFF
--- a/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
+++ b/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
@@ -189,10 +189,10 @@ public class RubyZlib {
     @JRubyMethod(name = "crc32", optional = 2, module = true, visibility = PRIVATE)
     public static IRubyObject crc32(IRubyObject recv, IRubyObject[] args) {
         args = Arity.scanArgs(recv.getRuntime(),args,0,2);
-        int start = 0;
+        long start = 0;
         ByteList bytes = null;
         if (!args[0].isNil()) bytes = args[0].convertToString().getByteList();
-        if (!args[1].isNil()) start = (int)RubyNumeric.num2long(args[1]);
+        if (!args[1].isNil()) start = RubyNumeric.num2long(args[1]);
 
         final boolean slowPath = start != 0;
         final int bytesLength = bytes == null ? 0 : bytes.length();


### PR DESCRIPTION
The code the seems to be a remnant of the time before `JZLib` and uses internals of `java.util.zip.CRC32` when same thing could be achieved through `JZLib`. 

This can cause a performance regression as methods in `CRC32` use intrinsics, but I would not _expect_  that to be major issue as running a lot of `CRC32` does not sound like the ideal use case for JRuby.

This should remove one invasive access warning from #4834