### PR TITLE
Revert "Require real path"

### DIFF
--- a/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
+++ b/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
@@ -167,16 +167,6 @@ class LibrarySearcher {
         DebugLog.Resource.logTry(pathWithSuffix);
         FileResource resource = JRubyFile.createResourceAsFile(runtime, pathWithSuffix);
         if (resource.exists()) {
-            if (resource.absolutePath() != resource.canonicalPath()) {
-                FileResource realResource = JRubyFile.createResourceAsFile(runtime, resource.canonicalPath());
-                if (realResource.exists()){
-                  resource = realResource;
-                  String scriptName = resolveScriptName(resource, resource.canonicalPath());
-                  String loadName = resolveLoadName(resource, searchName + suffix);
-                  return new FoundLibrary(ResourceLibrary.create(searchName, scriptName, resource), loadName);
-                }
-            }
-
             DebugLog.Resource.logFound(pathWithSuffix);
             String scriptName = resolveScriptName(resource, pathWithSuffix);
             String loadName = resolveLoadName(resource, searchName + suffix);


### PR DESCRIPTION
Reverts jruby/jruby#5109

I believe this broke some tests that depend on it *not* traversing symlinks, such as here: https://travis-ci.org/jruby/jruby/jobs/359034412

@ChrisBr I am about to merge 2.5 to master, so if you want to take another crack at this, base your PR on master.