### PR TITLE
Fix set initialization

### DIFF
--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -199,6 +199,7 @@ public class RubySet extends RubyObject implements Set {
     private IRubyObject initWithEnum(final ThreadContext context, final IRubyObject enume, final Block block) {
         if ( enume instanceof RubyArray ) {
             RubyArray ary = (RubyArray) enume;
+            if ( ary.size() == 0 ) return initialize(context, block);
             allocHash(context.runtime, ary.size());
             for ( int i = 0; i < ary.size(); i++ ) {
                 invokeAdd(context, block.yield(context, ary.eltInternal(i)));
@@ -208,6 +209,7 @@ public class RubySet extends RubyObject implements Set {
 
         if ( enume instanceof RubySet ) {
             RubySet set = (RubySet) enume;
+            if ( set.size() == 0 ) return initialize(context, block);
             allocHash(context.runtime, set.size());
             for ( IRubyObject elem : set.elementsOrdered() ) {
                 invokeAdd(context, block.yield(context, elem));

--- a/spec/ruby/library/set/initialize_spec.rb
+++ b/spec/ruby/library/set/initialize_spec.rb
@@ -14,11 +14,35 @@ describe "Set#initialize" do
     s.should include(3)
   end
 
+  it "should initialize with empty array and set" do
+    s = Set.new([])
+    s.size.should eql(0)
+
+    s = Set.new({})
+    s.size.should eql(0)
+  end
+
   it "preprocesses all elements by a passed block before adding to self" do
     s = Set.new([1, 2, 3]) { |x| x * x }
     s.size.should eql(3)
     s.should include(1)
     s.should include(4)
     s.should include(9)
+  end
+
+  it "should initialize with empty array and block" do
+    s = Set.new([]) { |x| x * x }
+    s.size.should eql(0)
+  end
+
+  it "should initialize with empty set and block" do
+    s = Set.new(Set.new) { |x| x * x }
+    s.size.should eql(0)
+  end
+
+  it "should initialize with just block" do
+    s = Set.new { |x| x * x }
+    s.size.should eql(0)
+    s.should eql(Set.new)
   end
 end


### PR DESCRIPTION
Fixes #5426 which is caused by the change in #5413

When the set is initialized with the empty array/set and block is also given, it should avoid calling `allocHash` with `bucket_size` which would be 0.
