### PR TITLE
less sync-ing with thread registration

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1266,7 +1266,7 @@ public final class Ruby implements Constantizable {
         initRubyPreludes();
 
         // everything booted, so SizedQueue should be available; set up root fiber
-        ThreadFiber.initRootFiber(context);
+        ThreadFiber.initRootFiber(context, context.getThread());
 
         if(config.isProfiling()) {
             // additional twiddling for profiled mode

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -707,7 +707,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         finalResult = result;
     }
 
-    public synchronized void beDead() {
+    public void beDead() {
         status.set(Status.DEAD);
     }
 

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -579,16 +579,21 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     }
 
     public static RubyThread adopt(IRubyObject recv, Thread t) {
-        return adoptThread(recv, t);
+        final Ruby runtime = recv.getRuntime();
+        return adoptThread(runtime, runtime.getThreadService(), (RubyClass) recv, t);
     }
 
-    private static RubyThread adoptThread(final IRubyObject recv, Thread t) {
-        final Ruby runtime = recv.getRuntime();
-        final RubyThread rubyThread = new RubyThread(runtime, (RubyClass) recv);
+    public static RubyThread adopt(Ruby runtime, ThreadService service, Thread thread) {
+        return adoptThread(runtime, service, runtime.getThread(), thread);
+    }
 
-        rubyThread.threadImpl = new NativeThread(rubyThread, t);
-        ThreadContext context = runtime.getThreadService().registerNewThread(rubyThread);
-        runtime.getThreadService().associateThread(t, rubyThread);
+    private static RubyThread adoptThread(final Ruby runtime, final ThreadService service,
+                                          final RubyClass recv, final Thread thread) {
+        final RubyThread rubyThread = new RubyThread(runtime, recv);
+
+        rubyThread.threadImpl = new NativeThread(rubyThread, thread);
+        ThreadContext context = service.registerNewThread(rubyThread);
+        service.associateThread(thread, rubyThread);
 
         context.preAdoptThread();
 

--- a/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
+++ b/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
@@ -31,18 +31,21 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
     public ThreadFiber(Ruby runtime, RubyClass klass) {
         super(runtime, klass);
     }
-    
-    public static void initRootFiber(ThreadContext context) {
-        Ruby runtime = context.runtime;
-        
-        ThreadFiber rootFiber = new ThreadFiber(runtime, runtime.getClass("Fiber")); // FIXME: getFiber()
 
-        RubyThread currentThread = context.getThread();
+    public static void initRootFiber(ThreadContext context) {
+        initRootFiber(context, context.getThread());
+    }
+
+    public static void initRootFiber(ThreadContext context, RubyThread currentThread) {
+        Ruby runtime = context.runtime;
+
+        ThreadFiber rootFiber = new ThreadFiber(runtime, runtime.getFiber());
+
         rootFiber.data = new FiberData(new FiberQueue(runtime), currentThread, rootFiber);
         rootFiber.thread = currentThread;
         context.setRootFiber(rootFiber);
     }
-    
+
     @JRubyMethod(visibility = Visibility.PRIVATE)
     public IRubyObject initialize(ThreadContext context, Block block) {
         Ruby runtime = context.runtime;

--- a/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
+++ b/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
@@ -32,10 +32,6 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
         super(runtime, klass);
     }
 
-    public static void initRootFiber(ThreadContext context) {
-        initRootFiber(context, context.getThread());
-    }
-
     public static void initRootFiber(ThreadContext context, RubyThread currentThread) {
         Ruby runtime = context.runtime;
 

--- a/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
+++ b/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
@@ -265,9 +265,9 @@ public class ThreadService {
         return rtList.toArray(new RubyThread[rtList.size()]);
     }
 
-    public synchronized ThreadContext registerNewThread(RubyThread thread) {
+    public ThreadContext registerNewThread(RubyThread thread) {
         ThreadContext context = ThreadContext.newContext(runtime);
-        localContext.set(new SoftReference<ThreadContext>(context));
+        localContext.set(new SoftReference<>(context));
         context.setThread(thread);
         ThreadFiber.initRootFiber(context, thread);
         return context;

--- a/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
+++ b/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
@@ -273,7 +273,7 @@ public class ThreadService {
         ThreadContext context = ThreadContext.newContext(runtime);
         localContext.set(new SoftReference<ThreadContext>(context));
         context.setThread(thread);
-        ThreadFiber.initRootFiber(context); // may be overwritten by fiber
+        ThreadFiber.initRootFiber(context, thread);
         return context;
     }
 

--- a/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
+++ b/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
@@ -237,7 +237,7 @@ public class ThreadService {
         rubyThreadMap.put(thread, rubyThread);
     }
 
-    public synchronized RubyThread[] getActiveRubyThreads() {
+    public RubyThread[] getActiveRubyThreads() {
     	// all threads in ruby thread group plus main thread
         ArrayList<RubyThread> rtList;
         synchronized(rubyThreadMap) {

--- a/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
+++ b/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
@@ -273,12 +273,12 @@ public class ThreadService {
         return context;
     }
 
-    public synchronized void associateThread(Object threadOrFuture, RubyThread rubyThread) {
-        rubyThreadMap.put(threadOrFuture, rubyThread);
+    public void associateThread(Object threadOrFuture, RubyThread rubyThread) {
+        rubyThreadMap.put(threadOrFuture, rubyThread); // synchronized
     }
 
-    public synchronized void unregisterThread(RubyThread thread) {
-        rubyThreadMap.remove(Thread.currentThread());
+    public void unregisterThread(RubyThread thread) {
+        rubyThreadMap.remove(Thread.currentThread()); // synchronized
         getCurrentContext().setThread(null);
         localContext.set(null);
     }

--- a/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
+++ b/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
@@ -267,9 +267,9 @@ public class ThreadService {
 
     public ThreadContext registerNewThread(RubyThread thread) {
         ThreadContext context = ThreadContext.newContext(runtime);
-        localContext.set(new SoftReference<>(context));
         context.setThread(thread);
         ThreadFiber.initRootFiber(context, thread);
+        localContext.set(new SoftReference<>(context));
         return context;
     }
 

--- a/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
+++ b/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
@@ -239,9 +239,9 @@ public class ThreadService {
 
     public synchronized RubyThread[] getActiveRubyThreads() {
     	// all threads in ruby thread group plus main thread
-
+        ArrayList<RubyThread> rtList;
         synchronized(rubyThreadMap) {
-            List<RubyThread> rtList = new ArrayList<>(rubyThreadMap.size());
+            rtList = new ArrayList<>(rubyThreadMap.size());
 
             for (Map.Entry<Object, RubyThread> entry : rubyThreadMap.entrySet()) {
                 Object key = entry.getKey();
@@ -261,9 +261,8 @@ public class ThreadService {
 
                 rtList.add(entry.getValue());
             }
-
-            return rtList.toArray(new RubyThread[rtList.size()]);
         }
+        return rtList.toArray(new RubyThread[rtList.size()]);
     }
 
     public synchronized ThreadContext registerNewThread(RubyThread thread) {

--- a/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
+++ b/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
@@ -224,10 +224,7 @@ public class ThreadService {
     }
 
     private SoftReference<ThreadContext> adoptCurrentThread() {
-        Thread current = Thread.currentThread();
-
-        RubyThread.adopt(runtime.getThread(), current);
-
+        RubyThread.adopt(runtime, this, Thread.currentThread());
         return localContext.get();
     }
 


### PR DESCRIPTION
... here's an interesting find while trying to upgrade an app stuck on JRuby 1.7.4

the app uses celluloid's actor model and under load degraded considerably (~ 10x).
with celluloid all calls upon actors are executed in fibers, which are kind of heavy under JRuby,
the system ends up operating with ~3000 threads and interestingly thread registration (those are fiber backing threads) accounts for quite some delay as its synchronizing on `ThreadService`.

now, that locking shouldn't be needed since the backing map is already a synchronized collection.

![screenshot_025](https://user-images.githubusercontent.com/45967/49088326-519c2980-f259-11e8-9098-e43ce2b69b7c.png)

... poked around history and there's no explicit reason for `registerNewThread` to lock on `ThreadService`
pretty much the only thing I could think of that might not work 'exactly' as before is listing threads (`getActiveRubyThreads()`) so I changed the order for the registration logic to write to the map last (after the thread/context gets fully initialized).

have patched this on top of of 9.1.17.0 and put under load - the 10x degradation was gone and all seems good, so far. still could use a review whether I did not miss anything.

also how would you guys feel about backporting to 9.1, assuming there's going to be a 9.1.18.0 ?
(as the 9.2 upgrade isn't :green_book: yet and I would hate for this app to stay behind on an old 1.7)
