### PR TITLE
[ji] lazy loading of Java (proxy) class extensions

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -4826,6 +4826,12 @@ public final class Ruby implements Constantizable {
         return dataClass;
     }
 
+    /**
+     * @return Class -> extension initializer map
+     * @note Internal API, subject to change!
+     */
+    public Map<Class, Consumer<RubyModule>> getJavaExtensionDefinitions() { return javaExtensionDefinitions; }
+
     @Deprecated
     private static final RecursiveFunctionEx<RecursiveFunction> LEGACY_RECURSE = new RecursiveFunctionEx<RecursiveFunction>() {
         @Override
@@ -5295,6 +5301,8 @@ public final class Ruby implements Constantizable {
     public final JavaSites sites = new JavaSites();
 
     private volatile MRIRecursionGuard mriRecursionGuard;
+
+    private final Map<Class, Consumer<RubyModule>> javaExtensionDefinitions = new WeakHashMap<>(); // caller-syncs
 
     // For strptime processing we cache the parsed format strings since most applications
     // reuse the same formats over and over.  This is also unbounded (for now) since all applications

--- a/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
@@ -126,7 +126,7 @@ public class JavaSupportImpl extends JavaSupport {
             @Override
             public synchronized RubyModule computeValue(Class<?> klass) {
                 RubyModule proxyKlass = Java.createProxyClassForClass(runtime, klass);
-                JavaExtensions.getInstance().define(klass, proxyKlass); // (lazy) load extensions
+                JavaExtensions.define(klass, proxyKlass); // (lazy) load extensions
                 return proxyKlass;
             }
         });

--- a/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
@@ -48,6 +48,7 @@ import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.Unrescuable;
+import org.jruby.javasupport.ext.JavaExtensions;
 import org.jruby.runtime.Helpers;
 import org.jruby.util.ArraySupport;
 import org.jruby.util.Loader;
@@ -124,7 +125,9 @@ public class JavaSupportImpl extends JavaSupport {
              */
             @Override
             public synchronized RubyModule computeValue(Class<?> klass) {
-                return Java.createProxyClassForClass(runtime, klass);
+                RubyModule proxyKlass = Java.createProxyClassForClass(runtime, klass);
+                JavaExtensions.getInstance().define(klass, proxyKlass); // (lazy) load extensions
+                return proxyKlass;
             }
         });
 

