### PR TITLE
Realign timeout with MRI.

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1730,7 +1730,6 @@ public final class Ruby implements Constantizable {
         addLazyBuiltin("bigdecimal.jar", "bigdecimal", "org.jruby.ext.bigdecimal.BigDecimalLibrary");
         addLazyBuiltin("io/wait.jar", "io/wait", "org.jruby.ext.io.wait.IOWaitLibrary");
         addLazyBuiltin("etc.jar", "etc", "org.jruby.ext.etc.EtcLibrary");
-        addLazyBuiltin("timeout.rb", "timeout", "org.jruby.ext.timeout.Timeout");
         addLazyBuiltin("socket.jar", "socket", "org.jruby.ext.socket.SocketLibrary");
         addLazyBuiltin("rbconfig.rb", "rbconfig", "org.jruby.ext.rbconfig.RbConfigLibrary");
         addLazyBuiltin("jruby/serialization.rb", "serialization", "org.jruby.ext.jruby.JRubySerializationLibrary");

--- a/core/src/main/java/org/jruby/ext/timeout/Timeout.java
+++ b/core/src/main/java/org/jruby/ext/timeout/Timeout.java
@@ -26,91 +26,40 @@
 
 package org.jruby.ext.timeout;
 
-import java.io.IOException;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyException;
-import org.jruby.RubyFixnum;
 import org.jruby.RubyKernel;
 import org.jruby.RubyModule;
 import org.jruby.RubyObject;
-import org.jruby.RubyRegexp;
 import org.jruby.RubyString;
 import org.jruby.RubyThread;
 import org.jruby.RubyTime;
 import org.jruby.anno.JRubyMethod;
-import org.jruby.common.IRubyWarnings;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.Block;
-import org.jruby.runtime.JavaSites;
 import org.jruby.runtime.ThreadContext;
-import static org.jruby.runtime.Visibility.*;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.runtime.load.Library;
 import org.jruby.threading.DaemonThreadFactory;
-import org.jruby.util.RegexpOptions;
 
-public class Timeout implements Library {
-    public void load(Ruby runtime, boolean wrap) throws IOException {
-        RubyModule timeout = runtime.defineModule("Timeout");
-        RubyClass RuntimeError = runtime.getRuntimeError();
-        RubyClass TimeoutError = runtime.defineClassUnder("Error", RuntimeError, RuntimeError.getAllocator(), timeout);
-        timeout.defineConstant("ExitException", TimeoutError);
+public class Timeout {
+    public static final String EXECUTOR_VARIABLE = "__executor__";
 
-        // Here we create an "anonymous" exception type used for unrolling the stack.
-        // MRI creates a new one for *every call* to timeout, which can be costly.
-        // We opt to use a single exception type for all cases to avoid this overhead.
-        RubyClass anonException = runtime.defineClassUnder("AnonymousException", runtime.getException(), runtime.getException().getAllocator(), timeout);
-        anonException.setBaseName(null); // clear basename so it's anonymous when raising
-
-        // These are not really used by timeout, but exposed for compatibility
-        timeout.defineConstant("THIS_FILE", RubyRegexp.newRegexp(runtime, "timeout\\.rb", new RegexpOptions()));
-        timeout.defineConstant("CALLER_OFFSET", RubyFixnum.newFixnum(runtime, 0));
-
+    public static void define(RubyModule timeout) {
         // Timeout module methods
         timeout.defineAnnotatedMethods(Timeout.class);
 
-        // Toplevel defines
-        runtime.getObject().defineConstant("TimeoutError", TimeoutError);
-        runtime.getObject().deprecateConstant(runtime, "TimeoutError");
-        runtime.getObject().defineAnnotatedMethods(TimeoutToplevel.class);
+        timeout.setInternalVariable(
+                EXECUTOR_VARIABLE,
+                new ScheduledThreadPoolExecutor(Runtime.getRuntime().availableProcessors(), new DaemonThreadFactory()));
     }
 
-    private static ScheduledExecutorService timeoutExecutor = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors(), new DaemonThreadFactory());
-
-    public static class TimeoutToplevel {
-        @JRubyMethod(visibility = PRIVATE)
-        public static IRubyObject timeout(ThreadContext context, IRubyObject self, IRubyObject seconds, Block block) {
-            warnToplevel(context);
-
-            return sites(context).timeout.call(context, self, context.runtime.getModule("Timeout"), seconds, block);
-        }
-
-        @JRubyMethod(visibility = PRIVATE)
-        public static IRubyObject timeout(ThreadContext context, IRubyObject self, IRubyObject seconds, IRubyObject exceptionType, Block block) {
-            warnToplevel(context);
-
-            return sites(context).timeout.call(context, self, context.runtime.getModule("Timeout"), seconds, exceptionType, block);
-        }
-        @JRubyMethod(visibility = PRIVATE)
-        public static IRubyObject timeout(ThreadContext context, IRubyObject self, IRubyObject seconds, IRubyObject exceptionType, IRubyObject message, Block block) {
-            warnToplevel(context);
-
-            return sites(context).timeout.call(context, self, context.runtime.getModule("Timeout"), seconds, exceptionType, message, block);
-        }
-
-        private static void warnToplevel(ThreadContext context) {
-            context.runtime.getWarnings().warn(IRubyWarnings.ID.DEPRECATED_METHOD, "Object#timeout is deprecated, use Timeout.timeout instead");
-        }
-    }
 
     @JRubyMethod(module = true)
     public static IRubyObject timeout(final ThreadContext context, IRubyObject recv, IRubyObject seconds, Block block) {
@@ -119,7 +68,7 @@ public class Timeout implements Library {
 
     @JRubyMethod(module = true)
     public static IRubyObject timeout(final ThreadContext context, IRubyObject recv, IRubyObject seconds, IRubyObject exceptionType, Block block) {
-        return timeout(context, recv, seconds, exceptionType, RubyString.newString(context.runtime, "execution expired"), block);
+        return timeout(context, recv, seconds, exceptionType, RubyString.newString(context.runtime, "execution expired").freeze(context), block);
     }
 
     @JRubyMethod(module = true)
@@ -140,12 +89,13 @@ public class Timeout implements Library {
                 TimeoutTask.newAnonymousTask(currentThread, timeout, latch, id, message.convertToString()) :
                 TimeoutTask.newTaskWithException(currentThread, timeout, latch, exceptionType, message.convertToString());
 
+        ScheduledThreadPoolExecutor executor = (ScheduledThreadPoolExecutor) timeout.getInternalVariables().getInternalVariable("__executor__");
+
         try {
-            return yieldWithTimeout(context, seconds, block, timeoutRunnable, latch);
-        }
-        catch (RaiseException re) {
+            return yieldWithTimeout(executor, context, seconds, block, timeoutRunnable, latch);
+        } catch (RaiseException re) {
             // if it's the exception we're expecting
-            if (re.getException().getMetaClass() == getAnonymousException(timeout)) {
+            if (re.getException().getMetaClass() == getDefaultException(timeout)) {
                 // and we were not given a specific exception
                 if ( exceptionType.isNil() ) {
                     raiseTimeoutErrorIfMatches(context, timeout, re, id);
@@ -161,18 +111,18 @@ public class Timeout implements Library {
         return seconds.isNil() || Helpers.invoke(context, seconds, "zero?").isTrue();
     }
 
-    private static IRubyObject yieldWithTimeout(ThreadContext context,
+    private static IRubyObject yieldWithTimeout(ScheduledThreadPoolExecutor executor, ThreadContext context,
         final IRubyObject seconds, final Block block,
         final Runnable runnable, final AtomicBoolean latch) throws RaiseException {
 
         final long micros = (long) ( RubyTime.convertTimeInterval(context, seconds) * 1000000 );
         Future timeoutFuture = null;
         try {
-            timeoutFuture = timeoutExecutor.schedule(runnable, micros, TimeUnit.MICROSECONDS);
+            timeoutFuture = executor.schedule(runnable, micros, TimeUnit.MICROSECONDS);
             return block.yield(context, seconds);
         }
         finally {
-            if ( timeoutFuture != null ) killTimeoutThread(context, timeoutFuture, latch);
+            if ( timeoutFuture != null ) killTimeoutThread(executor, context, timeoutFuture, latch);
             // ... when timeoutFuture == null there's likely an error thrown from schedule
         }
     }
@@ -211,32 +161,31 @@ public class Timeout implements Library {
             if ( latch.compareAndSet(false, true) ) {
                 if ( exception == null ) {
                     raiseAnonymous();
-                }
-                else {
+                } else {
                     raiseException();
                 }
             }
         }
 
         private void raiseAnonymous() {
-            final Ruby runtime = timeout.getRuntime();
-            IRubyObject anonException = getAnonymousException(timeout).newInstance(runtime.getCurrentContext(), message, Block.NULL_BLOCK);
+            // TODO: MRI calls Timeout::Error.catch here with the body of the timeout; we use __identifier__.
+            IRubyObject anonException =
+                    getDefaultException(timeout).newInstance(timeout.getRuntime().getCurrentContext(), message, Block.NULL_BLOCK);
             anonException.getInternalVariables().setInternalVariable("__identifier__", id);
             currentThread.raise(anonException);
         }
 
         private void raiseException() {
-            final Ruby runtime = timeout.getRuntime();
             currentThread.raise(exception, message);
         }
 
     }
 
-    private static void killTimeoutThread(ThreadContext context, final Future timeoutFuture, final AtomicBoolean latch) {
+    private static void killTimeoutThread(ScheduledThreadPoolExecutor executor, ThreadContext context, final Future timeoutFuture, final AtomicBoolean latch) {
         if (latch.compareAndSet(false, true) && timeoutFuture.cancel(false)) {
             // ok, exception will not fire
-            if (timeoutExecutor instanceof ScheduledThreadPoolExecutor && timeoutFuture instanceof Runnable) {
-                ((ScheduledThreadPoolExecutor) timeoutExecutor).remove((Runnable) timeoutFuture);
+            if (timeoutFuture instanceof Runnable) {
+                executor.remove((Runnable) timeoutFuture);
             }
         } else {
             // future is not cancellable, wait for it to run and then poll
@@ -250,22 +199,10 @@ public class Timeout implements Library {
         }
     }
 
-    private static IRubyObject raiseBecauseCritical(ThreadContext context) {
-        Ruby runtime = context.runtime;
-
-        return RubyKernel.raise(
-                context,
-                runtime.getKernel(),
-                new IRubyObject[] {
-                    runtime.getThreadError(),
-                    runtime.newString("timeout within critical section")
-                },
-                Block.NULL_BLOCK);
-    }
-
     private static IRubyObject raiseTimeoutErrorIfMatches(ThreadContext context,
         final IRubyObject timeout, final RaiseException ex, final IRubyObject id) {
-        // check if it's the exception intended for us (@see prepareRunnable):
+
+        // check if it's the exception intended for us
         if ( ex.getException().getInternalVariable("__identifier__") == id ) {
             final RubyException rubyException = ex.getException();
 
@@ -282,17 +219,11 @@ public class Timeout implements Library {
         return null;
     }
 
-    // Timeout::AnonymousException (@see above)
-    private static RubyClass getAnonymousException(final IRubyObject timeout) {
-        return getClassFrom(timeout, "AnonymousException");
+    private static RubyClass getDefaultException(final IRubyObject timeout) {
+        return getClassFrom(timeout, "Error");
     }
 
     private static RubyClass getClassFrom(final IRubyObject timeout, final String name) {
         return ((RubyModule) timeout).getClass(name); // Timeout::[name]
     }
-
-    private static JavaSites.TimeoutSites sites(ThreadContext context) {
-        return context.sites.Timeout;
-    }
-
 }

--- a/core/src/main/java/org/jruby/runtime/JavaSites.java
+++ b/core/src/main/java/org/jruby/runtime/JavaSites.java
@@ -42,7 +42,6 @@ public class JavaSites {
     public final RangeSites Range = new RangeSites();
     public final WarningSites Warning = new WarningSites();
     public final ZlibSites Zlib = new ZlibSites();
-    public final TimeoutSites Timeout = new TimeoutSites();
     public final ArgfSites Argf = new ArgfSites();
     public final TracePointSites TracePoint = new TracePointSites();
     public final MarshalSites Marshal = new MarshalSites();
@@ -441,10 +440,6 @@ public class JavaSites {
     public static class ZlibSites {
         public final RespondToCallSite reader_respond_to = new RespondToCallSite();
         public final RespondToCallSite writer_respond_to = new RespondToCallSite();
-    }
-
-    public static class TimeoutSites {
-        public final CallSite timeout = new FunctionalCachingCallSite("timeout");
     }
 
     public static class ArgfSites {

--- a/lib/ruby/stdlib/timeout.rb
+++ b/lib/ruby/stdlib/timeout.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: false
+# Timeout long-running blocks
+#
+# == Synopsis
+#
+#   require 'timeout'
+#   status = Timeout::timeout(5) {
+#     # Something that should be interrupted if it takes more than 5 seconds...
+#   }
+#
+# == Description
+#
+# Timeout provides a way to auto-terminate a potentially long-running
+# operation if it hasn't finished in a fixed amount of time.
+#
+# Previous versions didn't use a module for namespacing, however
+# #timeout is provided for backwards compatibility.  You
+# should prefer Timeout.timeout instead.
+#
+# == Copyright
+#
+# Copyright:: (C) 2000  Network Applied Communication Laboratory, Inc.
+# Copyright:: (C) 2000  Information-technology Promotion Agency, Japan
+
+module Timeout
+  # Raised by Timeout.timeout when the block times out.
+  class Error < RuntimeError
+    attr_reader :thread
+
+    def self.catch(*args)
+      exc = new(*args)
+      exc.instance_variable_set(:@thread, Thread.current)
+      ::Kernel.catch(exc) {yield exc}
+    end
+
+    def exception(*)
+      # TODO: use Fiber.current to see if self can be thrown
+      if self.thread == Thread.current
+        bt = caller
+        begin
+          throw(self, bt)
+        rescue UncaughtThrowError
+        end
+      end
+      self
+    end
+  end
+
+  # :stopdoc:
+  THIS_FILE = /\A#{Regexp.quote(__FILE__)}:/o
+  CALLER_OFFSET = ((c = caller[0]) && THIS_FILE =~ c) ? 1 : 0
+  private_constant :THIS_FILE, :CALLER_OFFSET
+  # :startdoc:
+
+  # Load executor-based timeout logic into module
+  org.jruby.ext.timeout.Timeout.define(self)
+end
+
+def timeout(*args, &block)
+  warn "Object##{__method__} is deprecated, use Timeout.timeout instead.", uplevel: 1
+  Timeout.timeout(*args, &block)
+end
+
+# Another name for Timeout::Error, defined for backwards compatibility with
+# earlier versions of timeout.rb.
+TimeoutError = Timeout::Error
+class Object
+  deprecate_constant :TimeoutError
+end

--- a/test/jruby/test_timeout.rb
+++ b/test/jruby/test_timeout.rb
@@ -115,43 +115,6 @@ class TestTimeout < Test::Unit::TestCase
     assert cls.new.timeout, "timeout should have returned 42"
   end
 
-  # GH-312: Nested timeouts trigger inner for outer's timeout
-  def test_nested_timeout
-    result = []
-    expected = [
-      'Timeout 2: Non-timeout exception',
-      'Timeout 2: ensure',
-      'Timeout 1: triggered',
-      'Timeout 1: ensure'
-    ]
-
-    begin
-      Timeout.timeout(1) do
-	begin
-	  Timeout.timeout(2) do
-	    sleep(5)
-	  end
-	rescue Timeout::Error
-	  result << 'Timeout 2: triggered'
-          raise
-        rescue Exception
-          result << 'Timeout 2: Non-timeout exception'
-          raise
-	ensure
-	  result << 'Timeout 2: ensure'
-	end
-      end
-    rescue Timeout::Error
-      result << 'Timeout 1: triggered'
-    rescue Exception
-      result << 'Timeout 1: Non-timeout exception'
-    ensure
-      result << 'Timeout 1: ensure'
-    end
-
-    assert_equal expected, result
-  end
-
   class Seconds
 
     attr_reader :value

--- a/test/jruby/test_timeout.rb
+++ b/test/jruby/test_timeout.rb
@@ -112,7 +112,7 @@ class TestTimeout < Test::Unit::TestCase
         end
       end
     end
-    assert cls.new.timeout, "timeout should have returned 42"
+    assert cls.new.timeout(0), "timeout should have returned 42"
   end
 
   class Seconds


### PR DESCRIPTION
Fixes #3834.

* Use Timeout::Error instead of leaky anonymous exception.
* Move executor to instance data from static.
* Clean up redundant, outdated code.
* Move sharable pieces back into timeout.rb.
* Eliminate builtin and load ext from timeout.rb.