### PR TITLE
Fix and deprecate Java interface constant accessors

### DIFF
--- a/core/src/main/java/org/jruby/java/invokers/StaticFieldGetter.java
+++ b/core/src/main/java/org/jruby/java/invokers/StaticFieldGetter.java
@@ -8,13 +8,23 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 public class StaticFieldGetter extends FieldMethodZero {
+    private boolean warnConstant;
 
-    public StaticFieldGetter(String name, RubyModule host, Field field) {
+    public StaticFieldGetter(String name, RubyModule host, Field field, boolean warnConstant) {
         super(name, host, field);
+
+        this.warnConstant = warnConstant;
     }
 
     @Override
     public final IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name) {
+        if (warnConstant) {
+            // Warn once about accessing what should be a constant via an accessor.
+            // See jruby/jruby#5730.
+            warnConstant = false;
+            context.runtime.getWarnings().warning("DEPRECATED: Accessing Java interface constant via accessor method. This behavior will go away in JRuby 9.3, please use constant-style A::B syntax for accessing '" + field.toString() + "'");
+        }
+
         try {
             return JavaUtil.convertJavaToUsableRubyObject(context.runtime, field.get(null));
         }

--- a/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
@@ -235,7 +235,7 @@ public class JavaProxy extends RubyObject {
 
         if ( Modifier.isStatic(field.getModifiers()) ) {
             if ( asReader ) {
-                target.getSingletonClass().addMethod(asName, new StaticFieldGetter(fieldName, target, field));
+                target.getSingletonClass().addMethod(asName, new StaticFieldGetter(fieldName, target, field, false));
             }
             if ( asWriter == null || asWriter ) {
                 if ( Modifier.isFinal(field.getModifiers()) ) {

--- a/core/src/main/java/org/jruby/javasupport/binding/ClassInitializer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/ClassInitializer.java
@@ -104,9 +104,9 @@ final class ClassInitializer extends Initializer {
 
             int modifiers = field.getModifiers();
             if (Modifier.isStatic(modifiers)) {
-                addField(state.staticInstallers, state.staticNames, field, Modifier.isFinal(modifiers), true);
+                addField(state.staticInstallers, state.staticNames, field, Modifier.isFinal(modifiers), true, false);
             } else {
-                addField(state.instanceInstallers, state.instanceNames, field, Modifier.isFinal(modifiers), false);
+                addField(state.instanceInstallers, state.instanceNames, field, Modifier.isFinal(modifiers), false, false);
             }
         }
     }

--- a/core/src/main/java/org/jruby/javasupport/binding/FieldInstaller.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/FieldInstaller.java
@@ -18,6 +18,6 @@ public abstract class FieldInstaller extends NamedInstaller {
     }
 
     public boolean isAccessible() {
-        return Modifier.isPublic(field.getModifiers()) && Modules.trySetAccessible(field);
+        return Modifier.isPublic(field.getModifiers()) || Modules.trySetAccessible(field);
     }
 }

--- a/core/src/main/java/org/jruby/javasupport/binding/Initializer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/Initializer.java
@@ -122,14 +122,15 @@ public abstract class Initializer {
             final Map<String, AssignedName> names,
             final Field field,
             final boolean isFinal,
-            final boolean isStatic) {
+            final boolean isStatic,
+            final boolean isConstant) {
 
         final String name = field.getName();
 
         if ( Priority.FIELD.lessImportantThan( names.get(name) ) ) return;
 
         names.put(name, new AssignedName(name, Priority.FIELD));
-        callbacks.put(name, isStatic ? new StaticFieldGetterInstaller(name, field) :
+        callbacks.put(name, isStatic ? new StaticFieldGetterInstaller(name, field, isConstant) :
                 new InstanceFieldGetterInstaller(name, field));
 
         if (!isFinal) {

--- a/core/src/main/java/org/jruby/javasupport/binding/InterfaceInitializer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/InterfaceInitializer.java
@@ -29,13 +29,16 @@ final class InterfaceInitializer extends Initializer {
             final Field field = fields[i];
             if ( javaClass != field.getDeclaringClass() ) continue;
 
-            if ( ConstantField.isConstant(field) ) {
+            boolean isConstant = ConstantField.isConstant(field);
+            if (isConstant) {
                 state.constantFields.add(new ConstantField(field));
             }
 
             final int mod = field.getModifiers();
             if ( Modifier.isStatic(mod) ) {
-                addField(state.staticInstallers, state.staticNames, field, Modifier.isFinal(mod), true);
+                // If we already are adding it as a constant, make the accessors warn about deprecated behavior.
+                // See jruby/jruby#5730.
+                addField(state.staticInstallers, state.staticNames, field, Modifier.isFinal(mod), true, isConstant);
             }
         }
 

--- a/core/src/main/java/org/jruby/javasupport/binding/StaticFieldGetterInstaller.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/StaticFieldGetterInstaller.java
@@ -9,14 +9,17 @@ import java.lang.reflect.Field;
 * Created by headius on 2/26/15.
 */
 public class StaticFieldGetterInstaller extends FieldInstaller {
+    final boolean warnConstant;
 
-    public StaticFieldGetterInstaller(String name, Field field) {
+    public StaticFieldGetterInstaller(String name, Field field, boolean warnConstant) {
         super(name, STATIC_FIELD, field);
+
+        this.warnConstant = warnConstant;
     }
 
     @Override void install(final RubyModule proxy) {
         if (isAccessible()) {
-            proxy.getSingletonClass().addMethod(name, new StaticFieldGetter(name, proxy, field));
+            proxy.getSingletonClass().addMethod(name, new StaticFieldGetter(name, proxy, field, warnConstant));
         }
     }
 }


### PR DESCRIPTION
This fixes #5730 and deprecates the behavior in question (accessing Java interface constant fields using Ruby accessor-style syntax).

We will remove this unintended behavior in 9.3.