### PR TITLE
Round Time#to_i down rather than truncating

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -832,7 +832,7 @@ public class RubyTime extends RubyObject {
 
     @JRubyMethod(name = {"to_i", "tv_sec"})
     public RubyInteger to_i() {
-        return getRuntime().newFixnum(getTimeInMillis() / 1000);
+        return getRuntime().newFixnum(Math.floorDiv(getTimeInMillis(), (long) 1000));
     }
 
     /**

--- a/spec/ruby/core/time/shared/to_i.rb
+++ b/spec/ruby/core/time/shared/to_i.rb
@@ -6,4 +6,11 @@ describe :time_to_i, shared: true do
   it "doesn't return an actual number of seconds in time" do
     Time.at(65.5).send(@method).should == 65
   end
+
+  it "rounds fractional seconds toward zero" do
+    t = Time.utc(1960, 1, 1, 0, 0, 0, 999_999)
+
+    t.to_f.to_i.should == -315619199
+    t.to_i.should == -315619200
+  end
 end


### PR DESCRIPTION
This fixes #6104. Needs specs though.