### PR TITLE
[fix] avoid exception propagation after runtime tear-down

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -3441,7 +3441,7 @@ public final class Ruby implements Constantizable {
         }
 
         // tear down thread references
-        getThreadService().teardown();
+        getThreadService().tearDown();
 
         // shut down executors
         getJITCompiler().shutdown();

--- a/core/src/main/java/org/jruby/internal/runtime/RubyRunnable.java
+++ b/core/src/main/java/org/jruby/internal/runtime/RubyRunnable.java
@@ -109,7 +109,7 @@ public class RubyRunnable implements ThreadedRunnable {
                 // Someone called exit!, so we need to kill the main thread
                 runtime.getThreadService().getMainThread().kill();
             } catch (Throwable t) {
-                rubyThread.exceptionRaised(t);
+                runtime.getThreadService().exceptionRaised(rubyThread, t);
             } finally {
                 rubyThread.dispose();
 

--- a/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
+++ b/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
@@ -155,15 +155,27 @@ public class ThreadService {
         this.rubyThreadMap = Collections.synchronizedMap(new WeakHashMap<Object, RubyThread>());
     }
 
+    @Deprecated
     public void teardown() {
-        // clear all thread-local context references
-        localContext = new ThreadLocal<>();
+        tearDown();
+    }
 
+    /**
+     * @see Ruby#tearDown(boolean)
+     */
+    public void tearDown() {
         // clear main context reference
         mainContext = null;
 
+        // clear all thread-local context references
+        localContext = new ThreadLocal<>();
+
         // clear thread map
         rubyThreadMap.clear();
+    }
+
+    public void exceptionRaised(RubyThread thread, Throwable ex) {
+        if (mainContext != null) thread.exceptionRaised(ex); // only propagate if runtime hasn't shutdown
     }
 
     public void initMainThread() {


### PR DESCRIPTION
this isn't the best solution for (long) loop-ing Ruby threads 
but hopefully better than 'false' Java errors printed to the user

follow-up on 9f72b0c83ec0087ef100a1eefee75d615e9f5544 resolves #5519 