### PR TITLE
Make many fields on Ruby final.

### DIFF
--- a/core/src/main/java/org/jruby/AbstractRubyMethod.java
+++ b/core/src/main/java/org/jruby/AbstractRubyMethod.java
@@ -88,7 +88,7 @@ public abstract class AbstractRubyMethod extends RubyObject implements DataType 
 
     @JRubyMethod(name = "eql?", required = 1)
     public IRubyObject op_eql(ThreadContext context, IRubyObject other) {
-        return context.runtime.newBoolean( equals(other) );
+        return RubyBoolean.newBoolean(context,  equals(other) );
     }
 
     @Override

--- a/core/src/main/java/org/jruby/BasicObjectStub.java
+++ b/core/src/main/java/org/jruby/BasicObjectStub.java
@@ -296,11 +296,11 @@ public final class BasicObjectStub {
     }
 
     public static IRubyObject op_equal(IRubyObject self, ThreadContext context, IRubyObject other) {
-        return getRuntime(self).newBoolean(self == other);
+        return RubyBoolean.newBoolean(context, self == other);
     }
 
     public static IRubyObject op_eqq(IRubyObject self, ThreadContext context, IRubyObject other) {
-        return getRuntime(self).newBoolean(self == other);
+        return RubyBoolean.newBoolean(context, self == other);
     }
 
     public static boolean eql(IRubyObject self, IRubyObject other) {

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -60,7 +60,6 @@ import org.jruby.ext.thread.Mutex;
 import org.jruby.ext.thread.SizedQueue;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.IRScriptBody;
-import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.runtime.IRReturnJump;
 import org.jruby.javasupport.Java;
 import org.jruby.javasupport.JavaClass;
@@ -167,7 +166,6 @@ import org.jruby.util.ClassDefiningJRubyClassLoader;
 import org.jruby.util.KCode;
 import org.jruby.util.SafePropertyAccessor;
 import org.jruby.util.cli.Options;
-import org.jruby.util.collections.WeakHashSet;
 import org.jruby.util.func.Function1;
 import org.jruby.util.io.FilenoUtil;
 import org.jruby.util.io.SelectorPool;
@@ -199,7 +197,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.Stack;
 import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
@@ -321,6 +318,315 @@ public final class Ruby implements Constantizable {
         filenoUtil = new FilenoUtil(posix);
 
         reinitialize(false);
+
+        // Construct key services
+        loadService = this.config.createLoadService(this);
+        javaSupport = loadJavaSupport();
+
+        executor = new ThreadPoolExecutor(
+                RubyInstanceConfig.POOL_MIN,
+                RubyInstanceConfig.POOL_MAX,
+                RubyInstanceConfig.POOL_TTL,
+                TimeUnit.SECONDS,
+                new SynchronousQueue<Runnable>(),
+                new DaemonThreadFactory("Ruby-" + getRuntimeNumber() + "-Worker"));
+
+        fiberExecutor = new ThreadPoolExecutor(
+                0,
+                Integer.MAX_VALUE,
+                RubyInstanceConfig.FIBER_POOL_TTL,
+                TimeUnit.SECONDS,
+                new SynchronousQueue<Runnable>(),
+                new DaemonThreadFactory("Ruby-" + getRuntimeNumber() + "-Fiber"));
+
+        // initialize the root of the class hierarchy completely
+        // Bootstrap the top of the hierarchy
+        basicObjectClass = RubyClass.createBootstrapClass(this, "BasicObject", null, RubyBasicObject.BASICOBJECT_ALLOCATOR);
+        objectClass = RubyClass.createBootstrapClass(this, "Object", basicObjectClass, RubyObject.OBJECT_ALLOCATOR);
+        moduleClass = RubyClass.createBootstrapClass(this, "Module", objectClass, RubyModule.MODULE_ALLOCATOR);
+        classClass = RubyClass.createBootstrapClass(this, "Class", moduleClass, RubyClass.CLASS_ALLOCATOR);
+
+        basicObjectClass.setMetaClass(classClass);
+        objectClass.setMetaClass(basicObjectClass);
+        moduleClass.setMetaClass(classClass);
+        classClass.setMetaClass(classClass);
+
+        RubyClass metaClass;
+        metaClass = basicObjectClass.makeMetaClass(classClass);
+        metaClass = objectClass.makeMetaClass(metaClass);
+        metaClass = moduleClass.makeMetaClass(metaClass);
+        classClass.makeMetaClass(metaClass);
+
+        RubyBasicObject.createBasicObjectClass(this, basicObjectClass);
+        RubyObject.createObjectClass(this, objectClass);
+        RubyModule.createModuleClass(this, moduleClass);
+        RubyClass.createClassClass(this, classClass);
+
+        // set constants now that they're initialized
+        basicObjectClass.setConstant("BasicObject", basicObjectClass);
+        objectClass.setConstant("BasicObject", basicObjectClass);
+        objectClass.setConstant("Object", objectClass);
+        objectClass.setConstant("Class", classClass);
+        objectClass.setConstant("Module", moduleClass);
+
+        // Initialize Kernel and include into Object
+        RubyModule kernel = kernelModule = RubyKernel.createKernelModule(this);
+        objectClass.includeModule(kernelModule);
+
+        // In 1.9 and later, Kernel.gsub is defined only when '-p' or '-n' is given on the command line
+        if (this.config.getKernelGsubDefined()) {
+            kernel.addMethod("gsub", new JavaMethod(kernel, Visibility.PRIVATE, "gsub") {
+
+                @Override
+                public IRubyObject call(ThreadContext context1, IRubyObject self, RubyModule clazz, String name, IRubyObject[] args, Block block) {
+                    switch (args.length) {
+                        case 1:
+                            return RubyKernel.gsub(context1, self, args[0], block);
+                        case 2:
+                            return RubyKernel.gsub(context1, self, args[0], args[1], block);
+                        default:
+                            throw newArgumentError(String.format("wrong number of arguments %d for 1..2", args.length));
+                    }
+                }
+            });
+        }
+
+        // Object is ready, create top self
+        topSelf = TopSelfFactory.createTopSelf(this, false);
+
+        // Pre-create all the core classes potentially referenced during startup
+        nilClass = RubyNil.createNilClass(this);
+        falseClass = RubyBoolean.createFalseClass(this);
+        trueClass = RubyBoolean.createTrueClass(this);
+
+        nilObject = new RubyNil(this);
+        nilPrefilledArray = new IRubyObject[NIL_PREFILLED_ARRAY_SIZE];
+        for (int i=0; i<NIL_PREFILLED_ARRAY_SIZE; i++) nilPrefilledArray[i] = nilObject;
+        singleNilArray = new IRubyObject[] {nilObject};
+
+        falseObject = new RubyBoolean.False(this);
+        falseObject.setFrozen(true);
+        trueObject = new RubyBoolean.True(this);
+        trueObject.setFrozen(true);
+
+        reportOnException = trueObject;
+
+        // Set up the main thread in thread service
+        threadService.initMainThread();
+
+        // Get the main threadcontext (gets constructed for us)
+        final ThreadContext context = getCurrentContext();
+
+        // Construct the top-level execution frame and scope for the main thread
+        context.prepareTopLevel(objectClass, topSelf);
+
+        // Initialize all the core classes
+        RubyClass dataClass = null;
+        if (profile.allowClass("Data")) {
+            dataClass = defineClass("Data", objectClass, ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR);
+            getObject().deprecateConstant(this, "Data");
+        }
+        this.dataClass = dataClass;
+
+        comparableModule = RubyComparable.createComparable(this);
+        enumerableModule = RubyEnumerable.createEnumerableModule(this);
+        stringClass = RubyString.createStringClass(this);
+
+        encodingService = new EncodingService(this);
+
+        symbolClass = RubySymbol.createSymbolClass(this);
+
+        threadGroupClass = profile.allowClass("ThreadGroup") ? RubyThreadGroup.createThreadGroupClass(this) : null;
+        threadClass = profile.allowClass("Thread") ? RubyThread.createThreadClass(this) : null;
+        exceptionClass = profile.allowClass("Exception") ? RubyException.createExceptionClass(this) : null;
+        numericClass = profile.allowClass("Numeric") ? RubyNumeric.createNumericClass(this) : null;
+        integerClass = profile.allowClass("Integer") ? RubyInteger.createIntegerClass(this) : null;
+        fixnumClass = profile.allowClass("Fixnum") ? RubyFixnum.createFixnumClass(this) : null;
+
+        encodingClass = RubyEncoding.createEncodingClass(this);
+        converterClass = RubyConverter.createConverterClass(this);
+
+        encodingService.defineEncodings();
+        encodingService.defineAliases();
+
+        // External should always have a value, but Encoding.external_encoding{,=} will lazily setup
+        String encoding = this.config.getExternalEncoding();
+        if (encoding != null && !encoding.equals("")) {
+            Encoding loadedEncoding = encodingService.loadEncoding(ByteList.create(encoding));
+            if (loadedEncoding == null) throw new MainExitException(1, "unknown encoding name - " + encoding);
+            setDefaultExternalEncoding(loadedEncoding);
+        } else {
+            Encoding consoleEncoding = encodingService.getConsoleEncoding();
+            Encoding availableEncoding = consoleEncoding == null ? encodingService.getLocaleEncoding() : consoleEncoding;
+            setDefaultExternalEncoding(availableEncoding);
+        }
+
+        // Filesystem should always have a value
+        if (Platform.IS_WINDOWS) {
+            setDefaultFilesystemEncoding(encodingService.getWindowsFilesystemEncoding(this));
+        } else {
+            setDefaultFilesystemEncoding(getDefaultExternalEncoding());
+        }
+
+        encoding = this.config.getInternalEncoding();
+        if (encoding != null && !encoding.equals("")) {
+            Encoding loadedEncoding = encodingService.loadEncoding(ByteList.create(encoding));
+            if (loadedEncoding == null) throw new MainExitException(1, "unknown encoding name - " + encoding);
+            setDefaultInternalEncoding(loadedEncoding);
+        }
+
+        complexClass = profile.allowClass("Complex") ? RubyComplex.createComplexClass(this) : null;
+        rationalClass = profile.allowClass("Rational") ? RubyRational.createRationalClass(this) : null;
+        hashClass = profile.allowClass("Hash") ? RubyHash.createHashClass(this) : null;
+        if (profile.allowClass("Array")) {
+            arrayClass = RubyArray.createArrayClass(this);
+            emptyFrozenArray = newEmptyArray();
+            emptyFrozenArray.setFrozen(true);
+        } else {
+            arrayClass = null;
+            emptyFrozenArray = null;
+        }
+        floatClass = profile.allowClass("Float") ? RubyFloat.createFloatClass(this) : null;
+        if (profile.allowClass("Bignum")) {
+            bignumClass = RubyBignum.createBignumClass(this);
+            // RubyRandom depends on Bignum existence.
+            randomClass = RubyRandom.createRandomClass(this);
+        } else {
+            bignumClass = null;
+            randomClass = null;
+            defaultRand = null;
+        }
+        ioClass = RubyIO.createIOClass(this);
+
+        structClass = profile.allowClass("Struct") ? RubyStruct.createStructClass(this) : null;
+        bindingClass = profile.allowClass("Binding") ? RubyBinding.createBindingClass(this) : null;
+        // Math depends on all numeric types
+        mathModule = profile.allowModule("Math") ? RubyMath.createMathModule(this) : null;
+        regexpClass = profile.allowClass("Regexp") ? RubyRegexp.createRegexpClass(this) : null;
+        rangeClass = profile.allowClass("Range") ? RubyRange.createRangeClass(this) : null;
+        objectSpaceModule = profile.allowModule("ObjectSpace") ? RubyObjectSpace.createObjectSpaceModule(this) : null;
+        gcModule = profile.allowModule("GC") ? RubyGC.createGCModule(this) : null;
+        procClass = profile.allowClass("Proc") ? RubyProc.createProcClass(this) : null;
+        methodClass = profile.allowClass("Method") ? RubyMethod.createMethodClass(this) : null;
+        matchDataClass = profile.allowClass("MatchData") ? RubyMatchData.createMatchDataClass(this) : null;
+        marshalModule = profile.allowModule("Marshal") ? RubyMarshal.createMarshalModule(this) : null;
+        dirClass = profile.allowClass("Dir") ? RubyDir.createDirClass(this) : null;
+        fileTestModule = profile.allowModule("FileTest") ? RubyFileTest.createFileTestModule(this) : null;
+        // depends on IO, FileTest
+        fileClass = profile.allowClass("File") ? RubyFile.createFileClass(this) : null;
+        fileStatClass = profile.allowClass("File::Stat") ? RubyFileStat.createFileStatClass(this) : null;
+        processModule = profile.allowModule("Process") ? RubyProcess.createProcessModule(this) : null;
+        timeClass = profile.allowClass("Time") ? RubyTime.createTimeClass(this) : null;
+        unboundMethodClass = profile.allowClass("UnboundMethod") ? RubyUnboundMethod.defineUnboundMethodClass(this) : null;
+
+        if (profile.allowModule("Signal")) RubySignal.createSignal(this);
+
+        if (profile.allowClass("Enumerator")) {
+            enumeratorClass = RubyEnumerator.defineEnumerator(this, enumerableModule);
+            generatorClass = RubyGenerator.createGeneratorClass(this, enumeratorClass);
+            yielderClass = RubyYielder.createYielderClass(this);
+        } else {
+            enumeratorClass = null;
+            generatorClass = null;
+            yielderClass = null;
+        }
+
+        continuationClass = initContinuation();
+
+        TracePoint.createTracePointClass(this);
+
+        warningModule = RubyWarnings.createWarningModule(this);
+
+        // Initialize exceptions
+        initExceptions();
+        Mutex.setup(this);
+        ConditionVariable.setup(this);
+        org.jruby.ext.thread.Queue.setup(this);
+        SizedQueue.setup(this);
+
+        fiberClass = new ThreadFiberLibrary().createFiberClass(this);
+
+        // set up defined messages
+        initDefinedMessages();
+
+        // set up thread statuses
+        initThreadStatuses();
+
+        // Create an IR manager and a top-level IR scope and bind it to the top-level static-scope object
+        irManager = new IRManager(this, getInstanceConfig());
+        // FIXME: This registers itself into static scope as a side-effect.  Let's make this
+        // relationship handled either more directly or through a descriptive method
+        // FIXME: We need a failing test case for this since removing it did not regress tests
+        IRScope top = new IRScriptBody(irManager, "", context.getCurrentScope().getStaticScope());
+        top.allocateInterpreterContext(Collections.EMPTY_LIST);
+
+        // Initialize the "dummy" class used as a marker
+        dummyClass = new RubyClass(this, classClass);
+        dummyClass.setFrozen(true);
+
+        // Create global constants and variables
+        RubyGlobal.createGlobals(this);
+
+        // Prepare LoadService and load path
+        getLoadService().init(this.config.getLoadPaths());
+
+        // out of base boot mode
+        bootingCore = false;
+
+        // Don't load boot-time libraries when debugging IR
+        if (!RubyInstanceConfig.DEBUG_PARSER) {
+            // initialize Java support
+            initJavaSupport();
+
+            // init Ruby-based kernel
+            initRubyKernel();
+
+            // Define blank modules for feature detection in preludes
+            if (!this.config.isDisableGems()) {
+                defineModule("Gem");
+            }
+            if (!this.config.isDisableDidYouMean()) {
+                defineModule("DidYouMean");
+            }
+
+            // Provide some legacy libraries
+            loadService.provide("enumerator", "enumerator.rb");
+            loadService.provide("rational", "rational.rb");
+            loadService.provide("complex", "complex.rb");
+            loadService.provide("thread", "thread.rb");
+
+            // Load preludes
+            initRubyPreludes();
+        }
+
+        SecurityHelper.checkCryptoRestrictions(this);
+
+        // everything booted, so SizedQueue should be available; set up root fiber
+        ThreadFiber.initRootFiber(context, context.getThread());
+
+        if(this.config.isProfiling()) {
+            // additional twiddling for profiled mode
+            getLoadService().require("jruby/profiler/shutdown_hook");
+
+            // recache core methods, since they'll have profiling wrappers now
+            kernelModule.invalidateCacheDescendants(); // to avoid already-cached methods
+            RubyKernel.recacheBuiltinMethods(this, kernelModule);
+            RubyBasicObject.recacheBuiltinMethods(this);
+        }
+
+        if (this.config.getLoadGemfile()) {
+            loadBundler();
+        }
+
+        deprecatedNetworkStackProperty();
+
+        // Done booting JRuby runtime
+        bootingRuntime = false;
+
+        // Require in all libraries specified on command line
+        for (String scriptName : this.config.getRequiredLibraries()) {
+            topSelf.callMethod(context, "require", RubyString.newString(this, scriptName));
+        }
     }
 
     public void registerMBeans() {
@@ -368,8 +674,9 @@ public final class Ruby implements Constantizable {
      */
     public static Ruby newInstance(RubyInstanceConfig config) {
         Ruby ruby = new Ruby(config);
-        ruby.init();
+
         setGlobalRuntimeFirstTimeOnly(ruby);
+
         return ruby;
     }
 
@@ -1193,131 +1500,6 @@ public final class Ruby implements Constantizable {
         return getModule(name) != null;
     }
 
-    /**
-     * This method is called immediately after constructing the Ruby instance.
-     * The main thread is prepared for execution, all core classes and libraries
-     * are initialized, and any libraries required on the command line are
-     * loaded.
-     */
-    private void init() {
-        // Construct key services
-        loadService = config.createLoadService(this);
-        javaSupport = loadJavaSupport();
-
-        executor = new ThreadPoolExecutor(
-                RubyInstanceConfig.POOL_MIN,
-                RubyInstanceConfig.POOL_MAX,
-                RubyInstanceConfig.POOL_TTL,
-                TimeUnit.SECONDS,
-                new SynchronousQueue<Runnable>(),
-                new DaemonThreadFactory("Ruby-" + getRuntimeNumber() + "-Worker"));
-
-        fiberExecutor = new ThreadPoolExecutor(
-                0,
-                Integer.MAX_VALUE,
-                RubyInstanceConfig.FIBER_POOL_TTL,
-                TimeUnit.SECONDS,
-                new SynchronousQueue<Runnable>(),
-                new DaemonThreadFactory("Ruby-" + getRuntimeNumber() + "-Fiber"));
-
-        // initialize the root of the class hierarchy completely
-        initRoot();
-
-        // Set up the main thread in thread service
-        threadService.initMainThread();
-
-        // Get the main threadcontext (gets constructed for us)
-        final ThreadContext context = getCurrentContext();
-
-        // Construct the top-level execution frame and scope for the main thread
-        context.prepareTopLevel(objectClass, topSelf);
-
-        // Initialize all the core classes
-        bootstrap();
-
-        // set up defined messages
-        initDefinedMessages();
-
-        // set up thread statuses
-        initThreadStatuses();
-
-        // Create an IR manager and a top-level IR scope and bind it to the top-level static-scope object
-        irManager = new IRManager(this, getInstanceConfig());
-        // FIXME: This registers itself into static scope as a side-effect.  Let's make this
-        // relationship handled either more directly or through a descriptive method
-        // FIXME: We need a failing test case for this since removing it did not regress tests
-        IRScope top = new IRScriptBody(irManager, "", context.getCurrentScope().getStaticScope());
-        top.allocateInterpreterContext(Collections.EMPTY_LIST);
-
-        // Initialize the "dummy" class used as a marker
-        dummyClass = new RubyClass(this, classClass);
-        dummyClass.setFrozen(true);
-
-        // Create global constants and variables
-        RubyGlobal.createGlobals(this);
-
-        // Prepare LoadService and load path
-        getLoadService().init(config.getLoadPaths());
-
-        // out of base boot mode
-        bootingCore = false;
-
-        // Don't load boot-time libraries when debugging IR
-        if (!RubyInstanceConfig.DEBUG_PARSER) {
-            // initialize Java support
-            initJavaSupport();
-
-            // init Ruby-based kernel
-            initRubyKernel();
-
-            // Define blank modules for feature detection in preludes
-            if (!config.isDisableGems()) {
-                defineModule("Gem");
-            }
-            if (!config.isDisableDidYouMean()) {
-                defineModule("DidYouMean");
-            }
-
-            // Provide some legacy libraries
-            loadService.provide("enumerator", "enumerator.rb");
-            loadService.provide("rational", "rational.rb");
-            loadService.provide("complex", "complex.rb");
-            loadService.provide("thread", "thread.rb");
-
-            // Load preludes
-            initRubyPreludes();
-        }
-
-        SecurityHelper.checkCryptoRestrictions(this);
-
-        // everything booted, so SizedQueue should be available; set up root fiber
-        ThreadFiber.initRootFiber(context, context.getThread());
-
-        if(config.isProfiling()) {
-            // additional twiddling for profiled mode
-            getLoadService().require("jruby/profiler/shutdown_hook");
-
-            // recache core methods, since they'll have profiling wrappers now
-            kernelModule.invalidateCacheDescendants(); // to avoid already-cached methods
-            RubyKernel.recacheBuiltinMethods(this);
-            RubyBasicObject.recacheBuiltinMethods(this);
-        }
-
-        if (config.getLoadGemfile()) {
-            loadBundler();
-        }
-
-        deprecatedNetworkStackProperty();
-
-        // Done booting JRuby runtime
-        bootingRuntime = false;
-
-        // Require in all libraries specified on command line
-        for (String scriptName : config.getRequiredLibraries()) {
-            topSelf.callMethod(context, "require", RubyString.newString(this, scriptName));
-        }
-    }
-
     public JavaSupport loadJavaSupport() {
         return new JavaSupportImpl(this);
     }
@@ -1333,12 +1515,6 @@ public final class Ruby implements Constantizable {
         } catch (Exception e) {
             return false;
         }
-    }
-
-    private void bootstrap() {
-        initCore();
-        initExceptions();
-        initLibraries();
     }
 
     private void initDefinedMessages() {
@@ -1357,253 +1533,20 @@ public final class Ruby implements Constantizable {
         }
     }
 
-    private void initRoot() {
-        // Bootstrap the top of the hierarchy
-        basicObjectClass = RubyClass.createBootstrapClass(this, "BasicObject", null, RubyBasicObject.BASICOBJECT_ALLOCATOR);
-        objectClass = RubyClass.createBootstrapClass(this, "Object", basicObjectClass, RubyObject.OBJECT_ALLOCATOR);
-        moduleClass = RubyClass.createBootstrapClass(this, "Module", objectClass, RubyModule.MODULE_ALLOCATOR);
-        classClass = RubyClass.createBootstrapClass(this, "Class", moduleClass, RubyClass.CLASS_ALLOCATOR);
-
-        basicObjectClass.setMetaClass(classClass);
-        objectClass.setMetaClass(basicObjectClass);
-        moduleClass.setMetaClass(classClass);
-        classClass.setMetaClass(classClass);
-
-        RubyClass metaClass;
-        metaClass = basicObjectClass.makeMetaClass(classClass);
-        metaClass = objectClass.makeMetaClass(metaClass);
-        metaClass = moduleClass.makeMetaClass(metaClass);
-        metaClass = classClass.makeMetaClass(metaClass);
-
-        RubyBasicObject.createBasicObjectClass(this, basicObjectClass);
-        RubyObject.createObjectClass(this, objectClass);
-        RubyModule.createModuleClass(this, moduleClass);
-        RubyClass.createClassClass(this, classClass);
-
-        // set constants now that they're initialized
-        basicObjectClass.setConstant("BasicObject", basicObjectClass);
-        objectClass.setConstant("BasicObject", basicObjectClass);
-        objectClass.setConstant("Object", objectClass);
-        objectClass.setConstant("Class", classClass);
-        objectClass.setConstant("Module", moduleClass);
-
-        // Initialize Kernel and include into Object
-        RubyModule kernel = RubyKernel.createKernelModule(this);
-        objectClass.includeModule(kernelModule);
-
-        // In 1.9 and later, Kernel.gsub is defined only when '-p' or '-n' is given on the command line
-        if (config.getKernelGsubDefined()) {
-            kernel.addMethod("gsub", new JavaMethod(kernel, Visibility.PRIVATE, "gsub") {
-
-                @Override
-                public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject[] args, Block block) {
-                    switch (args.length) {
-                        case 1:
-                            return RubyKernel.gsub(context, self, args[0], block);
-                        case 2:
-                            return RubyKernel.gsub(context, self, args[0], args[1], block);
-                        default:
-                            throw newArgumentError(String.format("wrong number of arguments %d for 1..2", args.length));
-                    }
-                }
-            });
-        }
-
-        // Object is ready, create top self
-        topSelf = TopSelfFactory.createTopSelf(this, false);
-
-        // Pre-create all the core classes potentially referenced during startup
-        RubyNil.createNilClass(this);
-        RubyBoolean.createFalseClass(this);
-        RubyBoolean.createTrueClass(this);
-
-        nilObject = new RubyNil(this);
-        for (int i=0; i<NIL_PREFILLED_ARRAY_SIZE; i++) nilPrefilledArray[i] = nilObject;
-        singleNilArray = new IRubyObject[] {nilObject};
-
-        falseObject = new RubyBoolean.False(this);
-        falseObject.setFrozen(true);
-        trueObject = new RubyBoolean.True(this);
-        trueObject.setFrozen(true);
-
-        reportOnException = trueObject;
-    }
-
-    private void initCore() {
-        if (profile.allowClass("Data")) {
-            dataClass = defineClass("Data", objectClass, ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR);
-            getObject().deprecateConstant(this, "Data");
-        }
-
-        RubyComparable.createComparable(this);
-        RubyEnumerable.createEnumerableModule(this);
-        RubyString.createStringClass(this);
-
-        encodingService = new EncodingService(this);
-
-        RubySymbol.createSymbolClass(this);
-
-        if (profile.allowClass("ThreadGroup")) {
-            RubyThreadGroup.createThreadGroupClass(this);
-        }
-        if (profile.allowClass("Thread")) {
-            RubyThread.createThreadClass(this);
-        }
-        if (profile.allowClass("Exception")) {
-            RubyException.createExceptionClass(this);
-        }
-
-        if (profile.allowClass("Numeric")) {
-            RubyNumeric.createNumericClass(this);
-        }
-        if (profile.allowClass("Integer")) {
-            RubyInteger.createIntegerClass(this);
-        }
-        if (profile.allowClass("Fixnum")) {
-            RubyFixnum.createFixnumClass(this);
-        }
-
-        RubyEncoding.createEncodingClass(this);
-        RubyConverter.createConverterClass(this);
-
-        encodingService.defineEncodings();
-        encodingService.defineAliases();
-
-        // External should always have a value, but Encoding.external_encoding{,=} will lazily setup
-        String encoding = config.getExternalEncoding();
-        if (encoding != null && !encoding.equals("")) {
-            Encoding loadedEncoding = encodingService.loadEncoding(ByteList.create(encoding));
-            if (loadedEncoding == null) throw new MainExitException(1, "unknown encoding name - " + encoding);
-            setDefaultExternalEncoding(loadedEncoding);
-        } else {
-            Encoding consoleEncoding = encodingService.getConsoleEncoding();
-            Encoding availableEncoding = consoleEncoding == null ? encodingService.getLocaleEncoding() : consoleEncoding;
-            setDefaultExternalEncoding(availableEncoding);
-        }
-
-        // Filesystem should always have a value
-        if (Platform.IS_WINDOWS) {
-            setDefaultFilesystemEncoding(encodingService.getWindowsFilesystemEncoding(this));
-        } else {
-            setDefaultFilesystemEncoding(getDefaultExternalEncoding());
-        }
-
-        encoding = config.getInternalEncoding();
-        if (encoding != null && !encoding.equals("")) {
-            Encoding loadedEncoding = encodingService.loadEncoding(ByteList.create(encoding));
-            if (loadedEncoding == null) throw new MainExitException(1, "unknown encoding name - " + encoding);
-            setDefaultInternalEncoding(loadedEncoding);
-        }
-
-        if (profile.allowClass("Complex")) {
-            RubyComplex.createComplexClass(this);
-        }
-        if (profile.allowClass("Rational")) {
-            RubyRational.createRationalClass(this);
-        }
-
-        if (profile.allowClass("Hash")) {
-            RubyHash.createHashClass(this);
-        }
-        if (profile.allowClass("Array")) {
-            RubyArray.createArrayClass(this);
-            emptyFrozenArray = newEmptyArray();
-            emptyFrozenArray.setFrozen(true);
-        }
-        if (profile.allowClass("Float")) {
-            RubyFloat.createFloatClass(this);
-        }
-        if (profile.allowClass("Bignum")) {
-            RubyBignum.createBignumClass(this);
-            // RubyRandom depends on Bignum existence.
-            RubyRandom.createRandomClass(this);
-        }
-        ioClass = RubyIO.createIOClass(this);
-
-        if (profile.allowClass("Struct")) {
-            RubyStruct.createStructClass(this);
-        }
-
-        if (profile.allowClass("Binding")) {
-            RubyBinding.createBindingClass(this);
-        }
-        // Math depends on all numeric types
-        if (profile.allowModule("Math")) {
-            RubyMath.createMathModule(this);
-        }
-        if (profile.allowClass("Regexp")) {
-            RubyRegexp.createRegexpClass(this);
-        }
-        if (profile.allowClass("Range")) {
-            RubyRange.createRangeClass(this);
-        }
-        if (profile.allowModule("ObjectSpace")) {
-            RubyObjectSpace.createObjectSpaceModule(this);
-        }
-        if (profile.allowModule("GC")) {
-            RubyGC.createGCModule(this);
-        }
-        if (profile.allowClass("Proc")) {
-            RubyProc.createProcClass(this);
-        }
-        if (profile.allowClass("Method")) {
-            RubyMethod.createMethodClass(this);
-        }
-        if (profile.allowClass("MatchData")) {
-            RubyMatchData.createMatchDataClass(this);
-        }
-        if (profile.allowModule("Marshal")) {
-            RubyMarshal.createMarshalModule(this);
-        }
-        if (profile.allowClass("Dir")) {
-            RubyDir.createDirClass(this);
-        }
-        if (profile.allowModule("FileTest")) {
-            RubyFileTest.createFileTestModule(this);
-        }
-        // depends on IO, FileTest
-        if (profile.allowClass("File")) {
-            RubyFile.createFileClass(this);
-        }
-        if (profile.allowClass("File::Stat")) {
-            RubyFileStat.createFileStatClass(this);
-        }
-        if (profile.allowModule("Process")) {
-            RubyProcess.createProcessModule(this);
-        }
-        if (profile.allowClass("Time")) {
-            RubyTime.createTimeClass(this);
-        }
-        if (profile.allowClass("UnboundMethod")) {
-            RubyUnboundMethod.defineUnboundMethodClass(this);
-        }
-        if (profile.allowModule("Signal")) {
-            RubySignal.createSignal(this);
-        }
-
-        if (profile.allowClass("Enumerator")) {
-            RubyEnumerator.defineEnumerator(this);
-        }
-
-        initContinuation();
-
-        TracePoint.createTracePointClass(this);
-
-        RubyWarnings.createWarningModule(this);
-    }
-
     @SuppressWarnings("deprecation")
-    private void initContinuation() {
+    private RubyClass initContinuation() {
         // Bare-bones class for backward compatibility
         if (profile.allowClass("Continuation")) {
             // Some third-party code (racc's cparse ext, at least) uses RubyContinuation directly, so we need this.
             // Most functionality lives in continuation.rb now.
-            RubyContinuation.createContinuation(this);
+            return RubyContinuation.createContinuation(this);
         }
+        return null;
     }
 
     public static final int NIL_PREFILLED_ARRAY_SIZE = RubyArray.ARRAY_DEFAULT_SIZE * 8;
-    private final IRubyObject nilPrefilledArray[] = new IRubyObject[NIL_PREFILLED_ARRAY_SIZE];
+    private final IRubyObject nilPrefilledArray[];
+
     public IRubyObject[] getNilPrefilledArray() {
         return nilPrefilledArray;
     }
@@ -1673,14 +1616,6 @@ public final class Ruby implements Constantizable {
         if (profile.allowClass("NativeException")) {
             nativeException = NativeException.createClass(this, runtimeError);
         }
-    }
-
-    private void initLibraries() {
-        Mutex.setup(this);
-        ConditionVariable.setup(this);
-        org.jruby.ext.thread.Queue.setup(this);
-        SizedQueue.setup(this);
-        new ThreadFiberLibrary().load(this, false);
     }
 
     private final Map<Integer, RubyClass> errnos = new HashMap<>();
@@ -1844,8 +1779,8 @@ public final class Ruby implements Constantizable {
     public RubyModule getKernel() {
         return kernelModule;
     }
+    @Deprecated
     void setKernel(RubyModule kernelModule) {
-        this.kernelModule = kernelModule;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1930,134 +1865,134 @@ public final class Ruby implements Constantizable {
     public RubyModule getComparable() {
         return comparableModule;
     }
+    @Deprecated
     void setComparable(RubyModule comparableModule) {
-        this.comparableModule = comparableModule;
     }
 
     public RubyClass getNumeric() {
         return numericClass;
     }
+    @Deprecated
     void setNumeric(RubyClass numericClass) {
-        this.numericClass = numericClass;
     }
 
     public RubyClass getFloat() {
         return floatClass;
     }
+    @Deprecated
     void setFloat(RubyClass floatClass) {
-        this.floatClass = floatClass;
     }
 
     public RubyClass getInteger() {
         return integerClass;
     }
+    @Deprecated
     void setInteger(RubyClass integerClass) {
-        this.integerClass = integerClass;
     }
 
     public RubyClass getFixnum() {
         return fixnumClass;
     }
+    @Deprecated
     void setFixnum(RubyClass fixnumClass) {
-        this.fixnumClass = fixnumClass;
     }
 
     public RubyClass getComplex() {
         return complexClass;
     }
+    @Deprecated
     void setComplex(RubyClass complexClass) {
-        this.complexClass = complexClass;
     }
 
     public RubyClass getRational() {
         return rationalClass;
     }
+    @Deprecated
     void setRational(RubyClass rationalClass) {
-        this.rationalClass = rationalClass;
     }
 
     public RubyModule getEnumerable() {
         return enumerableModule;
     }
+    @Deprecated
     void setEnumerable(RubyModule enumerableModule) {
-        this.enumerableModule = enumerableModule;
     }
 
     public RubyClass getEnumerator() {
         return enumeratorClass;
     }
+    @Deprecated
     void setEnumerator(RubyClass enumeratorClass) {
-        this.enumeratorClass = enumeratorClass;
     }
 
     public RubyClass getYielder() {
         return yielderClass;
     }
+    @Deprecated
     void setYielder(RubyClass yielderClass) {
-        this.yielderClass = yielderClass;
     }
 
     public RubyClass getGenerator() {
         return generatorClass;
     }
+    @Deprecated
     public void setGenerator(RubyClass generatorClass) {
-        this.generatorClass = generatorClass;
     }
 
     public RubyClass getFiber() {
         return fiberClass;
     }
+    @Deprecated
     public void setFiber(RubyClass fiberClass) {
-        this.fiberClass = fiberClass;
     }
 
     public RubyClass getString() {
         return stringClass;
     }
+    @Deprecated
     void setString(RubyClass stringClass) {
-        this.stringClass = stringClass;
     }
 
     public RubyClass getEncoding() {
         return encodingClass;
     }
+    @Deprecated
     void setEncoding(RubyClass encodingClass) {
-        this.encodingClass = encodingClass;
     }
 
     public RubyClass getConverter() {
         return converterClass;
     }
+    @Deprecated
     void setConverter(RubyClass converterClass) {
-        this.converterClass = converterClass;
     }
 
     public RubyClass getSymbol() {
         return symbolClass;
     }
+    @Deprecated
     void setSymbol(RubyClass symbolClass) {
-        this.symbolClass = symbolClass;
     }
 
     public RubyClass getArray() {
         return arrayClass;
     }
+    @Deprecated
     void setArray(RubyClass arrayClass) {
-        this.arrayClass = arrayClass;
     }
 
     public RubyClass getHash() {
         return hashClass;
     }
+    @Deprecated
     void setHash(RubyClass hashClass) {
-        this.hashClass = hashClass;
     }
 
     public RubyClass getRange() {
         return rangeClass;
     }
+    @Deprecated
     void setRange(RubyClass rangeClass) {
-        this.rangeClass = rangeClass;
     }
 
     /** Returns the "true" instance from the instance pool.
@@ -2088,141 +2023,141 @@ public final class Ruby implements Constantizable {
     public RubyClass getNilClass() {
         return nilClass;
     }
+    @Deprecated
     void setNilClass(RubyClass nilClass) {
-        this.nilClass = nilClass;
     }
 
     public RubyClass getTrueClass() {
         return trueClass;
     }
+    @Deprecated
     void setTrueClass(RubyClass trueClass) {
-        this.trueClass = trueClass;
     }
 
     public RubyClass getFalseClass() {
         return falseClass;
     }
+    @Deprecated
     void setFalseClass(RubyClass falseClass) {
-        this.falseClass = falseClass;
     }
 
     public RubyClass getProc() {
         return procClass;
     }
+    @Deprecated
     void setProc(RubyClass procClass) {
-        this.procClass = procClass;
     }
 
     public RubyClass getBinding() {
         return bindingClass;
     }
+    @Deprecated
     void setBinding(RubyClass bindingClass) {
-        this.bindingClass = bindingClass;
     }
 
     public RubyClass getMethod() {
         return methodClass;
     }
+    @Deprecated
     void setMethod(RubyClass methodClass) {
-        this.methodClass = methodClass;
     }
 
     public RubyClass getUnboundMethod() {
         return unboundMethodClass;
     }
+    @Deprecated
     void setUnboundMethod(RubyClass unboundMethodClass) {
-        this.unboundMethodClass = unboundMethodClass;
     }
 
     public RubyClass getMatchData() {
         return matchDataClass;
     }
+    @Deprecated
     void setMatchData(RubyClass matchDataClass) {
-        this.matchDataClass = matchDataClass;
     }
 
     public RubyClass getRegexp() {
         return regexpClass;
     }
+    @Deprecated
     void setRegexp(RubyClass regexpClass) {
-        this.regexpClass = regexpClass;
     }
 
     public RubyClass getTime() {
         return timeClass;
     }
+    @Deprecated
     void setTime(RubyClass timeClass) {
-        this.timeClass = timeClass;
     }
 
     public RubyModule getMath() {
         return mathModule;
     }
+    @Deprecated
     void setMath(RubyModule mathModule) {
-        this.mathModule = mathModule;
     }
 
     public RubyModule getMarshal() {
         return marshalModule;
     }
+    @Deprecated
     void setMarshal(RubyModule marshalModule) {
-        this.marshalModule = marshalModule;
     }
 
     public RubyClass getBignum() {
         return bignumClass;
     }
+    @Deprecated
     void setBignum(RubyClass bignumClass) {
-        this.bignumClass = bignumClass;
     }
 
     public RubyClass getDir() {
         return dirClass;
     }
+    @Deprecated
     void setDir(RubyClass dirClass) {
-        this.dirClass = dirClass;
     }
 
     public RubyClass getFile() {
         return fileClass;
     }
+    @Deprecated
     void setFile(RubyClass fileClass) {
-        this.fileClass = fileClass;
     }
 
     public RubyClass getFileStat() {
         return fileStatClass;
     }
+    @Deprecated
     void setFileStat(RubyClass fileStatClass) {
-        this.fileStatClass = fileStatClass;
     }
 
     public RubyModule getFileTest() {
         return fileTestModule;
     }
+    @Deprecated
     void setFileTest(RubyModule fileTestModule) {
-        this.fileTestModule = fileTestModule;
     }
 
     public RubyClass getIO() {
         return ioClass;
     }
+    @Deprecated
     void setIO(RubyClass ioClass) {
-        this.ioClass = ioClass;
     }
 
     public RubyClass getThread() {
         return threadClass;
     }
+    @Deprecated
     void setThread(RubyClass threadClass) {
-        this.threadClass = threadClass;
     }
 
     public RubyClass getThreadGroup() {
         return threadGroupClass;
     }
+    @Deprecated
     void setThreadGroup(RubyClass threadGroupClass) {
-        this.threadGroupClass = threadGroupClass;
     }
 
     public RubyThreadGroup getDefaultThreadGroup() {
@@ -2235,22 +2170,22 @@ public final class Ruby implements Constantizable {
     public RubyClass getContinuation() {
         return continuationClass;
     }
+    @Deprecated
     void setContinuation(RubyClass continuationClass) {
-        this.continuationClass = continuationClass;
     }
 
     public RubyClass getStructClass() {
         return structClass;
     }
+    @Deprecated
     void setStructClass(RubyClass structClass) {
-        this.structClass = structClass;
     }
 
     public RubyClass getRandomClass() {
         return randomClass;
     }
+    @Deprecated
     void setRandomClass(RubyClass randomClass) {
-        this.randomClass = randomClass;
     }
 
     public IRubyObject getTmsStruct() {
@@ -2277,22 +2212,22 @@ public final class Ruby implements Constantizable {
     public RubyModule getGC() {
         return gcModule;
     }
+    @Deprecated
     void setGC(RubyModule gcModule) {
-        this.gcModule = gcModule;
     }
 
     public RubyModule getObjectSpaceModule() {
         return objectSpaceModule;
     }
+    @Deprecated
     void setObjectSpaceModule(RubyModule objectSpaceModule) {
-        this.objectSpaceModule = objectSpaceModule;
     }
 
     public RubyModule getProcess() {
         return processModule;
     }
+    @Deprecated
     void setProcess(RubyModule processModule) {
-        this.processModule = processModule;
     }
 
     public RubyClass getProcStatus() {
@@ -2350,8 +2285,8 @@ public final class Ruby implements Constantizable {
         return warningModule;
     }
 
+    @Deprecated
     public void setWarning(RubyModule warningModule) {
-        this.warningModule = warningModule;
     }
 
     public RubyModule getErrno() {
@@ -2361,8 +2296,8 @@ public final class Ruby implements Constantizable {
     public RubyClass getException() {
         return exceptionClass;
     }
+    @Deprecated
     void setException(RubyClass exceptionClass) {
-        this.exceptionClass = exceptionClass;
     }
 
     public RubyClass getNameError() {
@@ -2538,9 +2473,6 @@ public final class Ruby implements Constantizable {
         return defaultRand;
     }
 
-    /**
-     * @deprecated internal API, to be hidden
-     */
     public void setDefaultRand(RubyRandom.RandomType defaultRand) {
         this.defaultRand = defaultRand;
     }
@@ -5096,12 +5028,12 @@ public final class Ruby implements Constantizable {
     private long globalState = 1;
 
     // Default objects
-    private IRubyObject topSelf;
+    private final IRubyObject topSelf;
     private IRubyObject rootFiber;
-    private RubyNil nilObject;
-    private IRubyObject[] singleNilArray;
-    private RubyBoolean trueObject;
-    private RubyBoolean falseObject;
+    private final RubyNil nilObject;
+    private final IRubyObject[] singleNilArray;
+    private final RubyBoolean trueObject;
+    private final RubyBoolean falseObject;
     final RubyFixnum[] fixnumCache = new RubyFixnum[2 * RubyFixnum.CACHE_OFFSET];
     final Object[] fixnumConstants = new Object[fixnumCache.length];
 
@@ -5116,33 +5048,119 @@ public final class Ruby implements Constantizable {
      * creating strings and arrays internally. They also provide much faster
      * access than going through normal hash lookup on the Object class.
      */
-    private RubyClass
-           basicObjectClass, objectClass, moduleClass, classClass, nilClass, trueClass,
-            falseClass, numericClass, floatClass, integerClass, fixnumClass,
-            complexClass, rationalClass, enumeratorClass, yielderClass, fiberClass, generatorClass,
-            arrayClass, hashClass, rangeClass, stringClass, encodingClass, converterClass, symbolClass,
-            procClass, bindingClass, methodClass, unboundMethodClass,
-            matchDataClass, regexpClass, timeClass, bignumClass, dirClass,
-            fileClass, fileStatClass, ioClass, threadClass, threadGroupClass,
-            continuationClass, structClass, tmsStruct, passwdStruct,
-            groupStruct, procStatusClass, exceptionClass, runtimeError, frozenError, ioError,
-            scriptError, nameError, nameErrorMessage, noMethodError, signalException,
-            rangeError, dummyClass, systemExit, localJumpError, nativeException,
-            systemCallError, fatal, interrupt, typeError, argumentError, uncaughtThrowError, indexError, stopIteration,
-            syntaxError, standardError, loadError, notImplementedError, securityError, noMemoryError,
-            regexpError, eofError, threadError, concurrencyError, systemStackError, zeroDivisionError, floatDomainError, mathDomainError,
-            encodingError, encodingCompatibilityError, converterNotFoundError, undefinedConversionError,
-            invalidByteSequenceError, fiberError, randomClass, keyError, locationClass, interruptedRegexpError, dataClass;
+    private final RubyClass basicObjectClass;
+    private final RubyClass objectClass;
+    private final RubyClass moduleClass;
+    private final RubyClass classClass;
+    private final RubyClass nilClass;
+    private final RubyClass trueClass;
+    private final RubyClass falseClass;
+    private final RubyClass numericClass;
+    private final RubyClass floatClass;
+    private final RubyClass integerClass;
+    private final RubyClass fixnumClass;
+    private final RubyClass complexClass;
+    private final RubyClass rationalClass;
+    private final RubyClass enumeratorClass;
+    private final RubyClass yielderClass;
+    private final RubyClass fiberClass;
+    private final RubyClass generatorClass;
+    private final RubyClass arrayClass;
+    private final RubyClass hashClass;
+    private final RubyClass rangeClass;
+    private final RubyClass stringClass;
+    private final RubyClass encodingClass;
+    private final RubyClass converterClass;
+    private final RubyClass symbolClass;
+    private final RubyClass procClass;
+    private final RubyClass bindingClass;
+    private final RubyClass methodClass;
+    private final RubyClass unboundMethodClass;
+    private final RubyClass matchDataClass;
+    private final RubyClass regexpClass;
+    private final RubyClass timeClass;
+    private final RubyClass bignumClass;
+    private final RubyClass dirClass;
+    private final RubyClass fileClass;
+    private final RubyClass fileStatClass;
+    private final RubyClass ioClass;
+    private final RubyClass threadClass;
+    private final RubyClass threadGroupClass;
+    private final RubyClass continuationClass;
+    private final RubyClass structClass;
+    private final RubyClass exceptionClass;
+    private final RubyClass dummyClass;
+    private final RubyClass randomClass;
+    private final RubyClass dataClass;
+
+    private RubyClass tmsStruct;
+    private RubyClass passwdStruct;
+    private RubyClass groupStruct;
+    private RubyClass procStatusClass;
+    private RubyClass runtimeError;
+    private RubyClass frozenError;
+    private RubyClass ioError;
+    private RubyClass scriptError;
+    private RubyClass nameError;
+    private RubyClass nameErrorMessage;
+    private RubyClass noMethodError;
+    private RubyClass signalException;
+    private RubyClass rangeError;
+    private RubyClass systemExit;
+    private RubyClass localJumpError;
+    private RubyClass nativeException;
+    private RubyClass systemCallError;
+    private RubyClass fatal;
+    private RubyClass interrupt;
+    private RubyClass typeError;
+    private RubyClass argumentError;
+    private RubyClass uncaughtThrowError;
+    private RubyClass indexError;
+    private RubyClass stopIteration;
+    private RubyClass syntaxError;
+    private RubyClass standardError;
+    private RubyClass loadError;
+    private RubyClass notImplementedError;
+    private RubyClass securityError;
+    private RubyClass noMemoryError;
+    private RubyClass regexpError;
+    private RubyClass eofError;
+    private RubyClass threadError;
+    private RubyClass concurrencyError;
+    private RubyClass systemStackError;
+    private RubyClass zeroDivisionError;
+    private RubyClass floatDomainError;
+    private RubyClass mathDomainError;
+    private RubyClass encodingError;
+    private RubyClass encodingCompatibilityError;
+    private RubyClass converterNotFoundError;
+    private RubyClass undefinedConversionError;
+    private RubyClass invalidByteSequenceError;
+    private RubyClass fiberError;
+    private RubyClass keyError;
+    private RubyClass locationClass;
+    private RubyClass interruptedRegexpError;
 
     /**
      * All the core modules we keep direct references to, for quick access and
      * to ensure they remain available.
      */
-    private RubyModule
-            kernelModule, comparableModule, enumerableModule, mathModule,
-            marshalModule, etcModule, fileTestModule, gcModule,
-            objectSpaceModule, processModule, procUIDModule, procGIDModule,
-            procSysModule, precisionModule, errnoModule, warningModule;
+    private final RubyModule kernelModule;
+    private final RubyModule comparableModule;
+    private final RubyModule enumerableModule;
+    private final RubyModule mathModule;
+    private final RubyModule marshalModule;
+    private RubyModule etcModule;
+    private final RubyModule fileTestModule;
+    private final RubyModule gcModule;
+    private final RubyModule objectSpaceModule;
+    private final RubyModule processModule;
+    private RubyModule procUIDModule;
+    private RubyModule procGIDModule;
+    private RubyModule procSysModule;
+    private RubyModule precisionModule;
+    private RubyModule errnoModule;
+    private final RubyModule warningModule;
 
     private DynamicMethod privateMethodMissing, protectedMethodMissing, variableMethodMissing,
             superMethodMissing, normalMethodMissing, defaultMethodMissing, defaultModuleMethodMissing,
@@ -5205,10 +5223,10 @@ public final class Ruby implements Constantizable {
 
     private final Parser parser = new Parser(this);
 
-    private LoadService loadService;
+    private final LoadService loadService;
 
     private Encoding defaultInternalEncoding, defaultExternalEncoding, defaultFilesystemEncoding;
-    private EncodingService encodingService;
+    private final EncodingService encodingService;
 
     private GlobalVariables globalVariables = new GlobalVariables(this);
     private final RubyWarnings warnings = new RubyWarnings(this);
@@ -5256,10 +5274,10 @@ public final class Ruby implements Constantizable {
     private final Object internalFinalizersMutex = new Object();
 
     // A thread pool to use for executing this runtime's Ruby threads
-    private ExecutorService executor;
+    private final ExecutorService executor;
 
     // A thread pool to use for running fibers
-    private ExecutorService fiberExecutor;
+    private final ExecutorService fiberExecutor;
 
     // A global object lock for class hierarchy mutations
     private final Object hierarchyLock = new Object();
@@ -5324,7 +5342,7 @@ public final class Ruby implements Constantizable {
 
     private StaticScopeFactory staticScopeFactory;
 
-    private IRManager irManager;
+    private final IRManager irManager;
 
     private FFI ffi;
 
@@ -5359,7 +5377,7 @@ public final class Ruby implements Constantizable {
         objectSpacer.addToObjectSpace(this, useObjectSpace, object);
     }
 
-    private RubyArray emptyFrozenArray;
+    private final RubyArray emptyFrozenArray;
 
     /**
      * A map from Ruby string data to a pre-frozen global version of that string.

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1758,16 +1758,6 @@ public final class Ruby implements Constantizable {
         return topSelf;
     }
 
-    @Deprecated
-    public IRubyObject getRootFiber() {
-        return rootFiber;
-    }
-
-    @Deprecated
-    public void setRootFiber(IRubyObject fiber) {
-        rootFiber = fiber;
-    }
-
     public void setCurrentDirectory(String dir) {
         currentDirectory = dir;
     }
@@ -1818,9 +1808,6 @@ public final class Ruby implements Constantizable {
 
     public RubyModule getKernel() {
         return kernelModule;
-    }
-    @Deprecated
-    void setKernel(RubyModule kernelModule) {
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1905,134 +1892,77 @@ public final class Ruby implements Constantizable {
     public RubyModule getComparable() {
         return comparableModule;
     }
-    @Deprecated
-    void setComparable(RubyModule comparableModule) {
-    }
 
     public RubyClass getNumeric() {
         return numericClass;
-    }
-    @Deprecated
-    void setNumeric(RubyClass numericClass) {
     }
 
     public RubyClass getFloat() {
         return floatClass;
     }
-    @Deprecated
-    void setFloat(RubyClass floatClass) {
-    }
 
     public RubyClass getInteger() {
         return integerClass;
-    }
-    @Deprecated
-    void setInteger(RubyClass integerClass) {
     }
 
     public RubyClass getFixnum() {
         return fixnumClass;
     }
-    @Deprecated
-    void setFixnum(RubyClass fixnumClass) {
-    }
 
     public RubyClass getComplex() {
         return complexClass;
-    }
-    @Deprecated
-    void setComplex(RubyClass complexClass) {
     }
 
     public RubyClass getRational() {
         return rationalClass;
     }
-    @Deprecated
-    void setRational(RubyClass rationalClass) {
-    }
 
     public RubyModule getEnumerable() {
         return enumerableModule;
-    }
-    @Deprecated
-    void setEnumerable(RubyModule enumerableModule) {
     }
 
     public RubyClass getEnumerator() {
         return enumeratorClass;
     }
-    @Deprecated
-    void setEnumerator(RubyClass enumeratorClass) {
-    }
 
     public RubyClass getYielder() {
         return yielderClass;
-    }
-    @Deprecated
-    void setYielder(RubyClass yielderClass) {
     }
 
     public RubyClass getGenerator() {
         return generatorClass;
     }
-    @Deprecated
-    public void setGenerator(RubyClass generatorClass) {
-    }
 
     public RubyClass getFiber() {
         return fiberClass;
-    }
-    @Deprecated
-    public void setFiber(RubyClass fiberClass) {
     }
 
     public RubyClass getString() {
         return stringClass;
     }
-    @Deprecated
-    void setString(RubyClass stringClass) {
-    }
 
     public RubyClass getEncoding() {
         return encodingClass;
-    }
-    @Deprecated
-    void setEncoding(RubyClass encodingClass) {
     }
 
     public RubyClass getConverter() {
         return converterClass;
     }
-    @Deprecated
-    void setConverter(RubyClass converterClass) {
-    }
 
     public RubyClass getSymbol() {
         return symbolClass;
-    }
-    @Deprecated
-    void setSymbol(RubyClass symbolClass) {
     }
 
     public RubyClass getArray() {
         return arrayClass;
     }
-    @Deprecated
-    void setArray(RubyClass arrayClass) {
-    }
 
     public RubyClass getHash() {
         return hashClass;
     }
-    @Deprecated
-    void setHash(RubyClass hashClass) {
-    }
 
     public RubyClass getRange() {
         return rangeClass;
-    }
-    @Deprecated
-    void setRange(RubyClass rangeClass) {
     }
 
     /** Returns the "true" instance from the instance pool.
@@ -2063,141 +1993,81 @@ public final class Ruby implements Constantizable {
     public RubyClass getNilClass() {
         return nilClass;
     }
-    @Deprecated
-    void setNilClass(RubyClass nilClass) {
-    }
 
     public RubyClass getTrueClass() {
         return trueClass;
-    }
-    @Deprecated
-    void setTrueClass(RubyClass trueClass) {
     }
 
     public RubyClass getFalseClass() {
         return falseClass;
     }
-    @Deprecated
-    void setFalseClass(RubyClass falseClass) {
-    }
 
     public RubyClass getProc() {
         return procClass;
-    }
-    @Deprecated
-    void setProc(RubyClass procClass) {
     }
 
     public RubyClass getBinding() {
         return bindingClass;
     }
-    @Deprecated
-    void setBinding(RubyClass bindingClass) {
-    }
 
     public RubyClass getMethod() {
         return methodClass;
-    }
-    @Deprecated
-    void setMethod(RubyClass methodClass) {
     }
 
     public RubyClass getUnboundMethod() {
         return unboundMethodClass;
     }
-    @Deprecated
-    void setUnboundMethod(RubyClass unboundMethodClass) {
-    }
 
     public RubyClass getMatchData() {
         return matchDataClass;
-    }
-    @Deprecated
-    void setMatchData(RubyClass matchDataClass) {
     }
 
     public RubyClass getRegexp() {
         return regexpClass;
     }
-    @Deprecated
-    void setRegexp(RubyClass regexpClass) {
-    }
 
     public RubyClass getTime() {
         return timeClass;
-    }
-    @Deprecated
-    void setTime(RubyClass timeClass) {
     }
 
     public RubyModule getMath() {
         return mathModule;
     }
-    @Deprecated
-    void setMath(RubyModule mathModule) {
-    }
 
     public RubyModule getMarshal() {
         return marshalModule;
-    }
-    @Deprecated
-    void setMarshal(RubyModule marshalModule) {
     }
 
     public RubyClass getBignum() {
         return bignumClass;
     }
-    @Deprecated
-    void setBignum(RubyClass bignumClass) {
-    }
 
     public RubyClass getDir() {
         return dirClass;
-    }
-    @Deprecated
-    void setDir(RubyClass dirClass) {
     }
 
     public RubyClass getFile() {
         return fileClass;
     }
-    @Deprecated
-    void setFile(RubyClass fileClass) {
-    }
 
     public RubyClass getFileStat() {
         return fileStatClass;
-    }
-    @Deprecated
-    void setFileStat(RubyClass fileStatClass) {
     }
 
     public RubyModule getFileTest() {
         return fileTestModule;
     }
-    @Deprecated
-    void setFileTest(RubyModule fileTestModule) {
-    }
 
     public RubyClass getIO() {
         return ioClass;
-    }
-    @Deprecated
-    void setIO(RubyClass ioClass) {
     }
 
     public RubyClass getThread() {
         return threadClass;
     }
-    @Deprecated
-    void setThread(RubyClass threadClass) {
-    }
 
     public RubyClass getThreadGroup() {
         return threadGroupClass;
-    }
-    @Deprecated
-    void setThreadGroup(RubyClass threadGroupClass) {
     }
 
     public RubyThreadGroup getDefaultThreadGroup() {
@@ -2210,22 +2080,13 @@ public final class Ruby implements Constantizable {
     public RubyClass getContinuation() {
         return continuationClass;
     }
-    @Deprecated
-    void setContinuation(RubyClass continuationClass) {
-    }
 
     public RubyClass getStructClass() {
         return structClass;
     }
-    @Deprecated
-    void setStructClass(RubyClass structClass) {
-    }
 
     public RubyClass getRandomClass() {
         return randomClass;
-    }
-    @Deprecated
-    void setRandomClass(RubyClass randomClass) {
     }
 
     public IRubyObject getTmsStruct() {
@@ -2252,22 +2113,13 @@ public final class Ruby implements Constantizable {
     public RubyModule getGC() {
         return gcModule;
     }
-    @Deprecated
-    void setGC(RubyModule gcModule) {
-    }
 
     public RubyModule getObjectSpaceModule() {
         return objectSpaceModule;
     }
-    @Deprecated
-    void setObjectSpaceModule(RubyModule objectSpaceModule) {
-    }
 
     public RubyModule getProcess() {
         return processModule;
-    }
-    @Deprecated
-    void setProcess(RubyModule processModule) {
     }
 
     public RubyClass getProcStatus() {
@@ -2325,19 +2177,12 @@ public final class Ruby implements Constantizable {
         return warningModule;
     }
 
-    @Deprecated
-    public void setWarning(RubyModule warningModule) {
-    }
-
     public RubyModule getErrno() {
         return errnoModule;
     }
 
     public RubyClass getException() {
         return exceptionClass;
-    }
-    @Deprecated
-    void setException(RubyClass exceptionClass) {
     }
 
     public RubyClass getNameError() {
@@ -5038,6 +4883,159 @@ public final class Ruby implements Constantizable {
             if (mriRecursionGuard != null) return mriRecursionGuard;
             return mriRecursionGuard = new MRIRecursionGuard(this);
         }
+    }
+
+    @Deprecated
+    public IRubyObject getRootFiber() {
+        return rootFiber;
+    }
+    @Deprecated
+    public void setRootFiber(IRubyObject fiber) {
+        rootFiber = fiber;
+    }
+    @Deprecated
+    void setKernel(RubyModule kernelModule) {
+    }
+    @Deprecated
+    void setComparable(RubyModule comparableModule) {
+    }
+    @Deprecated
+    void setNumeric(RubyClass numericClass) {
+    }
+    @Deprecated
+    void setFloat(RubyClass floatClass) {
+    }
+    @Deprecated
+    void setInteger(RubyClass integerClass) {
+    }
+    @Deprecated
+    void setFixnum(RubyClass fixnumClass) {
+    }
+    @Deprecated
+    void setComplex(RubyClass complexClass) {
+    }
+    @Deprecated
+    void setRational(RubyClass rationalClass) {
+    }
+    @Deprecated
+    void setEnumerable(RubyModule enumerableModule) {
+    }
+    @Deprecated
+    void setEnumerator(RubyClass enumeratorClass) {
+    }
+    @Deprecated
+    void setYielder(RubyClass yielderClass) {
+    }
+    @Deprecated
+    public void setGenerator(RubyClass generatorClass) {
+    }
+    @Deprecated
+    public void setFiber(RubyClass fiberClass) {
+    }
+    @Deprecated
+    void setString(RubyClass stringClass) {
+    }
+    @Deprecated
+    void setEncoding(RubyClass encodingClass) {
+    }
+    @Deprecated
+    void setConverter(RubyClass converterClass) {
+    }
+    @Deprecated
+    void setSymbol(RubyClass symbolClass) {
+    }
+    @Deprecated
+    void setArray(RubyClass arrayClass) {
+    }
+    @Deprecated
+    void setHash(RubyClass hashClass) {
+    }
+    @Deprecated
+    void setRange(RubyClass rangeClass) {
+    }
+    @Deprecated
+    void setNilClass(RubyClass nilClass) {
+    }
+    @Deprecated
+    void setTrueClass(RubyClass trueClass) {
+    }
+    @Deprecated
+    void setFalseClass(RubyClass falseClass) {
+    }
+    @Deprecated
+    void setProc(RubyClass procClass) {
+    }
+    @Deprecated
+    void setBinding(RubyClass bindingClass) {
+    }
+    @Deprecated
+    void setMethod(RubyClass methodClass) {
+    }
+    @Deprecated
+    void setUnboundMethod(RubyClass unboundMethodClass) {
+    }
+    @Deprecated
+    void setMatchData(RubyClass matchDataClass) {
+    }
+    @Deprecated
+    void setRegexp(RubyClass regexpClass) {
+    }
+    @Deprecated
+    void setTime(RubyClass timeClass) {
+    }
+    @Deprecated
+    void setMath(RubyModule mathModule) {
+    }
+    @Deprecated
+    void setMarshal(RubyModule marshalModule) {
+    }
+    @Deprecated
+    void setBignum(RubyClass bignumClass) {
+    }
+    @Deprecated
+    void setDir(RubyClass dirClass) {
+    }
+    @Deprecated
+    void setFile(RubyClass fileClass) {
+    }
+    @Deprecated
+    void setFileStat(RubyClass fileStatClass) {
+    }
+    @Deprecated
+    void setFileTest(RubyModule fileTestModule) {
+    }
+    @Deprecated
+    void setIO(RubyClass ioClass) {
+    }
+    @Deprecated
+    void setThread(RubyClass threadClass) {
+    }
+    @Deprecated
+    void setThreadGroup(RubyClass threadGroupClass) {
+    }
+    @Deprecated
+    void setContinuation(RubyClass continuationClass) {
+    }
+    @Deprecated
+    void setStructClass(RubyClass structClass) {
+    }
+    @Deprecated
+    void setRandomClass(RubyClass randomClass) {
+    }
+    @Deprecated
+    void setGC(RubyModule gcModule) {
+    }
+    @Deprecated
+    void setObjectSpaceModule(RubyModule objectSpaceModule) {
+    }
+    @Deprecated
+    void setProcess(RubyModule processModule) {
+    }
+    @Deprecated
+    public void setWarning(RubyModule warningModule) {
+    }
+    @Deprecated
+    void setException(RubyClass exceptionClass) {
     }
 
     private final ConcurrentHashMap<String, Invalidator> constantNameInvalidators =

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -281,14 +281,7 @@ public final class Ruby implements Constantizable {
         this.parserStats        = new ParserStats(this);
         this.caches             = new Caches();
 
-        Random myRandom;
-        try {
-            myRandom = new SecureRandom();
-        } catch (Throwable t) {
-            LOG.debug("unable to instantiate SecureRandom, falling back on Random", t);
-            myRandom = new Random();
-        }
-        this.random = myRandom;
+        this.random = initRandom();
 
         if (RubyInstanceConfig.CONSISTENT_HASHING_ENABLED) {
             this.hashSeedK0 = -561135208506705104l;
@@ -627,6 +620,17 @@ public final class Ruby implements Constantizable {
         for (String scriptName : this.config.getRequiredLibraries()) {
             topSelf.callMethod(context, "require", RubyString.newString(this, scriptName));
         }
+    }
+
+    private Random initRandom() {
+        Random myRandom;
+        try {
+            myRandom = new SecureRandom();
+        } catch (Throwable t) {
+            LOG.debug("unable to instantiate SecureRandom, falling back on Random", t);
+            myRandom = new Random();
+        }
+        return myRandom;
     }
 
     public void registerMBeans() {

--- a/core/src/main/java/org/jruby/RubyArgsFile.java
+++ b/core/src/main/java/org/jruby/RubyArgsFile.java
@@ -574,7 +574,7 @@ public class RubyArgsFile extends RubyObject {
 
         data.next_argv(context);
 
-        return RubyBoolean.newBoolean(context.runtime, isClosed(context, data.currentFile));
+        return RubyBoolean.newBoolean(context, isClosed(context, data.currentFile));
     }
 
     private static boolean isClosed(ThreadContext context, IRubyObject currentFile) {

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -109,7 +109,6 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     public static RubyClass createArrayClass(Ruby runtime) {
         RubyClass arrayc = runtime.defineClass("Array", runtime.getObject(), ARRAY_ALLOCATOR);
-        runtime.setArray(arrayc);
 
         arrayc.setClassIndex(ClassIndex.ARRAY);
         arrayc.setReifiedClass(RubyArray.class);

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -1452,7 +1452,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      */
     @JRubyMethod(name = "include?", required = 1)
     public RubyBoolean include_p(ThreadContext context, IRubyObject item) {
-        return context.runtime.newBoolean(includes(context, item));
+        return RubyBoolean.newBoolean(context, includes(context, item));
     }
 
     /** rb_ary_frozen_p
@@ -1461,7 +1461,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     @JRubyMethod(name = "frozen?")
     @Override
     public RubyBoolean frozen_p(ThreadContext context) {
-        return context.runtime.newBoolean(isFrozen() || (flags & TMPLOCK_ARR_F) != 0);
+        return RubyBoolean.newBoolean(context, isFrozen() || (flags & TMPLOCK_ARR_F) != 0);
     }
 
     /**
@@ -2185,7 +2185,8 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      */
     @JRubyMethod(name = "empty?")
     public IRubyObject empty_p() {
-        return realLength == 0 ? metaClass.runtime.getTrue() : metaClass.runtime.getFalse();
+        Ruby runtime = metaClass.runtime;
+        return realLength == 0 ? runtime.getTrue() : runtime.getFalse();
     }
 
     /** rb_ary_clear

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -1251,7 +1251,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      */
     @JRubyMethod(name = "!=", required = 1)
     public IRubyObject op_not_equal(ThreadContext context, IRubyObject other) {
-        return context.runtime.newBoolean(!sites(context).op_equal.call(context, this, this, other).isTrue());
+        return RubyBoolean.newBoolean(context, !sites(context).op_equal.call(context, this, this, other).isTrue());
     }
 
     /**
@@ -2082,13 +2082,12 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     }
 
     final RubyBoolean respond_to_p(ThreadContext context, IRubyObject methodName, final boolean includePrivate) {
-        final Ruby runtime = context.runtime;
         final String name = methodName.asJavaString();
-        if (getMetaClass().respondsToMethod(name, !includePrivate)) return runtime.getTrue();
+        if (getMetaClass().respondsToMethod(name, !includePrivate)) return context.tru;
         // MRI (1.9) always passes down a symbol when calling respond_to_missing?
-        if ( ! (methodName instanceof RubySymbol) ) methodName = runtime.newSymbol(name);
-        IRubyObject respond = sites(context).respond_to_missing.call(context, this, this, methodName, runtime.newBoolean(includePrivate));
-        return runtime.newBoolean( respond.isTrue() );
+        if ( ! (methodName instanceof RubySymbol) ) methodName = context.runtime.newSymbol(name);
+        IRubyObject respond = sites(context).respond_to_missing.call(context, this, this, methodName, RubyBoolean.newBoolean(context, includePrivate));
+        return RubyBoolean.newBoolean(context, respond.isTrue());
     }
 
     /** rb_obj_id
@@ -2163,7 +2162,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      *
      */
     public RubyBoolean tainted_p(ThreadContext context) {
-        return context.runtime.newBoolean(isTaint());
+        return RubyBoolean.newBoolean(context, isTaint());
     }
 
     /** rb_obj_taint
@@ -2255,7 +2254,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      *     a.frozen?   #=> true
      */
     public RubyBoolean frozen_p(ThreadContext context) {
-        return context.runtime.newBoolean(isFrozen());
+        return RubyBoolean.newBoolean(context, isFrozen());
     }
 
     /** rb_obj_is_instance_of
@@ -2310,7 +2309,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
             throw context.runtime.newTypeError("class or module required");
         }
 
-        return context.runtime.newBoolean(((RubyModule) type).isInstance(this));
+        return RubyBoolean.newBoolean(context, ((RubyModule) type).isInstance(this));
     }
 
     /** rb_obj_methods
@@ -2805,7 +2804,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      * @return
      */
     public IRubyObject op_not_match(ThreadContext context, IRubyObject arg) {
-        return context.runtime.newBoolean(!sites(context).match.call(context, this, this, arg).isTrue());
+        return RubyBoolean.newBoolean(context, !sites(context).match.call(context, this, this, arg).isTrue());
     }
 
 
@@ -2832,7 +2831,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      *     fred.instance_variable_defined?("@c")   #=> false
      */
     public IRubyObject instance_variable_defined_p(ThreadContext context, IRubyObject name) {
-        return context.runtime.newBoolean(variableTableContains(validateInstanceVariable(name)));
+        return RubyBoolean.newBoolean(context, variableTableContains(validateInstanceVariable(name)));
     }
 
     /** rb_obj_ivar_get

--- a/core/src/main/java/org/jruby/RubyBignum.java
+++ b/core/src/main/java/org/jruby/RubyBignum.java
@@ -1017,11 +1017,11 @@ public class RubyBignum extends RubyInteger {
         } else if (other instanceof RubyFloat) {
             double a = ((RubyFloat) other).value;
             if (Double.isNaN(a)) return context.fals;
-            return RubyBoolean.newBoolean(context.runtime, a == big2dbl(this));
+            return RubyBoolean.newBoolean(context, a == big2dbl(this));
         } else {
             return other.op_eqq(context, this);
         }
-        return RubyBoolean.newBoolean(context.runtime, value.compareTo(otherValue) == 0);
+        return RubyBoolean.newBoolean(context, value.compareTo(otherValue) == 0);
     }
 
     /** rb_big_eql
@@ -1087,7 +1087,7 @@ public class RubyBignum extends RubyInteger {
 
     @Override
     public IRubyObject zero_p(ThreadContext context) {
-        return context.runtime.newBoolean(isZero());
+        return RubyBoolean.newBoolean(context, isZero());
     }
 
     @Override
@@ -1201,22 +1201,20 @@ public class RubyBignum extends RubyInteger {
 
     @Override
     public IRubyObject isNegative(ThreadContext context) {
-        Ruby runtime = context.runtime;
         CachingCallSite op_lt_site = sites(context).basic_op_lt;
         if (op_lt_site.retrieveCache(metaClass).method.isBuiltin()) {
-            return runtime.newBoolean(value.signum() < 0);
+            return RubyBoolean.newBoolean(context, value.signum() < 0);
         }
-        return op_lt_site.call(context, this, this, RubyFixnum.zero(runtime));
+        return op_lt_site.call(context, this, this, RubyFixnum.zero(context.runtime));
     }
 
     @Override
     public IRubyObject isPositive(ThreadContext context) {
-        Ruby runtime = context.runtime;
         CachingCallSite op_gt_site = sites(context).basic_op_gt;
         if (op_gt_site.retrieveCache(metaClass).method.isBuiltin()) {
-            return runtime.newBoolean(value.signum() > 0);
+            return RubyBoolean.newBoolean(context, value.signum() > 0);
         }
-        return op_gt_site.call(context, this, this, RubyFixnum.zero(runtime));
+        return op_gt_site.call(context, this, this, RubyFixnum.zero(context.runtime));
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyBignum.java
+++ b/core/src/main/java/org/jruby/RubyBignum.java
@@ -58,7 +58,6 @@ public class RubyBignum extends RubyInteger {
         RubyClass bignum = runtime.getInteger();
         runtime.getObject().setConstant("Bignum", bignum);
         runtime.getObject().deprecateConstant(runtime, "Bignum");
-        runtime.setBignum(bignum);
 
         return bignum;
     }

--- a/core/src/main/java/org/jruby/RubyBinding.java
+++ b/core/src/main/java/org/jruby/RubyBinding.java
@@ -140,7 +140,7 @@ public class RubyBinding extends RubyObject {
 
     @JRubyMethod(name = "local_variable_defined?")
     public IRubyObject local_variable_defined_p(ThreadContext context, IRubyObject symbol) {
-        return context.runtime.newBoolean(binding.getEvalScope(context.runtime).getStaticScope().isDefined(symbol.asJavaString()) != -1);
+        return RubyBoolean.newBoolean(context, binding.getEvalScope(context.runtime).getStaticScope().isDefined(symbol.asJavaString()) != -1);
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/RubyBinding.java
+++ b/core/src/main/java/org/jruby/RubyBinding.java
@@ -74,7 +74,6 @@ public class RubyBinding extends RubyObject {
     
     public static RubyClass createBindingClass(Ruby runtime) {
         RubyClass bindingClass = runtime.defineClass("Binding", runtime.getObject(), BINDING_ALLOCATOR);
-        runtime.setBinding(bindingClass);
 
         bindingClass.setClassIndex(ClassIndex.BINDING);
         bindingClass.setReifiedClass(RubyBinding.class);

--- a/core/src/main/java/org/jruby/RubyBoolean.java
+++ b/core/src/main/java/org/jruby/RubyBoolean.java
@@ -133,6 +133,10 @@ public class RubyBoolean extends RubyObject implements Constantizable {
         return value ? runtime.getTrue() : runtime.getFalse();
     }
 
+    public static RubyBoolean newBoolean(ThreadContext context, boolean value) {
+        return value ? context.tru : context.fals;
+    }
+
     static final ByteList FALSE_BYTES = new ByteList(new byte[] { 'f','a','l','s','e' }, USASCIIEncoding.INSTANCE);
 
     public static class False extends RubyBoolean {

--- a/core/src/main/java/org/jruby/RubyBoolean.java
+++ b/core/src/main/java/org/jruby/RubyBoolean.java
@@ -103,7 +103,7 @@ public class RubyBoolean extends RubyObject implements Constantizable {
 
     public static RubyClass createFalseClass(Ruby runtime) {
         RubyClass falseClass = runtime.defineClass("FalseClass", runtime.getObject(), ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR);
-        runtime.setFalseClass(falseClass);
+
         falseClass.setClassIndex(ClassIndex.FALSE);
         falseClass.setReifiedClass(RubyBoolean.class);
         
@@ -117,7 +117,7 @@ public class RubyBoolean extends RubyObject implements Constantizable {
     
     public static RubyClass createTrueClass(Ruby runtime) {
         RubyClass trueClass = runtime.defineClass("TrueClass", runtime.getObject(), ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR);
-        runtime.setTrueClass(trueClass);
+
         trueClass.setClassIndex(ClassIndex.TRUE);
         trueClass.setReifiedClass(RubyBoolean.class);
         

--- a/core/src/main/java/org/jruby/RubyComparable.java
+++ b/core/src/main/java/org/jruby/RubyComparable.java
@@ -50,7 +50,6 @@ import static org.jruby.runtime.Helpers.invokedynamic;
 public class RubyComparable {
     public static RubyModule createComparable(Ruby runtime) {
         RubyModule comparableModule = runtime.defineModule("Comparable");
-        runtime.setComparable(comparableModule);
 
         comparableModule.defineAnnotatedMethods(RubyComparable.class);
 

--- a/core/src/main/java/org/jruby/RubyComparable.java
+++ b/core/src/main/java/org/jruby/RubyComparable.java
@@ -184,7 +184,7 @@ public class RubyComparable {
 
         if (result.isNil()) cmperr(recv, other);
 
-        return RubyBoolean.newBoolean(context.runtime, cmpint(context, result, recv, other) > 0);
+        return RubyBoolean.newBoolean(context, cmpint(context, result, recv, other) > 0);
     }
 
     /** cmp_ge
@@ -196,7 +196,7 @@ public class RubyComparable {
 
         if (result.isNil()) cmperr(recv, other);
 
-        return RubyBoolean.newBoolean(context.runtime, cmpint(context, result, recv, other) >= 0);
+        return RubyBoolean.newBoolean(context, cmpint(context, result, recv, other) >= 0);
     }
 
     /** cmp_lt
@@ -208,7 +208,7 @@ public class RubyComparable {
 
         if (result.isNil()) cmperr(recv, other);
 
-        return RubyBoolean.newBoolean(context.runtime, cmpint(context, result, recv, other) < 0);
+        return RubyBoolean.newBoolean(context, cmpint(context, result, recv, other) < 0);
     }
 
     public static RubyBoolean op_lt(ThreadContext context, CallSite cmp, IRubyObject recv, IRubyObject other) {
@@ -216,7 +216,7 @@ public class RubyComparable {
 
         if (result.isNil()) cmperr(recv, other);
 
-        return RubyBoolean.newBoolean(context.runtime, cmpint(context, result, recv, other) < 0);
+        return RubyBoolean.newBoolean(context, cmpint(context, result, recv, other) < 0);
     }
 
     /** cmp_le
@@ -228,7 +228,7 @@ public class RubyComparable {
 
         if (result.isNil()) cmperr(recv, other);
 
-        return RubyBoolean.newBoolean(context.runtime, cmpint(context, result, recv, other) <= 0);
+        return RubyBoolean.newBoolean(context, cmpint(context, result, recv, other) <= 0);
     }
 
     /** cmp_between
@@ -236,7 +236,7 @@ public class RubyComparable {
      */
     @JRubyMethod(name = "between?", required = 2)
     public static RubyBoolean between_p(ThreadContext context, IRubyObject recv, IRubyObject first, IRubyObject second) {
-        return context.runtime.newBoolean(op_lt(context, recv, first).isFalse() && op_gt(context, recv, second).isFalse());
+        return RubyBoolean.newBoolean(context, op_lt(context, recv, first).isFalse() && op_gt(context, recv, second).isFalse());
     }
 
     @JRubyMethod(name = "clamp")

--- a/core/src/main/java/org/jruby/RubyComplex.java
+++ b/core/src/main/java/org/jruby/RubyComplex.java
@@ -693,13 +693,13 @@ public class RubyComplex extends RubyNumeric {
             boolean test = f_equal(context, real, otherComplex.real).isTrue() &&
                     f_equal(context, image, otherComplex.image).isTrue();
 
-            return context.runtime.newBoolean(test);
+            return RubyBoolean.newBoolean(context, test);
         }
 
         if (other instanceof RubyNumeric && f_real_p(context, (RubyNumeric) other)) {
             boolean test = f_equal(context, real, other).isTrue() && f_zero_p(context, image);
 
-            return context.runtime.newBoolean(test);
+            return RubyBoolean.newBoolean(context, test);
         }
         
         return f_equal(context, other, this);
@@ -857,7 +857,7 @@ public class RubyComplex extends RubyNumeric {
     @JRubyMethod(name = "eql?")
     @Override
     public IRubyObject eql_p(ThreadContext context, IRubyObject other) {
-        return context.runtime.newBoolean(equals(context, other));
+        return RubyBoolean.newBoolean(context, equals(context, other));
     }
 
     private boolean equals(ThreadContext context, Object other) {

--- a/core/src/main/java/org/jruby/RubyComplex.java
+++ b/core/src/main/java/org/jruby/RubyComplex.java
@@ -107,7 +107,7 @@ public class RubyComplex extends RubyNumeric {
             complexc.undefineMethod(undef);
         }
 
-        complexc.defineConstant("I", RubyComplex.newComplexConvert(runtime.getCurrentContext(), RubyFixnum.zero(runtime), RubyFixnum.one(runtime)));
+        complexc.defineConstant("I", RubyComplex.convert(runtime.getCurrentContext(), complexc, RubyFixnum.zero(runtime), RubyFixnum.one(runtime)));
 
         return complexc;
     }
@@ -428,6 +428,7 @@ public class RubyComplex extends RubyNumeric {
     public static IRubyObject newComplexConvert(ThreadContext context, IRubyObject x, IRubyObject y) {
         return convert(context, context.runtime.getComplex(), x, y);
     }
+
 
     @Deprecated
     public static IRubyObject convert(ThreadContext context, IRubyObject clazz, IRubyObject[]args) {

--- a/core/src/main/java/org/jruby/RubyComplex.java
+++ b/core/src/main/java/org/jruby/RubyComplex.java
@@ -92,7 +92,6 @@ public class RubyComplex extends RubyNumeric {
         };
 
         RubyClass complexc = runtime.defineClass("Complex", runtime.getNumeric(), COMPLEX_ALLOCATOR);
-        runtime.setComplex(complexc);
 
         complexc.setClassIndex(ClassIndex.COMPLEX);
         complexc.setReifiedClass(RubyComplex.class);

--- a/core/src/main/java/org/jruby/RubyContinuation.java
+++ b/core/src/main/java/org/jruby/RubyContinuation.java
@@ -55,15 +55,15 @@ public class RubyContinuation extends RubyObject {
     private final Continuation continuation;
     private boolean disabled;
     
-    public static void createContinuation(Ruby runtime) {
+    public static RubyClass createContinuation(Ruby runtime) {
         RubyClass cContinuation = runtime.defineClass("Continuation",runtime.getObject(),runtime.getObject().getAllocator());
 
         cContinuation.setClassIndex(ClassIndex.CONTINUATION);
         cContinuation.setReifiedClass(RubyContinuation.class);
 
         cContinuation.getSingletonClass().undefineMethod("new");
-        
-        runtime.setContinuation(cContinuation);
+
+        return cContinuation;
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/RubyConverter.java
+++ b/core/src/main/java/org/jruby/RubyConverter.java
@@ -648,7 +648,7 @@ public class RubyConverter extends RubyObject {
 
         ec2 = ((RubyConverter)other).ec;
 
-        return context.runtime.newBoolean(ec1.equals(ec2));
+        return RubyBoolean.newBoolean(context, ec1.equals(ec2));
     }
     
     public static class EncodingErrorMethods {

--- a/core/src/main/java/org/jruby/RubyConverter.java
+++ b/core/src/main/java/org/jruby/RubyConverter.java
@@ -116,13 +116,14 @@ public class RubyConverter extends RubyObject {
 
     public static RubyClass createConverterClass(Ruby runtime) {
         RubyClass converterc = runtime.defineClassUnder("Converter", runtime.getData(), CONVERTER_ALLOCATOR, runtime.getEncoding());
-        runtime.setConverter(converterc);
+
         converterc.setClassIndex(ClassIndex.CONVERTER);
         converterc.setReifiedClass(RubyConverter.class);
         converterc.kindOf = new RubyModule.JavaClassKindOf(RubyConverter.class);
 
         converterc.defineAnnotatedMethods(RubyConverter.class);
         converterc.defineAnnotatedConstants(RubyConverter.class);
+
         return converterc;
     }
 

--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -94,7 +94,6 @@ public class RubyDir extends RubyObject implements Closeable {
 
     public static RubyClass createDirClass(Ruby runtime) {
         RubyClass dirClass = runtime.defineClass("Dir", runtime.getObject(), DIR_ALLOCATOR);
-        runtime.setDir(dirClass);
 
         dirClass.setClassIndex(ClassIndex.DIR);
         dirClass.setReifiedClass(RubyDir.class);

--- a/core/src/main/java/org/jruby/RubyEncoding.java
+++ b/core/src/main/java/org/jruby/RubyEncoding.java
@@ -72,7 +72,7 @@ public class RubyEncoding extends RubyObject implements Constantizable {
 
     public static RubyClass createEncodingClass(Ruby runtime) {
         RubyClass encodingc = runtime.defineClass("Encoding", runtime.getObject(), ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR);
-        runtime.setEncoding(encodingc);
+
         encodingc.setClassIndex(ClassIndex.ENCODING);
         encodingc.setReifiedClass(RubyEncoding.class);
         encodingc.kindOf = new RubyModule.JavaClassKindOf(RubyEncoding.class);

--- a/core/src/main/java/org/jruby/RubyEncoding.java
+++ b/core/src/main/java/org/jruby/RubyEncoding.java
@@ -528,7 +528,7 @@ public class RubyEncoding extends RubyObject implements Constantizable {
 
     @JRubyMethod(name = "ascii_compatible?")
     public IRubyObject asciiCompatible_p(ThreadContext context) {
-        return context.runtime.newBoolean(getEncoding().isAsciiCompatible());
+        return RubyBoolean.newBoolean(context, getEncoding().isAsciiCompatible());
     }
 
     @JRubyMethod(name = {"to_s", "name"})
@@ -580,7 +580,7 @@ public class RubyEncoding extends RubyObject implements Constantizable {
 
     @JRubyMethod(name = "dummy?")
     public IRubyObject dummy_p(ThreadContext context) {
-        return context.runtime.newBoolean(isDummy);
+        return RubyBoolean.newBoolean(context, isDummy);
     }
 
     @JRubyMethod(name = "compatible?", meta = true)

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -71,7 +71,6 @@ public class RubyEnumerable {
 
     public static RubyModule createEnumerableModule(Ruby runtime) {
         RubyModule enumModule = runtime.defineModule("Enumerable");
-        runtime.setEnumerable(enumModule);
 
         enumModule.defineAnnotatedMethods(RubyEnumerable.class);
 

--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -76,23 +76,18 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
 
     private FeedValue feedValue;
 
-    public static void defineEnumerator(Ruby runtime) {
-        final RubyModule Enumerable = runtime.getModule("Enumerable");
-
-        final RubyClass Enumerator;
-        Enumerator = runtime.defineClass("Enumerator", runtime.getObject(), ALLOCATOR);
+    public static RubyClass defineEnumerator(Ruby runtime, RubyModule Enumerable) {
+        final RubyClass Enumerator = runtime.defineClass("Enumerator", runtime.getObject(), ALLOCATOR);
 
         Enumerator.includeModule(Enumerable);
         Enumerator.defineAnnotatedMethods(RubyEnumerator.class);
-        runtime.setEnumerator(Enumerator);
-
-        RubyGenerator.createGeneratorClass(runtime);
-        RubyYielder.createYielderClass(runtime);
 
         final RubyClass FeedValue;
         FeedValue = runtime.defineClassUnder("FeedValue", runtime.getObject(), ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR, Enumerator);
         FeedValue.defineAnnotatedMethods(FeedValue.class);
         Enumerator.setConstantVisibility(runtime, "FeedValue", true);
+
+        return Enumerator;
     }
 
     private static final ObjectAllocator ALLOCATOR = new ObjectAllocator() {

--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -316,7 +316,7 @@ public class RubyException extends RubyObject {
                 getMetaClass().getRealClass() == other.getMetaClass().getRealClass() &&
                 callMethod(context, "message").equals(other.callMethod(context, "message")) &&
                 callMethod(context, "backtrace").equals(other.callMethod(context, "backtrace"));
-        return context.runtime.newBoolean(equal);
+        return RubyBoolean.newBoolean(context, equal);
     }
 
     @JRubyMethod(name = "cause")

--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -96,8 +96,6 @@ public class RubyFile extends RubyIO implements EncodingCapable {
 
         RubyClass fileClass = runtime.defineClass("File", runtime.getIO(), FILE_ALLOCATOR);
 
-        runtime.setFile(fileClass);
-
         fileClass.defineAnnotatedMethods(RubyFile.class);
 
         fileClass.setClassIndex(ClassIndex.FILE);

--- a/core/src/main/java/org/jruby/RubyFileStat.java
+++ b/core/src/main/java/org/jruby/RubyFileStat.java
@@ -83,7 +83,6 @@ public class RubyFileStat extends RubyObject {
     public static RubyClass createFileStatClass(Ruby runtime) {
         // TODO: NOT_ALLOCATABLE_ALLOCATOR is probably ok here. Confirm. JRUBY-415
         final RubyClass fileStatClass = runtime.getFile().defineClassUnder("Stat",runtime.getObject(), ALLOCATOR);
-        runtime.setFileStat(fileStatClass);
 
         fileStatClass.includeModule(runtime.getModule("Comparable"));
         fileStatClass.defineAnnotatedMethods(RubyFileStat.class);

--- a/core/src/main/java/org/jruby/RubyFileTest.java
+++ b/core/src/main/java/org/jruby/RubyFileTest.java
@@ -92,7 +92,7 @@ public class RubyFileTest {
             filename = TypeConverter.convertToType(filename, context.runtime.getIO(), "to_io");
         }
 
-        return context.runtime.newBoolean(fileResource(context, filename).isDirectory());
+        return RubyBoolean.newBoolean(context, fileResource(context, filename).isDirectory());
     }
 
     @JRubyMethod(name = "executable?", required = 1, module = true)
@@ -120,7 +120,7 @@ public class RubyFileTest {
     @JRubyMethod(name = {"exist?", "exists?"}, required = 1, module = true)
     public static IRubyObject exist_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
         // We get_path here to prevent doing it both existsOnClasspath and fileResource (Only call to_path once).
-        return context.runtime.newBoolean(exist(context, get_path(context, filename)));
+        return RubyBoolean.newBoolean(context, exist(context, get_path(context, filename)));
     }
 
     static boolean exist(ThreadContext context, RubyString path) {
@@ -138,7 +138,7 @@ public class RubyFileTest {
 
     @JRubyMethod(name = "file?", required = 1, module = true)
     public static RubyBoolean file_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
-        return context.runtime.newBoolean(fileResource(filename).isFile());
+        return RubyBoolean.newBoolean(context, fileResource(filename).isFile());
     }
 
     @JRubyMethod(name = "grpowned?", required = 1, module = true)
@@ -302,21 +302,19 @@ public class RubyFileTest {
 
     @JRubyMethod(name = {"empty?", "zero?"}, required = 1, module = true)
     public static RubyBoolean zero_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
-        Ruby runtime = context.runtime;
-
         FileResource resource = fileResource(context, filename);
 
         // FIXME: Ultimately we should return a valid stat() from this but without massive NUL coverage
         // this is less risky.
-        if (resource.isNull()) return runtime.newBoolean(true);
+        if (resource.isNull()) return RubyBoolean.newBoolean(context, true);
 
         FileStat stat = resource.stat();
 
-        if (stat == null) return runtime.getFalse();
+        if (stat == null) return context.fals;
         // MRI behavior, enforced by RubySpecs.
-        if (stat.isDirectory()) return runtime.newBoolean(Platform.IS_WINDOWS);
+        if (stat.isDirectory()) return RubyBoolean.newBoolean(context, Platform.IS_WINDOWS);
 
-        return runtime.newBoolean(stat.st_size() == 0L);
+        return RubyBoolean.newBoolean(context, stat.st_size() == 0L);
     }
 
     @JRubyMethod(name = "world_readable?", required = 1, module = true)

--- a/core/src/main/java/org/jruby/RubyFileTest.java
+++ b/core/src/main/java/org/jruby/RubyFileTest.java
@@ -53,7 +53,6 @@ public class RubyFileTest {
 
     public static RubyModule createFileTestModule(Ruby runtime) {
         RubyModule fileTestModule = runtime.defineModule("FileTest");
-        runtime.setFileTest(fileTestModule);
 
         fileTestModule.defineAnnotatedMethods(RubyFileTest.class);
 

--- a/core/src/main/java/org/jruby/RubyFixnum.java
+++ b/core/src/main/java/org/jruby/RubyFixnum.java
@@ -65,9 +65,9 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
 
     public static RubyClass createFixnumClass(Ruby runtime) {
         RubyClass fixnum = runtime.getInteger();
+
         runtime.getObject().setConstant("Fixnum", fixnum);
         runtime.getObject().deprecateConstant(runtime, "Fixnum");
-        runtime.setFixnum(fixnum);
 
         for (int i = 0; i < runtime.fixnumCache.length; i++) {
             runtime.fixnumCache[i] = new RubyFixnum(fixnum, i - CACHE_OFFSET);

--- a/core/src/main/java/org/jruby/RubyFixnum.java
+++ b/core/src/main/java/org/jruby/RubyFixnum.java
@@ -153,7 +153,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
 
     @Override
     public IRubyObject equal_p(ThreadContext context, IRubyObject obj) {
-        return context.runtime.newBoolean(this == obj || eql(obj));
+        return RubyBoolean.newBoolean(context, this == obj || eql(obj));
     }
 
     @Override
@@ -965,11 +965,11 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
     }
 
     public IRubyObject op_equal(ThreadContext context, long other) {
-        return RubyBoolean.newBoolean(context.runtime, value == other);
+        return RubyBoolean.newBoolean(context, value == other);
     }
 
     public IRubyObject op_equal(ThreadContext context, double other) {
-        return RubyBoolean.newBoolean(context.runtime, (double) value == other);
+        return RubyBoolean.newBoolean(context, (double) value == other);
     }
 
     public boolean op_equal_boolean(ThreadContext context, long other) {
@@ -982,7 +982,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
 
     private IRubyObject op_equalOther(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyBignum) {
-            return RubyBoolean.newBoolean(context.runtime,
+            return RubyBoolean.newBoolean(context,
                     BigInteger.valueOf(this.value).compareTo(((RubyBignum) other).value) == 0);
         }
         if (other instanceof RubyFloat) {
@@ -1051,14 +1051,14 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
     @Override
     public IRubyObject op_gt(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyFixnum) {
-            return RubyBoolean.newBoolean(context.runtime, value > ((RubyFixnum) other).value);
+            return RubyBoolean.newBoolean(context, value > ((RubyFixnum) other).value);
         }
 
         return op_gtOther(context, other);
     }
 
     public IRubyObject op_gt(ThreadContext context, long other) {
-        return RubyBoolean.newBoolean(context.runtime, value > other);
+        return RubyBoolean.newBoolean(context, value > other);
     }
 
     public boolean op_gt_boolean(ThreadContext context, long other) {
@@ -1067,11 +1067,11 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
 
     private IRubyObject op_gtOther(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyBignum) {
-            return RubyBoolean.newBoolean(context.runtime,
+            return RubyBoolean.newBoolean(context,
                     BigInteger.valueOf(value).compareTo(((RubyBignum) other).value) > 0);
         }
         if (other instanceof RubyFloat) {
-            return RubyBoolean.newBoolean(context.runtime, (double) value > ((RubyFloat) other).value);
+            return RubyBoolean.newBoolean(context, (double) value > ((RubyFloat) other).value);
         }
         return coerceRelOp(context, sites(context).op_gt, other);
     }
@@ -1082,13 +1082,13 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
     @Override
     public IRubyObject op_ge(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyFixnum) {
-            return RubyBoolean.newBoolean(context.runtime, value >= ((RubyFixnum) other).value);
+            return RubyBoolean.newBoolean(context, value >= ((RubyFixnum) other).value);
         }
         return op_geOther(context, other);
     }
 
     public IRubyObject op_ge(ThreadContext context, long other) {
-        return RubyBoolean.newBoolean(context.runtime, value >= other);
+        return RubyBoolean.newBoolean(context, value >= other);
     }
 
     public boolean op_ge_boolean(ThreadContext context, long other) {
@@ -1097,11 +1097,11 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
 
     private IRubyObject op_geOther(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyBignum) {
-            return RubyBoolean.newBoolean(context.runtime,
+            return RubyBoolean.newBoolean(context,
                     BigInteger.valueOf(value).compareTo(((RubyBignum) other).value) >= 0);
         }
         if (other instanceof RubyFloat) {
-            return RubyBoolean.newBoolean(context.runtime, (double) value >= ((RubyFloat) other).value);
+            return RubyBoolean.newBoolean(context, (double) value >= ((RubyFloat) other).value);
         }
         return coerceRelOp(context, sites(context).op_ge, other);
     }
@@ -1118,7 +1118,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
     }
 
     public IRubyObject op_lt(ThreadContext context, long other) {
-        return RubyBoolean.newBoolean(context.runtime, value < other);
+        return RubyBoolean.newBoolean(context, value < other);
     }
 
     public boolean op_lt_boolean(ThreadContext context, long other) {
@@ -1127,11 +1127,11 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
 
     private IRubyObject op_ltOther(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyBignum) {
-            return RubyBoolean.newBoolean(context.runtime,
+            return RubyBoolean.newBoolean(context,
                     BigInteger.valueOf(value).compareTo(((RubyBignum) other).value) < 0);
         }
         if (other instanceof RubyFloat) {
-            return RubyBoolean.newBoolean(context.runtime, (double) value < ((RubyFloat) other).value);
+            return RubyBoolean.newBoolean(context, (double) value < ((RubyFloat) other).value);
         }
         return coerceRelOp(context, sites(context).op_lt, other);
     }
@@ -1142,13 +1142,13 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
     @Override
     public IRubyObject op_le(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyFixnum) {
-            return RubyBoolean.newBoolean(context.runtime, value <= ((RubyFixnum) other).value);
+            return RubyBoolean.newBoolean(context, value <= ((RubyFixnum) other).value);
         }
         return op_leOther(context, other);
     }
 
     public IRubyObject op_le(ThreadContext context, long other) {
-        return RubyBoolean.newBoolean(context.runtime, value <= other);
+        return RubyBoolean.newBoolean(context, value <= other);
     }
 
     public boolean op_le_boolean(ThreadContext context, long other) {
@@ -1157,11 +1157,11 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
 
     private IRubyObject op_leOther(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyBignum) {
-            return RubyBoolean.newBoolean(context.runtime,
+            return RubyBoolean.newBoolean(context,
                     BigInteger.valueOf(value).compareTo(((RubyBignum) other).value) <= 0);
         }
         if (other instanceof RubyFloat) {
-            return RubyBoolean.newBoolean(context.runtime, (double) value <= ((RubyFloat) other).value);
+            return RubyBoolean.newBoolean(context, (double) value <= ((RubyFloat) other).value);
         }
         return coerceRelOp(context, sites(context).op_le, other);
     }
@@ -1343,7 +1343,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
      */
     @Override
     public IRubyObject zero_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context.runtime, value == 0);
+        return RubyBoolean.newBoolean(context, value == 0);
     }
 
     @Override
@@ -1428,22 +1428,20 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
 
     @Override
     public IRubyObject isNegative(ThreadContext context) {
-        Ruby runtime = context.runtime;
         CachingCallSite op_lt_site = sites(context).basic_op_lt;
         if (op_lt_site.retrieveCache(metaClass).method.isBuiltin()) {
-            return runtime.newBoolean(value < 0);
+            return RubyBoolean.newBoolean(context, value < 0);
         }
-        return op_lt_site.call(context, this, this, RubyFixnum.zero(runtime));
+        return op_lt_site.call(context, this, this, RubyFixnum.zero(context.runtime));
     }
 
     @Override
     public IRubyObject isPositive(ThreadContext context) {
-        Ruby runtime = context.runtime;
         CachingCallSite op_gt_site = sites(context).basic_op_gt;
         if (op_gt_site.retrieveCache(metaClass).method.isBuiltin()) {
-            return runtime.newBoolean(value > 0);
+            return RubyBoolean.newBoolean(context, value > 0);
         }
-        return op_gt_site.call(context, this, this, RubyFixnum.zero(runtime));
+        return op_gt_site.call(context, this, this, RubyFixnum.zero(context.runtime));
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyFloat.java
+++ b/core/src/main/java/org/jruby/RubyFloat.java
@@ -90,7 +90,6 @@ public class RubyFloat extends RubyNumeric {
 
     public static RubyClass createFloatClass(Ruby runtime) {
         RubyClass floatc = runtime.defineClass("Float", runtime.getNumeric(), ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR);
-        runtime.setFloat(floatc);
 
         floatc.setClassIndex(ClassIndex.FLOAT);
         floatc.setReifiedClass(RubyFloat.class);
@@ -110,12 +109,12 @@ public class RubyFloat extends RubyNumeric {
         floatc.defineConstant("MAX_EXP", RubyFixnum.newFixnum(runtime, MAX_EXP));
         floatc.defineConstant("MIN_10_EXP", RubyFixnum.newFixnum(runtime, MIN_10_EXP));
         floatc.defineConstant("MAX_10_EXP", RubyFixnum.newFixnum(runtime, MAX_10_EXP));
-        floatc.defineConstant("MIN", RubyFloat.newFloat(runtime, Double.MIN_NORMAL));
-        floatc.defineConstant("MAX", RubyFloat.newFloat(runtime, Double.MAX_VALUE));
-        floatc.defineConstant("EPSILON", RubyFloat.newFloat(runtime, EPSILON));
+        floatc.defineConstant("MIN", new RubyFloat(floatc, Double.MIN_NORMAL));
+        floatc.defineConstant("MAX", new RubyFloat(floatc, Double.MAX_VALUE));
+        floatc.defineConstant("EPSILON", new RubyFloat(floatc, EPSILON));
 
-        floatc.defineConstant("INFINITY", RubyFloat.newFloat(runtime, INFINITY));
-        floatc.defineConstant("NAN", RubyFloat.newFloat(runtime, NAN));
+        floatc.defineConstant("INFINITY", new RubyFloat(floatc, INFINITY));
+        floatc.defineConstant("NAN", new RubyFloat(floatc, NAN));
 
         floatc.defineAnnotatedMethods(RubyFloat.class);
 
@@ -135,6 +134,12 @@ public class RubyFloat extends RubyNumeric {
 
     public RubyFloat(Ruby runtime, double value) {
         super(runtime.getFloat());
+        this.value = value;
+        this.flags |= FROZEN_F;
+    }
+
+    private RubyFloat(RubyClass klass, double value) {
+        super(klass);
         this.value = value;
         this.flags |= FROZEN_F;
     }

--- a/core/src/main/java/org/jruby/RubyFloat.java
+++ b/core/src/main/java/org/jruby/RubyFloat.java
@@ -203,13 +203,13 @@ public class RubyFloat extends RubyNumeric {
     @Override
     @JRubyMethod(name = "negative?")
     public IRubyObject isNegative(ThreadContext context) {
-        return context.runtime.newBoolean(isNegative());
+        return RubyBoolean.newBoolean(context, isNegative());
     }
 
     @Override
     @JRubyMethod(name = "positive?")
     public IRubyObject isPositive(ThreadContext context) {
-        return context.runtime.newBoolean(isPositive());
+        return RubyBoolean.newBoolean(context, isPositive());
     }
 
     @Override
@@ -497,7 +497,7 @@ public class RubyFloat extends RubyNumeric {
         switch (other.getMetaClass().getClassIndex()) {
         case INTEGER:
         case FLOAT:
-            return RubyBoolean.newBoolean(context.runtime, value == ((RubyNumeric) other).getDoubleValue());
+            return RubyBoolean.newBoolean(context, value == ((RubyNumeric) other).getDoubleValue());
         default:
             // Numeric.equal
             return super.op_num_equal(context, other);
@@ -508,7 +508,7 @@ public class RubyFloat extends RubyNumeric {
         if (Double.isNaN(value)) {
             return context.fals;
         }
-        return RubyBoolean.newBoolean(context.runtime, value == other);
+        return RubyBoolean.newBoolean(context, value == other);
     }
 
     public boolean fastEqual(RubyFloat other) {
@@ -573,14 +573,14 @@ public class RubyFloat extends RubyNumeric {
         case INTEGER:
         case FLOAT:
             double b = ((RubyNumeric) other).getDoubleValue();
-            return RubyBoolean.newBoolean(context.runtime, !Double.isNaN(b) && value > b);
+            return RubyBoolean.newBoolean(context, !Double.isNaN(b) && value > b);
         default:
             return coerceRelOp(context, sites(context).op_gt, other);
         }
     }
 
     public IRubyObject op_gt(ThreadContext context, double other) {
-        return RubyBoolean.newBoolean(context.runtime, !Double.isNaN(other) && value > other);
+        return RubyBoolean.newBoolean(context, !Double.isNaN(other) && value > other);
     }
 
     /** flo_ge
@@ -592,14 +592,14 @@ public class RubyFloat extends RubyNumeric {
         case INTEGER:
         case FLOAT:
             double b = ((RubyNumeric) other).getDoubleValue();
-            return RubyBoolean.newBoolean(context.runtime, !Double.isNaN(b) && value >= b);
+            return RubyBoolean.newBoolean(context, !Double.isNaN(b) && value >= b);
         default:
             return coerceRelOp(context, sites(context).op_ge, other);
         }
     }
 
     public IRubyObject op_ge(ThreadContext context, double other) {
-        return RubyBoolean.newBoolean(context.runtime, !Double.isNaN(other) && value >= other);
+        return RubyBoolean.newBoolean(context, !Double.isNaN(other) && value >= other);
     }
 
     /** flo_lt
@@ -611,14 +611,14 @@ public class RubyFloat extends RubyNumeric {
         case INTEGER:
         case FLOAT:
             double b = ((RubyNumeric) other).getDoubleValue();
-            return RubyBoolean.newBoolean(context.runtime, !Double.isNaN(b) && value < b);
+            return RubyBoolean.newBoolean(context, !Double.isNaN(b) && value < b);
         default:
             return coerceRelOp(context, sites(context).op_lt, other);
 		}
     }
 
     public IRubyObject op_lt(ThreadContext context, double other) {
-        return RubyBoolean.newBoolean(context.runtime, !Double.isNaN(other) && value < other);
+        return RubyBoolean.newBoolean(context, !Double.isNaN(other) && value < other);
     }
 
     /** flo_le
@@ -630,14 +630,14 @@ public class RubyFloat extends RubyNumeric {
         case INTEGER:
         case FLOAT:
             double b = ((RubyNumeric) other).getDoubleValue();
-            return RubyBoolean.newBoolean(context.runtime, !Double.isNaN(b) && value <= b);
+            return RubyBoolean.newBoolean(context, !Double.isNaN(b) && value <= b);
         default:
             return coerceRelOp(context, sites(context).op_le, other);
 		}
 	}
 
     public IRubyObject op_le(ThreadContext context, double other) {
-        return RubyBoolean.newBoolean(context.runtime, !Double.isNaN(other) && value <= other);
+        return RubyBoolean.newBoolean(context, !Double.isNaN(other) && value <= other);
 	}
 
     /** flo_eql
@@ -712,7 +712,7 @@ public class RubyFloat extends RubyNumeric {
     @JRubyMethod(name = "zero?")
     @Override
     public IRubyObject zero_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context.runtime, value == 0.0);
+        return RubyBoolean.newBoolean(context, value == 0.0);
     }
 
     @Override
@@ -1151,10 +1151,11 @@ public class RubyFloat extends RubyNumeric {
      */
     @JRubyMethod(name = "finite?")
     public IRubyObject finite_p() {
+        Ruby runtime = metaClass.runtime;
         if (Double.isInfinite(value) || Double.isNaN(value)) {
-            return metaClass.runtime.getFalse();
+            return runtime.getFalse();
         }
-        return metaClass.runtime.getTrue();
+        return runtime.getTrue();
     }
 
     private ByteList marshalDump() {

--- a/core/src/main/java/org/jruby/RubyGC.java
+++ b/core/src/main/java/org/jruby/RubyGC.java
@@ -58,7 +58,6 @@ public class RubyGC {
 
     public static RubyModule createGCModule(Ruby runtime) {
         RubyModule result = runtime.defineModule("GC");
-        runtime.setGC(result);
         
         result.defineAnnotatedMethods(RubyGC.class);
         

--- a/core/src/main/java/org/jruby/RubyGC.java
+++ b/core/src/main/java/org/jruby/RubyGC.java
@@ -94,7 +94,7 @@ public class RubyGC {
 
     @JRubyMethod(module = true, visibility = PRIVATE)
     public static IRubyObject stress(ThreadContext context, IRubyObject recv) {
-        return context.runtime.newBoolean(stress);
+        return RubyBoolean.newBoolean(context, stress);
     }
 
     @JRubyMethod(name = "stress=", module = true, visibility = PRIVATE)

--- a/core/src/main/java/org/jruby/RubyGenerator.java
+++ b/core/src/main/java/org/jruby/RubyGenerator.java
@@ -40,18 +40,18 @@ import org.jruby.util.ArraySupport;
 
 @JRubyClass(name = "Enumerator::Generator")
 public class RubyGenerator extends RubyObject {
-    public static void createGeneratorClass(Ruby runtime) {
+    public static RubyClass createGeneratorClass(Ruby runtime, RubyClass enumeratorModule) {
         RubyClass genc = runtime.defineClassUnder("Generator", runtime.getObject(), new ObjectAllocator() {
             @Override
             public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
                 return new RubyGenerator(runtime, klazz);
             }
-        }, runtime.getEnumerator());
+        }, enumeratorModule);
 
         genc.includeModule(runtime.getEnumerable());
         genc.defineAnnotatedMethods(RubyGenerator.class);
 
-        runtime.setGenerator(genc);
+        return genc;
     }
 
     public RubyGenerator(Ruby runtime, RubyClass klass) {

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1085,12 +1085,9 @@ public class RubyHash extends RubyObject implements Map {
     }
 
     public RubyBoolean compare(final ThreadContext context, VisitorWithState<RubyHash> visitor, IRubyObject other) {
-
-        Ruby runtime = context.runtime;
-
         if (!(other instanceof RubyHash)) {
             if (!sites(context).respond_to_to_hash.respondsTo(context, other, other)) {
-                return runtime.getFalse();
+                return context.fals;
             }
             return Helpers.rbEqual(context, other, this);
         }
@@ -1098,16 +1095,16 @@ public class RubyHash extends RubyObject implements Map {
         final RubyHash otherHash = (RubyHash) other;
 
         if (this.size != otherHash.size) {
-            return runtime.getFalse();
+            return context.fals;
         }
 
         try {
             visitAll(context, visitor, otherHash);
         } catch (Mismatch e) {
-            return runtime.getFalse();
+            return context.fals;
         }
 
-        return runtime.getTrue();
+        return context.tru;
     }
 
     private static final VisitorWithState<RubyHash> FindMismatchUsingEqualVisitor = new VisitorWithState<RubyHash>() {
@@ -1185,7 +1182,7 @@ public class RubyHash extends RubyObject implements Map {
         final RubyHash otherHash = ((RubyBasicObject) other).convertToHash();
         if (size() >= otherHash.size()) return context.fals;
 
-        return RubyBoolean.newBoolean(context.runtime, hash_le(otherHash));
+        return RubyBoolean.newBoolean(context, hash_le(otherHash));
     }
 
     @JRubyMethod(name = "<=", required = 1)
@@ -1193,7 +1190,7 @@ public class RubyHash extends RubyObject implements Map {
         final RubyHash otherHash = other.convertToHash();
         if (size() > otherHash.size()) return context.fals;
 
-        return RubyBoolean.newBoolean(context.runtime, hash_le(otherHash));
+        return RubyBoolean.newBoolean(context, hash_le(otherHash));
     }
 
     @JRubyMethod(name = ">", required = 1)
@@ -1292,12 +1289,12 @@ public class RubyHash extends RubyObject implements Map {
      */
     @JRubyMethod(name = {"has_key?", "key?", "include?", "member?"}, required = 1)
     public RubyBoolean has_key_p(ThreadContext context, IRubyObject key) {
-        Ruby runtime = context.runtime;
-        return internalGetEntry(key) == NO_ENTRY ? runtime.getFalse() : runtime.getTrue();
+        return internalGetEntry(key) == NO_ENTRY ? context.fals : context.tru;
     }
 
     public RubyBoolean has_key_p(IRubyObject key) {
-        return internalGetEntry(key) == NO_ENTRY ? metaClass.runtime.getFalse() : metaClass.runtime.getTrue();
+        Ruby runtime = metaClass.runtime;
+        return internalGetEntry(key) == NO_ENTRY ? runtime.getFalse() : runtime.getTrue();
     }
 
     private static class Found extends RuntimeException {
@@ -1348,7 +1345,7 @@ public class RubyHash extends RubyObject implements Map {
      */
     @JRubyMethod(name = {"has_value?", "value?"}, required = 1)
     public RubyBoolean has_value_p(ThreadContext context, IRubyObject expected) {
-        return context.runtime.newBoolean(hasValue(context, expected));
+        return RubyBoolean.newBoolean(context, hasValue(context, expected));
     }
 
     private volatile int iteratorCount;
@@ -2095,7 +2092,7 @@ public class RubyHash extends RubyObject implements Map {
 
     @JRubyMethod(name = "compare_by_identity?")
     public IRubyObject compare_by_identity_p(ThreadContext context) {
-        return context.runtime.newBoolean(isComparedByIdentity());
+        return RubyBoolean.newBoolean(context, isComparedByIdentity());
     }
 
     @JRubyMethod
@@ -2787,7 +2784,8 @@ public class RubyHash extends RubyObject implements Map {
 
     @Deprecated
     public RubyBoolean empty_p() {
-        return size == 0 ? metaClass.runtime.getTrue() : metaClass.runtime.getFalse();
+        Ruby runtime = metaClass.runtime;
+        return size == 0 ? runtime.getTrue() : runtime.getFalse();
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -120,7 +120,6 @@ public class RubyHash extends RubyObject implements Map {
 
     public static RubyClass createHashClass(Ruby runtime) {
         RubyClass hashc = runtime.defineClass("Hash", runtime.getObject(), HASH_ALLOCATOR);
-        runtime.setHash(hashc);
 
         hashc.setClassIndex(ClassIndex.HASH);
         hashc.setReifiedClass(RubyHash.class);

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1295,7 +1295,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     @JRubyMethod(name = "autoclose?")
     public IRubyObject autoclose(ThreadContext context) {
-        return context.runtime.newBoolean(isAutoclose());
+        return RubyBoolean.newBoolean(context, isAutoclose());
     }
 
     @JRubyMethod(name = "autoclose=")
@@ -1319,7 +1319,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     // MRI: rb_io_binmode_p
     @JRubyMethod(name = "binmode?")
     public IRubyObject op_binmode(ThreadContext context) {
-        return RubyBoolean.newBoolean(context.runtime, getOpenFileChecked().isBinmode());
+        return RubyBoolean.newBoolean(context, getOpenFileChecked().isBinmode());
     }
 
     // rb_io_syswrite
@@ -1524,14 +1524,13 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
      */
     @JRubyMethod
     public RubyBoolean sync(ThreadContext context) {
-        Ruby runtime = context.runtime;
         OpenFile fptr;
 
         RubyIO io = GetWriteIO();
         fptr = io.getOpenFileChecked();
         fptr.lock();
         try {
-            return (fptr.getMode() & OpenFile.SYNC) != 0 ? runtime.getTrue() : runtime.getFalse();
+            return (fptr.getMode() & OpenFile.SYNC) != 0 ? context.tru : context.fals;
         } finally {
             fptr.unlock();
         }
@@ -1837,7 +1836,6 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     // rb_io_eof
     @JRubyMethod(name = {"eof?", "eof"})
     public RubyBoolean eof_p(ThreadContext context) {
-        Ruby runtime = context.runtime;
         OpenFile fptr;
 
         fptr = getOpenFileChecked();
@@ -1846,8 +1844,8 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         try {
             fptr.checkCharReadable(context);
 
-            if (fptr.READ_CHAR_PENDING()) return runtime.getFalse();
-            if (fptr.READ_DATA_PENDING()) return runtime.getFalse();
+            if (fptr.READ_CHAR_PENDING()) return context.fals;
+            if (fptr.READ_DATA_PENDING()) return context.fals;
             fptr.READ_CHECK(context);
             //        #if defined(RUBY_TEST_CRLF_ENVIRONMENT) || defined(_WIN32)
             //        if (!NEED_READCONV(fptr) && NEED_NEWLINE_DECORATOR_ON_READ(fptr)) {
@@ -1855,13 +1853,13 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
             //        }
             //        #endif
             if (fptr.fillbuf(context) < 0) {
-                return runtime.getTrue();
+                return context.tru;
             }
         } finally {
             if (locked) fptr.unlock();
         }
 
-        return runtime.getFalse();
+        return context.fals;
     }
 
     @JRubyMethod(name = {"tty?", "isatty"})
@@ -1950,7 +1948,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     @JRubyMethod(name = "closed?")
     public RubyBoolean closed_p(ThreadContext context) {
-        return context.runtime.newBoolean(isClosed());
+        return RubyBoolean.newBoolean(context, isClosed());
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -313,8 +313,6 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     public static RubyClass createIOClass(Ruby runtime) {
         RubyClass ioClass = runtime.defineClass("IO", runtime.getObject(), IO_ALLOCATOR);
 
-        runtime.setIO(ioClass);
-
         ioClass.setClassIndex(ClassIndex.IO);
         ioClass.setReifiedClass(RubyIO.class);
 

--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -119,12 +119,12 @@ public abstract class RubyInteger extends RubyNumeric {
 
     @Override
     public IRubyObject isNegative(ThreadContext context) {
-        return context.runtime.newBoolean(isNegative());
+        return RubyBoolean.newBoolean(context, isNegative());
     }
 
     @Override
     public IRubyObject isPositive(ThreadContext context) {
-        return context.runtime.newBoolean(isPositive());
+        return RubyBoolean.newBoolean(context, isPositive());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -70,7 +70,6 @@ public abstract class RubyInteger extends RubyNumeric {
     public static RubyClass createIntegerClass(Ruby runtime) {
         RubyClass integer = runtime.defineClass("Integer", runtime.getNumeric(),
                 ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR);
-        runtime.setInteger(integer);
 
         integer.setClassIndex(ClassIndex.INTEGER);
         integer.setReifiedClass(RubyInteger.class);

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -803,7 +803,7 @@ public class RubyKernel {
 
     @JRubyMethod(name = {"block_given?", "iterator?"}, module = true, visibility = PRIVATE, reads = BLOCK)
     public static RubyBoolean block_given_p(ThreadContext context, IRubyObject recv) {
-        return context.runtime.newBoolean(context.getCurrentFrame().getBlock().isGiven());
+        return RubyBoolean.newBoolean(context, context.getCurrentFrame().getBlock().isGiven());
     }
 
     @JRubyMethod(name = {"sprintf", "format"}, required = 1, rest = true, module = true, visibility = PRIVATE)

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -129,7 +129,6 @@ public class RubyKernel {
 
     public static RubyModule createKernelModule(Ruby runtime) {
         RubyModule module = runtime.defineModule("Kernel");
-        runtime.setKernel(module);
 
         module.defineAnnotatedMethods(RubyKernel.class);
 
@@ -145,7 +144,7 @@ public class RubyKernel {
             module.defineAnnotatedMethods(LoopMethods.class);
         }
 
-        recacheBuiltinMethods(runtime);
+        recacheBuiltinMethods(runtime, module);
 
         return module;
     }
@@ -156,11 +155,9 @@ public class RubyKernel {
      *
      * @param runtime
      */
-    static void recacheBuiltinMethods(Ruby runtime) {
-        RubyModule module = runtime.getKernel();
-
-        runtime.setRespondToMethod(module.searchMethod("respond_to?"));
-        runtime.setRespondToMissingMethod(module.searchMethod("respond_to_missing?"));
+    static void recacheBuiltinMethods(Ruby runtime, RubyModule kernelModule) {
+        runtime.setRespondToMethod(kernelModule.searchMethod("respond_to?"));
+        runtime.setRespondToMissingMethod(kernelModule.searchMethod("respond_to_missing?"));
     }
 
     @JRubyMethod(module = true, visibility = PRIVATE)

--- a/core/src/main/java/org/jruby/RubyMarshal.java
+++ b/core/src/main/java/org/jruby/RubyMarshal.java
@@ -61,7 +61,6 @@ public class RubyMarshal {
 
     public static RubyModule createMarshalModule(Ruby runtime) {
         RubyModule module = runtime.defineModule("Marshal");
-        runtime.setMarshal(module);
 
         module.defineAnnotatedMethods(RubyMarshal.class);
         module.defineConstant("MAJOR_VERSION", runtime.newFixnum(Constants.MARSHAL_MAJOR));

--- a/core/src/main/java/org/jruby/RubyMatchData.java
+++ b/core/src/main/java/org/jruby/RubyMatchData.java
@@ -71,7 +71,6 @@ public class RubyMatchData extends RubyObject {
 
     public static RubyClass createMatchDataClass(Ruby runtime) {
         RubyClass matchDataClass = runtime.defineClass("MatchData", runtime.getObject(), MATCH_DATA_ALLOCATOR);
-        runtime.setMatchData(matchDataClass);
 
         matchDataClass.setClassIndex(ClassIndex.MATCHDATA);
         matchDataClass.setReifiedClass(RubyMatchData.class);
@@ -81,6 +80,7 @@ public class RubyMatchData extends RubyObject {
 
         matchDataClass.getMetaClass().undefineMethod("new");
         matchDataClass.defineAnnotatedMethods(RubyMatchData.class);
+
         return matchDataClass;
     }
 

--- a/core/src/main/java/org/jruby/RubyMethod.java
+++ b/core/src/main/java/org/jruby/RubyMethod.java
@@ -75,7 +75,6 @@ public class RubyMethod extends AbstractRubyMethod {
     public static RubyClass createMethodClass(Ruby runtime) {
         // TODO: NOT_ALLOCATABLE_ALLOCATOR is probably ok here. Confirm. JRUBY-415
         RubyClass methodClass = runtime.defineClass("Method", runtime.getObject(), ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR);
-        runtime.setMethod(methodClass);
 
         methodClass.setClassIndex(ClassIndex.METHOD);
         methodClass.setReifiedClass(RubyMethod.class);

--- a/core/src/main/java/org/jruby/RubyMethod.java
+++ b/core/src/main/java/org/jruby/RubyMethod.java
@@ -155,7 +155,7 @@ public class RubyMethod extends AbstractRubyMethod {
     @Override
     @JRubyMethod(name = "==", required = 1)
     public RubyBoolean op_equal(ThreadContext context, IRubyObject other) {
-        return context.runtime.newBoolean( equals(other) );
+        return RubyBoolean.newBoolean(context,  equals(other) );
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1112,19 +1112,21 @@ public class RubyModule extends RubyObject {
 
         if (jrubyConstant == null) return false;
 
+        Ruby runtime = getRuntime();
+
         Class tp = field.getType();
         IRubyObject realVal;
 
         try {
             if(tp == Integer.class || tp == Integer.TYPE || tp == Short.class || tp == Short.TYPE || tp == Byte.class || tp == Byte.TYPE) {
-                realVal = RubyNumeric.int2fix(getRuntime(), field.getInt(null));
+                realVal = RubyNumeric.int2fix(runtime, field.getInt(null));
             } else if(tp == Boolean.class || tp == Boolean.TYPE) {
-                realVal = field.getBoolean(null) ? getRuntime().getTrue() : getRuntime().getFalse();
+                realVal = field.getBoolean(null) ? runtime.getTrue() : runtime.getFalse();
             } else {
-                realVal = getRuntime().getNil();
+                realVal = runtime.getNil();
             }
         } catch(Exception e) {
-            realVal = getRuntime().getNil();
+            realVal = runtime.getNil();
         }
 
         String[] names = jrubyConstant.value();
@@ -1346,7 +1348,7 @@ public class RubyModule extends RubyObject {
 
     @JRubyMethod(name = "singleton_class?")
     public IRubyObject singleton_class_p(ThreadContext context) {
-        return context.runtime.newBoolean(isSingleton());
+        return RubyBoolean.newBoolean(context, isSingleton());
     }
 
     public void addMethod(String id, DynamicMethod method) {
@@ -2578,7 +2580,7 @@ public class RubyModule extends RubyObject {
     @JRubyMethod(name = "===", required = 1)
     @Override
     public RubyBoolean op_eqq(ThreadContext context, IRubyObject obj) {
-        return context.runtime.newBoolean(isInstance(obj));
+        return RubyBoolean.newBoolean(context, isInstance(obj));
     }
 
     /**
@@ -2599,9 +2601,9 @@ public class RubyModule extends RubyObject {
 
         RubyModule otherModule = (RubyModule) other;
         if(otherModule.isIncluded()) {
-            return context.runtime.newBoolean(otherModule.isSame(this));
+            return RubyBoolean.newBoolean(context, otherModule.isSame(this));
         } else {
-            return context.runtime.newBoolean(isSame(otherModule));
+            return RubyBoolean.newBoolean(context, isSame(otherModule));
         }
     }
 
@@ -3179,21 +3181,21 @@ public class RubyModule extends RubyObject {
     public IRubyObject public_method_defined(ThreadContext context, IRubyObject symbol) {
         DynamicMethod method = searchMethod(TypeConverter.checkID(symbol).idString());
 
-        return context.runtime.newBoolean(!method.isUndefined() && method.getVisibility() == PUBLIC);
+        return RubyBoolean.newBoolean(context, !method.isUndefined() && method.getVisibility() == PUBLIC);
     }
 
     @JRubyMethod(name = "protected_method_defined?", required = 1)
     public IRubyObject protected_method_defined(ThreadContext context, IRubyObject symbol) {
         DynamicMethod method = searchMethod(TypeConverter.checkID(symbol).idString());
 
-        return context.runtime.newBoolean(!method.isUndefined() && method.getVisibility() == PROTECTED);
+        return RubyBoolean.newBoolean(context, !method.isUndefined() && method.getVisibility() == PROTECTED);
     }
 
     @JRubyMethod(name = "private_method_defined?", required = 1)
     public IRubyObject private_method_defined(ThreadContext context, IRubyObject symbol) {
         DynamicMethod method = searchMethod(TypeConverter.checkID(symbol).idString());
 
-        return context.runtime.newBoolean(!method.isUndefined() && method.getVisibility() == PRIVATE);
+        return RubyBoolean.newBoolean(context, !method.isUndefined() && method.getVisibility() == PRIVATE);
     }
 
     @JRubyMethod(name = "public_class_method", rest = true)

--- a/core/src/main/java/org/jruby/RubyNameError.java
+++ b/core/src/main/java/org/jruby/RubyNameError.java
@@ -252,7 +252,7 @@ public class RubyNameError extends RubyStandardError {
 
     @JRubyMethod(name = "private_call?")
     public IRubyObject private_call_p(ThreadContext context) {
-        return context.runtime.newBoolean(isPrivateCall());
+        return RubyBoolean.newBoolean(context, isPrivateCall());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyNil.java
+++ b/core/src/main/java/org/jruby/RubyNil.java
@@ -78,7 +78,7 @@ public class RubyNil extends RubyObject implements Constantizable {
     
     public static RubyClass createNilClass(Ruby runtime) {
         RubyClass nilClass = runtime.defineClass("NilClass", runtime.getObject(), NIL_ALLOCATOR);
-        runtime.setNilClass(nilClass);
+
         nilClass.setClassIndex(ClassIndex.NIL);
         nilClass.setReifiedClass(RubyNil.class);
         

--- a/core/src/main/java/org/jruby/RubyNil.java
+++ b/core/src/main/java/org/jruby/RubyNil.java
@@ -189,7 +189,7 @@ public class RubyNil extends RubyObject implements Constantizable {
      */
     @JRubyMethod(name = "|", required = 1)
     public static RubyBoolean op_or(ThreadContext context, IRubyObject recv, IRubyObject obj) {
-        return context.runtime.newBoolean(obj.isTrue());
+        return RubyBoolean.newBoolean(context, obj.isTrue());
     }
     
     /** nil_xor
@@ -197,7 +197,7 @@ public class RubyNil extends RubyObject implements Constantizable {
      */
     @JRubyMethod(name = "^", required = 1)
     public static RubyBoolean op_xor(ThreadContext context, IRubyObject recv, IRubyObject obj) {
-        return context.runtime.newBoolean(obj.isTrue());
+        return RubyBoolean.newBoolean(context, obj.isTrue());
     }
 
     @JRubyMethod(name = "nil?")

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -871,7 +871,7 @@ public class RubyNumeric extends RubyObject {
     */
     @JRubyMethod(name = "real?")
     public IRubyObject real_p(ThreadContext context) {
-        return context.runtime.newBoolean(isReal());
+        return RubyBoolean.newBoolean(context, isReal());
     }
 
     public boolean isReal() { return true; } // only RubyComplex isn't real

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -80,7 +80,6 @@ public class RubyNumeric extends RubyObject {
 
     public static RubyClass createNumericClass(Ruby runtime) {
         RubyClass numeric = runtime.defineClass("Numeric", runtime.getObject(), NUMERIC_ALLOCATOR);
-        runtime.setNumeric(numeric);
 
         numeric.setClassIndex(ClassIndex.NUMERIC);
         numeric.setReifiedClass(RubyNumeric.class);

--- a/core/src/main/java/org/jruby/RubyObject.java
+++ b/core/src/main/java/org/jruby/RubyObject.java
@@ -383,7 +383,7 @@ public class RubyObject extends RubyBasicObject {
      */
     @Override
     public IRubyObject op_eqq(ThreadContext context, IRubyObject other) {
-        return context.runtime.newBoolean(equalInternal(context, this, other));
+        return RubyBoolean.newBoolean(context, equalInternal(context, this, other));
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyObjectSpace.java
+++ b/core/src/main/java/org/jruby/RubyObjectSpace.java
@@ -208,7 +208,7 @@ public class RubyObjectSpace {
 
         @JRubyMethod(name = "key?")
         public IRubyObject key_p(ThreadContext context, IRubyObject key) {
-            return context.runtime.newBoolean(map.get(key) != null);
+            return RubyBoolean.newBoolean(context, map.get(key) != null);
         }
 
         private final WeakValuedIdentityMap<IRubyObject, IRubyObject> map = new WeakValuedIdentityMap<IRubyObject, IRubyObject>();

--- a/core/src/main/java/org/jruby/RubyObjectSpace.java
+++ b/core/src/main/java/org/jruby/RubyObjectSpace.java
@@ -54,11 +54,10 @@ public class RubyObjectSpace {
      */
     public static RubyModule createObjectSpaceModule(Ruby runtime) {
         RubyModule objectSpaceModule = runtime.defineModule("ObjectSpace");
-        runtime.setObjectSpaceModule(objectSpaceModule);
 
         objectSpaceModule.defineAnnotatedMethods(RubyObjectSpace.class);
 
-        WeakMap.createWeakMap(runtime);
+        WeakMap.createWeakMap(runtime, objectSpaceModule);
 
         return objectSpaceModule;
     }
@@ -180,8 +179,8 @@ public class RubyObjectSpace {
     }
 
     public static class WeakMap extends RubyObject {
-        static void createWeakMap(Ruby runtime) {
-            RubyClass weakMap = runtime.getObjectSpaceModule().defineClassUnder("WeakMap", runtime.getObject(), new ObjectAllocator() {
+        static void createWeakMap(Ruby runtime, RubyModule objectspaceModule) {
+            RubyClass weakMap = objectspaceModule.defineClassUnder("WeakMap", runtime.getObject(), new ObjectAllocator() {
                 public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
                     return new WeakMap(runtime, klazz);
                 }

--- a/core/src/main/java/org/jruby/RubyProc.java
+++ b/core/src/main/java/org/jruby/RubyProc.java
@@ -344,7 +344,7 @@ public class RubyProc extends RubyObject implements DataType {
 
     @JRubyMethod(name = "lambda?")
     public IRubyObject lambda_p(ThreadContext context) {
-        return context.runtime.newBoolean(isLambda());
+        return RubyBoolean.newBoolean(context, isLambda());
     }
 
     private boolean isLambda() {

--- a/core/src/main/java/org/jruby/RubyProc.java
+++ b/core/src/main/java/org/jruby/RubyProc.java
@@ -89,7 +89,6 @@ public class RubyProc extends RubyObject implements DataType {
 
     public static RubyClass createProcClass(Ruby runtime) {
         RubyClass procClass = runtime.defineClass("Proc", runtime.getObject(), ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR);
-        runtime.setProc(procClass);
 
         procClass.setClassIndex(ClassIndex.PROC);
         procClass.setReifiedClass(RubyProc.class);

--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -237,7 +237,7 @@ public class RubyProcess {
             if (!PosixShim.WAIT_MACROS.WIFEXITED(status)) {
                 return context.nil;
             }
-            return context.runtime.newBoolean(PosixShim.WAIT_MACROS.WEXITSTATUS(status) == EXIT_SUCCESS);
+            return RubyBoolean.newBoolean(context, PosixShim.WAIT_MACROS.WEXITSTATUS(status) == EXIT_SUCCESS);
         }
 
         @JRubyMethod(name = {"coredump?"})

--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -81,7 +81,6 @@ public class RubyProcess {
 
     public static RubyModule createProcessModule(Ruby runtime) {
         RubyModule process = runtime.defineModule("Process");
-        runtime.setProcess(process);
 
         // TODO: NOT_ALLOCATABLE_ALLOCATOR is probably ok here. Confirm. JRUBY-415
         RubyClass process_status = process.defineClassUnder("Status", runtime.getObject(), ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR);

--- a/core/src/main/java/org/jruby/RubyRandom.java
+++ b/core/src/main/java/org/jruby/RubyRandom.java
@@ -227,12 +227,14 @@ public class RubyRandom extends RubyObject {
     public static RubyClass createRandomClass(Ruby runtime) {
         RubyClass randomClass = runtime
                 .defineClass("Random", runtime.getObject(), RANDOM_ALLOCATOR);
+
         randomClass.defineAnnotatedMethods(RubyRandom.class);
+
         RubyRandom defaultRand = new RubyRandom(runtime, randomClass);
         defaultRand.random = new RandomType(randomSeed(runtime));
         randomClass.setConstant("DEFAULT", defaultRand);
         runtime.setDefaultRand(defaultRand.random);
-        runtime.setRandomClass(randomClass);
+
         return randomClass;
     }
 

--- a/core/src/main/java/org/jruby/RubyRandom.java
+++ b/core/src/main/java/org/jruby/RubyRandom.java
@@ -623,7 +623,7 @@ public class RubyRandom extends RubyObject {
         if (!getType().equals(obj.getType())) {
             return context.fals;
         }
-        return context.runtime.newBoolean(random.equals(((RubyRandom) obj).random));
+        return RubyBoolean.newBoolean(context, random.equals(((RubyRandom) obj).random));
     }
 
     // c: random_state

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -396,7 +396,7 @@ public class RubyRange extends RubyObject {
 
         RubyRange otherRange = (RubyRange) other;
 
-        return context.runtime.newBoolean(isExclusive == otherRange.isExclusive &&
+        return RubyBoolean.newBoolean(context, isExclusive == otherRange.isExclusive &&
                 invokedynamic(context, this.begin, equalityCheck, otherRange.begin).isTrue() &&
                 invokedynamic(context, this.end, equalityCheck, otherRange.end).isTrue());
     }
@@ -754,7 +754,7 @@ public class RubyRange extends RubyObject {
         if (rangeLe(context, begin, obj) == null) {
             return context.fals; // obj < start...end
         }
-        return context.runtime.newBoolean(isExclusive
+        return RubyBoolean.newBoolean(context, isExclusive
                 ? // begin <= obj < end || begin <= obj <= end
                 rangeLt(context, obj, end) != null : rangeLe(context, obj, end) != null);
     }

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -90,7 +90,6 @@ public class RubyRange extends RubyObject {
 
     public static RubyClass createRangeClass(Ruby runtime) {
         RubyClass result = runtime.defineClass("Range", runtime.getObject(), RANGE_ALLOCATOR);
-        runtime.setRange(result);
 
         result.setClassIndex(ClassIndex.RANGE);
         result.setReifiedClass(RubyRange.class);

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -440,7 +440,7 @@ public class RubyRational extends RubyNumeric {
 
     @Override
     public IRubyObject zero_p(ThreadContext context) {
-        return context.runtime.newBoolean(isZero());
+        return RubyBoolean.newBoolean(context, isZero());
     }
 
     @Override
@@ -455,12 +455,12 @@ public class RubyRational extends RubyNumeric {
 
     @Override
     public IRubyObject isNegative(ThreadContext context) {
-        return context.runtime.newBoolean(signum() < 0);
+        return RubyBoolean.newBoolean(context, signum() < 0);
     }
 
     @Override
     public IRubyObject isPositive(ThreadContext context) {
-        return context.runtime.newBoolean(signum() > 0);
+        return RubyBoolean.newBoolean(context, signum() > 0);
     }
 
     @Override
@@ -807,14 +807,14 @@ public class RubyRational extends RubyNumeric {
     }
 
     public final IRubyObject op_equal(ThreadContext context, RubyInteger other) {
-        if (num.isZero()) return context.runtime.newBoolean(other.isZero());
+        if (num.isZero()) return RubyBoolean.newBoolean(context, other.isZero());
         if (!(den instanceof RubyFixnum) || den.getLongValue() != 1) return context.fals;
         return f_equal(context, num, other);
     }
 
     final RubyBoolean op_equal(ThreadContext context, RubyRational other) {
-        if (num.isZero()) return context.runtime.newBoolean(other.num.isZero());
-        return context.runtime.newBoolean(
+        if (num.isZero()) return RubyBoolean.newBoolean(context, other.num.isZero());
+        return RubyBoolean.newBoolean(context,
                 f_equal(context, num, other.num).isTrue() && f_equal(context, den, other.den).isTrue());
     }
 

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -63,7 +63,6 @@ public class RubyRational extends RubyNumeric {
     
     public static RubyClass createRationalClass(Ruby runtime) {
         RubyClass rationalc = runtime.defineClass("Rational", runtime.getNumeric(), RATIONAL_ALLOCATOR);
-        runtime.setRational(rationalc);
 
         rationalc.setClassIndex(ClassIndex.RATIONAL);
         rationalc.setReifiedClass(RubyRational.class);

--- a/core/src/main/java/org/jruby/RubyRegexp.java
+++ b/core/src/main/java/org/jruby/RubyRegexp.java
@@ -1066,7 +1066,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         check();
         otherRegex.check();
 
-        return context.runtime.newBoolean(str.equal(otherRegex.str) && options.equals(otherRegex.options));
+        return RubyBoolean.newBoolean(context, str.equal(otherRegex.str) && options.equals(otherRegex.options));
     }
 
     @Deprecated
@@ -1356,7 +1356,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
 
     @JRubyMethod(name = "casefold?")
     public IRubyObject casefold_p(ThreadContext context) {
-        return context.runtime.newBoolean(getOptions().isIgnorecase());
+        return RubyBoolean.newBoolean(context, getOptions().isIgnorecase());
     }
 
     /** rb_reg_source
@@ -1549,7 +1549,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
 
     @JRubyMethod(name = "fixed_encoding?")
     public IRubyObject fixed_encoding_p(ThreadContext context) {
-        return context.runtime.newBoolean(options.isFixed());
+        return RubyBoolean.newBoolean(context, options.isFixed());
     }
 
     /** rb_reg_nth_match

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -142,7 +142,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     public static RubyClass createStringClass(Ruby runtime) {
         RubyClass stringClass = runtime.defineClass("String", runtime.getObject(), STRING_ALLOCATOR);
-        runtime.setString(stringClass);
+
         stringClass.setClassIndex(ClassIndex.STRING);
         stringClass.setReifiedClass(RubyString.class);
         stringClass.kindOf = new RubyModule.JavaClassKindOf(RubyString.class);

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1156,9 +1156,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     }
 
     private IRubyObject op_equalCommon(ThreadContext context, IRubyObject other) {
-        Ruby runtime = context.runtime;
-        if (!sites(context).respond_to_to_str.respondsTo(context, this, other)) return runtime.getFalse();
-        return sites(context).equals.call(context, this, other, this).isTrue() ? runtime.getTrue() : runtime.getFalse();
+        if (!sites(context).respond_to_to_str.respondsTo(context, this, other)) return context.fals;
+        return sites(context).equals.call(context, this, other, this).isTrue() ? context.tru : context.fals;
     }
 
     @JRubyMethod(name = "-@") // -'foo' returns frozen string
@@ -1716,7 +1715,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     @JRubyMethod(name = ">=")
     public IRubyObject op_ge19(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyString && cmpIsBuiltin(context)) {
-            return context.runtime.newBoolean(op_cmp((RubyString) other) >= 0);
+            return RubyBoolean.newBoolean(context, op_cmp((RubyString) other) >= 0);
         }
         return RubyComparable.op_ge(context, this, other);
     }
@@ -1728,7 +1727,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     @JRubyMethod(name = ">")
     public IRubyObject op_gt19(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyString && cmpIsBuiltin(context)) {
-            return context.runtime.newBoolean(op_cmp((RubyString) other) > 0);
+            return RubyBoolean.newBoolean(context, op_cmp((RubyString) other) > 0);
         }
         return RubyComparable.op_gt(context, this, other);
     }
@@ -1740,7 +1739,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     @JRubyMethod(name = "<=")
     public IRubyObject op_le19(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyString && cmpIsBuiltin(context)) {
-            return context.runtime.newBoolean(op_cmp((RubyString) other) <= 0);
+            return RubyBoolean.newBoolean(context, op_cmp((RubyString) other) <= 0);
         }
         return RubyComparable.op_le(context, this, other);
     }
@@ -1752,7 +1751,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     @JRubyMethod(name = "<")
     public IRubyObject op_lt19(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyString && cmpIsBuiltin(context)) {
-            return context.runtime.newBoolean(op_cmp((RubyString) other) < 0);
+            return RubyBoolean.newBoolean(context, op_cmp((RubyString) other) < 0);
         }
         return RubyComparable.op_lt(context, sites(context).cmp, this, other);
     }
@@ -1767,12 +1766,11 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @JRubyMethod(name = "eql?")
     public IRubyObject str_eql_p19(ThreadContext context, IRubyObject other) {
-        Ruby runtime = context.runtime;
         if (other instanceof RubyString) {
             RubyString otherString = (RubyString)other;
-            if (StringSupport.areComparable(this, otherString) && value.equal(otherString.value)) return runtime.getTrue();
+            if (StringSupport.areComparable(this, otherString) && value.equal(otherString.value)) return context.tru;
         }
-        return runtime.getFalse();
+        return context.fals;
     }
 
     private int caseMap(Ruby runtime, int flags, Encoding enc) {
@@ -4070,9 +4068,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      */
     @JRubyMethod(name = "include?")
     public RubyBoolean include_p(ThreadContext context, IRubyObject obj) {
-        Ruby runtime = context.runtime;
         RubyString coerced = obj.convertToString();
-        return StringSupport.index(this, coerced, 0, this.checkEncoding(coerced)) == -1 ? runtime.getFalse() : runtime.getTrue();
+        return StringSupport.index(this, coerced, 0, this.checkEncoding(coerced)) == -1 ? context.fals : context.tru;
     }
 
     @JRubyMethod
@@ -6255,12 +6252,12 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @JRubyMethod(name = "valid_encoding?")
     public IRubyObject valid_encoding_p(ThreadContext context) {
-        return context.runtime.newBoolean(scanForCodeRange() != CR_BROKEN);
+        return RubyBoolean.newBoolean(context, scanForCodeRange() != CR_BROKEN);
     }
 
     @JRubyMethod(name = "ascii_only?")
     public IRubyObject ascii_only_p(ThreadContext context) {
-        return context.runtime.newBoolean(scanForCodeRange() == CR_7BIT);
+        return RubyBoolean.newBoolean(context, scanForCodeRange() == CR_7BIT);
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -91,7 +91,7 @@ public class RubyStruct extends RubyObject {
 
     public static RubyClass createStructClass(Ruby runtime) {
         RubyClass structClass = runtime.defineClass("Struct", runtime.getObject(), ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR);
-        runtime.setStructClass(structClass);
+
         structClass.setClassIndex(ClassIndex.STRUCT);
         structClass.includeModule(runtime.getEnumerable());
         structClass.setReifiedClass(RubyStruct.class);

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -504,13 +504,13 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
     @JRubyMethod(name = "===", required = 1)
     @Override
     public IRubyObject op_eqq(ThreadContext context, IRubyObject other) {
-        return context.runtime.newBoolean(this == other);
+        return RubyBoolean.newBoolean(context, this == other);
     }
 
     @JRubyMethod(name = "==", required = 1)
     @Override
     public IRubyObject op_equal(ThreadContext context, IRubyObject other) {
-        return context.runtime.newBoolean(this == other);
+        return RubyBoolean.newBoolean(context, this == other);
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -132,7 +132,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
 
     public static RubyClass createSymbolClass(Ruby runtime) {
         RubyClass symbolClass = runtime.defineClass("Symbol", runtime.getObject(), ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR);
-        runtime.setSymbol(symbolClass);
+
         RubyClass symbolMetaClass = symbolClass.getMetaClass();
         symbolClass.setClassIndex(ClassIndex.SYMBOL);
         symbolClass.setReifiedClass(RubySymbol.class);

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -432,7 +432,6 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         // it must provide an allocator that can create empty object instances which
         // initialize then fills with appropriate data.
         RubyClass threadClass = runtime.defineClass("Thread", runtime.getObject(), ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR);
-        runtime.setThread(threadClass);
 
         threadClass.setClassIndex(ClassIndex.THREAD);
         threadClass.setReifiedClass(RubyThread.class);

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -1003,7 +1003,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         key = getSymbolKey(key);
         final Map<IRubyObject, IRubyObject> locals = getFiberLocals();
         synchronized (locals) {
-            return context.runtime.newBoolean(locals.containsKey(key));
+            return RubyBoolean.newBoolean(context, locals.containsKey(key));
         }
     }
 
@@ -1031,7 +1031,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         key = getSymbolKey(key);
         final Map<IRubyObject, IRubyObject> locals = getThreadLocals();
         synchronized (locals) {
-            return context.runtime.newBoolean(locals.containsKey(key));
+            return RubyBoolean.newBoolean(context, locals.containsKey(key));
         }
     }
 

--- a/core/src/main/java/org/jruby/RubyThreadGroup.java
+++ b/core/src/main/java/org/jruby/RubyThreadGroup.java
@@ -55,7 +55,6 @@ public class RubyThreadGroup extends RubyObject {
 
     public static RubyClass createThreadGroupClass(Ruby runtime) {
         RubyClass threadGroupClass = runtime.defineClass("ThreadGroup", runtime.getObject(), THREADGROUP_ALLOCATOR);
-        runtime.setThreadGroup(threadGroupClass);
 
         threadGroupClass.setClassIndex(ClassIndex.THREADGROUP);
         

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -373,8 +373,6 @@ public class RubyTime extends RubyObject {
         timeClass.setClassIndex(ClassIndex.TIME);
         timeClass.setReifiedClass(RubyTime.class);
 
-        runtime.setTime(timeClass);
-
         timeClass.includeModule(runtime.getComparable());
 
         timeClass.defineAnnotatedMethods(RubyTime.class);

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -587,7 +587,7 @@ public class RubyTime extends RubyObject {
     @Override
     public IRubyObject op_equal(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyTime) {
-            return context.runtime.newBoolean(cmp((RubyTime) other) == 0);
+            return RubyBoolean.newBoolean(context, cmp((RubyTime) other) == 0);
         }
         if (other == context.nil) {
             return context.fals;
@@ -599,7 +599,7 @@ public class RubyTime extends RubyObject {
     @JRubyMethod(name = ">=", required = 1)
     public IRubyObject op_ge(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyTime) {
-            return context.runtime.newBoolean(cmp((RubyTime) other) >= 0);
+            return RubyBoolean.newBoolean(context, cmp((RubyTime) other) >= 0);
         }
 
         return RubyComparable.op_ge(context, this, other);
@@ -608,7 +608,7 @@ public class RubyTime extends RubyObject {
     @JRubyMethod(name = ">", required = 1)
     public IRubyObject op_gt(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyTime) {
-            return context.runtime.newBoolean(cmp((RubyTime) other) > 0);
+            return RubyBoolean.newBoolean(context, cmp((RubyTime) other) > 0);
         }
 
         return RubyComparable.op_gt(context, this, other);
@@ -617,7 +617,7 @@ public class RubyTime extends RubyObject {
     @JRubyMethod(name = "<=", required = 1)
     public IRubyObject op_le(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyTime) {
-            return context.runtime.newBoolean(cmp((RubyTime) other) <= 0);
+            return RubyBoolean.newBoolean(context, cmp((RubyTime) other) <= 0);
         }
 
         return RubyComparable.op_le(context, this, other);
@@ -626,7 +626,7 @@ public class RubyTime extends RubyObject {
     @JRubyMethod(name = "<", required = 1)
     public IRubyObject op_lt(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyTime) {
-            return context.runtime.newBoolean(cmp((RubyTime) other) < 0);
+            return RubyBoolean.newBoolean(context, cmp((RubyTime) other) < 0);
         }
 
         return RubyComparable.op_lt(context, this, other);
@@ -738,7 +738,7 @@ public class RubyTime extends RubyObject {
     @Override
     public IRubyObject op_eqq(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyTime) {
-            return context.runtime.newBoolean(RubyNumeric.fix2int(invokedynamic(context, this, OP_CMP, other)) == 0);
+            return RubyBoolean.newBoolean(context, RubyNumeric.fix2int(invokedynamic(context, this, OP_CMP, other)) == 0);
         }
 
         return context.fals;
@@ -966,37 +966,37 @@ public class RubyTime extends RubyObject {
 
     @JRubyMethod(name = "sunday?")
     public RubyBoolean sunday_p(ThreadContext context) {
-        return context.runtime.newBoolean((dt.getDayOfWeek() % 7) == 0);
+        return RubyBoolean.newBoolean(context, (dt.getDayOfWeek() % 7) == 0);
     }
 
     @JRubyMethod(name = "monday?")
     public RubyBoolean monday_p(ThreadContext context) {
-        return context.runtime.newBoolean((dt.getDayOfWeek() % 7) == 1);
+        return RubyBoolean.newBoolean(context, (dt.getDayOfWeek() % 7) == 1);
     }
 
     @JRubyMethod(name = "tuesday?")
     public RubyBoolean tuesday_p(ThreadContext context) {
-        return context.runtime.newBoolean((dt.getDayOfWeek() % 7) == 2);
+        return RubyBoolean.newBoolean(context, (dt.getDayOfWeek() % 7) == 2);
     }
 
     @JRubyMethod(name = "wednesday?")
     public RubyBoolean wednesday_p(ThreadContext context) {
-        return context.runtime.newBoolean((dt.getDayOfWeek() % 7) == 3);
+        return RubyBoolean.newBoolean(context, (dt.getDayOfWeek() % 7) == 3);
     }
 
     @JRubyMethod(name = "thursday?")
     public RubyBoolean thursday_p(ThreadContext context) {
-        return context.runtime.newBoolean((dt.getDayOfWeek() % 7) == 4);
+        return RubyBoolean.newBoolean(context, (dt.getDayOfWeek() % 7) == 4);
     }
 
     @JRubyMethod(name = "friday?")
     public RubyBoolean friday_p(ThreadContext context) {
-        return context.runtime.newBoolean((dt.getDayOfWeek() % 7) == 5);
+        return RubyBoolean.newBoolean(context, (dt.getDayOfWeek() % 7) == 5);
     }
 
     @JRubyMethod(name = "saturday?")
     public RubyBoolean saturday_p(ThreadContext context) {
-        return context.runtime.newBoolean((dt.getDayOfWeek() % 7) == 6);
+        return RubyBoolean.newBoolean(context, (dt.getDayOfWeek() % 7) == 6);
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/RubyUnboundMethod.java
+++ b/core/src/main/java/org/jruby/RubyUnboundMethod.java
@@ -73,7 +73,6 @@ public class RubyUnboundMethod extends AbstractRubyMethod {
     public static RubyClass defineUnboundMethodClass(Ruby runtime) {
         RubyClass newClass = 
         	runtime.defineClass("UnboundMethod", runtime.getObject(), ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR);
-        runtime.setUnboundMethod(newClass);
 
         newClass.setClassIndex(ClassIndex.UNBOUNDMETHOD);
         newClass.setReifiedClass(RubyUnboundMethod.class);

--- a/core/src/main/java/org/jruby/RubyUnboundMethod.java
+++ b/core/src/main/java/org/jruby/RubyUnboundMethod.java
@@ -88,7 +88,7 @@ public class RubyUnboundMethod extends AbstractRubyMethod {
     @Override
     @JRubyMethod(name = "==", required = 1)
     public RubyBoolean op_equal(ThreadContext context, IRubyObject other) {
-        return context.runtime.newBoolean( equals(other) );
+        return RubyBoolean.newBoolean(context,  equals(other) );
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyYielder.java
+++ b/core/src/main/java/org/jruby/RubyYielder.java
@@ -44,11 +44,12 @@ public class RubyYielder extends RubyObject {
 
     public static RubyClass createYielderClass(Ruby runtime) {
         RubyClass yielderc = runtime.defineClassUnder("Yielder", runtime.getObject(), YIELDER_ALLOCATOR, runtime.getEnumerator());
-        runtime.setYielder(yielderc);
+
         yielderc.setClassIndex(ClassIndex.YIELDER);
         yielderc.kindOf = new RubyModule.JavaClassKindOf(RubyYielder.class);
 
         yielderc.defineAnnotatedMethods(RubyYielder.class);
+
         return yielderc;
     }
 

--- a/core/src/main/java/org/jruby/common/RubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/RubyWarnings.java
@@ -59,8 +59,6 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
         warning.defineAnnotatedMethods(RubyWarnings.class);
         warning.extend_object(warning);
 
-        runtime.setWarning(warning);
-
         return warning;
     }
 

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -1390,7 +1390,7 @@ public class RubyBigDecimal extends RubyNumeric {
                 case '=': {
                     if (falsyEqlCheck(context, arg)) return context.fals;
                     IRubyObject res = callCoerced(context, sites(context).op_eql, arg, false);
-                    return context.runtime.newBoolean(res != context.nil && res != context.fals);
+                    return RubyBoolean.newBoolean(context, res != context.nil && res != context.fals);
                 }
                 case '!':
                     if (falsyEqlCheck(context, arg)) return context.tru;
@@ -1413,12 +1413,12 @@ public class RubyBigDecimal extends RubyNumeric {
 
         switch (op) {
             case '*': return context.runtime.newFixnum(e);
-            case '=': return context.runtime.newBoolean(e == 0);
-            case '!': return context.runtime.newBoolean(e != 0);
-            case 'G': return context.runtime.newBoolean(e >= 0);
-            case '>': return context.runtime.newBoolean(e >  0);
-            case 'L': return context.runtime.newBoolean(e <= 0);
-            case '<': return context.runtime.newBoolean(e <  0);
+            case '=': return RubyBoolean.newBoolean(context, e == 0);
+            case '!': return RubyBoolean.newBoolean(context, e != 0);
+            case 'G': return RubyBoolean.newBoolean(context, e >= 0);
+            case '>': return RubyBoolean.newBoolean(context, e >  0);
+            case 'L': return RubyBoolean.newBoolean(context, e <= 0);
+            case '<': return RubyBoolean.newBoolean(context, e <  0);
         }
         return context.nil;
     }
@@ -1630,7 +1630,7 @@ public class RubyBigDecimal extends RubyNumeric {
 
     @JRubyMethod(name = "nan?")
     public IRubyObject nan_p(ThreadContext context) {
-        return context.runtime.newBoolean(isNaN());
+        return RubyBoolean.newBoolean(context, isNaN());
     }
 
     @Override
@@ -2111,7 +2111,7 @@ public class RubyBigDecimal extends RubyNumeric {
     @Override
     @JRubyMethod(name = "zero?")
     public IRubyObject zero_p(ThreadContext context) {
-        return context.runtime.newBoolean(isZero());
+        return RubyBoolean.newBoolean(context, isZero());
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -893,12 +893,12 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod(name = "julian?")
     public RubyBoolean julian_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context.runtime, isJulian());
+        return RubyBoolean.newBoolean(context, isJulian());
     }
 
     @JRubyMethod(name = "gregorian?")
     public RubyBoolean gregorian_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context.runtime, ! isJulian());
+        return RubyBoolean.newBoolean(context, ! isJulian());
     }
 
     public final boolean isJulian() {
@@ -1161,13 +1161,13 @@ public class RubyDate extends RubyObject {
     @JRubyMethod(name = "julian_leap?", meta = true)
     public static IRubyObject julian_leap_p(ThreadContext context, IRubyObject self, IRubyObject year) {
         final RubyInteger y = year.convertToInteger();
-        return context.runtime.newBoolean(isJulianLeap(y.getLongValue()));
+        return RubyBoolean.newBoolean(context, isJulianLeap(y.getLongValue()));
     }
 
     @JRubyMethod(name = "gregorian_leap?", alias = "leap?", meta = true)
     public static IRubyObject gregorian_leap_p(ThreadContext context, IRubyObject self, IRubyObject year) {
         final RubyInteger y = year.convertToInteger();
-        return context.runtime.newBoolean(isGregorianLeap(y.getLongValue()));
+        return RubyBoolean.newBoolean(context, isGregorianLeap(y.getLongValue()));
     }
 
     // All years divisible by 4 are leap years in the Julian calendar.
@@ -1191,7 +1191,7 @@ public class RubyDate extends RubyObject {
     @JRubyMethod(name = "leap?")
     public IRubyObject leap_p(ThreadContext context) {
         final long year = dt.getYear();
-        return context.runtime.newBoolean( isJulian() ? isJulianLeap(year) : isGregorianLeap(year) );
+        return RubyBoolean.newBoolean(context,  isJulian() ? isJulianLeap(year) : isGregorianLeap(year) );
     }
 
     //
@@ -2434,7 +2434,7 @@ public class RubyDate extends RubyObject {
             set_hash(context, hash, "mday", cstr2num(context.runtime, d, bp, ep));
         }
 
-        if (comp != null) set_hash(context, hash, "_comp", context.runtime.newBoolean(comp));
+        if (comp != null) set_hash(context, hash, "_comp", RubyBoolean.newBoolean(context, comp));
 
         return hash;
     }

--- a/core/src/main/java/org/jruby/ext/ffi/AbstractMemory.java
+++ b/core/src/main/java/org/jruby/ext/ffi/AbstractMemory.java
@@ -31,6 +31,7 @@ package org.jruby.ext.ffi;
 import java.nio.ByteOrder;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
+import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
@@ -192,7 +193,7 @@ abstract public class AbstractMemory extends MemoryObject {
     @JRubyMethod(name = "==", required = 1)
     @Override
     public IRubyObject op_equal(ThreadContext context, IRubyObject obj) {
-        return context.runtime.newBoolean(this.equals(obj));
+        return RubyBoolean.newBoolean(context, this.equals(obj));
     }
     
     /**

--- a/core/src/main/java/org/jruby/ext/ffi/AutoPointer.java
+++ b/core/src/main/java/org/jruby/ext/ffi/AutoPointer.java
@@ -7,6 +7,7 @@ import java.lang.ref.WeakReference;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.jruby.Ruby;
+import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.anno.JRubyClass;
@@ -175,7 +176,7 @@ public class AutoPointer extends Pointer {
 
     @JRubyMethod(name = "autorelease?")
     public final IRubyObject autorelease_p(ThreadContext context) {
-        return context.runtime.newBoolean(reaper != null ? !reaper.unmanaged : false);
+        return RubyBoolean.newBoolean(context, reaper != null ? !reaper.unmanaged : false);
     }
 
     private void setReaper(Reaper reaper) {

--- a/core/src/main/java/org/jruby/ext/ffi/DataConverter.java
+++ b/core/src/main/java/org/jruby/ext/ffi/DataConverter.java
@@ -2,6 +2,7 @@
 package org.jruby.ext.ffi;
 
 import org.jruby.Ruby;
+import org.jruby.RubyBoolean;
 import org.jruby.RubyModule;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
@@ -64,12 +65,12 @@ public class DataConverter {
     @JRubyMethod(name = "reference_required?", module=true)
     public static IRubyObject reference_required_p(ThreadContext context, IRubyObject self) {
         Object ref = module(self).getInternalVariable("reference_required");
-        return context.runtime.newBoolean(!(ref instanceof IRubyObject) || ((IRubyObject) ref).isTrue());
+        return RubyBoolean.newBoolean(context, !(ref instanceof IRubyObject) || ((IRubyObject) ref).isTrue());
     }
 
     @JRubyMethod(name = "reference_required", module=true, optional = 1)
     public static IRubyObject reference_required(ThreadContext context, IRubyObject self, IRubyObject[] args) {
-        module(self).setInternalVariable("reference_required", context.runtime.newBoolean(args.length < 1 || args[0].isTrue()));
+        module(self).setInternalVariable("reference_required", RubyBoolean.newBoolean(context, args.length < 1 || args[0].isTrue()));
         return self;
     }
 }

--- a/core/src/main/java/org/jruby/ext/ffi/MemoryPointer.java
+++ b/core/src/main/java/org/jruby/ext/ffi/MemoryPointer.java
@@ -124,7 +124,7 @@ public class MemoryPointer extends Pointer {
 
     @JRubyMethod(name = "==", required = 1)
     public IRubyObject op_equal(ThreadContext context, IRubyObject obj) {
-        return context.runtime.newBoolean(this == obj
+        return RubyBoolean.newBoolean(context, this == obj
                 || getAddress() == 0L && obj.isNil()
                 || (obj instanceof MemoryPointer
                 && ((MemoryPointer) obj).getAddress() == getAddress())
@@ -147,6 +147,6 @@ public class MemoryPointer extends Pointer {
 
     @JRubyMethod(name = "autorelease?")
     public final IRubyObject autorelease_p(ThreadContext context) {
-        return context.runtime.newBoolean(((AllocatedDirectMemoryIO) getMemoryIO()).isAutoRelease());
+        return RubyBoolean.newBoolean(context, ((AllocatedDirectMemoryIO) getMemoryIO()).isAutoRelease());
     }
 }

--- a/core/src/main/java/org/jruby/ext/ffi/Platform.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Platform.java
@@ -31,6 +31,7 @@ package org.jruby.ext.ffi;
 import java.nio.ByteOrder;
 import java.util.regex.Pattern;
 import org.jruby.Ruby;
+import org.jruby.RubyBoolean;
 import org.jruby.RubyModule;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
@@ -338,27 +339,27 @@ public class Platform {
     }
     @JRubyMethod(name = "windows?", module=true)
     public static IRubyObject windows_p(ThreadContext context, IRubyObject recv) {
-        return context.runtime.newBoolean(OS == OS.WINDOWS);
+        return RubyBoolean.newBoolean(context, OS == OS.WINDOWS);
     }
     @JRubyMethod(name = "mac?", module=true)
     public static IRubyObject mac_p(ThreadContext context, IRubyObject recv) {
-        return context.runtime.newBoolean(OS == OS.DARWIN);
+        return RubyBoolean.newBoolean(context, OS == OS.DARWIN);
     }
     @JRubyMethod(name = "unix?", module=true)
     public static IRubyObject unix_p(ThreadContext context, IRubyObject recv) {
-        return context.runtime.newBoolean(Platform.getPlatform().isUnix());
+        return RubyBoolean.newBoolean(context, Platform.getPlatform().isUnix());
     }
     @JRubyMethod(name = "bsd?", module=true)
     public static IRubyObject bsd_p(ThreadContext context, IRubyObject recv) {
-        return context.runtime.newBoolean(Platform.getPlatform().isBSD());
+        return RubyBoolean.newBoolean(context, Platform.getPlatform().isBSD());
     }
     @JRubyMethod(name = "linux?", module=true)
     public static IRubyObject linux_p(ThreadContext context, IRubyObject recv) {
-        return context.runtime.newBoolean(OS == OS.LINUX);
+        return RubyBoolean.newBoolean(context, OS == OS.LINUX);
     }
     @JRubyMethod(name = "solaris?", module=true)
     public static IRubyObject solaris_p(ThreadContext context, IRubyObject recv) {
-        return context.runtime.newBoolean(OS == OS.SOLARIS);
+        return RubyBoolean.newBoolean(context, OS == OS.SOLARIS);
     }
     /**
      * An extension over <code>System.getProperty</code> method.

--- a/core/src/main/java/org/jruby/ext/ffi/Pointer.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Pointer.java
@@ -142,7 +142,7 @@ public class Pointer extends AbstractMemory {
      */
     @JRubyMethod(name = "null?")
     public IRubyObject null_p(ThreadContext context) {
-        return context.runtime.newBoolean(getMemoryIO().isNull());
+        return RubyBoolean.newBoolean(context, getMemoryIO().isNull());
     }
 
 
@@ -172,7 +172,7 @@ public class Pointer extends AbstractMemory {
 
     @JRubyMethod(name = "==", required = 1)
     public IRubyObject op_equal(ThreadContext context, IRubyObject obj) {
-        return context.runtime.newBoolean(this == obj
+        return RubyBoolean.newBoolean(context, this == obj
                 || getAddress() == 0L && obj.isNil()
                 || (obj instanceof Pointer && ((Pointer) obj).getAddress() == getAddress()));
     }

--- a/core/src/main/java/org/jruby/ext/ffi/Struct.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Struct.java
@@ -348,7 +348,7 @@ public class Struct extends MemoryObject implements StructLayout.Storage {
 
     @JRubyMethod(name="null?")
     public IRubyObject null_p(ThreadContext context) {
-        return context.runtime.newBoolean(getMemory().getMemoryIO().isNull());
+        return RubyBoolean.newBoolean(context, getMemory().getMemoryIO().isNull());
     }
 
     @JRubyMethod(name = "order", required = 0)

--- a/core/src/main/java/org/jruby/ext/ffi/Type.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Type.java
@@ -3,6 +3,7 @@ package org.jruby.ext.ffi;
 
 import java.util.Map;
 import org.jruby.Ruby;
+import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.RubyNumeric;
@@ -216,18 +217,18 @@ public abstract class Type extends RubyObject {
         @Override
         @JRubyMethod(name = "==", required = 1)
         public IRubyObject op_equal(ThreadContext context, IRubyObject obj) {
-            return context.runtime.newBoolean(this.equals(obj));
+            return RubyBoolean.newBoolean(context, this.equals(obj));
         }
 
         @Override
         @JRubyMethod(name = "equal?", required = 1)
         public IRubyObject equal_p(ThreadContext context, IRubyObject obj) {
-            return context.runtime.newBoolean(this.equals(obj));
+            return RubyBoolean.newBoolean(context, this.equals(obj));
         }
         
         @JRubyMethod(name = "eql?", required = 1)
         public IRubyObject eql_p(ThreadContext context, IRubyObject obj) {
-            return context.runtime.newBoolean(this.equals(obj));
+            return RubyBoolean.newBoolean(context, this.equals(obj));
         }
 
     }

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/Function.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/Function.java
@@ -4,6 +4,7 @@ package org.jruby.ext.ffi.jffi;
 import com.kenai.jffi.CallingConvention;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
+import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyHash;
 import org.jruby.RubyModule;
@@ -160,7 +161,7 @@ public final class Function extends org.jruby.ext.ffi.AbstractInvoker {
 
     @JRubyMethod(name = { "autorelease?", "autorelease" })
     public final IRubyObject autorelease_p(ThreadContext context) {
-        return context.runtime.newBoolean(autorelease);
+        return RubyBoolean.newBoolean(context, autorelease);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/JITRuntime.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/JITRuntime.java
@@ -384,7 +384,7 @@ public final class JITRuntime {
     }
     
     public static IRubyObject newBoolean(ThreadContext context, int value) {
-        return context.runtime.newBoolean((value & 0x1) != 0);
+        return RubyBoolean.newBoolean(context, (value & 0x1) != 0);
     }
 
     public static IRubyObject newBoolean(Ruby runtime, int value) {
@@ -392,7 +392,7 @@ public final class JITRuntime {
     }
     
     public static IRubyObject newBoolean(ThreadContext context, long value) {
-        return context.runtime.newBoolean((value & 0x1L) != 0);
+        return RubyBoolean.newBoolean(context, (value & 0x1L) != 0);
     }
 
     public static IRubyObject newBoolean(Ruby runtime, long value) {

--- a/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
+++ b/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
+import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyObject;
 import org.jruby.RubyThread;
@@ -248,7 +249,7 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
 
     @JRubyMethod
     public IRubyObject __alive__(ThreadContext context) {
-        return context.runtime.newBoolean(alive());
+        return RubyBoolean.newBoolean(context, alive());
     }
     
     @JRubyMethod(meta = true)

--- a/core/src/main/java/org/jruby/ext/fiber/ThreadFiberLibrary.java
+++ b/core/src/main/java/org/jruby/ext/fiber/ThreadFiberLibrary.java
@@ -37,8 +37,8 @@ import org.jruby.runtime.builtin.IRubyObject;
 /**
  * A thread-based implementation of Ruby 1.9 Fiber library.
  */
-public class ThreadFiberLibrary implements Library {
-    public void load(final Ruby runtime, boolean wrap) {
+public class ThreadFiberLibrary {
+    public RubyClass createFiberClass(final Ruby runtime) {
         RubyClass cFiber = runtime.defineClass("Fiber", runtime.getObject(), new ObjectAllocator() {
             public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
                 return new ThreadFiber(runtime, klazz);
@@ -47,6 +47,6 @@ public class ThreadFiberLibrary implements Library {
 
         cFiber.defineAnnotatedMethods(ThreadFiber.class);
 
-        runtime.setFiber(cFiber);
+        return cFiber;
     }
 }

--- a/core/src/main/java/org/jruby/ext/io/wait/IOWaitLibrary.java
+++ b/core/src/main/java/org/jruby/ext/io/wait/IOWaitLibrary.java
@@ -29,6 +29,7 @@
 package org.jruby.ext.io.wait;
 
 import org.jruby.Ruby;
+import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyIO;
 import org.jruby.RubyNumeric;
@@ -79,18 +80,17 @@ public class IOWaitLibrary implements Library {
     @JRubyMethod(name = "ready?")
     public static IRubyObject ready(ThreadContext context, IRubyObject _io) {
         RubyIO io = (RubyIO)_io;
-        Ruby runtime = context.runtime;
         OpenFile fptr;
 //        ioctl_arg n;
 
         fptr = io.getOpenFileChecked();
         fptr.checkReadable(context);
-        if (fptr.readPending() != 0) return runtime.getTrue();
+        if (fptr.readPending() != 0) return context.tru;
         // TODO: better effort to get available bytes from our channel
 //        if (!FIONREAD_POSSIBLE_P(fptr->fd)) return Qnil;
 //        if (ioctl(fptr->fd, FIONREAD, &n)) return Qnil;
 //        if (n > 0) return Qtrue;
-        return runtime.newBoolean(fptr.readyNow(context));
+        return RubyBoolean.newBoolean(context, fptr.readyNow(context));
     }
 
     @JRubyMethod(optional = 1)

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyLibrary.java
@@ -86,12 +86,12 @@ public class JRubyLibrary implements Library {
     public static class JRubyConfig {
         @JRubyMethod(name = "rubygems_disabled?")
         public static IRubyObject rubygems_disabled_p(ThreadContext context, IRubyObject self) {
-            return context.runtime.newBoolean(context.runtime.getInstanceConfig().isDisableGems());
+            return RubyBoolean.newBoolean(context, context.runtime.getInstanceConfig().isDisableGems());
         }
 
         @JRubyMethod(name = "did_you_mean_disabled?")
         public static IRubyObject did_you_mean_disabled_p(ThreadContext context, IRubyObject self) {
-            return context.runtime.newBoolean(context.runtime.getInstanceConfig().isDisableDidYouMean());
+            return RubyBoolean.newBoolean(context, context.runtime.getInstanceConfig().isDisableDidYouMean());
         }
     }
 

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
@@ -89,7 +89,7 @@ public class JRubyUtilLibrary implements Library {
 
     @JRubyMethod(meta = true, name = "native_posix?")
     public static IRubyObject native_posix_p(ThreadContext context, IRubyObject self) {
-        return context.runtime.newBoolean(context.runtime.getPosix().isNative());
+        return RubyBoolean.newBoolean(context, context.runtime.getPosix().isNative());
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/ext/ripper/RubyRipper.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RubyRipper.java
@@ -31,6 +31,7 @@ package org.jruby.ext.ripper;
 
 import java.io.IOException;
 import org.jruby.Ruby;
+import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyHash;
 import org.jruby.RubyNumeric;
@@ -310,12 +311,12 @@ public class RubyRipper extends RubyObject {
 
     @JRubyMethod(name = "end_seen?")
     public IRubyObject end_seen_p(ThreadContext context) {
-        return context.runtime.newBoolean(parser.isEndSeen());
+        return RubyBoolean.newBoolean(context, parser.isEndSeen());
     }
 
     @JRubyMethod(name = "error?")
     public IRubyObject error_p(ThreadContext context) {
-        return context.runtime.newBoolean(parser.isError());
+        return RubyBoolean.newBoolean(context, parser.isError());
     }
     @JRubyMethod
     public IRubyObject filename(ThreadContext context) {
@@ -354,7 +355,7 @@ public class RubyRipper extends RubyObject {
 
     @JRubyMethod
     public IRubyObject yydebug(ThreadContext context) {
-        return context.runtime.newBoolean(parser.getYYDebug());
+        return RubyBoolean.newBoolean(context, parser.getYYDebug());
     }
     
     @JRubyMethod(name = "yydebug=")

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -325,7 +325,7 @@ public class RubySet extends RubyObject implements Set {
 
     @JRubyMethod(name = "empty?")
     public IRubyObject empty_p(ThreadContext context) {
-        return context.runtime.newBoolean( isEmpty() );
+        return RubyBoolean.newBoolean(context,  isEmpty() );
     }
 
     @JRubyMethod(name = "clear")
@@ -481,7 +481,7 @@ public class RubySet extends RubyObject implements Set {
      */
     @JRubyMethod(name = "include?", alias = { "member?", "===" })
     public RubyBoolean include_p(final ThreadContext context, IRubyObject obj) {
-        return context.runtime.newBoolean( containsImpl(obj) );
+        return RubyBoolean.newBoolean(context,  containsImpl(obj) );
     }
 
     final boolean containsImpl(IRubyObject obj) {
@@ -503,7 +503,7 @@ public class RubySet extends RubyObject implements Set {
                 return this.hash.op_ge(context, ((RubySet) set).hash);
             }
             // size >= set.size && set.all? { |o| include?(o) }
-            return context.runtime.newBoolean(
+            return RubyBoolean.newBoolean(context,
                     size() >= ((RubySet) set).size() && allElementsIncluded((RubySet) set)
             );
         }
@@ -518,7 +518,7 @@ public class RubySet extends RubyObject implements Set {
                 return this.hash.op_gt(context, ((RubySet) set).hash);
             }
             // size >= set.size && set.all? { |o| include?(o) }
-            return context.runtime.newBoolean(
+            return RubyBoolean.newBoolean(context,
                     size() > ((RubySet) set).size() && allElementsIncluded((RubySet) set)
             );
         }
@@ -532,7 +532,7 @@ public class RubySet extends RubyObject implements Set {
                 return this.hash.op_le(context, ((RubySet) set).hash);
             }
             // size >= set.size && set.all? { |o| include?(o) }
-            return context.runtime.newBoolean(
+            return RubyBoolean.newBoolean(context,
                     size() <= ((RubySet) set).size() && allElementsIncluded((RubySet) set)
             );
         }
@@ -546,7 +546,7 @@ public class RubySet extends RubyObject implements Set {
                 return this.hash.op_lt(context, ((RubySet) set).hash);
             }
             // size >= set.size && set.all? { |o| include?(o) }
-            return context.runtime.newBoolean(
+            return RubyBoolean.newBoolean(context,
                     size() < ((RubySet) set).size() && allElementsIncluded((RubySet) set)
             );
         }
@@ -559,7 +559,7 @@ public class RubySet extends RubyObject implements Set {
     @JRubyMethod(name = "intersect?")
     public IRubyObject intersect_p(final ThreadContext context, IRubyObject set) {
         if ( set instanceof RubySet ) {
-            return context.runtime.newBoolean( intersect((RubySet) set) );
+            return RubyBoolean.newBoolean(context,  intersect((RubySet) set) );
         }
         throw context.runtime.newArgumentError("value must be a set");
     }
@@ -587,7 +587,7 @@ public class RubySet extends RubyObject implements Set {
     @JRubyMethod(name = "disjoint?")
     public IRubyObject disjoint_p(final ThreadContext context, IRubyObject set) {
         if ( set instanceof RubySet ) {
-            return context.runtime.newBoolean( ! intersect((RubySet) set) );
+            return RubyBoolean.newBoolean(context,  ! intersect((RubySet) set) );
         }
         throw context.runtime.newArgumentError("value must be a set");
     }

--- a/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
+++ b/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
@@ -12,6 +12,7 @@ import jnr.netdb.Service;
 import jnr.unixsocket.UnixSocketAddress;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
+import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyObject;
 import org.jruby.RubyString;
@@ -396,22 +397,22 @@ public class Addrinfo extends RubyObject {
 
     @JRubyMethod(name = "ipv4?")
     public IRubyObject ipv4_p(ThreadContext context) {
-        return context.runtime.newBoolean(getAddressFamily() == AF_INET);
+        return RubyBoolean.newBoolean(context, getAddressFamily() == AF_INET);
     }
 
     @JRubyMethod(name = "ipv6?")
     public IRubyObject ipv6_p(ThreadContext context) {
-        return context.runtime.newBoolean(getAddressFamily() == AF_INET6);
+        return RubyBoolean.newBoolean(context, getAddressFamily() == AF_INET6);
     }
 
     @JRubyMethod(name = "unix?")
     public IRubyObject unix_p(ThreadContext context) {
-        return context.runtime.newBoolean(getAddressFamily() == AF_UNIX);
+        return RubyBoolean.newBoolean(context, getAddressFamily() == AF_UNIX);
     }
 
     @JRubyMethod(name = "ip?")
     public IRubyObject ip_p(ThreadContext context) {
-        return context.runtime.newBoolean(getAddressFamily() == AF_INET || getAddressFamily() == AF_INET6);
+        return RubyBoolean.newBoolean(context, getAddressFamily() == AF_INET || getAddressFamily() == AF_INET6);
     }
 
     @JRubyMethod
@@ -445,23 +446,23 @@ public class Addrinfo extends RubyObject {
     @JRubyMethod(name = "ipv4_private?")
     public IRubyObject ipv4_private_p(ThreadContext context) {
         if (getAddressFamily() == AF_INET) {
-            return context.runtime.newBoolean(getInet4Address().isSiteLocalAddress());
+            return RubyBoolean.newBoolean(context, getInet4Address().isSiteLocalAddress());
         }
-        return context.runtime.newBoolean(false);
+        return RubyBoolean.newBoolean(context, false);
     }
 
     @JRubyMethod(name = "ipv4_loopback?")
     public IRubyObject ipv4_loopback_p(ThreadContext context) {
       if (getAddressFamily() == AF_INET) {
-        return context.runtime.newBoolean(((InetSocketAddress) socketAddress).getAddress().isLoopbackAddress());
+        return RubyBoolean.newBoolean(context, ((InetSocketAddress) socketAddress).getAddress().isLoopbackAddress());
       }
-      return context.runtime.newBoolean(false);
+      return RubyBoolean.newBoolean(context, false);
     }
 
     @JRubyMethod(name = "ipv4_multicast?")
     public IRubyObject ipv4_multicast_p(ThreadContext context) {
         if (getAddressFamily() == AF_INET) {
-            return context.runtime.newBoolean(getInet4Address().isMulticastAddress());
+            return RubyBoolean.newBoolean(context, getInet4Address().isMulticastAddress());
         }
         return context.fals;
     }
@@ -469,7 +470,7 @@ public class Addrinfo extends RubyObject {
     @JRubyMethod(name = "ipv6_unspecified?")
     public IRubyObject ipv6_unspecified_p(ThreadContext context) {
         if (getAddressFamily() == AF_INET6) {
-            return context.runtime.newBoolean(getInet6Address().getHostAddress().equals("::"));
+            return RubyBoolean.newBoolean(context, getInet6Address().getHostAddress().equals("::"));
         }
         return context.fals;
     }
@@ -477,33 +478,33 @@ public class Addrinfo extends RubyObject {
     @JRubyMethod(name = "ipv6_loopback?")
     public IRubyObject ipv6_loopback_p(ThreadContext context) {
       if (getAddressFamily() == AF_INET6) {
-        return context.runtime.newBoolean(getInetSocketAddress().getAddress().isLoopbackAddress());
+        return RubyBoolean.newBoolean(context, getInetSocketAddress().getAddress().isLoopbackAddress());
       }
-      return context.runtime.newBoolean(false);
+      return RubyBoolean.newBoolean(context, false);
     }
 
     @JRubyMethod(name = "ipv6_multicast?")
     public IRubyObject ipv6_multicast_p(ThreadContext context) {
         if (getAddressFamily() == AF_INET6) {
-            return context.runtime.newBoolean(getInet6Address().isMulticastAddress());
+            return RubyBoolean.newBoolean(context, getInet6Address().isMulticastAddress());
         }
         return context.fals;
     }
 
     @JRubyMethod(name = "ipv6_linklocal?")
     public IRubyObject ipv6_linklocal_p(ThreadContext context) {
-        return context.runtime.newBoolean(getInetSocketAddress().getAddress().isLinkLocalAddress());
+        return RubyBoolean.newBoolean(context, getInetSocketAddress().getAddress().isLinkLocalAddress());
     }
 
     @JRubyMethod(name = "ipv6_sitelocal?")
     public IRubyObject ipv6_sitelocal_p(ThreadContext context) {
-        return context.runtime.newBoolean(((InetSocketAddress) socketAddress).getAddress().isSiteLocalAddress());
+        return RubyBoolean.newBoolean(context, ((InetSocketAddress) socketAddress).getAddress().isSiteLocalAddress());
     }
 
     @JRubyMethod(name = "ipv6_v4mapped?")
     public IRubyObject ipv6_v4mapped_p(ThreadContext context) {
         Inet6Address in6 = getInet6Address();
-        return context.runtime.newBoolean(in6 != null &&
+        return RubyBoolean.newBoolean(context, in6 != null &&
                 // Java always converts mapped ipv6 addresses to ipv4 form
                 in6.getHostAddress().indexOf(":") == -1);
     }
@@ -511,37 +512,37 @@ public class Addrinfo extends RubyObject {
     @JRubyMethod(name = "ipv6_v4compat?")
     public IRubyObject ipv6_v4compat_p(ThreadContext context) {
         Inet6Address in6 = getInet6Address();
-        return context.runtime.newBoolean(in6 != null && in6.isIPv4CompatibleAddress());
+        return RubyBoolean.newBoolean(context, in6 != null && in6.isIPv4CompatibleAddress());
     }
 
     @JRubyMethod(name = "ipv6_mc_nodelocal?")
     public IRubyObject ipv6_mc_nodelocal_p(ThreadContext context) {
         Inet6Address in6 = getInet6Address();
-        return context.runtime.newBoolean(in6 != null && in6.isMCNodeLocal());
+        return RubyBoolean.newBoolean(context, in6 != null && in6.isMCNodeLocal());
     }
 
     @JRubyMethod(name = "ipv6_mc_linklocal?")
     public IRubyObject ipv6_mc_linklocal_p(ThreadContext context) {
         Inet6Address in6 = getInet6Address();
-        return context.runtime.newBoolean(in6 != null && in6.isMCLinkLocal());
+        return RubyBoolean.newBoolean(context, in6 != null && in6.isMCLinkLocal());
     }
 
     @JRubyMethod(name = "ipv6_mc_sitelocal?")
     public IRubyObject ipv6_mc_sitelocal_p(ThreadContext context) {
         Inet6Address in6 = getInet6Address();
-        return context.runtime.newBoolean(in6 != null && in6.isMCSiteLocal());
+        return RubyBoolean.newBoolean(context, in6 != null && in6.isMCSiteLocal());
     }
 
     @JRubyMethod(name = "ipv6_mc_orglocal?")
     public IRubyObject ipv6_mc_orglocal_p(ThreadContext context) {
         Inet6Address in6 = getInet6Address();
-        return context.runtime.newBoolean(in6 != null && in6.isMCOrgLocal());
+        return RubyBoolean.newBoolean(context, in6 != null && in6.isMCOrgLocal());
     }
 
     @JRubyMethod(name = "ipv6_mc_global?")
     public IRubyObject ipv6_mc_global_p(ThreadContext context) {
         Inet6Address in6 = getInet6Address();
-        return context.runtime.newBoolean(in6 != null && in6.isMCGlobal());
+        return RubyBoolean.newBoolean(context, in6 != null && in6.isMCGlobal());
     }
 
     @JRubyMethod(notImplemented = true)

--- a/core/src/main/java/org/jruby/ext/socket/Option.java
+++ b/core/src/main/java/org/jruby/ext/socket/Option.java
@@ -222,7 +222,7 @@ public class Option extends RubyObject {
 
     @JRubyMethod
     public IRubyObject bool(ThreadContext context) {
-        final Ruby runtime = context.getRuntime();
+        final Ruby runtime = context.runtime;
 
         validateDataSize(runtime, data, 4);
 

--- a/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
@@ -114,7 +114,7 @@ public class RubyBasicSocket extends RubyIO {
 
     @JRubyMethod(name = "do_not_reverse_lookup")
     public IRubyObject do_not_reverse_lookup19(ThreadContext context) {
-        return context.runtime.newBoolean(doNotReverseLookup);
+        return RubyBoolean.newBoolean(context, doNotReverseLookup);
     }
 
     @JRubyMethod(name = "do_not_reverse_lookup=")
@@ -125,7 +125,7 @@ public class RubyBasicSocket extends RubyIO {
 
     @JRubyMethod(meta = true)
     public static IRubyObject do_not_reverse_lookup(ThreadContext context, IRubyObject recv) {
-        return context.runtime.newBoolean(context.runtime.isDoNotReverseLookupEnabled());
+        return RubyBoolean.newBoolean(context, context.runtime.isDoNotReverseLookupEnabled());
     }
 
     @JRubyMethod(name = "do_not_reverse_lookup=", meta = true)

--- a/core/src/main/java/org/jruby/ext/socket/RubyIPSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyIPSocket.java
@@ -186,15 +186,15 @@ public class RubyIPSocket extends RubyBasicSocket {
     }
 
     public static Boolean doReverseLookup(ThreadContext context, IRubyObject noreverse) {
-        Ruby runtime = context.runtime;
-
-        if (noreverse == runtime.getTrue()) {
+        if (noreverse == context.tru) {
             return false;
-        } else if (noreverse == runtime.getFalse()) {
+        } else if (noreverse == context.fals) {
             return true;
         } else if (noreverse == context.nil) {
             return null;
         } else {
+            Ruby runtime = context.runtime;
+
             TypeConverter.checkType(context, noreverse, runtime.getSymbol());
             switch (noreverse.toString()) {
                 case "numeric": return true;

--- a/core/src/main/java/org/jruby/ext/stringio/StringIO.java
+++ b/core/src/main/java/org/jruby/ext/stringio/StringIO.java
@@ -458,9 +458,8 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
     @JRubyMethod(name = {"eof", "eof?"})
     public IRubyObject eof(ThreadContext context) {
         checkReadable();
-        Ruby runtime = context.runtime;
-        if (ptr.pos < ptr.string.size()) return runtime.getFalse();
-        return runtime.getTrue();
+        if (ptr.pos < ptr.string.size()) return context.fals;
+        return context.tru;
     }
 
     private boolean isEndOfString() {

--- a/core/src/main/java/org/jruby/ext/thread/Mutex.java
+++ b/core/src/main/java/org/jruby/ext/thread/Mutex.java
@@ -76,7 +76,7 @@ public class Mutex extends RubyObject implements DataType {
 
     @JRubyMethod(name = "locked?")
     public RubyBoolean locked_p(ThreadContext context) {
-        return context.runtime.newBoolean(lock.isLocked());
+        return RubyBoolean.newBoolean(context, lock.isLocked());
     }
 
     @JRubyMethod
@@ -84,7 +84,7 @@ public class Mutex extends RubyObject implements DataType {
         if (lock.isHeldByCurrentThread()) {
             return context.fals;
         }
-        return context.runtime.newBoolean(context.getThread().tryLock(lock));
+        return RubyBoolean.newBoolean(context, context.getThread().tryLock(lock));
     }
 
     @JRubyMethod
@@ -169,7 +169,7 @@ public class Mutex extends RubyObject implements DataType {
 
     @JRubyMethod(name = "owned?")
     public IRubyObject owned_p(ThreadContext context) {
-        return context.runtime.newBoolean(lock.isHeldByCurrentThread());
+        return RubyBoolean.newBoolean(context, lock.isHeldByCurrentThread());
     }
 
     private void checkRelocking(ThreadContext context) {

--- a/core/src/main/java/org/jruby/ext/thread/Queue.java
+++ b/core/src/main/java/org/jruby/ext/thread/Queue.java
@@ -309,7 +309,7 @@ public class Queue extends RubyObject implements DataType {
     @JRubyMethod(name = "empty?")
     public RubyBoolean empty_p(ThreadContext context) {
         initializedCheck();
-        return context.runtime.newBoolean(count.get() == 0);
+        return RubyBoolean.newBoolean(context, count.get() == 0);
     }
 
     @JRubyMethod(name = {"length", "size"})
@@ -481,7 +481,7 @@ public class Queue extends RubyObject implements DataType {
     @JRubyMethod(name = "closed?")
     public IRubyObject closed_p(ThreadContext context) {
         initializedCheck();
-        return context.runtime.newBoolean(closed);
+        return RubyBoolean.newBoolean(context, closed);
     }
 
     public synchronized void shutdown() throws InterruptedException {

--- a/core/src/main/java/org/jruby/ext/tracepoint/TracePoint.java
+++ b/core/src/main/java/org/jruby/ext/tracepoint/TracePoint.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import org.jruby.Ruby;
 import org.jruby.RubyBinding;
+import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyObject;
 import org.jruby.RubySymbol;
@@ -162,7 +163,7 @@ public class TracePoint extends RubyObject {
     
     @JRubyMethod(name = "enabled?")
     public IRubyObject enabled_p(ThreadContext context) {
-        return context.runtime.newBoolean(enabled);
+        return RubyBoolean.newBoolean(context, enabled);
     }
     
     @JRubyMethod
@@ -263,7 +264,7 @@ public class TracePoint extends RubyObject {
             }
         }
         
-        IRubyObject old = context.runtime.newBoolean(enabled);
+        IRubyObject old = RubyBoolean.newBoolean(context, enabled);
         updateEnabled(context, toggle);
         
         return old;

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibInflate.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibInflate.java
@@ -204,7 +204,7 @@ public class JZlibInflate extends ZStream {
                 case com.jcraft.jzlib.JZlib.Z_OK:
                     flater.setInput(string.convertToString().getByteList().bytes(),
                             true);
-                    return getRuntime().getTrue();
+                    return context.tru;
                 case com.jcraft.jzlib.JZlib.Z_DATA_ERROR:
                     break;
                 default:
@@ -212,14 +212,14 @@ public class JZlibInflate extends ZStream {
             }
         }
         if (string.convertToString().getByteList().length() <= 0) {
-            return getRuntime().getFalse();
+            return context.fals;
         }
         flater.setInput(string.convertToString().getByteList().bytes(), true);
         switch (flater.sync()) {
             case com.jcraft.jzlib.JZlib.Z_OK:
-                return getRuntime().getTrue();
+                return context.tru;
             case com.jcraft.jzlib.JZlib.Z_DATA_ERROR:
-                return getRuntime().getFalse();
+                return context.fals;
             default:
                 throw RubyZlib.newStreamError(getRuntime(), "stream error");
         }

--- a/core/src/main/java/org/jruby/ext/zlib/ZStream.java
+++ b/core/src/main/java/org/jruby/ext/zlib/ZStream.java
@@ -29,6 +29,7 @@ package org.jruby.ext.zlib;
 
 import com.jcraft.jzlib.JZlib;
 import org.jruby.Ruby;
+import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyObject;
@@ -157,8 +158,7 @@ public abstract class ZStream extends RubyObject {
     @JRubyMethod(name = "finished?")
     public IRubyObject finished_p(ThreadContext context) {
         checkClosed();
-        Ruby runtime = context.getRuntime();
-        return internalFinished() ? runtime.getTrue() : runtime.getFalse();
+        return RubyBoolean.newBoolean(context, internalFinished());
     }
 
     @JRubyMethod(name = {"close", "end"})

--- a/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
@@ -509,7 +509,7 @@ public class InterpreterEngine {
             }
 
             case BOX_BOOLEAN: {
-                RubyBoolean f = context.runtime.newBoolean(getBooleanArg(booleans, ((BoxBooleanInstr) instr).getValue()));
+                RubyBoolean f = RubyBoolean.newBoolean(context, getBooleanArg(booleans, ((BoxBooleanInstr) instr).getValue()));
                 setResult(temp, currDynScope, ((BoxInstr)instr).getResult(), f);
                 break;
             }

--- a/core/src/main/java/org/jruby/ir/operands/Boolean.java
+++ b/core/src/main/java/org/jruby/ir/operands/Boolean.java
@@ -1,5 +1,6 @@
 package org.jruby.ir.operands;
 
+import org.jruby.RubyBoolean;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.persistence.IRReaderDecoder;
 import org.jruby.ir.persistence.IRWriterEncoder;
@@ -21,7 +22,7 @@ public class Boolean extends ImmutableLiteral {
 
     @Override
     public Object createCacheObject(ThreadContext context) {
-        return context.runtime.newBoolean(isTrue());
+        return RubyBoolean.newBoolean(context, isTrue());
     }
 
     public boolean isTrue()  {

--- a/core/src/main/java/org/jruby/ir/operands/UnboxedBoolean.java
+++ b/core/src/main/java/org/jruby/ir/operands/UnboxedBoolean.java
@@ -1,5 +1,6 @@
 package org.jruby.ir.operands;
 
+import org.jruby.RubyBoolean;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.persistence.IRReaderDecoder;
 import org.jruby.ir.persistence.IRWriterEncoder;
@@ -24,7 +25,7 @@ public class UnboxedBoolean extends ImmutableLiteral {
 
     @Override
     public Object createCacheObject(ThreadContext context) {
-        return context.runtime.newBoolean(isTrue());
+        return RubyBoolean.newBoolean(context, isTrue());
     }
 
     public boolean isTrue()  {

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -458,7 +458,7 @@ public class IRRuntimeHelpers {
         boolean ret = IRRuntimeHelpers.isRubyExceptionHandled(context, excType, excObj)
             || IRRuntimeHelpers.isJavaExceptionHandled(context, excType, excObj, false);
 
-        return context.runtime.newBoolean(ret);
+        return RubyBoolean.newBoolean(context, ret);
     }
 
     public static IRubyObject isEQQ(ThreadContext context, IRubyObject receiver, IRubyObject value, CallSite callSite, boolean splattedValue) {
@@ -1020,7 +1020,7 @@ public class IRRuntimeHelpers {
     public static RubyBoolean isBlockGiven(ThreadContext context, Object blk) {
         if (blk instanceof RubyProc) blk = ((RubyProc) blk).getBlock();
         if (blk instanceof RubyNil) blk = Block.NULL_BLOCK;
-        return context.runtime.newBoolean( ((Block) blk).isGiven() );
+        return RubyBoolean.newBoolean(context,  ((Block) blk).isGiven() );
     }
 
     public static IRubyObject receiveRestArg(ThreadContext context, Object[] args, int required, int argIndex, boolean acceptsKeywordArguments) {
@@ -1769,7 +1769,7 @@ public class IRRuntimeHelpers {
     }
 
     public static IRubyObject irNot(ThreadContext context, IRubyObject obj) {
-        return context.runtime.newBoolean(!(obj.isTrue()));
+        return RubyBoolean.newBoolean(context, !(obj.isTrue()));
     }
 
     @JIT

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -87,7 +87,7 @@ public final class ArrayJavaProxy extends JavaProxy {
 
     @JRubyMethod(name = "empty?")
     public RubyBoolean empty_p(ThreadContext context) {
-        return context.runtime.newBoolean( length() == 0 );
+        return RubyBoolean.newBoolean(context,  length() == 0 );
     }
 
     @JRubyMethod(name = "[]")
@@ -117,30 +117,30 @@ public final class ArrayJavaProxy extends JavaProxy {
         if ( componentClass.isPrimitive() ) {
             switch (componentClass.getName().charAt(0)) {
                 case 'b':
-                    if (componentClass == byte.class) return context.runtime.newBoolean( includes(context, (byte[]) array, obj) );
-                    else /* if (componentClass == boolean.class) */ return context.runtime.newBoolean( includes(context, (boolean[]) array, obj) );
+                    if (componentClass == byte.class) return RubyBoolean.newBoolean(context,  includes(context, (byte[]) array, obj) );
+                    else /* if (componentClass == boolean.class) */ return RubyBoolean.newBoolean(context,  includes(context, (boolean[]) array, obj) );
                     // break;
                 case 's':
-                    /* if (componentClass == short.class) */ return context.runtime.newBoolean( includes(context, (short[]) array, obj) );
+                    /* if (componentClass == short.class) */ return RubyBoolean.newBoolean(context,  includes(context, (short[]) array, obj) );
                     // break;
                 case 'c':
-                    /* if (componentClass == char.class) */ return context.runtime.newBoolean( includes(context, (char[]) array, obj) );
+                    /* if (componentClass == char.class) */ return RubyBoolean.newBoolean(context,  includes(context, (char[]) array, obj) );
                     // break;
                 case 'i':
-                    /* if (componentClass == int.class) */ return context.runtime.newBoolean( includes(context, (int[]) array, obj) );
+                    /* if (componentClass == int.class) */ return RubyBoolean.newBoolean(context,  includes(context, (int[]) array, obj) );
                     // break;
                 case 'l':
-                    /* if (componentClass == long.class) */ return context.runtime.newBoolean( includes(context, (long[]) array, obj) );
+                    /* if (componentClass == long.class) */ return RubyBoolean.newBoolean(context,  includes(context, (long[]) array, obj) );
                     // break;
                 case 'f':
-                    /* if (componentClass == float.class) */ return context.runtime.newBoolean( includes(context, (float[]) array, obj) );
+                    /* if (componentClass == float.class) */ return RubyBoolean.newBoolean(context,  includes(context, (float[]) array, obj) );
                     // break;
                 case 'd':
-                    /* if (componentClass == double.class) */ return context.runtime.newBoolean( includes(context, (double[]) array, obj) );
+                    /* if (componentClass == double.class) */ return RubyBoolean.newBoolean(context,  includes(context, (double[]) array, obj) );
                     // break;
             }
         }
-        return context.runtime.newBoolean( includes(context, (Object[]) array, obj) );
+        return RubyBoolean.newBoolean(context,  includes(context, (Object[]) array, obj) );
     }
 
     private boolean includes(final ThreadContext context, final Object[] array, final IRubyObject obj) {
@@ -542,7 +542,7 @@ public final class ArrayJavaProxy extends JavaProxy {
     public RubyBoolean op_equal(ThreadContext context, IRubyObject other) {
         if ( other instanceof RubyArray ) {
             // we respond_to? to_ary thus shall handle [1].to_java == [1]
-            return context.runtime.newBoolean( equalsRubyArray((RubyArray) other) );
+            return RubyBoolean.newBoolean(context,  equalsRubyArray((RubyArray) other) );
         }
         return eql_p(context, other);
     }
@@ -571,7 +571,7 @@ public final class ArrayJavaProxy extends JavaProxy {
         else if ( obj.getClass().isArray() ) {
             equals = arraysEquals(getObject(), obj);
         }
-        return context.runtime.newBoolean(equals);
+        return RubyBoolean.newBoolean(context, equals);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
@@ -18,6 +18,7 @@ import com.headius.backport9.modules.Modules;
 import org.jruby.AbstractRubyMethod;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
+import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyHash;
 import org.jruby.RubyMethod;
@@ -160,7 +161,7 @@ public class JavaProxy extends RubyObject {
 
     @JRubyMethod(name = "__persistent__", meta = true)
     public static IRubyObject persistent(final ThreadContext context, final IRubyObject clazz) {
-        return context.runtime.newBoolean(((RubyClass) clazz).getRealClass().getCacheProxy());
+        return RubyBoolean.newBoolean(context, ((RubyClass) clazz).getRealClass().getCacheProxy());
     }
 
     @Override
@@ -312,7 +313,7 @@ public class JavaProxy extends RubyObject {
     public IRubyObject equal_p(ThreadContext context, IRubyObject other) {
         if ( other instanceof JavaProxy ) {
             boolean equal = getObject() == ((JavaProxy) other).getObject();
-            return context.runtime.newBoolean(equal);
+            return RubyBoolean.newBoolean(context, equal);
         }
         return context.fals;
     }

--- a/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
@@ -304,7 +304,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         @Override
         public RubyBoolean compare_by_identity_p(ThreadContext context) {
             // NOTE: obviously little we can do to detect - but at least report Java built-in one :
-            return context.runtime.newBoolean( mapDelegate() instanceof java.util.IdentityHashMap );
+            return RubyBoolean.newBoolean(context,  mapDelegate() instanceof java.util.IdentityHashMap );
         }
 
         @Override // re-invent @JRubyMethod(name = "any?")

--- a/core/src/main/java/org/jruby/javasupport/JavaPackage.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaPackage.java
@@ -116,7 +116,7 @@ public class JavaPackage extends RubyModule {
     @JRubyMethod(name = "===")
     public RubyBoolean op_eqq(ThreadContext context, IRubyObject obj) {
         // maybe we could handle java.lang === java.lang.reflect as well ?
-        return context.runtime.newBoolean(obj == this || isInstance(obj));
+        return RubyBoolean.newBoolean(context, obj == this || isInstance(obj));
     }
 
     @JRubyMethod(name = "const_missing", required = 1)
@@ -214,8 +214,8 @@ public class JavaPackage extends RubyModule {
         */
 
         //if ( ! (mname instanceof RubySymbol) ) mname = context.runtime.newSymbol(name);
-        //IRubyObject respond = Helpers.invoke(context, this, "respond_to_missing?", mname, context.runtime.newBoolean(includePrivate));
-        //return context.runtime.newBoolean(respond.isTrue());
+        //IRubyObject respond = Helpers.invoke(context, this, "respond_to_missing?", mname, RubyBoolean.newBoolean(context, includePrivate));
+        //return RubyBoolean.newBoolean(context, respond.isTrue());
 
         return context.nil; // NOTE: this is wrong - should be true but compatibility first, for now
     }
@@ -243,7 +243,7 @@ public class JavaPackage extends RubyModule {
     }
 
     private RubyBoolean respond_to_missing(final ThreadContext context, IRubyObject mname, final boolean includePrivate) {
-        return context.runtime.newBoolean(BlankSlateWrapper.handlesMethod(TypeConverter.checkID(mname).idString()) == null);
+        return RubyBoolean.newBoolean(context, BlankSlateWrapper.handlesMethod(TypeConverter.checkID(mname).idString()) == null);
     }
 
     @JRubyMethod(name = "method_missing")
@@ -276,14 +276,14 @@ public class JavaPackage extends RubyModule {
 
     @JRubyMethod(name = "available?")
     public IRubyObject available_p(ThreadContext context) {
-        return context.runtime.newBoolean(isAvailable());
+        return RubyBoolean.newBoolean(context, isAvailable());
     }
 
     @JRubyMethod(name = "sealed?")
     public IRubyObject sealed_p(ThreadContext context) {
         final Package pkg = Package.getPackage(packageName);
         if ( pkg == null ) return context.nil;
-        return context.runtime.newBoolean(pkg.isSealed());
+        return RubyBoolean.newBoolean(context, pkg.isSealed());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/javasupport/JavaUtilities.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtilities.java
@@ -1,5 +1,6 @@
 package org.jruby.javasupport;
 
+import org.jruby.RubyBoolean;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyModule;
 import org.jruby.runtime.Block;
@@ -61,7 +62,7 @@ public class JavaUtilities {
     @JRubyMethod(name = "valid_java_identifier?", meta = true)
     public static IRubyObject valid_java_identifier_p(ThreadContext context, IRubyObject recv, IRubyObject name) {
         final String javaName = name.convertToString().decodeString();
-        return context.runtime.newBoolean(validJavaIdentifier(javaName));
+        return RubyBoolean.newBoolean(context, validJavaIdentifier(javaName));
     }
 
     private static boolean validJavaIdentifier(final String javaName) {

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -348,7 +348,7 @@ public abstract class JavaLang {
         @JRubyMethod(name = "real?")
         public static IRubyObject real_p(final ThreadContext context, final IRubyObject self) {
             java.lang.Number val = (java.lang.Number) self.toJava(java.lang.Number.class);
-            return context.runtime.newBoolean(val instanceof Integer || val instanceof Long ||
+            return RubyBoolean.newBoolean(context, val instanceof Integer || val instanceof Long ||
                                                     val instanceof Short || val instanceof Byte ||
                                                     val instanceof Float || val instanceof Double ||
                                                     val instanceof java.math.BigInteger || val instanceof java.math.BigDecimal);
@@ -366,14 +366,14 @@ public abstract class JavaLang {
         @JRubyMethod(name = "integer?")
         public static IRubyObject integer_p(final ThreadContext context, final IRubyObject self) {
             java.lang.Number val = (java.lang.Number) self.toJava(java.lang.Number.class);
-            return context.runtime.newBoolean(val instanceof Integer || val instanceof Long ||
+            return RubyBoolean.newBoolean(context, val instanceof Integer || val instanceof Long ||
                                                     val instanceof Short || val instanceof Byte ||
                                                     val instanceof java.math.BigInteger);
         }
 
         @JRubyMethod(name = "zero?")
         public static IRubyObject zero_p(final ThreadContext context, final IRubyObject self) {
-            return context.runtime.newBoolean(isZero(self));
+            return RubyBoolean.newBoolean(context, isZero(self));
         }
 
         private static boolean isZero(final IRubyObject self) {
@@ -409,13 +409,13 @@ public abstract class JavaLang {
         @JRubyMethod(name = "java_identifier_start?", meta = true)
         public static IRubyObject java_identifier_start_p(final ThreadContext context, final IRubyObject self,
                                                           final IRubyObject num) {
-            return context.runtime.newBoolean( java.lang.Character.isJavaIdentifierStart(int_char(num)) );
+            return RubyBoolean.newBoolean(context,  java.lang.Character.isJavaIdentifierStart(int_char(num)) );
         }
 
         @JRubyMethod(name = "java_identifier_part?", meta = true)
         public static IRubyObject java_identifier_part_p(final ThreadContext context, final IRubyObject self,
                                                          final IRubyObject num) {
-            return context.runtime.newBoolean( java.lang.Character.isJavaIdentifierPart(int_char(num)) );
+            return RubyBoolean.newBoolean(context,  java.lang.Character.isJavaIdentifierPart(int_char(num)) );
         }
 
         private static int int_char(IRubyObject num) { // str.ord -> Fixnum
@@ -474,13 +474,13 @@ public abstract class JavaLang {
         @JRubyMethod(name = "annotations?")
         public static IRubyObject annotations_p(final ThreadContext context, final IRubyObject self) {
             final java.lang.Class klass = unwrapJavaObject(self);
-            return context.runtime.newBoolean(klass.getAnnotations().length > 0);
+            return RubyBoolean.newBoolean(context, klass.getAnnotations().length > 0);
         }
 
         @JRubyMethod(name = "declared_annotations?")
         public static IRubyObject declared_annotations_p(final ThreadContext context, final IRubyObject self) {
             final java.lang.Class klass = unwrapJavaObject(self);
-            return context.runtime.newBoolean(klass.getDeclaredAnnotations().length > 0);
+            return RubyBoolean.newBoolean(context, klass.getDeclaredAnnotations().length > 0);
         }
 
         @JRubyMethod

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
@@ -133,7 +133,7 @@ public abstract class JavaUtil {
         @JRubyMethod(name = { "include?", "member?" }) // @override Enumerable#include?
         public static RubyBoolean include_p(final ThreadContext context, final IRubyObject self, final IRubyObject obj) {
             final java.util.Collection coll = unwrapIfJavaObject(self);
-            return context.runtime.newBoolean( coll.contains( obj.toJava(java.lang.Object.class) ) );
+            return RubyBoolean.newBoolean(context,  coll.contains( obj.toJava(java.lang.Object.class) ) );
         }
 
         // NOTE: first might conflict with some Java types (e.g. java.util.Deque) thus providing a ruby_ alias

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaUtilRegex.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaUtilRegex.java
@@ -74,14 +74,14 @@ public abstract class JavaUtilRegex {
 
         @JRubyMethod(name = "===", required = 1)
         public static IRubyObject eqq(final ThreadContext context, final IRubyObject self, IRubyObject str) {
-            return context.runtime.newBoolean( matcher(self, str).find() );
+            return RubyBoolean.newBoolean(context,  matcher(self, str).find() );
         }
 
         @JRubyMethod(name = "casefold?")
         public static IRubyObject casefold_p(final ThreadContext context, final IRubyObject self) {
             final java.util.regex.Pattern regex = unwrapJavaObject(self);
             boolean i = ( regex.flags() & java.util.regex.Pattern.CASE_INSENSITIVE ) != 0;
-            return context.runtime.newBoolean(i);
+            return RubyBoolean.newBoolean(context, i);
         }
 
         private static java.util.regex.Matcher matcher(final IRubyObject self, final IRubyObject str) {

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyReflectionObject.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyReflectionObject.java
@@ -69,7 +69,7 @@ public class JavaProxyReflectionObject extends RubyObject {
             }
             obj = (IRubyObject) wrappedObj;
         }
-        return context.runtime.newBoolean( this.equals(obj) );
+        return RubyBoolean.newBoolean(context,  this.equals(obj) );
     }
 
     @Deprecated
@@ -89,7 +89,7 @@ public class JavaProxyReflectionObject extends RubyObject {
             }
             obj = (IRubyObject) wrappedObj;
         }
-        return context.runtime.newBoolean(this == obj);
+        return RubyBoolean.newBoolean(context, this == obj);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -1957,10 +1957,9 @@ public class Helpers {
      * @return
      */
     public static RubyBoolean rbEqual(ThreadContext context, IRubyObject a, IRubyObject b) {
-        Ruby runtime = context.runtime;
-        if (a == b) return runtime.getTrue();
+        if (a == b) return context.tru;
         IRubyObject res = sites(context).op_equal.call(context, a, a, b);
-        return runtime.newBoolean(res.isTrue());
+        return RubyBoolean.newBoolean(context, res.isTrue());
     }
 
     /**
@@ -1972,10 +1971,9 @@ public class Helpers {
      * @return
      */
     public static RubyBoolean rbEqual(ThreadContext context, IRubyObject a, IRubyObject b, CallSite equal) {
-        Ruby runtime = context.runtime;
-        if (a == b) return runtime.getTrue();
+        if (a == b) return context.tru;
         IRubyObject res = equal.call(context, a, a, b);
-        return runtime.newBoolean(res.isTrue());
+        return RubyBoolean.newBoolean(context, res.isTrue());
     }
 
     /**
@@ -1987,10 +1985,9 @@ public class Helpers {
      * @return
      */
     public static RubyBoolean rbEql(ThreadContext context, IRubyObject a, IRubyObject b) {
-        Ruby runtime = context.runtime;
-        if (a == b) return runtime.getTrue();
+        if (a == b) return context.tru;
         IRubyObject res = invokedynamic(context, a, EQL, b);
-        return runtime.newBoolean(res.isTrue());
+        return RubyBoolean.newBoolean(context, res.isTrue());
     }
 
     /**

--- a/core/src/main/java/org/jruby/runtime/callsite/RespondToCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/RespondToCallSite.java
@@ -1,5 +1,6 @@
 package org.jruby.runtime.callsite;
 
+import org.jruby.RubyBoolean;
 import org.jruby.RubySymbol;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
@@ -99,7 +100,7 @@ public class RespondToCallSite extends MonomorphicCallSite {
             if (strName.equals(tuple.name) && !includePrivate == tuple.checkVisibility) return tuple.respondsToBoolean;
         }
         // go through normal call logic, which will hit overridden cacheAndCall
-        return super.call(context, caller, self, getRespondToNameSym(context), context.runtime.newBoolean(includePrivate)).isTrue();
+        return super.call(context, caller, self, getRespondToNameSym(context), RubyBoolean.newBoolean(context, includePrivate)).isTrue();
     }
 
     private RubySymbol getRespondToNameSym(ThreadContext context) {
@@ -166,6 +167,6 @@ public class RespondToCallSite extends MonomorphicCallSite {
         CacheEntry respondToLookupResult = klass.searchWithCache(newString);
         boolean respondsTo = Helpers.respondsToMethod(respondToLookupResult.method, checkVisibility);
 
-        return new RespondToTuple(newString, checkVisibility, respondToMethod, respondToLookupResult, context.runtime.newBoolean(respondsTo));
+        return new RespondToTuple(newString, checkVisibility, respondToMethod, respondToLookupResult, RubyBoolean.newBoolean(context, respondsTo));
     }
 }

--- a/core/src/main/java/org/jruby/util/MRIRecursionGuard.java
+++ b/core/src/main/java/org/jruby/util/MRIRecursionGuard.java
@@ -143,6 +143,7 @@ public class MRIRecursionGuard {
 
     private void recursivePush(IRubyObject list, IRubyObject obj, IRubyObject paired_obj) {
         IRubyObject pair_list;
+        Ruby runtime = this.runtime;
         final ThreadContext context = runtime.getCurrentContext();
         if (paired_obj == null) {
             ((RubyHash) list).op_aset(context, obj, runtime.getTrue());

--- a/core/src/main/java/org/jruby/util/Numeric.java
+++ b/core/src/main/java/org/jruby/util/Numeric.java
@@ -33,6 +33,7 @@ import org.joni.WarnCallback;
 import org.jcodings.specific.ASCIIEncoding;
 import org.jruby.Ruby;
 import org.jruby.RubyBignum;
+import org.jruby.RubyBoolean;
 import org.jruby.RubyComplex;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
@@ -390,7 +391,7 @@ public class Numeric {
      */
     public static IRubyObject f_equal(ThreadContext context, IRubyObject x, IRubyObject y) {
         if (x instanceof RubyFixnum && y instanceof RubyFixnum) {
-            return context.runtime.newBoolean(((RubyFixnum) x).getLongValue() == ((RubyFixnum) y).getLongValue());
+            return RubyBoolean.newBoolean(context, ((RubyFixnum) x).getLongValue() == ((RubyFixnum) y).getLongValue());
         }
 
         return sites(context).op_equals.call(context, x, x, y);

--- a/core/src/main/java/org/jruby/util/collections/StringArraySet.java
+++ b/core/src/main/java/org/jruby/util/collections/StringArraySet.java
@@ -97,7 +97,7 @@ public class StringArraySet extends RubyArray {
 
     @Override
     public final RubyBoolean include_p(ThreadContext context, IRubyObject item) {
-        return context.runtime.newBoolean(containsString(convertToString(item)));
+        return RubyBoolean.newBoolean(context, containsString(convertToString(item)));
     }
 
     @Override

--- a/core/src/main/java/org/jruby/util/io/OpenFile.java
+++ b/core/src/main/java/org/jruby/util/io/OpenFile.java
@@ -2353,7 +2353,7 @@ public class OpenFile implements Finalizable {
                             }
                             break retry;
                         }
-                        return noalloc ? runtime.getTrue() : RubyFixnum.newFixnum(runtime, (posix.getErrno() == null) ? 0 : posix.getErrno().longValue());
+                        return noalloc ? context.tru : RubyFixnum.newFixnum(runtime, (posix.getErrno() == null) ? 0 : posix.getErrno().longValue());
                     }
                     if (res == EConvResult.InvalidByteSequence ||
                             res == EConvResult.IncompleteInput ||


### PR DESCRIPTION
Many recent JITs have started to optimize repeat final field
accesses. This patch moves almost all core class and module init
into the Ruby constructor, so that those fields (as well as some
structural references) can be made final. This should help any
core classes that look up their own type on each construction
(which includes almost all of them) when those constructors are
inlined together with other accesses of the same field.