### PR TITLE
Isolate debug specs and run fast suite without --debug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ matrix:
     - env: PHASE='-Prake -Dtask=test:mri:extra'
     - env: PHASE='-Prake -Dtask=test:mri:stdlib'
     - env: PHASE='-Prake -Dtask=spec:ruby:fast'
+    - env: PHASE='-Prake -Dtask=spec:ruby:slow'
     - env: COMMAND=test/check_versions.sh
     - env: PHASE='-Ptest'
     - env: PHASE='-Pjruby_complete_jar_extended -Dinvoker.skip=true'

--- a/rakelib/commands.rake
+++ b/rakelib/commands.rake
@@ -95,7 +95,6 @@ def mspec(mspec_options = {}, java_options = {}, &code)
     arg :line => "-T -J-Demma.coverage.out.merge=true"
     arg :line => "-T -J-Demma.verbosity.level=silent"
     arg :line => "-T -J-XX:MaxMetaspaceSize=512M"
-    arg :line => "-T --debug"
     arg :line => "-f #{ms[:format]}"
     arg :line => "-B #{ms[:spec_config]}" if ms[:spec_config]
     arg :line => "#{ms[:spec_target]}" if ms[:spec_target]

--- a/rakelib/rubyspec.rake
+++ b/rakelib/rubyspec.rake
@@ -35,6 +35,14 @@ namespace :spec do
           :spec_target => ":fast"
   end
 
+  desc "Run slow specs"
+  task :'ruby:slow' do
+    mspec :compile_mode => "OFF",
+          :format => MSPEC_FORMAT,
+          :spec_target => ":slow",
+          :jruby_opts => "-I. --dev --debug"
+  end
+
   desc "Run rubyspecs expected to pass"
   task :ci => ['spec:tagged']
 

--- a/spec/jruby.2.5.mspec
+++ b/spec/jruby.2.5.mspec
@@ -63,6 +63,25 @@ class MSpecScript
     '^' + SPEC_DIR + '/language/predefined_spec.rb',
     '^' + SPEC_DIR + '/language/predefined/data_spec.rb',
     '^' + SPEC_DIR + '/library/net/http',
+
+    # These require --debug which slows down or changes other spec results
+    '^' + SPEC_DIR + '/core/tracepoint',
+  ]
+  
+  set :slow, [
+    SPEC_DIR + '/core/process',
+    SPEC_DIR + '/core/io/popen',
+    SPEC_DIR + '/core/argf/gets_spec.rb',
+    SPEC_DIR + '/core/argf/read_spec.rb',
+    SPEC_DIR + '/core/argf/readline_spec.rb',
+    SPEC_DIR + '/core/encoding/default_external_spec.rb',
+    SPEC_DIR + '/core/encoding/default_internal_spec.rb',
+    SPEC_DIR + '/core/io/pid_spec.rb',
+    SPEC_DIR + '/core/kernel/at_exit_spec.rb',
+    SPEC_DIR + '/language/predefined_spec.rb',
+    SPEC_DIR + '/language/predefined/data_spec.rb',
+    SPEC_DIR + '/library/net/http',
+    SPEC_DIR + '/core/tracepoint',
   ]
 
   # Enable features

--- a/spec/tags/ruby/core/encoding/default_external_tags.txt
+++ b/spec/tags/ruby/core/encoding/default_external_tags.txt
@@ -1,1 +1,2 @@
 fails:Encoding.default_external with command line options is not changed by the -U option
+fails:Encoding.default_external= also sets the filesystem encoding

--- a/spec/tags/ruby/core/process/groups_tags.txt
+++ b/spec/tags/ruby/core/process/groups_tags.txt
@@ -1,1 +1,2 @@
 fails:Process.groups sets the list of gids of groups in the supplemental group access list
+fails:Process.groups= raises Errno::EPERM

--- a/spec/tags/ruby/core/process/kill_tags.txt
+++ b/spec/tags/ruby/core/process/kill_tags.txt
@@ -1,5 +1,5 @@
 windows(JRUBY-4317):Process.kill raises an ArgumentError for unknown signals
-windows(hangs):Process.kill signals the process group if the PID is zero
+critical(hangs on OS X and Windows):Process.kill signals the process group if the PID is zero
 windows(hangs):Process.kill signals the process group if the signal number is negative
 windows(hangs):Process.kill signals the process group if the short signal name starts with a minus sign
 windows(hangs):Process.kill signals the process group if the full signal name starts with a minus sign

--- a/spec/tags/ruby/core/process/spawn_tags.txt
+++ b/spec/tags/ruby/core/process/spawn_tags.txt
@@ -78,3 +78,4 @@ fails:Process.spawn redirects both STDERR and STDOUT at the time to the given na
 fails:Process.spawn with Integer option keys maps the key to a file descriptor in the child that inherits the file descriptor from the parent specified by the value
 fails:Process.spawn raises an Errno::EACCES or Errno::EISDIR when passed a directory
 fails:Process.spawn defaults :close_others to true
+fails(linux):Process.spawn inside Dir.chdir kills extra chdir processes

--- a/spec/tags/ruby/core/process/spawn_tags.txt
+++ b/spec/tags/ruby/core/process/spawn_tags.txt
@@ -13,6 +13,7 @@ fails:Process.spawn joins the current process if pgroup: false
 fails:Process.spawn redirects STDOUT to the given file if out: String
 fails:Process.spawn redirects STDERR to the given file if err: String
 fails:Process.spawn when passed close_others: false does not close file descriptors >= 3 in the child process if fds are set close_on_exec=false
