### PR TITLE
Add opens for java.io and java.nio.channels to improve compat.

### DIFF
--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -367,7 +367,7 @@ if [ "$JRUBY_JSA" == "" ]; then
   JRUBY_JSA=${JRUBY_HOME}/lib/jruby.jsa
 fi
 
-# Determine whether to use -classpath or --module-path
+# Determine whether to pass module-related flags
 classmod_flag="-classpath"
 if [ -d $JAVA_HOME/jmods ]; then
   # Use module path instead of classpath
@@ -380,6 +380,9 @@ if [ -d $JAVA_HOME/jmods ]; then
   if [ -f $JRUBY_JSA ]; then
     JAVA_OPTS="$JAVA_OPTS -XX:+UnlockDiagnosticVMOptions -XX:SharedArchiveFile=$JRUBY_JSA"
   fi
+
+  # Add base opens we need for Ruby compatibility
+  JAVA_OPTS="$JAVA_OPTS --add-opens java.base/java.io=org.jruby.dist --add-opens java.base/java.nio.channels=org.jruby.dist"
 fi
 
 # Run JRuby!


### PR DESCRIPTION
These packages are reflected against so heavily and for so many
low-level Ruby compatibility features that we're opening them up
for now. This was forced because we load some extensions through
a URLClassLoader, and it appears that URLClassLoader-ed libraries
get stricter treatment when it comes to illegal accesess.

The following error resulted from Puma without the java.io opens:

```
=> Booting Puma
=> Rails 5.2.1 application starting in development
=> Run `rails server -h` for more startup options
Exiting
LoadError: load error: puma/java_io_buffer -- java.lang.reflect.InaccessibleObjectException: Unable to make field protected byte[] java.io.ByteArrayOutputStream.buf accessible: module java.base does not "opens java.io" to module org.jruby.dist
          require at org/jruby/RubyKernel.java:976
          require at /Users/headius/projects/jruby/lib/ruby/gems/shared/gems/activesupport-5.2.1/lib/active_support/dependencies.rb:287
  load_dependency at /Users/headius/projects/jruby/lib/ruby/gems/shared/gems/activesupport-5.2.1/lib/active_support/dependencies.rb:253
          require at /Users/headius/projects/jruby/lib/ruby/gems/shared/gems/activesupport-5.2.1/lib/active_support/dependencies.rb:287
           <main> at /Users/headius/projects/jruby/lib/ruby/gems/shared/gems/puma-3.12.0-java/lib/puma/io_buffer.rb:4
```