### PR TITLE
respect jit.max to stop compilation

### DIFF
--- a/core/src/main/java/org/jruby/RubyInstanceConfig.java
+++ b/core/src/main/java/org/jruby/RubyInstanceConfig.java
@@ -584,9 +584,11 @@ public class RubyInstanceConfig {
         this.jitMaxSize = jitMaxSize;
     }
 
-    public boolean isJitDisabled() {
-        // -1 jit.threshold is way of having interpreter not promote full builds
-        return getJitThreshold() < 0 || !getCompileMode().shouldJIT();
+    /**
+     * @return true if JIT compilation is enabled
+     */
+    public boolean isJitEnabled() {
+        return getJitThreshold() >= 0 && getCompileMode().shouldJIT();
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyInstanceConfig.java
+++ b/core/src/main/java/org/jruby/RubyInstanceConfig.java
@@ -584,6 +584,11 @@ public class RubyInstanceConfig {
         this.jitMaxSize = jitMaxSize;
     }
 
+    public boolean isJitDisabled() {
+        // -1 jit.threshold is way of having interpreter not promote full builds
+        return getJitThreshold() < 0 || !getCompileMode().shouldJIT();
+    }
+
     /**
      * @see Options#LAUNCH_INPROC
      */

--- a/core/src/main/java/org/jruby/compiler/BlockJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/BlockJITTask.java
@@ -56,7 +56,7 @@ class BlockJITTask extends JITCompiler.Task {
         if (excludeModuleName != null) {
             body.setCallCount(-1);
             if (jitCompiler.config.isJitLogging()) {
-                JITCompiler.log(body.getImplementationClass(), body.getFile(), body.getLine(), methodName, "skipping block in " + excludeModuleName);
+                JITCompiler.log(body, methodName, "skipping block in " + excludeModuleName);
             }
             return;
         }
@@ -95,7 +95,7 @@ class BlockJITTask extends JITCompiler.Task {
 
     @Override
     protected void logImpl(final String message, Object... reason) {
-        JITCompiler.log(body.getImplementationClass(), body.getFile(), body.getLine(), methodName, message, reason);
+        JITCompiler.log(body, methodName, message, reason);
     }
 
 }

--- a/core/src/main/java/org/jruby/compiler/BlockJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/BlockJITTask.java
@@ -90,7 +90,7 @@ class BlockJITTask extends JITCompiler.Task {
 
     @Override
     protected void logFailed(final Throwable ex) {
-        logImpl("could not compile; passes run: " + body.getIRScope().getExecutedPasses(), ex);
+        logImpl("could not compile block; passes run: " + body.getIRScope().getExecutedPasses(), ex);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/compiler/BlockJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/BlockJITTask.java
@@ -57,7 +57,7 @@ class BlockJITTask extends JITCompiler.Task {
             if (excludeModuleName != null) {
                 body.setCallCount(-1);
                 if (jitCompiler.config.isJitLogging()) {
-                    JITCompiler.log(body.getImplementationClass(), body.getFile(), body.getLine(), methodName, "skipping block in method: " + excludeModuleName + '#' + methodName);
+                    JITCompiler.log(body.getImplementationClass(), body.getFile(), body.getLine(), methodName, "skipping block in " + excludeModuleName);
                 }
                 return;
             }
@@ -100,7 +100,7 @@ class BlockJITTask extends JITCompiler.Task {
             }
         } catch (Throwable t) {
             if (jitCompiler.config.isJitLogging()) {
-                JITCompiler.log(body.getImplementationClass(), body.getFile(), body.getLine(), className + '.' + methodName, "Could not compile; passes run: " + body.getIRScope().getExecutedPasses(), t.getMessage());
+                JITCompiler.log(body.getImplementationClass(), body.getFile(), body.getLine(), className + '.' + methodName, "Could not compile; passes run: " + body.getIRScope().getExecutedPasses(), t.toString());
                 if (jitCompiler.config.isJitLoggingVerbose()) {
                     t.printStackTrace();
                 }

--- a/core/src/main/java/org/jruby/compiler/FullBuildTask.java
+++ b/core/src/main/java/org/jruby/compiler/FullBuildTask.java
@@ -7,7 +7,8 @@ import org.jruby.ir.interpreter.InterpreterContext;
  * Created by headius on 12/8/16.
  */
 class FullBuildTask implements Runnable {
-    private JITCompiler jitCompiler;
+
+    private final JITCompiler jitCompiler;
     private final Compilable<InterpreterContext> method;
 
     FullBuildTask(JITCompiler jitCompiler, Compilable<InterpreterContext> method) {
@@ -26,7 +27,7 @@ class FullBuildTask implements Runnable {
             method.completeBuild(method.getIRScope().prepareFullBuild());
 
             if (jitCompiler.config.isJitLogging()) {
-                JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), method.getName(), "done building");
+                JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), method.getName(), "done building"); // never logged
             }
         } catch (Throwable t) {
             if (jitCompiler.config.isJitLogging()) {

--- a/core/src/main/java/org/jruby/compiler/FullBuildTask.java
+++ b/core/src/main/java/org/jruby/compiler/FullBuildTask.java
@@ -32,7 +32,7 @@ class FullBuildTask implements Runnable {
         } catch (Throwable t) {
             if (jitCompiler.config.isJitLogging()) {
                 JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), method.getName(),
-                        "Could not build; passes run: " + method.getIRScope().getExecutedPasses(), t.getMessage());
+                        "Could not build; passes run: " + method.getIRScope().getExecutedPasses(), t.toString());
                 if (jitCompiler.config.isJitLoggingVerbose()) {
                     t.printStackTrace();
                 }

--- a/core/src/main/java/org/jruby/compiler/FullBuildTask.java
+++ b/core/src/main/java/org/jruby/compiler/FullBuildTask.java
@@ -27,12 +27,11 @@ class FullBuildTask implements Runnable {
             method.completeBuild(method.getIRScope().prepareFullBuild());
 
             if (jitCompiler.config.isJitLogging()) {
-                JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), method.getName(), "done building"); // never logged
+                JITCompiler.log(method, method.getName(), "done building");
             }
         } catch (Throwable t) {
             if (jitCompiler.config.isJitLogging()) {
-                JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), method.getName(),
-                        "Could not build; passes run: " + method.getIRScope().getExecutedPasses(), t.toString());
+                JITCompiler.log(method, method.getName(), "could not build; passes run: " + method.getIRScope().getExecutedPasses(), t);
                 if (jitCompiler.config.isJitLoggingVerbose()) {
                     t.printStackTrace();
                 }

--- a/core/src/main/java/org/jruby/compiler/JITCompiler.java
+++ b/core/src/main/java/org/jruby/compiler/JITCompiler.java
@@ -232,9 +232,7 @@ public class JITCompiler implements JITCompilerMBean {
     }
 
     static void log(RubyModule implementationClass, String file, int line, String name, String message, Object... reason) {
-        boolean isBlock = implementationClass == null;
-        String className = isBlock ? "<block>" : implementationClass.getBaseName();
-        if (className == null) className = "<anon class>";
+        String className = implementationClass.getName();
 
         StringBuilder builder = new StringBuilder(32);
         builder.append(message).append(": ").append(className);

--- a/core/src/main/java/org/jruby/compiler/JITCompiler.java
+++ b/core/src/main/java/org/jruby/compiler/JITCompiler.java
@@ -187,7 +187,7 @@ public class JITCompiler implements JITCompilerMBean {
 
         if (task instanceof Task && config.getJitMax() >= 0 && config.getJitMax() < getSuccessCount()) {
             if (config.isJitLogging()) {
-                JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), method.getName(), "skipping: jit.max threshold reached");
+                JITCompiler.log(method, method.getName(), "skipping: jit.max threshold reached");
             }
             return;
         }
@@ -231,13 +231,13 @@ public class JITCompiler implements JITCompilerMBean {
         }
     }
 
-    static void log(RubyModule implementationClass, String file, int line, String name, String message, Object... reason) {
-        String className = implementationClass.getName();
+    static void log(Compilable<?> target, String name, String message, Object... reason) {
+        String className = target.getImplementationClass().getName();
 
         StringBuilder builder = new StringBuilder(32);
         builder.append(message).append(": ").append(className);
         if (name != null) builder.append(' ').append(name);
-        builder.append(" at ").append(file).append(':').append(line);
+        builder.append(" at ").append(target.getFile()).append(':').append(target.getLine());
 
         if (reason.length > 0) {
             builder.append(" because of: \"");

--- a/core/src/main/java/org/jruby/compiler/JITCompiler.java
+++ b/core/src/main/java/org/jruby/compiler/JITCompiler.java
@@ -177,9 +177,6 @@ public class JITCompiler implements JITCompilerMBean {
     public void buildThresholdReached(ThreadContext context, final Compilable method) {
         final RubyInstanceConfig config = context.runtime.getInstanceConfig();
 
-        // Disable any other jit tasks from entering queue
-        method.setCallCount(-1);
-
         Runnable jitTask = getTaskFor(context, method);
 
         try {

--- a/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
@@ -29,14 +29,11 @@ package org.jruby.compiler;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 
-import org.jruby.MetaClass;
 import org.jruby.Ruby;
-import org.jruby.RubyModule;
 import org.jruby.ast.util.SexpMaker;
 import org.jruby.internal.runtime.methods.CompiledIRMethod;
 import org.jruby.ir.targets.JVMVisitor;
 import org.jruby.ir.targets.JVMVisitorMethodContext;
-import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.OneShotClassLoader;
 import org.jruby.util.collections.IntHashMap;
 

--- a/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
@@ -63,7 +63,7 @@ class MethodCompiledJITTask extends JITCompiler.Task {
             if (excludeModuleName != null) {
                 method.setCallCount(-1);
                 if (jitCompiler.config.isJitLogging()) {
-                    JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), methodName, "skipping method: " + excludeModuleName + '#' + methodName);
+                    JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), methodName, "skipping method in " + excludeModuleName);
                 }
                 return;
             }
@@ -118,7 +118,7 @@ class MethodCompiledJITTask extends JITCompiler.Task {
             }
         } catch (Throwable t) {
             if (jitCompiler.config.isJitLogging()) {
-                JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), className + '.' + methodName, "Could not compile; passes run: " + method.getIRScope().getExecutedPasses(), t.getMessage());
+                JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), className + '.' + methodName, "Could not compile; passes run: " + method.getIRScope().getExecutedPasses(), t.toString());
                 if (jitCompiler.config.isJitLoggingVerbose()) {
                     t.printStackTrace();
                 }

--- a/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
@@ -97,7 +97,7 @@ class MethodCompiledJITTask extends JITCompiler.Task {
 
     @Override
     protected void logFailed(final Throwable ex) {
-        logImpl("could not compile; passes run: " + method.getIRScope().getExecutedPasses(), ex);
+        logImpl("could not re-compile method; passes run: " + method.getIRScope().getExecutedPasses(), ex);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
@@ -55,63 +55,54 @@ class MethodCompiledJITTask extends JITCompiler.Task {
     }
 
     @Override
-    public void exec() {
-        try {
-            // Check if the method has been explicitly excluded
-            String excludeModuleName = checkExcludedMethod(jitCompiler.config, className, methodName, method.getImplementationClass());
-            if (excludeModuleName != null) {
-                method.setCallCount(-1);
-                if (jitCompiler.config.isJitLogging()) {
-                    JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), methodName, "skipping method in " + excludeModuleName);
-                }
-                return;
-            }
-
-            final String key = SexpMaker.sha1(method.getIRScope());
-            final Ruby runtime = jitCompiler.runtime;
-            JVMVisitor visitor = new JVMVisitor(runtime);
-            MethodJITClassGenerator generator = new MethodJITClassGenerator(className, methodName, key, runtime, method, visitor);
-
-            JVMVisitorMethodContext context = new JVMVisitorMethodContext();
-            generator.compile(context);
-
-            Class<?> sourceClass = defineClass(generator, visitor, method.getIRScope(), method.ensureInstrsReady());
-            if (sourceClass == null) return; // class could not be found nor generated; give up on JIT and bail out
-
-            // successfully got back a jitted method
-            long methodCount = jitCompiler.counts.successCount.incrementAndGet();
-
-            // logEvery n methods based on configuration
-            if (jitCompiler.config.getJitLogEvery() > 0) {
-                if (methodCount % jitCompiler.config.getJitLogEvery() == 0) {
-                    JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), methodName, "live compiled methods: " + methodCount);
-                }
-            }
-
+    public void exec() throws NoSuchMethodException, IllegalAccessException {
+        // Check if the method has been explicitly excluded
+        String excludeModuleName = checkExcludedMethod(jitCompiler.config, className, methodName, method.getImplementationClass());
+        if (excludeModuleName != null) {
+            method.setCallCount(-1);
             if (jitCompiler.config.isJitLogging()) {
-                JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), className + '.' + methodName, "done jitting");
+                logImpl("skipping method in " + excludeModuleName);
             }
+            return;
+        }
 
-            String variableName = context.getVariableName();
-            MethodHandle variable = JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, variableName, context.getNativeSignature(-1));
-            IntHashMap<MethodType> signatures = context.getNativeSignaturesExceptVariable();
+        final String key = SexpMaker.sha1(method.getIRScope());
+        final Ruby runtime = jitCompiler.runtime;
+        JVMVisitor visitor = new JVMVisitor(runtime);
+        MethodJITClassGenerator generator = new MethodJITClassGenerator(className, methodName, key, runtime, method, visitor);
 
-            method.setVariable(variable);
-            if (signatures.size() != 0) {
-                for (IntHashMap.Entry<MethodType> entry : signatures.entrySet()) {
-                    method.setSpecific(JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, context.getSpecificName(), entry.getValue()));
-                    break; // FIXME: only supports one arity
-                }
+        JVMVisitorMethodContext context = new JVMVisitorMethodContext();
+        generator.compile(context);
+
+        Class<?> sourceClass = defineClass(generator, visitor, method.getIRScope(), method.ensureInstrsReady());
+        if (sourceClass == null) return; // class could not be found nor generated; give up on JIT and bail out
+
+        String variableName = context.getVariableName();
+        MethodHandle variable = JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, variableName, context.getNativeSignature(-1));
+        IntHashMap<MethodType> signatures = context.getNativeSignaturesExceptVariable();
+
+        method.setVariable(variable);
+        if (signatures.size() != 0) {
+            for (IntHashMap.Entry<MethodType> entry : signatures.entrySet()) {
+                method.setSpecific(JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, context.getSpecificName(), entry.getValue()));
+                break; // FIXME: only supports one arity
             }
