### PR TITLE
add Random.random_number

### DIFF
--- a/core/src/main/java/org/jruby/RubyRandom.java
+++ b/core/src/main/java/org/jruby/RubyRandom.java
@@ -273,7 +273,7 @@ public class RubyRandom extends RubyObject {
         return this;
     }
 
-    @JRubyMethod(name = "rand", meta = true, optional = 1)
+    @JRubyMethod(name = "rand", alias = "random_number", meta = true, optional = 1)
     public static IRubyObject rand(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         RandomType random = getDefaultRand(context);
         if (args.length == 0) return randFloat(context, random);
@@ -315,12 +315,12 @@ public class RubyRandom extends RubyObject {
         return (args.length == 0) ? rand(context) : rand(context, args[0]);
     }
 
-    @JRubyMethod(name = "rand")
+    @JRubyMethod(name = "rand", alias = "random_number")
     public IRubyObject rand(ThreadContext context) {
         return randFloat(context, random);
     }
 
-    @JRubyMethod(name = "rand")
+    @JRubyMethod(name = "rand", alias = "random_number")
     public IRubyObject rand(ThreadContext context, IRubyObject arg) {
         return randomRand(context, arg, random);
     }


### PR DESCRIPTION
random_number is just an alias to rand

fixes
```
Random.new.random_number
```

`Random.random_number` (and `SecureRandom.bytes` https://github.com/jruby/jruby/issues/5773) is actually a ruby 2.6 feature, should I keep it or move it to 2.6 branch?

