### PR TITLE
Ruby 2.6 : Enumerator::ArithmeticSequence class, Numeric#step, Range#step

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -459,11 +459,13 @@ public final class Ruby implements Constantizable {
             generatorClass = RubyGenerator.createGeneratorClass(this, enumeratorClass);
             yielderClass = RubyYielder.createYielderClass(this);
             chainClass = RubyChain.createChainClass(this, enumeratorClass);
+            aseqClass = RubyArithmeticSequence.createArithmeticSequenceClass(this, enumeratorClass);
         } else {
             enumeratorClass = null;
             generatorClass = null;
             yielderClass = null;
             chainClass = null;
+            aseqClass = null;
         }
 
         continuationClass = initContinuation();
@@ -1944,6 +1946,10 @@ public final class Ruby implements Constantizable {
 
     public RubyClass getChain() {
         return chainClass;
+    }
+
+    public RubyClass getArithmeticSequence() {
+        return aseqClass;
     }
 
     public RubyClass getFiber() {
@@ -5120,6 +5126,7 @@ public final class Ruby implements Constantizable {
     private final RubyClass fiberClass;
     private final RubyClass generatorClass;
     private final RubyClass chainClass;
+    private final RubyClass aseqClass;
     private final RubyClass arrayClass;
     private final RubyClass hashClass;
     private final RubyClass rangeClass;

--- a/core/src/main/java/org/jruby/RubyArithmeticSequence.java
+++ b/core/src/main/java/org/jruby/RubyArithmeticSequence.java
@@ -128,16 +128,12 @@ public class RubyArithmeticSequence extends RubyObject {
                 block.yield(context, c);
                 c = ((RubyNumeric)c).op_plus(context, s);
             }
-            //FIXME : unreachable statement
-            //return this;
         }
 
         if (Helpers.rbEqual(context, step, int2fix(context.runtime, 0)).isTrue()) {
             while (true) {
                 block.yield(context, c);
             }
-            //FIXME : unreachable statement
-            //return this;
         }
 
         len_1 = ((RubyNumeric)((RubyNumeric)e).op_minus(context, c)).idiv(context, s);

--- a/core/src/main/java/org/jruby/RubyArithmeticSequence.java
+++ b/core/src/main/java/org/jruby/RubyArithmeticSequence.java
@@ -1,0 +1,169 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
+
+import org.jruby.runtime.Block;
+import org.jruby.RubyFixnum;
+
+import org.jruby.runtime.Helpers;
+import org.jruby.runtime.ObjectAllocator;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import org.jruby.util.ByteList;
+
+import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
+import static org.jruby.RubyEnumerator.SizeFn;
+
+import static org.jruby.runtime.Helpers.hashEnd;
+import static org.jruby.runtime.Helpers.hashStart;
+import static org.jruby.runtime.Helpers.murmurCombine;
+import static org.jruby.runtime.Helpers.safeHash;
+
+/**
+ * Implements Enumerator::ArithmeticSequence
+ */
+@JRubyClass(name = "Enumerator::ArithmeticSequence")
+public class RubyArithmeticSequence extends RubyObject {
+
+    private IRubyObject begin;
+    private IRubyObject end;
+    private IRubyObject step;
+    private IRubyObject excludeEnd;
+
+    public static RubyClass createArithmeticSequenceClass(Ruby runtime, RubyClass enumeratorModule) {
+        RubyClass sequencec = runtime.defineClassUnder("ArithmeticSequence", runtime.getObject(), new ObjectAllocator() {
+            @Override
+            public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
+                return new RubyArithmeticSequence(runtime, klazz);
+            }
+        }, enumeratorModule);
+
+        sequencec.includeModule(runtime.getEnumerable());
+        sequencec.defineAnnotatedMethods(RubyArithmeticSequence.class);
+
+        RubyClass seqMetaClass = sequencec.getMetaClass();
+        seqMetaClass.undefineMethod("new");
+
+        return sequencec;
+    }
+
+    public RubyArithmeticSequence(Ruby runtime, RubyClass klass) {
+        super(runtime, klass);
+    }
+
+    public RubyArithmeticSequence(Ruby runtime, RubyClass klass, IRubyObject begin, IRubyObject end, IRubyObject step, IRubyObject excludeEnd) {
+        super(runtime, klass);
+        this.begin = begin;
+        this.end = end;
+        this.step = step;
+        this.excludeEnd = excludeEnd;
+    }
+
+    public static RubyArithmeticSequence newArithmeticSequence(ThreadContext context, IRubyObject begin, IRubyObject end, IRubyObject step, IRubyObject excludeEnd) {
+        return new RubyArithmeticSequence(context.runtime, context.runtime.getArithmeticSequence(), begin, end, step, excludeEnd);
+    }
+
+    // arith_seq_eq
+    @JRubyMethod(name = "==")
+    @Override
+    public IRubyObject op_equal(ThreadContext context, IRubyObject other) {
+        if (!(other instanceof RubyArithmeticSequence)) {
+            return context.fals;
+        }
+
+        RubyArithmeticSequence aseqOther = (RubyArithmeticSequence)other;
+
+        if (!Helpers.rbEqual(context, this.begin, aseqOther.begin).isTrue()) {
+            return context.fals;
+        }
+
+        if (!Helpers.rbEqual(context, this.end, aseqOther.end).isTrue()) {
+            return context.fals;
+        }
+
+        if (!Helpers.rbEqual(context, this.step, aseqOther.step).isTrue()) {
+            return context.fals;
+        }
+
+        if (!Helpers.rbEqual(context, this.excludeEnd, aseqOther.excludeEnd).isTrue()) {
+            return context.fals;
+        }
+
+        return context.tru;
+    }
+
+    @Override
+    public RubyFixnum hash() {
+        return hash(metaClass.runtime.getCurrentContext());
+    }
+
+    @JRubyMethod(name = "hash")
+    public RubyFixnum hash(ThreadContext context) {
+        Ruby runtime = context.runtime;
+
+        IRubyObject v;
+
+        v = safeHash(context, excludeEnd);
+        long hash = hashStart(runtime, v.convertToInteger().getLongValue());
+
+        v = safeHash(context, begin);
+        hash = murmurCombine(hash, v.convertToInteger().getLongValue());
+
+        v = safeHash(context, end);
+        hash = murmurCombine(hash, v.convertToInteger().getLongValue());
+
+        v = safeHash(context, step);
+        hash = murmurCombine(hash, v.convertToInteger().getLongValue());
+        hash = hashEnd(hash);
+
+        return runtime.newFixnum(hash);
+    }
+
+    @JRubyMethod
+    public IRubyObject begin(ThreadContext context) {
+        return begin;
+    }
+
+    @JRubyMethod
+    public IRubyObject end(ThreadContext context) {
+        return end;
+    }
+
+    @JRubyMethod
+    public IRubyObject step(ThreadContext context) {
+        return step;
+    }
+
+    @JRubyMethod(name = "exclude_end?")
+    public IRubyObject exclude_end(ThreadContext context) {
+        return excludeEnd;
+    }
+}

--- a/core/src/main/java/org/jruby/RubyArithmeticSequence.java
+++ b/core/src/main/java/org/jruby/RubyArithmeticSequence.java
@@ -438,6 +438,74 @@ public class RubyArithmeticSequence extends RubyObject {
         return excludeEnd;
     }
 
+    // arith_seq_last
+    @JRubyMethod
+    public IRubyObject last(ThreadContext context) {
+        return last(context, null);
+    }
+
+    // arith_seq_last
+    @JRubyMethod
+    public IRubyObject last(ThreadContext context, IRubyObject num) {
+        Ruby runtime = context.runtime;
+        IRubyObject b = begin, e = end, s = step, len_1, len, last, nv;
+        RubyArray ary;
+        boolean last_is_adjusted;
+        long n;
+
+        if (e.isNil()) {
+            throw runtime.newRangeError("cannot get the last element of endless arithmetic sequence");
+        }
+
+        len_1 = ((RubyNumeric)((RubyNumeric)e).op_minus(context, b)).idiv(context, s);
+        if (Numeric.f_negative_p(context, len_1)) {
+            if (num == null) {
+                return context.nil;
+            }
+
+            return runtime.newEmptyArray();
+        }
+
+        last = ((RubyNumeric)b).op_plus(context, Numeric.f_mul(context, s, len_1));
+        if ((last_is_adjusted = excludeEnd.isTrue()) && Helpers.rbEqual(context, last, e).isTrue()) {
+            last = ((RubyNumeric)last).op_minus(context, s);
+        }
+
+        if (num == null) {
+            return last;
+        }
+
+        if (last_is_adjusted) {
+            len = len_1;
+        } else {
+            len = ((RubyNumeric)len_1).op_plus(context, int2fix(runtime, 1));
+        }
+
+        nv = num;
+        if (!(nv instanceof RubyInteger)) {
+            nv = num.convertToInteger();
+        }
+
+        if (Helpers.invokePublic(context, nv, ">", len).isTrue()) {
+            nv = len;
+        }
+
+        n = num2long(nv);
+        if (n < 0) {
+            throw runtime.newArgumentError("negative array size");
+        }
+
+        ary = RubyArray.newArray(runtime, n);
+        b = ((RubyNumeric)last).op_minus(context, Numeric.f_mul(context, s, nv));
+        while (n > 0) {
+            b = ((RubyNumeric)b).op_plus(context, s);
+            ary.append(b);
+            --n;
+        }
+
+        return ary;
+    }
+
     @JRubyMethod
     public IRubyObject size(ThreadContext context) {
         Ruby runtime = context.runtime;

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -969,7 +969,7 @@ public class RubyNumeric extends RubyObject {
                 step = RubyFixnum.one(context.runtime);
             }
             if ((to.isNil() || to instanceof RubyNumeric) && step instanceof RubyNumeric) {
-                return RubyArithmeticSequence.newArithmeticSequence(context, this, to, step, context.fals);
+                return RubyArithmeticSequence.newArithmeticSequence(context, this, "step", args, this, to, step, context.fals);
             }
 
             return enumeratorizeWithSize(context, this, "step", args, stepSizeFn(this, args));

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -598,7 +598,7 @@ public class RubyRange extends RubyObject {
     public IRubyObject step(final ThreadContext context, IRubyObject step, final Block block) {
         if (!block.isGiven()) {
             if (begin instanceof RubyNumeric && (end.isNil() || end instanceof RubyNumeric)) {
-                return RubyArithmeticSequence.newArithmeticSequence(context, begin, end, !step.isNil() ? step : RubyFixnum.one(context.runtime), isExclusive ? context.tru : context.fals);
+                return RubyArithmeticSequence.newArithmeticSequence(context, this, "step", !step.isNil() ? new IRubyObject[]{step} : null, begin, end, !step.isNil() ? step : RubyFixnum.one(context.runtime), isExclusive ? context.tru : context.fals);
             }
             if (step.isNil()) {
                 return enumeratorizeWithSize(context, this, "step", new IRubyObject[]{step}, stepSizeFn());

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -40,7 +40,6 @@ package org.jruby;
 import java.io.IOException;
 import java.util.List;
 import org.jcodings.Encoding;
-import org.jruby.RubyArithmeticSequence;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.JumpException;

--- a/core/src/main/java/org/jruby/runtime/JavaSites.java
+++ b/core/src/main/java/org/jruby/runtime/JavaSites.java
@@ -182,6 +182,8 @@ public class JavaSites {
         public final CallSite div = new FunctionalCachingCallSite("div");
         public final CallSite op_times = new FunctionalCachingCallSite("*");
         public final CallSite op_mod = new FunctionalCachingCallSite("%");
+        public final CallSite op_ge = new FunctionalCachingCallSite(">=");
+        public final CallSite op_le = new FunctionalCachingCallSite("<=");
         public final CachingCallSite op_lt = new FunctionalCachingCallSite("<");
         public final CachingCallSite op_gt = new FunctionalCachingCallSite(">");
         public final CheckedSites op_lt_checked = new CheckedSites("<");


### PR DESCRIPTION
This PR implements Enumerator::ArithmeticSequence class , Numeric#step and Range#step.

See MRI's NEWS file https://github.com/ruby/ruby/blob/ruby_2_6/NEWS