### PR TITLE
upgrade joda-time library to latest 2.9.9

### DIFF
--- a/pom.rb
+++ b/pom.rb
@@ -85,7 +85,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
               'ant.version' => '1.9.2',
               'asm.version' => '6.0',
               'jffi.version' => '1.2.16',
-              'joda.time.version' => '2.8.2' )
+              'joda.time.version' => '2.9.9' )
 
   plugin_management do
     jar( 'junit:junit:4.11',

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@ DO NOT MODIFIY - GENERATED CODE
     <version.jruby>${project.version}</version.jruby>
     <main.basedir>${project.basedir}</main.basedir>
     <github.global.server>github</github.global.server>
-    <joda.time.version>2.8.2</joda.time.version>
+    <joda.time.version>2.9.9</joda.time.version>
     <rspec-support.version>3.4.1</rspec-support.version>
     <polyglot.dump.pom>pom.xml</polyglot.dump.pom>
   </properties>


### PR DESCRIPTION
... not sure if there was a previous reason to stay so far behind

most changes are bugfixes and more importantly matching up TZ data rules
maybe the time-zone data should get regenerated as well ... https://github.com/jruby/joda-timezones ? 