### PR TITLE
fix duplicate declaration

### DIFF
--- a/pom.rb
+++ b/pom.rb
@@ -99,6 +99,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
               'Bundle-Description' =>  '${bundle.name} ${project.version} OSGi bundle',
               'Bundle-SymbolicName' =>  '${bundle.symbolic_name}'
             } ) do
+      dependency(groupId: 'biz.aQute.bnd', artifactId: 'biz.aQute.bndlib', version: '3.5.0')
       execute_goals( 'manifest',
                      :phase => 'prepare-package' )
     end
@@ -147,9 +148,6 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
 
     plugin 'org.eclipse.m2e:lifecycle-mapping:1.0.0'
     plugin :'scm-publish', '1.0-beta-2'
-    plugin 'org.apache.felix:maven-bundle-plugin' do
-      dependency(groupId: 'biz.aQute.bnd', artifactId: 'biz.aQute.bndlib', version: '3.5.0')
-    end
   end
 
   plugin( :site,


### PR DESCRIPTION
[WARNING] Some problems were encountered while building the effective model for org.jruby:jruby-core:jar:9.2.5.0-SNAPSHOT
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.felix:maven-bundle-plugin @ org.jruby:jruby-parent:9.2.5.0-SNAPSHOT, /jruby/pom.xml, line 338, column 17
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.jruby:jruby-parent:pom:9.2.5.0-SNAPSHOT
[WARNING] 'build.pluginManagement.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.felix:maven-bundle-plugin
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
