### PR TITLE
[ji] support java.math.BigDecimal#to_d

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -114,6 +114,7 @@ public class Java implements Library {
         org.jruby.javasupport.ext.JavaUtilRegex.define(runtime);
         org.jruby.javasupport.ext.JavaIo.define(runtime);
         org.jruby.javasupport.ext.JavaNet.define(runtime);
+        org.jruby.javasupport.ext.JavaMath.define(runtime);
 
         // load Ruby parts of the 'java' library
         runtime.getLoadService().load("jruby/java.rb", false);

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -32,9 +32,7 @@ import org.jruby.*;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyModule;
-import org.jruby.ext.bigdecimal.RubyBigDecimal;
 import org.jruby.internal.runtime.methods.JavaMethod;
-import org.jruby.javasupport.Java;
 import org.jruby.javasupport.JavaClass;
 import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
@@ -351,9 +349,6 @@ public abstract class JavaLang {
             if (val instanceof java.math.BigInteger) { // NOTE: should be moved into its own?
                 return RubyBignum.newBignum(context.runtime, (java.math.BigInteger) val);
             }
-            if (val instanceof java.math.BigDecimal) { // NOTE: should be moved into its own?
-                return RubyBignum.newBignum(context.runtime, ((java.math.BigDecimal) val).toBigInteger());
-            }
             return context.runtime.newFixnum(val.longValue());
         }
 
@@ -386,17 +381,7 @@ public abstract class JavaLang {
 
             // NOTE: a basic stub that always coverts Java numbers to Ruby ones (for simplicity)
             // gist being this is not expected to be used heavily, if so should get special care
-            final IRubyObject value;
-            if (val instanceof java.math.BigDecimal) {
-                final RubyClass klass = context.runtime.getClass("BigDecimal");
-                if (klass == null) { // user should require 'bigdecimal'
-                    throw context.runtime.newNameError("uninitialized constant BigDecimal", "BigDecimal");
-                }
-                value = new RubyBigDecimal(context.runtime, klass, (java.math.BigDecimal) val);
-            }
-            else {
-                value = convertJavaToUsableRubyObject(context.runtime, val);
-            }
+            final IRubyObject value = convertJavaToUsableRubyObject(context.runtime, val);
             return context.runtime.newArray(type, value);
         }
 

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaMath.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaMath.java
@@ -1,0 +1,96 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2019 The JRuby Team
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby.javasupport.ext;
+
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.RubyModule;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.anno.JRubyModule;
+import org.jruby.ext.bigdecimal.RubyBigDecimal;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import static org.jruby.javasupport.JavaUtil.unwrapIfJavaObject;
+
+/**
+ * Java::JavaMath package extensions.
+ *
+ * @author kares
+ */
+public class JavaMath {
+
+    public static void define(final Ruby runtime) {
+        JavaExtensions.put(runtime, java.math.BigDecimal.class, (proxyClass) -> BigDecimal.define(runtime, proxyClass));
+    }
+
+    @JRubyModule(name = "Java::JavaMath::BigDecimal")
+    public static class BigDecimal {
+
+        static RubyModule define(final Ruby runtime, final RubyModule proxy) {
+            proxy.defineAnnotatedMethods(BigDecimal.class);
+            return proxy;
+        }
+
+        @JRubyMethod(name = "to_d") // bigdecimal/util.rb
+        public static IRubyObject to_d(ThreadContext context, IRubyObject self) {
+            return asRubyBigDecimal(context.runtime, unwrapIfJavaObject(self));
+        }
+
+        @JRubyMethod(name = "to_f") // override from java.lang.Number
+        public static IRubyObject to_f(ThreadContext context, IRubyObject self) {
+            return asRubyBigDecimal(context.runtime, unwrapIfJavaObject(self)).to_f();
+        }
+
+        @JRubyMethod(name = { "to_i", "to_int" }) // override from java.lang.Number
+        public static IRubyObject to_i(ThreadContext context, IRubyObject self) {
+            return asRubyBigDecimal(context.runtime, unwrapIfJavaObject(self)).to_int(context);
+        }
+
+        @JRubyMethod(name = "coerce") // override from java.lang.Number
+        public static IRubyObject coerce(final ThreadContext context, final IRubyObject self, final IRubyObject type) {
+            return context.runtime.newArray(type, asRubyBigDecimal(context.runtime, unwrapIfJavaObject(self)));
+        }
+
+        @JRubyMethod(name = "to_r")
+        public static IRubyObject to_r(ThreadContext context, IRubyObject self) {
+            return asRubyBigDecimal(context.runtime, unwrapIfJavaObject(self)).to_r(context);
+        }
+
+        private static RubyBigDecimal asRubyBigDecimal(final Ruby runtime, final java.math.BigDecimal value) {
+            final RubyClass klass = runtime.getClass("BigDecimal");
+            if (klass == null) { // user should require 'bigdecimal'
+                throw runtime.newNameError("uninitialized constant BigDecimal", "BigDecimal");
+            }
+            return new RubyBigDecimal(runtime, klass, value);
+        }
+
+    }
+
+}

--- a/spec/java_integration/extensions/math_spec.rb
+++ b/spec/java_integration/extensions/math_spec.rb
@@ -1,0 +1,41 @@
+require File.dirname(__FILE__) + "/../spec_helper"
+
+describe "java.math.BigDecimal extensions" do
+
+  it 'supports zero? / nonzero? protocol' do
+    val = java.math.BigDecimal::ZERO
+    expect( val.zero? ).to eql true
+    val = java.math.BigDecimal.new('0')
+    expect( val.nonzero? ).to be nil
+    expect( val.zero? ).to eql true
+    expect( val.nonzero? ).to be nil
+
+    val = java.math.BigDecimal.new('0.1')
+    expect( val.zero? ).to eql false
+    expect( val.nonzero? ).to eql val
+    val = java.math.BigDecimal.new('0.00001')
+    expect( val.zero? ).to eql false
+    expect( val.nonzero? ).to eql val
+  end
+
+  it 'converts to a Float' do
+    val = java.math.BigDecimal.new('0.1')
+    expect( val.to_f ).to eql 0.1
+
+    val = java.math.BigDecimal.new('0.0')
+    expect( val.to_f ).to be_a Float
+    expect( val.to_f ).to eql 0.0
+  end
+
+  before(:all) { require 'bigdecimal' }
+
+  it 'supports to_d conversion' do
+    val = java.math.BigDecimal::ZERO
+    expect( val.to_d ).to be_a BigDecimal
+    expect( val.to_d.zero? ).to be true
+
+    val = java.math.BigDecimal.new('100.123')
+    expect( val.to_d ).to eql BigDecimal('100.123')
+  end
+
+end


### PR DESCRIPTION
`to_d` is a convention used by Ruby's BigDecimal (from bigdecimal/util.rb)

also explicitly re-def inherited Java Number extensions

NOTE: a reminder that this won't have negative impact on loading, since Java extension are lazy