### PR TITLE
Provide better thread name for enumerator/fiber workers.

### DIFF
--- a/core/src/main/java/org/jruby/RubyGenerator.java
+++ b/core/src/main/java/org/jruby/RubyGenerator.java
@@ -61,7 +61,7 @@ public class RubyGenerator extends RubyObject {
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args, Block block) {
         Ruby runtime = context.runtime;
 
-        final IRubyObject proc;
+        final RubyProc proc;
 
         if (args.length == 0) {
             proc = RubyProc.newProc(runtime, block, Block.Type.PROC);
@@ -70,7 +70,7 @@ public class RubyGenerator extends RubyObject {
                 throw runtime.newTypeError(args[0], runtime.getProc());
             }
 
-            proc = args[0];
+            proc = (RubyProc) args[0];
 
             if (block.isGiven()) {
                 runtime.getWarnings().warn(IRubyWarnings.ID.BLOCK_UNUSED, "given block not used");
@@ -102,5 +102,9 @@ public class RubyGenerator extends RubyObject {
         return ((RubyProc) proc).call(context, ArraySupport.newCopy(RubyYielder.newYielder(context, block), args), Block.NULL_BLOCK);
     }
 
-    private IRubyObject proc;
+    public RubyProc getProc() {
+        return proc;
+    }
+
+    private RubyProc proc;
 }

--- a/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
+++ b/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
@@ -254,16 +254,20 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
         final AtomicReference<RubyThread> fiberThread = new AtomicReference();
 
         // retry with GC once
-        boolean retried = true;
+        boolean retried = false;
 
-        try {
-            runtime.getFiberExecutor().execute(new Runnable() {
-                public void run() {
+        while (!retried) {
+            try {
+                runtime.getFiberExecutor().execute(() -> {
                     ThreadContext context = runtime.getCurrentContext();
                     context.setFiber(data.fiber.get());
                     context.useRecursionGuardsFrom(data.parent.getContext());
                     fiberThread.set(context.getThread());
                     context.getThread().setFiberCurrentThread(data.parent);
+
+                    Thread thread = Thread.currentThread();
+                    String oldName = thread.getName();
+                    thread.setName("Fiber thread for block at: " + block.getBinding().getFile() + ":" + block.getBinding().getLine());
 
                     try {
                         IRubyObject init = data.queue.pop(context);
@@ -315,17 +319,22 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
                         if (data.prev != null) {
                             data.prev.thread.raise(JavaUtil.convertJavaToUsableRubyObject(runtime, t));
                         }
+                    } finally {
+                        thread.setName(oldName);
                     }
+                });
+
+                // Successfully submitted to executor, break out of retry loop
+                break;
+            } catch (OutOfMemoryError oome) {
+                String oomeMessage = oome.getMessage();
+                if (!retried && oomeMessage != null && oomeMessage.contains("unable to create new native thread")) {
+                    // try to clean out stale enumerator threads by forcing GC
+                    System.gc();
+                    retried = true;
+                } else {
+                    throw oome;
                 }
-            });
-        } catch (OutOfMemoryError oome) {
-            String oomeMessage = oome.getMessage();
-            if (!retried && oomeMessage != null && oomeMessage.contains("unable to create new native thread")) {
-                // try to clean out stale enumerator threads by forcing GC
-                System.gc();
-                retried = true;
-            } else {
-                throw oome;
             }
         }
         


### PR DESCRIPTION
This patch sets the name of the threads used to drive fibers (or the similar Enumerator#next coroutines) in order to more easily audit and debug those threads. Relates to #5671 and fixes #5670.