### PR TITLE
#5699:adding the javax maven dependency to avoid "javax.annotation.Ge…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -251,6 +251,11 @@ DO NOT MODIFIY - GENERATED CODE
       <artifactId>backport9</artifactId>
       <version>1.3</version>
     </dependency>
+      <dependency>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+          <version>3.0.2</version>
+      </dependency>
   </dependencies>
   <build>
     <defaultGoal>package</defaultGoal>
@@ -641,6 +646,14 @@ DO NOT MODIFIY - GENERATED CODE
           </execution>
         </executions>
       </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <source>9</source>
+                <target>9</target>
+            </configuration>
+        </plugin>
     </plugins>
   </build>
   <profiles>


### PR DESCRIPTION
fixed the issue annotation not found compiler error.