### PR TITLE
Push signal traps and at_exit blocks to a common thread for exec.

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -3306,33 +3306,8 @@ public final class Ruby implements Constantizable {
             context.pushScope(new ManyVarsDynamicScope(topStaticScope, null));
         }
 
-        // use signal-handling thread to avoid races with trap(INT) and similar shutdown signals
+        // terminate signal-handling thread to avoid races with at_exit
         ExecutorService executor = (ExecutorService) getModule("Signal").getInternalVariable("executor");
-
-        int[] _status = {status};
-        while (!atExitBlocks.empty()) {
-            RubyProc proc = atExitBlocks.pop();
-            executor.submit((Runnable) () -> {
-                // IRubyObject oldExc = context.runtime.getGlobalVariables().get("$!"); // Save $!
-                try {
-                    proc.call(context, IRubyObject.NULL_ARRAY);
-                } catch (RaiseException rj) {
-                    RubyException raisedException = rj.getException();
-                    if (!getSystemExit().isInstance(raisedException)) {
-                        _status[0] = 1;
-                        printError(raisedException);
-                    } else {
-                        IRubyObject statusObj = raisedException.callMethod(context, "status");
-                        if (statusObj != null && !statusObj.isNil()) {
-                            _status[0] = RubyNumeric.fix2int(statusObj);
-                        }
-                    }
-                    // Reset $! now that rj has been handled
-                    // context.runtime.getGlobalVariables().set("$!", oldExc);
-                }
-            });
-        }
-
         try {
             executor.shutdown();
             if (!executor.awaitTermination(1, TimeUnit.HOURS)) {
@@ -3340,6 +3315,27 @@ public final class Ruby implements Constantizable {
             }
         } catch (InterruptedException ie) {
             throw newRuntimeError("interrupted while attempting to execute at_exit blocks");
+        }
+
+        while (!atExitBlocks.empty()) {
+            RubyProc proc = atExitBlocks.pop();
+            // IRubyObject oldExc = context.runtime.getGlobalVariables().get("$!"); // Save $!
+            try {
+                proc.call(context, IRubyObject.NULL_ARRAY);
+            } catch (RaiseException rj) {
+                RubyException raisedException = rj.getException();
+                if (!getSystemExit().isInstance(raisedException)) {
+                    status = 1;
+                    printError(raisedException);
+                } else {
+                    IRubyObject statusObj = raisedException.callMethod(context, "status");
+                    if (statusObj != null && !statusObj.isNil()) {
+                        status = RubyNumeric.fix2int(statusObj);
+                    }
+                }
+                // Reset $! now that rj has been handled
+                // context.runtime.getGlobalVariables().set("$!", oldExc);
+            }
         }
 
         // Fetches (and unsets) the SIGEXIT handler, if one exists.

--- a/core/src/main/java/org/jruby/RubySignal.java
+++ b/core/src/main/java/org/jruby/RubySignal.java
@@ -35,10 +35,14 @@ import org.jruby.anno.JRubyModule;
 import org.jruby.platform.Platform;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.threading.DaemonThreadFactory;
 import org.jruby.util.SignalFacade;
 import org.jruby.util.NoFunctionalitySignalFacade;
 
 import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
 
 @JRubyModule(name="Signal")
 public class RubySignal {
@@ -68,6 +72,11 @@ public class RubySignal {
         RubyModule mSignal = runtime.defineModule("Signal");
         
         mSignal.defineAnnotatedMethods(RubySignal.class);
+
+        // create single-threaded executor to handle signals and at_exit blocks
+        ExecutorService executor = Executors.newSingleThreadExecutor(new DaemonThreadFactory());
+        mSignal.setInternalVariable("executor", executor);
+
         //registerThreadDumpSignalHandler(runtime);
     }
 

--- a/core/src/main/java/org/jruby/util/NoFunctionalitySignalFacade.java
+++ b/core/src/main/java/org/jruby/util/NoFunctionalitySignalFacade.java
@@ -40,8 +40,8 @@ public class NoFunctionalitySignalFacade implements SignalFacade {
         return recv.getRuntime().getNil();
     }
 
-    public IRubyObject trap(Ruby runtime, BlockCallback block, String sig) {
-        return runtime.getNil();
+    public IRubyObject trap(IRubyObject recv, BlockCallback block, String sig) {
+        return recv.getRuntime().getNil();
     }
 
     public IRubyObject restorePlatformDefault(IRubyObject recv, IRubyObject sig) {

--- a/core/src/main/java/org/jruby/util/SignalFacade.java
+++ b/core/src/main/java/org/jruby/util/SignalFacade.java
@@ -37,7 +37,7 @@ import org.jruby.runtime.builtin.IRubyObject;
  */
 public interface SignalFacade {
     IRubyObject trap(IRubyObject recv, IRubyObject block, IRubyObject sig);
-    IRubyObject trap(Ruby runtime, BlockCallback block, String sig);
+    IRubyObject trap(IRubyObject recv, BlockCallback block, String sig);
     /**
      * Restores the platform (JVM's) default signal handler.
      */


### PR DESCRIPTION
This avoids races due to the signal traps running on the JVM's
signal-handling thread while we run at_exit blocks on JRuby's
main thread.

Fixes #5437.