### PR TITLE
Handle exception cause with null message

### DIFF
--- a/core/src/main/java/org/jruby/embed/jsr223/JRubyEngine.java
+++ b/core/src/main/java/org/jruby/embed/jsr223/JRubyEngine.java
@@ -214,7 +214,8 @@ public class JRubyEngine implements Compilable, Invocable, ScriptEngine {
             }
             return container.callMethod(receiver, method, args, Object.class);
         } catch (Exception e) {
-            if (e.getCause().getMessage().contains("undefined method")) {
+            if (e.getCause() != null && e.getCause().getMessage() != null
+                    && e.getCause().getMessage().contains("undefined method")) {
                 throw wrapMethodException(e);
             }
             throw wrapException(e);
@@ -239,7 +240,8 @@ public class JRubyEngine implements Compilable, Invocable, ScriptEngine {
             }
             return container.callMethod(container.getProvider().getRuntime().getTopSelf(), method, args, Object.class);
         } catch (Exception e) {
-            if (e.getCause().getMessage().contains("undefined method")) {
+            if (e.getCause() != null && e.getCause().getMessage() != null
+                    && e.getCause().getMessage().contains("undefined method")) {
                 throw wrapMethodException(e);
             }
             throw wrapException(e);

--- a/core/src/test/java/org/jruby/embed/jsr223/JRubyEngineTest.java
+++ b/core/src/test/java/org/jruby/embed/jsr223/JRubyEngineTest.java
@@ -618,6 +618,21 @@ public class JRubyEngineTest {
     }
 
     /**
+     * Test of invokeMethod method throwing an exception with a null message.
+     */
+    @Test
+    public void testInvokeMethodWithJavaException() throws Exception {
+        ScriptEngine instance = newScriptEngine();
+        instance.eval("def trigger_npe\nraise java.lang.NullPointerException.new\nend");
+        try {
+            Object result = ((Invocable) instance).invokeMethod(Object.class,"trigger_npe", null);
+            fail("Expected javax.script.ScriptException");
+        } catch (javax.script.ScriptException sex) {
+            // javax.script.ScriptException is expected
+        }
+    }
+
+    /**
      * Test of invokeFunction method, of class Jsr223JRubyEngine.
      */
     //@Test
@@ -641,6 +656,21 @@ public class JRubyEngineTest {
         assertTrue(((String)result).startsWith("Happy") || ((String) result).startsWith("You have"));
 
         instance.getBindings(ScriptContext.ENGINE_SCOPE).clear();
+    }
+
+    /**
+     * Test of invokeFunction method throwing an exception with a null message.
+     */
+    @Test
+    public void testInvokeFunctionWithJavaException() throws Exception {
+        ScriptEngine instance = newScriptEngine();
+        instance.eval("def trigger_npe\nraise java.lang.NullPointerException.new\nend");
+        try {
+            Object result = ((Invocable) instance).invokeFunction("trigger_npe", null);
+            fail("Expected javax.script.ScriptException");
+        } catch (javax.script.ScriptException sex) {
+            // javax.script.ScriptException is expected
+        }
     }
 
     /**


### PR DESCRIPTION
The handling of exc exceptions in the jsr223 JRubyEngine assumes that all exceptions have causes, and that the cause has a non-null message.  This is not always the case and results in a NullPointerException without the original exception.

I added a test for the two cases I know of.

I noticed that all the other tests for the jsr223 JRubyEngine are disabled.  Any reason for that?