### PR TITLE
Use JDK atomic move to more closely emulate POSIX rename.

### DIFF
--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -1104,15 +1104,11 @@ public class RubyFile extends RubyIO implements EncodingCapable {
             newFile.delete();
         }
 
-        // Check if source file and dest parent are on same filesystem or raise EXDEV
+        // Try atomic move from JDK
         Path oldPath = Paths.get(oldFile.toURI());
         Path destPath = Paths.get(dest.getAbsolutePath());
         try {
-            FileStore oldStore = Files.getFileStore(oldPath);
-            FileStore destStore = Files.getFileStore(destPath.getParent());
-            if (!oldStore.equals(destStore)) {
-                throw runtime.newErrnoEXDEVError("(" + oldFile + ", " + dest + ")");
-            }
+            Files.move(oldPath, destPath, StandardCopyOption.ATOMIC_MOVE);
         } catch (IOException ioe) {
             throw Helpers.newIOErrorFromException(runtime, ioe);
         }


### PR DESCRIPTION
Fixes #5318.

Note that this no longer does the explicit file store check,
because that failed in an unrelated way when running under a
FreeBSD jail. Instead this now relies on the Files subsystem of
JDK to percolate out the original error message, which we should
detect properly and turn into EXDEV.