### PR TITLE
[ji] change RubyException#toJava to convert by default

### DIFF
--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -336,7 +336,7 @@ public class RubyException extends RubyObject {
      */
     @Override
     public <T> T toJava(Class<T> target) {
-        if (target != Object.class && target.isAssignableFrom(RaiseException.class)) {
+        if (target.isAssignableFrom(RaiseException.class)) {
             return target.cast(toThrowable());
         }
         return super.toJava(target);

--- a/core/src/test/java/org/jruby/test/TestRubyException.java
+++ b/core/src/test/java/org/jruby/test/TestRubyException.java
@@ -53,7 +53,7 @@ public class TestRubyException extends TestCase {
 
 	public void testToJava() {
 		assertNotNull(exception.toJava(Object.class));
-		assertSame(exception, exception.toJava(Object.class));
+		assertSame(exception.toThrowable(), exception.toJava(Object.class));
 
 		Object throwable = exception.toJava(RaiseException.class);
 		assertNotNull(throwable);
@@ -68,7 +68,9 @@ public class TestRubyException extends TestCase {
 		assertSame(raise, raise.getException().toJava(Throwable.class));
 
 		assertNotNull(raise.getException().toJava(Object.class));
-		assertSame(raise.getException(), raise.getException().toJava(Object.class));
+		assertSame(raise, raise.getException().toJava(Object.class));
+
+		assertSame(raise.getException(), raise.getException().toJava(org.jruby.RubyObject.class));
 	}
 
 	public void testPrintBacktrace() {


### PR DESCRIPTION
**HINT: this targets JRuby 9.3 - do not merge till master moves 9.2 into a branch**

will now return a more 'familiar' Java type (Throwable instance)

... like the rest of RubyXXX hierarchy
(e.g. RubyString returning java.lang.String by default)