### PR TITLE
Improve how we acquire ThreadContext to eliminate null refs.

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
+++ b/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
@@ -197,10 +197,10 @@ public class ThreadService {
      * collected.
      */
     public final ThreadContext getCurrentContext() {
-        ThreadContext context = null;
+        ThreadContext context;
 
         // keep trying until we have a context
-        while (context == null) {
+        do {
             SoftReference<ThreadContext> ref = localContext.get();
             if (ref == null) {
                 context = adoptCurrentThread().getContext(); // registerNewThread will localContext.set(...)
@@ -210,7 +210,7 @@ public class ThreadService {
                     localContext.set(null);
                 }
             }
-        }
+        } while (context == null);
 
         return context;
     }

--- a/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
+++ b/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
@@ -197,21 +197,22 @@ public class ThreadService {
      * collected.
      */
     public final ThreadContext getCurrentContext() {
-        SoftReference<ThreadContext> ref = localContext.get();
-        if (ref == null) {
-            adoptCurrentThread(); // registerNewThread will localContext.set(...)
-            ref = localContext.get();
-        }
-        ThreadContext context;
-        if ((context = ref.get()) != null) {
-            return context;
+        ThreadContext context = null;
+
+        // keep trying until we have a context
+        while (context == null) {
+            SoftReference<ThreadContext> ref = localContext.get();
+            if (ref == null) {
+                context = adoptCurrentThread().getContext(); // registerNewThread will localContext.set(...)
+            } else {
+                if ((context = ref.get()) == null) {
+                    // context is null, wipe out the SoftReference (this could be done with a reference queue)
+                    localContext.set(null);
+                }
+            }
         }
 
-        // context is null, wipe out the SoftReference (this could be done with a reference queue)
-        localContext.set(null);
-
-        // go until a context is available, to clean up soft-refs that might have been collected
-        return getCurrentContext();
+        return context;
     }
 
     private RubyThread adoptCurrentThread() {


### PR DESCRIPTION
For #5936 we saw some cases where the SoftReference created here
came back as null, even after the "adopt" logic had run. While I
have not isolated an exact cause, there are thread locals, soft
references, and GC interacting here. Since the original logic did
not guarantee non-null references throughout the code, I've
modified it to always check and only proceed once it truly has
non-null references and eventually context in hand.