### PR TITLE
fix strict_base64 for shared strings

### DIFF
--- a/core/src/main/java/org/jruby/util/Pack.java
+++ b/core/src/main/java/org/jruby/util/Pack.java
@@ -819,13 +819,14 @@ public class Pack {
         byte[] buf = input.unsafeBytes();
         int begin = input.begin();
         int length = input.realSize();
+        int end = begin + length;
 
         if (length % 4 != 0) throw runtime.newArgumentError("invalid base64");
 
         int p = begin;
         byte[] out = new byte[3 * ((length + 3) / 4)];
 
-        while (p < length && s != '=') {
+        while (p < end && s != '=') {
             // obtain a
             s = buf[p++];
             a = b64_xtable[s];
@@ -857,7 +858,7 @@ public class Pack {
             out[index++] = (byte) (c << 6 | d);
         }
 
-        if (p < begin + length) throw runtime.newArgumentError("invalid base64");
+        if (p < end) throw runtime.newArgumentError("invalid base64");
 
         if (a != -1 && b != -1) {
             if (c == -1 && s == '=') {

--- a/spec/tags/ruby/library/base64/strict_decode64_tags.txt
+++ b/spec/tags/ruby/library/base64/strict_decode64_tags.txt
@@ -1,1 +1,0 @@
-fails:Base64#strict_decode64 returns the Base64-decoded version of the given shared string


### PR DESCRIPTION
it fails for shared strings if begin != 0
```
require 'base64'
url = "data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImFob3kuanMiXSwibmFtZXMiOlsiaGVsbG8iLCJ3b3JsZCJdLCJtYXBwaW5ncyI6IkFBQU0sU0FBU0EsUUFDUCxTQUFTQyxJQUNQLE9BQU8sRUFHVCxPQUFPQSxJQUFVQSIsInNvdXJjZXNDb250ZW50IjpbIiAgICAgIGZ1bmN0aW9uIGhlbGxvICgpIHtcbiAgICAgICAgZnVuY3Rpb24gd29ybGQgKCkge1xuICAgICAgICAgIHJldHVybiAyO1xuICAgICAgICB9O1xuXG4gICAgICAgIHJldHVybiB3b3JsZCgpICsgd29ybGQoKTtcbiAgICAgIH07XG4iXX0="

base = url.split(",").last
Base64.strict_decode64(base)
```

refs https://github.com/jruby/jruby/pull/5961