### PR TITLE
Remove nightly mention b/c DEV@cloud is EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ you can unpack and run in place.
 See [BUILDING](BUILDING.md) for information about prerequisites, how to compile JRuby from source
 and how to test it.
 
-Alternatively, if you need to test out some unreleased bits, there's [nightly builds](http://jruby.org/nightly).
-
 ## Authors
 
 Stefan Matthias Aust, Anders Bengtsson, Geert Bevin, Ola Bini,


### PR DESCRIPTION
The build links on https://www.jruby.org/nightly redirect to https://support.cloudbees.com/hc/en-us/articles/360008971551-DEV-cloud-End-of-Life

I think it's better to remove the mention until we found an alternative solution.