### PR TITLE
Warn when teardown is called with active threads.

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -3297,6 +3297,12 @@ public final class Ruby implements Constantizable {
     public void tearDown(boolean systemExit) {
         int status = 0;
 
+        // Check if there's live threads, since teardown may interfere with them
+        RubyThread[] activeRubyThreads = getThreadService().getActiveRubyThreads();
+        if (activeRubyThreads.length > 1) {
+            warnings.warn("teardown while live threads exist:\n" + Arrays.toString(activeRubyThreads));
+        }
+
         // clear out old style recursion guards so they don't leak
         mriRecursionGuard = null;
 


### PR DESCRIPTION
This has come up many times; Ruby threads are daemon threads by
default, which means they will not keep the main script from
exiting. As a result, if there's any threads still runnign when
the main script exits, we may tear down resources they need to
run properly. Even though they're about to die, they may produce
errors on the way out as shown in https://github.com/jruby/jruby/issues/5909#issuecomment-542470809
and other bug reports over the years like #5519, #3316, #3313 and
others.

This is not a fix for the behavior, but it introduces a
non-verbose warning if the JRuby runtime is torn down while
there's still active threads.