### PR TITLE
Do all socket connects nonblocking for interrupts

### DIFF
--- a/core/src/main/java/org/jruby/ext/socket/RubySocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubySocket.java
@@ -29,7 +29,6 @@
 package org.jruby.ext.socket;
 
 import java.io.IOException;
-import java.net.ConnectException;
 import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
 import java.net.InterfaceAddress;
@@ -44,6 +43,7 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ConnectionPendingException;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.SelectableChannel;
+import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.Enumeration;
 import java.util.regex.Pattern;
@@ -503,91 +503,90 @@ public class RubySocket extends RubyBasicSocket {
     }
 
     private IRubyObject doConnectNonblock(ThreadContext context, SocketAddress addr, boolean ex) {
+        Ruby runtime = context.runtime;
+
         Channel channel = getChannel();
 
         if ( ! (channel instanceof SelectableChannel) ) {
-            throw context.runtime.newErrnoENOPROTOOPTError();
+            throw runtime.newErrnoENOPROTOOPTError();
         }
 
-        SelectableChannel selectable = (SelectableChannel) channel;
-        synchronized (selectable.blockingLock()) {
-            boolean oldBlocking = selectable.isBlocking();
-            try {
-                selectable.configureBlocking(false);
+        boolean result = tryConnect(context, runtime, channel, addr, ex, false);
 
-                try {
-                    return doConnect(context, addr, ex);
-
-                } finally {
-                    selectable.configureBlocking(oldBlocking);
-                }
-
-            }
-            catch (ClosedChannelException e) {
-                throw context.runtime.newErrnoECONNREFUSEDError();
-            }
-            catch (IOException e) {
-                throw sockerr(context.runtime, "connect(2): name or service not known", e);
-            }
+        if ( !result ) {
+            if (!ex) return runtime.newSymbol("wait_writable");
+            throw runtime.newErrnoEINPROGRESSWritableError();
         }
+
+        return runtime.newFixnum(0);
     }
 
     protected IRubyObject doConnect(ThreadContext context, SocketAddress addr, boolean ex) {
         Ruby runtime = context.runtime;
         Channel channel = getChannel();
 
-        try {
-            boolean result = true;
-            if (channel instanceof SocketChannel) {
-                SocketChannel socket = (SocketChannel) channel;
+        tryConnect(context, runtime, channel, addr, ex, true);
 
-                if (socket.isConnectionPending()) {
-                    // connection initiated but not finished
-                    result = socket.finishConnect();
-                } else {
-                    result = socket.connect(addr);
+        return runtime.newFixnum(0);
+    }
+
+    private boolean tryConnect(ThreadContext context, Ruby runtime, Channel channel, SocketAddress addr, boolean ex, boolean blocking) {
+        SelectableChannel selectable = (SelectableChannel) channel;
+        try {
+            synchronized (selectable.blockingLock()) {
+                boolean oldBlocking = selectable.isBlocking();
+                try {
+                    selectable.configureBlocking(false);
+
+                    while (true) {
+                        boolean result = true;
+                        if (channel instanceof SocketChannel) {
+                            SocketChannel socket = (SocketChannel) channel;
+
+                            if (socket.isConnectionPending()) {
+                                // connection initiated but not finished
+                                result = socket.finishConnect();
+                            } else {
+                                result = socket.connect(addr);
+                            }
+                        } else if (channel instanceof UnixSocketChannel) {
+                            result = ((UnixSocketChannel) channel).connect((UnixSocketAddress) addr);
+
+                        } else if (channel instanceof DatagramChannel) {
+                            ((DatagramChannel) channel).connect(addr);
+                        } else {
+                            throw runtime.newErrnoENOPROTOOPTError();
+                        }
+
+                        if (!blocking || result) return result;
+
+                        while (!context.getThread().select(channel, this, SelectionKey.OP_CONNECT)) {
+                            context.pollThreadEvents();
+                        }
+                    }
+                } finally {
+                    selectable.configureBlocking(oldBlocking);
                 }
             }
-            else if (channel instanceof UnixSocketChannel) {
-                result = ((UnixSocketChannel) channel).connect((UnixSocketAddress) addr);
-
-            }
-            else if (channel instanceof DatagramChannel) {
-                ((DatagramChannel)channel).connect(addr);
-            }
-            else {
-                throw runtime.newErrnoENOPROTOOPTError();
-            }
-
-            if ( ! result ) {
-                if (!ex) return runtime.newSymbol("wait_writable");
-                throw runtime.newErrnoEINPROGRESSWritableError();
-            }
-        }
-        catch (AlreadyConnectedException e) {
-            if (!ex) return runtime.newFixnum(0);
+        } catch (ClosedChannelException e) {
+            throw context.runtime.newErrnoECONNREFUSEDError();
+        } catch (AlreadyConnectedException e) {
+            if (!ex) return false;
             throw runtime.newErrnoEISCONNError();
-        }
-        catch (ConnectionPendingException e) {
+        } catch (ConnectionPendingException e) {
             throw runtime.newErrnoEINPROGRESSWritableError();
-        }
-        catch (UnknownHostException e) {
+        } catch (UnknownHostException e) {
             throw SocketUtils.sockerr(runtime, "connect(2): unknown host");
-        }
-        catch (SocketException e) {
+        } catch (SocketException e) {
             // Subclasses of SocketException all indicate failure to connect, which leaves the channel closed.
             // At this point the socket channel is no longer usable, so we clean up.
             getOpenFile().cleanup(runtime, true);
             throw buildSocketException(runtime, e, "connect(2)", addr);
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             throw sockerr(runtime, "connect(2): name or service not known", e);
-        }
-        catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             throw sockerr(runtime, e.getMessage(), e);
         }
-
-        return runtime.newFixnum(0);
     }
 
     protected void doBind(ThreadContext context, SocketAddress iaddr) {


### PR DESCRIPTION
Direct blocking connects can't be interrupted through normal Ruby
thread events because a hard interrupt would destroy the related
channel. Like other IO, this change uses fully non-blocking
channels and selectors to handle blocking.

Fixes #6126