### PR TITLE
Use string index in String #sub/#gsub when String pattern passed without creating a Regexp

### DIFF
--- a/bench/core/string/bench_sub.rb
+++ b/bench/core/string/bench_sub.rb
@@ -1,0 +1,18 @@
+str1 = 'white chocolate'
+str2 = 'a1'
+str3 = 'dog'
+
+regex2 = /\d/
+regex3 = /\w+/
+
+benchmark 'sub-string' do
+  r1 = str1.sub('white', 'dark')
+end
+
+benchmark "sub-regex" do
+  r2 = str2.sub(regex2, '2')
+end
+
+benchmark "sub-regex-block" do
+  r3 = str3.sub(regex3) { |animal| animal == 'dog' ? 'cat' : 'dog' }
+end

--- a/core/src/main/java/org/jruby/util/StringSupport.java
+++ b/core/src/main/java/org/jruby/util/StringSupport.java
@@ -1616,6 +1616,38 @@ public final class StringSupport {
         return string.getCodeRange() == CR_7BIT || encoding.maxLength() == 1;
     }
 
+    /**
+     *
+     * @param source string to find index within
+     * @param other string to match in source
+     * @param offset in bytes to start looking
+     * @param enc encoding to use to walk the source string.
+     * @return
+     */
+    public static int index(ByteList source, ByteList other, int offset, Encoding enc) {
+        int sourceLen = source.realSize();
+        int sourceBegin = source.begin();
+        int otherLen = other.realSize();
+
+        if (otherLen == 0) return offset;
+        if (sourceLen - offset < otherLen) return -1;
+
+        byte[] sourceBytes = source.getUnsafeBytes();
+        int p = sourceBegin + offset;
+        int end = p + sourceLen;
+
+        while (true) {
+            int pos = source.indexOf(other, p - sourceBegin);
+            if (pos < 0) return pos;
+            pos -= (p - sourceBegin);
+            int t = enc.rightAdjustCharHead(sourceBytes, p, p + pos, end);
+            if (t == p + pos) return pos + offset;
+            if ((sourceLen -= t - p) <= 0) return -1;
+            offset += t - p;
+            p = t;
+        }
+    }
+
     public static int index(CodeRangeable sourceString, CodeRangeable otherString, int offset, Encoding enc) {
         if (otherString.scanForCodeRange() == CR_BROKEN) return -1;
 


### PR DESCRIPTION
This PR addresses #5905. It's still pretty naive, and I'm really not a Java programmer, so there's probably a few dumb mistakes and style things aside from the big MatchData problem.

The big known problem remaining is how to populate the `$~` `MatchData`. In MRI the `MatchData` from a string-only `String#sub` or `#gsub` will return a `Regexp` from `MatchData#regexp`. I don't think we currently have a way of doing that, so that means changes to `MatchData`.

MRI is clearly doing something odd here, because if you call `#inspect` on the `MatchData` returned from a string pattern `#sub`, it's in a different form to what you get from invoking it with a Regexp pattern (this from MRI 2.6.3):

```
~ $ irb
irb(main):001:0> "a".sub("a", "b")
=> "b"
irb(main):002:0> $~
=> #<MatchData: a>
irb(main):003:0> "a".sub(/a/, "b")
=> "b"
irb(main):004:0> $~
=> #<MatchData "a">
```

Once I know what the best approach to handling that is, I can fill the hole in the `#sub` implementation and `#gsub`'s returned `MatchData`s  will behave as expected.