### PR TITLE
Fix #5357

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -1088,6 +1088,7 @@ public class IRBuilder {
                 (argsAry = (ArrayNode) callNode.getArgsNode()).size() == 1 &&
                 argsAry.get(0) instanceof StrNode &&
                 !scope.maybeUsingRefinements() &&
+                receiverNode instanceof HashNode &&
                 callNode.getIterNode() == null) {
             StrNode keyNode = (StrNode) argsAry.get(0);
             addInstr(ArrayDerefInstr.create(scope, result, receiver, new FrozenString(keyNode.getValue(), keyNode.getCodeRange(), scope.getFileName(), keyNode.getLine())));

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -2000,7 +2000,7 @@ public class IRRuntimeHelpers {
             return ((RubyHash) target).op_aref(context, keyStr);
         }
 
-        return site.call(context, caller, target, keyStr);
+        return site.call(context, caller, target, keyStr.strDup(context.runtime));
     }
 
     public static DynamicMethod getRefinedMethodForClass(StaticScope refinedScope, RubyModule target, String methodId) {


### PR DESCRIPTION
https://github.com/jruby/jruby/pull/5357 introduced a bug

```proc {|a| a }["sometext"].frozen?```
without `# frozen_string_literal: true` it should return false

on the other hand hashes are frozen by default
```{"sometext": ''}["sometext"]``` = always frozen

spec
https://github.com/ruby/spec/pull/627