### PR TITLE
[ji] java_import now raise NameError on invalid names

### DIFF
--- a/core/src/main/ruby/jruby/java/core_ext/module.rb
+++ b/core/src/main/ruby/jruby/java/core_ext/module.rb
@@ -54,12 +54,14 @@ class Module
         end
       end
 
-      unless constant =~ /^[A-Z].*/
-        raise ArgumentError.new "cannot import class `" + java_class.name + "' as `" + constant + "'"
-      end
-
-      if !const_defined?(constant) || const_get(constant) != import_class
-        const_set(constant, import_class)
+      begin
+        if !const_defined?(constant) || const_get(constant) != import_class
+          const_set(constant, import_class)
+        end
+      rescue NameError => e
+        ex = e.exception("cannot import Java class #{java_class.name.inspect} as `#{constant}' : #{e.message}")
+        ex.set_backtrace e.backtrace
+        raise ex
       end
 
       import_class

--- a/core/src/main/ruby/jruby/java/core_ext/module.rb
+++ b/core/src/main/ruby/jruby/java/core_ext/module.rb
@@ -17,16 +17,16 @@ class Module
         unless JavaUtilities.valid_java_identifier?(import_class)
           raise ArgumentError.new "not a valid Java identifier: #{import_class}"
         end
-        raise ArgumentError.new "must use jvm-style name: #{import_class}" if import_class.include?('::')
+        raise ArgumentError.new "must use Java style name: #{import_class}" if import_class.include?('::')
         import_class = JavaUtilities.get_proxy_class(import_class)
+      when Java::JavaPackage
+        raise ArgumentError.new "java_import does not work for Java packages (try include_package instead)"
       when Module
-        if import_class.respond_to? "java_class"
-          # ok, it's a proxy
-        else
+        unless import_class.respond_to? :java_class
           raise ArgumentError.new "not a Java class or interface: #{import_class}"
         end
       else
-        raise ArgumentError.new "invalid Java class or interface: #{import_class}"
+        raise ArgumentError.new "invalid Java class or interface: #{import_class} (of type #{import_class.class})"
       end
 
       java_class = import_class.java_class
@@ -38,8 +38,8 @@ class Module
         # package can be nil if it's default or no package was defined by the classloader
         if package
           package_name = package.name
-        elsif java_class.canonical_name =~ /(.*)\.[^.]$/
-          package_name = $1
+        elsif m = java_class.canonical_name.match(/(.*)\.[^.]$/)
+          package_name = m[1]
         else
           package_name = ""
         end
@@ -49,8 +49,8 @@ class Module
         constant = class_name
 
         # Inner classes are separated with $, get last element
-        if constant =~ /\$([^$])$/
-          constant = $1
+        if m = constant.match(/\$([^$])$/)
+          constant = m[1]
         end
       end
 

--- a/spec/java_integration/module/java_import_spec.rb
+++ b/spec/java_integration/module/java_import_spec.rb
@@ -1,0 +1,33 @@
+require 'java'
+
+describe "java_import" do
+
+  it "should explode when trying to import a non-existant Java class" do
+    expect do
+      Module.new do
+        java_import('does.not.Exist')
+      end
+    end.to raise_error(NameError, /cannot load Java class.*?does.not.Exist.*?/)
+  end
+
+  it "should receive an array with the imported classes" do
+    mod = Module.new do
+      @import_1 = java_import()
+      @import_2 = java_import 'java.util.HashMap'
+
+      @import_3 = java_import java.util.Hashtable, Java::java::util::Hashtable, Java::JavaUtil::Hashtable
+    end
+
+    expect(mod.instance_variable_get(:@import_1)).to eq([])
+    expect(mod.instance_variable_get(:@import_2)).to eq([java.util.HashMap])
+    expect(mod.instance_variable_get(:@import_3)).to eq([java.util.Hashtable] * 3)
+  end
+
+  it "should import named inner class" do
+    mod = Module.new do
+      java_import 'java.nio.file.WatchEvent$Kind'
+    end
+    expect(mod::Kind).to be Java::JavaNioFile::WatchEvent::Kind
+  end
+end
+

--- a/spec/java_integration/module/java_import_spec.rb
+++ b/spec/java_integration/module/java_import_spec.rb
@@ -29,5 +29,22 @@ describe "java_import" do
     end
     expect(mod::Kind).to be Java::JavaNioFile::WatchEvent::Kind
   end
+
+  java_import "java_integration.fixtures.InnerClasses"
+
+  it "raises error importing lower-case names" do
+    expect do
+      Module.new { java_import InnerClasses::lowerInnerClass }
+    end.to raise_error(NameError, /cannot import Java class .*?InnerClasses\$lowerInnerClass.*?: wrong constant name lowerInnerClass/)
+  end
+
+  it "imports upper-case names successfully" do
+    mod = nil
+    expect do
+      mod = Module.new { java_import InnerClasses::CapsInnerClass }
+    end.not_to raise_error
+    expect(mod::CapsInnerClass).to eq(InnerClasses::CapsInnerClass)
+  end
+
 end
 

--- a/spec/java_integration/object/java_import_spec.rb
+++ b/spec/java_integration/object/java_import_spec.rb
@@ -1,16 +1,11 @@
-require 'java'
+describe "java_import" do
 
-describe "An object wanting to import Java classes" do
-  it "should explode when trying to import a non-existant Java class" do
-    expect{ java_import 'does.not.Exist' }.to raise_error(NameError)
-  end
+  before(:all) { require 'java' }
 
-  it "should receive an array with the imported classes" do
-    expect(java_import()).to eq([])
-    expect(java_import('java.util.Hashtable')).to eq([java.util.Hashtable])
-
-    imported_classes = java_import('java.util.Hashtable', java.util.Hashtable, Java::java.util.Hashtable, Java::JavaUtil::Hashtable)
-    expect(imported_classes).to eq([java.util.Hashtable] * 4)
+  it "still works (is deprecated) on Object target" do
+    obj = Object.new
+    expect(obj.send :java_import).to eq([])
+    expect(obj.send :java_import, 'java.util.Hashtable').to eq([java.util.Hashtable])
   end
 end
 

--- a/spec/java_integration/types/retrieval_spec.rb
+++ b/spec/java_integration/types/retrieval_spec.rb
@@ -191,19 +191,6 @@ describe "A Java class with inner classes" do
   it "allows const_missing on a Java class to trigger properly" do
     expect {
       InnerClasses::NonExistentClass
-    }.to raise_error(NameError)
-  end
-
-  it "raises error importing lower-case names" do
-    expect do
-      java_import InnerClasses::lowerInnerClass
-    end.to raise_error(ArgumentError)
-  end
-
-  it "imports upper-case names successfully" do
-    expect do
-      java_import InnerClasses::CapsInnerClass
-    end.not_to raise_error
-    expect(CapsInnerClass).to eq(InnerClasses::CapsInnerClass)
+    }.to raise_error(NameError, "uninitialized constant Java::Java_integrationFixtures::InnerClasses::NonExistentClass")
   end
 end


### PR DESCRIPTION
given invalid import names `java_import` will raise `NameError`, 

removing `constant =~ /^[A-Z].*/` capitalization validation, leaving that part to `const_set`
the `[A-Z]` validation did not handle multi-byte capital (UTF-8) characters that well ...
in theory Java class names support the full Unicode set not just ascii characters.