### PR TITLE
Fail gracefully when inner class const_missing finds nothing

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -1183,6 +1183,8 @@ public class Java implements Library {
 
         Class<?> enclosing = JavaClass.getJavaClass(context, enclosingClass);
 
+        if (enclosing == null) return null;
+
         final String fullName = enclosing.getName() + '$' + name;
 
         final RubyModule result = getProxyClassOrNull(runtime, fullName);

--- a/core/src/main/java/org/jruby/javasupport/JavaClass.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaClass.java
@@ -169,7 +169,7 @@ public class JavaClass extends JavaObject {
      * @return class
      */
     public static Class<?> getJavaClass(final ThreadContext context, final RubyModule proxy) {
-        return ((JavaClass) java_class(context, proxy)).javaClass();
+        return getJavaClassIfProxy(context, proxy);
     }
 
     /**


### PR DESCRIPTION
This should fix the issue reported as a comment in https://github.com/ruboto/JRuby9K_POC/issues/7.

The issue here appears to be that non-existent inner classes are not handled properly; the resulting null or nil values fail to cast to expected types and the superclass const_missing fallback never triggers.

The change I have here uses a different path for acquiring a reference to the proxy class, which then allows the fallback to fire properly.

The original change was made by @kares in #3333 but it appears the test cases added did not test the case where there is no inner class for the constant.