### PR TITLE
Bash cleanup

### DIFF
--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -284,15 +284,18 @@ do
      -J*)
          java_args=("${java_args[@]}" "${1#-J}") ;;
      # Pass -X... and -X? search options through
-     -X*\.\.\.|-X*\?)
+     -X*...|-X*\?)
         ruby_args=("${ruby_args[@]}" "$1") ;;
      # Match -Xa.b.c=d to translate to -Da.b.c=d as a java option
      -X*.*)
         java_args=("${java_args[@]}" "-Djruby.${1#-X}") ;;
      # Match switches that take an argument
-     -C|-e|-I|-S) ruby_args=("${ruby_args[@]}" "$1" "$2"); shift ;;
+     -C|-e|-I|-S)
+        ruby_args=("${ruby_args[@]}" "$1" "$2")
+        shift ;;
      # Match same switches with argument stuck together
-     -e*|-I*|-S*) ruby_args=("${ruby_args[@]}" "$1" ) ;;
+     -e*|-I*|-S*)
+        ruby_args=("${ruby_args[@]}" "$1" ) ;;
      # Run with JMX management enabled
      --manage)
         java_args=("${java_args[@]}" "-Dcom.sun.management.jmxremote")
@@ -329,19 +332,26 @@ do
      --ng*)
        echo "Error: Nailgun is no longer supported"
        exit 1 ;;
-     --environment) print_environment_log=1 ;;
+     --environment)
+       print_environment_log=1 ;;
      # warn but ignore
-     --1.8) echo "warning: --1.8 ignored" ;;
+     --1.8)
+       echo "warning: --1.8 ignored" ;;
      # warn but ignore
-     --1.9) echo "warning: --1.9 ignored" ;;
+     --1.9)
+       echo "warning: --1.9 ignored" ;;
      # warn but ignore
-     --2.0) echo "warning: --1.9 ignored" ;;
+     --2.0)
+       echo "warning: --1.9 ignored" ;;
      # Abort processing on the double dash
-     --) break ;;
+     --)
+       break ;;
      # Other opts go to ruby
-     -*) ruby_args=("${ruby_args[@]}" "$1") ;;
+     -*)
+       ruby_args=("${ruby_args[@]}" "$1") ;;
      # Abort processing on first non-opt arg
-     *) break ;;
+     *)
+       break ;;
     esac
     shift
 done

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -102,9 +102,8 @@ jruby_jsa_file="$JRUBY_HOME/lib/jruby.jsa"
 add_log
 add_log "JRuby executable:"
 add_log "  $BASH_SOURCE"
-command_line_options="$@"
 add_log "JRuby command line options:"
-add_log "  $command_line_options"
+add_log "  $*"
 add_log "Current directory:"
 add_log "  $(pwd)"
 

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -25,14 +25,6 @@ mode=""
 JAVA_CLASS_JRUBY_MAIN=org.jruby.Main
 java_class=$JAVA_CLASS_JRUBY_MAIN
 
-# Determine how to call expr (jruby/jruby#5091)
-# On Alpine linux, expr takes no -- arguments, and 'expr --' echoes '--'.
-_expr_dashed=$(expr -- 2>/dev/null)
-if [ "$_expr_dashed" != '--' ] ; then
-  alias expr="expr --"
-fi
-unset _expr_dashed
-
 # OpenJDK tries really hard to prevent you from using urandom.
 # See https://bugs.openjdk.java.net/browse/JDK-6202721
 # Non-file URL causes fallback to slow threaded SeedGenerator.
@@ -316,14 +308,8 @@ do
      -X*\.\.\.|-X*\?)
         ruby_args=("${ruby_args[@]}" "$1") ;;
      # Match -Xa.b.c=d to translate to -Da.b.c=d as a java option
