### PR TITLE
Improve Gem.ruby shim and test it

### DIFF
--- a/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
@@ -29,6 +29,7 @@
 
 package org.jruby.ext.jruby;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Enumeration;
@@ -141,7 +142,7 @@ public class JRubyUtilLibrary implements Library {
     public static IRubyObject classpath_launcher(ThreadContext context, IRubyObject recv) {
         final Ruby runtime = context.runtime;
         String launcher = runtime.getInstanceConfig().getEnvironment().get("RUBY");
-        if ( launcher == null ) launcher = ClasspathLauncher.jrubyCommand(runtime);
+        if ( launcher == null || !(new File(launcher.split(" -cp :")[0]).exists()) ) launcher = ClasspathLauncher.jrubyCommand(runtime);
         return runtime.newString(launcher);
     }
 

--- a/core/src/test/java/org/jruby/ext/JRubyUtilLibraryTest.java
+++ b/core/src/test/java/org/jruby/ext/JRubyUtilLibraryTest.java
@@ -1,0 +1,79 @@
+package org.jruby.ext;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import junit.framework.TestCase;
+import org.jruby.Ruby;
+import org.jruby.RubyInstanceConfig;
+import org.jruby.test.MockRubyObject;
+import org.jruby.util.ClasspathLauncher;
+
+import static org.jruby.ext.jruby.JRubyUtilLibrary.classpath_launcher;
+
+public class JRubyUtilLibraryTest extends TestCase {
+
+    /* Ugly hack to modify environmental variables for these tests only
+       source: https://stackoverflow.com/a/496849
+     */
+    public static void setEnv(Map<String, String> newenv) throws Exception {
+        Class[] classes = Collections.class.getDeclaredClasses();
+        Map<String, String> env = System.getenv();
+        for(Class cl : classes) {
+            if("java.util.Collections$UnmodifiableMap".equals(cl.getName())) {
+                Field field = cl.getDeclaredField("m");
+                field.setAccessible(true);
+                Object obj = field.get(env);
+                Map<String, String> map = (Map<String, String>) obj;
+                map.clear();
+                map.putAll(newenv);
+            }
+        }
+    }
+
+
+    public void testClasspathLauncherWithEnvVar() throws Exception {
+        RubyInstanceConfig config = new RubyInstanceConfig();
+        Ruby ruby = Ruby.newInstance(config);
+        String envRuby = ClasspathLauncher.jrubyCommand(ruby);
+        // Set it to be an existing directory
+        envRuby = (new File(envRuby)).getParent();
+        Map<String, String> newEnv = new HashMap<>(System.getenv());
+        newEnv.put("RUBY", envRuby);
+        setEnv(newEnv);
+        assertEquals(envRuby, System.getenv("RUBY"));
+        RubyInstanceConfig updatedConfig = new RubyInstanceConfig();
+        Ruby updatedRuby = Ruby.newInstance(updatedConfig);
+        assertEquals(envRuby, updatedRuby.getInstanceConfig().getEnvironment().get("RUBY"));
+        MockRubyObject obj = new MockRubyObject(updatedRuby);
+        assertEquals(envRuby, classpath_launcher(updatedRuby.getCurrentContext(), obj).asJavaString());
+    }
+
+    public void testClasspathLauncherWithBogusEnvVar() throws Exception {
+        // Set it to be a non-existing path
+        String envRuby = "foo";
+        Map<String, String> newEnv = new HashMap<>(System.getenv());
+        newEnv.put("RUBY", envRuby);
+        setEnv(newEnv);
+        assertEquals(envRuby, System.getenv("RUBY"));
+        RubyInstanceConfig config = new RubyInstanceConfig();
+        Ruby ruby = Ruby.newInstance(config);
+        assertEquals(envRuby, ruby.getInstanceConfig().getEnvironment().get("RUBY"));
+        MockRubyObject obj = new MockRubyObject(ruby);
+        assertEquals(ClasspathLauncher.jrubyCommand(ruby), classpath_launcher(ruby.getCurrentContext(), obj).asJavaString());
+    }
+
+    public void testClasspathLauncherWithoutEnvVar() throws Exception {
+        RubyInstanceConfig config = new RubyInstanceConfig();
+        Ruby ruby = Ruby.newInstance(config);
+        Map<String, String> newEnv = new HashMap<>(System.getenv());
+        newEnv.remove("RUBY");
+        setEnv(newEnv);
+        assertNull(System.getenv("RUBY"));
+        MockRubyObject obj = new MockRubyObject(ruby);
+        assertEquals(ClasspathLauncher.jrubyCommand(ruby), classpath_launcher(ruby.getCurrentContext(), obj).asJavaString());
+    }
+}

--- a/core/src/test/java/org/jruby/test/MainTestSuite.java
+++ b/core/src/test/java/org/jruby/test/MainTestSuite.java
@@ -38,6 +38,7 @@ package org.jruby.test;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
+import org.jruby.ext.JRubyUtilLibraryTest;
 import org.jruby.ext.posix.JavaFileStatTest;
 import org.jruby.javasupport.TestJava;
 import org.jruby.javasupport.TestJavaClass;
@@ -100,6 +101,7 @@ public class MainTestSuite extends TestSuite {
         suite.addTestSuite(TestRecursiveCheck.class);
         suite.addTestSuite(TestEncodingAPI.class);
         suite.addTestSuite(TestSignature.class);
+        suite.addTestSuite(JRubyUtilLibraryTest.class);
         // Disabled test due to difficulty of making WeakRef logic deterministic
 //        suite.addTestSuite(TestRegexpCache.class);
         return suite;


### PR DESCRIPTION
Since https://github.com/jruby/jruby/commit/4b749c3542ae36a8c3ca069bcbfce00871d612b8#diff-f0c4ea89199a6d5d1ede2bfd90cd89b8, jruby has differed from cruby in that ENV['RUBY'] overrides the value from (cruby) Gem.ruby.

We recently updated to jruby-9.2.0.0 in our test environments while testing our Java 10 compatibility. For some unknown reason, the environmental variable RUBY was set for all users in our server, which led to some confusion when using Gem.ruby in our application to check whether we were actually running JRuby, since it pointed to either the old Java launcher version or a non-existing ruby binary. I couldn't find ENV['RUBY'] being used outside of testing, so overriding (cruby) Gem.ruby with it no matter if it's a sensical value or not doesn't seem smart. I couldn't figure out some good way of overriding it for testing only, but I assume a decent compromise would be to only override if the value actually points to an existing file. Another option would be to drop the use of ENV['RUBY'] in the Java side, since all cruby libraries that use it seem to have some kind of EnvUtil (e.g. https://github.com/jruby/jruby/blob/master/test/mri/lib/envutil.rb#L17) already.  