### PR TITLE
Non-volatile instance variables

### DIFF
--- a/core/src/main/java/org/jruby/runtime/ivars/VariableAccessor.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/VariableAccessor.java
@@ -35,7 +35,7 @@ import org.jruby.RubyClass;
  * objects. Subclasses specialize this implementation appropriate to the
  * current JVM's capabilities and the mechanism for laying out variables.
  */
-public class VariableAccessor {
+public abstract class VariableAccessor {
     /** the name of the variable */
     protected final String name;
     /** the index allocated for it in the variable table */
@@ -147,6 +147,6 @@ public class VariableAccessor {
     }
 
     /** a dummy accessor that will always return null */
-    public static final VariableAccessor DUMMY_ACCESSOR = new VariableAccessor(null, null, -1, -1);
+    public static final VariableAccessor DUMMY_ACCESSOR = new VariableAccessor(null, null, -1, -1) {};
     
 }

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -167,9 +167,9 @@ public class Options {
     public static final Option<Boolean> NATIVE_EXEC = bool(MISCELLANEOUS, "native.exec", true, "Do a true process-obliterating native exec for Kernel#exec.");
     public static final Option<Boolean> ENUMERATOR_LIGHTWEIGHT = bool(MISCELLANEOUS, "enumerator.lightweight", true, "Use lightweight Enumerator#next logic when possible.");
     public static final Option<Boolean> CONSISTENT_HASHING = bool(MISCELLANEOUS, "consistent.hashing", false, "Generate consistent object hashes across JVMs");
-    public static final Option<Boolean> REIFY_VARIABLES = bool(MISCELLANEOUS, "reify.variables", !REIFY_CLASSES.load(), "Attempt to expand instance vars into Java fields");
+    public static final Option<Boolean> VOLATILE_VARIABLES = bool(MISCELLANEOUS, "volatile.variables", false, "Always ensure volatile semantics for instance variables.");
+    public static final Option<Boolean> REIFY_VARIABLES = bool(MISCELLANEOUS, "reify.variables", !(REIFY_CLASSES.load() || VOLATILE_VARIABLES.load()), "Attempt to expand instance vars into Java fields");
     public static final Option<Boolean> FCNTL_LOCKING = bool(MISCELLANEOUS, "file.flock.fcntl", true, "Use fcntl rather than flock for File#flock");
-    public static final Option<Boolean> VOLATILE_VARIABLES = bool(MISCELLANEOUS, "volatile.variables", true, "Always ensure volatile semantics for instance variables.");
     public static final Option<Boolean> RECORD_LEXICAL_HIERARCHY = bool(MISCELLANEOUS, "record.lexical.hierarchy", false, "Maintain children static scopes to support scope dumping.");
     public static final Option<String> PREFERRED_PRNG = string(MISCELLANEOUS, "preferred.prng", "NativePRNGNonBlocking", "Set the preferred JDK-supported random number generator to use.");
     public static final Option<Boolean> USE_FIXNUM_CACHE = bool(MISCELLANEOUS, "fixnum.cache", true, "Use a cache of low-valued Fixnum objects.");


### PR DESCRIPTION
So it turns out that since we turned on reified instance variables by default, those variables have not been volatile. This is actually good news, since we wanted to move away from a full volatility guarantee on instance variables in favor of explicit declaration (`attr_accessor :foo, volatile: true`) or libraries like concurrent-ruby.

This PR simply flips the switch for the remaining varTable-based instance variables, bringing them in line with field-based instance variables as far as volatility goes.

I have also filed #5186 to finish the reification project and *add back* the ability to turn on volatility as desired. This will be needed in any case to support declarative volatility in a future update to Ruby.