### PR TITLE
Test that lazy enumerator doesn't pre-evaluate

### DIFF
--- a/spec/ruby/core/enumerator/lazy/select_spec.rb
+++ b/spec/ruby/core/enumerator/lazy/select_spec.rb
@@ -5,4 +5,44 @@ require_relative 'shared/select'
 
 describe "Enumerator::Lazy#select" do
   it_behaves_like :enumerator_lazy_select, :select
+
+  it "doesn't pre-evaluate the next element" do
+    eval_count = 0
+    enum = %w[Text1 Text2 Text3].lazy.select do
+      eval_count += 1
+      true
+    end
+
+    lambda {
+      enum.next
+    }.should change { eval_count }.from(0).to(1)
+  end
+
+  it "doesn't over-evaluate when peeked" do
+    eval_count = 0
+    enum = %w[Text1 Text2 Text3].lazy.select do
+      eval_count += 1
+      true
+    end
+
+    lambda {
+      enum.peek
+      enum.peek
+    }.should change { eval_count }.from(0).to(1)
+  end
+
+  it "doesn't re-evaluate after peek" do
+    eval_count = 0
+    enum = %w[Text1 Text2 Text3].lazy.select do
+      eval_count += 1
+      true
+    end
+
+    lambda {
+      enum.peek
+      enum.next
+    }.should change { eval_count }.from(0).to(1)
+  end
 end
+
+


### PR DESCRIPTION
@headius These are some simple tests for the lazy enumerator issue you pushed patches for recently.  Unfortunately I haven't been able to get the build environment set up correctly to run them myself and see why they're failing (I keep getting a (OpenSSL::X509::StoreError) setting default path failed: No password supplied for PKCS#12 KeyStore error when attempting `mvn -Pbootstrap`)