### PR TITLE
Tweak Azure to use mvnw and Maven 3.6.0.

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.3.9/apache-maven-3.3.9-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.6.0/apache-maven-3.6.0-bin.zip

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,5 +10,5 @@ pool:
   vmImage: 'Ubuntu-16.04'
 
 steps:
-- script: mvn -B package -Ptest -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+- script: ./mvnw -B package -Ptest -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
   displayName: -Ptest


### PR DESCRIPTION
Attempting to get Azure Pipelines working again by forcing a slightly older Maven version.

It seems that https://issues.apache.org/jira/browse/MNG-6644 is causing the failures.