### PR TITLE
improve cross compile compatibility

### DIFF
--- a/core/src/main/java/org/jruby/RubyEncoding.java
+++ b/core/src/main/java/org/jruby/RubyEncoding.java
@@ -209,7 +209,7 @@ public class RubyEncoding extends RubyObject implements Constantizable {
     }
 
     private static byte[] getBytes(final ByteBuffer buffer) {
-        byte[] bytes = new byte[buffer.limit()];
+        byte[] bytes = new byte[((Buffer) buffer).limit()];
         buffer.get(bytes);
         return bytes;
     }
@@ -223,7 +223,7 @@ public class RubyEncoding extends RubyObject implements Constantizable {
             bytes = getBytes(buffer);
             off = 0;
         }
-        return new ByteList(bytes, off, off + buffer.limit(), enc, false);
+        return new ByteList(bytes, off, off + ((Buffer) buffer).limit(), enc, false);
     }
 
     public static byte[] encodeUTF16(String str) {
@@ -244,7 +244,7 @@ public class RubyEncoding extends RubyObject implements Constantizable {
 
     public static byte[] encode(CharSequence cs, Charset charset) {
         ByteBuffer buffer = charset.encode(CharBuffer.wrap(cs));
-        byte[] bytes = new byte[buffer.limit()];
+        byte[] bytes = new byte[((Buffer) buffer).limit()];
         buffer.get(bytes);
         return bytes;
     }
@@ -259,7 +259,7 @@ public class RubyEncoding extends RubyObject implements Constantizable {
 
     public static byte[] encode(String str, Charset charset) {
         ByteBuffer buffer = charset.encode(str);
-        byte[] bytes = new byte[buffer.limit()];
+        byte[] bytes = new byte[((Buffer) buffer).limit()];
         buffer.get(bytes);
         return bytes;
     }
@@ -303,12 +303,12 @@ public class RubyEncoding extends RubyObject implements Constantizable {
         public final ByteBuffer encode(String str) {
             ByteBuffer buf = byteBuffer;
             CharBuffer cbuf = charBuffer;
-            buf.clear();
+            ((Buffer) buf).clear();
             cbuf.clear();
             cbuf.put(str);
             cbuf.flip();
             encoder.encode(cbuf, buf, true);
-            buf.flip();
+            ((Buffer) buf).flip();
 
             return buf;
         }
@@ -316,14 +316,14 @@ public class RubyEncoding extends RubyObject implements Constantizable {
         public final ByteBuffer encode(CharSequence str) {
             ByteBuffer buf = byteBuffer;
             CharBuffer cbuf = charBuffer;
-            buf.clear();
+            ((Buffer) buf).clear();
             cbuf.clear();
             // NOTE: doesn't matter is we toString here in terms of speed
             // ... so we "safe" some space at least by not copy-ing char[]
             for (int i = 0; i < str.length(); i++) cbuf.put(str.charAt(i));
             cbuf.flip();
             encoder.encode(cbuf, buf, true);
-            buf.flip();
+            ((Buffer) buf).flip();
 
             return buf;
         }
@@ -332,9 +332,9 @@ public class RubyEncoding extends RubyObject implements Constantizable {
             CharBuffer cbuf = charBuffer;
             ByteBuffer buf = byteBuffer;
             cbuf.clear();
-            buf.clear();
+            ((Buffer) buf).clear();
             buf.put(bytes, start, length);
-            buf.flip();
+            ((Buffer) buf).flip();
             decoder.decode(buf, cbuf, true);
             cbuf.flip();
 

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -41,6 +41,7 @@ import java.io.Flushable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channel;
 import java.nio.channels.Channels;
@@ -4443,9 +4444,9 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
             if (n == -1) break;
 
-            buffer.flip();
+            ((Buffer) buffer).flip();
             to.write(buffer);
-            buffer.clear();
+            ((Buffer) buffer).clear();
 
             transferred += n;
             if (length > 0) {

--- a/core/src/main/java/org/jruby/embed/io/ReaderInputStream.java
+++ b/core/src/main/java/org/jruby/embed/io/ReaderInputStream.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
@@ -122,7 +123,7 @@ public class ReaderInputStream extends InputStream {
                     eof = true;
                 } else if (cr.isOverflow()) {
                     appendBytes(list, bbuf);
-                    bbuf.clear();
+                    ((Buffer) bbuf).clear();
                 }
             }
         }
@@ -130,11 +131,11 @@ public class ReaderInputStream extends InputStream {
     }
 
     private void appendBytes(List<byte[]> list, ByteBuffer bb) {
-        bb.flip();
-        int length = bb.limit();
+        ((Buffer) bb).flip();
+        int length = ((Buffer) bb).limit();
         totalBytes += length;
         byte[] dst = new byte[length];
-        System.arraycopy(bb.array(), bb.position(), dst, 0, length);
+        System.arraycopy(bb.array(), ((Buffer) bb).position(), dst, 0, length);
         list.add(dst);
     }
 

--- a/core/src/main/java/org/jruby/ext/ffi/io/FileDescriptorByteChannel.java
+++ b/core/src/main/java/org/jruby/ext/ffi/io/FileDescriptorByteChannel.java
@@ -31,6 +31,7 @@ package org.jruby.ext.ffi.io;
 import org.jruby.Ruby;
 import jnr.posix.LibC;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
 
@@ -74,7 +75,7 @@ public class FileDescriptorByteChannel implements ByteChannel {
         }
         int n = libc.read(fd, dst, dst.remaining());
         if (n > 0) {
-            dst.position(dst.position() + n);
+            dst.position(((Buffer) dst).position() + n);
         } else if (n == 0) {
             return -1; // EOF
         }
@@ -95,7 +96,7 @@ public class FileDescriptorByteChannel implements ByteChannel {
         }
         int n = libc.write(fd, src, src.remaining());
         if (n > 0) {
-            src.position(src.position() + n);
+            src.position(((Buffer) src).position() + n);
         }
         return n;
     }

--- a/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.net.Inet6Address;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channel;
 import java.nio.channels.DatagramChannel;
@@ -491,7 +492,7 @@ public class RubyBasicSocket extends RubyIO {
 
             if (read == 0) return null;
 
-            return new ByteList(buffer.array(), 0, buffer.position(), false);
+            return new ByteList(buffer.array(), 0, ((Buffer) buffer).position(), false);
         }
         catch (IOException e) {
             // All errors to sysread should be SystemCallErrors, but on a closed stream

--- a/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
@@ -44,6 +44,7 @@ import java.net.MulticastSocket;
 import java.net.StandardProtocolFamily;
 import java.net.UnknownHostException;
 import java.net.DatagramPacket;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.AlreadyBoundException;
 import java.nio.channels.Channel;
@@ -595,7 +596,7 @@ public class RubyUDPSocket extends RubyIPSocket {
             }
         }
 
-        RubyString result = runtime.newString(new ByteList(buf.array(), 0, buf.position(), false));
+        RubyString result = runtime.newString(new ByteList(buf.array(), 0, ((Buffer) buf).position(), false));
 
         if (tuple != null) {
             tuple.result = result;
@@ -626,8 +627,8 @@ public class RubyUDPSocket extends RubyIPSocket {
             throw runtime.newErrnoECONNRESETError();
         }
 
-        recv.flip();
-        RubyString result = runtime.newString(new ByteList(recv.array(), recv.position(), recv.limit(), false));
+        ((Buffer) recv).flip();
+        RubyString result = runtime.newString(new ByteList(recv.array(), ((Buffer) recv).position(), ((Buffer) recv).limit(), false));
 
         if (tuple != null) {
             tuple.result = result;

--- a/core/src/main/java/org/jruby/ext/socket/RubyUNIXSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUNIXSocket.java
@@ -63,6 +63,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.channels.Channel;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -181,7 +182,7 @@ public class RubyUNIXSocket extends RubyBasicSocket {
         ByteBuffer[] outIov = new ByteBuffer[1];
         outIov[0] = ByteBuffer.allocateDirect(dataBytes.length);
         outIov[0].put(dataBytes);
-        outIov[0].flip();
+        ((Buffer) outIov[0]).flip();
 
         outMessage.setIov(outIov);
 

--- a/core/src/main/java/org/jruby/ir/persistence/IRWriterStream.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRWriterStream.java
@@ -22,6 +22,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
@@ -61,7 +62,7 @@ public class IRWriterStream implements IRWriterEncoder, IRPersistenceValues {
     }
 
     private int offset() {
-        return buf.position() + PROLOGUE_LENGTH;
+        return ((Buffer) buf).position() + PROLOGUE_LENGTH;
     }
 
     /**
@@ -276,8 +277,8 @@ public class IRWriterStream implements IRWriterEncoder, IRPersistenceValues {
             stream.write(ByteBuffer.allocate(4).putInt(VERSION).array());
             stream.write(ByteBuffer.allocate(4).putInt(headersOffset).array());
             stream.write(ByteBuffer.allocate(4).putInt(poolOffset).array());
-            buf.flip();
-            stream.write(buf.array(), buf.position(), buf.limit());
+            ((Buffer) buf).flip();
+            stream.write(buf.array(), ((Buffer) buf).position(), ((Buffer) buf).limit());
             stream.close();
         } catch (IOException e) {
             try { if (stream != null) stream.close(); } catch (IOException e1) {}

--- a/core/src/main/java/org/jruby/util/IOChannel.java
+++ b/core/src/main/java/org/jruby/util/IOChannel.java
@@ -29,6 +29,7 @@
 package org.jruby.util;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channel;
 import java.nio.channels.ReadableByteChannel;
@@ -98,7 +99,7 @@ public abstract class IOChannel implements Channel {
         ByteList buffer;
 
         if (src.hasArray()) {
-            buffer = new ByteList(src.array(), src.position(), src.remaining(), true);
+            buffer = new ByteList(src.array(), ((Buffer) src).position(), src.remaining(), true);
         } else {
             buffer = new ByteList(src.remaining());
             buffer.append(src, src.remaining());

--- a/core/src/main/java/org/jruby/util/Pack.java
+++ b/core/src/main/java/org/jruby/util/Pack.java
@@ -37,6 +37,7 @@
 package org.jruby.util;
 
 import java.math.BigInteger;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -1096,7 +1097,7 @@ public class Pack {
                             if (safeGet(encode) == '\n') {
                                 safeGet(encode); // Possible Checksum Byte
                             } else if (encode.hasRemaining()) {
-                                encode.position(encode.position() - 1);
+                                encode.position(((Buffer) encode).position() - 1);
                             }
                         }
                     }
@@ -1192,7 +1193,7 @@ public class Pack {
                             }
                             if ((s == '=') || c == -1) {
                                 if (s == '=') {
-                                    encode.position(encode.position() - 1);
+                                    encode.position(((Buffer) encode).position() - 1);
                                 }
                                 break;
                             }
@@ -1205,7 +1206,7 @@ public class Pack {
                             }
                             if ((s == '=') || d == -1) {
                                 if (s == '=') {
-                                    encode.position(encode.position() - 1);
+                                    encode.position(((Buffer) encode).position() - 1);
                                 }
                                 break;
                             }
@@ -1298,7 +1299,7 @@ public class Pack {
                      }
 
                      try {
-                         encode.position(encode.position() - occurrences);
+                         encode.position(((Buffer) encode).position() - occurrences);
                      } catch (IllegalArgumentException e) {
                          throw runtime.newArgumentError("in `unpack': X outside of string");
                      }
@@ -1309,7 +1310,7 @@ public class Pack {
                       }
 
                       try {
-                          encode.position(encode.position() + occurrences);
+                          encode.position(((Buffer) encode).position() + occurrences);
                       } catch (IllegalArgumentException e) {
                           throw runtime.newArgumentError("in `unpack': x outside of string");
                       }
@@ -1323,7 +1324,7 @@ public class Pack {
                     long ul = 0;
                     long ulmask = (0xfeL << 56) & 0xffffffff;
                     RubyBignum big128 = RubyBignum.newBignum(runtime, 128);
-                    int pos = encode.position();
+                    int pos = ((Buffer) encode).position();
 
                     while (occurrences > 0 && pos < encode.limit()) {
                         ul <<= 7;

--- a/core/src/main/java/org/jruby/util/ShellLauncher.java
+++ b/core/src/main/java/org/jruby/util/ShellLauncher.java
@@ -40,6 +40,7 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.io.PrintStream;
 import java.lang.reflect.Field;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
@@ -1484,14 +1485,14 @@ public class ShellLauncher {
         public void run() {
             runtime.getCurrentContext().setEventHooksEnabled(false);
             ByteBuffer buf = ByteBuffer.allocateDirect(1024);
-            buf.clear();
+            ((Buffer) buf).clear();
             try {
                 while (!quit && inChannel.isOpen() && outChannel.isOpen()) {
                     int read = inChannel.read(buf);
                     if (read == -1) break;
-                    buf.flip();
+                    ((Buffer) buf).flip();
                     outChannel.write(buf);
-                    buf.clear();
+                    ((Buffer) buf).clear();
                 }
             } catch (Exception e) {
             } finally {

--- a/core/src/main/java/org/jruby/util/io/ChannelDescriptor.java
+++ b/core/src/main/java/org/jruby/util/io/ChannelDescriptor.java
@@ -34,6 +34,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channel;
 import java.nio.channels.Channels;
@@ -691,7 +692,7 @@ public class ChannelDescriptor {
         
         ByteBuffer buf = ByteBuffer.allocate(1);
         buf.put((byte)c);
-        buf.flip();
+        ((Buffer) buf).flip();
         
         return internalWrite(buf);
     }

--- a/core/src/main/java/org/jruby/util/io/NullChannel.java
+++ b/core/src/main/java/org/jruby/util/io/NullChannel.java
@@ -31,6 +31,7 @@ package org.jruby.util.io;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
@@ -47,7 +48,7 @@ public class NullChannel implements WritableByteChannel, ReadableByteChannel {
             throw new EOFException();
         }
         int length = buffer.remaining();
-        buffer.position(buffer.position() + length);
+        buffer.position(((Buffer) buffer).position() + length);
         return length;
     }
 

--- a/core/src/main/java/org/jruby/util/io/SelectBlob.java
+++ b/core/src/main/java/org/jruby/util/io/SelectBlob.java
@@ -38,6 +38,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.TypeConverter;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.*;
 import java.nio.channels.spi.SelectorProvider;
@@ -559,7 +560,7 @@ public class SelectBlob {
             } finally {
                 ByteBuffer buf = ByteBuffer.allocate(1);
                 buf.put((byte) 0);
-                buf.flip();
+                ((Buffer) buf).flip();
                 pipe.sink().write(buf);
             }
 

--- a/core/src/main/java/org/jruby/util/io/SelectExecutor.java
+++ b/core/src/main/java/org/jruby/util/io/SelectExecutor.java
@@ -10,6 +10,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.TypeConverter;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.Pipe;
 import java.nio.channels.SelectableChannel;
@@ -537,7 +538,7 @@ public class SelectExecutor {
             } finally {
                 ByteBuffer buf = ByteBuffer.allocate(1);
                 buf.put((byte) 0);
-                buf.flip();
+                ((Buffer) buf).flip();
                 pipe.sink().write(buf);
             }
 


### PR DESCRIPTION
The Java 9 ByteBuffer and CharBuffer classes introduces overloaded methods with covariant return types for the following methods used by the driver:

* position
* limit
* flip
* clear
* mark

Without casting, exceptions like this are thrown when executing on Java 8:

    java.lang.NoSuchMethodError: java.nio.ByteBuffer.limit(I)Ljava/nio/ByteBuffer

fixes https://github.com/jruby/jruby/issues/5450