### PR TITLE
Fixes underlying logic of slice_when / chunk_while to handle 1 element collections

### DIFF
--- a/core/src/main/ruby/jruby/kernel/enumerable.rb
+++ b/core/src/main/ruby/jruby/kernel/enumerable.rb
@@ -80,30 +80,29 @@ module Enumerable
   end
 
   def __slicey_chunky(invert, enum, block)
-    if respond_to?(:size) && size == 1
-      each {|x| enum.yield [x]}
-    else
-      ary = nil
-      last_after = nil
-      each_cons(2) do |before, after|
-        last_after = after
-        match = block.call before, after
+    ary = nil
+    last_after = nil
+    element_present = false
+    each_cons(2) do |before, after|
+      element_present = true
+      last_after = after
+      match = block.call before, after
 
-        ary ||= []
-        if invert ? !match : match
-          ary << before
-          enum.yield ary
-          ary = []
-        else
-          ary << before
-        end
-      end
-
-      unless ary.nil?
-        ary << last_after
+      ary ||= []
+      if invert ? !match : match
+        ary << before
         enum.yield ary
+        ary = []
+      else
+        ary << before
       end
     end
+
+    unless ary.nil?
+      ary << last_after
+      enum.yield ary
+    end
+    each { |x| enum.yield [x] } unless element_present
   end
   private :__slicey_chunky
 

--- a/spec/tags/ruby/core/enumerable/slice_when_tags.txt
+++ b/spec/tags/ruby/core/enumerable/slice_when_tags.txt
@@ -1,4 +1,1 @@
-fails:Enumerable#slice_when when given a block splits chunks between adjacent elements i and j where the block returns true
-fails:Enumerable#slice_when when given a block calls the block for length of the receiver enumerable minus one times
 fails:Enumerable#slice_when when an iterator method yields more than one value processes all yielded values
-fails:Enumerable#slice_when when given a block doesn't yield an empty array on a small enumerable


### PR DESCRIPTION
Enumerables with 1 element

Fixes #5275. Instead of checking for size 1 at the beginning, this change sets a
flag that never gets modified if `each_cons(2)` does not get called.
This happens in the case of 1 element Enumerables. The previous
behavior was fine for Enumerables that respond to `size` but fails
otherwise.