### PR TITLE
Time#nsec should always be positive

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -896,7 +896,7 @@ public class RubyTime extends RubyObject {
      * @return nano seconds (only)
      */
     public int getNanos() {
-        return (int) (getTimeInMillis() % 1000) * 1_000_000 + (int) getNSec();
+        return (int) (dt.getMillisOfSecond() * 1_000_000L + getNSec());
     }
 
     /**

--- a/spec/ruby/core/time/nsec_spec.rb
+++ b/spec/ruby/core/time/nsec_spec.rb
@@ -24,4 +24,8 @@ describe "Time#nsec" do
   it "returns the nanoseconds part of a Time constructed with an Rational number of microseconds" do
     Time.at(0, Rational(99, 10)).nsec.should == 9900
   end
+
+  it "returns a positive value for dates before the epoch" do
+    Time.utc(1969, 11, 12, 13, 18, 57, 404240).nsec.should == 404240000
+  end
 end

--- a/spec/ruby/core/time/usec_spec.rb
+++ b/spec/ruby/core/time/usec_spec.rb
@@ -36,4 +36,8 @@ describe "Time#usec" do
   it "returns the microseconds for time created by Time#local" do
     Time.local(1,2,3,4,5,Rational(6.78)).usec.should == 780000
   end
+
+  it "returns a positive value for dates before the epoch" do
+    Time.utc(1969, 11, 12, 13, 18, 57, 404240).usec.should == 404240
+  end
 end


### PR DESCRIPTION
This fixes Time#nsec to not return negative values for pre-epoch dates. Includes specs. Fixes #5438.