### PR TITLE
Shut down threads on teardown

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -3282,6 +3282,9 @@ public final class Ruby implements Constantizable {
             }
         }
 
+        // Shut down thread service after at_exit hooks have run
+        threadService.teardown();
+
         // Fetches (and unsets) the SIGEXIT handler, if one exists.
         IRubyObject trapResult = RubySignal.__jtrap_osdefault_kernel(this.getNil(), this.newString("EXIT"));
         if (trapResult instanceof RubyArray) {

--- a/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
+++ b/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
@@ -151,7 +151,7 @@ public class ThreadService extends ThreadLocal<SoftReference<ThreadContext>> {
     public void teardown() {
         // kill and await all live Ruby threads
         for (RubyThread rth : getActiveRubyThreads()) {
-            if (rth.getContext() == mainContext) return;
+            if (rth.isAdopted()) return;
 
             try {
                 rth.kill();


### PR DESCRIPTION
This change modifies our shutdown process to asynchronously interrupt and wait for all registered threads (excluding main) to allow them to complete execution.

Previously our behavior was to walk away from running threads. This behavior appears to have either changed in CRuby long ago, or we never implemented this behavior.

Note that this implementation does not currently differentiate between threads started from Ruby code and threads started by other code in the JVM that happened to get adopted by JRuby. We probably should not attempt to kill those adopted threads, and certainly don't want to try to join on them.

The following script illustrates some behavior of thread shutdown. This may be a good start at writing a spec.

```ruby
# normal Ruby thread should be interrupted and awaited
t = Thread.new {
  p 1
  begin
    sleep
  ensure
    p 2
  end
}

# at_exit blocks should be run after thread termination
at_exit { p 3 }

def four(*); p 4; end

# finalization at shutdown runs after after thread termination
o = Object.new
ObjectSpace.define_finalizer(o, method(:four))

# java daemon thread should not prevent shutdown and also not be interrupted
java.lang.Thread.new do
  java.lang.Thread.currentThread.daemon = true
  begin
    sleep
  ensure
    p 5
  end
end

exit # process should output "1 2 3 4" but not "5".
```