### PR TITLE
Remove hack for FileUtils.mv due to incorrect error raised from File.rename

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -3814,6 +3814,10 @@ public final class Ruby implements Constantizable {
         return newRaiseException(getErrno().getClass("EMSGSIZE"), null);
     }
 
+    public RaiseException newErrnoEXDEVError(String message) {
+        return newRaiseException(getErrno().getClass("EXDEV"), message);
+    }
+
     public RaiseException newIndexError(String message) {
         return newRaiseException(getIndexError(), message);
     }

--- a/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
@@ -402,7 +402,7 @@ public class TraceType {
         String message;
         try {
             message = exception.callMethod(context, "message").toString();
-        } catch (org.jruby.exceptions.Exception _) {
+        } catch (org.jruby.exceptions.Exception unused) {
             message = exception.message(context).toString();
         }
         if (exception.getMetaClass() == runtime.getRuntimeError() && message.length() == 0) {

--- a/lib/ruby/stdlib/fileutils.rb
+++ b/lib/ruby/stdlib/fileutils.rb
@@ -469,7 +469,7 @@ module FileUtils
         end
         begin
           File.rename s, d
-        rescue *MV_RESCUES
+        rescue EXDEV
           copy_entry s, d, true
           if secure
             remove_entry_secure s, force
@@ -483,15 +483,6 @@ module FileUtils
     end
   end
   module_function :mv
-
-  # JRuby raises EACCES because JDK reports errors differently
-  MV_RESCUES = begin
-    if RUBY_ENGINE == 'jruby'
-      [Errno::EXDEV, Errno::EACCES]
-    else
-      [Errno::EXDEV]
-    end
-  end
 
   alias move mv
   module_function :move


### PR DESCRIPTION
In MRI, File.rename will raise an EXDEV if the rename is attempted with paths that span devices (mounts). Up until this PR, we would raise EACCES in such a situation, requiring us to modify fileutils.rb to deal with both errors.

Because this is tweaking a very core behavior of File and FileUtils, I'm pushing to a branch to see how it affects our test runs.

This fix is an attempt to deal with at least part of Bundler's vendoring of a non-JRuby fileutils.rb. See bundler/bundler#6532.