### PR TITLE
[fix] retore $! on closure nested non-local returns

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -130,7 +130,7 @@ public class IRBuilder {
         }
     }
 
-    private static class RescueBlockInfo {
+    static class RescueBlockInfo {
         Label      entryLabel;             // Entry of the rescue block
         Variable   savedExceptionVariable; // Variable that contains the saved $! variable
 
@@ -1397,8 +1397,6 @@ public class IRBuilder {
         Operand superClass = (superNode == null) ? null : build(superNode);
         ByteList className = cpath.getName().getBytes();
         Operand container = getContainerFromCPath(cpath);
-
-        //System.out.println("MODULE IS SINGLE USE:"  + className +  ", " +  scope.getFile() + ":" + classNode.getEndLine());
 
         IRClassBody body = new IRClassBody(manager, scope, className, classNode.getLine(), classNode.getScope(), executesOnce);
         Variable bodyResult = addResultInstr(new DefineClassInstr(createTemporaryVariable(), body, container, superClass));
@@ -3093,8 +3091,6 @@ public class IRBuilder {
         ByteList moduleName = cpath.getName().getBytes();
         Operand container = getContainerFromCPath(cpath);
 
-        //System.out.println("MODULE IS " +  (executesOnce ? "" : "NOT") + " SINGLE USE:"  + moduleName +  ", " +  scope.getFile() + ":" + moduleNode.getEndLine());
-
         IRModuleBody body = new IRModuleBody(manager, scope, moduleName, moduleNode.getLine(), moduleNode.getScope(), executesOnce);
         Variable bodyResult = addResultInstr(new DefineModuleInstr(createTemporaryVariable(), body, container));
 
@@ -3579,8 +3575,11 @@ public class IRBuilder {
         // Save off exception & exception comparison type
         Variable exc = addResultInstr(new ReceiveRubyExceptionInstr(createTemporaryVariable()));
 
+        manager.setActiveRescueBlockStack(scope, activeRescueBlockStack);
         // Build the actual rescue block(s)
         buildRescueBodyInternal(rescueNode.getRescueNode(), rv, exc, rEndLabel);
+
+        manager.setActiveRescueBlockStack(scope, null);
 
         activeRescueBlockStack.pop();
         return rv;
@@ -3691,9 +3690,14 @@ public class IRBuilder {
                     addInstr(new CheckForLJEInstr(definedWithinMethod));
                 }
                 // for non-local returns (from rescue block) we need to restore $! so it does not get carried over
-                if (!activeRescueBlockStack.empty()) {
-                    RescueBlockInfo rbi = activeRescueBlockStack.peek();
-                    addInstr(new PutGlobalVarInstr(symbol("$!"), rbi.savedExceptionVariable));
+                if (activeRescueBlockStack.empty()) {
+                    // could still be in a parent scope that has the current closure returning (from a method)
+                    Stack<RescueBlockInfo> parentActiveRescueBlockStack = manager.getActiveRescueBlockStack(scope.getNearestMethod());
+                    if (parentActiveRescueBlockStack != null) {
+                        addRestoreErrorInfoInstrIfInsideRescueBlock(parentActiveRescueBlockStack);
+                    }
+                } else { // non-local return from current scope
+                    addRestoreErrorInfoInstrIfInsideRescueBlock(activeRescueBlockStack);
                 }
 
                 addInstr(new NonlocalReturnInstr(retVal, definedWithinMethod ? scope.getNearestMethod().getId() : "--none--"));
@@ -3718,6 +3722,13 @@ public class IRBuilder {
         // The expression that uses this result can never be executed beyond the return and hence the value itself is just
         // a placeholder operand.
         return U_NIL;
+    }
+
+    private void addRestoreErrorInfoInstrIfInsideRescueBlock(final Stack<RescueBlockInfo> activeRescueBlockStack) {
+        if (!activeRescueBlockStack.empty()) {
+            RescueBlockInfo rbi = activeRescueBlockStack.peek();
+            addInstr(new PutGlobalVarInstr(symbol("$!"), rbi.savedExceptionVariable));
+        }
     }
 
     public InterpreterContext buildEvalRoot(RootNode rootNode) {

--- a/core/src/main/java/org/jruby/ir/IRManager.java
+++ b/core/src/main/java/org/jruby/ir/IRManager.java
@@ -29,6 +29,9 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.Stack;
+import java.util.WeakHashMap;
+
 import org.jruby.ir.passes.DeadCodeElimination;
 import org.jruby.ir.passes.OptimizeDelegationPass;
 import org.jruby.ir.passes.OptimizeDynScopesPass;
@@ -395,6 +398,20 @@ public class IRManager {
     private Node parse(ThreadContext context, FileResource file, String fileName) throws IOException {
         try (InputStream stream = file.openInputStream()) {
             return context.runtime.parseFile(stream, fileName, null, 0);
+        }
+    }
+
+    private final WeakHashMap<IRScope, Stack<IRBuilder.RescueBlockInfo>> scopeRescueBlockStack = new WeakHashMap<>();
+
+    Stack<IRBuilder.RescueBlockInfo> getActiveRescueBlockStack(IRScope scope) {
+        return scopeRescueBlockStack.get(scope);
+    }
+
+    void setActiveRescueBlockStack(IRScope scope, Stack<IRBuilder.RescueBlockInfo> stack) {
+        if (stack == null) {
+            scopeRescueBlockStack.remove(scope);
+        } else {
+            scopeRescueBlockStack.put(scope, stack);
         }
     }
 }

--- a/spec/tags/ruby/language/predefined_tags.txt
+++ b/spec/tags/ruby/language/predefined_tags.txt
@@ -1,5 +1,5 @@
 fails:Global variable $0 raises a TypeError when not given an object that can be coerced to a String
 fails:Global variable $0 actually sets the program name
 windows:The predefined global constant ARGV contains Strings encoded in locale Encoding
-fails:Predefined global $! in bodies without ensure should be cleared when an exception is rescued even when a non-local return is present
+#fails:Predefined global $! in bodies without ensure should be cleared when an exception is rescued even when a non-local return is present
 fails(linux):Execution variable $: does not include the current directory


### PR DESCRIPTION
```ruby
def foo(e)
  fail("foo") if $! != e
  yield
end

def bar
  e = StandardError.new 'foo'
  begin
    raise e
  rescue
    fail("bar") if $! != e
    #1.times do
      foo(e) { return } # PROBLEM
    #end
  end
end

bar

fail("$! #{$!} not cleared!") if $! # FAILS - JRuby retains $!
puts "DONE"
```