### PR TITLE
Make the PosixShim errno field into a thread-local

### DIFF
--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -486,7 +486,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         }
 
         if (fptr.posix.ftruncate(fptr.fd(), pos) < 0) {
-            throw runtime.newErrnoFromErrno(fptr.posix.errno, fptr.getPath());
+            throw runtime.newErrnoFromErrno(fptr.posix.getErrno(), fptr.getPath());
         }
 
         return RubyFixnum.zero(runtime);

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1267,7 +1267,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         PosixShim shim = new PosixShim(runtime);
         ret = shim.open(runtime.getCurrentDirectory(), data.fname, data.oflags, data.perm);
         if (ret == null) {
-            data.errno = shim.errno;
+            data.errno = shim.getErrno();
             return null;
         }
         ChannelFD fd = new ChannelFD(ret, runtime.getPosix(), runtime.getFilenoUtil());
@@ -1389,14 +1389,14 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
             n = fptr.posix.write(fptr.fd(), strByteList.unsafeBytes(), strByteList.begin(), strByteList.getRealSize(), true);
 
             if (n == -1) {
-                if (fptr.posix.errno == Errno.EWOULDBLOCK || fptr.posix.errno == Errno.EAGAIN) {
+                if (fptr.posix.getErrno() == Errno.EWOULDBLOCK || fptr.posix.getErrno() == Errno.EAGAIN) {
                     if (no_exception) {
                         return runtime.newSymbol("wait_writable");
                     } else {
                         throw runtime.newErrnoEAGAINWritableError("write would block");
                     }
                 }
-                throw runtime.newErrnoFromErrno(fptr.posix.errno, fptr.getPath());
+                throw runtime.newErrnoFromErrno(fptr.posix.getErrno(), fptr.getPath());
             }
         } finally {
             if (locked) fptr.unlock();
@@ -4133,7 +4133,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         PosixShim posix = new PosixShim(runtime);
         Channel[] fds = posix.pipe();
         if (fds == null)
-            throw runtime.newErrnoFromErrno(posix.errno, "opening pipe");
+            throw runtime.newErrnoFromErrno(posix.getErrno(), "opening pipe");
 
 //        args[0] = klass;
 //        args[1] = INT2NUM(pipes[0]);

--- a/core/src/main/java/org/jruby/util/io/OpenFile.java
+++ b/core/src/main/java/org/jruby/util/io/OpenFile.java
@@ -40,7 +40,6 @@ import org.jruby.exceptions.RaiseException;
 import org.jruby.ext.fcntl.FcntlLibrary;
 import org.jruby.platform.Platform;
 import org.jruby.runtime.Block;
-import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
@@ -393,14 +392,14 @@ public class OpenFile implements Finalizable {
 
         if (wbuf.len != 0) {
             if (io_fflush(context) < 0) {
-                throw runtime.newErrnoFromErrno(posix.errno, "error flushing");
+                throw runtime.newErrnoFromErrno(posix.getErrno(), "error flushing");
             }
         }
         if (tiedIOForWriting != null) {
             OpenFile wfptr;
             wfptr = tiedIOForWriting.getOpenFileChecked();
             if (wfptr.io_fflush(context) < 0) {
-                throw runtime.newErrnoFromErrno(wfptr.posix.errno, wfptr.getPath());
+                throw runtime.newErrnoFromErrno(wfptr.posix.getErrno(), wfptr.getPath());
             }
         }
     }
@@ -443,11 +442,11 @@ public class OpenFile implements Finalizable {
     public boolean waitWritable(ThreadContext context, long timeout) {
         boolean locked = lock();
         try {
-            if (posix.errno == null) return false;
+            if (posix.getErrno() == null) return false;
 
             checkClosed();
 
-            switch (posix.errno) {
+            switch (posix.getErrno()) {
                 case EINTR:
                     //            case ERESTART: // not defined in jnr-constants
                     runtime.getCurrentContext().pollThreadEvents();
@@ -473,11 +472,11 @@ public class OpenFile implements Finalizable {
     public boolean waitReadable(ThreadContext context, long timeout) {
         boolean locked = lock();
         try {
-            if (posix.errno == null) return false;
+            if (posix.getErrno() == null) return false;
 
             checkClosed();
 
-            switch (posix.errno) {
+            switch (posix.getErrno()) {
                 case EINTR:
                     //            case ERESTART: // not defined in jnr-constants
                     runtime.getCurrentContext().pollThreadEvents();
@@ -590,7 +589,7 @@ public class OpenFile implements Finalizable {
         if (0 <= r) {
             wbuf.off += r;
             wbuf.len -= r;
-            posix.errno = Errno.EAGAIN;
+            posix.setErrno(Errno.EAGAIN);
         }
         return -1;
     }
@@ -656,9 +655,9 @@ public class OpenFile implements Finalizable {
         boolean locked = lock();
         try {
             if (io_fflush(context) < 0)
-                throw context.runtime.newErrnoFromErrno(posix.errno, "");
+                throw context.runtime.newErrnoFromErrno(posix.getErrno(), "");
             unread(context);
-            posix.errno = null;
+            posix.setErrno(null);
         } finally {
             if (locked) unlock();
         }
@@ -877,7 +876,7 @@ public class OpenFile implements Finalizable {
             }
             else {
                 if (io_fflush(context) < 0 && err == context.nil) {
-                    err = RubyFixnum.newFixnum(runtime, posix.errno == null ? 0 :posix.errno.longValue());
+                    err = RubyFixnum.newFixnum(runtime, posix.getErrno() == null ? 0 : posix.getErrno().longValue());
                 }
             }
         }
@@ -892,19 +891,19 @@ public class OpenFile implements Finalizable {
 	        /* stdio_file is deallocated anyway
              * even if fclose failed.  */
             if (posix.close(stdio_file) < 0 && err.isNil())
-                err = noraise ? context.tru : RubyNumeric.int2fix(runtime, posix.errno.intValue());
+                err = noraise ? context.tru : RubyNumeric.int2fix(runtime, posix.getErrno().intValue());
         } else if (fd != null) {
             /* fptr->fd may be closed even if close fails.
              * POSIX doesn't specify it.
              * We assumes it is closed.  */
             if ((posix.close(fd) < 0) && err.isNil())
-                err = noraise ? context.tru : runtime.newFixnum(posix.errno.intValue());
+                err = noraise ? context.tru : runtime.newFixnum(posix.getErrno().intValue());
         }
 
         if (!err.isNil() && !noraise) {
             if (err instanceof RubyFixnum || err instanceof RubyBignum) {
-                posix.errno = Errno.valueOf(RubyNumeric.num2int(err));
-                throw runtime.newErrnoFromErrno(posix.errno, pathv);
+                posix.setErrno(Errno.valueOf(RubyNumeric.num2int(err)));
+                throw runtime.newErrnoFromErrno(posix.getErrno(), pathv);
             } else {
                 throw ((RubyException)err).toThrowable();
             }
@@ -1282,7 +1281,7 @@ public class OpenFile implements Finalizable {
                         if (waitReadable(context, fd)) {
                             continue retry;
                         }
-                        throw context.runtime.newErrnoFromErrno(posix.errno, "channel: " + fd + (pathv != null ? " " + pathv : ""));
+                        throw context.runtime.newErrnoFromErrno(posix.getErrno(), "channel: " + fd + (pathv != null ? " " + pathv : ""));
                     }
                     break;
                 }
@@ -1410,12 +1409,12 @@ public class OpenFile implements Finalizable {
         boolean locked = lock();
         try {
             if (!fd.ch.isOpen()) {
-                posix.errno = Errno.EBADF;
+                posix.setErrno(Errno.EBADF);
                 return false;
             }
 
-            if (posix.errno != null && posix.errno != Errno.EAGAIN
-                    && posix.errno != Errno.EWOULDBLOCK && posix.errno != Errno.EINTR) {
+            if (posix.getErrno() != null && posix.getErrno() != Errno.EAGAIN
+                    && posix.getErrno() != Errno.EWOULDBLOCK && posix.getErrno() != Errno.EINTR) {
                 // Encountered a permanent error. Don't read again.
                 return false;
             }
@@ -1792,7 +1791,7 @@ public class OpenFile implements Finalizable {
         bufreadCall(context, arg);
         len = arg.len;
         // should be errno
-        if (len < 0) throw context.runtime.newErrnoFromErrno(posix.errno, pathv);
+        if (len < 0) throw context.runtime.newErrnoFromErrno(posix.getErrno(), pathv);
         return len;
     }
 
@@ -1968,10 +1967,10 @@ public class OpenFile implements Finalizable {
             if (rbuf.len == 0 || (mode & DUPLEX) != 0)
                 return;
             /* xxx: target position may be negative if buffer is filled by ungetc */
-            posix.errno = null;
+            posix.setErrno(null);
             r = posix.lseek(fd, -rbuf.len, PosixShim.SEEK_CUR);
-            if (r == -1 && posix.errno != null) {
-                if (posix.errno == Errno.ESPIPE)
+            if (r == -1 && posix.getErrno() != null) {
+                if (posix.getErrno() == Errno.ESPIPE)
                     mode |= DUPLEX;
                 return;
             }
@@ -2017,8 +2016,8 @@ public class OpenFile implements Finalizable {
             //        }
 
             pos = posix.lseek(fd, 0, PosixShim.SEEK_CUR);
-            if (pos == -1 && posix.errno != null) {
-                if (posix.errno == Errno.ESPIPE)
+            if (pos == -1 && posix.getErrno() != null) {
+                if (posix.getErrno() == Errno.ESPIPE)
                     mode |= DUPLEX;
                 return;
             }
@@ -2049,7 +2048,7 @@ public class OpenFile implements Finalizable {
                 }
                 read_size = readInternal(context, this, fd, bufBytes, buf, rbuf.len + newlines);
                 if (read_size < 0) {
-                    throw runtime.newErrnoFromErrno(posix.errno, pathv);
+                    throw runtime.newErrnoFromErrno(posix.getErrno(), pathv);
                 }
                 if (read_size == rbuf.len) {
                     posix.lseek(fd, r, PosixShim.SEEK_SET);
@@ -2214,7 +2213,7 @@ public class OpenFile implements Finalizable {
                     if (0 <= r) {
                         offset += r;
                         n -= r;
-                        posix.errno = Errno.EAGAIN;
+                        posix.setErrno(Errno.EAGAIN);
                     }
                     if (waitWritable(context)) {
                         checkClosed();
@@ -2354,7 +2353,7 @@ public class OpenFile implements Finalizable {
                             }
                             break retry;
                         }
-                        return noalloc ? runtime.getTrue() : RubyFixnum.newFixnum(runtime, (posix.errno == null) ? 0 : posix.errno.longValue());
+                        return noalloc ? runtime.getTrue() : RubyFixnum.newFixnum(runtime, (posix.getErrno() == null) ? 0 : posix.getErrno().longValue());
                     }
                     if (res == EConvResult.InvalidByteSequence ||
                             res == EConvResult.IncompleteInput ||
@@ -2370,7 +2369,7 @@ public class OpenFile implements Finalizable {
             while (res == EConvResult.DestinationBufferFull) {
                 if (wbuf.len == wbuf.capa) {
                     if (io_fflush(context) < 0)
-                        return noalloc ? context.tru : runtime.newFixnum(posix.errno == null ? 0 : posix.errno.longValue());
+                        return noalloc ? context.tru : runtime.newFixnum(posix.getErrno() == null ? 0 : posix.getErrno().longValue());
                 }
 
                 dsBytes = wbuf.ptr;
@@ -2557,11 +2556,11 @@ public class OpenFile implements Finalizable {
     }
 
     public Errno errno() {
-        return posix.errno;
+        return posix.getErrno();
     }
 
     public void errno(Errno newErrno) {
-        posix.errno = newErrno;
+        posix.setErrno(newErrno);
     }
 
     public static int cloexecDup2(PosixShim posix, ChannelFD oldfd, ChannelFD newfd) {
@@ -2602,7 +2601,7 @@ public class OpenFile implements Finalizable {
             int flags, flags2, ret;
             flags = posix.fcntlGetFD(fd); /* should not fail except EBADF. */
             if (flags == -1) {
-                throw new AssertionError(String.format("BUG: rb_maygvl_fd_fix_cloexec: fcntl(%d, F_GETFD) failed: %s", fd, posix.errno.description()));
+                throw new AssertionError(String.format("BUG: rb_maygvl_fd_fix_cloexec: fcntl(%d, F_GETFD) failed: %s", fd, posix.getErrno().description()));
             }
             if (fd <= 2)
                 flags2 = flags & ~FcntlLibrary.FD_CLOEXEC; /* Clear CLOEXEC for standard file descriptors: 0, 1, 2. */
@@ -2611,7 +2610,7 @@ public class OpenFile implements Finalizable {
             if (flags != flags2) {
                 ret = posix.fcntlSetFD(fd, flags2);
                 if (ret == -1) {
-                    throw new AssertionError(String.format("BUG: rb_maygvl_fd_fix_cloexec: fcntl(%d, F_SETFD, %d) failed: %s", fd, flags2, posix.errno.description()));
+                    throw new AssertionError(String.format("BUG: rb_maygvl_fd_fix_cloexec: fcntl(%d, F_SETFD, %d) failed: %s", fd, flags2, posix.getErrno().description()));
                 }
             }
         }

--- a/core/src/main/java/org/jruby/util/io/PopenExecutor.java
+++ b/core/src/main/java/org/jruby/util/io/PopenExecutor.java
@@ -543,13 +543,13 @@ public class PopenExecutor {
         switch (fmode & (OpenFile.READABLE|OpenFile.WRITABLE)) {
             case OpenFile.READABLE | OpenFile.WRITABLE:
                 if (API.rb_pipe(runtime, writePair) == -1)
-                    throw runtime.newErrnoFromErrno(posix.errno, prog.toString());
+                    throw runtime.newErrnoFromErrno(posix.getErrno(), prog.toString());
                 if (API.rb_pipe(runtime, pair) == -1) {
-                    e = posix.errno;
+                    e = posix.getErrno();
                     runtime.getPosix().close(writePair[1]);
                     runtime.getPosix().close(writePair[0]);
-                    posix.errno = e;
-                    throw runtime.newErrnoFromErrno(posix.errno, prog.toString());
+                    posix.setErrno(e);
+                    throw runtime.newErrnoFromErrno(posix.getErrno(), prog.toString());
                 }
 
                 if (eargp != null) prepareStdioRedirects(runtime, pair, writePair, eargp);
@@ -557,14 +557,14 @@ public class PopenExecutor {
                 break;
             case OpenFile.READABLE:
                 if (API.rb_pipe(runtime, pair) == -1)
-                    throw runtime.newErrnoFromErrno(posix.errno, prog.toString());
+                    throw runtime.newErrnoFromErrno(posix.getErrno(), prog.toString());
 
                 if (eargp != null) prepareStdioRedirects(runtime, pair, null, eargp);
 
                 break;
             case OpenFile.WRITABLE:
                 if (API.rb_pipe(runtime, pair) == -1)
-                    throw runtime.newErrnoFromErrno(posix.errno, prog.toString());
+                    throw runtime.newErrnoFromErrno(posix.getErrno(), prog.toString());
 
                 if (eargp != null) prepareStdioRedirects(runtime, null, pair, eargp);
 

--- a/core/src/main/java/org/jruby/util/io/PosixShim.java
+++ b/core/src/main/java/org/jruby/util/io/PosixShim.java
@@ -1,7 +1,6 @@
 package org.jruby.util.io;
 
 import java.io.Closeable;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channel;
@@ -55,20 +54,20 @@ public class PosixShim {
                     case SEEK_END:
                         return fd.chSeek.position(fd.chSeek.size() + offset).position();
                     default:
-                        errno = Errno.EINVAL;
+                        setErrno(Errno.EINVAL);
                         return -1;
                 }
             } catch (IllegalArgumentException e) {
-                errno = Errno.EINVAL;
+                setErrno(Errno.EINVAL);
                 return -1;
             } catch (IOException ioe) {
-                errno = Helpers.errnoFromException(ioe);
+                setErrno(Helpers.errnoFromException(ioe));
                 return -1;
             }
         } else if (fd.chNative != null) {
             // native channel, use native lseek
             long ret = posix.lseekLong(fd.chNative.getFD(), offset, type);
-            if (ret == -1) errno = Errno.valueOf(posix.errno());
+            if (ret == -1) setErrno(Errno.valueOf(posix.errno()));
             return ret;
         }
 
@@ -81,7 +80,7 @@ public class PosixShim {
             // stdio is not...so this bothers me slightly. -CON
             //
             // Original change made in 66b024fedbb2ee32316ccd9de8387931d07993ec
-            errno = Errno.EPIPE;
+            setErrno(Errno.EPIPE);
             return -1;
         }
 
@@ -101,7 +100,7 @@ public class PosixShim {
             }
 
             if (fd.chWrite == null) {
-                errno = Errno.EACCES;
+                setErrno(Errno.EACCES);
                 return -1;
             }
             int written = fd.chWrite.write(tmp);
@@ -109,14 +108,14 @@ public class PosixShim {
             if (written == 0 && length > 0) {
                 // if it's a nonblocking write against a file and we've hit EOF, do EAGAIN
                 if (nonblock) {
-                    errno = Errno.EAGAIN;
+                    setErrno(Errno.EAGAIN);
                     return -1;
                 }
             }
 
             return written;
         } catch (IOException ioe) {
-            errno = Helpers.errnoFromException(ioe);
+            setErrno(Helpers.errnoFromException(ioe));
             error = ioe;
             return -1;
         }
@@ -141,13 +140,13 @@ public class PosixShim {
                         if (position != -1 && size != -1 && position < size) {
                             // there should be bytes available...proceed
                         } else {
-                            errno = Errno.EAGAIN;
+                            setErrno(Errno.EAGAIN);
                             return -1;
                         }
                     } else if (fd.chNative != null && fd.isNativeFile) {
                         // it's a native file, so we don't do selection or nonblock
                     } else {
-                        errno = Errno.EAGAIN;
+                        setErrno(Errno.EAGAIN);
                         return -1;
                     }
                 }
@@ -161,7 +160,7 @@ public class PosixShim {
                 if (read == JAVA_EOF) {
                     read = NATIVE_EOF; // still treat EOF as EOF
                 } else if (read == 0) {
-                    errno = Errno.EAGAIN;
+                    setErrno(Errno.EAGAIN);
                     return -1;
                 } else {
                     return read;
@@ -173,7 +172,7 @@ public class PosixShim {
 
             return read;
         } catch (IOException ioe) {
-            errno = Helpers.errnoFromException(ioe);
+            setErrno(Helpers.errnoFromException(ioe));
             return -1;
         }
     }
@@ -193,7 +192,7 @@ public class PosixShim {
             // see jruby/jruby#3254 and jnr/jnr-posix#60
             int result = posix.flock(real_fd, lockMode);
             if (result < 0) {
-                errno = Errno.valueOf(posix.errno());
+                setErrno(Errno.valueOf(posix.errno()));
                 return -1;
             }
             return 0;
@@ -225,17 +224,17 @@ public class PosixShim {
                     }
                 }
             } catch (IOException ioe) {
-                errno = Helpers.errnoFromException(ioe);
+                setErrno(Helpers.errnoFromException(ioe));
                 return -1;
             } catch (OverlappingFileLockException ioe) {
-                errno = Errno.EINVAL;
+                setErrno(Errno.EINVAL);
                 errmsg = "overlapping file locks";
             }
             return lockFailedReturn(lockMode);
         } else {
             // We're not actually a real file, so we can't flock
             // FIXME: This needs to be ENOTSUP
-            errno = Errno.EINVAL;
+            setErrno(Errno.EINVAL);
             errmsg = "stream is not a file";
             return -1;
         }
@@ -260,7 +259,7 @@ public class PosixShim {
             if (errno == null) {
                 throw new RuntimeException("unknown IOException: " + ioe);
             }
-            this.errno = errno;
+            this.setErrno(errno);
             return -1;
         }
     }
@@ -281,11 +280,22 @@ public class PosixShim {
 
             return new Channel[]{source, sink};
         } catch (IOException ioe) {
-            errno = Helpers.errnoFromException(ioe);
+            setErrno(Helpers.errnoFromException(ioe));
             return null;
         }
     }
-    
+
+    /**
+     * The appropriate errno value for the last thrown error, if any.
+     */
+    public Errno getErrno() {
+        return errno.get();
+    }
+
+    public void setErrno(Errno errno) {
+        this.errno.set(errno);
+    }
+
     public interface WaitMacros {
         public abstract boolean WIFEXITED(long status);
         public abstract boolean WIFSIGNALED(long status);
@@ -390,7 +400,7 @@ public class PosixShim {
     public int setCloexec(int fd, boolean cloexec) {
         int ret = posix.fcntl(fd, Fcntl.F_GETFD);
         if (ret == -1) {
-            errno = Errno.valueOf(posix.errno());
+            setErrno(Errno.valueOf(posix.errno()));
             return -1;
         }
         if (
@@ -402,13 +412,13 @@ public class PosixShim {
                 ret | FcntlLibrary.FD_CLOEXEC :
                 ret & ~FcntlLibrary.FD_CLOEXEC;
         ret = posix.fcntlInt(fd, Fcntl.F_SETFD, ret);
-        if (ret == -1) errno = Errno.valueOf(posix.errno());
+        if (ret == -1) setErrno(Errno.valueOf(posix.errno()));
         return ret;
     }
 
     public int fcntlSetFD(int fd, int flags) {
         int ret = posix.fcntlInt(fd, Fcntl.F_SETFD, flags);
-        if (ret == -1) errno = Errno.valueOf(posix.errno());
+        if (ret == -1) setErrno(Errno.valueOf(posix.errno()));
         return ret;
     }
 
@@ -425,17 +435,17 @@ public class PosixShim {
         try {
             return JRubyFile.createResource(runtime, cwd, path).openChannel(flags, perm);
         } catch (ResourceException.FileExists e) {
-            errno = Errno.EEXIST;
+            setErrno(Errno.EEXIST);
         } catch (ResourceException.FileIsDirectory e) {
-            errno = Errno.EISDIR;
+            setErrno(Errno.EISDIR);
         } catch (ResourceException.FileIsNotDirectory e) {
-            errno = Errno.ENOTDIR;
+            setErrno(Errno.ENOTDIR);
         } catch (ResourceException.NotFound e) {
-            errno = Errno.ENOENT;
+            setErrno(Errno.ENOENT);
         } catch (ResourceException.PermissionDenied e) {
-            errno = Errno.EACCES;
+            setErrno(Errno.EACCES);
         } catch (ResourceException.TooManySymlinks e) {
-            errno = Errno.ELOOP;
+            setErrno(Errno.ELOOP);
         } catch (ResourceException ex) {
             throw ex.newRaiseException(runtime);
         } catch (IOException ex) {
@@ -490,17 +500,17 @@ public class PosixShim {
     public int ftruncate(ChannelFD fd, long pos) {
         if (fd.chNative != null) {
             int ret = posix.ftruncate(fd.chNative.getFD(), pos);
-            if (ret == -1) errno = Errno.valueOf(posix.errno());
+            if (ret == -1) setErrno(Errno.valueOf(posix.errno()));
             return ret;
         } else if (fd.chFile != null) {
             try {
                 fd.chFile.truncate(pos);
             } catch (IOException ioe) {
-                errno = Helpers.errnoFromException(ioe);
+                setErrno(Helpers.errnoFromException(ioe));
                 return -1;
             }
         } else {
-            errno = Errno.EINVAL;
+            setErrno(Errno.EINVAL);
             return -1;
         }
         return 0;
@@ -511,7 +521,7 @@ public class PosixShim {
             FileStat stat = posix.allocateStat();
             int ret = posix.fstat(fd.chNative.getFD(), stat);
             if (ret == -1) {
-                errno = Errno.valueOf(posix.errno());
+                setErrno(Errno.valueOf(posix.errno()));
                 return -1;
             }
             return stat.st_size();
@@ -519,18 +529,18 @@ public class PosixShim {
             try {
                 return fd.chSeek.size();
             } catch (IOException ioe) {
-                errno = Helpers.errnoFromException(ioe);
+                setErrno(Helpers.errnoFromException(ioe));
                 return -1;
             }
         } else {
             // otherwise just return -1 (should be rare, since size is only defined on File
-            errno = Errno.EINVAL;
+            setErrno(Errno.EINVAL);
             return -1;
         }
     }
 
     private void clear() {
-        errno = null;
+        setErrno(null);
         errmsg = null;
     }
 
@@ -545,7 +555,7 @@ public class PosixShim {
         // dependent, and so we will obey the JDK's policy of disallowing
         // exclusive locks on files opened only for read.
         if (fd.chWrite == null && (lockMode & LOCK_EX) > 0) {
-            errno = Errno.EINVAL;
+            setErrno(Errno.EINVAL);
             errmsg = "cannot acquire exclusive lock on File not opened for write";
             return -1;
         }
@@ -553,7 +563,7 @@ public class PosixShim {
         // Likewise, JDK does not allow acquiring a shared lock on files
         // that have not been opened for read. We comply here.
         if (fd.chRead == null && (lockMode & LOCK_SH) > 0) {
-            errno = Errno.EINVAL;
+            setErrno(Errno.EINVAL);
             errmsg = "cannot acquire shared lock on File not opened for read";
             return -1;
         }
@@ -632,10 +642,7 @@ public class PosixShim {
      */
     public Throwable error;
 
-    /**
-     * The appropriate errno value for the last thrown error, if any.
-     */
-    public Errno errno;
+    private ThreadLocal<Errno> errno = new ThreadLocal<>();
 
     /**
      * The recommended error message, if any.


### PR DESCRIPTION
In order to support concurrent reads and writes via the PosixShim,
we need to make errno be a thread-local. Some callers do their own
locking, releasing the lock before calling PosixShim, which causes
the errno updates and clears to step on other threads. It might be
possible to have those callers pass in their "unlock around" logic
as shown in #5706, but my first attempt did not work exactly right
and may introduces object overhead for stateful lambdas.

This implementation introduces thread-local read/write overhead to
all accessors of errno, but appears to be a clean way to keep this
field safe across concurrent IO operations.

Fixes #5706.