### PR TITLE
Implement oneshot_lines for coverage

### DIFF
--- a/core/src/main/java/org/jruby/ast/RootNode.java
+++ b/core/src/main/java/org/jruby/ast/RootNode.java
@@ -33,6 +33,7 @@ import java.util.List;
 
 import org.jruby.ParseResult;
 import org.jruby.ast.visitor.NodeVisitor;
+import org.jruby.ext.coverage.CoverageData;
 import org.jruby.lexer.yacc.ISourcePosition;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.DynamicScope;
@@ -51,13 +52,13 @@ public class RootNode extends Node implements ParseResult {
     private Node bodyNode;
     private String file;
     private int endPosition;
-    private boolean needsCodeCoverage;
+    private final int coverageMode;
 
     public RootNode(ISourcePosition position, DynamicScope scope, Node bodyNode, String file) {
-        this(position, scope, bodyNode, file, -1, false);
+        this(position, scope, bodyNode, file, -1, CoverageData.NONE);
     }
 
-    public RootNode(ISourcePosition position, DynamicScope scope, Node bodyNode, String file, int endPosition, boolean needsCodeCoverage) {
+    public RootNode(ISourcePosition position, DynamicScope scope, Node bodyNode, String file, int endPosition, int coverageMode) {
         super(position, bodyNode.containsVariableAssignment());
         
         this.scope = scope;
@@ -65,14 +66,14 @@ public class RootNode extends Node implements ParseResult {
         this.bodyNode = bodyNode;
         this.file = file;
         this.endPosition = endPosition;
-        this.needsCodeCoverage = needsCodeCoverage;
+        this.coverageMode = coverageMode;
 
         staticScope.setFile(file);
     }
 
     @Deprecated
     public RootNode(ISourcePosition position, DynamicScope scope, Node bodyNode, String file, int endPosition) {
-        this(position, scope, bodyNode, file, endPosition, false);
+        this(position, scope, bodyNode, file, endPosition, CoverageData.NONE);
     }
 
     public NodeType getNodeType() {
@@ -133,8 +134,8 @@ public class RootNode extends Node implements ParseResult {
     }
 
     // Is coverage enabled and is this a valid source file for coverage to apply?
-    public boolean needsCoverage() {
-        return needsCodeCoverage;
+    public int coverageMode() {
+        return coverageMode;
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -6,6 +6,7 @@ import org.jruby.RubySymbol;
 import org.jruby.ast.*;
 import org.jruby.ast.types.INameNode;
 import org.jruby.compiler.NotCompilableException;
+import org.jruby.ext.coverage.CoverageData;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.ArgumentDescriptor;
 import org.jruby.runtime.ArgumentType;
@@ -17,7 +18,6 @@ import org.jruby.ir.operands.*;
 import org.jruby.ir.operands.Boolean;
 import org.jruby.ir.operands.Float;
 import org.jruby.ir.transformations.inlining.SimpleCloneInfo;
-import org.jruby.runtime.Block;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.RubyEvent;
@@ -302,7 +302,7 @@ public class IRBuilder {
     protected IRScope scope;
     protected List<Instr> instructions;
     protected List<Object> argumentDescriptions;
-    protected boolean needsCodeCoverage;
+    protected int coverageMode;
     private boolean executesOnce = true;
 
     // Current index to put next BEGIN blocks and other things at the front of this scope.
@@ -318,12 +318,13 @@ public class IRBuilder {
         this.parent = parent;
         this.instructions = new ArrayList<>(50);
         this.activeRescuers.push(Label.UNRESCUED_REGION_LABEL);
+        this.coverageMode = parent == null ? CoverageData.NONE : parent.coverageMode;
 
         if (parent != null) executesOnce = parent.executesOnce;
     }
 
     private boolean needsCodeCoverage() {
-        return needsCodeCoverage || parent != null && parent.needsCodeCoverage();
+        return coverageMode != CoverageData.NONE || parent != null && parent.needsCodeCoverage();
     }
 
     public void addArgumentDescription(ArgumentType type, RubySymbol name) {
@@ -336,12 +337,15 @@ public class IRBuilder {
     public void addInstr(Instr instr) {
         if (needsLineNumInfo) {
             needsLineNumInfo = false;
-            addInstr(manager.newLineNumber(_lastProcessedLineNum));
+
+            if (needsCodeCoverage()) {
+                addInstr(new LineNumberInstr(_lastProcessedLineNum, true, (coverageMode & CoverageData.ONESHOT_LINES) != 0));
+            } else {
+                addInstr(manager.newLineNumber(_lastProcessedLineNum));
+            }
+
             if (RubyInstanceConfig.FULL_TRACE_ENABLED) {
                 addInstr(new TraceInstr(RubyEvent.LINE, methodNameFor(), getFileName(), _lastProcessedLineNum + 1));
-                if (needsCodeCoverage()) {
-                    addInstr(new TraceInstr(RubyEvent.COVERAGE, methodNameFor(), getFileName(), _lastProcessedLineNum + 1));
-                }
             }
         }
 
@@ -554,7 +558,7 @@ public class IRBuilder {
     }
 
     public Operand buildLambda(LambdaNode node) {
-        IRClosure closure = new IRClosure(manager, scope, node.getLine(), node.getScope(), Signature.from(node), needsCodeCoverage);
+        IRClosure closure = new IRClosure(manager, scope, node.getLine(), node.getScope(), Signature.from(node), coverageMode);
 
         // Create a new nested builder to ensure this gets its own IR builder state like the ensure block stack
         newIRBuilder(manager, closure).buildLambdaInner(node);
@@ -2056,8 +2060,8 @@ public class IRBuilder {
 
     // Called by defineMethod but called on a new builder so things like ensure block info recording
     // do not get confused.
-    protected InterpreterContext defineMethodInner(DefNode defNode, IRScope parent, boolean needsCodeCoverage) {
-        this.needsCodeCoverage = needsCodeCoverage;
+    protected InterpreterContext defineMethodInner(DefNode defNode, IRScope parent, int coverageMode) {
+        this.coverageMode = coverageMode;
 
         if (RubyInstanceConfig.FULL_TRACE_ENABLED) {
             // Explicit line number here because we need a line number for trace before we process any nodes
@@ -2109,7 +2113,7 @@ public class IRBuilder {
 
     private IRMethod defineNewMethod(MethodDefNode defNode, boolean isInstanceMethod) {
         return new IRMethod(manager, scope, defNode, defNode.getName().getBytes(), isInstanceMethod, defNode.getLine(),
-                defNode.getScope(), needsCodeCoverage());
+                defNode.getScope(), coverageMode);
     }
 
     public Operand buildDefn(MethodDefNode node) { // Instance method
@@ -2981,7 +2985,7 @@ public class IRBuilder {
     }
 
     public Operand buildIter(final IterNode iterNode) {
-        IRClosure closure = new IRClosure(manager, scope, iterNode.getLine(), iterNode.getScope(), Signature.from(iterNode), needsCodeCoverage);
+        IRClosure closure = new IRClosure(manager, scope, iterNode.getLine(), iterNode.getScope(), Signature.from(iterNode), coverageMode);
 
         // Create a new nested builder to ensure this gets its own IR builder state like the ensure block stack
         newIRBuilder(manager, closure).buildIterInner(iterNode);
@@ -3745,7 +3749,7 @@ public class IRBuilder {
 
     public InterpreterContext buildEvalRoot(RootNode rootNode) {
         executesOnce = false;
-        needsCodeCoverage = false;  // Assuming there is no path into build eval root without actually being an eval.
+        coverageMode = CoverageData.NONE;  // Assuming there is no path into build eval root without actually being an eval.
         addInstr(manager.newLineNumber(scope.getLine()));
 
         prepareImplicitState();                                    // recv_self, add frame block, etc)
@@ -3771,7 +3775,7 @@ public class IRBuilder {
     }
 
     private InterpreterContext buildRootInner(RootNode rootNode) {
-        needsCodeCoverage = rootNode.needsCoverage();
+        coverageMode = rootNode.coverageMode();
         prepareImplicitState();                                    // recv_self, add frame block, etc)
         addCurrentModule();                                        // %current_module
 

--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -339,7 +339,7 @@ public class IRBuilder {
             needsLineNumInfo = false;
 
             if (needsCodeCoverage()) {
-                addInstr(new LineNumberInstr(_lastProcessedLineNum, true, (coverageMode & CoverageData.ONESHOT_LINES) != 0));
+                addInstr(new LineNumberInstr(_lastProcessedLineNum, coverageMode));
             } else {
                 addInstr(manager.newLineNumber(_lastProcessedLineNum));
             }

--- a/core/src/main/java/org/jruby/ir/IRFlags.java
+++ b/core/src/main/java/org/jruby/ir/IRFlags.java
@@ -67,7 +67,6 @@ public enum IRFlags {
 
     DYNSCOPE_ELIMINATED,          // local var load/stores have been converted to tmp var accesses
     REUSE_PARENT_DYNSCOPE,        // for closures -- reuse parent's dynscope
-    CODE_COVERAGE,                // Was marked as needing code coverage (only used by lazy methods and converting closures->methods)
     FLAGS_COMPUTED;               // Have these flags been computed yet?
 
     public static final EnumSet<IRFlags> REQUIRE_ALL_FRAME_FIELDS =

--- a/core/src/main/java/org/jruby/ir/IRManager.java
+++ b/core/src/main/java/org/jruby/ir/IRManager.java
@@ -13,6 +13,7 @@ import org.jruby.ast.IScopingNode;
 import org.jruby.ast.ModuleNode;
 import org.jruby.ast.Node;
 import org.jruby.ast.RootNode;
+import org.jruby.ext.coverage.CoverageData;
 import org.jruby.ir.instructions.LineNumberInstr;
 import org.jruby.ir.instructions.ReceiveSelfInstr;
 import org.jruby.ir.instructions.ToggleBacktraceInstr;
@@ -370,7 +371,7 @@ public class IRManager {
             } else {
                 containingScope = new IRClassBody(this, script, scopeNode.getCPath().getName().getBytes(), 0, scopeNode.getScope(), false);
             }
-            IRMethod newMethod = new IRMethod(this, containingScope, defNode, context.runtime.newSymbol(method).getBytes(), true, 0, defNode.getScope(), false);
+            IRMethod newMethod = new IRMethod(this, containingScope, defNode, context.runtime.newSymbol(method).getBytes(), true, 0, defNode.getScope(), CoverageData.NONE);
 
             newMethod.prepareForCompilation();
 

--- a/core/src/main/java/org/jruby/ir/IRMethod.java
+++ b/core/src/main/java/org/jruby/ir/IRMethod.java
@@ -29,13 +29,11 @@ public class IRMethod extends IRScope {
     private volatile DefNode defNode;
 
     public IRMethod(IRManager manager, IRScope lexicalParent, DefNode defn, ByteList name,
-            boolean isInstanceMethod, int lineNumber, StaticScope staticScope, boolean needsCodeCoverage) {
-        super(manager, lexicalParent, name, lineNumber, staticScope);
+            boolean isInstanceMethod, int lineNumber, StaticScope staticScope, int coverageMode) {
+        super(manager, lexicalParent, name, lineNumber, staticScope, coverageMode);
 
         this.defNode = defn;
         this.isInstanceMethod = isInstanceMethod;
-
-        if (needsCodeCoverage) getFlags().add(IRFlags.CODE_COVERAGE);
 
         if (staticScope != null) {
             staticScope.setIRScope(this);
@@ -98,7 +96,7 @@ public class IRMethod extends IRScope {
         if (hasBeenBuilt()) return;
 
         IRBuilder.topIRBuilder(getManager(), this).
-                defineMethodInner(defNode, getLexicalParent(), getFlags().contains(IRFlags.CODE_COVERAGE)); // sets interpreterContext
+                defineMethodInner(defNode, getLexicalParent(), getCoverageMode()); // sets interpreterContext
         this.defNode = null;
     }
 

--- a/core/src/main/java/org/jruby/ir/Operation.java
+++ b/core/src/main/java/org/jruby/ir/Operation.java
@@ -141,6 +141,7 @@ public enum Operation {
     /** debugging ops **/
     LINE_NUM(OpFlags.f_is_book_keeping_op | OpFlags.f_is_debug_op),
     TRACE(OpFlags.f_is_book_keeping_op | OpFlags.f_is_debug_op | OpFlags.f_has_side_effect),
+    COVERAGE(OpFlags.f_is_book_keeping_op | OpFlags.f_is_debug_op | OpFlags.f_has_side_effect),
 
     /** JRuby-impl instructions **/
     ARG_SCOPE_DEPTH(0),

--- a/core/src/main/java/org/jruby/ir/instructions/LineNumberInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/LineNumberInstr.java
@@ -9,15 +9,31 @@ import org.jruby.ir.transformations.inlining.InlineCloneInfo;
 
 public class LineNumberInstr extends NoOperandInstr implements FixedArityInstr {
     public final int lineNumber;
+    public boolean coverage;
+    public final boolean oneshot;
 
-    public LineNumberInstr(int lineNumber) {
+    public LineNumberInstr(int lineNumber, boolean coverage, boolean oneshot) {
         super(Operation.LINE_NUM);
 
         this.lineNumber = lineNumber;
+        this.coverage = coverage;
+        this.oneshot = oneshot;
+    }
+
+    public LineNumberInstr(int lineNumber) {
+        this(lineNumber, false, false);
     }
 
     public int getLineNumber() {
         return lineNumber;
+    }
+
+    public boolean isCoverage() {
+        return coverage;
+    }
+
+    public boolean isOneshot() {
+        return oneshot;
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/LineNumberInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/LineNumberInstr.java
@@ -1,5 +1,6 @@
 package org.jruby.ir.instructions;
 
+import org.jruby.ext.coverage.CoverageData;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
 import org.jruby.ir.persistence.IRReaderDecoder;
@@ -9,19 +10,35 @@ import org.jruby.ir.transformations.inlining.InlineCloneInfo;
 
 public class LineNumberInstr extends NoOperandInstr implements FixedArityInstr {
     public final int lineNumber;
+
+    /**
+     * Whether to update coverage data when executing this instruction.
+     *
+     * Note this is non-final so that `oneshot_lines` mode can disable coverage.
+     */
     public boolean coverage;
+
+    /**
+     * Whether to disable coverage after the first execution.
+     *
+     * This allows lightweight "covered or not" coverage that only updates once per line.
+     */
     public final boolean oneshot;
 
-    public LineNumberInstr(int lineNumber, boolean coverage, boolean oneshot) {
+    public LineNumberInstr(int lineNumber, int coverageMode) {
         super(Operation.LINE_NUM);
 
         this.lineNumber = lineNumber;
-        this.coverage = coverage;
-        this.oneshot = oneshot;
+        this.coverage = coverageMode != CoverageData.NONE;
+        this.oneshot = (coverageMode & CoverageData.ONESHOT_LINES) != 0;
     }
 
     public LineNumberInstr(int lineNumber) {
-        this(lineNumber, false, false);
+        super(Operation.LINE_NUM);
+
+        this.lineNumber = lineNumber;
+        this.coverage = false;
+        this.oneshot = false;
     }
 
     public int getLineNumber() {

--- a/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
@@ -410,7 +410,12 @@ public class InterpreterEngine {
                 ((CheckArityInstr) instr).checkArity(context, currScope, args, block);
                 break;
             case LINE_NUM:
-                context.setLine(((LineNumberInstr)instr).lineNumber);
+                LineNumberInstr line = (LineNumberInstr) instr;
+                context.setLine(line.lineNumber);
+                if (line.coverage) {
+                    IRRuntimeHelpers.updateCoverage(context, currScope.getFile(), line.lineNumber);
+                    if (line.oneshot) line.coverage = false;
+                }
                 break;
             case TOGGLE_BACKTRACE:
                 context.setExceptionRequiresBacktrace(((ToggleBacktraceInstr) instr).requiresBacktrace());

--- a/core/src/main/java/org/jruby/ir/persistence/IRReader.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRReader.java
@@ -9,6 +9,7 @@ package org.jruby.ir.persistence;
 import org.jruby.EvalType;
 import org.jruby.Ruby;
 import org.jruby.RubyInstanceConfig;
+import org.jruby.ext.coverage.CoverageData;
 import org.jruby.ir.*;
 import org.jruby.parser.StaticScope;
 import org.jruby.parser.StaticScopeFactory;
@@ -138,9 +139,9 @@ public class IRReader implements IRPersistenceValues {
         case METACLASS_BODY:
             return new IRMetaClassBody(manager, lexicalParent, manager.getMetaClassName().getBytes(), line, staticScope);
         case INSTANCE_METHOD:
-            return new IRMethod(manager, lexicalParent, null, byteName, true, line, staticScope, false);
+            return new IRMethod(manager, lexicalParent, null, byteName, true, line, staticScope, CoverageData.NONE);
         case CLASS_METHOD:
-            return new IRMethod(manager, lexicalParent, null, byteName, false, line, staticScope, false);
+            return new IRMethod(manager, lexicalParent, null, byteName, false, line, staticScope, CoverageData.NONE);
         case MODULE_BODY:
             // FIXME: add saving on noe-time usage to writeer/reader
             return new IRModuleBody(manager, lexicalParent, byteName, line, staticScope, false);

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -672,11 +672,7 @@ public class IRRuntimeHelpers {
         CoverageData data = context.runtime.getCoverageData();
 
         if (data.isCoverageEnabled()) {
-            int[] lines = data.getCoverage().get(filename);
-
-            if (lines == null || lines.length <= line) return;
-
-            lines[line] += 1;
+            data.coverLine(filename, line);
         }
     }
 

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -33,6 +33,7 @@ import org.jruby.RubySymbol;
 import org.jruby.common.IRubyWarnings;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.Unrescuable;
+import org.jruby.ext.coverage.CoverageData;
 import org.jruby.internal.runtime.methods.CompiledIRMethod;
 import org.jruby.internal.runtime.methods.CompiledIRNoProtocolMethod;
 import org.jruby.internal.runtime.methods.DynamicMethod;
@@ -658,6 +659,25 @@ public class IRRuntimeHelpers {
         boolean printAll = Options.IR_PRINT_ALL.load();
 
         return (!booting && print) || (booting && printAll);
+    }
+
+    /**
+     * Update coverage data for the given file and zero-based line number.
+     *
+     * @param context
+     * @param filename
+     * @param line
+     */
+    public static void updateCoverage(ThreadContext context, String filename, int line) {
+        CoverageData data = context.runtime.getCoverageData();
+
+        if (data.isCoverageEnabled()) {
+            int[] lines = data.getCoverage().get(filename);
+
+            if (lines == null || lines.length <= line) return;
+
+            lines[line] += 1;
+        }
     }
 
     private static class DivvyKeywordsVisitor extends RubyHash.VisitorWithState {

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -1681,6 +1681,17 @@ public class JVMVisitor extends IRVisitor {
 
         lastLine = linenumberinstr.getLineNumber() + 1;
         jvmAdapter().line(lastLine);
+
+        if (linenumberinstr.coverage) {
+            jvmMethod().loadContext();
+            jvmAdapter().invokedynamic(
+                    "coverLine",
+                    sig(void.class, ThreadContext.class),
+                    Bootstrap.coverLineHandle(),
+                    jvm.methodData().scope.getFile(),
+                    linenumberinstr.getLineNumber(),
+                    linenumberinstr.oneshot ? 1 : 0);
+        }
     }
 
     @Override

--- a/core/src/main/java/org/jruby/parser/ParserSupport.java
+++ b/core/src/main/java/org/jruby/parser/ParserSupport.java
@@ -231,8 +231,12 @@ public class ParserSupport {
             if (topOfAST != null) newTopOfAST.add(topOfAST);
             topOfAST = newTopOfAST;
         }
-        
-        return new RootNode(position, result.getScope(), topOfAST, lexer.getFile(), endPosition, coverageData != null);
+
+        int coverageMode = coverageData == null ?
+                CoverageData.NONE :
+                coverageData.getMode();
+
+        return new RootNode(position, result.getScope(), topOfAST, lexer.getFile(), endPosition, coverageMode);
     }
     
     /* MRI: block_append */

--- a/core/src/main/java/org/jruby/runtime/profile/builtin/MethodData.java
+++ b/core/src/main/java/org/jruby/runtime/profile/builtin/MethodData.java
@@ -26,6 +26,8 @@
 
 package org.jruby.runtime.profile.builtin;
 
+import org.jruby.util.collections.IntList;
+
 import java.util.ArrayList;
 
 class MethodData extends InvocationSet {
@@ -35,36 +37,6 @@ class MethodData extends InvocationSet {
     MethodData(int serial) {
         super(new ArrayList<Invocation>());
         this.serialNumber = serial;
-    }
-
-    private static class IntList {
-
-        private int[] ints = new int[10];
-        private int size;
-
-        public void add(int i) {
-            if (size == ints.length) {
-                int[] newInts = new int[(int) (ints.length * 1.5 + 1)];
-                System.arraycopy(ints, 0, newInts, 0, ints.length);
-                ints = newInts;
-            }
-            ints[size++] = i;
-        }
-
-        public boolean contains(int i) {
-            for (int j = 0; j < size; j++) {
-                if (ints[j] == i) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        public int[] toIntArray() {
-            int[] newInts = new int[size];
-            System.arraycopy(ints, 0, newInts, 0, size);
-            return newInts;
-        }
     }
 
     public int[] parents() {

--- a/core/src/main/java/org/jruby/util/collections/IntList.java
+++ b/core/src/main/java/org/jruby/util/collections/IntList.java
@@ -1,0 +1,51 @@
+package org.jruby.util.collections;
+
+public class IntList {
+
+    private int[] ints = new int[10];
+    private int size;
+
+    public IntList() {
+    }
+
+    public IntList(int[] start) {
+        ints = start;
+        size = ints.length;
+    }
+
+    public int size() {
+        return size;
+    }
+
+    public int get(int i) {
+        return ints[i];
+    }
+
+    public void set(int i, int value) {
+        ints[i] = value;
+    }
+
+    public void add(int i) {
+        if (size == ints.length) {
+            int[] newInts = new int[(int) (ints.length * 1.5 + 1)];
+            System.arraycopy(ints, 0, newInts, 0, ints.length);
+            ints = newInts;
+        }
+        ints[size++] = i;
+    }
+
+    public boolean contains(int i) {
+        for (int j = 0; j < size; j++) {
+            if (ints[j] == i) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public int[] toIntArray() {
+        int[] newInts = new int[size];
+        System.arraycopy(ints, 0, newInts, 0, size);
+        return newInts;
+    }
+}


### PR DESCRIPTION
This commit also makes some substantial changes to how coverage is
compiled in IR and JIT.

* Coverage is now independent of tracing and adds behavior to the
  LineNumberInstr
* Coverage is always available
* Each covered LineNumber does its own update of coverage data
* Oneshot mode only updates once and then clears coverage flag
* JIT uses indy to bind the coverage updating logic, with oneshot
  clearing it to a no-op after the first execution