### PR TITLE
Added Tempfile#open from ruby-head

### DIFF
--- a/lib/ruby/stdlib/tempfile.rb
+++ b/lib/ruby/stdlib/tempfile.rb
@@ -11,6 +11,44 @@ JRuby::Util.load_ext("org.jruby.ext.tempfile.TempfileLibrary")
 
 class Tempfile
   include Dir::Tmpname
+
+  class << self
+    # Creates a new Tempfile.
+    #
+    # If no block is given, this is a synonym for Tempfile.new.
+    #
+    # If a block is given, then a Tempfile object will be constructed,
+    # and the block is run with said object as argument. The Tempfile
+    # object will be automatically closed after the block terminates.
+    # The call returns the value of the block.
+    #
+    # In any case, all arguments (<code>*args</code>) will be passed to Tempfile.new.
+    #
+    #   Tempfile.open('foo', '/home/temp') do |f|
+    #      # ... do something with f ...
+    #   end
+    #
+    #   # Equivalent:
+    #   f = Tempfile.open('foo', '/home/temp')
+    #   begin
+    #      # ... do something with f ...
+    #   ensure
+    #      f.close
+    #   end
+    def open(*args)
+      tempfile = new(*args)
+
+      if block_given?
+        begin
+          yield(tempfile)
+        ensure
+          tempfile.close
+        end
+      else
+        tempfile
+      end
+    end
+  end
 end
 
 # Creates a temporally file as usual File object (not Tempfile).


### PR DESCRIPTION
This PR adds the code from [tempfile.rb](https://github.com/ruby/ruby/blob/6c2b59f9237843a4570d0ab932705b3fa5c18524/lib/tempfile.rb#L265-L304) in MRI that defines the `Tempfile.open` method.

https://github.com/jruby/jruby/issues/5775