### PR TITLE
Attempt to fix #5421 windows oddity where some times a rename during bundle…

### DIFF
--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -1109,15 +1109,10 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         Path destPath = Paths.get(dest.getAbsolutePath());
         try {
             Files.move(oldPath, destPath, StandardCopyOption.ATOMIC_MOVE);
+            return RubyFixnum.zero(runtime);
         } catch (IOException ioe) {
             throw Helpers.newIOErrorFromException(runtime, ioe);
         }
-
-        if (oldFile.renameTo(dest)) { // try to rename one more time
-            return RubyFixnum.zero(runtime);
-        }
-
-        throw runtime.newErrnoEACCESError(oldNameJavaString + " or " + newNameJavaString);
     }
 
     @JRubyMethod(required = 1, meta = true)


### PR DESCRIPTION
… install would fail.

This I believe fixes #5421.

The fix is I think if we depend on Files.move to do it's thing we should not
try and rename a second time using the old way.  This happened to never
manifest on linux or macos because bundler stores files in another FS so
we never hit this code path.