### PR TITLE
Ruby 2.6: Add new method Binding#source_location

### DIFF
--- a/core/src/main/java/org/jruby/RubyBinding.java
+++ b/core/src/main/java/org/jruby/RubyBinding.java
@@ -194,4 +194,12 @@ public class RubyBinding extends RubyObject {
     public IRubyObject receiver(ThreadContext context) {
         return binding.getSelf();
     }
+
+    @JRubyMethod
+    public IRubyObject source_location(ThreadContext context) {
+        Ruby runtime = context.runtime;
+        IRubyObject filename = runtime.newString(binding.getFile()).freeze(context);
+        RubyFixnum line = runtime.newFixnum(binding.getLine() + 1); /* zero-based */
+        return runtime.newArray(filename, line);
+    }
 }


### PR DESCRIPTION
Hi folks,

This PR implements another Ruby 2.6 feature: Add new method Binding#source_location.

For more information, please see feature #14230. [1]

For reference, I include a link to the commit introducing the functionality in MRI. [2]

Thanks in advance for any feedback.

1. https://bugs.ruby-lang.org/issues/14230
2. https://github.com/ruby/ruby/commit/571e48b74422f5caa8ff6d91faf7e1a6bf4d2dc1