### PR TITLE
less locking in interpreter mode (due IRMethod)

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
@@ -3,16 +3,13 @@ package org.jruby.internal.runtime;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jruby.MetaClass;
 import org.jruby.Ruby;
-import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.compiler.Compilable;
 import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.internal.runtime.methods.IRMethodArgs;
 import org.jruby.ir.IRMethod;
 import org.jruby.ir.IRScope;
-import org.jruby.ir.JIT;
 import org.jruby.ir.instructions.GetFieldInstr;
 import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.instructions.PutFieldInstr;
@@ -33,8 +30,8 @@ public abstract class AbstractIRMethod extends DynamicMethod implements IRMethod
     protected final Signature signature;
     protected final IRScope method;
     protected final StaticScope staticScope;
-    protected InterpreterContext interpreterContext = null;
     protected int callCount = 0;
+    protected transient InterpreterContext interpreterContext; // cached from method
     private transient MethodData methodData;
 
     public AbstractIRMethod(IRScope method, Visibility visibility, RubyModule implementationClass) {
@@ -87,7 +84,28 @@ public abstract class AbstractIRMethod extends DynamicMethod implements IRMethod
         return ((IRMethod) method).getArgumentDescriptors();
     }
 
-    public abstract InterpreterContext ensureInstrsReady();
+    public InterpreterContext ensureInstrsReady() {
+        final InterpreterContext interpreterContext = this.interpreterContext;
+        if (interpreterContext == null) {
+            return this.interpreterContext = retrieveInterpreterContext();
+        }
+        return interpreterContext;
+    }
+
+    private InterpreterContext retrieveInterpreterContext() {
+        final InterpreterContext interpreterContext;
+        if (method instanceof IRMethod) {
+            interpreterContext = ((IRMethod) method).lazilyAcquireInterpreterContext();
+        } else {
+            interpreterContext = method.getInterpreterContext();
+        }
+
+        if (IRRuntimeHelpers.shouldPrintIR(implementationClass.getRuntime())) printMethodIR();
+
+        return interpreterContext;
+    }
+
+    protected abstract void printMethodIR() ;
 
     public Signature getSignature() {
         return signature;

--- a/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
@@ -160,4 +160,10 @@ public abstract class AbstractIRMethod extends DynamicMethod implements IRMethod
 
         return methodData;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getName() + '@' + Integer.toHexString(System.identityHashCode(this)) + ' ' + method + ' ' + getSignature();
+    }
+
 }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
@@ -74,15 +74,8 @@ public class CompiledIRMethod extends AbstractIRMethod implements Compilable<Dyn
     }
 
     @Override
-    public InterpreterContext ensureInstrsReady() {
-        // FIXME: duplicated from MixedModeIRMethod
-        if (method instanceof IRMethod) {
-            return ((IRMethod) method).lazilyAcquireInterpreterContext();
-        }
-
-        InterpreterContext ic = method.getInterpreterContext();
-
-        return ic;
+    protected void printMethodIR() {
+        // no-op
     }
 
     @Override

--- a/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
@@ -204,17 +204,4 @@ public class CompiledIRMethod extends AbstractIRMethod implements Compilable<Dyn
         }
     }
 
-    public String getFile() {
-        return method.getFile();
-    }
-
-    public int getLine() {
-        return method.getLine();
-    }
-
-    @Override
-    public String toString() {
-        return getClass().getName() + '@' + Integer.toHexString(hashCode()) + ' ' + method + ' ' + getSignature();
-    }
-
 }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRNoProtocolMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRNoProtocolMethod.java
@@ -91,4 +91,9 @@ public class CompiledIRNoProtocolMethod extends AbstractIRMethod {
         // AbstractIRMethod.getMethodData() calls this and we want IC since we have not eliminated any get/put fields.
         return method.getInterpreterContext();
     }
+
+    @Override
+    protected void printMethodIR() {
+        // no-op
+    }
 }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
@@ -5,7 +5,6 @@ import java.io.ByteArrayOutputStream;
 import org.jruby.RubyModule;
 import org.jruby.compiler.Compilable;
 import org.jruby.internal.runtime.AbstractIRMethod;
-import org.jruby.ir.IRMethod;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.interpreter.InterpreterContext;
 import org.jruby.ir.persistence.IRDumper;
@@ -53,24 +52,10 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
         }
     }
 
-    // FIXME: for subclasses we should override this method since it can be simple get
-    // FIXME: to avoid cost of synch call in lazilyacquire we can save the ic here
     @Override
