### PR TITLE
Fix off-by-one error causing Dir.glob("foo" + "{bar}") to fail if Java asserts are enabled

### DIFF
--- a/core/src/main/java/org/jruby/util/ByteList.java
+++ b/core/src/main/java/org/jruby/util/ByteList.java
@@ -539,7 +539,7 @@ public class ByteList implements Comparable, CharSequence, Serializable {
      */
     public void append(byte[] moreBytes, int start, int len) {
         assert moreBytes != null : "moreBytes is null";
-        assert start >= 0 && (start == 0 || start < moreBytes.length) : "Invalid start: " + start;
+        assert start >= 0 && start <= moreBytes.length : "Invalid start: " + start;
         assert len >= 0 && moreBytes.length - start >= len : "Bad length: " + len;
 
         grow(len);

--- a/spec/regression/GH-5612_glob_pattern_ending_in_curly_brace_fails_assert_in_ByteList_append_spec.rb
+++ b/spec/regression/GH-5612_glob_pattern_ending_in_curly_brace_fails_assert_in_ByteList_append_spec.rb
@@ -1,0 +1,33 @@
+describe org.jruby.util.ByteList do
+  describe "append(byte[], int, int)" do
+    it "throws AssertionError on invalid start or length" do
+      bytelist = org.jruby.util.ByteList.new
+      more_bytes = "foo".bytes.to_java(:byte)
+      expect { bytelist.append(more_bytes, 0, -1) }.to raise_error(java.lang.AssertionError)
+      expect { bytelist.append(more_bytes, 0, 4) }.to raise_error(java.lang.AssertionError)
+      expect { bytelist.append(more_bytes, 1, 3) }.to raise_error(java.lang.AssertionError)
+      expect { bytelist.append(more_bytes, -1, 0) }.to raise_error(java.lang.AssertionError)
+    end
+
+    it "does not throw for valid start and length" do
+      bytelist = org.jruby.util.ByteList.new
+      more_bytes = "foo".bytes.to_java(:byte)
+      expect { bytelist.append(more_bytes, 0, 3) }.not_to raise_error
+      expect { bytelist.append(more_bytes, 1, 1) }.not_to raise_error
+      expect { bytelist.append(more_bytes, 1, 2) }.not_to raise_error
+      expect { bytelist.append(more_bytes, 0, 0) }.not_to raise_error
+      expect { bytelist.append(more_bytes, 2, 0) }.not_to raise_error
+      expect { bytelist.append(more_bytes, 3, 0) }.not_to raise_error  # this is the case that was broken
+    end
+  end
+end
+
+describe Dir do
+  it "does not crash if a glob pattern ends in a curly brace" do
+    expect { Dir.glob("foo{bar}") }.not_to raise_error
+    expect { Dir["foo{bar}"] }.not_to raise_error
+    # make sure it also works when the pattern string is not an interned literal
+    expect { Dir.glob("foo" + "{bar}") }.not_to raise_error
+    expect { Dir["foo" + "{bar}"] }.not_to raise_error
+  end
+end


### PR DESCRIPTION
When Java asserts are enabled, `Dir.glob` and `Dir[]` crash if given a pattern that ends in a curly brace. However, this _only_ happens if the pattern string has not been interned. (Specifically, the underlying ByteList must have `bytes.length == realSize` for the bug to trigger. Apparently that's not usually the case for interned string literals.)

Here is a simple command-line test case:

    JAVA_OPTS=-ea bin/jruby -J-ea -e 'Dir.glob("foo" + "{bar}")'

(I have no idea why _both_ `JAVA_OPTS=-ea` and `-J-ea` are needed to enable Java asserts, but that seems to be the case. That might be a separate issue.)

On JRuby 9.2.6.0, running the command above produces the following output:

```
Unhandled Java exception: java.lang.AssertionError: Invalid start: 8
java.lang.AssertionError: Invalid start: 8
               append at org/jruby/util/ByteList.java:542
          push_braces at org/jruby/util/Dir.java:473
            push_glob at org/jruby/util/Dir.java:312
                 glob at org/jruby/RubyDir.java:271
                 call at org/jruby/RubyDir$INVOKER$s$0$2$glob.gen:-1
                 call at org/jruby/internal/runtime/methods/DynamicMethod.java:204
                 call at org/jruby/internal/runtime/methods/DynamicMethod.java:200
         cacheAndCall at org/jruby/runtime/callsite/CachingCallSite.java:346
                 call at org/jruby/runtime/callsite/CachingCallSite.java:172
    invokeOther3:glob at -e:1
               <main> at -e:1
  invokeWithArguments at java/lang/invoke/MethodHandle.java:627
                 load at org/jruby/ir/Compiler.java:94
            runScript at org/jruby/Ruby.java:854
          runNormally at org/jruby/Ruby.java:777
          runNormally at org/jruby/Ruby.java:795
          runFromMain at org/jruby/Ruby.java:607
        doRunFromMain at org/jruby/Main.java:415
          internalRun at org/jruby/Main.java:307
                  run at org/jruby/Main.java:234
                 main at org/jruby/Main.java:206
```

As it happens, this assertion error is also triggered by running RSpec with no arguments (and with Java asserts enabled), since the glob pattern it uses to find spec files (`"spec/{**{,/*/**}/*_spec.rb}"`by default) ends in a curly brace (and is constructed via concatenation at runtime, and thus not interned). In particular, running:

    JAVA_OPTS=-ea bin/jruby -J-ea -S rspec

fails with:

```
Unhandled Java exception: java.lang.AssertionError: Invalid start: 27
java.lang.AssertionError: Invalid start: 27
               append at org/jruby/util/ByteList.java:542
          push_braces at org/jruby/util/Dir.java:473
            push_glob at org/jruby/util/Dir.java:312
                 aref at org/jruby/RubyDir.java:230
                 call at org/jruby/RubyDir$INVOKER$s$0$0$aref.gen:-1
                 call at org/jruby/internal/runtime/methods/JavaMethod.java:797
                 call at org/jruby/internal/runtime/methods/DynamicMethod.java:200
                 ...
```

----

The cause of this bug is a simple off-by-one error in the assert at [ByteList.java line 524](
https://github.com/jruby/jruby/blob/9.2.6.0/core/src/main/java/org/jruby/util/ByteList.java#L524) (which was formerly commented out due to CI failures, and reintroduced into JRuby 9.2.6.0 by commit 607998ce). Instead of:

    assert start >= 0 && (start == 0 || start < moreBytes.length) : "Invalid start: " + start;

the correct assertion would simply be:

    assert start >= 0 && start <= moreBytes.length : "Invalid start: " + start;

This change permits the degenerate but valid use case of appending 0 bytes starting at the end of a non-empty byte array.

----

Ps. Here's one more direct test case that doesn't depend on the specific behavior of the Dir class:

    JAVA_OPTS=-ea bin/jruby -J-ea -e 'org.jruby.util.ByteList.new.append("foo".bytes.to_java(:byte), 3, 0)'

I would include this (and the first test case above) as specs in the PR, but it would seem that JRuby specs are currently run with Java asserts disabled by default, and I'm not sure how to change or work around that.