### PR TITLE
Refined send

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -31,7 +31,7 @@ package org.jruby;
 import org.jcodings.Encoding;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.ir.interpreter.Interpreter;
-import org.jruby.runtime.CallSite;
+import org.jruby.parser.StaticScope;
 import org.jruby.runtime.JavaSites;
 import org.jruby.runtime.JavaSites.BasicObjectSites;
 import org.jruby.runtime.callsite.CacheEntry;
@@ -1718,27 +1718,35 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     public IRubyObject send(ThreadContext context, IRubyObject arg0, Block block) {
         String name = RubySymbol.objectToSymbolString(arg0);
 
-        return getMetaClass().finvoke(context, this, name, block);
+        StaticScope staticScope = context.getCurrentStaticScope();
+
+        return getMetaClass().finvokeWithRefinements(context, this, staticScope, name, block);
     }
     @JRubyMethod(name = "__send__", omit = true)
     public IRubyObject send(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Block block) {
         String name = RubySymbol.objectToSymbolString(arg0);
 
-        return getMetaClass().finvoke(context, this, name, arg1, block);
+        StaticScope staticScope = context.getCurrentStaticScope();
+
+        return getMetaClass().finvokeWithRefinements(context, this, staticScope, name, arg1, block);
     }
     @JRubyMethod(name = "__send__", omit = true)
     public IRubyObject send(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
         String name = RubySymbol.objectToSymbolString(arg0);
 
-        return getMetaClass().finvoke(context, this, name, arg1, arg2, block);
+        StaticScope staticScope = context.getCurrentStaticScope();
+
+        return getMetaClass().finvokeWithRefinements(context, this, staticScope, name, arg1, arg2, block);
     }
     @JRubyMethod(name = "__send__", required = 1, rest = true, omit = true)
     public IRubyObject send(ThreadContext context, IRubyObject[] args, Block block) {
         String name = RubySymbol.objectToSymbolString(args[0]);
 
+        StaticScope staticScope = context.getCurrentStaticScope();
+
         final int length = args.length - 1;
         args = ( length == 0 ) ? IRubyObject.NULL_ARRAY : ArraySupport.newCopy(args, 1, length);
-        return getMetaClass().finvoke(context, this, name, args, block);
+        return getMetaClass().finvokeWithRefinements(context, this, staticScope, name, args, block);
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -32,6 +32,7 @@
 package org.jruby;
 
 import org.jruby.javasupport.JavaClass;
+import org.jruby.parser.StaticScope;
 import org.jruby.runtime.Arity;
 import org.jruby.runtime.JavaSites;
 import org.jruby.runtime.callsite.CachingCallSite;
@@ -484,7 +485,11 @@ public class RubyClass extends RubyModule {
     }
 
     public IRubyObject finvoke(ThreadContext context, IRubyObject self, String name, Block block) {
-        CacheEntry entry = searchWithCache(name);
+        return finvokeWithRefinements(context, self, null, name, block);
+    }
+
+    public IRubyObject finvokeWithRefinements(ThreadContext context, IRubyObject self, StaticScope staticScope, String name, Block block) {
+        CacheEntry entry = searchWithRefinements(name, staticScope);
         DynamicMethod method = entry.method;
 
         if (shouldCallMethodMissing(method)) {
@@ -495,8 +500,13 @@ public class RubyClass extends RubyModule {
 
     public IRubyObject finvoke(ThreadContext context, IRubyObject self, String name,
                                IRubyObject[] args, Block block) {
+        return finvokeWithRefinements(context, self, null, name, args, block);
+    }
+
+    public IRubyObject finvokeWithRefinements(ThreadContext context, IRubyObject self, StaticScope staticScope, String name,
+                                              IRubyObject[] args, Block block) {
         assert args != null;
-        CacheEntry entry = searchWithCache(name);
+        CacheEntry entry = searchWithRefinements(name, staticScope);
         DynamicMethod method = entry.method;
 
         if (shouldCallMethodMissing(method)) {
@@ -507,7 +517,12 @@ public class RubyClass extends RubyModule {
 
     public IRubyObject finvoke(ThreadContext context, IRubyObject self, String name,
                                IRubyObject arg, Block block) {
-        CacheEntry entry = searchWithCache(name);
+        return finvokeWithRefinements(context, self, null, name, arg, block);
+    }
+
+    public IRubyObject finvokeWithRefinements(ThreadContext context, IRubyObject self, StaticScope staticScope, String name,
+                               IRubyObject arg, Block block) {
+        CacheEntry entry = searchWithRefinements(name, staticScope);
         DynamicMethod method = entry.method;
 
         if (shouldCallMethodMissing(method)) {
@@ -518,7 +533,12 @@ public class RubyClass extends RubyModule {
 
     public IRubyObject finvoke(ThreadContext context, IRubyObject self, String name,
                                IRubyObject arg0, IRubyObject arg1, Block block) {
-        CacheEntry entry = searchWithCache(name);
+        return finvokeWithRefinements(context, self, null, name, arg0, arg1, block);
+    }
+
+    public IRubyObject finvokeWithRefinements(ThreadContext context, IRubyObject self, StaticScope staticScope, String name,
+                               IRubyObject arg0, IRubyObject arg1, Block block) {
+        CacheEntry entry = searchWithRefinements(name, staticScope);
         DynamicMethod method = entry.method;
 
         if (shouldCallMethodMissing(method)) {
@@ -529,7 +549,12 @@ public class RubyClass extends RubyModule {
 
     public IRubyObject finvoke(ThreadContext context, IRubyObject self, String name,
                                IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
-        CacheEntry entry = searchWithCache(name);
+        return finvokeWithRefinements(context, self, null, name, arg0, arg1, arg2, block);
+    }
+
+    public IRubyObject finvokeWithRefinements(ThreadContext context, IRubyObject self, StaticScope staticScope, String name,
+                               IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
+        CacheEntry entry = searchWithRefinements(name, staticScope);
         DynamicMethod method = entry.method;
 
         if (shouldCallMethodMissing(method)) {

--- a/core/src/main/java/org/jruby/ir/instructions/CallBase.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CallBase.java
@@ -268,6 +268,13 @@ public abstract class CallBase extends NOperandInstr implements ClosureAccepting
 
         if (potentiallySend(getId(), argsCount)) { // ok to look at raw string since we know we are looking for 7bit names.
             Operand meth = getArg1();
+
+            if (isPotentiallyRefined()) {
+                // send within a refined scope needs to reflect refinements
+                modifiedScope = true;
+                flags.add(REQUIRES_DYNSCOPE);
+            }
+
             if (meth instanceof StringLiteral) {
                 // This logic is intended to reduce the framing impact of send if we can
                 // statically determine the sent name and we know it does not need to be

--- a/test/mri/excludes/TestRefinement.rb
+++ b/test/mri/excludes/TestRefinement.rb
@@ -1,6 +1,5 @@
 exclude :test_prepend_into_refinement, "zsuper in module issue #5585"
 exclude :test_refine_prepended_class, "markers not being applied properly to prepended module"
-exclude :test_send_should_use_refinements, "todo"
 exclude :test_super_to_module, "issues finding proper super hierarchy, perhaps related to #5585"
 exclude :test_undef_original_method, "flaw in how we represent undef methods; they look the same as never-defined"
 exclude :test_undef_prepended_method, "flaw in how we represent undef methods; they look the same as never-defined"


### PR DESCRIPTION
Kernel#send and BasicObject#__send__ should honor refinements from the surrounding scope.

Note this forces sends in the presence of refinements to require a scope, which currently means a dynamic scope.

Fixes #5945 