### PR TITLE
Ruby 2.6: Add #to_h with block argument to Array, Enum, ENV, Hash and Struct

### DIFF
--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -49,6 +49,7 @@ import org.jruby.internal.runtime.ValueAccessor;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.Helpers;
 import org.jruby.platform.Platform;
+import org.jruby.runtime.Block;
 import org.jruby.runtime.Constants;
 import org.jruby.runtime.GlobalVariable;
 import org.jruby.runtime.IAccessor;
@@ -433,9 +434,15 @@ public class RubyGlobal {
             return RubyString.newStringShared(getRuntime(), ENV);
         }
 
+        @Deprecated
+        public RubyHash to_h() {
+            return to_h(getRuntime().getCurrentContext(), Block.NULL_BLOCK);
+        }
+
         @JRubyMethod
-        public RubyHash to_h(){
-            return to_hash();
+        public RubyHash to_h(ThreadContext context, Block block){
+            RubyHash h = to_hash();
+            return block.isGiven() ? h.to_h_block(context, block) : h;
         }
 
     }


### PR DESCRIPTION
Hi folks,

This PR implements another Ruby 2.6 feature: #to_h method in Array, Enumerable, ENV, Hash and Struct classes now can map their elements to new keys and values to a given block.

For more information, please see feature #15143 [1].

I believe all the related tests (MRI and ruby/spec) are passing:i [2], [3], [4], [5], [6], [7], [8], [9], [10], [11].

For reference, I include a link to the commit introducing the functionality in MRI. [12]

Thanks in advance for any feedback.

 1. https://bugs.ruby-lang.org/issues/15143
 2. https://github.com/ruby/ruby/blob/v2_6_0_preview3/spec/ruby/core/array/to_h_spec.rb#L38-L41
 3. https://github.com/ruby/ruby/blob/v2_6_0_preview3/spec/ruby/core/enumerable/to_h_spec.rb#L47-L53
 4. https://github.com/ruby/ruby/blob/v2_6_0_preview3/spec/ruby/core/env/to_h_spec.rb#L7-L17
 5. https://github.com/ruby/ruby/blob/v2_6_0_preview3/spec/ruby/core/hash/to_h_spec.rb#L10-L14
 6. https://github.com/ruby/ruby/blob/v2_6_0_preview3/spec/ruby/core/struct/to_h_spec.rb#L16-L22
 7. https://github.com/ruby/ruby/blob/v2_6_0_preview3/test/ruby/test_array.rb#L1634-L1653
 8. https://github.com/ruby/ruby/blob/v2_6_0_preview3/test/ruby/test_enum.rb#L183-L202
 9. https://github.com/ruby/ruby/blob/v2_6_0_preview3/test/ruby/test_env.rb#L400-L404
10. https://github.com/ruby/ruby/blob/v2_6_0_preview3/test/ruby/test_hash.rb#L868-L876
11. https://github.com/ruby/ruby/blob/v2_6_0_preview3/test/ruby/test_struct.rb#L365-L370
12. https://github.com/ruby/ruby/commit/abe75149d14d3286d3051c9e961ab6473a243a19
