### PR TITLE
Fix RubyString instances to raise FrozenError exceptions when mutations are attempted in debug mode…

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -909,7 +909,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
                 if (obj != null && obj instanceof RubyArray) {
                     RubyArray info = (RubyArray) obj;
                     if (info.getLength() == 2) {
-                        throw getRuntime().newRaiseException(getRuntime().getRuntimeError(),
+                        throw getRuntime().newRaiseException(getRuntime().getFrozenError(),
                                 "can't modify frozen String, created at " + info.eltInternal(0) + ":" + info.eltInternal(1));
                     }
                 }


### PR DESCRIPTION
String instances were raising FrozenError exceptions as expected since Ruby 2.5, when modifications on frozen instances are attempted but the same was not happening in debug mode (they were raising RuntimeError, the expected behavior until 2.4).

This should fix a lot of failures in ruby-2.5 branch.

/cc: https://github.com/jruby/jruby/issues/4876