### PR TITLE
Make subtract and addition operators work with DateTime objects

### DIFF
--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -1162,15 +1162,15 @@ public class RubyDate extends RubyObject {
         //   sub_millis -= 1
         //   ms += 1
         // end
-        RubyNumeric val = (RubyNumeric) RubyFixnum.newFixnum(runtime, DAY_MS).op_mul(context, n);
+        RubyNumeric val = (RubyNumeric) RubyFixnum.newFixnum(runtime, DAY_MS).op_mul(context, n).convertToFloat().round(context, RubyFixnum.newFixnum(context.runtime, 10));
 
         RubyArray res = (RubyArray) val.divmod(context, RubyFixnum.one(context.runtime));
         long ms = ((RubyInteger) res.eltInternal(0)).getLongValue();
         RubyNumeric sub = (RubyNumeric) res.eltInternal(1);
         //if ( sub.isZero() ) sub = RubyFixnum.zero(runtime); // avoid Rational(0, 1)
         RubyNumeric sub_millis = (RubyNumeric) subMillis(context.runtime).op_plus(context, sub);
-        int subNum = sub_millis.numerator(context).convertToInteger().getIntValue();
-        int subDen = sub_millis.denominator(context).convertToInteger().getIntValue();
+        long subNum = sub_millis.numerator(context).convertToInteger().getLongValue();
+        long subDen = sub_millis.denominator(context).convertToInteger().getLongValue();
         if (subNum / subDen >= 1) { // sub_millis >= 1
             subNum -= subDen; ms += 1; // sub_millis -= 1
         }

--- a/spec/ruby/library/datetime/add_spec.rb
+++ b/spec/ruby/library/datetime/add_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "DateTime#+" do
+  it "is able to add sub-millisecond precision values" do
+    datetime = DateTime.new(2017)
+    (datetime + 0.00001).to_time.usec.should == 864000
+  end
+end

--- a/spec/ruby/library/datetime/subtract_spec.rb
+++ b/spec/ruby/library/datetime/subtract_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../spec_helper'
+require 'date'
+
+describe "DateTime#-" do
+  it "is able to subtract sub-millisecond precision values" do
+    date = DateTime.new(2017)
+    ((date + 0.00001) - date).should == Rational(1, 100000)
+  end
+end


### PR DESCRIPTION
We recently discovered a few nasty bugs that affect DateTime calculations when the precision of time is high enough. 

As a practical example, when subtracting values produced by `DateTime.current` (via Active Support), you'll get weird results. e.g.:

```irb
[4] pry(main)> DateTime.current - DateTime.current
17841599/43200000
[5] pry(main)> DateTime.current - DateTime.current
-609/1000
```

I traced the problem down to `RubyDate#op_plus_numeric`, where value multiplication produce incorrect results seemingly due to floating point inaccuracy. I was able to "fix" the problem using round, but obviously that is not really elegant solution (maybe it should use BigDecimal under the hood or something?).

While I was working with this bug, I also discovered another bug, which turned out to be related: namely when adding sub-millisecond precision value to `DateTime` object, JRuby interpreter threw an error.

Both of the bugs are reproducible using provided specs.