### PR TITLE
Fix -x command line option to skip header

### DIFF
--- a/core/src/main/java/org/jruby/Main.java
+++ b/core/src/main/java/org/jruby/Main.java
@@ -296,9 +296,6 @@ public class Main {
             if (in == null) {
                 // no script to run, return success
                 return new Status();
-            } else if (config.isXFlag() && !config.hasShebangLine()) {
-                // no shebang was found and x option is set
-                throw new MainExitException(1, "jruby: no Ruby script found in input (LoadError)");
             } else if (config.getShouldCheckSyntax()) {
                 // check syntax only and exit
                 return doCheckSyntax(runtime, in, filename);

--- a/core/src/main/java/org/jruby/RubyInstanceConfig.java
+++ b/core/src/main/java/org/jruby/RubyInstanceConfig.java
@@ -424,9 +424,18 @@ public class RubyInstanceConfig {
     private static InputStream findScript(InputStream is) throws IOException {
         StringBuilder buf = new StringBuilder(64);
         BufferedReader br = new BufferedReader(new InputStreamReader(is));
-        String currentLine = br.readLine();
-        while (currentLine != null && !isRubyShebangLine(currentLine)) {
-            currentLine = br.readLine();
+
+        boolean foundRubyShebang = false;
+        String currentLine;
+        while ((currentLine = br.readLine()) != null) {
+            if (isRubyShebangLine(currentLine)) {
+                foundRubyShebang = true;
+                break;
+            }
+        }
+
+        if (!foundRubyShebang) {
+            throw new MainExitException(1, "jruby: no Ruby script found in input (LoadError)");
         }
 
         buf.append(currentLine).append('\n');


### PR DESCRIPTION
The -x option has been broken since 9e2d6dccb9e481fe25184202ee5a1762bb0fba28, as `parseShebangOptions` is no longer run, which is responsible for calling `setHasShebangLine`. As this is no longer done, `hasShebangLine` always returns false, even if there is a valid shebang.

The fix is to remove the check at this location and move it into the `findScript` function, which already searches for the ruby shebang.

Like mentioned in #4536, there seems to be a test for this, but it is not run during CI (at least I couldn't find it). Also parseShebangOptions seems to be dead code, which I can also remove if you want.