### PR TITLE
Implement Coverage.line_stub

### DIFF
--- a/lib/ruby/stdlib/coverage.rb
+++ b/lib/ruby/stdlib/coverage.rb
@@ -1,2 +1,23 @@
 # Load built-in coverage library
 JRuby::Util.load_ext("org.jruby.ext.coverage.CoverageLibrary")
+
+require 'jruby'
+
+module Coverage
+  def self.line_stub(file)
+    lines = File.foreach(file).map {nil}
+    root_node = JRuby.parse(File.read(file))
+
+    visitor = org.jruby.ast.visitor.NodeVisitor.impl do |name, node|
+      if node.newline?
+        lines[node.position.line] = 0
+      end
+
+      node.child_nodes.each {|child| child && child.accept(visitor)}
+    end
+
+    root_node.accept visitor
+
+    lines
+  end
+end


### PR DESCRIPTION
Fixes #6181

Note that the output here differs from CRuby, perhaps for the same reasons we don't pass other coverage tests. Some lines are not seen as coverable when they should be.

@enebo Did you look into those coverage tests any more? Would this be better using Ripper?

Output on CRuby:

```
[] ~/projects/jruby $ rvm ruby-2.6.5 do ruby -rcoverage -e 'p Coverage.line_stub("pom.rb")'
[0, nil, nil, 0, nil, 0, 0, 0, 0, 0, nil, 0, nil, 0, nil, 0, 0, 0, 0, nil, nil, nil, 0, nil, 0, 0, nil, nil, 0, 0, 0, nil, 0, nil, 0, 0, nil, 0, nil, 0, 0, nil, nil, 0, nil, nil, nil, 0, 0, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, nil, nil, 0, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, nil, nil, nil, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, nil, 0, 0, 0, nil, 0, 0, nil, nil, 0, 0, 0, 0, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, nil, 0, 0, nil, nil, 0, nil, nil, 0, nil, nil, nil, nil, nil, 0, nil, nil, nil, 0, nil, nil, nil, nil, 0, nil, 0, 0, nil, nil, 0, 0, 0, nil, nil, 0, 0, nil, 0, nil, 0, 0, nil, nil, nil, nil, 0, 0, nil, 0, nil, nil, nil, nil, 0, nil, 0, nil, 0, nil, 0, 0, 0, 0, nil, nil, nil, nil, nil, 0, 0, nil, 0, nil, 0, nil, nil, 0, 0, 0, nil, nil, nil, nil, 0, 0, nil, 0, 0, nil, nil, nil, 0, nil, 0, nil, 0, 0, nil, nil, nil, 0, nil, 0, nil, 0, nil, 0, 0, nil, nil, nil, 0, nil, 0, nil, 0, 0, nil, nil, nil, 0, 0, 0, 0, 0, nil, 0, 0, nil, nil, nil, 0, nil, 0, nil, 0, 0, 0, nil, nil, 0, 0, nil, nil, 0, 0, nil, 0, 0, nil, nil, nil, 0, 0, 0, nil, 0, nil, nil, 0, 0, 0, nil, 0, nil, nil, 0, 0, nil, nil, 0, 0, nil, nil, 0, nil, nil, nil, 0, nil, 0, 0, nil, nil, 0, 0, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, 0, nil, nil, 0, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, nil, nil, nil]
```

Output on JRuby:

```
[] ~/projects/jruby $ jruby -rcoverage -e 'p Coverage.line_stub("pom.rb")'
[0, 0, nil, 0, nil, 0, 0, 0, 0, 0, nil, 0, nil, 0, nil, 0, 0, 0, 0, nil, nil, nil, 0, nil, 0, 0, nil, nil, 0, 0, 0, nil, 0, nil, 0, 0, nil, 0, nil, 0, 0, nil, nil, 0, nil, nil, nil, 0, 0, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, nil, nil, 0, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, nil, nil, nil, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, nil, 0, 0, 0, nil, 0, 0, nil, nil, 0, 0, 0, 0, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, nil, 0, 0, nil, nil, 0, nil, nil, 0, nil, nil, nil, nil, nil, 0, nil, nil, nil, 0, nil, nil, nil, nil, 0, nil, 0, 0, nil, nil, 0, 0, 0, nil, nil, 0, 0, nil, 0, nil, 0, 0, nil, nil, nil, nil, 0, 0, nil, 0, nil, nil, nil, nil, 0, nil, 0, nil, 0, nil, 0, 0, 0, 0, nil, nil, nil, nil, nil, 0, 0, nil, 0, nil, 0, 0, nil, 0, 0, 0, nil, nil, nil, nil, 0, 0, nil, 0, 0, nil, nil, nil, 0, nil, 0, nil, 0, 0, nil, nil, nil, 0, nil, 0, nil, 0, nil, 0, 0, nil, nil, nil, 0, nil, 0, nil, 0, 0, nil, nil, nil, 0, 0, 0, 0, 0, nil, 0, 0, nil, nil, nil, 0, nil, 0, nil, 0, 0, 0, nil, nil, 0, 0, nil, nil, 0, 0, nil, 0, 0, nil, nil, nil, 0, 0, 0, nil, 0, nil, nil, 0, 0, 0, nil, 0, nil, nil, 0, 0, nil, nil, 0, 0, nil, nil, 0, nil, nil, nil, 0, nil, 0, 0, nil, nil, 0, 0, nil, nil, nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, nil, 0, nil, nil, nil, nil, 0, nil, nil, 0, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, 0, nil, nil, nil]
```