### PR TITLE
Bump mavengem-wagon version everywhere

### DIFF
--- a/maven/jruby-complete/src/it/runnable/Mavenfile
+++ b/maven/jruby-complete/src/it/runnable/Mavenfile
@@ -2,7 +2,7 @@
 
 # default versions will be overwritten by pom.rb from root directory
 properties( 'jruby.plugins.version' => '1.0.10',
-            'mavengem.wagon.version' => '0.2.0',
+            'mavengem.wagon.version' => '1.0.3',
             'jruby.version' => '9.0.5.0' )
 
 gemfile

--- a/test/pom.rb
+++ b/test/pom.rb
@@ -8,7 +8,7 @@ project 'JRuby Integration Tests' do
   inherit 'org.jruby:jruby-parent', version
   id 'org.jruby:jruby-tests'
 
-  extension 'org.torquebox.mojo:mavengem-wagon:0.2.0'
+  extension 'org.torquebox.mojo:mavengem-wagon:1.0.3'
 
   repository :id => :mavengems, :url => 'mavengem:http://rubygems.org'
   plugin_repository :id => :mavengems, :url => 'mavengem:http://rubygems.org'


### PR DESCRIPTION
It fixes `mvn -Pbootstrap` on my environment using java 11. Before I would get the following error when running integration tests:

