### PR TITLE
Ruby 2.6 : fix Enumerable#to_h with block.

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -2466,12 +2466,6 @@ public class RubyEnumerable {
             return context.nil;
         }
 
-        @Override
-        public IRubyObject call(ThreadContext context, IRubyObject arg, Block block) {
-            callImpl(context.runtime, arg);
-            return context.nil;
-        }
-
         private void callImpl(final Ruby runtime, IRubyObject value) {
             IRubyObject ary = TypeConverter.checkArrayType(runtime, value);
             if (ary.isNil()) throw runtime.newTypeError("wrong element type " + value.getMetaClass().getName() + " (expected array)");


### PR DESCRIPTION
This PR targets to make the following TravisCI test passed.
```
 30) Failure:
TestEnumerable#test_to_h_block [/Users/kiichi/git/jruby/test/mri/ruby/test_enum.rb:186]:
<{"hello"=>"world",
 "key"=>"value",
 "other_key"=>"other_value",
 "obtained"=>"via_to_ary"}> expected but was
<{"hello"=>"world",
 :key=>:value,
 "other_key"=>"other_value",
 :obtained=>:via_to_ary}>.
```