### PR TITLE
Revert updated jruby-readline

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -30,7 +30,7 @@ default_gems = [
     ImportedGem.new('fileutils', '1.1.0'),
     ImportedGem.new('ipaddr', '1.2.0'),
     ImportedGem.new('jar-dependencies', '${jar-dependencies.version}'),
-    ImportedGem.new('jruby-readline', '1.3.5'),
+    ImportedGem.new('jruby-readline', '1.2.2'),
     ImportedGem.new('jruby-openssl', '0.10.1'),
     ImportedGem.new('json', '${json.version}'),
     ImportedGem.new('psych', '3.0.3'),

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -99,7 +99,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>jruby-readline</artifactId>
-      <version>1.3.5</version>
+      <version>1.2.2</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -339,7 +339,7 @@ DO NOT MODIFIY - GENERATED CODE
           <exclude>gems/fileutils*1.1.0/*</exclude>
           <exclude>gems/ipaddr*1.2.0/*</exclude>
           <exclude>gems/jar-dependencies*${jar-dependencies.version}/*</exclude>
-          <exclude>gems/jruby-readline*1.3.5/*</exclude>
+          <exclude>gems/jruby-readline*1.2.2/*</exclude>
           <exclude>gems/jruby-openssl*0.10.1/*</exclude>
           <exclude>gems/json*${json.version}/*</exclude>
           <exclude>gems/psych*3.0.3/*</exclude>


### PR DESCRIPTION
This reverts commit e1d02a082998bed5b5167f0950dc3ef4281ad3a2, reversing
changes made to b43b9d86088e842ccb447e3068df425c3ff32590.

This reverts #5225.

The updated jruby-readline appears to be the cause of #5387 so I think we'll need to revert this for 9.2.1 and figure out what went wrong.