-     -X*)
-        val=${1:2}
-        if expr "$val" : '.*[.]' > /dev/null; then
-          java_args=("${java_args[@]}" "-Djruby.${val}")
-        else
-          ruby_args=("${ruby_args[@]}" "-X${val}")
-        fi
-        ;;
+     -X*.*)
+        java_args=("${java_args[@]}" "-Djruby.${1#-X}") ;;
      # Match switches that take an argument
      -C|-e|-I|-S) ruby_args=("${ruby_args[@]}" "$1" "$2"); shift ;;
      # Match same switches with argument stuck together

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -252,42 +252,37 @@ set -- $JRUBY_OPTS "$@"
 while [ $# -gt 0 ]
 do
     case $1 in
-    # Stuff after '-J' in this argument goes to JVM
-    -J*)
-        val=${1:2}
-        if [ "${val:0:4}" = "-Xmx" ]; then
-            JAVA_MEM="$val"
-        elif [ "${val:0:4}" = "-Xms" ]; then
-            JAVA_MEM_MIN="$val"
-        elif [ "${val:0:4}" = "-Xss" ]; then
-            JAVA_STACK="$val"
-        elif [ -z "${val}" ]; then
-            "$JAVACMD" -help
-            echo "(Prepend -J in front of these options when using 'jruby' command)"
-            exit
-        elif [ "${val}" = "-X" ]; then
-            "$JAVACMD" -X
-            echo "(Prepend -J in front of these options when using 'jruby' command)"
-            exit
-        elif [ "${val}" = "-classpath" ]; then
-            CP="$CP$CP_DELIMITER$2"
-            CLASSPATH=""
-            shift
-        elif [ "${val}" = "-cp" ]; then
-            CP="$CP$CP_DELIMITER$2"
-            CLASSPATH=""
-            shift
-        else
-            if [ "${val:0:3}" = "-ea" ]; then
-                VERIFY_JRUBY="yes"
-                java_args=("${java_args[@]}" "${1:2}")
-            elif [ "${val:0:20}" = "-Djava.security.egd=" ]; then
-                JAVA_SECURITY_EGD=${val:20}
-            else
-                java_args=("${java_args[@]}" "${1:2}")
-            fi
-        fi
-        ;;
+     # Stuff after '-J' in this argument goes to JVM
+     -J-Xmx*)
+         JAVA_MEM="${1#-J}" ;;
+     -J-Xms*)
+         JAVA_MEM_MIN="${1#-J}" ;;
+     -J-Xss*)
+         JAVA_STACK="${1#-J}" ;;
+     -J)
+         "$JAVACMD" -help
+         echo "(Prepend -J in front of these options when using 'jruby' command)"
+         exit ;;
+     -J-X)
+         "$JAVACMD" -X
+         echo "(Prepend -J in front of these options when using 'jruby' command)"
+         exit ;;
+     -J-classpath)
+         CP="$CP$CP_DELIMITER$2"
+         CLASSPATH=""
+         shift ;;
+     -J-cp)
+         CP="$CP$CP_DELIMITER$2"
+         CLASSPATH=""
+         shift ;;
+     -J-ea*)
+         VERIFY_JRUBY="yes"
+         java_args=("${java_args[@]}" "${1#-J}") ;;
+     -J-Djava.security.egd=*)
+         JAVA_SECURITY_EGD=${1#-J-Djava.security.egd=} ;;
+     # This must be the last check for -J
+     -J*)
+         java_args=("${java_args[@]}" "${1#-J}") ;;
      # Pass -X... and -X? search options through
      -X*\.\.\.|-X*\?)
         ruby_args=("${ruby_args[@]}" "$1") ;;

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -276,32 +276,32 @@ do
          shift ;;
      -J-ea*)
          VERIFY_JRUBY="yes"
-         java_args=("${java_args[@]}" "${1#-J}") ;;
+         java_args+=("${1#-J}") ;;
      -J-Djava.security.egd=*)
          JAVA_SECURITY_EGD=${1#-J-Djava.security.egd=} ;;
      # This must be the last check for -J
      -J*)
-         java_args=("${java_args[@]}" "${1#-J}") ;;
+         java_args+=("${1#-J}") ;;
      # Pass -X... and -X? search options through
      -X*...|-X*\?)
-        ruby_args=("${ruby_args[@]}" "$1") ;;
+        ruby_args+=("$1") ;;
      # Match -Xa.b.c=d to translate to -Da.b.c=d as a java option
      -X*.*)
-        java_args=("${java_args[@]}" "-Djruby.${1#-X}") ;;
+        java_args+=("-Djruby.${1#-X}") ;;
      # Match switches that take an argument
      -C|-e|-I|-S)
-        ruby_args=("${ruby_args[@]}" "$1" "$2")
+        ruby_args+=("$1" "$2")
         shift ;;
      # Match same switches with argument stuck together
      -e*|-I*|-S*)
