### PR TITLE
update to jruby-openssl 0.10.2

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -68,8 +68,8 @@ project 'JRuby Lib Setup' do
   # for testing out jruby-ossl before final release :
   #repository( :url => 'https://oss.sonatype.org/content/repositories/snapshots',
   #            :id => 'gem-snaphots' )
-  repository( :url => 'http://oss.sonatype.org/content/repositories/staging',
-              :id => 'gem-staging' )
+  #repository( :url => 'http://oss.sonatype.org/content/repositories/staging',
+  #            :id => 'gem-staging' )
 
   plugin( :clean,
           :filesets => [ { :directory => '${basedir}/ruby/gems/shared/specifications/default',

--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -21,7 +21,7 @@ default_gems = [
     ['ipaddr', '1.2.0'],
     ['jar-dependencies', '${jar-dependencies.version}'],
     ['jruby-readline', '1.3.7'],
-    ['jruby-openssl', '0.10.1'],
+    ['jruby-openssl', '0.10.2'],
     ['json', '${json.version}'],
     ['psych', '3.1.0'],
     ['rake-ant', '1.0.4'],
@@ -68,8 +68,8 @@ project 'JRuby Lib Setup' do
   # for testing out jruby-ossl before final release :
   #repository( :url => 'https://oss.sonatype.org/content/repositories/snapshots',
   #            :id => 'gem-snaphots' )
-  #repository( :url => 'http://oss.sonatype.org/content/repositories/staging',
-  #            :id => 'gem-staging' )
+  repository( :url => 'http://oss.sonatype.org/content/repositories/staging',
+              :id => 'gem-staging' )
 
   plugin( :clean,
           :filesets => [ { :directory => '${basedir}/ruby/gems/shared/specifications/default',

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -297,10 +297,6 @@ DO NOT MODIFIY - GENERATED CODE
       <id>mavengems</id>
       <url>mavengem:https://rubygems.org</url>
     </repository>
-    <repository>
-      <id>gem-staging</id>
-      <url>http://oss.sonatype.org/content/repositories/staging</url>
-    </repository>
   </repositories>
   <build>
     <extensions>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -112,7 +112,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>jruby-openssl</artifactId>
-      <version>0.10.1</version>
+      <version>0.10.2</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -297,6 +297,10 @@ DO NOT MODIFIY - GENERATED CODE
       <id>mavengems</id>
       <url>mavengem:https://rubygems.org</url>
     </repository>
+    <repository>
+      <id>gem-staging</id>
+      <url>http://oss.sonatype.org/content/repositories/staging</url>
+    </repository>
   </repositories>
   <build>
     <extensions>
@@ -329,9 +333,9 @@ DO NOT MODIFIY - GENERATED CODE
           <include>cache/jruby-readline*1.3.7.gem</include>
           <include>gems/jruby-readline*1.3.7/**</include>
           <include>specifications/jruby-readline*1.3.7.gemspec</include>
-          <include>cache/jruby-openssl*0.10.1.gem</include>
-          <include>gems/jruby-openssl*0.10.1/**</include>
-          <include>specifications/jruby-openssl*0.10.1.gemspec</include>
+          <include>cache/jruby-openssl*0.10.2.gem</include>
+          <include>gems/jruby-openssl*0.10.2/**</include>
+          <include>specifications/jruby-openssl*0.10.2.gemspec</include>
           <include>cache/json*${json.version}.gem</include>
           <include>gems/json*${json.version}/**</include>
           <include>specifications/json*${json.version}.gemspec</include>


### PR DESCRIPTION
CHANGELOG:

* update Bouncy-Castle to 1.61 (and handle supported BC compatibility)
* [fix] avoid NPE when CRL fails to parse (invalid str) (jruby/jruby#5619)
* hide (deprecated) Jopenssl constant 
* default OpenSSL.warn to warnings-enabled flag
* only un-restrict jce when its restricted
* OpenSSL::Cipher#update additional buffer argument (#170) (jruby/jruby#5242)