### PR TITLE
Enumerable#any?, all?, none? and one? now accept a pattern argument

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -4374,8 +4374,8 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     // Enumerable direct implementations (non-"each" versions)
     // NOTE: not a @JRubyMethod(name = "all?") as there's no Array#all? on MRI
-    public IRubyObject all_p(ThreadContext context, Block block) {
-        if (!isBuiltin("each")) return RubyEnumerable.all_pCommon(context, this, block);
+    public IRubyObject all_p(ThreadContext context, IRubyObject[] args, Block block) {
+        if (!isBuiltin("each")) return RubyEnumerable.all_pCommon(context, this, args, block);
         if (!block.isGiven()) return all_pBlockless(context);
 
         for (int i = 0; i < realLength; i++) {

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -1811,30 +1811,34 @@ public class RubyEnumerable {
         final Ruby runtime = context.runtime;
         final IRubyObject pattern = (args.length > 0) ? args[0] : null;
         final boolean patternGiven = pattern != null;
+        final ThreadContext localContext = context;
 
         try {
             if (block.isGiven() && !patternGiven) {
-                each(context, self, new JavaInternalBlockBody(runtime, context, "Enumerable#any?", block.getSignature()) {
-                    public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
-                        IRubyObject packedArg = packEnumValues(context, args);
-                        if (block.yield(context, packedArg).isTrue()) throw JumpException.SPECIAL_JUMP;
+                callEach(runtime, context, self, block.getSignature(), new BlockCallback() {
+                    public IRubyObject call(ThreadContext context, IRubyObject[] largs, Block blk) {
+                        checkContext(localContext, context, "any?");
+                        IRubyObject larg = packEnumValues(runtime, largs);
+                        if (block.yield(context, larg).isTrue()) throw JumpException.SPECIAL_JUMP;
                         return context.nil;
                     }
                 });
             } else {
                 if (patternGiven) {
-                    each(context, self, new JavaInternalBlockBody(runtime, context, "Enumerable#any?", Signature.ONE_REQUIRED) {
-                        public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
-                            IRubyObject packedArg = packEnumValues(context.runtime, args);
-                            if (pattern.callMethod(context, "===", packedArg).isTrue()) throw JumpException.SPECIAL_JUMP;
+                    callEach(runtime, context, self, Signature.ONE_REQUIRED, new BlockCallback() {
+                        public IRubyObject call(ThreadContext context, IRubyObject[] largs, Block blk) {
+                            checkContext(localContext, context, "any?");
+                            IRubyObject larg = packEnumValues(runtime, largs);
+                            if (pattern.callMethod(context, "===", larg).isTrue()) throw JumpException.SPECIAL_JUMP;
                             return context.nil;
                         }
                     });
                 } else {
-                    each(context, self, new JavaInternalBlockBody(runtime, context, "Enumerable#any?", Signature.ONE_REQUIRED) {
-                        public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
-                            IRubyObject packedArg = packEnumValues(context.runtime, args);
-                            if (packedArg.isTrue()) throw JumpException.SPECIAL_JUMP;
+                    callEach(runtime, context, self, Signature.ONE_REQUIRED, new BlockCallback() {
+                        public IRubyObject call(ThreadContext context, IRubyObject[] largs, Block blk) {
+                            checkContext(localContext, context, "any?");
+                            IRubyObject larg = packEnumValues(runtime, largs);
+                            if (larg.isTrue()) throw JumpException.SPECIAL_JUMP;
                             return context.nil;
                         }
                     });


### PR DESCRIPTION
Hi folks,

This is another change adding Ruby 2.5 support [1]: Enumerable#any?, all?, none? and one? now accept a pattern argument (feature #11286 [2]).

All associated MRI and ruby/spec tests ~~(except one [3] for #any?)~~ are passing.

Thanks for your review and feedback.

1. https://github.com/jruby/jruby/issues/4876
2. https://bugs.ruby-lang.org/issues/11286
3. ~~https://github.com/jruby/jruby/blob/3813f0a53c22af8122e8c2b70c7d87ae35323109/spec/ruby/core/enumerable/any_spec.rb#L214~~
