### PR TITLE
fix overflow in #i_gcd

### DIFF
--- a/core/src/main/java/org/jruby/util/Numeric.java
+++ b/core/src/main/java/org/jruby/util/Numeric.java
@@ -514,10 +514,10 @@ public class Numeric {
         if (x == Long.MIN_VALUE) {
             if (y == Long.MIN_VALUE)
                 return x;
-            return 1 << Long.numberOfTrailingZeros(Math.abs(y));
+            return 1L << Long.numberOfTrailingZeros(Math.abs(y));
         }
         if (y == Long.MIN_VALUE) {
-            return 1 << Long.numberOfTrailingZeros(Math.abs(x));
+            return 1L << Long.numberOfTrailingZeros(Math.abs(x));
         }
 
         x = Math.abs(x);


### PR DESCRIPTION
Long.numberOfTrailingZeros returns an integer
long result = 1 << int;

fixes
```
-9223372036854775808.gcd(0)
```
returns 1 but it should return 9223372036854775808

