### PR TITLE
Merge variadic method_missing indy fix from master

### DIFF
--- a/spec/compiler/general_spec.rb
+++ b/spec/compiler/general_spec.rb
@@ -1188,5 +1188,12 @@ modes.each do |mode|
         expect(x).to eq("global-variable")
       end
     end
+
+    it "handles method_missing dispatch forms" do
+      run('obj = Class.new { def method_missing(name, *args); [name, *args]; end }.new; obj.foo(1)') {|x| expect(x).to eq([:foo, 1])}
+      run('obj = Class.new { def method_missing(name, *args); [name, *args]; end }.new; obj.foo(1,2,3,4)') {|x| expect(x).to eq([:foo, 1, 2, 3, 4])}
+      run('obj = Class.new { def method_missing(name, *args); [name, *args]; end }.new; ary = 1.upto(4).to_a; obj.foo(*ary)') {|x| expect(x).to eq([:foo, 1, 2, 3, 4])}
+      run('obj = Class.new { def method_missing(name, *args); [name, *args]; end }.new; ary = 2.upto(4).to_a; obj.foo(1, *ary)') {|x| expect(x).to eq([:foo, 1, 2, 3, 4])}
+    end
   end
 end


### PR DESCRIPTION
This was previously fixed only on master in #6132, but in order to support #6191 I am merging it to the jruby-9.2 branch. We won't release a 9.2.12, but users can build this branch to get the patched version.