### PR TITLE
Ruby 2.6: Add support for endless range in more methods

### DIFF
--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -789,7 +789,7 @@ public class RubyRange extends RubyObject {
     public IRubyObject max(ThreadContext context, Block block) {
         boolean isNumeric = end instanceof RubyNumeric;
 
-        if (isEndless) return context.nil;
+        if (isEndless) throw context.runtime.newRangeError("cannot get the maximum element of endless range");
 
         if (block.isGiven() || (isExclusive && !isNumeric)) {
             return Helpers.invokeSuper(context, this, block);
@@ -830,6 +830,7 @@ public class RubyRange extends RubyObject {
 
     @JRubyMethod(frame = true)
     public IRubyObject max(ThreadContext context, IRubyObject arg, Block block) {
+        if (isEndless) throw context.runtime.newRangeError("cannot get the maximum element of endless range");
         return Helpers.invokeSuper(context, this, arg, block);
     }
 
@@ -872,6 +873,7 @@ public class RubyRange extends RubyObject {
 
     @JRubyMethod
     public IRubyObject last(ThreadContext context) {
+        if (isEndless) throw context.runtime.newRangeError("cannot get the last element of endless range");
         return end;
     }
 
@@ -882,6 +884,7 @@ public class RubyRange extends RubyObject {
 
     @JRubyMethod
     public IRubyObject last(ThreadContext context, IRubyObject arg) {
+        if (isEndless) throw context.runtime.newRangeError("cannot get the last element of endless range");
         return ((RubyArray) RubyKernel.new_array(context, this, this)).last(arg);
     }
 

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -475,6 +475,8 @@ public class RubyRange extends RubyObject {
     public IRubyObject to_a(ThreadContext context, final Block block) {
         final Ruby runtime = context.runtime;
 
+        if (isEndless) throw runtime.newRangeError("cannot convert endless range to an array");
+
         if (begin instanceof RubyFixnum && end instanceof RubyFixnum) {
             long lim = ((RubyFixnum) end).getLongValue();
             if (!isExclusive) {

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -890,6 +890,9 @@ public class RubyRange extends RubyObject {
         if (begin instanceof RubyNumeric && end instanceof RubyNumeric) {
             return RubyNumeric.intervalStepSize(context, begin, end, RubyFixnum.one(context.runtime), isExclusive);
         }
+
+        if (isEndless) return RubyFloat.newFloat(context.runtime, RubyFloat.INFINITY);
+
         return context.nil;
     }
 


### PR DESCRIPTION
Hi folks,

This PR iterates on the changes introduced on #5540.

Summary:

- Make Range#min, max, include?, cover?, and === to support endless range

- Range#to_a now raises RangeError if it is endless

- Range#size now returns Float::INFINITY if it is endless

- Range#last and #max raises a RangeError if it is endless
    
    
For more information, please see feature #12912. [1]

For reference, I include links to similar commits in MRI: [2] [3] [4] [5].

Thanks for the feedback.

1. https://bugs.ruby-lang.org/issues/12912
2. https://github.com/ruby/ruby/commit/db1bdecb0d925b4668c0735158fce466333848f1
3. https://github.com/ruby/ruby/commit/c19ecf05b4c728951e1a1e223a40ae6883a4f8e0
4. https://github.com/ruby/ruby/commit/342619300ce26f9a134249002270c5d38d5993b3
5. https://github.com/ruby/ruby/commit/cae45174190b49ca3c67ca606c5f4b71e3847842
