### PR TITLE
Time, DateTime: fix isTzRelative book keeping

### DIFF
--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -444,7 +444,7 @@ public class RubyDateTime extends RubyDate {
                 dt.getMillisOfSecond(), RubyTime.getTimeZone(runtime, this.off)
         );
 
-        RubyTime time = new RubyTime(runtime, runtime.getTime(), dt);
+        RubyTime time = new RubyTime(runtime, runtime.getTime(), dt, true);
         if (subMillisNum != 0) {
             RubyNumeric usec = (RubyNumeric)
                     subMillis(runtime).op_mul(context, RubyFixnum.newFixnum(runtime, 1_000_000));

--- a/spec/tags/ruby/core/time/gmtime_tags.txt
+++ b/spec/tags/ruby/core/time/gmtime_tags.txt
@@ -1,1 +1,0 @@
-fails:Time#gmtime on a frozen time does not raise an error if already in UTC

--- a/spec/tags/ruby/core/time/new_tags.txt
+++ b/spec/tags/ruby/core/time/new_tags.txt
@@ -2,4 +2,3 @@ fails:Time.new with a utc_offset argument returns a Time with a UTC offset of th
 fails:Time.new with a utc_offset argument raises ArgumentError if the String argument is not in an ASCII-compatible encoding
 fails:Time.new with a utc_offset argument with an argument that responds to #to_r coerces using #to_r
 fails:Time.new with a utc_offset argument with an argument that responds to #to_str coerces using #to_str
-fails:Time.new with a utc_offset argument returns a non-UTC time

--- a/test/jruby/test_date.rb
+++ b/test/jruby/test_date.rb
@@ -633,8 +633,8 @@ class TestDate < Test::Unit::TestCase
     assert_equal(3, time2.year)
     assert_equal(31, time2.day)
     assert_equal(0, time2.utc_offset)
-    assert_equal(time.zone, time2.zone) if defined? JRUBY_VERSION
-    # MRI: bug? <"UTC"> expected but was <nil>
+    assert_equal(false, time2.utc?)
+    assert_equal(nil, time2.zone)
   end
 
   def test_to_date

--- a/test/jruby/test_time.rb
+++ b/test/jruby/test_time.rb
@@ -115,6 +115,22 @@ class TestTime < Test::Unit::TestCase
     @@tz.nil? ? ENV.delete('TZ') : ENV['TZ'] = @@tz
   end
 
+  def test_preserve_relative_tz
+    time =  Time.new(2000, 1, 1, 0, 0, 0, 0)
+    assert_false time.utc?
+    assert_false time.clone.utc?
+    assert_false time.succ.utc?
+    assert_false time.succ.utc?
+    assert_false (time + 1).utc?
+    assert_false (time - 1).utc?
+  end
+
+  def test_relative_tz_to_non_relative
+    time =  Time.new(2000, 1, 1, 0, 0, 0, 0)
+    assert_false time.utc?
+    assert_true time.clone.utc.utc?
+  end
+
   def time_change(time, options) # from ActiveSupport
     new_year  = options.fetch(:year, time.year)
     new_month = options.fetch(:month, time.month)


### PR DESCRIPTION
Keep/adjust value of isTzRelative where required.

In Time:
* op_plus, op_minus
* clone
* localtime, gmtime/utc
* succ

In DateTime:
* to_time is always relative in MRI

Fixes #4784