### PR TITLE
taint flag

### DIFF
--- a/core/src/main/java/org/jruby/util/Pack.java
+++ b/core/src/main/java/org/jruby/util/Pack.java
@@ -1792,7 +1792,7 @@ public class Pack {
                         }
 
                         IRubyObject from = list.eltInternal(idx++);
-                        if(from.isTaint()) taintOutput = true;
+                        if (from.isTaint()) taintOutput = true;
 
                         lCurElemString = from == context.nil ? ByteList.EMPTY_BYTELIST : from.convertToString().getByteList();
 
@@ -1998,6 +1998,7 @@ public class Pack {
                         IRubyObject from = list.eltInternal(idx++);
                         if (from == context.nil) throw context.runtime.newTypeError(from, "Integer");
                         lCurElemString = from.convertToString().getByteList();
+                        if (from.isTaint()) taintOutput = true;
                         encodeUM(context.runtime, lCurElemString, occurrences, ignoreStar, (char) type, result);
                     }
                     break;
@@ -2005,6 +2006,7 @@ public class Pack {
                        if (listSize-- <= 0) throw context.runtime.newArgumentError(sTooFew);
 
                        IRubyObject from = list.eltInternal(idx++);
+                       if (from.isTaint()) taintOutput = true;
                        lCurElemString = from == context.nil ? ByteList.EMPTY_BYTELIST : from.asString().getByteList();
 
                        if (occurrences <= 1) {

--- a/spec/tags/ruby/core/array/pack/m_tags.txt
+++ b/spec/tags/ruby/core/array/pack/m_tags.txt
@@ -1,4 +1,0 @@
-fails:Array#pack with format 'M' returns a tainted string when a pack argument is tainted
-fails:Array#pack with format 'M' returns a untrusted string when a pack argument is untrusted
-fails:Array#pack with format 'm' returns a tainted string when a pack argument is tainted
-fails:Array#pack with format 'm' returns a untrusted string when a pack argument is untrusted

--- a/spec/tags/ruby/core/array/pack/u_tags.txt
+++ b/spec/tags/ruby/core/array/pack/u_tags.txt
@@ -1,2 +1,0 @@
-fails:Array#pack with format 'u' returns a tainted string when a pack argument is tainted
-fails:Array#pack with format 'u' returns a untrusted string when a pack argument is untrusted


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2018/10/17/not-propagated-taint-flag-in-some-formats-of-pack-cve-2018-16396/

```
Array#pack('M')
Array#pack('m')
Array#pack('u')
```
returns a tainted string when a pack argument is tainted

```
Array#pack('p')
Array#pack('P')
```
not implemented on jruby