### PR TITLE
Backward traces

### DIFF
--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -179,7 +179,7 @@ public class RubyException extends RubyObject {
 
     @JRubyMethod
     public IRubyObject full_message(ThreadContext context) {
-        return RubyString.newString(context.runtime, TraceType.Format.MRI.printBacktrace(this, false));
+        return RubyString.newString(context.runtime, TraceType.Format.MRI.printBacktrace(this, TraceType.Order.DOWN, false));
     }
 
     @JRubyMethod
@@ -187,7 +187,7 @@ public class RubyException extends RubyObject {
         Ruby runtime = context.runtime;
         IRubyObject optArg = ArgsUtil.getOptionsArg(runtime, opts);
         boolean highlight = false;
-        boolean reverse = false;
+        TraceType.Order order = TraceType.Order.DOWN;
 
         if (!optArg.isNil()) {
             IRubyObject[] highlightOrder = ArgsUtil.extractKeywordArgs(context, (RubyHash) optArg, FULL_MESSAGE_KEYS);
@@ -202,16 +202,15 @@ public class RubyException extends RubyObject {
             IRubyObject vOrder = highlightOrder[1];
             if (vOrder != UNDEF) {
                 vOrder = TypeConverter.checkID(vOrder);
-                if (vOrder == runtime.newSymbol("bottom")) reverse = true;
-                else if (vOrder == runtime.newSymbol("top")) reverse = false;
+                if (vOrder == runtime.newSymbol("down")) order = TraceType.Order.DOWN;
+                else if (vOrder == runtime.newSymbol("top")) order = TraceType.Order.TOP;
                 else {
                     throw runtime.newArgumentError("expected :top or :bottom as order: " + vOrder);
                 }
             }
         }
 
-        // TODO: reverse
-        return RubyString.newString(runtime, TraceType.Format.MRI.printBacktrace(this, highlight));
+        return RubyString.newString(runtime, TraceType.Format.MRI.printBacktrace(this, order, highlight));
     }
 
     @JRubyMethod(optional = 2, visibility = PRIVATE)

--- a/core/src/main/java/org/jruby/management/Runtime.java
+++ b/core/src/main/java/org/jruby/management/Runtime.java
@@ -32,7 +32,6 @@ package org.jruby.management;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.ref.SoftReference;
-import java.util.Arrays;
 
 import com.headius.backport9.stack.StackWalker;
 import org.jruby.Ruby;
@@ -40,6 +39,7 @@ import org.jruby.RubyException;
 import org.jruby.RubyThread;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.backtrace.TraceType;
 import org.jruby.runtime.backtrace.TraceType.Format;
 import org.jruby.runtime.backtrace.TraceType.Gather;
 
@@ -109,7 +109,7 @@ public class Runtime implements RuntimeMBean {
         if (tc != null) {
             RubyException exc = new RubyException(ruby, ruby.getRuntimeError(), "thread dump");
             exc.setBacktraceData(WALKER.walk(th.getNativeThread().getStackTrace(), stream -> gather.getBacktraceData(tc, stream)));
-            pw.println(Format.MRI.printBacktrace(exc, false));
+            pw.println(Format.MRI.printBacktrace(exc, TraceType.Order.TOP, false));
         } else {
             pw.println("    [no longer alive]");
         }
@@ -127,7 +127,7 @@ public class Runtime implements RuntimeMBean {
                 try {
                     result[0] = ruby.get().evalScriptlet(code).toString();
                 } catch (RaiseException re) {
-                    result[0] = ruby.get().getInstanceConfig().getTraceType().printBacktrace(re.getException(), false);
+                    result[0] = ruby.get().getInstanceConfig().getTraceType().printBacktrace(re.getException(), TraceType.Order.TOP, false);
                     // ruby.get().getGlobalVariables().set("$!", oldExc); // Restore $!
                 } catch (Throwable t) {
                     StringWriter sw = new StringWriter();

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -46,7 +46,6 @@ import org.jruby.RubyContinuation.Continuation;
 import org.jruby.RubyInstanceConfig;
 import org.jruby.RubyModule;
 import org.jruby.RubyRegexp;
-import org.jruby.RubyString;
 import org.jruby.RubyThread;
 import org.jruby.ast.executable.RuntimeCache;
 import org.jruby.exceptions.Unrescuable;
@@ -70,7 +69,6 @@ import org.jruby.util.log.LoggerFactory;
 
 import java.lang.ref.WeakReference;
 import java.security.SecureRandom;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Locale;
@@ -740,7 +738,7 @@ public final class ThreadContext {
     public void renderCurrentBacktrace(StringBuilder sb) {
         TraceType traceType = runtime.getInstanceConfig().getTraceType();
         BacktraceData backtraceData = traceType.getBacktrace(this);
-        traceType.getFormat().renderBacktrace(backtraceData.getBacktrace(runtime), sb, false);
+        traceType.getFormat().renderBacktrace(backtraceData.getBacktrace(runtime), sb, TraceType.Order.TOP, false);
     }
 
     private static final StackWalker WALKER;


### PR DESCRIPTION
Work in progress to implement backward traces and newer MRI formatting and highlighting from Ruby 2.5.

The relevant tests will be tagged for the stdlib merge in #5505.