### PR TITLE
normalized Float::MIN

### DIFF
--- a/core/src/main/java/org/jruby/RubyFloat.java
+++ b/core/src/main/java/org/jruby/RubyFloat.java
@@ -111,7 +111,7 @@ public class RubyFloat extends RubyNumeric {
         floatc.defineConstant("MAX_EXP", RubyFixnum.newFixnum(runtime, MAX_EXP));
         floatc.defineConstant("MIN_10_EXP", RubyFixnum.newFixnum(runtime, MIN_10_EXP));
         floatc.defineConstant("MAX_10_EXP", RubyFixnum.newFixnum(runtime, MAX_10_EXP));
-        floatc.defineConstant("MIN", RubyFloat.newFloat(runtime, Double.MIN_VALUE));
+        floatc.defineConstant("MIN", RubyFloat.newFloat(runtime, Double.MIN_NORMAL));
         floatc.defineConstant("MAX", RubyFloat.newFloat(runtime, Double.MAX_VALUE));
         floatc.defineConstant("EPSILON", RubyFloat.newFloat(runtime, EPSILON));
 

--- a/spec/tags/ruby/core/float/constants_tags.txt
+++ b/spec/tags/ruby/core/float/constants_tags.txt
@@ -1,1 +1,0 @@
-fails:Float constant MIN is 2.2250738585072014e-308


### PR DESCRIPTION
https://ruby-doc.org/core-2.5.0/Float.html

The smallest positive normalized number in a double-precision floating point.

Usually defaults to 2.2250738585072014e-308.

If the platform supports denormalized numbers, there are numbers between zero and Float::MIN. 0.0.next_float returns the smallest positive floating point number including denormalized numbers.

```
    public static final double MIN_VALUE = 0x0.0000000000001P-1022; // 4.9e-324
    public static final double MIN_NORMAL = 0x1.0p-1022; // 2.2250738585072014E-308
```