### PR TITLE
Tempfile.open should have arity 3, to allow IO options through.

### DIFF
--- a/core/src/main/java/org/jruby/ext/tempfile/Tempfile.java
+++ b/core/src/main/java/org/jruby/ext/tempfile/Tempfile.java
@@ -250,7 +250,7 @@ public class Tempfile extends RubyFile implements Finalizable {
         return open(context, recv, args, block);
     }
 
-    @JRubyMethod(required = 1, optional = 1, meta = true)
+    @JRubyMethod(required = 1, optional = 2, meta = true)
     public static IRubyObject open(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         RubyClass klass = (RubyClass) recv;
         Tempfile tempfile = (Tempfile) klass.newInstance(context, args, block);


### PR DESCRIPTION
Fixes #5456.

In #5456, @erikogan shows that his example code worked in 9.1.17.0, but I could find no changes to Tempfile during the past 9 months that would explain the regression.