### PR TITLE
[test] public field accessiblity in default package

### DIFF
--- a/spec/java_integration/packages/access_spec.rb
+++ b/spec/java_integration/packages/access_spec.rb
@@ -113,4 +113,10 @@ describe "class in default package" do
       Java::BadStaticInit.new
     end.to raise_error(NameError)
   end
+
+  it "has accessible public fields" do
+    expect( Java::DefaultPackageClass.new.x ).to eql 0
+    expect( Java::DefaultPackageClass.anY ).to eql 1
+  end
+
 end

--- a/test/DefaultPackageClass.java
+++ b/test/DefaultPackageClass.java
@@ -1,4 +1,8 @@
 public class DefaultPackageClass {
+
+    public transient int x;
+    public static long anY = 1L;
+
     public String foo() { return "foo"; }
 
     public static int compareTo(org.jruby.RubyObject o1, org.jruby.RubyObject o2) {


### PR DESCRIPTION
reported as GH-5684 ... 

after the proper fix is in https://github.com/headius/backport9/pull/1 (backport9 gets updated)