### PR TITLE
synchronize iteratorExitSync

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1594,7 +1594,7 @@ public class RubyHash extends RubyObject implements Map {
         ++iteratorCount;
     }
 
-    private void iteratorExitSync() {
+    private synchronized void iteratorExitSync() {
         --iteratorCount;
     }
 


### PR DESCRIPTION
I think iteratorExitSync should be synchronized like iteratorEntrySync?

    private volatile int iteratorCount;

    private synchronized void iteratorEntrySync() {
        ++iteratorCount;
    }
    private void iteratorExitSync() {
        --iteratorCount;
    }