### PR TITLE
Ruby 2.6: Add a new #then alias to Kernel#yield_self

### DIFF
--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1292,7 +1292,7 @@ public class RubyKernel {
         return context.nil;
     }
 
-    @JRubyMethod(module = true)
+    @JRubyMethod(module = true, alias = "then")
     public static IRubyObject yield_self(ThreadContext context, IRubyObject recv, Block block) {
         if (block.isGiven()) {
             return block.yield(context, recv);


### PR DESCRIPTION
Hi folks,

This PR implements another Ruby 2.6 feature: Add a new #then alias to Kernel#yield_self.

For more information, please see feature #14594 [1].

All its related tests are passing [2].

For reference, I include a link to the commit introducing the functionality in MRI. [3]

Thanks in advance for any feedback.



1. https://bugs.ruby-lang.org/issues/14594
2. https://github.com/ruby/ruby/blob/v2_6_0_rc1/spec/ruby/core/kernel/yield_self_spec.rb#L5-L7
3. https://github.com/ruby/ruby/commit/d53ee008911b5c3b22cff1566a9ef7e7d4cbe183