+critical(hangs):Process.spawn when passed close_others: true closes file descriptors >= 3 in the child process even if fds are set close_on_exec=false
 windows:Process.spawn executes the given command
 windows:Process.spawn returns the process ID of the new process as a Fixnum
 windows:Process.spawn returns immediately
@@ -75,3 +76,5 @@ fails:Process.spawn unsets other environment variables when given a true :unsete
 fails:Process.spawn unsets other environment variables when given a non-false :unsetenv_others option
 fails:Process.spawn redirects both STDERR and STDOUT at the time to the given name
 fails:Process.spawn with Integer option keys maps the key to a file descriptor in the child that inherits the file descriptor from the parent specified by the value
+fails:Process.spawn raises an Errno::EACCES or Errno::EISDIR when passed a directory
+fails:Process.spawn defaults :close_others to true

--- a/spec/tags/ruby/core/process/status/exitstatus_tags.txt
+++ b/spec/tags/ruby/core/process/status/exitstatus_tags.txt
@@ -1,0 +1,1 @@
+fails:Process::Status#exitstatus for a child that raised SignalException returns nil

--- a/spec/tags/ruby/core/process/status/termsig_tags.txt
+++ b/spec/tags/ruby/core/process/status/termsig_tags.txt
@@ -1,0 +1,1 @@
+fails:Process::Status#termsig for a child that raised SignalException returns the signal

--- a/spec/tags/ruby/language/predefined_tags.txt
+++ b/spec/tags/ruby/language/predefined_tags.txt
@@ -2,3 +2,4 @@ fails:Global variable $0 raises a TypeError when not given an object that can be
 fails:Global variable $0 actually sets the program name
 windows:The predefined global constant ARGV contains Strings encoded in locale Encoding
 fails:Predefined global $! in bodies without ensure should be cleared when an exception is rescued even when a non-local return is present
+fails(linux):Execution variable $: does not include the current directory

--- a/spec/tags/ruby/language/string_tags.txt
+++ b/spec/tags/ruby/language/string_tags.txt
@@ -1,4 +1,2 @@
 windows:Ruby character strings allows HEREDOC with <<'identifier', no interpolation
 windows:Ruby character strings allows HEREDOC with <<-'identifier', allowing to indent identifier, no interpolation
-fails(--debug is required for other tests, but turns on frozen string debugging):Ruby String literals with a magic frozen comment produce the same object for literals with the same content
-fails(--debug is required for other tests, but turns on frozen string debugging):Ruby String literals with a magic frozen comment produce the same object for literals with the same content in different files

--- a/spec/tags/ruby/library/net/http/http/get2_tags.txt
+++ b/spec/tags/ruby/library/net/http/http/get2_tags.txt
@@ -1,0 +1,1 @@
+critical(hangs on Travis, maybe Linux):Net::HTTP#get2 when passed no block sends a GET request to the passed path and returns the response

--- a/spec/tags/ruby/library/net/http/http/get2_tags.txt
+++ b/spec/tags/ruby/library/net/http/http/get2_tags.txt
@@ -1,1 +1,1 @@
-critical(hangs on Travis, maybe Linux):Net::HTTP#get2 when passed no block sends a GET request to the passed path and returns the response
+critical(hangs on Travis):Net::HTTP#get2 when passed no block sends a GET request to the passed path and returns the response

--- a/spec/tags/ruby/library/net/http/http/get_tags.txt
+++ b/spec/tags/ruby/library/net/http/http/get_tags.txt
@@ -1,0 +1,2 @@
+critical(setup hangs on travis):Net::HTTP.get when passed URI when passed URI returns the body of the specified uri
+critical(setup hangs on travis):Net::HTTP.get when passed URI when passed URI when passed host, path, port

--- a/spec/tags/ruby/library/net/http/http/post2_tags.txt
+++ b/spec/tags/ruby/library/net/http/http/post2_tags.txt
@@ -1,0 +1,5 @@
+critical(setup hangs on travis):Net::HTTP#post2 when passed no block sends a post request to the passed path and returns the response
+critical(setup hangs on travis):Net::HTTP#post2 when passed no block returns a Net::HTTPResponse object
+critical(setup hangs on travis):Net::HTTP#post2 when passed a block sends a post request to the passed path and returns the response
+critical(setup hangs on travis):Net::HTTP#post2 when passed a block yields the response to the passed block
+critical(setup hangs on travis):Net::HTTP#post2 when passed a block returns a Net::HTTPResponse object

--- a/spec/tags/ruby/library/net/http/http/post_tags.txt
+++ b/spec/tags/ruby/library/net/http/http/post_tags.txt
@@ -1,1 +1,1 @@
-fails:Net::HTTP#post sends an post request to the passed path and returns the response
+critical(hangs on travis):Net::HTTP#post sends an post request to the passed path and returns the response

--- a/spec/tags/ruby/library/net/http/http/post_tags.txt
+++ b/spec/tags/ruby/library/net/http/http/post_tags.txt
@@ -1,0 +1,1 @@
+fails:Net::HTTP#post sends an post request to the passed path and returns the response


### PR DESCRIPTION
I'm moving any specs that require --debug to the "slow" suite and enabling that suite in CI. This should speed up the main "fast" suite and allow us to untag some specs that are broken by --debug.