### PR TITLE
Reorder teardown and add a post-exit hook registry

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -3179,6 +3179,18 @@ public final class Ruby implements Constantizable {
     }
 
     /**
+     * Add a post-termination exit function that should be run to shut down JRuby internal services.
+     *
+     * This will be run toward the end of teardown, after all user code has finished executing (e.g. at_exit
+     * hooks and user-defined finalizers). The exit functions registered here are run in FILO order.
+     *
+     * @param postExit the {@link ExitFunction} to run after user exit hooks have completed
+     */
+    public void pushPostExitFunction(ExitFunction postExit) {
+        postExitBlocks.add(0, postExit);
+    }
+
+    /**
      * It is possible for looping or repeated execution to encounter the same END
      * block multiple times.  Rather than store extra runtime state we will just
      * make sure it is not already registered.  at_exit by contrast can push the
@@ -3249,58 +3261,40 @@ public final class Ruby implements Constantizable {
     // catch exception. This makes debugging really hard. This is why
     // tearDown(boolean) exists.
     public void tearDown(boolean systemExit) {
-        int status = 0;
+        final ThreadContext context = getCurrentContext();
+
+        int status = userTeardown(context);
+
+        systemTeardown(context);
+
+        if (systemExit && status != 0) {
+            throw newSystemExit(status);
+        }
+
+        // This is a rather gross way to ensure nobody else performs the same clearing of globalRuntime followed by
+        // initializing a new runtime, which would cause our clear below to clear the wrong runtime. Synchronizing
+        // against the class is a problem, but the overhead of teardown and creating new containers should outstrip
+        // a global synchronize around a few field accesses. -CON
+        if (this == globalRuntime) {
+            synchronized (Ruby.class) {
+                if (this == globalRuntime) {
+                    globalRuntime = null;
+                }
+            }
+        }
+    }
+
+    private void systemTeardown(ThreadContext context) {
+        // Shut down thread service after user-defined at_exit hooks and finalizers have run
+        threadService.teardown();
 
         // clear out old style recursion guards so they don't leak
         mriRecursionGuard = null;
 
-        final ThreadContext context = getCurrentContext();
-
-        // FIXME: 73df3d230b9d92c7237d581c6366df1b92ad9b2b exposed no toplevel scope existing anymore (I think the
-        // bogus scope I removed was playing surrogate toplevel scope and wallpapering this bug).  For now, add a
-        // bogus scope back for at_exit block run.  This is buggy if at_exit is capturing vars.
-        if (!context.hasAnyScopes()) {
-            StaticScope topStaticScope = getStaticScopeFactory().newLocalScope(null);
-            context.pushScope(new ManyVarsDynamicScope(topStaticScope, null));
-        }
-
-        // Run all exit functions from at_exit, END, or Java code
-        while (!exitBlocks.isEmpty()) {
-            ExitFunction fun = exitBlocks.remove(0);
-            int ret = fun.applyAsInt(context);
-            if (ret != 0) {
-                status = ret;
-            }
-        }
-
-        // Shut down thread service after at_exit hooks have run
-        threadService.teardown();
-
-        // Fetches (and unsets) the SIGEXIT handler, if one exists.
-        IRubyObject trapResult = RubySignal.__jtrap_osdefault_kernel(this.getNil(), this.newString("EXIT"));
-        if (trapResult instanceof RubyArray) {
-            IRubyObject[] trapResultEntries = ((RubyArray) trapResult).toJavaArray();
-            IRubyObject exitHandlerProc = trapResultEntries[0];
-            if (exitHandlerProc instanceof RubyProc) {
-                ((RubyProc) exitHandlerProc).call(context, getSingleNilArray());
-            }
-        }
-
-        if (finalizers != null) {
-            synchronized (finalizersMutex) {
-                for (Iterator<Finalizable> finalIter = new ArrayList<>(
-                        finalizers.keySet()).iterator(); finalIter.hasNext();) {
-                    Finalizable f = finalIter.next();
-                    if (f != null) {
-                        try {
-                            f.finalize();
-                        } catch (Throwable t) {
-                            // ignore
-                        }
-                    }
-                    finalIter.remove();
-                }
-            }
+        // Run post-user exit hooks, such as for shutting down internal JRuby services
+        while (!postExitBlocks.isEmpty()) {
+            ExitFunction fun = postExitBlocks.remove(0);
+            fun.applyAsInt(context);
         }
 
         synchronized (internalFinalizersMutex) {
@@ -3344,21 +3338,54 @@ public final class Ruby implements Constantizable {
         getExecutor().shutdown();
         getFiberExecutor().shutdown();
 
-        if (systemExit && status != 0) {
-            throw newSystemExit(status);
+        // Fetches (and unsets) the SIGEXIT handler, if one exists.
+        IRubyObject trapResult = RubySignal.__jtrap_osdefault_kernel(this.getNil(), this.newString("EXIT"));
+        if (trapResult instanceof RubyArray) {
+            IRubyObject[] trapResultEntries = ((RubyArray) trapResult).toJavaArray();
+            IRubyObject exitHandlerProc = trapResultEntries[0];
+            if (exitHandlerProc instanceof RubyProc) {
+                ((RubyProc) exitHandlerProc).call(context, getSingleNilArray());
+            }
+        }
+    }
+
+    private int userTeardown(ThreadContext context) {
+        int status = 0;
+
+        // FIXME: 73df3d230b9d92c7237d581c6366df1b92ad9b2b exposed no toplevel scope existing anymore (I think the
+        // bogus scope I removed was playing surrogate toplevel scope and wallpapering this bug).  For now, add a
+        // bogus scope back for at_exit block run.  This is buggy if at_exit is capturing vars.
+        if (!context.hasAnyScopes()) {
+            StaticScope topStaticScope = getStaticScopeFactory().newLocalScope(null);
+            context.pushScope(new ManyVarsDynamicScope(topStaticScope, null));
         }
 
-        // This is a rather gross way to ensure nobody else performs the same clearing of globalRuntime followed by
-        // initializing a new runtime, which would cause our clear below to clear the wrong runtime. Synchronizing
-        // against the class is a problem, but the overhead of teardown and creating new containers should outstrip
-        // a global synchronize around a few field accesses. -CON
-        if (this == globalRuntime) {
-            synchronized (Ruby.class) {
-                if (this == globalRuntime) {
-                    globalRuntime = null;
+        // Run all exit functions from user hooks like at_exit
+        while (!exitBlocks.isEmpty()) {
+            ExitFunction fun = exitBlocks.remove(0);
+            int ret = fun.applyAsInt(context);
+            if (ret != 0) {
+                status = ret;
+            }
+        }
+
+        if (finalizers != null) {
+            synchronized (finalizersMutex) {
+                for (Iterator<Finalizable> finalIter = new ArrayList<>(
+                        finalizers.keySet()).iterator(); finalIter.hasNext();) {
+                    Finalizable f = finalIter.next();
+                    if (f != null) {
+                        try {
+                            f.finalize();
+                        } catch (Throwable t) {
+                            // ignore
+                        }
+                    }
+                    finalIter.remove();
                 }
             }
         }
+        return status;
     }
 
     /**
@@ -5407,9 +5434,15 @@ public final class Ruby implements Constantizable {
         }
     };
 
-    // Contains a list of all blocks (as Procs) that should be called when
-    // the runtime environment exits.
+    /**
+     * Reserved for userland at_exit logic that runs before internal services start shutting down.
+     */
     private final List<ExitFunction> exitBlocks = Collections.synchronizedList(new LinkedList<>());
+
+    /**
+     * Registry of shutdown operations that should happen after all user code has been run (e.g. at_exit hooks).
+     */
+    private final List<ExitFunction> postExitBlocks = Collections.synchronizedList(new LinkedList<>());
 
     private Profile profile;
 

--- a/core/src/main/java/org/jruby/ext/timeout/Timeout.java
+++ b/core/src/main/java/org/jruby/ext/timeout/Timeout.java
@@ -69,7 +69,7 @@ public class Timeout {
         executor.setRemoveOnCancelPolicy(true);
         timeout.setInternalVariable(EXECUTOR_VARIABLE, executor);
 
-        timeout.getRuntime().pushExitFunction((context) -> { executor.shutdown(); return 0;});
+        timeout.getRuntime().pushPostExitFunction((context) -> { executor.shutdown(); return 0;});
     }
 
 


### PR DESCRIPTION
This PR fixes the following problems:

* Bad ordering of teardown that might interfere with user-defined exit hooks and finalizers.
* Timeout registering its shutdown hook as a normal `at_exit` hook, potentially breaking `at_exit` hooks that were registered earlier. (#6212) 