### PR TITLE
[#5287] Use epoll selector for file IO on macosx

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -157,7 +157,7 @@ If you are familiar with Java debuggers, you can attach one to a JRuby process u
 The exact flag may vary with debugger and platform:
 
 ```
-bin/jruby -T-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005 <rest of arguments>
+JRUBY_OPTS="-J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:5005" bin/jruby <rest of arguments>
 ```
 #### JRuby internal unit tests
 

--- a/core/pom.rb
+++ b/core/pom.rb
@@ -41,7 +41,7 @@ project 'JRuby Core' do
 
   # exclude jnr-ffi to avoid problems with shading and relocation of the asm packages
   jar 'com.github.jnr:jnr-netdb:1.1.6', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-enxio:0.18', :exclusions => ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-enxio:0.19', :exclusions => ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-unixsocket:0.20', :exclusions => ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-posix:3.0.45', :exclusions => ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-constants:0.9.11', :exclusions => ['com.github.jnr:jnr-ffi']

--- a/core/src/main/java/org/jruby/util/RegularFileResource.java
+++ b/core/src/main/java/org/jruby/util/RegularFileResource.java
@@ -205,7 +205,7 @@ class RegularFileResource implements FileResource {
             int fd = posix.open(absolutePath(), modeFlags.getFlags(), perm);
             if (fd < 0) throwFromErrno(posix.errno());
             posix.fcntlInt(fd, Fcntl.F_SETFD, posix.fcntl(fd, Fcntl.F_GETFD) | FcntlLibrary.FD_CLOEXEC);
-            return new NativeDeviceChannel(fd);
+            return new NativeDeviceChannel(fd, true);
         }
 
         if (modeFlags.isCreate()) {

--- a/core/src/test/java/org/jruby/runtime/io/RubyIOTest.java
+++ b/core/src/test/java/org/jruby/runtime/io/RubyIOTest.java
@@ -1,0 +1,57 @@
+package org.jruby.runtime.io;
+
+import org.jruby.embed.EvalFailedException;
+import org.jruby.embed.ScriptingContainer;
+import org.jruby.exceptions.EOFError;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.util.Random;
+import java.util.UUID;
+
+public class RubyIOTest {
+    private static final String SCRIPT = "read_file.rb";
+
+    private File file;
+
+    @Before
+    public void createFile() throws IOException {
+        file = generateTempFile();
+    }
+
+    @After
+    public void deleteFile() {
+        file.delete();
+    }
+
+    @Test(expected = EOFError.class)
+    public void sysread() throws Throwable {
+        ScriptingContainer scriptingContainer = new ScriptingContainer();
+        scriptingContainer.setArgv(new String[] { file.getAbsolutePath() });
+
+        InputStream inputStream = getClass().getResourceAsStream(SCRIPT);
+        try {
+            scriptingContainer.runScriptlet(inputStream, SCRIPT);
+        } catch (EvalFailedException efe) {
+            throw efe.getCause();
+        }
+    }
+
+    private File generateTempFile() throws IOException {
+        File file = File.createTempFile(UUID.randomUUID().toString(), null);
+        PrintWriter printWriter = new PrintWriter(new FileWriter(file));
+        int max = new Random().nextInt(100);
+        for (int i = 0; i < max; i++) {
+            printWriter.println(UUID.randomUUID().toString());
+        }
+        printWriter.close();
+        return file;
+    }
+}

--- a/core/src/test/resources/org/jruby/runtime/io/read_file.rb
+++ b/core/src/test/resources/org/jruby/runtime/io/read_file.rb
@@ -1,0 +1,6 @@
+open(ARGV[0]) do |f|
+  loop do
+    x = f.sysread(1024)
+    puts "read #{x.length}"
+  end
+end


### PR DESCRIPTION
This PR addresses https://github.com/jruby/jruby/issues/5287.

Without it, unit test gets stuck on the select call. See [Thread dump](https://gist.github.com/alexis779/b2eae94b3a90f9758e58499dbfeebf2f).

It needs https://github.com/jnr/jnr-enxio/pull/29 feature to avoid `KQSelector` and fallback on `EpollSelector`. We pass `isFile=true` in `NativeDeviceChannel` constructor in the case of a file. This avoids getting stuck on macosx when calling kevent system call at the end of the file.

kqueue does not support EOF. There is no easy way to skip select call to avoid blocking for ever.

We still want to use KQSelector for sockets. Just not vnodes.