### PR TITLE
improve BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -78,13 +78,13 @@ environment. This will do the following:
  needed to run integration tests.
 
 ```
-mvn -Pbootstrap
+./mvnw -Pbootstrap
 ```
 
 In case there is a problem with installing the jruby-launcher (due to missing compiler or so) use
 
 ```
-mvn -Pbootstrap-no-launcher
+./mvnw -Pbootstrap-no-launcher
 ```
 
 This only needs to be run once to install these gems or if you update
@@ -96,7 +96,7 @@ After changing Java code, you can recompile quickly by running one of the
 jar files by
 
 ```
-mvn -pl core
+./mvnw -pl core
 ```
 
 ### Day to Day Testing


### PR DESCRIPTION
following commands does not work for me.
`mvn -Pbootstrap`
`mvn -Pbootstrap-no-launcher`
`mvn -pl core`

My Env
```
$ ./mvnw -v
Apache Maven 3.6.0 (97c98ec64a1fdfee7767ce5ffb20918da4f719f3; 2018-10-25T03:41:47+09:00)
Maven home: /Users/xxx/.m2/wrapper/dists/apache-maven-3.6.0-bin/3rgjh30jneo7541hun7uggltkb/apache-maven-3.6.0
Java version: 11.0.2, vendor: Oracle Corporation, runtime: /Library/Java/JavaVirtualMachines/openjdk-11.0.2.jdk/Contents/Home
Default locale: ja_JP, platform encoding: UTF-8
OS name: "mac os x", version: "10.15", arch: "x86_64", family: "mac"
```
