### PR TITLE
[fix] interpret today TZ-relative but use GJ chrono

### DIFF
--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -78,7 +78,6 @@ public class RubyDate extends RubyObject {
 
     static final Logger LOG = LoggerFactory.getLogger(RubyDate.class);
 
-    static final GJChronology CHRONO_ITALY = GJChronology.getInstance();
     static final GJChronology CHRONO_ITALY_UTC = GJChronology.getInstance(DateTimeZone.UTC);
 
     // The Julian Day Number of the Day of Calendar Reform for Italy
@@ -714,13 +713,19 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod(meta = true)
     public static RubyDate today(ThreadContext context, IRubyObject self) { // sg=ITALY
-        return new RubyDate(context.runtime, (RubyClass) self, new DateTime(CHRONO_ITALY).withTimeAtStartOfDay());
+        return new RubyDate(context.runtime, (RubyClass) self, todayDate(context, CHRONO_ITALY_UTC));
     }
 
     @JRubyMethod(meta = true)
     public static RubyDate today(ThreadContext context, IRubyObject self, IRubyObject sg) {
         final long start = val2sg(context, sg);
-        return new RubyDate(context.runtime, (RubyClass) self, new DateTime(getChronology(context, start, 0)).withTimeAtStartOfDay(), 0, start);
+        final Chronology chrono = getChronology(context, start, 0);
+        return new RubyDate(context.runtime, (RubyClass) self, todayDate(context, chrono), 0, start);
+    }
+
+    private static DateTime todayDate(final ThreadContext context, final Chronology chrono) {
+        org.joda.time.LocalDate today = new org.joda.time.LocalDate(RubyTime.getLocalTimeZone(context.runtime));
+        return new DateTime(today.getYear(), today.getMonthOfYear(), today.getDayOfMonth(), 0, 0, chrono);
     }
 
     @JRubyMethod(name = "_valid_civil?", meta = true, required = 3, optional = 1)


### PR DESCRIPTION
this should match the logic that was in place in 9.1.17.0
... expected to, finally and properly, resolve GH-5418 
(reverts previous attempt #5560 - which reverted d6a93ceff8ef9822c43cbd86f83cfbfa132222f2)

@enebo or @headius when merging please run `test:jruby` and `test:mri:core` on the branch
since CI is UTC - pretty confident it should be all good but just to double check.