### PR TITLE
Support Time ranges in rand

### DIFF
--- a/core/src/main/java/org/jruby/util/TypeConverter.java
+++ b/core/src/main/java/org/jruby/util/TypeConverter.java
@@ -297,6 +297,7 @@ public class TypeConverter {
     // rb_check_to_float
     public static IRubyObject checkFloatType(Ruby runtime, IRubyObject obj) {
         if (obj instanceof RubyFloat) return obj;
+        if (!(obj instanceof RubyNumeric)) return runtime.getNil();
 
         ThreadContext context = runtime.getCurrentContext();
         TypeConverterSites sites = sites(context);

--- a/spec/ruby/core/kernel/fixtures/classes.rb
+++ b/spec/ruby/core/kernel/fixtures/classes.rb
@@ -435,7 +435,7 @@ module KernelSpecs
   CustomRangeFloat = Struct.new(:value) do
     def to_f; value; end
     def <=>(other); to_f <=> other.to_f; end
-    def -(other); self.class.new(to_f - other.to_f); end
+    def -(other); to_f - other.to_f; end
     def +(other); self.class.new(to_f + other.to_f); end
   end
 end

--- a/spec/ruby/core/kernel/fixtures/classes.rb
+++ b/spec/ruby/core/kernel/fixtures/classes.rb
@@ -424,6 +424,20 @@ module KernelSpecs
     def f2_call_lineno; method(:f3).source_location[1] + 1; end
     def f3_call_lineno; method(:f4).source_location[1] + 1; end
   end
+
+  CustomRangeInteger = Struct.new(:value) do
+    def to_int; value; end
+    def <=>(other); to_int <=> other.to_int; end
+    def -(other); self.class.new(to_int - other.to_int); end
+    def +(other); self.class.new(to_int + other.to_int); end
+  end
+
+  CustomRangeFloat = Struct.new(:value) do
+    def to_f; value; end
+    def <=>(other); to_f <=> other.to_f; end
+    def -(other); self.class.new(to_f - other.to_f); end
+    def +(other); self.class.new(to_f + other.to_f); end
+  end
 end
 
 class EvalSpecs

--- a/spec/ruby/core/kernel/rand_spec.rb
+++ b/spec/ruby/core/kernel/rand_spec.rb
@@ -132,6 +132,12 @@ describe "Kernel.rand" do
   it "returns the range start/end when Integer range is 0" do
     rand(42..42).should eql(42)
   end
+
+  it "supports custom object types" do
+    rand(KernelSpecs::CustomRangeInteger.new(1)..KernelSpecs::CustomRangeInteger.new(42)).should be_an_instance_of(KernelSpecs::CustomRangeInteger)
+    rand(KernelSpecs::CustomRangeFloat.new(1.0)..KernelSpecs::CustomRangeFloat.new(42.0)).should be_an_instance_of(KernelSpecs::CustomRangeFloat)
+    rand(Time.now..Time.now).should be_an_instance_of(Time)
+  end
 end
 
 describe "Kernel#rand" do

--- a/spec/ruby/core/random/fixtures/classes.rb
+++ b/spec/ruby/core/random/fixtures/classes.rb
@@ -9,7 +9,7 @@ module RandomSpecs
   CustomRangeFloat = Struct.new(:value) do
     def to_f; value; end
     def <=>(other); to_f <=> other.to_f; end
-    def -(other); self.class.new(to_f - other.to_f); end
+    def -(other); to_f - other.to_f; end
     def +(other); self.class.new(to_f + other.to_f); end
   end
 end

--- a/spec/ruby/core/random/fixtures/classes.rb
+++ b/spec/ruby/core/random/fixtures/classes.rb
@@ -1,0 +1,15 @@
+module RandomSpecs
+  CustomRangeInteger = Struct.new(:value) do
+    def to_int; value; end
+    def <=>(other); to_int <=> other.to_int; end
+    def -(other); self.class.new(to_int - other.to_int); end
+    def +(other); self.class.new(to_int + other.to_int); end
+  end
+
+  CustomRangeFloat = Struct.new(:value) do
+    def to_f; value; end
+    def <=>(other); to_f <=> other.to_f; end
+    def -(other); self.class.new(to_f - other.to_f); end
+    def +(other); self.class.new(to_f + other.to_f); end
+  end
+end

--- a/spec/ruby/core/random/rand_spec.rb
+++ b/spec/ruby/core/random/rand_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
 
 describe "Random.rand" do
   it "returns a Float if no max argument is passed" do
@@ -163,6 +164,12 @@ end
 describe "Random#rand with Range" do
   it "returns an element from the Range" do
     Random.new.rand(20..43).should be_an_instance_of(Fixnum)
+  end
+
+  it "supports custom object types" do
+    rand(RandomSpecs::CustomRangeInteger.new(1)..RandomSpecs::CustomRangeInteger.new(42)).should be_an_instance_of(RandomSpecs::CustomRangeInteger)
+    rand(RandomSpecs::CustomRangeFloat.new(1.0)..RandomSpecs::CustomRangeFloat.new(42.0)).should be_an_instance_of(RandomSpecs::CustomRangeFloat)
+    rand(Time.now..Time.now).should be_an_instance_of(Time)
   end
 
   it "returns an object that is a member of the Range" do


### PR DESCRIPTION
JRuby is currently converting Time objects to floats when generating a
random value from a range:

```
$ RBENV_VERSION=jruby-9.2.7.0 ruby -e 'puts rand(Time.now..Time.now)'
1562034267.423605
```

MRI returns a Time object:

```
$ RBENV_VERSION=2.6.3 ruby -e 'puts rand(Time.now..Time.now)'
2019-07-01 19:27:25 -0700
```

I believe the `RubyNumeric` check I added is the same as what MRI uses
in `rb_check_to_float`: https://github.com/ruby/ruby/blob/0b858425e1e4f2de40dc0d8e5dd105a2fd93e478/object.c#L3769