### PR TITLE
Temporarily revert open-addressing Hash for concurrency reasons.

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -77,93 +77,35 @@ import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
 import static org.jruby.runtime.Visibility.PRIVATE;
 import static org.jruby.RubyEnumerator.SizeFn;
 
-/* The original package implemented classic bucket-based hash tables
-   with entries doubly linked for an access by their insertion order.
-   To decrease pointer chasing and as a consequence to improve a data
-   locality the current implementation is based on storing entries in
-   an array and using hash tables with open addressing.  The current
-   entries are more compact in comparison with the original ones and
-   this also improves the data locality.
-   The hash table has two arrays called *bins* and *entries*.
-     bins:
-    -------
-   |       |                  entries array:
-   |-------|            --------------------------------
-   | index |           |      | entry:  |        |      |
-   |-------|           |      |         |        |      |
-   | ...   |           | ...  | hash    |  ...   | ...  |
-   |-------|           |      | key     |        |      |
-   | empty |           |      | record  |        |      |
-   |-------|            --------------------------------
-   | ...   |                   ^                  ^
-   |-------|                   |_ entries start   |_ entries bound
-   |deleted|
-    -------
-   o The entry array contains table entries in the same order as they
-     were inserted.
-     When the first entry is deleted, a variable containing index of
-     the current first entry (*entries start*) is changed.  In all
-     other cases of the deletion, we just mark the entry as deleted by
-     using a reserved hash value.
-     Such organization of the entry storage makes operations of the
-     table shift and the entries traversal very fast.
-     To keep the objects small, we store keys and values in the same array
-     like this:
-    |---------|
-    | key 1   |
-    |---------|
-    | value 1 |
-    |---------|
-    | key 2   |
-    |-------  |
-    | value 2 |
-    |---------|
-    |...      |
-     ---------
-     This means keys are always stored at INDEX * 2 and values are always
-     stored at (INDEX * 2) + 1.
-   o The bins provide access to the entries by their keys.  The
-     key hash is mapped to a bin containing *index* of the
-     corresponding entry in the entry array.
-     The bin array size is always power of two, it makes mapping very
-     fast by using the corresponding lower bits of the hash.
-     Generally it is not a good idea to ignore some part of the hash.
-     But alternative approach is worse.  For example, we could use a
-     modulo operation for mapping and a prime number for the size of
-     the bin array.  Unfortunately, the modulo operation for big
-     64-bit numbers are extremely slow (it takes more than 100 cycles
-     on modern Intel CPUs).
-     Still other bits of the hash value are used when the mapping
-     results in a collision.  In this case we use a secondary hash
-     value which is a result of a function of the collision bin
-     index and the original hash value.  The function choice
-     guarantees that we can traverse all bins and finally find the
-     corresponding bin as after several iterations the function
-     becomes a full cycle linear congruential generator because it
-     satisfies requirements of the Hull-Dobell theorem.
-     When an entry is removed from the table besides marking the
-     hash in the corresponding entry described above, we also mark
-     the bin by a special value in order to find entries which had
-     a collision with the removed entries.
-     There are two reserved values for the bins.  One denotes an
-     empty bin, another one denotes a bin for a deleted entry.
-   o The length of the bin array is at least two times more than the
-     entry array length.  This keeps the table load factor healthy.
-     The trigger of rebuilding the table is always a case when we can
-     not insert an entry anymore at the entries bound.  We could
-     change the entries bound too in case of deletion but than we need
-     a special code to count bins with corresponding deleted entries
-     and reset the bin values when there are too many bins
-     corresponding deleted entries
-     Table rebuilding is done by creation of a new entry array and
-     bins of an appropriate size.  We also try to reuse the arrays
-     in some cases by compacting the array and removing deleted
-     entries.
-   o To save memory very small tables have no allocated arrays
-     bins.  We use a linear search for an access by a key.
-     However, we maintain an hashes array in this case for a fast skip
-     when iterating over the entries array.
-*/
+// Design overview:
+//
+// RubyHash is implemented as hash table with a singly-linked list of
+// RubyHash.RubyHashEntry objects for each bucket.  RubyHashEntry objects
+// are also kept in a doubly-linked list which reflects their insertion
+// order and is used for iteration.  For simplicity, this latter list is
+// circular; a dummy RubyHashEntry, RubyHash.head, is used to mark the
+// ends of the list.
+//
+// When an entry is removed from the table, it is also removed from the
+// doubly-linked list.  However, while the reference to the previous
+// RubyHashEntry is cleared (to mark the entry as dead), the reference
+// to the next RubyHashEntry is preserved so that iterators are not
+// invalidated: any iterator with a reference to a dead entry can climb
+// back up into the list of live entries by chasing next references until
+// it finds a live entry (or head).
+//
+// Ordinarily, this scheme would require O(N) time to clear a hash (since
+// each RubyHashEntry would need to be visited and unlinked from the
+// iteration list), but RubyHash also maintains a generation count.  Every
+// time the hash is cleared, the doubly-linked list is simply discarded and
+// the generation count incremented.  Iterators check to see whether the
+// generation count has changed; if it has, they reset themselves back to
+// the new start of the list.
+//
+// This design means that iterators are never invalidated by changes to the
+// hashtable, and they do not need to modify the structure during their
+// lifecycle.
+//
 
 /** Implementation of the Hash class.
  *
@@ -274,9 +216,13 @@ public class RubyHash extends RubyObject implements Map {
     /** rb_hash_new
      *
      */
+    public static final RubyHash newSmallHash(Ruby runtime) {
+        return new RubyHash(runtime, 1);
+    }
+
     public static RubyHash newKwargs(Ruby runtime, String key, IRubyObject value) {
-        RubyHash kwargs = new RubyHash(runtime);
-        kwargs.fastASet(runtime.newSymbol(key), value);
+        RubyHash kwargs = newSmallHash(runtime);
+        kwargs.fastASetSmall(runtime.newSymbol(key), value);
         return kwargs;
     }
 
@@ -289,16 +235,9 @@ public class RubyHash extends RubyObject implements Map {
         return new RubyHash(runtime, valueMap, defaultValue);
     }
 
-    private IRubyObject[] entries;
-    private int[] hashes;
-    private int[] bins;
-    private int start = 0;
-    private int end = 0;
+    private RubyHashEntry[] table;
     protected int size = 0;
-    private static int A = 5;
-    private static int C = 1;
-    final static int EMPTY_BIN = -1;
-    final static int DELETED_BIN = -2;
+    private int threshold;
 
     private static final int PROCDEFAULT_HASH_F = ObjectFlags.PROCDEFAULT_HASH_F;
 
