### PR TITLE
Add log.singletons and .verbose to track singleton class creation.

### DIFF
--- a/core/src/main/java/org/jruby/MetaClass.java
+++ b/core/src/main/java/org/jruby/MetaClass.java
@@ -31,6 +31,9 @@
 package org.jruby;
 
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.cli.Options;
+import org.jruby.util.log.Logger;
+import org.jruby.util.log.LoggerFactory;
 
 public final class MetaClass extends RubyClass {
 
@@ -48,6 +51,21 @@ public final class MetaClass extends RubyClass {
         // use same ClassIndex as metaclass, since we're technically still of that type
         setClassIndex(superClass.getClassIndex());
         superClass.addSubclass(this);
+
+        if (LOG_SINGLETONS || LOG_SINGLETONS_VERBOSE) {
+            logSingleton(runtime, superClass, attached);
+        }
+    }
+
+    private static void logSingleton(Ruby runtime, RubyClass superClass, RubyBasicObject attached) {
+        if (runtime.isBooting()) return; // don't log singleton created during boot
+
+        String attachedString = attached == null ? "null object" : "object of type " + attached.getMetaClass();
+        LOG.info("singleton class created for type " + superClass + " attached to " + attachedString);
+
+        if (LOG_SINGLETONS_VERBOSE) {
+            LOG.info(new Exception("singleton creation stack trace"));
+        }
     }
 
     @Override
@@ -103,5 +121,9 @@ public final class MetaClass extends RubyClass {
     }
 
     private RubyBasicObject attached;
+
+    private static final Logger LOG = LoggerFactory.getLogger(MetaClass.class);
+    private static final boolean LOG_SINGLETONS = Options.LOG_SINGLETONS.load();
+    private static final boolean LOG_SINGLETONS_VERBOSE = Options.LOG_SINGLETONS_VERBOSE.load();
 
 }

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -194,6 +194,8 @@ public class Options {
     public static final Option<Boolean> LOG_BACKTRACES = bool(DEBUG, "log.backtraces", false, "Log every time an exception backtrace is generated.");
     public static final Option<Boolean> LOG_CALLERS = bool(DEBUG, "log.callers", false, "Log every time a Kernel#caller backtrace is generated.");
     public static final Option<Boolean> LOG_WARNINGS = bool(DEBUG, "log.warnings", false, "Log every time a built-in warning backtrace is generated.");
+    public static final Option<Boolean> LOG_SINGLETONS = bool(DEBUG, "log.singletons", false, "Log every time a singleton class is created.");
+    public static final Option<Boolean> LOG_SINGLETONS_VERBOSE = bool(DEBUG, "log.singletons.verbose", false, "Log a stack trace every time a singleton class is created.");
     public static final Option<String> LOGGER_CLASS = string(DEBUG, "logger.class", new String[]{"class name"}, "org.jruby.util.log.StandardErrorLogger", "Use specified class for logging.");
     public static final Option<Boolean> DUMP_INSTANCE_VARS = bool(DEBUG, "dump.variables", false, "Dump class + instance var names on first new of Object subclasses.");
     public static final Option<Boolean> REWRITE_JAVA_TRACE = bool(DEBUG, "rewrite.java.trace", true, "Rewrite stack traces from exceptions raised in Java calls.");


### PR DESCRIPTION
Singleton objects, usually created via `extend` or `def obj.meth`,
frequently waste CPU cycles and memory. It's also easy to
accidentally trigger an object to become a singleton. These
properties will make it easy to track all singleton classes
created by an application, along with an optional stack trace.