### PR TITLE
Use IndyBinder instead of generated invokers.

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -142,19 +142,6 @@ project 'JRuby Core' do
                      :id => 'add-populators',
                      'sources' => [ '${anno.sources}' ] )
     end
-
-    plugin 'org.codehaus.mojo:exec-maven-plugin' do
-      execute_goals( 'exec',
-                     :id => 'invoker-generator',
-                     'arguments' => [ '-Djruby.bytecode.version=${base.java.version}',
-                                      '-classpath',
-                                      xml( '<classpath/>' ),
-                                      'org.jruby.anno.InvokerGenerator',
-                                      '${anno.sources}/annotated_classes.txt',
-                                      '${project.build.outputDirectory}' ],
-                     'executable' =>  'java',
-                     'classpathScope' =>  'compile' )
-    end
   end
 
   plugin( :compiler,
@@ -172,7 +159,7 @@ project 'JRuby Core' do
                    :id => 'anno',
                    :phase => 'process-resources',
                    'includes' => [ 'org/jruby/anno/FrameField.java',
-                                   'org/jruby/anno/AnnotationBinder.java',
+                                   'org/jruby/anno/IndyBinder.java',
                                    'org/jruby/anno/JRubyMethod.java',
                                    'org/jruby/anno/FrameField.java',
                                    'org/jruby/CompatVersion.java',
@@ -183,7 +170,7 @@ project 'JRuby Core' do
                    :id => 'default-compile',
                    :phase => 'compile',
                    'debug' => 'true',
-                   'annotationProcessors' => [ 'org.jruby.anno.AnnotationBinder' ],
+                   'annotationProcessors' => [ 'org.jruby.anno.IndyBinder' ],
                    'generatedSourcesDirectory' =>  'target/generated-sources',
                    'compilerArgs' => [ '-XDignore.symbol.file=true',
                                        '-J-Duser.language=en',

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -420,31 +420,6 @@ DO NOT MODIFIY - GENERATED CODE
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>invoker-generator</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <arguments>
-                <argument>-Djruby.bytecode.version=${base.java.version}</argument>
-                <argument>-classpath</argument>
-                <classpath />
-                <argument>org.jruby.anno.InvokerGenerator</argument>
-                <argument>${anno.sources}/annotated_classes.txt</argument>
-                <argument>${project.build.outputDirectory}</argument>
-              </arguments>
-              <executable>java</executable>
-              <classpathScope>compile</classpathScope>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <executions>
           <execution>
@@ -456,7 +431,7 @@ DO NOT MODIFIY - GENERATED CODE
             <configuration>
               <includes>
                 <include>org/jruby/anno/FrameField.java</include>
-                <include>org/jruby/anno/AnnotationBinder.java</include>
+                <include>org/jruby/anno/IndyBinder.java</include>
                 <include>org/jruby/anno/JRubyMethod.java</include>
                 <include>org/jruby/anno/FrameField.java</include>
                 <include>org/jruby/CompatVersion.java</include>
@@ -475,7 +450,7 @@ DO NOT MODIFIY - GENERATED CODE
             <configuration>
               <debug>true</debug>
               <annotationProcessors>
-                <annotationProcessor>org.jruby.anno.AnnotationBinder</annotationProcessor>
+                <annotationProcessor>org.jruby.anno.IndyBinder</annotationProcessor>
               </annotationProcessors>
               <generatedSourcesDirectory>target/generated-sources</generatedSourcesDirectory>
               <compilerArgs>


### PR DESCRIPTION
This is an experimental PR to try (again) to use only invokedynamic method handles rather than our generated classes.

In my quick tests, this binder does not appear to have any difference in performance from running with the normal generated invokers.

The logic works like this:

* Like AnnotationBinder, a class is generated for each Java-based Ruby class with code to wire up all methods. However IndyBinder generates bytecode, so it can statically reference  the handles pointing at each Java-based method on the core class.
* Instead of generating an "INVOKER" class for each method binding, IndyBinder constructs HandleMethod with deferred Callable<MethodHandle> for each slot, which when executed will actually instantiate the related method handle.

There are a couple reasons why this change makes sense:

* The invokers constitute a few thousand classes, perhaps a thousand of which get loaded on every startup. The indy version will load no classes and only generate the handles for method arities actually called.
* Those thousands of classes must be in the jar file. Using the indy binding reduces the size of the main JRuby jar by over 2MB (based on current master, 2.07MB).

I am looking to get this running in Travis and get others familiar with the project to try it out and see how their startup time is affected.  I'm also interested in the runtime performance aspects, but mostly  because I have not audited the indy-based binding logic to see if it is properly taking advantage of the available handles.