### PR TITLE
Fix tagged as failed spec for Enumerable#slice_when

### DIFF
--- a/core/src/main/ruby/jruby/kernel/enumerable.rb
+++ b/core/src/main/ruby/jruby/kernel/enumerable.rb
@@ -102,7 +102,7 @@ module Enumerable
       ary << last_after
       enum.yield ary
     end
-    each { |x| enum.yield [x] } unless element_present
+    each_entry { |x| enum.yield [x] } unless element_present
   end
   private :__slicey_chunky
 

--- a/spec/tags/ruby/core/enumerable/slice_when_tags.txt
+++ b/spec/tags/ruby/core/enumerable/slice_when_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#slice_when when an iterator method yields more than one value processes all yielded values


### PR DESCRIPTION
In order to iterate correctly over Enumerable elements, #each_entry method should be used, because that method will convert multiple values from yield to an array, if required.

This is a fix similar to https://github.com/jruby/jruby/pull/5302.