### PR TITLE
Restart dead enumerator

### DIFF
--- a/core/src/main/ruby/jruby/kernel/enumerator.rb
+++ b/core/src/main/ruby/jruby/kernel/enumerator.rb
@@ -90,7 +90,7 @@ class Enumerator
     end
 
     def next
-      reset unless @fiber
+      reset unless @fiber&.__alive__
 
       val = @fiber.resume
 

--- a/spec/ruby/core/enumerator/next_spec.rb
+++ b/spec/ruby/core/enumerator/next_spec.rb
@@ -24,4 +24,15 @@ describe "Enumerator#next" do
     @enum.rewind
     @enum.next.should == 1
   end
+
+  it "restarts the enumerator if an exception terminated a previous iteration" do
+    exception = StandardError.new
+    enum = Enumerator.new do
+      raise exception
+    end
+
+    result = 2.times.map { enum.next rescue $! }
+
+    result.should == [exception, exception]
+  end
 end

--- a/spec/tags/ruby/core/enumerator/lazy/chunk_while_tags.txt
+++ b/spec/tags/ruby/core/enumerator/lazy/chunk_while_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerator::Lazy#chunk_while works with an infinite enumerable

--- a/spec/tags/ruby/core/enumerator/lazy/slice_after_tags.txt
+++ b/spec/tags/ruby/core/enumerator/lazy/slice_after_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerator::Lazy#slice_after works with an infinite enumerable

--- a/spec/tags/ruby/core/enumerator/lazy/slice_before_tags.txt
+++ b/spec/tags/ruby/core/enumerator/lazy/slice_before_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerator::Lazy#slice_before works with an infinite enumerable

--- a/spec/tags/ruby/core/enumerator/lazy/slice_when_tags.txt
+++ b/spec/tags/ruby/core/enumerator/lazy/slice_when_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerator::Lazy#slice_when works with an infinite enumerable

--- a/spec/tags/ruby/core/enumerator/lazy/take_tags.txt
+++ b/spec/tags/ruby/core/enumerator/lazy/take_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerator::Lazy#take sets given count to size if the old size is Infinity

--- a/spec/tags/ruby/core/enumerator/yielder/append_tags.txt
+++ b/spec/tags/ruby/core/enumerator/yielder/append_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerator::Yielder#<< doesn't double-wrap Arrays


### PR DESCRIPTION
This fixes the remaining failure in CSV as discussed in #6157. Enumerators that fail prematurely due to an exception should be re-started on the next call to `next`.