```
(...)
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for JRuby 9.2.10.0-SNAPSHOT:
[INFO]
[INFO] JRuby .............................................. SUCCESS [  0.303 s]
[INFO] JRuby Core ......................................... SUCCESS [  9.286 s]
[INFO] JRuby Lib Setup .................................... SUCCESS [  3.578 s]
[INFO] JRuby Integration Tests ............................ FAILURE [  3.722 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  21.088 s
[INFO] Finished at: 2020-02-14T12:06:53+01:00
[INFO] ------------------------------------------------------------------------
---------------------------------------------------
constituent[0]: file:/usr/share/maven/conf/logging/
constituent[1]: file:/usr/share/maven/lib/maven-builder-support-3.x.jar
constituent[2]: file:/usr/share/maven/lib/maven-resolver-provider-3.x.jar
constituent[3]: file:/usr/share/maven/lib/maven-compat-3.x.jar
constituent[4]: file:/usr/share/maven/lib/commons-cli.jar
constituent[5]: file:/usr/share/maven/lib/plexus-interpolation.jar
constituent[6]: file:/usr/share/maven/lib/cdi-api.jar
constituent[7]: file:/usr/share/maven/lib/maven-resolver-connector-basic.jar
constituent[8]: file:/usr/share/maven/lib/maven-resolver-spi.jar
constituent[9]: file:/usr/share/maven/lib/maven-model-3.x.jar
constituent[10]: file:/usr/share/maven/lib/commons-io.jar
constituent[11]: file:/usr/share/maven/lib/plexus-utils.jar
constituent[12]: file:/usr/share/maven/lib/maven-core-3.x.jar
constituent[13]: file:/usr/share/maven/lib/plexus-cipher.jar
constituent[14]: file:/usr/share/maven/lib/maven-settings-3.x.jar
constituent[15]: file:/usr/share/maven/lib/guava.jar
constituent[16]: file:/usr/share/maven/lib/wagon-http-shaded.jar
constituent[17]: file:/usr/share/maven/lib/maven-model-builder-3.x.jar
constituent[18]: file:/usr/share/maven/lib/maven-shared-utils.jar
constituent[19]: file:/usr/share/maven/lib/sisu-inject.jar
constituent[20]: file:/usr/share/maven/lib/jcl-over-slf4j.jar
constituent[21]: file:/usr/share/maven/lib/wagon-provider-api.jar
constituent[22]: file:/usr/share/maven/lib/maven-resolver-transport-wagon.jar
constituent[23]: file:/usr/share/maven/lib/sisu-plexus.jar
constituent[24]: file:/usr/share/maven/lib/maven-resolver-api.jar
constituent[25]: file:/usr/share/maven/lib/jansi.jar
constituent[26]: file:/usr/share/maven/lib/maven-resolver-impl.jar
constituent[27]: file:/usr/share/maven/lib/maven-slf4j-provider-3.x.jar
constituent[28]: file:/usr/share/maven/lib/aopalliance.jar
constituent[29]: file:/usr/share/maven/lib/maven-resolver-util.jar
constituent[30]: file:/usr/share/maven/lib/guice.jar
constituent[31]: file:/usr/share/maven/lib/plexus-component-annotations.jar
constituent[32]: file:/usr/share/maven/lib/plexus-sec-dispatcher.jar
constituent[33]: file:/usr/share/maven/lib/commons-lang3.jar
constituent[34]: file:/usr/share/maven/lib/maven-plugin-api-3.x.jar
constituent[35]: file:/usr/share/maven/lib/wagon-file.jar
constituent[36]: file:/usr/share/maven/lib/maven-embedder-3.x.jar
constituent[37]: file:/usr/share/maven/lib/jsr250-api.jar
constituent[38]: file:/usr/share/maven/lib/slf4j-api.jar
constituent[39]: file:/usr/share/maven/lib/maven-artifact-3.x.jar
constituent[40]: file:/usr/share/maven/lib/maven-settings-builder-3.x.jar
constituent[41]: file:/usr/share/maven/lib/maven-repository-metadata-3.x.jar
constituent[42]: file:/usr/share/maven/lib/javax.inject.jar
---------------------------------------------------
Exception in thread "main" java.lang.ExceptionInInitializerError
	at org.torquebox.mojo.mavengem.wagon.MavenGemWagon.rubygemsFactory(MavenGemWagon.java:88)
	at org.torquebox.mojo.mavengem.wagon.MavenGemWagon.newConnection(MavenGemWagon.java:102)
	at org.torquebox.mojo.mavengem.wagon.MavenGemWagon.fillInputData(MavenGemWagon.java:64)
	at org.apache.maven.wagon.StreamWagon.getInputStream(StreamWagon.java:126)
	at org.apache.maven.wagon.StreamWagon.getIfNewer(StreamWagon.java:88)
	at org.apache.maven.wagon.StreamWagon.get(StreamWagon.java:61)
	at org.eclipse.aether.transport.wagon.WagonTransporter$GetTaskRunner.run(WagonTransporter.java:567)
	at org.eclipse.aether.transport.wagon.WagonTransporter.execute(WagonTransporter.java:435)
	at org.eclipse.aether.transport.wagon.WagonTransporter.get(WagonTransporter.java:412)
	at org.eclipse.aether.connector.basic.BasicRepositoryConnector$GetTaskRunner.runTask(BasicRepositoryConnector.java:456)
	at org.eclipse.aether.connector.basic.BasicRepositoryConnector$TaskRunner.run(BasicRepositoryConnector.java:363)
	at org.eclipse.aether.util.concurrency.RunnableErrorForwarder$1.run(RunnableErrorForwarder.java:75)
	at org.eclipse.aether.connector.basic.BasicRepositoryConnector$DirectExecutor.execute(BasicRepositoryConnector.java:642)
	at org.eclipse.aether.connector.basic.BasicRepositoryConnector.get(BasicRepositoryConnector.java:262)
	at org.eclipse.aether.internal.impl.DefaultArtifactResolver.performDownloads(DefaultArtifactResolver.java:489)
	at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:390)
	at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifacts(DefaultArtifactResolver.java:215)
	at org.eclipse.aether.internal.impl.DefaultArtifactResolver.resolveArtifact(DefaultArtifactResolver.java:192)
	at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.loadPom(DefaultArtifactDescriptorReader.java:240)
	at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.readArtifactDescriptor(DefaultArtifactDescriptorReader.java:171)
	at org.eclipse.aether.internal.impl.DefaultRepositorySystem.readArtifactDescriptor(DefaultRepositorySystem.java:240)
	at org.apache.maven.plugin.internal.DefaultPluginDependenciesResolver.resolve(DefaultPluginDependenciesResolver.java:103)
	at org.apache.maven.plugin.internal.DefaultMavenPluginManager.getPluginDescriptor(DefaultMavenPluginManager.java:182)
	at org.apache.maven.plugin.internal.DefaultMavenPluginManager.getMojoDescriptor(DefaultMavenPluginManager.java:286)
	at org.apache.maven.plugin.DefaultBuildPluginManager.getMojoDescriptor(DefaultBuildPluginManager.java:244)
	at org.apache.maven.lifecycle.internal.DefaultLifecycleExecutionPlanCalculator.setupMojoExecution(DefaultLifecycleExecutionPlanCalculator.java:169)
	at org.apache.maven.lifecycle.internal.DefaultLifecycleExecutionPlanCalculator.setupMojoExecutions(DefaultLifecycleExecutionPlanCalculator.java:154)
	at org.apache.maven.lifecycle.internal.DefaultLifecycleExecutionPlanCalculator.calculateExecutionPlan(DefaultLifecycleExecutionPlanCalculator.java:130)
	at org.apache.maven.lifecycle.internal.DefaultLifecycleExecutionPlanCalculator.calculateExecutionPlan(DefaultLifecycleExecutionPlanCalculator.java:144)
	at org.apache.maven.lifecycle.internal.builder.BuilderCommon.resolveBuildPlan(BuilderCommon.java:97)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:111)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:56)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:305)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:192)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:105)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:956)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:192)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: org.jruby.embed.EvalFailedException: (OpenSSL::X509::StoreError) setting default path failed: No password supplied for PKCS#12 KeyStore.
	at org.jruby.embed.internal.EmbedEvalUnitImpl.run(EmbedEvalUnitImpl.java:133)
	at org.jruby.embed.ScriptingContainer.runUnit(ScriptingContainer.java:1340)
	at org.jruby.embed.ScriptingContainer.runScriptlet(ScriptingContainer.java:1333)
	at org.sonatype.nexus.ruby.DefaultRubygemsGateway.<init>(DefaultRubygemsGateway.java:43)
	at org.torquebox.mojo.mavengem.RubygemsFactory.<clinit>(RubygemsFactory.java:27)
	... 48 more
Caused by: org.jruby.exceptions.RaiseException: (OpenSSL::X509::StoreError) setting default path failed: No password supplied for PKCS#12 KeyStore.
	at org.jruby.ext.openssl.X509Store.set_default_paths(org/jruby/ext/openssl/X509Store.java:165)
	at RUBY.SSLContext(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/jopenssl19/openssl/ssl-internal.rb:31)
	at RUBY.SSL(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/jopenssl19/openssl/ssl-internal.rb:22)
	at RUBY.OpenSSL(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/jopenssl19/openssl/ssl-internal.rb:21)
	at RUBY.(root)(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/jopenssl19/openssl/ssl-internal.rb:20)
	at org.jruby.RubyKernel.load(org/jruby/RubyKernel.java:1087)
	at RUBY.(root)(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/openssl/ssl-internal.rb:1)
	at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:1071)
	at Kernel.require(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:55)
	at Kernel.require(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:53)
	at RUBY.(root)(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/openssl/ssl-internal.rb:4)
	at org.jruby.RubyKernel.load(org/jruby/RubyKernel.java:1087)
	at RUBY.(root)(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/jopenssl19/openssl.rb:1)
	at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:1071)
	at Kernel.require(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:55)
	at Kernel.require(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:53)
	at RUBY.(root)(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/jopenssl19/openssl.rb:21)
	at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:1071)
	at Kernel.require(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:55)
	at Kernel.require(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:53)
	at RUBY.(root)(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/jopenssl/load.rb:1)
	at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:1071)
	at Kernel.require(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:55)
	at Kernel.require(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:53)
	at RUBY.(root)(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/jopenssl/load.rb:24)
	at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:1071)
	at Kernel.require(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:55)
	at Kernel.require(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:53)
	at RUBY.(root)(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/openssl.rb:1)
	at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:1071)
	at Kernel.require(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:55)
	at Kernel.require(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:53)
	at RUBY.(root)(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/openssl.rb:1)
	at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:1071)
	at Kernel.require(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:55)
	at Kernel.require(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:53)
	at RUBY.(root)(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/rubygems/security.rb:1)
	at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:1071)
	at Kernel.require(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:55)
	at Kernel.require(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:53)
	at RUBY.(root)(uri:classloader:/META-INF/jruby.home/lib/ruby/shared/rubygems/security.rb:11)
```

Now they succeed:

```
(...)
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for JRuby 9.2.10.0-SNAPSHOT:
[INFO]
[INFO] JRuby .............................................. SUCCESS [  0.328 s]
[INFO] JRuby Core ......................................... SUCCESS [ 10.141 s]
[INFO] JRuby Lib Setup .................................... SUCCESS [  3.695 s]
[INFO] JRuby Integration Tests ............................ SUCCESS [ 32.281 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  50.027 s
[INFO] Finished at: 2020-02-14T12:10:41+01:00
[INFO] ------------------------------------------------------------------------
```

Not sure which of the two changes included in this commit fixed it, but I assume it's fine to bump the version in both places.