### PR TITLE
Ruby 2.6 : fix Enumerator::Lazy#find_all and #filter

### DIFF
--- a/core/src/main/ruby/jruby/kernel/enumerator.rb
+++ b/core/src/main/ruby/jruby/kernel/enumerator.rb
@@ -230,8 +230,13 @@ class Enumerator
         yielder.yield values if yield values
       end.__set_inspect :find_all
     end
-    alias_method :find_all, :select
-    alias_method :filter, :select
+    def filter
+      _block_error(:filter) unless block_given?
+      Lazy.new(self) do |yielder, *values|
+        values = values.first unless values.size > 1
+        yielder.yield values if yield values
+      end.__set_inspect :filter
+    end
 
     def reject
       _block_error(:reject) unless block_given?


### PR DESCRIPTION
This PR targets to make the following TravisCI test passed.

```
TestLazyEnumerator#test_inspect [/Users/kiichi/git/jruby/test/mri/ruby/test_lazy_enumerator.rb:450]:
<"#<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: 1..10>:map>:collect>:flat_map>:collect_concat>:select>:find_all>:reject>:grep(1)>:zip(\"a\"..\"c\")>:take(10)>:take_while>:drop(3)>:drop_while>:cycle(3)>"> expected but was
<"#<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: 1..10>:map>:collect>:flat_map>:collect_concat>:select>:select>:reject>:grep(1)>:zip(\"a\"..\"c\")>:take(10)>:take_while>:drop(3)>:drop_while>:cycle(3)>">.
```