### PR TITLE
Use right -sourcepath when jruby is invoked via jdb

### DIFF
--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -281,7 +281,8 @@ do
             JAVACMD="$JAVA_HOME/bin/jdb"
           fi
         fi 
-        java_args=("${java_args[@]}" "-sourcepath" "$JRUBY_HOME/lib/ruby/1.9:.")
+        JDB_SOURCEPATH="${JRUBY_HOME}/core/src/main/java:${JRUBY_HOME}/lib/ruby/stdlib:."
+        java_args=("${java_args[@]}" "-sourcepath" "$JDB_SOURCEPATH")
         JRUBY_OPTS=("${JRUBY_OPTS[@]}" "-X+C") ;;
      --client)
         JAVA_VM=-client ;;

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -226,7 +226,8 @@ do
         else
           JAVACMD="$JAVA_HOME/bin/jdb"
         fi 
-        java_args="${java_args} -sourcepath $JRUBY_HOME/lib/ruby/1.9:."
+        JDB_SOURCEPATH="${JRUBY_HOME}/core/src/main/java:${JRUBY_HOME}/lib/ruby/stdlib:."
+        java_args="${java_args} -sourcepath ${JDB_SOURCEPATH}"
         JRUBY_OPTS="${JRUBY_OPTS} -X+C" ;;
      --client)
         JAVA_VM=-client ;;


### PR DESCRIPTION
When --jdb flag is passed to jruby, it's using an incorrect value for -sourcepath flag. This makes the debugger unable to show the source code of the class being debugged.

Before:

```
shirley:jruby miguel$ ./bin/jruby --jdb -e '[0][1..50] = 2'
Initializing jdb ...
> stop in org.jruby.RubyRange.begLen0
Deferring breakpoint org.jruby.RubyRange.begLen0.
It will be set after the class is loaded.
> run
run org.jruby.Main -e "[0][1..50] = 2"
Set uncaught java.lang.Throwable
Set deferred uncaught java.lang.Throwable
>
VM Started: Set deferred breakpoint org.jruby.RubyRange.begLen0

Breakpoint hit: "thread=main", org.jruby.RubyRange.begLen0(), line=188 bci=0

main[1] list
Source file not found: RubyRange.java
main[1] exit
shirley:jruby miguel$ 
```

After:

```
shirley:jruby miguel$ ./bin/jruby --jdb -e '[0][1..50] = 2'
Initializing jdb ...
> stop in org.jruby.RubyRange.begLen0
Deferring breakpoint org.jruby.RubyRange.begLen0.
It will be set after the class is loaded.
> run
run org.jruby.Main -e "[0][1..50] = 2"
Set uncaught java.lang.Throwable
Set deferred uncaught java.lang.Throwable
> 
VM Started: Set deferred breakpoint org.jruby.RubyRange.begLen0

Breakpoint hit: "thread=main", org.jruby.RubyRange.begLen0(), line=188 bci=0
188            long beg = RubyNumeric.num2long(this.begin);

main[1] list
184            return new long[]{beg, len};
185        }
186    
187        final long begLen0(long len) {
188 =>         long beg = RubyNumeric.num2long(this.begin);
189    
190            if (beg < 0) {
191                beg += len;
192                if (beg < 0) {
193                    throw getRuntime().newRangeError(beg + ".." + (isExclusive ? "." : "") + end + " out of range");
main[1] exit
shirley:jruby miguel$ 
```
