### PR TITLE
fix max range for usec

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -1796,7 +1796,7 @@ public class RubyTime extends RubyObject {
             } else {
                 int i_args4 = argToInt(context, args, 4 + 2, 0);
 
-                if (i_args4 < 0 || i_args4 >= TIME_SCALE) {
+                if (i_args4 < 0 || i_args4 >= TIME_SCALE / 1000) {
                     throw runtime.newArgumentError("argument out of range.");
                 }
 

--- a/spec/ruby/core/time/shared/time_params.rb
+++ b/spec/ruby/core/time/shared/time_params.rb
@@ -230,6 +230,10 @@ describe :time_params_microseconds, shared: true do
     t.usec.should == 123
   end
 
+  it "raises an ArgumentError for out of range microsecond" do
+    lambda { Time.send(@method, 2000, 1, 1, 20, 15, 1, 1000000) }.should raise_error(ArgumentError)
+  end
+
   it "handles fractional microseconds as a Float" do
     t = Time.send(@method, 2000, 1, 1, 20, 15, 1, 1.75)
     t.usec.should == 1


### PR DESCRIPTION
follow up for https://github.com/jruby/jruby/pull/5440

```
Time.utc(1969, 11, 12, 13, 18, 57, 1000000).usec
```
mri
```
ArgumentError (subsecx out of range)
```
jruby
```
0
```
jruby + patch
```
ArgumentError (argument out of range)
```