### PR TITLE
Move all JI setAccessible to trySetAccessible.

### DIFF
--- a/core/src/main/java/org/jruby/RubyInstanceConfig.java
+++ b/core/src/main/java/org/jruby/RubyInstanceConfig.java
@@ -1837,7 +1837,7 @@ public class RubyInstanceConfig {
 
     public static final boolean JIT_LOADING_DEBUG = Options.JIT_DEBUG.load();
 
-    public static final boolean CAN_SET_ACCESSIBLE = Options.JI_SETACCESSIBLE.load();
+    public static final boolean SET_ACCESSIBLE = Options.JI_SETACCESSIBLE.load();
 
     // properties for logging exceptions, backtraces, and caller invocations
     public static final boolean LOG_EXCEPTIONS = Options.LOG_EXCEPTIONS.load();
@@ -2044,4 +2044,6 @@ public class RubyInstanceConfig {
      */
     @Deprecated
     public static final boolean NATIVE_NET_PROTOCOL = Options.NATIVE_NET_PROTOCOL.load();
+    @Deprecated
+    public static final boolean CAN_SET_ACCESSIBLE = Options.JI_SETACCESSIBLE.load();
 }

--- a/core/src/main/java/org/jruby/java/invokers/FieldMethodOne.java
+++ b/core/src/main/java/org/jruby/java/invokers/FieldMethodOne.java
@@ -2,6 +2,7 @@ package org.jruby.java.invokers;
 
 import java.lang.reflect.Field;
 
+import com.headius.backport9.modules.Modules;
 import org.jruby.Ruby;
 import org.jruby.RubyModule;
 import org.jruby.internal.runtime.methods.JavaMethod;
@@ -25,7 +26,7 @@ public abstract class FieldMethodOne extends JavaMethod.JavaMethodOne {
 
     protected FieldMethodOne(RubyModule host, Field field, String name) {
         super(host, Visibility.PUBLIC, name);
-        if ( ! Ruby.isSecurityRestricted() ) field.setAccessible(true);
+        Modules.trySetAccessible(field, Ruby.class);
         this.field = field;
     }
 

--- a/core/src/main/java/org/jruby/java/invokers/FieldMethodOne.java
+++ b/core/src/main/java/org/jruby/java/invokers/FieldMethodOne.java
@@ -2,10 +2,10 @@ package org.jruby.java.invokers;
 
 import java.lang.reflect.Field;
 
-import com.headius.backport9.modules.Modules;
 import org.jruby.Ruby;
 import org.jruby.RubyModule;
 import org.jruby.internal.runtime.methods.JavaMethod;
+import org.jruby.javasupport.Java;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -26,7 +26,7 @@ public abstract class FieldMethodOne extends JavaMethod.JavaMethodOne {
 
     protected FieldMethodOne(RubyModule host, Field field, String name) {
         super(host, Visibility.PUBLIC, name);
-        Modules.trySetAccessible(field, Ruby.class);
+        Java.trySetAccessible(field);
         this.field = field;
     }
 

--- a/core/src/main/java/org/jruby/java/invokers/FieldMethodZero.java
+++ b/core/src/main/java/org/jruby/java/invokers/FieldMethodZero.java
@@ -2,11 +2,11 @@ package org.jruby.java.invokers;
 
 import java.lang.reflect.Field;
 
-import com.headius.backport9.modules.Modules;
 import org.jruby.Ruby;
 import org.jruby.RubyModule;
 import org.jruby.internal.runtime.methods.JavaMethod;
 import org.jruby.java.proxies.JavaProxy;
+import org.jruby.javasupport.Java;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -27,7 +27,7 @@ public abstract class FieldMethodZero extends JavaMethod.JavaMethodZero {
 
     protected FieldMethodZero(RubyModule host, Field field, String name) {
         super(host, Visibility.PUBLIC, name);
-        Modules.trySetAccessible(field, Ruby.class);
+        Java.trySetAccessible(field);
         this.field = field;
     }
 

--- a/core/src/main/java/org/jruby/java/invokers/FieldMethodZero.java
+++ b/core/src/main/java/org/jruby/java/invokers/FieldMethodZero.java
@@ -2,6 +2,7 @@ package org.jruby.java.invokers;
 
 import java.lang.reflect.Field;
 
+import com.headius.backport9.modules.Modules;
 import org.jruby.Ruby;
 import org.jruby.RubyModule;
 import org.jruby.internal.runtime.methods.JavaMethod;
@@ -26,7 +27,7 @@ public abstract class FieldMethodZero extends JavaMethod.JavaMethodZero {
 
     protected FieldMethodZero(RubyModule host, Field field, String name) {
         super(host, Visibility.PUBLIC, name);
-        if ( ! Ruby.isSecurityRestricted() ) field.setAccessible(true);
+        Modules.trySetAccessible(field, Ruby.class);
         this.field = field;
     }
 

--- a/core/src/main/java/org/jruby/java/invokers/RubyToJavaInvoker.java
+++ b/core/src/main/java/org/jruby/java/invokers/RubyToJavaInvoker.java
@@ -34,7 +34,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 
-import com.headius.backport9.modules.Modules;
 import org.jruby.Ruby;
 import org.jruby.RubyModule;
 import org.jruby.exceptions.RaiseException;
@@ -43,11 +42,11 @@ import org.jruby.java.dispatch.CallableSelector;
 import org.jruby.java.proxies.ArrayJavaProxy;
 import org.jruby.java.proxies.ConcreteJavaProxy;
 import org.jruby.java.proxies.JavaProxy;
+import org.jruby.javasupport.Java;
 import org.jruby.javasupport.JavaCallable;
 import org.jruby.javasupport.JavaConstructor;
 import org.jruby.javasupport.ParameterTypes;
 import org.jruby.runtime.Arity;
-import org.jruby.runtime.Helpers;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.cli.Options;
@@ -57,7 +56,6 @@ import org.jruby.util.collections.NonBlockingHashMapLong;
 import static org.jruby.util.CodegenUtils.prettyParams;
 
 public abstract class RubyToJavaInvoker<T extends JavaCallable> extends JavaMethod {
-    // implements CallableCache<T> {
 
     static final NonBlockingHashMapLong NULL_CACHE = new NullHashMapLong();
 
@@ -349,7 +347,7 @@ public abstract class RubyToJavaInvoker<T extends JavaCallable> extends JavaMeth
                 !Ruby.isSecurityRestricted() &&
                 Options.JI_SETACCESSIBLE.load() &&
                 accessible instanceof Member) {
-            try { Modules.trySetAccessible(accessible, Ruby.class); }
+            try { Java.trySetAccessible(accessible); }
             catch (SecurityException e) {}
             catch (RuntimeException re) {
                 rethrowIfNotInaccessibleObject(re);
@@ -377,7 +375,7 @@ public abstract class RubyToJavaInvoker<T extends JavaCallable> extends JavaMeth
                     if (accessible.isAccessible()) continue;
                     if (!(accessible instanceof Member)) continue;
 
-                    Modules.trySetAccessible(accessible, Ruby.class);
+                    Java.trySetAccessible(accessible);
                 }
             }
             catch (SecurityException e) {}

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -1641,10 +1641,4 @@ public class Java implements Library {
         return single;
     }
 
-    /**
-     * @see JavaUtil#CAN_SET_ACCESSIBLE
-     */
-    @SuppressWarnings("unused") private static final byte HIDDEN_STATIC_FIELD = 72;
-    public static final String HIDDEN_STATIC_FIELD_NAME = "HIDDEN_STATIC_FIELD";
-
 }

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -34,7 +34,9 @@
 
 package org.jruby.javasupport;
 
+import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Member;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -51,6 +53,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.headius.backport9.modules.Modules;
 import org.jcodings.Encoding;
 
 import org.jruby.*;
@@ -1639,6 +1642,18 @@ public class Java implements Library {
             else return null; // not a functional iface
         }
         return single;
+    }
+
+    /**
+     * Try to set the given member to be accessible, considering open modules and avoiding the actual setAccessible
+     * call when it would produce a JPMS warning. All classes on Java 8 are considered open, allowing setAccessible
+     * to proceed.
+     *
+     * The open check is based on this class, Java.java, which will be in whatever core or dist JRuby module you are
+     * using.
+     */
+    public static <T extends AccessibleObject & Member> boolean trySetAccessible(T member) {
+        return Modules.trySetAccessible(member, Java.class);
     }
 
 }

--- a/core/src/main/java/org/jruby/javasupport/JavaMethod.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaMethod.java
@@ -44,7 +44,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 
-import com.headius.backport9.modules.Modules;
 import org.jruby.Ruby;
 import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
@@ -112,7 +111,7 @@ public class JavaMethod extends JavaCallable {
             try {
                 if ( Modifier.isPublic(method.getModifiers()) &&
                     ! Modifier.isPublic(method.getDeclaringClass().getModifiers()) ) {
-                    Modules.trySetAccessible(method, Ruby.class);
+                    Java.trySetAccessible(method);
                 }
             } catch (SecurityException se) {
                 // we shouldn't get here if JavaClass.CAN_SET_ACCESSIBLE is doing

--- a/core/src/main/java/org/jruby/javasupport/JavaMethod.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaMethod.java
@@ -44,9 +44,11 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 
+import com.headius.backport9.modules.Modules;
 import org.jruby.Ruby;
 import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
+import org.jruby.RubyInstanceConfig;
 import org.jruby.RubyModule;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyClass;
@@ -105,12 +107,12 @@ public class JavaMethod extends JavaCallable {
         // Special classes like Collections.EMPTY_LIST are inner classes that are private but
         // implement public interfaces.  Their methods are all public methods for the public
         // interface.  Let these public methods execute via setAccessible(true).
-        if (JavaUtil.CAN_SET_ACCESSIBLE) {
+        if (RubyInstanceConfig.SET_ACCESSIBLE) {
             // we should be able to setAccessible ok...
             try {
                 if ( Modifier.isPublic(method.getModifiers()) &&
                     ! Modifier.isPublic(method.getDeclaringClass().getModifiers()) ) {
-                    method.setAccessible(true);
+                    Modules.trySetAccessible(method, Ruby.class);
                 }
             } catch (SecurityException se) {
                 // we shouldn't get here if JavaClass.CAN_SET_ACCESSIBLE is doing

--- a/core/src/main/java/org/jruby/javasupport/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtil.java
@@ -94,35 +94,6 @@ import org.jruby.util.TypeConverter;
 import org.jruby.util.cli.Options;
 
 public class JavaUtil {
-
-    public static final boolean CAN_SET_ACCESSIBLE;
-
-    static {
-        boolean canSetAccessible = false;
-
-        if (RubyInstanceConfig.CAN_SET_ACCESSIBLE) {
-            try {
-                // We want to check if we can access a commonly-existing private field through reflection.
-                // If so, we're probably able to access some other fields too later on.
-                Field f = Java.class.getDeclaredField(Java.HIDDEN_STATIC_FIELD_NAME);
-                f.setAccessible(true);
-                canSetAccessible = f.getByte(null) == 72;
-            }
-            catch (Exception t) {
-                // added this so if things are weird in the future we can debug without
-                // spinning a new binary
-                if (Options.JI_LOGCANSETACCESSIBLE.load()) {
-                    t.printStackTrace();
-                }
-
-                // assume any exception means we can't suppress access checks
-                canSetAccessible = false;
-            }
-        }
-
-        CAN_SET_ACCESSIBLE = canSetAccessible;
-    }
-
     public static IRubyObject[] convertJavaArrayToRuby(final Ruby runtime, final Object[] objects) {
         if ( objects == null || objects.length == 0 ) return IRubyObject.NULL_ARRAY;
 
@@ -1643,4 +1614,7 @@ public class JavaUtil {
         }
         return (JavaObject)obj;
     }
+
+    @Deprecated
+    public static final boolean CAN_SET_ACCESSIBLE = true;
 }

--- a/core/src/main/java/org/jruby/javasupport/binding/ConstructorInvokerInstaller.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/ConstructorInvokerInstaller.java
@@ -1,5 +1,8 @@
 package org.jruby.javasupport.binding;
 
+import com.headius.backport9.modules.Modules;
+import org.jruby.Ruby;
+import org.jruby.RubyInstanceConfig;
 import org.jruby.RubyModule;
 import org.jruby.java.invokers.ConstructorInvoker;
 import org.jruby.javasupport.JavaUtil;
@@ -25,9 +28,9 @@ public class ConstructorInvokerInstaller extends MethodInstaller {
 
     // called only by initializing thread; no synchronization required
     void addConstructor(final Constructor ctor, final Class<?> clazz) {
-        if (JavaUtil.CAN_SET_ACCESSIBLE) {
+        if (RubyInstanceConfig.SET_ACCESSIBLE) {
             try {
-                ctor.setAccessible(true);
+                Modules.trySetAccessible(ctor, Ruby.class);
             } catch(SecurityException e) {}
         }
         this.constructors.add(ctor);

--- a/core/src/main/java/org/jruby/javasupport/binding/ConstructorInvokerInstaller.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/ConstructorInvokerInstaller.java
@@ -1,11 +1,9 @@
 package org.jruby.javasupport.binding;
 
-import com.headius.backport9.modules.Modules;
-import org.jruby.Ruby;
 import org.jruby.RubyInstanceConfig;
 import org.jruby.RubyModule;
 import org.jruby.java.invokers.ConstructorInvoker;
-import org.jruby.javasupport.JavaUtil;
+import org.jruby.javasupport.Java;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -30,7 +28,7 @@ public class ConstructorInvokerInstaller extends MethodInstaller {
     void addConstructor(final Constructor ctor, final Class<?> clazz) {
         if (RubyInstanceConfig.SET_ACCESSIBLE) {
             try {
-                Modules.trySetAccessible(ctor, Ruby.class);
+                Java.trySetAccessible(ctor);
             } catch(SecurityException e) {}
         }
         this.constructors.add(ctor);

--- a/core/src/main/java/org/jruby/javasupport/binding/FieldInstaller.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/FieldInstaller.java
@@ -1,7 +1,6 @@
 package org.jruby.javasupport.binding;
 
-import com.headius.backport9.modules.Modules;
-import org.jruby.Ruby;
+import org.jruby.javasupport.Java;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -19,6 +18,6 @@ public abstract class FieldInstaller extends NamedInstaller {
     }
 
     public boolean isAccessible() {
-        return Modifier.isPublic(field.getModifiers()) || Modules.trySetAccessible(field, Ruby.class);
+        return Modifier.isPublic(field.getModifiers()) || Java.trySetAccessible(field);
     }
 }

--- a/core/src/main/java/org/jruby/javasupport/binding/FieldInstaller.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/FieldInstaller.java
@@ -1,6 +1,7 @@
 package org.jruby.javasupport.binding;
 
 import com.headius.backport9.modules.Modules;
+import org.jruby.Ruby;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -18,6 +19,6 @@ public abstract class FieldInstaller extends NamedInstaller {
     }
 
     public boolean isAccessible() {
-        return Modifier.isPublic(field.getModifiers()) || Modules.trySetAccessible(field);
+        return Modifier.isPublic(field.getModifiers()) || Modules.trySetAccessible(field, Ruby.class);
     }
 }

--- a/core/src/main/java/org/jruby/javasupport/binding/Initializer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/Initializer.java
@@ -1,6 +1,5 @@
 package org.jruby.javasupport.binding;
 
-import com.headius.backport9.modules.Modules;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
@@ -540,7 +539,7 @@ public abstract class Initializer {
             if ( Modifier.isPrivate(mod) ) continue;
 
             // Skip protected methods if we can't set accessible
-            if ( !Modifier.isPublic(mod) && !Modules.trySetAccessible(method, Java.class)) continue;
+            if ( !Modifier.isPublic(mod) && !Java.trySetAccessible(method)) continue;
 
             // ignore bridge methods because we'd rather directly call methods that this method
             // is bridging (and such methods are by definition always available.)

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
@@ -28,6 +28,7 @@
 
 package org.jruby.javasupport.ext;
 
+import com.headius.backport9.modules.Modules;
 import org.jruby.*;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
@@ -44,7 +45,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 
-import static org.jruby.javasupport.JavaUtil.CAN_SET_ACCESSIBLE;
 import static org.jruby.javasupport.JavaUtil.convertJavaArrayToRuby;
 import static org.jruby.javasupport.JavaUtil.convertJavaToUsableRubyObject;
 import static org.jruby.javasupport.JavaUtil.unwrapIfJavaObject;
@@ -603,7 +603,7 @@ public abstract class JavaUtil {
                 }
             }
             if ( best != null ) {
-                if ( CAN_SET_ACCESSIBLE ) best.setAccessible(true);
+                if ( RubyInstanceConfig.SET_ACCESSIBLE ) Modules.trySetAccessible(best, Ruby.class);
                 return (java.util.Collection) best.newInstance(coll);
             }
         }

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
@@ -28,14 +28,11 @@
 
 package org.jruby.javasupport.ext;
 
-import com.headius.backport9.modules.Modules;
 import org.jruby.*;
-import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyModule;
 import org.jruby.java.proxies.JavaProxy;
 import org.jruby.javasupport.Java;
-import org.jruby.javasupport.JavaClass;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
@@ -43,7 +40,6 @@ import org.jruby.runtime.builtin.IRubyObject;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Collections;
 
 import static org.jruby.javasupport.JavaUtil.convertJavaArrayToRuby;
 import static org.jruby.javasupport.JavaUtil.convertJavaToUsableRubyObject;
@@ -603,7 +599,7 @@ public abstract class JavaUtil {
                 }
             }
             if ( best != null ) {
-                if ( RubyInstanceConfig.SET_ACCESSIBLE ) Modules.trySetAccessible(best, Ruby.class);
+                if ( RubyInstanceConfig.SET_ACCESSIBLE ) Java.trySetAccessible(best);
                 return (java.util.Collection) best.newInstance(coll);
             }
         }

--- a/core/src/main/java/org/jruby/management/BeanManagerImpl.java
+++ b/core/src/main/java/org/jruby/management/BeanManagerImpl.java
@@ -13,6 +13,8 @@ import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.NotCompliantMBeanException;
 import javax.management.ObjectName;
+
+import com.headius.backport9.modules.Modules;
 import org.jruby.Ruby;
 import org.jruby.compiler.JITCompilerMBean;
 import org.jruby.util.log.Logger;
@@ -74,7 +76,7 @@ public class BeanManagerImpl implements BeanManager {
         try {
             Class agent = Class.forName("sun.management.Agent");
             Method shutdown = agent.getDeclaredMethod("stopRemoteManagementAgent");
-            shutdown.setAccessible(true);
+            Modules.trySetAccessible(shutdown, Ruby.class);
             shutdown.invoke(null);
             return true;
         } catch (Exception e) {
@@ -86,6 +88,7 @@ public class BeanManagerImpl implements BeanManager {
         try {
             Class agent = Class.forName("sun.management.Agent");
             Method start = agent.getMethod("startAgent");
+            Modules.trySetAccessible(start, Ruby.class);
             start.invoke(null);
             return true;
         } catch (Exception e) {

--- a/core/src/main/java/org/jruby/management/BeanManagerImpl.java
+++ b/core/src/main/java/org/jruby/management/BeanManagerImpl.java
@@ -14,9 +14,9 @@ import javax.management.MalformedObjectNameException;
 import javax.management.NotCompliantMBeanException;
 import javax.management.ObjectName;
 
-import com.headius.backport9.modules.Modules;
 import org.jruby.Ruby;
 import org.jruby.compiler.JITCompilerMBean;
+import org.jruby.javasupport.Java;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
 
@@ -76,7 +76,7 @@ public class BeanManagerImpl implements BeanManager {
         try {
             Class agent = Class.forName("sun.management.Agent");
             Method shutdown = agent.getDeclaredMethod("stopRemoteManagementAgent");
-            Modules.trySetAccessible(shutdown, Ruby.class);
+            Java.trySetAccessible(shutdown);
             shutdown.invoke(null);
             return true;
         } catch (Exception e) {
@@ -88,7 +88,7 @@ public class BeanManagerImpl implements BeanManager {
         try {
             Class agent = Class.forName("sun.management.Agent");
             Method start = agent.getMethod("startAgent");
-            Modules.trySetAccessible(start, Ruby.class);
+            Java.trySetAccessible(start);
             start.invoke(null);
             return true;
         } catch (Exception e) {

--- a/core/src/main/java/org/jruby/runtime/encoding/EncodingService.java
+++ b/core/src/main/java/org/jruby/runtime/encoding/EncodingService.java
@@ -1,5 +1,6 @@
 package org.jruby.runtime.encoding;
 
+import com.headius.backport9.modules.Modules;
 import org.jcodings.Encoding;
 import org.jcodings.EncodingDB;
 import org.jcodings.EncodingDB.Entry;
@@ -78,7 +79,7 @@ public final class EncodingService {
             if (console != null) {
                 final String CONSOLE_CHARSET = "cs";
                 Field fcs = Console.class.getDeclaredField(CONSOLE_CHARSET);
-                fcs.setAccessible(true);
+                Modules.trySetAccessible(fcs, Ruby.class);
                 Charset cs = (Charset) fcs.get(console);
                 consoleEncoding = loadEncoding(ByteList.create(cs.name()));
             }

--- a/core/src/main/java/org/jruby/runtime/encoding/EncodingService.java
+++ b/core/src/main/java/org/jruby/runtime/encoding/EncodingService.java
@@ -1,6 +1,5 @@
 package org.jruby.runtime.encoding;
 
-import com.headius.backport9.modules.Modules;
 import org.jcodings.Encoding;
 import org.jcodings.EncodingDB;
 import org.jcodings.EncodingDB.Entry;
@@ -11,6 +10,7 @@ import org.jcodings.util.CaseInsensitiveBytesHash;
 import org.jcodings.util.Hash.HashEntryIterator;
 import org.jruby.Ruby;
 import org.jruby.RubyEncoding;
+import org.jruby.javasupport.Java;
 import org.jruby.platform.Platform;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
@@ -79,7 +79,7 @@ public final class EncodingService {
             if (console != null) {
                 final String CONSOLE_CHARSET = "cs";
                 Field fcs = Console.class.getDeclaredField(CONSOLE_CHARSET);
-                Modules.trySetAccessible(fcs, Ruby.class);
+                Java.trySetAccessible(fcs);
                 Charset cs = (Charset) fcs.get(console);
                 consoleEncoding = loadEncoding(ByteList.create(cs.name()));
             }

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -29,7 +29,6 @@
 
 package org.jruby.util.cli;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -202,7 +201,7 @@ public class Options {
     public static final Option<Boolean> REWRITE_JAVA_TRACE = bool(DEBUG, "rewrite.java.trace", true, "Rewrite stack traces from exceptions raised in Java calls.");
 
     // TODO: Replace flag that's false on 9 with proper module checks
-    public static final Option<Boolean> JI_SETACCESSIBLE = bool(JAVA_INTEGRATION, "ji.setAccessible", calculateSetAccessibleDefault(), "Try to set inaccessible Java methods to be accessible.");
+    public static final Option<Boolean> JI_SETACCESSIBLE = bool(JAVA_INTEGRATION, "ji.setAccessible", true, "Try to set inaccessible Java methods to be accessible.");
     public static final Option<Boolean> JI_LOGCANSETACCESSIBLE = bool(JAVA_INTEGRATION, "ji.logCanSetAccessible", false, "Log whether setAccessible is working.");
     public static final Option<Boolean> JI_UPPER_CASE_PACKAGE_NAME_ALLOWED = bool(JAVA_INTEGRATION, "ji.upper.case.package.name.allowed", false, "Allow Capitalized Java package names.");
     public static final Option<Boolean> INTERFACES_USEPROXY = bool(JAVA_INTEGRATION, "interfaces.useProxy", false, "Use java.lang.reflect.Proxy for interface impl.");
@@ -310,15 +309,6 @@ public class Options {
     private static boolean calculateInvokedynamicDefault() {
         // We were defaulting on for Java 8 and might again later if JEP 210 helps reduce warmup time.
         return false;
-    }
-
-    /**
-     * Java 9 has much more restrictive reflection access to e.g. java.lang classes, and raises a Java 9-specific
-     * error. For now we default ji.setAccessible to false so we don't attempt it.
-     */
-    private static boolean calculateSetAccessibleDefault() {
-        String version = SafePropertyAccessor.getProperty("java.specification.version", "1.7");
-        return new BigDecimal(version).compareTo(new BigDecimal("1.9")) < 0;
     }
 
     private enum SearchMode { PREFIX,  CONTAINS }

--- a/core/src/main/java/org/jruby/util/io/ChannelHelper.java
+++ b/core/src/main/java/org/jruby/util/io/ChannelHelper.java
@@ -10,9 +10,8 @@
  */
 package org.jruby.util.io;
 
-import com.headius.backport9.modules.Modules;
-import org.jruby.Ruby;
 import org.jruby.RubyInstanceConfig;
+import org.jruby.javasupport.Java;
 
 import java.io.ByteArrayInputStream;
 import java.io.FilterInputStream;
@@ -113,7 +112,7 @@ public abstract class ChannelHelper {
             while (filteredStream instanceof FilterOutputStream) {
                 try {
                     OutputStream tmpStream =
-                            Modules.trySetAccessible(filterOutField, Ruby.class)
+                            Java.trySetAccessible(filterOutField)
                                     ? (OutputStream) filterOutField.get(filteredStream)
                                     : null;
 
@@ -154,7 +153,7 @@ public abstract class ChannelHelper {
             while (filteredStream instanceof FilterInputStream) {
                 try {
                     InputStream tmpStream =
-                            Modules.trySetAccessible(filterInField, Ruby.class)
+                            Java.trySetAccessible(filterInField)
                                     ? (InputStream) filterInField.get(filteredStream)
                                     : null;
 
@@ -186,7 +185,7 @@ public abstract class ChannelHelper {
         if (isDripSwitchable(stream)) {
             try {
                 Field out = stream.getClass().getDeclaredField("out");
-                return Modules.trySetAccessible(out, Ruby.class) ? (OutputStream) out.get(stream) : null;
+                return Java.trySetAccessible(out) ? (OutputStream) out.get(stream) : null;
             } catch (Exception e) {
             }
         }
@@ -197,7 +196,7 @@ public abstract class ChannelHelper {
         if (isDripSwitchable(stream)) {
             try {
                 Field in = stream.getClass().getDeclaredField("in");
-                return Modules.trySetAccessible(in, Ruby.class) ? (InputStream) in.get(stream) : null;
+                return Java.trySetAccessible(in) ? (InputStream) in.get(stream) : null;
             } catch (Exception e) {
             }
         }

--- a/core/src/main/java/org/jruby/util/io/ChannelHelper.java
+++ b/core/src/main/java/org/jruby/util/io/ChannelHelper.java
@@ -11,6 +11,7 @@
 package org.jruby.util.io;
 
 import com.headius.backport9.modules.Modules;
+import org.jruby.Ruby;
 import org.jruby.RubyInstanceConfig;
 
 import java.io.ByteArrayInputStream;
@@ -112,7 +113,9 @@ public abstract class ChannelHelper {
             while (filteredStream instanceof FilterOutputStream) {
                 try {
                     OutputStream tmpStream =
-                            Modules.trySetAccessible(filterOutField) ? (OutputStream) filterOutField.get(filteredStream) : null;
+                            Modules.trySetAccessible(filterOutField, Ruby.class)
+                                    ? (OutputStream) filterOutField.get(filteredStream)
+                                    : null;
 
                     // try to unwrap as a Drip stream
                     if (!(tmpStream instanceof FilterOutputStream)) {
@@ -151,7 +154,9 @@ public abstract class ChannelHelper {
             while (filteredStream instanceof FilterInputStream) {
                 try {
                     InputStream tmpStream =
-                            Modules.trySetAccessible(filterInField) ? (InputStream) filterInField.get(filteredStream) : null;
+                            Modules.trySetAccessible(filterInField, Ruby.class)
+                                    ? (InputStream) filterInField.get(filteredStream)
+                                    : null;
 
                     // could not acquire
                     if (tmpStream == null) break;
@@ -181,7 +186,7 @@ public abstract class ChannelHelper {
         if (isDripSwitchable(stream)) {
             try {
                 Field out = stream.getClass().getDeclaredField("out");
-                return Modules.trySetAccessible(out) ? (OutputStream) out.get(stream) : null;
+                return Modules.trySetAccessible(out, Ruby.class) ? (OutputStream) out.get(stream) : null;
             } catch (Exception e) {
             }
         }
@@ -192,7 +197,7 @@ public abstract class ChannelHelper {
         if (isDripSwitchable(stream)) {
             try {
                 Field in = stream.getClass().getDeclaredField("in");
-                return Modules.trySetAccessible(in) ? (InputStream) in.get(stream) : null;
+                return Modules.trySetAccessible(in, Ruby.class) ? (InputStream) in.get(stream) : null;
             } catch (Exception e) {
             }
         }

--- a/core/src/main/java/org/jruby/util/io/FilenoUtil.java
+++ b/core/src/main/java/org/jruby/util/io/FilenoUtil.java
@@ -11,8 +11,8 @@ import jnr.posix.POSIX;
 import jnr.unixsocket.UnixServerSocketChannel;
 import jnr.unixsocket.UnixSocketChannel;
 
+import org.jruby.javasupport.Java;
 import org.jruby.platform.Platform;
-import org.jruby.util.cli.Options;
 import org.jruby.util.collections.NonBlockingHashMapLong;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
@@ -198,7 +198,7 @@ public class FilenoUtil {
                 selChImpl = Class.forName("sun.nio.ch.SelChImpl");
                 try {
                     getFD = selChImpl.getMethod("getFD");
-                    if (!Modules.trySetAccessible(getFD, ReflectiveAccess.class)) {
+                    if (!Java.trySetAccessible(getFD)) {
                         getFD = null;
                     }
                 } catch (Exception e) {
@@ -217,7 +217,7 @@ public class FilenoUtil {
                 fileChannelImpl = Class.forName("sun.nio.ch.FileChannelImpl");
                 try {
                     fd = fileChannelImpl.getDeclaredField("fd");
-                    if (!Modules.trySetAccessible(fd, ReflectiveAccess.class)) {
+                    if (!Java.trySetAccessible(fd)) {
                         fd = null;
                     }
                 } catch (Exception e) {
@@ -233,7 +233,7 @@ public class FilenoUtil {
             Field ffd;
             try {
                 ffd = FileDescriptor.class.getDeclaredField("fd");
-                if (!Modules.trySetAccessible(ffd, ReflectiveAccess.class)) {
+                if (!Java.trySetAccessible(ffd)) {
                     ffd = null;
                 }
             } catch (Exception e) {


### PR DESCRIPTION
The logic previously was depending on the ji.setAccessible
property, which by default would simply refuse to set accessible
*at all* when the Java version was >= "1.9" (also showing this
logic was introduced very early in the Java 9 development cycle.)

That default is removed here, along with a the CAN_SET_ACCESSIBLE
static field in RubyInstanceConfig deprecated and replaced with
the original meaning of this property, simply whether to attempt
setAccessible.

The direct calls to setAccessible have been replaced by the
trySetAccessible in backport9 library that checks if the target
member's module is open to JRuby, allowing users to opt-in to that
reflective access if their application needs it. Previously these
cases still skipped setAccessible just due to being on Java 9+.

Most of the changes here were masked by the property, but I have
also fixed several others that were not guarded by the property
or that were otherwise used in booting JRuby or extending Java
integration.

This fixes #5841 by allowing `java_method` Method objects to
go ahead and trySetAccessible when the module is open.

This relates to #5821, which fixed in 9.2.8 a similar issue where
even an open module would not set fields and methods accessible.