### PR TITLE
Use parent thread for Thread.current within a fiber

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -925,7 +925,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
 
     @JRubyMethod(meta = true)
     public static RubyThread current(IRubyObject recv) {
-        return recv.getRuntime().getCurrentContext().getThread();
+        return recv.getRuntime().getCurrentContext().getFiberCurrentThread();
     }
 
     @JRubyMethod(meta = true)


### PR DESCRIPTION
This is the start of experiments in making Thread.current, among other things, pretend that a Fiber is equivalent to its master thread, rather than being its own thread.

This work was triggered by me running the socketry/async specs and seeing that there's some locking done across fibers that's expected to treat them all as owning the lock. In this case, it's
an RSpec reentrant lock implementation that aggregates a Mutex and the thread that acquired it and compares that thread with Thread.current to avoid relocking.

For JRuby the following changes were needed to make the lock work:

* Thread.current must point at the "Fiber current thread" rather than the "Fiber thread". We have attempted this in the past and run afoul of system-level locking that saw through to the real
locks.
* Mutex#owned? had to do a similar check, aggregating a reference   to the Fiber current thread that originally locked it and using that for comparison with the current Fiber current thread.

With these changes the async specs run to completion with 16 errors that I have not looked into yet.

See #1806.