-        } catch (Throwable t) {
-            if (jitCompiler.config.isJitLogging()) {
-                JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), className + '.' + methodName, "Could not compile; passes run: " + method.getIRScope().getExecutedPasses(), t.toString());
-                if (jitCompiler.config.isJitLoggingVerbose()) {
-                    t.printStackTrace();
-                }
-            }
-
-            jitCompiler.counts.failCount.incrementAndGet();
         }
     }
+
+    @Override
+    protected void logJitted() {
+        logImpl("(compiled) method done jitting");
+    }
+
+    @Override
+    protected void logFailed(final Throwable ex) {
+        logImpl("could not compile; passes run: " + method.getIRScope().getExecutedPasses(), ex);
+    }
+
+    @Override
+    protected void logImpl(final String message, Object... reason) {
+        JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), methodName, message, reason);
+    }
+
 }

--- a/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
@@ -102,7 +102,7 @@ class MethodCompiledJITTask extends JITCompiler.Task {
 
     @Override
     protected void logImpl(final String message, Object... reason) {
-        JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), methodName, message, reason);
+        JITCompiler.log(method, methodName, message, reason);
     }
 
 }

--- a/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
@@ -42,94 +42,89 @@ import static org.jruby.compiler.MethodJITTask.*;
 /**
  * Created by enebo on 10/30/18.
  */
