### PR TITLE
Support overriding `Exception#message`

### DIFF
--- a/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
@@ -399,7 +399,12 @@ public class TraceType {
         boolean color = console && runtime.getInstanceConfig().getBacktraceColor();
 
         // exception line
-        String message = exception.message(context).toString();
+        String message;
+        try {
+            message = exception.callMethod(context, "message").toString();
+        } catch (org.jruby.exceptions.Exception _) {
+            message = exception.message(context).toString();
+        }
         if (exception.getMetaClass() == runtime.getRuntimeError() && message.length() == 0) {
             message = "No current exception";
         }


### PR DESCRIPTION
In CRuby, an uncaught exception messages users with the exception's message, considering if it's overriden or not.

e.g.
```ruby
class A < StandardError
  def message
    'hello'
  end
end

raise A
```

* CRuby stderr: `/tmp/vu4TBd5/647:7:in `<main>': hello (A)`
* JRuby stderr: `A: A\n <main> at /tmp/vu4TBd5/648:7`

This pull request changes JRuby behaviour similar to CRuby's.

* (patched) JRuby stderr: `A: hello\n <main> at /tmp/vu4TBd5/650:7`

Note that if the overriden `message` method raises an exception, it shouldn't message the internal exception, but the external exception, according to CRuby Bug #14566 https://bugs.ruby-lang.org/issues/14566

This pullreq already considers that.

e.g.
```ruby
class A < StandardError
  def message
    raise 'boom boom!'
  end
end

raise A
```

* CRuby stderr: `/tmp/vu4TBd5/655:7:in `<main>': A`
* (patched) JRuby stderr: `A: A\n <main> at /tmp/vu4TBd5/656:7"

I'm not fluent in Java, so please let me know if there's somewhere you don't feel good! I'm more than happy to update my commit.