### PR TITLE
[ji] RubyString implements CharSequence

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -6169,10 +6169,14 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @Override
     public <T> T toJava(Class<T> target) {
-        if (target.isAssignableFrom(String.class)) {
+        // converting on Comparable.class due target.isAssignableFrom(String.class) compatibility (< 9.2)
+        if (target == String.class || target == Comparable.class || target == Object.class) {
             return target.cast(decodeString());
         }
-        if (target.isAssignableFrom(ByteList.class)) {
+        if (target == CharSequence.class) { // explicitly here
+            return (T) this; // used to convert to java.lang.String (< 9.2)
+        }
+        if (target == ByteList.class) {
             return target.cast(value);
         }
         if (target == Character.class || target == Character.TYPE) {

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -117,7 +117,7 @@ import static org.jruby.RubyEnumerator.SizeFn;
  *
  */
 @JRubyClass(name="String", include={"Enumerable", "Comparable"})
-public class RubyString extends RubyObject implements EncodingCapable, MarshalEncoding, CodeRangeable {
+public class RubyString extends RubyObject implements CharSequence, EncodingCapable, MarshalEncoding, CodeRangeable {
     public static final String DEBUG_INFO_FIELD = "@debug_created_info";
 
     private static final ASCIIEncoding ASCII = ASCIIEncoding.INSTANCE;
@@ -2518,14 +2518,17 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         return value.getRealSize();
     }
 
-    /** rb_str_length
-     *
-     */
-    public RubyFixnum length() {
-        return length19();
+    // MRI: rb_str_length
+    @JRubyMethod(name = {"length", "size"})
+    public RubyFixnum rubyLength(final ThreadContext context) {
+        return rubyLength(context.runtime);
     }
 
-    @JRubyMethod(name = {"length", "size"})
+    private RubyFixnum rubyLength(final Ruby runtime) {
+        return runtime.newFixnum(strLength());
+    }
+
+    @Deprecated
     public RubyFixnum length19() {
         return getRuntime().newFixnum(strLength());
     }
@@ -2533,6 +2536,38 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     @JRubyMethod(name = "bytesize")
     public RubyFixnum bytesize() {
         return getRuntime().newFixnum(value.getRealSize());
+    }
+
+
+    // CharSequence
+
+    @Override
+    public int length() {
+        return strLength();
+    }
+
+    @Override
+    public char charAt(int offset) {
+        int length = value.getRealSize();
+
+        if (length < 1) throw new StringIndexOutOfBoundsException(offset);
+
+        Encoding enc = value.getEncoding();
+        if (singleByteOptimizable(enc)) {
+            if (offset >= length || offset < 0) throw new StringIndexOutOfBoundsException(offset);
+            return (char) value.get(offset);
+        }
+
+        return multibyteCharAt(enc, offset, length);
+    }
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+        IRubyObject subStr = substr19(getRuntime(), start, end);
+        if (subStr.isNil()) {
+            throw new StringIndexOutOfBoundsException("String index out of range: <" + start + ", " + end + ")");
+        }
+        return (RubyString) subStr;
     }
 
     private SizeFn eachByteSizeFn() {
@@ -3337,7 +3372,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         int p;
         int s = value.getBegin();
         int end = s + length;
-        byte[]bytes = value.getUnsafeBytes();
+        byte[] bytes = value.getUnsafeBytes();
 
         if (beg < 0) {
             if (len > -beg) len = -beg;
@@ -3379,6 +3414,38 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
             len = StringSupport.offset(enc, bytes, p, end, len);
         }
         return makeShared(runtime, p - s, len);
+    }
+
+    private char multibyteCharAt(Encoding enc, int beg, int length) {
+        int p;
+        int s = value.getBegin();
+        int end = s + length;
+        byte[] bytes = value.getUnsafeBytes();
+
+
+        if (beg > 0 && beg > StringSupport.strLengthFromRubyString(this, enc)) {
+            throw new StringIndexOutOfBoundsException(beg);
+        }
+
+        if (isCodeRangeValid() && enc.isUTF8()) {
+            p = StringSupport.utf8Nth(bytes, s, end, beg);
+        } else if (enc.isFixedWidth()) {
+            int w = enc.maxLength();
+            p = s + beg * w;
+            if (p > end || w > end - p) {
+                throw new StringIndexOutOfBoundsException(beg);
+            }
+        } else if ((p = StringSupport.nth(enc, bytes, s, end, beg)) == end) {
+            throw new StringIndexOutOfBoundsException(beg);
+        }
+        int codepoint = enc.mbcToCode(bytes, p, end);
+
+        if (Character.isBmpCodePoint(codepoint)) {
+            return (char) codepoint;
+        }
+
+        // we can only return high surrogate here
+        return Character.highSurrogate(codepoint);
     }
 
     /* rb_str_splice */
@@ -5543,7 +5610,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         return new SizeFn() {
             @Override
             public IRubyObject size(IRubyObject[] args) {
-                return self.length();
+                return self.rubyLength(getRuntime());
             }
         };
     }
@@ -5651,7 +5718,7 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
         }
         else {
             if (wantarray)
-                ary = RubyArray.newArray(runtime, str.length().getLongValue());
+                ary = RubyArray.newArray(runtime, str.length());
             else
                 return enumeratorizeWithSize(context, str, name, eachCodepointSizeFn());
         }
@@ -5704,11 +5771,10 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     }
 
     private SizeFn eachCodepointSizeFn() {
-        final RubyString self = this;
         return new SizeFn() {
             @Override
             public IRubyObject size(IRubyObject[] args) {
-                return self.length();
+                return rubyLength(getRuntime());
             }
         };
     }
@@ -5716,14 +5782,13 @@ public class RubyString extends RubyObject implements EncodingCapable, MarshalEn
     private static ByteList GRAPHEME_CLUSTER_PATTERN = new ByteList(new byte[] {(byte)'\\', (byte)'X'});
 
     private SizeFn eachGraphemeClusterSizeFn() {
-        final RubyString self = this;
         return new SizeFn() {
             @Override
             public IRubyObject size(IRubyObject[] args) {
-                Ruby runtime = self.getRuntime();
-                ByteList value = self.getByteList();
+                Ruby runtime = getRuntime();
+                ByteList value = getByteList();
                 Encoding enc = value.getEncoding();
-                if (!enc.isUnicode() || isSingleByteOptimizable(self, enc)) return self.length();
+                if (!enc.isUnicode() || isSingleByteOptimizable(RubyString.this, enc)) return rubyLength(runtime);
 
                 Regex reg = RubyRegexp.getRegexpFromCache(runtime, GRAPHEME_CLUSTER_PATTERN, enc, RegexpOptions.NULL_OPTIONS);
                 int beg = value.getBegin();

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -2563,7 +2563,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @Override
     public CharSequence subSequence(int start, int end) {
-        IRubyObject subStr = substr19(getRuntime(), start, end);
+        IRubyObject subStr = substr19(getRuntime(), start, end - start);
         if (subStr.isNil()) {
             throw new StringIndexOutOfBoundsException("String index out of range: <" + start + ", " + end + ")");
         }

--- a/spec/java_integration/types/coercion_spec.rb
+++ b/spec/java_integration/types/coercion_spec.rb
@@ -694,10 +694,10 @@ describe "String\#to_java" do
   end
 
   describe "when passed java.lang.CharSequence" do
-    it "coerces to java.lang.String" do
+    it "returns a RubyString" do
       cs = "123".to_java java.lang.CharSequence
 
-      expect(cs.class).to eq(java.lang.String)
+      expect(cs.class).to eq(org.jruby.RubyString)
     end
   end
 
@@ -706,6 +706,15 @@ describe "String\#to_java" do
       cs = "123".to_java java.lang.Object
 
       expect(cs.class).to eq(java.lang.String)
+    end
+  end
+
+  describe "when passed org.jruby.util.ByteList" do
+    it "coerces to java.lang.String" do
+      cs = "123".to_java 'org.jruby.util.ByteList'
+
+      expect(cs.class).to eq(org.jruby.util.ByteList)
+      expect(cs.toString).to eq('123')
     end
   end
 

--- a/test/jruby/test_helper.rb
+++ b/test/jruby/test_helper.rb
@@ -128,6 +128,15 @@ module TestHelper
     assert run_in_sub_runtime(script)
   end
 
+  def assert_java_raises(type)
+    begin
+      yield
+      fail("expected to raise (#{type}) but did not")
+    rescue java.lang.Throwable => ex
+      raise(ex) unless ex.is_a?(type)
+    end
+  end
+
   def self.included(base)
     if defined? Test::Unit::TestCase
       if base < Test::Unit::TestCase

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -1382,7 +1382,8 @@ class TestHigherJavasupport < Test::Unit::TestCase
     str = 'fo0'.to_java('java.lang.CharSequence')
     assert_equal 'o'.ord, str.charAt(1)
     assert_equal 3, str.length
-    assert_equal 'o0', str.subSequence(1, 2)
+    assert_equal 'f', str.subSequence(0, 1)
+    assert_equal 'o0', str.subSequence(1, 3)
     assert 'fo0'.to_java.contentEquals('fo0')
     assert_java_raises(java.lang.StringIndexOutOfBoundsException) { str.charAt(5) }
     assert_java_raises(java.lang.StringIndexOutOfBoundsException) { str.charAt(-2) }

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -1378,6 +1378,18 @@ class TestHigherJavasupport < Test::Unit::TestCase
     assert_equal('foo', String.from_java_bytes('foo'.to_java_bytes))
   end
 
+  def test_string_as_charsequence
+    str = 'fo0'.to_java('java.lang.CharSequence')
+    assert_equal 'o'.ord, str.charAt(1)
+    assert_equal 3, str.length
+    assert_equal 'o0', str.subSequence(1, 2)
+    assert 'fo0'.to_java.contentEquals('fo0')
+    assert_java_raises(java.lang.StringIndexOutOfBoundsException) { str.charAt(5) }
+    assert_java_raises(java.lang.StringIndexOutOfBoundsException) { str.charAt(-2) }
+    assert_java_raises(java.lang.StringIndexOutOfBoundsException) { str.subSequence(3, 2) }
+    assert_java_raises(java.lang.StringIndexOutOfBoundsException) { str.subSequence(0, -2) }
+  end
+
   # JRUBY-2088
   def test_package_notation_with_arguments
     assert_raises(ArgumentError) do


### PR DESCRIPTION
found this :paintbrush: at https://github.com/jruby/jruby/pull/3937/files#diff-2f8f0aefd8a8637512ce6c017da265b9

knew I saw a draft of this somewhere but did not find it until I checked some old PRs :)

... there's an opportunity here to have `RubyString implements CharSequence`
this is expected to fit nicely esp. will avoid conversions on logging libraries e.g. log4j2 
(so one doesn't need to do an if check: `logger.debug('foo') if logger.isDebugEnabled`)

but its a breaking change in 2 ways : 
- `RubyString#length` needs to be changed (to return int) -> not expected to be used much
- seeing a `java.lang.CharSequence` by JI will no longer conver to a java string

both seem acceptable for a major release such as 9.2 (we sure can not do this in a minor one)