### PR TITLE
[ji] make inspect on Java proxies work

### DIFF
--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -491,7 +491,12 @@ public final class ArrayJavaProxy extends JavaProxy {
 
     @JRubyMethod
     public RubyString inspect(ThreadContext context) {
-        return RubyString.newString(context.runtime, arrayToString());
+        return inspect(context.runtime, null); // -> toStringImpl
+    }
+
+    @Override
+    CharSequence toStringImpl(final Ruby runtime, final IRubyObject opts) {
+        return arrayToString();
     }
 
     @Override

--- a/core/src/main/java/org/jruby/java/proxies/ConcreteJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ConcreteJavaProxy.java
@@ -1,8 +1,8 @@
 package org.jruby.java.proxies;
 
-import org.jruby.Ruby;
-import org.jruby.RubyClass;
-import org.jruby.RubyModule;
+import org.jruby.*;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.ast.util.ArgsUtil;
 import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.javasupport.Java;
 import org.jruby.runtime.Block;
@@ -12,6 +12,16 @@ import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.callsite.CacheEntry;
+import org.jruby.runtime.callsite.CachingCallSite;
+import org.jruby.runtime.callsite.FunctionalCachingCallSite;
+import org.jruby.util.CodegenUtils;
+import org.jruby.util.StringSupport;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
 
 public class ConcreteJavaProxy extends JavaProxy {
 
@@ -235,4 +245,135 @@ public class ConcreteJavaProxy extends JavaProxy {
 
         throw getRuntime().newTypeError("failed to coerce " + clazz.getName() + " to " + type.getName());
     }
+
+    @JRubyMethod
+    public RubyString reflective_inspect(ThreadContext context) {
+        return RubyString.newString(context.runtime, reflectiveToString(context, null));
+    }
+
+    @JRubyMethod
+    public RubyString reflective_inspect(ThreadContext context, IRubyObject opts) {
+        return RubyString.newString(context.runtime, reflectiveToString(context, opts == context.nil ? null : opts.convertToHash()));
+    }
+
+    @JRubyMethod
+    public IRubyObject inspect(ThreadContext context) {
+        return inspect(context.runtime, null); // -> toStringImpl
+    }
+
+    @Override
+    CharSequence toStringImpl(final Ruby runtime, final IRubyObject opts) {
+        final ThreadContext context = runtime.getCurrentContext();
+        DynamicMethod toString = toStringIfNotFromObject(context);
+        if (toString == null) {
+            return reflectiveToString(context, (RubyHash) opts); // a replacement for java.lang.Object#toString
+        }
+        IRubyObject str = toString.call(context, this, getMetaClass(), "toString");
+        return str == context.nil ? "null" : str.convertToString(); // we don't return a nil (unlike to_s)
+    }
+
+    private transient CachingCallSite toStringSite;
+
+    private DynamicMethod toStringIfNotFromObject(final ThreadContext context) {
+        if (toStringSite == null) toStringSite = new FunctionalCachingCallSite("toString");
+
+        CacheEntry cache = toStringSite.retrieveCache(getMetaClass());
+
+        return (cache.method.getImplementationClass() != context.runtime.getJavaSupport().getObjectClass()) ? cache.method : null;
+    }
+
+    private StringBuilder reflectiveToString(final ThreadContext context, final RubyHash opts) {
+        String[] excludedFields = null;
+        if (opts != null) { // NOTE: support nested excludes?!?
+            IRubyObject[] args = ArgsUtil.extractKeywordArgs(context, opts, "exclude");
+            if (args[0] instanceof RubyArray) {
+                excludedFields = (String[]) ((RubyArray) args[0]).toArray(StringSupport.EMPTY_STRING_ARRAY);
+            }
+        }
+
+        final StringBuilder buffer = new StringBuilder(192);
+
+        final Object obj = getObject();
+        Class<?> clazz = obj.getClass();
+
+        // TODO use meta-class name?
+        buffer.append("#<").append(getMetaClass().getRealClass().getName())
+              .append(":0x").append(Integer.toHexString(inspectHashCode()));
+
+        final Ruby runtime = context.runtime;
+
+        if (runtime.isInspecting(obj)) return buffer.append(" ...>");
+
+        try {
+            runtime.registerInspecting(obj);
+
+            char sep = appendFields(context, buffer, obj, clazz, '\0', excludedFields);
+
+            while (clazz.getSuperclass() != null) {
+                clazz = clazz.getSuperclass();
+                sep = appendFields(context, buffer, obj, clazz, sep, excludedFields);
+            }
+
+            return buffer.append('>');
+        }
+        finally {
+            runtime.unregisterInspecting(obj);
+        }
+    }
+
+    private static char appendFields(final ThreadContext context, final StringBuilder buffer,
+                                     Object obj, Class<?> clazz, char sep, final String[] excludedFields) {
+        final Field[] fields = clazz.getDeclaredFields();
+        AccessibleObject.setAccessible(fields, true);
+
+        for (final Field field : fields) {
+            if (accept(field, excludedFields)) {
+                buffer.append(' ');
+                if (sep == '\0') sep = ',';
+                else buffer.append(sep);
+
+                try {
+                    buffer.append(field.getName()).append('=').append(toStringValue(context, field.get(obj)));
+                }
+                catch (IllegalAccessException ex) { throw new AssertionError(ex); } // we've set accessible
+            }
+        }
+        return sep;
+    }
+
+    private static CharSequence toStringValue(final ThreadContext context, final Object value) {
+        if (value == null) return "null";
+        if (value instanceof CharSequence) return (CharSequence) value; // String
+        final Class<?> klass = value.getClass();
+        // take short-cuts for known Java toString impls :
+        if (klass.isPrimitive() || klass.isEnum()) return value.toString();
+        if (klass == Integer.class || klass == Long.class ||
+            klass == Short.class || klass == Byte.class ||
+            klass == Double.class || klass == Float.class ||
+            klass == Boolean.class || klass == Character.class) return value.toString();
+        //if (klass.isSynthetic()) return value.toString(); // TODO skip - unwrap class!?!
+        if (value instanceof IRubyObject) {
+            if (value instanceof JavaProxy) {
+                return ((JavaProxy) value).toStringImpl(context.runtime, null);
+            }
+            return ((IRubyObject) value).inspect().convertToString();
+        }
+        return ((JavaProxy) Java.wrapJavaObject(context.runtime, value)).toStringImpl(context.runtime, null);
+    }
+
+    private static final char INNER_CLASS_SEPARATOR_CHAR = '$';
+
+    private static boolean accept(final Field field, final String[] excludedFields) {
+        final int mod = field.getModifiers();
+        if (Modifier.isTransient(mod) || Modifier.isStatic(mod)) return false;
+
+        final String name = field.getName();
+        if (name.indexOf(INNER_CLASS_SEPARATOR_CHAR) != -1) return false;
+        if (excludedFields != null && Arrays.binarySearch(excludedFields, name) >= 0) {
+            return false;
+        }
+
+        return true;
+    }
+
 }

--- a/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
@@ -13,15 +13,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.jruby.AbstractRubyMethod;
-import org.jruby.Ruby;
-import org.jruby.RubyArray;
-import org.jruby.RubyClass;
-import org.jruby.RubyHash;
-import org.jruby.RubyMethod;
-import org.jruby.RubyModule;
-import org.jruby.RubyObject;
-import org.jruby.RubyUnboundMethod;
+import org.jruby.*;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.common.IRubyWarnings;
 import org.jruby.java.invokers.InstanceFieldGetter;
@@ -434,6 +426,21 @@ public class JavaProxy extends RubyObject {
     protected int inspectHashCode() {
         return System.identityHashCode(object);
     }
+
+    @Override
+    public IRubyObject inspect() {
+        return inspect(getRuntime(), null);
+    }
+
+    final RubyString inspect(final Ruby runtime, final IRubyObject opts) {
+        return RubyString.newString(runtime, toStringImpl(runtime, opts));
+    }
+
+    CharSequence toStringImpl(final Ruby runtime, final IRubyObject opts) {
+        return String.valueOf(object);
+    }
+
+    // toString() dispatches the shared RubyObject to_s site, maybe setup a custom for (Concrete)JavaProxy?
 
     private Method getMethod(ThreadContext context, String name, Class... argTypes) {
         try {

--- a/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
@@ -438,13 +438,37 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         return getOrCreateRubyHashMap().set_default_proc(proc);
     }
 
-    /** rb_hash_inspect
+    /**
+     * <code>hash_inspect</code> provided for compatibility if in a need to revert to pre 9.2 behaviour
      *
+     * <code>MapJavaProxy.class_eval { public alias_method :inspect, :hash_inspect }</code>
+     *
+     * @since 9.2
      */
-    @JRubyMethod(name = "inspect")
-    public IRubyObject inspect(ThreadContext context) {
+    @Deprecated // ... since 9.2 inspect on Java proxies means -> toString
+    @JRubyMethod(name = "hash_inspect", visibility = Visibility.PRIVATE)
+    public IRubyObject hash_inspect(ThreadContext context) {
         return getOrCreateRubyHashMap().inspect(context);
     }
+
+    @Deprecated // only for binary compatibility
+    public IRubyObject inspect(ThreadContext context) { return super.inspect(context); }
+
+    /**
+     * <code>hash_inspect</code> provided for compatibility if in a need to revert to pre 9.2 behaviour
+     *
+     * <code>MapJavaProxy.class_eval { public alias_method :inspect, :hash_inspect }</code>
+     *
+     * @since 9.2
+     */
+    @Deprecated // ... since 9.2 to_s on Java proxies is aliased toString
+    @JRubyMethod(name = "hash_to_s", visibility = Visibility.PRIVATE)
+    public IRubyObject hash_to_s(ThreadContext context) {
+        return getOrCreateRubyHashMap().to_s(context);
+    }
+
+    @Deprecated // only for binary compatibility
+    public IRubyObject to_s(ThreadContext context) { return super.to_s(); }
 
     /** rb_hash_size
      *
@@ -477,14 +501,6 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         TypeConverter.checkType(context, newProc, context.runtime.getProc());
 
         return (RubyProc) newProc;
-    }
-
-    /** rb_hash_to_s
-     *
-     */
-    @JRubyMethod(name = "to_s")
-    public IRubyObject to_s(ThreadContext context) {
-        return getOrCreateRubyHashMap().to_s(context);
     }
 
     /** rb_hash_rehash

--- a/core/src/main/java/org/jruby/javasupport/JavaProxyMethods.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaProxyMethods.java
@@ -80,7 +80,7 @@ public class JavaProxyMethods {
         return ((JavaObject)recv.dataGetStruct()).op_equal(rhs);
     }
     
-    @JRubyMethod
+    @Deprecated // NOTE: handled by JavaProxy hierarchy (with java.lang.Object#to_s)
     public static IRubyObject to_s(IRubyObject recv) {
         if (recv instanceof JavaProxy) {
             return JavaObject.to_s(recv.getRuntime(), ((JavaProxy) recv).getObject());
@@ -90,7 +90,7 @@ public class JavaProxyMethods {
         return ((RubyBasicObject) recv).to_s();
     }
 
-    @JRubyMethod
+    @Deprecated // NOTE: handled by JavaProxy
     public static IRubyObject inspect(IRubyObject recv) {
         if (recv instanceof RubyBasicObject) {
             return ((RubyBasicObject) recv).hashyInspect();

--- a/core/src/main/java/org/jruby/javasupport/JavaSupport.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupport.java
@@ -77,8 +77,10 @@ public abstract class JavaSupport {
 
     public abstract RubyClass getJavaObjectClass();
 
+    @Deprecated // no longer used
     public abstract JavaClass getObjectJavaClass();
 
+    @Deprecated // no longer set
     public abstract void setObjectJavaClass(JavaClass objectJavaClass);
 
     public abstract RubyClass getJavaArrayClass();
@@ -91,6 +93,11 @@ public abstract class JavaSupport {
 
     @Deprecated
     public abstract RubyModule getPackageModuleTemplate();
+
+    /**
+     * @return Java::JavaLang::Object (proxy) class
+     */
+    public abstract RubyClass getObjectClass();
 
     public abstract RubyClass getJavaProxyClass();
 

--- a/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
@@ -88,8 +88,8 @@ public class JavaSupportImpl extends JavaSupport {
     private RubyModule javaModule;
     private RubyModule javaUtilitiesModule;
     private RubyModule javaArrayUtilitiesModule;
+    private RubyClass objectClass;
     private RubyClass javaObjectClass;
-    private JavaClass objectJavaClass;
     private RubyClass javaClassClass;
     private RubyClass javaPackageClass;
     private RubyClass javaArrayClass;
@@ -265,12 +265,23 @@ public class JavaSupportImpl extends JavaSupport {
         return javaProxyConstructorClass = getJavaModule().getClass("JavaProxyConstructor");
     }
 
+    @Override
+    public RubyClass getObjectClass() {
+        RubyClass clazz;
+        if ((clazz = objectClass) != null) return clazz;
+        return objectClass = (RubyClass) getProxyClassFromCache(java.lang.Object.class);
+    }
+
+    private transient JavaClass objectJavaClass;
+
     public JavaClass getObjectJavaClass() {
-        return objectJavaClass;
+        JavaClass clazz;
+        if ((clazz = objectJavaClass) != null) return clazz;
+        return objectJavaClass = getJavaClassFromCache(java.lang.Object.class);
     }
 
     public void setObjectJavaClass(JavaClass objectJavaClass) {
-        this.objectJavaClass = objectJavaClass;
+        assert false; /* no longer used */
     }
 
     public RubyClass getJavaArrayClass() {

--- a/core/src/main/java/org/jruby/javasupport/binding/Initializer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/Initializer.java
@@ -488,14 +488,12 @@ public abstract class Initializer {
         // we scan all superclasses, but avoid adding superclass methods with
         // same name+signature as subclass methods (see JRUBY-3130)
         for ( Class<?> klass = javaClass; klass != null; klass = klass.getSuperclass() ) {
-            // only add class's methods if it's public or we can set accessible
-            // (see JRUBY-4799)
+            // only add class's methods if it's public or we can set accessible (see JRUBY-4799)
             if (Modifier.isPublic(klass.getModifiers()) || JavaUtil.CAN_SET_ACCESSIBLE) {
                 // for each class, scan declared methods for new signatures
                 try {
-                    // add methods, including static if this is the actual class,
-                    // and replacing child methods with equivalent parent methods
-                    addNewMethods(nameMethods, DECLARED_METHODS.get(klass), klass == javaClass, true);
+                    // add methods, including static if this is the actual class
+                    addNewMethods(nameMethods, DECLARED_METHODS.get(klass), klass == javaClass, false);
                 }
                 catch (SecurityException e) { /* ignored */ }
             }

--- a/spec/java_integration/types/inspect_spec.rb
+++ b/spec/java_integration/types/inspect_spec.rb
@@ -1,8 +1,29 @@
 require File.dirname(__FILE__) + "/../spec_helper"
 
-describe "A Java object's builtin inspect method" do
-  it "produces the \"hashy\" inspect output" do
+describe "inspect method" do
+
+  it "produces \"hashy\" inspect output for java.lang.Object" do
     o = java.lang.Object.new
     expect(o.inspect).to match(/\#<Java::JavaLang::Object:0x[0-9a-f]+>/)
   end
+
+  it 'returns toString when overriden in Java types' do
+    expect(java.lang.Short.new(1).inspect).to eql '1'
+
+    expect(java.util.concurrent.TimeUnit::DAYS.inspect).to eql 'DAYS'
+
+    date = java.sql.Date.new(0)
+    expect(date.inspect).to eql '1970-01-01'
+    expect(date.toLocalDate.inspect).to eql date.to_s
+    time = java.sql.Timestamp.new(0)
+    expect(time.toInstant.inspect).to eql '1970-01-01T00:00:00Z'
+
+    expect(java.math.BigInteger.new('1').inspect).to eql '1'
+    expect(java.math.BigDecimal.new('3.6').to_s).to eql '3.6'
+
+    expect(java.lang.String.new('str').inspect).to eql 'str'
+
+    expect(java.util.ArrayList.new([1, '2']).inspect).to eql '[1, 2]'
+  end
+
 end


### PR DESCRIPTION
... `inspect` will now call `toString` on a Java proxy (unless its `java.lang.Object#toString` in which case we do the same "bare" hashy-inspect)

the motivation here is https://github.com/jruby/jruby/issues/5182 ... have seen "useless" hashy-inspect on Java proxied types too many times.

the approach here is the following: proxies use a call-site to determine whether `toString` is overriden.
the side effect is that I reverted an old 'feature' where Java (instance) methods, such as *toString*, only show-up at the lowest level in the Ruby class hierarchy - as explained on https://github.com/jruby/jruby/issues/5182#issuecomment-397203127.

there's likely a "cleaner" way -> having `inspect` alias-ed whenever a type we process has `toString`, maybe we shall eventually refactor to that but there's a much more interesting feature that I am pursuing :

current default `inspect` (for any Java class missing a custom `toString`) does only hashy-inspect without any details. would like to be able to reflectively inspect such hierarchies similar to how Ruby shows all instance variables - while I got it working its not currently usable as there's inconsistencies that I need to think through (more on that elsewhere).

in terms of compatibility there's some "breaking" change related to `java.util.Map` proxies, which seem to have been historically approached differently than the others - the internally sync state with a `Hash`. 
1. this remains the case however [due](https://github.com/jruby/jruby/issues/5182#issuecomment-397203127) noted above - there was an internal "bug" where colliding methods would prefer Hash-like ones instead of the explicit Java override (e.g. `clear` had the same effect but did not return void as is prescribed by `java.util.Map` but instead `self` from `RubyHash`).
2. the `inspect` for map proxy needed to be changed, otherwise it would be weird to have a special exception for the `Map` hierarchy from `inspect` doing `toString` on Java proxies (methods for restoring previous behavior provided).