### PR TITLE
Time: minimal fix for Rails Time.change() problem

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -983,7 +983,10 @@ public class RubyTime extends RubyObject {
     public IRubyObject zone() {
         if (isTzRelative) return getRuntime().getNil();
 
-        RubyString zone = getRuntime().newString(getZoneName());
+        String zoneName = getZoneName();
+        if ("".equals(zoneName)) return getRuntime().getNil();
+
+        RubyString zone = getRuntime().newString(zoneName);
         if (zone.isAsciiOnly()) zone.setEncoding(USASCIIEncoding.INSTANCE);
         return zone;
     }


### PR DESCRIPTION
When there is no timezone (empty string), return nil like MRI.

See also jruby/activerecord-jdbc-adapter#980