### PR TITLE
[fix] lock interruptibly / interrupt thread

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -1984,6 +1984,9 @@ public class RubyThread extends RubyObject implements ExecutionContext {
 
         // If this thread is sleeping or stopped, wake it
         notify();
+
+        // interrupt lock acquiring if any
+        getNativeThread().interrupt();
     }
 
     public void setInterrupt() {

--- a/core/src/main/java/org/jruby/ext/thread/Mutex.java
+++ b/core/src/main/java/org/jruby/ext/thread/Mutex.java
@@ -92,7 +92,10 @@ public class Mutex extends RubyObject implements DataType {
         try {
             thread.enterSleep();
             checkRelocking(context);
-            thread.lock(lock);
+            thread.lockInterruptibly(lock);
+        } catch (InterruptedException ie) {
+            context.pollThreadEvents();
+            throw context.runtime.newConcurrencyError("interrupted waiting for mutex");
         } finally {
             thread.exitSleep();
         }


### PR DESCRIPTION
Fixes #5476 

Revert [lock commit](https://github.com/jruby/jruby/commit/6a436e9a12df1c9929d5c8c22c4025fed5adef57) to be able to interrupt thread trying to acquire a lock.
Otherwise deadlock may appear if lock was already acquired by another thread.

`Thread#join` would block forever even though `Thread#kill` was called right before:

```
m = Mutex.new
m.lock

t = Thread.new do
  m.lock
end

t.kill
t.join
```

This is equivalent to following Java test
```
import org.junit.Test;

import java.util.concurrent.locks.Lock;
import java.util.concurrent.locks.ReentrantLock;

public class ThreadInterruptTest {

   @Test
   public void interrupt() {
      final Lock lock = new ReentrantLock();
      lock.lock();

      Thread thread = new Thread(() -> {
         try {
            lock.lockInterruptibly();
         } catch (InterruptedException ie) {
            System.err.println("lock acquiring was interrupted");
            return;
         }
      });
      thread.start();

      thread.interrupt();

      try {
         thread.join();
      } catch (InterruptedException ie) {
         System.err.println("Can not join thread");
         return;
      }
   }
}
``` 

2 conditions need to happen to avoid getting stuck
- call `Thread#lockInterruptibly` to acquire lock
- call `Thread#interrupt` to unblock thread

### Thread Dumps
Here are the thread dumps to illustrate the deadlock:

Main thread:
```
"main@1" prio=5 tid=0x1 nid=NA waiting
  java.lang.Thread.State: WAITING
	  at java.lang.Object.wait(Object.java:-1)
	  at java.lang.Thread.join(Thread.java:1260)
	  at org.jruby.internal.runtime.NativeThread.join(NativeThread.java:75)
	  at org.jruby.RubyThread.join(RubyThread.java:1079)
	  at org.jruby.RubyThread$INVOKER$i$0$1$join.call(RubyThread$INVOKER$i$0$1$join.gen:-1)
```

New thread:
```
"Ruby-0-Thread-1: thread_kill.rb:4@6126" daemon prio=5 tid=0xe nid=NA waiting
  java.lang.Thread.State: WAITING
	  at sun.misc.Unsafe.park(Unsafe.java:-1)
	  at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
	  at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:836)
	  at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireQueued(AbstractQueuedSynchronizer.java:870)
	  at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:1199)
	  at java.util.concurrent.locks.ReentrantLock$NonfairSync.lock(ReentrantLock.java:209)
	  at java.util.concurrent.locks.ReentrantLock.lock(ReentrantLock.java:285)
	  at org.jruby.RubyThread.lock(RubyThread.java:2087)
	  at org.jruby.ext.thread.Mutex.lock(Mutex.java:95)
	  at org.jruby.ext.thread.Mutex$INVOKER$i$0$0$lock.call(Mutex$INVOKER$i$0$0$lock.gen:-1)
```