### PR TITLE
[Zlib][CRC32] Trim 'start' value to 32-bit for negative long integers

### DIFF
--- a/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
+++ b/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
@@ -193,6 +193,7 @@ public class RubyZlib {
         ByteList bytes = null;
         if (!args[0].isNil()) bytes = args[0].convertToString().getByteList();
         if (!args[1].isNil()) start = RubyNumeric.num2long(args[1]);
+        start &= 0xFFFFFFFFL;
 
         final boolean slowPath = start != 0;
         final int bytesLength = bytes == null ? 0 : bytes.length();

--- a/spec/ruby/library/zlib/crc32_spec.rb
+++ b/spec/ruby/library/zlib/crc32_spec.rb
@@ -24,6 +24,8 @@ describe "Zlib.crc32" do
     Zlib.crc32(test_string, 1).should == 1809313411
     Zlib.crc32(test_string, 2**8).should == 1722745982
     Zlib.crc32(test_string, 2**16).should == 1932511220
+    Zlib.crc32("p", ~305419896).should == 4046865307
+    Zlib.crc32("p", -305419897).should == 4046865307
     lambda { Zlib.crc32(test_string, 2**128) }.should raise_error(RangeError)
   end
 


### PR DESCRIPTION
As discussed in https://github.com/jruby/jruby/issues/5290#issuecomment-427845262, The while loop in gf2_matrix_times should terminate after 32 iterations. That means the value of 'start' should be 0 after (start>>32). Trimming the value beyond 32 bits ensures that behavior.

FIX #5290 