### PR TITLE
Only use the UTC formatter if time was not specified as relative.

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -777,7 +777,7 @@ public class RubyTime extends RubyObject {
 
     private String inspectCommon(final DateTimeFormatter formatter, final DateTimeFormatter utcFormatter) {
         DateTimeFormatter simpleDateFormat;
-        if (dt.getZone() == DateTimeZone.UTC) {
+        if (dt.getZone() == DateTimeZone.UTC && !isTzRelative) {
             simpleDateFormat = utcFormatter;
         } else {
             simpleDateFormat = formatter;


### PR DESCRIPTION
Fixes #5400.

As far as I could tell, in MRI they have a tri-state flag on RTIME:

* gmt = 0 means non-UTC format
* gmt = 1 means UTC format
* gmt = 2 means relative offset, non-UTC format

We have a single `isTzRelative` flag that, when combined with the actual zone of the DateTime object, can be used to emulate these three states.