### PR TITLE
make SecureRandom.rand public

### DIFF
--- a/core/src/main/java/org/jruby/ext/securerandom/RubySecureRandom.java
+++ b/core/src/main/java/org/jruby/ext/securerandom/RubySecureRandom.java
@@ -93,12 +93,12 @@ public class RubySecureRandom {
         return bytes;
     }
 
-    @JRubyMethod(meta = true)
+    @JRubyMethod(meta = true, name = {"random_number", "rand"})
     public static IRubyObject random_number(ThreadContext context, IRubyObject self) {
         return randomDouble(context);
     }
 
-    @JRubyMethod(meta = true)
+    @JRubyMethod(meta = true, name = {"random_number", "rand"})
     public static IRubyObject random_number(ThreadContext context, IRubyObject self, IRubyObject n) {
         if (n instanceof RubyFixnum) {
             final long bound = ((RubyFixnum) n).getLongValue();


### PR DESCRIPTION
similar problem as https://github.com/jruby/jruby/issues/5773

in mri https://github.com/ruby/ruby/blob/master/random.c#L1568

```
require 'securerandom'
SecureRandom.rand
Traceback (most recent call last):
        6: from /home/ahorek/.rvm/rubies/jruby-head/bin/irb:13:in `<main>'
        5: from org/jruby/RubyKernel.java:1199:in `catch'
        4: from org/jruby/RubyKernel.java:1199:in `catch'
        3: from org/jruby/RubyKernel.java:1430:in `loop'
        2: from org/jruby/RubyKernel.java:1067:in `eval'
        1: from (irb):4:in `evaluate'
NoMethodError (private method `rand' called for SecureRandom:Module)

[1,2,3].shuffle(random: SecureRandom)
Traceback (most recent call last):
        8: from /home/ahorek/.rvm/rubies/jruby-head/bin/irb:13:in `<main>'
        7: from org/jruby/RubyKernel.java:1199:in `catch'
        6: from org/jruby/RubyKernel.java:1199:in `catch'
        5: from org/jruby/RubyKernel.java:1430:in `loop'
        4: from org/jruby/RubyKernel.java:1067:in `eval'
        3: from (irb):9:in `evaluate'
        2: from org/jruby/RubyArray.java:4289:in `shuffle'
        1: from org/jruby/RubyArray.java:4267:in `shuffle!'
NoMethodError (private method `rand' called for SecureRandom:Module)
```