### PR TITLE
Check arity earlier in JavaConstructor#new_instance

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/JavaConstructor.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaConstructor.java
@@ -213,12 +213,18 @@ public class JavaConstructor extends JavaCallable {
 
     @JRubyMethod(rest = true)
     public final IRubyObject new_instance(final IRubyObject[] args) {
-        return new_instance( convertArguments(args) );
+        checkArity(args.length);
+
+        return newInstanceExactArity( convertArguments(args) );
     }
 
     public final IRubyObject new_instance(final Object[] arguments) {
         checkArity(arguments.length);
 
+        return newInstanceExactArity(arguments);
+    }
+
+    private IRubyObject newInstanceExactArity(Object[] arguments) {
         try {
             Object result = constructor.newInstance(arguments);
             return JavaObject.wrap(getRuntime(), result);


### PR DESCRIPTION
If this call were made with the wrong number of arguments, it could easily walk off the type array due to the lack of arity checking in the convertArguments call.

Fixes #6079.