-        ruby_args=("${ruby_args[@]}" "$1" ) ;;
+        ruby_args+=("$1") ;;
      # Run with JMX management enabled
      --manage)
-        java_args=("${java_args[@]}" "-Dcom.sun.management.jmxremote")
-        java_args=("${java_args[@]}" "-Djruby.management.enabled=true") ;;
+        java_args+=("-Dcom.sun.management.jmxremote")
+        java_args+=("-Djruby.management.enabled=true") ;;
      # Don't launch a GUI window, no matter what
      --headless)
-        java_args=("${java_args[@]}" "-Djava.awt.headless=true") ;;
+        java_args+=("-Djava.awt.headless=true") ;;
      # Run under JDB
      --jdb)
         if [ -z "$JAVA_HOME" ] ; then
@@ -314,8 +314,8 @@ do
           fi
         fi
         JDB_SOURCEPATH="${JRUBY_HOME}/core/src/main/java:${JRUBY_HOME}/lib/ruby/stdlib:."
-        java_args=("${java_args[@]}" "-sourcepath" "$JDB_SOURCEPATH")
-        JRUBY_OPTS=("${JRUBY_OPTS[@]}" "-X+C") ;;
+        java_args+=("-sourcepath" "$JDB_SOURCEPATH")
+        JRUBY_OPTS+=("-X+C") ;;
      --client|--server|--noclient)
         echo "Warning: the $1 flag is deprecated and has no effect most JVMs" ;;
      --dev)
@@ -323,9 +323,9 @@ do
         # For OpenJ9 use environment variable to enable quickstart and shareclasses
         export OPENJ9_JAVA_OPTIONS="-Xquickstart -Xshareclasses" ;;
      --sample)
-        java_args=("${java_args[@]}" "-Xprof") ;;
+        java_args+=("-Xprof") ;;
      --record)
-        java_args=("${java_args[@]}" "-XX:+FlightRecorder" "-XX:StartFlightRecording=dumponexit=true") ;;
+        java_args+=("-XX:+FlightRecorder" "-XX:StartFlightRecording=dumponexit=true") ;;
      --no-bootclasspath)
         NO_BOOTCLASSPATH=true ;;
      --ng*)
@@ -347,7 +347,7 @@ do
        break ;;
      # Other opts go to ruby
      -*)
-       ruby_args=("${ruby_args[@]}" "$1") ;;
+       ruby_args+=("$1") ;;
      # Abort processing on first non-opt arg
      *)
        break ;;
@@ -357,11 +357,11 @@ done
 
 # Force JDK to use specified java.security.egd rand source
 if [ -n "$JAVA_SECURITY_EGD" ]; then
-  java_args=("${java_args[@]}" "-Djava.security.egd=$JAVA_SECURITY_EGD")
+  java_args+=("-Djava.security.egd=$JAVA_SECURITY_EGD")
 fi
 
 # Append the rest of the arguments
-ruby_args=("${ruby_args[@]}" "$@")
+ruby_args+=("$@")
 
 # Put the ruby_args back into the position arguments $1, $2 etc
 set -- "${ruby_args[@]}"

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -425,26 +425,20 @@ fi
 # Include all options from files at the beginning of the Java command line
 JAVA_OPTS="$java_opts_from_files $JAVA_OPTS"
 
+# Don't quote JAVA_OPTS; we want it to expand
+jvm_command=("$JAVACMD" $JAVA_OPTS "$JFFI_OPTS" "${java_args[@]}")
+
 if [ "$NO_BOOTCLASSPATH" ] || [ "$VERIFY_JRUBY" ]; then
-
-  # Don't quote JAVA_OPTS; we want it to expand
-  jvm_command=("$JAVACMD" $JAVA_OPTS "$JFFI_OPTS" "${java_args[@]}" "${classpath_args[@]}" \
-    "-Djruby.home=$JRUBY_HOME" \
-    "-Djruby.lib=$JRUBY_HOME/lib" "-Djruby.script=jruby" \
-    "-Djruby.shell=$JRUBY_SHELL" \
-    "$java_class" "$@")
-
+  jvm_command+=("${classpath_args[@]}")
 else
