### PR TITLE
Ruby 2.6 : Add Random.bytes

### DIFF
--- a/core/src/main/java/org/jruby/RubyRandom.java
+++ b/core/src/main/java/org/jruby/RubyRandom.java
@@ -683,12 +683,16 @@ public class RubyRandom extends RubyObject {
     // c: random_s_bytes
     @JRubyMethod(meta = true)
     public static IRubyObject bytes(ThreadContext context, IRubyObject recv, IRubyObject arg) {
-        return ((RubyRandom) (context.runtime.getRandomClass()).getConstant("DEFAULT")).bytes(context, arg);
+        return bytesCommon(context, getDefaultRand(context), arg);
     }
 
     // c: rb_random_bytes
     @JRubyMethod(name = "bytes")
     public IRubyObject bytes(ThreadContext context, IRubyObject arg) {
+        return bytesCommon(context, random, arg);
+    }
+
+    private static IRubyObject bytesCommon(ThreadContext context, RandomType random, IRubyObject arg) {
         int n = RubyNumeric.num2int(arg);
         byte[] bytes = new byte[n];
         int idx = 0;

--- a/core/src/main/java/org/jruby/RubyRandom.java
+++ b/core/src/main/java/org/jruby/RubyRandom.java
@@ -680,6 +680,12 @@ public class RubyRandom extends RubyObject {
         return this;
     }
 
+    // c: random_s_bytes
+    @JRubyMethod(meta = true)
+    public static IRubyObject bytes(ThreadContext context, IRubyObject recv, IRubyObject arg) {
+        return ((RubyRandom) (context.runtime.getRandomClass()).getConstant("DEFAULT")).bytes(context, arg);
+    }
+
     // c: rb_random_bytes
     @JRubyMethod(name = "bytes")
     public IRubyObject bytes(ThreadContext context, IRubyObject arg) {


### PR DESCRIPTION
This PR implements Random.bytes method.

See Feature [#4938](https://bugs.ruby-lang.org/issues/4938)