### PR TITLE
Fix Hash#shift when at capacity

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1916,6 +1916,10 @@ public class RubyHash extends RubyObject implements Map {
         modify();
         IRubyObject key, value;
 
+        int start = this.start;
+        int end = this.end;
+        IRubyObject[] entries = this.entries;
+
         key = entries[start * NUMBER_OF_ENTRIES];
         value = entries[(start * NUMBER_OF_ENTRIES) + 1];
 

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1914,12 +1914,12 @@ public class RubyHash extends RubyObject implements Map {
     @JRubyMethod(name = "shift")
     public IRubyObject shift(ThreadContext context) {
         modify();
-        IRubyObject key, value, lastKey;
+        IRubyObject key, value;
+
         key = entries[start * NUMBER_OF_ENTRIES];
         value = entries[(start * NUMBER_OF_ENTRIES) + 1];
 
-        lastKey = entries[end * NUMBER_OF_ENTRIES];
-        if (key != lastKey) {
+        if (getLength() == end || key != entries[end * NUMBER_OF_ENTRIES]) {
             RubyArray result = RubyArray.newArray(context.runtime, key, value);
             internalDeleteEntry(key, value);
             return result;

--- a/spec/ruby/core/hash/shift_spec.rb
+++ b/spec/ruby/core/hash/shift_spec.rb
@@ -61,4 +61,19 @@ describe "Hash#shift" do
     lambda { HashSpecs.frozen_hash.shift  }.should raise_error(frozen_error_class)
     lambda { HashSpecs.empty_frozen_hash.shift }.should raise_error(frozen_error_class)
   end
+
+  it "works when the hash is at capacity" do
+    # We try a wide range of sizes in hopes that this will cover all implementationss base Hash size.
+    results = []
+    1.upto(100) do |n|
+      h = {}
+      n.times do |i|
+        h[i] = i
+      end
+      h.shift
+      results << h.size
+    end
+
+    results.should == 0.upto(99).to_a
+  end
 end


### PR DESCRIPTION
This fixes #5392.

@ChrisBr Please review this fix! I was not sure if this is the best way to proceed. Other methods that mutate the Hash usually call checkResize, which avoids the issue. Since we're shifting it should not need to grow, so I added the additional length check instead.