@@ -307,12 +246,9 @@ public class RubyHash extends RubyObject implements Map {
     private RubyHash(Ruby runtime, RubyClass klass, RubyHash other) {
         super(runtime, klass);
         this.ifNone = UNDEF;
-        entries = other.internalCopyTable();
-        bins = other.internalCopyBins();
-        hashes = other.internalCopyHashes();
+        threshold = INITIAL_THRESHOLD;
+        table = other.internalCopyTable(head);
         size = other.size;
-        start = other.start;
-        end = other.end;
     }
 
     public RubyHash(Ruby runtime, RubyClass klass) {
@@ -341,9 +277,11 @@ public class RubyHash extends RubyObject implements Map {
         allocFirst(buckets);
     }
 
-    protected RubyHash(Ruby runtime, RubyClass metaClass, IRubyObject defaultValue) {
+    protected RubyHash(Ruby runtime, RubyClass metaClass, IRubyObject defaultValue, RubyHashEntry[] initialTable, int threshold) {
         super(runtime, metaClass);
         this.ifNone = defaultValue;
+        this.threshold = threshold;
+        this.table = initialTable;
     }
 
     /*
@@ -368,28 +306,18 @@ public class RubyHash extends RubyObject implements Map {
     }
 
     private final void allocFirst() {
-        entries = new IRubyObject[MRI_INITIAL_CAPACITY << 1];
-        hashes = new int[MRI_INITIAL_CAPACITY];
+        threshold = INITIAL_THRESHOLD;
+        table = new RubyHashEntry[MRI_HASH_RESIZE ? MRI_INITIAL_CAPACITY : JAVASOFT_INITIAL_CAPACITY];
     }
 
-    private final void allocFirst(final int buckets) {
-        if (buckets <= MAX_CAPACITY_FOR_TABLES_WITHOUT_BINS) {
-            allocFirst();
-        } else {
-            int nextPowOfTwo = nextPowOfTwo(buckets);
-            entries = new IRubyObject[nextPowOfTwo << 1];
-            bins = new int[nextPowOfTwo << 1];
-            hashes = new int[nextPowOfTwo];
-            Arrays.fill(bins, EMPTY_BIN);
-        }
-    }
-
-    private static int nextPowOfTwo(final int i) {
-        return Integer.MIN_VALUE >>> Integer.numberOfLeadingZeros(i - 1) << 1; // i > 1
+    private final void allocFirst(int buckets) {
+        threshold = INITIAL_THRESHOLD;
+        table = new RubyHashEntry[buckets];
     }
 
     private final void alloc() {
         generation++;
+        head.prevAdded = head.nextAdded = head;
         allocFirst();
     }
 
@@ -399,29 +327,57 @@ public class RubyHash extends RubyObject implements Map {
      * ============================
      */
 
-    private static final int MAX_POWER2_FOR_TABLES_WITHOUT_BINS = 3;
-    private static final int MAX_CAPACITY_FOR_TABLES_WITHOUT_BINS = 1 << MAX_POWER2_FOR_TABLES_WITHOUT_BINS;
-    private static final int MRI_INITIAL_CAPACITY = 8;
-    private final static int NUMBER_OF_ENTRIES = 2;
+    public static final int MRI_PRIMES[] = {
+        8 + 3, 16 + 3, 32 + 5, 64 + 3, 128 + 3, 256 + 27, 512 + 9, 1024 + 9, 2048 + 5, 4096 + 3,
+        8192 + 27, 16384 + 43, 32768 + 3, 65536 + 45, 131072 + 29, 262144 + 3, 524288 + 21, 1048576 + 7,
+        2097152 + 17, 4194304 + 15, 8388608 + 9, 16777216 + 43, 33554432 + 35, 67108864 + 15,
+        134217728 + 29, 268435456 + 3, 536870912 + 11, 1073741824 + 85, 0
+    };
+
+    private static final int JAVASOFT_INITIAL_CAPACITY = 8; // 16 ?
+    private static final int MRI_INITIAL_CAPACITY = MRI_PRIMES[0];
+
+    private static final int INITIAL_THRESHOLD = JAVASOFT_INITIAL_CAPACITY - (JAVASOFT_INITIAL_CAPACITY >> 2);
+    private static final int MAXIMUM_CAPACITY = 1 << 30;
 
     public static final RubyHashEntry NO_ENTRY = new RubyHashEntry();
     private int generation = 0; // generation count for O(1) clears
+    private final RubyHashEntry head = new RubyHashEntry();
+
+    { head.prevAdded = head.nextAdded = head; }
 
     public static final class RubyHashEntry implements Map.Entry {
         IRubyObject key;
         IRubyObject value;
-        private RubyHash hash;
+        private RubyHashEntry next;
+        private RubyHashEntry prevAdded;
+        private RubyHashEntry nextAdded;
+        private int hash;
 
         RubyHashEntry() {
             key = NEVER;
         }
 
-        public RubyHashEntry(IRubyObject k, IRubyObject v, RubyHash h) {
-            key = k; value = v; hash = h;
+        public RubyHashEntry(int h, IRubyObject k, IRubyObject v, RubyHashEntry e, RubyHashEntry head) {
+            key = k; value = v; next = e; hash = h;
+            if (head != null) {
+                prevAdded = head.prevAdded;
+                nextAdded = head;
+                nextAdded.prevAdded = this;
+                prevAdded.nextAdded = this;
+            }
         }
 
-        public RubyHashEntry(IRubyObject k, IRubyObject v) {
-            key = k; value = v;
+        public void detach() {
+            if (prevAdded != null) {
+                prevAdded.nextAdded = nextAdded;
+                nextAdded.prevAdded = prevAdded;
+                prevAdded = null;
+            }
+        }
+
+        public boolean isLive() {
+            return prevAdded != null;
         }
 
         @Override
@@ -444,9 +400,7 @@ public class RubyHash extends RubyObject implements Map {
         public Object setValue(Object value) {
             IRubyObject oldValue = this.value;
             if (value instanceof IRubyObject) {
-                IRubyObject rubyValue = (IRubyObject)value;
-                this.value = rubyValue;
-                this.hash.internalPut(key, rubyValue);
+                this.value = (IRubyObject)value;
             } else {
                 throw new UnsupportedOperationException("directEntrySet() doesn't support setValue for non IRubyObject instance entries, convert them manually or use entrySet() instead");
             }
@@ -473,39 +427,77 @@ public class RubyHash extends RubyObject implements Map {
         return h ^ (h >>> 7) ^ (h >>> 4);
     }
 
+    private static int JavaSoftBucketIndex(final int h, final int length) {
+        return h & (length - 1);
+    }
+
     private static int MRIHashValue(int h) {
         return h & HASH_SIGN_BIT_MASK;
     }
 
     private static final int HASH_SIGN_BIT_MASK = ~(1 << 31);
-
-    private final synchronized void resize(final int newCapacity) {
-        final IRubyObject[] newEntries = new IRubyObject[newCapacity << 1];
-        final int[] newBins = new int[newCapacity << 1];
-        final int[] newHashes = new int[newCapacity];
-        Arrays.fill(newBins, EMPTY_BIN);
-        System.arraycopy(entries, 0, newEntries, 0, entries.length);
-        System.arraycopy(hashes, 0, newHashes, 0, hashes.length);
-
-        for (int i = start; i < end; i++) {
-            if (entries[i * NUMBER_OF_ENTRIES] == null) continue;
-
-            int bin = bucketIndex(hashes[i], newBins.length);
-            int index = newBins[bin];
-            while(index != EMPTY_BIN) {
-              bin = secondaryBucketIndex(bin, newBins.length);
-              index = newBins[bin];
-            }
-            newBins[bin] = i;
-        }
-
-        bins = newBins;
-        hashes = newHashes;
-        entries = newEntries;
+    private static int MRIBucketIndex(final int h, final int length) {
+        return ((h & HASH_SIGN_BIT_MASK) % length);
     }
 
+    private final synchronized void resize(int newCapacity) {
+        final RubyHashEntry[] oldTable = table;
+        final RubyHashEntry[] newTable = new RubyHashEntry[newCapacity];
+
+        for (int j = 0; j < oldTable.length; j++) {
+            RubyHashEntry entry = oldTable[j];
+            oldTable[j] = null;
+
+            while (entry != null) {
+                RubyHashEntry next = entry.next;
+                int i = bucketIndex(entry.hash, newCapacity);
+                entry.next = newTable[i];
+                newTable[i] = entry;
+                entry = next;
+            }
+        }
+
+        table = newTable;
+    }
+
+    private final void JavaSoftCheckResize() {
+        if (overThreshold()) {
+            RubyHashEntry[] tbl = table;
+            if (tbl.length == MAXIMUM_CAPACITY) {
+                threshold = Integer.MAX_VALUE;
+                return;
+            }
+            resizeAndAdjustThreshold(table);
+        }
+    }
+
+    private boolean overThreshold() {
+        return size > threshold;
+    }
+
+    private void resizeAndAdjustThreshold(RubyHashEntry[] oldTable) {
+        int newCapacity = oldTable.length << 1;
+        resize(newCapacity);
+        threshold = newCapacity - (newCapacity >> 2);
+    }
+
+    private static final int MIN_CAPA = 8;
+    private static final int ST_DEFAULT_MAX_DENSITY = 5;
+    private final void MRICheckResize() {
+        if (size / table.length > ST_DEFAULT_MAX_DENSITY) {
+            int forSize = table.length + 1; // size + 1;
+            for (int i=0, newCapacity = MIN_CAPA; i < MRI_PRIMES.length; i++, newCapacity <<= 1) {
+                if (newCapacity > forSize) {
+                    resize(MRI_PRIMES[i]);
+                    return;
+                }
+            }
+            return; // suboptimal for large hashes (> 1073741824 + 85 entries) not very likely to happen
+        }
+    }
     // ------------------------------
     private static final boolean MRI_HASH = true;
+    private static final boolean MRI_HASH_RESIZE = true;
 
     protected final int hashValue(final IRubyObject key) {
         final int h = isComparedByIdentity() ? System.identityHashCode(key) : key.hashCode();
@@ -513,20 +505,11 @@ public class RubyHash extends RubyObject implements Map {
     }
 
     private static int bucketIndex(final int h, final int length) {
-        // binary AND ($NUMBER - 1) is the same as MODULO
-        return h & (length - 1);
-    }
-
-    private static int secondaryBucketIndex(final int bucketIndex, final int length) {
-      return (A * bucketIndex + C) & (length - 1);
+        return MRI_HASH ? MRIBucketIndex(h, length) : JavaSoftBucketIndex(h, length);
     }
 
     private void checkResize() {
-        if (getLength() == end) {
-            resize(entries.length << 2);
-            return;
-        }
-        return;
+        if (MRI_HASH_RESIZE) MRICheckResize(); else JavaSoftCheckResize();
     }
 
     protected final void checkIterating() {
@@ -537,283 +520,141 @@ public class RubyHash extends RubyObject implements Map {
 
     // put implementation
 
-    protected IRubyObject internalPut(final IRubyObject key, final IRubyObject value) {
-      checkResize();
-      int bin, index;
-      IRubyObject result;
-      final int hash = hashValue(key);
+    private final void internalPut(final IRubyObject key, final IRubyObject value) {
+        internalPut(key, value, true);
+    }
 
-      if (shouldSearchLinear()) {
-          index = internalGetIndexLinearSearch(hash, key);
-          result = internalSetValue(index, value);
-          if (result != null) return result;
-          internalPutLinearSearch(hash, key, value);
-      } else {
-          bin = internalGetBinOpenAddressing(hash, key);
-          result = internalSetValueByBin(bin, value);
-          if (result != null) return result;
-          internalPutOpenAdressing(hash, bin, key, value);
-      }
+    private final void internalPutSmall(final IRubyObject key, final IRubyObject value) {
+        internalPutNoResize(key, value, true);
+    }
 
-      // no existing entry
-      return null;
+    protected void internalPut(final IRubyObject key, final IRubyObject value, final boolean checkForExisting) {
+        checkResize();
+
+        internalPutNoResize(key, value, checkForExisting);
     }
 
     protected final IRubyObject internalJavaPut(final IRubyObject key, final IRubyObject value) {
-        return internalPut(key, value);
+        checkResize();
+
+        return internalPutNoResize(key, value, true);
     }
 
-    private final int getLength() {
-        return entries.length / NUMBER_OF_ENTRIES;
-    }
+    protected IRubyObject internalPutNoResize(final IRubyObject key, final IRubyObject value, final boolean checkForExisting) {
+        final int hash = hashValue(key);
+        final int i = bucketIndex(hash, table.length);
 
-    private final boolean shouldSearchLinear() {
-        return getLength() <= MAX_CAPACITY_FOR_TABLES_WITHOUT_BINS;
-    }
+        if (checkForExisting) {
+            for (RubyHashEntry entry = table[i]; entry != null; entry = entry.next) {
+                if (internalKeyExist(entry, hash, key)) {
+                    IRubyObject existing = entry.value;
+                    entry.value = value;
 
-    private final IRubyObject internalPutOpenAdressing(final int hash, int bin, final IRubyObject key, final IRubyObject value) {
-        checkIterating();
-        int localBin = (bin == EMPTY_BIN) ? bucketIndex(hash, bins.length) : bin;
-        int index = bins[localBin];
-        entries[end * NUMBER_OF_ENTRIES] = key;
-        entries[end * NUMBER_OF_ENTRIES + 1] = value;
-        while(index != EMPTY_BIN && index != DELETED_BIN) {
-            localBin = secondaryBucketIndex(localBin, bins.length);
-            index = bins[localBin];
+                    return existing;
+                }
+            }
         }
-        bins[localBin] = end;
-        hashes[end] = hash;
-        size++;
-        end++;
 
-        // no existing entry
-        return null;
-    }
-
-    private final IRubyObject internalPutLinearSearch(final int hash, final IRubyObject key, final IRubyObject value) {
         checkIterating();
-        entries[end * NUMBER_OF_ENTRIES] = key;
-        entries[end * NUMBER_OF_ENTRIES + 1] = value;
-        hashes[end] = hash;
+
+        table[i] = new RubyHashEntry(hash, key, value, table[i], head);
         size++;
-        end++;
 
         // no existing entry
         return null;
-    }
-
-    private final IRubyObject internalSetValue(final int index, final IRubyObject value) {
-        if (index < 0) return null;
-        final IRubyObject result = entries[(index * NUMBER_OF_ENTRIES) + 1];
-        entries[(index * NUMBER_OF_ENTRIES) + 1] = value;
-        return result;
-    }
-
-    private final IRubyObject internalSetValueByBin(final int bin, final IRubyObject value) {
-        if (bin < 0) return null;
-        int index = bins[bin];
-        return internalSetValue(index, value);
     }
 
     // get implementation
 
-    private final IRubyObject internalGetValue(final int index) {
-        if (index < 0) return null;
-        return entries[(index * NUMBER_OF_ENTRIES) + 1];
-    }
-
-    private final int internalGetBinOpenAddressing(final int hash, final IRubyObject key) {
-        int bin = bucketIndex(hash, bins.length);
-        int index = bins[bin];
-
-        for (int round = 0; round < bins.length && index != EMPTY_BIN; round++) {
-            if (round == bins.length) break;
-
-            if (index != DELETED_BIN) {
-                IRubyObject otherKey = entries[index * NUMBER_OF_ENTRIES];
-                int otherHash = hashes[index];
-
-                if (internalKeyExist(key, hash, otherKey, otherHash)) return bin;
-            }
-
-            bin = secondaryBucketIndex(bin, bins.length);
-            index = bins[bin];
-        }
-
-        return EMPTY_BIN;
-    }
-
-    private final int internalGetIndexLinearSearch(final int hash, final IRubyObject key) {
-        for(int i = start; i < end; i++) {
-            IRubyObject otherKey = entries[i * NUMBER_OF_ENTRIES];
-            if (otherKey == null) continue;
-
-            int otherHash = hashes[i];
-
-            if (internalKeyExist(key, hash, otherKey, otherHash)) return i;
-        }
-        return EMPTY_BIN;
-    }
-
     protected IRubyObject internalGet(IRubyObject key) { // specialized for value
-        if (isEmpty()) return null;
-        final int hash = hashValue(key);
-        int index;
-
-        if (shouldSearchLinear()) {
-            index = internalGetIndexLinearSearch(hash, key);
-        } else {
-            final int bin = internalGetBinOpenAddressing(hash, key);
-            if (bin < 0) return null;
-            index = bins[bin];
-        }
-        return internalGetValue(index);
+        return internalGetEntry(key).value;
     }
 
     protected RubyHashEntry internalGetEntry(IRubyObject key) {
-        IRubyObject value = internalGet(key);
-        return value == null ? NO_ENTRY : new RubyHashEntry(key, value, this);
+        if (size == 0) return NO_ENTRY;
+
+        final int hash = hashValue(key);
+        for (RubyHashEntry entry = table[bucketIndex(hash, table.length)]; entry != null; entry = entry.next) {
+            if (internalKeyExist(entry, hash, key)) {
+                return entry;
+            }
+        }
+        return NO_ENTRY;
     }
 
     final RubyHashEntry getEntry(IRubyObject key) {
         return internalGetEntry(key);
     }
 
-    private boolean internalKeyExist(IRubyObject key, int hash, IRubyObject otherKey, int otherHash) {
-        return (hash == otherHash && (key == otherKey || (!isComparedByIdentity() && key.eql(otherKey))));
+    private boolean internalKeyExist(RubyHashEntry entry, int hash, IRubyObject key) {
+        return (entry.hash == hash
+            && (entry.key == key || (!isComparedByIdentity() && key.eql(entry.key))));
     }
 
     // delete implementation
 
-    protected IRubyObject internalDelete(final IRubyObject key) {
-        if (isEmpty()) return null;
-        return internalDelete(hashValue(key), MATCH_KEY, key, null);
+
+    protected RubyHashEntry internalDelete(final IRubyObject key) {
+        if (size == 0) return NO_ENTRY;
+
+        return internalDelete(hashValue(key), MATCH_KEY, key);
     }
 
     protected RubyHashEntry internalDeleteEntry(final RubyHashEntry entry) {
         // n.b. we need to recompute the hash in case the key object was modified
-        // TODO this is for backward compatibility in JavaMapProxy
-        IRubyObject value = internalDelete(hashValue(entry.key), MATCH_ENTRY, entry.key, entry.value);
-        return value == null ? NO_ENTRY : new RubyHashEntry(entry.key, value);
+        return internalDelete(hashValue(entry.key), MATCH_ENTRY, entry);
     }
 
-    protected IRubyObject internalDeleteEntry(final IRubyObject key, final IRubyObject value) {
-        // n.b. we need to recompute the hash in case the key object was modified
-        return internalDelete(hashValue(key), MATCH_ENTRY, key, value);
-    }
+    private final RubyHashEntry internalDelete(final int hash, final EntryMatchType matchType, final Object obj) {
+        final int i = bucketIndex(hash, table.length);
 
-    private final IRubyObject internalDeleteOpenAddressing(final int hash, final EntryMatchType matchType, final IRubyObject key, final IRubyObject value) {
-        int bin = bucketIndex(hash, bins.length);
-        int index = bins[bin];
-
-        for (int round = 0; round < bins.length && index != EMPTY_BIN; round++) {
-            if (index != DELETED_BIN) {
-                IRubyObject otherKey = entries[index * NUMBER_OF_ENTRIES];
-                IRubyObject otherValue = entries[(index * NUMBER_OF_ENTRIES) + 1];
-
-                if (otherKey != null && matchType.matches(key, value, otherKey, otherValue)) {
-                  bins[bin] = DELETED_BIN;
-                  hashes[index] = 0;
-                  entries[index * NUMBER_OF_ENTRIES] = null;
-                  entries[(index * NUMBER_OF_ENTRIES) + 1] = null;
-                  size--;
-
-                  updateStartAndEndPointer();
-                  return otherValue;
+        RubyHashEntry entry = table[i];
+        if (entry != null) {
+            RubyHashEntry prior = null;
+            for (; entry != null; prior = entry, entry = entry.next) {
+                if (entry.hash == hash && matchType.matches(entry, obj)) {
+                    if (prior != null) {
+                        prior.next = entry.next;
+                    } else {
+                        table[i] = entry.next;
+                    }
+                    entry.detach();
+                    size--;
+                    return entry;
                 }
             }
-            bin = secondaryBucketIndex(bin, bins.length);
-            index = bins[bin];
         }
 
-        return null;  // no entry found
-    }
-
-    private final IRubyObject internalDeleteLinearSearch(final EntryMatchType matchType, final IRubyObject key, final IRubyObject value) {
-        for(int index = start; index < end; index++) {
-            IRubyObject otherKey = entries[index * NUMBER_OF_ENTRIES];
-            IRubyObject otherValue = entries[(index * NUMBER_OF_ENTRIES) + 1];
-
-            if (otherKey == null) continue;
-
-            if (matchType.matches(key, value, otherKey, otherValue)) {
-              hashes[index] = 0;
-              entries[index * NUMBER_OF_ENTRIES] = null;
-              entries[(index * NUMBER_OF_ENTRIES) + 1] = null;
-              size--;
-
-              updateStartAndEndPointer();
-              return otherValue;
-            }
-        }
-
-        // no entry
-        return null;
-    }
-
-    private final void updateStartAndEndPointer() {
-        if (isEmpty()) {
-            start = 0;
-            end = 0;
-        } else {
-            while (entries[start * NUMBER_OF_ENTRIES] == null) {
-                start++;
-            }
-            while(entries[lastElementsIndex() * NUMBER_OF_ENTRIES] == null && lastElementsIndex() > 0) {
-                end--;
-            }
-        }
-    }
-
-    private int lastElementsIndex() {
-        return end - 1;
-    }
-
-    private final IRubyObject internalDelete(final int hash, final EntryMatchType matchType, final IRubyObject key, final IRubyObject value) {
-        if (isEmpty()) return null;
-        if (shouldSearchLinear()) {
-            return internalDeleteLinearSearch(matchType, key, value);
-        } else {
-            return internalDeleteOpenAddressing(hash, matchType, key, value);
-        }
+        return NO_ENTRY;
     }
 
     private static abstract class EntryMatchType {
-        public abstract boolean matches(final IRubyObject key, final IRubyObject value, final IRubyObject otherKey, final IRubyObject otherValue);
+        public abstract boolean matches(final RubyHashEntry entry, final Object obj);
     }
 
     private static final EntryMatchType MATCH_KEY = new EntryMatchType() {
         @Override
-        public boolean matches(final IRubyObject key, final IRubyObject value, final IRubyObject otherKey, final IRubyObject otherValue) {
-            return key == otherKey || key.eql(otherKey);
+        public boolean matches(final RubyHashEntry entry, final Object obj) {
+            final IRubyObject key = entry.key;
+            return obj == key || (((IRubyObject)obj).eql(key));
         }
     };
 
     private static final EntryMatchType MATCH_ENTRY = new EntryMatchType() {
         @Override
-        public boolean matches(final IRubyObject key, final IRubyObject value, final IRubyObject otherKey, final IRubyObject otherValue) {
-            return (key == otherKey || key.eql(otherKey)) &&
-                (value == otherValue || value.equals(otherValue));
+        public boolean matches(final RubyHashEntry entry, final Object obj) {
+            return entry.equals(obj);
         }
     };
 
-    private final IRubyObject[] internalCopyTable() {
-        IRubyObject[] newTable = new RubyObject[entries.length];
-        System.arraycopy(entries, 0, newTable, 0, entries.length);
-        return newTable;
-    }
+    private final RubyHashEntry[] internalCopyTable(RubyHashEntry destHead) {
+         RubyHashEntry[]newTable = new RubyHashEntry[table.length];
 
-    private final int[] internalCopyBins() {
-        if(shouldSearchLinear()) return null;
-        int[] newBins = new int[bins.length];
-        System.arraycopy(bins, 0, newBins, 0, bins.length);
-        return newBins;
-    }
-
-    private final int[] internalCopyHashes() {
-        int[] newHashes = new int[hashes.length];
-        System.arraycopy(hashes, 0, newHashes, 0, hashes.length);
-        return newHashes;
+         for (RubyHashEntry entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
+             int i = bucketIndex(entry.hash, table.length);
+             newTable[i] = new RubyHashEntry(entry.hash, entry.key, entry.value, newTable[i], destHead);
+         }
+         return newTable;
     }
 
     public static abstract class VisitorWithState<T> {
@@ -836,22 +677,18 @@ public class RubyHash extends RubyObject implements Map {
         int startGeneration = generation;
         long count = size;
         int index = 0;
-
-        for (int i = start; i < end && count != 0; i++) {
+        // visit not more than size entries
+        for (RubyHashEntry entry = head.nextAdded; entry != head && count != 0; entry = entry.nextAdded) {
             if (startGeneration != generation) {
                 startGeneration = generation;
-                i = start;
+                entry = head.nextAdded;
+                if (entry == head) break;
             }
-
-            IRubyObject key = entries[i * NUMBER_OF_ENTRIES];
-            IRubyObject value = entries[(i * NUMBER_OF_ENTRIES) + 1];
-
-            if(key == null || value == null) continue;
-
-            visitor.visit(context, this, key, value, index++, state);
-            count--;
+            if (entry != null && entry.isLive()) {
+                visitor.visit(context, this, entry.key, entry.value, index++, state);
+                count--;
+            }
         }
-
         // it does not handle all concurrent modification cases,
         // but at least provides correct marshal as we have exactly size entries visited (count == 0)
         // or if count < 0 - skipped concurrent modification checks
@@ -860,15 +697,17 @@ public class RubyHash extends RubyObject implements Map {
 
     public <T> boolean allSymbols() {
         int startGeneration = generation;
-
-        for (int i = start; i < end; i++) {
+        // visit not more than size entries
+        RubyHashEntry head = this.head;
+        for (RubyHashEntry entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
             if (startGeneration != generation) {
                 startGeneration = generation;
-                i = start;
+                entry = head.nextAdded;
+                if (entry == head) break;
             }
-
-            IRubyObject key = entries[i * NUMBER_OF_ENTRIES];
-            if (key != null && !(key instanceof RubySymbol)) return false;
+            if (entry != null && entry.isLive()) {
+                if (!(entry.key instanceof RubySymbol)) return false;
+            }
         }
         return true;
     }
@@ -1029,7 +868,7 @@ public class RubyHash extends RubyObject implements Map {
      */
     @JRubyMethod(name = "inspect")
     public IRubyObject inspect(ThreadContext context) {
-        if (isEmpty()) return RubyString.newUSASCIIString(context.runtime, "{}");
+        if (size == 0) return RubyString.newUSASCIIString(context.runtime, "{}");
         if (context.runtime.isInspecting(this)) return RubyString.newUSASCIIString(context.runtime, "{...}");
 
         try {
@@ -1068,7 +907,7 @@ public class RubyHash extends RubyObject implements Map {
      */
     @JRubyMethod(name = "empty?")
     public RubyBoolean empty_p() {
-        return isEmpty() ? getRuntime().getTrue() : getRuntime().getFalse();
+        return size == 0 ? getRuntime().getTrue() : getRuntime().getFalse();
     }
 
     /** rb_hash_to_a
@@ -1119,93 +958,31 @@ public class RubyHash extends RubyObject implements Map {
         }
 
         modify();
-        if (shouldSearchLinear()){
-            rehashLinearSearch();
-        } else {
-            rehashOpenAddressing();
+        final RubyHashEntry[] oldTable = table;
+        final RubyHashEntry[] newTable = new RubyHashEntry[oldTable.length];
+        for (int j = 0; j < oldTable.length; j++) {
+            RubyHashEntry entry = oldTable[j];
+            oldTable[j] = null;
+            while (entry != null) {
+                RubyHashEntry next = entry.next;
+                entry.hash = hashValue(entry.key); // update the hash value
+                int i = bucketIndex(entry.hash, newTable.length);
+
+                if (newTable[i] != null && internalKeyExist(newTable[i], entry.hash, entry.key)) {
+                    RubyHashEntry tmpNext = entry.nextAdded;
+                    RubyHashEntry tmpPrev = entry.prevAdded;
+                    tmpPrev.nextAdded = tmpNext;
+                    tmpPrev.prevAdded = tmpPrev;
+                    size--;
+                } else {
+                    entry.next = newTable[i];
+                    newTable[i] = entry;
+                }
+                entry = next;
+            }
         }
+        table = newTable;
         return this;
-    }
-
-    private void rehashOpenAddressing() {
-        IRubyObject[] newEntries = new IRubyObject[entries.length];
-        int[] newBins = new int[bins.length];
-        int[] newHashes = new int[hashes.length];
-        Arrays.fill(newBins, EMPTY_BIN);
-
-        int newIndex = 0;
-        for(int i = start; i < end; i++) {
-            IRubyObject key = entries[i * NUMBER_OF_ENTRIES];
-            if (key == null) continue;
-
-            int hash = hashValue(key);
-            int bin = bucketIndex(hash, newBins.length);
-            int index = newBins[bin];
-
-            boolean exists = false;
-            while(index != EMPTY_BIN) {
-                // Note: otherKey should never be null here as we are filling with new entries and newBins
-                // cannot be non-EMPTY_BIN and not contain a valid newEntry.
-                IRubyObject otherKey = newEntries[index * NUMBER_OF_ENTRIES];
-                int otherHash = newHashes[index];
-                if (internalKeyExist(key, hash, otherKey, otherHash)) {
-                    // exists, we do not need to add this key
-                    exists = true;
-                    break;
-                }
-
-                bin = secondaryBucketIndex(bin, newBins.length);
-                index = newBins[bin];
-            }
-
-            if (!exists) {
-                newBins[bin] = newIndex;
-                newEntries[newIndex * NUMBER_OF_ENTRIES] = key;
-                newEntries[(newIndex * NUMBER_OF_ENTRIES) + 1] = entries[(i * NUMBER_OF_ENTRIES) + 1];
-                newHashes[newIndex] = hash;
-                newIndex++;
-            }
-        }
-
-        bins = newBins;
-        entries = newEntries;
-        hashes = newHashes;
-        end = size = newIndex;
-        start = 0;
-    }
-
-    private void rehashLinearSearch() {
-        IRubyObject[] newEntries = new IRubyObject[entries.length];
-        int[] newHashes = new int[hashes.length];
-        int newIndex = 0;
-
-        for(int i = start; i < end; i++) {
-            IRubyObject key = entries[i * NUMBER_OF_ENTRIES];
-            if (key == null) continue;
-
-            int newHash = hashValue(key);
-            boolean exists = false;
-            for(int j = 0; j < i; j++) {
-                int otherHash = hashes[j];
-                IRubyObject otherKey = newEntries[j * NUMBER_OF_ENTRIES];
-                if (internalKeyExist(key, newHash, otherKey, otherHash)) {
-                    exists = true;
-                    break;
-                }
-            }
-
-            if (!exists) {
-                newEntries[newIndex * NUMBER_OF_ENTRIES] = key;
-                newEntries[(newIndex * NUMBER_OF_ENTRIES) + 1] = entries[(i * NUMBER_OF_ENTRIES) + 1];
-                newHashes[newIndex] = newHash;
-                newIndex++;
-            }
-        }
-
-        entries = newEntries;
-        hashes = newHashes;
-        end = size = newIndex;
-        start = 0;
     }
 
     /** rb_hash_to_hash
@@ -1231,6 +1008,10 @@ public class RubyHash extends RubyObject implements Map {
         internalPut(key, value);
     }
 
+    public final void fastASetSmall(IRubyObject key, IRubyObject value) {
+        internalPutSmall(key, value);
+    }
+
     public final void fastASetCheckString(Ruby runtime, IRubyObject key, IRubyObject value) {
       if (key instanceof RubyString && !isComparedByIdentity()) {
           op_asetForString(runtime, (RubyString) key, value);
@@ -1239,11 +1020,27 @@ public class RubyHash extends RubyObject implements Map {
       }
     }
 
+    public final void fastASetSmallCheckString(Ruby runtime, IRubyObject key, IRubyObject value) {
+        if (key instanceof RubyString) {
+            op_asetSmallForString(runtime, (RubyString) key, value);
+        } else {
+            internalPutSmall(key, value);
+        }
+    }
+
     public final void fastASet(Ruby runtime, IRubyObject key, IRubyObject value, boolean prepareString) {
         if (prepareString) {
             fastASetCheckString(runtime, key, value);
         } else {
             fastASet(key, value);
+        }
+    }
+
+    public final void fastASetSmall(Ruby runtime, IRubyObject key, IRubyObject value, boolean prepareString) {
+        if (prepareString) {
+            fastASetSmallCheckString(runtime, key, value);
+        } else {
+            fastASetSmall(key, value);
         }
     }
 
@@ -1258,32 +1055,26 @@ public class RubyHash extends RubyObject implements Map {
         return value;
     }
 
+
     protected void op_asetForString(Ruby runtime, RubyString key, IRubyObject value) {
-        final int hash = hashValue(key);
-        if (shouldSearchLinear()) {
-            final int index = internalGetIndexLinearSearch(hash, key);
-            if (internalSetValue(index, value) != null) return;
-            if (!key.isFrozen()) key = (RubyString)key.dupFrozen();
-            checkResize();
-
-            // It could be that we changed from linear search to open addressing with the resize
-            if (shouldSearchLinear()){
-                internalPutLinearSearch(hash, key, value);
-            } else {
-                internalPutOpenAdressing(hash, EMPTY_BIN, key, value);
-            }
-            return;
+        final RubyHashEntry entry = internalGetEntry(key);
+        if (entry != NO_ENTRY) {
+            entry.value = value;
         } else {
-            final int oldBinsLength = bins.length;
-            int bin = internalGetBinOpenAddressing(hash, key);
-            if (internalSetValueByBin(bin, value) != null) return;
-
+            checkIterating();
             if (!key.isFrozen()) key = (RubyString)key.dupFrozen();
-            checkResize();
-            // we need to calculate the bin again if we changed the size
-            if (bins.length != oldBinsLength)
-              bin = internalGetBinOpenAddressing(hash, key);
-            internalPutOpenAdressing(hash, bin, key, value);
+            internalPut(key, value, false);
+        }
+    }
+
+    protected void op_asetSmallForString(Ruby runtime, RubyString key, IRubyObject value) {
+        final RubyHashEntry entry = internalGetEntry(key);
+        if (entry != NO_ENTRY) {
+            entry.value = value;
+        } else {
+            checkIterating();
+            if (!key.isFrozen()) key = (RubyString)key.dupFrozen();
+            internalPutNoResize(key, value, false);
         }
     }
 
@@ -1501,13 +1292,11 @@ public class RubyHash extends RubyObject implements Map {
     @JRubyMethod(name = {"has_key?", "key?", "include?", "member?"}, required = 1)
     public RubyBoolean has_key_p(ThreadContext context, IRubyObject key) {
         Ruby runtime = context.runtime;
-        IRubyObject result = internalGet(key);
-        return result == null ? runtime.getFalse() : runtime.getTrue();
+        return internalGetEntry(key) == NO_ENTRY ? runtime.getFalse() : runtime.getTrue();
     }
 
     public RubyBoolean has_key_p(IRubyObject key) {
-        IRubyObject result = internalGet(key);
-        return result == null ? getRuntime().getFalse() : getRuntime().getTrue();
+        return internalGetEntry(key) == NO_ENTRY ? getRuntime().getFalse() : getRuntime().getTrue();
     }
 
     private static class Found extends RuntimeException {
@@ -1906,16 +1695,10 @@ public class RubyHash extends RubyObject implements Map {
     public IRubyObject shift(ThreadContext context) {
         modify();
 
-        int start = this.start;
-        int end = this.end;
-
-        IRubyObject[] entries = this.entries;
-        IRubyObject key = entries[start * NUMBER_OF_ENTRIES];
-        IRubyObject value = entries[(start * NUMBER_OF_ENTRIES) + 1];
-
-        if (getLength() == end || key != entries[end * NUMBER_OF_ENTRIES]) {
-            RubyArray result = RubyArray.newArray(context.runtime, key, value);
-            internalDeleteEntry(key, value);
+        RubyHashEntry entry = head.nextAdded;
+        if (entry != head) {
+            RubyArray result = RubyArray.newArray(context.runtime, entry.key, entry.value);
+            internalDeleteEntry(entry);
             return result;
         }
 
@@ -1925,7 +1708,7 @@ public class RubyHash extends RubyObject implements Map {
     }
 
     public final boolean fastDelete(IRubyObject key) {
-        return internalDelete(key) != null;
+        return internalDelete(key) != NO_ENTRY;
     }
 
     /** rb_hash_delete
@@ -1935,8 +1718,8 @@ public class RubyHash extends RubyObject implements Map {
     public IRubyObject delete(ThreadContext context, IRubyObject key, Block block) {
         modify();
 
-        final IRubyObject value = internalDelete(key);
-        if (value != null) return value;
+        final RubyHashEntry entry = internalDelete(key);
+        if (entry != NO_ENTRY) return entry.value;
 
         if (block.isGiven()) return block.yield(context, key);
         return context.nil;
@@ -2076,7 +1859,7 @@ public class RubyHash extends RubyObject implements Map {
 
         if (size > 0) {
             alloc();
-            start = end = size = 0;
+            size = 0;
         }
 
         return this;
@@ -2275,23 +2058,20 @@ public class RubyHash extends RubyObject implements Map {
 
     @JRubyMethod(name = "compact!")
     public IRubyObject compact_bang(ThreadContext context) {
-        boolean changed = false;
-        modify();
-        iteratorEntry();
-        try {
-            IRubyObject value, key;
-            for (int i = start; i < end; i++) {
-                value = entries[(i * NUMBER_OF_ENTRIES) + 1];
-                if (value == context.nil) {
-                    key = entries[(i * NUMBER_OF_ENTRIES)];
-                    internalDelete(key);
-                    changed = true;
-                }
-            }
-        } finally {
-            iteratorExit();
+      boolean changed = false;
+      modify();
+      iteratorEntry();
+      try {
+        for (RubyHashEntry entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
+          if (entry.value == context.nil) {
+            internalDelete(entry.key);
+            changed = true;
+          }
         }
-        return changed ? this : context.nil;
+      } finally {
+        iteratorExit();
+      }
+      return changed ? this : context.nil;
     }
 
     @JRubyMethod(name = "compare_by_identity")
@@ -2339,14 +2119,10 @@ public class RubyHash extends RubyObject implements Map {
     private IRubyObject any_p_i(ThreadContext context, Block block) {
         iteratorEntry();
         try {
-            for (int i = start; i < end; i++) {
-                IRubyObject key = entries[i * NUMBER_OF_ENTRIES];
-                IRubyObject value = entries[(i * NUMBER_OF_ENTRIES) + 1];
-
-                if (key == null || value == null) continue;
-
-                IRubyObject newAssoc = RubyArray.newArray(context.runtime, key, value);
-                if (block.yield(context, newAssoc).isTrue()) return context.tru;
+            for (RubyHashEntry entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
+                IRubyObject newAssoc = RubyArray.newArray(context.runtime, entry.key, entry.value);
+                if (block.yield(context, newAssoc).isTrue())
+                    return context.tru;
             }
             return context.fals;
         } finally {
@@ -2357,13 +2133,9 @@ public class RubyHash extends RubyObject implements Map {
     private IRubyObject any_p_i_fast(ThreadContext context, Block block) {
         iteratorEntry();
         try {
-            for (int i = start; i < end; i++) {
-                IRubyObject key = entries[i * NUMBER_OF_ENTRIES];
-                IRubyObject value = entries[(i * NUMBER_OF_ENTRIES) + 1];
-
-                if (key == null || value == null) continue;
-
-                if (block.yieldArray(context, context.runtime.newArray(key, value), null).isTrue()) return context.tru;
+            for (RubyHashEntry entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
+                if (block.yieldArray(context, context.runtime.newArray(entry.key, entry.value), null).isTrue())
+                    return context.tru;
             }
             return context.fals;
         } finally {
@@ -2374,13 +2146,8 @@ public class RubyHash extends RubyObject implements Map {
     private IRubyObject any_p_p(ThreadContext context, IRubyObject pattern) {
         iteratorEntry();
         try {
-            for (int i = start; i < end; i++) {
-                IRubyObject key = entries[i * NUMBER_OF_ENTRIES];
-                IRubyObject value = entries[(i * NUMBER_OF_ENTRIES) + 1];
-
-                if (key == null || value == null) continue;
-
-                IRubyObject newAssoc = RubyArray.newArray(context.runtime, key, value);
+            for (RubyHashEntry entry = head.nextAdded; entry != head; entry = entry.nextAdded) {
+                IRubyObject newAssoc = RubyArray.newArray(context.runtime, entry.key, entry.value);
                 if (pattern.callMethod(context, "===", newAssoc).isTrue())
                     return context.tru;
             }
@@ -2534,7 +2301,7 @@ public class RubyHash extends RubyObject implements Map {
     @Override
     public Object remove(Object key) {
         IRubyObject rubyKey = JavaUtil.convertJavaToUsableRubyObject(getRuntime(), key);
-        return internalDelete(rubyKey);
+        return internalDelete(rubyKey).value;
     }
 
     @Override
@@ -2687,44 +2454,25 @@ public class RubyHash extends RubyObject implements Map {
 
     private class BaseIterator implements Iterator {
         final private EntryView view;
-        private IRubyObject key, value;
-        private boolean peeking, hasNext;
-        private int startGeneration, index, end;
+        private RubyHashEntry entry;
+        private boolean peeking;
+        private int startGeneration;
 
         public BaseIterator(EntryView view) {
             this.view = view;
-            this.startGeneration = RubyHash.this.generation;
-            this.index = RubyHash.this.start;
-            this.end = RubyHash.this.end;
-            this.hasNext = RubyHash.this.size > 0;
+            this.entry = head;
+            this.startGeneration = generation;
         }
 
         private void advance(boolean consume) {
             if (!peeking) {
                 do {
-                    if (startGeneration != RubyHash.this.generation) {
-                        startGeneration = RubyHash.this.generation;
-                        index = RubyHash.this.start;
-                        key = entries[index * NUMBER_OF_ENTRIES];
-                        value = entries[(index * NUMBER_OF_ENTRIES) + 1];
-                        index++;
-                        hasNext = RubyHash.this.size > 0;
-                    } else {
-                        if (index < end) {
-                            key = entries[index * NUMBER_OF_ENTRIES];
-                            value = entries[(index * NUMBER_OF_ENTRIES) + 1];
-                            index++;
-                            hasNext = true;
-                        } else {
-                            hasNext = false;
-                        }
+                    if (startGeneration != generation) {
+                        startGeneration = generation;
+                        entry = head;
                     }
-                    while((key == null || value == null) && index < end && hasNext) {
-                        key = entries[index * NUMBER_OF_ENTRIES];
-                        value = entries[(index * NUMBER_OF_ENTRIES) + 1];
-                        index++;
-                    }
-                } while ((key == null || value == null) && index < size);
+                    entry = entry.nextAdded;
+                } while (entry != head && !entry.isLive());
             }
             peeking = !consume;
         }
@@ -2732,11 +2480,11 @@ public class RubyHash extends RubyObject implements Map {
         @Override
         public Object next() {
             advance(true);
-            if (!hasNext) {
+            if (entry == head) {
                 peeking = true; // remain where we are
                 throw new NoSuchElementException();
             }
-            return view.convertEntry(getRuntime(), RubyHash.this, key, value);
+            return view.convertEntry(getRuntime(), entry);
         }
 
         // once hasNext has been called, we commit to next() returning
@@ -2744,28 +2492,28 @@ public class RubyHash extends RubyObject implements Map {
         @Override
         public boolean hasNext() {
             advance(false);
-            return hasNext;
+            return entry != head;
         }
 
         @Override
         public void remove() {
-            if (!hasNext) {
+            if (entry == head) {
                 throw new IllegalStateException("Iterator out of range");
             }
-            internalDeleteEntry(key, value);
+            internalDeleteEntry(entry);
         }
     }
 
     private static abstract class EntryView {
-        public abstract Object convertEntry(Ruby runtime, RubyHash hash, IRubyObject key, IRubyObject value);
+        public abstract Object convertEntry(Ruby runtime, RubyHashEntry value);
         public abstract boolean contains(RubyHash hash, Object o);
         public abstract boolean remove(RubyHash hash, Object o);
     }
 
     private static final EntryView DIRECT_KEY_VIEW = new EntryView() {
         @Override
-        public Object convertEntry(Ruby runtime, RubyHash hash, IRubyObject key, IRubyObject value) {
-            return key;
+        public Object convertEntry(Ruby runtime, RubyHashEntry entry) {
+            return entry.key;
         }
         @Override
         public boolean contains(RubyHash hash, Object o) {
@@ -2775,14 +2523,14 @@ public class RubyHash extends RubyObject implements Map {
         @Override
         public boolean remove(RubyHash hash, Object o) {
             if (!(o instanceof IRubyObject)) return false;
-            return hash.internalDelete((IRubyObject)o) != null;
+            return hash.internalDelete((IRubyObject)o) != NO_ENTRY;
         }
     };
 
     private static final EntryView KEY_VIEW = new EntryView() {
         @Override
-        public Object convertEntry(Ruby runtime, RubyHash hash, IRubyObject key, IRubyObject value) {
-            return key.toJava(Object.class);
+        public Object convertEntry(Ruby runtime, RubyHashEntry entry) {
+            return entry.key.toJava(Object.class);
         }
         @Override
         public boolean contains(RubyHash hash, Object o) {
@@ -2796,8 +2544,8 @@ public class RubyHash extends RubyObject implements Map {
 
     private static final EntryView DIRECT_VALUE_VIEW = new EntryView() {
         @Override
-        public Object convertEntry(Ruby runtime, RubyHash hash, IRubyObject key, IRubyObject value) {
-            return value;
+        public Object convertEntry(Ruby runtime, RubyHashEntry entry) {
+            return entry.value;
         }
         @Override
         public boolean contains(RubyHash hash, Object o) {
@@ -2811,14 +2559,14 @@ public class RubyHash extends RubyObject implements Map {
             IRubyObject obj = (IRubyObject) o;
             IRubyObject key = hash.internalIndex(obj.getRuntime().getCurrentContext(), obj);
             if (key == null) return false;
-            return hash.internalDelete(key) != null;
+            return hash.internalDelete(key) != NO_ENTRY;
         }
     };
 
     private static final EntryView VALUE_VIEW = new EntryView() {
         @Override
-        public Object convertEntry(Ruby runtime, RubyHash hash, IRubyObject key, IRubyObject value) {
-            return value.toJava(Object.class);
+        public Object convertEntry(Ruby runtime, RubyHashEntry entry) {
+            return entry.value.toJava(Object.class);
         }
         @Override
         public boolean contains(RubyHash hash, Object o) {
@@ -2829,14 +2577,14 @@ public class RubyHash extends RubyObject implements Map {
             IRubyObject value = JavaUtil.convertJavaToUsableRubyObject(hash.getRuntime(), o);
             IRubyObject key = hash.internalIndex(hash.getRuntime().getCurrentContext(), value);
             if (key == null) return false;
-            return hash.internalDelete(key) != null;
+            return hash.internalDelete(key) != NO_ENTRY;
         }
     };
 
     private static final EntryView DIRECT_ENTRY_VIEW = new EntryView() {
         @Override
-        public Object convertEntry(Ruby runtime, RubyHash hash, IRubyObject key, IRubyObject value) {
-            return new RubyHashEntry(key, value);
+        public Object convertEntry(Ruby runtime, RubyHashEntry entry) {
+            return entry;
         }
         @Override
         public boolean contains(RubyHash hash, Object o) {
@@ -2848,56 +2596,50 @@ public class RubyHash extends RubyObject implements Map {
         @Override
         public boolean remove(RubyHash hash, Object o) {
             if (!(o instanceof RubyHashEntry)) return false;
-            RubyHashEntry candidate = (RubyHashEntry)o;
-            return hash.internalDeleteEntry(candidate.key, candidate.value) != null;
+            return hash.internalDeleteEntry((RubyHashEntry)o) != NO_ENTRY;
         }
     };
 
     private static final EntryView ENTRY_VIEW = new EntryView() {
         @Override
-        public Object convertEntry(Ruby runtime, RubyHash hash, IRubyObject key, IRubyObject value) {
-            return new ConvertingEntry(runtime, hash, key, value);
+        public Object convertEntry(Ruby runtime, RubyHashEntry entry) {
+            return new ConvertingEntry(runtime, entry);
         }
         @Override
         public boolean contains(RubyHash hash, Object o) {
             if (!(o instanceof ConvertingEntry)) return false;
             ConvertingEntry entry = (ConvertingEntry)o;
-            RubyHashEntry tmp = new RubyHashEntry(entry.key, entry.value);
-            RubyHashEntry candidate = hash.internalGetEntry(entry.key);
-            return candidate != NO_ENTRY && tmp.equals(candidate);
+            RubyHashEntry candidate = hash.internalGetEntry(entry.entry.key);
+            return candidate != NO_ENTRY && entry.entry.equals(candidate);
         }
         @Override
         public boolean remove(RubyHash hash, Object o) {
             if (!(o instanceof ConvertingEntry)) return false;
             ConvertingEntry entry = (ConvertingEntry)o;
-            return hash.internalDeleteEntry(entry.key, entry.value) != null;
+            return hash.internalDeleteEntry(entry.entry) != NO_ENTRY;
         }
     };
 
     private static class ConvertingEntry implements Map.Entry {
-        private final IRubyObject key, value;
+        private final RubyHashEntry entry;
         private final Ruby runtime;
-        private RubyHash hash;
 
-        public ConvertingEntry(Ruby runtime, RubyHash otherHash, IRubyObject key, IRubyObject value) {
-            this.key = key;
-            this.value = value;
+        public ConvertingEntry(Ruby runtime, RubyHashEntry entry) {
+            this.entry = entry;
             this.runtime = runtime;
-            this.hash = otherHash;
         }
 
         @Override
         public Object getKey() {
-            return key.toJava(Object.class);
+            return entry.key.toJava(Object.class);
         }
         @Override
         public Object getValue() {
-            return value.toJava(Object.class);
+            return entry.value.toJava(Object.class);
         }
         @Override
         public Object setValue(Object o) {
-            IRubyObject value = JavaUtil.convertJavaToUsableRubyObject(runtime, o);
-            return hash.internalPut(key, value);
+            return entry.setValue(JavaUtil.convertJavaToUsableRubyObject(runtime, o));
         }
 
         @Override
@@ -2905,14 +2647,13 @@ public class RubyHash extends RubyObject implements Map {
             if (!(o instanceof ConvertingEntry)) {
                 return false;
             }
-            ConvertingEntry otherEntry = (ConvertingEntry)o;
-            return (key == otherEntry.key || key.eql(otherEntry.key)) &&
-                    (value == otherEntry.value || value.equals(otherEntry.value));
+            ConvertingEntry other = (ConvertingEntry)o;
+            return entry.equals(other.entry);
         }
 
         @Override
         public int hashCode() {
-            return key.hashCode() ^ value.hashCode();
+            return entry.hashCode();
         }
     }
 
@@ -2947,6 +2688,11 @@ public class RubyHash extends RubyObject implements Map {
     @Deprecated
     public final void fastASetCheckString19(Ruby runtime, IRubyObject key, IRubyObject value) {
         fastASetCheckString(runtime, key, value);
+    }
+
+    @Deprecated
+    public final void fastASetSmallCheckString19(Ruby runtime, IRubyObject key, IRubyObject value) {
+        fastASetSmallCheckString(runtime, key, value);
     }
 
     @Deprecated
@@ -2988,5 +2734,10 @@ public class RubyHash extends RubyObject implements Map {
             default:
                 throw context.runtime.newArgumentError(args.length, 1);
         }
+    }
+
+    @Deprecated
+    protected void internalPutSmall(final IRubyObject key, final IRubyObject value, final boolean checkForExisting) {
+        internalPutNoResize(key, value, checkForExisting);
     }
 }

--- a/core/src/main/java/org/jruby/RubyNil.java
+++ b/core/src/main/java/org/jruby/RubyNil.java
@@ -157,7 +157,7 @@ public class RubyNil extends RubyObject implements Constantizable {
     
     @JRubyMethod
     public static RubyHash to_h(ThreadContext context, IRubyObject recv) {
-        return new RubyHash(context.runtime);
+        return RubyHash.newSmallHash(context.runtime);
     }
 
     /** nil_inspect

--- a/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
+++ b/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
@@ -376,8 +376,8 @@ public class RubyPathname extends RubyObject {
             args[1] = _args[1];
         }
 
-        args[2] = new RubyHash(runtime);
-        ((RubyHash) args[2]).fastASet(runtime.newSymbol("base"), context.runtime.getFile().callMethod(context, "realpath", getPath()));
+        args[2] = RubyHash.newSmallHash(runtime);
+        ((RubyHash) args[2]).fastASetSmall(runtime.newSymbol("base"), context.runtime.getFile().callMethod(context, "realpath", getPath()));
 
         JavaSites.PathnameSites sites = sites(context);
         CallSite glob = sites.glob;

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -549,8 +549,8 @@ public class IRRuntimeHelpers {
         final IRubyObject maybeKwargs = toHash(context, args[length - 1]);
 
         if (maybeKwargs != null) {
-            if (maybeKwargs == context.nil) { // nil on to_hash is supposed to keep itself as real value so we need to make kwargs hash
-                return ArraySupport.newCopy(args, new RubyHash(context.runtime));
+            if (maybeKwargs.isNil()) { // nil on to_hash is supposed to keep itself as real value so we need to make kwargs hash
+                return ArraySupport.newCopy(args, RubyHash.newSmallHash(context.runtime));
             }
 
             RubyHash kwargs = (RubyHash) maybeKwargs;
@@ -573,7 +573,7 @@ public class IRRuntimeHelpers {
 
         if (visitor.syms == null) {
             // no symbols, use empty kwargs hash
-            visitor.syms = new RubyHash(context.runtime);
+            visitor.syms = RubyHash.newSmallHash(context.runtime);
         }
 
         if (visitor.others != null) { // rest args exists too expand args
@@ -607,11 +607,11 @@ public class IRRuntimeHelpers {
         @Override
         public void visit(ThreadContext context, RubyHash self, IRubyObject key, IRubyObject value, int index, Object unused) {
             if (key instanceof RubySymbol) {
-                if (syms == null) syms = new RubyHash(context.runtime);
-                syms.fastASet(key, value);
+                if (syms == null) syms = RubyHash.newSmallHash(context.runtime);
+                syms.fastASetSmall(key, value);
             } else {
-                if (others == null) others = new RubyHash(context.runtime);
-                others.fastASet(key, value);
+                if (others == null) others = RubyHash.newSmallHash(context.runtime);
+                others.fastASetSmall(key, value);
             }
         }
     };
@@ -1087,7 +1087,7 @@ public class IRRuntimeHelpers {
     public static IRubyObject receiveKeywordRestArg(ThreadContext context, IRubyObject[] args, int required, boolean keywordArgumentSupplied) {
         RubyHash keywordArguments = extractKwargsHash(context, args, required, keywordArgumentSupplied);
 
-        return keywordArguments == null ? new RubyHash(context.runtime) : keywordArguments;
+        return keywordArguments == null ? RubyHash.newSmallHash(context.runtime) : keywordArguments;
     }
 
     public static IRubyObject setCapturedVar(ThreadContext context, IRubyObject matchRes, String id) {
@@ -1269,10 +1269,10 @@ public class IRRuntimeHelpers {
         int length = pairs.length / 2;
         boolean useSmallHash = length <= 10;
 
-        RubyHash hash = useSmallHash ? RubyHash.newHash(runtime) : new RubyHash(runtime);
+        RubyHash hash = useSmallHash ? RubyHash.newHash(runtime) : RubyHash.newSmallHash(runtime);
         for (int i = 0; i < pairs.length;) {
             if (useSmallHash) {
-                hash.fastASet(runtime, pairs[i++], pairs[i++], true);
+                hash.fastASetSmall(runtime, pairs[i++], pairs[i++], true);
             } else {
                 hash.fastASet(runtime, pairs[i++], pairs[i++], true);
             }

--- a/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
@@ -103,11 +103,12 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
     }
 
     private static final class RubyHashMap extends RubyHash {
+        static final RubyHashEntry[] EMPTY_TABLE = new RubyHashEntry[0];
 
         private final MapJavaProxy receiver;
 
         RubyHashMap(Ruby runtime, MapJavaProxy receiver) {
-            super(runtime, runtime.getHash(), runtime.getNil());
+            super(runtime, runtime.getHash(), runtime.getNil(), EMPTY_TABLE, 0);
             this.receiver = receiver;
         }
 
@@ -176,7 +177,12 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         }
 
         @Override
-        public IRubyObject internalPut(final IRubyObject key, final IRubyObject value) {
+        public void internalPut(final IRubyObject key, final IRubyObject value, final boolean checkForExisting) {
+            internalPutNoResize(key, value, checkForExisting);
+        }
+
+        @Override
+        protected final IRubyObject internalPutNoResize(IRubyObject key, IRubyObject value, boolean checkForExisting) {
             @SuppressWarnings("unchecked")
             Ruby runtime = getRuntime();
             final Map<Object, Object> map = mapDelegate();
@@ -200,6 +206,11 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         }
 
         @Override
+        protected final void op_asetSmallForString(Ruby runtime, RubyString key, IRubyObject value) {
+            op_asetForString(runtime, key, value);
+        }
+
+        @Override
         public IRubyObject internalGet(IRubyObject key) {
             Object result = mapDelegate().get(key.toJava(Object.class));
             if (result == null) return null;
@@ -213,14 +224,14 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
             Object value = map.get(convertedKey);
 
             if (value != null) {
-                return new RubyHashEntry(key, JavaUtil.convertJavaToUsableRubyObject(getRuntime(), value));
+                return new RubyHashEntry(key.hashCode(), key, JavaUtil.convertJavaToUsableRubyObject(getRuntime(), value), null, null);
             }
 
             return NO_ENTRY;
         }
 
         @Override
-        public IRubyObject internalDelete(final IRubyObject key) {
+        public RubyHashEntry internalDelete(final IRubyObject key) {
             final Map map = mapDelegate();
             Object convertedKey = key.toJava(Object.class);
             Object value = map.get(convertedKey);
@@ -228,9 +239,9 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
             if (value != null) {
                 map.remove(convertedKey);
                 setSize( map.size() );
-                return JavaUtil.convertJavaToUsableRubyObject(getRuntime(), value);
+                return new RubyHashEntry(key.hashCode(), key, JavaUtil.convertJavaToUsableRubyObject(getRuntime(), value), null, null);
             }
-            return null;
+            return NO_ENTRY;
         }
 
         @Override // NOTE: likely won't be called

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -1280,17 +1280,17 @@ public class Helpers {
 
     public static RubyHash constructSmallHash(Ruby runtime,
                                               IRubyObject key1, IRubyObject value1, boolean prepareString1) {
-        RubyHash hash = new RubyHash(runtime);
-        hash.fastASet(runtime, key1, value1, prepareString1);
+        RubyHash hash = RubyHash.newSmallHash(runtime);
+        hash.fastASetSmall(runtime, key1, value1, prepareString1);
         return hash;
     }
 
     public static RubyHash constructSmallHash(Ruby runtime,
                                               IRubyObject key1, IRubyObject value1, boolean prepareString1,
                                               IRubyObject key2, IRubyObject value2, boolean prepareString2) {
-        RubyHash hash = new RubyHash(runtime);
-        hash.fastASet(runtime, key1, value1, prepareString1);
-        hash.fastASet(runtime, key2, value2, prepareString2);
+        RubyHash hash = RubyHash.newSmallHash(runtime);
+        hash.fastASetSmall(runtime, key1, value1, prepareString1);
+        hash.fastASetSmall(runtime, key2, value2, prepareString2);
         return hash;
     }
 
@@ -1298,10 +1298,10 @@ public class Helpers {
                                               IRubyObject key1, IRubyObject value1, boolean prepareString1,
                                               IRubyObject key2, IRubyObject value2, boolean prepareString2,
                                               IRubyObject key3, IRubyObject value3, boolean prepareString3) {
-        RubyHash hash = new RubyHash(runtime);
-        hash.fastASet(runtime, key1, value1, prepareString1);
-        hash.fastASet(runtime, key2, value2, prepareString2);
-        hash.fastASet(runtime, key3, value3, prepareString3);
+        RubyHash hash = RubyHash.newSmallHash(runtime);
+        hash.fastASetSmall(runtime, key1, value1, prepareString1);
+        hash.fastASetSmall(runtime, key2, value2, prepareString2);
+        hash.fastASetSmall(runtime, key3, value3, prepareString3);
         return hash;
     }
 
@@ -1310,11 +1310,11 @@ public class Helpers {
                                               IRubyObject key2, IRubyObject value2, boolean prepareString2,
                                               IRubyObject key3, IRubyObject value3, boolean prepareString3,
                                               IRubyObject key4, IRubyObject value4, boolean prepareString4) {
-        RubyHash hash = new RubyHash(runtime);
-        hash.fastASet(runtime, key1, value1, prepareString1);
-        hash.fastASet(runtime, key2, value2, prepareString2);
-        hash.fastASet(runtime, key3, value3, prepareString3);
-        hash.fastASet(runtime, key4, value4, prepareString4);
+        RubyHash hash = RubyHash.newSmallHash(runtime);
+        hash.fastASetSmall(runtime, key1, value1, prepareString1);
+        hash.fastASetSmall(runtime, key2, value2, prepareString2);
+        hash.fastASetSmall(runtime, key3, value3, prepareString3);
+        hash.fastASetSmall(runtime, key4, value4, prepareString4);
         return hash;
     }
 
@@ -1324,12 +1324,12 @@ public class Helpers {
                                               IRubyObject key3, IRubyObject value3, boolean prepareString3,
                                               IRubyObject key4, IRubyObject value4, boolean prepareString4,
                                               IRubyObject key5, IRubyObject value5, boolean prepareString5) {
-        RubyHash hash = new RubyHash(runtime);
-        hash.fastASet(runtime, key1, value1, prepareString1);
-        hash.fastASet(runtime, key2, value2, prepareString2);
-        hash.fastASet(runtime, key3, value3, prepareString3);
-        hash.fastASet(runtime, key4, value4, prepareString4);
-        hash.fastASet(runtime, key5, value5, prepareString5);
+        RubyHash hash = RubyHash.newSmallHash(runtime);
+        hash.fastASetSmall(runtime, key1, value1, prepareString1);
+        hash.fastASetSmall(runtime, key2, value2, prepareString2);
+        hash.fastASetSmall(runtime, key3, value3, prepareString3);
+        hash.fastASetSmall(runtime, key4, value4, prepareString4);
+        hash.fastASetSmall(runtime, key5, value5, prepareString5);
         return hash;
     }
 


### PR DESCRIPTION
While verifying JRuby 9.2.1, @enebo discovered that certain
concurrent uses of a simple Rails app were triggering intermittent
errors, and forcing the JIT to run very quickly produced NPEs
under concurrent load. In 6b2fa457 @enebo was able to fix this
by adding a null check, but we could not explain how a null could
appear at that point in the code unless the hash had been
corrupted, perhaps across threads.

Additional testing with a number of contrived scripts seems to
show that the new open-addressing hash (plus its linear mode) is
more fragile under concurrency than the old linked buckets
implementation. This is in a way, by design: the new
implementation reduces indirection and allocation by packing
keys and values into a contiguous area of memory, opening up
potential for more races against the same data.

In order to have a stable 9.2.1 release, we are temporarily
rolling back this change until we can get a better grasp of the
changes needed to make it as least as concurrency-friendly as the
old hash implementation, if not properly concurrency-safe (which
may or may not be easier in this new implementation).