### PR TITLE
Always search full hierarchy for highest definition of a cvar.

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -3713,13 +3713,14 @@ public class RubyModule extends RubyObject {
      */
     public IRubyObject setClassVar(String name, IRubyObject value) {
         RubyModule module = this;
+        RubyModule highest = this;
         do {
             if (module.hasClassVariable(name)) {
-                return module.storeClassVariable(name, value);
+                highest = module;
             }
         } while ((module = module.getSuperClass()) != null);
 
-        return storeClassVariable(name, value);
+        return highest.storeClassVariable(name, value);
     }
 
     @Deprecated
@@ -3759,10 +3760,15 @@ public class RubyModule extends RubyObject {
         assert IdUtil.isClassVariable(name);
         Object value;
         RubyModule module = this;
+        RubyModule highest = null;
 
         do {
-            if ((value = module.fetchClassVariable(name)) != null) return (IRubyObject)value;
+            if (module.hasClassVariable(name)) {
+                highest = module;
+            }
         } while ((module = module.getSuperClass()) != null);
+
+        if (highest != null) return highest.fetchClassVariable(name);
 
         return null;
     }


### PR DESCRIPTION
This makes the feature basically useless for anything requiring
performance, since it always has to search the entire hierarchy
for a late-assigned value further up.

Additional work using our weak subclass hierarchy might be able
to make reads slightly cheaper (giving up at first successfuly
read) by walking down the hierarchy on every write and killing
other vars, but the concurrency aspects of that make my head spin.

Fixes #1554.