### PR TITLE
remove MaxPermSize

### DIFF
--- a/maven/jruby/src/templates/hellowarld/Mavenfile
+++ b/maven/jruby/src/templates/hellowarld/Mavenfile
@@ -32,7 +32,7 @@ profile 'cuba' do
 end
 
 profile 'rails4' do
-  properties :framework => 'rails4', 'wildfly.javaOpts' => '-XX:MaxPermSize=512m'
+  properties :framework => 'rails4', 'wildfly.javaOpts' => '-XX:MaxMetaspaceSize=512m'
 end
 
 profile 'webrick' do

--- a/rakelib/commands.rake
+++ b/rakelib/commands.rake
@@ -113,7 +113,7 @@ def mspec(mspec_options = {}, java_options = {}, &code)
     arg :line => "-T -J-Demma.coverage.out.merge=true"
     arg :line => "-T -J-Demma.verbosity.level=silent"
     arg :line => "-T -J#{JVM_MODEL}" if JVM_MODEL
-    arg :line => "-T -J-XX:MaxPermSize=512M" if ENV_JAVA["java.version"] !~ /\A1\.8/
+    arg :line => "-T -J-XX:MaxMetaspaceSize=512M"
     arg :line => "-T --debug"
     arg :line => "-f #{ms[:format]}"
     arg :line => "-B #{ms[:spec_config]}" if ms[:spec_config]

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -48,7 +48,7 @@ namespace :test do
   task :rake_targets => long_tests
   task :extended => long_tests
 
-  max_meta_size = ENV_JAVA['java.specification.version'] > '1.7' ? '-XX:MaxMetaspaceSize' : '-XX:MaxPermSize'
+  max_meta_size = "-XX:MaxMetaspaceSize"
   get_meta_size = proc do |default_size = 452|
     (ENV['JAVA_OPTS'] || '').index(max_meta_size) || (ENV['JRUBY_OPTS'] || '').index(max_meta_size) ?
         '' : "-J#{max_meta_size}=#{default_size}M"


### PR DESCRIPTION
The command line flags PermSize and MaxPermSize have been removed and are ignored. If used on the command line a warning will be emitted for each.

    Java HotSpot(TM) Server VM warning: ignoring option PermSize=32m; support 
    was removed in 8.0

    Java HotSpot(TM) Server VM warning: ignoring option MaxPermSize=128m; support 
    was removed in 8.0

since jruby 9.2 supports only java 8+, MaxPermSize should be replaced in favour of MaxMetaspaceSize

http://www.oracle.com/technetwork/java/javase/8-compatibility-guide-2156366.html