### PR TITLE
Restructure indy-based math binding.

### DIFF
--- a/core/src/main/java/org/jruby/runtime/invokedynamic/MathLinker.java
+++ b/core/src/main/java/org/jruby/runtime/invokedynamic/MathLinker.java
@@ -91,6 +91,8 @@ public class MathLinker {
     private static final CallType[] CALL_TYPES = CallType.values();
 
     private static final int[] ARG_2_TO_0 = new int[] { 2 }; // MethodHandles.permuteArguments clones the array
+    public static final MethodHandle FLOAT_TEST_ARG_2_TO_0 = permuteArguments(FLOAT_TEST, methodType(boolean.class, ThreadContext.class, IRubyObject.class, IRubyObject.class), ARG_2_TO_0);
+    public static final MethodHandle FIXNUM_TEST_ARG_2_TO_0 = permuteArguments(FIXNUM_TEST, methodType(boolean.class, ThreadContext.class, IRubyObject.class, IRubyObject.class), ARG_2_TO_0);
 
     public static CallSite fixnumOperatorBootstrap(Lookup lookup, String name, MethodType type, long value, int callType, String file, int line) throws NoSuchMethodException, IllegalAccessException {
         List<String> names = StringSupport.split(name, ':');
@@ -130,72 +132,77 @@ public class MathLinker {
     }
     
     public static IRubyObject fixnumOperator(ThreadContext context, IRubyObject caller, IRubyObject self, JRubyCallSite site, long value) throws Throwable {
-        String operator = site.name;
-        String opMethod = MethodIndex.getFastFixnumOpsMethod(operator);
-        String name = "fixnum_" + opMethod;
-        MethodHandle target = null;
-        
-        if (operator.equals("+") || operator.equals("-")) {
-            MethodType type = methodType(IRubyObject.class, ThreadContext.class, IRubyObject.class, IRubyObject.class);
-            if (value == 1) {
-                name += "_one";
-                target = lookup().findStatic(MathLinker.class, name, type);
-            } else if (value == 2) {
-                name += "_two";
-                target = lookup().findStatic(MathLinker.class, name, type);
-            }
-        }
-        if (target == null) target = findTargetImpl(name, IRubyObject.class, value);
-
         Ruby runtime = context.runtime;
-        MethodHandle fallback = FIXNUM_OPERATOR_FAIL;
+        String operator = site.name;
 
-        fallback = insertArguments(fallback, 3, site, runtime.newFixnum(value));
+        MethodHandle target = null;
 
-        MethodHandle test = FIXNUM_TEST;
-        test = permuteArguments(test, methodType(boolean.class, ThreadContext.class, IRubyObject.class, IRubyObject.class), ARG_2_TO_0);
+        MethodHandle fallback = insertArguments(FIXNUM_OPERATOR_FAIL, 3, site, runtime.newFixnum(value));
 
-        if (LOG_BINDING) LOG.debug(name + "\tFixnum operation at site #" + site.siteID + " (" + site.file() + ":" + site.line() + ") bound directly");
-
-        RubyClass classFixnum = runtime.getFixnum();
         CacheEntry entry = searchWithCache(operator, caller, self.getMetaClass(), site);
-        if (entry == null || !entry.method.isBuiltin()) {
-            site.setTarget(fallback); // invalid - fallback on slow-path
+
+        if (!(self instanceof RubyFixnum) || entry == null || !entry.method.isBuiltin()) {
+            site.setTarget(target = fallback); // invalid - fallback on slow-path
+
+            if (LOG_BINDING) LOG.debug(site.name + "\tFixnum operation at site #" + site.siteID + " (" + site.file() + ":" + site.line() + ") bound indirectly");
         } else {
-            // confirm it's a Fixnum
-            target = guardWithTest(test, target, fallback);
+            String opMethod = MethodIndex.getFastFixnumOpsMethod(operator);
+            String name = "fixnum_" + opMethod;
+
+            if (operator.equals("+") || operator.equals("-")) {
+                MethodType type = methodType(IRubyObject.class, ThreadContext.class, IRubyObject.class, IRubyObject.class);
+                if (value == 1) {
+                    name += "_one";
+                    target = lookup().findStatic(MathLinker.class, name, type);
+                } else if (value == 2) {
+                    name += "_two";
+                    target = lookup().findStatic(MathLinker.class, name, type);
+                }
+            }
+
+            if (target == null) target = findTargetImpl(name, IRubyObject.class, value);
+
+            RubyClass classFixnum = runtime.getFixnum();
+
+            // confirm it's still a Fixnum
+            target = guardWithTest(FIXNUM_TEST_ARG_2_TO_0, target, fallback);
             target = ((SwitchPoint) classFixnum.getInvalidator().getData()).guardWithTest(target, fallback);
             site.setTarget(target);
+
+            if (LOG_BINDING) LOG.debug(name + "\tFixnum operation at site #" + site.siteID + " (" + site.file() + ":" + site.line() + ") bound directly");
         }
         
         return (IRubyObject) target.invokeWithArguments(context, caller, self);
     }
     
     public static boolean fixnumBoolean(ThreadContext context, IRubyObject caller, IRubyObject self, JRubyCallSite site, long value) throws Throwable {
+        Ruby runtime = context.runtime;
         String operator = site.name;
-        String opMethod = MethodIndex.getFastFixnumOpsMethod(operator);
-        String name = "fixnum_boolean_" + opMethod;
+
         MethodHandle target = null;
 
-        if (target == null) target = findTargetImpl(name, boolean.class, value);
+        MethodHandle fallback = insertArguments(FIXNUM_BOOLEAN_FAIL, 3, site, runtime.newFixnum(value));
 
-        MethodHandle fallback = FIXNUM_BOOLEAN_FAIL;
-        fallback = insertArguments(fallback, 3, site, context.runtime.newFixnum(value));
-
-        MethodHandle test = FIXNUM_TEST;
-        test = permuteArguments(test, methodType(boolean.class, ThreadContext.class, IRubyObject.class, IRubyObject.class), ARG_2_TO_0);
-
-        if (LOG_BINDING) LOG.debug(name + "\tFixnum boolean operation at site #" + site.siteID + " (" + site.file() + ":" + site.line() + ") bound directly");
-
-        RubyClass classFixnum = context.runtime.getFixnum();
         CacheEntry entry = searchWithCache(operator, caller, self.getMetaClass(), site);
-        if (entry == null || !entry.method.isBuiltin()) {
-            site.setTarget(fallback); // invalid - fallback on slow-path
+
+        if (!(self instanceof RubyFixnum) || entry == null || !entry.method.isBuiltin()) {
+            site.setTarget(target = fallback); // invalid - fallback on slow-path
+
+            if (LOG_BINDING) LOG.debug(site.name + "\tFixnum boolean operation at site #" + site.siteID + " (" + site.file() + ":" + site.line() + ") bound indirectly");
         } else {
-            // confirm it's a Fixnum
-            target = guardWithTest(test, target, fallback);
+            String opMethod = MethodIndex.getFastFixnumOpsMethod(operator);
+            String name = "fixnum_boolean_" + opMethod;
+
+            if (target == null) target = findTargetImpl(name, boolean.class, value);
+
+            RubyClass classFixnum = runtime.getFixnum();
+
+            // confirm it's still a Fixnum
+            target = guardWithTest(FIXNUM_TEST_ARG_2_TO_0, target, fallback);
             target = ((SwitchPoint) classFixnum.getInvalidator().getData()).guardWithTest(target, fallback);
             site.setTarget(target);
+
+            if (LOG_BINDING) LOG.debug(name + "\tFixnum boolean operation at site #" + site.siteID + " (" + site.file() + ":" + site.line() + ") bound directly");
         }
         
         return (Boolean) target.invokeWithArguments(context, caller, self);
@@ -314,31 +321,33 @@ public class MathLinker {
     }
     
     public static IRubyObject floatOperator(ThreadContext context, IRubyObject caller, IRubyObject self, JRubyCallSite site, double value) throws Throwable {
+        Ruby runtime = context.runtime;
         String operator = site.name;
-        String opMethod = MethodIndex.getFastFloatOpsMethod(operator);
-        String name = "float_" + opMethod;
+
         MethodHandle target = null;
 
-        if (target == null) target = findTargetImpl(name, IRubyObject.class, value);
+        MethodHandle fallback = insertArguments(FLOAT_OPERATOR_FAIL, 3, site, RubyFloat.newFloat(runtime, value));
 
-        Ruby runtime = context.runtime;
-        MethodHandle fallback = FLOAT_OPERATOR_FAIL;
-
-        fallback = insertArguments(fallback, 3, site, RubyFloat.newFloat(runtime, value));
-
-        MethodHandle test = FLOAT_TEST;
-        test = permuteArguments(test, methodType(boolean.class, ThreadContext.class, IRubyObject.class, IRubyObject.class), ARG_2_TO_0);
-        if (LOG_BINDING) LOG.debug(name + "\tFloat operation at site #" + site.siteID + " (" + site.file() + ":" + site.line() + ") bound directly");
-
-        RubyClass classFloat = runtime.getFloat();
         CacheEntry entry = searchWithCache(operator, caller, self.getMetaClass(), site);
-        if (entry == null || !entry.method.isBuiltin()) {
+
+        if (!(self instanceof RubyFloat) || entry == null || !entry.method.isBuiltin()) {
             site.setTarget(fallback); // invalid - fallback on slow-path
+
+            if (LOG_BINDING) LOG.debug(site.name + "\tFloat operation at site #" + site.siteID + " (" + site.file() + ":" + site.line() + ") bound indirectly");
         } else {
-            // confirm it's a Float
-            target = guardWithTest(test, target, fallback);
+            String opMethod = MethodIndex.getFastFloatOpsMethod(operator);
+            String name = "float_" + opMethod;
+
+            if (target == null) target = findTargetImpl(name, IRubyObject.class, value);
+
+            RubyClass classFloat = runtime.getFloat();
+
+            // confirm it's still a Float
+            target = guardWithTest(FLOAT_TEST_ARG_2_TO_0, target, fallback);
             target = ((SwitchPoint) classFloat.getInvalidator().getData()).guardWithTest(target, fallback);
             site.setTarget(target);
+
+            if (LOG_BINDING) LOG.debug(name + "\tFloat operation at site #" + site.siteID + " (" + site.file() + ":" + site.line() + ") bound directly");
         }
         
         return (IRubyObject) target.invokeWithArguments(context, caller, self);


### PR DESCRIPTION
This primarily adds a hard RubyFixnum or RubyFloat type check on
self, to ensure we're not even attempting fast bindings for other
types. It also reduces overall binding overhead in that case by
moving direct indy logic out of the fail path and moves a couple
more adapted method handles to constants.

Fixes #5938.