### PR TITLE
expand #succ for bignums

### DIFF
--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -348,6 +348,8 @@ public abstract class RubyInteger extends RubyNumeric {
     public IRubyObject succ(ThreadContext context) {
         if (this instanceof RubyFixnum) {
             return ((RubyFixnum) this).op_plus_one(context);
+        } else if (this instanceof RubyBignum) {
+            return ((RubyBignum) this).op_plus(context, 1);
         } else {
             return numFuncall(context, this, sites(context).op_plus, RubyFixnum.one(context.runtime));
         }


### PR DESCRIPTION
just do the same as mri https://github.com/ruby/ruby/blob/e7ea6e078fecb70fbc91b04878b69f696749afac/numeric.c#L3320

```
after
                 big      6.596M (? 7.8%) i/s -     32.708M in   4.995933s
before
                 big      4.264M (? 5.7%) i/s -     21.237M in   4.994988s
```

+indy
```
after
                 big      8.865M (? 2.6%) i/s -     44.215M in   4.991349s
before
                 big      4.704M (? 4.4%) i/s -     23.487M in   5.004868s
```

```
require 'benchmark/ips'

Benchmark.ips do |x|
  x.report('fix') { 5.succ }
  x.report('big') { 500000000000000000000000000000000000000000000000000000000000000000000000004.succ }
end
```