+  jvm_command+=(-Xbootclasspath/a:"$JRUBY_CP" \
+    -classpath "$CP$CP_DELIMITER$CLASSPATH" "-Djruby.home=$JRUBY_HOME")
+fi
 
-  # Run normally
-
-  jvm_command=("$JAVACMD" $JAVA_OPTS "$JFFI_OPTS" "${java_args[@]}" -Xbootclasspath/a:"$JRUBY_CP" -classpath "$CP$CP_DELIMITER$CLASSPATH" \
-    "-Djruby.home=$JRUBY_HOME" \
+jvm_command+=("-Djruby.home=$JRUBY_HOME" \
     "-Djruby.lib=$JRUBY_HOME/lib" "-Djruby.script=jruby" \
     "-Djruby.shell=$JRUBY_SHELL" \
     "$java_class" "$@")
-
-fi
 
 add_log
 add_log "Java command line:"

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -292,9 +292,6 @@ do
      -C|-e|-I|-S)
         ruby_args+=("$1" "$2")
         shift ;;
-     # Match same switches with argument stuck together
-     -e*|-I*|-S*)
-        ruby_args+=("$1") ;;
      # Run with JMX management enabled
      --manage)
         java_args+=("-Dcom.sun.management.jmxremote")
@@ -334,14 +331,8 @@ do
      --environment)
        print_environment_log=1 ;;
      # warn but ignore
-     --1.8)
-       echo "warning: --1.8 ignored" ;;
-     # warn but ignore
-     --1.9)
-       echo "warning: --1.9 ignored" ;;
-     # warn but ignore
-     --2.0)
-       echo "warning: --1.9 ignored" ;;
+     --1.8|--1.9|--2.0)
+       echo "warning: $1 ignored" ;;
      # Abort processing on the double dash
      --)
        break ;;

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -171,25 +171,11 @@ process_java_opts "$installed_jruby_java_opts_file"
 process_java_opts "$home_jruby_java_opts_file"
 process_java_opts "$pwd_jruby_java_opts_file"
 
-# ----- Process special JRuby options into JVM options -------------------------------
-
-unset JRUBY_OPTS_TEMP
-for opt in ${JRUBY_OPTS[@]}; do
-    JRUBY_OPTS_TEMP="${JRUBY_OPTS_TEMP} $opt"
-    if [ $opt == "-server" ]; then # JRUBY-4204
-        add_log "Enabling -server mode"
-        JAVA_VM="-server"
-    fi
-done
-JRUBY_OPTS=${JRUBY_OPTS_TEMP}
-
 # Capture some Java options to be passed separately
 unset JAVA_OPTS_TEMP
 JAVA_OPTS_TEMP=""
 for opt in "${JAVA_OPTS[@]}"; do
   case $opt in
-    -server)
-      JAVA_VM="-server";;
     -Xmx*)
       JAVA_MEM="$opt";;
     -Xms*)
@@ -333,18 +319,12 @@ do
         JDB_SOURCEPATH="${JRUBY_HOME}/core/src/main/java:${JRUBY_HOME}/lib/ruby/stdlib:."
         java_args=("${java_args[@]}" "-sourcepath" "$JDB_SOURCEPATH")
         JRUBY_OPTS=("${JRUBY_OPTS[@]}" "-X+C") ;;
-     --client)
-        JAVA_VM=-client
-        echo "Warning: the --client flag is deprecated and has no effect most JVMs" ;;
-     --server)
-        JAVA_VM=-server
-        echo "Warning: the --server flag is deprecated and has no effect most JVMs" ;;
+     --client|--server|--noclient)
+        echo "Warning: the $1 flag is deprecated and has no effect most JVMs" ;;
      --dev)
         process_java_opts "$dev_mode_opts_file"
         # For OpenJ9 use environment variable to enable quickstart and shareclasses
         export OPENJ9_JAVA_OPTIONS="-Xquickstart -Xshareclasses" ;;
-     --noclient)         # JRUBY-4296
-        unset JAVA_VM ;; # For IBM JVM, neither '-client' nor '-server' is applicable
      --sample)
         java_args=("${java_args[@]}" "-Xprof") ;;
      --record)

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -20,10 +20,9 @@ fi
 
 declare -a java_args
 declare -a ruby_args
-mode=""
 
 JAVA_CLASS_JRUBY_MAIN=org.jruby.Main