--- a/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
@@ -126,7 +126,7 @@ public class JavaSupportImpl extends JavaSupport {
             @Override
             public synchronized RubyModule computeValue(Class<?> klass) {
                 RubyModule proxyKlass = Java.createProxyClassForClass(runtime, klass);
-                JavaExtensions.define(klass, proxyKlass); // (lazy) load extensions
+                JavaExtensions.define(runtime, klass, proxyKlass); // (lazy) load extensions
                 return proxyKlass;
             }
         });

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaExtensions.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaExtensions.java
@@ -1,0 +1,43 @@
+package org.jruby.javasupport.ext;
+
+import org.jruby.Ruby;
+import org.jruby.RubyModule;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.function.Consumer;
+
+/**
+ * Lazy Java class extensions initialization.
+ *
+ * @note Internal API
+ * @author kares
+ */
+public class JavaExtensions {
+
+    private static final boolean IMMEDIATE = false;
+
+    private static final JavaExtensions INSTANCE = new JavaExtensions();
+
+    public static JavaExtensions getInstance() { return INSTANCE; }
+
+    static void put(final Ruby runtime, Class javaClass, Consumer<RubyModule> proxyClass) {
+        if (IMMEDIATE) {
+            proxyClass.accept( org.jruby.javasupport.Java.getProxyClass(runtime, javaClass) );
+            return;
+        }
+        Object previous = INSTANCE.definitions.put(javaClass, proxyClass);
+        assert previous == null;
+    }
+
+    private JavaExtensions() { /* hidden */ }
+
+    final Map<Class, Consumer<RubyModule>> definitions = new WeakHashMap<>();
+
+    public void define(final Class javaClass, final RubyModule proxyClass) {
+        definitions.getOrDefault(javaClass, NOOP).accept(proxyClass);
+    }
+
+    private static final Consumer<RubyModule> NOOP = (noop) -> { /* no extensions */ };
+
+}

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaExtensions.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaExtensions.java
@@ -17,25 +17,20 @@ public class JavaExtensions {
 
     private static final boolean IMMEDIATE = false;
 
-    private static final JavaExtensions INSTANCE = new JavaExtensions();
-
-    public static JavaExtensions getInstance() { return INSTANCE; }
+    private JavaExtensions() { /* hidden */ }
 
     static void put(final Ruby runtime, Class javaClass, Consumer<RubyModule> proxyClass) {
         if (IMMEDIATE) {
             proxyClass.accept( org.jruby.javasupport.Java.getProxyClass(runtime, javaClass) );
             return;
         }
-        Object previous = INSTANCE.definitions.put(javaClass, proxyClass);
+        Object previous = runtime.getJavaExtensionDefinitions().put(javaClass, proxyClass);
         assert previous == null;
     }
 
-    private JavaExtensions() { /* hidden */ }
-
-    final Map<Class, Consumer<RubyModule>> definitions = new WeakHashMap<>();
-
-    public void define(final Class javaClass, final RubyModule proxyClass) {
-        definitions.getOrDefault(javaClass, NOOP).accept(proxyClass);
+    public static void define(final Class javaClass, final RubyModule proxyClass) {
+        final Ruby runtime = proxyClass.getRuntime();
+        runtime.getJavaExtensionDefinitions().getOrDefault(javaClass, NOOP).accept(proxyClass);
     }
 
     private static final Consumer<RubyModule> NOOP = (noop) -> { /* no extensions */ };

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaExtensions.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaExtensions.java
@@ -2,9 +2,8 @@ package org.jruby.javasupport.ext;
 
 import org.jruby.Ruby;
 import org.jruby.RubyModule;
+import org.jruby.util.cli.Options;
 
-import java.util.Map;
-import java.util.WeakHashMap;
 import java.util.function.Consumer;
 
 /**
@@ -15,12 +14,12 @@ import java.util.function.Consumer;
  */
 public class JavaExtensions {
 
-    private static final boolean IMMEDIATE = false;
+    private static final boolean LAZY = Options.JI_LOAD_LAZY.load();;
 
     private JavaExtensions() { /* hidden */ }
 
     static void put(final Ruby runtime, Class javaClass, Consumer<RubyModule> proxyClass) {
-        if (IMMEDIATE) {
+        if (!LAZY) {
             proxyClass.accept( org.jruby.javasupport.Java.getProxyClass(runtime, javaClass) );
             return;
         }
@@ -28,8 +27,7 @@ public class JavaExtensions {
         assert previous == null;
     }
 
-    public static void define(final Class javaClass, final RubyModule proxyClass) {
-        final Ruby runtime = proxyClass.getRuntime();
+    public static void define(final Ruby runtime, final Class javaClass, final RubyModule proxyClass) {
         runtime.getJavaExtensionDefinitions().getOrDefault(javaClass, NOOP).accept(proxyClass);
     }
 

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaIo.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaIo.java
@@ -32,7 +32,6 @@ import org.jruby.Ruby;
 import org.jruby.RubyIO;
 import org.jruby.RubyModule;
 import org.jruby.internal.runtime.methods.JavaMethod;
-import org.jruby.javasupport.Java;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -47,16 +46,17 @@ import static org.jruby.runtime.Visibility.PUBLIC;
 public abstract class JavaIo {
 
     public static void define(final Ruby runtime) {
-        RubyModule proxyClass;
+        JavaExtensions.put(runtime, java.io.InputStream.class, (proxyClass) -> {
+            proxyClass.addMethodInternal("to_io", new InputStreamToIO(proxyClass));
+        });
 
-        proxyClass = Java.getProxyClass(runtime, java.io.InputStream.class);
-        proxyClass.addMethodInternal("to_io", new InputStreamToIO(proxyClass));
+        JavaExtensions.put(runtime, java.io.OutputStream.class, (proxyClass) -> {
+            proxyClass.addMethodInternal("to_io", new OutputStreamToIO(proxyClass));
+        });
 
-        proxyClass = Java.getProxyClass(runtime, java.io.OutputStream.class);
-        proxyClass.addMethodInternal("to_io", new OutputStreamToIO(proxyClass));
-
-        proxyClass = Java.getProxyClass(runtime, java.nio.channels.Channel.class);
-        proxyClass.addMethodInternal("to_io", new ChannelToIO(proxyClass));
+        JavaExtensions.put(runtime, java.nio.channels.Channel.class, (proxyClass) -> {
+            proxyClass.addMethodInternal("to_io", new ChannelToIO(proxyClass));
+        });
     }
 
     private static final class InputStreamToIO extends JavaMethod.JavaMethodZeroOrOne {

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -80,10 +80,10 @@ public abstract class JavaLang {
     @JRubyModule(name = "Java::JavaLang::Iterable", include = "Enumerable")
     public static class Iterable {
 
-        static RubyModule define(final Ruby runtime, final RubyModule Iterable) {
-            Iterable.includeModule( runtime.getEnumerable() ); // include Enumerable
-            Iterable.defineAnnotatedMethods(Iterable.class);
-            return Iterable;
+        static RubyModule define(final Ruby runtime, final RubyModule proxy) {
+            proxy.includeModule( runtime.getEnumerable() ); // include Enumerable
+            proxy.defineAnnotatedMethods(Iterable.class);
+            return proxy;
         }
 
         @JRubyMethod
@@ -177,10 +177,10 @@ public abstract class JavaLang {
     @JRubyClass(name = "Java::JavaLang::Comparable", include = "Comparable")
     public static class Comparable {
 
-        static RubyModule define(final Ruby runtime, final RubyModule Comparable) {
-            Comparable.includeModule( runtime.getComparable() ); // include Comparable
-            Comparable.defineAnnotatedMethods(Comparable.class);
-            return Comparable;
+        static RubyModule define(final Ruby runtime, final RubyModule proxy) {
+            proxy.includeModule( runtime.getComparable() ); // include Comparable
+            proxy.defineAnnotatedMethods(Comparable.class);
+            return proxy;
         }
 
         @JRubyMethod(name = "<=>")
@@ -205,9 +205,9 @@ public abstract class JavaLang {
     @JRubyClass(name = "Java::JavaLang::Throwable")
     public static class Throwable {
 
-        static RubyModule define(final Ruby runtime, final RubyClass Throwable) {
-            Throwable.defineAnnotatedMethods(Throwable.class);
-            return Throwable;
+        static RubyModule define(final Ruby runtime, final RubyClass proxy) {
+            proxy.defineAnnotatedMethods(Throwable.class);
+            return proxy;
         }
 
         @JRubyMethod // stackTrace => backtrace
@@ -273,9 +273,9 @@ public abstract class JavaLang {
     @JRubyModule(name = "Java::JavaLang::Runnable")
     public static class Runnable {
 
-        static RubyModule define(final Ruby runtime, final RubyModule Runnable) {
-            Runnable.defineAnnotatedMethods(Runnable.class);
-            return Runnable;
+        static RubyModule define(final Ruby runtime, final RubyModule proxy) {
+            proxy.defineAnnotatedMethods(Runnable.class);
+            return proxy;
         }
 
         @JRubyMethod
@@ -321,13 +321,13 @@ public abstract class JavaLang {
     @JRubyClass(name = "Java::JavaLang::Number")
     public static class Number {
 
-        static RubyClass define(final Ruby runtime, final RubyClass Number) {
-            Number.defineAnnotatedMethods(Number.class);
+        static RubyClass define(final Ruby runtime, final RubyClass proxy) {
+            proxy.defineAnnotatedMethods(Number.class);
 
-            Number.defineAlias("to_int", "longValue");
-            Number.defineAlias("to_f", "doubleValue");
+            proxy.defineAlias("to_int", "longValue");
+            proxy.defineAlias("to_f", "doubleValue");
 
-            return Number;
+            return proxy;
         }
 
         @JRubyMethod(name = "to_f")
@@ -405,10 +405,9 @@ public abstract class JavaLang {
     @JRubyClass(name = "Java::JavaLang::Character")
     public static class Character {
 
-        static RubyClass define(final Ruby runtime, final RubyClass Character) {
-            System.out.println("defining Character extensions: proxy-class: " + Character);
-            Character.defineAnnotatedMethods(Character.class);
-            return (RubyClass) Character;
+        static RubyClass define(final Ruby runtime, final RubyClass proxy) {
+            proxy.defineAnnotatedMethods(Character.class);
+            return proxy;
         }
 
         @JRubyMethod(name = "java_identifier_start?", meta = true)
@@ -438,10 +437,10 @@ public abstract class JavaLang {
     @JRubyClass(name = "Java::JavaLang::Class")
     public static class Class {
 
-        static RubyClass define(final Ruby runtime, final RubyClass Class) {
-            Class.includeModule( runtime.getComparable() ); // include Comparable
-            Class.defineAnnotatedMethods(Class.class);
-            return (RubyClass) Class;
+        static RubyClass define(final Ruby runtime, final RubyClass proxy) {
+            proxy.includeModule( runtime.getComparable() ); // include Comparable
+            proxy.defineAnnotatedMethods(Class.class);
+            return proxy;
         }
 
         @JRubyMethod(name = "ruby_class")
@@ -599,9 +598,9 @@ public abstract class JavaLang {
     @JRubyClass(name = "Java::JavaLang::ClassLoader")
     public static class ClassLoader {
 
-        static RubyModule define(final Ruby runtime, final RubyClass ClassLoader) {
-            ClassLoader.defineAnnotatedMethods(ClassLoader.class);
-            return ClassLoader;
+        static RubyModule define(final Ruby runtime, final RubyClass proxy) {
+            proxy.defineAnnotatedMethods(ClassLoader.class);
+            return proxy;
         }
 
         @JRubyMethod

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLangReflect.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLangReflect.java
@@ -31,7 +31,6 @@ package org.jruby.javasupport.ext;
 import org.jruby.*;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
-import org.jruby.javasupport.Java;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -50,16 +49,15 @@ import static org.jruby.javasupport.JavaUtil.unwrapJavaObject;
 public abstract class JavaLangReflect {
 
     public static void define(final Ruby runtime) {
-        Constructor.define(runtime);
-        Field.define(runtime);
-        Method.define(runtime);
+        JavaExtensions.put(runtime, java.lang.reflect.Constructor.class, (proxyClass) -> Constructor.define(runtime, (RubyClass) proxyClass));
+        JavaExtensions.put(runtime, java.lang.reflect.Field.class, (proxyClass) -> Field.define(runtime, (RubyClass) proxyClass));
+        JavaExtensions.put(runtime, java.lang.reflect.Method.class, (proxyClass) -> Method.define(runtime, (RubyClass) proxyClass));
     }
 
     @JRubyClass(name = "Java::JavaLangReflect::Constructor")
     public static class Constructor {
 
-        static RubyClass define(final Ruby runtime) {
-            final RubyModule Constructor = Java.getProxyClass(runtime, java.lang.reflect.Constructor.class);
+        static RubyClass define(final Ruby runtime, final RubyClass Constructor) {
             Constructor.defineAnnotatedMethods(Constructor.class);
             return (RubyClass) Constructor;
         }
@@ -120,8 +118,7 @@ public abstract class JavaLangReflect {
     @JRubyClass(name = "Java::JavaLangReflect::Method")
     public static class Method {
 
-        static RubyClass define(final Ruby runtime) {
-            final RubyModule Method = Java.getProxyClass(runtime, java.lang.reflect.Method.class);
+        static RubyClass define(final Ruby runtime, final RubyClass Method) {
             Method.defineAnnotatedMethods(Method.class);
             return (RubyClass) Method;
         }
@@ -201,8 +198,7 @@ public abstract class JavaLangReflect {
     @JRubyClass(name = "Java::JavaLangReflect::Field")
     public static class Field {
 
-        static RubyClass define(final Ruby runtime) {
-            final RubyModule Field = Java.getProxyClass(runtime, java.lang.reflect.Field.class);
+        static RubyClass define(final Ruby runtime, final RubyClass Field) {
             Field.defineAnnotatedMethods(Field.class);
             return (RubyClass) Field;
         }

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLangReflect.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLangReflect.java
@@ -57,9 +57,9 @@ public abstract class JavaLangReflect {
     @JRubyClass(name = "Java::JavaLangReflect::Constructor")
     public static class Constructor {
 
-        static RubyClass define(final Ruby runtime, final RubyClass Constructor) {
-            Constructor.defineAnnotatedMethods(Constructor.class);
-            return (RubyClass) Constructor;
+        static RubyClass define(final Ruby runtime, final RubyClass proxy) {
+            proxy.defineAnnotatedMethods(Constructor.class);
+            return proxy;
         }
 
         @JRubyMethod
@@ -118,9 +118,9 @@ public abstract class JavaLangReflect {
     @JRubyClass(name = "Java::JavaLangReflect::Method")
     public static class Method {
 
-        static RubyClass define(final Ruby runtime, final RubyClass Method) {
-            Method.defineAnnotatedMethods(Method.class);
-            return (RubyClass) Method;
+        static RubyClass define(final Ruby runtime, final RubyClass proxy) {
+            proxy.defineAnnotatedMethods(Method.class);
+            return proxy;
         }
 
         @JRubyMethod
@@ -198,9 +198,9 @@ public abstract class JavaLangReflect {
     @JRubyClass(name = "Java::JavaLangReflect::Field")
     public static class Field {
 
-        static RubyClass define(final Ruby runtime, final RubyClass Field) {
-            Field.defineAnnotatedMethods(Field.class);
-            return (RubyClass) Field;
+        static RubyClass define(final Ruby runtime, final RubyClass proxy) {
+            proxy.defineAnnotatedMethods(Field.class);
+            return proxy;
         }
 
         @JRubyMethod // alias value_type name

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaNet.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaNet.java
@@ -32,7 +32,6 @@ import org.jruby.Ruby;
 import org.jruby.RubyIO;
 import org.jruby.RubyModule;
 import org.jruby.internal.runtime.methods.JavaMethod;
-import org.jruby.javasupport.Java;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
@@ -52,10 +51,9 @@ import static org.jruby.runtime.Visibility.PUBLIC;
 public abstract class JavaNet {
 
     public static void define(final Ruby runtime) {
-        RubyModule proxyClass;
-
-        proxyClass = Java.getProxyClass(runtime, java.net.URL.class);
-        proxyClass.addMethodInternal("open", new URLOpenMethod(proxyClass));
+        JavaExtensions.put(runtime, java.net.URL.class, (proxyClass) -> {
+            proxyClass.addMethodInternal("open", new URLOpenMethod(proxyClass));
+        });
     }
 
     private static final class URLOpenMethod extends JavaMethod.JavaMethodZeroOrNBlock {

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
@@ -69,10 +69,10 @@ public abstract class JavaUtil {
     @JRubyModule(name = "Java::JavaUtil::Enumeration", include = "Enumerable")
     public static class Enumeration {
 
-        static RubyModule define(final Ruby runtime, final RubyModule Enumeration) {
-            Enumeration.includeModule( runtime.getEnumerable() ); // include Enumerable
-            Enumeration.defineAnnotatedMethods(Enumeration.class);
-            return Enumeration;
+        static RubyModule define(final Ruby runtime, final RubyModule proxy) {
+            proxy.includeModule( runtime.getEnumerable() ); // include Enumerable
+            proxy.defineAnnotatedMethods(Enumeration.class);
+            return proxy;
         }
 
         @JRubyMethod
@@ -91,10 +91,10 @@ public abstract class JavaUtil {
     @JRubyModule(name = "Java::JavaUtil::Iterator", include = "Enumerable")
     public static class Iterator {
 
-        static RubyModule define(final Ruby runtime, final RubyModule Iterator) {
-            Iterator.includeModule( runtime.getEnumerable() ); // include Enumerable
-            Iterator.defineAnnotatedMethods(Iterator.class);
-            return Iterator;
+        static RubyModule define(final Ruby runtime, final RubyModule proxy) {
+            proxy.includeModule( runtime.getEnumerable() ); // include Enumerable
+            proxy.defineAnnotatedMethods(Iterator.class);
+            return proxy;
         }
 
         @JRubyMethod
@@ -113,10 +113,10 @@ public abstract class JavaUtil {
     @JRubyModule(name = "Java::JavaUtil::Collection", include = "Enumerable")
     public static class Collection {
 
-        static RubyModule define(final Ruby runtime, final RubyModule Collection) {
-            Collection.includeModule( runtime.getEnumerable() ); // include Enumerable
-            Collection.defineAnnotatedMethods(Collection.class);
-            return Collection;
+        static RubyModule define(final Ruby runtime, final RubyModule proxy) {
+            proxy.includeModule( runtime.getEnumerable() ); // include Enumerable
+            proxy.defineAnnotatedMethods(Collection.class);
+            return proxy;
         }
 
         @JRubyMethod(name = { "length", "size" })
@@ -256,9 +256,9 @@ public abstract class JavaUtil {
     @JRubyModule(name = "Java::JavaUtil::List")
     public static class List {
 
-        static RubyModule define(final Ruby runtime, final RubyModule List) {
-            List.defineAnnotatedMethods(List.class);
-            return List;
+        static RubyModule define(final Ruby runtime, final RubyModule proxy) {
+            proxy.defineAnnotatedMethods(List.class);
+            return proxy;
         }
 
         @JRubyMethod(name = "[]") // act safe on indexes compared to get(idx) throwing IndexOutOfBoundsException

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
@@ -60,18 +60,16 @@ import static org.jruby.runtime.invokedynamic.MethodNames.OP_EQUAL;
 public abstract class JavaUtil {
 
     public static void define(final Ruby runtime) {
-        Enumeration.define(runtime);
-        Iterator.define(runtime);
-        Collection.define(runtime);
-        List.define(runtime);
+        JavaExtensions.put(runtime, java.util.Enumeration.class, (proxyClass) -> Enumeration.define(runtime, proxyClass));
+        JavaExtensions.put(runtime, java.util.Iterator.class, (proxyClass) -> Iterator.define(runtime, proxyClass));
+        JavaExtensions.put(runtime, java.util.Collection.class, (proxyClass) -> Collection.define(runtime, proxyClass));
+        JavaExtensions.put(runtime, java.util.List.class, (proxyClass) -> List.define(runtime, proxyClass));
     }
 
     @JRubyModule(name = "Java::JavaUtil::Enumeration", include = "Enumerable")
     public static class Enumeration {
 
-        static RubyModule define(final Ruby runtime) {
-            final RubyModule Enumeration = //Java.getProxyClass(runtime, java.util.Enumeration.class);
-                JavaClass.get(runtime, java.util.Enumeration.class).getProxyModule();
+        static RubyModule define(final Ruby runtime, final RubyModule Enumeration) {
             Enumeration.includeModule( runtime.getEnumerable() ); // include Enumerable
             Enumeration.defineAnnotatedMethods(Enumeration.class);
             return Enumeration;
@@ -93,9 +91,7 @@ public abstract class JavaUtil {
     @JRubyModule(name = "Java::JavaUtil::Iterator", include = "Enumerable")
     public static class Iterator {
 
-        static RubyModule define(final Ruby runtime) {
-            final RubyModule Iterator = //Java.getProxyClass(runtime, java.util.Iterator.class);
-                JavaClass.get(runtime, java.util.Iterator.class).getProxyModule();
+        static RubyModule define(final Ruby runtime, final RubyModule Iterator) {
             Iterator.includeModule( runtime.getEnumerable() ); // include Enumerable
             Iterator.defineAnnotatedMethods(Iterator.class);
             return Iterator;
@@ -117,9 +113,7 @@ public abstract class JavaUtil {
     @JRubyModule(name = "Java::JavaUtil::Collection", include = "Enumerable")
     public static class Collection {
 
-        static RubyModule define(final Ruby runtime) {
-            final RubyModule Collection = //Java.getProxyClass(runtime, java.util.Collection.class);
-                    JavaClass.get(runtime, java.util.Collection.class).getProxyModule();
+        static RubyModule define(final Ruby runtime, final RubyModule Collection) {
             Collection.includeModule( runtime.getEnumerable() ); // include Enumerable
             Collection.defineAnnotatedMethods(Collection.class);
             return Collection;
@@ -262,9 +256,7 @@ public abstract class JavaUtil {
     @JRubyModule(name = "Java::JavaUtil::List")
     public static class List {
 
-        static RubyModule define(final Ruby runtime) {
-            final RubyModule List = //Java.getProxyClass(runtime, java.util.List.class);
-                    JavaClass.get(runtime, java.util.List.class).getProxyModule();
+        static RubyModule define(final Ruby runtime, final RubyModule List) {
             List.defineAnnotatedMethods(List.class);
             return List;
         }

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaUtilRegex.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaUtilRegex.java
@@ -31,7 +31,6 @@ package org.jruby.javasupport.ext;
 import org.jruby.*;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
-import org.jruby.javasupport.Java;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -46,17 +45,16 @@ import static org.jruby.javasupport.JavaUtil.unwrapJavaObject;
 public abstract class JavaUtilRegex {
 
     public static void define(final Ruby runtime) {
-        Pattern.define(runtime);
-        Matcher.define(runtime);
+        JavaExtensions.put(runtime, java.util.regex.Pattern.class, (proxyClass) -> Pattern.define(runtime, (RubyClass) proxyClass));
+        JavaExtensions.put(runtime, java.util.regex.Matcher.class, (proxyClass) -> Matcher.define(runtime, (RubyClass) proxyClass));
     }
 
     @JRubyClass(name = "Java::JavaUtilRegex::Pattern")
     public static class Pattern {
 
-        static RubyClass define(final Ruby runtime) {
-            final RubyModule Pattern = Java.getProxyClass(runtime, java.util.regex.Pattern.class);
+        static RubyClass define(final Ruby runtime, final RubyClass Pattern) {
             Pattern.defineAnnotatedMethods(Pattern.class);
-            return (RubyClass) Pattern;
+            return Pattern;
         }
 
         @JRubyMethod(name = "=~", required = 1)
@@ -96,8 +94,7 @@ public abstract class JavaUtilRegex {
     @JRubyClass(name = "Java::JavaUtilRegex::Matcher")
     public static class Matcher {
 
-        static RubyClass define(final Ruby runtime) {
-            final RubyModule Matcher = Java.getProxyClass(runtime, java.util.regex.Matcher.class);
+        static RubyClass define(final Ruby runtime, final RubyClass Matcher) {
             Matcher.defineAnnotatedMethods(Matcher.class);
             return (RubyClass) Matcher;
         }

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaUtilRegex.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaUtilRegex.java
@@ -52,9 +52,9 @@ public abstract class JavaUtilRegex {
     @JRubyClass(name = "Java::JavaUtilRegex::Pattern")
     public static class Pattern {
 
-        static RubyClass define(final Ruby runtime, final RubyClass Pattern) {
-            Pattern.defineAnnotatedMethods(Pattern.class);
-            return Pattern;
+        static RubyClass define(final Ruby runtime, final RubyClass proxy) {
+            proxy.defineAnnotatedMethods(Pattern.class);
+            return proxy;
         }
 
         @JRubyMethod(name = "=~", required = 1)
@@ -94,9 +94,9 @@ public abstract class JavaUtilRegex {
     @JRubyClass(name = "Java::JavaUtilRegex::Matcher")
     public static class Matcher {
 
-        static RubyClass define(final Ruby runtime, final RubyClass Matcher) {
-            Matcher.defineAnnotatedMethods(Matcher.class);
-            return (RubyClass) Matcher;
+        static RubyClass define(final Ruby runtime, final RubyClass proxy) {
+            proxy.defineAnnotatedMethods(Matcher.class);
+            return (RubyClass) proxy;
         }
 
         @JRubyMethod

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -203,6 +203,7 @@ public class Options {
     public static final Option<String> JI_PROXYCLASSFACTORY = string(JAVA_INTEGRATION, "ji.proxyClassFactory", "Allow external envs to replace JI proxy class factory");
     public static final Option<Boolean> JI_AMBIGUOUS_CALLS_DEBUG = bool(JAVA_INTEGRATION, "ji.ambiguous.calls.debug", false, "Toggle verbose reporting of all ambiguous calls to Java objects");
     public static final Option<Boolean> AOT_LOADCLASSES = bool(JAVA_INTEGRATION, "aot.loadClasses", false, "Look for .class before .rb to load AOT-compiled code");
+    public static final Option<Boolean> JI_LOAD_LAZY = bool(JAVA_INTEGRATION, "ji.load.lazy", true, "Load Java support (class extensions) lazily on demand or ahead of time.");
 
     public static final Option<Integer> PROFILE_MAX_METHODS = integer(PROFILING, "profile.max.methods", 100000, "Maximum number of methods to consider for profiling.");
 


### PR DESCRIPTION
- seems to work fine to the limited testing that I did locally
- the gist is - Java extensions load on demand as Java classes are (first) used
- theoretically we could also add a flag to disable the laziness and behave as before

also ... we could safely add more extensions now and do not have to worry much about bloating load times

did not run any numbers yet, but hopefully we do not do much JI internally on `gem list`, `rake` etc