### PR TITLE
[fix] jit.excludes for block using class (and method) name

### DIFF
--- a/core/src/main/java/org/jruby/compiler/Compilable.java
+++ b/core/src/main/java/org/jruby/compiler/Compilable.java
@@ -1,5 +1,7 @@
 package org.jruby.compiler;
 
+import org.jruby.MetaClass;
+import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.interpreter.InterpreterContext;
@@ -13,9 +15,61 @@ public interface Compilable<T> {
     public void completeBuild(T buildResult);
     public IRScope getIRScope();
     public InterpreterContext ensureInstrsReady();
-    public String getClassName(ThreadContext context);
-    public String getName();
-    public String getFile();
-    public int getLine();
+
+    /**
+     * Return the owning module/class name.
+     * @return method/block owner's name
+     */
+    default String getOwnerName() {
+        RubyModule implClass = getImplementationClass();
+        return implClass == null ? null : resolveFullName(implClass);
+    }
+
+    /**
+     * @return method/closure identifier
+     */
+    String getName();
+
+    /**
+     * @return method/block source file
+     */
+    String getFile();
+
+    /**
+     * @return method/block source file line
+     */
+    int getLine();
+
     public RubyModule getImplementationClass();
+
+    @Deprecated
+    default String getClassName(ThreadContext context) {
+        return getOwnerName();
+    }
+
+    /**
+     * Resolve the fully qualified name.
+     * @param implementationClass
+     * @return class/module name e.g. Foo::Bar::Baz
+     */
+    static String resolveFullName(RubyModule implementationClass) {
+        String className;
+        if (implementationClass.isSingleton()) {
+            MetaClass metaClass = (MetaClass)implementationClass;
+            RubyClass realClass = metaClass.getRealClass();
+            // if real class is Class
+            if (realClass == implementationClass.getRuntime().getClassClass()) {
+                // use the attached class's name
+                className = ((RubyClass) metaClass.getAttached()).getName();
+            } else {
+                // use the real class name
+                className = realClass.getName();
+            }
+        } else {
+            // use the class name
+            className = implementationClass.getName();
+        }
+        return className;
+    }
+
 }

--- a/core/src/main/java/org/jruby/compiler/JITCompiler.java
+++ b/core/src/main/java/org/jruby/compiler/JITCompiler.java
@@ -170,11 +170,11 @@ public class JITCompiler implements JITCompilerMBean {
 
     public Runnable getTaskFor(ThreadContext context, Compilable method) {
         if (method instanceof MixedModeIRMethod) {
-            return new MethodJITTask(this, (MixedModeIRMethod) method, method.getClassName(context));
+            return new MethodJITTask(this, (MixedModeIRMethod) method, method.getOwnerName());
         } else if (method instanceof MixedModeIRBlockBody) {
-            return new BlockJITTask(this, (MixedModeIRBlockBody) method, method.getClassName(context));
+            return new BlockJITTask(this, (MixedModeIRBlockBody) method, method.getOwnerName());
         } else if (method instanceof CompiledIRMethod) {
-            return new MethodCompiledJITTask(this, (CompiledIRMethod) method, method.getClassName(context));
+            return new MethodCompiledJITTask(this, (CompiledIRMethod) method, method.getOwnerName());
         }
 
         return new FullBuildTask(this, method);

--- a/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
@@ -112,27 +112,6 @@ public abstract class AbstractIRMethod extends DynamicMethod implements IRMethod
         }
     }
 
-    @JIT
-    public String getClassName(ThreadContext context) {
-        String className;
-        if (implementationClass.isSingleton()) {
-            MetaClass metaClass = (MetaClass)implementationClass;
-            RubyClass realClass = metaClass.getRealClass();
-            // if real class is Class
-            if (realClass == context.runtime.getClassClass()) {
-                // use the attached class's name
-                className = ((RubyClass) metaClass.getAttached()).getName();
-            } else {
-                // use the real class name
-                className = realClass.getName();
-            }
-        } else {
-            // use the class name
-            className = implementationClass.getName();
-        }
-        return className;
-    }
-
     public String getFile() {
         return method.getFile();
     }

--- a/core/src/main/java/org/jruby/runtime/InterpretedIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/InterpretedIRBlockBody.java
@@ -82,7 +82,7 @@ public class InterpretedIRBlockBody extends IRBlockBody implements Compilable<In
     }
 
     @Override
-    public String getClassName(ThreadContext context) {
+    public String getOwnerName() {
         return null;
     }
 

--- a/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
@@ -96,11 +96,6 @@ public class MixedModeIRBlockBody extends IRBlockBody implements Compilable<Comp
     }
 
     @Override
-    public String getClassName(ThreadContext context) {
-        return closure.getId();
-    }
-
-    @Override
     public String getName() {
         return closure.getId();
     }


### PR DESCRIPTION
wasn't working since the (internal) closure id was returned
since block tasks will know the impl module - return that
and use the common logic for extracting owner name