### PR TITLE
Add test for #6197

### DIFF
--- a/spec/java_integration/fixtures/InheritsFromAbstractClass.java
+++ b/spec/java_integration/fixtures/InheritsFromAbstractClass.java
@@ -1,6 +1,6 @@
 package java_integration.fixtures;
 
-class InheritsFromAbstractClass extends TrivialAbstractClass {
+public class InheritsFromAbstractClass extends TrivialAbstractClass {
     public InheritsFromAbstractClass() {
 
     }

--- a/spec/java_integration/fixtures/InheritsFromAbstractClass.java
+++ b/spec/java_integration/fixtures/InheritsFromAbstractClass.java
@@ -1,0 +1,7 @@
+package java_integration.fixtures;
+
+class InheritsFromAbstractClass extends TrivialAbstractClass {
+    public InheritsFromAbstractClass() {
+
+    }
+}

--- a/spec/java_integration/fixtures/TrivialAbstractClass.java
+++ b/spec/java_integration/fixtures/TrivialAbstractClass.java
@@ -1,0 +1,7 @@
+package java_integration.fixtures;
+
+abstract class TrivialAbstractClass {
+    public boolean aMethod() {
+        return true;
+    }
+}

--- a/spec/java_integration/methods/dispatch_spec.rb
+++ b/spec/java_integration/methods/dispatch_spec.rb
@@ -4,6 +4,7 @@ java_import "java_integration.fixtures.ClassWithVarargs"
 java_import "java_integration.fixtures.CoreTypeMethods"
 java_import "java_integration.fixtures.StaticMethodSelection"
 java_import "java_integration.fixtures.UsesSingleMethodInterface"
+java_import "java_integration.fixtures.InheritsFromAbstractClass"
 
 describe "Non-overloaded static Java methods" do
   it "should raise ArgumentError when called with incorrect arity" do
@@ -291,6 +292,14 @@ describe "A Java method dispatch downstream from a Kernel#catch block" do
         UsesSingleMethodInterface.new(nil, nil, nil, nil) { throw :foo }
       end
     end.not_to raise_error
+  end
+end
+
+# JRUBY-6197
+describe "A Java method dispatch to a method inherited from a class marked abstract" do
+  it "should be found and callable" do
+    obj = InheritsFromAbstractClass.new
+    expect(obj.aMethod).to be(true)
   end
 end
 


### PR DESCRIPTION
Test exercising dispatch to a method on a Java object which is inherited from an
abstract class is failing with NoMethodError. Illustrates #6197 