### PR TITLE
Bucket size of zero is not valid. For bucketless, use small.

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -2039,19 +2039,28 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     @JRubyMethod(name = "to_h")
     public IRubyObject to_h(ThreadContext context) {
+        Ruby runtime = context.runtime;
         int realLength = this.realLength;
-        RubyHash hash = new RubyHash(context.runtime, realLength);
+
+        boolean useSmallHash = realLength <= 10;
+        RubyHash hash = useSmallHash ? RubyHash.newHash(runtime) : RubyHash.newSmallHash(runtime);
 
         for (int i = 0; i < realLength; i++) {
             IRubyObject elt = eltInternal(i).checkArrayType();
             if (elt == context.nil) {
                 throw context.runtime.newTypeError("wrong element type " + eltInternal(i).getMetaClass().getRealClass() + " at " + i + " (expected array)");
             }
+
             RubyArray ary = (RubyArray)elt;
             if (ary.getLength() != 2) {
                 throw context.runtime.newArgumentError("wrong array length at " + i + " (expected 2, was " + ary.getLength() + ")");
             }
-            hash.op_aset(context, ary.eltInternal(0), ary.eltInternal(1));
+
+            if (useSmallHash) {
+                hash.fastASetSmall(runtime, ary.eltInternal(0), ary.eltInternal(1), true);
+            } else {
+                hash.fastASet(runtime, ary.eltInternal(0), ary.eltInternal(1), true);
+            }
         }
         return hash;
     }

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -2043,7 +2043,8 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         int realLength = this.realLength;
 
         boolean useSmallHash = realLength <= 10;
-        RubyHash hash = useSmallHash ? RubyHash.newHash(runtime) : RubyHash.newSmallHash(runtime);
+
+        RubyHash hash = useSmallHash ? RubyHash.newSmallHash(runtime) : RubyHash.newHash(runtime);
 
         for (int i = 0; i < realLength; i++) {
             IRubyObject elt = eltInternal(i).checkArrayType();

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -311,6 +311,7 @@ public class RubyHash extends RubyObject implements Map {
     }
 
     private final void allocFirst(int buckets) {
+        if (buckets <= 0) throw new ArrayIndexOutOfBoundsException("invalid bucket size: " + buckets);
         threshold = INITIAL_THRESHOLD;
         table = new RubyHashEntry[buckets];
     }

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1269,7 +1269,8 @@ public class IRRuntimeHelpers {
         int length = pairs.length / 2;
         boolean useSmallHash = length <= 10;
 
-        RubyHash hash = useSmallHash ? RubyHash.newHash(runtime) : RubyHash.newSmallHash(runtime);
+        RubyHash hash = useSmallHash ? RubyHash.newSmallHash(runtime) : RubyHash.newHash(runtime);
+
         for (int i = 0; i < pairs.length;) {
             if (useSmallHash) {
                 hash.fastASetSmall(runtime, pairs[i++], pairs[i++], true);


### PR DESCRIPTION
This implementation supplied 0 for `buckets` which causes the older RubyHash impl to crash when resizing. I believe what was intended was to use a smallest-possible Hash and slowly fill it, so I modified the logic to use the small hash paths.