-java_class=$JAVA_CLASS_JRUBY_MAIN
+java_class="$JAVA_CLASS_JRUBY_MAIN"
 
 # OpenJDK tries really hard to prevent you from using urandom.
 # See https://bugs.openjdk.java.net/browse/JDK-6202721
@@ -35,30 +34,30 @@ fi
 
 # Gather environment information as we go
 environment_log=$'JRuby Environment\n================='
-function add_log() {
+add_log() {
     environment_log+=$'\n'"$1"
 }
 
 # Logic to process "arguments files" on both Java 8 and Java 9+
 unset java_opts_from_files
-function process_java_opts {
-  java_opts_file=$1
-  if [[ -r $java_opts_file ]]; then
+process_java_opts() {
+  java_opts_file="$1"
+  if [ -r "$java_opts_file" ]; then
     add_log
     add_log "Adding Java options from: $java_opts_file"
 
     while read -r line; do
-      if [[ $line ]]; then
+      if [ "$line" ]; then
           add_log "  $line"
       fi
-    done < $java_opts_file
+    done < "$java_opts_file"
 
     # On Java 9+, add an @argument for the given file.
     # On earlier versions the file contents will be read and expanded on the Java command line.
-    if [[ $is_java9 ]]; then
+    if [ "$is_java9" ]; then
       java_opts_from_files="$java_opts_from_files @$java_opts_file"
     else
-      java_opts_from_files="$java_opts_from_files $(cat $java_opts_file)"
+      java_opts_from_files="$java_opts_from_files $(cat "$java_opts_file")"
     fi
   fi
 }
@@ -66,7 +65,7 @@ function process_java_opts {
 # ----- Determine JRUBY_HOME based on this executable's path ------------------
 
 # get the absolute path of the executable
-BASE_DIR=$(cd -P -- "$(dirname -- "$BASH_SOURCE")" >/dev/null && pwd -P)
+BASE_DIR="$(cd -P -- "$(dirname -- "$BASH_SOURCE")" >/dev/null && pwd -P)"
 SELF_PATH="$BASE_DIR/$(basename -- "$BASH_SOURCE")"
 
 # resolve symlinks
@@ -76,8 +75,8 @@ while [ -h "$SELF_PATH" ]; do
     # 3) get the physical pwd
     # 4) append the basename
     SYM="$(readlink "$SELF_PATH")"
-    BASE_SYM=$(cd -P -- "$(dirname -- "$SELF_PATH")" >/dev/null && pwd -P)
-    SELF_PATH="$(cd "$BASE_SYM" && cd $(dirname -- "$SYM") && pwd -P)/$(basename -- "$SYM")"
+    BASE_SYM="$(cd -P -- "$(dirname -- "$SELF_PATH")" >/dev/null && pwd -P)"
+    SELF_PATH="$(cd "$BASE_SYM" && cd "$(dirname -- "$SYM")" && pwd -P)/$(basename -- "$SYM")"
 done
 
 JRUBY_HOME="${SELF_PATH%/*/*}"
@@ -96,7 +95,7 @@ pwd_jruby_java_opts_file="$PWD/.jruby.java_opts"
 dev_mode_opts_file="$JRUBY_HOME/bin/.dev_mode.java_opts"
 
 # Default JVM Class Data Sharing Archive (jsa) file for JVMs that support it
-jruby_jsa_file=${JRUBY_HOME}/lib/jruby.jsa
+jruby_jsa_file="$JRUBY_HOME/lib/jruby.jsa"
 
 # ----- Initialize environment log -------------------------
 
@@ -117,10 +116,9 @@ add_log "  JAVA_OPTS: $JAVA_OPTS"
 
 # ----- Discover JVM and prep environment to run it ---------------------------
 
-# Detect cygwin, darwin, and mingw environments
-case "`uname`" in
+# Detect cygwin and mingw environments
+case "$(uname)" in
   CYGWIN*) cygwin=true;;
-  Darwin) darwin=true;;
   MINGW*) jruby.exe "$@"; exit $?;;
 esac
 
@@ -128,30 +126,30 @@ esac
 if [ -z "$JAVACMD" ] ; then
   if [ -z "$JAVA_HOME" ] ; then
     JAVACMD='java'
