### PR TITLE
Improve RubyHash#resize performance

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -733,6 +733,7 @@ public class RubyHash extends RubyObject implements Map {
                 otherValue = entries[(index * NUMBER_OF_ENTRIES) + 1];
                 if (matchType.matches(key, value, otherKey, otherValue)) {
                   bins[bin] = DELETED_BIN;
+                  hashes[index] = 0;
                   entries[index * NUMBER_OF_ENTRIES] = null;
                   entries[(index * NUMBER_OF_ENTRIES) + 1] = null;
                   size--;
@@ -759,6 +760,7 @@ public class RubyHash extends RubyObject implements Map {
                 continue;
 
             if (matchType.matches(key, value, otherKey, otherValue)) {
+              hashes[index] = 0;
               entries[index * NUMBER_OF_ENTRIES] = null;
               entries[(index * NUMBER_OF_ENTRIES) + 1] = null;
               size--;


### PR DESCRIPTION
as we store now the hash values, we do not need to recalculate the hashes while resizing again.
Also using System.arraycopy for entries and hashes arrays seems to be faster than manually assigning them inside the loop.

## Benchmark 

```
benchmark:
  10: 'tmp = {}; i = 0; while i < 10; tmp[i.to_s] = i; i += 1; end;'
  20: 'tmp = {}; i = 0; while i < 20; tmp[i.to_s] = i; i += 1; end;'
  30: 'tmp = {}; i = 0; while i < 30; tmp[i.to_s] = i; i += 1; end;'
  40: 'tmp = {}; i = 0; while i < 40; tmp[i.to_s] = i; i += 1; end;'
  50: 'tmp = {}; i = 0; while i < 50; tmp[i.to_s] = i; i += 1; end;'
  60: 'tmp = {}; i = 0; while i < 60; tmp[i.to_s] = i; i += 1; end;'
  70: 'tmp = {}; i = 0; while i < 70; tmp[i.to_s] = i; i += 1; end;'
  80: 'tmp = {}; i = 0; while i < 80; tmp[i.to_s] = i; i += 1; end;'
  90: 'tmp = {}; i = 0; while i < 90; tmp[i.to_s] = i; i += 1; end;'
  100: 'tmp = {}; i = 0; while i < 100; tmp[i.to_s] = i; i += 1; end;'
```

```
Warming up --------------------------------------
                  10   566.558k i/s -    570.267k times in 1.006546s (1.77μs/i)
                  20   270.042k i/s -    275.120k times in 1.018805s (3.70μs/i)
                  30   201.843k i/s -    204.498k times in 1.013154s (4.95μs/i)
                  40   143.105k i/s -    150.535k times in 1.051917s (6.99μs/i)
                  50   119.197k i/s -    123.097k times in 1.032718s (8.39μs/i)
                  60    99.200k i/s -    100.827k times in 1.016405s (10.08μs/i)
                  70    77.240k i/s -     79.838k times in 1.033635s (12.95μs/i)
                  80    65.777k i/s -     67.920k times in 1.032576s (15.20μs/i)
                  90    61.631k i/s -     62.453k times in 1.013339s (16.23μs/i)
                 100    54.605k i/s -     56.488k times in 1.034492s (18.31μs/i)
Calculating -------------------------------------
                      bin/jruby  jruby-9.2.1.0-dev  jruby-9.2.0.0 
                  10   711.586k           701.286k       704.778k i/s -      1.700M times in 2.388570s 2.423654s 2.411643s
                  20   321.324k           302.121k       334.296k i/s -    810.125k times in 2.521209s 2.681458s 2.423378s
                  30   239.461k           197.403k       250.212k i/s -    605.528k times in 2.528711s 3.067478s 2.420059s
                  40   171.903k           131.317k       169.674k i/s -    429.316k times in 2.497435s 3.269313s 2.530241s
                  50   128.795k           110.135k       140.688k i/s -    357.591k times in 2.776439s 3.246837s 2.541730s
                  60   105.906k            94.417k       117.455k i/s -    297.598k times in 2.810011s 3.151951s 2.533721s
                  70   101.439k            71.614k        90.587k i/s -    231.720k times in 2.284337s 3.235695s 2.557970s
                  80    77.377k            76.307k        80.680k i/s -    197.331k times in 2.550264s 2.586007s 2.445860s
                  90    68.088k            66.144k        67.540k i/s -    184.892k times in 2.715494s 2.795294s 2.737522s
                 100    61.661k            53.884k        61.975k i/s -    163.813k times in 2.656681s 3.040103s 2.643221s

Comparison:
                               10
           bin/jruby:    711586.5 i/s 
       jruby-9.2.0.0:    704778.3 i/s - 1.01x  slower
   jruby-9.2.1.0-dev:    701285.7 i/s - 1.01x  slower

                               20
       jruby-9.2.0.0:    334295.8 i/s 
           bin/jruby:    321324.0 i/s - 1.04x  slower
   jruby-9.2.1.0-dev:    302121.1 i/s - 1.11x  slower

                               30
       jruby-9.2.0.0:    250212.1 i/s 
           bin/jruby:    239461.1 i/s - 1.04x  slower
   jruby-9.2.1.0-dev:    197402.5 i/s - 1.27x  slower

                               40
           bin/jruby:    171902.7 i/s 
       jruby-9.2.0.0:    169673.9 i/s - 1.01x  slower
   jruby-9.2.1.0-dev:    131316.9 i/s - 1.31x  slower

                               50
       jruby-9.2.0.0:    140688.1 i/s 
           bin/jruby:    128794.8 i/s - 1.09x  slower
   jruby-9.2.1.0-dev:    110135.2 i/s - 1.28x  slower

                               60
       jruby-9.2.0.0:    117454.9 i/s 
           bin/jruby:    105906.4 i/s - 1.11x  slower
   jruby-9.2.1.0-dev:     94417.1 i/s - 1.24x  slower

                               70
           bin/jruby:    101438.6 i/s 
       jruby-9.2.0.0:     90587.5 i/s - 1.12x  slower
   jruby-9.2.1.0-dev:     71613.7 i/s - 1.42x  slower

                               80
       jruby-9.2.0.0:     80679.6 i/s 
           bin/jruby:     77376.7 i/s - 1.04x  slower
   jruby-9.2.1.0-dev:     76307.2 i/s - 1.06x  slower

                               90
           bin/jruby:     68087.8 i/s 
       jruby-9.2.0.0:     67539.9 i/s - 1.01x  slower
   jruby-9.2.1.0-dev:     66144.0 i/s - 1.03x  slower

                              100
       jruby-9.2.0.0:     61974.8 i/s 
           bin/jruby:     61660.8 i/s - 1.01x  slower
   jruby-9.2.1.0-dev:     53884.0 i/s - 1.15x  slower

```
