### PR TITLE
Time: fix TZ offset

### DIFF
--- a/test/jruby/test_time.rb
+++ b/test/jruby/test_time.rb
@@ -93,6 +93,14 @@ class TestTime < Test::Unit::TestCase
     t = Time.parse '2003-07-16t15:28:11.2233+01:00'
     t1 = time_change t, usec: 223000
     assert_equal '2003-07-16 14:28:11 UTC', t1.dup.utc.to_s
+
+    t2 = t.clone
+    t3 = time_change t2, usec: 223000
+    assert_equal '2003-07-16 14:28:11 UTC', t3.dup.utc.to_s
+
+    t4 = t1.clone
+    t5 = time_change t4, usec: 223000
+    assert_equal '2003-07-16 14:28:11 UTC', t5.dup.utc.to_s
   end
 
   @@tz = ENV['TZ']


### PR DESCRIPTION
The setTzRelative flag wasn't set everywhere where it should. For one,
the 9.2 changes to initTime() broke Rails' Time.change(). While this
would have been fixable by setting the flag as well, it's just way
too fragile. When a new Time is created based on an instance with
the flag set, it was simply lost. Just returning nil instead of ""
in zone() would fix the basic Rails test, but thing like inspect on
a cloned or otherwise copied-and-adjusted object would still break...

So instead, just remove the flag altogether and evaluate where needed.
This does indeed fix the Rails case, verified this time.

See also jruby/activerecord-jdbc-adapter#980