### PR TITLE
Update jffi to 1.2.18 for refreshed 32-bit ARM support.

### DIFF
--- a/pom.rb
+++ b/pom.rb
@@ -83,7 +83,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
               'jruby-launcher.version' => '1.1.6',
               'ant.version' => '1.9.8',
               'asm.version' => '6.2.1',
-              'jffi.version' => '1.2.17',
+              'jffi.version' => '1.2.18',
               'joda.time.version' => '2.9.9' )
 
   plugin_management do

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@ DO NOT MODIFIY - GENERATED CODE
     <its.j2ee>j2ee*/pom.xml</its.j2ee>
     <its.osgi>osgi*/pom.xml</its.osgi>
     <jar-dependencies.version>0.4.0</jar-dependencies.version>
-    <jffi.version>1.2.17</jffi.version>
+    <jffi.version>1.2.18</jffi.version>
     <joda.time.version>2.9.9</joda.time.version>
     <jruby-launcher.version>1.1.6</jruby-launcher.version>
     <jruby.basedir>${project.basedir}</jruby.basedir>


### PR DESCRIPTION
This pulls in the latest jffi, which has a new 32-bit ARM binary
rebuilt for hard-float EABI that appears to be typical on modern
ARM Linux distributions.

Fixes #5362.
Fixes #5192.

This will likely fail in travis until the jffi binary has propagated, so the build will need to be restarted.