### PR TITLE
Bind only public interface methods for private classes

### DIFF
--- a/spec/java_integration/object/marshal_spec.rb
+++ b/spec/java_integration/object/marshal_spec.rb
@@ -22,33 +22,6 @@ describe "A Java object" do
     expect( marshaled ).to eql data
   end
 
-  java_import 'java_integration.fixtures.InnerClasses'
-
-  it "marshals local Java class" do
-    hash = { :local => InnerClasses.localMethodClass }
-    caps_method = hash[:local].capsMethod
-
-    #pending 'Marshal.load can not resolve local class: Java::Java_integrationFixtures::InnerClasses::1CapsImpl'
-
-    local = Marshal.load(Marshal.dump(hash))[:local]
-    expect( local.class.java_class.member_class? ).to be false
-    expect( local.class.java_class.anonymous_class? ).to be false
-    expect( local.capsMethod ).to eql caps_method
-  end
-
-  it "marshals anonymous Java class" do
-    array = [ InnerClasses.anonymousMethodClass ]
-    caps_method = array[0].capsMethod
-
-    #pending 'Marshal.load can not resolve anonymous class: Java::Java_integrationFixtures::InnerClasses::1'
-
-    anon = Marshal.load(Marshal.dump(array))[0]
-
-    expect( anon.class.java_class.member_class? ).to be false
-    expect( anon.class.java_class.anonymous_class? ).to be true
-    expect( anon.capsMethod ).to eql caps_method
-  end
-
   it "marshals anonymous (enum) class" do
     mic = java.util.concurrent.TimeUnit::MICROSECONDS
     mil = java.util.concurrent.TimeUnit::MILLISECONDS


### PR DESCRIPTION
This includes two fixes introduced (at least in part) by #5832:

* Private classes were considered for method binding even though
  we no longer set them accessible on Java 9+ when they have not
  already been opened. This resulted in Java 9+ environments
  producing method errors when they attempted to dispatch to those
  methods on private classes.
* In order to fix the above for private classes with public
  interfaces, this patch also fixes how we traverse a class's
  implemented interfaces. Possibly from changes in #5832, we were
  not walking an interface's superinterfaces, causing us to only
  walk one level in such cases.

In my local tests, this caused failures in `spec:ji` for specs accessing the following classes; I do not believe that these methods should be callable, since they are on private inner classes without any public interface method:

https://github.com/jruby/jruby/blob/b35397b767ccf9b8a0f29e23f9b338576802acc9/spec/java_integration/fixtures/InnerClasses.java#L78-L95