### PR TITLE
Restore the backtrace element for the `new` call

### DIFF
--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -905,35 +905,35 @@ public class RubyClass extends RubyModule {
     /** rb_class_new_instance
     *
     */
-    @JRubyMethod(name = "new", omit = true)
+    @JRubyMethod(name = "new")
     public IRubyObject newInstance(ThreadContext context, Block block) {
         IRubyObject obj = allocate();
         baseCallSites[CS_IDX_INITIALIZE].call(context, obj, obj, block);
         return obj;
     }
 
-    @JRubyMethod(name = "new", omit = true)
+    @JRubyMethod(name = "new")
     public IRubyObject newInstance(ThreadContext context, IRubyObject arg0, Block block) {
         IRubyObject obj = allocate();
         baseCallSites[CS_IDX_INITIALIZE].call(context, obj, obj, arg0, block);
         return obj;
     }
 
-    @JRubyMethod(name = "new", omit = true)
+    @JRubyMethod(name = "new")
     public IRubyObject newInstance(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Block block) {
         IRubyObject obj = allocate();
         baseCallSites[CS_IDX_INITIALIZE].call(context, obj, obj, arg0, arg1, block);
         return obj;
     }
 
-    @JRubyMethod(name = "new", omit = true)
+    @JRubyMethod(name = "new")
     public IRubyObject newInstance(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
         IRubyObject obj = allocate();
         baseCallSites[CS_IDX_INITIALIZE].call(context, obj, obj, arg0, arg1, arg2, block);
         return obj;
     }
 
-    @JRubyMethod(name = "new", rest = true, omit = true)
+    @JRubyMethod(name = "new", rest = true)
     public IRubyObject newInstance(ThreadContext context, IRubyObject[] args, Block block) {
         IRubyObject obj = allocate();
         baseCallSites[CS_IDX_INITIALIZE].call(context, obj, obj, args, block);


### PR DESCRIPTION
This was removed in 2011 by aa4e8bb8dd after it broke some
libraries that mined information out of the backtrace,
specifically RSpec 2. Since then, RSpec and other libraries have
become more robust about how they present and manipulate
backtraces, so this commit puts those frames back.

This is a partial fix for #6055, but invokedynamic "new" logic
will still omit that frame when calling the core "new" method.