### PR TITLE
Allow public methods from non-public superclasses to bind

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
@@ -163,11 +163,14 @@ public class MethodGatherer {
     public static void eachAccessibleMethod(final Class<?> javaClass, Predicate<Method[]> classProcessor, Predicate<Method[]> interfaceProcessor) {
         HashMap<String, List<Method>> nameMethods = new HashMap<>(32);
 
+        boolean isPublic = Modifier.isPublic(javaClass.getModifiers());
+
         // we scan all superclasses, but avoid adding superclass methods with
         // same name+signature as subclass methods (see JRUBY-3130)
         for ( Class<?> klass = javaClass; klass != null; klass = klass.getSuperclass() ) {
-            // only add class's methods if it's public (JIRA issue JRUBY-4799)
-            if (Modifier.isPublic(klass.getModifiers()) && Modules.isExported(klass, Java.class)) {
+            // only add if target class is public or source class is public, and package is exported
+            if (Modules.isExported(klass, Java.class) &&
+                    (isPublic || Modifier.isPublic(klass.getModifiers()))) {
                 // for each class, scan declared methods for new signatures
                 try {
                     // add methods, including static if this is the actual class,
@@ -202,7 +205,7 @@ public class MethodGatherer {
         int childModifiers, parentModifiers;
 
         return parent.getDeclaringClass().isAssignableFrom(child.getDeclaringClass())
-                && child.getReturnType() == parent.getReturnType()
+                && parent.getReturnType().isAssignableFrom(child.getReturnType())
                 && child.isVarArgs() == parent.isVarArgs()
                 && Modifier.isPublic(childModifiers = child.getModifiers()) == Modifier.isPublic(parentModifiers = parent.getModifiers())
                 && Modifier.isProtected(childModifiers) == Modifier.isProtected(parentModifiers)
@@ -233,7 +236,10 @@ public class MethodGatherer {
                             // and virtual dispatch will call the subclass impl anyway.
                             // Used for instance methods, for which we usually want to use the highest-up
                             // callable implementation.
-                            childMethods.set(i, method);
+                            // GH-6199: Only replace child method if parent class is public.
+                            if (Modifier.isPublic(method.getDeclaringClass().getModifiers())) {
+                                childMethods.set(i, method);
+                            }
                         } else {
                             // just skip the new method, since we don't need it (already found one)
                             // used for interface methods, which we want to add unconditionally

--- a/core/src/main/java/org/jruby/javasupport/binding/MethodInstaller.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/MethodInstaller.java
@@ -5,6 +5,7 @@ import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.javasupport.JavaUtil;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -26,9 +27,14 @@ public abstract class MethodInstaller extends NamedInstaller {
     // called only by initializing thread; no synchronization required
     final void addMethod(final Method method, final Class<?> clazz) {
         this.methods.add(method);
+        Class<?> declaringClass = method.getDeclaringClass();
+
+        // Only bind this method if it is local to the target class or if it is
+        // declared in an interface or non-public superclass.
         localMethod |=
-            clazz == method.getDeclaringClass() ||
-            method.getDeclaringClass().isInterface();
+            clazz == declaringClass ||
+                    !Modifier.isPublic(declaringClass.getModifiers()) ||
+                    declaringClass.isInterface();
     }
 
     // called only by initializing thread; no synchronization required


### PR DESCRIPTION
The existing logic will never bind any methods declared on a non-
public superclass, but this is incorrect behavior if the subclass
is public. A public subclass will expose public methods from any
superclass, regardless of the superclass's visibility, so we need
to also bind those methods.

There are two changes here:

* Allow methods to be gathered from non-public superclasses if the
  target class is public.
* Allow those methods to be bound even if there's no definition on
  the target class (no so-called "local method")

This fixes #6197