-class MethodCompiledJITTask implements Runnable {
-    private final JITCompiler jitCompiler;
+class MethodCompiledJITTask extends JITCompiler.Task {
+
     private final String className;
     private final CompiledIRMethod method;
     private final String methodName;
 
     public MethodCompiledJITTask(JITCompiler jitCompiler, CompiledIRMethod method, String className) {
-        this.jitCompiler = jitCompiler;
+        super(jitCompiler);
         this.method = method;
         this.className = className;
         this.methodName = method.getName();
     }
 
     @Override
-    public void run() {
-        // We synchronize against the JITCompiler object so at most one code body will jit at once in a given runtime.
-        // This works around unsolved concurrency issues within the process of preparing and jitting the IR.
-        // See #4739 for a reproduction script that produced various errors without this.
-        synchronized (jitCompiler) {
-            try {
-                // Check if the method has been explicitly excluded
-                String excludeModuleName = checkExcludedMethod(jitCompiler.config, className, methodName, method);
-                if (excludeModuleName != null) {
-                    method.setCallCount(-1);
-                    if (jitCompiler.config.isJitLogging()) {
-                        JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), methodName, "skipping method: " + excludeModuleName + '#' + methodName);
-                    }
-                    return;
-                }
-
-                String key = SexpMaker.sha1(method.getIRScope());
-                Ruby runtime = jitCompiler.runtime;
-                JVMVisitor visitor = new JVMVisitor(runtime);
-                MethodJITClassGenerator generator = new MethodJITClassGenerator(className, methodName, key, runtime, method, visitor);
-
-                JVMVisitorMethodContext context = new JVMVisitorMethodContext();
-                generator.compile(context);
-
-                // FIXME: reinstate active bytecode size check
-                // At this point we still need to reinstate the bytecode size check, to ensure we're not loading code
-                // that's so big that JVMs won't even try to compile it. Removed the check because with the new IR JIT
-                // bytecode counts often include all nested scopes, even if they'd be different methods. We need a new
-                // mechanism of getting all method sizes.
-                Class sourceClass = visitor.defineFromBytecode(method.getIRScope(), generator.bytecode(), new OneShotClassLoader(runtime.getJRubyClassLoader()));
-
-                if (sourceClass == null) {
-                    // class could not be found nor generated; give up on JIT and bail out
-                    jitCompiler.counts.failCount.incrementAndGet();
-                    return;
-                } else {
-                    generator.updateCounters(jitCompiler.counts, method.ensureInstrsReady());
-                }
-
-                // successfully got back a jitted method
-                long methodCount = jitCompiler.counts.successCount.incrementAndGet();
-
-                // logEvery n methods based on configuration
-                if (jitCompiler.config.getJitLogEvery() > 0) {
-                    if (methodCount % jitCompiler.config.getJitLogEvery() == 0) {
-                        JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), methodName, "live compiled methods: " + methodCount);
-                    }
-                }
-
+    public void exec() {
+        try {
+            // Check if the method has been explicitly excluded
+            String excludeModuleName = checkExcludedMethod(jitCompiler.config, className, methodName, method);
+            if (excludeModuleName != null) {
+                method.setCallCount(-1);
                 if (jitCompiler.config.isJitLogging()) {
-                    JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), className + '.' + methodName, "done jitting");
+                    JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), methodName, "skipping method: " + excludeModuleName + '#' + methodName);
                 }
-
-                String variableName = context.getVariableName();
-                MethodHandle variable = JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, variableName, context.getNativeSignature(-1));
-                IntHashMap<MethodType> signatures = context.getNativeSignaturesExceptVariable();
-
-                method.setVariable(variable);
-                if (signatures.size() != 0) {
-                    for (IntHashMap.Entry<MethodType> entry : signatures.entrySet()) {
-                        method.setSpecific(JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, context.getSpecificName(), entry.getValue()));
-                        break; // FIXME: only supports one arity
-                    }
-                }
-            } catch (Throwable t) {
-                if (jitCompiler.config.isJitLogging()) {
-                    JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), className + '.' + methodName, "Could not compile; passes run: " + method.getIRScope().getExecutedPasses(), t.getMessage());
-                    if (jitCompiler.config.isJitLoggingVerbose()) {
-                        t.printStackTrace();
-                    }
-                }
-
-                jitCompiler.counts.failCount.incrementAndGet();
+                return;
             }
+
+            String key = SexpMaker.sha1(method.getIRScope());
+            Ruby runtime = jitCompiler.runtime;
+            JVMVisitor visitor = new JVMVisitor(runtime);
+            MethodJITClassGenerator generator = new MethodJITClassGenerator(className, methodName, key, runtime, method, visitor);
+
+            JVMVisitorMethodContext context = new JVMVisitorMethodContext();
+            generator.compile(context);
+
+            // FIXME: reinstate active bytecode size check
+            // At this point we still need to reinstate the bytecode size check, to ensure we're not loading code
+            // that's so big that JVMs won't even try to compile it. Removed the check because with the new IR JIT
+            // bytecode counts often include all nested scopes, even if they'd be different methods. We need a new
+            // mechanism of getting all method sizes.
+            Class sourceClass = visitor.defineFromBytecode(method.getIRScope(), generator.bytecode(), new OneShotClassLoader(runtime.getJRubyClassLoader()));
+
+            if (sourceClass == null) {
+                // class could not be found nor generated; give up on JIT and bail out
+                jitCompiler.counts.failCount.incrementAndGet();
+                return;
+            } else {
+                generator.updateCounters(jitCompiler.counts, method.ensureInstrsReady());
+            }
+
+            // successfully got back a jitted method
+            long methodCount = jitCompiler.counts.successCount.incrementAndGet();
+
+            // logEvery n methods based on configuration
+            if (jitCompiler.config.getJitLogEvery() > 0) {
+                if (methodCount % jitCompiler.config.getJitLogEvery() == 0) {
+                    JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), methodName, "live compiled methods: " + methodCount);
+                }
+            }
+
+            if (jitCompiler.config.isJitLogging()) {
+                JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), className + '.' + methodName, "done jitting");
+            }
+
+            String variableName = context.getVariableName();
+            MethodHandle variable = JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, variableName, context.getNativeSignature(-1));
+            IntHashMap<MethodType> signatures = context.getNativeSignaturesExceptVariable();
+
+            method.setVariable(variable);
+            if (signatures.size() != 0) {
+                for (IntHashMap.Entry<MethodType> entry : signatures.entrySet()) {
+                    method.setSpecific(JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, context.getSpecificName(), entry.getValue()));
+                    break; // FIXME: only supports one arity
+                }
+            }
+        } catch (Throwable t) {
+            if (jitCompiler.config.isJitLogging()) {
+                JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), className + '.' + methodName, "Could not compile; passes run: " + method.getIRScope().getExecutedPasses(), t.getMessage());
+                if (jitCompiler.config.isJitLoggingVerbose()) {
+                    t.printStackTrace();
+                }
+            }
+
+            jitCompiler.counts.failCount.incrementAndGet();
         }
     }
 }

--- a/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
@@ -59,7 +59,7 @@ class MethodCompiledJITTask extends JITCompiler.Task {
     public void exec() {
         try {
             // Check if the method has been explicitly excluded
-            String excludeModuleName = checkExcludedMethod(jitCompiler.config, className, methodName, method);
+            String excludeModuleName = checkExcludedMethod(jitCompiler.config, className, methodName, method.getImplementationClass());
             if (excludeModuleName != null) {
                 method.setCallCount(-1);
                 if (jitCompiler.config.isJitLogging()) {

--- a/core/src/main/java/org/jruby/compiler/MethodJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/MethodJITTask.java
@@ -118,7 +118,7 @@ class MethodJITTask extends JITCompiler.Task {
 
     @Override
     protected void logImpl(String message, Object... reason) {
-        JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), methodName, message, reason);
+        JITCompiler.log(method, methodName, message, reason);
     }
 
     static String checkExcludedMethod(final RubyInstanceConfig config, final String className, final String methodName,

--- a/core/src/main/java/org/jruby/compiler/MethodJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/MethodJITTask.java
@@ -35,7 +35,6 @@ import org.jruby.RubyBasicObject;
 import org.jruby.RubyInstanceConfig;
 import org.jruby.RubyModule;
 import org.jruby.ast.util.SexpMaker;
-import org.jruby.internal.runtime.AbstractIRMethod;
 import org.jruby.internal.runtime.methods.CompiledIRMethod;
 import org.jruby.internal.runtime.methods.MixedModeIRMethod;
 import org.jruby.ir.targets.JVMVisitor;
@@ -64,7 +63,7 @@ class MethodJITTask extends JITCompiler.Task {
             if (excludeModuleName != null) {
                 method.setCallCount(-1);
                 if (jitCompiler.config.isJitLogging()) {
-                    JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), methodName, "skipping method: " + excludeModuleName + '#' + methodName);
+                    JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), methodName, "skipping method in " + excludeModuleName);
                 }
                 return;
             }
@@ -135,7 +134,7 @@ class MethodJITTask extends JITCompiler.Task {
             }
         } catch (Throwable t) {
             if (jitCompiler.config.isJitLogging()) {
-                JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), className + '.' + methodName, "Could not compile; passes run: " + method.getIRScope().getExecutedPasses(), t.getMessage());
+                JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), className + '.' + methodName, "Could not compile; passes run: " + method.getIRScope().getExecutedPasses(), t.toString());
                 if (jitCompiler.config.isJitLoggingVerbose()) {
                     t.printStackTrace();
                 }

