### PR TITLE
bump asm version + remove asm-analysis

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -37,7 +37,6 @@ project 'JRuby Core' do
 
   jar 'org.ow2.asm:asm:${asm.version}'
   jar 'org.ow2.asm:asm-commons:${asm.version}'
-  jar 'org.ow2.asm:asm-analysis:${asm.version}'
   jar 'org.ow2.asm:asm-util:${asm.version}'
 
   # exclude jnr-ffi to avoid problems with shading and relocation of the asm packages

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -79,11 +79,6 @@ DO NOT MODIFIY - GENERATED CODE
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-analysis</artifactId>
-      <version>${asm.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
       <artifactId>asm-util</artifactId>
       <version>${asm.version}</version>
     </dependency>

--- a/pom.rb
+++ b/pom.rb
@@ -82,7 +82,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
               'jar-dependencies.version' => '0.4.0',
               'jruby-launcher.version' => '1.1.6',
               'ant.version' => '1.9.8',
-              'asm.version' => '6.2',
+              'asm.version' => '6.2.1',
               'jffi.version' => '1.2.17',
               'joda.time.version' => '2.9.9' )
 

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@ DO NOT MODIFIY - GENERATED CODE
     <rake.version>12.3.0</rake.version>
     <base.javac.version>1.8</base.javac.version>
     <test-unit.version>3.2.7</test-unit.version>
-    <asm.version>6.2</asm.version>
+    <asm.version>6.2.1</asm.version>
     <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     <rspec-core.version>3.6.0</rspec-core.version>
     <power_assert.version>1.1.1</power_assert.version>


### PR DESCRIPTION
... rest of asm jars seems to be used, for now

@enebo do you need asm-analysis.jar around?