### PR TITLE
Ignore nil for ifnone argument in Enumerable#find

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -4744,7 +4744,7 @@ float_loop:
             if (block.yield(context, value).isTrue()) return value;
         }
 
-        return ifnone != null ? sites(context).call.call(context, ifnone, ifnone) : context.nil;
+        return ifnone != null && !ifnone.isNil() ? sites(context).call.call(context, ifnone, ifnone) : context.nil;
     }
 
     public static void marshalTo(RubyArray array, MarshalStream output) throws IOException {

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -618,7 +618,7 @@ public class RubyEnumerable {
             return result[0];
         }
 
-        return ifnone != null ? ifnone.callMethod(context, "call") : runtime.getNil();
+        return ifnone != null && !ifnone.isNil() ? ifnone.callMethod(context, "call") : runtime.getNil();
     }
 
     @JRubyMethod

--- a/spec/ruby/core/enumerable/shared/find.rb
+++ b/spec/ruby/core/enumerable/shared/find.rb
@@ -49,6 +49,10 @@ describe :enumerable_find, shared: true do
     @empty.send(@method, fail_proc) {|e| true}.should == "yay"
   end
 
+  it "ignores the ifnone argument when nil" do
+    @numerous.send(@method, nil) {|e| false }.should == nil
+  end
+
   it "passes through the values yielded by #each_with_index" do
     [:a, :b].each_with_index.send(@method) { |x, i| ScratchPad << [x, i]; nil }
     ScratchPad.recorded.should == [[:a, 0], [:b, 1]]


### PR DESCRIPTION
MRI allows calling `find(nil)` and treats it as if no ifnone proc was
passed:

```
$ RBENV_VERSION=2.5.3 ruby -e 'puts [1,2,3].find(nil) { false }.inspect'
nil
$ RBENV_VERSION=jruby-9.2.7.0 ruby -e 'puts [1,2,3].find(nil) { false }.inspect'
NoMethodError: undefined method `call' for nil:NilClass
Did you mean?  caller
    find at org/jruby/RubyEnumerable.java:656
  <main> at -e:1
```