### PR TITLE
Proc source location gives wrong result

### DIFF
--- a/core/src/main/java/org/jruby/parser/RubyParser.java
+++ b/core/src/main/java/org/jruby/parser/RubyParser.java
@@ -4469,9 +4469,8 @@ states[443] = new ParserState() {
 };
 states[444] = new ParserState() {
   @Override public Object execute(ParserSupport support, RubyLexer lexer, Object yyVal, Object[] yyVals, int yyTop) {
-                    /* FIXME: probably need to correct location here*/
-                    yyVal = new IterNode(lexer.getPosition(), ((ArgsNode)yyVals[-1+yyTop]), ((Node)yyVals[0+yyTop]), support.getCurrentScope());
-                     support.popCurrentScope();
+                    yyVal = new IterNode(((ISourcePositionHolder)yyVals[-4+yyTop]).getPosition(), ((ArgsNode)yyVals[-1+yyTop]), ((Node)yyVals[0+yyTop]), support.getCurrentScope());
+                    support.popCurrentScope();
                     lexer.getCmdArgumentState().reset(((Long)yyVals[-2+yyTop]).longValue());
     return yyVal;
   }
@@ -4486,9 +4485,8 @@ states[445] = new ParserState() {
 };
 states[446] = new ParserState() {
   @Override public Object execute(ParserSupport support, RubyLexer lexer, Object yyVal, Object[] yyVals, int yyTop) {
-                    /* FIXME: probably need to correct location here*/
-                    yyVal = new IterNode(lexer.getPosition(), ((ArgsNode)yyVals[-1+yyTop]), ((Node)yyVals[0+yyTop]), support.getCurrentScope());
-                     support.popCurrentScope();
+                    yyVal = new IterNode(((ISourcePositionHolder)yyVals[-4+yyTop]).getPosition(), ((ArgsNode)yyVals[-1+yyTop]), ((Node)yyVals[0+yyTop]), support.getCurrentScope());
+                    support.popCurrentScope();
                     lexer.getCmdArgumentState().reset(((Long)yyVals[-2+yyTop]).longValue());
     return yyVal;
   }
@@ -5718,7 +5716,7 @@ states[647] = new ParserState() {
   }
 };
 }
-					// line 2764 "RubyParser.y"
+					// line 2762 "RubyParser.y"
 
     /** The parse method use an lexer stream and parse it to an AST node 
      * structure
@@ -5733,4 +5731,4 @@ states[647] = new ParserState() {
         return support.getResult();
     }
 }
-					// line 10626 "-"
+					// line 10624 "-"

--- a/core/src/main/java/org/jruby/parser/RubyParser.y
+++ b/core/src/main/java/org/jruby/parser/RubyParser.y
@@ -1963,9 +1963,8 @@ brace_body      : {
                     $$ = Long.valueOf(lexer.getCmdArgumentState().getStack()) >> 1;
                     lexer.getCmdArgumentState().reset();
                 } opt_block_param compstmt {
-                    // FIXME: probably need to correct location here
-                    $$ = new IterNode(lexer.getPosition(), $2, $3, support.getCurrentScope());
-                     support.popCurrentScope();
+                    $$ = new IterNode($<ISourcePositionHolder>-1.getPosition(), $2, $3, support.getCurrentScope());
+                    support.popCurrentScope();
                     lexer.getCmdArgumentState().reset($<Long>1.longValue());
                 }
 
@@ -1974,9 +1973,8 @@ do_body 	: {
                     $$ = Long.valueOf(lexer.getCmdArgumentState().getStack());
                     lexer.getCmdArgumentState().reset();
                 } opt_block_param bodystmt {
-                    // FIXME: probably need to correct location here
-                    $$ = new IterNode(lexer.getPosition(), $2, $3, support.getCurrentScope());
-                     support.popCurrentScope();
+                    $$ = new IterNode($<ISourcePositionHolder>-1.getPosition(), $2, $3, support.getCurrentScope());
+                    support.popCurrentScope();
                     lexer.getCmdArgumentState().reset($<Long>1.longValue());
                 }
  


### PR DESCRIPTION
### Environment
* Ruby version: jruby 9.2.0.0 (2.5.0) 2018-05-24 81156a8 Java HotSpot(TM) 64-Bit Server VM 25.152-b16 on 1.8.0_152-b16 +jit [darwin-x86_64]
* OS/platform: macOS 10.13.5

### Expected Behavior

On ruby 2.5.0 and jruby-9.1.17.0 the following script:

```ruby
expected = __LINE__ + 1
proc = Proc.new do


end

p "#{expected} == #{proc.source_location[1]}"
```

Prints: `2 == 2`



### Actual Behavior

On jruby-9.2.0.0 it prints `2 == 5`

### Investigation

I found this bug by noticing that `rspec` with line filters (e.g. `rspec test_file.rb:20`) was not working.

I traced this back to https://github.com/jruby/jruby/commit/ca254718c8cab05f97ebb527f3f370f375695104

I am doubtful that the fix I proposed in this PR is adequate however it was quite fun to look around this. 

Tested with fast specs, mri's _test_lambda_ and _test_proc_. No spec failures were added but also none were fixed :(