### PR TITLE
Allow generating reified Ruby classes with actual name.

### DIFF
--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -175,6 +175,7 @@ public class Options {
     public static final Option<Boolean> VOLATILE_VARIABLES = bool(MISCELLANEOUS, "volatile.variables", false, "Always ensure volatile semantics for instance variables.");
     public static final Option<Boolean> REIFY_VARIABLES = bool(MISCELLANEOUS, "reify.variables", !(REIFY_CLASSES.load() || VOLATILE_VARIABLES.load()), "Attempt to expand instance vars into Java fields");
     public static final Option<Integer> REIFY_VARIABLES_MAX = integer(MISCELLANEOUS, "reify.variables.max", 50, "Maximum number of reified instance variable fields");
+    public static final Option<Boolean> REIFY_VARIABLES_NAME = bool(MISCELLANEOUS, "reify.variables.name", false, "Reify variables into a class named after the Ruby class");
     public static final Option<Boolean> FCNTL_LOCKING = bool(MISCELLANEOUS, "file.flock.fcntl", true, "Use fcntl rather than flock for File#flock");
     public static final Option<Boolean> RECORD_LEXICAL_HIERARCHY = bool(MISCELLANEOUS, "record.lexical.hierarchy", false, "Maintain children static scopes to support scope dumping.");
     public static final Option<String> PREFERRED_PRNG = string(MISCELLANEOUS, "preferred.prng", "NativePRNGNonBlocking", "Set the preferred JDK-supported random number generator to use.");


### PR DESCRIPTION
This partially addresses #4643.

One of the main features of the old "reify.classes" feature was that all Object subclasses would reify as their actual names. This is needed for JVM tooling to separate different types of Ruby object since normally they'll all appear to be RubyObject or one of the specialized subclasses like RubyObject1.

However the other features of reify.classes are difficult to reconcile with reified variables from reify.variables, due to the complexity of mapping a Ruby class hierarchy into a Java class hierarchy at the same time we are reifying variables into fields.

This patch goes partway to restore the actual names by forcing reify.variables to use the actual Ruby class name without attempting to match the class hierarchy or generate the other Java methods from reify.classes.

Pass -Xreify.variables.name to get this new behavior (off by default).

```
$ jruby -e "module Foo; class Bar; end; end; puts JRuby.ref(Foo::Bar.new).getClass"
org.jruby.gen.RubyObject0

$ jruby -Xreify.variables.name -e "module Foo; class Bar; end; end; puts JRuby.ref(Foo::Bar.new).getClass"
org.jruby.gen.Foo.Bar
```