### PR TITLE
Fix sub-millisecond datetime difference handling

### DIFF
--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -1213,6 +1213,7 @@ public class RubyDate extends RubyObject {
 
         RubyNumeric subDiff = subMillisDiff(context, that);
         if ( ! subDiff.isZero() ) { // diff += diff_sub;
+            subDiff = subDiff.convertToRational().op_div(context, RubyFixnum.newFixnum(context.runtime, DAY_MS));  // #5493
             return (RubyNumeric) diffMillis.op_plus(context, subDiff);
         }
         return diffMillis;

--- a/spec/ruby/library/datetime/add_spec.rb
+++ b/spec/ruby/library/datetime/add_spec.rb
@@ -4,6 +4,6 @@ require 'date'
 describe "DateTime#+" do
   it "is able to add sub-millisecond precision values" do
     datetime = DateTime.new(2017)
-    (datetime + 0.00001).to_time.usec.should == 864000
+    (datetime + 0.00001001).to_time.usec.should == 864864
   end
 end

--- a/spec/ruby/library/datetime/subtract_spec.rb
+++ b/spec/ruby/library/datetime/subtract_spec.rb
@@ -4,6 +4,16 @@ require 'date'
 describe "DateTime#-" do
   it "is able to subtract sub-millisecond precision values" do
     date = DateTime.new(2017)
-    ((date + 0.00001) - date).should == Rational(1, 100000)
+    diff = Rational(123456789, 24*60*60*1000*1000)
+    ((date + diff) - date).should == diff
+    (date - (date + diff)).should == -diff
+    (date - (date - diff)).should == diff
+    ((date - diff) - date).should == -diff
+  end
+
+  it "correctly calculates sub-millisecond time differences" do  #5493
+    dt1 = DateTime.new(2018, 1, 1, 0, 0, 30)
+    dt2 = DateTime.new(2018, 1, 1, 0, 1, 29.000001)
+    ((dt2 - dt1) * 24 * 60 * 60).should == 59.000001
   end
 end


### PR DESCRIPTION
This patch fixes issue #5493 and adds the test case from the report as a new spec. It also fixes the existing DateTime add/subtract specs to actually use sub-millisecond differences like their descriptions say.