### PR TITLE
Multiple adjustments to the Exception and raise logic.

### DIFF
--- a/core/src/main/java/org/jruby/NativeException.java
+++ b/core/src/main/java/org/jruby/NativeException.java
@@ -84,14 +84,6 @@ public class NativeException extends RubyException {
         return exceptionClass;
     }
 
-    @Override
-    public void prepareBacktrace(ThreadContext context) {
-        // if it's null, use cause's trace to build a raw stack trace
-        if (backtraceData == null) {
-            backtraceData = WALKER.walk(cause.getStackTrace(), stream -> TraceType.Gather.RAW.getBacktraceData(getRuntime().getCurrentContext(), stream));
-        }
-    }
-
     @JRubyMethod
     public final IRubyObject cause() {
         return Java.getInstance(getRuntime(), getCause());

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -99,7 +99,6 @@ import org.jruby.embed.Extension;
 import org.jruby.exceptions.MainExitException;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.ext.JRubyPOSIXHandler;
-import org.jruby.ext.LateLoadingLibrary;
 import org.jruby.ext.coverage.CoverageData;
 import org.jruby.ext.ffi.FFI;
 import org.jruby.ext.fiber.ThreadFiber;
@@ -144,7 +143,6 @@ import org.jruby.runtime.encoding.EncodingService;
 import org.jruby.runtime.invokedynamic.MethodNames;
 import org.jruby.runtime.load.BasicLibraryService;
 import org.jruby.runtime.load.CompiledScriptLoader;
-import org.jruby.runtime.load.Library;
 import org.jruby.runtime.load.LoadService;
 import org.jruby.runtime.opto.Invalidator;
 import org.jruby.runtime.opto.OptoFactory;
@@ -4314,7 +4312,7 @@ public final class Ruby implements Constantizable {
         RubyException ex = RubyStopIteration.newInstance(context, result, message);
 
         if (!RubyInstanceConfig.STOPITERATION_BACKTRACE) {
-            ex.forceBacktrace(disabledBacktrace());
+            ex.setBacktrace(disabledBacktrace());
         }
 
         return ex.toThrowable();

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -853,14 +853,15 @@ public class RubyKernel {
         IRubyObject cause = null;
         IRubyObject maybeOpts = ArgsUtil.getOptionsArg(runtime, args);
         if (!maybeOpts.isNil()) {
-            argc--;
             RubyHash opt = (RubyHash) maybeOpts;
             cause = opt.delete(context, runtime.newSymbol("cause"));
 
             if (!cause.isNil()) {
                 forceCause = true;
 
-                if (argc == 0) throw runtime.newArgumentError("only cause is given with no arguments");
+                if (opt.isEmpty() && --argc == 0) { // more opts will be passed along
+                    throw runtime.newArgumentError("only cause is given with no arguments");
+                }
             }
         }
 

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1223,7 +1223,7 @@ public class RubyKernel {
         return RubyUncaughtThrowError.newUncaughtThrowError(runtime, tag, value, message).toThrowable();
     }
 
-    @JRubyMethod(module = true, visibility = PRIVATE)
+    @JRubyMethod(module = true, visibility = PRIVATE, omit = true)
     public static IRubyObject warn(ThreadContext context, IRubyObject recv, IRubyObject _message) {
         if (_message instanceof RubyArray) {
             RubyArray messageArray = _message.convertToArray();
@@ -1248,9 +1248,8 @@ public class RubyKernel {
     }
 
     public static final String[] WARN_VALID_KEYS = { "uplevel" };
-    private static final StackWalker WALKER = StackWalker.getInstance();
 
-    @JRubyMethod(module = true, rest = true, visibility = PRIVATE)
+    @JRubyMethod(module = true, rest = true, visibility = PRIVATE, omit = true)
     public static IRubyObject warn(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         boolean kwargs = false;
         int uplevel = 0;

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -50,6 +50,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import com.headius.backport9.stack.StackWalker;
 import jnr.constants.platform.Errno;
 import jnr.posix.POSIX;
 
@@ -850,17 +851,16 @@ public class RubyKernel {
 
         // semi extract_raise_opts :
         IRubyObject cause = null;
-        if ( argc > 0 ) {
-            IRubyObject last = args[argc - 1];
-            if ( last instanceof RubyHash ) {
-                RubyHash opt = (RubyHash) last; RubySymbol key;
-                if ( ! opt.isEmpty() && ( opt.has_key_p( context, key = runtime.newSymbol("cause") ) == runtime.getTrue() ) ) {
-                    cause = opt.delete(context, key, Block.NULL_BLOCK);
-                    forceCause = true;
-                    if ( opt.isEmpty() && --argc == 0 ) { // more opts will be passed along
-                        throw runtime.newArgumentError("only cause is given with no arguments");
-                    }
-                }
+        IRubyObject maybeOpts = ArgsUtil.getOptionsArg(runtime, args);
+        if (!maybeOpts.isNil()) {
+            argc--;
+            RubyHash opt = (RubyHash) maybeOpts;
+            cause = opt.delete(context, runtime.newSymbol("cause"));
+
+            if (!cause.isNil()) {
+                forceCause = true;
+
+                if (argc == 0) throw runtime.newArgumentError("only cause is given with no arguments");
             }
         }
 
@@ -894,7 +894,7 @@ public class RubyKernel {
                 break;
             default:
                 RubyException exception = convertToException(context, args[0], args[1]);
-                exception.forceBacktrace(args[2]);
+                exception.setBacktrace(args[2]);
                 raise = exception.toThrowable();
                 break;
         }
@@ -1248,6 +1248,7 @@ public class RubyKernel {
     }
 
     public static final String[] WARN_VALID_KEYS = { "uplevel" };
+    private static final StackWalker WALKER = StackWalker.getInstance();
 
     @JRubyMethod(module = true, rest = true, visibility = PRIVATE)
     public static IRubyObject warn(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
@@ -1271,7 +1272,7 @@ public class RubyKernel {
         int numberOfMessages = kwargs ? args.length - 1 : args.length;
 
         if (kwargs) {
-            RubyStackTraceElement element = context.runtime.getInstanceConfig().getTraceType().getBacktraceElement(context, uplevel);
+            RubyStackTraceElement element = context.getSingleBacktrace(uplevel);
 
             RubyString baseMessage = context.runtime.newString();
             baseMessage.catString(element.getFileName() + ':' + element.getLineNumber() + ": warning: ");

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -851,16 +851,17 @@ public class RubyKernel {
 
         // semi extract_raise_opts :
         IRubyObject cause = null;
-        IRubyObject maybeOpts = ArgsUtil.getOptionsArg(runtime, args);
-        if (!maybeOpts.isNil()) {
-            RubyHash opt = (RubyHash) maybeOpts;
-            cause = opt.delete(context, runtime.newSymbol("cause"));
-
-            if (!cause.isNil()) {
-                forceCause = true;
-
-                if (opt.isEmpty() && --argc == 0) { // more opts will be passed along
-                    throw runtime.newArgumentError("only cause is given with no arguments");
+        if (argc > 0) {
+            IRubyObject last = args[argc - 1];
+            if (last instanceof RubyHash) {
+                RubyHash opt = (RubyHash) last;
+                RubySymbol key;
+                if (!opt.isEmpty() && (opt.has_key_p(context, key = runtime.newSymbol("cause")) == runtime.getTrue())) {
+                    cause = opt.delete(context, key, Block.NULL_BLOCK);
+                    forceCause = true;
+                    if (opt.isEmpty() && --argc == 0) { // more opts will be passed along
+                        throw runtime.newArgumentError("only cause is given with no arguments");
+                    }
                 }
             }
         }

--- a/core/src/main/java/org/jruby/exceptions/RaiseException.java
+++ b/core/src/main/java/org/jruby/exceptions/RaiseException.java
@@ -94,22 +94,10 @@ public class RaiseException extends JumpException {
         preRaise(context, (IRubyObject) null);
     }
 
-    private void preRaise(ThreadContext context, StackTraceElement[] javaTrace) {
-        context.runtime.incrementExceptionCount();
-        doSetLastError(context);
-        doCallEventHook(context);
-
-        if (RubyInstanceConfig.LOG_EXCEPTIONS) TraceType.logException(exception);
-
-        if (requiresBacktrace(context)) {
-            exception.prepareIntegratedBacktrace(context, javaTrace);
-        }
-    }
-
     private boolean requiresBacktrace(ThreadContext context) {
         // We can only omit backtraces of descendents of Standard error for 'foo rescue nil'
         return context.exceptionRequiresBacktrace ||
-                ! context.runtime.getStandardError().isInstance(exception) ||
+                !context.runtime.getStandardError().isInstance(exception) ||
                 context.runtime.isDebug();
     }
 
@@ -120,16 +108,14 @@ public class RaiseException extends JumpException {
 
         if (RubyInstanceConfig.LOG_EXCEPTIONS) TraceType.logException(exception);
 
-        // We can only omit backtraces of descendents of Standard error for 'foo rescue nil'
-        if (requiresBacktrace(context)) {
-            if (backtrace == null) {
-                exception.prepareBacktrace(context);
-            } else {
-                exception.forceBacktrace(backtrace);
-                if ( backtrace.isNil() ) return;
-            }
+        backtrace = backtrace == null ? exception.callMethod("backtrace") : backtrace;
 
+        if (backtrace.isNil()) {
+            // No backtrace provided or overridden, capture at this point in stack
+            exception.captureBacktrace(context);
             setStackTrace(RaiseException.javaTraceFromRubyTrace(exception.getBacktraceElements()));
+        } else {
+            // Backtrace provided
         }
     }
 
@@ -157,27 +143,6 @@ public class RaiseException extends JumpException {
             newTrace[i] = trace[i].asStackTraceElement();
         }
         return newTrace;
-    }
-
-    @Deprecated
-    public static RaiseException createNativeRaiseException(Ruby runtime, Throwable cause) {
-        return createNativeRaiseException(runtime, cause, null);
-    }
-
-    @Deprecated
-    public static RaiseException createNativeRaiseException(Ruby runtime, Throwable cause, Member target) {
-        org.jruby.NativeException nativeException = new org.jruby.NativeException(runtime, runtime.getNativeException(), cause);
-
-        return new RaiseException(cause, nativeException);
-    }
-
-    @Deprecated
-    public RaiseException(Throwable cause, org.jruby.NativeException nativeException) {
-        super(nativeException.getMessageAsJavaString(), cause);
-        providedMessage = super.getMessage(); // cause.getClass().getId() + ": " + message
-        setException(nativeException);
-        preRaise(nativeException.getRuntime().getCurrentContext(), nativeException.getCause().getStackTrace());
-        setStackTrace(RaiseException.javaTraceFromRubyTrace(exception.getBacktraceElements()));
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/management/Runtime.java
+++ b/core/src/main/java/org/jruby/management/Runtime.java
@@ -40,6 +40,7 @@ import org.jruby.RubyException;
 import org.jruby.RubyThread;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.backtrace.BacktraceData;
 import org.jruby.runtime.backtrace.TraceType.Format;
 import org.jruby.runtime.backtrace.TraceType.Gather;
 
@@ -108,7 +109,7 @@ public class Runtime implements RuntimeMBean {
         ThreadContext tc = th.getContext();
         if (tc != null) {
             RubyException exc = new RubyException(ruby, ruby.getRuntimeError(), "thread dump");
-            exc.setBacktraceData(WALKER.walk(th.getNativeThread().getStackTrace(), stream -> gather.getBacktraceData(tc, stream)));
+            exc.toThrowable();
             pw.println(Format.MRI.printBacktrace(exc, false));
         } else {
             pw.println("    [no longer alive]");

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -976,21 +976,6 @@ public class Helpers {
         context.setErrorInfo(exception);
     }
 
-    @Deprecated
-    public static void storeNativeExceptionInErrorInfo(Throwable currentThrowable, ThreadContext context) {
-        IRubyObject exception;
-        if (currentThrowable instanceof RaiseException) {
-            exception = ((RaiseException)currentThrowable).getException();
-        } else {
-            Ruby runtime = context.runtime;
-
-            // wrap Throwable in a NativeException object
-            exception = new NativeException(runtime, runtime.getNativeException(), currentThrowable);
-            ((NativeException)exception).prepareIntegratedBacktrace(context, currentThrowable.getStackTrace());
-        }
-        context.setErrorInfo(exception);
-    }
-
     public static void clearErrorInfo(ThreadContext context) {
         context.setErrorInfo(context.nil);
     }

--- a/core/src/main/java/org/jruby/runtime/JavaSites.java
+++ b/core/src/main/java/org/jruby/runtime/JavaSites.java
@@ -47,6 +47,7 @@ public class JavaSites {
     public final MarshalSites Marshal = new MarshalSites();
     public final PathnameSites Pathname = new PathnameSites();
     public final DateSites Date = new DateSites();
+    public final RaiseExceptionSites RaiseException = new RaiseExceptionSites();
 
     public static class BasicObjectSites {
         public final CallSite respond_to = new FunctionalCachingCallSite("respond_to?");
@@ -465,6 +466,10 @@ public class JavaSites {
 
     public static class DateSites {
         public final CallSite zone_to_diff = new FunctionalCachingCallSite("zone_to_diff");
+    }
+
+    public static class RaiseExceptionSites {
+        public final CallSite backtrace = new FunctionalCachingCallSite("backtrace");
     }
 
     public static class CheckedSites {

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -835,7 +835,7 @@ public final class ThreadContext {
 
         if (RubyInstanceConfig.LOG_WARNINGS) TraceType.logWarning(trace);
 
-        return trace.length == 0 ? null : trace[0];
+        return trace.length == 0 ? null : trace[trace.length - 1];
     }
 
     /**

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -746,16 +746,7 @@ public final class ThreadContext {
         traceType.getFormat().renderBacktrace(backtraceData.getBacktrace(runtime), sb, false);
     }
 
-    private static final StackWalker WALKER;
-
-    static {
-        StackWalker walker = null;
-        try {
-            walker = StackWalker.getInstance();
-        } catch (Throwable t) {
-        }
-        WALKER = walker;
-    }
+    private static final StackWalker WALKER = StackWalker.getInstance();
 
     public IRubyObject createCallerBacktrace(int level, Integer length) {
         return WALKER.walk(stream -> createCallerBacktrace(level, length, stream));
@@ -837,14 +828,23 @@ public final class ThreadContext {
      *
      * @return the nearest stack trace element
      */
-    public RubyStackTraceElement getSingleBacktrace() {
+    public RubyStackTraceElement getSingleBacktrace(int level) {
         runtime.incrementWarningCount();
 
-        RubyStackTraceElement[] trace = WALKER.walk(stream -> getPartialTrace(0, 1, stream));
+        RubyStackTraceElement[] trace = WALKER.walk(stream -> getPartialTrace(level, 1, stream));
 
         if (RubyInstanceConfig.LOG_WARNINGS) TraceType.logWarning(trace);
 
         return trace.length == 0 ? null : trace[0];
+    }
+
+    /**
+     * Same as calling getSingleBacktrace(0);
+     *
+     * @see #getSingleBacktrace(int)
+     */
+    public RubyStackTraceElement getSingleBacktrace() {
+        return getSingleBacktrace(0);
     }
 
     public boolean isEventHooksEnabled() {

--- a/core/src/main/java/org/jruby/runtime/backtrace/BacktraceData.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/BacktraceData.java
@@ -2,6 +2,7 @@ package org.jruby.runtime.backtrace;
 
 import com.headius.backport9.stack.StackWalker;
 import org.jruby.Ruby;
+import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.JavaNameMangler;
 
 import java.io.Serializable;


### PR DESCRIPTION
* Request backtrace from exception object before raise, so that
  pre-set backtrace or overridden #backtrace skip native trace
  gathering.
* Eliminate some redundant or unused backtrace-gathering methods.
* Fix Kernel#warn uplevel logic to use partial traces (Java 9).

The fixes here allow two additional ways of blunting the cost of
raising an exception (by eliminating the native stack trace):

* Call Exception#set_backtrace before raising
* Use an Exception subtype that overrides Exception#backtrace

This improves the performance of these scenarios to be roughly
equivalent to the three-arg form of Kernel#raise.

Fixes #5605.