### PR TITLE
Do a fast dup of args when all symbols, due to kwarg processing.

### DIFF
--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -555,7 +555,7 @@ public class IRRuntimeHelpers {
             RubyHash kwargs = (RubyHash) maybeKwargs;
 
             if (kwargs.allSymbols()) {
-                args[length - 1] = kwargs;
+                args[length - 1] = kwargs.dupFast(context);
             } else {
                 args = homogenizeKwargs(context, args, kwargs);
             }

--- a/spec/ruby/language/method_spec.rb
+++ b/spec/ruby/language/method_spec.rb
@@ -1281,6 +1281,19 @@ describe "A method" do
       result.should == [1, nil, nil, {foo: :bar}, nil, {}]
     end
   end
+
+  context "assigns keyword arguments from a passed Hash without modifying it" do
+    evaluate <<-ruby do
+        def m(a: nil); a; end
+      ruby
+
+      options = {a: 1}.freeze
+      lambda do
+        m(options).should == 1
+      end.should_not raise_error
+      options.should == {a: 1}
+    end
+  end
 end
 
 describe "A method call with a space between method name and parentheses" do

--- a/spec/ruby/language/method_spec.rb
+++ b/spec/ruby/language/method_spec.rb
@@ -1269,7 +1269,7 @@ describe "A method" do
         def m(a, b = nil, c = nil, d, e: nil, **f)
           [a, b, c, d, e, f]
         end
-    ruby
+      ruby
 
       result = m(1, 2)
       result.should == [1, nil, nil, 2, nil, {}]


### PR DESCRIPTION
Keyword argument processing currently mutates the incoming Hash,
calling delete as arguments are distributed to local variables.
This allows easy support for the keyword rest argument, since it
just gets whatever's left, but it forces us to make this defensive
copy. We also can skip some duping if the keyword arguments are
all literal and not just contained in an opaque hash. Of course
we really just need to wire up straight-through keyword args
dispatch.

Fixes #5267.