### PR TITLE
Propagate ThreadContext through to_a implementations

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -1258,13 +1258,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     }
 
     protected SizeFn enumLengthFn() {
-        final RubyArray self = this;
-        return new SizeFn() {
-            @Override
-            public IRubyObject size(IRubyObject[] args) {
-                return self.length();
-            }
-        };
+        return (context, args) -> this.length();
     }
 
     /** rb_ary_push - specialized rb_ary_store
@@ -3858,7 +3852,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return new SizeFn() {
             CallSite op_times = sites(context).op_times;
             @Override
-            public IRubyObject size(IRubyObject[] args) {
+            public IRubyObject size(ThreadContext context, IRubyObject[] args) {
                 Ruby runtime = context.runtime;
                 IRubyObject n = context.nil;
 
@@ -3957,7 +3951,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     @JRubyMethod(name = "combination")
     public IRubyObject combination(ThreadContext context, IRubyObject num, Block block) {
         Ruby runtime = context.runtime;
-        if (!block.isGiven()) return enumeratorizeWithSize(context, this, "combination", new IRubyObject[]{num}, combinationSize(context));
+        if (!block.isGiven()) return enumeratorizeWithSize(context, this, "combination", new IRubyObject[]{num}, combinationSize());
 
         int n = RubyNumeric.num2int(num);
 
@@ -4015,17 +4009,13 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         }
     }
 
-    private SizeFn combinationSize(final ThreadContext context) {
-        final RubyArray self = this;
-        return new SizeFn() {
-            @Override
-            public IRubyObject size(IRubyObject[] args) {
-                long n = self.realLength;
-                assert args != null && args.length > 0 && args[0] instanceof RubyNumeric; // #combination ensures arg[0] is numeric
-                long k = ((RubyNumeric) args[0]).getLongValue();
+    private SizeFn combinationSize() {
+        return (context, args) -> {
+            long n = this.realLength;
+            assert args != null && args.length > 0 && args[0] instanceof RubyNumeric; // #combination ensures arg[0] is numeric
+            long k = ((RubyNumeric) args[0]).getLongValue();
 
-                return binomialCoefficient(context, k, n);
-            }
+            return binomialCoefficient(context, k, n);
         };
     }
 
@@ -4047,7 +4037,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     @JRubyMethod(name = "repeated_combination")
     public IRubyObject repeatedCombination(ThreadContext context, IRubyObject num, Block block) {
         Ruby runtime = context.runtime;
-        if (!block.isGiven()) return enumeratorizeWithSize(context, this, "repeated_combination", new IRubyObject[] { num }, repeatedCombinationSize(context));
+        if (!block.isGiven()) return enumeratorizeWithSize(context, this, "repeated_combination", new IRubyObject[] { num }, repeatedCombinationSize());
 
         int n = RubyNumeric.num2int(num);
 
@@ -4068,21 +4058,17 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return this;
     }
 
-    private SizeFn repeatedCombinationSize(final ThreadContext context) {
-        final RubyArray self = this;
-        return new SizeFn() {
-            @Override
-            public IRubyObject size(IRubyObject[] args) {
-                long n = self.realLength;
-                assert args != null && args.length > 0 && args[0] instanceof RubyNumeric; // #repeated_combination ensures arg[0] is numeric
-                long k = ((RubyNumeric) args[0]).getLongValue();
+    private SizeFn repeatedCombinationSize() {
+        return (context, args) -> {
+            long n = this.realLength;
+            assert args != null && args.length > 0 && args[0] instanceof RubyNumeric; // #repeated_combination ensures arg[0] is numeric
+            long k = ((RubyNumeric) args[0]).getLongValue();
 
-                if (k == 0) {
-                    return RubyFixnum.one(context.runtime);
-                }
-
-                return binomialCoefficient(context, k, n + k - 1);
+            if (k == 0) {
+                return RubyFixnum.one(context.runtime);
             }
+
+            return binomialCoefficient(context, k, n + k - 1);
         };
     }
 
@@ -4148,12 +4134,12 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      */
     @JRubyMethod(name = "permutation")
     public IRubyObject permutation(ThreadContext context, IRubyObject num, Block block) {
-        return block.isGiven() ? permutationCommon(context, RubyNumeric.num2int(num), false, block) : enumeratorizeWithSize(context, this, "permutation", new IRubyObject[] { num }, permutationSize(context));
+        return block.isGiven() ? permutationCommon(context, RubyNumeric.num2int(num), false, block) : enumeratorizeWithSize(context, this, "permutation", new IRubyObject[] { num }, permutationSize());
     }
 
     @JRubyMethod(name = "permutation")
     public IRubyObject permutation(ThreadContext context, Block block) {
-        return block.isGiven() ? permutationCommon(context, realLength, false, block) : enumeratorizeWithSize(context, this, "permutation", permutationSize(context));
+        return block.isGiven() ? permutationCommon(context, realLength, false, block) : enumeratorizeWithSize(context, this, "permutation", permutationSize());
     }
 
     @JRubyMethod(name = "repeated_permutation")
