### PR TITLE
An attempt at fixing #5420.

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -171,7 +171,7 @@ project 'JRuby Lib Setup' do
 
         log "copy gem content to #{stdlib_dir}"
         # assume default require_path
-        require_base = File.join( gems, "#{gemname}*", 'lib' )
+        require_base = File.join( gems, "#{gem_name}*", 'lib' )
         require_files = File.join( require_base, '*' )
 
         # copy in new ones and mark writable for future updates (e.g. minitest)
@@ -193,7 +193,7 @@ project 'JRuby Lib Setup' do
         end
 
         # copy bin files if the gem has any
-        bin = File.join( gems, "#{gemname}", 'bin' )
+        bin = File.join( gems, "#{gem_name}", 'bin' )
         if File.exists? bin
           Dir[ File.join( bin, '*' ) ].each do |f|
             log "copy to bin: #{File.basename( f )}"
@@ -203,8 +203,8 @@ project 'JRuby Lib Setup' do
           end
         end
 
-        if g.default_spec
-          specfile_wildcard = "#{gemname}*.gemspec"
+        if true # default_spec was always true for these?
+          specfile_wildcard = "#{gem_name}*.gemspec"
           specfile = Dir[ File.join( specs,  specfile_wildcard ) ].first
 
           unless specfile
@@ -214,7 +214,7 @@ project 'JRuby Lib Setup' do
           specname = File.basename( specfile )
           log "copy to specifications/default: #{specname}"
 
-          spec = Gem::Package.new( Dir[ File.join( cache, "#{gemname}*.gem" ) ].first ).spec
+          spec = Gem::Package.new( Dir[ File.join( cache, "#{gem_name}*.gem" ) ].first ).spec
           File.open( File.join( default_specs, specname ), 'w' ) do |f|
             f.print( spec.to_ruby )
           end
@@ -300,7 +300,6 @@ project 'JRuby Lib Setup' do
         ]
       end.flatten
       includes incl
-      p incl
       target_path '${jruby.complete.gems}'
     end
 

--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -14,30 +14,20 @@ def log(message=nil)
   puts message unless MORE_QUIET
 end
 
-class ImportedGem
-  attr_reader :name, :version, :default_spec
-
-  def initialize( name, version, default_spec = true )
-    @name = name
-    @version = version
-    @default_spec = default_spec
-  end
-end
-
 default_gems = [
-    ImportedGem.new('cmath', '1.0.0'),
-    ImportedGem.new('csv', '1.0.0'),
-    ImportedGem.new('fileutils', '1.1.0'),
-    ImportedGem.new('ipaddr', '1.2.0'),
-    ImportedGem.new('jar-dependencies', '${jar-dependencies.version}'),
-    ImportedGem.new('jruby-readline', '1.2.2'),
-    ImportedGem.new('jruby-openssl', '0.10.1'),
-    ImportedGem.new('json', '${json.version}'),
-    ImportedGem.new('psych', '3.0.3'),
-    ImportedGem.new('rake-ant', '1.0.4'),
-    ImportedGem.new('rdoc', '${rdoc.version}'),
-    ImportedGem.new('scanf', '1.0.0'),
-    ImportedGem.new('webrick', '1.4.2'),
+    ['cmath', '1.0.0'],
+    ['csv', '1.0.0'],
+    ['fileutils', '1.1.0'],
+    ['ipaddr', '1.2.0'],
+    ['jar-dependencies', '${jar-dependencies.version}'],
+    ['jruby-readline', '1.2.2'],
+    ['jruby-openssl', '0.10.1'],
+    ['json', '${json.version}'],
+    ['psych', '3.0.3'],
+    ['rake-ant', '1.0.4'],
+    ['rdoc', '${rdoc.version}'],
+    ['scanf', '1.0.0'],
+    ['webrick', '1.4.2'],
 ]
 
 bundled_gems = [
@@ -88,9 +78,9 @@ project 'JRuby Lib Setup' do
                            :includes => [ 'org/**/*.jar' ] } ] )
 
   # tell maven to download the respective gem artifacts
-  default_gems.each do |g|
+  default_gems.each do |name, version|
     # use provided scope so it is not a real dependency for runtime
-    dependency 'rubygems', g.name, g.version, :type => 'gem', :scope => :provided do
+    dependency 'rubygems', name, version, :type => 'gem', :scope => :provided do
       exclusion 'rubygems:jar-dependencies'
     end
   end
@@ -102,7 +92,7 @@ project 'JRuby Lib Setup' do
     end
   end
 
-  default_gemnames = default_gems.collect { |g| g.name }
+  default_gemnames = default_gems.collect { |name, _| name }
 
   plugin :dependency,
     :useRepositoryLayout => true,
@@ -166,21 +156,22 @@ project 'JRuby Lib Setup' do
       end
     end
 
