### PR TITLE
[fix] inspect builtin

### DIFF
--- a/core/src/main/java/org/jruby/ext/ffi/Type.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Type.java
@@ -185,8 +185,8 @@ public abstract class Type extends RubyObject {
             this.sym = runtime.newSymbol(symName);
         }
 
-        @JRubyMethod(name = "to_s")
-        public final IRubyObject to_s(ThreadContext context) {
+        @JRubyMethod(name = "inspect")
+        public final IRubyObject inspect(ThreadContext context) {
             return RubyString.newString(context.runtime,
                     String.format("#<FFI::Type::Builtin:%s size=%d alignment=%d>",
                     nativeType.name(), size, alignment));


### PR DESCRIPTION
MRI
```
FFI::Type::Builtin::FLOAT
=> #<FFI::Type::Builtin:FLOAT32 size=4 alignment=4>
FFI::Type::Builtin::FLOAT.to_s
=> "#<FFI::Type::Builtin:0x0000000003b0d918>"
```

jruby
```
FFI::Type::Builtin::FLOAT
#<FFI::Type::Builtin:0x60e67c06>
FFI::Type::Builtin::FLOAT.to_s
"#<FFI::Type::Builtin:FLOAT size=4 alignment=4>"
```

jruby + patch
```
FFI::Type::Builtin::FLOAT
"#<FFI::Type::Builtin:FLOAT size=4 alignment=4>"
FFI::Type::Builtin::FLOAT.to_s
#<FFI::Type::Builtin:0x60e67c06>
```