### PR TITLE
Fix toplevel method visibility in jit/fullint script scopes.

### DIFF
--- a/core/src/main/java/org/jruby/ir/instructions/PushMethodFrameInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/PushMethodFrameInstr.java
@@ -6,18 +6,25 @@ import org.jruby.ir.Operation;
 import org.jruby.ir.persistence.IRReaderDecoder;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.ir.transformations.inlining.SimpleCloneInfo;
+import org.jruby.runtime.Visibility;
 
 public class PushMethodFrameInstr extends NoOperandInstr implements FixedArityInstr {
     private final RubySymbol frameName;
+    private final Visibility visibility;
     
-    public PushMethodFrameInstr(RubySymbol frameName) {
+    public PushMethodFrameInstr(RubySymbol frameName, Visibility visibility) {
         super(Operation.PUSH_METHOD_FRAME);
 
         this.frameName = frameName;
+        this.visibility = visibility;
     }
 
     public RubySymbol getFrameName() {
         return frameName;
+    }
+
+    public Visibility getVisibility() {
+        return visibility;
     }
 
     @Override
@@ -26,7 +33,7 @@ public class PushMethodFrameInstr extends NoOperandInstr implements FixedArityIn
     }
 
     public static PushMethodFrameInstr decode(IRReaderDecoder d) {
-        return new PushMethodFrameInstr(d.decodeSymbol());
+        return new PushMethodFrameInstr(d.decodeSymbol(), Visibility.values()[d.decodeByte()]);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
@@ -16,6 +16,7 @@ import org.jruby.ir.instructions.LineNumberInstr;
 import org.jruby.ir.instructions.NonlocalReturnInstr;
 import org.jruby.ir.instructions.PopBlockFrameInstr;
 import org.jruby.ir.instructions.PushBlockFrameInstr;
+import org.jruby.ir.instructions.PushMethodFrameInstr;
 import org.jruby.ir.instructions.ReceiveArgBase;
 import org.jruby.ir.instructions.ReceivePostReqdArgInstr;
 import org.jruby.ir.instructions.ReceivePreReqdArgInstr;
@@ -383,10 +384,7 @@ public class InterpreterEngine {
                 break;
             case PUSH_METHOD_FRAME:
                 context.preMethodFrameOnly(implClass, name, self, blockArg);
-                // Only the top-level script scope has PRIVATE visibility.
-                // This is already handled as part of Interpreter.execute above.
-                // Everything else is PUBLIC by default.
-                context.setCurrentVisibility(Visibility.PUBLIC);
+                context.setCurrentVisibility(((PushMethodFrameInstr) instr).getVisibility());
                 break;
             case PUSH_BACKREF_FRAME:
                 context.preBackrefMethod();

--- a/core/src/main/java/org/jruby/ir/passes/AddCallProtocolInstructions.java
+++ b/core/src/main/java/org/jruby/ir/passes/AddCallProtocolInstructions.java
@@ -11,6 +11,7 @@ import org.jruby.ir.operands.TemporaryVariable;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.representations.BasicBlock;
 import org.jruby.ir.representations.CFG;
+import org.jruby.runtime.Visibility;
 
 import java.util.ListIterator;
 
@@ -135,7 +136,9 @@ public class AddCallProtocolInstructions extends CompilerPass {
                     if (scope.needsOnlyBackref()) {
                         entryBB.addInstr(new PushBackrefFrameInstr());
                     } else {
-                        entryBB.addInstr(new PushMethodFrameInstr(scope.getName()));
+                        entryBB.addInstr(new PushMethodFrameInstr(
+                                scope.getName(),
+                                scope.isScriptScope() ? Visibility.PRIVATE : Visibility.PUBLIC));
                     }
                 }
                 if (requireBinding) entryBB.addInstr(new PushMethodBindingInstr());

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -1770,7 +1770,7 @@ public class JVMVisitor extends IRVisitor {
         // FIXME: this should be part of explicit call protocol only when needed, optimizable, and correct for the scope
         // See also CompiledIRMethod.call
         jvmMethod().loadContext();
-        jvmAdapter().getstatic(p(Visibility.class), "PUBLIC", ci(Visibility.class));
+        jvmAdapter().getstatic(p(Visibility.class), pushframeinstr.getVisibility().name(), ci(Visibility.class));
         jvmAdapter().invokevirtual(p(ThreadContext.class), "setCurrentVisibility", sig(void.class, Visibility.class));
     }
 


### PR DESCRIPTION
Toplevel scopes were only getting defaulted to private visibility
for the startup interpreter, which does not ever use in-IR call
protocol. When the toplevel script body is first optimized to
fullint or compiled to bytecode, call protocol is installed with
no external preamble code to set visibility to private, so the
visibility was defaulting back to public as in non-script scopes.
This change adds visibility to the frame push instruction, so top-
level scripts will use private in their frame push.

This fixes regression in test:jruby:aot test_timeout.rb toplevel
timeout test, which relied on the non-self call to timeout to see
the toplevel private method and trigger method_missing. This began
to fail with my timeout update because the method is now defined
in Ruby code rather than manually in Java code (the latter of
which explicitly set private visibility).