### PR TITLE
attempt to share loader for JIT-ed classes

### DIFF
--- a/core/src/main/java/org/jruby/compiler/BlockJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/BlockJITTask.java
@@ -84,6 +84,11 @@ class BlockJITTask extends JITCompiler.Task {
     }
 
     @Override
+    protected String getSourceFile() {
+        return body.getFile();
+    }
+
+    @Override
     protected void logJitted() {
         logImpl("block done jitting");
     }

--- a/core/src/main/java/org/jruby/compiler/ClassLoaderMode.java
+++ b/core/src/main/java/org/jruby/compiler/ClassLoaderMode.java
@@ -1,0 +1,7 @@
+package org.jruby.compiler;
+
+public enum ClassLoaderMode {
+    UNIQUE,
+    SHARED,
+    SHARED_SOURCE;
+}

--- a/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
@@ -91,6 +91,11 @@ class MethodCompiledJITTask extends JITCompiler.Task {
     }
 
     @Override
+    protected String getSourceFile() {
+        return method.getFile();
+    }
+
+    @Override
     protected void logJitted() {
         logImpl("(compiled) method done jitting");
     }

--- a/core/src/main/java/org/jruby/compiler/MethodJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/MethodJITTask.java
@@ -107,6 +107,11 @@ class MethodJITTask extends JITCompiler.Task {
     }
 
     @Override
+    protected String getSourceFile() {
+        return method.getFile();
+    }
+
+    @Override
     protected void logJitted() {
         logImpl("method done jitting");
     }

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import java.util.HashSet;
 
 import com.headius.options.Option;
+import org.jruby.compiler.ClassLoaderMode;
 import org.jruby.runtime.Constants;
 import org.jruby.util.KCode;
 import org.jruby.util.SafePropertyAccessor;
@@ -115,6 +116,7 @@ public class Options {
     public static final Option<Boolean> JIT_DEBUG = bool(JIT, "jit.debug", false, "Log loading of JITed bytecode.");
     public static final Option<Boolean> JIT_BACKGROUND = bool(JIT, "jit.background", JIT_THRESHOLD.load() != 0, "Run the JIT compiler in a background thread. Off if jit.threshold=0.");
     public static final Option<Boolean> JIT_KERNEL = bool(JIT, "jit.kernel", false, "Run the JIT compiler while the pure-Ruby kernel is booting.");
+    public static final Option<ClassLoaderMode> JIT_LOADER_MODE = enumeration(JIT, "jit.loader.mode", ClassLoaderMode.class, ClassLoaderMode.UNIQUE, "Set JIT class loader to use. UNIQUE class loader per class; SHARED loader for all classes");
 
     public static final Option<String> IR_DEBUG_IGV          = string(IR, "ir.debug.igv", (String) null, "Specify file:line of scope to jump to IGV");
     public static final Option<Boolean> IR_DEBUG             = bool(IR, "ir.debug", false, "Debug generation of JRuby IR.");


### PR DESCRIPTION
introduces a `-Xjit.loader.mode` which is either UNIQUE (default), SHARED or SHARED_SOURCE

most of it is making `WeakValueMap` implement `Map` as I originally did something else here ...
so I've kept that code and just did a fake `Map` for the single (shared) global class-loader.
that can be changed as needed to a cleaner (proper oop) way.

the SHARED_SOURCE was so far only tested with jruby's test suite, the JITed class-loader count went down to 10% ... and meta-space was much less fragmented - saving around 8% of allocated space.

was not sure whether we should attempt to somehow detect `eval`-ed pieces
and not share them with the same source file but rather always on their own?
given that SHARED_SOURCE isn't changed to be the new default, we can also decide later.

also if you have suggestions for better naming the option or the enum values.

