### PR TITLE
Socket error fixes

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -2038,8 +2038,6 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         try {
             if (fptr == null) return context.nil;
             if (fptr.fd() == null) return context.nil;
-            if (!fptr.fd().ch.isOpen()) return context.nil;
-            
             final Ruby runtime = context.runtime;
 
             fptr.finalizeFlush(context, false);

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -2038,9 +2038,9 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         try {
             if (fptr == null) return context.nil;
             if (fptr.fd() == null) return context.nil;
+            if (!fptr.fd().ch.isOpen()) return context.nil;
+            
             final Ruby runtime = context.runtime;
-
-            fptr.finalizeFlush(context, false);
 
             fptr.finalizeFlush(context, false);
 

--- a/core/src/main/java/org/jruby/ext/socket/RubyServerSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyServerSocket.java
@@ -235,7 +235,7 @@ public class RubyServerSocket extends RubySocket {
             throw SocketUtils.sockerr(runtime, "bind(2): unknown host");
         }
         catch (SocketException e) {
-            handleSocketException(runtime, e, "bind(2)", iaddr);
+            throw buildSocketException(runtime, e, "bind(2)", iaddr);
         }
         catch (IOException e) {
             throw sockerr(runtime, "bind(2): name or service not known", e);

--- a/core/src/main/java/org/jruby/ext/socket/RubySocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubySocket.java
@@ -683,17 +683,6 @@ public class RubySocket extends RubyBasicSocket {
     }
 
     @Override
-    @JRubyMethod
-    public IRubyObject close(final ThreadContext context) {
-        if (getOpenFile() != null) {
-            if (isClosed()) return context.nil;
-            openFile.checkClosed();
-            return rbIoClose(context);
-        }
-        return context.nil;
-    }
-
-    @Override
     public RubyBoolean closed_p(ThreadContext context) {
         if (getOpenFile() == null) return context.fals;
 

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -302,6 +302,15 @@ public class Helpers {
                     return Errno.EMSGSIZE;
                 case "Is a directory":
                     return Errno.EISDIR;
+                case "Operation timed out":
+                    return Errno.ETIMEDOUT;
+                case "No route to host":
+                    return Errno.EHOSTUNREACH;
+                case "permission denied":
+                case "Permission denied":
+                    return Errno.EACCES;
+                case "Protocol family unavailable":
+                    return Errno.EADDRNOTAVAIL;
             }
         }
         return null;


### PR DESCRIPTION
This fixes issues from #5709 and #5754.

* Unify logic for turning Java exceptions into Errno based on their messages. This allows the proper errors to be raised for ETIMEDOUT and EHOSTUNREACH within socket logic.
* Check for closed channel when doing the final flush logic in IO. This allows channels closed elsewhere or sockets not completely established to be closed again without error.
* Remove custom Socket#close since it should now work with the modified IO#close finalization logic.