### PR TITLE
Remove tag for "str".freeze idempotency test.

### DIFF
--- a/spec/tags/ruby/core/string/freeze_tags.txt
+++ b/spec/tags/ruby/core/string/freeze_tags.txt
@@ -1,1 +1,0 @@
-critical(sporadic, see #5070):String#freeze produces the same object whenever called on an instance of a literal in the source


### PR DESCRIPTION
This was likely failing because we ran the full RubySpec suite
with --debug when run through rake. This turned on frozen string
debugging, which disabled the deduplication this spec tests.

Fixes #5070.