### PR TITLE
Never return the internal module name as a mutable string.

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -558,7 +558,7 @@ public class RubyModule extends RubyObject {
 
     /**
      * Generate a fully-qualified class name or a #-style name for anonymous and singleton classes which
-     * is properly encoded.
+     * is properly encoded. The returned string is always frozen.
      *
      * @return a properly encoded class name.
      *
@@ -618,6 +618,8 @@ public class RubyModule extends RubyObject {
             fullName.cat19(parent).cat19(colons);
         }
         fullName.cat19(rubyBaseName());
+
+        fullName.setFrozen(true);
 
         if (cache) cachedRubyName = fullName;
 
@@ -2219,7 +2221,7 @@ public class RubyModule extends RubyObject {
 
     @JRubyMethod(name = "name")
     public IRubyObject name19() {
-        return getBaseName() == null ? getRuntime().getNil() : rubyName();
+        return getBaseName() == null ? getRuntime().getNil() : rubyName().strDup(getRuntime());
     }
 
     protected final IRubyObject cloneMethods(RubyModule clone) {

--- a/spec/ruby/core/module/name_spec.rb
+++ b/spec/ruby/core/module/name_spec.rb
@@ -65,4 +65,14 @@ describe "Module#name" do
     ModuleSpecs::Anonymous::E = m
     m::N.name.should == "ModuleSpecs::Anonymous::E::N"
   end
+
+  it "returns a mutable string" do
+    ModuleSpecs.name.frozen?.should be_false
+  end
+
+  it "returns a mutable string that when mutated does not modify the original module name" do
+    ModuleSpecs.name << "foo"
+
+    ModuleSpecs.name.should == "ModuleSpecs"
+  end
 end


### PR DESCRIPTION
This duplicates logic in `to_s` that dups the module name before
returning it, but also ensures that any cached module name is
frozen so it can't be modified in place.

Fixes #5480.