### PR TITLE
Allow repeated close of any IO to succeed.

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1972,7 +1972,8 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
         fptr = openFile;
         checkInitialized();
-        return fptr.fd() == null;
+        ChannelFD fd = fptr.fd();
+        return fd == null || !fd.ch.isOpen();
     }
 
     /**

--- a/core/src/main/java/org/jruby/ext/socket/RubySocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubySocket.java
@@ -686,17 +686,6 @@ public class RubySocket extends RubyBasicSocket {
     }
 
     @Override
-    @JRubyMethod
-    public IRubyObject close(final ThreadContext context) {
-        if (getOpenFile() != null) {
-            if (isClosed()) return context.nil;
-            openFile.checkClosed();
-            return rbIoClose(context);
-        }
-        return context.nil;
-    }
-
-    @Override
     public RubyBoolean closed_p(ThreadContext context) {
         if (getOpenFile() == null) return context.fals;
 


### PR DESCRIPTION
This relates to #5709 but breaks at least one spec:

```
File.open opens a file with a file descriptor d and a block FAILED
Expected Errno::EBADF but no exception was raised (nil was returned)
/Users/headius/projects/jruby/spec/ruby/core/file/open_spec.rb:173:in `block in <main>'
```

There may be other failures, but it's debateable whether they
represent behavior we need to emulate.