### PR TITLE
multicast receive broken everywhere

### DIFF
--- a/test/jruby/test_socket.rb
+++ b/test/jruby/test_socket.rb
@@ -7,23 +7,23 @@ require 'ipaddr'
 class SocketTest < Test::Unit::TestCase
   include TestHelper
 
-  # Disabled for now. See https://github.com/jruby/jruby/issues/620
-  #
-  def test_multicast_send_and_receive
-    multicast_addr, port = "225.4.5.6", 6789
-    multicast_msg = "Hello from automated JRuby test suite"
+  if !WINDOWS # #5656 is tracking issue for this.
+    def test_multicast_send_and_receive
+      multicast_addr, port = "225.4.5.6", 6789
+      multicast_msg = "Hello from automated JRuby test suite"
   
-    assert_nothing_raised do
-      socket = UDPSocket.new
-      ip =  IPAddr.new(multicast_addr).hton + IPAddr.new("0.0.0.0").hton
-      socket.setsockopt(Socket::IPPROTO_IP, Socket::IP_ADD_MEMBERSHIP, ip)
-      socket.bind(Socket::INADDR_ANY, port)
-      socket.send(multicast_msg, 0, multicast_addr, port)
-      msg, info = socket.recvfrom(1024)
-      assert_equal(multicast_msg, msg)
-      assert_equal(multicast_msg.size, msg.size)
-      assert_equal(port, info[1])
-      socket.close
+      assert_nothing_raised do
+        socket = UDPSocket.new
+        ip =  IPAddr.new(multicast_addr).hton + IPAddr.new("0.0.0.0").hton
+        socket.setsockopt(Socket::IPPROTO_IP, Socket::IP_ADD_MEMBERSHIP, ip)
+        socket.bind(Socket::INADDR_ANY, port)
+        socket.send(multicast_msg, 0, multicast_addr, port)
+        msg, info = socket.recvfrom(1024)
+        assert_equal(multicast_msg, msg)
+        assert_equal(multicast_msg.size, msg.size)
+        assert_equal(port, info[1])
+        socket.close
+      end
     end
   end
 

--- a/test/jruby/test_socket.rb
+++ b/test/jruby/test_socket.rb
@@ -9,27 +9,23 @@ class SocketTest < Test::Unit::TestCase
 
   # Disabled for now. See https://github.com/jruby/jruby/issues/620
   #
-  # # Should this work on windows? JRUBY-6665
-  # if !WINDOWS
-  #   def test_multicast_send_and_receive
-  #     multicast_addr = "225.4.5.6"
-  #     port = 6789
-  #     multicast_msg = "Hello from automated JRuby test suite"
-  #
-  #     assert_nothing_raised do
-  #       socket = UDPSocket.new
-  #       ip =  IPAddr.new(multicast_addr).hton + IPAddr.new("0.0.0.0").hton
-  #       socket.setsockopt(Socket::IPPROTO_IP, Socket::IP_ADD_MEMBERSHIP, ip)
-  #       socket.bind(Socket::INADDR_ANY, port)
-  #       socket.send(multicast_msg, 0, multicast_addr, port)
-  #       msg, info = socket.recvfrom(1024)
-  #       assert_equal(multicast_msg, msg)
-  #       assert_equal(multicast_msg.size, msg.size)
-  #       assert_equal(port, info[1])
-  #       socket.close
-  #     end
-  #   end
-  # end
+  def test_multicast_send_and_receive
+    multicast_addr, port = "225.4.5.6", 6789
+    multicast_msg = "Hello from automated JRuby test suite"
+  
+    assert_nothing_raised do
+      socket = UDPSocket.new
+      ip =  IPAddr.new(multicast_addr).hton + IPAddr.new("0.0.0.0").hton
+      socket.setsockopt(Socket::IPPROTO_IP, Socket::IP_ADD_MEMBERSHIP, ip)
+      socket.bind(Socket::INADDR_ANY, port)
+      socket.send(multicast_msg, 0, multicast_addr, port)
+      msg, info = socket.recvfrom(1024)
+      assert_equal(multicast_msg, msg)
+      assert_equal(multicast_msg.size, msg.size)
+      assert_equal(port, info[1])
+      socket.close
+    end
+  end
 
   def test_tcp_socket_allows_nil_for_hostname
     assert_nothing_raised do


### PR DESCRIPTION
This is an attempt at fixing #5656.  I could not get the reporters server code to work on linux much less the other platforms referenced.  I believe it was something underneath this source line in original code:

```java
socket.multicastStateManager.getMulticastSocket().getChannel();
```

in Java source of getChannel() is literally 'return null'.  Based on changes over the years I suspect something changed in our implementation (like maybe we subclassed the channel?).  This version just uses the socket itself to receive and it blocks and also seems to work.  I also added the equivalent logic if somehow the socket is in a messed up state and tried to mark itself as non-blocking.

With that said I am not confident so I need some eyeballs...