### PR TITLE
Hold a hard reference to Ruby threads

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -61,10 +61,11 @@ import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.ThreadKill;
 import org.jruby.exceptions.Unrescuable;
 import org.jruby.ext.thread.Mutex;
-import org.jruby.internal.runtime.NativeThread;
+import org.jruby.internal.runtime.RubyNativeThread;
 import org.jruby.internal.runtime.RubyRunnable;
 import org.jruby.internal.runtime.ThreadLike;
 import org.jruby.internal.runtime.ThreadService;
+import org.jruby.internal.runtime.AdoptedNativeThread;
 import org.jruby.java.proxies.ConcreteJavaProxy;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.Arity;
@@ -447,7 +448,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         RubyThread rubyThread = new RubyThread(runtime, threadClass, true);
 
         // TODO: need to isolate the "current" thread from class creation
-        rubyThread.threadImpl = new NativeThread(rubyThread, Thread.currentThread());
+        rubyThread.threadImpl = new AdoptedNativeThread(rubyThread, Thread.currentThread());
         runtime.getThreadService().setMainThread(Thread.currentThread(), rubyThread);
 
         // set to default thread group
@@ -592,7 +593,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
                                           final RubyClass recv, final Thread thread) {
         final RubyThread rubyThread = new RubyThread(runtime, recv, true);
 
-        rubyThread.threadImpl = new NativeThread(rubyThread, thread);
+        rubyThread.threadImpl = new AdoptedNativeThread(rubyThread, thread);
         ThreadContext context = service.registerNewThread(rubyThread);
         service.associateThread(thread, rubyThread);
 
@@ -622,7 +623,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
             this.file = context.getFile();
             this.line = context.getLine();
             initThreadName(runtime, thread, file, line);
-            threadImpl = new NativeThread(this, thread);
+            threadImpl = new RubyNativeThread(this, thread);
 
             addToCorrectThreadGroup(context);
 
@@ -1795,8 +1796,8 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     }
 
     public StackTraceElement[] javaBacktrace() {
-        if (threadImpl instanceof NativeThread) {
-            return ((NativeThread)threadImpl).getThread().getStackTrace();
+        if (threadImpl instanceof RubyNativeThread) {
+            return ((RubyNativeThread)threadImpl).getThread().getStackTrace();
         }
 
         // Future-based threads can't get a Java trace

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -620,9 +620,12 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         try {
             Thread thread = new Thread(runnable);
             thread.setDaemon(true);
+
             this.file = context.getFile();
             this.line = context.getLine();
+
             initThreadName(runtime, thread, file, line);
+            
             threadImpl = new RubyNativeThread(this, thread);
 
             addToCorrectThreadGroup(context);
@@ -633,6 +636,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
             // copy parent thread's interrupt masks
             copyInterrupts(context, context.getThread().interruptMaskStack, this.interruptMaskStack);
 
+            // start the native thread
             thread.start();
 
             // We yield here to hopefully permit the target thread to schedule

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -1800,12 +1800,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     }
 
     public StackTraceElement[] javaBacktrace() {
-        if (threadImpl instanceof RubyNativeThread) {
-            return ((RubyNativeThread)threadImpl).getThread().getStackTrace();
-        }
-
-        // Future-based threads can't get a Java trace
-        return EMPTY_STACK_TRACE;
+        return threadImpl.getStackTrace();
     }
 
     private boolean isCurrent() {

--- a/core/src/main/java/org/jruby/internal/runtime/AdoptedNativeThread.java
+++ b/core/src/main/java/org/jruby/internal/runtime/AdoptedNativeThread.java
@@ -45,10 +45,6 @@ public class AdoptedNativeThread implements ThreadLike {
         this.nativeThread = new WeakReference<>(nativeThread);
     }
     
-    public void start() {
-        throw new RuntimeException("BUG: can't start an adopted thread");
-    }
-    
     public void interrupt() {
         Thread thread = getThread();
         if (thread != null) thread.interrupt();

--- a/core/src/main/java/org/jruby/internal/runtime/AdoptedNativeThread.java
+++ b/core/src/main/java/org/jruby/internal/runtime/AdoptedNativeThread.java
@@ -29,6 +29,7 @@
 package org.jruby.internal.runtime;
 
 import org.jruby.RubyThread;
+import org.jruby.runtime.backtrace.BacktraceData;
 
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
@@ -89,7 +90,7 @@ public class AdoptedNativeThread implements ThreadLike {
         return false;
     }
 
-    public final Thread getThread() {
+    final Thread getThread() {
         return nativeThread.get();
     }
 
@@ -99,6 +100,15 @@ public class AdoptedNativeThread implements ThreadLike {
 
     public Thread nativeThread() {
         return nativeThread.get();
+    }
+
+    @Override
+    public StackTraceElement[] getStackTrace() {
+        Thread thread = nativeThread();
+
+        if (thread == null) return BacktraceData.EMPTY_STACK_TRACE;
+
+        return thread.getStackTrace();
     }
 
     @Override

--- a/core/src/main/java/org/jruby/internal/runtime/AdoptedNativeThread.java
+++ b/core/src/main/java/org/jruby/internal/runtime/AdoptedNativeThread.java
@@ -1,0 +1,133 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2007 Charles O Nutter <headius@headius.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby.internal.runtime;
+
+import org.jruby.RubyThread;
+
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+
+/**
+ * A ThreadLike that weakly references its native thread, for adopted JVM threads we don't want to root.
+ */
+public class AdoptedNativeThread implements ThreadLike {
+    private final Reference<Thread> nativeThread;
+    public final RubyThread rubyThread;
+
+    public AdoptedNativeThread(RubyThread rubyThread, Thread nativeThread) {
+        this.rubyThread = rubyThread;
+        this.nativeThread = new WeakReference<>(nativeThread);
+    }
+    
+    public void start() {
+        throw new RuntimeException("BUG: can't start an adopted thread");
+    }
+    
+    public void interrupt() {
+        Thread thread = getThread();
+        if (thread != null) thread.interrupt();
+    }
+    
+    public boolean isAlive() {
+        Thread thread = getThread();
+        if (thread != null) return thread.isAlive();
+        return false;
+    }
+    
+    public void join() throws InterruptedException {
+        Thread thread = getThread();
+        if (thread != null) thread.join();
+    }
+    
+    public void join(long timeoutMillis) throws InterruptedException {
+        Thread thread = getThread();
+        if (thread != null) thread.join(timeoutMillis);
+    }
+    
+    public int getPriority() {
+        Thread thread = getThread();
+        if (thread != null) return thread.getPriority();
+        return 0;
+    }
+    
+    public void setPriority(int priority) {
+        Thread thread = getThread();
+        if (thread != null) thread.setPriority(priority);
+    }
+    
+    public boolean isCurrent() {
+        return getThread() == Thread.currentThread();
+    }
+    
+    public boolean isInterrupted() {
+        Thread thread = getThread();
+        if (thread != null) {
+            return thread.isInterrupted();
+        }
+        return false;
+    }
+
+    public final Thread getThread() {
+        return nativeThread.get();
+    }
+
+    public String toString() {
+        return String.valueOf(getThread());
+    }
+
+    public Thread nativeThread() {
+        return nativeThread.get();
+    }
+
+    @Override
+    public void setRubyName(String id) {
+        try {
+            Thread thread = getThread();
+            if (thread != null) thread.setName(id);
+        } catch (SecurityException ignore) { } // current thread can not modify
+    }
+
+    @Override
+    @Deprecated
+    public String getRubyName() {
+        Thread thread = getThread();
+        if (thread != null) return thread.getName();
+        return null;
+    }
+
+    @Override
+    public String getReportName() {
+        String nativeName = "";
+
+        Thread thread = getThread();
+        if (thread != null) nativeName = thread.getName();
+
+        return nativeName.equals("") ? "(unnamed)" :  nativeName;
+    }
+}

--- a/core/src/main/java/org/jruby/internal/runtime/RubyNativeThread.java
+++ b/core/src/main/java/org/jruby/internal/runtime/RubyNativeThread.java
@@ -36,83 +36,65 @@ import org.jruby.RubyThread;
 import org.jruby.runtime.builtin.IRubyObject;
 
 /**
- * @author cnutter
+ * A ThreadLike wrapped around a native Thread, for Ruby threads we start and control.
  */
-public class NativeThread implements ThreadLike {
-    private final Reference<Thread> nativeThread;
+public class RubyNativeThread implements ThreadLike {
+    private final Thread thread;
     public final RubyThread rubyThread;
     public String rubyName;
     
-    public NativeThread(RubyThread rubyThread, Thread nativeThread) {
+    public RubyNativeThread(RubyThread rubyThread, Thread nativeThread) {
         this.rubyThread = rubyThread;
-        this.nativeThread = new WeakReference<>(nativeThread);
+        this.thread = nativeThread;
         this.rubyName = null;
     }
     
     public void start() {
-        Thread thread = getThread();
-        
-        if (thread == null) {
-            throw new RuntimeException("BUG: thread was collected before start()");
-        }
-
         thread.start();
     }
     
     public void interrupt() {
-        Thread thread = getThread();
-        if (thread != null) thread.interrupt();
+        thread.interrupt();
     }
     
     public boolean isAlive() {
-        Thread thread = getThread();
-        if (thread != null) return thread.isAlive();
-        return false;
+        return thread.isAlive();
     }
     
     public void join() throws InterruptedException {
-        Thread thread = getThread();
-        if (thread != null) thread.join();
+        thread.join();
     }
     
     public void join(long timeoutMillis) throws InterruptedException {
-        Thread thread = getThread();
-        if (thread != null) thread.join(timeoutMillis);
+        thread.join(timeoutMillis);
     }
     
     public int getPriority() {
-        Thread thread = getThread();
-        if (thread != null) return thread.getPriority();
-        return 0;
+        return thread.getPriority();
     }
     
     public void setPriority(int priority) {
-        Thread thread = getThread();
-        if (thread != null) thread.setPriority(priority);
+        thread.setPriority(priority);
     }
     
     public boolean isCurrent() {
-        return getThread() == Thread.currentThread();
+        return thread == Thread.currentThread();
     }
     
     public boolean isInterrupted() {
-        Thread thread = getThread();
-        if (thread != null) {
-            return thread.isInterrupted();
-        }
-        return false;
+        return thread.isInterrupted();
     }
 
     public final Thread getThread() {
-        return nativeThread.get();
+        return thread;
     }
 
     public String toString() {
-        return String.valueOf(getThread());
+        return String.valueOf(thread);
     }
 
     public Thread nativeThread() {
-        return nativeThread.get();
+        return thread;
     }
 
     @Override
@@ -131,8 +113,7 @@ public class NativeThread implements ThreadLike {
     public String getReportName() {
         String nativeName = "";
 
-        Thread thread = getThread();
-        if (thread != null) nativeName = thread.getName();
+        nativeName = thread.getName();
 
         if (rubyName == null || rubyName.length() == 0) {
             return nativeName.equals("") ? "(unnamed)" :  nativeName;

--- a/core/src/main/java/org/jruby/internal/runtime/RubyNativeThread.java
+++ b/core/src/main/java/org/jruby/internal/runtime/RubyNativeThread.java
@@ -81,16 +81,17 @@ public class RubyNativeThread implements ThreadLike {
         return thread.isInterrupted();
     }
 
-    public final Thread getThread() {
-        return thread;
-    }
-
     public String toString() {
         return String.valueOf(thread);
     }
 
     public Thread nativeThread() {
         return thread;
+    }
+
+    @Override
+    public StackTraceElement[] getStackTrace() {
+        return thread.getStackTrace();
     }
 
     @Override
@@ -125,9 +126,6 @@ public class RubyNativeThread implements ThreadLike {
         // "Ruby-0-Thread-17@worker#1: (irb):21"
         String newName;
         String setName = rubyName;
-        Thread thread = getThread();
-
-        if (thread == null) return;
 
         final String currentName = thread.getName();
         if (currentName != null && currentName.startsWith(RUBY_THREAD_PREFIX)) {

--- a/core/src/main/java/org/jruby/internal/runtime/RubyNativeThread.java
+++ b/core/src/main/java/org/jruby/internal/runtime/RubyNativeThread.java
@@ -49,10 +49,6 @@ public class RubyNativeThread implements ThreadLike {
         this.rubyName = null;
     }
     
-    public void start() {
-        thread.start();
-    }
-    
     public void interrupt() {
         thread.interrupt();
     }

--- a/core/src/main/java/org/jruby/internal/runtime/ThreadLike.java
+++ b/core/src/main/java/org/jruby/internal/runtime/ThreadLike.java
@@ -28,6 +28,8 @@
 
 package org.jruby.internal.runtime;
 
+import org.jruby.runtime.backtrace.BacktraceData;
+
 import java.util.concurrent.ExecutionException;
 
 public interface ThreadLike {
@@ -54,6 +56,8 @@ public interface ThreadLike {
     public String getRubyName();
 
     public String getReportName();
+
+    public StackTraceElement[] getStackTrace();
 
     ThreadLike DUMMY = new ThreadLike() {
         @Override
@@ -104,6 +108,11 @@ public interface ThreadLike {
         @Override
         public String getReportName() {
             return "uninitialized thread";
+        }
+
+        @Override
+        public StackTraceElement[] getStackTrace() {
+            return BacktraceData.EMPTY_STACK_TRACE;
         }
     };
 }

--- a/core/src/main/java/org/jruby/internal/runtime/ThreadLike.java
+++ b/core/src/main/java/org/jruby/internal/runtime/ThreadLike.java
@@ -31,8 +31,6 @@ package org.jruby.internal.runtime;
 import java.util.concurrent.ExecutionException;
 
 public interface ThreadLike {
-    public void start();
-    
     public void interrupt();
     
     public boolean isAlive();
@@ -58,9 +56,6 @@ public interface ThreadLike {
     public String getReportName();
 
     ThreadLike DUMMY = new ThreadLike() {
-        @Override
-        public void start() {}
-
         @Override
         public void interrupt() {}
 


### PR DESCRIPTION
The old logic maintained a weak reference to the native thread
associated with a Ruby thread, in order to avoid keeping its
resources alive longer than the thread's lifecycle. However in
the case shown in #6142, it seems likely that under heavy load the
native thread gets collected before it starts running. Because of
the logic we have to silently ignore collected references, the
NativeThread.start method simply returns if the thread has gone
away, giving us no indication that the thread never actually ran.

This patch splits our NativeThread into two types:

* RubyNativeThread, which holds a hard reference to the native
  Thread and implements start to call Thread#start.
* AdoptedNativeThread, which holds a weak reference to the native
  Thread and errors (BUG!) if we attempt to call call start on
  that adopted thread.

I believe this will fix the issue in #6142. This may explain other
"one in a million" failures we have never quite tracked down.