### PR TITLE
Require real path

### DIFF
--- a/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
+++ b/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
@@ -167,6 +167,16 @@ class LibrarySearcher {
         DebugLog.Resource.logTry(pathWithSuffix);
         FileResource resource = JRubyFile.createResourceAsFile(runtime, pathWithSuffix);
         if (resource.exists()) {
+            if (resource.absolutePath() != resource.canonicalPath()) {
+                FileResource realResource = JRubyFile.createResourceAsFile(runtime, resource.canonicalPath());
+                if (realResource.exists()){
+                  resource = realResource;
+                  String scriptName = resolveScriptName(resource, resource.canonicalPath());
+                  String loadName = resolveLoadName(resource, searchName + suffix);
+                  return new FoundLibrary(ResourceLibrary.create(searchName, scriptName, resource), loadName);
+                }
+            }
+
             DebugLog.Resource.logFound(pathWithSuffix);
             String scriptName = resolveScriptName(resource, pathWithSuffix);
             String loadName = resolveLoadName(resource, searchName + suffix);


### PR DESCRIPTION
expand load paths to real paths to get rid of duplicate loading from
symbolic-linked directories. [Feature #10222]
https://github.com/ruby/ruby/commit/b6d3927e16357408720203a949cfa8741b9ebf6c

This fixes

- ``test/mri/ruby/test_require.rb#test_symlink_load_path``