### PR TITLE
fix copy & paste error

### DIFF
--- a/core/src/main/java/org/jruby/util/ShellLauncher.java
+++ b/core/src/main/java/org/jruby/util/ShellLauncher.java
@@ -674,7 +674,7 @@ public class ShellLauncher {
         try {
             pi = Class.forName("java.lang.ProcessImpl");
             handle = pi.getDeclaredField("handle");
-            Java.trySetAccessible(pid);
+            Java.trySetAccessible(handle);
         } catch (Exception e) {
             // ignore and use hashcode
         }


### PR DESCRIPTION
fixes a wrong reference introduced by https://github.com/jruby/jruby/commit/e8dbe9c269f7723badb89d137b2a1d52b3d3400b