### PR TITLE
test, review & avoid (regressed) mutex behavior

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -340,7 +340,9 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     }
 
     private int pendingInterruptCheckMask(ThreadContext context, IRubyObject err) {
-        List<IRubyObject> ancestors = err.getMetaClass().getAncestorList();
+        if (interruptMaskStack.isEmpty()) return INTERRUPT_NONE; // fast return
+
+        List<IRubyObject> ancestors = getMetaClass(err).getAncestorList();
         int ancestorsLen = ancestors.size();
 
         List<RubyHash> maskStack = interruptMaskStack;

--- a/core/src/main/java/org/jruby/ext/thread/Mutex.java
+++ b/core/src/main/java/org/jruby/ext/thread/Mutex.java
@@ -74,7 +74,7 @@ public class Mutex extends RubyObject implements DataType {
     }
 
     @JRubyMethod(name = "locked?")
-    public synchronized RubyBoolean locked_p(ThreadContext context) {
+    public RubyBoolean locked_p(ThreadContext context) {
         return context.runtime.newBoolean(lock.isLocked());
     }
 
@@ -107,13 +107,12 @@ public class Mutex extends RubyObject implements DataType {
     }
 
     @JRubyMethod
-    public synchronized IRubyObject unlock(ThreadContext context) {
-        Ruby runtime = context.runtime;
+    public IRubyObject unlock(ThreadContext context) {
         if (!lock.isLocked()) {
-            throw runtime.newThreadError("Mutex is not locked");
+            throw context.runtime.newThreadError("Mutex is not locked");
         }
         if (!lock.isHeldByCurrentThread()) {
-            throw runtime.newThreadError("Mutex is not owned by calling thread");
+            throw context.runtime.newThreadError("Mutex is not owned by calling thread");
         }
 
         boolean hasQueued = lock.hasQueuedThreads();

--- a/core/src/main/java/org/jruby/util/io/OpenFile.java
+++ b/core/src/main/java/org/jruby/util/io/OpenFile.java
@@ -2674,7 +2674,7 @@ public class OpenFile implements Finalizable {
 
                 // raise will also wake the thread from selection
                 RubyException exception = (RubyException) runtime.getIOError().newInstance(context, runtime.newString("stream closed in another thread"), Block.NULL_BLOCK);
-                thread.raise(Helpers.arrayOf(exception), Block.NULL_BLOCK);
+                thread.raise(exception);
             }
         }
     }

--- a/test/jruby/test_thread.rb
+++ b/test/jruby/test_thread.rb
@@ -419,9 +419,9 @@ class TestThread < Test::Unit::TestCase
     def count; @mutex.synchronize { @count } end
 
     def wait(timeout = nil)
-      Timeout::timeout timeout do
-        @mutex.synchronize { @conditional.wait @mutex if @count > 0 }
-        true
+      @mutex.synchronize do
+        return :nowait if @count == 0
+        @conditional.wait @mutex, timeout
       end
     end
   end
@@ -436,8 +436,6 @@ class TestThread < Test::Unit::TestCase
   private :wait_for_latch
 
   def test_count_down_latch
-    require 'timeout'
-
     (ENV['TIMES'] || 10_000).to_i.times do |i|
       print '*' if $VERBOSE
       assert wait_for_latch # should not raise


### PR DESCRIPTION
these changes are based on reviewing code for #5520 

than there's the actual "wild" fix: https://github.com/jruby/jruby/compare/mutex-fix?expand=1#diff-330867c3ee2ffcb2a20e80af7bf9b4b3R161 ... as this line doing synchronization locking seems to be causing the problem (see explanation at GH-5520)

not entirely sure - why it's happening, yet, maybe it relates to delivering interrupts on the main thread?

to reproduce, just run the test that is added here : 
```
TIMES=100_000 bin/jruby test/jruby/test_thread.rb --name=/latch/
```

.. changing the line back to a blocking collection should make the test fail e.g.
```diff
    /** Stack of interrupt masks active for this thread */
-    private final List<RubyHash> interruptMaskStack = new CopyOnWriteArrayList<>();
+    private final List<RubyHash> interruptMaskStack = new Vector<>();
```
https://github.com/jruby/jruby/compare/mutex-fix?expand=1#diff-330867c3ee2ffcb2a20e80af7bf9b4b3R161

@headius feel free to push to the branch as/if needed. while I'd like to understand why that line causes such a regression I might not have the time to look in detail (next week).
