### PR TITLE
[ji] align Java array (with post 1.8 conventions)

### DIFF
--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -754,15 +754,13 @@ public final class ArrayJavaProxy extends JavaProxy {
         final int arrayLength = Array.getLength( array );
 
         if ( rFirst instanceof RubyFixnum && rLength instanceof RubyFixnum ) {
-            int first = (int) ((RubyFixnum) rFirst).getLongValue();
-            int length = (int) ((RubyFixnum) rLength).getLongValue();
+            int first = RubyFixnum.fix2int((RubyFixnum) rFirst);
+            int length = RubyFixnum.fix2int((RubyFixnum) rLength);
 
             if ( length > arrayLength ) {
-                throw context.runtime.newIndexError("length specifed is longer than array");
+                throw context.runtime.newIndexError("length specified is longer than array");
             }
-            if ( length <= 0 ) {
-                return ArrayUtils.emptyJavaArrayDirect(context, array.getClass().getComponentType());
-            }
+            if ( length < 0 ) return context.nil;
 
             first = first >= 0 ? first : arrayLength + first;
             return ArrayUtils.javaArraySubarrayDirect(context, array, first, length);

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -730,16 +730,18 @@ public final class ArrayJavaProxy extends JavaProxy {
             int last = RubyFixnum.fix2int((RubyFixnum) rLast);
 
             first = first >= 0 ? first : arrayLength + first;
+            if (first < 0 || first >= arrayLength) return context.nil;
+
             last = last >= 0 ? last : arrayLength + last;
 
             int newLength = last - first;
             if ( !range.isExcludeEnd() ) newLength++;
 
-            if ( newLength <= 0 ) {
+            if (newLength <= 0) {
                 return ArrayUtils.emptyJavaArrayDirect(context, array.getClass().getComponentType());
             }
 
-            return ArrayUtils.javaArraySubarrayDirect(context, array, first, newLength);
+            return subarrayProxy(context, array, arrayLength, first, newLength);
         }
         throw context.runtime.newTypeError("only Integer ranges supported");
     }
@@ -757,15 +759,27 @@ public final class ArrayJavaProxy extends JavaProxy {
             int first = RubyFixnum.fix2int((RubyFixnum) rFirst);
             int length = RubyFixnum.fix2int((RubyFixnum) rLength);
 
-            if ( length > arrayLength ) {
+            if (length > arrayLength) {
                 throw context.runtime.newIndexError("length specified is longer than array");
             }
-            if ( length < 0 ) return context.nil;
+            if (length < 0) return context.nil;
 
             first = first >= 0 ? first : arrayLength + first;
-            return ArrayUtils.javaArraySubarrayDirect(context, array, first, length);
+
+            if (first >= arrayLength) return context.nil;
+
+            return subarrayProxy(context, array, arrayLength, first, length);
         }
         throw context.runtime.newTypeError("only Integer ranges supported");
+    }
+
+    private IRubyObject subarrayProxy(ThreadContext context, Object ary, final int aryLength, int index, int size) {
+        if (index + size > aryLength) size = aryLength - index;
+
+        ArrayJavaProxy proxy = ArrayUtils.newProxiedArray(context.runtime, ary.getClass().getComponentType(), converter, size);
+        System.arraycopy(ary, index, proxy.getObject(), 0, size);
+
+        return proxy;
     }
 
     private static final class ArrayNewMethod extends org.jruby.internal.runtime.methods.JavaMethod.JavaMethodOne {

--- a/core/src/main/java/org/jruby/java/util/ArrayUtils.java
+++ b/core/src/main/java/org/jruby/java/util/ArrayUtils.java
@@ -107,7 +107,7 @@ public class ArrayUtils {
     }
 
     private static RaiseException mapIndexOutOfBoundsException(final Ruby runtime, final Object array, int index) {
-        return runtime.newArgumentError("index out of bounds for java array (" +
+        return runtime.newIndexError("index out of bounds for java array (" +
                 index + " for length " + Array.getLength(array) + ')');
     }
 

--- a/spec/java_integration/types/array_spec.rb
+++ b/spec/java_integration/types/array_spec.rb
@@ -1345,9 +1345,9 @@ describe "ArrayJavaProxy" do
       expect( %w|a b c d e|.to_java[6, 2] ).to be nil
     end
 
-    # it "returns nil if length is negative with [index, length]" do
-    #   expect( %w|a b c d e|.to_java[3, -1] ).to be nil
-    # end
+    it "returns nil if length is negative with [index, length]" do
+      expect( %w|a b c d e|.to_java[3, -1] ).to be nil
+    end
 
     it "returns nil if no requested index is in the array with [m..n]" do
       expect( %w|a b c d e|.to_java[6..10] ).to be nil

--- a/spec/java_integration/types/array_spec.rb
+++ b/spec/java_integration/types/array_spec.rb
@@ -1349,17 +1349,22 @@ describe "ArrayJavaProxy" do
       expect( %w|a b c d e|.to_java[3, -1] ).to be nil
     end
 
+    it 'raises IndexError for invalid [index]' do
+      expect { [ "a", "b", "c", "d", "e" ].to_java[-10] }.to raise_error(IndexError)
+      expect { [ "a", "b", "c", "d", "e" ].to_java[5] }.to raise_error(IndexError)
+    end
+
     it "returns nil if no requested index is in the array with [m..n]" do
       expect( %w|a b c d e|.to_java[6..10] ).to be nil
     end
 
-    # it "returns nil if range start is not in the array with [m..n]" do
-    #   expect( [ "a", "b", "c", "d", "e" ].to_java[-10..2] ).to be nil
-    #   expect( [ "a", "b", "c", "d", "e" ].to_java[10..12] ).to be nil
-    # end
-    it 'raises IndexError for invalid [index]' do
-      expect { [ "a", "b", "c", "d", "e" ].to_java[-10] }.to raise_error(IndexError)
-      expect { [ "a", "b", "c", "d", "e" ].to_java[5] }.to raise_error(IndexError)
+    it "returns sub-array even if upper range is out of array [m..n]" do
+      expect( %w|a b c d e|.to_java[3..10] ).to eql ['d', 'e'].to_java
+    end
+
+    it "returns nil if range start is not in the array with [m..n]" do
+      expect( [ "a", "b", "c", "d", "e" ].to_java[10..12] ).to be nil
+      expect( [ "a", "b", "c", "d", "e" ].to_java[-10..2] ).to be nil
     end
 
     it "returns a subarray where m, n negatives and m < n with [m..n]" do

--- a/spec/java_integration/types/array_spec.rb
+++ b/spec/java_integration/types/array_spec.rb
@@ -1324,7 +1324,7 @@ describe "ArrayJavaProxy" do
     end
 
     it "raises an ArgumentError when 2 or more arguments are passed" do
-      expect { [:a, :b].to_java.at(0,1) }.to raise_error(ArgumentError)
+      expect { [:a, :b].to_java.at(0, 1) }.to raise_error(ArgumentError)
     end
 
   end
@@ -1357,6 +1357,10 @@ describe "ArrayJavaProxy" do
     #   expect( [ "a", "b", "c", "d", "e" ].to_java[-10..2] ).to be nil
     #   expect( [ "a", "b", "c", "d", "e" ].to_java[10..12] ).to be nil
     # end
+    it 'raises IndexError for invalid [index]' do
+      expect { [ "a", "b", "c", "d", "e" ].to_java[-10] }.to raise_error(IndexError)
+      expect { [ "a", "b", "c", "d", "e" ].to_java[5] }.to raise_error(IndexError)
+    end
 
     it "returns a subarray where m, n negatives and m < n with [m..n]" do
       expect( [ "a", "b", "c", "d", "e" ].to_java[-3..-2] ).to eql ["c", "d"].to_java

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -304,7 +304,7 @@ class TestHigherJavasupport < Test::Unit::TestCase
     assert_equal [10, 1234], array.entries
     assert_equal 10, array.min
 
-    assert_raises(ArgumentError) { array[3] } # IndexOutOfBoundsException
+    assert_raises(IndexError) { array[3] } # IndexOutOfBoundsException
 
     array = Java::int[5].new
     assert_equal 5, array.size
@@ -313,8 +313,8 @@ class TestHigherJavasupport < Test::Unit::TestCase
     assert_equal 1, array[1]
     assert_equal 4, array.max
 
-    assert_raises(ArgumentError) { array[6] } # IndexOutOfBoundsException
-    assert_raises(ArgumentError) { array[-1] } # IndexOutOfBoundsException
+    assert_raises(IndexError) { array[6] } # IndexOutOfBoundsException
+    assert_raises(IndexError) { array[-1] } # IndexOutOfBoundsException
 
     room_array = Room[1].new
     assert_equal 1, room_array.length


### PR DESCRIPTION
- `j_ary = [ 1 ].to_java; j_ary[2]` shall raise `IndexError` (instead of `ArgumentError`)
- handle edge cases e.g. `[ "a", "b", "c" ].to_java[-10..2]` similar to a Ruby `Array` (`nil`)

the first one might be considered a bug as well as a breaking change -> maybe target 9.3?