--- a/core/src/main/java/org/jruby/compiler/MethodJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/MethodJITTask.java
@@ -43,109 +43,105 @@ import org.jruby.ir.targets.JVMVisitorMethodContext;
 import org.jruby.util.OneShotClassLoader;
 import org.jruby.util.collections.IntHashMap;
 
-class MethodJITTask implements Runnable {
-    private JITCompiler jitCompiler;
+class MethodJITTask extends JITCompiler.Task {
+
     private final String className;
     private final MixedModeIRMethod method;
     private final String methodName;
 
     public MethodJITTask(JITCompiler jitCompiler, MixedModeIRMethod method, String className) {
-        this.jitCompiler = jitCompiler;
+        super(jitCompiler);
         this.method = method;
         this.className = className;
         this.methodName = method.getName();
     }
 
-    public void run() {
-        // We synchronize against the JITCompiler object so at most one code body will jit at once in a given runtime.
-        // This works around unsolved concurrency issues within the process of preparing and jitting the IR.
-        // See #4739 for a reproduction script that produced various errors without this.
-        synchronized (jitCompiler) {
-            try {
-                // Check if the method has been explicitly excluded
-                String excludeModuleName = checkExcludedMethod(jitCompiler.config, className, methodName, method);
-                if (excludeModuleName != null) {
-                    method.setCallCount(-1);
-                    if (jitCompiler.config.isJitLogging()) {
-                        JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), methodName, "skipping method: " + excludeModuleName + '#' + methodName);
-                    }
-                    return;
-                }
-
-                String key = SexpMaker.sha1(method.getIRScope());
-                Ruby runtime = jitCompiler.runtime;
-                JVMVisitor visitor = new JVMVisitor(runtime);
-                MethodJITClassGenerator generator = new MethodJITClassGenerator(className, methodName, key, runtime, method, visitor);
-
-                JVMVisitorMethodContext context = new JVMVisitorMethodContext();
-                generator.compile(context);
-
-                // FIXME: reinstate active bytecode size check
-                // At this point we still need to reinstate the bytecode size check, to ensure we're not loading code
-                // that's so big that JVMs won't even try to compile it. Removed the check because with the new IR JIT
-                // bytecode counts often include all nested scopes, even if they'd be different methods. We need a new
-                // mechanism of getting all method sizes.
-                Class sourceClass = visitor.defineFromBytecode(method.getIRScope(), generator.bytecode(), new OneShotClassLoader(runtime.getJRubyClassLoader()));
-
-                if (sourceClass == null) {
-                    // class could not be found nor generated; give up on JIT and bail out
-                    jitCompiler.counts.failCount.incrementAndGet();
-                    return;
-                } else {
-                    generator.updateCounters(jitCompiler.counts, method.ensureInstrsReady());
-                }
-
-                // successfully got back a jitted method
-                long methodCount = jitCompiler.counts.successCount.incrementAndGet();
-
-                // logEvery n methods based on configuration
-                if (jitCompiler.config.getJitLogEvery() > 0) {
-                    if (methodCount % jitCompiler.config.getJitLogEvery() == 0) {
-                        JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), methodName, "live compiled methods: " + methodCount);
-                    }
-                }
-
+    @Override
+    public void exec() {
+        try {
+            // Check if the method has been explicitly excluded
+            String excludeModuleName = checkExcludedMethod(jitCompiler.config, className, methodName, method);
+            if (excludeModuleName != null) {
+                method.setCallCount(-1);
                 if (jitCompiler.config.isJitLogging()) {
-                    JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), className + '.' + methodName, "done jitting");
+                    JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), methodName, "skipping method: " + excludeModuleName + '#' + methodName);
                 }
+                return;
+            }
 
-                String variableName = context.getVariableName();
-                MethodHandle variable = JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, variableName, context.getNativeSignature(-1));
-                IntHashMap<MethodType> signatures = context.getNativeSignaturesExceptVariable();
+            String key = SexpMaker.sha1(method.getIRScope());
+            Ruby runtime = jitCompiler.runtime;
+            JVMVisitor visitor = new JVMVisitor(runtime);
+            MethodJITClassGenerator generator = new MethodJITClassGenerator(className, methodName, key, runtime, method, visitor);
 
-                if (signatures.size() == 0) {
-                    // only variable-arity
+            JVMVisitorMethodContext context = new JVMVisitorMethodContext();
+            generator.compile(context);
+
+            // FIXME: reinstate active bytecode size check
+            // At this point we still need to reinstate the bytecode size check, to ensure we're not loading code
+            // that's so big that JVMs won't even try to compile it. Removed the check because with the new IR JIT
+            // bytecode counts often include all nested scopes, even if they'd be different methods. We need a new
+            // mechanism of getting all method sizes.
+            Class sourceClass = visitor.defineFromBytecode(method.getIRScope(), generator.bytecode(), new OneShotClassLoader(runtime.getJRubyClassLoader()));
+
+            if (sourceClass == null) {
+                // class could not be found nor generated; give up on JIT and bail out
+                jitCompiler.counts.failCount.incrementAndGet();
+                return;
+            } else {
+                generator.updateCounters(jitCompiler.counts, method.ensureInstrsReady());
+            }
+
+            // successfully got back a jitted method
+            long methodCount = jitCompiler.counts.successCount.incrementAndGet();
+
+            // logEvery n methods based on configuration
+            if (jitCompiler.config.getJitLogEvery() > 0) {
+                if (methodCount % jitCompiler.config.getJitLogEvery() == 0) {
+                    JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), methodName, "live compiled methods: " + methodCount);
+                }
+            }
+
+            if (jitCompiler.config.isJitLogging()) {
+                JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), className + '.' + methodName, "done jitting");
+            }
+
+            String variableName = context.getVariableName();
+            MethodHandle variable = JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, variableName, context.getNativeSignature(-1));
+            IntHashMap<MethodType> signatures = context.getNativeSignaturesExceptVariable();
+
+            if (signatures.size() == 0) {
+                // only variable-arity
+                method.completeBuild(
+                        new CompiledIRMethod(
+                                variable,
+                                method.getIRScope(),
+                                method.getVisibility(),
+                                method.getImplementationClass()));
+
+            } else {
+                // also specific-arity
+                for (IntHashMap.Entry<MethodType> entry : signatures.entrySet()) {
                     method.completeBuild(
                             new CompiledIRMethod(
                                     variable,
+                                    JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, context.getSpecificName(), entry.getValue()),
+                                    entry.getKey(),
                                     method.getIRScope(),
                                     method.getVisibility(),
                                     method.getImplementationClass()));
-
-                } else {
-                    // also specific-arity
-                    for (IntHashMap.Entry<MethodType> entry : signatures.entrySet()) {
-                        method.completeBuild(
-                                new CompiledIRMethod(
-                                        variable,
-                                        JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, context.getSpecificName(), entry.getValue()),
-                                        entry.getKey(),
-                                        method.getIRScope(),
-                                        method.getVisibility(),
-                                        method.getImplementationClass()));
-                        break; // FIXME: only supports one arity
-                    }
+                    break; // FIXME: only supports one arity
                 }
-            } catch (Throwable t) {
-                if (jitCompiler.config.isJitLogging()) {
-                    JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), className + '.' + methodName, "Could not compile; passes run: " + method.getIRScope().getExecutedPasses(), t.getMessage());
-                    if (jitCompiler.config.isJitLoggingVerbose()) {
-                        t.printStackTrace();
-                    }
-                }
-
-                jitCompiler.counts.failCount.incrementAndGet();
             }
+        } catch (Throwable t) {
+            if (jitCompiler.config.isJitLogging()) {
+                JITCompiler.log(method.getImplementationClass(), method.getFile(), method.getLine(), className + '.' + methodName, "Could not compile; passes run: " + method.getIRScope().getExecutedPasses(), t.getMessage());
+                if (jitCompiler.config.isJitLoggingVerbose()) {
+                    t.printStackTrace();
+                }
+            }
+
+            jitCompiler.counts.failCount.incrementAndGet();
         }
     }
 

