### PR TITLE
Re-add command line specs to CI and tag new failures

### DIFF
--- a/spec/jruby.mspec
+++ b/spec/jruby.mspec
@@ -61,6 +61,7 @@ class MSpecScript
       SPEC_DIR + '/library/net/http',
       # This requires --debug which slows down or changes other spec results
       SPEC_DIR + '/core/tracepoint',
+      *get(:command_line)
   ]
 
   set :fast, [

--- a/spec/tags/ruby/command_line/dash_encoding_tags.txt
+++ b/spec/tags/ruby/command_line/dash_encoding_tags.txt
@@ -1,0 +1,5 @@
+fails:The --encoding command line option does not accept a third encoding
+fails:The --encoding command line option sets Encoding.default_external and optionally Encoding.default_internal if given a single encoding with an =
+fails:The --encoding command line option sets Encoding.default_external and optionally Encoding.default_internal if given a single encoding as a separate argument
+fails:The --encoding command line option sets Encoding.default_external and optionally Encoding.default_internal if given two encodings with an =
+fails:The --encoding command line option sets Encoding.default_external and optionally Encoding.default_internal if given two encodings as a separate argument

--- a/spec/tags/ruby/command_line/dash_external_encoding_tags.txt
+++ b/spec/tags/ruby/command_line/dash_external_encoding_tags.txt
@@ -1,0 +1,2 @@
+fails:The --external-encoding command line option sets Encoding.default_external if given an encoding with an =
+fails:The --external-encoding command line option sets Encoding.default_external if given an encoding as a separate argument

--- a/spec/tags/ruby/command_line/dash_internal_encoding_tags.txt
+++ b/spec/tags/ruby/command_line/dash_internal_encoding_tags.txt
@@ -1,0 +1,2 @@
+fails:The --internal-encoding command line option sets Encoding.default_internal if given an encoding with an =
+fails:The --internal-encoding command line option sets Encoding.default_internal if given an encoding as a separate argument

--- a/spec/tags/ruby/command_line/dash_upper_i_tags.txt
+++ b/spec/tags/ruby/command_line/dash_upper_i_tags.txt
@@ -1,0 +1,2 @@
+fails:The -I command line option adds the path expanded from CWD to $LOAD_PATH
+fails:The -I command line option expands a path from CWD even if it does not exist

--- a/spec/tags/ruby/command_line/dash_upper_i_tags.txt
+++ b/spec/tags/ruby/command_line/dash_upper_i_tags.txt
@@ -1,2 +1,3 @@
+critical(fails on Travis):The -I command line option adds the path at the front of $LOAD_PATH
 fails:The -I command line option adds the path expanded from CWD to $LOAD_PATH
 fails:The -I command line option expands a path from CWD even if it does not exist

--- a/spec/tags/ruby/command_line/dash_upper_k_tags.txt
+++ b/spec/tags/ruby/command_line/dash_upper_k_tags.txt
@@ -1,2 +1,5 @@
 fails:The -K command line option sets __ENCODING__ to Encoding::Windows_31J with -Ks
 fails:The -K command line option sets __ENCODING__ to Encoding::Windows_31J with -KS
+fails:The -K command line option ignores unknown codes
+fails:The -K command line option sets __ENCODING__ and Encoding.default_external to Encoding::Windows_31J with -Ks
+fails:The -K command line option sets __ENCODING__ and Encoding.default_external to Encoding::Windows_31J with -KS

--- a/spec/tags/ruby/command_line/dash_upper_s_tags.txt
+++ b/spec/tags/ruby/command_line/dash_upper_s_tags.txt
@@ -1,0 +1,1 @@
+fails:The -S command line option runs launcher found in PATH, but only code after the first /#!.*ruby.*/-ish line in target file

--- a/spec/tags/ruby/command_line/dash_upper_x_tags.txt
+++ b/spec/tags/ruby/command_line/dash_upper_x_tags.txt
@@ -1,0 +1,3 @@
+fails:The -X command line option changes the PWD when using a file
+fails:The -X command line option does not need a space after -C for the argument
+fails:The -X command line option changes the PWD when using -e

--- a/spec/tags/ruby/command_line/dash_x_tags.txt
+++ b/spec/tags/ruby/command_line/dash_x_tags.txt
@@ -1,2 +1,3 @@
 windows:The -x command line option runs code after the first /#!.*ruby.*/-ish line in target file
 fails:The -x command line option runs code after the first /#!.*ruby.*/-ish line in target file
+fails:The -x command line option behaves as -x was set when non-ruby shebang is encountered on first line

--- a/spec/tags/ruby/command_line/feature_tags.txt
+++ b/spec/tags/ruby/command_line/feature_tags.txt
@@ -1,0 +1,2 @@
+fails:The --enable and --disable flags can be used with rubyopt
+fails:The --enable and --disable flags can be used with all

--- a/spec/tags/ruby/command_line/frozen_strings_tags.txt
+++ b/spec/tags/ruby/command_line/frozen_strings_tags.txt
@@ -1,0 +1,3 @@
+fails:The --enable-frozen-string-literal flag causes string literals to produce the same object for literals with the same content
+fails:The --enable-frozen-string-literal flag causes string literals to produce the same object for literals with the same content in different files
+fails:The --debug flag produces debugging info on attempted frozen string modification


### PR DESCRIPTION
At some point we stopped including the command line specs in our CI runs. This PR restores them and tags off failures from recent spec updates.

Fixes #5705.