### PR TITLE
[fix] make Date/DateTime equality consistent

### DIFF
--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -758,18 +758,50 @@ public class RubyDate extends RubyObject {
 
     @Override
     @JRubyMethod(name = "eql?", required = 1)
-    public IRubyObject eql_p(IRubyObject other) throws RuntimeException {
+    public IRubyObject eql_p(IRubyObject other) {
         if (other instanceof RubyDate) {
             return getRuntime().newBoolean( equals((RubyDate) other) );
         }
         return getRuntime().getFalse();
     }
 
+    /**
+     * The relationship operator for Date.
+     *
+     * Compares dates by Julian Day Number.  When comparing two DateTime instances, or a DateTime with a Date,
+     * the instances will be regarded as equivalent if they fall on the same date in local time.
+     * @param context
+     * @param other
+     * @return true/false/nil
+     */
+    @Override
+    @JRubyMethod(name = "===", required = 1)
+    public IRubyObject op_eqq(ThreadContext context, IRubyObject other) {
+        if (other instanceof RubyDate) {
+            return f_equal(context, jd(context), ((RubyDate) other).jd(context));
+        }
+        if (other instanceof RubyNumeric) {
+            return f_equal(context, jd(context), other);
+        }
+        return fallback_eqq(context, other); // rb_num_coerce_cmp(self, other, "==")
+    }
+
+    private IRubyObject fallback_eqq(ThreadContext context, IRubyObject other) {
+        RubyArray res;
+        try {
+            res = (RubyArray) other.callMethod(context, "coerce", this);
+        } catch (RaiseException ex) {
+            if (ex.getException() instanceof RubyNoMethodError) return context.nil;
+            throw ex;
+        }
+        return f_equal(context, res.eltInternal(0), res.eltInternal(1));
+    }
+
     @Override
     @JRubyMethod(name = "<=>", required = 1)
-    public IRubyObject op_cmp(ThreadContext context, IRubyObject other) throws RaiseException {
+    public IRubyObject op_cmp(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyDate) {
-            return context.runtime.newFixnum(cmp((RubyDate) other));
+            return context.runtime.newFixnum(cmp(context, (RubyDate) other));
         }
 
         // other (Numeric) - interpreted as an Astronomical Julian Day Number.
@@ -782,14 +814,13 @@ public class RubyDate extends RubyObject {
         // considered as falling on midnight UTC.
 
         if (other instanceof RubyNumeric) {
-            final IRubyObject ajd = ajd(context);
-            return context.sites.Numeric.op_cmp.call(context, ajd, ajd, other);
+            return f_cmp(context, ajd(context), other);
         }
 
         return fallback_cmp(context, other);
     }
 
-    private int cmp(final RubyDate that) {
+    private int cmp(ThreadContext context, final RubyDate that) {
         int cmp = this.dt.compareTo(that.dt); // 0, +1, -1
 
         if (cmp == 0) {
@@ -800,14 +831,13 @@ public class RubyDate extends RubyObject {
                 if (subNum1 > subNum2) return +1;
                 return 0;
             }
-            return cmpSubMillis(that);
+            return cmpSubMillis(context, that);
         }
 
         return cmp;
     }
 
-    private int cmpSubMillis(final RubyDate that) {
-        ThreadContext context = getRuntime().getCurrentContext();
+    private int cmpSubMillis(ThreadContext context, final RubyDate that) {
         RubyNumeric diff = subMillisDiff(context, that);
         return diff.isZero() ? 0 : ( Numeric.f_negative_p(context, diff) ? -1 : +1 );
     }
@@ -816,8 +846,7 @@ public class RubyDate extends RubyObject {
         RubyArray res;
         try {
             res = (RubyArray) other.callMethod(context, "coerce", this);
-        }
-        catch (RaiseException ex) {
+        } catch (RaiseException ex) {
             if (ex.getException() instanceof RubyNoMethodError) return context.nil;
             throw ex;
         }

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -54,9 +54,6 @@ import org.jruby.util.ByteList;
 
 import java.io.Serializable;
 import java.time.*;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
 
 /**
  * JRuby's <code>DateTime</code> implementation - 'native' parts.
@@ -233,7 +230,7 @@ public class RubyDateTime extends RubyDate {
             throw context.runtime.newArgumentError("invalid date");
         }
 
-        return new RubyDateTime(context.runtime, (RubyClass) self, dt, off, sg, subMillisNum, subMillisDen);
+        return (RubyDateTime) new RubyDateTime(context.runtime, (RubyClass) self, dt, off, sg, subMillisNum, subMillisDen).normalizeSubMillis();
     }
 
     static long getDay(ThreadContext context, IRubyObject day, final long[] rest) {

--- a/lib/ruby/stdlib/date.rb
+++ b/lib/ruby/stdlib/date.rb
@@ -523,28 +523,6 @@ class Date
     define_method(n.downcase + '?') { wday == i }
   end
 
-  # The relationship operator for Date.
-  #
-  # Compares dates by Julian Day Number.  When comparing
-  # two DateTime instances, or a DateTime with a Date,
-  # the instances will be regarded as equivalent if they
-  # fall on the same date in local time.
-  def === (other)
-    case other
-    when Numeric
-      jd == other
-    when Date
-      jd == other.jd
-    else
-      begin
-        l, r = other.coerce(self)
-        l === r
-      rescue NoMethodError
-        false
-      end
-    end
-  end
-
   # Step the current date forward +step+ days at a
   # time (or backward, if +step+ is negative) until
   # we reach +limit+ (inclusive), yielding the resultant

--- a/test/jruby/test_date.rb
+++ b/test/jruby/test_date.rb
@@ -279,6 +279,20 @@ class TestDate < Test::Unit::TestCase
     assert_equal(123456.to_r/100_000_000, d.sec_fraction)
   end
 
+  def test_parse_eql_with_sec_fraction
+    d1 = DateTime.parse('2018-01-14T22:25:19.1')
+    d2 = DateTime.new(2018, 1, 14, 22, 25, 19.1)
+    assert_equal(d1, d2)
+    assert d1.eql?(d2), "#{d1.inspect} isnt eql? to #{d2.inspect}"
+    assert d2.eql?(d1), "#{d2.inspect} isnt eql? to #{d1.inspect}"
+
+    d1 = DateTime.new(2018, 1, 14, 22, 55, 59.00123456, "+9")
+    d2 = DateTime.parse('2018-01-14T22:55:59.00123456+09:00')
+    assert_equal(d1, d2)
+    assert d1.eql?(d2), "#{d1.inspect} isnt eql? to #{d2.inspect}"
+    assert d2.eql?(d1), "#{d2.inspect} isnt eql? to #{d1.inspect}"
+  end
+
   def test_equality_details
     d1 = DateTime.parse('2018-01-14T22:25:19.1')
     d2 = DateTime.new(2018, 1, 14, 22, 25, 19.1)

--- a/test/jruby/test_date.rb
+++ b/test/jruby/test_date.rb
@@ -279,6 +279,24 @@ class TestDate < Test::Unit::TestCase
     assert_equal(123456.to_r/100_000_000, d.sec_fraction)
   end
 
+  def test_equality_details
+    d1 = DateTime.parse('2018-01-14T22:25:19.1')
+    d2 = DateTime.new(2018, 1, 14, 22, 25, 19.1)
+
+    assert_equal false, d1 == 1
+    assert_equal false, d1 === 1
+    assert_equal false, d1 === Date.today
+    assert_equal true, d1 === d2.to_date
+    assert_equal true, d1.to_date === d2
+    assert_equal false, d1 == d2.to_date
+    assert_equal false, d1.to_date == d2
+    assert_equal false, d2 == BasicObject.new
+    assert_equal nil, d2 === BasicObject.new
+    assert_equal nil, d2 === :sym
+    assert_equal true, d2 === d1
+    assert_equal false, d2 === DateTime.now
+  end
+
   def test_new_invalid
     y = Rational(2005/2); m = -Rational(5/2); d = Rational(31/3);
 


### PR DESCRIPTION
`eql?` wasn't consistent with `==` (sub-millis rational needed normalization)
and also return from `===` wasn't matching MRI 2.5 ()