### PR TITLE
Range should raise TypeError if necessary method is not defined

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -1484,7 +1484,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
             ThreadContext context = runtime.getCurrentContext();
             ArraySites sites = sites(context);
 
-            if (RubyRange.isRangeLike(context, arg0, sites.respond_to_begin, sites.respond_to_end)) {
+            if (RubyRange.isRangeLike(context, arg0, sites.begin_checked, sites.end_checked, sites.exclude_end_checked)) {
                 RubyRange range = RubyRange.rangeFromRangeLike(context, arg0, sites.begin, sites.end, sites.exclude_end);
 
                 long[] beglen = range.begLen(realLength, 0);
@@ -1538,7 +1538,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
             ThreadContext context = getRuntime().getCurrentContext();
             ArraySites sites = sites(context);
 
-            if (RubyRange.isRangeLike(context, arg0, sites.respond_to_begin, sites.respond_to_end)) {
+            if (RubyRange.isRangeLike(context, arg0, sites.begin_checked, sites.end_checked, sites.exclude_end_checked)) {
                 RubyRange range = RubyRange.rangeFromRangeLike(context, arg0, sites.begin, sites.end, sites.exclude_end);
 
                 long beg = range.begLen0(realLength);

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -954,6 +954,22 @@ public class RubyRange extends RubyObject {
                 respond_to_end.respondsTo(context, obj, obj);
     }
 
+    /**
+     * Return true if the given object responds to "begin", "end" and "exclude_end?" methods.
+     *
+     * @param context current context
+     * @param obj possibly range-like object
+     * @param begin_checked checked site for begin
+     * @param end_checked checked site for end
+     * @param exclude_end_checked checked site for exclude_end?
+     * @return
+     */
+    public static boolean isRangeLike(ThreadContext context, IRubyObject obj, JavaSites.CheckedSites begin_checked, JavaSites.CheckedSites end_checked, JavaSites.CheckedSites exclude_end_checked) {
+        return (obj.checkCallMethod(context, begin_checked) != null) &&
+                (obj.checkCallMethod(context, end_checked) != null) &&
+                (obj.checkCallMethod(context, exclude_end_checked) != null);
+    }
+
     // MRI: rb_range_beg_len
     public static IRubyObject rangeBeginLength(ThreadContext context, IRubyObject range, int len, int[] begLen, int err) {
         JavaSites.RangeSites sites = sites(context);

--- a/core/src/main/java/org/jruby/runtime/JavaSites.java
+++ b/core/src/main/java/org/jruby/runtime/JavaSites.java
@@ -91,6 +91,9 @@ public class JavaSites {
     }
 
     public static class ArraySites {
+        public final CheckedSites begin_checked = new CheckedSites("begin");
+        public final CheckedSites end_checked = new CheckedSites("end");
+        public final CheckedSites exclude_end_checked = new CheckedSites("exclude_end?");
         public final CheckedSites to_ary_checked = new CheckedSites("to_ary");
         public final RespondToCallSite respond_to_to_ary = new RespondToCallSite("to_ary");
         public final CallSite to_ary = new FunctionalCachingCallSite("to_ary");


### PR DESCRIPTION
Hi folks,

This PR should fix remaining failures [1] for Range in ruby-2.5 MRI test suite.

1. https://github.com/jruby/jruby/blob/1b7c3308ba68151b1f5e48cb351155dac58ddc50/test/mri/ruby/test_range.rb#L390

For more information, please see bug #14048.

Thanks for your review and feedback.

/cc: #4876