### PR TITLE
[fix] Enumerable#first block signature (matches MRI)

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -406,7 +406,7 @@ public class RubyEnumerable {
         final IRubyObject[] holder = new IRubyObject[]{ context.nil };
 
         try {
-            each(context, self, new JavaInternalBlockBody(context.runtime, context, null, Signature.ONE_REQUIRED) {
+            each(context, self, new JavaInternalBlockBody(context.runtime, context, "Enumerable#first", Signature.OPTIONAL) {
                 public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
                     IRubyObject packedArg = packEnumValues(context.runtime, args);
                     holder[0] = packedArg;
@@ -428,7 +428,7 @@ public class RubyEnumerable {
         final RubyArray result = RubyArray.newArray(runtime, firstCount);
 
         try {
-            each(context, self, new JavaInternalBlockBody(runtime, context, null, Signature.ONE_REQUIRED) {
+            each(context, self, new JavaInternalBlockBody(runtime, context, "Enumerable#first", Signature.OPTIONAL) {
                 private long iter = firstCount;
                 public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
                     IRubyObject packedArg = packEnumValues(context.runtime, args);

--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -30,29 +30,18 @@ package org.jruby;
 
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyModule;
-import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.StopIteration;
-import org.jruby.exceptions.Unrescuable;
 import org.jruby.runtime.Arity;
-import org.jruby.runtime.Binding;
 import org.jruby.runtime.Block;
-import org.jruby.runtime.BlockCallback;
-import org.jruby.runtime.CallBlock;
-import org.jruby.runtime.Helpers;
 import org.jruby.runtime.JavaSites;
 import org.jruby.runtime.ObjectAllocator;
-import org.jruby.runtime.Signature;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ArraySupport;
 import org.jruby.util.ByteList;
-import org.jruby.util.cli.Options;
 
 import java.util.Arrays;
-import java.util.NoSuchElementException;
 import java.util.Spliterator;
-import java.util.concurrent.Future;
-import java.util.concurrent.SynchronousQueue;
 import java.util.stream.Stream;
 
 import static org.jruby.runtime.Visibility.PRIVATE;

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -65,7 +65,6 @@ import org.jruby.util.TypeConverter;
 import java.io.IOException;
 import java.util.AbstractCollection;
 import java.util.AbstractSet;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;

--- a/core/src/main/java/org/jruby/RubyYielder.java
+++ b/core/src/main/java/org/jruby/RubyYielder.java
@@ -28,7 +28,6 @@ package org.jruby;
 
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
-import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.BlockCallback;
 import org.jruby.runtime.CallBlock19;
@@ -113,17 +112,13 @@ public class RubyYielder extends RubyObject {
     }
 
     @JRubyMethod(rest = true)
-    public IRubyObject yield(ThreadContext context, IRubyObject[]args) {
+    public IRubyObject yield(ThreadContext context, IRubyObject[] args) {
         checkInit();
-        return proc.call(context, args, Block.NULL_BLOCK);
+        return proc.call(context, args);
     }
 
     @JRubyMethod(name = "<<", rest = true)
-    public IRubyObject op_lshift(ThreadContext context, IRubyObject[]args) {
-        if (args.length == 1 &&
-                args[0] instanceof RubyArray &&
-                ((RubyArray) args[0]).getLength() == 1)
-            args[0] = RubyArray.newArray(context.runtime, args[0]);
+    public IRubyObject op_lshift(ThreadContext context, IRubyObject[] args) {
         yield(context, args);
         return this;
     }

--- a/core/src/main/java/org/jruby/runtime/CallBlock.java
+++ b/core/src/main/java/org/jruby/runtime/CallBlock.java
@@ -59,10 +59,10 @@ public class CallBlock extends BlockBody {
         this.dummyScope = context.runtime.getStaticScopeFactory().getDummyScope();
     }
 
-    private IRubyObject[] adjustArgs(Block block, IRubyObject[] args) {
+    static IRubyObject[] adjustArgs(Block block, IRubyObject[] args) {
         Signature signature = block.getSignature();
         int required = signature.required();
-        if (signature.isFixed() && required  > 0 && required < args.length) args = ArraySupport.newCopy(args, required);
+        if (required > 0 && required < args.length && signature.isFixed()) args = ArraySupport.newCopy(args, required);
 
         return args;
     }

--- a/core/src/main/java/org/jruby/runtime/JavaInternalBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/JavaInternalBlockBody.java
@@ -47,10 +47,10 @@ public abstract class JavaInternalBlockBody extends BlockBody {
         }
     }
 
-    private IRubyObject[] adjustArgs(Block block, IRubyObject[] args) {
+    private static IRubyObject[] adjustArgs(Block block, IRubyObject[] args) {
         Signature signature = block.getSignature();
         int required = signature.required();
-        if (signature.isFixed() && required  > 0 && required < args.length) args = ArraySupport.newCopy(args, required);
+        if (signature.isFixed() && required > 0 && required < args.length) args = ArraySupport.newCopy(args, required);
 
         return args;
     }

--- a/core/src/main/java/org/jruby/runtime/JavaInternalBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/JavaInternalBlockBody.java
@@ -47,22 +47,14 @@ public abstract class JavaInternalBlockBody extends BlockBody {
         }
     }
 
-    private static IRubyObject[] adjustArgs(Block block, IRubyObject[] args) {
-        Signature signature = block.getSignature();
-        int required = signature.required();
-        if (signature.isFixed() && required > 0 && required < args.length) args = ArraySupport.newCopy(args, required);
-
-        return args;
-    }
-
     @Override
     public IRubyObject call(ThreadContext context, Block block, IRubyObject[] args) {
-        return yield(context, block, adjustArgs(block, args), null);
+        return yield(context, block, CallBlock.adjustArgs(block, args), null);
     }
 
     @Override
     public IRubyObject call(ThreadContext context, Block block, IRubyObject[] args, Block blockArg) {
-        return yield(context, block, adjustArgs(block, args), null, blockArg);
+        return yield(context, block, CallBlock.adjustArgs(block, args), null, blockArg);
     }
 
     @Override
@@ -76,7 +68,7 @@ public abstract class JavaInternalBlockBody extends BlockBody {
     protected IRubyObject doYield(ThreadContext context, Block block, IRubyObject[] args, IRubyObject self) {
         threadCheck(context);
 
-        return yield(context, adjustArgs(block, args));
+        return yield(context, CallBlock.adjustArgs(block, args));
     }
     
     public abstract IRubyObject yield(ThreadContext context, IRubyObject[] args);


### PR DESCRIPTION
we can than remove the hack from https://github.com/jruby/jruby/pull/2458

... and get some reported (Enumerator) behaviour to work properly, namely : 
- fixes #5044
- #4108 seems working, except `Enumerator.new {|y| y.yield([1])}.lazy.map {|e| e}.to_a`