### PR TITLE
fix move on windows #5421

### DIFF
--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -1117,6 +1117,10 @@ public class RubyFile extends RubyIO implements EncodingCapable {
             return RubyFixnum.zero(runtime);
         }
 
+        if (!oldFile.exists() && newFile.exists()) {
+            return RubyFixnum.zero(runtime);
+        }
+
         throw runtime.newErrnoEACCESError(oldNameJavaString + " or " + newNameJavaString);
     }
 


### PR DESCRIPTION
1/ oldFile.renameTo(dest)
-> fails for unknown reason, see the original issue #5421
2/ Files.move(oldPath, destPath, StandardCopyOption.ATOMIC_MOVE)
-> moves the file and removes the original
3/ (oldFile.renameTo(dest)) { // try to rename one more time
-> fails because the original file doesn't exist anymore

I'm not sure if it's safe, but it works for me

cc @headius