### PR TITLE
Improve errno detect

### DIFF
--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -1,5 +1,7 @@
 package org.jruby.runtime;
 
+import java.io.EOFException;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Array;
 
@@ -199,6 +201,10 @@ public class Helpers {
         // Try specific exception types by rethrowing and catching.
         try {
             throw t;
+        } catch (FileNotFoundException fnfe) {
+            return Errno.ENOENT;
+        } catch (EOFException fnfe) {
+            return Errno.EPIPE;
         } catch (AtomicMoveNotSupportedException amnse) {
             return Errno.EXDEV;
         } catch (ClosedChannelException cce) {

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -190,7 +190,7 @@ public class Helpers {
      * level error. In most cases, the only way to determine the cause of the IOException is by inspecting its contents,
      * usually by checking the error message string. This is obviously fragile and breaks on platforms localized to
      * languages other than English, so we also try as much as possible to detect the cause of the error by its actual
-     * type (if it is indeed a specialized subtype of IOException.
+     * type (if it is indeed a specialized subtype of IOException).
      *
      * @param t the exception to convert to an {@link Errno}
      * @return the resulting {@link Errno} value, or null if none could be determined.

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -203,7 +203,7 @@ public class Helpers {
             throw t;
         } catch (FileNotFoundException fnfe) {
             return Errno.ENOENT;
-        } catch (EOFException fnfe) {
+        } catch (EOFException eofe) {
             return Errno.EPIPE;
         } catch (AtomicMoveNotSupportedException amnse) {
             return Errno.EXDEV;


### PR DESCRIPTION
Additional exception types added to the static-typed logic in our IOException-to-Errno detector.

Remnants of #5416 deemed too risky for last-minute.