### PR TITLE
Fix Hash#initialize spec tagged as failed

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -927,6 +927,7 @@ public class RubyHash extends RubyObject implements Map {
         } else {
             Arity.checkArgumentCount(getRuntime(), args, 0, 1);
             if (args.length == 1) ifNone = args[0];
+            if (args.length == 0) ifNone = UNDEF;
         }
         return this;
     }

--- a/spec/tags/ruby/core/hash/initialize_tags.txt
+++ b/spec/tags/ruby/core/hash/initialize_tags.txt
@@ -1,1 +1,0 @@
-fails:Hash#initialize can be used to reset the default value


### PR DESCRIPTION
Hi folks,

This change should fix a failed spec for Hash#initialize.

Hash#initialize can be used to reset the default value.

Cheers,