### PR TITLE
fix an edge case in gcd calculation

### DIFF
--- a/core/src/main/java/org/jruby/util/Numeric.java
+++ b/core/src/main/java/org/jruby/util/Numeric.java
@@ -552,7 +552,7 @@ public class Numeric {
      *
      */
     public static IRubyObject f_gcd(ThreadContext context, IRubyObject x, IRubyObject y) {
-        if (x instanceof RubyFixnum && y instanceof RubyFixnum) {
+        if (x instanceof RubyFixnum && y instanceof RubyFixnum && ((RubyFixnum)x).getLongValue() != Long.MIN_VALUE) {
             return RubyFixnum.newFixnum(context.runtime, i_gcd(((RubyFixnum)x).getLongValue(), ((RubyFixnum)y).getLongValue()));
         }
 
@@ -563,11 +563,8 @@ public class Numeric {
         if (f_zero_p(context, y)) return x;
 
         for (;;) {
-            if (x instanceof RubyFixnum) {
-                if (((RubyFixnum)x).getLongValue() == 0) return y;
-                if (y instanceof RubyFixnum) {
-                    return RubyFixnum.newFixnum(context.runtime, i_gcd(((RubyFixnum)x).getLongValue(), ((RubyFixnum)y).getLongValue()));
-                }
+            if (x instanceof RubyFixnum && y instanceof RubyFixnum && ((RubyFixnum)x).getLongValue() != Long.MIN_VALUE) {
+                return RubyFixnum.newFixnum(context.runtime, i_gcd(((RubyFixnum)x).getLongValue(), ((RubyFixnum)y).getLongValue()));
             }
             IRubyObject z = x;
             x = f_mod(context, y, x);
@@ -577,7 +574,7 @@ public class Numeric {
 
     // 'fast' gcd version
     public static RubyInteger f_gcd(ThreadContext context, RubyInteger x, RubyInteger y) {
-        if (x instanceof RubyFixnum && y instanceof RubyFixnum) {
+        if (x instanceof RubyFixnum && y instanceof RubyFixnum && ((RubyFixnum)x).getLongValue() != Long.MIN_VALUE) {
             return RubyFixnum.newFixnum(context.runtime, i_gcd(((RubyFixnum)x).getLongValue(), ((RubyFixnum)y).getLongValue()));
         }
 

--- a/spec/ruby/core/integer/gcd_spec.rb
+++ b/spec/ruby/core/integer/gcd_spec.rb
@@ -43,6 +43,17 @@ describe "Integer#gcd" do
     bignum.gcd(99).should == 99
   end
 
+  it "doesn't cause an integer overflow" do
+    [2 ** (1.size * 8 - 2), 0x8000000000000000].each do |max|
+      [max - 1, max, max + 1].each do |num|
+        num.gcd(num).should == num
+        (-num).gcd(num).should == num
+        (-num).gcd(-num).should == num
+        num.gcd(-num).should == num
+      end
+    end
+  end
+
   it "raises an ArgumentError if not given an argument" do
     lambda { 12.gcd }.should raise_error(ArgumentError)
   end


### PR DESCRIPTION
fixes
```
-9223372036854775808.gcd(-9223372036854775808)
```
should return 9223372036854775808 not -9223372036854775808

MRI uses FIXNUM_P macro instead of (x instanceof RubyFixnum), so -9223372036854775808 is properly delegated to a bignum logic