### PR TITLE
Thread.report_on_exception default value is now true

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1388,7 +1388,7 @@ public final class Ruby implements Constantizable {
         trueObject = new RubyBoolean.True(this);
         trueObject.setFrozen(true);
 
-        reportOnException = falseObject;
+        reportOnException = trueObject;
     }
 
     private void initCore() {

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -1730,7 +1730,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     protected void printReportExceptionWarning() {
         PrintStream errorStream = getRuntime().getErrorStream();
         String name = threadImpl.getReportName();
-        errorStream.println("warning: thread \"" + name + "\" terminated with exception:");
+        errorStream.println("warning: thread \"" + name + "\" terminated with exception (report_on_exception is true):");
     }
 
     /**


### PR DESCRIPTION
Hi folks,

This is another change targeting Ruby 2.5 [1]: Thread.report_on_exception default value is now true (feature 14143).

Thanks for your review and feedback.

1. https://github.com/jruby/jruby/issues/4876
2. https://bugs.ruby-lang.org/issues/14143