### PR TITLE
Ruby 2.6: Add Dir instance methods #each_child and #children

### DIFF
--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -659,6 +659,14 @@ public class RubyDir extends RubyObject implements Closeable {
 // ----- Ruby Instance Methods -------------------------------------------------
 
     /**
+     * Returns an array containing all of the filenames except for "." and "..".
+     */
+    @JRubyMethod(name = "children")
+    public IRubyObject children(ThreadContext context) {
+        return childrenCommon(context, this, path, context.nil);
+    }
+
+    /**
      * Closes the directory stream.
      */
     @JRubyMethod(name = "close")

--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -745,6 +745,16 @@ public class RubyDir extends RubyObject implements Closeable {
         return each_child(context, context.runtime.getDefaultEncoding(), block);
     }
 
+    @JRubyMethod(name = "each_child")
+    public IRubyObject rb_each_child(ThreadContext context, Block block) {
+        if (block.isGiven()) {
+            each_child(context, block);
+            return context.nil;
+        }
+
+        return enumeratorize(context.runtime, children(context), "each");
+    }
+
     @Override
     @JRubyMethod
     public IRubyObject inspect() {


### PR DESCRIPTION
Hi folks,

This PR implements another Ruby 2.6 feature: Add Dir new instance methods #each_child and #children.

For more information, please see feature #13969. [1]

All its related tests are passing. [2]

For reference, I include a link to the commit introducing the functionality in MRI. [3]

Thanks in advance for any feedback.

1. https://bugs.ruby-lang.org/issues/13969
2. https://github.com/ruby/ruby/blob/v2_6_0_rc2/test/ruby/test_dir.rb#L268-L278
3. https://github.com/ruby/ruby/commit/6a3a7e9114c3ede47d15f0d2a73f392cfcdd1ea7