### PR TITLE
Remove usages of deprecated ConfigMap (again)

### DIFF
--- a/lib/ruby/stdlib/rubygems/defaults/jruby.rb
+++ b/lib/ruby/stdlib/rubygems/defaults/jruby.rb
@@ -31,15 +31,15 @@ module Gem
   # to preserve the old location: lib/ruby/gems.
   def self.default_dir
     dir = RbConfig::CONFIG["default_gem_home"]
-    dir ||= File.join(ConfigMap[:libdir], 'ruby', 'gems', 'shared')
+    dir ||= File.join(RbConfig::CONFIG['libdir'], 'ruby', 'gems', 'shared')
     dir
   end
 
   # Default locations for RubyGems' .rb and bin files
   def self.default_rubygems_dirs
     [
-        File.join(ConfigMap[:libdir], 'ruby', 'stdlib'),
-        ConfigMap[:bindir]
+        File.join(RbConfig::CONFIG['libdir'], 'ruby', 'stdlib'),
+        RbConfig::CONFIG['bindir']
     ]
   end
 


### PR DESCRIPTION
This issue was initially reported here: https://github.com/jruby/jruby/issues/6030

It breaks `rspec-rails`' `jruby-head` build: https://travis-ci.org/github/rspec/rspec-rails/jobs/670723126

This was supposed to fix it: https://github.com/jruby/jruby/pull/5966/files

And this as well: https://github.com/jruby/jruby/commit/637b17ce3f9981f84840a54803cc83bcd0571a98#diff-2d9baebc59d1732672e3dba0ba309e84

Somehow, those changes did not reflect on `master`.