### PR TITLE
Enhanced exit blocks

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -53,7 +53,6 @@ import org.jruby.ast.VCallNode;
 import org.jruby.ast.WhileNode;
 import org.jruby.compiler.Constantizable;
 import org.jruby.compiler.NotCompilableException;
-import org.jruby.ext.jruby.JRubyLibrary;
 import org.jruby.ext.jruby.JRubyUtilLibrary;
 import org.jruby.ext.thread.ConditionVariable;
 import org.jruby.ext.thread.Mutex;
@@ -196,10 +195,10 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Stack;
 import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
@@ -3148,13 +3147,25 @@ public final class Ruby implements Constantizable {
     }
 
     /**
+     * Add an exit function to be run on runtime exit. Functions are run in FILO order.
+     *
+     * @param func the function to be run
+     */
+    public void pushExitFunction(ExitFunction func) {
+        exitBlocks.add(0, func);
+    }
+
+    /**
      * Push block onto exit stack.  When runtime environment exits
      * these blocks will be evaluated.
      *
      * @return the element that was pushed onto stack
      */
     public IRubyObject pushExitBlock(RubyProc proc) {
-        atExitBlocks.push(proc);
+        ProcExitFunction func = new ProcExitFunction(proc);
+
+        pushExitFunction(func);
+
         return proc;
     }
 
