### PR TITLE
Wrap Process.wait* calls with pthread_kill logic.

### DIFF
--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -42,6 +42,7 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyModule;
 import jnr.posix.POSIX;
+import org.jruby.javasupport.Java;
 import org.jruby.platform.Platform;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.BlockCallback;
@@ -49,6 +50,9 @@ import org.jruby.runtime.CallBlock;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.Signature;
 import org.jruby.runtime.ThreadContext;
+
+import static org.jruby.runtime.Helpers.throwException;
+import static org.jruby.runtime.Helpers.tryThrow;
 import static org.jruby.runtime.Visibility.*;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.invokedynamic.MethodNames;
@@ -56,6 +60,7 @@ import org.jruby.runtime.marshal.CoreObjectType;
 import org.jruby.util.ShellLauncher;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.util.TypeConverter;
+import org.jruby.util.cli.Options;
 import org.jruby.util.io.PopenExecutor;
 import org.jruby.util.io.PosixShim;
 
@@ -65,6 +70,8 @@ import static org.jruby.util.WindowsFFI.Kernel32.*;
 
 import java.lang.management.ThreadMXBean;
 import java.lang.management.ManagementFactory;
+import java.lang.reflect.Method;
+import java.util.function.ToIntFunction;
 
 /**
  */
@@ -900,18 +907,72 @@ public class RubyProcess {
 
     public static long waitpid(Ruby runtime, long pid, int flags) {
         int[] status = new int[1];
-        runtime.getPosix().errno(0);
-        pid = runtime.getPosix().waitpid(pid, status, flags);
+        POSIX posix = runtime.getPosix();
+        ThreadContext context = runtime.getCurrentContext();
+
+        posix.errno(0);
+
+        int res = pthreadKillable(context, ctx -> posix.waitpid(pid, status, flags));
+
         raiseErrnoIfSet(runtime, ECHILD);
 
-        if (pid > 0) {
-            runtime.getCurrentContext().setLastExitStatus(RubyProcess.RubyStatus.newProcessStatus(runtime, status[0], pid));
+        if (res > 0) {
+            context.setLastExitStatus(RubyProcess.RubyStatus.newProcessStatus(runtime, status[0], res));
         }
         else {
-            runtime.getCurrentContext().setLastExitStatus(runtime.getNil());
+            context.setLastExitStatus(runtime.getNil());
         }
 
-        return pid;
+        return res;
+    }
+
+    private static final Method NATIVE_THREAD_SIGNAL;
+    private static final Method NATIVE_THREAD_CURRENT;
+
+    static {
+        Method m1 = null;
+        Method m2 = null;
+        try {
+            // NativeThread is not public on Windows builds of Open JDK
+            Class nativeThread = Class.forName("sun.nio.ch.NativeThread");
+            Method signal = nativeThread.getDeclaredMethod("signal", long.class);
+            Method current = nativeThread.getDeclaredMethod("current");
+            if (Java.trySetAccessible(signal) && Java.trySetAccessible(current)) {
+                m1 = signal;
+                m2 = current;
+            }
+        } catch (NoSuchMethodException | ClassNotFoundException e) {
+            // ignore and leave it null
+        }
+        NATIVE_THREAD_SIGNAL = m1;
+        NATIVE_THREAD_CURRENT = m2;
+
+    }
+
+    private static int pthreadKillable(ThreadContext context, ToIntFunction<ThreadContext> blockingCall) {
+        if (Platform.IS_WINDOWS || !Options.NATIVE_PTHREAD_KILL.load() || NATIVE_THREAD_CURRENT == null) {
+            // Can't use pthread_kill on Windows
+            return blockingCall.applyAsInt(context);
+        }
+
+        do try {
+            return context.getThread().executeTask(context, blockingCall, new RubyThread.Task<ToIntFunction<ThreadContext>, Integer>() {
+                long threadID = tryThrow(() -> (Long) NATIVE_THREAD_CURRENT.invoke(null));
+
+                @Override
+                public Integer run(ThreadContext context, ToIntFunction<ThreadContext> blockingCall) {
+                    return blockingCall.applyAsInt(context);
+                }
+
+                @Override
+                public void wakeup(RubyThread thread, ToIntFunction<ThreadContext> blockingCall) {
+                    tryThrow(() -> NATIVE_THREAD_SIGNAL.invoke(null, threadID));
+                }
+            });
+        } catch (InterruptedException ie) {
+            context.pollThreadEvents();
+            // try again
+        } while (true);
     }
 
     private interface NonNativeErrno {
@@ -935,17 +996,21 @@ public class RubyProcess {
     }
 
     public static IRubyObject wait(Ruby runtime, IRubyObject[] args) {
-
         if (args.length > 0) {
             return waitpid(runtime, args);
         }
 
         int[] status = new int[1];
-        runtime.getPosix().errno(0);
-        int pid = runtime.getPosix().wait(status);
+        POSIX posix = runtime.getPosix();
+        ThreadContext context = runtime.getCurrentContext();
+
+        posix.errno(0);
+
+        int pid = pthreadKillable(context, ctx -> posix.wait(status));
+
         raiseErrnoIfSet(runtime, ECHILD);
 
-        runtime.getCurrentContext().setLastExitStatus(RubyProcess.RubyStatus.newProcessStatus(runtime, status[0], pid));
+        context.setLastExitStatus(RubyProcess.RubyStatus.newProcessStatus(runtime, status[0], pid));
         return runtime.newFixnum(pid);
     }
 
@@ -963,10 +1028,14 @@ public class RubyProcess {
         RubyArray results = runtime.newArray();
 
         int[] status = new int[1];
-        int result = posix.wait(status);
+        ThreadContext currentContext = runtime.getCurrentContext();
+
+        int result = pthreadKillable(currentContext, ctx -> posix.wait(status));
+
         while (result != -1) {
             results.append(runtime.newArray(runtime.newFixnum(result), RubyProcess.RubyStatus.newProcessStatus(runtime, status[0], result)));
-            result = posix.wait(status);
+
+            result = pthreadKillable(currentContext, ctx -> posix.wait(status));
         }
 
         return results;

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
+import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
 
 import jnr.constants.platform.Errno;
@@ -2379,6 +2380,15 @@ public class Helpers {
 
     public static void throwException(final Throwable e) {
         Helpers.<RuntimeException>throwsUnchecked(e);
+    }
+
+    public static <T> T tryThrow(Callable<T> call) {
+        try {
+            return call.call();
+        } catch (Throwable t) {
+            throwException(t);
+            return null; // not reached
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -142,6 +142,7 @@ public class Options {
     public static final Option<Boolean> FFI_COMPILE_INVOKEDYNAMIC = bool(NATIVE, "ffi.compile.invokedynamic", false, "Use invokedynamic to bind FFI invocations.");
     public static final Option<Boolean> FFI_COMPILE_REIFY = bool(NATIVE, "ffi.compile.reify", false, "Reify FFI compiled classes.");
     public static final Option<Boolean> NATIVE_STDIO = bool(NATIVE, "native.stdio", true, "Use native wrappers around the default stdio descriptors.");
+    public static final Option<Boolean> NATIVE_PTHREAD_KILL = bool(NATIVE, "native.pthread_kill", true, "Use pthread_kill to interrupt blocking kernel calls.");
 
     public static final Option<Boolean> REGEXP_INTERRUPTIBLE = bool(NATIVE, "regexp.interruptible", false, "Allow regexp operations to be interuptible from Ruby.");
 


### PR DESCRIPTION
This addresses #1050 in the same way CRuby implements this. In
CRuby, the wait functions are called directly, and the
`pthread_kill` function is used to force the call to be
interrupted. It turns out the JVM also uses `pthread_kill` to
interrupt blocking native calls, so we use the same binding they
do.

Note that this will only be used on non-Windows, but the JDK's
binding of `NativeThread.signal` might already be stubbed out
there.