### PR TITLE
improve rational performance

### DIFF
--- a/core/src/main/java/org/jruby/RubyNil.java
+++ b/core/src/main/java/org/jruby/RubyNil.java
@@ -238,7 +238,7 @@ public class RubyNil extends RubyObject implements Constantizable {
      */
     @JRubyMethod
     public static IRubyObject to_r(ThreadContext context, IRubyObject recv) {
-        return RubyRational.newRationalCanonicalize(context, RubyFixnum.zero(context.runtime));
+        return RubyRational.newRationalCanonicalize(context, 0);
     }
 
     /** nilclass_rationalize


### PR DESCRIPTION
this patch reduces allocations and performance by specializing #canonicalizeInternal for long arguments

i took https://github.com/jruby/jruby/pull/5364 as a baseline
```
         Time#subsec      6.295M (±17.4%) i/s -     28.872M in   4.986291s
            nil#to_r     16.621M (±10.2%) i/s -     81.430M in   4.989624s
           Time#to_r      6.258M (±10.3%) i/s -     30.531M in   4.993177s
          Date#parse    218.346k (± 4.2%) i/s -      1.098M in   5.040803s
```

patch
```
         Time#subsec      6.922M (±18.0%) i/s -     31.771M in   4.983271s
            nil#to_r     21.401M (±15.0%) i/s -    102.020M in   4.986780s
           Time#to_r      7.347M (± 6.8%) i/s -     36.455M in   4.992077s
          Date#parse    230.798k (± 3.7%) i/s -      1.154M in   5.005673s
```

benchmark
```ruby
require 'benchmark/ips'
require 'date'

Benchmark.ips do |x|
  x.report "Time#subsec" do |t|
    time = Time.now
    t.times { time.subsec }
  end

  x.report "nil#to_r" do |t|
    t.times { nil.to_r }
  end

  x.report "Time#to_r" do |t|
    time = Time.now
    t.times { time.to_r }
  end

  x.report "Date#parse" do |t|
    date = '2018-07-17'
    t.times { Date.parse(date, false) }
  end
end
```