### PR TITLE
Force the sequel build to pass every command.

### DIFF
--- a/tool/sequel-travis.sh
+++ b/tool/sequel-travis.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -v
+set -v -e
 
 # set up JRuby
 mvn clean package


### PR DESCRIPTION
Previously it would fall back on the system "ruby" command if
JRuby failed to build, producing a false positive.