### PR TITLE
Reduce block overhead

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -772,9 +772,8 @@ public class RubyModule extends RubyObject {
     }
 
     private void yieldRefineBlock(ThreadContext context, RubyModule refinement, Block block) {
-        block = block.cloneBlockAndFrame();
+        block = block.cloneBlockAndFrame(EvalType.MODULE_EVAL);
 
-        block.setEvalType(EvalType.MODULE_EVAL);
         block.getBinding().setSelf(refinement);
 
         RubyModule overlayModule = block.getBody().getStaticScope().getOverlayModuleForWrite(context);

--- a/core/src/main/java/org/jruby/RubyProc.java
+++ b/core/src/main/java/org/jruby/RubyProc.java
@@ -265,7 +265,7 @@ public class RubyProc extends RubyObject implements DataType {
     public final IRubyObject call(ThreadContext context, IRubyObject[] args, Block blockCallArg) {
         IRubyObject[] preppedArgs = prepareArgs(context, type, block.getBody(), args);
 
-        return call(context, preppedArgs, null, blockCallArg);
+        return block.call(context, preppedArgs, blockCallArg);
     }
 
     public final IRubyObject call(ThreadContext context, IRubyObject arg) {
@@ -274,10 +274,6 @@ public class RubyProc extends RubyObject implements DataType {
 
     public final IRubyObject call(ThreadContext context, IRubyObject... args) {
         return block.call(context, args);
-    }
-
-    public final IRubyObject call(ThreadContext context, IRubyObject[] args, IRubyObject self, Block passedBlock) {
-        return call(context, args, self, null, passedBlock);
     }
 
     public final IRubyObject call(ThreadContext context, IRubyObject[] args, IRubyObject self, RubyModule sourceModule, Block passedBlock) {
@@ -370,6 +366,11 @@ public class RubyProc extends RubyObject implements DataType {
     @Deprecated
     public IRubyObject to_s19() {
         return to_s();
+    }
+
+    @Deprecated
+    public final IRubyObject call(ThreadContext context, IRubyObject[] args, IRubyObject self, Block passedBlock) {
+        return block.call(context, args, passedBlock);
     }
 
 }

--- a/core/src/main/java/org/jruby/RubyProc.java
+++ b/core/src/main/java/org/jruby/RubyProc.java
@@ -174,7 +174,7 @@ public class RubyProc extends RubyObject implements DataType {
                     oldBinding.getMethod(),
                     oldBinding.getFile(),
                     oldBinding.getLine());
-            block = new Block(procBlock.getBody(), newBinding);
+            block = new Block(procBlock.getBody(), newBinding, type);
 
             // Mark as escaped, so non-local flow errors immediately
             block.escape();
@@ -184,15 +184,18 @@ public class RubyProc extends RubyObject implements DataType {
             StaticScope newScope = oldScope.duplicate();
             block.getBody().setStaticScope(newScope);
         } else {
-            // just use as is
-            block = procBlock;
+            // just use as is unless type differs
+            if (type != procBlock.type) {
+                block = procBlock.cloneBlockAsType(type);
+            } else {
+                block = procBlock;
+            }
         }
 
         // force file/line info into the new block's binding
         block.getBinding().setFile(block.getBody().getFile());
         block.getBinding().setLine(block.getBody().getLine());
 
-        block.type = type;
         block.setProcObject(this);
 
         // pre-request dummy scope to avoid clone overhead in lightweight blocks

--- a/core/src/main/java/org/jruby/RubyProc.java
+++ b/core/src/main/java/org/jruby/RubyProc.java
@@ -51,6 +51,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.marshal.DataType;
 
+import static org.jruby.runtime.Helpers.arrayOf;
 import static org.jruby.util.RubyStringBuilder.types;
 
 /**
@@ -261,11 +262,52 @@ public class RubyProc extends RubyObject implements DataType {
         return args;
     }
 
+    private static IRubyObject[] checkArityForLambda(ThreadContext context, Block.Type type, BlockBody blockBody, IRubyObject... args) {
+        if (type == Block.Type.LAMBDA) {
+            blockBody.getSignature().checkArity(context.runtime, args);
+        }
+
+        return args;
+    }
+
     @JRubyMethod(name = {"call", "[]", "yield", "==="}, rest = true, omit = true)
     public final IRubyObject call(ThreadContext context, IRubyObject[] args, Block blockCallArg) {
-        IRubyObject[] preppedArgs = prepareArgs(context, type, block.getBody(), args);
+        return block.call(
+                context,
+                prepareArgs(context, type, block.getBody(), args),
+                blockCallArg);
+    }
 
-        return block.call(context, preppedArgs, blockCallArg);
+    @JRubyMethod(name = {"call", "[]", "yield", "==="}, omit = true)
+    public final IRubyObject call(ThreadContext context, Block blockCallArg) {
+        return block.call(
+                context,
+                checkArityForLambda(context, type, block.getBody(), NULL_ARRAY),
+                blockCallArg);
+    }
+
+    @JRubyMethod(name = {"call", "[]", "yield", "==="}, omit = true)
+    public final IRubyObject call(ThreadContext context, IRubyObject arg0, Block blockCallArg) {
+        return block.call(
+                context,
+                prepareArgs(context, type, block.getBody(), arrayOf(arg0)),
+                blockCallArg);
+    }
+
+    @JRubyMethod(name = {"call", "[]", "yield", "==="}, omit = true)
+    public final IRubyObject call(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Block blockCallArg) {
+        return block.call(
+                context,
+                checkArityForLambda(context, type, block.getBody(), arg0, arg1),
+                blockCallArg);
+    }
+
+    @JRubyMethod(name = {"call", "[]", "yield", "==="}, omit = true)
+    public final IRubyObject call(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block blockCallArg) {
+        return block.call(
+                context,
+                checkArityForLambda(context, type, block.getBody(), arg0, arg1, arg2),
+                blockCallArg);
     }
 
     public final IRubyObject call(ThreadContext context, IRubyObject arg) {

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -263,7 +263,7 @@ public class RubyStruct extends RubyObject {
 
         if (block.isGiven()) {
             // Since this defines a new class, run the block as a module-eval.
-            block.setEvalType(EvalType.MODULE_EVAL);
+            block = block.cloneBlockForEval(newStruct, EvalType.MODULE_EVAL);
             // Struct bodies should be public by default, so set block visibility to public. JRUBY-1185.
             block.getBinding().setVisibility(Visibility.PUBLIC);
             block.yieldNonArray(runtime.getCurrentContext(), newStruct, newStruct);

--- a/core/src/main/java/org/jruby/compiler/BlockJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/BlockJITTask.java
@@ -84,6 +84,7 @@ class BlockJITTask extends JITCompiler.Task {
                 new CompiledIRBlockBody(
                         JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, jittedName, JVMVisitor.CLOSURE_SIGNATURE.type()),
                         body.getIRScope(),
+                        body,
                         ((IRClosure) body.getIRScope()).getSignature().encode()));
     }
 

--- a/core/src/main/java/org/jruby/compiler/BlockJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/BlockJITTask.java
@@ -84,7 +84,6 @@ class BlockJITTask extends JITCompiler.Task {
                 new CompiledIRBlockBody(
                         JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, jittedName, JVMVisitor.CLOSURE_SIGNATURE.type()),
                         body.getIRScope(),
-                        body,
                         ((IRClosure) body.getIRScope()).getSignature().encode()));
     }
 

--- a/core/src/main/java/org/jruby/ir/instructions/CallBase.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CallBase.java
@@ -41,7 +41,7 @@ public abstract class CallBase extends NOperandInstr implements ClosureAccepting
     private transient boolean targetRequiresCallersFrame;    // Does this call make use of the caller's frame?
     private transient boolean dontInline;
     private transient boolean[] splatMap;
-    private transient boolean procNew;
+    protected transient boolean procNew;
     private boolean potentiallyRefined;
     private transient Set<FrameField> frameReads;
     private transient Set<FrameField> frameWrites;

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/ZeroOperandArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/ZeroOperandArgNoBlockCallInstr.java
@@ -36,8 +36,12 @@ public class ZeroOperandArgNoBlockCallInstr extends CallInstr {
 
     @Override
     public Instr clone(CloneInfo ii) {
-        return new ZeroOperandArgNoBlockCallInstr(ii.getScope(), getOperation(), getCallType(), ii.getRenamedVariable(result), getName(),
+        ZeroOperandArgNoBlockCallInstr zeroOperandArgNoBlockCallInstr = new ZeroOperandArgNoBlockCallInstr(ii.getScope(), getOperation(), getCallType(), ii.getRenamedVariable(result), getName(),
                 getReceiver().cloneForInlining(ii), cloneCallArgs(ii), isPotentiallyRefined(), getCallSite(), getCallSiteId());
+
+        zeroOperandArgNoBlockCallInstr.setProcNew(procNew);
+
+        return zeroOperandArgNoBlockCallInstr;
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/passes/AddCallProtocolInstructions.java
+++ b/core/src/main/java/org/jruby/ir/passes/AddCallProtocolInstructions.java
@@ -85,6 +85,9 @@ public class AddCallProtocolInstructions extends CompilerPass {
         // to allocate a dynamic scope for it and add binding push/pop instructions.
         if (!explicitCallProtocolSupported(scope)) return null;
 
+        scope.getFlags().remove(IRFlags.FLAGS_COMPUTED);
+        scope.computeScopeFlags();
+
         CFG cfg = scope.getCFG();
 
         // For now, we always require frame for closures

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -2050,9 +2050,6 @@ public class IRRuntimeHelpers {
             self = useBindingSelf(block.getBinding());
         }
 
-        // Clear block's eval type
-        block.setEvalType(EvalType.NONE);
-
         // Return self in case it has been updated
         return self;
     }

--- a/core/src/main/java/org/jruby/ir/targets/Bootstrap.java
+++ b/core/src/main/java/org/jruby/ir/targets/Bootstrap.java
@@ -1370,7 +1370,7 @@ public class Bootstrap {
     }
 
     static String logBlock(Block block) {
-        return "[" + block.getBody() + " " + block.getFrame() + "]";
+        return "[" + block.getBody().getFile() + ":" + block.getBody().getLine() + "]";
     }
 
     private static final Binder BINDING_MAKER_BINDER = Binder.from(Binding.class, ThreadContext.class, IRubyObject.class, DynamicScope.class);

--- a/core/src/main/java/org/jruby/ir/targets/YieldSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/YieldSite.java
@@ -73,7 +73,7 @@ public class YieldSite extends MutableCallSite {
     }
 
     public IRubyObject yield(ThreadContext context, Block block, IRubyObject arg) throws Throwable {
-        if (++bindCount < MAX_REBIND && Options.INVOKEDYNAMIC_YIELD.load()) {
+        if (Options.INVOKEDYNAMIC_YIELD.load()) {
             if (++bindCount >= MAX_REBIND) {
                 if (Options.INVOKEDYNAMIC_LOG_BINDING.load()) {
                     LOG.info("yield \tdisabled due to polymorphism:" + Bootstrap.logBlock(block));

--- a/core/src/main/java/org/jruby/runtime/Block.java
+++ b/core/src/main/java/org/jruby/runtime/Block.java
@@ -78,7 +78,7 @@ public class Block {
     private boolean escaped;
 
     /** What block to use for determining escape; defaults to this */
-    private Block escapeBlock = this;
+    private final Block escapeBlock;
 
     /**
      * All Block variables should either refer to a real block or this NULL_BLOCK.
@@ -90,11 +90,20 @@ public class Block {
         NULL_BLOCK.getBinding().getFrame().updateFrame(null, null, "", NULL_BLOCK);
     }
 
-    public Block(BlockBody body, Binding binding, Type type) {
+    private Block(BlockBody body, Binding binding, Type type, Block escapeBlock) {
         assert binding != null;
         this.body = body;
         this.binding = binding;
         this.type = type;
+        this.escapeBlock = escapeBlock;
+    }
+
+    private Block(BlockBody body, Binding binding, Type type) {
+        assert binding != null;
+        this.body = body;
+        this.binding = binding;
+        this.type = type;
+        this.escapeBlock = this;
     }
 
     public Block(BlockBody body, Binding binding) {
@@ -192,25 +201,19 @@ public class Block {
     }
 
     public Block cloneBlock() {
-        Block newBlock = new Block(body, binding, type);
-
-        newBlock.escapeBlock = this;
+        Block newBlock = new Block(body, binding, type, this);
 
         return newBlock;
     }
 
     public Block cloneBlockAsType(Type newType) {
-        Block newBlock = new Block(body, binding, newType);
-
-        newBlock.escapeBlock = this;
+        Block newBlock = new Block(body, binding, newType, this);
 
         return newBlock;
     }
 
     public Block cloneBlockAndBinding() {
-        Block newBlock = new Block(body, binding.clone(), type);
-
-        newBlock.escapeBlock = this;
+        Block newBlock = new Block(body, binding.clone(), type, this);
 
         return newBlock;
     }
@@ -226,9 +229,7 @@ public class Block {
                 oldBinding.getFile(),
                 oldBinding.getLine());
 
-        Block newBlock = new Block(body, binding, type);
-
-        newBlock.escapeBlock = this;
+        Block newBlock = new Block(body, binding, type, this);
 
         return newBlock;
     }

--- a/core/src/main/java/org/jruby/runtime/Block.java
+++ b/core/src/main/java/org/jruby/runtime/Block.java
@@ -98,7 +98,7 @@ public class Block {
         this.escapeBlock = escapeBlock;
     }
 
-    private Block(BlockBody body, Binding binding, Type type) {
+    public Block(BlockBody body, Binding binding, Type type) {
         assert binding != null;
         this.body = body;
         this.binding = binding;

--- a/core/src/main/java/org/jruby/runtime/Block.java
+++ b/core/src/main/java/org/jruby/runtime/Block.java
@@ -80,6 +80,8 @@ public class Block {
     /** What block to use for determining escape; defaults to this */
     private final Block escapeBlock;
 
+    EvalType evalType;
+
     /**
      * All Block variables should either refer to a real block or this NULL_BLOCK.
      */
@@ -122,17 +124,17 @@ public class Block {
         //
         // FIXME: Rather than modify static-scope, it seems we ought to set a field in block-body which is then
         // used to tell dynamic-scope that it is a dynamic scope for a thread body.  Anyway, to be revisited later!
-        DynamicScope newScope = DynamicScope.newDynamicScope(body.getStaticScope(), parentScope, body.getEvalType());
+        DynamicScope newScope = DynamicScope.newDynamicScope(body.getStaticScope(), parentScope, evalType);
         if (type == Block.Type.LAMBDA) newScope.setLambda(true);
         return newScope;
     }
 
     public EvalType getEvalType() {
-        return body.getEvalType();
+        return evalType;
     }
 
     public void setEvalType(EvalType evalType) {
-        body.setEvalType(evalType);
+        this.evalType = evalType;
     }
 
     public IRubyObject call(ThreadContext context, IRubyObject[] args) {

--- a/core/src/main/java/org/jruby/runtime/Block.java
+++ b/core/src/main/java/org/jruby/runtime/Block.java
@@ -68,7 +68,7 @@ public class Block {
      */
     private RubyProc proc = null;
 
-    public Type type = Type.NORMAL;
+    public final Type type;
 
     private final Binding binding;
 
@@ -90,14 +90,19 @@ public class Block {
         NULL_BLOCK.getBinding().getFrame().updateFrame(null, null, "", NULL_BLOCK);
     }
 
-    public Block(BlockBody body, Binding binding) {
+    public Block(BlockBody body, Binding binding, Type type) {
         assert binding != null;
         this.body = body;
         this.binding = binding;
+        this.type = type;
+    }
+
+    public Block(BlockBody body, Binding binding) {
+        this(body, binding, Type.NORMAL);
     }
 
     public Block(BlockBody body) {
-        this(body, Block.NULL_BLOCK.getBinding());
+        this(body, Block.NULL_BLOCK.getBinding(), Type.NORMAL);
     }
 
     public DynamicScope allocScope(DynamicScope parentScope) {
@@ -187,18 +192,24 @@ public class Block {
     }
 
     public Block cloneBlock() {
-        Block newBlock = new Block(body, binding);
+        Block newBlock = new Block(body, binding, type);
 
-        newBlock.type = type;
+        newBlock.escapeBlock = this;
+
+        return newBlock;
+    }
+
+    public Block cloneBlockAsType(Type newType) {
+        Block newBlock = new Block(body, binding, newType);
+
         newBlock.escapeBlock = this;
 
         return newBlock;
     }
 
     public Block cloneBlockAndBinding() {
-        Block newBlock = new Block(body, binding.clone());
+        Block newBlock = new Block(body, binding.clone(), type);
 
-        newBlock.type = type;
         newBlock.escapeBlock = this;
 
         return newBlock;
@@ -215,9 +226,8 @@ public class Block {
                 oldBinding.getFile(),
                 oldBinding.getLine());
 
-        Block newBlock = new Block(body, binding);
+        Block newBlock = new Block(body, binding, type);
 
-        newBlock.type = type;
         newBlock.escapeBlock = this;
 
         return newBlock;

--- a/core/src/main/java/org/jruby/runtime/BlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/BlockBody.java
@@ -50,7 +50,7 @@ import java.lang.invoke.MethodHandles;
 public abstract class BlockBody {
 
     protected final Signature signature;
-    protected volatile MethodHandle testBlockBody;
+    protected MethodHandle testBlockBody;
 
     public BlockBody(Signature signature) {
         this.signature = signature;

--- a/core/src/main/java/org/jruby/runtime/BlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/BlockBody.java
@@ -60,14 +60,6 @@ public abstract class BlockBody {
         return signature;
     }
 
-    public EvalType getEvalType()  {
-        return null; // method should be abstract - isn't due compatibility
-    }
-
-    public void setEvalType(EvalType evalType) {
-        // NOOP - but "real" block bodies should track their eval-type
-    }
-
     public boolean canCallDirect() {
         return false;
     }

--- a/core/src/main/java/org/jruby/runtime/CompiledIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/CompiledIRBlockBody.java
@@ -33,13 +33,15 @@ public class CompiledIRBlockBody extends IRBlockBody {
         closure.getStaticScope().determineModule();
     }
 
-    private static final MethodHandle VALUE_TO_ARRAY = Binder.from(IRubyObject[].class, IRubyObject.class).invokeStaticQuiet(MethodHandles.lookup(), IRRuntimeHelpers.class, "singleBlockArgToArray");
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
 
-    private static final MethodHandle WRAP_VALUE = Binder.from(IRubyObject[].class, IRubyObject.class).invokeStaticQuiet(MethodHandles.lookup(), CompiledIRBlockBody.class, "wrapValue");
+    private static final MethodHandle VALUE_TO_ARRAY = Binder.from(IRubyObject[].class, IRubyObject.class).invokeStaticQuiet(LOOKUP, IRRuntimeHelpers.class, "singleBlockArgToArray");
+
+    private static final MethodHandle WRAP_VALUE = Binder.from(IRubyObject[].class, IRubyObject.class).invokeStaticQuiet(LOOKUP, CompiledIRBlockBody.class, "wrapValue");
 
     private static final MethodHandle CHECK_ARITY = Binder
             .from(void.class, ThreadContext.class, Block.class, IRubyObject[].class, Block.class)
-            .invokeStaticQuiet(MethodHandles.lookup(), CompiledIRBlockBody.class, "checkArity");
+            .invokeStaticQuiet(LOOKUP, CompiledIRBlockBody.class, "checkArity");
 
     private static void checkArity(ThreadContext context, Block selfBlock, IRubyObject[] args, Block block) {
         if (selfBlock.type == Block.Type.LAMBDA) {

--- a/core/src/main/java/org/jruby/runtime/CompiledIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/CompiledIRBlockBody.java
@@ -17,22 +17,6 @@ public class CompiledIRBlockBody extends IRBlockBody {
     protected MethodHandle normalYieldSpecificHandle;
     protected MethodHandle normalYieldUnwrapHandle;
 
-    public CompiledIRBlockBody(MethodHandle handle, IRScope closure, IRBlockBody evalTypeBody, long encodedSignature) {
-        super(closure, Signature.decode(encodedSignature), evalTypeBody);
-        // evalType copied (shared) on MixedModeIRBlockBody#completeBuild
-        this.handle = handle;
-        MethodHandle callHandle = MethodHandles.insertArguments(handle, 2, closure.getStaticScope(), null);
-        // This is gross and should be done in IR rather than in the handles.
-        this.callHandle = MethodHandles.foldArguments(callHandle, CHECK_ARITY);
-        this.yieldDirectHandle = MethodHandles.insertArguments(
-                MethodHandles.insertArguments(handle, 2, closure.getStaticScope()),
-                4,
-                Block.NULL_BLOCK);
-
-        // Done in the interpreter (WrappedIRClosure) but we do it here
-        closure.getStaticScope().determineModule();
-    }
-
     public CompiledIRBlockBody(MethodHandle handle, IRScope closure, long encodedSignature) {
         super(closure, Signature.decode(encodedSignature));
         // evalType copied (shared) on MixedModeIRBlockBody#completeBuild

--- a/core/src/main/java/org/jruby/runtime/CompiledIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/CompiledIRBlockBody.java
@@ -17,6 +17,22 @@ public class CompiledIRBlockBody extends IRBlockBody {
     protected MethodHandle normalYieldSpecificHandle;
     protected MethodHandle normalYieldUnwrapHandle;
 
+    public CompiledIRBlockBody(MethodHandle handle, IRScope closure, IRBlockBody evalTypeBody, long encodedSignature) {
+        super(closure, Signature.decode(encodedSignature), evalTypeBody);
+        // evalType copied (shared) on MixedModeIRBlockBody#completeBuild
+        this.handle = handle;
+        MethodHandle callHandle = MethodHandles.insertArguments(handle, 2, closure.getStaticScope(), null);
+        // This is gross and should be done in IR rather than in the handles.
+        this.callHandle = MethodHandles.foldArguments(callHandle, CHECK_ARITY);
+        this.yieldDirectHandle = MethodHandles.insertArguments(
+                MethodHandles.insertArguments(handle, 2, closure.getStaticScope()),
+                4,
+                Block.NULL_BLOCK);
+
+        // Done in the interpreter (WrappedIRClosure) but we do it here
+        closure.getStaticScope().determineModule();
+    }
+
     public CompiledIRBlockBody(MethodHandle handle, IRScope closure, long encodedSignature) {
         super(closure, Signature.decode(encodedSignature));
         // evalType copied (shared) on MixedModeIRBlockBody#completeBuild

--- a/core/src/main/java/org/jruby/runtime/IRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/IRBlockBody.java
@@ -13,21 +13,17 @@ public abstract class IRBlockBody extends ContextAwareBlockBody {
     protected final String fileName;
     protected final int lineNumber;
     protected final IRClosure closure;
-    ThreadLocal<EvalType> evalType;
+    final ThreadLocal<EvalType> evalType;
 
     public IRBlockBody(IRScope closure, Signature signature) {
         // ThreadLocal not set by default to avoid having many thread-local values initialized
         // servers such as Tomcat tend to do thread-local checks when un-deploying apps,
         // for JRuby leads to 100s of SEVERE warnings for a mid-size (booted) Rails app
-        this(closure, signature, new ThreadLocal());
-    }
-
-    /* internal */ IRBlockBody(IRScope closure, Signature signature, ThreadLocal evalType) {
         super(closure.getStaticScope(), signature);
         this.closure = (IRClosure) closure;
         this.fileName = closure.getFile();
         this.lineNumber = closure.getLine();
-        this.evalType = evalType;
+        this.evalType = new ThreadLocal<>();
     }
 
     public final EvalType getEvalType() {

--- a/core/src/main/java/org/jruby/runtime/IRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/IRBlockBody.java
@@ -13,20 +13,6 @@ public abstract class IRBlockBody extends ContextAwareBlockBody {
     protected final String fileName;
     protected final int lineNumber;
     protected final IRClosure closure;
-    final ThreadLocal<EvalType> evalType;
-    final IRBlockBody evalTypeBody;
-
-    public IRBlockBody(IRScope closure, Signature signature, IRBlockBody evalTypeBody) {
-        // ThreadLocal not set by default to avoid having many thread-local values initialized
-        // servers such as Tomcat tend to do thread-local checks when un-deploying apps,
-        // for JRuby leads to 100s of SEVERE warnings for a mid-size (booted) Rails app
-        super(closure.getStaticScope(), signature);
-        this.closure = (IRClosure) closure;
-        this.fileName = closure.getFile();
-        this.lineNumber = closure.getLine();
-        this.evalType = null;
-        this.evalTypeBody = evalTypeBody;
-    }
 
     public IRBlockBody(IRScope closure, Signature signature) {
         // ThreadLocal not set by default to avoid having many thread-local values initialized
@@ -36,21 +22,6 @@ public abstract class IRBlockBody extends ContextAwareBlockBody {
         this.closure = (IRClosure) closure;
         this.fileName = closure.getFile();
         this.lineNumber = closure.getLine();
-        this.evalType = new ThreadLocal<>();
-        this.evalTypeBody = this;
-    }
-
-    public final EvalType getEvalType() {
-        final EvalType type = evalTypeBody.evalType.get();
-        return type == null ? EvalType.NONE : type;
-    }
-
-    public void setEvalType(final EvalType type) {
-        if (type == null || type == EvalType.NONE) {
-            evalTypeBody.evalType.remove();
-        } else {
-            evalTypeBody.evalType.set(type);
-        }
     }
 
     @Override

--- a/core/src/main/java/org/jruby/runtime/MethodBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/MethodBlockBody.java
@@ -89,10 +89,4 @@ public class MethodBlockBody extends ContextAwareBlockBody {
     public ArgumentDescriptor[] getArgumentDescriptors() {
         return argsDesc;
     }
-
-    @Override
-    public void setEvalType(EvalType evalType) {
-        // nop
-    }
-
 }

--- a/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
@@ -58,7 +58,6 @@ public class MixedModeIRBlockBody extends IRBlockBody implements Compilable<Comp
     @Override
     public void completeBuild(CompiledIRBlockBody blockBody) {
         setCallCount(-1);
-        blockBody.evalType = this.evalType; // share with parent
         this.jittedBody = blockBody;
     }
 

--- a/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
@@ -38,12 +38,6 @@ public class MixedModeIRBlockBody extends IRBlockBody implements Compilable<Comp
     }
 
     @Override
-    public void setEvalType(EvalType evalType) {
-        super.setEvalType(evalType); // so that getEvalType is correct
-        if (jittedBody != null) jittedBody.setEvalType(evalType);
-    }
-
-    @Override
     public boolean canCallDirect() {
         return jittedBody != null || (interpreterContext != null && interpreterContext.hasExplicitCallProtocol());
     }

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -102,7 +102,7 @@ public class Options {
     public static final Option<Boolean> INVOKEDYNAMIC_CLASS_VALUES = bool(INVOKEDYNAMIC, "invokedynamic.class.values", false, "Use ClassValue to store class-specific data.");
     public static final Option<Integer> INVOKEDYNAMIC_GLOBAL_MAXFAIL = integer(INVOKEDYNAMIC, "invokedynamic.global.maxfail", 0, "Maximum global cache failures after which to use slow path.");
     public static final Option<Boolean> INVOKEDYNAMIC_HANDLES = bool(INVOKEDYNAMIC, "invokedynamic.handles", false, "Use MethodHandles rather than generated code to bind Ruby methods.");
-    public static final Option<Boolean> INVOKEDYNAMIC_YIELD = bool(INVOKEDYNAMIC, "invokedynamic.yield", false, "Bind yields directly using invokedynamic.");
+    public static final Option<Boolean> INVOKEDYNAMIC_YIELD = bool(INVOKEDYNAMIC, "invokedynamic.yield", true, "Bind yields directly using invokedynamic.");
 
     // NOTE: -1 jit.threshold is way of having interpreter not promote full builds
     public static final Option<Integer> JIT_THRESHOLD = integer(JIT, "jit.threshold", Constants.JIT_THRESHOLD, "Set the JIT threshold to the specified method invocation count.");


### PR DESCRIPTION
This PR contains several improvements to block dispatch to reduce overhead.

* Make Block.type final, to take advantage of final optimizations in some JVM JITs. If it needs to be modified, the Block should be cloned. Most blocks will never need this since they're always normal or always lambda.
* Move BlockBody.evalType to Block and make it a final field. This eliminates the ThreadLocal in IRBlockBody and avoids constantly updating it back to normal, which was done every call to any IR block in the system.
* Make escapeBlock final. This is only ever set at construction time and never modified again. Setting it here allows final optimizations to reduce loads when checking for escaped blocks.
* Reset and recalculate IRScope flags before running AddCallProtocol. This allows ACP to reduce how much framing/scoping is needed when other passes (like DeadCode) have removed code. Previously the flags would be tainted by earlier calculation and never cleared after optimizations have run.
* Enable indy-based direct block yielding. This allows a monomorphic yield yo be inlined into its called. This feature was available before behind a property, but was not enabled by default due to the lack of guards against polymorphic blocks.
* Disable indy-based yielding when a polymorphic block is detected. This can be expanded in the future to a PIC for small-morphic yields, but the long term solutions will be using IR inlining or method splitting to keep yields naturally monomorphic.
* Minor improvements to Proc#call to reduce how many levels of calls are necessary and to arity-split for reduced argument overhead along some paths.