### PR TITLE
Use all the tricks to properly eliminate illegal access warnings

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -73,7 +73,7 @@ project 'JRuby Core' do
 
   jar 'me.qmx.jitescript:jitescript:0.4.1', :exclusions => ['org.ow2.asm:asm-all']
 
-  jar 'com.headius:backport9:1.6'
+  jar 'com.headius:backport9:1.7'
 
   jar 'javax.annotation:javax.annotation-api:1.3.1', scope: 'compile'
 

--- a/core/pom.rb
+++ b/core/pom.rb
@@ -73,7 +73,7 @@ project 'JRuby Core' do
 
   jar 'me.qmx.jitescript:jitescript:0.4.1', :exclusions => ['org.ow2.asm:asm-all']
 
-  jar 'com.headius:backport9:1.5'
+  jar 'com.headius:backport9:1.6'
 
   jar 'javax.annotation:javax.annotation-api:1.3.1', scope: 'compile'
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -249,7 +249,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>com.headius</groupId>
       <artifactId>backport9</artifactId>
-      <version>1.6</version>
+      <version>1.7</version>
     </dependency>
     <dependency>
       <groupId>javax.annotation</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -249,7 +249,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>com.headius</groupId>
       <artifactId>backport9</artifactId>
-      <version>1.5</version>
+      <version>1.6</version>
     </dependency>
     <dependency>
       <groupId>javax.annotation</groupId>

--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -30,9 +30,9 @@
 
 package org.jruby;
 
+import com.headius.backport9.modules.Modules;
 import jnr.constants.platform.RLIM;
 import jnr.constants.platform.RLIMIT;
-import jnr.constants.platform.Signal;
 import jnr.constants.platform.Sysconf;
 import jnr.ffi.byref.IntByReference;
 import jnr.posix.RLimit;
@@ -43,6 +43,7 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyModule;
 import jnr.posix.POSIX;
 import org.jruby.javasupport.Java;
+import org.jruby.javasupport.JavaUtil;
 import org.jruby.platform.Platform;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.BlockCallback;
@@ -68,6 +69,8 @@ import static org.jruby.runtime.Helpers.invokedynamic;
 import static org.jruby.util.WindowsFFI.kernel32;
 import static org.jruby.util.WindowsFFI.Kernel32.*;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.management.ThreadMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Method;
@@ -925,38 +928,45 @@ public class RubyProcess {
         return res;
     }
 
