### PR TITLE
Eliminate transient objects for looking up symbol by bytelist

### DIFF
--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -39,6 +39,7 @@ package org.jruby;
 
 import org.jcodings.Encoding;
 import org.jcodings.specific.ASCIIEncoding;
+import org.jcodings.specific.ISO8859_1Encoding;
 import org.jcodings.specific.USASCIIEncoding;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
@@ -1203,13 +1204,15 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
         return str.hashCode();
     }
 
-    private static int javaStringHashCode(ByteList iso8859) {
+    // This should be identical to iso8859.toString().hashCode().
+    public static int javaStringHashCode(ByteList iso8859) {
         int h = 0;
-        int length = iso8859.length();
-        if (length > 0) {
-            byte val[] = iso8859.getUnsafeBytes();
-            int begin = iso8859.begin();
-            h = new String(val, begin, length, RubyEncoding.ISO).hashCode();
+        int begin = iso8859.begin();
+        int end = begin + iso8859.realSize();
+        byte[] bytes = iso8859.unsafeBytes();
+        for (int i = begin; i < end; i++) {
+            int v = bytes[i] & 0xFF;
+            h = 31 * h + v;
         }
         return h;
     }

--- a/core/src/test/java/org/jruby/test/TestRubySymbol.java
+++ b/core/src/test/java/org/jruby/test/TestRubySymbol.java
@@ -31,12 +31,14 @@
 
 package org.jruby.test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 import junit.framework.TestCase;
 
 import org.jruby.Ruby;
 import org.jruby.RubySymbol;
+import org.jruby.util.ByteList;
 
 public class TestRubySymbol extends TestCase {
     private Ruby runtime;
@@ -68,5 +70,14 @@ public class TestRubySymbol extends TestCase {
         if (runtime.isSiphashEnabled()) {
             assertEquals(1706472664, sym.hashCode());
         }
+
+        // check that our ISO8859_1 byte-based hashcode calculation matches Java's for an ISO8859_1-sourced string
+        byte[] bytes = "abcd1234åøüê".getBytes(StandardCharsets.UTF_8);
+        ByteList byteList = new ByteList(bytes);
+        String isoStr1 = new String(bytes, StandardCharsets.ISO_8859_1);
+        String isoStr2 = byteList.toString();
+
+        assertEquals(isoStr1.hashCode(), RubySymbol.javaStringHashCode(byteList));
+        assertEquals(isoStr2.hashCode(), RubySymbol.javaStringHashCode(byteList));
     }
 }


### PR DESCRIPTION
The old logic constructed an intermediate java.lang.String and
called hashCode, which in turn created an ISO8859_1 decoder and
buffers to do the decoding. This showed up in heap profiles of the
state_machine library, but would generically affect any case where
a Ruby String was used to retrieve a Ruby Symbol.

The logic here should match what an ISO8859_1 Java String would
do. The accompanying tests makes sure this is so.

For the profiled run in question, the only ISO8859_1 decoders in the process were created by the old logic:

```
          percent          live          alloc'ed  stack class
 rank   self  accum     bytes objs     bytes  objs trace name
    1  3.35%  3.35%   4555392 94904  38400480 800010 422602 char[]
    2  2.84%  6.18%   3863800 96595  34070960 851774 327174 sun.nio.cs.ISO_8859_1$Decoder
    3  2.09%  8.27%   2847120 71178  23995240 599881 424712 org.jruby.RubyString
    4  1.67%  9.95%   2277696 94904  19200240 800010 422601 java.lang.String
    5  1.39% 11.34%   1898080 47452  15990000 399750 424724 org.jruby.RubyHash$RubyHashEntry
    6  1.03% 12.37%   1403040 87690   5635392 352212 411554 org.jruby.runtime.builtin.IRubyObject[]
...
```