### PR TITLE
BUILDING.md: Mention Java 8 JDK is required

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -3,7 +3,7 @@ Building JRuby from Source
 
 Prerequisites:
 
-* A [Java 7-compatible (or higher) Java development kit (JDK)](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
+* A [Java 8-compatible (or higher) Java development kit (JDK)](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
   * If `JAVA_HOME` is not set on Mac OS X: `export JAVA_HOME=$(/usr/libexec/java_home)`
 * [Maven](https://maven.apache.org/download.cgi) 3+
 * [Apache Ant](https://ant.apache.org/bindownload.cgi) 1.8+ (see https://github.com/jruby/jruby/issues/2236)


### PR DESCRIPTION
This PR adds a note to the build documentation that the **required JDK is 8** and later.

  - See #5247