### PR TITLE
Fix Hash#rehash for open addressing

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1182,7 +1182,7 @@ public class RubyHash extends RubyObject implements Map {
                 }
 
                 bin = secondaryBucketIndex(bin, newBins.length);
-                index = bins[bin];
+                index = newBins[bin];
             }
 
             if (!exists) {


### PR DESCRIPTION
We used the old bins array to get the index instead of the new one.
This caused that the bins array was wrongly calculated if a
collisions occours and eventually did not found keys in the hash
anymore.

Fix #5304