### PR TITLE
Use Java 9 stack walking to reduce the cost of #caller and friends

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -74,6 +74,7 @@ project 'JRuby Core' do
   jar 'me.qmx.jitescript:jitescript:0.4.1', :exclusions => ['org.ow2.asm:asm-all']
 
   jar 'com.headius:modulator:1.0'
+  jar 'com.headius:backport9:1.1'
 
   plugin_management do
     plugin( 'org.eclipse.m2e:lifecycle-mapping:1.0.0',

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -251,6 +251,11 @@ DO NOT MODIFIY - GENERATED CODE
       <artifactId>modulator</artifactId>
       <version>1.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.headius</groupId>
+      <artifactId>backport9</artifactId>
+      <version>1.1</version>
+    </dependency>
   </dependencies>
   <build>
     <defaultGoal>package</defaultGoal>

--- a/core/src/main/java/org/jruby/NativeException.java
+++ b/core/src/main/java/org/jruby/NativeException.java
@@ -29,6 +29,8 @@
 package org.jruby;
 
 import java.lang.reflect.Member;
+import java.util.Arrays;
+
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.RaiseException;
@@ -84,7 +86,7 @@ public class NativeException extends RubyException {
     public void prepareBacktrace(ThreadContext context) {
         // if it's null, use cause's trace to build a raw stack trace
         if (backtraceData == null) {
-            backtraceData = TraceType.Gather.RAW.getBacktraceData(getRuntime().getCurrentContext(), cause.getStackTrace());
+            backtraceData = TraceType.Gather.RAW.getBacktraceData(getRuntime().getCurrentContext(), Arrays.stream(cause.getStackTrace()));
         }
     }
 

--- a/core/src/main/java/org/jruby/NativeException.java
+++ b/core/src/main/java/org/jruby/NativeException.java
@@ -31,6 +31,7 @@ package org.jruby;
 import java.lang.reflect.Member;
 import java.util.Arrays;
 
+import com.headius.backport9.stack.StackWalker;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.RaiseException;
@@ -49,6 +50,7 @@ public class NativeException extends RubyException {
     private final Throwable cause;
     private final String messageAsJavaString;
     public static final String CLASS_NAME = "NativeException";
+    private static final StackWalker WALKER = StackWalker.getInstance();
 
     public NativeException(Ruby runtime, RubyClass rubyClass, Throwable cause) {
         this(runtime, rubyClass, cause, buildMessage(cause));
@@ -86,7 +88,7 @@ public class NativeException extends RubyException {
     public void prepareBacktrace(ThreadContext context) {
         // if it's null, use cause's trace to build a raw stack trace
         if (backtraceData == null) {
-            backtraceData = TraceType.Gather.RAW.getBacktraceData(getRuntime().getCurrentContext(), Arrays.stream(cause.getStackTrace()));
+            backtraceData = WALKER.walk(cause.getStackTrace(), stream -> TraceType.Gather.RAW.getBacktraceData(getRuntime().getCurrentContext(), stream));
         }
     }
 

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1109,7 +1109,7 @@ public class RubyKernel {
 
     private static IRubyObject callerInternal(ThreadContext context, IRubyObject recv, IRubyObject level, IRubyObject length) {
         int[] ll = levelAndLengthFromArgs(context, level, length, 1);
-        return context.createCallerBacktrace(ll[0], ll[1], Arrays.stream(Thread.currentThread().getStackTrace()));
+        return context.createCallerBacktrace(ll[0], ll[1]);
     }
 
     @JRubyMethod(module = true, visibility = PRIVATE, omit = true)
@@ -1129,7 +1129,7 @@ public class RubyKernel {
 
     private static IRubyObject callerLocationsInternal(ThreadContext context, IRubyObject level, IRubyObject length) {
         int[] ll = levelAndLengthFromArgs(context, level, length, 1);
-        return context.createCallerLocations(ll[0], ll[1], Arrays.stream(Thread.currentThread().getStackTrace()));
+        return context.createCallerLocations(ll[0], ll[1]);
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -39,6 +39,7 @@ import java.nio.channels.Channel;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Optional;
@@ -1636,10 +1637,8 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         // nativeThread may have finished
         if (myContext == null || nativeThread == null || !nativeThread.isAlive()) return context.nil;
 
-        Integer[] ll = RubyKernel.levelAndLengthFromArgs(context, level, length, 0);
-        Integer levelInt = ll[0], lengthInt = ll[1];
-
-        return myContext.createCallerBacktrace(levelInt, lengthInt, getNativeThread().getStackTrace());
+        int[] ll = RubyKernel.levelAndLengthFromArgs(context, level, length, 0);
+        return myContext.createCallerBacktrace(ll[0], ll[1], Arrays.stream(getNativeThread().getStackTrace()));
     }
 
     @JRubyMethod
@@ -1666,10 +1665,8 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         // nativeThread may have finished
         if (myContext == null || nativeThread == null || !nativeThread.isAlive()) return context.nil;
 
-        Integer[] ll = RubyKernel.levelAndLengthFromArgs(context, level, length, 0);
-        Integer levelInt = ll[0], lengthInt = ll[1];
-
-        return myContext.createCallerLocations(levelInt, lengthInt, getNativeThread().getStackTrace());
+        int[] ll = RubyKernel.levelAndLengthFromArgs(context, level, length, 0);
+        return myContext.createCallerLocations(ll[0], ll[1], Arrays.stream(getNativeThread().getStackTrace()));
     }
 
     @JRubyMethod(name = "report_on_exception=")

--- a/core/src/main/java/org/jruby/management/Runtime.java
+++ b/core/src/main/java/org/jruby/management/Runtime.java
@@ -34,6 +34,7 @@ import java.io.StringWriter;
 import java.lang.ref.SoftReference;
 import java.util.Arrays;
 
+import com.headius.backport9.stack.StackWalker;
 import org.jruby.Ruby;
 import org.jruby.RubyException;
 import org.jruby.RubyThread;
@@ -44,6 +45,8 @@ import org.jruby.runtime.backtrace.TraceType.Gather;
 
 public class Runtime implements RuntimeMBean {
     private final SoftReference<Ruby> ruby;
+
+    private static final StackWalker WALKER = StackWalker.getInstance();
 
     public Runtime(Ruby ruby) {
         this.ruby = new SoftReference<Ruby>(ruby);
@@ -105,7 +108,7 @@ public class Runtime implements RuntimeMBean {
         ThreadContext tc = th.getContext();
         if (tc != null) {
             RubyException exc = new RubyException(ruby, ruby.getRuntimeError(), "thread dump");
-            exc.setBacktraceData(gather.getBacktraceData(tc, Arrays.stream(th.getNativeThread().getStackTrace())));
+            exc.setBacktraceData(WALKER.walk(th.getNativeThread().getStackTrace(), stream -> gather.getBacktraceData(tc, stream)));
             pw.println(Format.MRI.printBacktrace(exc, false));
         } else {
             pw.println("    [no longer alive]");

--- a/core/src/main/java/org/jruby/management/Runtime.java
+++ b/core/src/main/java/org/jruby/management/Runtime.java
@@ -32,6 +32,7 @@ package org.jruby.management;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.ref.SoftReference;
+import java.util.Arrays;
 
 import org.jruby.Ruby;
 import org.jruby.RubyException;
@@ -104,7 +105,7 @@ public class Runtime implements RuntimeMBean {
         ThreadContext tc = th.getContext();
         if (tc != null) {
             RubyException exc = new RubyException(ruby, ruby.getRuntimeError(), "thread dump");
-            exc.setBacktraceData(gather.getBacktraceData(tc, th.getNativeThread().getStackTrace()));
+            exc.setBacktraceData(gather.getBacktraceData(tc, Arrays.stream(th.getNativeThread().getStackTrace())));
             pw.println(Format.MRI.printBacktrace(exc, false));
         } else {
             pw.println("    [no longer alive]");

--- a/core/src/main/java/org/jruby/runtime/backtrace/BacktraceData.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/BacktraceData.java
@@ -6,22 +6,24 @@ import org.jruby.util.JavaNameMangler;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 public class BacktraceData implements Serializable {
 
     public static final StackTraceElement[] EMPTY_STACK_TRACE = new StackTraceElement[0];
 
     private RubyStackTraceElement[] backtraceElements;
-    private final StackTraceElement[] javaTrace;
-    private final BacktraceElement[] rubyTrace;
+    private final Stream<StackTraceElement> stackStream;
+    private final Stream<BacktraceElement> rubyTrace;
     private final boolean fullTrace;
     private final boolean maskNative;
     private final boolean includeNonFiltered;
 
-    public BacktraceData(StackTraceElement[] javaTrace, BacktraceElement[] rubyTrace, boolean fullTrace, boolean maskNative, boolean includeNonFiltered) {
-        this.javaTrace = javaTrace;
+    public BacktraceData(Stream<StackTraceElement> stackStream, Stream<BacktraceElement> rubyTrace, boolean fullTrace, boolean maskNative, boolean includeNonFiltered) {
+        this.stackStream = stackStream;
         this.rubyTrace = rubyTrace;
         this.fullTrace = fullTrace;
         this.maskNative = maskNative;
@@ -29,8 +31,8 @@ public class BacktraceData implements Serializable {
     }
 
     public static final BacktraceData EMPTY = new BacktraceData(
-            EMPTY_STACK_TRACE,
-            BacktraceElement.EMPTY_ARRAY,
+            Stream.empty(),
+            Stream.empty(),
             false,
             false,
             false);
@@ -42,38 +44,45 @@ public class BacktraceData implements Serializable {
         return backtraceElements;
     }
 
+    public final RubyStackTraceElement[] getPartialBacktrace(Ruby runtime, int level) {
+        if (backtraceElements == null) {
+            backtraceElements = constructBacktrace(runtime.getBoundMethods(), level);
+        }
+        return backtraceElements;
+    }
+
     @SuppressWarnings("unchecked")
     public RubyStackTraceElement[] getBacktraceWithoutRuby() {
         return constructBacktrace(Collections.EMPTY_MAP);
+
+    }
+    private RubyStackTraceElement[] constructBacktrace(Map<String, Map<String, String>> boundMethods) {
+        return constructBacktrace(boundMethods, Integer.MAX_VALUE);
     }
 
-    private RubyStackTraceElement[] constructBacktrace(Map<String, Map<String, String>> boundMethods) {
-        ArrayList<RubyStackTraceElement> trace = new ArrayList<>(javaTrace.length);
+    private RubyStackTraceElement[] constructBacktrace(Map<String, Map<String, String>> boundMethods, int count) {
+        ArrayList<RubyStackTraceElement> trace = new ArrayList<>();
 
         // used for duplicating the previous Ruby frame when masking native calls
         boolean dupFrame = false; String dupFrameName = null;
 
-        // a running index into the Ruby backtrace stack, incremented for each
-        // interpreter frame we encounter in the Java backtrace.
-        int rubyFrameIndex = rubyTrace == null ? -1 : rubyTrace.length - 1;
-
         // loop over all elements in the Java stack trace
-        for (int i = 0; i < javaTrace.length; i++) {
-
-            StackTraceElement element = javaTrace[i];
+        Iterator<StackTraceElement> stackIter = stackStream.iterator();
+        Iterator<BacktraceElement> backIter = rubyTrace.iterator();
+        while (stackIter.hasNext() && trace.size() < count) {
+            StackTraceElement element = stackIter.next();
 
             // skip unnumbered frames
             int line = element.getLineNumber();
 
-            String className = element.getClassName();
-            String methodName = element.getMethodName();
             String filename = element.getFileName();
+            String methodName = element.getMethodName();
+            String className = element.getClassName();
 
             if (filename != null) {
 
                 // Don't process .java files
                 if (!filename.endsWith(".java")) {
-
                     List<String> mangledTuple = JavaNameMangler.decodeMethodTuple(methodName);
                     if (mangledTuple != null) {
                         FrameType type = JavaNameMangler.decodeFrameTypeFromMangledName(mangledTuple.get(1));
@@ -119,10 +128,10 @@ public class BacktraceData implements Serializable {
 
             // Interpreted frames
             final FrameType frameType;
-            if ( rubyFrameIndex >= 0 && (frameType = FrameType.getInterpreterFrame(className, methodName)) != null ) {
+            if ( backIter.hasNext() && (frameType = FrameType.getInterpreterFrame(className, methodName)) != null ) {
 
                 // pop interpreter frame
-                BacktraceElement rubyFrame = rubyTrace[rubyFrameIndex--];
+                BacktraceElement rubyFrame = backIter.next();
 
                 // construct Ruby trace element
                 final String newName;

--- a/core/src/main/java/org/jruby/runtime/backtrace/BacktraceData.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/BacktraceData.java
@@ -1,5 +1,6 @@
 package org.jruby.runtime.backtrace;
 
+import com.headius.backport9.stack.StackWalker;
 import org.jruby.Ruby;
 import org.jruby.util.JavaNameMangler;
 
@@ -16,13 +17,13 @@ public class BacktraceData implements Serializable {
     public static final StackTraceElement[] EMPTY_STACK_TRACE = new StackTraceElement[0];
 
     private RubyStackTraceElement[] backtraceElements;
-    private final Stream<StackTraceElement> stackStream;
+    private final Stream<StackWalker.StackFrame> stackStream;
     private final Stream<BacktraceElement> rubyTrace;
     private final boolean fullTrace;
     private final boolean maskNative;
     private final boolean includeNonFiltered;
 
-    public BacktraceData(Stream<StackTraceElement> stackStream, Stream<BacktraceElement> rubyTrace, boolean fullTrace, boolean maskNative, boolean includeNonFiltered) {
+    public BacktraceData(Stream<StackWalker.StackFrame> stackStream, Stream<BacktraceElement> rubyTrace, boolean fullTrace, boolean maskNative, boolean includeNonFiltered) {
         this.stackStream = stackStream;
         this.rubyTrace = rubyTrace;
         this.fullTrace = fullTrace;
@@ -67,10 +68,10 @@ public class BacktraceData implements Serializable {
         boolean dupFrame = false; String dupFrameName = null;
 
         // loop over all elements in the Java stack trace
-        Iterator<StackTraceElement> stackIter = stackStream.iterator();
+        Iterator<StackWalker.StackFrame> stackIter = stackStream.iterator();
         Iterator<BacktraceElement> backIter = rubyTrace.iterator();
         while (stackIter.hasNext() && trace.size() < count) {
-            StackTraceElement element = stackIter.next();
+            StackWalker.StackFrame element = stackIter.next();
 
             // skip unnumbered frames
             int line = element.getLineNumber();

--- a/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
@@ -6,6 +6,7 @@ import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
+import com.headius.backport9.stack.StackWalker;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyClass;
@@ -19,6 +20,7 @@ import org.jruby.util.log.LoggerFactory;
 public class TraceType {
 
     private static final Logger LOG = LoggerFactory.getLogger(TraceType.class);
+    private static final StackWalker WALKER = StackWalker.getInstance();
 
     private final Gather gather;
     private final Format format;
@@ -169,7 +171,7 @@ public class TraceType {
          * Full raw backtraces with all Java frames included.
          */
         RAW {
-            public BacktraceData getBacktraceData(ThreadContext context, Stream<StackTraceElement> stackStream) {
+            public BacktraceData getBacktraceData(ThreadContext context, Stream<StackWalker.StackFrame> stackStream) {
                 return new BacktraceData(
                         stackStream,
                         Stream.empty(),
@@ -183,7 +185,7 @@ public class TraceType {
          * A backtrace with interpreted frames intact, but don't remove Java frames.
          */
         FULL {
-            public BacktraceData getBacktraceData(ThreadContext context, Stream<StackTraceElement> stackStream) {
+            public BacktraceData getBacktraceData(ThreadContext context, Stream<StackWalker.StackFrame> stackStream) {
                 return new BacktraceData(
                         stackStream,
                         context.getBacktrace(),
@@ -197,7 +199,7 @@ public class TraceType {
          * A normal Ruby-style backtrace, but which includes any non-org.jruby frames
          */
         INTEGRATED {
-            public BacktraceData getBacktraceData(ThreadContext context, Stream<StackTraceElement> stackStream) {
+            public BacktraceData getBacktraceData(ThreadContext context, Stream<StackWalker.StackFrame> stackStream) {
                 return new BacktraceData(
                         stackStream,
                         context.getBacktrace(),
@@ -211,7 +213,7 @@ public class TraceType {
          * Normal Ruby-style backtrace, showing only Ruby and core class methods.
          */
         NORMAL {
-            public BacktraceData getBacktraceData(ThreadContext context, Stream<StackTraceElement> stackStream) {
+            public BacktraceData getBacktraceData(ThreadContext context, Stream<StackWalker.StackFrame> stackStream) {
                 return new BacktraceData(
                         stackStream,
                         context.getBacktrace(),
@@ -225,7 +227,7 @@ public class TraceType {
          * Normal Ruby-style backtrace, showing only Ruby and core class methods.
          */
         CALLER {
-            public BacktraceData getBacktraceData(ThreadContext context, Stream<StackTraceElement> stackStream) {
+            public BacktraceData getBacktraceData(ThreadContext context, Stream<StackWalker.StackFrame> stackStream) {
                 return new BacktraceData(
                         stackStream,
                         context.getBacktrace(),
@@ -242,12 +244,15 @@ public class TraceType {
          * @return
          */
         public BacktraceData getBacktraceData(ThreadContext context) {
-            BacktraceData data = getBacktraceData(context, Arrays.stream(Thread.currentThread().getStackTrace()));
+            return WALKER.walk(Thread.currentThread().getStackTrace(), stream -> {
+                BacktraceData data = getBacktraceData(context, stream);
 
-            context.runtime.incrementBacktraceCount();
-            if (RubyInstanceConfig.LOG_BACKTRACES) logBacktrace(context.runtime, data.getBacktrace(context.runtime));
+                context.runtime.incrementBacktraceCount();
+                if (RubyInstanceConfig.LOG_BACKTRACES)
+                    logBacktrace(context.runtime, data.getBacktrace(context.runtime));
 
-            return data;
+                return data;
+            });
         }
 
         /**
@@ -259,21 +264,20 @@ public class TraceType {
          * @return
          */
         public BacktraceData getIntegratedBacktraceData(ThreadContext context, StackTraceElement[] javaTrace) {
-            Gather useGather = this;
+            Gather useGather = this == NORMAL ? INTEGRATED : this;
 
-            if (useGather == NORMAL) {
-                useGather = INTEGRATED;
-            }
+            return WALKER.walk(javaTrace, stream -> {
+                BacktraceData data = useGather.getBacktraceData(context, stream);
 
-            BacktraceData data = useGather.getBacktraceData(context, Arrays.stream(javaTrace));
+                context.runtime.incrementBacktraceCount();
+                if (RubyInstanceConfig.LOG_BACKTRACES)
+                    logBacktrace(context.runtime, data.getBacktrace(context.runtime));
 
-            context.runtime.incrementBacktraceCount();
-            if (RubyInstanceConfig.LOG_BACKTRACES) logBacktrace(context.runtime, data.getBacktrace(context.runtime));
-
-            return data;
+                return data;
+            });
         }
 
-        public abstract BacktraceData getBacktraceData(ThreadContext context, Stream<StackTraceElement> javaTrace);
+        public abstract BacktraceData getBacktraceData(ThreadContext context, Stream<StackWalker.StackFrame> javaTrace);
     }
 
     public enum Format {

--- a/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
@@ -3,6 +3,8 @@ package org.jruby.runtime.backtrace;
 import java.io.ByteArrayOutputStream;
 import java.io.FileDescriptor;
 import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.stream.Stream;
 
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
@@ -167,10 +169,10 @@ public class TraceType {
          * Full raw backtraces with all Java frames included.
          */
         RAW {
-            public BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace) {
+            public BacktraceData getBacktraceData(ThreadContext context, Stream<StackTraceElement> stackStream) {
                 return new BacktraceData(
-                        javaTrace,
-                        BacktraceElement.EMPTY_ARRAY,
+                        stackStream,
+                        Stream.empty(),
                         true,
                         false,
                         false);
@@ -181,9 +183,9 @@ public class TraceType {
          * A backtrace with interpreted frames intact, but don't remove Java frames.
          */
         FULL {
-            public BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace) {
+            public BacktraceData getBacktraceData(ThreadContext context, Stream<StackTraceElement> stackStream) {
                 return new BacktraceData(
-                        javaTrace,
+                        stackStream,
                         context.getBacktrace(),
                         true,
                         false,
@@ -195,9 +197,9 @@ public class TraceType {
          * A normal Ruby-style backtrace, but which includes any non-org.jruby frames
          */
         INTEGRATED {
-            public BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace) {
+            public BacktraceData getBacktraceData(ThreadContext context, Stream<StackTraceElement> stackStream) {
                 return new BacktraceData(
-                        javaTrace,
+                        stackStream,
                         context.getBacktrace(),
                         false,
                         false,
@@ -209,9 +211,9 @@ public class TraceType {
          * Normal Ruby-style backtrace, showing only Ruby and core class methods.
          */
         NORMAL {
-            public BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace) {
+            public BacktraceData getBacktraceData(ThreadContext context, Stream<StackTraceElement> stackStream) {
                 return new BacktraceData(
-                        javaTrace,
+                        stackStream,
                         context.getBacktrace(),
                         false,
                         context.runtime.getInstanceConfig().getBacktraceMask(),
@@ -223,9 +225,9 @@ public class TraceType {
          * Normal Ruby-style backtrace, showing only Ruby and core class methods.
          */
         CALLER {
-            public BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace) {
+            public BacktraceData getBacktraceData(ThreadContext context, Stream<StackTraceElement> stackStream) {
                 return new BacktraceData(
-                        javaTrace,
+                        stackStream,
                         context.getBacktrace(),
                         false,
                         true,
@@ -240,7 +242,7 @@ public class TraceType {
          * @return
          */
         public BacktraceData getBacktraceData(ThreadContext context) {
-            BacktraceData data = getBacktraceData(context, Thread.currentThread().getStackTrace());
+            BacktraceData data = getBacktraceData(context, Arrays.stream(Thread.currentThread().getStackTrace()));
 
             context.runtime.incrementBacktraceCount();
             if (RubyInstanceConfig.LOG_BACKTRACES) logBacktrace(context.runtime, data.getBacktrace(context.runtime));
@@ -263,7 +265,7 @@ public class TraceType {
                 useGather = INTEGRATED;
             }
 
-            BacktraceData data = useGather.getBacktraceData(context, javaTrace);
+            BacktraceData data = useGather.getBacktraceData(context, Arrays.stream(javaTrace));
 
             context.runtime.incrementBacktraceCount();
             if (RubyInstanceConfig.LOG_BACKTRACES) logBacktrace(context.runtime, data.getBacktrace(context.runtime));
@@ -271,7 +273,7 @@ public class TraceType {
             return data;
         }
 
-        public abstract BacktraceData getBacktraceData(ThreadContext context, StackTraceElement[] javaTrace);
+        public abstract BacktraceData getBacktraceData(ThreadContext context, Stream<StackTraceElement> javaTrace);
     }
 
     public enum Format {


### PR DESCRIPTION
This PR modifies our logic for building stack traces to be streamable and to use the Java 9 StackWalker API to reduce the load of partial walks.

This is a work in progress.