### PR TITLE
Ruby 2.6 : fix StringIO#write method logic

### DIFF
--- a/core/src/main/java/org/jruby/ext/stringio/StringIO.java
+++ b/core/src/main/java/org/jruby/ext/stringio/StringIO.java
@@ -1205,13 +1205,18 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
                 ptr.pos = olen;
             }
             if (ptr.pos == olen) {
-                EncodingUtils.encStrBufCat(runtime, ptr.string, strByteList, enc);
+                if (enc == EncodingUtils.ascii8bitEncoding(runtime) || encStr == EncodingUtils.ascii8bitEncoding(runtime)) {
+                    EncodingUtils.encStrBufCat(runtime, ptr.string, strByteList, enc);
+                    ptr.string.infectBy(str);
+                } else {
+                    ptr.string.cat19(str);
+                }
             } else {
                 strioExtend(ptr.pos, len);
                 ByteList ptrByteList = ptr.string.getByteList();
                 System.arraycopy(strByteList.getUnsafeBytes(), strByteList.getBegin(), ptrByteList.getUnsafeBytes(), ptrByteList.begin() + ptr.pos, len);
+                ptr.string.infectBy(str);
             }
-            ptr.string.infectBy(str);
             ptr.string.infectBy(this);
             ptr.pos += len;
         }

--- a/test/mri/excludes/TestCSVEncodings.rb
+++ b/test/mri/excludes/TestCSVEncodings.rb
@@ -1,4 +1,2 @@
-exclude :test_encoding_is_upgraded_during_writing_as_needed, "needs investigation, #6157"
-exclude :test_encoding_is_upgraded_for_ascii_content_during_writing_as_needed, "needs investigation, #6157"
 exclude :test_reading_with_most_encodings, "needs investigation, #6157"
 exclude :test_regular_expression_escaping, "needs investigation, #6157"


### PR DESCRIPTION
Fix StringIO#write method logic.

Ported from MRI 2.6. https://github.com/ruby/ruby/blob/46a5d1b4a63f624f2c5c5b6f710cc1a176c88b02/ext/stringio/stringio.c#L1275-L1314

This change to make the following TravisCI test passed.
```
TestCSVEncodings
 test_encoding_is_upgraded_during_writing_as_needed
 test_encoding_is_upgraded_for_ascii_content_during_writing_as_needed
```

link  #6157