### PR TITLE
Bump `json` version provided by default

### DIFF
--- a/pom.rb
+++ b/pom.rb
@@ -65,7 +65,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
               'polyglot.dump.readonly' => 'true',
               'jruby.plugins.version' => '1.0.10',
 
-              'json.version' => '2.2.0',
+              'json.version' => '2.3.0',
               'rspec.version' => '3.7.0',
               'rspec-core.version' => '3.7.0',
               'rspec-expectations.version' => '3.7.0',

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ DO NOT MODIFIY - GENERATED CODE
     <jruby-launcher.version>1.1.6</jruby-launcher.version>
     <jruby.basedir>${project.basedir}</jruby.basedir>
     <jruby.plugins.version>1.0.10</jruby.plugins.version>
-    <json.version>2.2.0</json.version>
+    <json.version>2.3.0</json.version>
     <main.basedir>${project.basedir}</main.basedir>
     <minitest.version>5.10.3</minitest.version>
     <polyglot.dump.pom>pom.xml</polyglot.dump.pom>


### PR DESCRIPTION
The 2.2.0 version gemspec provided by prints an annoying warning when read:

```
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
Gem::Specification#rubyforge_project= called from /home/deivid/.rbenv/versions/jruby-9.2.11.0/lib/ruby/gems/shared/specifications/default/json-2.2.0-java.gemspec:18.
```