### PR TITLE
Do not alias a Java IsEqual to equal?

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
@@ -80,6 +80,8 @@ public class MethodGatherer {
         INSTANCE_RESERVED_NAMES.put("class", new AssignedName("class", Priority.RESERVED));
         // "initialize" has meaning only for an instance (as opposed to a class)
         INSTANCE_RESERVED_NAMES.put("initialize", new AssignedName("initialize", Priority.RESERVED));
+        // "equal?" should not be overridden (GH-5990)
+        INSTANCE_RESERVED_NAMES.put("equal?", new AssignedName("equal?", Priority.RESERVED));
     }
 
     // TODO: other reserved names?

--- a/spec/java_integration/fixtures/IsEqualClass.java
+++ b/spec/java_integration/fixtures/IsEqualClass.java
@@ -1,0 +1,12 @@
+package java_integration.fixtures;
+
+public class IsEqualClass {
+    private boolean called = false;
+    public boolean getCalled() {
+        return called;
+    }
+    public boolean isEqual(IsEqualClass other) {
+        called = true;
+        return true;
+    }
+}

--- a/spec/java_integration/methods/equals_spec.rb
+++ b/spec/java_integration/methods/equals_spec.rb
@@ -6,3 +6,18 @@ describe "A class that implements Comparable" do
     expect(java.util.Date.new.==('foo')).to eq(false)
   end
 end
+
+describe "A class that defines an isEqual method" do
+  it "does not override JavaProxy#equal?" do
+    a = Java::java_integration.fixtures.IsEqualClass.new
+
+    # a.class.instance_method(:equal?).should == JavaProxy.instance_method(:equal?)
+    JRuby.ref(a.class).searchMethod("equal?").should == JRuby.ref(JavaProxy).searchMethod("equal?")
+
+    a.equal?(a).should be_truthy
+    a.getCalled.should be_falsy
+
+    a.isEqual(a).should be_truthy
+    a.getCalled.should be_truthy
+  end
+end


### PR DESCRIPTION
The `equal?` method should always be identity equality and not get overridden if a class defines an `isEqual` method as in Joda's AbstractPartial does.

Fixes #5990.