### PR TITLE
Terminate and await signal executor to avoid races with at_exit.

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -53,7 +53,6 @@ import org.jruby.ast.VCallNode;
 import org.jruby.ast.WhileNode;
 import org.jruby.compiler.Constantizable;
 import org.jruby.compiler.NotCompilableException;
-import org.jruby.exceptions.Exception;
 import org.jruby.exceptions.LocalJumpError;
 import org.jruby.exceptions.SystemExit;
 import org.jruby.ext.jruby.JRubyLibrary;
@@ -3335,7 +3334,7 @@ public final class Ruby implements Constantizable {
                 if (statusObj != null && !statusObj.isNil()) {
                     status = RubyNumeric.fix2int(statusObj);
                 }
-            } catch (Exception e) {
+            } catch (RaiseException e) {
                 status = 1;
                 printError(e.getException());
             } catch (IRReturnJump irj) {

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -53,6 +53,9 @@ import org.jruby.ast.VCallNode;
 import org.jruby.ast.WhileNode;
 import org.jruby.compiler.Constantizable;
 import org.jruby.compiler.NotCompilableException;
+import org.jruby.exceptions.Exception;
+import org.jruby.exceptions.LocalJumpError;
+import org.jruby.exceptions.SystemExit;
 import org.jruby.ext.jruby.JRubyLibrary;
 import org.jruby.ext.jruby.JRubyUtilLibrary;
 import org.jruby.ext.thread.ConditionVariable;
@@ -3301,16 +3304,20 @@ public final class Ruby implements Constantizable {
             context.pushScope(new ManyVarsDynamicScope(topStaticScope, null));
         }
 
+        // use signal-handling thread to avoid races with trap(INT) and similar shutdown signals
+        ExecutorService executor = (ExecutorService) getModule("Signal").getInternalVariable("executor");
+
+        int[] _status = {status};
         while (!atExitBlocks.empty()) {
             RubyProc proc = atExitBlocks.pop();
-            // IRubyObject oldExc = context.runtime.getGlobalVariables().get("$!"); // Save $!
-            try {
-                proc.call(context, IRubyObject.NULL_ARRAY);
-            } catch (RaiseException rj) {
-                // END { return } can generally be statically determined during build time so we generate the LJE
-                // then.  This if captures the static side of this. See IReturnJump below for dynamic case
-                if (rj.getException() instanceof RubyLocalJumpError) {
-                    RubyLocalJumpError rlje = (RubyLocalJumpError) rj.getException();
+            executor.submit((Runnable) () -> {
+                // IRubyObject oldExc = context.runtime.getGlobalVariables().get("$!"); // Save $!
+                try {
+                    proc.call(context, IRubyObject.NULL_ARRAY);
+                } catch (LocalJumpError lje) {
+                    // END { return } can generally be statically determined during build time so we generate the LJE
+                    // then.  This if captures the static side of this. See IReturnJump below for dynamic case
+                    RubyLocalJumpError rlje = (RubyLocalJumpError) lje.getException();
                     String filename = proc.getBlock().getBinding().filename;
 
                     if (rlje.getReason() == RubyLocalJumpError.Reason.RETURN) {
@@ -3318,30 +3325,36 @@ public final class Ruby implements Constantizable {
                     } else {
                         getWarnings().warn(filename, "break from proc-closure");
                     }
-
-                } else {
-                    RubyException raisedException = rj.getException();
-                    if (!getSystemExit().isInstance(raisedException)) {
-                        status = 1;
-                        printError(raisedException);
-                    } else {
-                        IRubyObject statusObj = raisedException.callMethod(context, "status");
-                        if (statusObj != null && !statusObj.isNil()) {
-                            status = RubyNumeric.fix2int(statusObj);
-                        }
+                } catch (SystemExit se) {
+                    RubySystemExit raisedException = (RubySystemExit) se.getException();
+                    _status[0] = 1;
+                    printError(raisedException);
+                } catch (Exception e) {
+                    IRubyObject statusObj = e.getException().callMethod(context, "status");
+                    if (statusObj != null && !statusObj.isNil()) {
+                        _status[0] = RubyNumeric.fix2int(statusObj);
                     }
                     // Reset $! now that rj has been handled
                     // context.runtime.getGlobalVariables().set("$!", oldExc);
-                }
-            }  catch (IRReturnJump e) {
-                // This capture dynamic returns happening in an end block where it cannot be statically determined
-                // (like within an eval.
+                } catch (IRReturnJump irj) {
+                    // This capture dynamic returns happening in an end block where it cannot be statically determined
+                    // (like within an eval.
 
-                // This is partially similar to code in eval_error.c:error_handle but with less actual cases.
-                // IR treats END blocks are closures and as such we see this special non-local return jump type
-                // bubble this far out as we exec each END proc.
-                getWarnings().warn(proc.getBlock().getBinding().filename, "unexpected return");
+                    // This is partially similar to code in eval_error.c:error_handle but with less actual cases.
+                    // IR treats END blocks are closures and as such we see this special non-local return jump type
+                    // bubble this far out as we exec each END proc.
+                    getWarnings().warn(proc.getBlock().getBinding().filename, "unexpected return");
+                }
+            });
+        }
+
+        try {
+            executor.shutdown();
+            if (!executor.awaitTermination(1, TimeUnit.HOURS)) {
+                throw newRuntimeError("failed to execute at_exit blocks within 1h timeout");
             }
+        } catch (InterruptedException ie) {
+            throw newRuntimeError("interrupted while attempting to execute at_exit blocks");
         }
 
         // Fetches (and unsets) the SIGEXIT handler, if one exists.

--- a/core/src/main/java/org/jruby/RubySignal.java
+++ b/core/src/main/java/org/jruby/RubySignal.java
@@ -35,10 +35,14 @@ import org.jruby.anno.JRubyModule;
 import org.jruby.platform.Platform;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.threading.DaemonThreadFactory;
 import org.jruby.util.SignalFacade;
 import org.jruby.util.NoFunctionalitySignalFacade;
 
 import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
 
 @JRubyModule(name="Signal")
 public class RubySignal {
@@ -68,6 +72,11 @@ public class RubySignal {
         RubyModule mSignal = runtime.defineModule("Signal");
         
         mSignal.defineAnnotatedMethods(RubySignal.class);
+
+        // create single-threaded executor to handle signals and at_exit blocks
+        ExecutorService executor = Executors.newSingleThreadExecutor(new DaemonThreadFactory());
+        mSignal.setInternalVariable("executor", executor);
+
         //registerThreadDumpSignalHandler(runtime);
     }
 

--- a/core/src/main/java/org/jruby/util/NoFunctionalitySignalFacade.java
+++ b/core/src/main/java/org/jruby/util/NoFunctionalitySignalFacade.java
@@ -40,8 +40,8 @@ public class NoFunctionalitySignalFacade implements SignalFacade {
         return recv.getRuntime().getNil();
     }
 
-    public IRubyObject trap(Ruby runtime, BlockCallback block, String sig) {
-        return runtime.getNil();
+    public IRubyObject trap(IRubyObject recv, BlockCallback block, String sig) {
+        return recv.getRuntime().getNil();
     }
 
     public IRubyObject restorePlatformDefault(IRubyObject recv, IRubyObject sig) {

--- a/core/src/main/java/org/jruby/util/SignalFacade.java
+++ b/core/src/main/java/org/jruby/util/SignalFacade.java
@@ -37,7 +37,7 @@ import org.jruby.runtime.builtin.IRubyObject;
  */
 public interface SignalFacade {
     IRubyObject trap(IRubyObject recv, IRubyObject block, IRubyObject sig);
-    IRubyObject trap(Ruby runtime, BlockCallback block, String sig);
+    IRubyObject trap(IRubyObject recv, BlockCallback block, String sig);
     /**
      * Restores the platform (JVM's) default signal handler.
      */


### PR DESCRIPTION
This restores #5441 for additional work before it is merged or dropped.