-    JAVA_HOME=$(dirname $(dirname `which java`))
+    JAVA_HOME="$(dirname "$(dirname "$(command -v java)")")"
   else
     if $cygwin; then
-      JAVACMD="`cygpath -u "$JAVA_HOME"`/bin/java"
+      JAVACMD="$(cygpath -u "$JAVA_HOME")/bin/java"
     else
       JAVACMD="$JAVA_HOME/bin/java"
     fi
   fi
 else
-  expanded_javacmd=`which $JAVACMD`
-  if [[ -z "$JAVA_HOME" && -x $expanded_javacmd ]] ; then
-    JAVA_HOME=$(dirname $(dirname $expanded_javacmd))
+  expanded_javacmd="$(command -v "$JAVACMD")"
+  if [ -z "$JAVA_HOME" ] && [ -x "$expanded_javacmd" ] ; then
+    JAVA_HOME="$(dirname "$(dirname "$expanded_javacmd")")"
   fi
 fi
 
 # Detect Java 9+ by the presence of a jmods directory in JAVA_HOME
-if [ -d $JAVA_HOME/jmods ]; then
+if [ -d "$JAVA_HOME"/jmods ]; then
   is_java9=1
 fi
 
 add_log "  JAVACMD: $JAVACMD"
 add_log "  JAVA_HOME: $JAVA_HOME"
 
-if [[ $is_java9 ]]; then
+if [ "$is_java9" ]; then
   add_log
   add_log "Detected Java modules at $JAVA_HOME/jmods"
 fi
@@ -169,9 +167,9 @@ fi
 # * command line flags
 
 # Add local and global .jruby.java_opts
-process_java_opts $installed_jruby_java_opts_file
-process_java_opts $home_jruby_java_opts_file
-process_java_opts $pwd_jruby_java_opts_file
+process_java_opts "$installed_jruby_java_opts_file"
+process_java_opts "$home_jruby_java_opts_file"
+process_java_opts "$pwd_jruby_java_opts_file"
 
 # ----- Process special JRuby options into JVM options -------------------------------
 
@@ -188,22 +186,22 @@ JRUBY_OPTS=${JRUBY_OPTS_TEMP}
 # Capture some Java options to be passed separately
 unset JAVA_OPTS_TEMP
 JAVA_OPTS_TEMP=""
-for opt in ${JAVA_OPTS[@]}; do
+for opt in "${JAVA_OPTS[@]}"; do
   case $opt in
     -server)
       JAVA_VM="-server";;
     -Xmx*)
-      JAVA_MEM=$opt;;
+      JAVA_MEM="$opt";;
     -Xms*)
-      JAVA_MEM_MIN=$opt;;
+      JAVA_MEM_MIN="$opt";;
     -Xss*)
-      JAVA_STACK=$opt;;
+      JAVA_STACK="$opt";;
     *)
-      JAVA_OPTS_TEMP="${JAVA_OPTS_TEMP} $opt";;
+      JAVA_OPTS_TEMP="$JAVA_OPTS_TEMP $opt";;
   esac
 done
 
-JAVA_OPTS=$JAVA_OPTS_TEMP
+JAVA_OPTS="$JAVA_OPTS_TEMP"
 
 # ----- Set up the JRuby class/module path ------------------------------------
 
@@ -216,31 +214,31 @@ for j in "$JRUBY_HOME"/lib/jruby.jar "$JRUBY_HOME"/lib/jruby-complete.jar; do
     fi
     if [ "$JRUBY_CP" ]; then
         JRUBY_CP="$JRUBY_CP$CP_DELIMITER$j"
-        else
+    else
         JRUBY_CP="$j"
     fi
-    if [ $JRUBY_ALREADY_ADDED ]; then
+    if [ "$JRUBY_ALREADY_ADDED" ]; then
         echo "WARNING: more than one JRuby JAR found in lib directory"
     fi
     JRUBY_ALREADY_ADDED=true
 done
 
 if $cygwin; then
-    JRUBY_CP=`cygpath -p -w "$JRUBY_CP"`
+    JRUBY_CP="$(cygpath -p -w "$JRUBY_CP")"
 fi
 
 # ----- Add additional jars from lib to classpath -----------------------------
 
-if [ "$JRUBY_PARENT_CLASSPATH" != "" ]; then
+if [ "$JRUBY_PARENT_CLASSPATH" ]; then
     # Use same classpath propagated from parent jruby
