### PR TITLE
Struct#values should return an array which is independent of the struct

### DIFF
--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -603,7 +603,7 @@ public class RubyStruct extends RubyObject {
     @JRubyMethod(name = {"to_a", "values"})
     @Override
     public RubyArray to_a() {
-        return RubyArray.newArrayMayCopy(getRuntime(), values);
+        return getRuntime().newArray(values);
     }
 
     @JRubyMethod


### PR DESCRIPTION
Struct#to_a and Struct#values should return an Array which is independent to the Struct. So subsequent modifications to the struct should not be visible in a previously retrieved values array. In MRI a new Array is created at each call to #values or #to_a.

Fixes https://github.com/jruby/jruby/issues/5372.