### PR TITLE
Use Java 8 stack walker when full trace is requested.

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -1647,27 +1647,27 @@ public class RubyThread extends RubyObject implements ExecutionContext {
 
     @JRubyMethod(name = "backtrace")
     public IRubyObject backtrace(ThreadContext context) {
-        return backtraceInternal(null, null);
+        return backtraceInternal(context, null, null);
     }
 
     @JRubyMethod(name = "backtrace")
     public IRubyObject backtrace(ThreadContext context, IRubyObject level) {
-        return backtraceInternal(level, null);
+        return backtraceInternal(context, level, null);
     }
 
     @JRubyMethod(name = "backtrace")
     public IRubyObject backtrace(ThreadContext context, IRubyObject level, IRubyObject length) {
-        return backtraceInternal(level, length);
+        return backtraceInternal(context, level, length);
     }
 
-    private IRubyObject backtraceInternal(IRubyObject level, IRubyObject length) {
+    private IRubyObject backtraceInternal(ThreadContext callerContext, IRubyObject level, IRubyObject length) {
         ThreadContext context = getContext();
         Thread nativeThread = getNativeThread();
 
         // context can be nil if we have not started or GC has claimed our context
         // nativeThread can be null if the thread has terminated and GC has claimed it
         // nativeThread may have finished
-        if (context == null || nativeThread == null || !nativeThread.isAlive()) return context.nil;
+        if (context == null || nativeThread == null || !nativeThread.isAlive()) return callerContext.nil;
 
         return RubyKernel.withLevelAndLength(
                 context, level, length, 0,
@@ -1676,27 +1676,27 @@ public class RubyThread extends RubyObject implements ExecutionContext {
 
     @JRubyMethod
     public IRubyObject backtrace_locations(ThreadContext context) {
-        return backtraceLocationsInternal(null, null);
+        return backtraceLocationsInternal(context, null, null);
     }
 
     @JRubyMethod
     public IRubyObject backtrace_locations(ThreadContext context, IRubyObject level) {
-        return backtraceLocationsInternal(level, null);
+        return backtraceLocationsInternal(context, level, null);
     }
 
     @JRubyMethod
     public IRubyObject backtrace_locations(ThreadContext context, IRubyObject level, IRubyObject length) {
-        return backtraceLocationsInternal(level, length);
+        return backtraceLocationsInternal(context, level, length);
     }
 
-    private IRubyObject backtraceLocationsInternal(IRubyObject level, IRubyObject length) {
+    private IRubyObject backtraceLocationsInternal(ThreadContext callerContext, IRubyObject level, IRubyObject length) {
         ThreadContext context = getContext();
         Thread nativeThread = getNativeThread();
 
         // context can be nil if we have not started or GC has claimed our context
         // nativeThread can be null if the thread has terminated and GC has claimed it
         // nativeThread may have finished
-        if (context == null || nativeThread == null || !nativeThread.isAlive()) return context.nil;
+        if (context == null || nativeThread == null || !nativeThread.isAlive()) return callerContext.nil;
 
         return RubyKernel.withLevelAndLength(
                 context, level, length, 0,

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -37,6 +37,7 @@
 package org.jruby.runtime;
 
 import com.headius.backport9.stack.StackWalker;
+import com.headius.backport9.stack.impl.StackWalker8;
 import org.jcodings.Encoding;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
@@ -746,11 +747,8 @@ public final class ThreadContext {
         traceType.getFormat().renderBacktrace(backtraceData.getBacktrace(runtime), sb, false);
     }
 
-    private static final StackWalker WALKER = StackWalker.getInstance();
-
-    public IRubyObject createCallerBacktrace(int level, Integer length) {
-        return WALKER.walk(stream -> createCallerBacktrace(level, length, stream));
-    }
+    public static final StackWalker WALKER = StackWalker.getInstance();
+    public static final StackWalker WALKER8 = new StackWalker8();
 
     /**
      * Create an Array with backtrace information for Kernel#caller
@@ -777,10 +775,6 @@ public final class ThreadContext {
         RubyArray backTrace = RubyArray.newArrayMayCopy(runtime, traceArray);
         if (RubyInstanceConfig.LOG_CALLERS) TraceType.logCaller(backTrace);
         return backTrace;
-    }
-
-    public IRubyObject createCallerLocations(int level, Integer length) {
-        return WALKER.walk(stream -> createCallerLocations(level, length, stream));
     }
 
     /**

--- a/core/src/main/java/org/jruby/util/func/ObjectIntIntFunction.java
+++ b/core/src/main/java/org/jruby/util/func/ObjectIntIntFunction.java
@@ -1,0 +1,5 @@
+package org.jruby.util.func;
+
+public interface ObjectIntIntFunction<T, R> {
+    R apply(T t, int i, int j);
+}


### PR DESCRIPTION
This is faster than using the Java 9+ stack walker API to generate
a full trace and resolves at least part of GH-5857.