### PR TITLE
return early if one of the arrays is empty

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -3454,13 +3454,11 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     public IRubyObject op_and(IRubyObject other) {
         Ruby runtime = getRuntime();
         RubyArray ary2 = other.convertToArray();
-        RubyHash hash = ary2.makeHash();
+        if (realLength == 0 || ary2.realLength == 0) return newEmptyArray(runtime);
 
         int maxSize = realLength < ary2.realLength ? realLength : ary2.realLength;
-
-        if (maxSize == 0) return newEmptyArray(runtime);
-
         RubyArray ary3 = newBlankArray(runtime, maxSize);
+        RubyHash hash = ary2.makeHash();
 
         int index = 0;
         for (int i = 0; i < realLength; i++) {
@@ -3482,13 +3480,12 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     public IRubyObject op_or(IRubyObject other) {
         Ruby runtime = getRuntime();
         RubyArray ary2 = other.convertToArray();
-        RubyHash set = makeHash(ary2);
 
         int maxSize = realLength + ary2.realLength;
-
         if (maxSize == 0) return newEmptyArray(runtime);
 
         RubyArray ary3 = newBlankArray(runtime, maxSize);
+        RubyHash set = makeHash(ary2);
 
         int index = 0;
         for (int i = 0; i < realLength; i++) {


### PR DESCRIPTION
```
require 'benchmark/ips'
Benchmark.ips do |x|
  x.report('&', "[] & Array.new(200)")
end
```

before
```
  &    177.163k (± 5.2%) i/s -    886.145k in   5.015640s
```
after
```
  &      2.941M (± 5.4%) i/s -     14.643M in   4.996883s
```