### PR TITLE
Allows CompiledIRMethod to inline methods when it is the host scope.

### DIFF
--- a/core/src/main/java/org/jruby/compiler/JITCompiler.java
+++ b/core/src/main/java/org/jruby/compiler/JITCompiler.java
@@ -34,6 +34,7 @@ import org.jruby.Ruby;
 import org.jruby.RubyEncoding;
 import org.jruby.RubyInstanceConfig;
 import org.jruby.RubyModule;
+import org.jruby.internal.runtime.methods.CompiledIRMethod;
 import org.jruby.internal.runtime.methods.MixedModeIRMethod;
 import org.jruby.runtime.MethodIndex;
 import org.jruby.runtime.MixedModeIRBlockBody;
@@ -150,6 +151,8 @@ public class JITCompiler implements JITCompilerMBean {
             return new MethodJITTask(this, (MixedModeIRMethod) method, method.getClassName(context));
         } else if (method instanceof MixedModeIRBlockBody) {
             return new BlockJITTask(this, (MixedModeIRBlockBody) method, method.getClassName(context));
+        } else if (method instanceof CompiledIRMethod) {
+            return new MethodCompiledJITTask(this, (CompiledIRMethod) method, method.getClassName(context));
         }
 
         return new FullBuildTask(this, method);

--- a/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
@@ -1,0 +1,122 @@
+package org.jruby.compiler;
+
+import org.jruby.MetaClass;
+import org.jruby.Ruby;
+import org.jruby.RubyModule;
+import org.jruby.ast.util.SexpMaker;
+import org.jruby.internal.runtime.methods.CompiledIRMethod;
+import org.jruby.ir.targets.JVMVisitor;
+import org.jruby.ir.targets.JVMVisitorMethodContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.OneShotClassLoader;
+import org.jruby.util.collections.IntHashMap;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+
+/**
+ * Created by enebo on 10/30/18.
+ */
+public class MethodCompiledJITTask implements Runnable {
+    private final JITCompiler jitCompiler;
+    private final String className;
+    private final CompiledIRMethod method;
+    private final String methodName;
+
+    public MethodCompiledJITTask(JITCompiler jitCompiler, CompiledIRMethod method, String className) {
+        this.jitCompiler = jitCompiler;
+        this.method = method;
+        this.className = className;
+        this.methodName = method.getName();
+    }
+
+    @Override
+    public void run() {
+        // We synchronize against the JITCompiler object so at most one code body will jit at once in a given runtime.
+        // This works around unsolved concurrency issues within the process of preparing and jitting the IR.
+        // See #4739 for a reproduction script that produced various errors without this.
+        synchronized (jitCompiler) {
+            try {
+                // Check if the method has been explicitly excluded
+                if (jitCompiler.config.getExcludedMethods().size() > 0) {
+                    String excludeModuleName = className;
+                    if (method.getImplementationClass().getMethodLocation().isSingleton()) {
+                        IRubyObject possibleRealClass = ((MetaClass) method.getImplementationClass()).getAttached();
+                        if (possibleRealClass instanceof RubyModule) {
+                            excludeModuleName = "Meta:" + ((RubyModule) possibleRealClass).getName();
+                        }
+                    }
+
+                    if ((jitCompiler.config.getExcludedMethods().contains(excludeModuleName)
+                            || jitCompiler.config.getExcludedMethods().contains(excludeModuleName + '#' + methodName)
+                            || jitCompiler.config.getExcludedMethods().contains(methodName))) {
+                        method.setCallCount(-1);
+
+                        if (jitCompiler.config.isJitLogging()) {
+                            JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), methodName, "skipping method: " + excludeModuleName + '#' + methodName);
+                        }
+                        return;
+                    }
+                }
+
+                String key = SexpMaker.sha1(method.getIRScope());
+                Ruby runtime = jitCompiler.runtime;
+                JVMVisitor visitor = new JVMVisitor(runtime);
+                MethodJITClassGenerator generator = new MethodJITClassGenerator(className, methodName, key, runtime, method, visitor);
+
+                JVMVisitorMethodContext context = new JVMVisitorMethodContext();
+                generator.compile(context);
+
+                // FIXME: reinstate active bytecode size check
+                // At this point we still need to reinstate the bytecode size check, to ensure we're not loading code
+                // that's so big that JVMs won't even try to compile it. Removed the check because with the new IR JIT
+                // bytecode counts often include all nested scopes, even if they'd be different methods. We need a new
+                // mechanism of getting all method sizes.
+                Class sourceClass = visitor.defineFromBytecode(method.getIRScope(), generator.bytecode(), new OneShotClassLoader(runtime.getJRubyClassLoader()));
+
+                if (sourceClass == null) {
+                    // class could not be found nor generated; give up on JIT and bail out
+                    jitCompiler.counts.failCount.incrementAndGet();
+                    return;
+                } else {
+                    generator.updateCounters(jitCompiler.counts, method.ensureInstrsReady());
+                }
+
+                // successfully got back a jitted method
+                long methodCount = jitCompiler.counts.successCount.incrementAndGet();
+
+                // logEvery n methods based on configuration
+                if (jitCompiler.config.getJitLogEvery() > 0) {
+                    if (methodCount % jitCompiler.config.getJitLogEvery() == 0) {
+                        JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), methodName, "live compiled methods: " + methodCount);
+                    }
+                }
+
+                if (jitCompiler.config.isJitLogging()) {
+                    JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), className + '.' + methodName, "done jitting");
+                }
+
+                String variableName = context.getVariableName();
+                MethodHandle variable = JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, variableName, context.getNativeSignature(-1));
+                IntHashMap<MethodType> signatures = context.getNativeSignaturesExceptVariable();
+
+                method.setVariable(variable);
+                if (signatures.size() != 0) {
+                    for (IntHashMap.Entry<MethodType> entry : signatures.entrySet()) {
+                        method.setSpecific(JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, context.getSpecificName(), entry.getValue()));
+                        break; // FIXME: only supports one arity
+                    }
+                }
+            } catch (Throwable t) {
+                if (jitCompiler.config.isJitLogging()) {
+                    JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), className + '.' + methodName, "Could not compile; passes run: " + method.getIRScope().getExecutedPasses(), t.getMessage());
+                    if (jitCompiler.config.isJitLoggingVerbose()) {
+                        t.printStackTrace();
+                    }
+                }
+
+                jitCompiler.counts.failCount.incrementAndGet();
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/jruby/compiler/MethodJITClassGenerator.java
+++ b/core/src/main/java/org/jruby/compiler/MethodJITClassGenerator.java
@@ -27,15 +27,14 @@
 package org.jruby.compiler;
 
 import org.jruby.Ruby;
