### PR TITLE
Add native.popen option to disable native popen.

### DIFF
--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -1632,7 +1632,7 @@ public class RubyProcess {
     public static RubyFixnum spawn(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Ruby runtime = context.runtime;
 
-        if (runtime.getPosix().isNative() && !Platform.IS_WINDOWS) {
+        if (PopenExecutor.nativePopenAvailable(runtime)) {
             return PopenExecutor.spawn(context, args);
         }
 

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -146,6 +146,7 @@ public class Options {
     public static final Option<Boolean> FFI_COMPILE_REIFY = bool(NATIVE, "ffi.compile.reify", false, "Reify FFI compiled classes.");
     public static final Option<Boolean> NATIVE_STDIO = bool(NATIVE, "native.stdio", true, "Use native wrappers around the default stdio descriptors.");
     public static final Option<Boolean> NATIVE_PTHREAD_KILL = bool(NATIVE, "native.pthread_kill", true, "Use pthread_kill to interrupt blocking kernel calls.");
+    public static final Option<Boolean> NATIVE_POPEN = bool(NATIVE, "native.popen", true, "Use native calls to posix_spawn for subprocess execution.");
 
     public static final Option<Boolean> REGEXP_INTERRUPTIBLE = bool(NATIVE, "regexp.interruptible", false, "Allow regexp operations to be interuptible from Ruby.");
 

--- a/core/src/main/java/org/jruby/util/io/PopenExecutor.java
+++ b/core/src/main/java/org/jruby/util/io/PopenExecutor.java
@@ -31,6 +31,7 @@ import org.jruby.util.ByteList;
 import org.jruby.util.ShellLauncher;
 import org.jruby.util.StringSupport;
 import org.jruby.util.TypeConverter;
+import org.jruby.util.cli.Options;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -45,6 +46,16 @@ import java.util.Set;
  * Port of MRI's popen+exec logic.
  */
 public class PopenExecutor {
+    /**
+     * Check properties and runtime state to determine whether a native popen is possible.
+     *
+     * @param runtime current runtime
+     * @return true if popen can use native code, false otherwise
+     */
+    public static boolean nativePopenAvailable(Ruby runtime) {
+        return Options.NATIVE_POPEN.load() && runtime.getPosix().isNative() && !Platform.IS_WINDOWS;
+    }
+
     // MRI: check_pipe_command
     public static IRubyObject checkPipeCommand(ThreadContext context, IRubyObject filenameOrCommand) {
         RubyString filenameStr = filenameOrCommand.convertToString();


### PR DESCRIPTION
Our native subprocess logic has some quirks, and for cases where
it is a problem like #5911 it would be good to be able to disable
native popen/spawn/backquote without disabling all of native
support. This PR adds the property `jruby.native.popen` defaulting
to true. Users can force the use of the built-in JDK process logic
by passing `-Xnative.popen=false` to JRuby or passing
to the JVM `-Djruby.native.popen=false`.