### PR TITLE
Define a proper annotation parameter for DynamicMethod.Version

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/methods/DynamicMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/DynamicMethod.java
@@ -75,7 +75,7 @@ public abstract class DynamicMethod {
 
     @Retention(RetentionPolicy.RUNTIME)
     public @interface Version {
-        int version = 0;
+        public int version() default 0;
     }
 
     /**


### PR DESCRIPTION
This parameter is set to 0 in
InvocationMethodFactory.createJavaMethodCtor and in the precompiled
INVOKER classes.  This works somehow on the JVM, but fails in the
DalvikVM.

Source for defining annotation parameters:
https://docs.oracle.com/javase/tutorial/java/annotations/declaring.html