### PR TITLE
Implement Java::JavaLang::Throwable#full_message

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -39,6 +39,7 @@ import org.jruby.runtime.Block;
 import org.jruby.runtime.JavaInternalBlockBody;
 import org.jruby.runtime.Signature;
 import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.backtrace.TraceType;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import java.lang.reflect.Modifier;
@@ -234,6 +235,16 @@ public abstract class JavaLang {
             java.lang.Throwable throwable = unwrapIfJavaObject(self);
             final String msg = throwable.getLocalizedMessage(); // does getMessage
             return msg == null ? RubyString.newEmptyString(context.runtime) : RubyString.newString(context.runtime, msg);
+        }
+
+        @JRubyMethod
+        public static IRubyObject full_message(final ThreadContext context, final IRubyObject self) {
+            return full_message(context, self, null);
+        }
+
+        @JRubyMethod
+        public static IRubyObject full_message(final ThreadContext context, final IRubyObject self, final IRubyObject opts) {
+            return RubyString.newString(context.runtime, TraceType.printFullMessage(context, self, opts));
         }
 
         @JRubyMethod // Ruby exception to_s is the same as message

--- a/spec/java_integration/addons/throwable_spec.rb
+++ b/spec/java_integration/addons/throwable_spec.rb
@@ -8,27 +8,33 @@ describe "A Java Throwable" do
     expect {trace = ex.backtrace}.not_to raise_error
     expect(trace).to eq(ex.stack_trace.map(&:to_s))
   end
-  
+
   it "implements backtrace= as a no-op" do
     ex = java.lang.IllegalStateException.new
     backtrace = ex.backtrace
     ex.set_backtrace ['blah']
     expect(ex.backtrace).to eq backtrace
   end
-  
+
   it "implements to_s as message" do
     ex = java.lang.Exception.new
     expect(ex.to_s).to eq ''
     expect(ex.to_s).to eq ex.message
-    
+
     ex = java.lang.RuntimeException.new('hello')
     expect(ex.to_s).to eq 'hello'
     expect(ex.to_s).to eq ex.message
   end
-  
+
   it "implements inspect as toString" do
     ex = java.lang.Exception.new('hello')
     expect(ex.inspect).to eq "java.lang.Exception: hello"
+  end
+
+  it "implements full_message" do
+    ex = java.lang.Exception.new('hello')
+    expect(ex.full_message).to match /hello \(Java::JavaLang::Exception\)/
+    expect(ex.full_message(:highlight => true, :order => :top)).to match /hello \(Java::JavaLang::Exception\)/
   end
 
   it "can be rescued by rescue Exception" do
@@ -38,7 +44,7 @@ describe "A Java Throwable" do
       expect(e).to eq(ex)
     end
   end
-  
+
   it "can be rescued by rescue java.lang.Throwable" do
     begin
       raise ex = java.lang.Exception.new
@@ -46,7 +52,7 @@ describe "A Java Throwable" do
       expect(e).to eq(ex)
     end
   end
-  
+
   it "can be rescued by rescue Object" do
     begin
       raise ex = java.lang.Exception.new


### PR DESCRIPTION
Since Java throwables are treated similarly to regular Ruby exceptions,
I think it makes sense to implement `full_message` for easier logging
and debugging.

This moves the `RubyException` implementation to `TraceType` so that it
can be shared with `Throwable`. I had to change the `exception` argument
type in `printBacktraceMRI` in order to support the exception-like
object that `Throwable` provides.

Closes: https://github.com/jruby/jruby/issues/5906