### PR TITLE
[fix] RubyException#toJava(Object) shouldn't return null

### DIFF
--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -335,9 +335,9 @@ public class RubyException extends RubyObject {
      * @return the converted result
      */
     @Override
-    public Object toJava(Class target) {
-        if (target.isAssignableFrom(RaiseException.class)) {
-            return target.cast(throwable);
+    public <T> T toJava(Class<T> target) {
+        if (target != Object.class && target.isAssignableFrom(RaiseException.class)) {
+            return target.cast(toThrowable());
         }
         return super.toJava(target);
     }


### PR DESCRIPTION
... a regression since the exception hierarchy rewrite in **9.2**
spotted at: https://github.com/sparklemotion/nokogiri/issues/1818

for compat `rubyException.toJava(Object.class)` shall return self