### PR TITLE
Fix failed Ruby 2.5 ruby/spec tests for String

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -4063,10 +4063,11 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
 
     @JRubyMethod(name = "delete_suffix!")
     public IRubyObject delete_suffix_bang(ThreadContext context, IRubyObject arg) {
-      RubyString result = (RubyString) delete_suffix(context, arg);
-      if (equals(result)) return context.runtime.getNil();
-      replaceInternal19(0, this.strLength(), result);
-      return this;
+        modifyCheck();
+        RubyString result = (RubyString) delete_suffix(context, arg);
+        if (equals(result)) return context.runtime.getNil();
+        replaceInternal19(0, this.strLength(), result);
+        return this;
     }
 
     @JRubyMethod(name = "start_with?", rest = true)

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -4054,6 +4054,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
 
     @JRubyMethod(name = "delete_prefix!")
     public IRubyObject delete_prefix_bang(ThreadContext context, IRubyObject arg) {
+        modifyCheck();
         RubyString result = (RubyString) delete_prefix(context, arg);
         if (equals(result)) return context.runtime.getNil();
         replaceInternal19(0, this.strLength(), result);

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -4046,7 +4046,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     @JRubyMethod(name = "delete_suffix")
     public IRubyObject delete_suffix(ThreadContext context, IRubyObject arg) {
         RubyString suffix = arg.convertToString();
-        if (!this.end_with_p(context, suffix).isTrue()) return this;
+        if (!this.end_with_p(context, suffix).isTrue()) return this.dup();
         if (suffix.value.getRealSize() == this.value.getRealSize()) return newEmptyString(context.runtime, value.getEncoding());
         RubyString result = (RubyString) substr19(context.runtime, 0, this.strLength() - suffix.strLength());
         return result.isEmpty() ? this : result;

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -4037,7 +4037,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     @JRubyMethod(name = "delete_prefix")
     public IRubyObject delete_prefix(ThreadContext context, IRubyObject arg) {
         RubyString prefix = arg.convertToString();
-        if (!this.start_with_p(context, prefix).isTrue()) return this;
+        if (!this.start_with_p(context, prefix).isTrue()) return this.dup();
         if (prefix.value.getRealSize() == this.value.getRealSize()) return newEmptyString(context.runtime, value.getEncoding());
         RubyString result = (RubyString) substr19(context.runtime, prefix.strLength(), this.strLength() - prefix.strLength());
         return result.isEmpty() ? this : result;

--- a/core/src/main/java/org/jruby/util/Sprintf.java
+++ b/core/src/main/java/org/jruby/util/Sprintf.java
@@ -90,6 +90,7 @@ public class Sprintf {
     private static final String ERR_MALFORMED_DOT_NUM = "malformed format string - %.[0-9]";
     private static final String ERR_MALFORMED_STAR_NUM = "malformed format string - %*[0-9]";
     private static final String ERR_ILLEGAL_FORMAT_CHAR = "illegal format character - %";
+    private static final String ERR_INCOMPLETE_FORMAT_SPEC = "incomplete format specifier; use %%%% (double %%) instead";
     private static final String ERR_MALFORMED_NAME = "malformed name - unmatched parenthesis";
 
     private static final ThreadLocal<Map<Locale, NumberFormat>> LOCALE_NUMBER_FORMATS = new ThreadLocal<Map<Locale, NumberFormat>>();
@@ -1413,6 +1414,7 @@ public class Sprintf {
             if (incomplete) {
                 if (flags == FLAG_NONE) {
                     // dangling '%' char
+                    if (format[length - 1] == '%') raiseArgumentError(args,ERR_INCOMPLETE_FORMAT_SPEC);
                     buf.append('%');
                 } else {
                     raiseArgumentError(args,ERR_ILLEGAL_FORMAT_CHAR);


### PR DESCRIPTION
Hi folks,

This PR should fix most of the remaining failures for String in ruby-2.5 ruby/spec suite.

- https://github.com/jruby/jruby/commit/2e1987d0b7dd7eb5177c73a5eb902df487eaefc1 and https://github.com/jruby/jruby/commit/77cc454b2f5d49b436e09db763aa265cd59607af fix failed assertions like https://github.com/jruby/jruby/blob/f06aa9daa7e23be15e06be953128f5063b42a431/spec/ruby/core/string/delete_prefix_spec.rb#L15.

- https://github.com/jruby/jruby/commit/113bde333d0d8d806a05713820025b6451b87b90 and https://github.com/jruby/jruby/commit/617e7835d3a087186a58e0e1cdc5dbcdf901d1ed fix failed assertions like https://github.com/jruby/jruby/blob/f06aa9daa7e23be15e06be953128f5063b42a431/spec/ruby/core/string/delete_suffix_spec.rb#L77.

- https://github.com/jruby/jruby/commit/49a74b95fbd7a00a22cdeb0a1a25192c196ecd55 fix failed assertions like https://github.com/jruby/jruby/blob/f06aa9daa7e23be15e06be953128f5063b42a431/spec/ruby/core/string/modulo_spec.rb#L31.

Thanks for your review and feedback.

/cc: https://github.com/jruby/jruby/issues/4876