### PR TITLE
Add Complimentary Regression Test for GH-5203

### DIFF
--- a/test/jruby/test_string.rb
+++ b/test/jruby/test_string.rb
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 require 'test/unit'
+require 'stringio'
 
 class TestString < Test::Unit::TestCase
 
@@ -97,7 +98,7 @@ class TestString < Test::Unit::TestCase
   end
 
   # GH-5203
-  def test_string_buffer_sharing_in_stringio; require 'stringio'
+  def test_string_buffer_sharing_in_stringio
     zero = 0
     strio = StringIO.new "123\nabcdefghijklmnopqrstuvxyz\n#{zero}\n"
     ary = []; strio.each_line { |line| ary << line }
@@ -105,6 +106,23 @@ class TestString < Test::Unit::TestCase
     strio.write('456')
     assert_equal ["123\n", "abcdefghijklmnopqrstuvxyz\n", "0\n"], ary
     assert_equal "456\nabcdefghijklmnopqrstuvxyz\n0\n", strio.string
+  end
+
+  # GH-5203
+  def test_string_buffer_sharing_in_stringio_from_regex
+    strio = StringIO.new
+    strio << "<Region>hello</Region>"
+    strio.rewind
+
+    str = strio.read
+    match = str.match("<Region>([a-zA-Z]+)</Region>")[1]
+
+    strio.seek 0
+    strio.truncate 0
+    strio << '1234567890'
+
+    assert_equal str, "<Region>hello</Region>"
+    assert_equal match, "hello"
   end
 
   private


### PR DESCRIPTION
The regression test in https://github.com/jruby/jruby/commit/b0875446c80d496a7f0e4b71183beef0839f4de1 is very good. Unlike the regression test in https://github.com/jruby/jruby/commit/b0875446c80d496a7f0e4b71183beef0839f4de1, however, the AWS S3 SDK receives a string via a regex and encounters the same bug. 

The regression test in this PR mimics the S3 SDK by receiving a string from a regex match and asserts that the string is not mutated via StringIO manipulation.

This regression test fails without https://github.com/jruby/jruby/commit/b0875446c80d496a7f0e4b71183beef0839f4de1 , but succeeds with that fix.

Related to https://github.com/jruby/jruby/issues/5203#issuecomment-408656779. cc/ @kares 