### PR TITLE
Inline first-level loads into "kernel" Ruby files.

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -154,6 +154,21 @@ project 'JRuby Core' do
                      'executable' =>  'java',
                      'classpathScope' =>  'compile' )
     end
+
+    plugin 'org.codehaus.mojo:exec-maven-plugin' do
+      execute_goals( :exec,
+                     id: 'condense-kernel-files',
+                     arguments: [ '-classpath',
+                                      xml( '<classpath/>' ),
+                                      'org.jruby.anno.LoadInliner',
+                                      'src/main/ruby',
+                                      '${project.build.outputDirectory}',
+                                      'jruby/kernel.rb',
+                                      'jruby/preludes.rb',
+                                      'jruby/java.rb'],
+                     executable: 'java',
+                     classpathScope: 'compile' )
+    end
   end
 
   plugin( :compiler,

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -434,6 +434,33 @@ DO NOT MODIFIY - GENERATED CODE
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>condense-kernel-files</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <arguments>
+                <argument>-classpath</argument>
+                <classpath />
+                <argument>org.jruby.anno.LoadInliner</argument>
+                <argument>src/main/ruby</argument>
+                <argument>${project.build.outputDirectory}</argument>
+                <argument>jruby/kernel.rb</argument>
+                <argument>jruby/preludes.rb</argument>
+                <argument>jruby/java.rb</argument>
+              </arguments>
+              <executable>java</executable>
+              <classpathScope>compile</classpathScope>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <executions>
           <execution>

--- a/core/src/main/java/org/jruby/anno/LoadInliner.java
+++ b/core/src/main/java/org/jruby/anno/LoadInliner.java
@@ -1,0 +1,47 @@
+package org.jruby.anno;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+
+public class LoadInliner {
+    public static void main(String[] args) {
+        File sourceDir = new File(args[0]);
+        File targetDir = new File(args[1]);
+
+        for (int i = 2; i < args.length; i++) {
+            File sourceFile = new File(sourceDir, args[i]);
+            File targetFile = new File(targetDir, args[i]);
+
+            System.out.println("inlining loads from " + sourceFile + " into " + targetFile);
+
+            try (FileInputStream fis = new FileInputStream(sourceFile);
+                 FileOutputStream fos = new FileOutputStream(targetFile)) {
+
+                PrintStream pos = new PrintStream(fos);
+
+                byte[] bytes = new byte[fis.available()];
+                fis.read(bytes);
+
+                String[] lines = new String(bytes).split("\n");
+                for (String line : lines) {
+                    if (line.startsWith("load '")) {
+                        String inlined = line.substring(6, line.length() - 1);
+                        try (FileInputStream fis2 = new FileInputStream(new File(sourceDir, inlined))) {
+                            byte[] bytes2 = new byte[fis2.available()];
+                            fis2.read(bytes2);
+                            String inlinedSource = "# " + inlined + "\n\n" + new String(bytes2) + "\n";
+                            pos.println(inlinedSource);
+                        }
+                    } else {
+                        pos.println(line);
+                    }
+                }
+            } catch (IOException ioe) {
+                throw new RuntimeException(ioe);
+            }
+        }
+    }
+}

--- a/core/src/main/ruby/jruby/java.rb
+++ b/core/src/main/ruby/jruby/java.rb
@@ -33,6 +33,8 @@
 # the terms of any one of the EPL, the GPL or the LGPL.
 ###### END LICENSE BLOCK ######
 
+# Extensions to Ruby classes
+
 # These are loads so they don't pollute LOADED_FEATURES
-load 'jruby/java/core_ext.rb'
-load 'jruby/java/java_ext.rb'
+load 'jruby/java/core_ext/module.rb'
+load 'jruby/java/core_ext/object.rb'

--- a/core/src/main/ruby/jruby/java/core_ext.rb
+++ b/core/src/main/ruby/jruby/java/core_ext.rb
@@ -1,5 +1,0 @@
-# Extensions to Ruby classes
-
-# These are loads so they don't pollute LOADED_FEATURES
-load 'jruby/java/core_ext/module.rb'
-load 'jruby/java/core_ext/object.rb'

--- a/core/src/main/ruby/jruby/java/java_ext.rb
+++ b/core/src/main/ruby/jruby/java/java_ext.rb
@@ -1,8 +1,0 @@
-# Extensions to Java classes
-
-# These are loads so they don't pollute LOADED_FEATURES
-# load 'jruby/java/java_ext/java.lang.rb' - moved to native
-# load 'jruby/java/java_ext/java.util.rb' - moved to native
-# load 'jruby/java/java_ext/java.util.regex.rb' - moved to native
-# load 'jruby/java/java_ext/java.io.rb'  - moved to native
-# load 'jruby/java/java_ext/java.net.rb'  - moved to native


### PR DESCRIPTION
This adds a trivial inliner to the build that reads in some of our
"kernel" Ruby source files and inlines any top-level "load" calls
with the target file's source. This reduces the number of loads
executed during JRuby boot from over twenty down to just five.