### PR TITLE
Fix Enumerable#uniq for entry pair

### DIFF
--- a/core/src/main/ruby/jruby/kernel/enumerable.rb
+++ b/core/src/main/ruby/jruby/kernel/enumerable.rb
@@ -123,7 +123,7 @@ module Enumerable
         values << obj
       end
     else
-      each do |obj|
+      each_entry do |obj|
         next if hash.key? obj
         hash[obj] = obj unless hash.key? obj
         values << obj


### PR DESCRIPTION
The second part of the pair was ignored before which resulted e.g.

```
class Foo
  include Enumerable
  def each
    yield 1
    yield 1,2
  end
end.new.to_enum.uniq -> [1] instead of [1, [1,2]]
```

Fixes test/mri/ruby/test_enum.rb#test_uniq test.