### PR TITLE
Add Array#difference

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -3463,6 +3463,39 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return ary3;
     }
 
+    /** rb_ary_difference_multi
+     *
+     */
+    @JRubyMethod(name = "difference", rest = true)
+    public IRubyObject difference(ThreadContext context, IRubyObject[] args) {
+        boolean[] isHash = new boolean[args.length];
+        RubyArray[] arrays = new RubyArray[args.length];
+        RubyHash[] hashes = new RubyHash[args.length];
+
+        RubyArray diff = newArray(context.runtime);
+
+        for (int i = 0; i < args.length; i++) {
+            arrays[i] = args[i].convertToArray();
+            isHash[i] = (realLength > ARRAY_DEFAULT_SIZE && arrays[i].realLength > ARRAY_DEFAULT_SIZE);
+            if (isHash[i]) hashes[i] = arrays[i].makeHash();
+        }
+
+        for (int i = 0; i < realLength; i++) {
+            IRubyObject elt = elt(i);
+            int j;
+            for (j = 0; j < args.length; j++) {
+                if (isHash[j]) {
+                    if (hashes[j].fastARef(elt) != null) break;
+                } else {
+                    if (arrays[j].includes(context, elt)) break;
+                }
+            }
+            if (j == args.length) diff.append(elt);
+        }
+
+        return diff;
+    }
+
     /** rb_ary_and
      *
      */


### PR DESCRIPTION
Analogous to #5464.

I was reviewing some new features and decided to take a shot with implementing new Array#difference method.

The implementation is based on what they did in MRI [1] and is passing all its related tests [2].

For more information, please see feature #14097 [3].

Thanks in advance for any feedback.

1. https://github.com/ruby/ruby/commit/d65d5533ab117b46211917450293f9c602519375
2. https://github.com/ruby/ruby/blob/v2_6_0_preview3/test/ruby/test_array.rb#L279-L298
3. https://bugs.ruby-lang.org/issues/14097