### PR TITLE
Fix Enumerator fiber leaks

### DIFF
--- a/core/src/main/ruby/jruby/kernel/enumerator.rb
+++ b/core/src/main/ruby/jruby/kernel/enumerator.rb
@@ -115,10 +115,14 @@ class Enumerator
 
   class Lazy < Enumerator
 
-    def initialize(obj, size = nil)
-      _block_error(:new) unless block_given?
+    def initialize(obj, size = nil, &block)
+      _block_error(:new) unless block
       @receiver = obj
-      super(size) do |yielder, *args|
+      super(size, &self.class.make_proc(obj, &block))
+    end
+
+    def self.make_proc(obj)
+      proc do |yielder, *args|
         catch yielder do
           obj.each(*args) do |*x|
             yield yielder, *x


### PR DESCRIPTION
This PR will include commits to reduce the chance of `Enumerator#next` fibers leaking.

The original issue is #6004.

So far most of the leaks appear to be caused by combining `Enumerator::Lazy` with `Enumerator#next`, since many lazy paths construct new Lazy instances in such a way that they are hard-referenced by the eventual fiber.