### PR TITLE
fix custom call-site performance regression

### DIFF
--- a/core/src/main/java/org/jruby/ext/ffi/AutoPointer.java
+++ b/core/src/main/java/org/jruby/ext/ffi/AutoPointer.java
@@ -94,7 +94,7 @@ public class AutoPointer extends Pointer {
         ClassData classData = (ClassData) ffiHandle;
 
         // If no release method is defined, then memory leaks will result.
-        DynamicMethod releaseMethod = classData.releaseCallSite.retrieveCache(getMetaClass().getMetaClass(), classData.releaseCallSite.getMethodName()).method;
+        DynamicMethod releaseMethod = classData.releaseCallSite.retrieveCache((IRubyObject) getMetaClass()).method;
         if (releaseMethod.isUndefined()) {
             throw runtime.newRuntimeError("release method undefined");
 
@@ -130,7 +130,7 @@ public class AutoPointer extends Pointer {
         }
 
         ReleaserData releaserData = (ReleaserData) ffiHandle;
-        DynamicMethod releaseMethod = releaserData.releaseCallSite.retrieveCache(releaser.getMetaClass(), releaserData.releaseCallSite.getMethodName()).method;
+        DynamicMethod releaseMethod = releaserData.releaseCallSite.retrieveCache(releaser).method;
         // If no release method is defined, then memory leaks will result.
         if (releaseMethod.isUndefined()) {
             throw context.runtime.newRuntimeError("call method undefined");

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/JITRuntime.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/JITRuntime.java
@@ -499,7 +499,7 @@ public final class JITRuntime {
         } else if (parameter instanceof RubyNil) {
             return NilPointerParameterStrategy.NullMemoryIO.INSTANCE;
 
-        } else if (!(conversionMethod = callSite.retrieveCache(parameter.getMetaClass(), callSite.getMethodName()).method).isUndefined()) {
+        } else if (!(conversionMethod = callSite.retrieveCache(parameter).method).isUndefined()) {
             IRubyObject convertedParameter = conversionMethod.call(context, parameter, parameter.getMetaClass(), callSite.getMethodName(), Block.NULL_BLOCK);
             if (convertedParameter instanceof RubyString) {
                 return StringParameterStrategy.getMemoryIO((RubyString) convertedParameter, isDirect, checkStringSafety);
@@ -573,7 +573,7 @@ public final class JITRuntime {
     }
 
     public static DynamicMethod getConversionMethod(IRubyObject parameter, CachingCallSite callSite) {
-        DynamicMethod method = callSite.retrieveCache(parameter.getMetaClass(), callSite.getMethodName()).method;
+        DynamicMethod method = callSite.retrieveCache(parameter).method;
         if (method.isUndefined()) {
             throw parameter.getRuntime().newTypeError("cannot convert parameter of type " + parameter.getMetaClass()
                     + " to native pointer; does not respond to :" + callSite.getMethodName());

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/NativeCallbackFactory.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/NativeCallbackFactory.java
@@ -65,7 +65,7 @@ public class NativeCallbackFactory {
     }
 
     NativeCallbackPointer newCallback(IRubyObject callable, CachingCallSite callSite) {
-        if (callSite.retrieveCache(callable.getMetaClass(), callSite.getMethodName()).method.isUndefined()) {
+        if (callSite.retrieveCache(callable).method.isUndefined()) {
             throw runtime.newArgumentError("callback does not respond to :" + callSite.getMethodName());
         }
 

--- a/core/src/main/java/org/jruby/runtime/callsite/BitAndCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/BitAndCallSite.java
@@ -10,18 +10,43 @@ public class BitAndCallSite extends MonomorphicCallSite {
         super("&");
     }
 
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long fixnum) {
-        if (self instanceof RubyFixnum && isBuiltin(((RubyFixnum) self).getMetaClass())) {
-            return ((RubyFixnum) self).op_and(context, fixnum);
+    @Override
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) {
+            return ((RubyFixnum) self).op_and(context, arg1);
         }
-        return super.call(context, caller, self, fixnum);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg) {
-        if (self instanceof RubyFixnum && isBuiltin(((RubyFixnum) self).getMetaClass())) {
-            return ((RubyFixnum) self).op_and(context, arg);
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) {
+            return ((RubyFixnum) self).op_and(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
+
+    @Override
+    protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Fixnum targets
+        if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
+            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return cache = entry;
+    }
+
+    @Override
+    public boolean isBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        return super.isBuiltin(self);
+    }
+
+    private static class FixnumEntry extends CacheEntry {
+
+        FixnumEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
+    }
+
 }

--- a/core/src/main/java/org/jruby/runtime/callsite/BitAndCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/BitAndCallSite.java
@@ -3,6 +3,7 @@ package org.jruby.runtime.callsite;
 import org.jruby.RubyFixnum;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import static org.jruby.RubyBasicObject.getMetaClass;
 
 public class BitAndCallSite extends MonomorphicCallSite {
 
@@ -12,32 +13,40 @@ public class BitAndCallSite extends MonomorphicCallSite {
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) {
-            return ((RubyFixnum) self).op_and(context, arg1);
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_and(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) {
-            return ((RubyFixnum) self).op_and(context, arg1);
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_and(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Fixnum targets
         if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
-            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return cache = new FixnumEntry(entry); // tagged entry - do isBuiltin check once
         }
         return cache = entry;
     }
 
     @Override
     public boolean isBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FixnumEntry;
+        }
         return super.isBuiltin(self);
     }
 

--- a/core/src/main/java/org/jruby/runtime/callsite/BitOrCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/BitOrCallSite.java
@@ -3,6 +3,7 @@ package org.jruby.runtime.callsite;
 import org.jruby.RubyFixnum;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import static org.jruby.RubyBasicObject.getMetaClass;
 
 public class BitOrCallSite extends MonomorphicCallSite {
 
@@ -12,32 +13,40 @@ public class BitOrCallSite extends MonomorphicCallSite {
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) {
-            return ((RubyFixnum) self).op_or(context, arg1);
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_or(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) {
-            return ((RubyFixnum) self).op_or(context, arg1);
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_or(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Fixnum targets
         if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
-            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return cache = new FixnumEntry(entry); // tagged entry - do isBuiltin check once
         }
         return cache = entry;
     }
 
     @Override
     public boolean isBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FixnumEntry;
+        }
         return super.isBuiltin(self);
     }
 

--- a/core/src/main/java/org/jruby/runtime/callsite/CmpCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/CmpCallSite.java
@@ -5,8 +5,6 @@ import org.jruby.RubyFloat;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
-import static org.jruby.RubyBasicObject.getMetaClass;
-
 public class CmpCallSite extends BimorphicCallSite {
 
     public CmpCallSite() {
@@ -14,33 +12,79 @@ public class CmpCallSite extends BimorphicCallSite {
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg) {
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
         if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_cmp(context, arg);
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_cmp(context, arg1);
         } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_cmp(context, arg);
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_cmp(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg) {
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
         if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_cmp(context, arg);
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_cmp(context, arg1);
         } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_cmp(context, arg);
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_cmp(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg) {
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg1) {
         if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_cmp(context, arg);
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_cmp(context, arg1);
         } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(self.getMetaClass())) return ((RubyFloat) self).op_cmp(context, arg);
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_cmp(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
+    }
+
+    @Override
+    protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Fixnum targets
+        if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
+            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return cache = entry;
+    }
+
+    @Override
+    protected CacheEntry setSecondaryCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Float targets
+        if (self instanceof RubyFloat && entry.method.isBuiltin()) {
+            return secondaryCache = new FloatEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return secondaryCache = entry;
+    }
+
+    @Override
+    public boolean isBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        return super.isBuiltin(self);
+    }
+
+    @Override
+    public boolean isSecondaryBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFloat && secondaryCache instanceof FloatEntry) return true;
+        return super.isSecondaryBuiltin(self);
+    }
+
+    private static class FixnumEntry extends CacheEntry {
+
+        FixnumEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
+    }
+
+    private static class FloatEntry extends CacheEntry {
+
+        FloatEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
     }
 
 }

--- a/core/src/main/java/org/jruby/runtime/callsite/CmpCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/CmpCallSite.java
@@ -4,6 +4,7 @@ import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import static org.jruby.RubyBasicObject.getMetaClass;
 
 public class CmpCallSite extends BimorphicCallSite {
 
@@ -14,9 +15,15 @@ public class CmpCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_cmp(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_cmp(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_cmp(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_cmp(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
@@ -24,50 +31,66 @@ public class CmpCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_cmp(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_cmp(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_cmp(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_cmp(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg1) {
-        if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_cmp(context, arg1);
+        if (self instanceof RubyFloat) {
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_cmp(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_cmp(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_cmp(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Fixnum targets
         if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
-            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return cache = new FixnumEntry(entry); // tagged entry - do isBuiltin check once
         }
         return cache = entry;
     }
 
     @Override
     protected CacheEntry setSecondaryCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Float targets
         if (self instanceof RubyFloat && entry.method.isBuiltin()) {
-            return secondaryCache = new FloatEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return secondaryCache = new FloatEntry(entry); // tagged entry - do isBuiltin check once
         }
         return secondaryCache = entry;
     }
 
     @Override
     public boolean isBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FixnumEntry;
+        }
         return super.isBuiltin(self);
     }
 
     @Override
     public boolean isSecondaryBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFloat && secondaryCache instanceof FloatEntry) return true;
+        if (self instanceof RubyFloat) {
+            CacheEntry cache = this.secondaryCache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FloatEntry;
+        }
         return super.isSecondaryBuiltin(self);
     }
 

--- a/core/src/main/java/org/jruby/runtime/callsite/DivCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/DivCallSite.java
@@ -4,6 +4,7 @@ import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import static org.jruby.RubyBasicObject.getMetaClass;
 
 public class DivCallSite extends BimorphicCallSite {
 
@@ -14,9 +15,15 @@ public class DivCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_div(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_div(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_div(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_div(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
@@ -24,9 +31,15 @@ public class DivCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_div(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_div(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_div(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_div(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
@@ -34,38 +47,45 @@ public class DivCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg1) {
         if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_div(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_div(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Fixnum targets
         if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
-            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return cache = new FixnumEntry(entry); // tagged entry - do isBuiltin check once
         }
         return cache = entry;
     }
 
     @Override
     protected CacheEntry setSecondaryCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Float targets
         if (self instanceof RubyFloat && entry.method.isBuiltin()) {
-            return secondaryCache = new FloatEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return secondaryCache = new FloatEntry(entry); // tagged entry - do isBuiltin check once
         }
         return secondaryCache = entry;
     }
 
     @Override
     public boolean isBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FixnumEntry;
+        }
         return super.isBuiltin(self);
     }
 
     @Override
     public boolean isSecondaryBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFloat && secondaryCache instanceof FloatEntry) return true;
+        if (self instanceof RubyFloat) {
+            CacheEntry cache = this.secondaryCache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FloatEntry;
+        }
         return super.isSecondaryBuiltin(self);
     }
 

--- a/core/src/main/java/org/jruby/runtime/callsite/DivCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/DivCallSite.java
@@ -5,8 +5,6 @@ import org.jruby.RubyFloat;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
-import static org.jruby.RubyBasicObject.getMetaClass;
-
 public class DivCallSite extends BimorphicCallSite {
 
     public DivCallSite() {
@@ -14,30 +12,77 @@ public class DivCallSite extends BimorphicCallSite {
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg) {
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
         if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_div(context, arg);
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_div(context, arg1);
         } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_div(context, arg);
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_div(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg) {
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
+        if (self instanceof RubyFixnum) {
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_div(context, arg1);
+        } else if (self instanceof RubyFloat) {
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_div(context, arg1);
+        }
+        return super.call(context, caller, self, arg1);
+    }
+
+    @Override
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg1) {
         if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(self.getMetaClass())) return ((RubyFloat) self).op_div(context, arg);
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_div(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg) {
-        if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_div(context, arg);
-        } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_div(context, arg);
+    protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Fixnum targets
+        if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
+            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
         }
-        return super.call(context, caller, self, arg);
+        return cache = entry;
     }
+
+    @Override
+    protected CacheEntry setSecondaryCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Float targets
+        if (self instanceof RubyFloat && entry.method.isBuiltin()) {
+            return secondaryCache = new FloatEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return secondaryCache = entry;
+    }
+
+    @Override
+    public boolean isBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        return super.isBuiltin(self);
+    }
+
+    @Override
+    public boolean isSecondaryBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFloat && secondaryCache instanceof FloatEntry) return true;
+        return super.isSecondaryBuiltin(self);
+    }
+
+    private static class FixnumEntry extends CacheEntry {
+
+        FixnumEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
+    }
+
+    private static class FloatEntry extends CacheEntry {
+
+        FloatEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
+    }
+
 }

--- a/core/src/main/java/org/jruby/runtime/callsite/EqCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/EqCallSite.java
@@ -4,7 +4,6 @@ import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
-
 import static org.jruby.RubyBasicObject.getMetaClass;
 
 public class EqCallSite extends BimorphicCallSite {
@@ -16,9 +15,15 @@ public class EqCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_equal(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_equal(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_equal(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_equal(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
@@ -26,9 +31,15 @@ public class EqCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_equal(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_equal(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_equal(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_equal(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
@@ -36,40 +47,50 @@ public class EqCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_equal(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_equal(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_equal(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_equal(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Fixnum targets
         if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
-            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return cache = new FixnumEntry(entry); // tagged entry - do isBuiltin check once
         }
         return cache = entry;
     }
 
     @Override
     protected CacheEntry setSecondaryCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Float targets
         if (self instanceof RubyFloat && entry.method.isBuiltin()) {
-            return secondaryCache = new FloatEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return secondaryCache = new FloatEntry(entry); // tagged entry - do isBuiltin check once
         }
         return secondaryCache = entry;
     }
 
     @Override
     public boolean isBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FixnumEntry;
+        }
         return super.isBuiltin(self);
     }
 
     @Override
     public boolean isSecondaryBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFloat && secondaryCache instanceof FloatEntry) return true;
+        if (self instanceof RubyFloat) {
+            CacheEntry cache = this.secondaryCache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FloatEntry;
+        }
         return super.isSecondaryBuiltin(self);
     }
 

--- a/core/src/main/java/org/jruby/runtime/callsite/GeCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/GeCallSite.java
@@ -5,8 +5,6 @@ import org.jruby.RubyFloat;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
-import static org.jruby.RubyBasicObject.getMetaClass;
-
 public class GeCallSite extends BimorphicCallSite {
 
     public GeCallSite() {
@@ -14,31 +12,77 @@ public class GeCallSite extends BimorphicCallSite {
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg) {
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
         if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_ge(context, arg);
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_ge(context, arg1);
         } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_ge(context, arg);
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_ge(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg) {
-        if (self instanceof RubyFloat && isSecondaryBuiltin(getMetaClass(self))) {
-            return ((RubyFloat) self).op_ge(context, arg);
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
+        if (self instanceof RubyFixnum) {
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_ge(context, arg1);
+        } else if (self instanceof RubyFloat) {
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_ge(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg) {
-        if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_ge(context, arg);
-        } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_ge(context, arg);
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg1) {
+        if (self instanceof RubyFloat) {
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_ge(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
+    }
+
+    @Override
+    protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Fixnum targets
+        if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
+            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return cache = entry;
+    }
+
+    @Override
+    protected CacheEntry setSecondaryCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Float targets
+        if (self instanceof RubyFloat && entry.method.isBuiltin()) {
+            return secondaryCache = new FloatEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return secondaryCache = entry;
+    }
+
+    @Override
+    public boolean isBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        return super.isBuiltin(self);
+    }
+
+    @Override
+    public boolean isSecondaryBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFloat && secondaryCache instanceof FloatEntry) return true;
+        return super.isSecondaryBuiltin(self);
+    }
+
+    private static class FixnumEntry extends CacheEntry {
+
+        FixnumEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
+    }
+
+    private static class FloatEntry extends CacheEntry {
+
+        FloatEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
     }
 
 }

--- a/core/src/main/java/org/jruby/runtime/callsite/GtCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/GtCallSite.java
@@ -5,8 +5,6 @@ import org.jruby.RubyFloat;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
-import static org.jruby.RubyBasicObject.getMetaClass;
-
 public class GtCallSite extends BimorphicCallSite {
 
     public GtCallSite() {
@@ -14,31 +12,77 @@ public class GtCallSite extends BimorphicCallSite {
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg) {
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
         if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_gt(context, arg);
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_gt(context, arg1);
         } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_gt(context, arg);
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_gt(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg) {
-        if (self instanceof RubyFloat && isSecondaryBuiltin(getMetaClass(self))) {
-            return ((RubyFloat) self).op_gt(context, arg);
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
+        if (self instanceof RubyFixnum) {
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_gt(context, arg1);
+        } else if (self instanceof RubyFloat) {
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_gt(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg) {
-        if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_gt(context, arg);
-        } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_gt(context, arg);
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg1) {
+        if (self instanceof RubyFloat) {
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_gt(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
+    }
+
+    @Override
+    protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Fixnum targets
+        if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
+            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return cache = entry;
+    }
+
+    @Override
+    protected CacheEntry setSecondaryCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Float targets
+        if (self instanceof RubyFloat && entry.method.isBuiltin()) {
+            return secondaryCache = new FloatEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return secondaryCache = entry;
+    }
+
+    @Override
+    public boolean isBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        return super.isBuiltin(self);
+    }
+
+    @Override
+    public boolean isSecondaryBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFloat && secondaryCache instanceof FloatEntry) return true;
+        return super.isSecondaryBuiltin(self);
+    }
+
+    private static class FixnumEntry extends CacheEntry {
+
+        FixnumEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
+    }
+
+    private static class FloatEntry extends CacheEntry {
+
+        FloatEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
     }
 
 }

--- a/core/src/main/java/org/jruby/runtime/callsite/GtCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/GtCallSite.java
@@ -4,6 +4,7 @@ import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import static org.jruby.RubyBasicObject.getMetaClass;
 
 public class GtCallSite extends BimorphicCallSite {
 
@@ -14,9 +15,15 @@ public class GtCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_gt(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_gt(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_gt(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_gt(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
@@ -24,9 +31,15 @@ public class GtCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_gt(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_gt(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_gt(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_gt(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
@@ -34,38 +47,45 @@ public class GtCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg1) {
         if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_gt(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_gt(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Fixnum targets
         if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
-            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return cache = new FixnumEntry(entry); // tagged entry - do isBuiltin check once
         }
         return cache = entry;
     }
 
     @Override
     protected CacheEntry setSecondaryCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Float targets
         if (self instanceof RubyFloat && entry.method.isBuiltin()) {
-            return secondaryCache = new FloatEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return secondaryCache = new FloatEntry(entry); // tagged entry - do isBuiltin check once
         }
         return secondaryCache = entry;
     }
 
     @Override
     public boolean isBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FixnumEntry;
+        }
         return super.isBuiltin(self);
     }
 
     @Override
     public boolean isSecondaryBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFloat && secondaryCache instanceof FloatEntry) return true;
+        if (self instanceof RubyFloat) {
+            CacheEntry cache = this.secondaryCache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FloatEntry;
+        }
         return super.isSecondaryBuiltin(self);
     }
 

--- a/core/src/main/java/org/jruby/runtime/callsite/LeCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/LeCallSite.java
@@ -4,6 +4,7 @@ import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import static org.jruby.RubyBasicObject.getMetaClass;
 
 public class LeCallSite extends BimorphicCallSite {
 
@@ -14,9 +15,15 @@ public class LeCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_le(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_le(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_le(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_le(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
@@ -24,9 +31,15 @@ public class LeCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_le(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_le(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_le(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_le(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
@@ -34,38 +47,45 @@ public class LeCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg1) {
         if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_le(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_le(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Fixnum targets
         if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
-            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return cache = new FixnumEntry(entry); // tagged entry - do isBuiltin check once
         }
         return cache = entry;
     }
 
     @Override
     protected CacheEntry setSecondaryCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Float targets
         if (self instanceof RubyFloat && entry.method.isBuiltin()) {
-            return secondaryCache = new FloatEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return secondaryCache = new FloatEntry(entry); // tagged entry - do isBuiltin check once
         }
         return secondaryCache = entry;
     }
 
     @Override
     public boolean isBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FixnumEntry;
+        }
         return super.isBuiltin(self);
     }
 
     @Override
     public boolean isSecondaryBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFloat && secondaryCache instanceof FloatEntry) return true;
+        if (self instanceof RubyFloat) {
+            CacheEntry cache = this.secondaryCache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FloatEntry;
+        }
         return super.isSecondaryBuiltin(self);
     }
 

--- a/core/src/main/java/org/jruby/runtime/callsite/LeCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/LeCallSite.java
@@ -5,8 +5,6 @@ import org.jruby.RubyFloat;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
-import static org.jruby.RubyBasicObject.getMetaClass;
-
 public class LeCallSite extends BimorphicCallSite {
 
     public LeCallSite() {
@@ -14,31 +12,77 @@ public class LeCallSite extends BimorphicCallSite {
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg) {
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
         if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_le(context, arg);
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_le(context, arg1);
         } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_le(context, arg);
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_le(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg) {
-        if (self instanceof RubyFloat && isSecondaryBuiltin(getMetaClass(self))) {
-            return ((RubyFloat) self).op_le(context, arg);
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
+        if (self instanceof RubyFixnum) {
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_le(context, arg1);
+        } else if (self instanceof RubyFloat) {
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_le(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg) {
-        if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_le(context, arg);
-        } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_le(context, arg);
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg1) {
+        if (self instanceof RubyFloat) {
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_le(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
+    }
+
+    @Override
+    protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Fixnum targets
+        if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
+            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return cache = entry;
+    }
+
+    @Override
+    protected CacheEntry setSecondaryCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Float targets
+        if (self instanceof RubyFloat && entry.method.isBuiltin()) {
+            return secondaryCache = new FloatEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return secondaryCache = entry;
+    }
+
+    @Override
+    public boolean isBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        return super.isBuiltin(self);
+    }
+
+    @Override
+    public boolean isSecondaryBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFloat && secondaryCache instanceof FloatEntry) return true;
+        return super.isSecondaryBuiltin(self);
+    }
+
+    private static class FixnumEntry extends CacheEntry {
+
+        FixnumEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
+    }
+
+    private static class FloatEntry extends CacheEntry {
+
+        FloatEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
     }
 
 }

--- a/core/src/main/java/org/jruby/runtime/callsite/LtCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/LtCallSite.java
@@ -5,8 +5,6 @@ import org.jruby.RubyFloat;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
-import static org.jruby.RubyBasicObject.getMetaClass;
-
 public class LtCallSite extends BimorphicCallSite {
 
     public LtCallSite() {
@@ -14,31 +12,77 @@ public class LtCallSite extends BimorphicCallSite {
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg) {
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
         if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_lt(context, arg);
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_lt(context, arg1);
         } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_lt(context, arg);
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_lt(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg) {
-        if (self instanceof RubyFloat && isSecondaryBuiltin(self.getMetaClass())) {
-            return ((RubyFloat) self).op_lt(context, arg);
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
+        if (self instanceof RubyFixnum) {
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_lt(context, arg1);
+        } else if (self instanceof RubyFloat) {
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_lt(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg) {
-        if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_lt(context, arg);
-        } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_lt(context, arg);
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg1) {
+        if (self instanceof RubyFloat) {
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_lt(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
+    }
+
+    @Override
+    protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Fixnum targets
+        if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
+            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return cache = entry;
+    }
+
+    @Override
+    protected CacheEntry setSecondaryCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Float targets
+        if (self instanceof RubyFloat && entry.method.isBuiltin()) {
+            return secondaryCache = new FloatEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return secondaryCache = entry;
+    }
+
+    @Override
+    public boolean isBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        return super.isBuiltin(self);
+    }
+
+    @Override
+    public boolean isSecondaryBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFloat && secondaryCache instanceof FloatEntry) return true;
+        return super.isSecondaryBuiltin(self);
+    }
+
+    private static class FixnumEntry extends CacheEntry {
+
+        FixnumEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
+    }
+
+    private static class FloatEntry extends CacheEntry {
+
+        FloatEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
     }
 
 }

--- a/core/src/main/java/org/jruby/runtime/callsite/LtCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/LtCallSite.java
@@ -4,6 +4,7 @@ import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import static org.jruby.RubyBasicObject.getMetaClass;
 
 public class LtCallSite extends BimorphicCallSite {
 
@@ -14,9 +15,15 @@ public class LtCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_lt(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_lt(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_lt(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_lt(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
@@ -24,9 +31,15 @@ public class LtCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_lt(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_lt(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_lt(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_lt(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
@@ -34,38 +47,45 @@ public class LtCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg1) {
         if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_lt(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_lt(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Fixnum targets
         if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
-            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return cache = new FixnumEntry(entry); // tagged entry - do isBuiltin check once
         }
         return cache = entry;
     }
 
     @Override
     protected CacheEntry setSecondaryCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Float targets
         if (self instanceof RubyFloat && entry.method.isBuiltin()) {
-            return secondaryCache = new FloatEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return secondaryCache = new FloatEntry(entry); // tagged entry - do isBuiltin check once
         }
         return secondaryCache = entry;
     }
 
     @Override
     public boolean isBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FixnumEntry;
+        }
         return super.isBuiltin(self);
     }
 
     @Override
     public boolean isSecondaryBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFloat && secondaryCache instanceof FloatEntry) return true;
+        if (self instanceof RubyFloat) {
+            CacheEntry cache = this.secondaryCache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FloatEntry;
+        }
         return super.isSecondaryBuiltin(self);
     }
 

--- a/core/src/main/java/org/jruby/runtime/callsite/MinusCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/MinusCallSite.java
@@ -5,8 +5,6 @@ import org.jruby.RubyFloat;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
-import static org.jruby.RubyBasicObject.getMetaClass;
-
 public class MinusCallSite extends BimorphicCallSite {
 
     public MinusCallSite() {
@@ -14,33 +12,79 @@ public class MinusCallSite extends BimorphicCallSite {
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg) {
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
         if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_minus(context, arg);
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_minus(context, arg1);
         } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_minus(context, arg);
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_minus(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg) {
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
         if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_minus(context, arg);
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_minus(context, arg1);
         } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_minus(context, arg);
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_minus(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg) {
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg1) {
         if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_minus(context, arg);
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_minus(context, arg1);
         } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_minus(context, arg);
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_minus(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
+    }
+
+    @Override
+    protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Fixnum targets
+        if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
+            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return cache = entry;
+    }
+
+    @Override
+    protected CacheEntry setSecondaryCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Float targets
+        if (self instanceof RubyFloat && entry.method.isBuiltin()) {
+            return secondaryCache = new FloatEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return secondaryCache = entry;
+    }
+
+    @Override
+    public boolean isBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        return super.isBuiltin(self);
+    }
+
+    @Override
+    public boolean isSecondaryBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFloat && secondaryCache instanceof FloatEntry) return true;
+        return super.isSecondaryBuiltin(self);
+    }
+
+    private static class FixnumEntry extends CacheEntry {
+
+        FixnumEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
+    }
+
+    private static class FloatEntry extends CacheEntry {
+
+        FloatEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
     }
 
 }

--- a/core/src/main/java/org/jruby/runtime/callsite/MinusCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/MinusCallSite.java
@@ -4,6 +4,7 @@ import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import static org.jruby.RubyBasicObject.getMetaClass;
 
 public class MinusCallSite extends BimorphicCallSite {
 
@@ -14,9 +15,15 @@ public class MinusCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_minus(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_minus(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_minus(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_minus(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
@@ -24,9 +31,15 @@ public class MinusCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_minus(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_minus(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_minus(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_minus(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
@@ -34,40 +47,50 @@ public class MinusCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_minus(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_minus(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_minus(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_minus(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Fixnum targets
         if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
-            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return cache = new FixnumEntry(entry); // tagged entry - do isBuiltin check once
         }
         return cache = entry;
     }
 
     @Override
     protected CacheEntry setSecondaryCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Float targets
         if (self instanceof RubyFloat && entry.method.isBuiltin()) {
-            return secondaryCache = new FloatEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return secondaryCache = new FloatEntry(entry); // tagged entry - do isBuiltin check once
         }
         return secondaryCache = entry;
     }
 
     @Override
     public boolean isBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FixnumEntry;
+        }
         return super.isBuiltin(self);
     }
 
     @Override
     public boolean isSecondaryBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFloat && secondaryCache instanceof FloatEntry) return true;
+        if (self instanceof RubyFloat) {
+            CacheEntry cache = this.secondaryCache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FloatEntry;
+        }
         return super.isSecondaryBuiltin(self);
     }
 

--- a/core/src/main/java/org/jruby/runtime/callsite/ModCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/ModCallSite.java
@@ -14,28 +14,75 @@ public class ModCallSite extends BimorphicCallSite {
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg) {
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
         if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_mod(context, arg);
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_mod(context, arg1);
+        }
+        return super.call(context, caller, self, arg1);
+    }
+
+    @Override
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
+        if (self instanceof RubyFixnum) {
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_mod(context, arg1);
         } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_mod(context, arg);
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_mod(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg) {
-        if (self instanceof RubyFloat && isSecondaryBuiltin(getMetaClass(self))) {
-            return ((RubyFloat) self).op_mod(context, arg);
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg1) {
+        if (self instanceof RubyFloat) {
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_mod(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg) {
-        if (self instanceof RubyFixnum && isBuiltin(getMetaClass(self))) {
-            return ((RubyFixnum) self).op_mod(context, arg);
+    protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Fixnum targets
+        if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
+            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
         }
-        return super.call(context, caller, self, arg);
+        return cache = entry;
     }
+
+    @Override
+    protected CacheEntry setSecondaryCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Float targets
+        if (self instanceof RubyFloat && entry.method.isBuiltin()) {
+            return secondaryCache = new FloatEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return secondaryCache = entry;
+    }
+
+    @Override
+    public boolean isBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        return super.isBuiltin(self);
+    }
+
+    @Override
+    public boolean isSecondaryBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFloat && secondaryCache instanceof FloatEntry) return true;
+        return super.isSecondaryBuiltin(self);
+    }
+
+    private static class FixnumEntry extends CacheEntry {
+
+        FixnumEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
+    }
+
+    private static class FloatEntry extends CacheEntry {
+
+        FloatEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
+    }
+
 }

--- a/core/src/main/java/org/jruby/runtime/callsite/ModCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/ModCallSite.java
@@ -4,7 +4,6 @@ import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
-
 import static org.jruby.RubyBasicObject.getMetaClass;
 
 public class ModCallSite extends BimorphicCallSite {
@@ -16,7 +15,10 @@ public class ModCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_mod(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_mod(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
@@ -24,9 +26,15 @@ public class ModCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_mod(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_mod(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_mod(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_mod(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
@@ -34,38 +42,45 @@ public class ModCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg1) {
         if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_mod(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_mod(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Fixnum targets
         if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
-            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return cache = new FixnumEntry(entry); // tagged entry - do isBuiltin check once
         }
         return cache = entry;
     }
 
     @Override
     protected CacheEntry setSecondaryCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Float targets
         if (self instanceof RubyFloat && entry.method.isBuiltin()) {
-            return secondaryCache = new FloatEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return secondaryCache = new FloatEntry(entry); // tagged entry - do isBuiltin check once
         }
         return secondaryCache = entry;
     }
 
     @Override
     public boolean isBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FixnumEntry;
+        }
         return super.isBuiltin(self);
     }
 
     @Override
     public boolean isSecondaryBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFloat && secondaryCache instanceof FloatEntry) return true;
+        if (self instanceof RubyFloat) {
+            CacheEntry cache = this.secondaryCache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FloatEntry;
+        }
         return super.isSecondaryBuiltin(self);
     }
 

--- a/core/src/main/java/org/jruby/runtime/callsite/MulCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/MulCallSite.java
@@ -4,7 +4,6 @@ import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
-
 import static org.jruby.RubyBasicObject.getMetaClass;
 
 public class MulCallSite extends BimorphicCallSite {
@@ -16,9 +15,15 @@ public class MulCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_mul(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_mul(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_mul(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_mul(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
@@ -26,9 +31,15 @@ public class MulCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_mul(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_mul(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_mul(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_mul(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
@@ -36,40 +47,50 @@ public class MulCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_mul(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_mul(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_mul(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_mul(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Fixnum targets
         if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
-            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return cache = new FixnumEntry(entry); // tagged entry - do isBuiltin check once
         }
         return cache = entry;
     }
 
     @Override
     protected CacheEntry setSecondaryCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Float targets
         if (self instanceof RubyFloat && entry.method.isBuiltin()) {
-            return secondaryCache = new FloatEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return secondaryCache = new FloatEntry(entry); // tagged entry - do isBuiltin check once
         }
         return secondaryCache = entry;
     }
 
     @Override
     public boolean isBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FixnumEntry;
+        }
         return super.isBuiltin(self);
     }
 
     @Override
     public boolean isSecondaryBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFloat && secondaryCache instanceof FloatEntry) return true;
+        if (self instanceof RubyFloat) {
+            CacheEntry cache = this.secondaryCache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FloatEntry;
+        }
         return super.isSecondaryBuiltin(self);
     }
 

--- a/core/src/main/java/org/jruby/runtime/callsite/MulCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/MulCallSite.java
@@ -14,33 +14,79 @@ public class MulCallSite extends BimorphicCallSite {
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg) {
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
         if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_mul(context, arg);
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_mul(context, arg1);
         } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_mul(context, arg);
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_mul(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg) {
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
         if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_mul(context, arg);
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_mul(context, arg1);
         } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_mul(context, arg);
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_mul(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg) {
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg1) {
         if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_mul(context, arg);
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_mul(context, arg1);
         } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_mul(context, arg);
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_mul(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
+    }
+
+    @Override
+    protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Fixnum targets
+        if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
+            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return cache = entry;
+    }
+
+    @Override
+    protected CacheEntry setSecondaryCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Float targets
+        if (self instanceof RubyFloat && entry.method.isBuiltin()) {
+            return secondaryCache = new FloatEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return secondaryCache = entry;
+    }
+
+    @Override
+    public boolean isBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        return super.isBuiltin(self);
+    }
+
+    @Override
+    public boolean isSecondaryBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFloat && secondaryCache instanceof FloatEntry) return true;
+        return super.isSecondaryBuiltin(self);
+    }
+
+    private static class FixnumEntry extends CacheEntry {
+
+        FixnumEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
+    }
+
+    private static class FloatEntry extends CacheEntry {
+
+        FloatEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
     }
 
 }

--- a/core/src/main/java/org/jruby/runtime/callsite/PlusCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/PlusCallSite.java
@@ -5,8 +5,6 @@ import org.jruby.RubyFloat;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
-import static org.jruby.RubyBasicObject.getMetaClass;
-
 public class PlusCallSite extends BimorphicCallSite {
 
     public PlusCallSite() {
@@ -14,33 +12,79 @@ public class PlusCallSite extends BimorphicCallSite {
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg) {
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
         if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_plus(context, arg);
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_plus(context, arg1);
         } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_plus(context, arg);
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_plus(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg) {
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
         if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_plus(context, arg);
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_plus(context, arg1);
         } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_plus(context, arg);
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_plus(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg) {
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg1) {
         if (self instanceof RubyFixnum) {
-            if (isBuiltin(getMetaClass(self))) return ((RubyFixnum) self).op_plus(context, arg);
+            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_plus(context, arg1);
         } else if (self instanceof RubyFloat) {
-            if (isSecondaryBuiltin(getMetaClass(self))) return ((RubyFloat) self).op_plus(context, arg);
+            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_plus(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
+    }
+
+    @Override
+    protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Fixnum targets
+        if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
+            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return cache = entry;
+    }
+
+    @Override
+    protected CacheEntry setSecondaryCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Float targets
+        if (self instanceof RubyFloat && entry.method.isBuiltin()) {
+            return secondaryCache = new FloatEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return secondaryCache = entry;
+    }
+
+    @Override
+    public boolean isBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        return super.isBuiltin(self);
+    }
+
+    @Override
+    public boolean isSecondaryBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFloat && secondaryCache instanceof FloatEntry) return true;
+        return super.isSecondaryBuiltin(self);
+    }
+
+    private static class FixnumEntry extends CacheEntry {
+
+        FixnumEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
+    }
+
+    private static class FloatEntry extends CacheEntry {
+
+        FloatEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
     }
 
 }

--- a/core/src/main/java/org/jruby/runtime/callsite/PlusCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/PlusCallSite.java
@@ -4,6 +4,7 @@ import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import static org.jruby.RubyBasicObject.getMetaClass;
 
 public class PlusCallSite extends BimorphicCallSite {
 
@@ -14,9 +15,15 @@ public class PlusCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_plus(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_plus(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_plus(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_plus(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
@@ -24,9 +31,15 @@ public class PlusCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_plus(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_plus(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_plus(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_plus(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
@@ -34,40 +47,50 @@ public class PlusCallSite extends BimorphicCallSite {
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, double arg1) {
         if (self instanceof RubyFixnum) {
-            if (cache instanceof FixnumEntry) return ((RubyFixnum) self).op_plus(context, arg1);
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_plus(context, arg1);
+            }
         } else if (self instanceof RubyFloat) {
-            if (secondaryCache instanceof FloatEntry) return ((RubyFloat) self).op_plus(context, arg1);
+            CacheEntry cache = this.secondaryCache;
+            if (cache instanceof FloatEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFloat) self).op_plus(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Fixnum targets
         if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
-            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return cache = new FixnumEntry(entry); // tagged entry - do isBuiltin check once
         }
         return cache = entry;
     }
 
     @Override
     protected CacheEntry setSecondaryCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Float targets
         if (self instanceof RubyFloat && entry.method.isBuiltin()) {
-            return secondaryCache = new FloatEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return secondaryCache = new FloatEntry(entry); // tagged entry - do isBuiltin check once
         }
         return secondaryCache = entry;
     }
 
     @Override
     public boolean isBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FixnumEntry;
+        }
         return super.isBuiltin(self);
     }
 
     @Override
     public boolean isSecondaryBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFloat && secondaryCache instanceof FloatEntry) return true;
+        if (self instanceof RubyFloat) {
+            CacheEntry cache = this.secondaryCache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FloatEntry;
+        }
         return super.isSecondaryBuiltin(self);
     }
 

--- a/core/src/main/java/org/jruby/runtime/callsite/RespondToCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/RespondToCallSite.java
@@ -112,7 +112,7 @@ public class RespondToCallSite extends MonomorphicCallSite {
 
     @Override
     protected IRubyObject cacheAndCall(IRubyObject caller, RubyClass selfType, ThreadContext context, IRubyObject self, IRubyObject arg) {
-        final CacheEntry entry = selfType.searchWithCache(methodName);
+        CacheEntry entry = selfType.searchWithCache(methodName);
         final DynamicMethod method = entry.method;
         if (methodMissing(method, caller)) {
             return callMethodMissing(context, self, selfType, method, arg);
@@ -132,13 +132,13 @@ public class RespondToCallSite extends MonomorphicCallSite {
         }
 
         // normal logic if it's not the builtin respond_to? method
-        cache = entry;
+        entry = setCache(entry, self); // cache = entry;
         return method.call(context, self, entry.sourceModule, methodName, arg);
     }
 
     @Override
     protected IRubyObject cacheAndCall(IRubyObject caller, RubyClass selfType, ThreadContext context, IRubyObject self, IRubyObject arg0, IRubyObject arg1) {
-        final CacheEntry entry = selfType.searchWithCache(methodName);
+        CacheEntry entry = selfType.searchWithCache(methodName);
         final DynamicMethod method = entry.method;
         if (methodMissing(method, caller)) {
             return callMethodMissing(context, self, selfType, method, arg0, arg1);
@@ -158,7 +158,7 @@ public class RespondToCallSite extends MonomorphicCallSite {
         }
 
         // normal logic if it's not the builtin respond_to? method
-        cache = entry;
+        entry = setCache(entry, self); // cache = entry;
         return method.call(context, self, entry.sourceModule, methodName, arg0, arg1);
     }
 

--- a/core/src/main/java/org/jruby/runtime/callsite/ShiftLeftCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/ShiftLeftCallSite.java
@@ -4,26 +4,48 @@ import org.jruby.RubyFixnum;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
-import static org.jruby.RubyBasicObject.getMetaClass;
-
 public class ShiftLeftCallSite extends MonomorphicCallSite {
     public ShiftLeftCallSite() {
         super("<<");
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long fixnum) {
-        if (self instanceof RubyFixnum && isBuiltin(getMetaClass(self))) {
-            return ((RubyFixnum) self).op_lshift(context, fixnum);
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) {
+            return ((RubyFixnum) self).op_lshift(context, arg1);
         }
-        return super.call(context, caller, self, fixnum);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg) {
-        if (self instanceof RubyFixnum && isBuiltin(getMetaClass(self))) {
-            return ((RubyFixnum) self).op_lshift(context, arg);
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) {
+            return ((RubyFixnum) self).op_lshift(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
     }
+
+    @Override
+    protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Fixnum targets
+        if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
+            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return cache = entry;
+    }
+
+    @Override
+    public boolean isBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        return super.isBuiltin(self);
+    }
+
+    private static class FixnumEntry extends CacheEntry {
+
+        FixnumEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
+    }
+
 }

--- a/core/src/main/java/org/jruby/runtime/callsite/ShiftLeftCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/ShiftLeftCallSite.java
@@ -3,6 +3,7 @@ package org.jruby.runtime.callsite;
 import org.jruby.RubyFixnum;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import static org.jruby.RubyBasicObject.getMetaClass;
 
 public class ShiftLeftCallSite extends MonomorphicCallSite {
     public ShiftLeftCallSite() {
@@ -11,32 +12,40 @@ public class ShiftLeftCallSite extends MonomorphicCallSite {
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) {
-            return ((RubyFixnum) self).op_lshift(context, arg1);
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_lshift(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) {
-            return ((RubyFixnum) self).op_lshift(context, arg1);
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_lshift(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Fixnum targets
         if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
-            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return cache = new FixnumEntry(entry); // tagged entry - do isBuiltin check once
         }
         return cache = entry;
     }
 
     @Override
     public boolean isBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FixnumEntry;
+        }
         return super.isBuiltin(self);
     }
 

--- a/core/src/main/java/org/jruby/runtime/callsite/ShiftRightCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/ShiftRightCallSite.java
@@ -4,8 +4,6 @@ import org.jruby.RubyFixnum;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
-import static org.jruby.RubyBasicObject.getMetaClass;
-
 public class ShiftRightCallSite extends MonomorphicCallSite {
 
     public ShiftRightCallSite() {
@@ -13,19 +11,42 @@ public class ShiftRightCallSite extends MonomorphicCallSite {
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long fixnum) {
-        if (self instanceof RubyFixnum && isBuiltin(getMetaClass(self))) {
-            return ((RubyFixnum) self).op_rshift(context, fixnum);
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) {
+            return ((RubyFixnum) self).op_rshift(context, arg1);
         }
-        return super.call(context, caller, self, fixnum);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg) {
-        if (self instanceof RubyFixnum && isBuiltin(getMetaClass(self))) {
-            return ((RubyFixnum) self).op_rshift(context, arg);
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) {
+            return ((RubyFixnum) self).op_rshift(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
+    }
+
+    @Override
+    protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Fixnum targets
+        if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
+            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return cache = entry;
+    }
+
+    @Override
+    public boolean isBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        return super.isBuiltin(self);
+    }
+
+    private static class FixnumEntry extends CacheEntry {
+
+        FixnumEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
     }
 
 }

--- a/core/src/main/java/org/jruby/runtime/callsite/ShiftRightCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/ShiftRightCallSite.java
@@ -3,6 +3,7 @@ package org.jruby.runtime.callsite;
 import org.jruby.RubyFixnum;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import static org.jruby.RubyBasicObject.getMetaClass;
 
 public class ShiftRightCallSite extends MonomorphicCallSite {
 
@@ -12,32 +13,40 @@ public class ShiftRightCallSite extends MonomorphicCallSite {
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) {
-            return ((RubyFixnum) self).op_rshift(context, arg1);
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_rshift(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) {
-            return ((RubyFixnum) self).op_rshift(context, arg1);
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_rshift(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Fixnum targets
         if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
-            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return cache = new FixnumEntry(entry); // tagged entry - do isBuiltin check once
         }
         return cache = entry;
     }
 
     @Override
     public boolean isBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FixnumEntry;
+        }
         return super.isBuiltin(self);
     }
 

--- a/core/src/main/java/org/jruby/runtime/callsite/XorCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/XorCallSite.java
@@ -4,26 +4,47 @@ import org.jruby.RubyFixnum;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
-import static org.jruby.RubyBasicObject.getMetaClass;
-
 public class XorCallSite extends MonomorphicCallSite {
     public XorCallSite() {
         super("^");
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long fixnum) {
-        if (self instanceof RubyFixnum && isBuiltin(getMetaClass(self))) {
-            return ((RubyFixnum) self).op_xor(context, fixnum);
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) {
+            return ((RubyFixnum) self).op_xor(context, arg1);
         }
-        return super.call(context, caller, self, fixnum);
+        return super.call(context, caller, self, arg1);
     }
 
     @Override
-    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg) {
-        if (self instanceof RubyFixnum && isBuiltin(getMetaClass(self))) {
-            return ((RubyFixnum) self).op_xor(context, arg);
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) {
+            return ((RubyFixnum) self).op_xor(context, arg1);
         }
-        return super.call(context, caller, self, arg);
+        return super.call(context, caller, self, arg1);
+    }
+
+    @Override
+    protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
+        // used as a primary cache - for Fixnum targets
+        if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
+            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+        }
+        return cache = entry;
+    }
+
+    @Override
+    public boolean isBuiltin(final IRubyObject self) {
+        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        return super.isBuiltin(self);
+    }
+
+    private static class FixnumEntry extends CacheEntry {
+
+        FixnumEntry(CacheEntry entry) {
+            super(entry.method, entry.sourceModule, entry.token);
+        }
+
     }
 }

--- a/core/src/main/java/org/jruby/runtime/callsite/XorCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/XorCallSite.java
@@ -3,6 +3,7 @@ package org.jruby.runtime.callsite;
 import org.jruby.RubyFixnum;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import static org.jruby.RubyBasicObject.getMetaClass;
 
 public class XorCallSite extends MonomorphicCallSite {
     public XorCallSite() {
@@ -11,32 +12,40 @@ public class XorCallSite extends MonomorphicCallSite {
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, long arg1) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) {
-            return ((RubyFixnum) self).op_xor(context, arg1);
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_xor(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) {
-            return ((RubyFixnum) self).op_xor(context, arg1);
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache instanceof FixnumEntry && cache.typeOk(getMetaClass(self))) {
+                return ((RubyFixnum) self).op_xor(context, arg1);
+            }
         }
         return super.call(context, caller, self, arg1);
     }
 
     @Override
     protected CacheEntry setCache(final CacheEntry entry, final IRubyObject self) {
-        // used as a primary cache - for Fixnum targets
         if (self instanceof RubyFixnum && entry.method.isBuiltin()) {
-            return cache = new FixnumEntry(entry); // tagged entry replacement - a (costly) isBuiltin replacement
+            return cache = new FixnumEntry(entry); // tagged entry - do isBuiltin check once
         }
         return cache = entry;
     }
 
     @Override
     public boolean isBuiltin(final IRubyObject self) {
-        if (self instanceof RubyFixnum && cache instanceof FixnumEntry) return true;
+        if (self instanceof RubyFixnum) {
+            CacheEntry cache = this.cache;
+            if (cache.typeOk(getMetaClass(self))) return cache instanceof FixnumEntry;
+        }
         return super.isBuiltin(self);
     }
 
@@ -47,4 +56,5 @@ public class XorCallSite extends MonomorphicCallSite {
         }
 
     }
+
 }


### PR DESCRIPTION
restores interpreter 'fast' Fixnum/Float operations performance, which degraded after doing the `isBuiltin` checks (#4736)

there's a bit of refactoring needed for the CachingCallSite API used
we're adding a `CacheEntry setCache(CacheEntry entry, IRubyObject self)`
and checks such as `isBuiltin(RubyClass)` change to -> `isBuitlin(IRubyObject self)`
... this is the way JRuby intends to use these APIs anyway, so no harm done there

the gist of better performance is adding logic in custom sites when `setCache` happens,
do the builtin and target check there so that on the hot-path, taking the direct specific (Fixnum/Float) branch becomes 2 `instanceof` checks (edit: plus the obvious type "token" check)