### PR TITLE
[fix] singleton meta class

### DIFF
--- a/core/src/main/java/org/jruby/MetaClass.java
+++ b/core/src/main/java/org/jruby/MetaClass.java
@@ -34,10 +34,15 @@ import org.jruby.runtime.builtin.IRubyObject;
 
 public final class MetaClass extends RubyClass {
 
+    @Deprecated
+    public MetaClass(Ruby runtime, RubyClass superClass, IRubyObject attached) {
+        this(runtime, superClass, (RubyBasicObject) attached);
+    }
+
     /**
      * rb_class_boot for meta classes ({@link #makeMetaClass(RubyClass)})
      */
-    public MetaClass(Ruby runtime, RubyClass superClass, IRubyObject attached) {
+    MetaClass(Ruby runtime, RubyClass superClass, RubyBasicObject attached) {
         super(runtime, superClass, false);
         this.attached = attached;
         // use same ClassIndex as metaclass, since we're technically still of that type
@@ -89,14 +94,14 @@ public final class MetaClass extends RubyClass {
         return attached == target ? this : super.toSingletonClass(target);
     }
 
-    public IRubyObject getAttached() {
+    public RubyBasicObject getAttached() {
         return attached;
     }
 
-    public void setAttached(IRubyObject attached) {
+    public void setAttached(RubyBasicObject attached) {
         this.attached = attached;
     }
 
-    private IRubyObject attached;
+    private RubyBasicObject attached;
 
 }

--- a/core/src/main/java/org/jruby/MetaClass.java
+++ b/core/src/main/java/org/jruby/MetaClass.java
@@ -74,10 +74,11 @@ public final class MetaClass extends RubyClass {
 
     private RubyClass getSuperSingletonMetaClass() {
         if (attached instanceof RubyClass) {
-            final RubyClass superClass = ((RubyClass) attached).superClass;
+            RubyClass superClass = ((RubyClass) attached).getSuperClass();
+            if (superClass != null) superClass = superClass.getRealClass();
             // #<Class:BasicObject>'s singleton class == Class.singleton_class
             if (superClass == null) return runtime.getClassClass().getSingletonClass();
-            return superClass.getRealClass().getSingletonClass().getMetaClass();
+            return superClass.getMetaClass().getSingletonClass();
         }
 
         return getSuperClass().getRealClass().getMetaClass(); // NOTE: is this correct?

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -533,7 +533,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      */
     @Override
     public RubyClass getSingletonClass() {
-        RubyClass klass = getMetaClass().initMetaClass(this);
+        RubyClass klass = getMetaClass().toSingletonClass(this);
 
         klass.setTaint(isTaint());
         if (isFrozen()) klass.setFrozen(true);
@@ -551,7 +551,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         MetaClass klass = new MetaClass(getRuntime(), superClass, this); // rb_class_boot
         setMetaClass(klass);
 
-        klass.setMetaClass(superClass.getRealClass().getMetaClass());
+        klass.setMetaClass(superClass.getRealClass().metaClass);
 
         superClass.addSubclass(klass);
 
@@ -2337,9 +2337,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
             }
         } else if (all) {
             metaClass.populateInstanceMethodNames(seen, methods, PRIVATE, false, true, true);
-        } else {
-            // do nothing, leave empty
-        }
+        } // else - do nothing, leave empty
 
         return methods;
     }

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -994,10 +994,10 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         return rbCloneInternal(context, kwfreeze);
     }
 
-    private IRubyObject rbCloneInternal(ThreadContext context, boolean freeze) {
-        Ruby runtime = context.runtime;
+    private RubyBasicObject rbCloneInternal(ThreadContext context, boolean freeze) {
 
         if (isSpecialObject()) {
+            final Ruby runtime = context.runtime;
             if (!freeze) throw runtime.newArgumentError(str(runtime, "can't unfreeze ", types(runtime, getType())));
 
             return this;
@@ -1017,7 +1017,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
 
 
     protected RubyClass getSingletonClassClone() {
-        return getSingletonClassCloneAndAttach(UNDEF);
+        return getSingletonClassCloneAndAttach(null);
     }
 
     /** rb_singleton_class_clone
@@ -1027,7 +1027,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      *
      * @return either a real class, or a clone of the current singleton class
      */
-    protected RubyClass getSingletonClassCloneAndAttach(IRubyObject attach) {
+    protected RubyClass getSingletonClassCloneAndAttach(RubyBasicObject attach) {
         RubyClass klass = getMetaClass();
 
         if (!klass.isSingleton()) {

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -533,13 +533,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      */
     @Override
     public RubyClass getSingletonClass() {
-        RubyClass klass = getMetaClass();
-
-        if (klass.isSingleton() && ((MetaClass) klass).getAttached() == this) {
-            // no-op
-        } else {
-            klass = makeMetaClass(klass);
-        }
+        RubyClass klass = getMetaClass().initMetaClass(this);
 
         klass.setTaint(isTaint());
         if (isFrozen()) klass.setFrozen(true);
@@ -1040,7 +1034,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
             return klass;
         }
 
-        RubyClass clone = new MetaClass(getRuntime(), klass.getSuperClass(), attach);
+        MetaClass clone = new MetaClass(getRuntime(), klass.getSuperClass(), attach);
         clone.flags = klass.flags;
 
         if (this instanceof RubyClass) {
@@ -1049,9 +1043,8 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
             clone.setMetaClass(klass.getSingletonClassClone());
         }
 
-        if (klass.hasVariables()) {
-            clone.syncVariables(klass);
-        }
+        if (klass.hasVariables()) clone.syncVariables(klass);
+
         clone.syncConstants(klass);
 
         klass.cloneMethods(clone);

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -483,22 +483,11 @@ public class RubyClass extends RubyModule {
         return clazz;
     }
 
-    /** rb_make_metaclass
-     *
+    /**
+     * @see #getSingletonClass()
      */
-    @Override
-    public RubyClass makeMetaClass(RubyClass superClass) {
-        if (isSingleton()) { // could be pulled down to RubyClass in future
-            MetaClass klass = new MetaClass(runtime, superClass, this); // rb_class_boot
-            setMetaClass(klass);
-
-            klass.setMetaClass(klass);
-            klass.setSuperClass(getSuperClass().getRealClass().getMetaClass());
-
-            return klass;
-        } else {
-            return super.makeMetaClass(superClass);
-        }
+    RubyClass initMetaClass(RubyBasicObject target) { // replaced after makeMetaClass with MetaClass's initMetaClass
+        return target.makeMetaClass(this);
     }
 
     public boolean notVisibleAndNotMethodMissing(DynamicMethod method, String name, IRubyObject caller, CallType callType) {
@@ -1282,7 +1271,7 @@ public class RubyClass extends RubyModule {
         if (!(superClass instanceof RubyClass)) {
             throw superClass.getRuntime().newTypeError("superclass must be a Class (" + superClass.getMetaClass() + " given)");
         }
-        if (((RubyClass)superClass).isSingleton()) {
+        if (((RubyClass) superClass).isSingleton()) {
             throw superClass.getRuntime().newTypeError("can't make subclass of virtual class");
         }
         if (superClass == superClass.getRuntime().getClassClass()) {

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -379,8 +379,7 @@ public class RubyClass extends RubyModule {
             this.realClass = null;
             this.variableTableManager = new VariableTableManager(this);
         } else {
-            this.realClass = superClass.realClass;
-            if (realClass != null) {
+            if ((this.realClass = superClass.realClass) != null) {
                 this.variableTableManager = realClass.variableTableManager;
             } else {
                 this.variableTableManager = new VariableTableManager(this);
@@ -486,7 +485,8 @@ public class RubyClass extends RubyModule {
     /**
      * @see #getSingletonClass()
      */
-    RubyClass initMetaClass(RubyBasicObject target) { // replaced after makeMetaClass with MetaClass's initMetaClass
+    RubyClass toSingletonClass(RubyBasicObject target) {
+        // replaced after makeMetaClass with MetaClass's toSingletonClass
         return target.makeMetaClass(this);
     }
 

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1286,7 +1286,7 @@ public class RubyModule extends RubyObject {
             RubyModule c = this;
 
             if (c.isSingleton()) {
-                IRubyObject obj = ((MetaClass)c).getAttached();
+                IRubyObject obj = ((MetaClass) c).getAttached();
 
                 if (obj instanceof RubyModule) {
                     c = (RubyModule) obj;
@@ -1301,8 +1301,7 @@ public class RubyModule extends RubyObject {
         methodLocation.addMethod(name, UndefinedMethod.getInstance());
 
         if (isSingleton()) {
-            IRubyObject singleton = ((MetaClass)this).getAttached();
-            singleton.callMethod(context, "singleton_method_undefined", runtime.newSymbol(name));
+            ((MetaClass) this).getAttached().callMethod(context, "singleton_method_undefined", runtime.newSymbol(name));
         } else {
             callMethod(context, "method_undefined", runtime.newSymbol(name));
         }
@@ -1340,7 +1339,7 @@ public class RubyModule extends RubyObject {
 
         if (this instanceof MetaClass) {
             // FIXME: Gross and not quite right. See MRI's rb_frozen_class_p logic
-            ((RubyBasicObject) ((MetaClass) this).getAttached()).testFrozen();
+            ((MetaClass) this).getAttached().testFrozen();
         }
 
         addMethodInternal(id, method);
@@ -1391,8 +1390,7 @@ public class RubyModule extends RubyObject {
         }
 
         if (isSingleton()) {
-            IRubyObject singleton = ((MetaClass)this).getAttached();
-            singleton.callMethod(context, "singleton_method_removed", name);
+            ((MetaClass) this).getAttached().callMethod(context, "singleton_method_removed", name);
         } else {
             callMethod(context, "method_removed", name);
         }
@@ -2376,17 +2374,10 @@ public class RubyModule extends RubyObject {
             IRubyObject attached = ((MetaClass) this).getAttached();
             RubyString buffer = runtime.newString("#<Class:");
 
-            if (attached != null) { // FIXME: figure out why we getService null sometimes
-                if (attached instanceof RubyClass || attached instanceof RubyModule) {
-                    buffer.cat19(attached.inspect().convertToString());
-                } else {
-                    try {
-                        buffer.cat19((RubyString) attached.anyToString());
-                    } catch (NullPointerException npe) {
-                        npe.printStackTrace();
-                        throw npe;
-                    }
-                }
+            if (attached instanceof RubyModule) {
+                buffer.cat19(attached.inspect().convertToString());
+            } else if (attached != null) {
+                buffer.cat19((RubyString) attached.anyToString());
             }
             buffer.cat19(runtime.newString(">"));
 
@@ -3021,7 +3012,7 @@ public class RubyModule extends RubyObject {
         defineAlias(newSym.idString(), oldSym.idString());
 
         if (isSingleton()) {
-            ((MetaClass)this).getAttached().callMethod(context, "singleton_method_added", newSym);
+            ((MetaClass) this).getAttached().callMethod(context, "singleton_method_added", newSym);
         } else {
             callMethod(context, "method_added", newSym);
         }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
@@ -281,7 +281,7 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
             // if real class is Class
             if (realClass == context.runtime.getClassClass()) {
                 // use the attached class's name
-                className = ((RubyClass)metaClass.getAttached()).getName();
+                className = ((RubyClass) metaClass.getAttached()).getName();
             } else {
                 // use the real class name
                 className = realClass.getName();

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -1617,7 +1617,7 @@ public class Helpers {
         }
     }
 
-    private static void callSingletonMethodHook(IRubyObject receiver, ThreadContext context, RubySymbol name) {
+    private static void callSingletonMethodHook(RubyBasicObject receiver, ThreadContext context, RubySymbol name) {
         receiver.callMethod(context, "singleton_method_added", name);
     }
 

--- a/core/src/main/java/org/jruby/runtime/profile/builtin/ProfilePrinter.java
+++ b/core/src/main/java/org/jruby/runtime/profile/builtin/ProfilePrinter.java
@@ -28,13 +28,13 @@ package org.jruby.runtime.profile.builtin;
 
 import org.jruby.MetaClass;
 import org.jruby.Ruby;
+import org.jruby.RubyBasicObject;
 import org.jruby.RubyClass;
 import org.jruby.RubyIO;
 import org.jruby.RubyInstanceConfig.ProfilingMode;
 import org.jruby.RubyModule;
 import org.jruby.RubyObject;
 import org.jruby.internal.runtime.methods.DynamicMethod;
-import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.collections.IntHashMap;
 import org.jruby.util.collections.IntHashMap.Entry;
 
@@ -183,12 +183,12 @@ public abstract class ProfilePrinter {
         Ruby runtime = module.getRuntime();
 
         if (module instanceof MetaClass) {
-            IRubyObject obj = ((MetaClass) module).getAttached();
+            RubyBasicObject obj = ((MetaClass) module).getAttached();
             if (obj instanceof RubyModule) {
                 return str(runtime, types(runtime, (RubyModule) obj), ".", ids(runtime, id));
             } 
             if (obj instanceof RubyObject) {
-                return str(runtime, types(runtime, ((RubyObject) obj).getType()), "(singleton)#", ids(runtime, id));
+                return str(runtime, types(runtime, obj.getType()), "(singleton)#", ids(runtime, id));
             }
             return str(runtime, "unknown#", ids(runtime, id));
         }

--- a/test/jruby/test_class.rb
+++ b/test/jruby/test_class.rb
@@ -338,27 +338,28 @@ class TestClass < Test::Unit::TestCase
     assert_equal klass_name, klass.name
   end
 
-  class Foo
+  class S1
     class << self
+      include Enumerable
       class << self
         def foo; :foo end
       end
       def self.bar; :bar end
     end
+    include Kernel
   end
 
-  class Bar < Foo; end
+  class S2 < S1
+    include Enumerable
+  end
 
   def test_singleton_class_user_class
-    assert_same Foo.singleton_class, Bar.singleton_class.superclass
+    assert_same S1.singleton_class, S2.singleton_class.superclass
 
-    foo_singleton_singleton_class = Foo.singleton_class.singleton_class
-    assert_same foo_singleton_singleton_class, Bar.singleton_class.singleton_class.superclass
+    singleton_singleton_class = S1.singleton_class.singleton_class
+    assert_same singleton_singleton_class, S2.singleton_class.singleton_class.superclass
 
-    puts "Object.singleton_class.singleton_class: #{Object.singleton_class.singleton_class}"
-    puts "foo_singleton_singleton_class.superclass: #{foo_singleton_singleton_class.superclass}"
-
-    assert_same Object.singleton_class.singleton_class, foo_singleton_singleton_class.superclass
+    assert_same Object.singleton_class.singleton_class, singleton_singleton_class.superclass
   end
 
   def test_singleton_class_base_hierarchy
@@ -369,21 +370,27 @@ class TestClass < Test::Unit::TestCase
   end
 
   def test_singleton_class_subclasses
-    classes = ObjectSpace.each_object(Foo.singleton_class.singleton_class).to_a
-    assert_include classes, Foo.singleton_class
-    assert_include classes, Bar.singleton_class
-    assert_equal 2, classes.size
+    classes = ObjectSpace.each_object(S1.singleton_class.singleton_class).to_a
+    assert_include classes, S1.singleton_class
+    assert_include classes, S2.singleton_class
+    assert_equal 3, classes.size, classes.inspect
 
-    classes = ObjectSpace.each_object(Bar.singleton_class.singleton_class).to_a
-    assert_equal [ Bar.singleton_class ], classes
+    classes = ObjectSpace.each_object(S2.singleton_class.singleton_class).to_a
+    assert_equal [ S2.singleton_class ], classes
   end
 
   def test_singleton_class_methods
-    assert_include Foo.singleton_class.methods(false), :foo
-    assert_include Foo.singleton_class.methods(false), :bar
+    methods = S1.singleton_class.methods(false)
+    assert_include methods, :foo
+    assert_include methods, :bar
 
-    assert_include Bar.singleton_class.methods, :foo
-    assert_include Bar.singleton_class.methods, :bar
+    methods = S2.singleton_class.methods
+    #assert_include methods, :foo
+    #assert_include methods, :bar
+
+    methods = Class.new(S1).singleton_class.methods
+    #assert_include methods, :foo
+    #assert_include methods, :bar
   end
 
 end


### PR DESCRIPTION
JRuby seem to never have `Foo.singleton_class.singleton_class` working as expected
... mostly following super-class hierarchy with singleton classes

this gets the class hierarchy working, not sure what is left to be done for module's singleton
left the "super meta class" logic as it was for now

fixes GH-287 ... an old timer :)