-    public InterpreterContext ensureInstrsReady() {
-        if (interpreterContext == null) {
-            if (method instanceof IRMethod) {
-                interpreterContext = ((IRMethod) method).lazilyAcquireInterpreterContext();
-            }
-            interpreterContext = method.getInterpreterContext();
-
-            if (IRRuntimeHelpers.shouldPrintIR(implementationClass.getRuntime())) {
-                ByteArrayOutputStream baos = IRDumper.printIR(method, false, true);
-
-                LOG.info("Printing simple IR for " + method.getId() + ":\n" + new String(baos.toByteArray()));
-            }
-        }
-
-        return interpreterContext;
+    protected void printMethodIR() {
+        ByteArrayOutputStream baos = IRDumper.printIR(method, false, true);
+        LOG.info("Printing simple IR for " + method.getId() + ":\n" + new String(baos.toByteArray()));
     }
 
     @Override

--- a/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
@@ -2,11 +2,9 @@ package org.jruby.internal.runtime.methods;
 
 import java.io.ByteArrayOutputStream;
 
-import org.jruby.Ruby;
 import org.jruby.RubyModule;
 import org.jruby.compiler.Compilable;
 import org.jruby.internal.runtime.AbstractIRMethod;
-import org.jruby.ir.IRMethod;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.interpreter.InterpreterContext;
 import org.jruby.ir.persistence.IRDumper;
@@ -54,22 +52,10 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
         }
     }
 
-    // FIXME: for subclasses we should override this method since it can be simple get
-    // FIXME: to avoid cost of synch call in lazilyacquire we can save the ic here
-    public InterpreterContext ensureInstrsReady() {
-        if (method instanceof IRMethod) {
-            return ((IRMethod) method).lazilyAcquireInterpreterContext();
-        }
-
-        InterpreterContext ic = method.getInterpreterContext();
-
-        if (IRRuntimeHelpers.shouldPrintIR(implementationClass.getRuntime())) {
-            ByteArrayOutputStream baos = IRDumper.printIR(method, false);
-
-            LOG.info("Printing simple IR for " + method.getId() + ":\n" + new String(baos.toByteArray()));
-        }
-
-        return ic;
+    @Override
+    protected void printMethodIR() {
+        ByteArrayOutputStream baos = IRDumper.printIR(method, false);
+        LOG.info("Printing simple IR for " + method.getId() + ":\n" + new String(baos.toByteArray()));
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/IRMethod.java
+++ b/core/src/main/java/org/jruby/ir/IRMethod.java
@@ -43,8 +43,7 @@ public class IRMethod extends IRScope {
     }
 
     private synchronized void buildMethodImpl() {
-        DefNode defNode = this.defNode;
-        if (defNode == null) return;
+        if (hasBeenBuilt()) return;
 
         IRBuilder.topIRBuilder(getManager(), this).
                 defineMethodInner(defNode, getLexicalParent(), getFlags().contains(IRFlags.CODE_COVERAGE)); // sets interpreterContext

--- a/core/src/main/java/org/jruby/ir/IRMethod.java
+++ b/core/src/main/java/org/jruby/ir/IRMethod.java
@@ -52,7 +52,7 @@ public class IRMethod extends IRScope {
     }
 
     public synchronized BasicBlock[] prepareForCompilation() {
-        if (!hasBeenBuilt()) buildMethodImpl();
+        buildMethodImpl();
 
         return super.prepareForCompilation();
     }


### PR DESCRIPTION
a load test profiled showed some lower (but likely often unnecessary) numbers around:
```
org.jruby.ir.IRMethod.lazilyAcquireInterpreterContext()	
org.jruby.internal.runtime.methods.MixedModeIRMethod.ensureInstrsReady()	
org.jruby.internal.runtime.methods.MixedModeIRMethod.call(ThreadContext, IRubyObject, RubyModule, String, IRubyObject, IRubyObject, Block)	
org.jruby.RubyClass.finvoke(ThreadContext, IRubyObject, String, IRubyObject, IRubyObject, Block)	
org.jruby.RubyBasicObject.send(ThreadContext, IRubyObject, IRubyObject, IRubyObject, Block)	
org.jruby.RubyKernel.send(ThreadContext, IRubyObject, IRubyObject, IRubyObject, IRubyObject, Block)
org.jruby.RubyKernel$INVOKER$s$send.call(ThreadContext, IRubyObject, RubyModule, String, IRubyObject, IRubyObject, IRubyObject, Block)	
org.jruby.runtime.callsite.CachingCallSite.call(ThreadContext, IRubyObject, IRubyObject, IRubyObject, IRubyObject, IRubyObject, Block)	
jruby.$2_dot_3_dot_0.gems.actionview_minus_4_dot_2_dot_11_dot_1.lib.action_view.template.invokeOther2:send(ThreadContext, IRubyObject, IRubyObject, IRubyObject, IRubyObject, IRubyObject, Block)
jruby.$2_dot_3_dot_0.gems.actionview_minus_4_dot_2_dot_11_dot_1.lib.action_view.template.RUBY$block$render$1(ThreadContext, Block, StaticScope, IRubyObject, IRubyObject[], Block)	
```
in a sample 3 threads were blocked for a total of 400ms (and more samples showed a similar trace)