### PR TITLE
jruby-jars.gemspec: Drop rubyforge_project

### DIFF
--- a/maven/jruby-jars/jruby-jars.gemspec
+++ b/maven/jruby-jars/jruby-jars.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
   s.summary = 'The core JRuby code and the JRuby stdlib as jar files.'
   s.homepage = 'https://github.com/jruby/jruby/tree/master/maven/jruby-jars'
   s.description = File.read('README.txt', encoding: 'UTF-8').split(/\n{2,}/)[3]
-  s.rubyforge_project = 'jruby/jruby'
   s.licenses = %w(EPL-1.0 GPL-2.0 LGPL-2.1)
   s.files = Dir['[A-Z]*'] + Dir['lib/**/*.rb'] + Dir[ "lib/jruby-*-#{version}*.jar" ] + Dir[ 'test/**/*'] + [ 'jruby-jars.gemspec' ]
 end


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436