-import org.jruby.internal.runtime.methods.MixedModeIRMethod;
+import org.jruby.internal.runtime.AbstractIRMethod;
 import org.jruby.ir.interpreter.InterpreterContext;
 import org.jruby.ir.targets.JVMVisitor;
 import org.jruby.ir.targets.JVMVisitorMethodContext;
-import org.jruby.util.JavaNameMangler;
 import org.jruby.util.cli.Options;
 
 public class MethodJITClassGenerator extends JITClassGenerator {
-    public MethodJITClassGenerator(String className, String methodName, String key, Ruby ruby, MixedModeIRMethod method, JVMVisitor visitor) {
+    public MethodJITClassGenerator(String className, String methodName, String key, Ruby ruby, AbstractIRMethod method, JVMVisitor visitor) {
         super(className, methodName, key, ruby, visitor);
         this.method = method;
     }
@@ -79,5 +78,5 @@ public class MethodJITClassGenerator extends JITClassGenerator {
     public String toString() {
         return methodName + "() at " + method.getFile() + ':' + method.getLine();
     }
-    private final MixedModeIRMethod method;
+    private final AbstractIRMethod method;
 }

--- a/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
@@ -3,11 +3,14 @@ package org.jruby.internal.runtime;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jruby.MetaClass;
+import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.internal.runtime.methods.IRMethodArgs;
 import org.jruby.ir.IRMethod;
 import org.jruby.ir.IRScope;
+import org.jruby.ir.JIT;
 import org.jruby.ir.instructions.GetFieldInstr;
 import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.instructions.PutFieldInstr;
@@ -90,8 +93,25 @@ public abstract class AbstractIRMethod extends DynamicMethod implements IRMethod
         }
     }
 
