### PR TITLE
Remove the "Fatal" constant since it's hidden in MRI.

### DIFF
--- a/core/src/main/java/org/jruby/RubyFatal.java
+++ b/core/src/main/java/org/jruby/RubyFatal.java
@@ -44,6 +44,9 @@ public class RubyFatal extends RubyException {
     static RubyClass define(Ruby runtime, RubyClass exceptionClass) {
         RubyClass fatalClass = runtime.defineClass("Fatal", exceptionClass, (r, klass) -> new RubyFatal(runtime, klass));
 
+        // Remove the constant so it's not accessible (jruby/jruby#5648)
+        runtime.getObject().deleteConstant("Fatal");
+
         return fatalClass;
     }
 


### PR DESCRIPTION
This allows users to define their own Fatal class or module
without conflicting.

Fixes #5648.