### PR TITLE
Remove usages of deprecated ConfigMap

### DIFF
--- a/lib/ruby/stdlib/rubygems/defaults/jruby.rb
+++ b/lib/ruby/stdlib/rubygems/defaults/jruby.rb
@@ -31,15 +31,15 @@ module Gem
   # to preserve the old location: lib/ruby/gems.
   def self.default_dir
     dir = RbConfig::CONFIG["default_gem_home"]
-    dir ||= File.join(ConfigMap[:libdir], 'ruby', 'gems', 'shared')
+    dir ||= File.join(RbConfig::CONFIG['libdir'], 'ruby', 'gems', 'shared')
     dir
   end
 
   # Default locations for RubyGems' .rb and bin files
   def self.default_rubygems_dirs
     [
-        File.join(ConfigMap[:libdir], 'ruby', 'stdlib'),
-        ConfigMap[:bindir]
+        File.join(RbConfig::CONFIG['libdir'], 'ruby', 'stdlib'),
+        RbConfig::CONFIG['bindir']
     ]
   end
 

--- a/test/mri/lib/envutil.rb
+++ b/test/mri/lib/envutil.rb
@@ -291,7 +291,6 @@ if defined?(RbConfig)
     end
     dir = File.dirname(ruby)
     CONFIG['bindir'] = dir
-    Gem::ConfigMap[:bindir] = dir if defined?(Gem::ConfigMap)
   end
 end
 


### PR DESCRIPTION
Rubygems deprecated it in https://github.com/rubygems/rubygems/pull/2857.