### PR TITLE
Dereference proc from interface impl singleton

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtil.java
@@ -59,6 +59,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.jruby.MetaClass;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyBasicObject;
@@ -262,6 +264,11 @@ public class JavaUtil {
             // Proc implementing an interface, pull in the catch-all code that lets the proc get invoked
             // no matter what method is called on the interface
             final RubyClass singletonClass = rubyObject.getSingletonClass();
+
+            // We clear the "attached" proc so the singleton class and by extension the method cache in the interface
+            // impl does not root the proc and its binding in the host classloader. See GH-4968.
+            ((MetaClass) singletonClass).setAttached(singletonClass.getSuperClass());
+
             final Java.ProcToInterface procToIface = new Java.ProcToInterface(singletonClass);
             singletonClass.addMethod("method_missing", procToIface);
             // similar to Iface.impl { ... } - bind interface method(s) to avoid Java-Ruby conflicts

--- a/core/src/main/java/org/jruby/javasupport/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtil.java
@@ -254,6 +254,10 @@ public class JavaUtil {
     public static <T> T convertProcToInterface(ThreadContext context, RubyBasicObject rubyObject, Class<T> targetType) {
         final Ruby runtime = context.runtime;
 
+        // Capture original class; we only detach the singleton for natural Proc instances
+        RubyClass procClass = rubyObject.getMetaClass();
+
+        // Extend the interfaces into the proc's class. This creates a singleton class to connect up the Java proxy.
         final RubyModule ifaceModule = Java.getInterfaceModule(runtime, JavaClass.get(runtime, targetType));
         if ( ! ifaceModule.isInstance(rubyObject) ) {
             ifaceModule.callMethod(context, "extend_object", rubyObject);
@@ -265,9 +269,11 @@ public class JavaUtil {
             // no matter what method is called on the interface
             final RubyClass singletonClass = rubyObject.getSingletonClass();
 
-            // We clear the "attached" proc so the singleton class and by extension the method cache in the interface
-            // impl does not root the proc and its binding in the host classloader. See GH-4968.
-            ((MetaClass) singletonClass).setAttached(singletonClass.getSuperClass());
+            if (procClass == runtime.getProc()) {
+                // We reattach the singleton class to the Proc class object to prevent the method cache in the interface
+                // impl from rooting the proc and its binding in the host classloader. See GH-4968.
+                ((MetaClass) singletonClass).setAttached(runtime.getProc());
+            }
 
             final Java.ProcToInterface procToIface = new Java.ProcToInterface(singletonClass);
             singletonClass.addMethod("method_missing", procToIface);

--- a/spec/java_integration/interfaces/implementation_spec.rb
+++ b/spec/java_integration/interfaces/implementation_spec.rb
@@ -342,6 +342,26 @@ describe "Single-method Java interfaces" do
 
     expect(interfaces).to include(SingleMethodInterface.java_class)
   end
+
+  it "preserves singleton Proc behavior and callbacks" do
+    pr = proc { }
+    def pr.singleton_method_added(name)
+      (@names ||= []) << [name, self]
+    end
+
+    old_singleton_class = pr.singleton_class
+
+    r = Runnable.impl(&pr)
+
+    def pr.another_method; end
+
+    expect(pr.singleton_class).to eq old_singleton_class
+
+    expect(pr.instance_variable_get(:@names)).to eq [
+        [:singleton_method_added, pr],
+        [:another_method, pr]
+    ]
+  end
 end
 
 describe "A bean-like Java interface" do


### PR DESCRIPTION
By holding a reference to the proc, we anchor the proc's binding to the singleton class. When methods from the singleton class are cached elsewhere, such as for Java interface proxies (see GH-4968) we end up keeping the proc's binding alive longer than we'd like.

This patch detaches the proc object from the singleton, instead pointing it at the Proc class. The side effects from this include(at least) that any new singleton methods defined on that proc's singleton class will dispatch to hook methods (like singleton_method_defined) on Proc, rather than on the proc object. It's unknown whether this would affect any existing code.