### PR TITLE
[fix] restore rescue nil performance 

### DIFF
--- a/bench/core/kernel/bench_raise.rb
+++ b/bench/core/kernel/bench_raise.rb
@@ -1,0 +1,48 @@
+require 'benchmark/ips'
+
+Benchmark.ips do |x|
+
+  x.config(:time => 10, :warmup => 10)
+
+  x.report("raise(msg) default") do
+    begin
+      raise 'default'
+    rescue => ex
+      ex && true
+    end
+  end
+
+  x.report("raise(class, msg)") do
+    begin
+      raise RuntimeError, 'def'
+    rescue => ex
+      ex && true
+    end
+  end
+
+  x.report("raise(class, msg, nil)") do
+    begin
+      raise RuntimeError, 'nil', nil
+    rescue => ex
+      ex && true
+    end
+  end
+
+  trace = caller.dup
+  x.report("raise(class, msg, trace)") do
+    begin
+      raise RuntimeError, 'nil', backtrace
+    rescue => ex
+      ex && true
+    end
+  end
+
+  x.report("raise(class, msg) rescue nil") do
+    (raise RuntimeError, 'def') rescue nil
+  end
+
+  x.report("raise(class, msg, trace) rescue nil") do
+    (raise RuntimeError, 'def', trace) rescue nil
+  end
+
+end

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -1234,17 +1234,18 @@ public final class ThreadContext {
     }
 
     public void setExceptionRequiresBacktrace(boolean exceptionRequiresBacktrace) {
+        if (runtime.isDebug()) return; // leave true default
         this.exceptionRequiresBacktrace = exceptionRequiresBacktrace;
     }
 
     @JIT
     public void exceptionBacktraceOn() {
-        this.exceptionRequiresBacktrace = true;
+        setExceptionRequiresBacktrace(true);
     }
 
     @JIT
     public void exceptionBacktraceOff() {
-        this.exceptionRequiresBacktrace = false;
+        setExceptionRequiresBacktrace(false);
     }
 
     private Map<String, Map<IRubyObject, IRubyObject>> symToGuards;


### PR DESCRIPTION

initially I thought `rescue nil` back-trace capturing is disabled on purpose
but seems it simply got lost at f64a3e0

follow-up on https://github.com/jruby/jruby/pull/6014

should introduce some perf.testing to avoid loosing performance