### PR TITLE
backport fd leak in resolv

### DIFF
--- a/lib/ruby/stdlib/resolv.rb
+++ b/lib/ruby/stdlib/resolv.rb
@@ -739,35 +739,47 @@ class Resolv
         def initialize(*nameserver_port)
           super()
           @nameserver_port = nameserver_port
-          @socks_hash = {}
-          @socks = []
-          nameserver_port.each {|host, port|
-            if host.index(':')
-              bind_host = "::"
-              af = Socket::AF_INET6
-            else
-              bind_host = "0.0.0.0"
-              af = Socket::AF_INET
-            end
-            next if @socks_hash[bind_host]
-            begin
-              sock = UDPSocket.new(af)
-            rescue Errno::EAFNOSUPPORT
-              next # The kernel doesn't support the address family.
-            end
-            sock.do_not_reverse_lookup = true
-            DNS.bind_random_port(sock, bind_host)
-            @socks << sock
-            @socks_hash[bind_host] = sock
+          @initialized = false
+          @mutex = Thread::Mutex.new
+        end
+
+        def lazy_initialize
+          @mutex.synchronize {
+            next if @initialized
+            @initialized = true
+            @socks_hash = {}
+            @socks = []
+            @nameserver_port.each {|host, port|
+              if host.index(':')
+                bind_host = "::"
+                af = Socket::AF_INET6
+              else
+                bind_host = "0.0.0.0"
+                af = Socket::AF_INET
+              end
+              next if @socks_hash[bind_host]
+              begin
+                sock = UDPSocket.new(af)
+              rescue Errno::EAFNOSUPPORT
+                next # The kernel doesn't support the address family.
+              end
+              @socks << sock
+              @socks_hash[bind_host] = sock
+              sock.do_not_reverse_lookup = true
+              DNS.bind_random_port(sock, bind_host)
+            }
           }
+          self
         end
 
         def recv_reply(readable_socks)
+          lazy_initialize
           reply, from = readable_socks[0].recvfrom(UDPSize)
           return reply, [IPAddr.new(from[3]),from[1]]
         end
 
         def sender(msg, data, host, port=Port)
+          lazy_initialize
           sock = @socks_hash[host.index(':') ? "::" : "0.0.0.0"]
           return nil if !sock
           service = [IPAddr.new(host), port]
@@ -779,9 +791,14 @@ class Resolv
         end
 
         def close
-          super
-          @senders.each_key {|service, id|
-            DNS.free_request_id(service[0], service[1], id)
+          @mutex.synchronize {
+            if @initialized
+              super
+              @senders.each_key {|service, id|
+                DNS.free_request_id(service[0], service[1], id)
+              }
+              @initialized = false
+            end
           }
         end
 
@@ -805,20 +822,32 @@ class Resolv
           super()
           @host = host
           @port = port
-          is_ipv6 = host.index(':')
-          sock = UDPSocket.new(is_ipv6 ? Socket::AF_INET6 : Socket::AF_INET)
-          @socks = [sock]
-          sock.do_not_reverse_lookup = true
-          DNS.bind_random_port(sock, is_ipv6 ? "::" : "0.0.0.0")
-          sock.connect(host, port)
+          @mutex = Thread::Mutex.new
+          @initialized = false
+        end
+
+        def lazy_initialize
+          @mutex.synchronize {
+            next if @initialized
+            @initialized = true
+            is_ipv6 = @host.index(':')
+            sock = UDPSocket.new(is_ipv6 ? Socket::AF_INET6 : Socket::AF_INET)
+            @socks = [sock]
+            sock.do_not_reverse_lookup = true
+            DNS.bind_random_port(sock, is_ipv6 ? "::" : "0.0.0.0")
+            sock.connect(@host, @port)
+          }
+          self
         end
 
         def recv_reply(readable_socks)
+          lazy_initialize
           reply = readable_socks[0].recv(UDPSize)
           return reply, nil
         end
 
         def sender(msg, data, host=@host, port=@port)
+          lazy_initialize
           unless host == @host && port == @port
             raise RequestError.new("host/port don't match: #{host}:#{port}")
           end
@@ -829,10 +858,15 @@ class Resolv
         end
 
         def close
-          super
-          @senders.each_key {|from, id|
-            DNS.free_request_id(@host, @port, id)
-          }
+          @mutex.synchronize do
+            if @initialized
+              super
+              @senders.each_key {|from, id|
+                DNS.free_request_id(@host, @port, id)
+              }
+              @initialized = false
+            end
+          end
         end
 
         class Sender < Requester::Sender # :nodoc:
@@ -846,6 +880,7 @@ class Resolv
 
       class MDNSOneShot < UnconnectedUDP # :nodoc:
         def sender(msg, data, host, port=Port)
+          lazy_initialize
           id = DNS.allocate_request_id(host, port)
           request = msg.encode
           request[0,2] = [id].pack('n')
@@ -855,6 +890,7 @@ class Resolv
         end
 
         def sender_for(addr, msg)
+          lazy_initialize
           @senders[msg.id]
         end
       end

--- a/test/mri/resolv/test_dns.rb
+++ b/test/mri/resolv/test_dns.rb
@@ -3,6 +3,7 @@ require 'test/unit'
 require 'resolv'
 require 'socket'
 require 'tempfile'
+require 'minitest/mock'
 
 class TestResolvDNS < Test::Unit::TestCase
   def setup
@@ -245,5 +246,23 @@ class TestResolvDNS < Test::Unit::TestCase
       }
     }
     assert_operator(2**14, :<, m.to_s.length)
+  end
+
+  def assert_no_fd_leak
+    socket = assert_throw(self) do |tag|
+      Resolv::DNS.stub(:bind_random_port, ->(s, *) {throw(tag, s)}) do
+        yield.getname("8.8.8.8")
+      end
+    end
+
+    assert_predicate(socket, :closed?, "file descriptor leaked")
+  end
+
+  def test_no_fd_leak_connected
+    assert_no_fd_leak {Resolv::DNS.new(nameserver_port: [['127.0.0.1', 53]])}
+  end
+
+  def test_no_fd_leak_unconnected
+    assert_no_fd_leak {Resolv::DNS.new}
   end
 end


### PR DESCRIPTION
this patch restores the original patch in https://github.com/jruby/jruby/pull/5074
it was merged, but reverted later https://github.com/jruby/jruby/issues/5479

I think we should fork it to avoid regression until https://bugs.ruby-lang.org/issues/15414 is resolved