### PR TITLE
Properly recombine varargs with method name for indy m_m

### DIFF
--- a/core/src/main/java/org/jruby/ir/targets/indy/Bootstrap.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/Bootstrap.java
@@ -3,6 +3,7 @@ package org.jruby.ir.targets.indy;
 import com.headius.invokebinder.Binder;
 import com.headius.invokebinder.Signature;
 import com.headius.invokebinder.SmartBinder;
+import com.headius.invokebinder.SmartHandle;
 import org.jcodings.Encoding;
 import org.jcodings.EncodingDB;
 import org.jruby.*;
@@ -627,11 +628,37 @@ public class Bootstrap {
         SmartBinder binder;
         DynamicMethod method = entry.method;
 
-        binder = SmartBinder.from(site.signature)
-                .permute("context", "self", "arg.*", "block")
-                .insert(2, new String[]{"rubyClass", "name", "argName"}, new Class[]{RubyModule.class, String.class, IRubyObject.class}, entry.sourceModule, site.name(), self.getRuntime().newSymbol(site.methodName))
-                .insert(0, "method", DynamicMethod.class, method)
-                .collect("args", "arg.*");
+        if (site.arity >= 0) {
+            binder = SmartBinder.from(site.signature)
+                    .permute("context", "self", "arg.*", "block")
+                    .insert(2,
+                            new String[]{"rubyClass", "name", "argName"}
+                            , new Class[]{RubyModule.class, String.class, IRubyObject.class},
+                            entry.sourceModule,
+                            site.name(),
+                            self.getRuntime().newSymbol(site.methodName))
+                    .insert(0, "method", DynamicMethod.class, method)
+                    .collect("args", "arg.*");
+        } else {
+            SmartHandle fold = SmartBinder.from(
+                    site.signature
+                            .permute("context", "self", "args", "block")
+                            .changeReturn(IRubyObject[].class))
+                    .permute("args")
+                    .insert(0, "argName", IRubyObject.class, self.getRuntime().newSymbol(site.methodName))
+                    .invokeStaticQuiet(LOOKUP, Helpers.class, "arrayOf");
+
+            binder = SmartBinder.from(site.signature)
+                    .permute("context", "self", "args", "block")
+                    .fold("args2", fold)
+                    .permute("context", "self", "args2", "block")
+                    .insert(2,
+                            new String[]{"rubyClass", "name"}
+                            , new Class[]{RubyModule.class, String.class},
+                            entry.sourceModule,
+                            site.name())
+                    .insert(0, "method", DynamicMethod.class, method);
+        }
 
         if (Options.INVOKEDYNAMIC_LOG_BINDING.load()) {
             LOG.info(site.name() + "\tbound to method_missing for " + method + ", " + Bootstrap.logMethod(method));

--- a/spec/compiler/general_spec.rb
+++ b/spec/compiler/general_spec.rb
@@ -1248,5 +1248,12 @@ modes.each do |mode|
         expect(x).to eq(/foo/)
       end
     end
+
+    it "handles method_missing dispatch forms" do
+      run('obj = Class.new { def method_missing(name, *args); [name, *args]; end }.new; obj.foo(1)') {|x| expect(x).to eq([:foo, 1])}
+      run('obj = Class.new { def method_missing(name, *args); [name, *args]; end }.new; obj.foo(1,2,3,4)') {|x| expect(x).to eq([:foo, 1, 2, 3, 4])}
+      run('obj = Class.new { def method_missing(name, *args); [name, *args]; end }.new; ary = 1.upto(4).to_a; obj.foo(*ary)') {|x| expect(x).to eq([:foo, 1, 2, 3, 4])}
+      run('obj = Class.new { def method_missing(name, *args); [name, *args]; end }.new; ary = 2.upto(4).to_a; obj.foo(1, *ary)') {|x| expect(x).to eq([:foo, 1, 2, 3, 4])}
+    end
   end
 end


### PR DESCRIPTION
The method name (as a symbol) was not being properly recombined
with the incoming arguments array, so any varargs calls would
error out while attempting to bind a method_missing target.

This change folds the combined array back into the arguments so
it can bind properly.

Fixes #6130