### PR TITLE
enable Integer#sqrt

### DIFF
--- a/core/src/main/java/org/jruby/RubyFixnum.java
+++ b/core/src/main/java/org/jruby/RubyFixnum.java
@@ -1452,8 +1452,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
         }
 
         long n = value;
-        // FIXME: this is obviously not super efficient, but floorSqrt(long) did not pass tests
-        long sq = floorSqrt(BigInteger.valueOf(n)).longValue();
+        long sq = floorSqrt(n);
         
         return RubyFixnum.newFixnum(runtime, sq);
     }

--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -150,13 +150,13 @@ public abstract class RubyInteger extends RubyNumeric {
 
     public abstract IRubyObject sqrt(ThreadContext context);
 
-    // floorSqrt :: unsigned long -> unsigned int
+    // floorSqrt :: unsigned long -> unsigned long
     // Gives the exact floor of the square root of x, treated as unsigned.
     // Public domain code from http://www.codecodex.com/wiki/Calculate_an_integer_square_root
-    public static final int floorSqrt(final long x) {
-        if ((x & 0xfff0000000000000L) == 0L) return (int) StrictMath.sqrt(x);
-        final long result = (long) StrictMath.sqrt(2.0d*(x >>> 1));
-        return result*result - x > 0L ? (int) result - 1 : (int) result;
+    public static final long floorSqrt(final long x) {
+        if ((x & 0xfff0000000000000L) == 0L) return (long) StrictMath.sqrt(x);
+        final long result = (long) StrictMath.sqrt(2.0d*(x >>> 1));  
+        return result*result - x > 0L ? (long) result - 1 : (long) result;
     }
 
     // floorSqrt :: BigInteger -> BigInteger


### PR DESCRIPTION
```ruby
require 'benchmark/ips'

def sqrt
  1000.times do |num|
    Integer.sqrt(num)
  end
end

Benchmark.ips do |x|
  x.report('sqrt') { sqrt }
end
```

master
```
 sqrt      9.153k (±20.4%) i/s -     42.000k in   5.027226s
```
patch
```
 sqrt     16.244k (±14.2%) i/s -     79.422k in   5.063626s
```