-    default_gems.each do |g|
-      pom_version = ctx.project.properties.get( g.version[2..-2] ) || g.version
-      version = pom_version.sub( /-SNAPSHOT/, '' )
+    default_gems.each do |name, version|
+      version = ctx.project.properties.get(version[2..-2]) || version
+      version = version.sub( /-SNAPSHOT/, '' )
+      gem_name = "#{name}-#{version}"
 
       # install the gem unless already installed
-      if Dir[ File.join( default_specs, "#{g.name}-#{version}*.gemspec" ) ].empty?
+      if Dir[ File.join( default_specs, "#{gem_name}*.gemspec" ) ].empty?
 
         log
-        log "--- gem #{g.name}-#{version} ---"
+        log "--- gem #{gem_name} ---"
 
         # copy the gem content to stdlib
 
         log "copy gem content to #{stdlib_dir}"
         # assume default require_path
-        require_base = File.join( gems, "#{g.name}-#{version}*", 'lib' )
+        require_base = File.join( gems, "#{gemname}*", 'lib' )
         require_files = File.join( require_base, '*' )
 
         # copy in new ones and mark writable for future updates (e.g. minitest)
@@ -202,7 +193,7 @@ project 'JRuby Lib Setup' do
         end
 
         # copy bin files if the gem has any
-        bin = File.join( gems, "#{g.name}-#{version}", 'bin' )
+        bin = File.join( gems, "#{gemname}", 'bin' )
         if File.exists? bin
           Dir[ File.join( bin, '*' ) ].each do |f|
             log "copy to bin: #{File.basename( f )}"
@@ -213,7 +204,7 @@ project 'JRuby Lib Setup' do
         end
 
         if g.default_spec
-          specfile_wildcard = "#{g.name}-#{version}*.gemspec"
+          specfile_wildcard = "#{gemname}*.gemspec"
           specfile = Dir[ File.join( specs,  specfile_wildcard ) ].first
 
           unless specfile
@@ -223,7 +214,7 @@ project 'JRuby Lib Setup' do
           specname = File.basename( specfile )
           log "copy to specifications/default: #{specname}"
 
-          spec = Gem::Package.new( Dir[ File.join( cache, "#{g.name}-#{version}*.gem" ) ].first ).spec
+          spec = Gem::Package.new( Dir[ File.join( cache, "#{gemname}*.gem" ) ].first ).spec
           File.open( File.join( default_specs, specname ), 'w' ) do |f|
             f.print( spec.to_ruby )
           end
@@ -301,24 +292,21 @@ project 'JRuby Lib Setup' do
     resource do
       directory '${gem.home}'
       # assume all dependencies are met with this gems + the default gems
-      incl = bundled_gems.collect do |bgem|
+      incl = (default_gems + bundled_gems).collect do |name, version|
         [
-          "cache/#{bgem[0]}*#{bgem[1]}.gem",
-          "gems/#{bgem[0]}*#{bgem[1]}/*",
-          "specifications/#{bgem[0]}*#{bgem[1]}.gemspec"
+          "cache/#{name}*#{version}.gem",
+          "gems/#{name}*#{version}/**",
+          "specifications/#{name}*#{version}.gemspec"
         ]
       end.flatten
-      excl = default_gems.collect do |bgem|
-        "gems/#{bgem.name}*#{bgem.version}/*"
-      end
       includes incl
-      excludes excl
+      p incl
       target_path '${jruby.complete.gems}'
     end
 
     resource do
       directory '${gem.home}'
-      includes 'gems/rake-${rake.version}/bin/r*', 'gems/rdoc-${rdoc.version}/bin/r*', 'specifications/default/*.gemspec'
+      includes 'specifications/default/*.gemspec'
       target_path '${jruby.complete.gems}'
     end
 

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -311,50 +311,72 @@ DO NOT MODIFIY - GENERATED CODE
         <targetPath>${jruby.complete.gems}</targetPath>
         <directory>${gem.home}</directory>
         <includes>