@@ -3162,20 +3173,18 @@ public final class Ruby implements Constantizable {
      * It is possible for looping or repeated execution to encounter the same END
      * block multiple times.  Rather than store extra runtime state we will just
      * make sure it is not already registered.  at_exit by contrast can push the
-     * same block many times (and should use pushExistBlock).
+     * same block many times (and should use pushExitBlock).
      */
     public void pushEndBlock(RubyProc proc) {
-        if (alreadyRegisteredEndBlock(proc) != null) return;
+        if (alreadyRegisteredEndBlock(proc)) return;
         pushExitBlock(proc);
     }
 
-    private RubyProc alreadyRegisteredEndBlock(RubyProc newProc) {
-        Block block = newProc.getBlock();
-
-        for (RubyProc proc: atExitBlocks) {
-            if (block.equals(proc.getBlock())) return proc;
+    private boolean alreadyRegisteredEndBlock(RubyProc newProc) {
+        if (exitBlocks.stream().anyMatch((func) -> func.matches(newProc))) {
+            return true;
         }
-        return null;
+        return false;
     }
 
     // use this for JRuby-internal finalizers
@@ -3246,48 +3255,8 @@ public final class Ruby implements Constantizable {
             context.pushScope(new ManyVarsDynamicScope(topStaticScope, null));
         }
 
-        while (!atExitBlocks.empty()) {
-            RubyProc proc = atExitBlocks.pop();
-            // IRubyObject oldExc = context.runtime.getGlobalVariables().get("$!"); // Save $!
-            try {
-                proc.call(context, IRubyObject.NULL_ARRAY);
-            } catch (RaiseException rj) {
-                // END { return } can generally be statically determined during build time so we generate the LJE
-                // then.  This if captures the static side of this. See IReturnJump below for dynamic case
-                if (rj.getException() instanceof RubyLocalJumpError) {
-                    RubyLocalJumpError rlje = (RubyLocalJumpError) rj.getException();
-                    String filename = proc.getBlock().getBinding().filename;
-
-                    if (rlje.getReason() == RubyLocalJumpError.Reason.RETURN) {
-                        getWarnings().warn(filename, "unexpected return");
-                    } else {
-                        getWarnings().warn(filename, "break from proc-closure");
-                    }
-
-                } else {
-                    RubyException raisedException = rj.getException();
-                    if (!getSystemExit().isInstance(raisedException)) {
-                        status = 1;
-                        printError(raisedException);
-                    } else {
-                        IRubyObject statusObj = raisedException.callMethod(context, "status");
-                        if (statusObj != null && !statusObj.isNil()) {
-                            status = RubyNumeric.fix2int(statusObj);
-                        }
-                    }
-                    // Reset $! now that rj has been handled
-                    // context.runtime.getGlobalVariables().set("$!", oldExc);
-                }
-            }  catch (IRReturnJump e) {
-                // This capture dynamic returns happening in an end block where it cannot be statically determined
-                // (like within an eval.
-
-                // This is partially similar to code in eval_error.c:error_handle but with less actual cases.
-                // IR treats END blocks are closures and as such we see this special non-local return jump type
-                // bubble this far out as we exec each END proc.
-                getWarnings().warn(proc.getBlock().getBinding().filename, "unexpected return");
-            }
-        }
+        // Run all exit functions from at_exit, END, or Java code
+        exitBlocks.forEach((fun) -> fun.accept(context));
 
         // Fetches (and unsets) the SIGEXIT handler, if one exists.
         IRubyObject trapResult = RubySignal.__jtrap_osdefault_kernel(this.getNil(), this.newString("EXIT"));
@@ -5403,7 +5372,7 @@ public final class Ruby implements Constantizable {
 
     // Contains a list of all blocks (as Procs) that should be called when
     // the runtime environment exits.
-    private final Stack<RubyProc> atExitBlocks = new Stack<>();
+    private final List<ExitFunction> exitBlocks = Collections.synchronizedList(new LinkedList<>());
 
     private Profile profile;
 
@@ -5539,6 +5508,65 @@ public final class Ruby implements Constantizable {
 
     public void addToObjectSpace(boolean useObjectSpace, IRubyObject object) {
         objectSpacer.addToObjectSpace(this, useObjectSpace, object);
+    }
+
+    public interface ExitFunction extends Consumer<ThreadContext> {
+        default boolean matches(Object o) { return o == this; }
+    }
+
+    private class ProcExitFunction implements ExitFunction {
+        private final RubyProc proc;
+
+        public ProcExitFunction(RubyProc proc) {
+            this.proc = proc;
+        }
+
+        public boolean matches(Object o) {
+            return (o instanceof RubyProc) && ((RubyProc) o).getBlock() == proc.getBlock();
+        }
+
+        @Override
+        public void accept(ThreadContext context) {
+            try {
+                // IRubyObject oldExc = context.runtime.getGlobalVariables().get("$!"); // Save $!
+                proc.call(context, IRubyObject.NULL_ARRAY);
+
+            } catch (RaiseException rj) {
+                // END { return } can generally be statically determined during build time so we generate the LJE
+                // then.  This if captures the static side of this. See IReturnJump below for dynamic case
+                if (rj.getException() instanceof RubyLocalJumpError) {
+                    RubyLocalJumpError rlje = (RubyLocalJumpError) rj.getException();
+                    String filename = proc.getBlock().getBinding().filename;
+
+                    if (rlje.getReason() == RubyLocalJumpError.Reason.RETURN) {
+                        Ruby.this.getWarnings().warn(filename, "unexpected return");
+                    } else {
+                        Ruby.this.getWarnings().warn(filename, "break from proc-closure");
+                    }
+
+                } else {
+                    RubyException raisedException = rj.getException();
+                    if (Ruby.this.getSystemExit().isInstance(raisedException)) {
+                        // ignore additional exit requests from at_exit blocks
+                        // see jruby/jruby#5437 and related issues
+                    } else {
+                        // display but do not propagate other errors raised during at_exit
+                        Ruby.this.printError(raisedException);
+                    }
+                    // Reset $! now that rj has been handled
+                    // context.runtime.getGlobalVariables().set("$!", oldExc);
+                }
+
+            } catch (IRReturnJump e) {
+                // This capture dynamic returns happening in an end block where it cannot be statically determined
+                // (like within an eval.
+
+                // This is partially similar to code in eval_error.c:error_handle but with less actual cases.
+                // IR treats END blocks are closures and as such we see this special non-local return jump type
+                // bubble this far out as we exec each END proc.
+                Ruby.this.getWarnings().warn(proc.getBlock().getBinding().filename, "unexpected return");
+            }
+        }
     }
 
     private final RubyArray emptyFrozenArray;

--- a/core/src/main/java/org/jruby/ext/timeout/Timeout.java
+++ b/core/src/main/java/org/jruby/ext/timeout/Timeout.java
@@ -69,7 +69,7 @@ public class Timeout {
         executor.setRemoveOnCancelPolicy(true);
         timeout.setInternalVariable(EXECUTOR_VARIABLE, executor);
 
-        timeout.getRuntime().pushExitFunction((context) -> executor.shutdown());
+        timeout.getRuntime().pushExitFunction((context) -> { executor.shutdown(); return 0;});
     }
 
 

--- a/core/src/main/java/org/jruby/ext/timeout/Timeout.java
+++ b/core/src/main/java/org/jruby/ext/timeout/Timeout.java
@@ -68,6 +68,8 @@ public class Timeout {
                 new ScheduledThreadPoolExecutor(Runtime.getRuntime().availableProcessors(), new DaemonThreadFactory());
         executor.setRemoveOnCancelPolicy(true);
         timeout.setInternalVariable(EXECUTOR_VARIABLE, executor);
+
+        timeout.getRuntime().pushExitFunction((context) -> executor.shutdown());
     }
 
 

--- a/lib/ruby/stdlib/timeout.rb
+++ b/lib/ruby/stdlib/timeout.rb
@@ -56,10 +56,6 @@ end
 # Load executor-based timeout logic into Timeout mod
 JRuby::Util.load_ext('org.jruby.ext.timeout.Timeout')
 
-at_exit do
-  Timeout.to_java.getInternalVariable('__executor__').shutdown
-end
-
 def timeout(*args, &block)
   warn "Object##{__method__} is deprecated, use Timeout.timeout instead.", uplevel: 1
   Timeout.timeout(*args, &block)


### PR DESCRIPTION
This adds the ability to register an exit hook from Java using a simple function object. It also switches the Timeout library from using `at_exit` to using this API for executor shutdown.

See #6127 which, due to the lack of such an API, was forced to dig around in JRuby internals from Ruby code.

There may be other places where this could be used but I did not audit other `at_exit` consumers.