### PR TITLE
Time: fix localtime(), getlocal(), parse() for TZ offset

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -499,6 +499,7 @@ public class RubyTime extends RubyObject {
     @JRubyMethod(name = "localtime")
     public RubyTime localtime(ThreadContext context, IRubyObject arg) {
         final DateTimeZone zone = getTimeZoneFromUtcOffset(context, arg);
+        setIsTzRelative(true);
         return adjustTimeZone(context.runtime, zone);
     }
 
@@ -549,7 +550,9 @@ public class RubyTime extends RubyObject {
             return newTime(context.runtime, dt.withZone(getLocalTimeZone(context.runtime)), nsec);
         }
         DateTimeZone dtz = getTimeZoneFromUtcOffset(context, arg);
-        return newTime(context.runtime, dt.withZone(dtz), nsec);
+        RubyTime time = newTime(context.runtime, dt.withZone(dtz), nsec);
+        time.setIsTzRelative(true);
+        return time;
     }
 
     @Deprecated

--- a/spec/tags/ruby/core/time/zone_tags.txt
+++ b/spec/tags/ruby/core/time/zone_tags.txt
@@ -1,2 +1,1 @@
-fails:Time#zone returns nil when getting the local time with a fixed offset
 fails:Time#zone defaults to UTC when bad zones given

--- a/test/jruby/test_time.rb
+++ b/test/jruby/test_time.rb
@@ -1,4 +1,5 @@
 require 'test/unit'
+require 'time'
 
 class TestTime < Test::Unit::TestCase
 
@@ -86,6 +87,12 @@ class TestTime < Test::Unit::TestCase
     assert_equal 59, time.sec
     assert_equal Time.now.zone, time.zone
     assert_equal 999999999, time.nsec
+  end
+
+  def test_parse_and_change
+    t = Time.parse '2003-07-16t15:28:11.2233+01:00'
+    t1 = time_change t, usec: 223000
+    assert_equal '2003-07-16 14:28:11 UTC', t1.dup.utc.to_s
   end
 
   @@tz = ENV['TZ']


### PR DESCRIPTION
When a time is parsed with a TZ offset, t.zone returned an empty
string instead of nil like MRI. This in turn breaks ActiveSupport
Time.change() which then constructs new time values with the wrong
zone, ignoring the offset.

See jruby/activerecord-jdbc-adapter#980