### PR TITLE
Address dangling threads in Timeout module

### DIFF
--- a/core/src/main/java/org/jruby/ext/timeout/Timeout.java
+++ b/core/src/main/java/org/jruby/ext/timeout/Timeout.java
@@ -33,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.jcodings.specific.UTF8Encoding;
-import org.jruby.Finalizable;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyException;
@@ -69,13 +68,6 @@ public class Timeout {
                 new ScheduledThreadPoolExecutor(Runtime.getRuntime().availableProcessors(), new DaemonThreadFactory());
         executor.setRemoveOnCancelPolicy(true);
         timeout.setInternalVariable(EXECUTOR_VARIABLE, executor);
-        // shut down executor on runtime shutdown
-        timeout.getRuntime().addFinalizer(new Finalizable() {
-            @Override
-            public void finalize() throws Throwable {
-                executor.shutdown();
-            }
-        });
     }
 
 

--- a/core/src/main/java/org/jruby/ext/timeout/Timeout.java
+++ b/core/src/main/java/org/jruby/ext/timeout/Timeout.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.jcodings.specific.UTF8Encoding;
+import org.jruby.Finalizable;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyException;
@@ -68,6 +69,13 @@ public class Timeout {
                 new ScheduledThreadPoolExecutor(Runtime.getRuntime().availableProcessors(), new DaemonThreadFactory());
         executor.setRemoveOnCancelPolicy(true);
         timeout.setInternalVariable(EXECUTOR_VARIABLE, executor);
+        // shut down executor on runtime shutdown
+        timeout.getRuntime().addFinalizer(new Finalizable() {
+            @Override
+            public void finalize() throws Throwable {
+                executor.shutdown();
+            }
+        });
     }
 
 

--- a/lib/ruby/stdlib/timeout.rb
+++ b/lib/ruby/stdlib/timeout.rb
@@ -56,6 +56,10 @@ end
 # Load executor-based timeout logic into Timeout mod
 JRuby::Util.load_ext('org.jruby.ext.timeout.Timeout')
 
+at_exit do
+  Timeout.to_java.getInternalVariable('__executor__').shutdown
+end
+
 def timeout(*args, &block)
   warn "Object##{__method__} is deprecated, use Timeout.timeout instead.", uplevel: 1
   Timeout.timeout(*args, &block)


### PR DESCRIPTION
Some JVM-based projects (e.g. [puppetlabs/puppetserver](https://github.com/puppetlabs/jruby-utils/blob/2f5897fa01123f5d930c9e07ae93e8bfacd17811/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj#L194)) that embed JRuby using `ScriptingContainer` and use the `timeout` module suffer thread leaks when recycling `ScriptingContainer`s.  Such users appear to expect `ScriptingContainer#terminate` to clean up all allocated resources (within reason) including threads.

This PR is an attempt to do so by shutting down the `ScheduledThreadPoolExecutor` created during the initialization of the `Timeout` module on Ruby teardown.