### PR TITLE
update jruby-readline to new release

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -78,8 +78,8 @@ project 'JRuby Lib Setup' do
   # for testing out jruby-ossl before final release :
   #repository( :url => 'https://oss.sonatype.org/content/repositories/snapshots',
   #            :id => 'gem-snaphots' )
-  repository( :url => 'http://oss.sonatype.org/content/repositories/staging',
-              :id => 'gem-staging' )
+  #repository( :url => 'http://oss.sonatype.org/content/repositories/staging',
+  #            :id => 'gem-staging' )
 
   plugin( :clean,
           :filesets => [ { :directory => '${basedir}/ruby/gems/shared/specifications/default',

--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -30,7 +30,7 @@ default_gems = [
     ImportedGem.new('fileutils', '1.1.0'),
     ImportedGem.new('ipaddr', '1.2.0'),
     ImportedGem.new('jar-dependencies', '${jar-dependencies.version}'),
-    ImportedGem.new('jruby-readline', '1.3.0'),
+    ImportedGem.new('jruby-readline', '1.3.5'),
     ImportedGem.new('jruby-openssl', '0.10.0'),
     ImportedGem.new('json', '${json.version}'),
     ImportedGem.new('psych', '3.0.2'),

--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -30,7 +30,7 @@ default_gems = [
     ImportedGem.new('fileutils', '1.1.0'),
     ImportedGem.new('ipaddr', '1.2.0'),
     ImportedGem.new('jar-dependencies', '${jar-dependencies.version}'),
-    ImportedGem.new('jruby-readline', '1.2.2'),
+    ImportedGem.new('jruby-readline', '1.3.0'),
     ImportedGem.new('jruby-openssl', '0.10.0'),
     ImportedGem.new('json', '${json.version}'),
     ImportedGem.new('psych', '3.0.2'),
@@ -78,8 +78,8 @@ project 'JRuby Lib Setup' do
   # for testing out jruby-ossl before final release :
   #repository( :url => 'https://oss.sonatype.org/content/repositories/snapshots',
   #            :id => 'gem-snaphots' )
-  #repository( :url => 'http://oss.sonatype.org/content/repositories/staging',
-  #            :id => 'gem-staging' )
+  repository( :url => 'http://oss.sonatype.org/content/repositories/staging',
+              :id => 'gem-staging' )
 
   plugin( :clean,
           :filesets => [ { :directory => '${basedir}/ruby/gems/shared/specifications/default',

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -297,10 +297,6 @@ DO NOT MODIFIY - GENERATED CODE
       <id>mavengems</id>
       <url>mavengem:https://rubygems.org</url>
     </repository>
-    <repository>
-      <id>gem-staging</id>
-      <url>http://oss.sonatype.org/content/repositories/staging</url>
-    </repository>
   </repositories>
   <build>
     <extensions>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -99,7 +99,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>jruby-readline</artifactId>
-      <version>1.2.2</version>
+      <version>1.3.0</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -297,6 +297,10 @@ DO NOT MODIFIY - GENERATED CODE
       <id>mavengems</id>
       <url>mavengem:https://rubygems.org</url>
     </repository>
+    <repository>
+      <id>gem-staging</id>
+      <url>http://oss.sonatype.org/content/repositories/staging</url>
+    </repository>
   </repositories>
   <build>
     <extensions>
@@ -339,7 +343,7 @@ DO NOT MODIFIY - GENERATED CODE
           <exclude>gems/fileutils*1.1.0/*</exclude>
           <exclude>gems/ipaddr*1.2.0/*</exclude>
           <exclude>gems/jar-dependencies*${jar-dependencies.version}/*</exclude>
-          <exclude>gems/jruby-readline*1.2.2/*</exclude>
+          <exclude>gems/jruby-readline*1.3.0/*</exclude>
           <exclude>gems/jruby-openssl*0.10.0/*</exclude>
           <exclude>gems/json*${json.version}/*</exclude>
           <exclude>gems/psych*3.0.2/*</exclude>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -99,7 +99,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>jruby-readline</artifactId>
-      <version>1.3.0</version>
+      <version>1.3.5</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -343,7 +343,7 @@ DO NOT MODIFIY - GENERATED CODE
           <exclude>gems/fileutils*1.1.0/*</exclude>
           <exclude>gems/ipaddr*1.2.0/*</exclude>
           <exclude>gems/jar-dependencies*${jar-dependencies.version}/*</exclude>
-          <exclude>gems/jruby-readline*1.3.0/*</exclude>
+          <exclude>gems/jruby-readline*1.3.5/*</exclude>
           <exclude>gems/jruby-openssl*0.10.0/*</exclude>
           <exclude>gems/json*${json.version}/*</exclude>
           <exclude>gems/psych*3.0.2/*</exclude>


### PR DESCRIPTION
... now using `JRuby::Util.load_ext` mechanism for #5205

+ updated JLine to 2.14.6 
   contains a couple of interesting features/fixes - wonder why it lagged behind
   e.g. OSv support, HP-UX working, avoided (class) memory leaks, printing "Display all 104 possibilities? (y or n)" on a new line, ...

UPDATE: there seems to be one visible regression under Linux - printing space after irb completion

believe we can fix that and also make jruby-readline usable as a standalone gem
... should we eventually also push to RubyGems? (would be great to test out new release under Windows)