### PR TITLE
Use external when windows filesystem encoding is not found

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1488,7 +1488,10 @@ public final class Ruby implements Constantizable {
         if (Platform.IS_WINDOWS) {
             encoding = SafePropertyAccessor.getProperty("file.encoding", "UTF-8");
             Encoding filesystemEncoding = encodingService.loadEncoding(ByteList.create(encoding));
-            if (filesystemEncoding == null) throw new MainExitException(1, "unknown encoding name - " + encoding);
+
+            // Use default external if file.encoding does not point at an encoding we recognize
+            if (filesystemEncoding == null) filesystemEncoding = getDefaultExternalEncoding();
+
             setDefaultFilesystemEncoding(filesystemEncoding);
         } else {
             setDefaultFilesystemEncoding(getDefaultExternalEncoding());

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -64,11 +64,9 @@ import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.runtime.IRReturnJump;
 import org.jruby.javasupport.Java;
 import org.jruby.javasupport.JavaClass;
-import org.jruby.javasupport.JavaObject;
 import org.jruby.javasupport.JavaPackage;
 import org.jruby.javasupport.JavaSupport;
 import org.jruby.javasupport.JavaSupportImpl;
-import org.jruby.javasupport.proxy.JavaProxyClass;
 import org.jruby.lexer.yacc.ISourcePosition;
 import org.jruby.management.Caches;
 import org.jruby.parser.StaticScope;
@@ -1486,13 +1484,7 @@ public final class Ruby implements Constantizable {
 
         // Filesystem should always have a value
         if (Platform.IS_WINDOWS) {
-            encoding = SafePropertyAccessor.getProperty("file.encoding", "UTF-8");
-            Encoding filesystemEncoding = encodingService.loadEncoding(ByteList.create(encoding));
-
-            // Use default external if file.encoding does not point at an encoding we recognize
-            if (filesystemEncoding == null) filesystemEncoding = getDefaultExternalEncoding();
-
-            setDefaultFilesystemEncoding(filesystemEncoding);
+            setDefaultFilesystemEncoding(encodingService.getWindowsFilesystemEncoding(this));
         } else {
             setDefaultFilesystemEncoding(getDefaultExternalEncoding());
         }

--- a/core/src/main/java/org/jruby/runtime/encoding/EncodingService.java
+++ b/core/src/main/java/org/jruby/runtime/encoding/EncodingService.java
@@ -19,11 +19,14 @@ import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.jcodings.specific.USASCIIEncoding;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyString;
 import org.jruby.ext.nkf.RubyNKF;
+import org.jruby.util.SafePropertyAccessor;
 import org.jruby.util.io.EncodingUtils;
 
 public final class EncodingService {
@@ -44,6 +47,7 @@ public final class EncodingService {
     private static final ByteList EXTERNAL_BL = ByteList.create("external");
     private static final ByteList INTERNAL_BL = ByteList.create("internal");
     private static final ByteList FILESYSTEM_BL = ByteList.create("filesystem");
+    private static final Pattern MS_CP_PATTERN = Pattern.compile("^MS([0-9]+)$");
 
     public EncodingService(Ruby runtime) {
         this.runtime = runtime;
@@ -420,6 +424,27 @@ public final class EncodingService {
         if (!name.getEncoding().isAsciiCompatible()) {
             throw runtime.newArgumentError("invalid name encoding (non ASCII)");
         }
+    }
+
+    public Encoding getWindowsFilesystemEncoding(Ruby ruby) {
+        String encoding = SafePropertyAccessor.getProperty("file.encoding", "UTF-8");
+        Encoding filesystemEncoding = loadEncoding(ByteList.create(encoding));
+
+        // Use default external if file.encoding does not point at an encoding we recognize
+        if (filesystemEncoding == null) {
+            // if the encoding name matches /^MS[0-9]+/ we can assume it's a Windows code page and use CP### to look it up.
+            Matcher match = MS_CP_PATTERN.matcher(encoding);
+            if (match.find()) {
+                encoding = "CP" + match.group(1);
+                filesystemEncoding = loadEncoding(ByteList.create(encoding));
+            }
+        }
+
+        if (filesystemEncoding == null) {
+            filesystemEncoding = ruby.getDefaultExternalEncoding();
+        }
+
+        return filesystemEncoding;
     }
 
     /**


### PR DESCRIPTION
If the `file.encoding` property does not point at an encoding we recognize, such as "MS950" from #5707, we would hard error during JRuby initialization. This PR modifies that behavior to fall back on whatever we determine is the default external encoding.

This mitigates the error seen in #5707 but it may not match CRuby behavior exactly.

cc @enebo @lopex 