+    @JIT
     public String getClassName(ThreadContext context) {
-        return null;
+        String className;
+        if (implementationClass.isSingleton()) {
+            MetaClass metaClass = (MetaClass)implementationClass;
+            RubyClass realClass = metaClass.getRealClass();
+            // if real class is Class
+            if (realClass == context.runtime.getClassClass()) {
+                // use the attached class's name
+                className = ((RubyClass) metaClass.getAttached()).getName();
+            } else {
+                // use the real class name
+                className = realClass.getName();
+            }
+        } else {
+            // use the class name
+            className = implementationClass.getName();
+        }
+        return className;
     }
 
     public String getFile() {

--- a/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
@@ -1,28 +1,26 @@
 package org.jruby.internal.runtime.methods;
 
 import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 
-import com.headius.invokebinder.Binder;
+import org.jruby.MetaClass;
+import org.jruby.RubyClass;
 import org.jruby.RubyModule;
+import org.jruby.compiler.Compilable;
 import org.jruby.internal.runtime.AbstractIRMethod;
 import org.jruby.ir.IRMethod;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.interpreter.InterpreterContext;
-import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.runtime.ArgumentDescriptor;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.Helpers;
-import org.jruby.runtime.Signature;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 
-public class CompiledIRMethod extends AbstractIRMethod {
-    private final MethodHandle variable;
+public class CompiledIRMethod extends AbstractIRMethod implements Compilable<DynamicMethod>  {
+    private MethodHandle variable;
 
-    private final MethodHandle specific;
+    private MethodHandle specific;
     private final int specificArity;
 
     public CompiledIRMethod(MethodHandle variable, IRScope method, Visibility visibility,
@@ -45,6 +43,8 @@ public class CompiledIRMethod extends AbstractIRMethod {
         assert method.hasExplicitCallProtocol();
 
         setHandle(variable);
+
+        method.compilable = this;
     }
 
     public MethodHandle getHandleFor(int arity) {
@@ -55,8 +55,22 @@ public class CompiledIRMethod extends AbstractIRMethod {
         return null;
     }
 
+    public void setVariable(MethodHandle variable) {
+        this.variable = variable;
+    }
+
+    public void setSpecific(MethodHandle specific) {
+        this.specific = specific;
+    }
+
+
     public ArgumentDescriptor[] getArgumentDescriptors() {
         return ((IRMethod)method).getArgumentDescriptors();
+    }
+
+    @Override
+    public void completeBuild(DynamicMethod buildResult) {
+        // unused but part of compilable interface.  jit task uses setVariable and setSpecific to update code.
     }
 
     @Override

--- a/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
@@ -276,26 +276,6 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
         }
     }
 
-    public String getClassName(ThreadContext context) {
-        String className;
-        if (implementationClass.isSingleton()) {
-            MetaClass metaClass = (MetaClass)implementationClass;
-            RubyClass realClass = metaClass.getRealClass();
-            // if real class is Class
-            if (realClass == context.runtime.getClassClass()) {
-                // use the attached class's name
-                className = ((RubyClass) metaClass.getAttached()).getName();
-            } else {
-                // use the real class name
-                className = realClass.getName();
-            }
-        } else {
-            // use the class name
-            className = implementationClass.getName();
-        }
-        return className;
-    }
-
     @Override
     public DynamicMethod dup() {
         MixedModeIRMethod x = (MixedModeIRMethod) super.dup();

--- a/core/src/main/java/org/jruby/runtime/callsite/ProfilingCachingCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/ProfilingCachingCallSite.java
@@ -45,7 +45,7 @@ public class ProfilingCachingCallSite extends CachingCallSite {
         if (!hostScope.inliningAllowed()) return;
 
         // CompiledIRMethod* is not supported
-        boolean targetIsIR = cache.method instanceof MixedModeIRMethod || cache.method instanceof InterpretedIRMethod;
+        boolean targetIsIR = cache.method instanceof AbstractIRMethod;
         boolean siteIsIR = hostScope.compilable != null;
 
         AbstractIRMethod targetMethod;
@@ -65,10 +65,13 @@ public class ProfilingCachingCallSite extends CachingCallSite {
             if (IRManager.IR_INLINER_VERBOSE) LOG.info("PROFILE: " + hostScope + " -> " + self.getMetaClass().rubyName() + "#" + methodName + " - " + totalMonomorphicCalls);
 
             IRMethod scopeToInline = (IRMethod) (targetMethod).getIRScope();
-            if (cache.method instanceof InterpretedIRMethod) {
+            AbstractIRMethod hostMethod = (AbstractIRMethod) hostScope.compilable;
+            if (hostMethod instanceof InterpretedIRMethod) {
                 hostScope.inlineMethod(scopeToInline, callSiteId, cache.token, false);
-            } else { // MixedModelIRMethod
+            } else if (hostMethod instanceof MixedModeIRMethod) {
                 hostScope.inlineMethodJIT(scopeToInline, callSiteId, cache.token, false);
+            } else {
+                hostScope.inlineMethodCompiled(scopeToInline, callSiteId, cache.token, false);
             }
         }
     }


### PR DESCRIPTION
Allows inliner to work on main scripts which are made with IRCompiledMethod.  I can see a bit of redundancy but I would prefer we address that with a later refactoring (plus inliner is still young enough we may decide we need more in JIT compilation infrastructure).