### PR TITLE
Fix windows_stub_script to use jruby.exe

### DIFF
--- a/lib/ruby/stdlib/rubygems/installer.rb
+++ b/lib/ruby/stdlib/rubygems/installer.rb
@@ -799,7 +799,7 @@ TEXT
       # stub & ruby.exe withing same folder.  Portable
       <<-TEXT
 @ECHO OFF
-@"%~dp0ruby.exe" "%~dpn0" %*
+@"%~dp0#{ruby_exe}" "%~dpn0" %*
       TEXT
     elsif bindir.downcase.start_with? rb_topdir.downcase
       # stub within ruby folder, but not standard bin.  Portable
@@ -809,14 +809,14 @@ TEXT
       rel  = to.relative_path_from from
       <<-TEXT
 @ECHO OFF
-@"%~dp0#{rel}/ruby.exe" "%~dpn0" %*
+@"%~dp0#{rel}/#{ruby_exe}" "%~dpn0" %*
       TEXT
     else
       # outside ruby folder, maybe -user-install or bundler.  Portable, but ruby
       # is dependent on PATH
       <<-TEXT
 @ECHO OFF
-@ruby.exe "%~dpn0" %*
+@#{ruby_exe} "%~dpn0" %*
       TEXT
     end
   end


### PR DESCRIPTION
* It would try to use ruby.exe, which is currently not shipped as part of JRuby distributions.
* See https://github.com/jruby/jruby-launcher/issues/29#issuecomment-586701997

This of course should probably be fixed in RubyGems upstream.
I'll let you handle that.