### PR TITLE
Clear references to threads and thread contexts on teardown.

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -3370,8 +3370,6 @@ public final class Ruby implements Constantizable {
             }
         }
 
-        getThreadService().disposeCurrentThread();
-
         getBeanManager().unregisterCompiler();
         getBeanManager().unregisterConfig();
         getBeanManager().unregisterParserStats();
@@ -3387,6 +3385,8 @@ public final class Ruby implements Constantizable {
             ProfileCollection profileCollection = threadService.getMainThread().getContext().getProfileCollection();
             printProfileData(profileCollection);
         }
+
+        getThreadService().teardown();
 
         if (systemExit && status != 0) {
             throw newSystemExit(status);

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -41,6 +41,7 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Vector;
 import java.util.WeakHashMap;
@@ -382,6 +383,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     }
 
     public ThreadContext getContext() {
+        WeakReference<ThreadContext> contextRef = this.contextRef;
         return contextRef == null ? null : contextRef.get();
     }
 

--- a/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
+++ b/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
@@ -121,7 +121,7 @@ public class ThreadService {
      * through ThreadContext instances every time a Java thread enters and exits
      * Ruby space.
      */
-    private final ThreadLocal<SoftReference<ThreadContext>> localContext;
+    private ThreadLocal<SoftReference<ThreadContext>> localContext;
 
     /**
      * The Java thread group into which we register all Ruby threads. This is
@@ -158,6 +158,17 @@ public class ThreadService {
     public void disposeCurrentThread() {
         localContext.set(null);
         rubyThreadMap.remove(Thread.currentThread());
+    }
+
+    public void teardown() {
+        // clear all thread-local context references
+        localContext = new ThreadLocal<SoftReference<ThreadContext>>();
+
+        // clear main context reference
+        mainContext = null;
+
+        // clear thread map
+        rubyThreadMap.clear();
     }
 
     public void initMainThread() {


### PR DESCRIPTION
This change clears the following on JRuby runtime teardown:

* The thread-local context reference in ThreadService
  (dereferenced entirely)
* The mainContext reference in ThreadService
* The mapping from native threads to RubyThread instances.

This should clear all JRuby-specific runtime data attached to
both Ruby and adopted Java threads.

Fixes #3313.
Supersedes #3316.