### PR TITLE
Fix some failed Enumerable#find_index specs

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -706,8 +706,7 @@ public class RubyEnumerable {
         try {
             callEach(runtime, context, self, callbackArity, new BlockCallback() {
                 public IRubyObject call(ThreadContext ctx, IRubyObject[] largs, Block blk) {
-                    IRubyObject larg = packEnumValues(runtime, largs);
-                    if (block.yield(ctx, larg).isTrue()) throw JumpException.SPECIAL_JUMP;
+                    if (block.yieldValues(ctx, largs).isTrue()) throw JumpException.SPECIAL_JUMP;
                     result[0]++;
                     return runtime.getNil();
                 }
@@ -745,7 +744,7 @@ public class RubyEnumerable {
         final long result[] = new long[] {0};
 
         try {
-            callEach(runtime, context, self, Signature.ONE_ARGUMENT, new BlockCallback() {
+            callEach(runtime, context, self, Signature.OPTIONAL, new BlockCallback() {
                 public IRubyObject call(ThreadContext ctx, IRubyObject[] largs, Block blk) {
                     IRubyObject larg = packEnumValues(ctx, largs);
                     if (equalInternal(ctx, larg, cond)) throw JumpException.SPECIAL_JUMP;

--- a/spec/tags/ruby/core/enumerable/find_index_tags.txt
+++ b/spec/tags/ruby/core/enumerable/find_index_tags.txt
@@ -1,2 +1,0 @@
-fails:Enumerable#find_index without block gathers whole arrays as elements when each yields multiple
-fails:Enumerable#find_index with block given a greedy yield parameter passes a gathered array to the parameter


### PR DESCRIPTION
Hi folks,

This change should fix the remaining failing specs for Enumerable#find_index.

This change removes the assumption that #each would yield passing always a single object. It could yield without passing parameters, passing one or more objects or yield an explicit array (empty or not).