### PR TITLE
MRI compatibility with IO::sysopen for serial ports on windows

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1212,7 +1212,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         StringSupport.checkStringSafety(context.runtime, fname);
         fname = ((RubyString)fname).dupFrozen();
         fd = sysopen(runtime, fname.toString(), oflags, perm);
-        return runtime.newFixnum(fd.bestFileno());
+        return runtime.newFixnum(fd.bestFileno(true));
     }
 
     public static class Sysopen {
@@ -1271,8 +1271,8 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
             data.errno = shim.getErrno();
             return null;
         }
-        ChannelFD fd = new ChannelFD(ret, runtime.getPosix(), runtime.getFilenoUtil());
-        if (fd.realFileno > 0 && runtime.getPosix().isNative()) {
+        ChannelFD fd = new ChannelFD(ret, runtime.getPosix(), runtime.getFilenoUtil(), data.oflags);
+        if (fd.realFileno > 0 && runtime.getPosix().isNative() && !Platform.IS_WINDOWS) {
             OpenFile.fdFixCloexec(shim, fd.realFileno);
         }
 

--- a/core/src/main/java/org/jruby/util/RegularFileResource.java
+++ b/core/src/main/java/org/jruby/util/RegularFileResource.java
@@ -306,6 +306,7 @@ class RegularFileResource implements FileResource {
     static IOException mapFileNotFoundOnGetChannel(final FileResource file, final FileNotFoundException ex) {
         // Java throws FileNotFoundException both if the file doesn't exist or there were
         // permission issues, but Ruby needs to disambiguate those two cases
+    	// TODO: add windows serial port check
         return file.exists() ?
                 new ResourceException.PermissionDenied(file.absolutePath()) :
                 new ResourceException.NotFound(file.absolutePath());

--- a/core/src/main/java/org/jruby/util/RegularFileResource.java
+++ b/core/src/main/java/org/jruby/util/RegularFileResource.java
@@ -256,7 +256,9 @@ class RegularFileResource implements FileResource {
             throw new ResourceException.FileIsDirectory(absolutePath());
         }
 
-        if (!file.exists()) {
+        // File.exists() returns false on Windows COM port paths, so ignore
+        // them for now and deal with the exception later
+        if (!file.exists() && !JRubyFile.isComPort(file.getPath())) {
             throw new ResourceException.NotFound(absolutePath());
         }
 

--- a/core/src/main/java/org/jruby/util/io/ChannelFD.java
+++ b/core/src/main/java/org/jruby/util/io/ChannelFD.java
@@ -23,13 +23,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 * Created by headius on 5/24/14.
 */
 public class ChannelFD implements Closeable {
-    public ChannelFD(Channel fd, POSIX posix, FilenoUtil filenoUtil) {
+    public ChannelFD(Channel fd, POSIX posix, FilenoUtil filenoUtil, int flags) {
         assert fd != null;
         this.ch = fd;
         this.posix = posix;
         this.filenoUtil = filenoUtil;
+        this.openflags = flags;
 
-        initFileno();
+        initFileno(false);
         initChannelTypes();
 
         refs = new AtomicInteger(1);
@@ -38,8 +39,22 @@ public class ChannelFD implements Closeable {
         filenoUtil.registerWrapper(fakeFileno, this);
     }
 
-    private void initFileno() {
+    public ChannelFD(Channel fd, POSIX posix, FilenoUtil filenoUtil) {
+        this(fd, posix, filenoUtil, -1);
+    }
+
+    private void initFileno(boolean allocate) {
         realFileno = FilenoUtil.filenoFrom(ch);
+        if (Platform.IS_WINDOWS && realFileno == -1 && openflags >= 0) {
+            if (allocate) {
+                // TODO: ensure we aren't leaking multiple handles for the same channel/handle
+                realFileno = FilenoUtil.filenoFromHandleIn(ch, openflags); // TODO: ensure these flags are correct for windows
+                needsClosing = realFileno != -1;
+                maybeHandle = false;
+            } else {
+                maybeHandle = true;
+            }
+        }
         if (realFileno == -1) {
             fakeFileno = filenoUtil.getNewFileno();
         } else {
@@ -75,7 +90,7 @@ public class ChannelFD implements Closeable {
         // TODO: not sure how well this combines native and non-native streams
         // simulate dup2 by forcing filedes's channel into filedes2
         this.ch = dup2Source.ch;
-        initFileno();
+        initFileno(false);
         initChannelTypes();
 
         this.refs = dup2Source.refs;
@@ -93,6 +108,18 @@ public class ChannelFD implements Closeable {
 
     public int bestFileno() {
         return realFileno == -1 ? fakeFileno : realFileno;
+    }
+
+    // lazily create windows resources
+    public int bestFileno(boolean forceFileno) {
+        if (maybeHandle && forceFileno) {
+            initFileno(true);
+            assert maybeHandle == false : "lazy handle creation state changed";
+            // Hopefully we don't overwrite existing files
+            filenoUtil.registerWrapper(realFileno, this);
+            filenoUtil.registerWrapper(fakeFileno, this);
+        }
+        return bestFileno();
     }
 
     private void finish() throws IOException {
@@ -114,6 +141,9 @@ public class ChannelFD implements Closeable {
                 // if we're the last referrer, close the channel
                 try {
                     ch.close();
+                    if (needsClosing) {
+                        FilenoUtil.closeFilenoHandle(realFileno);
+                    }
                 } finally {
                     filenoUtil.unregisterWrapper(realFileno);
                     filenoUtil.unregisterWrapper(fakeFileno);
@@ -164,4 +194,7 @@ public class ChannelFD implements Closeable {
     private final POSIX posix;
     public boolean isNativeFile = false;
     private final FilenoUtil filenoUtil;
+    private boolean needsClosing = false;
+    private boolean maybeHandle = false;
+    private final int openflags;
 }

--- a/core/src/main/java/org/jruby/util/io/ChannelFD.java
+++ b/core/src/main/java/org/jruby/util/io/ChannelFD.java
@@ -48,7 +48,7 @@ public class ChannelFD implements Closeable {
         if (Platform.IS_WINDOWS && realFileno == -1 && openflags >= 0) {
             if (allocate) {
                 // TODO: ensure we aren't leaking multiple handles for the same channel/handle
-                realFileno = FilenoUtil.filenoFromHandleIn(ch, openflags); // TODO: ensure these flags are correct for windows
+                realFileno = filenoUtil.filenoFromHandleIn(ch, openflags); // TODO: ensure these flags are correct for windows
                 needsClosing = realFileno != -1;
                 maybeHandle = false;
             } else {
@@ -142,7 +142,7 @@ public class ChannelFD implements Closeable {
                 try {
                     ch.close();
                     if (needsClosing) {
-                        FilenoUtil.closeFilenoHandle(realFileno);
+                        filenoUtil.closeFilenoHandle(realFileno);
                     }
                 } finally {
                     filenoUtil.unregisterWrapper(realFileno);

--- a/core/src/main/java/org/jruby/util/io/OpenFile.java
+++ b/core/src/main/java/org/jruby/util/io/OpenFile.java
@@ -2518,9 +2518,7 @@ public class OpenFile implements Finalizable {
     }
 
     public int getFileno() {
-        int fileno = fd.realFileno;
-        if (fileno != -1) return fileno;
-        return fd.fakeFileno;
+        return fd.bestFileno(true);
     }
 
     // rb_thread_flock


### PR DESCRIPTION
These changes make JRuby be compatible with MRI's API's and behaviors on Windows serial ports.

Fileno is now real in most cases, but lazily generated in most cases to avoid sucking up 2x the number of file resources.

I put the WinC interface in FilenoUtils arbitrarily, I wasn't sure the best place to put it