### PR TITLE
Make Symbol#to_s return frozen strings  

### DIFF
--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -94,6 +94,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
     private final ByteList symbolBytes;
     private final int hashCode;
     private Object constant;
+    private RubyString rubyString;
 
     /**
      *
@@ -484,6 +485,10 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
     }
 
     final RubyString to_s(Ruby runtime) {
+        if (true) { // Add check for runtime flag here?
+            if (rubyString == null) rubyString = runtime.freezeAndDedupString(RubyString.newStringShared(runtime, symbolBytes));
+            return rubyString;
+        }
         return RubyString.newStringShared(runtime, symbolBytes);
     }
 


### PR DESCRIPTION
This is a PR to explore the possibility of adding support for returning frozen strings. We'll probably want to have a JRuby flag until the spec is hammered out for the ruby language in general.

This relates to https://bugs.ruby-lang.org/issues/16150 