### PR TITLE
ProcessBuilder#environment

### DIFF
--- a/core/src/main/ruby/jruby/kernel/jruby/process_manager.rb
+++ b/core/src/main/ruby/jruby/kernel/jruby/process_manager.rb
@@ -25,7 +25,7 @@ module JRuby
       pb = ProcessBuilder.new(config.exec_args)
       pb.redirect_input(Redirect::INHERIT)
       pb.redirect_error(Redirect::INHERIT)
-      pb.environment(ShellLauncher.get_current_env(JRuby.runtime))
+      pb.environment
       cwd = JRuby.runtime.current_directory
       cwd = cwd.start_with?('uri:classloader:/') ? ENV_JAVA['user.dir'] : cwd
       pb.directory(JFile.new(cwd))


### PR DESCRIPTION
this is a question.

Before this was merged https://github.com/jruby/jruby/pull/5316
shelling on windows was broken

```
irb(main):001:0> `dir`
ArgumentError: wrong number of arguments (1 for 0)
                          ` at uri:classloader:/jruby/kernel/jruby/process_manager.rb:28
                          ` at uri:classloader:/jruby/kernel/jruby/process_manager.rb:50
```

now it works fine, but according to the javadoc ProcessBuilder#environment don't accept an argument
https://docs.oracle.com/javase/7/docs/api/java/lang/ProcessBuilder.html#environment()

am I missing something?

```
java version "10.0.2" 2018-07-17
Java(TM) SE Runtime Environment 18.3 (build 10.0.2+13)
Java HotSpot(TM) 64-Bit Server VM 18.3 (build 10.0.2+13, mixed mode)
```