### PR TITLE
speedup BigDecimal division

### DIFF
--- a/core/src/main/java/org/jruby/ext/bigdecimal/Multiplication.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/Multiplication.java
@@ -1,0 +1,111 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jruby.ext.bigdecimal;
+
+import java.math.BigInteger;
+
+// NOTE: from Android's sources
+// https://android.googlesource.com/platform/libcore/+/refs/heads/master/luni/src/main/java/java/math/Multiplication.java
+
+/**
+ * Static library that provides all multiplication of {@link BigInteger} methods.
+ */
+class Multiplication {
+    /** Just to denote that this class can't be instantiated. */
+    private Multiplication() {}
+
+    /**
+     * An array with the first powers of ten in {@code BigInteger} version.
+     * ({@code 10^0,10^1,...,10^31})
+     */
+    static final BigInteger[] bigTenPows = new BigInteger[32];
+    /**
+     * An array with the first powers of five in {@code BigInteger} version.
+     * ({@code 5^0,5^1,...,5^31})
+     */
+    static final BigInteger bigFivePows[] = new BigInteger[32];
+    static {
+        int i;
+        long fivePow = 1L;
+        for (i = 0; i <= 18; i++) {
+            bigFivePows[i] = BigInteger.valueOf(fivePow);
+            bigTenPows[i] = BigInteger.valueOf(fivePow << i);
+            fivePow *= 5;
+        }
+        for (; i < bigTenPows.length; i++) {
+            bigFivePows[i] = bigFivePows[i - 1].multiply(bigFivePows[1]);
+            bigTenPows[i] = bigTenPows[i - 1].multiply(BigInteger.TEN);
+        }
+    }
+
+    /**
+     * It calculates a power of ten, which exponent could be out of 32-bit range.
+     * Note that internally this method will be used in the worst case with
+     * an exponent equals to: {@code Integer.MAX_VALUE - Integer.MIN_VALUE}.
+     * @param exp the exponent of power of ten, it must be positive.
+     * @return a {@code BigInteger} with value {@code 10<sup>exp</sup>}.
+     */
+    static BigInteger powerOf10(long exp) {
+        // PRE: exp >= 0
+        int intExp = (int)exp;
+        // "SMALL POWERS"
+        if (exp < bigTenPows.length) {
+            // The largest power that fit in 'long' type
+            return bigTenPows[intExp];
+        } else if (exp <= 50) {
+            // To calculate:    10^exp
+            return BigInteger.TEN.pow(intExp);
+        }
+        BigInteger res;
+        try {
+            // "LARGE POWERS"
+            if (exp <= Integer.MAX_VALUE) {
+                // To calculate:    5^exp * 2^exp
+                res = bigFivePows[1].pow(intExp).shiftLeft(intExp);
+            } else {
+                /*
+                 * "HUGE POWERS"
+                 *
+                 * This branch probably won't be executed since the power of ten is too
+                 * big.
+                 */
+                // To calculate:    5^exp
+                BigInteger powerOfFive = bigFivePows[1].pow(Integer.MAX_VALUE);
+                res = powerOfFive;
+                long longExp = exp - Integer.MAX_VALUE;
+                intExp = (int) (exp % Integer.MAX_VALUE);
+                while (longExp > Integer.MAX_VALUE) {
+                    res = res.multiply(powerOfFive);
+                    longExp -= Integer.MAX_VALUE;
+                }
+                res = res.multiply(bigFivePows[1].pow(intExp));
+                // To calculate:    5^exp << exp
+                res = res.shiftLeft(Integer.MAX_VALUE);
+                longExp = exp - Integer.MAX_VALUE;
+                while (longExp > Integer.MAX_VALUE) {
+                    res = res.shiftLeft(Integer.MAX_VALUE);
+                    longExp -= Integer.MAX_VALUE;
+                }
+                res = res.shiftLeft(intExp);
+            }
+        } catch (OutOfMemoryError error) {
+            throw new ArithmeticException(error.getMessage());
+        }
+        return res;
+    }
+
+}

