### PR TITLE
Fix TestLoad#test_symlinked_jar

### DIFF
--- a/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
+++ b/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
@@ -170,12 +170,11 @@ class LibrarySearcher {
             if (resource.absolutePath() != resource.canonicalPath()) {
                 FileResource expandedResource = JRubyFile.createResourceAsFile(runtime, resource.canonicalPath());
                 if (expandedResource.exists()){
-                    resource = expandedResource;
-                    String scriptName = resolveScriptName(resource, resource.canonicalPath());
-                    String loadName = resolveLoadName(resource, searchName + suffix);
+                    String scriptName = resolveScriptName(expandedResource, expandedResource.canonicalPath());
+                    String loadName = resolveLoadName(expandedResource, searchName + suffix);
                     return new FoundLibrary(ResourceLibrary.create(searchName, scriptName, resource), loadName);
                 }
-          }
+            }
             DebugLog.Resource.logFound(pathWithSuffix);
             String scriptName = resolveScriptName(resource, pathWithSuffix);
             String loadName = resolveLoadName(resource, searchName + suffix);


### PR DESCRIPTION
Introduced in https://github.com/jruby/jruby/pull/5121.
Ruby 2.5 loads now the real path of symlinked libraries.
We will now use the file extension of the symlink
to decide what ResourceLibrary to load.