### PR TITLE
add java 10, 11 opcodes

### DIFF
--- a/core/src/main/java/org/jruby/RubyInstanceConfig.java
+++ b/core/src/main/java/org/jruby/RubyInstanceConfig.java
@@ -1889,7 +1889,9 @@ public class RubyInstanceConfig {
             case "9" :
                 return Opcodes.V9;
             case "10" :
-                return Opcodes.V9; // TODO: switch when `V10 = 54` added
+                return Opcodes.V10;
+            case "11" :
+                return Opcodes.V11;
         }
     }
 


### PR DESCRIPTION
fixes warnings
WARNING: Illegal reflective access by org.jruby.util.SecurityHelper to field java.lang.reflect.Field.modifiers
WARNING: Please consider reporting this to the maintainers of org.jruby.util.SecurityHelper
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release