@@ -4162,17 +4148,15 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     }
 
     private SizeFn repeatedPermutationSize(final ThreadContext context) {
-        final Ruby runtime = context.runtime;
-        final RubyArray self = this;
-
         return new SizeFn() {
             CallSite op_exp = sites(context).op_exp;
             @Override
-            public IRubyObject size(IRubyObject[] args) {
-                RubyFixnum n = self.length();
+            public IRubyObject size(ThreadContext context, IRubyObject[] args) {
+                RubyFixnum n = RubyArray.this.length();
                 assert args != null && args.length > 0 && args[0] instanceof RubyNumeric; // #repeated_permutation ensures arg[0] is numeric
                 long k = ((RubyNumeric) args[0]).getLongValue();
 
+                Ruby runtime = context.runtime;
                 if (k < 0) {
                     return RubyFixnum.zero(runtime);
                 }
@@ -4208,24 +4192,19 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return this;
     }
 
-    private SizeFn permutationSize(final ThreadContext context) {
-        final RubyArray self = this;
+    private SizeFn permutationSize() {
+        return (context, args) -> {
+            long n = this.realLength;
+            long k;
 
-        return new SizeFn() {
-            @Override
-            public IRubyObject size(IRubyObject[] args) {
-                long n = self.realLength;
-                long k;
-
-                if (args != null && args.length > 0) {
-                    assert args[0] instanceof RubyNumeric; // #permutation ensures arg[0] is numeric
-                    k = ((RubyNumeric) args[0]).getLongValue();
-                } else {
-                    k = n;
-                }
-
-                return descendingFactorial(context, n, k);
+            if (args != null && args.length > 0) {
+                assert args[0] instanceof RubyNumeric; // #permutation ensures arg[0] is numeric
+                k = ((RubyNumeric) args[0]).getLongValue();
+            } else {
+                k = n;
             }
+
+            return descendingFactorial(context, n, k);
         };
     }
 

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -5464,4 +5464,16 @@ float_loop:
     public IRubyObject flatten_bang19(ThreadContext context) {
         return flatten_bang(context);
     }
+
+    @Deprecated
+    @Override
+    public RubyArray to_a() {
+        final RubyClass metaClass = this.metaClass;
+        Ruby runtime = metaClass.runtime;
+        final RubyClass arrayClass = runtime.getArray();
+        if (metaClass != arrayClass) {
+            return dupImpl(runtime, arrayClass);
+        }
+        return this;
+    }
 }

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -705,13 +705,14 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     public IRubyObject dup() {
         if (metaClass.getClassIndex() != ClassIndex.ARRAY) return super.dup();
 
-        RubyArray dup = dupImpl(metaClass.runtime.getArray());
+        Ruby runtime = metaClass.runtime;
+        RubyArray dup = dupImpl(runtime, runtime.getArray());
         dup.flags |= flags & TAINTED_F; // from DUP_SETUP
         return dup;
     }
 
-    protected RubyArray dupImpl(RubyClass metaClass) {
-        RubyArray dup = new RubyArray(metaClass.runtime, metaClass, values, begin, realLength, true);
+    protected RubyArray dupImpl(Ruby runtime, RubyClass metaClass) {
+        RubyArray dup = new RubyArray(runtime, metaClass, values, begin, realLength, true);
         dup.isShared = this.isShared = true;
         return dup;
     }
@@ -723,7 +724,8 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         // In 1.9, rb_ary_dup logic changed so that on subclasses of Array,
         // dup returns an instance of Array, rather than an instance of the subclass
         // Also, taintedness and trustedness are not inherited to duplicates
-        return dupImpl(metaClass.runtime.getArray());
+        Ruby runtime = metaClass.runtime;
+        return dupImpl(runtime, runtime.getArray());
     }
 
     /** rb_ary_replace
@@ -2031,11 +2033,12 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      */
     @JRubyMethod(name = "to_a")
     @Override
-    public RubyArray to_a() {
+    public RubyArray to_a(ThreadContext context) {
         final RubyClass metaClass = this.metaClass;
-        final RubyClass arrayClass = metaClass.runtime.getArray();
+        Ruby runtime = context.runtime;
+        final RubyClass arrayClass = runtime.getArray();
         if (metaClass != arrayClass) {
-            return dupImpl(arrayClass);
+            return dupImpl(runtime, arrayClass);
         }
         return this;
     }

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -2572,9 +2572,10 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      *
      *  The default to_a method is deprecated.
      */
-    public RubyArray to_a() {
-        getRuntime().getWarnings().warn(ID.DEPRECATED_METHOD, "default 'to_a' will be obsolete");
-        return getRuntime().newArray(this);
+    public RubyArray to_a(ThreadContext context) {
+        Ruby runtime = context.runtime;
+        runtime.getWarnings().warn(ID.DEPRECATED_METHOD, "default 'to_a' will be obsolete");
+        return runtime.newArray(this);
     }
 
     /** rb_obj_instance_eval
@@ -3224,6 +3225,11 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     @Deprecated
     public IRubyObject op_match19(ThreadContext context, IRubyObject arg) {
         return context.nil;
+    }
+
+    @Deprecated
+    public RubyArray to_a() {
+        return to_a(getRuntime().getCurrentContext());
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -53,7 +53,6 @@ import org.jruby.util.TypeConverter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.jruby.RubyEnumerator.enumeratorize;
@@ -223,7 +222,7 @@ public class RubyEnumerable {
     @JRubyMethod
     public static IRubyObject cycle(ThreadContext context, IRubyObject self, final Block block) {
         if (!block.isGiven()) {
-            return enumeratorizeWithSize(context, self, "cycle", cycleSizeFn(context, self));
+            return enumeratorizeWithSize(context, self, "cycle", cycleSizeFn(self));
         }
 
         return cycleCommon(context, self, -1, block);
@@ -233,7 +232,7 @@ public class RubyEnumerable {
     public static IRubyObject cycle(ThreadContext context, IRubyObject self, IRubyObject arg, final Block block) {
         if (arg.isNil()) return cycle(context, self, block);
         if (!block.isGiven()) {
-            return enumeratorizeWithSize(context, self, "cycle", new IRubyObject[] { arg }, cycleSizeFn(context, self));
+            return enumeratorizeWithSize(context, self, "cycle", new IRubyObject[] { arg }, cycleSizeFn(self));
         }
 
         long times = RubyNumeric.num2long(arg);
@@ -276,35 +275,32 @@ public class RubyEnumerable {
         return context.nil;
     }
 
-    private static SizeFn cycleSizeFn(final ThreadContext context, final IRubyObject self) {
-        return new SizeFn() {
-            @Override
-            public IRubyObject size(IRubyObject[] args) {
-                Ruby runtime = context.runtime;
-                long mul = 0;
-                IRubyObject n = runtime.getNil();
+    private static SizeFn cycleSizeFn(final IRubyObject self) {
+        return (context, args) -> {
+            Ruby runtime = context.runtime;
+            long mul = 0;
+            IRubyObject n = runtime.getNil();
 
-                if (args != null && args.length > 0) {
-                    n = args[0];
-                    if (!n.isNil()) mul = n.convertToInteger().getLongValue();
-                }
-
-                IRubyObject size = enumSizeFn(context, self).size(args);
-                if (size == null || size.isNil() || size.equals(RubyFixnum.zero(runtime))) {
-                    return size;
-                }
-
-                if (n == null || n.isNil()) {
-                    return RubyFloat.newFloat(runtime, RubyFloat.INFINITY);
-                }
-
-                if (mul <= 0) {
-                    return RubyFixnum.zero(runtime);
-                }
-
-                n = RubyFixnum.newFixnum(runtime, mul);
-                return size.callMethod(context, "*", n);
+            if (args != null && args.length > 0) {
+                n = args[0];
+                if (!n.isNil()) mul = n.convertToInteger().getLongValue();
             }
+
+            IRubyObject size = enumSizeFn(self).size(context, args);
+            if (size == null || size.isNil() || size.equals(RubyFixnum.zero(runtime))) {
+                return size;
+            }
+
+            if (n == null || n.isNil()) {
+                return RubyFloat.newFloat(runtime, RubyFloat.INFINITY);
+            }
+
+            if (mul <= 0) {
+                return RubyFixnum.zero(runtime);
+            }
+
+            n = RubyFixnum.newFixnum(runtime, mul);
+            return size.callMethod(context, "*", n);
         };
     }
 
@@ -536,7 +532,7 @@ public class RubyEnumerable {
         IRubyObject[][] valuesAndCriteria;
 
         if (!block.isGiven()) {
-            return enumeratorizeWithSize(context, self, "sort_by", enumSizeFn(context, self));
+            return enumeratorizeWithSize(context, self, "sort_by", enumSizeFn(self));
         }
 
         if (self instanceof RubyArray) {
@@ -816,7 +812,7 @@ public class RubyEnumerable {
 
     public static IRubyObject selectCommon(ThreadContext context, IRubyObject self, final Block block, String methodName) {
         if (!block.isGiven()) {
-            return enumeratorizeWithSize(context, self, methodName, enumSizeFn(context, self));
+            return enumeratorizeWithSize(context, self, methodName, enumSizeFn(self));
         }
 
         final RubyArray result = context.runtime.newArray();
@@ -850,7 +846,7 @@ public class RubyEnumerable {
     @JRubyMethod
     public static IRubyObject reject(ThreadContext context, IRubyObject self, final Block block) {
         if (!block.isGiven()) {
-            return enumeratorizeWithSize(context, self, "reject", enumSizeFn(context, self));
+            return enumeratorizeWithSize(context, self, "reject", enumSizeFn(self));
         }
 
         final RubyArray result = context.runtime.newArray();
@@ -919,7 +915,7 @@ public class RubyEnumerable {
             });
             return result;
         } else {
-            return enumeratorizeWithSize(context, self, methodName, enumSizeFn(context, self));
+            return enumeratorizeWithSize(context, self, methodName, enumSizeFn(self));
         }
     }
 
@@ -974,7 +970,7 @@ public class RubyEnumerable {
             });
             return ary;
         } else {
-            return enumeratorizeWithSize(context, self, methodName, enumSizeFn(context, self));
+            return enumeratorizeWithSize(context, self, methodName, enumSizeFn(self));
         }
     }
 
@@ -1161,7 +1157,7 @@ public class RubyEnumerable {
         final RubyArray arr_false = runtime.newArray();
 
         if (!block.isGiven()) {
-            return enumeratorizeWithSize(context, self, "partition", enumSizeFn(context, self));
+            return enumeratorizeWithSize(context, self, "partition", enumSizeFn(self));
         }
 
         callEach(context, self, Signature.OPTIONAL, new BlockCallback() {
@@ -1260,7 +1256,7 @@ public class RubyEnumerable {
 
     @JRubyMethod(name = "each_with_index", rest = true)
     public static IRubyObject each_with_index(ThreadContext context, IRubyObject self, IRubyObject[] args, Block block) {
-        return block.isGiven() ? each_with_indexCommon(context, self, block, args) : enumeratorizeWithSize(context, self, "each_with_index", args, enumSizeFn(context, self));
+        return block.isGiven() ? each_with_indexCommon(context, self, block, args) : enumeratorizeWithSize(context, self, "each_with_index", args, enumSizeFn(self));
     }
 
     @Deprecated @SuppressWarnings("deprecation")
@@ -1270,12 +1266,12 @@ public class RubyEnumerable {
 
     @JRubyMethod(required = 1)
     public static IRubyObject each_with_object(ThreadContext context, IRubyObject self, IRubyObject arg, Block block) {
-        return block.isGiven() ? each_with_objectCommon(context, self, block, arg) : enumeratorizeWithSize(context, self, "each_with_object", new IRubyObject[] { arg }, enumSizeFn(context, self));
+        return block.isGiven() ? each_with_objectCommon(context, self, block, arg) : enumeratorizeWithSize(context, self, "each_with_object", new IRubyObject[] { arg }, enumSizeFn(self));
     }
 
     @JRubyMethod(rest = true)
     public static IRubyObject each_entry(ThreadContext context, final IRubyObject self, final IRubyObject[] args, final Block block) {
-        return block.isGiven() ? each_entryCommon(context, self, args, block) : enumeratorizeWithSize(context, self, "each_entry", args, enumSizeFn(context, self));
+        return block.isGiven() ? each_entryCommon(context, self, args, block) : enumeratorizeWithSize(context, self, "each_entry", args, enumSizeFn(self));
     }
 
     public static IRubyObject each_entryCommon(ThreadContext context, final IRubyObject self, final IRubyObject[] args, final Block block) {
@@ -1302,7 +1298,7 @@ public class RubyEnumerable {
         if (size <= 0) throw context.runtime.newArgumentError("invalid size");
 
         return block.isGiven() ? each_sliceCommon(context, self, size, block) :
-                enumeratorizeWithSize(context, self, "each_slice", new IRubyObject[]{arg}, eachSliceSizeFn(context, self));
+                enumeratorizeWithSize(context, self, "each_slice", new IRubyObject[]{arg}, eachSliceSizeFn(self));
     }
 
     static IRubyObject each_sliceCommon(ThreadContext context, IRubyObject self, final int size, final Block block) {
@@ -1326,25 +1322,22 @@ public class RubyEnumerable {
         return context.nil;
     }
 
-    private static SizeFn eachSliceSizeFn(final ThreadContext context, final IRubyObject self) {
-        return new SizeFn() {
-            @Override
-            public IRubyObject size(IRubyObject[] args) {
-                Ruby runtime = context.runtime;
-                assert args != null && args.length > 0 && args[0] instanceof RubyNumeric; // #each_slice ensures arg[0] is numeric
-                long sliceSize = ((RubyNumeric) args[0]).getLongValue();
-                if (sliceSize <= 0) {
-                    throw runtime.newArgumentError("invalid slice size");
-                }
-
-                IRubyObject size = enumSizeFn(context, self).size(args);
-                if (size == null || size.isNil()) {
-                    return runtime.getNil();
-                }
-
-                IRubyObject n = size.callMethod(context, "+", RubyFixnum.newFixnum(runtime, sliceSize - 1));
-                return n.callMethod(context, "/", RubyFixnum.newFixnum(runtime, sliceSize));
+    private static SizeFn eachSliceSizeFn(final IRubyObject self) {
+        return (context, args) -> {
+            Ruby runtime = context.runtime;
+            assert args != null && args.length > 0 && args[0] instanceof RubyNumeric; // #each_slice ensures arg[0] is numeric
+            long sliceSize = ((RubyNumeric) args[0]).getLongValue();
+            if (sliceSize <= 0) {
+                throw runtime.newArgumentError("invalid slice size");
             }
+
+            IRubyObject size = enumSizeFn(self).size(context, args);
+            if (size == null || size.isNil()) {
+                return runtime.getNil();
+            }
+
+            IRubyObject n = size.callMethod(context, "+", RubyFixnum.newFixnum(runtime, sliceSize - 1));
+            return n.callMethod(context, "/", RubyFixnum.newFixnum(runtime, sliceSize));
         };
     }
 
@@ -1357,7 +1350,7 @@ public class RubyEnumerable {
     public static IRubyObject each_cons(ThreadContext context, IRubyObject self, IRubyObject arg, final Block block) {
         int size = (int) RubyNumeric.num2long(arg);
         if (size <= 0) throw context.runtime.newArgumentError("invalid size");
-        return block.isGiven() ? each_consCommon(context, self, size, block) : enumeratorizeWithSize(context, self, "each_cons", new IRubyObject[] { arg }, eachConsSizeFn(context, self));
+        return block.isGiven() ? each_consCommon(context, self, size, block) : enumeratorizeWithSize(context, self, "each_cons", new IRubyObject[] { arg }, eachConsSizeFn(self));
     }
 
     static IRubyObject each_consCommon(ThreadContext context, IRubyObject self, final int size, final Block block) {
@@ -1375,39 +1368,36 @@ public class RubyEnumerable {
         return context.nil;
     }
 
-    private static SizeFn eachConsSizeFn(final ThreadContext context, final IRubyObject self) {
-        return new SizeFn() {
-            @Override
-            public IRubyObject size(IRubyObject[] args) {
-                Ruby runtime = context.runtime;
-                assert args != null && args.length > 0 && args[0] instanceof RubyNumeric; // #each_cons ensures arg[0] is numeric
-                long consSize = ((RubyNumeric) args[0]).getLongValue();
-                if (consSize <= 0) {
-                    throw runtime.newArgumentError("invalid size");
-                }
-
-                IRubyObject size = enumSizeFn(context, self).size(args);
-                if (size == null || size.isNil()) {
-                    return runtime.getNil();
-                }
-
-                IRubyObject n = size.callMethod(context, "+", RubyFixnum.newFixnum(runtime, 1 - consSize));
-                RubyFixnum zero = RubyFixnum.zero(runtime);
-                return RubyComparable.cmpint(context, n.callMethod(context, "<=>", zero), n, zero) == -1 ? zero : n;
+    private static SizeFn eachConsSizeFn(final IRubyObject self) {
+        return (context, args) -> {
+            Ruby runtime = context.runtime;
+            assert args != null && args.length > 0 && args[0] instanceof RubyNumeric; // #each_cons ensures arg[0] is numeric
+            long consSize = ((RubyNumeric) args[0]).getLongValue();
+            if (consSize <= 0) {
+                throw runtime.newArgumentError("invalid size");
             }
+
+            IRubyObject size = enumSizeFn(self).size(context, args);
+            if (size == null || size.isNil()) {
+                return runtime.getNil();
+            }
+
+            IRubyObject n = size.callMethod(context, "+", RubyFixnum.newFixnum(runtime, 1 - consSize));
+            RubyFixnum zero = RubyFixnum.zero(runtime);
+            return RubyComparable.cmpint(context, n.callMethod(context, "<=>", zero), n, zero) == -1 ? zero : n;
         };
     }
 
     @JRubyMethod
     public static IRubyObject reverse_each(ThreadContext context, IRubyObject self, Block block) {
         return block.isGiven() ? reverse_eachInternal(context, self, to_a(context, self), block) :
-            enumeratorizeWithSize(context, self, "reverse_each", enumSizeFn(context, self));
+            enumeratorizeWithSize(context, self, "reverse_each", enumSizeFn(self));
     }
 
     @JRubyMethod(rest = true)
     public static IRubyObject reverse_each(ThreadContext context, IRubyObject self, IRubyObject[] args, Block block) {
         return block.isGiven() ? reverse_eachInternal(context, self, to_a(context, self, args), block) :
-            enumeratorizeWithSize(context, self, "reverse_each", args, enumSizeFn(context, self));
+            enumeratorizeWithSize(context, self, "reverse_each", args, enumSizeFn(self));
     }
 
     private static IRubyObject reverse_eachInternal(ThreadContext context, IRubyObject self, IRubyObject obj, Block block) {
@@ -1473,7 +1463,7 @@ public class RubyEnumerable {
     public static IRubyObject max_by(ThreadContext context, IRubyObject self, IRubyObject arg, final Block block) {
         if (arg == context.nil) return singleExtentBy(context, self, "max", SORT_MAX, block);
 
-        if (!block.isGiven()) return enumeratorizeWithSize(context, self, "max_by", enumSizeFn(context, self));
+        if (!block.isGiven()) return enumeratorizeWithSize(context, self, "max_by", enumSizeFn(self));
 
         // TODO: Replace with an implementation (quickselect, etc) which requires O(k) memory rather than O(n) memory
         RubyArray sorted = (RubyArray)sort_by(context, self, block);
@@ -1489,7 +1479,7 @@ public class RubyEnumerable {
     public static IRubyObject min_by(ThreadContext context, IRubyObject self, IRubyObject arg, final Block block) {
         if (arg == context.nil) return singleExtentBy(context, self, "min", SORT_MIN, block);
 
-        if (!block.isGiven()) return enumeratorizeWithSize(context, self, "min_by", enumSizeFn(context, self));
+        if (!block.isGiven()) return enumeratorizeWithSize(context, self, "min_by", enumSizeFn(self));
 
         // TODO: Replace with an implementation (quickselect, etc) which requires O(k) memory rather than O(n) memory
         RubyArray sorted = (RubyArray)sort_by(context, self, block);
@@ -1522,7 +1512,7 @@ public class RubyEnumerable {
     }
 
     private static IRubyObject singleExtentBy(final ThreadContext context, IRubyObject self, final String op, final int sortDirection, final Block block) {
-        if (!block.isGiven()) return enumeratorizeWithSize(context, self, op, enumSizeFn(context, self));
+        if (!block.isGiven()) return enumeratorizeWithSize(context, self, op, enumSizeFn(self));
 
         final IRubyObject result[] = new IRubyObject[] { context.nil };
 
@@ -1600,7 +1590,7 @@ public class RubyEnumerable {
     @JRubyMethod
     public static IRubyObject minmax_by(final ThreadContext context, IRubyObject self, final Block block) {
 
-        if (!block.isGiven()) return enumeratorizeWithSize(context, self, "minmax_by", enumSizeFn(context, self));
+        if (!block.isGiven()) return enumeratorizeWithSize(context, self, "minmax_by", enumSizeFn(self));
 
         final IRubyObject result[] = new IRubyObject[] { context.nil, context.nil };
 
@@ -2125,7 +2115,7 @@ public class RubyEnumerable {
     public static IRubyObject group_by(ThreadContext context, IRubyObject self, final Block block) {
         final Ruby runtime = context.runtime;
 
-        if (!block.isGiven()) return enumeratorizeWithSize(context, self, "group_by", enumSizeFn(context, self));
+        if (!block.isGiven()) return enumeratorizeWithSize(context, self, "group_by", enumSizeFn(self));
 
         final RubyHash result = new RubyHash(runtime);
 
@@ -2165,7 +2155,7 @@ public class RubyEnumerable {
         final Ruby runtime = context.runtime;
 
         if(!block.isGiven()) {
-            return enumeratorizeWithSize(context, self, "chunk", enumSizeFn(context, self));
+            return enumeratorizeWithSize(context, self, "chunk", enumSizeFn(self));
         }
 
         IRubyObject enumerator = context.runtime.getEnumerator().allocate();
@@ -2213,13 +2203,10 @@ public class RubyEnumerable {
         }
     }
 
-    static SizeFn enumSizeFn(final ThreadContext context, final IRubyObject self) {
-        return new SizeFn() {
-            @Override
-            public IRubyObject size(IRubyObject[] args) {
-                IRubyObject size = self.checkCallMethod(context, sites(context).size_checked);
-                return size == null ? context.nil : size;
-            }
+    static SizeFn enumSizeFn(final IRubyObject self) {
+        return (context, args) -> {
+            IRubyObject size = self.checkCallMethod(context, sites(context).size_checked);
+            return size == null ? context.nil : size;
         };
     }
 

--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -216,7 +216,7 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
                 if (size != null && !size.respondsTo("call")) size = null;
                 sizeFn = ((RubyEnumerator) object).sizeFn;
             } else {
-                sizeFn = RubyEnumerable.enumSizeFn(context, object);
+                sizeFn = RubyEnumerable.enumSizeFn(object);
             }
         }
 
@@ -492,12 +492,12 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
     @JRubyMethod(required = 1)
     public IRubyObject each_with_object(final ThreadContext context, IRubyObject arg, Block block) {
         return block.isGiven() ? RubyEnumerable.each_with_objectCommon(context, this, block, arg) :
-                enumeratorizeWithSize(context, this, "each_with_object", new IRubyObject[]{arg}, enumSizeFn(context));
+                enumeratorizeWithSize(context, this, "each_with_object", new IRubyObject[]{arg}, enumSizeFn());
     }
 
     @JRubyMethod
     public IRubyObject with_object(ThreadContext context, final IRubyObject arg, final Block block) {
-        return block.isGiven() ? RubyEnumerable.each_with_objectCommon(context, this, block, arg) : enumeratorizeWithSize(context, this, "with_object", new IRubyObject[]{arg}, enumSizeFn(context));
+        return block.isGiven() ? RubyEnumerable.each_with_objectCommon(context, this, block, arg) : enumeratorizeWithSize(context, this, "with_object", new IRubyObject[]{arg}, enumSizeFn());
     }
 
     @JRubyMethod(rest = true)
@@ -535,7 +535,7 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
     @JRubyMethod
     public final IRubyObject size(ThreadContext context) {
         if (sizeFn != null) {
-            return sizeFn.size(methodArgs);
+            return sizeFn.size(context, methodArgs);
         }
 
         IRubyObject size = this.size;
@@ -561,14 +561,8 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
         return -1;
     }
 
-    private SizeFn enumSizeFn(final ThreadContext context) {
-        final RubyEnumerator self = this;
-        return new SizeFn() {
-            @Override
-            public IRubyObject size(IRubyObject[] args) {
-                return self.size(context);
-            }
-        };
+    private SizeFn enumSizeFn() {
+        return (context, args) -> this.size(context);
     }
 
     private IRubyObject with_index_common(ThreadContext context, final Block block, final String rubyMethodName, IRubyObject arg) {
@@ -576,8 +570,8 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
         final int index = arg.isNil() ? 0 : RubyNumeric.num2int(arg);
         if ( ! block.isGiven() ) {
             return arg.isNil() ?
-                    enumeratorizeWithSize(context, this, rubyMethodName, enumSizeFn(context)) :
-                        enumeratorizeWithSize(context, this, rubyMethodName, new IRubyObject[]{runtime.newFixnum(index)}, enumSizeFn(context));
+                    enumeratorizeWithSize(context, this, rubyMethodName, enumSizeFn()) :
+                        enumeratorizeWithSize(context, this, rubyMethodName, new IRubyObject[]{runtime.newFixnum(index)}, enumSizeFn());
         }
 
         return RubyEnumerable.callEach(runtime, context, this, new RubyEnumerable.EachWithIndex(block, index));
@@ -667,7 +661,7 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
      * TODO (CON): fix this to receive context and state to we're not reallocating it all the time
      */
     public interface SizeFn {
-        IRubyObject size(IRubyObject[] args);
+        IRubyObject size(ThreadContext context, IRubyObject[] args);
     }
 
     private static JavaSites.FiberSites sites(ThreadContext context) {

--- a/core/src/main/java/org/jruby/RubyFixnum.java
+++ b/core/src/main/java/org/jruby/RubyFixnum.java
@@ -287,7 +287,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
             }
             return this;
         }
-        return RubyEnumerator.enumeratorizeWithSize(context, this, "times", timesSizeFn(context.runtime));
+        return RubyEnumerator.enumeratorizeWithSize(context, this, "times", timesSizeFn());
     }
     /** rb_fix_ceil
      *

--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -473,10 +473,9 @@ public class RubyGlobal {
         }
 
         @Override
-        public RubyHash to_hash() {
-            Ruby runtime = getRuntime();
-            RubyHash hash = RubyHash.newHash(runtime);
-            hash.replace(runtime.getCurrentContext(), this);
+        public RubyHash to_hash(ThreadContext context) {
+            RubyHash hash = RubyHash.newHash(context.runtime);
+            hash.replace(context, this);
             return hash;
         }
 

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -926,12 +926,12 @@ public class RubyHash extends RubyObject implements Map {
      */
     @JRubyMethod(name = "to_a")
     @Override
-    public RubyArray to_a() {
-        final Ruby runtime = metaClass.runtime;
+    public RubyArray to_a(ThreadContext context) {
+        final Ruby runtime = context.runtime;
         try {
             final RubyArray result = RubyArray.newBlankArrayInternal(runtime, size);
 
-            visitAll(runtime.getCurrentContext(), RubyHash.StoreKeyValueVisitor, result);
+            visitAll(context, RubyHash.StoreKeyValueVisitor, result);
 
             result.setTaint(isTaint());
             return result;
@@ -1595,7 +1595,7 @@ public class RubyHash extends RubyObject implements Map {
 
     @Deprecated
     public IRubyObject sort(ThreadContext context, Block block) {
-        return to_a().sort_bang(context, block);
+        return to_a(context).sort_bang(context, block);
     }
 
     /** rb_hash_index
@@ -2059,14 +2059,14 @@ public class RubyHash extends RubyObject implements Map {
 
     @JRubyMethod
     public IRubyObject flatten(ThreadContext context) {
-        RubyArray ary = to_a();
+        RubyArray ary = to_a(context);
         sites(context).flatten_bang.call(context, ary, ary, RubyFixnum.one(context.runtime));
         return ary;
     }
 
     @JRubyMethod
     public IRubyObject flatten(ThreadContext context, IRubyObject level) {
-        RubyArray ary = to_a();
+        RubyArray ary = to_a(context);
         sites(context).flatten_bang.call(context, ary, ary, level);
         return ary;
     }

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -901,13 +901,7 @@ public class RubyHash extends RubyObject implements Map {
     }
 
     private SizeFn enumSizeFn() {
-        final RubyHash self = this;
-        return new RubyEnumerator.SizeFn() {
-            @Override
-            public IRubyObject size(IRubyObject[] args) {
-                return self.rb_size();
-            }
-        };
+        return (context, args) -> this.rb_size(context);
     }
 
     /** rb_hash_empty_p
@@ -1911,7 +1905,7 @@ public class RubyHash extends RubyObject implements Map {
         modify();
         final RubyHash otherHash = other.convertToHash();
 
-        if (otherHash.empty_p().isTrue()) return this;
+        if (otherHash.empty_p(context).isTrue()) return this;
 
         otherHash.visitAll(context, new MergeVisitor(this), block);
 
@@ -1969,7 +1963,7 @@ public class RubyHash extends RubyObject implements Map {
 
         if (this == otherHash) return this;
 
-        rb_clear();
+        rb_clear(context);
 
         if (!isComparedByIdentity() && otherHash.isComparedByIdentity()) {
             setComparedByIdentity(true);
@@ -2097,7 +2091,7 @@ public class RubyHash extends RubyObject implements Map {
     public IRubyObject compare_by_identity(ThreadContext context) {
         modify();
         setComparedByIdentity(true);
-        return rehash();
+        return rehash(context);
     }
 
     @JRubyMethod(name = "compare_by_identity?")
@@ -2339,7 +2333,7 @@ public class RubyHash extends RubyObject implements Map {
 
     @Override
     public void clear() {
-        rb_clear();
+        rb_clear(getRuntime().getCurrentContext());
     }
 
     @Override
@@ -2814,13 +2808,6 @@ public class RubyHash extends RubyObject implements Map {
 
     @Deprecated
     public RubyHash rb_clear() {
-        modify();
-
-        if (size > 0) {
-            alloc();
-            size = 0;
-        }
-
-        return this;
+        return rb_clear(getRuntime().getCurrentContext());
     }
 }

--- a/core/src/main/java/org/jruby/RubyMatchData.java
+++ b/core/src/main/java/org/jruby/RubyMatchData.java
@@ -872,4 +872,20 @@ public class RubyMatchData extends RubyObject {
         return regs == null ? 1 : regs.numRegs;
     }
 
+    @Deprecated
+    @Override
+    public RubyArray to_a() {
+        return match_array(getRuntime(), 0);
+    }
+
+    @Deprecated
+    public IRubyObject op_aref(IRubyObject idx) {
+        return op_aref(getRuntime().getCurrentContext(), idx);
+    }
+
+    @Deprecated
+    public IRubyObject op_aref(IRubyObject idx, IRubyObject rest) {
+        return op_aref(getRuntime().getCurrentContext(), idx, rest);
+    }
+
 }

--- a/core/src/main/java/org/jruby/RubyMatchData.java
+++ b/core/src/main/java/org/jruby/RubyMatchData.java
@@ -432,8 +432,8 @@ public class RubyMatchData extends RubyObject {
      */
     @JRubyMethod
     @Override
-    public RubyArray to_a() {
-        return match_array(metaClass.runtime, 0);
+    public RubyArray to_a(ThreadContext context) {
+        return match_array(context.runtime, 0);
     }
 
     @JRubyMethod(rest = true)
@@ -576,26 +576,26 @@ public class RubyMatchData extends RubyObject {
 
     @Deprecated
     public IRubyObject op_aref19(IRubyObject idx, IRubyObject rest) {
-        return op_aref(idx, rest);
+        return op_aref(getRuntime().getCurrentContext(), idx, rest);
     }
 
     /** match_aref
      *
      */
     @JRubyMethod(name = "[]")
-    public IRubyObject op_aref(IRubyObject idx) {
+    public IRubyObject op_aref(ThreadContext context, IRubyObject idx) {
         check();
         IRubyObject result = op_arefCommon(idx);
-        return result == null ? to_a().aref(idx) : result;
+        return result == null ? to_a(context).aref(idx) : result;
     }
 
     /** match_aref
     *
     */
     @JRubyMethod(name = "[]")
-    public IRubyObject op_aref(IRubyObject idx, IRubyObject rest) {
+    public IRubyObject op_aref(ThreadContext context, IRubyObject idx, IRubyObject rest) {
         IRubyObject result;
-        return !rest.isNil() || (result = op_arefCommon(idx)) == null ? to_a().aref(idx, rest) : result;
+        return !rest.isNil() || (result = op_arefCommon(idx)) == null ? to_a(context).aref(idx, rest) : result;
     }
 
     private IRubyObject op_arefCommon(IRubyObject idx) {

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -49,7 +49,6 @@ import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.runtime.callsite.CachingCallSite;
 import org.jruby.util.ByteList;
 import org.jruby.util.ConvertBytes;
 import org.jruby.util.ConvertDouble;
@@ -956,7 +955,7 @@ public class RubyNumeric extends RubyObject {
     @JRubyMethod(optional = 2)
     public IRubyObject step(ThreadContext context, IRubyObject[] args, Block block) {
         if (!block.isGiven()) {
-            return enumeratorizeWithSize(context, this, "step", args, stepSizeFn(context, this, args));
+            return enumeratorizeWithSize(context, this, "step", args, stepSizeFn(this, args));
         }
 
         IRubyObject[] newArgs = new IRubyObject[2];
@@ -1214,15 +1213,12 @@ public class RubyNumeric extends RubyObject {
         return (RubyNumeric) result;
     }
 
-    private SizeFn stepSizeFn(final ThreadContext context, final IRubyObject from, final IRubyObject[] args) {
-        return new SizeFn() {
-            // MRI: num_step_size
-            @Override
-            public IRubyObject size(IRubyObject[] args) {
-                IRubyObject[] newArgs = new IRubyObject[2];
-                scanStepArgs(context, args, newArgs);
-                return intervalStepSize(context, from, newArgs[0], newArgs[1], false);
-            }
+    private SizeFn stepSizeFn(final IRubyObject from, final IRubyObject[] args) {
+        // MRI: num_step_size
+        return (context, args1) -> {
+            IRubyObject[] newArgs = new IRubyObject[2];
+            scanStepArgs(context, args1, newArgs);
+            return intervalStepSize(context, from, newArgs[0], newArgs[1], false);
         };
     }
 

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -43,7 +43,6 @@ import org.jcodings.Encoding;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.JumpException;
-import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.BlockCallback;
 import org.jruby.runtime.CallBlock;
@@ -522,7 +521,7 @@ public class RubyRange extends RubyObject {
     @JRubyMethod(name = "each")
     public IRubyObject each(final ThreadContext context, final Block block) {
         if (!block.isGiven()) {
-            return enumeratorizeWithSize(context, this, "each", enumSizeFn(context));
+            return enumeratorizeWithSize(context, this, "each", enumSizeFn());
         }
         if (begin instanceof RubyFixnum && end instanceof RubyFixnum) {
             fixnumEach(context, block);
@@ -571,14 +570,14 @@ public class RubyRange extends RubyObject {
 
     @JRubyMethod(name = "step")
     public IRubyObject step(final ThreadContext context, final Block block) {
-        return block.isGiven() ? stepCommon(context, RubyFixnum.one(context.runtime), block) : enumeratorizeWithSize(context, this, "step", stepSizeFn(context));
+        return block.isGiven() ? stepCommon(context, RubyFixnum.one(context.runtime), block) : enumeratorizeWithSize(context, this, "step", stepSizeFn());
     }
 
     @JRubyMethod(name = "step")
     public IRubyObject step(final ThreadContext context, IRubyObject step, final Block block) {
         Ruby runtime = context.runtime;
         if (!block.isGiven()) {
-            return enumeratorizeWithSize(context, this, "step", new IRubyObject[]{step}, stepSizeFn(context));
+            return enumeratorizeWithSize(context, this, "step", new IRubyObject[]{step}, stepSizeFn());
         }
 
         if (!(step instanceof RubyNumeric)) {
@@ -655,47 +654,37 @@ public class RubyRange extends RubyObject {
         }
     }
 
-    private SizeFn enumSizeFn(final ThreadContext context) {
-        final RubyRange self = this;
-        return new SizeFn() {
-            @Override
-            public IRubyObject size(IRubyObject[] args) {
-                return self.size(context);
-            }
-        };
+    private SizeFn enumSizeFn() {
+        return (ctx, args) -> this.size(ctx);
     }
 
-    private SizeFn stepSizeFn(final ThreadContext context) {
-        final RubyRange self = this;
-        return new SizeFn() {
-            @Override
-            public IRubyObject size(IRubyObject[] args) {
-                Ruby runtime = context.runtime;
-                IRubyObject begin = self.begin;
-                IRubyObject end = self.end;
-                IRubyObject step;
+    private SizeFn stepSizeFn() {
+        return (context, args) -> {
+            Ruby runtime = context.runtime;
+            IRubyObject begin = this.begin;
+            IRubyObject end = this.end;
+            IRubyObject step;
 
-                if (args != null && args.length > 0) {
-                    step = args[0];
-                    if (!(step instanceof RubyNumeric)) {
-                        step.convertToInteger();
-                    }
-                } else {
-                    step = RubyFixnum.one(runtime);
+            if (args != null && args.length > 0) {
+                step = args[0];
+                if (!(step instanceof RubyNumeric)) {
+                    step.convertToInteger();
                 }
-
-                if (step.callMethod(context, "<", RubyFixnum.zero(runtime)).isTrue()) {
-                    throw runtime.newArgumentError("step can't be negative");
-                } else if (!step.callMethod(context, ">", RubyFixnum.zero(runtime)).isTrue()) {
-                    throw runtime.newArgumentError("step can't be 0");
-                }
-
-                if (begin instanceof RubyNumeric && end instanceof RubyNumeric) {
-                    return intervalStepSize(context, begin, end, step, self.isExclusive);
-                }
-
-                return context.nil;
+            } else {
+                step = RubyFixnum.one(runtime);
             }
+
+            if (step.callMethod(context, "<", RubyFixnum.zero(runtime)).isTrue()) {
+                throw runtime.newArgumentError("step can't be negative");
+            } else if (!step.callMethod(context, ">", RubyFixnum.zero(runtime)).isTrue()) {
+                throw runtime.newArgumentError("step can't be 0");
+            }
+
+            if (begin instanceof RubyNumeric && end instanceof RubyNumeric) {
+                return intervalStepSize(context, begin, end, step, this.isExclusive);
+            }
+
+            return context.nil;
         };
     }
 

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -629,7 +629,7 @@ public class RubyStruct extends RubyObject {
     @JRubyMethod(name = {"to_a", "values"})
     @Override
     public RubyArray to_a(ThreadContext context) {
-        return getRuntime().newArray(values);
+        return context.runtime.newArray(values);
     }
 
     @JRubyMethod
@@ -964,6 +964,12 @@ public class RubyStruct extends RubyObject {
         public IRubyObject call(ThreadContext context, RubyStruct self, IRubyObject obj, boolean recur) {
             return self.inspectStruct(context, recur);
         }
+    }
+
+    @Deprecated
+    @Override
+    public RubyArray to_a() {
+        return getRuntime().newArray(values);
     }
 
 }

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -519,13 +519,7 @@ public class RubyStruct extends RubyObject {
     }
 
     private SizeFn enumSizeFn() {
-        final RubyStruct self = this;
-        return new SizeFn() {
-            @Override
-            public IRubyObject size(IRubyObject[] args) {
-                return self.size();
-            }
-        };
+        return (context, args) -> size();
     }
 
     public IRubyObject set(IRubyObject value, int index) {

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -628,7 +628,7 @@ public class RubyStruct extends RubyObject {
 
     @JRubyMethod(name = {"to_a", "values"})
     @Override
-    public RubyArray to_a() {
+    public RubyArray to_a(ThreadContext context) {
         return getRuntime().newArray(values);
     }
 

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -818,8 +818,8 @@ public class RubyTime extends RubyObject {
 
     @JRubyMethod
     @Override
-    public RubyArray to_a() {
-        return RubyArray.newArrayNoCopy(getRuntime(), sec(), min(), hour(), mday(), month(), year(), wday(), yday(), isdst(), zone());
+    public RubyArray to_a(ThreadContext context) {
+        return RubyArray.newArrayNoCopy(context.runtime, sec(), min(), hour(), mday(), month(), year(), wday(), yday(), isdst(), zone());
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -337,7 +337,7 @@ public class RubySet extends RubyObject implements Set {
     }
 
     protected void clearImpl() {
-        hash.rb_clear();
+        hash.rb_clear(getRuntime().getCurrentContext());
     }
 
     /**
@@ -603,12 +603,7 @@ public class RubySet extends RubyObject implements Set {
     }
 
     private RubyEnumerator.SizeFn enumSize() {
-        return new RubyEnumerator.SizeFn() {
-            @Override
-            public IRubyObject size(IRubyObject[] args) {
-                return getRuntime().newFixnum( RubySet.this.size() );
-            }
-        };
+        return (context, args) -> context.runtime.newFixnum( size() );
     }
 
     /**
@@ -890,7 +885,7 @@ public class RubySet extends RubyObject implements Set {
 
     @JRubyMethod(name = "reset")
     public IRubyObject reset(ThreadContext context) {
-        this.hash.rehash();
+        this.hash.rehash(context);
         return this;
     }
 

--- a/core/src/main/java/org/jruby/ext/set/RubySortedSet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySortedSet.java
@@ -143,7 +143,7 @@ public class RubySortedSet extends RubySet implements SortedSet {
 
     @Override
     protected void clearImpl() {
-        hash.rb_clear();
+        hash.rb_clear(getRuntime().getCurrentContext());
         order.clear();
     }
 

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -919,7 +919,7 @@ public class IRRuntimeHelpers {
         hash.modify();
         final RubyHash otherHash = explicitKwarg.convertToHash();
 
-        if (otherHash.empty_p().isTrue()) return hash;
+        if (otherHash.empty_p(context).isTrue()) return hash;
 
         otherHash.visitAll(context, new KwargMergeVisitor(hash), Block.NULL_BLOCK);
 

--- a/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
@@ -85,19 +85,19 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         return MapJavaProxy;
     }
 
-    private RubyHashMap getOrCreateRubyHashMap() {
+    private RubyHashMap getOrCreateRubyHashMap(Ruby runtime) {
         if (wrappedMap == null) {
-            wrappedMap = new RubyHashMap(getRuntime(), this);
+            wrappedMap = new RubyHashMap(runtime, this);
         }
         // (JavaProxy)recv).getObject() might raise exception when
         // wrong number of args are given to the constructor.
-        IRubyObject oldExc = getRuntime().getGlobalVariables().get("$!"); // Save $!
+        IRubyObject oldExc = runtime.getGlobalVariables().get("$!"); // Save $!
         try {
             wrappedMap.setSize( getMapObject().size() );
         }
         catch (RaiseException e) {
             wrappedMap.setSize(0);
-            getRuntime().getGlobalVariables().set("$!", oldExc); // Restore $!
+            runtime.getGlobalVariables().set("$!", oldExc); // Restore $!
         }
         return wrappedMap;
     }
@@ -137,9 +137,9 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         }
 
         @Override
-        public RubyArray to_a() {
+        public RubyArray to_a(ThreadContext context) {
             syncSize();
-            return super.to_a();
+            return super.to_a(context);
         }
 
         @Override
@@ -406,36 +406,36 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
 
     @JRubyMethod(name = "default")
     public IRubyObject default_value_get(ThreadContext context) {
-        return getOrCreateRubyHashMap().default_value_get(context);
+        return getOrCreateRubyHashMap(context.runtime).default_value_get(context);
     }
 
     @JRubyMethod(name = "default")
     public IRubyObject default_value_get(ThreadContext context, IRubyObject arg) {
-        return getOrCreateRubyHashMap().default_value_get(context, arg);
+        return getOrCreateRubyHashMap(context.runtime).default_value_get(context, arg);
     }
 
     /** rb_hash_set_default
      *
      */
     @JRubyMethod(name = "default=", required = 1)
-    public IRubyObject default_value_set(final IRubyObject defaultValue) {
-        return getOrCreateRubyHashMap().default_value_set(defaultValue);
+    public IRubyObject default_value_set(ThreadContext context, final IRubyObject defaultValue) {
+        return getOrCreateRubyHashMap(context.runtime).default_value_set(defaultValue);
     }
 
     /** rb_hash_default_proc
      *
      */
     @JRubyMethod(name = "default_proc")
-    public IRubyObject default_proc() {
-        return getOrCreateRubyHashMap().default_proc();
+    public IRubyObject default_proc(ThreadContext context) {
+        return getOrCreateRubyHashMap(context.runtime).default_proc();
     }
 
     /** rb_hash_set_default_proc
      *
      */
     @JRubyMethod(name = "default_proc=")
-    public IRubyObject set_default_proc(IRubyObject proc) {
-        return getOrCreateRubyHashMap().set_default_proc(proc);
+    public IRubyObject set_default_proc(ThreadContext context, IRubyObject proc) {
+        return getOrCreateRubyHashMap(context.runtime).set_default_proc(proc);
     }
 
     /** rb_hash_inspect
@@ -443,36 +443,37 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "inspect")
     public IRubyObject inspect(ThreadContext context) {
-        return getOrCreateRubyHashMap().inspect(context);
+        return getOrCreateRubyHashMap(context.runtime).inspect(context);
     }
 
     /** rb_hash_size
      *
      */
     @JRubyMethod(name = {"size", "length"})
-    public RubyFixnum rb_size() {
-        return getOrCreateRubyHashMap().rb_size();
+    public RubyFixnum rb_size(ThreadContext context) {
+        return getOrCreateRubyHashMap(context.runtime).rb_size();
     }
 
     /** rb_hash_empty_p
      *
      */
     @JRubyMethod(name = "empty?")
-    public RubyBoolean empty_p() {
-        return getOrCreateRubyHashMap().empty_p();
+    public RubyBoolean empty_p(ThreadContext context) {
+        return getOrCreateRubyHashMap(context.runtime).empty_p();
     }
 
     /** rb_hash_to_a
      *
      */
+    @Override
     @JRubyMethod(name = "to_a")
-    public RubyArray to_a() {
-        return getOrCreateRubyHashMap().to_a();
+    public RubyArray to_a(ThreadContext context) {
+        return getOrCreateRubyHashMap(context.runtime).to_a(context);
     }
 
     @JRubyMethod(name = "to_proc")
     public RubyProc to_proc(ThreadContext context) {
-        IRubyObject newProc = getOrCreateRubyHashMap().callMethod("to_proc");
+        IRubyObject newProc = getOrCreateRubyHashMap(context.runtime).callMethod("to_proc");
 
         TypeConverter.checkType(context, newProc, context.runtime.getProc());
 
@@ -484,23 +485,23 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "to_s")
     public IRubyObject to_s(ThreadContext context) {
-        return getOrCreateRubyHashMap().to_s(context);
+        return getOrCreateRubyHashMap(context.runtime).to_s(context);
     }
 
     /** rb_hash_rehash
      *
      */
     @JRubyMethod(name = "rehash", notImplemented = true)
-    public RubyHash rehash() {
-        return getOrCreateRubyHashMap().rehash();
+    public RubyHash rehash(ThreadContext context) {
+        return getOrCreateRubyHashMap(context.runtime).rehash();
     }
 
     /** rb_hash_to_hash
      *
      */
     @JRubyMethod(name = { "to_hash", "to_h" })
-    public RubyHash to_hash() {
-        return getOrCreateRubyHashMap().to_hash();
+    public RubyHash to_hash(ThreadContext context) {
+        return getOrCreateRubyHashMap(context.runtime).to_hash();
     }
 
     /** rb_hash_aset
@@ -508,7 +509,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = {"[]=", "store"}, required = 2)
     public IRubyObject op_aset(ThreadContext context, IRubyObject key, IRubyObject value) {
-        return getOrCreateRubyHashMap().op_aset(context, key, value);
+        return getOrCreateRubyHashMap(context.runtime).op_aset(context, key, value);
     }
 
     /** rb_hash_equal
@@ -516,7 +517,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "==")
     public IRubyObject op_equal(final ThreadContext context, IRubyObject other) {
-        return getOrCreateRubyHashMap().op_equal(context, other);
+        return getOrCreateRubyHashMap(context.runtime).op_equal(context, other);
     }
 
     /** rb_hash_eql
@@ -524,7 +525,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "eql?")
     public IRubyObject op_eql(final ThreadContext context, IRubyObject other) {
-        return getOrCreateRubyHashMap().op_eql(context, other);
+        return getOrCreateRubyHashMap(context.runtime).op_eql(context, other);
     }
 
     /** rb_hash_aref
@@ -532,35 +533,35 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "[]", required = 1)
     public IRubyObject op_aref(ThreadContext context, IRubyObject key) {
-        return getOrCreateRubyHashMap().op_aref(context, key);
+        return getOrCreateRubyHashMap(context.runtime).op_aref(context, key);
     }
 
     @JRubyMethod(name = "<", required = 1)
     public IRubyObject op_lt(ThreadContext context, IRubyObject other) {
-        return getOrCreateRubyHashMap().op_lt(context, other);
+        return getOrCreateRubyHashMap(context.runtime).op_lt(context, other);
     }
 
     @JRubyMethod(name = "<=", required = 1)
     public IRubyObject op_le(ThreadContext context, IRubyObject other) {
-        return getOrCreateRubyHashMap().op_le(context, other);
+        return getOrCreateRubyHashMap(context.runtime).op_le(context, other);
     }
 
     @JRubyMethod(name = ">", required = 1)
     public IRubyObject op_gt(ThreadContext context, IRubyObject other) {
-        return getOrCreateRubyHashMap().op_gt(context, other);
+        return getOrCreateRubyHashMap(context.runtime).op_gt(context, other);
     }
 
     @JRubyMethod(name = ">=", required = 1)
     public IRubyObject op_ge(ThreadContext context, IRubyObject other) {
-        return getOrCreateRubyHashMap().op_ge(context, other);
+        return getOrCreateRubyHashMap(context.runtime).op_ge(context, other);
     }
 
     /** rb_hash_hash
      *
      */
     @JRubyMethod(name = "hash")
-    public RubyFixnum hash() {
-        return getOrCreateRubyHashMap().hash();
+    public RubyFixnum hash(ThreadContext context) {
+        return getOrCreateRubyHashMap(context.runtime).hash();
     }
 
     /** rb_hash_fetch
@@ -568,12 +569,12 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod
     public IRubyObject fetch(ThreadContext context, IRubyObject key, Block block) {
-        return getOrCreateRubyHashMap().fetch(context, key, block);
+        return getOrCreateRubyHashMap(context.runtime).fetch(context, key, block);
     }
 
     @JRubyMethod
     public IRubyObject fetch(ThreadContext context, IRubyObject key, IRubyObject _default, Block block) {
-        return getOrCreateRubyHashMap().fetch(context, key, _default, block);
+        return getOrCreateRubyHashMap(context.runtime).fetch(context, key, _default, block);
     }
 
     /** rb_hash_has_key_p
@@ -581,7 +582,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = {"has_key?", "key?", "include?", "member?"}, required = 1)
     public RubyBoolean has_key_p(ThreadContext context, IRubyObject key) {
-        return getOrCreateRubyHashMap().has_key_p(context, key);
+        return getOrCreateRubyHashMap(context.runtime).has_key_p(context, key);
     }
 
     /** rb_hash_has_value
@@ -589,7 +590,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = {"has_value?", "value?"}, required = 1)
     public RubyBoolean has_value_p(ThreadContext context, IRubyObject expected) {
-        return getOrCreateRubyHashMap().has_value_p(context, expected);
+        return getOrCreateRubyHashMap(context.runtime).has_value_p(context, expected);
     }
 
     /** rb_hash_each
@@ -597,7 +598,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = {"each", "each_pair"})
     public IRubyObject each(final ThreadContext context, final Block block) {
-        return getOrCreateRubyHashMap().each(context, block);
+        return getOrCreateRubyHashMap(context.runtime).each(context, block);
     }
 
     /** rb_hash_each_value
@@ -605,7 +606,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "each_value")
     public IRubyObject each_value(final ThreadContext context, final Block block) {
-        return getOrCreateRubyHashMap().each_value(context, block);
+        return getOrCreateRubyHashMap(context.runtime).each_value(context, block);
     }
 
     /** rb_hash_each_key
@@ -613,7 +614,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "each_key")
     public IRubyObject each_key(final ThreadContext context, final Block block) {
-        return getOrCreateRubyHashMap().each_key(context, block);
+        return getOrCreateRubyHashMap(context.runtime).each_key(context, block);
     }
 
     /** rb_hash_select_bang
@@ -621,7 +622,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "select!")
     public IRubyObject select_bang(final ThreadContext context, final Block block) {
-        return getOrCreateRubyHashMap().select_bang(context, block);
+        return getOrCreateRubyHashMap(context.runtime).select_bang(context, block);
     }
 
     /** rb_hash_keep_if
@@ -629,7 +630,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "keep_if")
     public IRubyObject keep_if(final ThreadContext context, final Block block) {
-        return getOrCreateRubyHashMap().keep_if(context, block);
+        return getOrCreateRubyHashMap(context.runtime).keep_if(context, block);
     }
 
     /** rb_hash_index
@@ -637,7 +638,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "index")
     public IRubyObject index(ThreadContext context, IRubyObject expected) {
-        return getOrCreateRubyHashMap().index(context, expected);
+        return getOrCreateRubyHashMap(context.runtime).index(context, expected);
     }
 
     /** rb_hash_key
@@ -645,7 +646,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "key")
     public IRubyObject key(ThreadContext context, IRubyObject expected) {
-        return getOrCreateRubyHashMap().key(context, expected);
+        return getOrCreateRubyHashMap(context.runtime).key(context, expected);
     }
 
     /** rb_hash_keys
@@ -653,15 +654,15 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "keys")
     public RubyArray keys(ThreadContext context) {
-        return getOrCreateRubyHashMap().keys(context);
+        return getOrCreateRubyHashMap(context.runtime).keys(context);
     }
 
     /** rb_hash_values
      *
      */
     @JRubyMethod(name = { "values", "ruby_values" }) // collision with java.util.Map#values
-    public RubyArray rb_values() {
-        return getOrCreateRubyHashMap().rb_values();
+    public RubyArray rb_values(ThreadContext context) {
+        return getOrCreateRubyHashMap(context.runtime).rb_values();
     }
 
     /** rb_hash_shift
@@ -669,7 +670,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "shift", notImplemented = true)
     public IRubyObject shift(ThreadContext context) {
-        return getOrCreateRubyHashMap().shift(context);
+        return getOrCreateRubyHashMap(context.runtime).shift(context);
     }
 
     /** rb_hash_delete
@@ -677,7 +678,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "delete")
     public IRubyObject delete(ThreadContext context, IRubyObject key, Block block) {
-        return getOrCreateRubyHashMap().delete(context, key, block);
+        return getOrCreateRubyHashMap(context.runtime).delete(context, key, block);
     }
 
     /** rb_hash_select
@@ -685,7 +686,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "select")
     public IRubyObject select(final ThreadContext context, final Block block) {
-        return getOrCreateRubyHashMap().select(context, block);
+        return getOrCreateRubyHashMap(context.runtime).select(context, block);
     }
 
     /** rb_hash_delete_if
@@ -693,7 +694,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "delete_if")
     public IRubyObject delete_if(final ThreadContext context, final Block block) {
-        return getOrCreateRubyHashMap().delete_if(context, block);
+        return getOrCreateRubyHashMap(context.runtime).delete_if(context, block);
     }
 
     /** rb_hash_reject
@@ -701,7 +702,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "reject")
     public IRubyObject reject(final ThreadContext context, final Block block) {
-        return getOrCreateRubyHashMap().reject(context, block);
+        return getOrCreateRubyHashMap(context.runtime).reject(context, block);
     }
 
     /** rb_hash_reject_bang
@@ -709,15 +710,15 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "reject!")
     public IRubyObject reject_bang(final ThreadContext context, final Block block) {
-        return getOrCreateRubyHashMap().reject_bang(context, block);
+        return getOrCreateRubyHashMap(context.runtime).reject_bang(context, block);
     }
 
     /** rb_hash_clear
      *
      */
     @JRubyMethod(name = { "clear", "ruby_clear" }) // collision with java.util.Map#clear (return type)
-    public IRubyObject rb_clear() {
-        return getOrCreateRubyHashMap().rb_clear();
+    public IRubyObject rb_clear(ThreadContext context) {
+        return getOrCreateRubyHashMap(context.runtime).rb_clear();
     }
 
     /** rb_hash_invert
@@ -725,7 +726,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "invert")
     public RubyHash invert(final ThreadContext context) {
-        return getOrCreateRubyHashMap().invert(context);
+        return getOrCreateRubyHashMap(context.runtime).invert(context);
     }
 
     /** rb_hash_merge_bang
@@ -733,7 +734,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = { "merge!", "update" }, required = 1)
     public RubyHash merge_bang(final ThreadContext context, final IRubyObject other, final Block block) {
-        return getOrCreateRubyHashMap().merge_bang(context, other, block);
+        return getOrCreateRubyHashMap(context.runtime).merge_bang(context, other, block);
     }
 
     /** rb_hash_merge
@@ -741,7 +742,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = { "merge", "ruby_merge" }) // collision with java.util.Map#merge on Java 8+
     public RubyHash merge(ThreadContext context, IRubyObject other, Block block) {
-        return getOrCreateRubyHashMap().merge(context, other, block);
+        return getOrCreateRubyHashMap(context.runtime).merge(context, other, block);
     }
 
     /** rb_hash_initialize_copy
@@ -749,7 +750,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "initialize_copy", visibility = Visibility.PRIVATE)
     public RubyHash initialize_copy(ThreadContext context, IRubyObject other) {
-        return getOrCreateRubyHashMap().initialize_copy(context, other);
+        return getOrCreateRubyHashMap(context.runtime).initialize_copy(context, other);
     }
 
     /** rb_hash_replace
@@ -757,7 +758,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = { "replace", "ruby_replace" }, required = 1) // collision with java.util.Map#replace on Java 8+
     public RubyHash replace(final ThreadContext context, IRubyObject other) {
-        return getOrCreateRubyHashMap().replace(context, other);
+        return getOrCreateRubyHashMap(context.runtime).replace(context, other);
     }
 
     /** rb_hash_values_at
@@ -765,32 +766,32 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "values_at", rest = true)
     public RubyArray values_at(ThreadContext context, IRubyObject[] args) {
-        return getOrCreateRubyHashMap().values_at(context, args);
+        return getOrCreateRubyHashMap(context.runtime).values_at(context, args);
     }
 
     @JRubyMethod(name = "fetch_values", rest = true)
     public RubyArray fetch_values(ThreadContext context, IRubyObject[] args, Block block) {
-        return getOrCreateRubyHashMap().fetch_values(context, args, block);
+        return getOrCreateRubyHashMap(context.runtime).fetch_values(context, args, block);
     }
 
     @JRubyMethod(name = "assoc")
     public IRubyObject assoc(final ThreadContext context, final IRubyObject obj) {
-        return getOrCreateRubyHashMap().assoc(context, obj);
+        return getOrCreateRubyHashMap(context.runtime).assoc(context, obj);
     }
 
     @JRubyMethod(name = "rassoc")
     public IRubyObject rassoc(final ThreadContext context, final IRubyObject obj) {
-        return getOrCreateRubyHashMap().rassoc(context, obj);
+        return getOrCreateRubyHashMap(context.runtime).rassoc(context, obj);
     }
 
     @JRubyMethod(name = "flatten")
     public IRubyObject flatten(ThreadContext context) {
-        return getOrCreateRubyHashMap().flatten(context);
+        return getOrCreateRubyHashMap(context.runtime).flatten(context);
     }
 
     @JRubyMethod(name = "flatten")
     public IRubyObject flatten(ThreadContext context, IRubyObject level) {
-        return getOrCreateRubyHashMap().flatten(context, level);
+        return getOrCreateRubyHashMap(context.runtime).flatten(context, level);
     }
 
     @JRubyMethod(name = "compare_by_identity")
@@ -800,7 +801,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
 
     @JRubyMethod(name = "compare_by_identity?")
     public IRubyObject compare_by_identity_p(ThreadContext context) {
-        return getOrCreateRubyHashMap().compare_by_identity_p(context);
+        return getOrCreateRubyHashMap(context.runtime).compare_by_identity_p(context);
     }
 
     @Override
@@ -815,12 +816,12 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
 
     @JRubyMethod(name = "any?", optional = 1)
     public IRubyObject any_p(ThreadContext context, IRubyObject[] args, Block block) {
-        return getOrCreateRubyHashMap().any_p(context, args, block);
+        return getOrCreateRubyHashMap(context.runtime).any_p(context, args, block);
     }
 
     @JRubyMethod(name = "dig", required = 1, rest = true)
     public IRubyObject dig(ThreadContext context, IRubyObject[] args) {
-        return getOrCreateRubyHashMap().dig(context, args);
+        return getOrCreateRubyHashMap(context.runtime).dig(context, args);
     }
 
     @SuppressWarnings("unchecked")
@@ -845,17 +846,17 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
 
     @Override
     public final RubyHash convertToHash() {
-        return getOrCreateRubyHashMap();
+        return getOrCreateRubyHashMap(getRuntime());
     }
 
     @Deprecated
     public IRubyObject op_aset19(ThreadContext context, IRubyObject key, IRubyObject value) {
-        return getOrCreateRubyHashMap().op_aset19(context, key, value);
+        return getOrCreateRubyHashMap(context.runtime).op_aset19(context, key, value);
     }
 
     @Deprecated
     public IRubyObject sort(ThreadContext context, Block block) {
-        return getOrCreateRubyHashMap().sort(context, block);
+        return getOrCreateRubyHashMap(context.runtime).sort(context, block);
     }
 
 }

--- a/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
@@ -121,13 +121,13 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         private Map mapDelegate() { return receiver.getMapObject(); }
 
         @Override
-        public RubyFixnum rb_size() {
-            return getRuntime().newFixnum( mapDelegate().size() );
+        public RubyFixnum rb_size(ThreadContext context) {
+            return context.runtime.newFixnum( mapDelegate().size() );
         }
 
         @Override
-        public RubyBoolean empty_p() {
-            return mapDelegate().isEmpty() ? getRuntime().getTrue() : getRuntime().getFalse();
+        public RubyBoolean empty_p(ThreadContext context) {
+            return mapDelegate().isEmpty() ? context.tru : context.fals;
         }
 
         @Override
@@ -143,7 +143,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         }
 
         @Override
-        public RubyFixnum hash() {
+        public RubyFixnum hash(ThreadContext context) {
             return getRuntime().newFixnum( mapDelegate().hashCode() );
         }
 
@@ -296,7 +296,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         }
 
         @Override
-        public RubyHash rehash() {
+        public RubyHash rehash(ThreadContext context) {
             // java.util.Map does not expose rehash, and many maps don't use hashing, so we do nothing. #3142
             return this;
         }
@@ -359,7 +359,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         }
 
         @Override
-        public RubyHash rb_clear() {
+        public RubyHash rb_clear(ThreadContext context) {
             mapDelegate().clear();
             setSize( 0 );
             return this;
@@ -371,8 +371,8 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         }
 
         @Override
-        public RubyHash to_hash() {
-            final Ruby runtime = getRuntime();
+        public RubyHash to_hash(ThreadContext context) {
+            final Ruby runtime = context.runtime;
             final RubyHash hash = new RubyHash(runtime);
             @SuppressWarnings("unchecked")
             Set<Map.Entry> entries = mapDelegate().entrySet();

--- a/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
@@ -459,7 +459,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "empty?")
     public RubyBoolean empty_p(ThreadContext context) {
-        return getOrCreateRubyHashMap(context.runtime).empty_p();
+        return getOrCreateRubyHashMap(context.runtime).empty_p(context);
     }
 
     /** rb_hash_to_a
@@ -493,7 +493,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "rehash", notImplemented = true)
     public RubyHash rehash(ThreadContext context) {
-        return getOrCreateRubyHashMap(context.runtime).rehash();
+        return getOrCreateRubyHashMap(context.runtime).rehash(context);
     }
 
     /** rb_hash_to_hash
@@ -662,7 +662,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = { "values", "ruby_values" }) // collision with java.util.Map#values
     public RubyArray rb_values(ThreadContext context) {
-        return getOrCreateRubyHashMap(context.runtime).rb_values();
+        return getOrCreateRubyHashMap(context.runtime).rb_values(context);
     }
 
     /** rb_hash_shift
@@ -718,7 +718,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = { "clear", "ruby_clear" }) // collision with java.util.Map#clear (return type)
     public IRubyObject rb_clear(ThreadContext context) {
-        return getOrCreateRubyHashMap(context.runtime).rb_clear();
+        return getOrCreateRubyHashMap(context.runtime).rb_clear(context);
     }
 
     /** rb_hash_invert

--- a/core/src/main/java/org/jruby/specialized/RubyArrayOneObject.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArrayOneObject.java
@@ -103,8 +103,8 @@ public class RubyArrayOneObject extends RubyArraySpecialized {
     }
 
     @Override
-    protected RubyArray dupImpl(RubyClass metaClass) {
-        if (!packed()) return super.dupImpl(metaClass);
+    protected RubyArray dupImpl(Ruby runtime, RubyClass metaClass) {
+        if (!packed()) return super.dupImpl(runtime, metaClass);
         return new RubyArrayOneObject(metaClass, this);
     }
 

--- a/core/src/main/java/org/jruby/specialized/RubyArrayTwoObject.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArrayTwoObject.java
@@ -117,8 +117,8 @@ public class RubyArrayTwoObject extends RubyArraySpecialized {
     }
 
     @Override
-    protected RubyArray dupImpl(RubyClass metaClass) {
-        if (!packed()) return super.dupImpl(metaClass);
+    protected RubyArray dupImpl(Ruby runtime, RubyClass metaClass) {
+        if (!packed()) return super.dupImpl(runtime, metaClass);
         return new RubyArrayTwoObject(metaClass, this);
     }
 


### PR DESCRIPTION
This avoids bouncing through the metaClass to get the runtime,
which happens in these methods and in several downstream calls.
Several cases also needed the context, so this saves the extra
overhead of traversing the runtime, thread service, and thread
local to get the context.

This is a PR to get input. Some signatures change without a class-local replacement, so code compiled to those signatures on those classes would fail. I didn't want to leave deprecated no-arg versions all over the place.

There are also many other core IRubyObject methods that don't accept context.

I have not done any perf measurements but it's probably negligible. The main benefit is that the context will almost always be in cache for a given thread, since we pass it through almost all call paths.