### PR TITLE
Revert "SKip prepended roots when including a stack of modules."

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -3435,11 +3435,9 @@ public class RubyModule extends RubyObject {
     private List<RubyModule> gatherModules(RubyModule baseModule) {
         // build a list of all modules to consider for inclusion
         List<RubyModule> modulesToInclude = new ArrayList<RubyModule>();
-        for (; baseModule != null; baseModule = baseModule.superClass) {
-            // skip prepended roots
-            if (baseModule != baseModule.getMethodLocation()) continue;
-
+        while (baseModule != null) {
             modulesToInclude.add(baseModule.getDelegate());
+            baseModule = baseModule.getSuperClass();
         }
 
         return modulesToInclude;


### PR DESCRIPTION
This reverts commit be0ada01d39184cb97a7bb3b4ccb43d8078d7b9a which causes #5748.