### PR TITLE
Synchronize variable reification against real class.

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -5092,16 +5092,11 @@ public class RubyModule extends RubyObject {
         HashSet<String> set = new HashSet();
         RubyModule cls = this;
         while (cls != null) {
-            for (DynamicMethod method : cls.getNonIncludedClass().getMethodLocation().getMethods().values()) {
-                MethodData methodData = method.getMethodData();
-                set.addAll(methodData.getIvarNames());
-            }
+            Map<String, DynamicMethod> methods = cls.getNonIncludedClass().getMethodLocation().getMethods();
 
-            if (cls instanceof RubyClass) {
-                cls = cls.getSuperClass();
-            } else {
-                break;
-            }
+            methods.forEach((name, method) -> set.addAll(method.getMethodData().getIvarNames()));
+
+            cls = cls.getSuperClass();
         }
         return set;
     }

--- a/core/src/main/java/org/jruby/RubyObject.java
+++ b/core/src/main/java/org/jruby/RubyObject.java
@@ -153,28 +153,32 @@ public class RubyObject extends RubyBasicObject {
     public static final ObjectAllocator IVAR_INSPECTING_OBJECT_ALLOCATOR = new ObjectAllocator() {
         @Override
         public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-            synchronized (klass.getRealClass()) {
-                ObjectAllocator allocator = klass.getAllocator();
+            ObjectAllocator allocator = klass.getAllocator();
 
-                if (allocator == this) {
-                    // proceed, we are the first one to get here
-                    Set<String> foundVariables = klass.discoverInstanceVariables();
+            if (allocator == this) {
+                // eagerly gather variables outside of sync
+                Set<String> foundVariables = klass.discoverInstanceVariables();
 
-                    if (Options.DUMP_INSTANCE_VARS.load()) {
-                        System.err.println(klass + ";" + foundVariables);
+                synchronized (klass.getRealClass()) {
+                    // check again before reifying
+                    allocator = klass.getAllocator();
+
+                    if (allocator == this) {
+                        // proceed, we are the first one to get here
+
+                        if (Options.DUMP_INSTANCE_VARS.load()) {
+                            System.err.println(klass + ";" + foundVariables);
+                        }
+
+                        allocator = RubyObjectSpecializer.specializeForVariables(klass, foundVariables);
+
+                        // invalidate metaclass so new allocator is picked up for specialized .new
+                        klass.metaClass.invalidateCacheDescendants();
                     }
-
-                    allocator = RubyObjectSpecializer.specializeForVariables(klass, foundVariables);
-
-                    // invalidate metaclass so new allocator is picked up for specialized .new
-                    klass.metaClass.invalidateCacheDescendants();
-
-                    return allocator.allocate(runtime, klass);
-                } else {
-                    // someone else replaced allocator while we waited for lock, use it
-                    return allocator.allocate(runtime, klass);
                 }
             }
+
+            return allocator.allocate(runtime, klass);
         }
     };
 

--- a/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/AbstractIRMethod.java
@@ -143,19 +143,7 @@ public abstract class AbstractIRMethod extends DynamicMethod implements IRMethod
      */
     public MethodData getMethodData() {
         if (methodData == null) {
-            List<String> ivarNames = new ArrayList<>();
-            InterpreterContext context = ensureInstrsReady();
-            for (Instr i : context.getInstructions()) {
-                switch (i.getOperation()) {
-                    case GET_FIELD:
-                        ivarNames.add(((GetFieldInstr) i).getId());
-                        break;
-                    case PUT_FIELD:
-                        ivarNames.add(((PutFieldInstr) i).getId());
-                        break;
-                }
-            }
-            methodData = new MethodData(method.getId(), method.getFile(), ivarNames);
+            methodData = ((IRMethod) getIRScope()).getMethodData();
         }
 
         return methodData;


### PR DESCRIPTION
This is likely at least a partial fix for #5910, where it appears
that multiple threads all trigger reificatin of a class's
variables at the same time, leading to some of those threads
choosing a different reified type and ultimately class casting
exceptions.

The change here synchronizes against the class's "real" class,
which should be the one on which we attach the allocated. This
should force multiple threads all allocating the first instance
at once to wait for each other, eventually falling back on the
new allocator that does not re-reify the type.

This will eventually be moot once individual object instances hold
a reference to their own layout managers.