### PR TITLE
Reuse existing source position if it matches

### DIFF
--- a/core/src/main/java/org/jruby/lexer/LexingCommon.java
+++ b/core/src/main/java/org/jruby/lexer/LexingCommon.java
@@ -266,8 +266,11 @@ public abstract class LexingCommon {
     }
 
     public ISourcePosition getPosition() {
+        ISourcePosition tokline = this.tokline;
+        int ruby_sourceline = this.ruby_sourceline;
+
         if (tokline != null && ruby_sourceline == tokline.getLine()) return tokline;
-        return new SimpleSourcePosition(getFile(), ruby_sourceline);
+        return this.tokline = new SimpleSourcePosition(getFile(), ruby_sourceline);
     }
 
     public int getLineOffset() {


### PR DESCRIPTION
This seems simple enough but causes some off-by-one issues for reasons I have not managed to figure out.

If this change can work, it reduces SimpleSourcePosition allocation during `-e 1` from 46240 (1110264 bytes) to 13984 instances (335616 bytes).