### PR TITLE
Use expand_path logic for Dir.glob base path

### DIFF
--- a/core/src/main/java/org/jruby/util/StringSupport.java
+++ b/core/src/main/java/org/jruby/util/StringSupport.java
@@ -172,6 +172,10 @@ public final class StringSupport {
         return new StringBuilder(str1.length() + str2.length()).append(str1).append(str2);
     }
 
+    public static String concat(final String str1, final String str2) {
+        return new StringBuilder(str1.length() + str2.length()).append(str1).append(str2).toString();
+    }
+
     public static String delete(final String str, final char c) { // str.replaceAll(c.toString(), "")
         char[] ary = null; int end = 0, s = 0;
         for (int i = 0; i < str.length(); i++) {

--- a/test/jruby.index
+++ b/test/jruby.index
@@ -95,8 +95,7 @@ jruby/test_uri_classloader
 jruby/test_rexml_document
 jruby/test_missing_jruby_home
 jruby/test_ast_inspector
-# Disabled temporarily, see jruby/jruby#6060
-#jruby/test_jarred_gems
+jruby/test_jarred_gems
 jruby/test_dir_with_plusses
 jruby/test_jar
 jruby/test_require


### PR DESCRIPTION
This should fix issues reported with RubyGems 3.0.6 and jarred resources.

Fixes #6060 
Fixes #6082 
Fixes #6083 

I have reverted the tests we disabled in 9.2.10.0 but a more direct test of this behavior (i.e. passing a `base:` URI to Dir.glob) would be useful to make sure we don't regress.