### PR TITLE
Ruby 2.6 : fix failling transcode tests.

### DIFF
--- a/core/src/main/java/org/jruby/util/io/EncodingUtils.java
+++ b/core/src/main/java/org/jruby/util/io/EncodingUtils.java
@@ -904,7 +904,7 @@ public class EncodingUtils {
                     if (!ecopts.isNil()) {
                         rep = ((RubyHash)ecopts).op_aref(context, runtime.newSymbol("replace"));
                     }
-                    dest = ((RubyString)str).scrub(context, rep, Block.NULL_BLOCK);
+                    dest = ((RubyString)str).encStrScrub(context, senc_p[0], rep, Block.NULL_BLOCK);
                     if (dest.isNil()) dest = str;
                     self_p[0] = dest;
                     return dencindex;

--- a/test/mri/excludes/TestTranscode.rb
+++ b/test/mri/excludes/TestTranscode.rb
@@ -1,3 +1,1 @@
-exclude :test_invalid_replace_string, "Unicode update? #4731"
-exclude :test_scrub_encode_with_coderange, "needs investigation, new in 2.5"
 exclude :test_to_cp50221, "needs investigation"


### PR DESCRIPTION
This fixes failling TestTranscode#test_invalid_replace_string and #test_scrub_encode_with_coderange.

see https://github.com/ruby/ruby/blob/v2_6_6/string.c#L10152-L10172
      https://github.com/ruby/ruby/blob/v2_6_6/transcode.c#L2703