### PR TITLE
spec/ruby: Bring in some changes from upstream

### DIFF
--- a/spec/ruby/core/process/status/exitstatus_spec.rb
+++ b/spec/ruby/core/process/status/exitstatus_spec.rb
@@ -1,7 +1,6 @@
 require_relative '../../../spec_helper'
 
 describe "Process::Status#exitstatus" do
-
   before :each do
     ruby_exe("exit(42)")
   end
@@ -10,4 +9,17 @@ describe "Process::Status#exitstatus" do
     $?.exitstatus.should == 42
   end
 
+  describe "for a child that raised SignalException" do
+    before :each do
+      ruby_exe("raise SignalException, 'SIGTERM'")
+    end
+
+    platform_is_not :windows do
+      # The exitstatus is not set in these cases. See the termsig_spec
+      # for info on where the signal number (SIGTERM) is available.
+      it "returns nil" do
+        $?.exitstatus.should == nil
+      end
+    end
+  end
 end

--- a/spec/ruby/core/process/status/termsig_spec.rb
+++ b/spec/ruby/core/process/status/termsig_spec.rb
@@ -13,6 +13,18 @@ describe "Process::Status#termsig" do
     end
   end
 
+  describe "for a child that raised SignalException" do
+    before :each do
+      ruby_exe("raise SignalException, 'SIGTERM'")
+    end
+
+    platform_is_not :windows do
+      it "returns the signal" do
+        $?.termsig.should == Signal.list["TERM"]
+      end
+    end
+  end
+
   describe "for a child that was sent a signal" do
 
     before :each do


### PR DESCRIPTION
This is a followup to #5134 which brings in the changes I did in https://github.com/ruby/spec/pull/596 into our tree also. They highlight a current issue in JRuby that should be fixed at one point or another.

(There were other, mostly `BigDecimal`-related changes coming from there also, but I picked _only_ the relevant changes from the spec tree for now. I don't know what the official process is for updating these; I looked for a Rake task but couldn't find any.)

----

Here are the results from these tests, illustrating the problem & current, incorrect behavior in JRuby. These specs pass on MRI.

```
$ ~/git/3rd-party/mspec/bin/mspec core/process/status
$ ruby /Users/plundberg/git/3rd-party/mspec/bin/mspec-run core/process/status
jruby 9.2.0.0-SNAPSHOT (2.5.0) 2018-04-12 34bec6e Java HotSpot(TM) 64-Bit Server VM 10+46 on 10+46 +jit [darwin-x86_64]

1)
Process::Status#exitstatus for a child that raised SignalException returns nil FAILED
Expected 143
 to equal nil

/Volumes/git/3rd-party/jruby/spec/ruby/core/process/status/exitstatus_spec.rb:21:in `block in (root)'
org/jruby/RubyBasicObject.java:2596:in `instance_eval'
org/jruby/RubyEnumerable.java:1737:in `all?'
org/jruby/RubyArray.java:1778:in `each'
org/jruby/RubyArray.java:1778:in `each'
/Volumes/git/3rd-party/jruby/spec/ruby/core/process/status/exitstatus_spec.rb:3:in `<main>'
org/jruby/RubyKernel.java:990:in `load'
org/jruby/RubyBasicObject.java:2596:in `instance_eval'
org/jruby/RubyArray.java:1778:in `each'

2)
Process::Status#termsig for a child that raised SignalException returns the signal FAILED
Expected nil
 to equal 15

/Volumes/git/3rd-party/jruby/spec/ruby/core/process/status/termsig_spec.rb:23:in `block in (root)'
org/jruby/RubyBasicObject.java:2596:in `instance_eval'
org/jruby/RubyEnumerable.java:1737:in `all?'
org/jruby/RubyArray.java:1778:in `each'
org/jruby/RubyArray.java:1778:in `each'
/Volumes/git/3rd-party/jruby/spec/ruby/core/process/status/termsig_spec.rb:3:in `<main>'
org/jruby/RubyKernel.java:990:in `load'
org/jruby/RubyBasicObject.java:2596:in `instance_eval'
org/jruby/RubyArray.java:1778:in `each'
[- | ==================100%================== | 00:00:00]      2F      0E

Finished in 43.987804 seconds

16 files, 13 examples, 13 expectations, 2 failures, 0 errors, 0 taggede, 3 examples, 3 expectations, 1 failure, 0 errors, 0 tagged
```