+          <include>cache/cmath*1.0.0.gem</include>
+          <include>gems/cmath*1.0.0/**</include>
+          <include>specifications/cmath*1.0.0.gemspec</include>
+          <include>cache/csv*1.0.0.gem</include>
+          <include>gems/csv*1.0.0/**</include>
+          <include>specifications/csv*1.0.0.gemspec</include>
+          <include>cache/fileutils*1.1.0.gem</include>
+          <include>gems/fileutils*1.1.0/**</include>
+          <include>specifications/fileutils*1.1.0.gemspec</include>
+          <include>cache/ipaddr*1.2.0.gem</include>
+          <include>gems/ipaddr*1.2.0/**</include>
+          <include>specifications/ipaddr*1.2.0.gemspec</include>
+          <include>cache/jar-dependencies*${jar-dependencies.version}.gem</include>
+          <include>gems/jar-dependencies*${jar-dependencies.version}/**</include>
+          <include>specifications/jar-dependencies*${jar-dependencies.version}.gemspec</include>
+          <include>cache/jruby-readline*1.2.2.gem</include>
+          <include>gems/jruby-readline*1.2.2/**</include>
+          <include>specifications/jruby-readline*1.2.2.gemspec</include>
+          <include>cache/jruby-openssl*0.10.1.gem</include>
+          <include>gems/jruby-openssl*0.10.1/**</include>
+          <include>specifications/jruby-openssl*0.10.1.gemspec</include>
+          <include>cache/json*${json.version}.gem</include>
+          <include>gems/json*${json.version}/**</include>
+          <include>specifications/json*${json.version}.gemspec</include>
+          <include>cache/psych*3.0.3.gem</include>
+          <include>gems/psych*3.0.3/**</include>
+          <include>specifications/psych*3.0.3.gemspec</include>
+          <include>cache/rake-ant*1.0.4.gem</include>
+          <include>gems/rake-ant*1.0.4/**</include>
+          <include>specifications/rake-ant*1.0.4.gemspec</include>
+          <include>cache/rdoc*${rdoc.version}.gem</include>
+          <include>gems/rdoc*${rdoc.version}/**</include>
+          <include>specifications/rdoc*${rdoc.version}.gemspec</include>
+          <include>cache/scanf*1.0.0.gem</include>
+          <include>gems/scanf*1.0.0/**</include>
+          <include>specifications/scanf*1.0.0.gemspec</include>
+          <include>cache/webrick*1.4.2.gem</include>
+          <include>gems/webrick*1.4.2/**</include>
+          <include>specifications/webrick*1.4.2.gemspec</include>
           <include>cache/did_you_mean*1.2.0.gem</include>
-          <include>gems/did_you_mean*1.2.0/*</include>
+          <include>gems/did_you_mean*1.2.0/**</include>
           <include>specifications/did_you_mean*1.2.0.gemspec</include>
           <include>cache/minitest*${minitest.version}.gem</include>
-          <include>gems/minitest*${minitest.version}/*</include>
+          <include>gems/minitest*${minitest.version}/**</include>
           <include>specifications/minitest*${minitest.version}.gemspec</include>
           <include>cache/net-telnet*0.1.1.gem</include>
-          <include>gems/net-telnet*0.1.1/*</include>
+          <include>gems/net-telnet*0.1.1/**</include>
           <include>specifications/net-telnet*0.1.1.gemspec</include>
           <include>cache/power_assert*${power_assert.version}.gem</include>
-          <include>gems/power_assert*${power_assert.version}/*</include>
+          <include>gems/power_assert*${power_assert.version}/**</include>
           <include>specifications/power_assert*${power_assert.version}.gemspec</include>
           <include>cache/rake*${rake.version}.gem</include>
-          <include>gems/rake*${rake.version}/*</include>
+          <include>gems/rake*${rake.version}/**</include>
           <include>specifications/rake*${rake.version}.gemspec</include>
           <include>cache/test-unit*${test-unit.version}.gem</include>
-          <include>gems/test-unit*${test-unit.version}/*</include>
+          <include>gems/test-unit*${test-unit.version}/**</include>
           <include>specifications/test-unit*${test-unit.version}.gemspec</include>
           <include>cache/xmlrpc*0.3.0.gem</include>
-          <include>gems/xmlrpc*0.3.0/*</include>
+          <include>gems/xmlrpc*0.3.0/**</include>
           <include>specifications/xmlrpc*0.3.0.gemspec</include>
         </includes>
-        <excludes>
-          <exclude>gems/cmath*1.0.0/*</exclude>
-          <exclude>gems/csv*1.0.0/*</exclude>
-          <exclude>gems/fileutils*1.1.0/*</exclude>
-          <exclude>gems/ipaddr*1.2.0/*</exclude>
-          <exclude>gems/jar-dependencies*${jar-dependencies.version}/*</exclude>
-          <exclude>gems/jruby-readline*1.2.2/*</exclude>
-          <exclude>gems/jruby-openssl*0.10.1/*</exclude>
-          <exclude>gems/json*${json.version}/*</exclude>
-          <exclude>gems/psych*3.0.3/*</exclude>
-          <exclude>gems/rake-ant*1.0.4/*</exclude>
-          <exclude>gems/rdoc*${rdoc.version}/*</exclude>
-          <exclude>gems/scanf*1.0.0/*</exclude>
-          <exclude>gems/webrick*1.4.2/*</exclude>
-        </excludes>
       </resource>
       <resource>
         <targetPath>${jruby.complete.gems}</targetPath>
         <directory>${gem.home}</directory>
         <includes>
-          <include>gems/rake-${rake.version}/bin/r*</include>
-          <include>gems/rdoc-${rdoc.version}/bin/r*</include>
           <include>specifications/default/*.gemspec</include>
         </includes>
       </resource>


### PR DESCRIPTION
More or less all default and installed gems will completely include themselves
into stdlib artifact which in turn will make them available when making the
jruby-dist package.

What makes me uncertain that this is right is the previous code went through
some pains to not include everything.  I am guessing there is something we don't
want and I am now including it?

Second part of this was unneeded but I removed the ImportedGem class and just
had both gem types use a nested array of arrays leveraging block destructuring.