### PR TITLE
Handle symbol dumping properly

### DIFF
--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -837,6 +837,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
         if (state.isIvarWaiting()) {
             input.unmarshalInt(); // throw-away, always single ivar of encoding
             Encoding enc = input.getEncodingFromUnmarshaled(input.unmarshalObject());
+            if (enc == null) throw new RuntimeException("BUG: No encoding found in marshal stream");
             result.getBytes().setEncoding(enc);
             state.setIvarWaiting(false);
         }

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -828,17 +828,18 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
             byteList.setEncoding(USASCIIEncoding.INSTANCE);
         }
 
+        // Need symbol to register before encoding, so this is a little leaky
+        RubySymbol result = newSymbol(input.getRuntime(), byteList);
+
+        input.registerLinkTarget(result);
+
         // consume encoding ivar before making string
         if (state.isIvarWaiting()) {
             input.unmarshalInt(); // throw-away, always single ivar of encoding
             Encoding enc = input.getEncodingFromUnmarshaled(input.unmarshalObject());
-            byteList.setEncoding(enc);
+            result.getBytes().setEncoding(enc);
             state.setIvarWaiting(false);
         }
-
-        RubySymbol result = newSymbol(input.getRuntime(), byteList);
-
-        input.registerLinkTarget(result);
 
         return result;
     }

--- a/core/src/main/java/org/jruby/runtime/marshal/MarshalStream.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/MarshalStream.java
@@ -147,10 +147,7 @@ public class MarshalStream extends FilterOutputStream {
     }
 
     private void writeAndRegister(IRubyObject value) throws IOException {
-        ByteList sym;
-        if (value instanceof RubySymbol && cache.isSymbolRegistered(sym = ((RubySymbol) value).getBytes())) {
-            cache.writeSymbolLink(this, sym);
-        } else if (!(value instanceof RubySymbol) && cache.isRegistered(value)) {
+        if (!(value instanceof RubySymbol) && cache.isRegistered(value)) {
             cache.writeLink(this, value);
         } else {
             value.getMetaClass().smartDump(this, value);

--- a/core/src/main/java/org/jruby/runtime/marshal/UnmarshalStream.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/UnmarshalStream.java
@@ -494,8 +494,8 @@ public class UnmarshalStream extends InputStream {
                 throw runtime.newArgumentError("invalid encoding in marshaling stream: " + encodingName);
             }
             enc = entry.getEncoding();
-
         }
+
         return enc;
     }
 

--- a/spec/tags/ruby/core/marshal/dump_tags.txt
+++ b/spec/tags/ruby/core/marshal/dump_tags.txt
@@ -1,5 +1,4 @@
 fails:Marshal.dump with a Time dumps the zone and the offset
-fails(travis):Marshal.dump with a String dumps a String with instance variables
 fails(travis):Marshal.dump with an Exception dumps the message for the exception
 fails:Marshal.dump with a Symbol dumps a binary encoded Symbol
 fails:Marshal.dump with an Exception dumps an empty Exception


### PR DESCRIPTION
This PR is for #5523. In that issue, we found that the order a symbol and its encoding are being registered are correct, but when unmarshaling the symbol we register the encoding first. This led to the actual symbol content being treated as the encoding key, and the encoding value became the hash value associated to the original symbol. Then everything was off by one.

There's an issue here, though, in that the symbol is created and registered with our internal tables before its encoding is set correctly. This is also how MRI works, but they don't have issues for obvious reasons.