### PR TITLE
Remove array expansion of JAVA_OPTS environment variable

### DIFF
--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -173,7 +173,7 @@ process_java_opts "$pwd_jruby_java_opts_file"
 # Capture some Java options to be passed separately
 unset JAVA_OPTS_TEMP
 JAVA_OPTS_TEMP=""
-for opt in "${JAVA_OPTS[@]}"; do
+for opt in $JAVA_OPTS; do
   case $opt in
     -Xmx*)
       JAVA_MEM="$opt";;


### PR DESCRIPTION
Looks like I broke something in my bash cleanup. This variable can never start as an array since it's from the environment. Treating it as an array parses all the options as one, so none of the variables the case statement get set right.
It is expanded correctly later, so the flags are passed to java, but the default value of -Xss is appended and overrides the previous one (I assume).
Setting JAVA_OPTS to something not starting with -Xss, e.g. `-Xms256m -Xss4096k` and putting this:
```bash
printf JAVA_OPTS: ; printf ' "%s"' $JAVA_OPTS; echo
```
somewhere late in the script shows the incorrect behaviour.
