### PR TITLE
fix float formating regression (half-even rounding)

### DIFF
--- a/test/jruby.index
+++ b/test/jruby.index
@@ -68,6 +68,7 @@ jruby/test_require_once
 jruby/test_respond_to
 jruby/test_set
 jruby/test_socket
+jruby/test_sprintf
 jruby/test_string_java_bytes
 jruby/test_string_printf
 jruby/test_string_to_number

--- a/test/jruby/test_sprintf.rb
+++ b/test/jruby/test_sprintf.rb
@@ -15,5 +15,26 @@ class TestFormat < Test::Unit::TestCase
     s = format("%01.0f", n).to_s
     assert(s === "1234567892", "Test failed, value of #{s} did not match '1234567892'.")
   end
+
+  def test_round_half_even
+    assert_equal("5.00", sprintf("%.2f",5.005))
+    assert_equal("5.01", sprintf("%.2f",5.0059))
+    assert_equal("5.01", sprintf("%.2f",5.0051))
+    assert_equal("5.00", sprintf("%.2f",5.0050))
+    assert_equal("5.01", sprintf("%.2f",5.00501))
+    assert_equal("5.000", sprintf("%.3f",5.0005))
+
+    assert_equal("5.02", sprintf("%.2f",5.015))
+    assert_equal("5.02", sprintf("%.2f",5.025))
+
+    assert_equal("97.66A", "%.2fA" % 97.6562)
+    assert_equal("29.56B", "%.2fB" % 29.5562)
+
+    assert_equal "28.554", sprintf("%.3f", 28.5535)
+    assert_equal "97.7X", sprintf("%.1fX", 97.65625)
+
+    assert_equal("28.554", "%.3f" % 28.5535)
+    assert_equal("97.7X", "%.1fX" % 97.65625)
+  end
 end
 

--- a/test/jruby/test_sprintf.rb
+++ b/test/jruby/test_sprintf.rb
@@ -1,0 +1,19 @@
+require 'test/unit'
+
+# Test that core class methods are correctly raising errors for incorrect call
+# arities.
+class TestFormat < Test::Unit::TestCase
+  # Test Case based on https://github.com/jruby/jruby/issues/5556
+  def test_sprintf_one
+    n = 97.65625
+    s = format("%f %f %.1f", n, n.round(1), n).to_s
+    assert(s === "97.656250 97.700000 97.7", "Test failed, value of #{s} did not match '97.656250 97.700000 97.7'.")
+  end
+  
+  def test_sprintf_two
+    n = 1234567892.0
+    s = format("%01.0f", n).to_s
+    assert(s === "1234567892", "Test failed, value of #{s} did not match '1234567892'.")
+  end
+end
+


### PR DESCRIPTION
resolves https://github.com/jruby/jruby/issues/5556

relates to introducing half even rounding (as identified in the issue): https://github.com/jruby/jruby/commit/bc2ba39ed88096f0d3557231e10bb22a84ee9508
... which need some special care to only apply if there's no tail left

credits to @lassiter for identifying the 'breaking' commit + putting up tests