### PR TITLE
[fix] DateTime (civil) Float sec rounding

### DIFF
--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -1162,7 +1162,7 @@ public class RubyDate extends RubyObject {
         throw context.runtime.newTypeError("expected numeric");
     }
 
-    IRubyObject op_plus_numeric(ThreadContext context, RubyNumeric n) {
+    RubyDate op_plus_numeric(ThreadContext context, RubyNumeric n) {
         final Ruby runtime = context.runtime;
         // ms, sub = (n * 86_400_000).divmod(1)
         // sub = 0 if sub == 0 # avoid Rational(0, 1)
@@ -1181,9 +1181,7 @@ public class RubyDate extends RubyObject {
 
         if ( sub.isZero() ) ; // done - noop
         else if ( sub instanceof RubyFloat ) {
-            final int SUB_MS_PRECISION = 1_000_000_000;
-            long s = Math.round(((RubyFloat) sub).getDoubleValue() * SUB_MS_PRECISION);
-            sub = (RubyNumeric) RubyRational.newRationalCanonicalize(context, s, SUB_MS_PRECISION);
+            sub = roundToPrecision(context, (RubyFloat) sub, SUB_MS_PRECISION);
             sub_millis = (RubyNumeric) sub_millis.op_plus(context, sub);
         }
         else {
@@ -1196,6 +1194,13 @@ public class RubyDate extends RubyObject {
             subNum -= subDen; ms += 1; // sub_millis -= 1
         }
         return newInstance(context, dt.plus(ms), off, start, subNum, subDen);
+    }
+
+    static final int SUB_MS_PRECISION = 1_000_000_000;
+
+    static RubyNumeric roundToPrecision(ThreadContext context, RubyFloat sub, final long precision) {
+        long s = Math.round(sub.getDoubleValue() * precision);
+        return (RubyNumeric) RubyRational.newRationalCanonicalize(context, s, precision);
     }
 
     @JRubyMethod(name = "-")

--- a/test/jruby/test_date.rb
+++ b/test/jruby/test_date.rb
@@ -269,6 +269,16 @@ class TestDate < Test::Unit::TestCase
     end
   end
 
+  def test_new_with_float
+    d = DateTime.new(2018, 1, 14, 22, 25, 19.1)
+    assert_equal '#<DateTime: 2018-01-14T22:25:19+00:00 ((2458133j,80719s,100000000n),+0s,2299161j)>', d.inspect
+    assert_equal(1.to_r/10, d.sec_fraction)
+
+    d = DateTime.new(2018, 1, 14, 22, 55, 59.00123456, "+9")
+    assert_equal '#<DateTime: 2018-01-14T22:55:59+09:00 ((2458133j,50159s,1234560n),+32400s,2299161j)>', d.inspect
+    assert_equal(123456.to_r/100_000_000, d.sec_fraction)
+  end
+
   def test_new_invalid
     y = Rational(2005/2); m = -Rational(5/2); d = Rational(31/3);
 


### PR DESCRIPTION
noticed a lot of (new) DateTime failures on 2.6 branch from CSV tests
turns out they were all related to sec arg rounding when a `Float` is given.

this patch will handle such cases ~ as MRI, its not matching C logic but is quite close.