### PR TITLE
[#5288] Overwrite parent class with module wrapper

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -920,7 +920,8 @@ public class RubyModule extends RubyObject {
 
         for (module = module.getSuperClass(); module != null && module != klass; module = module.getSuperClass()) {
             module.setFlag(IS_OVERLAID_F, true);
-            c = new IncludedModuleWrapper(cref.getRuntime(), c.getSuperClass(), module);
+            c.setSuperClass(new IncludedModuleWrapper(cref.getRuntime(), c.getSuperClass(), module));
+            c = c.getSuperClass();
             c.refinedClass = klass;
         }
 

--- a/test/jruby.index
+++ b/test/jruby.index
@@ -63,6 +63,7 @@ jruby/test_parsing
 jruby/test_pathname
 jruby/test_random
 jruby/test_rbconfig
+jruby/test_refinement_include
 jruby/test_require_once
 jruby/test_respond_to
 jruby/test_set

--- a/test/jruby/test_refinement_include.rb
+++ b/test/jruby/test_refinement_include.rb
@@ -1,0 +1,28 @@
+require 'test/unit'
+
+module Xorcist
+  module_function
+  def to_string(x)
+    x.to_s
+  end
+
+  module StringMethods
+    def to_string
+      Xorcist.to_string(self)
+    end
+  end
+
+  module Refinements
+    refine Integer do
+      include Xorcist::StringMethods
+    end
+  end
+end
+
+class TestRefinementInclude < Test::Unit::TestCase
+  using Xorcist::Refinements
+
+  def test_include
+    assert_equal("123", 123.to_string)
+  end
+end


### PR DESCRIPTION
Fixes `Module#refine` regression when using `Module#include` to inject functions.

Compare latest refinement [commit](https://github.com/jruby/jruby/commit/1839880a1eb3c05904bb6f5a8a327ae02e12d59b#diff-b0dc42ec523c3c3de1ac9ff40bc56852L880) with CRuby [rb_using_refinement](https://github.com/ruby/ruby/blob/trunk/eval.c#L1342-L1347).

`RubyModule#setSuperClass` call was dropped. We add it back again.
