### PR TITLE
Mark custom classloaders as parallel capable

### DIFF
--- a/core/src/main/java/org/jruby/util/JRubyClassLoader.java
+++ b/core/src/main/java/org/jruby/util/JRubyClassLoader.java
@@ -58,6 +58,9 @@ import org.jruby.util.log.LoggerFactory;
  * <code>require</code> and <code>load</code>
  */
 public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
+    static {
+        registerAsParallelCapable();
+    }
 
     private static final Logger LOG = LoggerFactory.getLogger(JRubyClassLoader.class);
 

--- a/core/src/main/java/org/jruby/util/OneShotClassLoader.java
+++ b/core/src/main/java/org/jruby/util/OneShotClassLoader.java
@@ -4,6 +4,9 @@ package org.jruby.util;
  * Represents a class loader designed to load exactly one class.
 */
 public class OneShotClassLoader extends ClassLoader implements ClassDefiningClassLoader {
+    static {
+        registerAsParallelCapable();
+    }
 
     public OneShotClassLoader(JRubyClassLoader parent) {
         super(parent);


### PR DESCRIPTION
These classloaders apparently led to a deadlock inside Azul Zing
when using the ReadyNow feature that saves class and JIT data
betwen runs. This should be a benign change, since these loaders
typically only ever load one class, but we'll let it back for a
while.