### PR TITLE
Fix failed Enumerable#uniq spec when yielded with multiple arguments

### DIFF
--- a/core/src/main/ruby/jruby/kernel/enumerable.rb
+++ b/core/src/main/ruby/jruby/kernel/enumerable.rb
@@ -116,7 +116,7 @@ module Enumerable
     values = []
     hash = {}
     if block_given?
-      each do |obj|
+      each_entry do |obj|
         ret = yield(*obj)
         next if hash.key? ret
         hash[ret] = obj

--- a/spec/tags/ruby/core/enumerable/uniq_tags.txt
+++ b/spec/tags/ruby/core/enumerable/uniq_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#uniq when yielded with multiple arguments returns all yield arguments as an array


### PR DESCRIPTION
Hi folks,

This should fix another failed spec for Enumerable#uniq spec.

Use case: when yielded with multiple arguments, returns all yield arguments as an array.