### PR TITLE
Try running MRI core tests in parallel (four-way).

### DIFF
--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -88,7 +88,7 @@ namespace :test do
     jruby_opts.each do |task, opts|
       task task do
         ENV['JRUBY_OPTS'] = "#{ENV['JRUBY_OPTS']} -J-Xmx2G -Xbacktrace.style=mri -Xdebug.fullTrace #{opts}"
-        ruby "test/mri/runner.rb #{ADDITIONAL_TEST_OPTIONS} --excludes=test/mri/excludes -q -- #{mri_test_files}"
+        ruby "test/mri/runner.rb #{ADDITIONAL_TEST_OPTIONS} --excludes=test/mri/excludes -q -j 4 -- #{mri_test_files}"
       end
       namespace :stdlib do
         task task do

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -88,7 +88,7 @@ namespace :test do
     jruby_opts.each do |task, opts|
       task task do
         ENV['JRUBY_OPTS'] = "#{ENV['JRUBY_OPTS']} -J-Xmx2G -Xbacktrace.style=mri -Xdebug.fullTrace #{opts}"
-        ruby "test/mri/runner.rb #{ADDITIONAL_TEST_OPTIONS} --excludes=test/mri/excludes -q -j 4 -- #{mri_test_files}"
+        ruby "test/mri/runner.rb #{ADDITIONAL_TEST_OPTIONS} --excludes=test/mri/excludes -q -j 2 -- #{mri_test_files}"
       end
       namespace :stdlib do
         task task do


### PR DESCRIPTION
Testing the improvement and stability of "-j  4" parallel execution of the MRI tests.

A large number of these tests spawn and wait for subprocesses to boot; if those can run in parallel it may speed up the overall run time substantially. However I got a few failures locally on OS X and I'm unsure if they are supposed to pass. I will re-run locally without parallelism to see if MacOS has decayed.