### PR TITLE
keep executable bin/exe executable

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -233,7 +233,10 @@ project 'JRuby Lib Setup' do
 
     # fix file permissions of installed gems
     ( Dir[ File.join( jruby_gems, '**/*' ) ] + Dir[ File.join( jruby_gems, '**/.*' ) ] ).each do |f|
-      File.chmod( 0644, f ) rescue nil if File.file?( f )
+      if File.file?( f )
+        mod = f.include?('/bin/') || f.include?('/exe/') ? 0755 : 0644
+        File.chmod( mod, f ) rescue nil
+      end
     end
   end
 


### PR DESCRIPTION
ad https://github.com/jruby/jruby/pull/5803#issuecomment-515658854

@headius not sure about the bin scripts. for example if I install `gem install xmlrpc` then there are no scripts in $GEM_HOME/bin but with `gem install bundle` I do get them copied to bin.

the only difference I see that we miss the executable bits on for example lib/ruby/gems/shared/gems/xmlrpc-0.3.0/bin/*
which I fix with this PR

do I miss something ?