### PR TITLE
Numeric#clone and #dup no longer raises TypeError

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -511,7 +511,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
 
     // MRI: special_object_p
     public boolean isSpecialObject() {
-        return isImmediate() || this instanceof RubyBignum || this instanceof RubyFloat;
+        return isImmediate() || this instanceof RubyBignum || this instanceof RubyFloat || this instanceof RubyRational || this instanceof RubyComplex;
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -1403,6 +1403,27 @@ public class RubyNumeric extends RubyObject {
         return context.runtime.getNil();
     }
 
+    @JRubyMethod(name = "clone", required = 0, optional = 1)
+    public IRubyObject rbClone(IRubyObject[] args) {
+        if (args.length == 0) return this;
+
+        Ruby runtime = args[0].getRuntime();
+
+        if (!(args[0] instanceof RubyHash)) {
+            throw runtime.newArgumentError("wrong number of arguments (given " + args.length + ", expected 0)");
+        }
+
+        IRubyObject[] rets = ArgsUtil.extractKeywordArgs(runtime.getCurrentContext(), args[0].convertToHash(), "freeze");
+        if (!rets[0].isTrue()) throw runtime.newArgumentError("can't unfreeze " + getType());
+
+        return this;
+    }
+
+    @Override
+    public IRubyObject dup() {
+        return this;
+    }
+
     public static IRubyObject numFuncall(ThreadContext context, IRubyObject x, CallSite site) {
         return context.safeRecurse(new NumFuncall0(), site, x, site.methodName, true);
     }


### PR DESCRIPTION
Hi folks,

This is another change targeting Ruby 2.5 [1]: Numeric#clone and #dup no longer raises TypeError (bug #13237).

It returns the receiver instead as well as Integer and Float.

1. https://github.com/jruby/jruby/issues/4876
2. https://bugs.ruby-lang.org/issues/13237