### PR TITLE
use same parameter for DNS.allocate_request_id/free_request_id to fix leak

### DIFF
--- a/lib/ruby/stdlib/resolv.rb
+++ b/lib/ruby/stdlib/resolv.rb
@@ -783,7 +783,7 @@ class Resolv
           sock = @socks_hash[host.index(':') ? "::" : "0.0.0.0"]
           return nil if !sock
           service = [IPAddr.new(host), port]
-          id = DNS.allocate_request_id(host, port)
+          id = DNS.allocate_request_id(service[0].to_s, port)
           request = msg.encode
           request[0,2] = [id].pack('n')
           return @senders[[service, id]] =
@@ -795,7 +795,7 @@ class Resolv
             if @initialized
               super
               @senders.each_key {|service, id|
-                DNS.free_request_id(service[0], service[1], id)
+                DNS.free_request_id(service[0].to_s, service[1], id)
               }
               @initialized = false
             end


### PR DESCRIPTION
As described in logstash-plugins/logstash-filter-dns#52 

`resolv.rb` was updated from upstream Ruby stdlib starting at JRuby 9.2.0.0 which essentially re-introduced issue logstash-plugins/logstash-filter-dns#40 where all DNS request will eventually systematically time out.

This problem will only be triggered if there are multiple nameserver hosts specified OR if there is no nameserver host but there are more than one host in `/etc/resolv.conf` resulting in the usage of the `UnconnectedUDP` class in `resolv.rb`.

Essentially the problem is that the [`DNS.allocate_request_id(host, port)` call](https://github.com/jruby/jruby/blob/9.2.0.0/lib/ruby/stdlib/resolv.rb#L790) will cache the allocated id using the `host` and `port` parameters. 

But the cache cleanup will be done in the `close` method by the [DNS.free_request_id(service[0], service[1], id) call](https://github.com/jruby/jruby/blob/9.2.0.0/lib/ruby/stdlib/resolv.rb#L802) where the `service[0]` [will be `IPAddr.new(host)`](https://github.com/jruby/jruby/blob/9.2.0.0/lib/ruby/stdlib/resolv.rb#L789) and not the original `host` string used in the `sender` method leading to not finding the original cache key and not freeing it from the cache which is 64k elements wide and once full, the `allocate_request_id` method [will loop forever](https://github.com/jruby/jruby/blob/9.2.0.0/lib/ruby/stdlib/resolv.rb#L636-L638).

This fix just makes sure that the exact same parameters are used in both `DNS.allocate_request_id` and `DNS.free_request_id` using the `IPAddr#to_s` which will always yield the same host string. 

I am planning on submitting this issue upstream in Ruby but I figured I'd also submit here to provide a potential quicker turnaround for this nasty bug.
