### PR TITLE
Restore LibC module into Fiddle namespace and add malloc.

### DIFF
--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -41,6 +41,19 @@ module Fiddle
       raise TypeError.new("cannot convert #{dl_type} to ffi") unless ffi_type
       ffi_type
     end
+
+    module LibC
+      extend FFI::Library
+      ffi_lib FFI::Library::LIBC
+      attach_function :malloc, [ :size_t ], :pointer
+      attach_function :malloc_direct, :malloc, [ :size_t ], :long
+      attach_function :realloc, [ :pointer, :size_t ], :pointer
+      FREE = attach_function :free, [ :pointer ], :void
+    end
+  end
+
+  def self.malloc(size)
+    JRuby::LibC.malloc_direct(size)
   end
 
   class Function
@@ -165,7 +178,7 @@ module Fiddle
     end
 
     def self.malloc(size, free = nil)
-      self.new(LibC.malloc(size), size, free ? free : LibC::FREE)
+      self.new(JRuby::LibC.malloc(size), size, free ? free : JRuby::LibC::FREE)
     end
 
     def null?


### PR DESCRIPTION
The LibC module was previously used only by Fiddle::Pointer and
was removed during a stdlib update. This commit restores it, moves
it under the Fiddle::JRuby namespace, and adds the missing
Fiddle.malloc to fix #5786.

However, other places in Fiddle return FFI::Pointer for pointer references. Other parts of Fiddle don't properly handle this type, resulting in errors like this when those references are passed to other Fiddle-bound calls:

```
TypeError: cannot convert parameter to native pointer
  SDL_RenderCopy at /Users/headius/projects/jruby/doomfire/lib/doomfire/ffi_sdl.rb:46
    print_pixels at /Users/headius/projects/jruby/doomfire/lib/doomfire/sdl.rb:121
       fire_loop at /Users/headius/projects/jruby/doomfire/lib/doomfire/sdl.rb:72
            loop at org/jruby/RubyKernel.java:1425
       fire_loop at /Users/headius/projects/jruby/doomfire/lib/doomfire/sdl.rb:57
             run at /Users/headius/projects/jruby/doomfire/lib/doomfire/sdl.rb:47
          <main> at exe/doomfire:28
```

Clearly there's something missing in our Fiddle to handle unwrapping these FFI::Pointer objects, or else we need to retool things to always unwrap pointers before returning them from Fiddle.