--- a/core/src/main/java/org/jruby/compiler/MethodJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/MethodJITTask.java
@@ -113,7 +113,7 @@ class MethodJITTask extends JITCompiler.Task {
 
     @Override
     protected void logFailed(final Throwable ex) {
-        logImpl("could not compile; passes run: " + method.getIRScope().getExecutedPasses(), ex);
+        logImpl("could not compile method; passes run: " + method.getIRScope().getExecutedPasses(), ex);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/compiler/MethodJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/MethodJITTask.java
@@ -60,7 +60,7 @@ class MethodJITTask extends JITCompiler.Task {
     public void exec() {
         try {
             // Check if the method has been explicitly excluded
-            String excludeModuleName = checkExcludedMethod(jitCompiler.config, className, methodName, method);
+            String excludeModuleName = checkExcludedMethod(jitCompiler.config, className, methodName, method.getImplementationClass());
             if (excludeModuleName != null) {
                 method.setCallCount(-1);
                 if (jitCompiler.config.isJitLogging()) {
@@ -146,11 +146,11 @@ class MethodJITTask extends JITCompiler.Task {
     }
 
     static String checkExcludedMethod(final RubyInstanceConfig config, final String className, final String methodName,
-                                      final AbstractIRMethod method) {
+                                      final RubyModule implementationClass) {
         if (config.getExcludedMethods().size() > 0) {
             String excludeModuleName = className;
-            if (method.getImplementationClass().getMethodLocation().isSingleton()) {
-                RubyBasicObject possibleRealClass = ((MetaClass) method.getImplementationClass()).getAttached();
+            if (implementationClass.getMethodLocation().isSingleton()) {
+                RubyBasicObject possibleRealClass = ((MetaClass) implementationClass).getAttached();
                 if (possibleRealClass instanceof RubyModule) {
                     excludeModuleName = "Meta:" + ((RubyModule) possibleRealClass).getName();
                 }

--- a/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
@@ -4,8 +4,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jruby.MetaClass;
+import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
+import org.jruby.compiler.Compilable;
 import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.internal.runtime.methods.IRMethodArgs;
 import org.jruby.ir.IRMethod;
@@ -32,8 +34,8 @@ public abstract class AbstractIRMethod extends DynamicMethod implements IRMethod
     protected final IRScope method;
     protected final StaticScope staticScope;
     protected InterpreterContext interpreterContext = null;
-    protected int callCount = 0;
-    private MethodData methodData;
+    protected volatile int callCount = 0;
+    private transient MethodData methodData;
 
     public AbstractIRMethod(IRScope method, Visibility visibility, RubyModule implementationClass) {
         super(implementationClass, visibility, method.getId());
@@ -42,21 +44,40 @@ public abstract class AbstractIRMethod extends DynamicMethod implements IRMethod
         this.staticScope.determineModule();
         this.signature = staticScope.getSignature();
 
-        // -1 jit.threshold is way of having interpreter not promote full builds.
-        if (Options.JIT_THRESHOLD.load() == -1) callCount = -1;
+        final Ruby runtime = implementationClass.getRuntime();
+        if (runtime.getInstanceConfig().isJitDisabled()) setCallCount(-1);
 
         // If we are printing, do the build right at creation time so we can see it
-        if (IRRuntimeHelpers.shouldPrintIR(implementationClass.getRuntime())) {
+        if (IRRuntimeHelpers.shouldPrintIR(runtime)) {
             ensureInstrsReady();
+        }
+    }
+
+    public static <T extends AbstractIRMethod & Compilable> void tryJit(ThreadContext context, T self) {
+        final Ruby runtime = context.runtime;
+        if (runtime.isBooting() && !Options.JIT_KERNEL.load()) return; // don't JIT during runtime boot
+
+        if (self.callCount < 0) return;
+        // we don't synchronize callCount++ it does not matter if count isn't accurate
+        if (self.callCount++ >= runtime.getInstanceConfig().getJitThreshold()) {
+            synchronized (self) { // disable same jit tasks from entering queue twice
+                if (self.callCount >= 0) {
+                    self.callCount = Integer.MIN_VALUE; // so that callCount++ stays < 0
+
+                    runtime.getJITCompiler().buildThresholdReached(context, self);
+                }
+            }
+        }
+    }
+
+    public final void setCallCount(int callCount) {
+        synchronized (this) {
+            this.callCount = callCount;
         }
     }
 
     public IRScope getIRScope() {
         return method;
-    }
-
-    public void setCallCount(int callCount) {
-        this.callCount = callCount;
     }
 
     public StaticScope getStaticScope() {

--- a/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
@@ -34,7 +34,7 @@ public abstract class AbstractIRMethod extends DynamicMethod implements IRMethod
     protected final IRScope method;
     protected final StaticScope staticScope;
     protected InterpreterContext interpreterContext = null;
-    protected volatile int callCount = 0;
+    protected int callCount = 0;
     private transient MethodData methodData;
 
     public AbstractIRMethod(IRScope method, Visibility visibility, RubyModule implementationClass) {

--- a/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
@@ -45,7 +45,7 @@ public abstract class AbstractIRMethod extends DynamicMethod implements IRMethod
         this.signature = staticScope.getSignature();
 
         final Ruby runtime = implementationClass.getRuntime();
-        if (runtime.getInstanceConfig().isJitDisabled()) setCallCount(-1);
+        if (!runtime.getInstanceConfig().isJitEnabled()) setCallCount(-1);
 
         // If we are printing, do the build right at creation time so we can see it
         if (IRRuntimeHelpers.shouldPrintIR(runtime)) {

--- a/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
@@ -45,8 +45,6 @@ public abstract class AbstractIRMethod extends DynamicMethod implements IRMethod
         this.signature = staticScope.getSignature();
 
         final Ruby runtime = implementationClass.getRuntime();
-        if (!runtime.getInstanceConfig().isJitEnabled()) setCallCount(-1);
-
         // If we are printing, do the build right at creation time so we can see it
         if (IRRuntimeHelpers.shouldPrintIR(runtime)) {
             ensureInstrsReady();

--- a/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
@@ -29,6 +29,10 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
     public InterpretedIRMethod(IRScope method, Visibility visibility, RubyModule implementationClass) {
         super(method, visibility, implementationClass);
 
+        // -1 jit.threshold is way of having interpreter not promote full builds
+        // regardless of compile mode (even when OFF full-builds are promoted)
+        if (implementationClass.getRuntime().getInstanceConfig().getJitThreshold() == -1) setCallCount(-1);
+
         // This is so profiled callsite can access the sites original method (callsites has IRScope in it).
         method.compilable = this;
     }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
@@ -1,6 +1,7 @@
 package org.jruby.internal.runtime.methods;
 
-import org.jruby.Ruby;
+import java.io.ByteArrayOutputStream;
+
 import org.jruby.RubyModule;
 import org.jruby.compiler.Compilable;
 import org.jruby.internal.runtime.AbstractIRMethod;
@@ -14,11 +15,8 @@ import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.util.cli.Options;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
-
-import java.io.ByteArrayOutputStream;
 
 /**
  * Method for -X-C (interpreted only execution).  See MixedModeIRMethod for inter/JIT method impl.
@@ -28,26 +26,11 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
 
     private boolean displayedCFG = false; // FIXME: Remove when we find nicer way of logging CFG
 
-    protected InterpreterContext interpreterContext = null;
-    protected int callCount = 0;
-
     public InterpretedIRMethod(IRScope method, Visibility visibility, RubyModule implementationClass) {
         super(method, visibility, implementationClass);
 
-        // -1 jit.threshold is way of having interpreter not promote full builds.
-        if (Options.JIT_THRESHOLD.load() == -1) callCount = -1;
-
-        // If we are printing, do the build right at creation time so we can see it
-        if (IRRuntimeHelpers.shouldPrintIR(implementationClass.getRuntime())) {
-            ensureInstrsReady();
-        }
-
         // This is so profiled callsite can access the sites original method (callsites has IRScope in it).
         method.compilable = this;
-    }
-
-    public void setCallCount(int callCount) {
-        this.callCount = callCount;
     }
 
     protected void post(InterpreterContext ic, ThreadContext context) {
@@ -127,7 +110,6 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
         if (IRRuntimeHelpers.isDebug()) doDebug();
 
         if (callCount >= 0) promoteToFullBuild(context);
-
         return INTERPRET_METHOD(context, ensureInstrsReady(), clazz, self, name, block);
     }
 
@@ -136,7 +118,6 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
         if (IRRuntimeHelpers.isDebug()) doDebug();
 
         if (callCount >= 0) promoteToFullBuild(context);
-
         return INTERPRET_METHOD(context, ensureInstrsReady(), clazz, self, name, Block.NULL_BLOCK);
     }
 
@@ -292,13 +273,9 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
     // Unlike JIT in MixedMode this will always successfully build but if using executor pool it may take a while
     // and replace interpreterContext asynchronously.
     private void promoteToFullBuild(ThreadContext context) {
-        Ruby runtime = context.runtime;
+        tryJit(context, this);
 
-        if (runtime.isBooting() && !Options.JIT_KERNEL.load()) return;   // don't Promote to full build during runtime boot
-
-        if (callCount++ >= Options.JIT_THRESHOLD.load()) runtime.getJITCompiler().buildThresholdReached(context, this);
-
-        if (IRRuntimeHelpers.shouldPrintIR(implementationClass.getRuntime())) {
+        if (IRRuntimeHelpers.shouldPrintIR(context.runtime)) {
             ByteArrayOutputStream baos = IRDumper.printIR(method, true, true);
 
             LOG.info("Printing full IR for " + method.getId() + ":\n" + new String(baos.toByteArray()));

--- a/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
@@ -2,6 +2,7 @@ package org.jruby.internal.runtime.methods;
 
 import java.io.ByteArrayOutputStream;
 
+import org.jruby.Ruby;
 import org.jruby.RubyModule;
 import org.jruby.compiler.Compilable;
 import org.jruby.internal.runtime.AbstractIRMethod;
@@ -28,6 +29,7 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
     public MixedModeIRMethod(IRScope method, Visibility visibility, RubyModule implementationClass) {
         super(method, visibility, implementationClass);
 
+        if (!implementationClass.getRuntime().getInstanceConfig().isJitEnabled()) setCallCount(-1);
         // This is so profiled callsite can access the sites original method (callsites has IRScope in it).
         method.compilable = this;
     }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
@@ -1,8 +1,7 @@
 package org.jruby.internal.runtime.methods;
 
 import java.io.ByteArrayOutputStream;
-import org.jruby.MetaClass;
-import org.jruby.RubyClass;
+
 import org.jruby.RubyModule;
 import org.jruby.compiler.Compilable;
 import org.jruby.internal.runtime.AbstractIRMethod;
@@ -16,7 +15,6 @@ import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.util.cli.Options;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
 
@@ -25,17 +23,10 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
 
     private boolean displayedCFG = false; // FIXME: Remove when we find nicer way of logging CFG
 
-    private volatile int callCount = 0;
-    private volatile DynamicMethod actualMethod;
+    private volatile DynamicMethod actualMethod; // JIT-ed method
 
     public MixedModeIRMethod(IRScope method, Visibility visibility, RubyModule implementationClass) {
         super(method, visibility, implementationClass);
-
-        // disable JIT if JIT is disabled
-        if (!implementationClass.getRuntime().getInstanceConfig().getCompileMode().shouldJIT() ||
-                Options.JIT_THRESHOLD.load() < 0) {
-            callCount = -1;
-        }
 
         // This is so profiled callsite can access the sites original method (callsites has IRScope in it).
         method.compilable = this;
@@ -83,12 +74,11 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
     public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject[] args, Block block) {
         if (IRRuntimeHelpers.isDebug()) doDebug();
 
-        if (callCount >= 0) tryJit(context);
-
         DynamicMethod jittedMethod = actualMethod;
         if (jittedMethod != null) {
             return jittedMethod.call(context, self, clazz, name, args, block);
         }
+        if (callCount >= 0) tryJit(context, this);
         return INTERPRET_METHOD(context, ensureInstrsReady(), clazz, self, name, args, block);
     }
 
@@ -116,12 +106,11 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
     public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, Block block) {
         if (IRRuntimeHelpers.isDebug()) doDebug();
 
-        if (callCount >= 0) tryJit(context);
-
         DynamicMethod jittedMethod = actualMethod;
         if (jittedMethod != null) {
             return jittedMethod.call(context, self, clazz, name, block);
         }
+        if (callCount >= 0) tryJit(context, this);
         return INTERPRET_METHOD(context, ensureInstrsReady(), clazz, self, name, block);
     }
 
@@ -149,12 +138,11 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
     public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject arg0, Block block) {
         if (IRRuntimeHelpers.isDebug()) doDebug();
 
-        if (callCount >= 0) tryJit(context);
-
         DynamicMethod jittedMethod = actualMethod;
         if (jittedMethod != null) {
             return jittedMethod.call(context, self, clazz, name, arg0, block);
         }
+        if (callCount >= 0) tryJit(context, this);
         return INTERPRET_METHOD(context, ensureInstrsReady(), clazz, self, name, arg0, block);
     }
 
@@ -182,12 +170,11 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
     public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject arg0, IRubyObject arg1, Block block) {
         if (IRRuntimeHelpers.isDebug()) doDebug();
 
-        if (callCount >= 0) tryJit(context);
-
         DynamicMethod jittedMethod = actualMethod;
         if (jittedMethod != null) {
             return jittedMethod.call(context, self, clazz, name, arg0, arg1, block);
         }
+        if (callCount >= 0) tryJit(context, this);
         return INTERPRET_METHOD(context, ensureInstrsReady(), clazz, self, name, arg0, arg1, block);
     }
 
@@ -214,12 +201,12 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
     @Override
     public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
         if (IRRuntimeHelpers.isDebug()) doDebug();
-        if (callCount >= 0) tryJit(context);
 
         DynamicMethod jittedMethod = actualMethod;
         if (jittedMethod != null) {
             return jittedMethod.call(context, self, clazz, name, arg0, arg1, arg2, block);
         }
+        if (callCount >= 0) tryJit(context, this);
         return INTERPRET_METHOD(context, ensureInstrsReady(), clazz, self, name, arg0, arg1, arg2, block);
     }
 
@@ -266,16 +253,6 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
         getImplementationClass().invalidateCacheDescendants();
     }
 
-    private void tryJit(ThreadContext context) {
-        if (context.runtime.isBooting() && !Options.JIT_KERNEL.load()) return; // don't JIT during runtime boot
-
-        synchronized (this) {
-            if (callCount >= 0 && callCount++ >= Options.JIT_THRESHOLD.load()) {
-                context.runtime.getJITCompiler().buildThresholdReached(context, this);
-            }
-        }
-    }
-
     @Override
     public DynamicMethod dup() {
         MixedModeIRMethod x = (MixedModeIRMethod) super.dup();
@@ -283,12 +260,6 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
         x.actualMethod = actualMethod;
 
         return x;
-    }
-
-    public void setCallCount(int callCount) {
-        synchronized (this) {
-            this.callCount = callCount;
-        }
     }
 
 }

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -624,12 +624,12 @@ public class IRRuntimeHelpers {
      * @param runtime the current runtime
      * @return whether to print IR
      */
-    public static boolean shouldPrintIR(Ruby runtime) {
+    public static boolean shouldPrintIR(final Ruby runtime) {
         boolean booting = runtime.isBooting();
         boolean print = Options.IR_PRINT.load();
         boolean printAll = Options.IR_PRINT_ALL.load();
 
-        return (print && !booting) || (booting && printAll);
+        return (!booting && print) || (booting && printAll);
     }
 
     private static class DivvyKeywordsVisitor extends RubyHash.VisitorWithState {

--- a/core/src/main/java/org/jruby/management/Config.java
+++ b/core/src/main/java/org/jruby/management/Config.java
@@ -43,12 +43,24 @@ public class Config implements ConfigMBean {
         return ruby.get().getInstanceConfig().getJitThreshold();
     }
 
+    public void setJitThreshold(int threshold) {
+        ruby.get().getInstanceConfig().setJitThreshold(threshold);
+    }
+
     public int getJitMax() {
         return ruby.get().getInstanceConfig().getJitMax();
     }
 
+    public void setJitMax(int max) {
+        ruby.get().getInstanceConfig().setJitMax(max);
+    }
+
     public int getJitMaxSize() {
         return ruby.get().getInstanceConfig().getJitMaxSize();
+    }
+
+    public void setJitMaxSize(int maxSize) {
+        ruby.get().getInstanceConfig().setJitMaxSize(maxSize);
     }
 
     public boolean isRunRubyInProcess() {
@@ -151,8 +163,4 @@ public class Config implements ConfigMBean {
         return ruby.get().getInstanceConfig().getExcludedMethods().toString();
     }
 
-    @Deprecated
-    public String getCompatVersion() {
-        return org.jruby.CompatVersion.RUBY2_1.name();
-    }
 }

--- a/core/src/main/java/org/jruby/management/ConfigMBean.java
+++ b/core/src/main/java/org/jruby/management/ConfigMBean.java
@@ -8,8 +8,11 @@ public interface ConfigMBean {
     public boolean isJitLoggingVerbose();
     public int getJitLogEvery();
     public int getJitThreshold();
+    void setJitThreshold(int threshold);
     public int getJitMax();
+    void setJitMax(int max);
     public int getJitMaxSize();
+    void setJitMaxSize(int maxSize);
     public boolean isRunRubyInProcess();
     public String getCurrentDirectory();
     public boolean isObjectSpaceEnabled();
@@ -37,5 +40,7 @@ public interface ConfigMBean {
     public String getExcludedMethods();
 
     @Deprecated
-    public String getCompatVersion();
+    default String getCompatVersion() {
+        return org.jruby.CompatVersion.RUBY2_1.name();
+    }
 }

--- a/core/src/main/java/org/jruby/runtime/InterpretedIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/InterpretedIRBlockBody.java
@@ -3,6 +3,7 @@ package org.jruby.runtime;
 import java.io.ByteArrayOutputStream;
 
 import org.jruby.Ruby;
+import org.jruby.RubyInstanceConfig;
 import org.jruby.RubyModule;
 import org.jruby.compiler.Compilable;
 import org.jruby.ir.IRClosure;
@@ -30,9 +31,9 @@ public class InterpretedIRBlockBody extends IRBlockBody implements Compilable<In
         this.pushScope = true;
         this.reuseParentScope = false;
 
-        // JIT currently JITs blocks along with their method and no on-demand by themselves.
-        // We only promote to full build here if we are -X-C.
-        if (!closure.getManager().getInstanceConfig().isJitEnabled()) setCallCount(-1);
+        // -1 jit.threshold is way of having interpreter not promote full builds
+        // regardless of compile mode (even when OFF full-builds are promoted)
+        if (closure.getManager().getInstanceConfig().getJitThreshold() == -1) setCallCount(-1);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/runtime/InterpretedIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/InterpretedIRBlockBody.java
@@ -32,7 +32,7 @@ public class InterpretedIRBlockBody extends IRBlockBody implements Compilable<In
 
         // JIT currently JITs blocks along with their method and no on-demand by themselves.
         // We only promote to full build here if we are -X-C.
-        if (closure.getManager().getInstanceConfig().isJitDisabled()) setCallCount(-1);
+        if (!closure.getManager().getInstanceConfig().isJitEnabled()) setCallCount(-1);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/runtime/InterpretedIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/InterpretedIRBlockBody.java
@@ -30,11 +30,9 @@ public class InterpretedIRBlockBody extends IRBlockBody implements Compilable<In
         this.pushScope = true;
         this.reuseParentScope = false;
 
-        // JIT currently JITs blocks along with their method and no on-demand by themselves.  We only
-        // promote to full build here if we are -X-C.
-        if (closure.getManager().getInstanceConfig().getCompileMode().shouldJIT() || Options.JIT_THRESHOLD.load() == -1) {
-            callCount = -1;
-        }
+        // JIT currently JITs blocks along with their method and no on-demand by themselves.
+        // We only promote to full build here if we are -X-C.
+        if (closure.getManager().getInstanceConfig().isJitDisabled()) setCallCount(-1);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
@@ -181,7 +181,7 @@ public class MixedModeIRBlockBody extends IRBlockBody implements Compilable<Comp
     }
 
     public RubyModule getImplementationClass() {
-        return null;
+        return closure.getStaticScope().getModule();
     }
 
 }

--- a/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
@@ -1,9 +1,11 @@
 package org.jruby.runtime;
 
+import java.io.ByteArrayOutputStream;
+
 import org.jruby.EvalType;
+import org.jruby.Ruby;
 import org.jruby.RubyModule;
 import org.jruby.compiler.Compilable;
-import org.jruby.compiler.NotCompilableException;
 import org.jruby.ir.IRClosure;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.interpreter.Interpreter;
@@ -15,16 +17,14 @@ import org.jruby.util.cli.Options;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
 
-import java.io.ByteArrayOutputStream;
-
 public class MixedModeIRBlockBody extends IRBlockBody implements Compilable<CompiledIRBlockBody> {
     private static final Logger LOG = LoggerFactory.getLogger(MixedModeIRBlockBody.class);
 
     protected boolean pushScope;
     protected boolean reuseParentScope;
     private boolean displayedCFG = false; // FIXME: Remove when we find nicer way of logging CFG
-    private volatile int callCount = 0;
     private InterpreterContext interpreterContext;
+    private volatile int callCount = 0;
     private volatile CompiledIRBlockBody jittedBody;
 
     public MixedModeIRBlockBody(IRClosure closure, Signature signature) {
@@ -32,12 +32,9 @@ public class MixedModeIRBlockBody extends IRBlockBody implements Compilable<Comp
         this.pushScope = true;
         this.reuseParentScope = false;
 
-        // JIT currently JITs blocks along with their method and no on-demand by themselves.  We only
-        // promote to full build here if we are -X-C.
-        if (!closure.getManager().getInstanceConfig().getCompileMode().shouldJIT() ||
-                Options.JIT_THRESHOLD.load() < 0) {
-            callCount = -1;
-        }
+        // JIT currently JITs blocks along with their method and no on-demand by themselves.
+        // We only promote to full build here if we are -X-C.
+        if (closure.getManager().getInstanceConfig().isJitDisabled()) setCallCount(-1);
     }
 
     @Override
@@ -156,29 +153,28 @@ public class MixedModeIRBlockBody extends IRBlockBody implements Compilable<Comp
     }
 
     private void promoteToFullBuild(ThreadContext context) {
-        if (context.runtime.isBooting() && !Options.JIT_KERNEL.load()) return; // don't JIT during runtime boot
+        final Ruby runtime = context.runtime;
+        if (runtime.isBooting() && !Options.JIT_KERNEL.load()) return; // don't JIT during runtime boot
 
-        if (callCount >= 0) {
-            synchronized (this) {
-                // check call count again
-                if (callCount < 0) return;
-
-                if (callCount++ >= Options.JIT_THRESHOLD.load()) {
-                    callCount = -1;
+        if (this.callCount < 0) return;
+        // we don't synchronize callCount++ it does not matter if count isn't accurate
+        if (this.callCount++ >= runtime.getInstanceConfig().getJitThreshold()) {
+            synchronized (this) { // disable same jit tasks from entering queue twice
+                if (this.callCount >= 0) {
+                    this.callCount = Integer.MIN_VALUE; // so that callCount++ stays < 0
 
                     // ensure we've got code ready for JIT
                     ensureInstrsReady();
                     closure.getNearestTopLocalVariableScope().prepareForCompilation();
 
-                    // if we don't have an explicit protocol, disable JIT
                     if (!closure.hasExplicitCallProtocol()) {
                         if (Options.JIT_LOGGING.load()) {
                             LOG.info("JIT failed; no protocol found in block: " + closure);
                         }
-                        return;
+                        return; // do not JIT if we don't have an explicit protocol
                     }
 
-                    context.runtime.getJITCompiler().buildThresholdReached(context, this);
+                    runtime.getJITCompiler().buildThresholdReached(context, this);
                 }
             }
         }

--- a/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
@@ -34,7 +34,7 @@ public class MixedModeIRBlockBody extends IRBlockBody implements Compilable<Comp
 
         // JIT currently JITs blocks along with their method and no on-demand by themselves.
         // We only promote to full build here if we are -X-C.
-        if (closure.getManager().getInstanceConfig().isJitDisabled()) setCallCount(-1);
+        if (!closure.getManager().getInstanceConfig().isJitEnabled()) setCallCount(-1);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
@@ -24,7 +24,7 @@ public class MixedModeIRBlockBody extends IRBlockBody implements Compilable<Comp
     protected boolean reuseParentScope;
     private boolean displayedCFG = false; // FIXME: Remove when we find nicer way of logging CFG
     private InterpreterContext interpreterContext;
-    private volatile int callCount = 0;
+    private int callCount = 0;
     private volatile CompiledIRBlockBody jittedBody;
 
     public MixedModeIRBlockBody(IRClosure closure, Signature signature) {

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -103,6 +103,7 @@ public class Options {
     public static final Option<Boolean> INVOKEDYNAMIC_HANDLES = bool(INVOKEDYNAMIC, "invokedynamic.handles", false, "Use MethodHandles rather than generated code to bind Ruby methods.");
     public static final Option<Boolean> INVOKEDYNAMIC_YIELD = bool(INVOKEDYNAMIC, "invokedynamic.yield", false, "Bind yields directly using invokedynamic.");
 
+    // NOTE: -1 jit.threshold is way of having interpreter not promote full builds
     public static final Option<Integer> JIT_THRESHOLD = integer(JIT, "jit.threshold", Constants.JIT_THRESHOLD, "Set the JIT threshold to the specified method invocation count.");
     public static final Option<Integer> JIT_MAX = integer(JIT, "jit.max", Constants.JIT_MAX_LIMIT, "Set the max count of active methods eligible for JIT-compilation.");
     public static final Option<Integer> JIT_MAXSIZE = integer(JIT, "jit.maxsize", Constants.JIT_MAX_SIZE_LIMIT, "Set the max size (in IR instructions) for a method to be eligible to JIT.");

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -104,7 +104,7 @@ public class Options {
     public static final Option<Boolean> INVOKEDYNAMIC_YIELD = bool(INVOKEDYNAMIC, "invokedynamic.yield", false, "Bind yields directly using invokedynamic.");
 
     public static final Option<Integer> JIT_THRESHOLD = integer(JIT, "jit.threshold", Constants.JIT_THRESHOLD, "Set the JIT threshold to the specified method invocation count.");
-    public static final Option<Integer> JIT_MAX = integer(JIT, "jit.max", Constants.JIT_MAX_METHODS_LIMIT, "Set the max count of active methods eligible for JIT-compilation.");
+    public static final Option<Integer> JIT_MAX = integer(JIT, "jit.max", Constants.JIT_MAX_LIMIT, "Set the max count of active methods eligible for JIT-compilation.");
     public static final Option<Integer> JIT_MAXSIZE = integer(JIT, "jit.maxsize", Constants.JIT_MAX_SIZE_LIMIT, "Set the max size (in IR instructions) for a method to be eligible to JIT.");
     public static final Option<Boolean> JIT_LOGGING = bool(JIT, "jit.logging", false, "Enable JIT logging (reports successful compilation).");
     public static final Option<Boolean> JIT_LOGGING_VERBOSE = bool(JIT, "jit.logging.verbose", false, "Enable verbose JIT logging (reports failed compilation).");

--- a/core/src/main/resources/org/jruby/runtime/Constants.java
+++ b/core/src/main/resources/org/jruby/runtime/Constants.java
@@ -67,11 +67,18 @@ public final class Constants {
      * Default size for chained compilation.
      */
     public static final int CHAINED_COMPILE_LINE_COUNT_DEFAULT = 500;
-    
+
+    /**
+     * The max count of active methods and blocks eligible for JIT-compilation.
+     * After this numbers of JIT-ed classes the compiler stops compiling.
+     */
+    public static final int JIT_MAX_LIMIT = 10000;
+
     /**
      * The max count of active methods eligible for JIT-compilation.
      */
-    public static final int JIT_MAX_METHODS_LIMIT = 4096;
+    @Deprecated
+    public static final int JIT_MAX_METHODS_LIMIT = JIT_MAX_LIMIT;
 
     /**
      * The max size of JIT-compiled methods (full class size) allowed.

--- a/core/src/main/resources/org/jruby/runtime/Constants.java
+++ b/core/src/main/resources/org/jruby/runtime/Constants.java
@@ -83,7 +83,7 @@ public final class Constants {
     /**
      * The max size of JIT-compiled methods (full class size) allowed.
      */
-    public static final int JIT_MAX_SIZE_LIMIT = 2000;
+    public static final int JIT_MAX_SIZE_LIMIT = 1000;
 
     /**
      * The JIT threshold to the specified method invocation count.

--- a/core/src/test/java/org/jruby/embed/ScriptingContainerTest.java
+++ b/core/src/test/java/org/jruby/embed/ScriptingContainerTest.java
@@ -2363,33 +2363,20 @@ public class ScriptingContainerTest {
      * Test of getJitThreshold method, of class ScriptingContainer.
      */
     @Test
-    public void testGetJitThreshold() {
+    public void testGetSetJitThreshold() {
         logger1.info("getJitThreshold");
         ScriptingContainer instance = new ScriptingContainer(LocalContextScope.THREADSAFE);
         instance.setError(pstream);
         instance.setOutput(pstream);
         instance.setWriter(writer);
         instance.setErrorWriter(writer);
-        int expResult = 50;
-        int result = instance.getJitThreshold();
-        assertEquals(expResult, result);
+        assertEquals(Constants.JIT_THRESHOLD, instance.getJitThreshold());
+        assertTrue(instance.getJitThreshold() > 0);
 
-        instance.terminate();
-    }
-
-    /**
-     * Test of setJitThreshold method, of class ScriptingContainer.
-     */
-    @Test
-    public void testSetJitThreshold() {
         logger1.info("setJitThreshold");
-        int threshold = 0;
-        ScriptingContainer instance = new ScriptingContainer(LocalContextScope.THREADSAFE);
-        instance.setError(pstream);
-        instance.setOutput(pstream);
-        instance.setWriter(writer);
-        instance.setErrorWriter(writer);
-        instance.setJitThreshold(threshold);
+        instance.setJitThreshold(0);
+        assertEquals(0, instance.getJitThreshold());
+        assertEquals(0, instance.getProvider().getRubyInstanceConfig().getJitThreshold());
 
         instance.terminate();
     }
@@ -2398,33 +2385,20 @@ public class ScriptingContainerTest {
      * Test of getJitMax method, of class ScriptingContainer.
      */
     @Test
-    public void testGetJitMax() {
+    public void testGetSetJitMax() {
         logger1.info("getJitMax");
         ScriptingContainer instance = new ScriptingContainer(LocalContextScope.THREADSAFE);
         instance.setError(pstream);
         instance.setOutput(pstream);
         instance.setWriter(writer);
         instance.setErrorWriter(writer);
-        int expResult = 4096;
-        int result = instance.getJitMax();
-        assertEquals(expResult, result);
+        assertEquals(Constants.JIT_MAX_LIMIT, instance.getJitMax());
+        assertTrue(instance.getJitMax() > 0);
 
-        instance.terminate();
-    }
-
-    /**
-     * Test of setJitMax method, of class ScriptingContainer.
-     */
-    @Test
-    public void testSetJitMax() {
         logger1.info("setJitMax");
-        int max = 0;
-        ScriptingContainer instance = new ScriptingContainer(LocalContextScope.THREADSAFE);
-        instance.setError(pstream);
-        instance.setOutput(pstream);
-        instance.setWriter(writer);
-        instance.setErrorWriter(writer);
-        instance.setJitMax(max);
+        instance.setJitMax(-1);
+        assertEquals(-1, instance.getJitMax());
+        assertEquals(-1, instance.getProvider().getRubyInstanceConfig().getJitMax());
 
         instance.terminate();
     }


### PR DESCRIPTION
... after some time esp. for big (Rails) apps that seemingly always execute some 'new-hot' methods

JIT parts also seemed ripe for a cleanup, so there's a few bits such as :
- not having multiple `callCount` in a hierarchy
- negated JIT condition - JITing when JIT meant to be disabled
- get JIT excludes to also exclude block compilations
- more useful ji logging - seeing exception.toString failures

aside from these, there's 2 simple but important changes : 

- `-Xjit.max=10000` default, to compilations and not leak meta-space
  even for a large Rails app this should be conservative as it takes several hours to reach the limit
  from a production app 10_000 JIT compiles means having around 550 of allocated meta-space

- `Xjit.maxsize` reduced from 2000 -> 1000 again based on real world production data
  there's very little JIT eligible large methods in Rails, so this further helps a bit saving on meta-space

also, since I will like to add JMX setters for the jit params, they are being read from the instance config