### PR TITLE
Add Array#union

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -3519,6 +3519,56 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return ary3;
     }
 
+    /** rb_ary_union_multi
+     *
+     */
+    @JRubyMethod(name = "union", rest = true)
+    public IRubyObject union(ThreadContext context, IRubyObject[] args) {
+        Ruby runtime = context.runtime;
+        RubyArray[] arrays = new RubyArray[args.length];
+        RubyArray result;
+
+        int maxSize = realLength;
+        for (int i = 0; i < args.length; i++) {
+            arrays[i] = args[i].convertToArray();
+            maxSize += arrays[i].realLength;
+        }
+        if (maxSize == 0) return newEmptyArray(runtime);
+
+        if (maxSize <= ARRAY_DEFAULT_SIZE) {
+            result = newArray(runtime);
+
+            result.unionInternal(context, this);
+            result.unionInternal(context, arrays);
+
+            return result;
+        }
+
+        RubyHash set = makeHash();
+
+        for (int i = 0; i < arrays.length; i++) {
+            for (int j = 0; j < arrays[i].realLength; j++) {
+                set.fastASet(arrays[i].elt(j), NEVER);
+            }
+        }
+
+        result = set.keys();
+        return result;
+    }
+
+    /** rb_ary_union
+     *
+     */
+    private void unionInternal(ThreadContext context, RubyArray... args) {
+        for (int i = 0; i < args.length; i++) {
+            for (int j = 0; j < args[i].realLength; j++) {
+                IRubyObject elt = args[i].elt(j);
+                if (includes(context, elt)) continue;
+                append(elt);
+            }
+        }
+    }
+
     /** rb_ary_sort
      *
      */


### PR DESCRIPTION
Hi folks, do we have a branch to start to merge changes related to Ruby 2.6 features?

I was reviewing some new features and decided to take a shot with implementing new Array#union method.

The implementation is more or less based on what they did in MRI [1] and is passing all its related tests [2].

For more information, please see feature #14097 [3].

Thanks in advance for any feedback.

1. https://github.com/ruby/ruby/commit/744e816f55757df92caa49b4787cf06af6120a20
2. https://github.com/ruby/ruby/blob/v2_6_0_preview3/test/ruby/test_array.rb#L1931-L1967
3. https://bugs.ruby-lang.org/issues/14097