### PR TITLE
CGI.escapeHTML restore the original encoding

### DIFF
--- a/lib/ruby/stdlib/cgi/util.rb
+++ b/lib/ruby/stdlib/cgi/util.rb
@@ -49,9 +49,12 @@ module CGI::Util
       table = Hash[TABLE_FOR_ESCAPE_HTML__.map {|pair|pair.map {|s|s.encode(enc)}}]
       string = string.gsub(/#{"['&\"<>]".encode(enc)}/, table)
       string.encode!(origenc) if origenc
-      return string
+      string
+    else
+      string = string.b
+      string.gsub!(/['&\"<>]/, TABLE_FOR_ESCAPE_HTML__)
+      string.force_encoding(enc)
     end
-    string.gsub(/['&\"<>]/, TABLE_FOR_ESCAPE_HTML__)
   end
 
   begin

--- a/spec/tags/ruby/library/cgi/escapeHTML_tags.txt
+++ b/spec/tags/ruby/library/cgi/escapeHTML_tags.txt
@@ -1,1 +1,0 @@
-fails:CGI.escapeHTML escapes invalid encoding


### PR DESCRIPTION
fixes https://github.com/jruby/jruby/issues/6093