### PR TITLE
"==" can be redefined

### DIFF
--- a/core/src/main/java/org/jruby/RubyObject.java
+++ b/core/src/main/java/org/jruby/RubyObject.java
@@ -387,10 +387,12 @@ public class RubyObject extends RubyBasicObject {
     }
 
     private static boolean fastNumEqualInternal(final ThreadContext context, final IRubyObject a, final IRubyObject b) {
-        if (a instanceof RubyFixnum) {
-            if (b instanceof RubyFixnum) return ((RubyFixnum) a).fastEqual((RubyFixnum) b);
-        } else if (a instanceof RubyFloat) {
-            if (b instanceof RubyFloat) return ((RubyFloat) a).fastEqual((RubyFloat) b);
+        if (a instanceof RubyFixnum && b instanceof RubyFixnum &&
+            !context.runtime.getFixnum().isRefinement() && context.runtime.getFixnum().isMethodBuiltin("==")) {
+                return ((RubyFixnum) a).fastEqual((RubyFixnum) b);
+        } else if (a instanceof RubyFloat && b instanceof RubyFloat &&
+            !context.runtime.getFloat().isRefinement() && context.runtime.getFloat().isMethodBuiltin("==")) {
+                return ((RubyFloat) a).fastEqual((RubyFloat) b);
         }
         return invokedynamic(context, a, OP_EQUAL, b).isTrue();
     }

--- a/core/src/main/java/org/jruby/runtime/JavaSites.java
+++ b/core/src/main/java/org/jruby/runtime/JavaSites.java
@@ -248,6 +248,7 @@ public class JavaSites {
         public final CallSite op_lt = new FunctionalCachingCallSite("<");
         public final CachingCallSite basic_op_lt = new FunctionalCachingCallSite("<");
         public final CachingCallSite basic_op_gt = new FunctionalCachingCallSite(">");
+        public final CachingCallSite op_equal = new FunctionalCachingCallSite("==");
         public final CallSite op_exp_complex = new FunctionalCachingCallSite("**");
         public final CallSite op_lt_bignum = new FunctionalCachingCallSite("<");
         public final CallSite op_exp_rational = new FunctionalCachingCallSite("**");
@@ -294,7 +295,7 @@ public class JavaSites {
         public final CallSite op_le = new FunctionalCachingCallSite("<=");
         public final CallSite op_gt = new FunctionalCachingCallSite(">");
         public final CallSite op_lt = new FunctionalCachingCallSite("<");
-        public final CallSite op_equal = new FunctionalCachingCallSite("==");
+        public final CachingCallSite op_equal = new FunctionalCachingCallSite("==");
         public final RespondToCallSite respond_to_infinite = new RespondToCallSite("infinite?");
         public final CallSite infinite = new FunctionalCachingCallSite("infinite?");
     }

--- a/test/mri/excludes/TestArray.rb
+++ b/test/mri/excludes/TestArray.rb
@@ -1,6 +1,5 @@
 exclude :test_aset_error, "needs investigation"
 exclude :test_combination_with_callcc, "no callcc"
-exclude :test_count, "needs investigation"
 exclude :test_flatten_with_callcc, "no callcc"
 exclude :test_permutation, "super flaky on travis"
 exclude :test_permutation_with_callcc, "no callcc"


### PR DESCRIPTION
```
     ARY = Array.new(100) { |i| i }
      class Integer
        def == other
          ARY.replace([])
          self.equal?(other)
        end
      end
      ARY.count(42) == 0

=> true
```


unfortunatelly isMethodBuiltin is very expensive
```
require 'benchmark/ips'
a = Array.new(200, 6)

Benchmark.ips do |x|
  x.report('include') { a.include?(5) }
end
```

master
```
 1.044M (± 7.3%) i/s -      5.211M in   5.023214s
```
this patch
```
 462.594k (± 3.2%) i/s -      2.319M in   5.019374s
```
mri
```
 681.590k (± 9.3%) i/s -      3.389M in   5.020591s
```