### PR TITLE
Allow blocks that happen within an eval to JIT.

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRClosure.java
+++ b/core/src/main/java/org/jruby/ir/IRClosure.java
@@ -34,7 +34,7 @@ public class IRClosure extends IRScope {
 
     private boolean isEND;         // Does this represent and END { } closure?
 
-    private Signature signature;
+    protected Signature signature;
 
     // We allow closures who happen to be assigned to calls named 'defined_method' to save the original
     // AST so we can attempt to convert those blocks to full methods.

--- a/core/src/main/java/org/jruby/ir/IREvalScript.java
+++ b/core/src/main/java/org/jruby/ir/IREvalScript.java
@@ -3,6 +3,7 @@ package org.jruby.ir;
 import org.jruby.EvalType;
 import org.jruby.ir.operands.Label;
 import org.jruby.parser.StaticScope;
+import org.jruby.runtime.Signature;
 import org.jruby.util.ByteList;
 
 public class IREvalScript extends IRClosure {
@@ -15,6 +16,7 @@ public class IREvalScript extends IRClosure {
         super(manager, lexicalParent, lineNumber, staticScope, EVAL_);
 
         this.fileName = fileName;
+        this.signature = Signature.NO_ARGUMENTS;
 
         if (!getManager().isDryRun() && staticScope != null) {
             // SSS FIXME: This is awkward!

--- a/core/src/main/java/org/jruby/ir/passes/AddCallProtocolInstructions.java
+++ b/core/src/main/java/org/jruby/ir/passes/AddCallProtocolInstructions.java
@@ -28,7 +28,7 @@ public class AddCallProtocolInstructions extends CompilerPass {
 
     private boolean explicitCallProtocolSupported(IRScope scope) {
         return scope instanceof IRMethod
-                || (scope instanceof IRClosure && !(scope instanceof IREvalScript))
+                || (scope instanceof IRClosure)
                 || (scope instanceof IRModuleBody && !(scope instanceof IRMetaClassBody)
                 || (scope instanceof IRScriptBody)
         );

--- a/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
@@ -160,7 +160,7 @@ public class MixedModeIRBlockBody extends IRBlockBody implements Compilable<Comp
 
                     // ensure we've got code ready for JIT
                     ensureInstrsReady();
-                    closure.getNearestTopLocalVariableScope().prepareForCompilation();
+                    closure.getNearestUncompiledScope().prepareForCompilation();
 
                     if (!closure.hasExplicitCallProtocol()) {
                         if (Options.JIT_LOGGING.load()) {


### PR DESCRIPTION
Two things prevent a block in an eval from jitting:

* If the method containing the eval has not been jitted, when
  we walk up to it we will jit that body and the eval will just
  be seen as a method call. No further compilation will walk into
  the eval.
* If the method containing the eval has already been jitted, we
  similarly walk up to that method, see it has been jitted, and
  proceed no further.

This PR is a small proof-of-concept that changes how the parent
walking happens. Instead of walking all the way to the method
body, this modified logic will walk only up to the nearest
unjitted body, which in this case would be the eval. The eval
body itself won't actually jit, but in order to allow the block it
contains to jit we must at least process it to full IR. Then the
block can also JIT and we proceed from there with the jitted
version.

This still has the problem of walking up to a nearest method body
that has not been jitted; we will stop there and compile the eval
as a call.

I am submitting this as a partially working PR for us to debate
whether this is likely to be valuable. The only cases that do not
jit now would be a block directly in an eval body, like so:

```ruby
def foo
  eval "
    proc { woohoo }
  "
end
```

Methods defined within an eval act as their own JIT root, so they
are not affected by this issue. I have not done any research to
see how common it is to eval a proc for later (heavy) use.