--- a/core/src/main/java/org/jruby/ext/bigdecimal/Multiplication.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/Multiplication.java
@@ -28,26 +28,35 @@ class Multiplication {
     /** Just to denote that this class can't be instantiated. */
     private Multiplication() {}
 
+    static final BigInteger FIVE = BigInteger.valueOf(5);
+
     /**
      * An array with the first powers of ten in {@code BigInteger} version.
      * ({@code 10^0,10^1,...,10^31})
      */
     static final BigInteger[] bigTenPows = new BigInteger[32];
-    /**
-     * An array with the first powers of five in {@code BigInteger} version.
-     * ({@code 5^0,5^1,...,5^31})
-     */
-    static final BigInteger bigFivePows[] = new BigInteger[32];
+
     static {
-        int i;
-        long fivePow = 1L;
-        for (i = 0; i <= 18; i++) {
-            bigFivePows[i] = BigInteger.valueOf(fivePow);
-            bigTenPows[i] = BigInteger.valueOf(fivePow << i);
-            fivePow *= 5;
-        }
-        for (; i < bigTenPows.length; i++) {
-            bigFivePows[i] = bigFivePows[i - 1].multiply(bigFivePows[1]);
+        bigTenPows[0]  = BigInteger.ONE;
+        bigTenPows[1]  = BigInteger.TEN;
+        bigTenPows[2]  = BigInteger.valueOf(100);
+        bigTenPows[3]  = BigInteger.valueOf(1000);
+        bigTenPows[4]  = BigInteger.valueOf(10000);
+        bigTenPows[5]  = BigInteger.valueOf(100000);
+        bigTenPows[6]  = BigInteger.valueOf(1000000);
+        bigTenPows[7]  = BigInteger.valueOf(10000000);
+        bigTenPows[8]  = BigInteger.valueOf(100000000);
+        bigTenPows[9]  = BigInteger.valueOf(1000000000);
+        bigTenPows[10] = BigInteger.valueOf(10000000000L);
+        bigTenPows[11] = BigInteger.valueOf(100000000000L);
+        bigTenPows[12] = BigInteger.valueOf(1000000000000L);
+        bigTenPows[13] = BigInteger.valueOf(10000000000000L);
+        bigTenPows[14] = BigInteger.valueOf(100000000000000L);
+        bigTenPows[15] = BigInteger.valueOf(1000000000000000L);
+        bigTenPows[16] = BigInteger.valueOf(10000000000000000L);
+        bigTenPows[17] = BigInteger.valueOf(100000000000000000L);
+        bigTenPows[18] = BigInteger.valueOf(1000000000000000000L);
+        for (int i=19; i < bigTenPows.length; i++) {
             bigTenPows[i] = bigTenPows[i - 1].multiply(BigInteger.TEN);
         }
     }
@@ -75,7 +84,7 @@ class Multiplication {
             // "LARGE POWERS"
             if (exp <= Integer.MAX_VALUE) {
                 // To calculate:    5^exp * 2^exp
-                res = bigFivePows[1].pow(intExp).shiftLeft(intExp);
+                res = FIVE.pow(intExp).shiftLeft(intExp);
             } else {
                 /*
                  * "HUGE POWERS"
@@ -84,7 +93,7 @@ class Multiplication {
                  * big.
                  */
                 // To calculate:    5^exp
-                BigInteger powerOfFive = bigFivePows[1].pow(Integer.MAX_VALUE);
+                BigInteger powerOfFive = FIVE.pow(Integer.MAX_VALUE);
                 res = powerOfFive;
                 long longExp = exp - Integer.MAX_VALUE;
                 intExp = (int) (exp % Integer.MAX_VALUE);
@@ -92,7 +101,7 @@ class Multiplication {
                     res = res.multiply(powerOfFive);
                     longExp -= Integer.MAX_VALUE;
                 }
-                res = res.multiply(bigFivePows[1].pow(intExp));
+                res = res.multiply(FIVE.pow(intExp));
                 // To calculate:    5^exp << exp
                 res = res.shiftLeft(Integer.MAX_VALUE);
                 longExp = exp - Integer.MAX_VALUE;

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -1212,15 +1212,11 @@ public class RubyBigDecimal extends RubyNumeric {
     private RubyBigDecimal quoImpl(ThreadContext context, RubyBigDecimal that) {
         int mx = this.value.precision();
         int mxb = that.value.precision();
-
         if (mx < mxb) mx = mxb;
         mx = (mx + 1) * BASE_FIG;
 
         final int limit = getPrecLimit(context.runtime);
         if (limit > 0 && limit < mx) mx = limit;
-        else { // second guess since the * BASE_FIG tends to get us too much -> division gets *really* slow
-            mx = (int) Math.min(this.value.precision() + (long) Math.ceil(that.value.precision() * 8.1), mx);
-        }
 
         MathContext mathContext = new MathContext(mx, getRoundingMode(context.runtime));
         return new RubyBigDecimal(context.runtime, divide(this.value, that.value, mathContext)).setResult(limit);
@@ -1229,60 +1225,33 @@ public class RubyBigDecimal extends RubyNumeric {
     // NOTE: base on Android's
     // https://android.googlesource.com/platform/libcore/+/refs/heads/master/luni/src/main/java/java/math/BigDecimal.java
     private static BigDecimal divide(BigDecimal target, BigDecimal divisor, MathContext mc) {
+        assert mc.getPrecision() != 0; // NOTE: handled by divSpecialCases
         /* Calculating how many zeros must be append to 'dividend'
          * to obtain a  quotient with at least 'mc.precision()' digits */
-        long trailingZeros = mc.getPrecision() + 2L + divisor.precision() - target.precision();
+        long trailingZeros = (long) mc.getPrecision() + 1L + divisor.precision() - target.precision();
         long diffScale = (long) target.scale() - divisor.scale();
         long newScale = diffScale; // scale of the final quotient
-        int compRem; // to compare the remainder
-        int i = 1; // index
-        final BigInteger[] TEN_POW = Multiplication.bigTenPows;
-        int lastPow = TEN_POW.length - 1; // last power of ten
-        BigInteger integerQuot; // for temporal results
         BigInteger quotAndRem[] = { target.unscaledValue() };
-        assert mc.getPrecision() != 0;
-        // NOTE: handled by divSpecialCases
-        // In special cases it reduces the problem to call the dual method
-        //if ((mc.getPrecision() == 0) || (target.isZero()) || (divisor.isZero())) {
-        //    return target.divide(divisor);
-        //}
+        final BigInteger divScaled = divisor.unscaledValue();
         if (trailingZeros > 0) {
             // To append trailing zeros at end of dividend
-            quotAndRem[0] = target.unscaledValue().multiply( Multiplication.powerOf10(trailingZeros) );
+            quotAndRem[0] = quotAndRem[0].multiply(Multiplication.powerOf10(trailingZeros));
             newScale += trailingZeros;
         }
-        quotAndRem = quotAndRem[0].divideAndRemainder( divisor.unscaledValue() );
-        integerQuot = quotAndRem[0];
+        quotAndRem = quotAndRem[0].divideAndRemainder(divScaled);
+        BigInteger integerQuot = quotAndRem[0];
         // Calculating the exact quotient with at least 'mc.precision()' digits
         if (quotAndRem[1].signum() != 0) {
             // Checking if:   2 * remainder >= divisor ?
-            compRem = shiftLeftOneBit(quotAndRem[1]).compareTo( divisor.unscaledValue() );
+            int compRem = shiftLeftOneBit(quotAndRem[1]).compareTo(divScaled);
             // quot := quot * 10 + r;     with 'r' in {-6,-5,-4, 0,+4,+5,+6}
             integerQuot = integerQuot.multiply(BigInteger.TEN)
                     .add(BigInteger.valueOf(quotAndRem[0].signum() * (5 + compRem)));
             newScale++;
-        } else {
-            // To strip trailing zeros until the preferred scale is reached
-            while (!integerQuot.testBit(0)) {
-                quotAndRem = integerQuot.divideAndRemainder(TEN_POW[i]);
-                if ((quotAndRem[1].signum() == 0)
-                        && (newScale - i >= diffScale)) {
-                    newScale -= i;
-                    if (i < lastPow) {
-                        i++;
-                    }
-                    integerQuot = quotAndRem[0];
-                } else {
-                    if (i == 1) {
-                        break;
-                    }
-                    i = 1;
-                }
-            }
-        }
-        // To perform rounding
+        } // else BigDecimal() will scale 'down'
         return new BigDecimal(integerQuot, safeLongToInt(newScale), mc);
     }
+
 
     private static BigInteger shiftLeftOneBit(BigInteger i) { return i.shiftLeft(1); }
 

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -1223,7 +1223,74 @@ public class RubyBigDecimal extends RubyNumeric {
         }
 
         MathContext mathContext = new MathContext(mx, getRoundingMode(context.runtime));
-        return new RubyBigDecimal(context.runtime, this.value.divide(that.value, mathContext)).setResult();
+        return new RubyBigDecimal(context.runtime, divide(this.value, that.value, mathContext)).setResult(limit);
+    }
+
+    // NOTE: base on Android's
+    // https://android.googlesource.com/platform/libcore/+/refs/heads/master/luni/src/main/java/java/math/BigDecimal.java
+    private static BigDecimal divide(BigDecimal target, BigDecimal divisor, MathContext mc) {
+        /* Calculating how many zeros must be append to 'dividend'
+         * to obtain a  quotient with at least 'mc.precision()' digits */
+        long trailingZeros = mc.getPrecision() + 2L + divisor.precision() - target.precision();
+        long diffScale = (long) target.scale() - divisor.scale();
+        long newScale = diffScale; // scale of the final quotient
+        int compRem; // to compare the remainder
+        int i = 1; // index
+        final BigInteger[] TEN_POW = Multiplication.bigTenPows;
+        int lastPow = TEN_POW.length - 1; // last power of ten
+        BigInteger integerQuot; // for temporal results
+        BigInteger quotAndRem[] = { target.unscaledValue() };
+        assert mc.getPrecision() != 0;
+        // NOTE: handled by divSpecialCases
+        // In special cases it reduces the problem to call the dual method
+        //if ((mc.getPrecision() == 0) || (target.isZero()) || (divisor.isZero())) {
+        //    return target.divide(divisor);
+        //}
+        if (trailingZeros > 0) {
+            // To append trailing zeros at end of dividend
+            quotAndRem[0] = target.unscaledValue().multiply( Multiplication.powerOf10(trailingZeros) );
+            newScale += trailingZeros;
+        }
+        quotAndRem = quotAndRem[0].divideAndRemainder( divisor.unscaledValue() );
+        integerQuot = quotAndRem[0];
+        // Calculating the exact quotient with at least 'mc.precision()' digits
+        if (quotAndRem[1].signum() != 0) {
+            // Checking if:   2 * remainder >= divisor ?
+            compRem = shiftLeftOneBit(quotAndRem[1]).compareTo( divisor.unscaledValue() );
+            // quot := quot * 10 + r;     with 'r' in {-6,-5,-4, 0,+4,+5,+6}
+            integerQuot = integerQuot.multiply(BigInteger.TEN)
+                    .add(BigInteger.valueOf(quotAndRem[0].signum() * (5 + compRem)));
+            newScale++;
+        } else {
+            // To strip trailing zeros until the preferred scale is reached
+            while (!integerQuot.testBit(0)) {
+                quotAndRem = integerQuot.divideAndRemainder(TEN_POW[i]);
+                if ((quotAndRem[1].signum() == 0)
+                        && (newScale - i >= diffScale)) {
+                    newScale -= i;
+                    if (i < lastPow) {
+                        i++;
+                    }
+                    integerQuot = quotAndRem[0];
+                } else {
+                    if (i == 1) {
+                        break;
+                    }
+                    i = 1;
+                }
+            }
+        }
+        // To perform rounding
+        return new BigDecimal(integerQuot, safeLongToInt(newScale), mc);
+    }
+
+    private static BigInteger shiftLeftOneBit(BigInteger i) { return i.shiftLeft(1); }
+
+    private static int safeLongToInt(long longValue) {
+        if (longValue < Integer.MIN_VALUE || longValue > Integer.MAX_VALUE) {
+            throw new ArithmeticException("Out of int range: " + longValue);
+        }
+        return (int) longValue;
     }
 
     private static RubyBigDecimal div2Impl(ThreadContext context, RubyNumeric a, RubyNumeric b, final int ix) {

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -1216,6 +1216,12 @@ public class RubyBigDecimal extends RubyNumeric {
         if (mx < mxb) mx = mxb;
         mx = (mx + 1) * BASE_FIG;
 
+        final int limit = getPrecLimit(context.runtime);
+        if (limit > 0 && limit < mx) mx = limit;
+        else { // second guess since the * BASE_FIG tends to get us too much -> division gets *really* slow
+            mx = (int) Math.min(this.value.precision() + (long) Math.ceil(that.value.precision() * 8.1), mx);
+        }
+
         MathContext mathContext = new MathContext(mx, getRoundingMode(context.runtime));
         return new RubyBigDecimal(context.runtime, this.value.divide(that.value, mathContext)).setResult();
     }

--- a/test/jruby/test_big_decimal.rb
+++ b/test/jruby/test_big_decimal.rb
@@ -427,19 +427,6 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_equal(4.124045235, (BigDecimal('0.9932') / (700 * BigDecimal('0.344045') / BigDecimal('1000.0'))).round(9))
   end
 
-  def test_zero_p # from MRI test_bigdecimal.rb
-    # BigDecimal.mode(BigDecimal::EXCEPTION_INFINITY, false)
-    # BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
-
-    assert_equal(true, BigDecimal("0").zero?)
-    assert_equal(true, BigDecimal("-0").zero?)
-    assert_equal(false, BigDecimal("1").zero?)
-    #assert_equal(true, BigDecimal("0E200000000000000").zero?)
-    assert_equal(false, BigDecimal("Infinity").zero?)
-    assert_equal(false, BigDecimal("-Infinity").zero?)
-    assert_equal(false, BigDecimal("NaN").zero?)
-  end
-
   def test_power_of_three # from MRI test_bigdecimal.rb
     x = BigDecimal(3)
     assert_equal(81, x ** 4)

--- a/test/jruby/test_big_decimal.rb
+++ b/test/jruby/test_big_decimal.rb
@@ -22,7 +22,7 @@ class TestBigDecimal < Test::Unit::TestCase
     number = java.lang.Number
     assert_equal java.math.BigDecimal.new('8.0111'), BigDecimal('8.0111').to_java(number)
     assert_equal java.lang.Long, 1000.to_java(number).class
-  end
+  end if defined? JRUBY_VERSION
 
   def test_no_singleton_methods_on_bigdecimal
     num = BigDecimal("0.001")
@@ -404,14 +404,14 @@ class TestBigDecimal < Test::Unit::TestCase
     # MRI (2.5):
     # 0.8130081300813008130081300813008130081300813008130081300813008130081300813008130081300813008130081e-92
     puts "\n#{__method__} #{small} / #{denom} = #{res} (#{res.precs})" if $VERBOSE
-    assert res.to_s.length > 30, "not enough precision: #{res}" # in JRuby 9.1 'only' 20
+    assert res.to_s.length > 40, "not enough precision: #{res}" # in JRuby 9.1 'only' 20
     assert_equal BigDecimal('0.81300813e-92'), res.round(100)
 
     val1 = BigDecimal('1'); val2 = BigDecimal('3')
     res = val1 / val2
     puts "\n#{__method__} #{val1} / #{val2} = #{res} (#{res.precs})" if $VERBOSE
-    #assert 18 <= res.precs.first, "unexpected precision: #{res.precs.first}"
-    #assert res.precs.first <= 20, "unexpected precision: #{res.precs.first}"
+    assert 18 <= res.precs.first, "unexpected precision: #{res.precs.first}"
+    assert res.precs.first <= 20, "unexpected precision: #{res.precs.first}"
     assert_equal '0.333333333333333333e0', res.to_s
 
     val1 = BigDecimal("1.00000000000000000001"); val2 = Rational(1, 3)

--- a/test/jruby/test_big_decimal.rb
+++ b/test/jruby/test_big_decimal.rb
@@ -404,14 +404,14 @@ class TestBigDecimal < Test::Unit::TestCase
     # MRI (2.5):
     # 0.8130081300813008130081300813008130081300813008130081300813008130081300813008130081300813008130081e-92
     puts "\n#{__method__} #{small} / #{denom} = #{res} (#{res.precs})" if $VERBOSE
-    assert res.to_s.length > 40, "not enough precision: #{res}" # in JRuby 9.1 only 20
-    assert_equal BigDecimal('0.81300813e-92'),  res.round(100)
+    assert res.to_s.length > 30, "not enough precision: #{res}" # in JRuby 9.1 'only' 20
+    assert_equal BigDecimal('0.81300813e-92'), res.round(100)
 
     val1 = BigDecimal('1'); val2 = BigDecimal('3')
     res = val1 / val2
     puts "\n#{__method__} #{val1} / #{val2} = #{res} (#{res.precs})" if $VERBOSE
-    assert 18 <= res.precs.first, "unexpected precision: #{res.precs.first}"
-    assert res.precs.first <= 20, "unexpected precision: #{res.precs.first}"
+    #assert 18 <= res.precs.first, "unexpected precision: #{res.precs.first}"
+    #assert res.precs.first <= 20, "unexpected precision: #{res.precs.first}"
     assert_equal '0.333333333333333333e0', res.to_s
 
     val1 = BigDecimal("1.00000000000000000001"); val2 = Rational(1, 3)
@@ -444,7 +444,7 @@ class TestBigDecimal < Test::Unit::TestCase
     x = BigDecimal(3)
     assert_equal(81, x ** 4)
     #assert_equal(1.quo(81), x ** -4)
-    assert_in_delta(1.0/81, x ** -4)
+    assert_in_delta(1.0/81, x ** -4, 0.00000000001)
   end
 
   def test_div # from MRI test_bigdecimal.rb
@@ -456,8 +456,10 @@ class TestBigDecimal < Test::Unit::TestCase
     assert_equal(-2, BigDecimal("2") / -1)
 
     #assert_equal(BigDecimal('1486.868686869'), BigDecimal('1472.0') / BigDecimal('0.99'), '[ruby-core:59365] [#9316]')
+    assert_in_delta(BigDecimal('1486.868686869'), BigDecimal('1472.0') / BigDecimal('0.99'), 0.000000001)
 
     #assert_equal(4.124045235, BigDecimal('0.9932') / (700 * BigDecimal('0.344045') / BigDecimal('1000.0')), '[#9305]')
+    assert_in_delta(4.124045235, BigDecimal('0.9932') / (700 * BigDecimal('0.344045') / BigDecimal('1000.0')), 0.000000001)
 
     BigDecimal.mode(BigDecimal::EXCEPTION_INFINITY, false)
     assert_positive_zero(BigDecimal("1.0")  / BigDecimal("Infinity"))


### PR DESCRIPTION
in certain cases its really slow e.g. a `x / 2` as discovered from https://github.com/jruby/jruby/issues/5650

```ruby
TIMES = (ENV['TIMES'] || 10_000_000).to_i

Benchmark.bmbm do |bm|
  bm.report("/2 flt") {
    rad_per_deg = Math::PI/180
    loc1 = [46.3625, 15.114444]
    loc2 = [46.055556, 14.508333]
    val = ((loc2[1]-loc1[1]) * rad_per_deg)
    TIMES.times { val / 2 }
  }

  bm.report("/2 dec") {
    rad_per_deg = Math::PI/180
    loc1 = [BigDecimal('46.3625'), BigDecimal('15.114444')]
    loc2 = [BigDecimal('46.055556'), BigDecimal('14.508333')]
    val = ((loc2[1]-loc1[1]) * rad_per_deg)
    TIMES.times { val / 2 }
  }

  bm.report(" 1/1280") {
    one = BigDecimal(1)
    div = BigDecimal(1280)
    TIMES.times { one / div }
  }
end
```
here the `"/2 dec"` case is very slow - on JRuby **9.2.6** taking **400s**, while MRI takes **10s** : 
```
                 user     system      total        real
/2 flt       0.670000   0.030000   0.700000 (  0.351421)
/2 dec     444.870000   0.930000 445.800000 (434.352299)
 1/1280     38.520000   0.100000  38.620000 ( 36.827996)

/2 flt       0.433256   0.000000   0.433256 (  0.433262)
/2 dec       9.910286   0.000000   9.910286 (  9.910299)
 1/1280      7.118558   0.000000   7.118558 (  7.118567)
```
... with this patch JRuby gets close to MRI's performance (**over 30x improvement** for the above / 2 case) : 
```
/2 flt       0.740000   0.020000   0.760000 (  0.379111)
/2 dec      14.560000   0.240000  14.800000 ( 13.860334)
 1/1280      7.760000   0.030000   7.790000 (  6.865561)
```

Should be noted that **only division (backed by `java.math.BigDecimal#divide(another, context)`) seemed slow**, other decimal operations are either faster on on par with MRI. The 'new' division algorithm is based on Android's sources (ASF2 license) with a few tweaks and a major (in terms of performance) change of not down scaling exact results (remainder 0). Leaving that off to [`java.math.BigDecimal(BigInteger, int, MathContext)`](https://docs.oracle.com/javase/8/docs/api/java/math/BigDecimal.html#BigDecimal-java.math.BigInteger-int-java.math.MathContext-) which will reduce the scale `- n` (doing `BigInteger div 10^n`) faster than we can using public API.