### PR TITLE
RFC: Do not add CLASSPATH to the module path

### DIFF
--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -374,10 +374,9 @@ if [ "$JRUBY_JSA" == "" ]; then
 fi
 
 # Determine whether to pass module-related flags
-classmod_flag="-classpath"
 if [ -d $JAVA_HOME/jmods ]; then
-  # Use module path instead of classpath
-  classmod_flag="--module-path"
+  # Use module path instead of classpath for the jruby libs
+  classpath_args=(--module-path "$JRUBY_CP" -classpath "$CP$CP_DELIMITER$CLASSPATH")
 
   # Switch to non-boot path since we can't use bootclasspath on 9+
   NO_BOOTCLASSPATH=1
@@ -389,6 +388,8 @@ if [ -d $JAVA_HOME/jmods ]; then
 
   # Add base opens we need for Ruby compatibility
   JAVA_OPTS="$JAVA_OPTS --add-opens java.base/java.io=org.jruby.dist --add-opens java.base/java.nio.channels=org.jruby.dist --add-opens java.base/sun.nio.ch=org.jruby.dist"
+else
+  classpath_args=(-classpath "$JRUBY_CP$CP_DELIMITER$CP$CP_DELIMITER$CLASSPATH")
 fi
 
 # Run JRuby!
@@ -409,7 +410,7 @@ elif [[ "$NO_BOOTCLASSPATH" != "" || "$VERIFY_JRUBY" != "" ]]; then
     JRUBY_OPTS=''
   fi
 
-  jvm_command=("$JAVACMD" $JAVA_OPTS "$JFFI_OPTS" "${java_args[@]}" ${classmod_flag} "$JRUBY_CP$CP_DELIMITER$CP$CP_DELIMITER$CLASSPATH" \
+  jvm_command=("$JAVACMD" $JAVA_OPTS "$JFFI_OPTS" "${java_args[@]}" "${classpath_args[@]}" \
     "-Djruby.home=$JRUBY_HOME" \
     "-Djruby.lib=$JRUBY_HOME/lib" -Djruby.script=jruby \
     "-Djruby.shell=$JRUBY_SHELL" \


### PR DESCRIPTION
960efcb13aa8fe6d44098ebe83ceeb7f90160445 and 7c4bf9c5d47aaa3f17d49636ee2dcb0dcded81b7 changed the starter so that the `$CLASSPATH` is added to the module path when running on java9+.

Treating the CLASSPATH as modules will create automatic modules for all entries that are not actually modules. This can lead to several problems, e.g. the automatic module name is determined by the name of the jar or directory, which fails when one component is not a valid java identifier. Another issue is that several automatic modules might export the same package, which is not allowed and leads to an error.

While the first problems is relatively easy to fix, the second one requires large changes and might not even possible if you are using third-party libraries (e.g. we are using UNO, which [has problems with this](https://bugs.documentfoundation.org/show_bug.cgi?id=117331)).

To fix these issues, we can use the module path just for jruby libraries and pass the CLASSPATH using `-classpath`, as both can be combined.

Note that I haven't done extensive testing, because I first wanted to hear what you think about this approach.

Unresolved questions:
 - [ ] Are there any unintended side effects?
 - [ ] Should $CP also go into the module path?
 - [ ] What about the other starters?