### PR TITLE
throw ArgumentError instead of SecurityError

### DIFF
--- a/core/src/main/java/org/jruby/util/StringSupport.java
+++ b/core/src/main/java/org/jruby/util/StringSupport.java
@@ -762,7 +762,7 @@ public final class StringSupport {
 
     /**
      * Check whether input object's string value contains a null byte, and if so
-     * throw SecurityError.
+     * throw ArgumentError.
      * @param runtime
      * @param value
      */
@@ -773,7 +773,7 @@ public final class StringSupport {
         final int end = bl.length();
         for (int i = bl.begin(); i < end; ++i) {
             if (array[i] == (byte) 0) {
-                throw runtime.newSecurityError("string contains null byte");
+                throw runtime.newArgumentError("string contains null byte");
             }
         }
     }


### PR DESCRIPTION
String tests Poison null byte raises error
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected ArgumentError, got #<SecurityError: string contains null byte> with backtrace:
         # ./spec/ffi/string_spec.rb:27:in `block in <main>'
         # ./spec/ffi/string_spec.rb:27:in `block in <main>'
         # ./spec/ffi/string_spec.rb:27:in `block in <main>'

https://github.com/jruby/jruby/pull/5948