### PR TITLE
Consistently resolve path of jruby.bash

### DIFF
--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -49,7 +49,7 @@ while [ -h "$SELF_PATH" ]; do
     SELF_PATH="$(cd "$BASE_DIR" && cd $(dirname -- "$SYM") && pwd -P)/$(basename -- "$SYM")"
 done
 
-JRUBY_HOME="$SELF_PATH"
+JRUBY_HOME="${SELF_PATH%/*/*}"
 
 if [ -z "$JRUBY_OPTS" ] ; then
   JRUBY_OPTS=""

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -36,28 +36,20 @@ if [ -z "$JAVA_VM" ]; then
 fi
 
 # get the absolute path of the executable
-SELF_PATH=$(builtin cd -P -- "$(dirname -- "$0")" >/dev/null && pwd -P) && SELF_PATH=$SELF_PATH/$(basename -- "$0")
+BASE_DIR=$(cd -P -- "$(dirname -- "$BASH_SOURCE")" >/dev/null && pwd -P)
+SELF_PATH="$BASE_DIR/$(basename -- "$BASH_SOURCE")"
 
 # resolve symlinks
 while [ -h "$SELF_PATH" ]; do
     # 1) cd to directory of the symlink
     # 2) cd to the directory of where the symlink points
-    # 3) get the pwd
+    # 3) get the physical pwd
     # 4) append the basename
-    DIR=$(dirname -- "$SELF_PATH")
-    SYM=$(readlink "$SELF_PATH")
-    SELF_PATH=$(cd "$DIR" && cd $(dirname -- "$SYM") && pwd)/$(basename -- "$SYM")
+    SYM="$(readlink "$SELF_PATH")"
+    SELF_PATH="$(cd "$BASE_DIR" && cd $(dirname -- "$SYM") && pwd -P)/$(basename -- "$SYM")"
 done
 
-PRG=$SELF_PATH
-
-JRUBY_HOME_1=`dirname "$PRG"`           # the ./bin dir
-if [ "$JRUBY_HOME_1" = '.' ] ; then
-  cwd=`pwd`
-  JRUBY_HOME=`dirname $cwd` # JRUBY-2699
-else
-  JRUBY_HOME=`dirname "$JRUBY_HOME_1"`  # the . dir
-fi
+JRUBY_HOME="$SELF_PATH"
 
 if [ -z "$JRUBY_OPTS" ] ; then
   JRUBY_OPTS=""


### PR DESCRIPTION
The bash script sometimes returns an incorrect path for `JRUBY_HOME`. I came up with a bunch of cases where it would return the wrong directory, in no particular order:

1. a directory in PATH is a symlink
2. a directory in PATH is in a symlink
3. the executable is a symlink in PATH
4. the executable is in a directory that is a symlink
5. the executable is a symlink that points to an executable in a directory that is a symlink
6. the executable is being read from a pipe

Simply replacing `$0` with `$BASH_SOURCE` fixes case 3. Obviously this is bash-specific, so this can't be ported to the sh script.
Case 4 are solved by using readlink on the executable until it isn't a symlink. The script already did this, so I made some changes to solve other issues.
Cases 1, 2, and 5 are solved by running `pwd -P` in the directory of the executable.
I don't know how to solve case 6 without hardcoding a directory to check.

Because `pwd -P` always returns the absolute working directory, it seems running `dirname "$SELF_PATH"` is unnecessary, so I removed it.
If anyone can think of any other torture tests, let me know.