### PR TITLE
use optimized CGIEscape

### DIFF
--- a/core/src/main/java/org/jruby/ext/cgi/escape/CGIEscape.java
+++ b/core/src/main/java/org/jruby/ext/cgi/escape/CGIEscape.java
@@ -426,10 +426,10 @@ public class CGIEscape implements Library {
     public void load(Ruby runtime, boolean wrap) {
         RubyClass rb_cCGI = runtime.defineClass("CGI", runtime.getObject(), runtime.getObject().getAllocator());
         RubyModule rb_mEscape = rb_cCGI.defineModuleUnder("Escape");
+        RubyModule rb_mUtil   = rb_cCGI.defineModuleUnder("Util");
         rb_mEscape.defineAnnotatedMethods(CGIEscape.class);
-        // We do this in cgi/util.rb to work around jruby/jruby#4531.
-//        rb_mUtil.prependModule(rb_mEscape);
-//        rb_mEscape.extend_object(rb_cCGI);
+        rb_mUtil.prependModule(rb_mEscape);
+        rb_mEscape.extend_object(rb_cCGI);
     }
 
     // PORTED FROM OTHER FILES IN MRI


### PR DESCRIPTION
as commented in https://github.com/jruby/jruby/issues/5937

`CGI.escapeHTML` does always use a pure ruby version which is slower

https://github.com/ruby/ruby/blob/master/ext/cgi/escape/escape.c#L408

```
ruby
CGI.escapeHTML    242.472  (? 7.0%) i/s -      1.220k in   5.061783s
optimized
CGI.escapeHTML    804.555  (? 5.6%) i/s -      4.032k in   5.027866s
```