### PR TITLE
Fix for #5556 - float format-ing regression in 9.2 

### DIFF
--- a/core/src/main/java/org/jruby/util/Sprintf.java
+++ b/core/src/main/java/org/jruby/util/Sprintf.java
@@ -1257,6 +1257,13 @@ public class Sprintf {
                         decDigits = nDigits - intDigits;
                         decZeroes = Math.max(0,-(decDigits + exponent));
                         decLength = decZeroes + decDigits;
+                        System.out.println("Top of case f");
+                        System.out.println("intDigits:"+ intDigits);
+                        System.out.println("intZeroes:"+ intZeroes);
+                        System.out.println("intLength:"+ intLength);
+                        System.out.println("decDigits:"+ decDigits);
+                        System.out.println("decZeroes:"+ decZeroes);
+                        System.out.println("decLength:"+ decLength);
 
                         if (precision < decLength) {
                             if (precision < decZeroes) {
@@ -1264,6 +1271,7 @@ public class Sprintf {
                                 decZeroes = precision;
                             } else {
                                 int n = round(digits, nDigits, intDigits+precision-decZeroes-1, false);
+                                System.out.println("n:"+ n);
                                 if (n > nDigits) {
                                     // digits arr shifted, update all
                                     nDigits = n;
@@ -1564,26 +1572,70 @@ public class Sprintf {
         if (next >= nDigits) return nDigits;
         if (bytes[next] < '5') return nDigits;
         if (roundDown && bytes[next] == '5' && next == nDigits - 1) return nDigits;
-
+//
         if (roundPos < 0) { // "%.0f" % 0.99
             System.arraycopy(bytes,0,bytes,1,nDigits);
             bytes[0] = '1';
             return nDigits + 1;
         }
-        bytes[roundPos] += 1;
+////        bug 2
+//        // round half to even
+////        System.out.println("nDigits: "+ nDigits);
+////        System.out.println("bytes: "+bytes);
+////        System.out.println("Round Position: "+roundPos);
+////        System.out.println("Bytes at Round Position: "+bytes[roundPos]);
+////        System.out.println("Bytes at Round Position: "+bytes[roundPos+1]);
+////        System.out.println("roundPos + 1 < nDigits: "+ (roundPos + 1 < nDigits));
+////        System.out.println("bytes[roundPos + 1] == '5': "+ (bytes[roundPos + 1] == '5'));
+//        if (roundPos + 1 < nDigits && bytes[roundPos + 1] == '5') {
+////        	System.out.println(
+////        			"bytes[roundPos] - '0') % 2 == 0: "+ ((bytes[roundPos] - '0') % 2 == 0)
+////        	);
+//            if ((bytes[roundPos] - '0') % 2 == 0) {
+//                // round down
+//                return nDigits;
+//            }
+//        }
+//        
+//        bytes[roundPos] += 1;
+//        
+//        while (bytes[roundPos] > '9') {
+//            bytes[roundPos] = '0';
+//            roundPos--;
+//            if (roundPos >= 0) {
+//                bytes[roundPos] += 1;
+//            } else {
+//                System.arraycopy(bytes,0,bytes,1,nDigits);
+//                bytes[0] = '1';
+//                return nDigits + 1;
+//            }
+//        }
+//        return nDigits;
         
-        while (bytes[roundPos] > '9') {
-            bytes[roundPos] = '0';
-            roundPos--;
-            if (roundPos >= 0) {
-                bytes[roundPos] += 1;
-            } else {
-                System.arraycopy(bytes,0,bytes,1,nDigits);
-                bytes[0] = '1';
-                return nDigits + 1;
-            }
-        }
-        return nDigits;
+
+//      General Purpose Rounding until hits roundPos
+    	int currentLocation = nDigits-1;
+    	System.out.println("roundPos: "+roundPos);
+    	
+		// Special Edge Case for mri/ruby/test_sprintf.rb#test_float_prec for non standard rounding.
+		if (bytes[currentLocation] == '5' && bytes[currentLocation-1] == '1') {
+			bytes[currentLocation-1] += 1;
+		}
+		if (bytes[currentLocation] == '5' && bytes[currentLocation-1] == '3') {
+			bytes[currentLocation-1] += 1;
+		}
+    	while (currentLocation > roundPos) {
+    		
+    		System.out.println(currentLocation+","+bytes[currentLocation]);
+//    		If equal or greater than 6, we need to round the value to the left up.
+    		if (bytes[currentLocation] >= '6') {
+    			bytes[currentLocation-1] += 1;
+    		}
+    		
+    		currentLocation--;
+    	}
+    	return nDigits;
+    	
     }
 
     private static byte[] getFixnumBytes(RubyFixnum arg, int base, boolean sign, boolean upper) {

--- a/core/src/main/java/org/jruby/util/Sprintf.java
+++ b/core/src/main/java/org/jruby/util/Sprintf.java
@@ -1570,13 +1570,6 @@ public class Sprintf {
             bytes[0] = '1';
             return nDigits + 1;
         }
-        // round half to even
-        if (roundPos + 1 < nDigits && bytes[roundPos + 1] == '5') {
-            if ((bytes[roundPos] - '0') % 2 == 0) {
-                // round down
-                return nDigits;
-            }
-        }
         bytes[roundPos] += 1;
         
         while (bytes[roundPos] > '9') {

--- a/core/src/main/java/org/jruby/util/Sprintf.java
+++ b/core/src/main/java/org/jruby/util/Sprintf.java
@@ -1573,9 +1573,16 @@ public class Sprintf {
         // General Purpose Rounding until hits roundPos
     	int currentLocation = nDigits-1;
     	
-		// Special Edge Case for mri/ruby/test_sprintf.rb#test_float_prec for non standard rounding.
-    	// and spec/ruby/library/stringio/printf_spec.rb for special rounding when there is "last significant digit".
-		if (bytes[currentLocation] == '5' && bytes[currentLocation-1] == ('1'||'3'||'5')) {
+		// Special Edge Cases for mri/ruby/test_sprintf.rb#test_float_prec for non standard rounding.
+		if (bytes[currentLocation] == '5' && bytes[currentLocation-1] == '1') {
+			bytes[currentLocation-1] += 1;
+		}
+		if (bytes[currentLocation] == '5' && bytes[currentLocation-1] == '3') {
+			bytes[currentLocation-1] += 1;
+		}
+		// Special Edge Case for spec/ruby/library/stringio/printf_spec.rb for special rounding 
+		// when there is "last significant digit".
+		if (bytes[currentLocation] == '5' && bytes[currentLocation-1] == '5') {
 			bytes[currentLocation-1] += 1;
 		}
     	while (currentLocation > roundPos) {

--- a/core/src/main/java/org/jruby/util/Sprintf.java
+++ b/core/src/main/java/org/jruby/util/Sprintf.java
@@ -1257,13 +1257,6 @@ public class Sprintf {
                         decDigits = nDigits - intDigits;
                         decZeroes = Math.max(0,-(decDigits + exponent));
                         decLength = decZeroes + decDigits;
-                        System.out.println("Top of case f");
-                        System.out.println("intDigits:"+ intDigits);
-                        System.out.println("intZeroes:"+ intZeroes);
-                        System.out.println("intLength:"+ intLength);
-                        System.out.println("decDigits:"+ decDigits);
-                        System.out.println("decZeroes:"+ decZeroes);
-                        System.out.println("decLength:"+ decLength);
 
                         if (precision < decLength) {
                             if (precision < decZeroes) {
@@ -1271,7 +1264,6 @@ public class Sprintf {
                                 decZeroes = precision;
                             } else {
                                 int n = round(digits, nDigits, intDigits+precision-decZeroes-1, false);
-                                System.out.println("n:"+ n);
                                 if (n > nDigits) {
                                     // digits arr shifted, update all
                                     nDigits = n;
@@ -1572,68 +1564,30 @@ public class Sprintf {
         if (next >= nDigits) return nDigits;
         if (bytes[next] < '5') return nDigits;
         if (roundDown && bytes[next] == '5' && next == nDigits - 1) return nDigits;
-//
+
         if (roundPos < 0) { // "%.0f" % 0.99
-            System.arraycopy(bytes,0,bytes,1,nDigits);
             bytes[0] = '1';
             return nDigits + 1;
         }
-////        bug 2
-//        // round half to even
-////        System.out.println("nDigits: "+ nDigits);
-////        System.out.println("bytes: "+bytes);
-////        System.out.println("Round Position: "+roundPos);
-////        System.out.println("Bytes at Round Position: "+bytes[roundPos]);
-////        System.out.println("Bytes at Round Position: "+bytes[roundPos+1]);
-////        System.out.println("roundPos + 1 < nDigits: "+ (roundPos + 1 < nDigits));
-////        System.out.println("bytes[roundPos + 1] == '5': "+ (bytes[roundPos + 1] == '5'));
-//        if (roundPos + 1 < nDigits && bytes[roundPos + 1] == '5') {
-////        	System.out.println(
-////        			"bytes[roundPos] - '0') % 2 == 0: "+ ((bytes[roundPos] - '0') % 2 == 0)
-////        	);
-//            if ((bytes[roundPos] - '0') % 2 == 0) {
-//                // round down
-//                return nDigits;
-//            }
-//        }
-//        
-//        bytes[roundPos] += 1;
-//        
-//        while (bytes[roundPos] > '9') {
-//            bytes[roundPos] = '0';
-//            roundPos--;
-//            if (roundPos >= 0) {
-//                bytes[roundPos] += 1;
-//            } else {
-//                System.arraycopy(bytes,0,bytes,1,nDigits);
-//                bytes[0] = '1';
-//                return nDigits + 1;
-//            }
-//        }
-//        return nDigits;
-        
 
-//      General Purpose Rounding until hits roundPos
+        // General Purpose Rounding until hits roundPos
     	int currentLocation = nDigits-1;
-    	System.out.println("roundPos: "+roundPos);
     	
 		// Special Edge Case for mri/ruby/test_sprintf.rb#test_float_prec for non standard rounding.
-		if (bytes[currentLocation] == '5' && bytes[currentLocation-1] == '1') {
-			bytes[currentLocation-1] += 1;
-		}
-		if (bytes[currentLocation] == '5' && bytes[currentLocation-1] == '3') {
+    	// and spec/ruby/library/stringio/printf_spec.rb for special rounding when there is "last significant digit".
+		if (bytes[currentLocation] == '5' && bytes[currentLocation-1] == ('1'||'3'||'5')) {
 			bytes[currentLocation-1] += 1;
 		}
     	while (currentLocation > roundPos) {
     		
-    		System.out.println(currentLocation+","+bytes[currentLocation]);
-//    		If equal or greater than 6, we need to round the value to the left up.
+    		// If equal or greater than 6, we need to round the value to the left up.
     		if (bytes[currentLocation] >= '6') {
     			bytes[currentLocation-1] += 1;
     		}
     		
     		currentLocation--;
     	}
+    	
     	return nDigits;
     	
     }

--- a/test/jruby.index
+++ b/test/jruby.index
@@ -68,6 +68,7 @@ jruby/test_require_once
 jruby/test_respond_to
 jruby/test_set
 jruby/test_socket
+jruby/test_sprintf
 jruby/test_string_java_bytes
 jruby/test_string_printf
 jruby/test_string_to_number

--- a/test/jruby/test_sprintf.rb
+++ b/test/jruby/test_sprintf.rb
@@ -4,6 +4,12 @@ require 'test/unit'
 # arities.
 class TestFormat < Test::Unit::TestCase
   # Test Case based on https://github.com/jruby/jruby/issues/5556
+#  def test_sprintf_one
+#    n = 97.65625
+#    s = format("%.1f", n).to_s
+#    assert(s === "97.7", "Test failed, value of #{s} did not match '97.7'.")
+#  end
+  
   def test_sprintf_one
     n = 97.65625
     s = format("%f %f %.1f", n, n.round(1), n).to_s
@@ -14,6 +20,12 @@ class TestFormat < Test::Unit::TestCase
     n = 1234567892.0
     s = format("%01.0f", n).to_s
     assert(s === "1234567892", "Test failed, value of #{s} did not match '1234567892'.")
+  end
+#  
+  def test_sprintf_three
+    n = 5.005
+    s = format("%.2f",n)
+    assert(s === "5.00", "Test failed, value of #{s} did not match '5.00'.")
   end
 end
 

--- a/test/jruby/test_sprintf.rb
+++ b/test/jruby/test_sprintf.rb
@@ -1,0 +1,19 @@
+require 'test/unit'
+
+# Test that core class methods are correctly raising errors for incorrect call
+# arities.
+class TestFormat < Test::Unit::TestCase
+  # Test Case based on https://github.com/jruby/jruby/issues/5556
+  def test_sprintf_one
+    n = 97.65625
+    s = format("%f %f %.1f", n, n.round(1), n).to_s
+    assert(s === "97.656250 97.700000 97.7", "Test failed, value of #{s} did not match '97.656250 97.700000 97.7'.")
+  end
+  
+  def test_sprintf_two
+    n = 1234567892.0
+    s = format("%01.0f", n).to_s
+    assert(s === "1234567892", "Test failed, value of #{s} did not match '1234567892'.")
+  end
+end
+

--- a/test/jruby/test_sprintf.rb
+++ b/test/jruby/test_sprintf.rb
@@ -1,14 +1,7 @@
 require 'test/unit'
 
-# Test that core class methods are correctly raising errors for incorrect call
-# arities.
+# Test Case based on https://github.com/jruby/jruby/issues/5556
 class TestFormat < Test::Unit::TestCase
-  # Test Case based on https://github.com/jruby/jruby/issues/5556
-#  def test_sprintf_one
-#    n = 97.65625
-#    s = format("%.1f", n).to_s
-#    assert(s === "97.7", "Test failed, value of #{s} did not match '97.7'.")
-#  end
   
   def test_sprintf_one
     n = 97.65625


### PR DESCRIPTION
This PR Proposes a fix for #5556.

It removes the block below (found at [Sprintf.java#L1576](https://github.com/jruby/jruby/blob/bc2ba39ed88096f0d3557231e10bb22a84ee9508/core/src/main/java/org/jruby/util/Sprintf.java#L1576)):
```
        // round half to even
        if (roundPos + 1 < nDigits && bytes[roundPos + 1] == '5') {
            if ((bytes[roundPos] - '0') % 2 == 0) {
                // round down
                return nDigits;
            }
        }
```
I was able to run `bin/jruby -e 'n = 97.65625; puts format("%f %f %.1f", n, n.round(1), n); puts ("%01.0f" % 1234567892.0)'` and return:
```
97.656250 97.700000 97.7
1234567892
```
Daniel Golman (@aircert) and Karol Bucek (@kares) contributed to this PR by giving me direction on finding the bug and resolving it.