### PR TITLE
Cache method_missing target

### DIFF
--- a/core/src/main/java/org/jruby/ir/targets/Bootstrap.java
+++ b/core/src/main/java/org/jruby/ir/targets/Bootstrap.java
@@ -620,6 +620,23 @@ public class Bootstrap {
         return binder.invokeVirtualQuiet(LOOKUP, "call").handle();
     }
 
+    static MethodHandle buildMethodMissingHandle(InvokeSite site, CacheEntry entry, IRubyObject self) {
+        SmartBinder binder;
+        DynamicMethod method = entry.method;
+
+        binder = SmartBinder.from(site.signature)
+                .permute("context", "self", "arg.*", "block")
+                .insert(2, new String[]{"rubyClass", "name", "argName"}, new Class[]{RubyModule.class, String.class, IRubyObject.class}, entry.sourceModule, site.name(), self.getRuntime().newSymbol(site.methodName))
+                .insert(0, "method", DynamicMethod.class, method)
+                .collect("args", "arg.*");
+
+        if (Options.INVOKEDYNAMIC_LOG_BINDING.load()) {
+            LOG.info(site.name() + "\tbound to method_missing for " + method + ", " + Bootstrap.logMethod(method));
+        }
+
+        return binder.invokeVirtualQuiet(LOOKUP, "call").handle();
+    }
+
     static MethodHandle buildAttrHandle(InvokeSite site, CacheEntry entry, IRubyObject self) {
         DynamicMethod method = entry.method;
 

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -386,8 +386,8 @@ public class Helpers {
         }
     }
 
-    private static class MethodMissingMethod extends DynamicMethod {
-        private final CacheEntry entry;
+    public static class MethodMissingMethod extends DynamicMethod {
+        public final CacheEntry entry;
         private final CallType lastCallStatus;
         private final Visibility lastVisibility;
 
@@ -2534,6 +2534,13 @@ public class Helpers {
 
     public static <T> T[] arrayOf(T... values) {
         return values;
+    }
+
+    public static IRubyObject[] arrayOf(IRubyObject first, IRubyObject... values) {
+        IRubyObject[] newValues = new IRubyObject[values.length + 1];
+        newValues[0] = first;
+        System.arraycopy(values, 0, newValues, 1, values.length);
+        return newValues;
     }
 
     public static <T> T[] arrayOf(Class<T> t, int size, T fill) {


### PR DESCRIPTION
This logic will cache the target class's method_missing impl when
a method call fails to find a natural method table entry. This
scenario was a source of failed call sites in Redmine's json
builder and in the Rails StringInquirer class used for Rails.env.
With this change in place Redmine json issue requests improved by
roughly 15%.