### PR TITLE
:newline option to File.open implies text mode now. (Part of #5118)

### DIFF
--- a/core/src/main/java/org/jruby/util/io/EncodingUtils.java
+++ b/core/src/main/java/org/jruby/util/io/EncodingUtils.java
@@ -1608,8 +1608,12 @@ public class EncodingUtils {
             throw runtime.newArgumentError("ASCII incompatible encoding needs binmode");
         }
 
+        if ((fmode & OpenFile.BINMODE) != 0 && (ecflags & EConvFlags.NEWLINE_DECORATOR_MASK) != 0) {
+            throw runtime.newArgumentError("newline decorator with binary mode");
+        }
+
         if ((fmode & OpenFile.BINMODE) == 0 && (EncodingUtils.DEFAULT_TEXTMODE != 0 || (ecflags & EConvFlags.NEWLINE_DECORATOR_MASK) != 0)) {
-            fmode |= EncodingUtils.DEFAULT_TEXTMODE;
+            fmode |= OpenFile.TEXTMODE;
             fmode_p[0] = fmode;
         } else if (EncodingUtils.DEFAULT_TEXTMODE == 0 && (ecflags & EConvFlags.NEWLINE_DECORATOR_MASK) == 0) {
             fmode &= ~OpenFile.TEXTMODE;


### PR DESCRIPTION
The corresponding MRI tests are already present [here](https://github.com/jruby/jruby/blob/master/test/mri/ruby/test_io_m17n.rb#L1612-L1648).
Implements [Ruby Bug #13350](https://bugs.ruby-lang.org/issues/13350).