### PR TITLE
Ruby 2.6 : fix Struct#to_h exception message

### DIFF
--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -648,7 +648,7 @@ public class RubyStruct extends RubyObject {
                 RubyArray ary = (RubyArray)key_value_pair;
 
                 if (ary.getLength() != 2) {
-                    throw context.runtime.newArgumentError("wrong array length at " + i + " (expected 2, was " + ary.getLength() + ")");
+                    throw context.runtime.newArgumentError("element has wrong array length (expected 2, was " + ary.getLength() + ")");
                 }
 
                 hash.op_aset(context, ary.eltInternal(0), ary.eltInternal(1));


### PR DESCRIPTION
This PR targets to make the following TravisCI test passed.

```
13)
Struct#to_h with block raises ArgumentError if block returns longer or shorter array ERROR
ArgumentError: wrong array length at 0 (expected 2, was 3)
org/jruby/RubyStruct.java:651:in `to_h'
/home/travis/build/jruby/jruby/spec/ruby/core/struct/to_h_spec.rb:27:in `block in <main>'
/home/travis/build/jruby/jruby/spec/ruby/core/struct/to_h_spec.rb:26:in `block in <main>'
org/jruby/RubyBasicObject.java:2687:in `instance_exec'
org/jruby/RubyArray.java:4557:in `all?'
org/jruby/RubyArray.java:1817:in `each'
org/jruby/RubyArray.java:1817:in `each'
/home/travis/build/jruby/jruby/spec/ruby/core/struct/to_h_spec.rb:4:in `<main>'
org/jruby/RubyKernel.java:1051:in `load'
org/jruby/RubyBasicObject.java:2687:in `instance_exec'
org/jruby/RubyArray.java:1817:in `each'
```