### PR TITLE
Ruby 2.6: Hash#merge, Hash#merge! and Hash#update now accept multiple arguments

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1923,17 +1923,25 @@ public class RubyHash extends RubyObject implements Map {
         }
     };
 
+    @Deprecated
+    public RubyHash merge_bang(ThreadContext context, IRubyObject other, Block block) {
+        return merge_bang(context, new IRubyObject[]{other}, block);
+    }
+
     /** rb_hash_update
      *
      */
-    @JRubyMethod(name = {"merge!", "update"}, required = 1)
-    public RubyHash merge_bang(ThreadContext context, IRubyObject other, Block block) {
+    @JRubyMethod(name = {"merge!", "update"}, rest = true)
+    public RubyHash merge_bang(ThreadContext context, IRubyObject[] others, Block block) {
         modify();
-        final RubyHash otherHash = other.convertToHash();
 
-        if (otherHash.empty_p().isTrue()) return this;
+        if (others.length == 0) return this;
 
-        otherHash.visitAll(context, new MergeVisitor(this), block);
+        for (int i = 0; i < others.length; i++) {
+            final RubyHash otherHash = others[i].convertToHash();
+            if (otherHash.empty_p().isTrue()) continue;
+            otherHash.visitAll(context, new MergeVisitor(this), block);
+        }
 
         return this;
     }
@@ -1960,12 +1968,17 @@ public class RubyHash extends RubyObject implements Map {
         return merge_bang(context, other, block);
     }
 
+    @Deprecated
+    public RubyHash merge(ThreadContext context, IRubyObject other, Block block) {
+        return merge(context, new IRubyObject[]{other}, block);
+    }
+
     /** rb_hash_merge
      *
      */
-    @JRubyMethod
-    public RubyHash merge(ThreadContext context, IRubyObject other, Block block) {
-        return ((RubyHash)dup()).merge_bang(context, other, block);
+    @JRubyMethod(rest = true)
+    public RubyHash merge(ThreadContext context, IRubyObject[] others, Block block) {
+        return ((RubyHash)dup()).merge_bang(context, others, block);
     }
 
     @JRubyMethod(name = "initialize_copy", required = 1, visibility = PRIVATE)

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1683,7 +1683,7 @@ public class RubyKernel {
 
         // else old JDK logic
         if (args[0] instanceof RubyHash) {
-            runtime.getENV().merge_bang(context, (RubyHash) args[0], Block.NULL_BLOCK);
+            runtime.getENV().merge_bang(context, new IRubyObject[]{args[0]}, Block.NULL_BLOCK);
             // drop the first element for calling systemCommon()
             args = ArraySupport.newCopy(args, 1, args.length - 1);
         }
@@ -1775,7 +1775,7 @@ public class RubyKernel {
         if (env != null && env != context.nil) {
             RubyHash envMap = env.convertToHash();
             if (envMap != null) {
-                runtime.getENV().merge_bang(context, envMap, Block.NULL_BLOCK);
+                runtime.getENV().merge_bang(context, new IRubyObject[]{envMap}, Block.NULL_BLOCK);
             }
         }
 

--- a/core/src/main/java/org/jruby/ext/ffi/Enums.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Enums.java
@@ -97,7 +97,7 @@ public final class Enums extends RubyObject {
             if (tag != null && !tag.isNil())
                 taggedEnums.fastASet(tag, item);
         }
-        symbolMap.merge_bang(context, ((Enum)item).symbol_map(context), Block.NULL_BLOCK);
+        symbolMap.merge_bang(context, new IRubyObject[]{((Enum)item).symbol_map(context)}, Block.NULL_BLOCK);
         return item;
     }
 

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -627,7 +627,7 @@ public class RubySet extends RubyObject implements Set {
 
     protected void addImplSet(final ThreadContext context, final RubySet set) {
         // NOTE: MRI cheats - does not call Set#add thus we do not care ...
-        hash.merge_bang(context, set.hash, Block.NULL_BLOCK);
+        hash.merge_bang(context, new IRubyObject[]{set.hash}, Block.NULL_BLOCK);
     }
 
     /**

--- a/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
@@ -727,20 +727,30 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         return getOrCreateRubyHashMap().invert(context);
     }
 
+    @Deprecated
+    public RubyHash merge_bang(final ThreadContext context, final IRubyObject other, final Block block) {
+        return merge_bang(context, new IRubyObject[]{other}, block);
+    }
+
     /** rb_hash_merge_bang
      *
      */
-    @JRubyMethod(name = { "merge!", "update" }, required = 1)
-    public RubyHash merge_bang(final ThreadContext context, final IRubyObject other, final Block block) {
-        return getOrCreateRubyHashMap().merge_bang(context, other, block);
+    @JRubyMethod(name = { "merge!", "update" }, rest = true)
+    public RubyHash merge_bang(final ThreadContext context, final IRubyObject[] others, final Block block) {
+        return getOrCreateRubyHashMap().merge_bang(context, others, block);
+    }
+
+    @Deprecated
+    public RubyHash merge(ThreadContext context, IRubyObject other, Block block) {
+        return merge(context, new IRubyObject[]{other}, block);
     }
 
     /** rb_hash_merge
      *
      */
-    @JRubyMethod(name = { "merge", "ruby_merge" }) // collision with java.util.Map#merge on Java 8+
-    public RubyHash merge(ThreadContext context, IRubyObject other, Block block) {
-        return getOrCreateRubyHashMap().merge(context, other, block);
+    @JRubyMethod(name = { "merge", "ruby_merge" }, rest = true) // collision with java.util.Map#merge on Java 8+
+    public RubyHash merge(ThreadContext context, IRubyObject[] others, Block block) {
+        return getOrCreateRubyHashMap().merge(context, others, block);
     }
 
     /** rb_hash_initialize_copy


### PR DESCRIPTION
Hi folks,

This PR implements another Ruby 2.6 feature: Make the number of arguments of Hash#merge variable.

For more information, please see feature #15111. [1]

All its related tests are passing. [2]

For reference, I include a link to the commit introducing the functionality in MRI. [3]

Thanks in advance for any feedback.

1. https://bugs.ruby-lang.org/issues/15111
2. https://github.com/ruby/ruby/blob/v2_6_0_rc2/test/ruby/test_hash.rb#L1162-L1191
3. https://github.com/ruby/ruby/commit/085f5ef95742a1da3fe7e66e9ad36e22afdb3e91