-    CP=$JRUBY_PARENT_CLASSPATH
+    CP="$JRUBY_PARENT_CLASSPATH"
 else
     # add other jars in lib to CP for command-line execution
     for j in "$JRUBY_HOME"/lib/*.jar; do
-        if [ "$j" == "$JRUBY_HOME"/lib/jruby.jar ]; then
+        if [ "$j" = "$JRUBY_HOME"/lib/jruby.jar ]; then
           continue
         fi
-        if [ "$j" == "$JRUBY_HOME"/lib/jruby-complete.jar ]; then
+        if [ "$j" = "$JRUBY_HOME"/lib/jruby-complete.jar ]; then
           continue
         fi
         if [ "$CP" ]; then
@@ -250,8 +248,8 @@ else
         fi
     done
 
-    if [ "$CP" != "" ] && $cygwin; then
-        CP=`cygpath -p -w "$CP"`
+    if [ "$CP" ] && $cygwin; then
+        CP="$(cygpath -p -w "$CP")"
     fi
 fi
 
@@ -267,22 +265,22 @@ fi
 set -- $JRUBY_OPTS "$@"
 while [ $# -gt 0 ]
 do
-    case "$1" in
+    case $1 in
     # Stuff after '-J' in this argument goes to JVM
     -J*)
         val=${1:2}
         if [ "${val:0:4}" = "-Xmx" ]; then
-            JAVA_MEM=$val
+            JAVA_MEM="$val"
         elif [ "${val:0:4}" = "-Xms" ]; then
-            JAVA_MEM_MIN=$val
+            JAVA_MEM_MIN="$val"
         elif [ "${val:0:4}" = "-Xss" ]; then
-            JAVA_STACK=$val
-        elif [ "${val}" = "" ]; then
-            $JAVACMD -help
+            JAVA_STACK="$val"
+        elif [ -z "${val}" ]; then
+            "$JAVACMD" -help
             echo "(Prepend -J in front of these options when using 'jruby' command)"
             exit
         elif [ "${val}" = "-X" ]; then
-            $JAVACMD -X
+            "$JAVACMD" -X
             echo "(Prepend -J in front of these options when using 'jruby' command)"
             exit
         elif [ "${val}" = "-classpath" ]; then
@@ -327,7 +325,7 @@ do
           JAVACMD='jdb'
         else
           if $cygwin; then
-            JAVACMD="`cygpath -u "$JAVA_HOME"`/bin/jdb"
+            JAVACMD="$(cygpath -u "$JAVA_HOME")/bin/jdb"
           else
             JAVACMD="$JAVA_HOME/bin/jdb"
           fi
@@ -342,7 +340,7 @@ do
         JAVA_VM=-server
         echo "Warning: the --server flag is deprecated and has no effect most JVMs" ;;
      --dev)
-        process_java_opts $dev_mode_opts_file
+        process_java_opts "$dev_mode_opts_file"
         # For OpenJ9 use environment variable to enable quickstart and shareclasses
         export OPENJ9_JAVA_OPTIONS="-Xquickstart -Xshareclasses" ;;
      --noclient)         # JRUBY-4296
@@ -374,7 +372,7 @@ do
 done
 
 # Force JDK to use specified java.security.egd rand source
-if [[ -n "$JAVA_SECURITY_EGD" ]]; then
+if [ -n "$JAVA_SECURITY_EGD" ]; then
   java_args=("${java_args[@]}" "-Djava.security.egd=$JAVA_SECURITY_EGD")
 fi
 
@@ -392,19 +390,18 @@ JFFI_OPTS="-Djffi.boot.library.path=$JRUBY_HOME/lib/jni"
 
 if $cygwin; then
   use_exec=false
-  JRUBY_HOME=`cygpath --mixed "$JRUBY_HOME"`
-  JRUBY_SHELL=`cygpath --mixed "$JRUBY_SHELL"`
+  JRUBY_HOME="$(cygpath --mixed "$JRUBY_HOME")"
+  JRUBY_SHELL="$(cygpath --mixed "$JRUBY_SHELL")"
 
-  if [[ ( "${1:0:1}" = "/" ) && ( ( -f "$1" ) || ( -d "$1" )) ]]; then
-    win_arg=`cygpath -w "$1"`
+  if [ "${1:0:1}" = "/" ] && [ -f "$1" ] || [ -d "$1" ]; then
+    win_arg="$(cygpath -w "$1")"
     shift
     win_args=("$win_arg" "$@")
     set -- "${win_args[@]}"
   fi
 
   # fix JLine to use UnixTerminal
-  stty -icanon min 1 -echo > /dev/null 2>&1
-  if [ $? = 0 ]; then
+  if stty -icanon min 1 -echo > /dev/null 2>&1; then
     JAVA_OPTS="$JAVA_OPTS -Djline.terminal=jline.UnixTerminal"
   fi
 
@@ -412,7 +409,7 @@ fi
 
 # ----- Module and Class Data Sharing flags for Java 9+ -----------------------
 
-if [[ $is_java9 ]]; then
+if [ "$is_java9" ]; then
   # Use module path instead of classpath for the jruby libs
   classpath_args=(--module-path "$JRUBY_CP" -classpath "$CP$CP_DELIMITER$CLASSPATH")
 
@@ -420,15 +417,15 @@ if [[ $is_java9 ]]; then
   NO_BOOTCLASSPATH=1
 
   # Add base opens we need for Ruby compatibility
-  process_java_opts $jruby_module_opts_file
+  process_java_opts "$jruby_module_opts_file"
 
   # Allow overriding default JSA file location
-  if [ "$JRUBY_JSA" == "" ]; then
-    JRUBY_JSA=$jruby_jsa_file
+  if [ -z "$JRUBY_JSA" ]; then
+    JRUBY_JSA="$jruby_jsa_file"
   fi
 
   # If we have a jruby.jsa file, enable AppCDS
-  if [ -f $JRUBY_JSA ]; then
+  if [ -f "$JRUBY_JSA" ]; then
     add_log
     add_log "Detected Class Data Sharing archive:"
     add_log "  $JRUBY_JSA"
@@ -444,13 +441,14 @@ fi
 # Include all options from files at the beginning of the Java command line
 JAVA_OPTS="$java_opts_from_files $JAVA_OPTS"
 
-if [[ "$NO_BOOTCLASSPATH" != "" || "$VERIFY_JRUBY" != "" ]]; then
+if [ "$NO_BOOTCLASSPATH" ] || [ "$VERIFY_JRUBY" ]; then
 
+  # Don't quote JAVA_OPTS; we want it to expand
   jvm_command=("$JAVACMD" $JAVA_OPTS "$JFFI_OPTS" "${java_args[@]}" "${classpath_args[@]}" \
     "-Djruby.home=$JRUBY_HOME" \
-    "-Djruby.lib=$JRUBY_HOME/lib" -Djruby.script=jruby \
+    "-Djruby.lib=$JRUBY_HOME/lib" "-Djruby.script=jruby" \
     "-Djruby.shell=$JRUBY_SHELL" \
-    $java_class $mode "$@")
+    "$java_class" "$@")
 
 else
 
@@ -458,18 +456,17 @@ else
 
   jvm_command=("$JAVACMD" $JAVA_OPTS "$JFFI_OPTS" "${java_args[@]}" -Xbootclasspath/a:"$JRUBY_CP" -classpath "$CP$CP_DELIMITER$CLASSPATH" \
     "-Djruby.home=$JRUBY_HOME" \
-    "-Djruby.lib=$JRUBY_HOME/lib" -Djruby.script=jruby \
+    "-Djruby.lib=$JRUBY_HOME/lib" "-Djruby.script=jruby" \
     "-Djruby.shell=$JRUBY_SHELL" \
-    $java_class $mode "$@")
+    "$java_class" "$@")
 
 fi
 
-full_java_command="${jvm_command[@]}"
 add_log
 add_log "Java command line:"
-add_log "  $full_java_command"
+add_log "  ${jvm_command[*]}"
 
-if [[ $print_environment_log ]]; then
+if [ "$print_environment_log" ]; then
   echo "$environment_log"
   exit 0
 fi


### PR DESCRIPTION
Here are a bunch of changes cleaning up the Bash launcher. Most of it is assisted by [shellcheck](https://www.shellcheck.net).
Changes include syntax improvements, removing unused variables, and some minimal syntax changes to make it easier to port to POSIX shell in the future.
See commit messages for more details.