### PR TITLE
[fix] properly calculate warning ($VERBOSE) default

### DIFF
--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -189,7 +189,7 @@ public class RubyGlobal {
         }
 
         RubyInstanceConfig.Verbosity verbose = runtime.getInstanceConfig().getVerbosity();
-        IRubyObject verboseValue = null;
+        IRubyObject verboseValue;
         if (verbose == RubyInstanceConfig.Verbosity.NIL) {
             verboseValue = runtime.getNil();
         } else if(verbose == RubyInstanceConfig.Verbosity.TRUE) {

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -220,8 +220,8 @@ public class Options {
     public static final Option<Boolean> CLI_PROCESS_LINE_ENDS = bool(CLI, "cli.process.line.ends", false, "Enable line ending processing. Same as -l.");
     public static final Option<Boolean> CLI_ASSUME_LOOP = bool(CLI, "cli.assume.loop", false, "Wrap execution with a gets() loop. Same as -n.");
     public static final Option<Boolean> CLI_ASSUME_PRINT = bool(CLI, "cli.assume.print", false, "Print $_ after each execution of script. Same as -p.");
-    public static final Option<Boolean> CLI_VERBOSE = bool(CLI, "cli.verbose", false, "Verbose mode, as -w or -W2. Sets default for cli.warning.level.");
-    public static final Option<Verbosity> CLI_WARNING_LEVEL = enumeration(CLI, "cli.warning.level", Verbosity.class, CLI_VERBOSE.load() ? Verbosity.TRUE : Verbosity.FALSE, "Warning level (off=0,normal=1,on=2). Same as -W.");
+    public static final Option<Boolean> CLI_VERBOSE = bool(CLI, "cli.verbose", null, "Verbose mode, as -w or -W2. Sets default for cli.warning.level.");
+    public static final Option<Verbosity> CLI_WARNING_LEVEL = enumeration(CLI, "cli.warning.level", Verbosity.class, calculateVerbosityDefault(), "Warning level (off=0,normal=1,on=2). Same as -W.");
     public static final Option<Boolean> CLI_PARSER_DEBUG = bool(CLI, "cli.parser.debug", false, "Enable parser debug logging. Same as -y.");
     public static final Option<Boolean> CLI_VERSION = bool(CLI, "cli.version", false, "Print version to stderr. Same as --version.");
     public static final Option<Boolean> CLI_BYTECODE = bool(CLI, "cli.bytecode", false, "Print target script bytecode to stderr. Same as --bytecode.");
@@ -297,7 +297,12 @@ public class Options {
     }
 
     private static <T extends Enum<T>> Option<T> enumeration(Category category, String name, Class<T> enumClass, T defval, String description) {
-        Option<T> option = Option.enumeration("jruby", name, category, defval, description);
+        Option<T> option;
+        if (defval == null) {
+            option = Option.enumeration("jruby", name, category, enumClass, description);
+        } else {
+            option = Option.enumeration("jruby", name, category, defval, description);
+        }
         _loadedOptions.add(option);
         return option;
     }
@@ -314,6 +319,12 @@ public class Options {
     private static boolean calculateSetAccessibleDefault() {
         String version = SafePropertyAccessor.getProperty("java.specification.version", "1.7");
         return new BigDecimal(version).compareTo(new BigDecimal("1.9")) < 0;
+    }
+
+    private static Verbosity calculateVerbosityDefault() {
+        Boolean verbose = CLI_VERBOSE.load();
+        if (verbose == null) return Verbosity.NIL;
+        return verbose ? Verbosity.TRUE : Verbosity.FALSE;
     }
 
     private enum SearchMode { PREFIX,  CONTAINS }


### PR DESCRIPTION

noticed this while implementing the deprecation warning `Object#=~` for 2.6
the 3 state warning level was only using true/false states so it ended up printing warnings by default
JRuby should keep a `nil` (falsy) warning level by default, as Verbosity enum was intended to

no one complained about this on 9.1/9.2 so I am targeting 2.6 for now, its present on 9.2 as well