### PR TITLE
Allocate method on NilClass should raise TypeError

### DIFF
--- a/core/src/main/java/org/jruby/RubyNil.java
+++ b/core/src/main/java/org/jruby/RubyNil.java
@@ -72,7 +72,7 @@ public class RubyNil extends RubyObject implements Constantizable {
     public static final ObjectAllocator NIL_ALLOCATOR = new ObjectAllocator() {
         @Override
         public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-            return runtime.getNil();
+            throw runtime.newTypeError("allocator undefined for NilClass");
         }
     };
     

--- a/spec/tags/ruby/core/nil/nilclass_tags.txt
+++ b/spec/tags/ruby/core/nil/nilclass_tags.txt
@@ -1,1 +1,0 @@
-fails:NilClass .allocate raises a TypeError


### PR DESCRIPTION
I noticed an small difference between MRI and JRuby specs. According to them, to try to allocate space for a new instance of NilClass should raise a TypeError instead of returning nil.