### PR TITLE
Ruby 2.6: Add a new #filter alias for #select

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -2648,12 +2648,12 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return result;
     }
 
-    @JRubyMethod
+    @JRubyMethod(name = "select", alias = "filter")
     public IRubyObject select(ThreadContext context, Block block) {
         return block.isGiven() ? selectCommon(context, block) : enumeratorizeWithSize(context, this, "select", enumLengthFn());
     }
 
-    @JRubyMethod(name = "select!")
+    @JRubyMethod(name = "select!", alias = "filter!")
     public IRubyObject select_bang(ThreadContext context, Block block) {
         if (!block.isGiven()) return enumeratorizeWithSize(context, this, "select!", enumLengthFn());
 

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -786,7 +786,7 @@ public class RubyEnumerable {
         return selectCommon(context, self, block, "select");
     }
 
-    @JRubyMethod
+    @JRubyMethod(alias = "filter")
     public static IRubyObject find_all(ThreadContext context, IRubyObject self, final Block block) {
         return selectCommon(context, self, block, "find_all");
     }

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1545,7 +1545,7 @@ public class RubyHash extends RubyObject implements Map {
         }
     }
 
-    @JRubyMethod(name = "select!")
+    @JRubyMethod(name = "select!", alias = "filter!")
     public IRubyObject select_bang(final ThreadContext context, final Block block) {
         if (block.isGiven()) return keep_ifCommon(context, block) ? this : context.nil;
 
@@ -1734,7 +1734,7 @@ public class RubyHash extends RubyObject implements Map {
     /** rb_hash_select
      *
      */
-    @JRubyMethod(name = "select")
+    @JRubyMethod(name = "select", alias = "filter")
     public IRubyObject select(final ThreadContext context, final Block block) {
         final Ruby runtime = context.runtime;
         if (!block.isGiven()) return enumeratorizeWithSize(context, this, "select", enumSizeFn());

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -724,7 +724,7 @@ public class RubySet extends RubyObject implements Set {
     }
 
     // Equivalent to Set#keep_if, but returns nil if no changes were made.
-    @JRubyMethod(name = "select!")
+    @JRubyMethod(name = "select!", alias = "filter!")
     public IRubyObject select_bang(final ThreadContext context, Block block) {
         if ( ! block.isGiven() ) {
             return enumeratorizeWithSize(context, this, "select!", enumSize());

--- a/core/src/main/ruby/jruby/kernel/enumerator.rb
+++ b/core/src/main/ruby/jruby/kernel/enumerator.rb
@@ -86,6 +86,7 @@ class Enumerator
       end.__set_inspect :select
     end
     alias_method :find_all, :select
+    alias_method :filter, :select
 
     def reject
       _block_error(:reject) unless block_given?


### PR DESCRIPTION
Hi folks,

This PR implements another Ruby 2.6 feature: Add a new #filter alias for #select.

For more information, please see feature #13784 [1].

I believe all the related tests (MRI and ruby/spec) are passing: [2], [3], [4], [5], [6], [7], [8], [9], [10], [11].

For reference, I included a link to the commit introducing the functionality in MRI. [12]

Thanks in advance for any feedback.

1. https://bugs.ruby-lang.org/issues/13784
2. https://github.com/ruby/ruby/blob/v2_6_0_rc1/spec/ruby/core/array/filter_spec.rb
3. https://github.com/ruby/ruby/blob/v2_6_0_rc1/spec/ruby/core/enumerable/filter_spec.rb
4. https://github.com/ruby/ruby/blob/v2_6_0_rc1/spec/ruby/core/hash/filter_spec.rb
5. https://github.com/ruby/ruby/blob/v2_6_0_rc1/spec/ruby/library/set/filter_spec.rb
6. https://github.com/ruby/ruby/blob/v2_6_0_rc1/spec/ruby/library/set/sortedset/filter_spec.rb
7. https://github.com/ruby/ruby/blob/v2_6_0_rc1/test/ruby/test_array.rb#L2384-L2401
8. https://github.com/ruby/ruby/blob/v2_6_0_rc1/test/ruby/test_env.rb#L225-L235
9. https://github.com/ruby/ruby/blob/v2_6_0_rc1/test/ruby/test_env.rb#L269-L282
10. https://github.com/ruby/ruby/blob/v2_6_0_rc1/test/ruby/test_hash.rb#L1056-L1092
11. https://github.com/ruby/ruby/blob/v2_6_0_rc1/test/test_set.rb#L548-L564
12. https://github.com/ruby/ruby/commit/b1a8c64483b5ba5e4a391aa68234e7bde6355034