### PR TITLE
Splatted kwarg struct init

### DIFF
--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -356,22 +356,16 @@ public class RubyStruct extends RubyObject {
 
         IRubyObject keywordInit = RubyStruct.getInternalVariable(classOf(), "__keyword_init__");
 
-        Ruby runtime = context.runtime;
-        IRubyObject nil = context.nil;
-
         if (keywordInit.isTrue()) {
-            IRubyObject maybeKwargs = ArgsUtil.getOptionsArg(runtime, args);
-            int argc = maybeKwargs.isNil() ? args.length : args.length - 1;
+            if (args.length > 1) throw context.runtime.newArgumentError("wrong number of arguments (given " + args.length + ", expected 0)");
 
-            if (argc >= 1) throw runtime.newArgumentError("wrong number of arguments (given " + argc + ", expected 0)");
-
-            setupStructValuesFromHash(context, (RubyHash) maybeKwargs);
+            return initialize(context, args[0]);
         } else {
             System.arraycopy(args, 0, values, 0, args.length);
-            Helpers.fillNil(values, args.length, values.length, runtime);
+            Helpers.fillNil(values, args.length, values.length, context.runtime);
         }
 
-        return nil;
+        return context.nil;
     }
 
     private void setupStructValuesFromHash(ThreadContext context, RubyHash kwArgs) {
@@ -398,11 +392,19 @@ public class RubyStruct extends RubyObject {
 
     @JRubyMethod(visibility = PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject arg0) {
-        IRubyObject nil = context.nil;
-        if (arg0 instanceof RubyHash) {
-            setupStructValuesFromHash(context, (RubyHash) arg0);
+        Ruby runtime = context.runtime;
+
+        IRubyObject keywordInit = RubyStruct.getInternalVariable(classOf(), "__keyword_init__");
+        if (keywordInit.isTrue()) {
+            IRubyObject maybeKwargs = ArgsUtil.getOptionsArg(runtime, arg0);
+
+            if (maybeKwargs.isNil()) throw context.runtime.newArgumentError("wrong number of arguments (given 1, expected 0)");
+
+            setupStructValuesFromHash(context, (RubyHash) maybeKwargs);
+
             return context.nil;
         } else {
+            IRubyObject nil = context.nil;
             return initializeInternal(context, 1, arg0, nil, nil);
         }
     }

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -357,7 +357,7 @@ public class RubyStruct extends RubyObject {
         IRubyObject keywordInit = RubyStruct.getInternalVariable(classOf(), "__keyword_init__");
 
         if (keywordInit.isTrue()) {
-            if (args.length > 1) throw context.runtime.newArgumentError("wrong number of arguments (given " + args.length + ", expected 0)");
+            if (args.length != 1) throw context.runtime.newArgumentError("wrong number of arguments (given " + args.length + ", expected 0)");
 
             return initialize(context, args[0]);
         } else {

--- a/spec/ruby/core/struct/new_spec.rb
+++ b/spec/ruby/core/struct/new_spec.rb
@@ -130,6 +130,17 @@ describe "Struct.new" do
     it "fails with too many arguments" do
       lambda { StructClasses::Ruby.new('2.0', 'i686', true) }.should raise_error(ArgumentError)
     end
+
+    it "passes a hash as a normal argument" do
+      type = Struct.new(:args)
+
+      obj = type.new(keyword: :arg)
+      obj2 = type.new(*[{keyword: :arg}])
+
+      obj.should == obj2
+      obj.args.should == {keyword: :arg}
+      obj2.args.should == {keyword: :arg}
+    end
   end
 
   ruby_version_is "2.5" do
@@ -161,6 +172,12 @@ describe "Struct.new" do
         it "raises ArgumentError when passed a list of arguments" do
           -> {
             @struct_with_kwa.new("elefant", 4)
+          }.should raise_error(ArgumentError, /wrong number of arguments/)
+        end
+
+        it "raises ArgumentError when passed a single non-hash argument" do
+          -> {
+            @struct_with_kwa.new("elefant")
           }.should raise_error(ArgumentError, /wrong number of arguments/)
         end
       end


### PR DESCRIPTION
This includes a fix and spec for initializing a non-kwarg Struct with a splatted Hash-containing array of arguments, as in this snippit that reproduces #5448:

```ruby
Struct.new(:args).new(*[{keyword: :arg}])
```

The Hash should not be interpreted to be keyword init of the Struct, since it is not a kwarg-initializable Struct. We simply weren't checking this flag on one path, and assuming a single Hash arg was always for kwarg init.