### PR TITLE
Create new pgroup when spawning process in chdir

### DIFF
--- a/core/src/main/java/org/jruby/util/io/PopenExecutor.java
+++ b/core/src/main/java/org/jruby/util/io/PopenExecutor.java
@@ -111,6 +111,10 @@ public class PopenExecutor {
             prog = (RubyString)prog.strDup(runtime).prepend(context, RubyString.newString(runtime, "cd '" + eargp.chdir_dir + "'; "));
             eargp.chdir_dir = null;
             eargp.chdir_given_clear();
+
+            // create new pgroup to prevent orphaned processes when the parent is killed
+            eargp.attributes.add(SpawnAttribute.pgroup(0));
+            eargp.attributes.add(SpawnAttribute.flags((short)SpawnAttribute.SETPGROUP));
         }
 
         if (execargRunOptions(context, runtime, eargp, sarg, errmsg) < 0) {

--- a/spec/ruby/core/process/spawn_spec.rb
+++ b/spec/ruby/core/process/spawn_spec.rb
@@ -391,6 +391,39 @@ describe "Process.spawn" do
     end
   end
 
+  # chdir
+
+  platform_is_not :windows do
+    context "chdir" do
+      def child_pids(pid)
+        `pgrep -P #{pid}`.each_line.map { |p| p.strip.to_i }
+      end
+
+      it "does not create extra process without chdir" do
+        child_pids(Process.spawn("cat")).size.should == 0
+      end
+
+      it "kills extra chdir processes" do
+        pid = Dir.chdir("/tmp") { Process.spawn("cat") }
+
+        children = child_pids(pid)
+        children.size.should == 1
+
+        Process.kill("TERM", pid)
+        Process.wait(pid, Process::WNOHANG)
+
+        # wait a bit for children to die
+        sleep(1)
+
+        children.each do |child|
+          lambda do
+            Process.kill("TERM", child)
+          end.should raise_error(Errno::ESRCH)
+        end
+      end
+    end
+  end
+
   # :umask
 
   it "uses the current umask by default" do


### PR DESCRIPTION
`Process.spawn` is leaving orphaned processes when run inside
`Dir.chdir`:

```ruby
>> JRUBY_VERSION
=> "9.2.0.0"
>> Dir.chdir('/tmp') { Process.spawn('cat') }
=> 88255
```

```bash
$ ps xao pid,ppid,pgid,comm | grep -E ' (cat|sh)'
88255 88092 88092 sh
88256 88255 88092 cat
```

```ruby
>> Process.kill('TERM', 88255)
=> 1
```

```bash
$ ps xao pid,ppid,pgid,comm | grep -E ' (cat|sh)'
88256     1 88092 cat
```

I believe the issue is that adding the `cd` command (for chdir) causes a
second process to start. That process is grouped with the main java one
and doesn't die when its parent (`sh`) is killed.

This change creates a new process group for the `sh` command, which
causes the child process to die when the parent is killed.

I ran into this issue using Foreman to manage some JRuby processes.