### PR TITLE
[feat] jit.exclude based on path/to/impl_file.rb

### DIFF
--- a/core/src/main/java/org/jruby/RubyInstanceConfig.java
+++ b/core/src/main/java/org/jruby/RubyInstanceConfig.java
@@ -1764,6 +1764,8 @@ public class RubyInstanceConfig {
      * Comma-separated list of methods to exclude from JIT compilation.
      * Specify as "Module", "Module#method" or "method".
      *
+     * Also supports excluding based on implementation_file.rb syntax.
+     *
      * Set with the <tt>jruby.jit.exclude</tt> system property.
      */
     public static final String COMPILE_EXCLUDE = Options.JIT_EXCLUDE.load();

--- a/core/src/main/java/org/jruby/compiler/BlockJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/BlockJITTask.java
@@ -52,7 +52,7 @@ class BlockJITTask extends JITCompiler.Task {
     @Override
     public void exec() throws NoSuchMethodException, IllegalAccessException {
         // Check if the method has been explicitly excluded
-        String excludeModuleName = checkExcludedMethod(jitCompiler.config, className, methodName, body.getImplementationClass());
+        String excludeModuleName = checkExcludedMethod(jitCompiler.config, className, methodName, body);
         if (excludeModuleName != null) {
             body.setCallCount(-1);
             if (jitCompiler.config.isJitLogging()) {

--- a/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
@@ -57,11 +57,11 @@ class MethodCompiledJITTask extends JITCompiler.Task {
     @Override
     public void exec() throws NoSuchMethodException, IllegalAccessException {
         // Check if the method has been explicitly excluded
-        String excludeModuleName = checkExcludedMethod(jitCompiler.config, className, methodName, method.getImplementationClass());
+        String excludeModuleName = checkExcludedMethod(jitCompiler.config, className, methodName, method);
         if (excludeModuleName != null) {
             method.setCallCount(-1);
             if (jitCompiler.config.isJitLogging()) {
-                logImpl("skipping method in " + excludeModuleName);
+                logImpl("skipping (compiled) method in " + excludeModuleName);
             }
             return;
         }

--- a/core/src/main/java/org/jruby/compiler/MethodJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/MethodJITTask.java
@@ -57,7 +57,7 @@ class MethodJITTask extends JITCompiler.Task {
     @Override
     public void exec() throws NoSuchMethodException, IllegalAccessException {
         // Check if the method has been explicitly excluded
-        String excludeModuleName = checkExcludedMethod(jitCompiler.config, className, methodName, method.getImplementationClass());
+        String excludeModuleName = checkExcludedMethod(jitCompiler.config, className, methodName, method);
         if (excludeModuleName != null) {
             method.setCallCount(-1);
             if (jitCompiler.config.isJitLogging()) {
@@ -122,8 +122,9 @@ class MethodJITTask extends JITCompiler.Task {
     }
 
     static String checkExcludedMethod(final RubyInstanceConfig config, final String className, final String methodName,
-                                      final RubyModule implementationClass) {
+                                      final Compilable target) {
         if (config.getExcludedMethods().size() > 0) {
+            final RubyModule implementationClass = target.getImplementationClass();
             String excludeModuleName = className;
             if (implementationClass.getMethodLocation().isSingleton()) {
                 RubyBasicObject possibleRealClass = ((MetaClass) implementationClass).getAttached();
@@ -132,9 +133,11 @@ class MethodJITTask extends JITCompiler.Task {
                 }
             }
 
-            if ((config.getExcludedMethods().contains(excludeModuleName)
+            if (config.getExcludedMethods().contains(excludeModuleName)
+                    || config.getExcludedMethods().contains(methodName)
                     || config.getExcludedMethods().contains(excludeModuleName + '#' + methodName)
-                    || config.getExcludedMethods().contains(methodName))) {
+                    || config.getExcludedMethods().contains(target.getFile())
+                    || config.getExcludedMethods().contains(target.getFile() + ':' + target.getLine())) {
 
                 return excludeModuleName; // true - excluded
             }


### PR DESCRIPTION
since there's currently no way to exclude dynamic evals (e.g. from Rails)

allows us to handle excludes as long as FILE is set ... e.g. [excluding generated attribute methods](https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/attribute_methods.rb#L48)