### PR TITLE
review String -> RubyString UTF (8) encoding

### DIFF
--- a/bench/src/main/java/org/jruby/benchmark/EncodingBenchmark.java
+++ b/bench/src/main/java/org/jruby/benchmark/EncodingBenchmark.java
@@ -1,0 +1,115 @@
+package org.jruby.benchmark;
+
+import java.util.concurrent.TimeUnit;
+
+import org.jruby.Ruby;
+import org.jruby.RubyString;
+import org.jruby.RubyEncoding;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@Warmup(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+public class EncodingBenchmark {
+
+    private static final int INVOCATIONS = 1_000_000;
+
+    private static final Ruby RUBY = Ruby.newInstance();
+
+    private static final String SHORT_STR = "1234567890";
+
+    private static final String LONG_STR = "1234567890_abcdefghijklmnoprstuvxyz-ABCDEFGHIJKLMNOPQRSTUVXYZ";
+
+    private static final String VERY_LONG_STR;
+    static {
+        StringBuilder str = new StringBuilder(1025);
+        for (int i = 0; i < 21; i++) {
+            str.append("ABCDEFGHIJKLMNOPQRSTUVXYZ"); // 25 chars * 21 == 1025
+        }
+        VERY_LONG_STR = str.toString();
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void benchShortRubyStringNew(final Blackhole blackhole) {
+        final String STR = SHORT_STR;
+        for (int i = 0; i < INVOCATIONS; i++) consume(RubyString.newString(RUBY, STR), blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void benchShortRubyStringNewCharSequence(final Blackhole blackhole) {
+        final CharSequence STR = new StringBuilder(SHORT_STR);
+        for (int i = 0; i < INVOCATIONS; i++) consume(RubyString.newString(RUBY, STR), blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void benchLongRubyStringNew(final Blackhole blackhole) {
+        final String STR = LONG_STR;
+        for (int i = 0; i < INVOCATIONS; i++) consume(RubyString.newString(RUBY, STR), blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void benchLongRubyStringNewCharSequence(final Blackhole blackhole) {
+        final CharSequence STR = new StringBuilder(LONG_STR);
+        for (int i = 0; i < INVOCATIONS; i++) consume(RubyString.newString(RUBY, STR), blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void benchLongRubyStringNewCharSequence2(final Blackhole blackhole) {
+        final CharSequence STR = java.nio.CharBuffer.wrap(LONG_STR);
+        for (int i = 0; i < INVOCATIONS; i++) consume(RubyString.newString(RUBY, STR), blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void benchLongRubyStringNewCharSequence3(final Blackhole blackhole) {
+        final CharSequence STR = LONG_STR.substring(0);
+        for (int i = 0; i < INVOCATIONS; i++) consume(RubyString.newString(RUBY, STR), blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void benchVeryLongRubyStringNew(final Blackhole blackhole) {
+        final String STR = VERY_LONG_STR;
+        for (int i = 0; i < INVOCATIONS; i++) consume(RubyString.newString(RUBY, STR), blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void benchVeryLongRubyStringNewCharSequence(final Blackhole blackhole) {
+        final CharSequence STR = new StringBuilder(VERY_LONG_STR);
+        for (int i = 0; i < INVOCATIONS; i++) consume(RubyString.newString(RUBY, STR), blackhole);
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(INVOCATIONS)
+    public void benchVeryLongRubyStringNewCharSequence2(final Blackhole blackhole) {
+        final CharSequence STR = java.nio.CharBuffer.wrap(VERY_LONG_STR);
+        for (int i = 0; i < INVOCATIONS; i++) consume(RubyString.newString(RUBY, STR), blackhole);
+    }
+
+    private static void consume(final RubyString str, final Blackhole blackhole) {
+        blackhole.consume( str );
+    }
+
+}

--- a/core/src/main/java/org/jruby/RubyEncoding.java
+++ b/core/src/main/java/org/jruby/RubyEncoding.java
@@ -116,14 +116,12 @@ public class RubyEncoding extends RubyObject implements Constantizable {
     }
 
     public final Encoding getEncoding() {
-        // TODO: make threadsafe
         if (encoding == null) encoding = getRuntime().getEncodingService().loadEncoding(name);
         return encoding;
     }
 
     private static Encoding extractEncodingFromObject(IRubyObject obj) {
         if (obj instanceof RubyEncoding) return ((RubyEncoding) obj).getEncoding();
-        if (obj instanceof RubySymbol) return ((RubySymbol) obj).asString().getEncoding();
         if (obj instanceof EncodingCapable) return ((EncodingCapable) obj).getEncoding();
 
         return null;

--- a/core/src/main/java/org/jruby/RubyEncoding.java
+++ b/core/src/main/java/org/jruby/RubyEncoding.java
@@ -232,6 +232,10 @@ public class RubyEncoding extends RubyObject implements Constantizable {
         return encode(str, UTF16);
     }
 
+    static ByteList doEncodeUTF16(String str) {
+        return doEncode(str, UTF16, UTF16BEEncoding.INSTANCE);
+    }
+
     static ByteList doEncodeUTF16(CharSequence str) {
         return doEncode(str, UTF16, UTF16BEEncoding.INSTANCE);
     }
@@ -241,6 +245,10 @@ public class RubyEncoding extends RubyObject implements Constantizable {
         byte[] bytes = new byte[buffer.limit()];
         buffer.get(bytes);
         return bytes;
+    }
+
+    static ByteList doEncode(String cs, Charset charset, Encoding enc) {
+        return getByteList(charset.encode(CharBuffer.wrap(cs)), enc, false);
     }
 
     static ByteList doEncode(CharSequence cs, Charset charset, Encoding enc) {

--- a/core/src/main/java/org/jruby/RubyEncoding.java
+++ b/core/src/main/java/org/jruby/RubyEncoding.java
@@ -185,7 +185,7 @@ public class RubyEncoding extends RubyObject implements Constantizable {
 
     public static byte[] encodeUTF8(CharSequence str) {
         if (str.length() > CHAR_THRESHOLD) {
-            return getBytes(UTF8.encode(CharBuffer.wrap(str)));
+            return getBytes(UTF8.encode(toCharBuffer(str)));
         }
         return getBytes(getUTF8Coder().encode(str));
     }
@@ -199,9 +199,13 @@ public class RubyEncoding extends RubyObject implements Constantizable {
 
     static ByteList doEncodeUTF8(CharSequence str) {
         if (str.length() > CHAR_THRESHOLD) {
-            return getByteList(UTF8.encode(CharBuffer.wrap(str)), UTF8Encoding.INSTANCE, false);
+            return getByteList(UTF8.encode(toCharBuffer(str)), UTF8Encoding.INSTANCE, false);
         }
         return getByteList(getUTF8Coder().encode(str), UTF8Encoding.INSTANCE, true);
+    }
+
+    private static CharBuffer toCharBuffer(CharSequence str) {
+        return str instanceof CharBuffer ? (CharBuffer) str : CharBuffer.wrap(str);
     }
 
     private static byte[] getBytes(final ByteBuffer buffer) {
@@ -250,7 +254,7 @@ public class RubyEncoding extends RubyObject implements Constantizable {
     }
 
     static ByteList doEncode(CharSequence cs, Charset charset, Encoding enc) {
-        return getByteList(charset.encode(CharBuffer.wrap(cs)), enc, false);
+        return getByteList(charset.encode(toCharBuffer(cs)), enc, false);
     }
 
     public static byte[] encode(String str, Charset charset) {

--- a/core/src/main/java/org/jruby/RubyEncoding.java
+++ b/core/src/main/java/org/jruby/RubyEncoding.java
@@ -219,16 +219,12 @@ public class RubyEncoding extends RubyObject implements Constantizable {
     }
 
     public static byte[] encodeUTF16(String str) {
-        if (VALUE_FIELD_OFFSET == -1) return encode(str, UTF16);
-        char[] chars = (char[]) UnsafeHolder.U.getObject(str, VALUE_FIELD_OFFSET);
-        int length = chars.length * 2;
-        byte[] bytes = new byte[length];
-        UnsafeHolder.U.copyMemory(chars, CHAR_ARRAY_BASE, bytes, BYTE_ARRAY_BASE, length);
-        return bytes;
+        return encode(str, UTF16);
     }
 
     public static byte[] encodeUTF16(CharSequence str) {
-        return encodeUTF16(str.toString());
+        return encode(str, UTF16);
+    }
     }
 
     public static byte[] encode(CharSequence cs, Charset charset) {

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -509,13 +509,11 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     }
 
     public static RubyString newUTF8String(Ruby runtime, String str) {
-        ByteList byteList = new ByteList(RubyEncoding.encodeUTF8(str), UTF8Encoding.INSTANCE, false);
-        return new RubyString(runtime, runtime.getString(), byteList);
+        return new RubyString(runtime, runtime.getString(), RubyEncoding.doEncodeUTF8(str));
     }
 
     public static RubyString newUTF16String(Ruby runtime, String str) {
-        ByteList byteList = new ByteList(RubyEncoding.encodeUTF16(str), UTF16BEEncoding.INSTANCE, false);
-        return new RubyString(runtime, runtime.getString(), byteList);
+        return new RubyString(runtime, runtime.getString(), RubyEncoding.doEncodeUTF16(str));
     }
 
     public static RubyString newUnicodeString(Ruby runtime, CharSequence str) {
@@ -528,13 +526,11 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     }
 
     public static RubyString newUTF8String(Ruby runtime, CharSequence str) {
-        ByteList byteList = new ByteList(RubyEncoding.encodeUTF8(str), UTF8Encoding.INSTANCE, false);
-        return new RubyString(runtime, runtime.getString(), byteList);
+        return new RubyString(runtime, runtime.getString(), RubyEncoding.doEncodeUTF8(str));
     }
 
     public static RubyString newUTF16String(Ruby runtime, CharSequence str) {
-        ByteList byteList = new ByteList(RubyEncoding.encodeUTF16(str), UTF16BEEncoding.INSTANCE, false);
-        return new RubyString(runtime, runtime.getString(), byteList);
+        return new RubyString(runtime, runtime.getString(), RubyEncoding.doEncodeUTF16(str));
     }
 
     /**
@@ -6158,6 +6154,9 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     }
 
     public static ByteList encodeBytelist(CharSequence value, Encoding encoding) {
+        if (encoding == UTF8) {
+            return RubyEncoding.doEncodeUTF8(value);
+        }
 
         Charset charset = EncodingUtils.charsetForEncoding(encoding);
 
@@ -6166,16 +6165,12 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
             return EncodingUtils.transcodeString(value.toString(), encoding, 0);
         }
 
-        byte[] bytes;
-        if (charset == RubyEncoding.UTF8) {
-            bytes = RubyEncoding.encodeUTF8(value);
-        } else if (charset == RubyEncoding.UTF16) {
-            bytes = RubyEncoding.encodeUTF16(value);
-        } else {
-            bytes = RubyEncoding.encode(value, charset);
+        if (charset == RubyEncoding.UTF16) {
+            byte[] bytes = RubyEncoding.encodeUTF16(value);
+            return new ByteList(bytes, encoding, false);
         }
 
-        return new ByteList(bytes, encoding, false);
+        return RubyEncoding.doEncode(value, charset, encoding);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/runtime/encoding/EncodingService.java
+++ b/core/src/main/java/org/jruby/runtime/encoding/EncodingService.java
@@ -51,9 +51,8 @@ public final class EncodingService {
         aliases = EncodingDB.getAliases();
         ascii8bit = encodings.get("ASCII-8BIT".getBytes()).getEncoding();
 
-        Charset javaDefaultCharset = Charset.defaultCharset();
-        ByteList javaDefaultBL = new ByteList(javaDefaultCharset.name().getBytes());
-        Entry javaDefaultEntry = findEncodingOrAliasEntry(javaDefaultBL);
+        String javaDefaultCharset = Charset.defaultCharset().name();
+        Entry javaDefaultEntry = findEncodingOrAliasEntry(javaDefaultCharset.getBytes());
         javaDefault = javaDefaultEntry == null ? ascii8bit : javaDefaultEntry.getEncoding();
 
         encodingList = new IRubyObject[encodings.size()];
@@ -204,15 +203,15 @@ public final class EncodingService {
     }
 
     public void defineAliases() {
-        HashEntryIterator hei = aliases.entryIterator();
-        while (hei.hasNext()) {
+        HashEntryIterator i = aliases.entryIterator();
+        while (i.hasNext()) {
             CaseInsensitiveBytesHash.CaseInsensitiveBytesHashEntry<Entry> e =
-                    ((CaseInsensitiveBytesHash.CaseInsensitiveBytesHashEntry<Entry>)hei.next());
-            Entry ee = e.value;
+                    ((CaseInsensitiveBytesHash.CaseInsensitiveBytesHashEntry<Entry>)i.next());
+            Entry entry = e.value;
 
             // The constant names must be treated by the the <code>encodingNames</code> helper.
             for (String constName : EncodingUtils.encodingNames(e.bytes, e.p, e.end)) {
-                defineEncodingConstant(runtime, (RubyEncoding) encodingList[ee.getIndex()], constName);
+                defineEncodingConstant(runtime, (RubyEncoding) encodingList[entry.getIndex()], constName);
             }
         }
     }
@@ -478,7 +477,7 @@ public final class EncodingService {
 
     private Entry findEntryFromEncoding(Encoding e) {
         if (e == null) return null;
-        return findEncodingEntry(new ByteList(e.getName()));
+        return findEncodingEntry(e.getName());
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/util/RubyDateFormatter.java
+++ b/core/src/main/java/org/jruby/util/RubyDateFormatter.java
@@ -180,17 +180,6 @@ public class RubyDateFormatter {
         }
     }
 
-    public static void main(String[] args) {
-        // composed + special, keys of the switch below
-        StringBuilder buf = new StringBuilder("cDxFnQRrTXtvZ+z");
-        for (int i = 'A'; i <= 'z'; i++) {
-            if (Format.conversionToToken(i) != null) {
-                buf.append((char) i);
-            }
-        }
-        System.out.println(buf.toString());
-    }
-
     public static class Token {
         private final Format format;
         private final Object data;
@@ -276,7 +265,7 @@ public class RubyDateFormatter {
             throw runtime.newArgumentError("format should have ASCII compatible encoding");
         }
 
-        final List<Token> compiledPattern = new LinkedList<Token>();
+        final List<Token> compiledPattern = new LinkedList<>();
         if (enc != ASCIIEncoding.INSTANCE) { // default for ByteList
             compiledPattern.add(new Token(Format.FORMAT_ENCODING, enc));
         }
@@ -681,4 +670,5 @@ public class RubyDateFormatter {
     public Date parse(String source, ParsePosition pos) {
         throw new UnsupportedOperationException();
     }
+
 }


### PR DESCRIPTION
first UTF-16 is broken on Java 10+ since it assumes `char[]` value String internals (using Unsafe)

doing that, spotted a few less copy `byte[]`/`char[]` opportunities and started micro-benchmarking

by separating String/CharSequence paths down the encoding pipe there seems to be gains (maybe its likely due HotSpot's JIT assuming the CS method as mono-morphic as they only get a `StringBuilder`)

but since the micro benchmark wasn't assuring (non StringBuilder CharSequence paths do get slower in JMH) I did some AR-JDBC "raw" AR benchmarking ...
surprisingly this seems to make sense as there seems to be a noticeable almost 5% speed gain
