### PR TITLE
Fix known binary compat issues with new Java 9 overloads.

### DIFF
--- a/core/src/main/java/org/jruby/RubyEncoding.java
+++ b/core/src/main/java/org/jruby/RubyEncoding.java
@@ -28,7 +28,6 @@ package org.jruby;
 
 import java.lang.ref.SoftReference;
 import java.lang.reflect.Field;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
@@ -57,6 +56,9 @@ import org.jruby.util.ByteList;
 import org.jruby.util.StringSupport;
 import org.jruby.util.io.EncodingUtils;
 import org.jruby.util.unsafe.UnsafeHolder;
+
+import static org.jruby.util.io.BufferHelper.clearBuffer;
+import static org.jruby.util.io.BufferHelper.flipBuffer;
 
 @JRubyClass(name="Encoding")
 public class RubyEncoding extends RubyObject implements Constantizable {
@@ -303,12 +305,12 @@ public class RubyEncoding extends RubyObject implements Constantizable {
         public final ByteBuffer encode(String str) {
             ByteBuffer buf = byteBuffer;
             CharBuffer cbuf = charBuffer;
-            buf.clear();
-            cbuf.clear();
+            clearBuffer(buf);
+            clearBuffer(cbuf);
             cbuf.put(str);
-            cbuf.flip();
+            flipBuffer(cbuf);
             encoder.encode(cbuf, buf, true);
-            buf.flip();
+            flipBuffer(buf);
 
             return buf;
         }
@@ -316,14 +318,14 @@ public class RubyEncoding extends RubyObject implements Constantizable {
         public final ByteBuffer encode(CharSequence str) {
             ByteBuffer buf = byteBuffer;
             CharBuffer cbuf = charBuffer;
-            buf.clear();
-            cbuf.clear();
+            clearBuffer(buf);
+            clearBuffer(cbuf);
             // NOTE: doesn't matter is we toString here in terms of speed
             // ... so we "safe" some space at least by not copy-ing char[]
             for (int i = 0; i < str.length(); i++) cbuf.put(str.charAt(i));
-            cbuf.flip();
+            flipBuffer(cbuf);
             encoder.encode(cbuf, buf, true);
-            buf.flip();
+            flipBuffer(buf);
 
             return buf;
         }
@@ -331,12 +333,12 @@ public class RubyEncoding extends RubyObject implements Constantizable {
         public final CharBuffer decode(byte[] bytes, int start, int length) {
             CharBuffer cbuf = charBuffer;
             ByteBuffer buf = byteBuffer;
-            cbuf.clear();
-            buf.clear();
+            clearBuffer(cbuf);
+            clearBuffer(buf);
             buf.put(bytes, start, length);
-            buf.flip();
+            flipBuffer(buf);
             decoder.decode(buf, cbuf, true);
-            cbuf.flip();
+            flipBuffer(cbuf);
 
             return cbuf;
         }

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -105,6 +105,9 @@ import static org.jruby.RubyEnumerator.enumeratorize;
 import static org.jruby.runtime.Visibility.*;
 import static org.jruby.util.RubyStringBuilder.str;
 import static org.jruby.util.RubyStringBuilder.types;
+import static org.jruby.util.io.BufferHelper.clearBuffer;
+import static org.jruby.util.io.BufferHelper.flipBuffer;
+import static org.jruby.util.io.BufferHelper.limitBuffer;
 import static org.jruby.util.io.ChannelHelper.*;
 import static org.jruby.util.io.EncodingUtils.vmodeVperm;
 import static org.jruby.util.io.EncodingUtils.vperm;
@@ -4437,15 +4440,15 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
             if (length > 0 && length < chunkSize) {
                 // last read should limit to remaining length
-                buffer.limit((int)length);
+                limitBuffer(buffer, (int)length);
             }
             long n = from.read(buffer);
 
             if (n == -1) break;
 
-            buffer.flip();
+            flipBuffer(buffer);
             to.write(buffer);
-            buffer.clear();
+            clearBuffer(buffer);
 
             transferred += n;
             if (length > 0) {

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -49,6 +49,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import jnr.constants.platform.Errno;
 import jnr.posix.POSIX;

--- a/core/src/main/java/org/jruby/embed/io/ReaderInputStream.java
+++ b/core/src/main/java/org/jruby/embed/io/ReaderInputStream.java
@@ -42,6 +42,10 @@ import java.nio.charset.CodingErrorAction;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.jruby.util.io.BufferHelper.clearBuffer;
+import static org.jruby.util.io.BufferHelper.flipBuffer;
+import static org.jruby.util.io.BufferHelper.limitBuffer;
+
 /**
  * A ReaderInputStream converts java.io.Reader to java.io.InputStream. The
  * ReaderInputStream reads data in a given Reader object into its internal buffer
@@ -105,12 +109,12 @@ public class ReaderInputStream extends InputStream {
         ByteBuffer bbuf = ByteBuffer.allocate(DEFAULT_BYTE_BUFFER_SIZE);
         List<byte[]> list = new ArrayList<byte[]>();
         while (true) {
-            cbuf.clear();
+            clearBuffer(cbuf);
             int size = reader.read(cbuf);
             if (size <= 0) {
                 break;
             }
-            cbuf.limit(cbuf.position());
+            limitBuffer(cbuf, cbuf.position());
             cbuf.rewind();
             boolean eof = false;
             while (!eof) {
@@ -122,7 +126,7 @@ public class ReaderInputStream extends InputStream {
                     eof = true;
                 } else if (cr.isOverflow()) {
                     appendBytes(list, bbuf);
-                    bbuf.clear();
+                    clearBuffer(bbuf);
                 }
             }
         }
@@ -130,7 +134,7 @@ public class ReaderInputStream extends InputStream {
     }
 
     private void appendBytes(List<byte[]> list, ByteBuffer bb) {
-        bb.flip();
+        flipBuffer(bb);
         int length = bb.limit();
         totalBytes += length;
         byte[] dst = new byte[length];

--- a/core/src/main/java/org/jruby/embed/io/WriterOutputStream.java
+++ b/core/src/main/java/org/jruby/embed/io/WriterOutputStream.java
@@ -40,6 +40,9 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
 
+import static org.jruby.util.io.BufferHelper.clearBuffer;
+import static org.jruby.util.io.BufferHelper.flipBuffer;
+
 /**
  * A WriterOutputStream converts java.io.Writer to java.io.OutputStream.
  *
@@ -203,12 +206,12 @@ public class WriterOutputStream extends OutputStream {
 
     private void byte2char(ByteBuffer bytes, CharBuffer chars) throws IOException {
         decoder.reset();
-        chars.clear();
+        clearBuffer(chars);
         CoderResult result = decoder.decode(bytes, chars, true);
         if (result.isError() || result.isOverflow()) {
             throw new IOException(result.toString());
         } else if (result.isUnderflow()) {
-            chars.flip();
+            flipBuffer(chars);
         }
     }
 }

--- a/core/src/main/java/org/jruby/ext/ffi/IOModule.java
+++ b/core/src/main/java/org/jruby/ext/ffi/IOModule.java
@@ -40,6 +40,8 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.io.OpenFile;
 
+import static org.jruby.util.io.BufferHelper.limitBuffer;
+
 /**
 * FFI specific I/O routines
  */
@@ -77,7 +79,7 @@ public class IOModule {
 
             if (count < buffer.remaining()) {
                 buffer = buffer.duplicate();
-                buffer.limit(count);
+                limitBuffer(buffer, count);
             }
 
             // TODO: This used to use ChannelStream and honor its buffers; it does not honor OpenFile buffers now

--- a/core/src/main/java/org/jruby/ext/ffi/Util.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Util.java
@@ -42,6 +42,8 @@ import org.jruby.javasupport.JavaObject;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import static org.jruby.util.io.BufferHelper.positionBuffer;
+
 /**
  *
  */
@@ -159,7 +161,7 @@ public final class Util {
 
     public static final ByteBuffer slice(ByteBuffer buf, int offset) {
         ByteBuffer tmp = buf.duplicate();
-        tmp.position((int) offset);
+        positionBuffer(tmp, offset);
         return tmp.slice();
     }
 

--- a/core/src/main/java/org/jruby/ext/ffi/io/FileDescriptorByteChannel.java
+++ b/core/src/main/java/org/jruby/ext/ffi/io/FileDescriptorByteChannel.java
@@ -34,6 +34,8 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
 
+import static org.jruby.util.io.BufferHelper.positionBuffer;
+
 /**
  * An implementation of ByteChannel that reads from and writes to a native unix
  * file descriptor.
@@ -74,7 +76,7 @@ public class FileDescriptorByteChannel implements ByteChannel {
         }
         int n = libc.read(fd, dst, dst.remaining());
         if (n > 0) {
-            dst.position(dst.position() + n);
+            positionBuffer(dst, dst.position() + n);
         } else if (n == 0) {
             return -1; // EOF
         }
@@ -95,7 +97,7 @@ public class FileDescriptorByteChannel implements ByteChannel {
         }
         int n = libc.write(fd, src, src.remaining());
         if (n > 0) {
-            src.position(src.position() + n);
+            positionBuffer(src, src.position() + n);
         }
         return n;
     }

--- a/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
@@ -72,6 +72,8 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 import org.jruby.util.io.Sockaddr;
 
+import static org.jruby.util.io.BufferHelper.flipBuffer;
+
 
 /**
  * @author <a href="mailto:pldms@mac.com">Damian Steer</a>
@@ -626,7 +628,7 @@ public class RubyUDPSocket extends RubyIPSocket {
             throw runtime.newErrnoECONNRESETError();
         }
 
-        recv.flip();
+        flipBuffer(recv);
         RubyString result = runtime.newString(new ByteList(recv.array(), recv.position(), recv.limit(), false));
 
         if (tuple != null) {

--- a/core/src/main/java/org/jruby/ext/socket/RubyUNIXSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUNIXSocket.java
@@ -66,6 +66,8 @@ import java.nio.channels.Channel;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import static org.jruby.util.io.BufferHelper.flipBuffer;
+
 
 @JRubyClass(name="UNIXSocket", parent="BasicSocket")
 public class RubyUNIXSocket extends RubyBasicSocket {
@@ -181,7 +183,7 @@ public class RubyUNIXSocket extends RubyBasicSocket {
         ByteBuffer[] outIov = new ByteBuffer[1];
         outIov[0] = ByteBuffer.allocateDirect(dataBytes.length);
         outIov[0].put(dataBytes);
-        outIov[0].flip();
+        flipBuffer(outIov[0]);
 
         outMessage.setIov(outIov);
 

--- a/core/src/main/java/org/jruby/ir/persistence/IRReaderStream.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRReaderStream.java
@@ -36,6 +36,8 @@ import org.jruby.runtime.RubyEvent;
 import org.jruby.runtime.Signature;
 import org.jruby.util.ByteList;
 
+import static org.jruby.util.io.BufferHelper.positionBuffer;
+
 /**
  *
  * @author enebo
@@ -191,7 +193,7 @@ public class IRReaderStream implements IRReaderDecoder, IRPersistenceValues {
     public List<Instr> decodeInstructionsAt(IRScope scope, int offset) {
         currentScope = scope;
         vars = new HashMap<>();
-        buf.position(offset);
+        positionBuffer(buf, offset);
 
         int numberOfInstructions = decodeInt();
         if (RubyInstanceConfig.IR_READING_DEBUG) System.out.println("Number of Instructions: " + numberOfInstructions);
@@ -452,7 +454,7 @@ public class IRReaderStream implements IRReaderDecoder, IRPersistenceValues {
 
     @Override
     public void seek(int headersOffset) {
-        buf.position(headersOffset);
+        positionBuffer(buf, headersOffset);
     }
 
     public Operand decode(OperandType type) {

--- a/core/src/main/java/org/jruby/ir/persistence/IRWriterStream.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRWriterStream.java
@@ -29,6 +29,8 @@ import org.jruby.runtime.RubyEvent;
 import org.jruby.runtime.Signature;
 import org.jruby.util.ByteList;
 
+import static org.jruby.util.io.BufferHelper.flipBuffer;
+
 // FIXME: Make into a base class at some point to play with different formats
 
 /**
@@ -276,7 +278,7 @@ public class IRWriterStream implements IRWriterEncoder, IRPersistenceValues {
             stream.write(ByteBuffer.allocate(4).putInt(VERSION).array());
             stream.write(ByteBuffer.allocate(4).putInt(headersOffset).array());
             stream.write(ByteBuffer.allocate(4).putInt(poolOffset).array());
-            buf.flip();
+            flipBuffer(buf);
             stream.write(buf.array(), buf.position(), buf.limit());
             stream.close();
         } catch (IOException e) {

--- a/core/src/main/java/org/jruby/util/Pack.java
+++ b/core/src/main/java/org/jruby/util/Pack.java
@@ -56,6 +56,8 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import static org.jruby.util.TypeConverter.toFloat;
+import static org.jruby.util.io.BufferHelper.positionBuffer;
+import static org.jruby.util.io.BufferHelper.markBuffer;
 
 public class Pack {
     private static final byte[] sSp10 = "          ".getBytes();
@@ -875,9 +877,9 @@ public class Pack {
                 case '@' :
                     try {
                         if (occurrences == IS_STAR) {
-                            encode.position(encodedString.begin() + encode.remaining());
+                            positionBuffer(encode, encodedString.begin() + encode.remaining());
                         } else {
-                            encode.position(encodedString.begin() + occurrences);
+                            positionBuffer(encode, encodedString.begin() + occurrences);
                         }
                     } catch (IllegalArgumentException iae) {
                         throw runtime.newArgumentError("@ outside of string");
@@ -1096,7 +1098,7 @@ public class Pack {
                             if (safeGet(encode) == '\n') {
                                 safeGet(encode); // Possible Checksum Byte
                             } else if (encode.hasRemaining()) {
-                                encode.position(encode.position() - 1);
+                                positionBuffer(encode, encode.position() - 1);
                             }
                         }
                     }
@@ -1192,7 +1194,7 @@ public class Pack {
                             }
                             if ((s == '=') || c == -1) {
                                 if (s == '=') {
-                                    encode.position(encode.position() - 1);
+                                    positionBuffer(encode, encode.position() - 1);
                                 }
                                 break;
                             }
@@ -1205,7 +1207,7 @@ public class Pack {
                             }
                             if ((s == '=') || d == -1) {
                                 if (s == '=') {
-                                    encode.position(encode.position() - 1);
+                                    positionBuffer(encode, encode.position() - 1);
                                 }
                                 break;
                             }
@@ -1243,7 +1245,7 @@ public class Pack {
                                 lElem[index++] = (byte)c;
                             } else {
                                 if (!encode.hasRemaining()) break;
-                                encode.mark();
+                                markBuffer(encode);
                                 int c1 = safeGet(encode);
                                 if (c1 == '\n' || (c1 == '\r' && (c1 = safeGet(encode)) == '\n')) continue;
                                 int d1 = Character.digit(c1, 16);
@@ -1251,7 +1253,7 @@ public class Pack {
                                     encode.reset();
                                     break;
                                 }
-                                encode.mark();
+                                markBuffer(encode);
                                 if (!encode.hasRemaining()) break;
                                 int c2 = safeGet(encode);
                                 int d2 = Character.digit(c2, 16);
@@ -1298,7 +1300,7 @@ public class Pack {
                      }
 
                      try {
-                         encode.position(encode.position() - occurrences);
+                         positionBuffer(encode, encode.position() - occurrences);
                      } catch (IllegalArgumentException e) {
                          throw runtime.newArgumentError("in `unpack': X outside of string");
                      }
@@ -1309,7 +1311,7 @@ public class Pack {
                       }
 
                       try {
-                          encode.position(encode.position() + occurrences);
+                          positionBuffer(encode, encode.position() + occurrences);
                       } catch (IllegalArgumentException e) {
                           throw runtime.newArgumentError("in `unpack': x outside of string");
                       }
@@ -1353,7 +1355,7 @@ public class Pack {
                         }
                     }
                     try {
-                        encode.position(pos);
+                        positionBuffer(encode, pos);
                     } catch (IllegalArgumentException e) {
                         throw runtime.newArgumentError("in `unpack': poorly encoded input");
                     }

--- a/core/src/main/java/org/jruby/util/ShellLauncher.java
+++ b/core/src/main/java/org/jruby/util/ShellLauncher.java
@@ -29,6 +29,8 @@
 package org.jruby.util;
 
 import static java.lang.System.out;
+import static org.jruby.util.io.BufferHelper.clearBuffer;
+import static org.jruby.util.io.BufferHelper.flipBuffer;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -1484,14 +1486,14 @@ public class ShellLauncher {
         public void run() {
             runtime.getCurrentContext().setEventHooksEnabled(false);
             ByteBuffer buf = ByteBuffer.allocateDirect(1024);
-            buf.clear();
+            clearBuffer(buf);
             try {
                 while (!quit && inChannel.isOpen() && outChannel.isOpen()) {
                     int read = inChannel.read(buf);
                     if (read == -1) break;
-                    buf.flip();
+                    flipBuffer(buf);
                     outChannel.write(buf);
-                    buf.clear();
+                    clearBuffer(buf);
                 }
             } catch (Exception e) {
             } finally {

--- a/core/src/main/java/org/jruby/util/StrptimeParser.java
+++ b/core/src/main/java/org/jruby/util/StrptimeParser.java
@@ -693,7 +693,8 @@ public class StrptimeParser {
 
                 if (vBig == null) {
                     try {
-                        long tmp = Math.multiplyExact(v, 10);
+                        // Using 10L to avoid binary incompat with Java 8 (jruby/jruby#5451)
+                        long tmp = Math.multiplyExact(v, 10L);
                         tmp = Math.addExact(tmp, toInt(c));
                         v = tmp;
                     }

--- a/core/src/main/java/org/jruby/util/io/BufferHelper.java
+++ b/core/src/main/java/org/jruby/util/io/BufferHelper.java
@@ -1,0 +1,70 @@
+package org.jruby.util.io;
+
+import java.nio.Buffer;
+
+/**
+ * Utility functions to help avoid binary incompatibility due to variadic return types on Java 9.
+ *
+ * Java 9 introduced new overloads of several Buffer methods on its subclasses. Because those methods
+ * return the actual type of the subclass, they are incompatible with Java 8 where no such overloads
+ * exist. This utility casts all buffers to Buffer and makes the call from there, avoiding binding
+ * directly to the overloads that don't exist on Java 8.
+ *
+ * See https://github.com/jruby/jruby/pull/5451
+ */
+public class BufferHelper {
+    /**
+     * Invoke Buffer.clear always using Buffer as the target, to avoid binary incompatibility on Java 8.
+     *
+     * @param buf the buffer
+     * @param <T> any java.nio.Buffer type
+     * @return the buffer
+     */
+    public static <T extends Buffer> T clearBuffer(T buf) {
+        return (T) buf.clear();
+    }
+
+    /**
+     * Invoke Buffer.flip always using Buffer as the target, to avoid binary incompatibility on Java 8.
+     *
+     * @param buf the buffer
+     * @param <T> any java.nio.Buffer type
+     * @return the buffer
+     */
+    public static <T extends Buffer> T flipBuffer(T buf) {
+        return (T) buf.flip();
+    }
+
+    /**
+     * Invoke Buffer.limit always using Buffer as the target, to avoid binary incompatibility on Java 8.
+     *
+     * @param buf the buffer
+     * @param <T> any java.nio.Buffer type
+     * @return the buffer
+     */
+    public static <T extends Buffer> T limitBuffer(T buf, int limit) {
+        return (T) buf.limit(limit);
+    }
+
+    /**
+     * Invoke Buffer.position always using Buffer as the target, to avoid binary incompatibility on Java 8.
+     *
+     * @param buf the buffer
+     * @param <T> any java.nio.Buffer type
+     * @return the buffer
+     */
+    public static <T extends Buffer> T positionBuffer(T buf, int limit) {
+        return (T) buf.position(limit);
+    }
+
+    /**
+     * Invoke Buffer.mark always using Buffer as the target, to avoid binary incompatibility on Java 8.
+     *
+     * @param buf the buffer
+     * @param <T> any java.nio.Buffer type
+     * @return the buffer
+     */
+    public static <T extends Buffer> T markBuffer(T buf) {
+        return (T) buf.mark();
+    }
+}

--- a/core/src/main/java/org/jruby/util/io/ChannelDescriptor.java
+++ b/core/src/main/java/org/jruby/util/io/ChannelDescriptor.java
@@ -54,6 +54,8 @@ import org.jruby.util.JRubyFile;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
 
+import static org.jruby.util.io.BufferHelper.flipBuffer;
+
 /**
  * ChannelDescriptor provides an abstraction similar to the concept of a
  * "file descriptor" on any POSIX system. In our case, it's a numbered object
@@ -691,7 +693,7 @@ public class ChannelDescriptor {
         
         ByteBuffer buf = ByteBuffer.allocate(1);
         buf.put((byte)c);
-        buf.flip();
+        flipBuffer(buf);
         
         return internalWrite(buf);
     }

--- a/core/src/main/java/org/jruby/util/io/ChannelStream.java
+++ b/core/src/main/java/org/jruby/util/io/ChannelStream.java
@@ -57,6 +57,11 @@ import org.jruby.util.ResourceException;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
 
+import static org.jruby.util.io.BufferHelper.clearBuffer;
+import static org.jruby.util.io.BufferHelper.flipBuffer;
+import static org.jruby.util.io.BufferHelper.limitBuffer;
+import static org.jruby.util.io.BufferHelper.positionBuffer;
+
 /**
  * This file implements a seekable IO file.
  */
@@ -117,7 +122,7 @@ public class ChannelStream implements Stream, Finalizable {
         this.descriptor = descriptor;
         this.modes = descriptor.getOriginalModes();
         buffer = ByteBuffer.allocate(BUFSIZE);
-        buffer.flip();
+        flipBuffer(buffer);
         this.reading = true;
         this.autoclose = autoclose;
         runtime.addInternalFinalizer(this);
@@ -212,9 +217,9 @@ public class ChannelStream implements Stream, Finalizable {
 
     @Override
     public final int refillBuffer() throws IOException {
-        buffer.clear();
+        clearBuffer(buffer);
         int n = ((ReadableByteChannel) descriptor.getChannel()).read(buffer);
-        buffer.flip();
+        flipBuffer(buffer);
         return n;
     }
 
@@ -242,7 +247,7 @@ public class ChannelStream implements Stream, Finalizable {
         }
 
         // unread back
-        buffer.position(buffer.position() - 1);
+        positionBuffer(buffer, buffer.position() - 1);
 
         ByteList buf = new ByteList(40);
 
@@ -261,9 +266,9 @@ public class ChannelStream implements Stream, Finalizable {
                         // terminate and advance buffer when we find our char
                         buf.append(bytes, offset, i - offset);
                         if (i >= max) {
-                            buffer.clear();
+                            clearBuffer(buffer);
                         } else {
-                            buffer.position(i + 1);
+                            positionBuffer(buffer, i + 1);
                         }
                         break ReadLoop;
                     }
@@ -453,13 +458,13 @@ public class ChannelStream implements Stream, Finalizable {
                 //
                 ByteBuffer tmp = buf.duplicate();
                 if (tmp.remaining() > MAX_READ_CHUNK) {
-                    tmp.limit(tmp.position() + MAX_READ_CHUNK);
+                    limitBuffer(tmp, tmp.position() + MAX_READ_CHUNK);
                 }
                 int n = channel.read(tmp);
                 if (n <= 0) {
                     break;
                 }
-                buf.position(tmp.position());
+                positionBuffer(buf, tmp.position());
             }
             eof = true;
             result.length(buf.position());
@@ -516,9 +521,9 @@ public class ChannelStream implements Stream, Finalizable {
                 // Need to clamp source (buffer) size to avoid overrun
                 //
                 ByteBuffer tmp = buffer.duplicate();
-                tmp.limit(tmp.position() + dst.remaining());
+                limitBuffer(tmp, tmp.position() + dst.remaining());
                 dst.put(tmp);
-                buffer.position(tmp.position());
+                positionBuffer(buffer, tmp.position());
             }
         }
 
@@ -693,13 +698,13 @@ public class ChannelStream implements Stream, Finalizable {
         if (reading || !modes.isWritable() || buffer.position() == 0) return; // Don't bother
 
         int len = buffer.position();
-        buffer.flip();
+        flipBuffer(buffer);
         int n = descriptor.write(buffer);
 
         if(n != len) {
             // TODO: check the return value here
         }
-        buffer.clear();
+        clearBuffer(buffer);
     }
 
     /**
@@ -710,7 +715,7 @@ public class ChannelStream implements Stream, Finalizable {
         if (reading || !modes.isWritable() || buffer.position() == 0) return false; // Don't bother
         int len = buffer.position();
         int nWritten = 0;
-        buffer.flip();
+        flipBuffer(buffer);
 
         // For Sockets, only write as much as will fit.
         if (descriptor.getChannel() instanceof SelectableChannel) {
@@ -735,7 +740,7 @@ public class ChannelStream implements Stream, Finalizable {
             buffer.compact();
             return false;
         }
-        buffer.clear();
+        clearBuffer(buffer);
         return true;
     }
 
@@ -804,8 +809,8 @@ public class ChannelStream implements Stream, Finalizable {
             if (reading) {
                 // for SEEK_CUR, need to adjust for buffered data
                 adj = buffer.remaining();
-                buffer.clear();
-                buffer.flip();
+                clearBuffer(buffer);
+                flipBuffer(buffer);
             } else {
                 flushWrite();
             }
@@ -846,8 +851,8 @@ public class ChannelStream implements Stream, Finalizable {
     private void ensureRead() throws IOException, BadDescriptorException {
         if (reading) return;
         flushWrite();
-        buffer.clear();
-        buffer.flip();
+        clearBuffer(buffer);
+        flipBuffer(buffer);
         reading = true;
     }
 
@@ -868,8 +873,8 @@ public class ChannelStream implements Stream, Finalizable {
         } else {
             // libc flushes writes on any read from the actual file, so we flush here
             flushWrite();
-            buffer.clear();
-            buffer.flip();
+            clearBuffer(buffer);
+            flipBuffer(buffer);
             reading = true;
         }
     }
@@ -882,7 +887,7 @@ public class ChannelStream implements Stream, Finalizable {
             }
         }
         // FIXME: Clearing read buffer here...is this appropriate?
-        buffer.clear();
+        clearBuffer(buffer);
         reading = false;
     }
 
@@ -1031,7 +1036,7 @@ public class ChannelStream implements Stream, Finalizable {
                 int bytesToRead = Math.min(BULK_READ_SIZE, dst.remaining());
                 if (bytesToRead < dst.remaining()) {
                     tmpDst = dst.duplicate();
-                    tmpDst.limit(tmpDst.position() + bytesToRead);
+                    limitBuffer(tmpDst, tmpDst.position() + bytesToRead);
                 }
             }
             int n = descriptor.read(tmpDst);
@@ -1193,9 +1198,9 @@ public class ChannelStream implements Stream, Finalizable {
     private void invalidateBuffer() throws IOException, BadDescriptorException {
         if (!reading) flushWrite();
         int posOverrun = buffer.remaining(); // how far ahead we are when reading
-        buffer.clear();
+        clearBuffer(buffer);
         if (reading) {
-            buffer.flip();
+            flipBuffer(buffer);
             // if the read buffer is ahead, back up
             SeekableByteChannel fileChannel = (SeekableByteChannel) descriptor.getChannel();
             if (posOverrun != 0) fileChannel.position(fileChannel.position() - posOverrun);
@@ -1439,9 +1444,9 @@ public class ChannelStream implements Stream, Finalizable {
         flushWrite();
 
         // reset buffer
-        buffer.clear();
+        clearBuffer(buffer);
         if (reading) {
-            buffer.flip();
+            flipBuffer(buffer);
         }
 
         this.modes = modes;

--- a/core/src/main/java/org/jruby/util/io/NullChannel.java
+++ b/core/src/main/java/org/jruby/util/io/NullChannel.java
@@ -35,6 +35,8 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 
+import static org.jruby.util.io.BufferHelper.positionBuffer;
+
 /**
  *
  * @author headius
@@ -47,7 +49,7 @@ public class NullChannel implements WritableByteChannel, ReadableByteChannel {
             throw new EOFException();
         }
         int length = buffer.remaining();
-        buffer.position(buffer.position() + length);
+        positionBuffer(buffer, buffer.position() + length);
         return length;
     }
 

--- a/core/src/main/java/org/jruby/util/io/SelectBlob.java
+++ b/core/src/main/java/org/jruby/util/io/SelectBlob.java
@@ -47,6 +47,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import org.jruby.exceptions.RaiseException;
 
+import static org.jruby.util.io.BufferHelper.flipBuffer;
+
 /**
  * This is a reimplementation of MRI's IO#select logic. It has been rewritten
  * from an earlier version in JRuby to improve performance and readability.
@@ -559,7 +561,7 @@ public class SelectBlob {
             } finally {
                 ByteBuffer buf = ByteBuffer.allocate(1);
                 buf.put((byte) 0);
-                buf.flip();
+                flipBuffer(buf);
                 pipe.sink().write(buf);
             }
 

--- a/core/src/main/java/org/jruby/util/io/SelectExecutor.java
+++ b/core/src/main/java/org/jruby/util/io/SelectExecutor.java
@@ -23,6 +23,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import static org.jruby.util.io.BufferHelper.flipBuffer;
+
 /**
  * Created by headius on 6/3/14.
  */
@@ -537,7 +539,7 @@ public class SelectExecutor {
             } finally {
                 ByteBuffer buf = ByteBuffer.allocate(1);
                 buf.put((byte) 0);
-                buf.flip();
+                flipBuffer(buf);
                 pipe.sink().write(buf);
             }
 


### PR DESCRIPTION
Fixes #5451.

This is basically the same as @ahorek patch in #5459 but I addressed my review comments.