-    private static final Method NATIVE_THREAD_SIGNAL;
-    private static final Method NATIVE_THREAD_CURRENT;
+    private static final MethodHandle NATIVE_THREAD_SIGNAL;
+    private static final MethodHandle NATIVE_THREAD_CURRENT;
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
 
     static {
-        Method m1 = null;
-        Method m2 = null;
+        MethodHandle signalHandle = null;
+        MethodHandle currentHandle = null;
+
         try {
             // NativeThread is not public on Windows builds of Open JDK
             Class nativeThread = Class.forName("sun.nio.ch.NativeThread");
+
             Method signal = nativeThread.getDeclaredMethod("signal", long.class);
             Method current = nativeThread.getDeclaredMethod("current");
-            if (Java.trySetAccessible(signal) && Java.trySetAccessible(current)) {
-                m1 = signal;
-                m2 = current;
-            }
+
+            signalHandle = JavaUtil.getHandleSafe(signal, RubyProcess.class, LOOKUP);
+            currentHandle = JavaUtil.getHandleSafe(current, RubyProcess.class, LOOKUP);
         } catch (NoSuchMethodException | ClassNotFoundException e) {
             // ignore and leave it null
         }
-        NATIVE_THREAD_SIGNAL = m1;
-        NATIVE_THREAD_CURRENT = m2;
+
+        NATIVE_THREAD_SIGNAL = signalHandle;
+        NATIVE_THREAD_CURRENT = currentHandle;
 
     }
 
     private static int pthreadKillable(ThreadContext context, ToIntFunction<ThreadContext> blockingCall) {
-        if (Platform.IS_WINDOWS || !Options.NATIVE_PTHREAD_KILL.load() || NATIVE_THREAD_CURRENT == null) {
+        if (Platform.IS_WINDOWS
+                || !Options.NATIVE_PTHREAD_KILL.load()
+                || NATIVE_THREAD_SIGNAL == null
+                || NATIVE_THREAD_CURRENT == null) {
             // Can't use pthread_kill on Windows
             return blockingCall.applyAsInt(context);
         }
 
         do try {
+            final long threadID = (long) NATIVE_THREAD_CURRENT.invokeExact();
+
             return context.getThread().executeTask(context, blockingCall, new RubyThread.Task<ToIntFunction<ThreadContext>, Integer>() {
-                final long threadID = tryThrow(() -> (Long) NATIVE_THREAD_CURRENT.invoke(null));
 
                 @Override
                 public Integer run(ThreadContext context, ToIntFunction<ThreadContext> blockingCall) {
@@ -965,12 +975,18 @@ public class RubyProcess {
 
                 @Override
                 public void wakeup(RubyThread thread, ToIntFunction<ThreadContext> blockingCall) {
-                    tryThrow(() -> NATIVE_THREAD_SIGNAL.invoke(null, threadID));
+                    try {
+                        NATIVE_THREAD_SIGNAL.invokeExact(null, threadID);
+                    } catch (Throwable t) {
+                        throwException(t);
+                    }
                 }
             });
         } catch (InterruptedException ie) {
             context.pollThreadEvents();
             // try again
+        } catch (Throwable t) {
+            throwException(t);
         } while (true);
     }
 

--- a/core/src/main/java/org/jruby/ext/ffi/io/FileDescriptorIO.java
+++ b/core/src/main/java/org/jruby/ext/ffi/io/FileDescriptorIO.java
@@ -102,30 +102,4 @@ public class FileDescriptorIO extends RubyIO {
     public static RubyIO wrap(ThreadContext context, IRubyObject recv, IRubyObject fd) {
         return new FileDescriptorIO(context.runtime, fd);
     }
-
-    static class FileDescriptorHelper {
-        static final java.lang.reflect.Constructor<java.io.FileDescriptor> CONSTRUCTOR;
-        static {
-            java.lang.reflect.Constructor<java.io.FileDescriptor> constructor;
-            try {
-                constructor = java.io.FileDescriptor.class.getDeclaredConstructor(int.class);
-                constructor.setAccessible(true);
-            } catch (Throwable t) {
-                constructor = null;
-            }
-            CONSTRUCTOR = constructor;
-        }
-
-        public static java.io.FileDescriptor wrap(int fileno) {
-            try {
-                return CONSTRUCTOR != null ? CONSTRUCTOR.newInstance(fileno) : new java.io.FileDescriptor();
-            } catch (IllegalAccessException iae) {
-                return new java.io.FileDescriptor();
-            } catch (InstantiationException ie) {
-                return new java.io.FileDescriptor();
-            } catch (java.lang.reflect.InvocationTargetException ite) {
-                return new java.io.FileDescriptor();
-            }
-        }
-    }
 }

--- a/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
@@ -1,6 +1,5 @@
 package org.jruby.javasupport.binding;
 
-import com.headius.backport9.modules.Modules;
 import org.jruby.Ruby;
 import org.jruby.RubyModule;
 import org.jruby.internal.runtime.methods.JavaMethod;
@@ -8,7 +7,6 @@ import org.jruby.java.invokers.ConstructorInvoker;
 import org.jruby.javasupport.Java;
 import org.jruby.javasupport.JavaClass;
 import org.jruby.javasupport.JavaSupport;
-import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -669,7 +667,7 @@ public class MethodGatherer {
             if (Modifier.isPrivate(mod)) return false;
 
             // Skip protected methods if we can't set accessible
-            if (!Modifier.isPublic(mod) && !Modules.trySetAccessible(method, Java.class)) return false;
+            if (!Modifier.isPublic(mod) && !Java.trySetAccessible(method)) return false;
 
             // ignore bridge methods because we'd rather directly call methods that this method
             // is bridging (and such methods are by definition always available.)

--- a/core/src/main/java/org/jruby/util/ShellLauncher.java
+++ b/core/src/main/java/org/jruby/util/ShellLauncher.java
@@ -64,6 +64,7 @@ import org.jruby.RubyInstanceConfig;
 import org.jruby.RubyModule;
 import org.jruby.RubyString;
 import jnr.posix.util.Platform;
+import org.jruby.javasupport.Java;
 import org.jruby.runtime.Helpers;
 import org.jruby.ext.rbconfig.RbConfigLibrary;
 import org.jruby.runtime.ThreadContext;
@@ -661,7 +662,7 @@ public class ShellLauncher {
         try {
             up = Class.forName("java.lang.UNIXProcess");
             pid = up.getDeclaredField("pid");
-            pid.setAccessible(true);
+            Java.trySetAccessible(pid);
         } catch (Exception e) {
             // ignore and try windows version
         }
@@ -673,7 +674,7 @@ public class ShellLauncher {
         try {
             pi = Class.forName("java.lang.ProcessImpl");
             handle = pi.getDeclaredField("handle");
-            handle.setAccessible(true);
+            Java.trySetAccessible(pid);
         } catch (Exception e) {
             // ignore and use hashcode
         }

--- a/core/src/main/java/org/jruby/util/io/FilenoUtil.java
+++ b/core/src/main/java/org/jruby/util/io/FilenoUtil.java
@@ -1,5 +1,6 @@
 package org.jruby.util.io;
 
+import com.headius.backport9.modules.Module;
 import com.headius.backport9.modules.Modules;
 import jnr.enxio.channels.NativeSelectableChannel;
 import jnr.ffi.LibraryLoader;
@@ -259,8 +260,13 @@ public class FilenoUtil {
 
             if (selChImplGetFD == null || fileChannelGetFD == null || fdGetFileno == null) {
                 // Warn users since we don't currently handle half-native process control.
-                LOG.warn("Native subprocess control requires open access to sun.nio.ch\n" +
-                        "Pass '--add-opens java.base/sun.nio.ch=org.jruby.dist' or '=org.jruby.core' to enable.");
+                Module module = Modules.getModule(ReflectiveAccess.class);
+                String moduleName = module.getName();
+                if (moduleName == null) {
+                    moduleName = "ALL-UNNAMED";
+                }
+                LOG.warn("Native subprocess control requires open access to the JDK IO subsystem\n" +
+                        "Pass '--add-opens java.base/sun.nio.ch=" + moduleName + " --add-opens java.base/java.io=" + moduleName + "' to enable.");
             }
         }
 

--- a/core/src/main/java/org/jruby/util/io/FilenoUtil.java
+++ b/core/src/main/java/org/jruby/util/io/FilenoUtil.java
@@ -13,15 +13,26 @@ import jnr.unixsocket.UnixSocketChannel;
 
 import org.jruby.javasupport.Java;
 import org.jruby.platform.Platform;
+import org.jruby.runtime.Helpers;
 import org.jruby.util.collections.NonBlockingHashMapLong;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
 
 import java.io.FileDescriptor;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.channels.Channel;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.ObjIntConsumer;
+import java.util.function.Predicate;
+import java.util.function.ToIntFunction;
+
+import static java.lang.invoke.MethodType.methodType;
 
 /**
  * Utilities for working with native fileno and Java structures that wrap them.
@@ -37,30 +48,30 @@ public class FilenoUtil {
     }
 
     public static FileDescriptor getDescriptorFromChannel(Channel channel) {
-        if (ReflectiveAccess.SEL_CH_IMPL_GET_FD != null && ReflectiveAccess.SEL_CH_IMPL.isInstance(channel)) {
+        if (ReflectiveAccess.SEL_CH_IMPL_GET_FD != null && ReflectiveAccess.SEL_CH_IMPL.test(channel)) {
             // Pipe Source and Sink, Sockets, and other several other selectable channels
             try {
-                return (FileDescriptor) ReflectiveAccess.SEL_CH_IMPL_GET_FD.invoke(channel);
+                return ReflectiveAccess.SEL_CH_IMPL_GET_FD.apply(channel);
             } catch (Exception e) {
                 // return bogus below
             }
-        } else if (ReflectiveAccess.FILE_CHANNEL_IMPL_FD != null && ReflectiveAccess.FILE_CHANNEL_IMPL.isInstance(channel)) {
+        } else if (ReflectiveAccess.FILE_CHANNEL_IMPL_GET_FD != null && ReflectiveAccess.FILE_CHANNEL_IMPL.test(channel)) {
             // FileChannels
             try {
-                return (FileDescriptor) ReflectiveAccess.FILE_CHANNEL_IMPL_FD.get(channel);
+                return ReflectiveAccess.FILE_CHANNEL_IMPL_GET_FD.apply(channel);
             } catch (Exception e) {
                 // return bogus below
             }
-        } else if (ReflectiveAccess.FILE_DESCRIPTOR_FD != null) {
+        } else if (ReflectiveAccess.FILE_DESCRIPTOR_SET_FILENO != null) {
             FileDescriptor unixFD = new FileDescriptor();
 
             // UNIX sockets, from jnr-unixsocket
             try {
                 if (channel instanceof UnixSocketChannel) {
-                    ReflectiveAccess.FILE_DESCRIPTOR_FD.set(unixFD, ((UnixSocketChannel)channel).getFD());
+                    ReflectiveAccess.FILE_DESCRIPTOR_SET_FILENO.accept(unixFD, ((UnixSocketChannel)channel).getFD());
                     return unixFD;
                 } else if (channel instanceof UnixServerSocketChannel) {
-                    ReflectiveAccess.FILE_DESCRIPTOR_FD.set(unixFD, ((UnixServerSocketChannel)channel).getFD());
+                    ReflectiveAccess.FILE_DESCRIPTOR_SET_FILENO.accept(unixFD, ((UnixServerSocketChannel)channel).getFD());
                     return unixFD;
                 }
             } catch (Exception e) {
@@ -120,7 +131,7 @@ public class FilenoUtil {
     }
 
     private static int getFilenoUsingReflection(Channel channel) {
-        if (ReflectiveAccess.FILE_DESCRIPTOR_FD != null) {
+        if (ReflectiveAccess.FILE_DESCRIPTOR_GET_FILENO != null) {
             return filenoFrom(getDescriptorFromChannel(channel));
         }
         return -1;
@@ -129,7 +140,7 @@ public class FilenoUtil {
     public static int filenoFrom(FileDescriptor fd) {
         if (fd.valid()) {
             try {
-                return (Integer) ReflectiveAccess.FILE_DESCRIPTOR_FD.get(fd);
+                return ReflectiveAccess.FILE_DESCRIPTOR_GET_FILENO.applyAsInt(fd);
             } catch (Exception e) {
                 // failed to get
             }
@@ -138,7 +149,7 @@ public class FilenoUtil {
         return -1;
     }
 
-    public static HANDLE handleFrom(Channel channel) {
+    private static HANDLE handleFrom(Channel channel) {
         if (channel instanceof NativeSelectableChannel) {
             return HANDLE.valueOf(((NativeSelectableChannel)channel).getFD()); // TODO: this is an int. Do windows handles ever grow larger?
         }
@@ -147,7 +158,7 @@ public class FilenoUtil {
     }
 
     private static HANDLE getHandleUsingReflection(Channel channel) {
-        if (ReflectiveAccess.FILE_DESCRIPTOR_FD != null) {
+        if (ReflectiveAccess.FILE_DESCRIPTOR_GET_FILENO != null) {
             return JavaLibCHelper.gethandle(getDescriptorFromChannel(channel));
         }
         return HANDLE.valueOf(-1);
@@ -181,71 +192,166 @@ public class FilenoUtil {
 
     static final Logger LOG = LoggerFactory.getLogger(FilenoUtil.class);
 
+
     private static class ReflectiveAccess {
+        private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+
+        private static final Predicate<Object> SEL_CH_IMPL;
+        private static final MethodHandle SEL_CH_IMPL_GET_FD_HANDLE;
+        private static final Function<Object, FileDescriptor> SEL_CH_IMPL_GET_FD;
+        private static final Predicate<Object> FILE_CHANNEL_IMPL;
+        private static final MethodHandle FILE_CHANNEL_IMPL_GET_FD_HANDLE;
+        private static final Function<Object, FileDescriptor> FILE_CHANNEL_IMPL_GET_FD;
+        private static final MethodHandle FILE_DESCRIPTOR_SET_FILENO_HANDLE;
+        private static final ObjIntConsumer<FileDescriptor> FILE_DESCRIPTOR_SET_FILENO;
+        private static final MethodHandle FILE_DESCRIPTOR_GET_FILENO_HANDLE;
+        private static final ToIntFunction<FileDescriptor> FILE_DESCRIPTOR_GET_FILENO;
+
         static {
-            // open package "sun.nio.ch" (from java.base) for org.jruby.dist module
+            MethodHandle selChImplGetFD = null;
+            Predicate isSelChImpl = null;
+
             try {
-                Modules.addOpens(FileDescriptor.class, "sun.nio.ch", ReflectiveAccess.class);
-            } catch (RuntimeException re) {
+                Class selChImpl = Class.forName("sun.nio.ch.SelChImpl");
+
+                isSelChImpl = selChImpl::isInstance;
+
+                Method getFD = selChImpl.getDeclaredMethod("getFD");
+
+                selChImplGetFD = getHandleSafe(getFD);
+            } catch (Throwable e) {
+                // leave it null
+            }
+
+            SEL_CH_IMPL = isSelChImpl;
+            SEL_CH_IMPL_GET_FD_HANDLE = selChImplGetFD;
+            SEL_CH_IMPL_GET_FD = selChImplGetFD == null ? null : (obj) -> {
+                try {
+                    return (FileDescriptor) SEL_CH_IMPL_GET_FD_HANDLE.invoke(obj);
+                } catch (Throwable t) {
+                    Helpers.throwException(t);
+                    return null; // not reached
+                }
+            };
+
+            Predicate isFileChannelImpl = null;
+            MethodHandle fileChannelGetFD = null;
+
+            try {
+                Class fileChannelImpl = Class.forName("sun.nio.ch.FileChannelImpl");
+
+                isFileChannelImpl = fileChannelImpl::isInstance;
+
+                Field fd = fileChannelImpl.getDeclaredField("fd");
+
+                fileChannelGetFD = getGetterSafe(fd);
+            } catch (Throwable e) {
+                // leave it null
+            }
+
+            FILE_CHANNEL_IMPL = isFileChannelImpl;
+            FILE_CHANNEL_IMPL_GET_FD_HANDLE = fileChannelGetFD;
+            FILE_CHANNEL_IMPL_GET_FD = fileChannelGetFD == null ? null : (obj) -> {
+                try {
+                    return (FileDescriptor) FILE_CHANNEL_IMPL_GET_FD_HANDLE.invoke(obj);
+                } catch (Throwable t) {
+                    Helpers.throwException(t);
+                    return null; // not reached
+                }
+            };
+
+            MethodHandle fdGetFileno = null;
+            MethodHandle fdSetFileno = null;
+
+            try {
+                Field fd = FileDescriptor.class.getDeclaredField("fd");
+
+                fdGetFileno = getGetterSafe(fd);
+                fdSetFileno = getSetterSafe(fd);
+            } catch (Throwable e) {
+                // leave it null
+            }
+            
+            FILE_DESCRIPTOR_GET_FILENO_HANDLE = fdGetFileno;
+            FILE_DESCRIPTOR_GET_FILENO = fileChannelGetFD == null ? null : (obj) -> {
+                try {
+                    return (int) FILE_DESCRIPTOR_GET_FILENO_HANDLE.invoke(obj);
+                } catch (Throwable t) {
+                    Helpers.throwException(t);
+                    return -1; // not reached
+                }
+            };
+            FILE_DESCRIPTOR_SET_FILENO_HANDLE = fdSetFileno;
+            FILE_DESCRIPTOR_SET_FILENO = fdSetFileno == null ? null : (obj, i) -> {
+                try {
+                    FILE_DESCRIPTOR_SET_FILENO_HANDLE.invoke(obj, i);
+                } catch (Throwable t) {
+                    Helpers.throwException(t);
+                }
+            };
+
+            if (selChImplGetFD == null || fileChannelGetFD == null || fdGetFileno == null) {
                 // Warn users since we don't currently handle half-native process control.
                 LOG.warn("Native subprocess control requires open access to sun.nio.ch\n" +
                         "Pass '--add-opens java.base/sun.nio.ch=org.jruby.dist' or '=org.jruby.core' to enable.");
             }
-
-            Method getFD;
-            Class selChImpl;
-            try {
-                selChImpl = Class.forName("sun.nio.ch.SelChImpl");
-                try {
-                    getFD = selChImpl.getMethod("getFD");
-                    if (!Java.trySetAccessible(getFD)) {
-                        getFD = null;
-                    }
-                } catch (Exception e) {
-                    getFD = null;
-                }
-            } catch (Exception e) {
-                selChImpl = null;
-                getFD = null;
-            }
-            SEL_CH_IMPL = selChImpl;
-            SEL_CH_IMPL_GET_FD = getFD;
-
-            Field fd;
-            Class fileChannelImpl;
-            try {
-                fileChannelImpl = Class.forName("sun.nio.ch.FileChannelImpl");
-                try {
-                    fd = fileChannelImpl.getDeclaredField("fd");
-                    if (!Java.trySetAccessible(fd)) {
-                        fd = null;
-                    }
-                } catch (Exception e) {
-                    fd = null;
-                }
-            } catch (Exception e) {
-                fileChannelImpl = null;
-                fd = null;
-            }
-            FILE_CHANNEL_IMPL = fileChannelImpl;
-            FILE_CHANNEL_IMPL_FD = fd;
-
-            Field ffd;
-            try {
-                ffd = FileDescriptor.class.getDeclaredField("fd");
-                if (!Java.trySetAccessible(ffd)) {
-                    ffd = null;
-                }
-            } catch (Exception e) {
-                ffd = null;
-            }
-            FILE_DESCRIPTOR_FD = ffd;
         }
 
-        private static final Class SEL_CH_IMPL;
-        private static final Method SEL_CH_IMPL_GET_FD;
-        private static final Class FILE_CHANNEL_IMPL;
-        private static final Field FILE_CHANNEL_IMPL_FD;
-        private static final Field FILE_DESCRIPTOR_FD;
+        static MethodHandle getHandleSafe(Method method) {
+            try {
+                return LOOKUP.unreflect(method);
+            } catch (IllegalAccessException iae) {
+                // try again with setAccessible
+                Class<?> declaringClass = method.getDeclaringClass();
+                Modules.addOpens(declaringClass, declaringClass.getPackage().getName(), ReflectiveAccess.class);
+                if (Java.trySetAccessible(method)) {
+                    try {
+                        return LOOKUP.unreflect(method);
+                    } catch (IllegalAccessException iae2) {
+                        // ignore, return null below
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        static MethodHandle getGetterSafe(Field field) {
+            try {
+                return LOOKUP.unreflectGetter(field);
+            } catch (IllegalAccessException iae) {
+                // try again with setAccessible
+                Class<?> declaringClass = field.getDeclaringClass();
+                Modules.addOpens(declaringClass, declaringClass.getPackage().getName(), ReflectiveAccess.class);
+                if (Java.trySetAccessible(field)) {
+                    try {
+                        return LOOKUP.unreflectGetter(field);
+                    } catch (IllegalAccessException iae2) {
+                        // ignore, return null below
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        static MethodHandle getSetterSafe(Field field) {
+            try {
+                return LOOKUP.unreflectSetter(field);
+            } catch (IllegalAccessException iae) {
+                // try again with setAccessible
+                Class<?> declaringClass = field.getDeclaringClass();
+                Modules.addOpens(declaringClass, declaringClass.getPackage().getName(), ReflectiveAccess.class);
+                if (Java.trySetAccessible(field)) {
+                    try {
+                        return LOOKUP.unreflectSetter(field);
+                    } catch (IllegalAccessException iae2) {
+                        // ignore, return null below
+                    }
+                }
+            }
+
+            return null;
+        }
     }
 }

--- a/core/src/main/java/org/jruby/util/io/SeekableByteChannelImpl.java
+++ b/core/src/main/java/org/jruby/util/io/SeekableByteChannelImpl.java
@@ -10,6 +10,8 @@
  */
 package org.jruby.util.io;
 
+import org.jruby.javasupport.Java;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -147,7 +149,7 @@ final class SeekableByteChannelImpl extends AbstractInterruptibleChannel
     private static Field accessibleField(final String name) {
         try {
             Field field = ByteArrayInputStream.class.getDeclaredField(name);
-            field.setAccessible(true);
+            Java.trySetAccessible(field);
             return field;
         }
         catch (NoSuchFieldException ex) {

--- a/core/src/main/java/org/jruby/util/unsafe/UnsafeHolder.java
+++ b/core/src/main/java/org/jruby/util/unsafe/UnsafeHolder.java
@@ -27,8 +27,9 @@
 
 package org.jruby.util.unsafe;
 
+import org.jruby.javasupport.Java;
+
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 
 public final class UnsafeHolder {
     
@@ -43,7 +44,7 @@ public final class UnsafeHolder {
         try {
             Class unsafeClass = Class.forName("sun.misc.Unsafe");
             Field f = unsafeClass.getDeclaredField("theUnsafe");
-            f.setAccessible(true);
+            Java.trySetAccessible(f);
             return (sun.misc.Unsafe) f.get(null);
         } catch (Exception e) {
             return null;


### PR DESCRIPTION
This PR attempts to tweak all of our uses of `setAccessible` for accessing internal JDK classes to do the "right thing", be that using method handles, `addOpens`, or other tweaks to open up these classes if we legally can or fall back gracefully to degraded functionality *without warnings*.

The general strategy is described in the first commit to FilenoUtil, but I summarize it again here:

* Reflecting against these classes should always succeed if they are present, so this does not change.
* Instead of using the Field or Method directly, we unreflect it into a MethodHandle. This lets us know we have a fully-accessible way to deal with the reflected access, and since it raises errors instead of silently warns, we can fall back for inaccessible structures.
* When we are dealing with an inaccessible structure, use `Module.addOpens` to make it *really* open, which then gives us a workable method handle and no warning output.

Much of this is to deal with the unfortunate fact that our current check, `Module.isOpen`, will always return true for the unnamed module *but still warn when you set it accessible*. This "kinda-sorta-open" state is a bug in my opinion, but at least explicitly using `addOpens` promotes it to a fully-open state with no warnings.

I will endeavor to eliminate all warnings in all modes with as little fallback as necessary.