### PR TITLE
Fix mvnw jar file path for Cygwin

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -225,10 +225,14 @@ MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG $@"
 export MAVEN_CMD_LINE_ARGS
 
 WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+MAVEN_WRAPPER_JAR="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar"
+if $cygwin; then
+  MAVEN_WRAPPER_JAR="$(cygpath --path --windows "$MAVEN_WRAPPER_JAR")"
+fi
 
 exec "$JAVACMD" \
   $MAVEN_OPTS \
-  -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
+  -classpath $MAVEN_WRAPPER_JAR \
   "-Dmaven.home=${M2_HOME}" "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
   ${WRAPPER_LAUNCHER} $MAVEN_CMD_LINE_ARGS
 


### PR DESCRIPTION
mvnw failed under Cygwin with Windows JDK with the following error message.
Error: Could not find or load main class org.apache.maven.wrapper.MavenWrapperMain
This is because maven-wrapper.jar could not be found, and this PR fixes it.