### PR TITLE
Ruby 2.6: Switch Range#=== to use cover? instead of include?

### DIFF
--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -706,6 +706,12 @@ public class RubyRange extends RubyObject {
     // framed for invokeSuper
     @JRubyMethod(name = {"include?", "member?"}, frame = true)
     public IRubyObject include_p(ThreadContext context, final IRubyObject obj) {
+        IRubyObject result = includeCommon(context, obj);
+        if (result != UNDEF) return result;
+        return Helpers.invokeSuper(context, this, obj, Block.NULL_BLOCK);
+    }
+
+    private IRubyObject includeCommon(ThreadContext context, final IRubyObject obj) {
         final Ruby runtime = context.runtime;
 
         boolean iterable = begin instanceof RubyNumeric || end instanceof RubyNumeric ||
@@ -738,7 +744,7 @@ public class RubyRange extends RubyObject {
             }
         }
 
-        return Helpers.invokeSuper(context, this, obj, Block.NULL_BLOCK);
+        return UNDEF;
     }
 
     private static boolean discreteObject(ThreadContext context, IRubyObject obj) {
@@ -757,7 +763,9 @@ public class RubyRange extends RubyObject {
 
     @JRubyMethod(name = "===")
     public IRubyObject eqq_p(ThreadContext context, IRubyObject obj) {
-        return callMethod(context, "include?", obj);
+        IRubyObject result = includeCommon(context, obj);
+        if (result != UNDEF) return result;
+        return callMethod(context, "cover?", obj);
     }
 
     @JRubyMethod(name = "cover?")


### PR DESCRIPTION
Hi folks,

This PR implements another Ruby 2.6 feature: Switch Range#=== to use cover? instead of include?

For more information, please see feature #14575. [1]

All its related tests are passing. [2] [3]

For reference, I include a link to the commit introducing the functionality in MRI. [4]

Thanks in advance for any feedback.

1. https://bugs.ruby-lang.org/issues/14575
2. https://github.com/ruby/ruby/blob/v2_6_0/test/ruby/test_range.rb#L505-L513
3. https://github.com/ruby/spec/blob/7fa95f66e355c2f122c5edd79e4c5e8f5e42c8f0/core/range/case_compare_spec.rb#L14-L19
4. https://github.com/ruby/ruby/commit/989e07c0f2fa664a54e52a475c2fcc145f06539d
