### PR TITLE
Include output of `inspect` in ConcurrencyError

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -2600,7 +2600,9 @@ public class RubyHash extends RubyObject implements Map {
 
     private final RaiseException concurrentModification() {
         return getRuntime().newConcurrencyError(
-                "Detected invalid hash contents due to unsynchronized modifications with concurrent users");
+                "Detected invalid hash contents due to unsynchronized modifications with concurrent users." +
+                " inspect: " + inspectHash( getRuntime().getCurrentContext() ).asJavaString()
+        );
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -2600,8 +2600,8 @@ public class RubyHash extends RubyObject implements Map {
 
     private final RaiseException concurrentModification() {
         return getRuntime().newConcurrencyError(
-                "Detected invalid hash contents due to unsynchronized modifications with concurrent users." +
-                " inspect: " + inspectHash( getRuntime().getCurrentContext() ).asJavaString()
+                "Detected invalid hash contents due to unsynchronized modifications with concurrent users: " +
+                inspect().asJavaString()
         );
     }
 


### PR DESCRIPTION
Adding `inspect` to the exception message when a `ConcurrencyError` is raised to make identifying the offending structure straightforward.