### PR TITLE
Fix multi-arity method binding.

### DIFF
--- a/core/src/main/java/org/jruby/anno/MethodDescriptor.java
+++ b/core/src/main/java/org/jruby/anno/MethodDescriptor.java
@@ -33,6 +33,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
 
 public abstract class MethodDescriptor<T> {
+    public static final String IRUBYOBJECT_ARRAY_CLASS_NAME = "[Lorg.jruby.runtime.builtin.IRubyObject;";
     public final boolean isStatic;
     public final boolean hasContext;
     public final boolean hasBlock;
@@ -87,10 +88,10 @@ public abstract class MethodDescriptor<T> {
 
             if (hasBlock) {
                 // args should be before block
-                hasVarArgs = parameterAsString(methodObject, parameterCount - 2).equals("org.jruby.runtime.builtin.IRubyObject[]");
+                hasVarArgs = parameterAsString(methodObject, parameterCount - 2).equals(IRUBYOBJECT_ARRAY_CLASS_NAME);
             } else {
                 // args should be at end
-                hasVarArgs = parameterAsString(methodObject, parameterCount - 1).equals("org.jruby.runtime.builtin.IRubyObject[]");
+                hasVarArgs = parameterAsString(methodObject, parameterCount - 1).equals(IRUBYOBJECT_ARRAY_CLASS_NAME);
             }
         } else {
             if (isStatic && (parameterCount < 1 || !parameterAsString(methodObject, 0).equals("org.jruby.runtime.builtin.IRubyObject"))) {
@@ -98,9 +99,9 @@ public abstract class MethodDescriptor<T> {
             }
 
             if (hasBlock) {
-                hasVarArgs = parameterCount > 1 && parameterAsString(methodObject, parameterCount - 2).equals("org.jruby.runtime.builtin.IRubyObject[]");
+                hasVarArgs = parameterCount > 1 && parameterAsString(methodObject, parameterCount - 2).equals(IRUBYOBJECT_ARRAY_CLASS_NAME);
             } else {
-                hasVarArgs = parameterCount > 0 && parameterAsString(methodObject, parameterCount - 1).equals("org.jruby.runtime.builtin.IRubyObject[]");
+                hasVarArgs = parameterCount > 0 && parameterAsString(methodObject, parameterCount - 1).equals(IRUBYOBJECT_ARRAY_CLASS_NAME);
             }
         }
 


### PR DESCRIPTION
We have apparently not been binding multi-arity rest methods well
for some time; the logic to look for "hasVarargs" was not using
the correct class.getName() for an IRubyObject[], resulting in
any variable-arity-or-rest methods always getting routed to the
rest path, because the min/max logic breaks without hasVarargs.

This could regress easily without tests, but I'm not sure of the best way to test that all this generated code is working right.

This was discovered while investigating #5448, which weirdly was caused by this bug to go down a rest path, and then via JavaMethodN.call re-route to a specific-arity version that had a bug.