### PR TITLE
Pre-generate DynamicScope shapes at build time

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -154,6 +154,16 @@ project 'JRuby Core' do
                                       '${project.build.outputDirectory}' ],
                      'executable' =>  'java',
                      'classpathScope' =>  'compile' )
+
+      execute_goals( 'exec',
+                     :id => 'scope-generator',
+                     'arguments' => [ '-Djruby.bytecode.version=${base.java.version}',
+                                      '-classpath',
+                                      xml( '<classpath/>' ),
+                                      'org.jruby.runtime.scope.DynamicScopeGenerator',
+                                      '${project.build.outputDirectory}' ],
+                     'executable' =>  'java',
+                     'classpathScope' =>  'compile' )
     end
   end
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -432,6 +432,24 @@ DO NOT MODIFIY - GENERATED CODE
               <classpathScope>compile</classpathScope>
             </configuration>
           </execution>
+          <execution>
+            <id>scope-generator</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <arguments>
+                <argument>-Djruby.bytecode.version=${base.java.version}</argument>
+                <argument>-classpath</argument>
+                <classpath />
+                <argument>org.jruby.runtime.scope.DynamicScopeGenerator</argument>
+                <argument>${project.build.outputDirectory}</argument>
+              </arguments>
+              <executable>java</executable>
+              <classpathScope>compile</classpathScope>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/core/src/main/java/org/jruby/parser/StaticScope.java
+++ b/core/src/main/java/org/jruby/parser/StaticScope.java
@@ -68,7 +68,7 @@ import org.jruby.runtime.scope.ManyVarsDynamicScope;
  * 
  */
 public class StaticScope implements Serializable {
-    private static final int MAX_SPECIALIZED_SIZE = 50;
+    public static final int MAX_SPECIALIZED_SIZE = 50;
     private static final long serialVersionUID = 3423852552352498148L;
     private static final MethodHandles.Lookup LOOKUP = MethodHandles.publicLookup();
 

--- a/core/src/main/java/org/jruby/util/ClassDefiningJRubyClassLoader.java
+++ b/core/src/main/java/org/jruby/util/ClassDefiningJRubyClassLoader.java
@@ -33,7 +33,7 @@ import java.security.ProtectionDomain;
 
 public class ClassDefiningJRubyClassLoader extends URLClassLoader implements ClassDefiningClassLoader {
 
-    final static ProtectionDomain DEFAULT_DOMAIN;
+    public final static ProtectionDomain DEFAULT_DOMAIN;
 
     static {
         ProtectionDomain defaultDomain = null;


### PR DESCRIPTION
This PR pregenerates all DynamicScope subclasses we normally generate at runtime. The classes are included in the JRuby jar file so none of these classes are generated at runtime.

The logic here uses the max generated size as the max to pregenerate, resulting in no runtime generation happening. Currently, we generate up to 50-wide, so this PR currently generates 51 classes into JRuby.jar. Typical Ruby code will use only the smallest sizes, so this may be wasteful. The full set of 51 classes increases the size of my local jruby.jar by about 90k.

We may want to consider pregenerating fewer classes (if the size of the jar is important) as well as possibly generating fewer shapes overall (since there are diminishing returns to create e.g. a 50-wide scope class that's only used for one method).