### PR TITLE
Always use full logic for processing glob segments.

### DIFF
--- a/core/src/main/java/org/jruby/util/Dir.java
+++ b/core/src/main/java/org/jruby/util/Dir.java
@@ -579,9 +579,15 @@ public class Dir {
 
                 continue;
             case '\\':
-                if (escape && i == end) return false;
+                // We treat backslash as a magic character, since otherwise logic in glob_helper does not unescape.
+                // See jruby/jruby#5333 for more details.
 
-                break;
+//                if (escape && i == end) return false;
+//                break;
+
+                if (escape) return true; // force magic logic whenever there's escaped chars
+
+                continue;
             default:
                 if (FNM_SYSCASE == 0 && nocase && Character.isLetter((char)(bytes[i] & 0xFF))) return true;
             }
@@ -731,8 +737,7 @@ public class Dir {
             if ( path[ptr] == '/' ) ptr++;
 
             final int SLASH_INDEX = indexOf(path, ptr, end, (byte) '/');
-            if ( true || // disable this magic check, since the else branch is missing unescape logic
-                    has_magic(path, ptr, SLASH_INDEX == -1 ? end : SLASH_INDEX, flags) ) {
+            if (has_magic(path, ptr, SLASH_INDEX == -1 ? end : SLASH_INDEX, flags) ) {
                 finalize: do {
                     byte[] base = extract_path(path, begin, ptr);
                     byte[] dir = begin == ptr ? new byte[] { '.' } : base;

--- a/core/src/main/java/org/jruby/util/Dir.java
+++ b/core/src/main/java/org/jruby/util/Dir.java
@@ -731,7 +731,8 @@ public class Dir {
             if ( path[ptr] == '/' ) ptr++;
 
             final int SLASH_INDEX = indexOf(path, ptr, end, (byte) '/');
-            if ( has_magic(path, ptr, SLASH_INDEX == -1 ? end : SLASH_INDEX, flags) ) {
+            if ( true || // disable this magic check, since the else branch is missing unescape logic
+                    has_magic(path, ptr, SLASH_INDEX == -1 ? end : SLASH_INDEX, flags) ) {
                 finalize: do {
                     byte[] base = extract_path(path, begin, ptr);
                     byte[] dir = begin == ptr ? new byte[] { '.' } : base;


### PR DESCRIPTION
This is a workaround for issues found in #5333. I discovered while
researching a fix for that bug that our `glob_helper` appears to
be missing "else" logic for the segment processing that handles
magic characters and unescaping. Put simply, if there's no magic
in the segment it leaves it entirely unprocessed, allowing its
contents to just get rolled into the next segment loop (which may
or may not also have magic). However this leaves escapes in place.

This "fix" basically just omits the magic check for each segment
and allows full processing.