### PR TITLE
Improved integration with Ruby and Java exceptions

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -4243,9 +4243,14 @@ public final class Ruby implements Constantizable {
     }
 
     /**
-     * @param exceptionClass
-     * @param message
-     * @return
+     * Construct a new RaiseException wrapping a new Ruby exception object appropriate to the given exception class.
+     *
+     * There are additional forms of this construction logic in {@link RaiseException#from}.
+     *
+     * @param exceptionClass the exception class from which to construct the exception object
+     * @param message a simple message for the exception
+     * @return a new RaiseException wrapping a new Ruby exception
+     * @see RaiseException#from(Ruby, RubyClass, String)
      */
     public RaiseException newRaiseException(RubyClass exceptionClass, String message) {
         return RaiseException.from(this, exceptionClass, message);

--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -369,6 +369,11 @@ public class RubyException extends RubyObject {
     public void setCause(IRubyObject cause) {
         this.cause = cause;
 
+        // don't do anything to throwable for null/nil cause to avoid forcing backtrace
+        // * if we have no cause yet, it's a no-op
+        // * if we have a cause, we can't change it
+        if (cause == null || cause.isNil()) return;
+
         Throwable t = toThrowable();
         Object javaCause;
 

--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -201,13 +201,28 @@ public class RubyException extends RubyObject {
         return (RubyException) exceptionClass.newInstance(runtime.getCurrentContext(), RubyString.newString(runtime, msg), Block.NULL_BLOCK);
     }
 
+    /**
+     * Construct a new RubyException object from the given exception class and message.
+     *
+     * @param context the current thread context
+     * @param exceptionClass the exception class
+     * @param message the message for the exception
+     * @return the new exception object
+     */
     public static RubyException newException(ThreadContext context, RubyClass exceptionClass, RubyString message) {
         return (RubyException) exceptionClass.newInstance(context, message, Block.NULL_BLOCK);
     }
 
-    @Deprecated
-    public static IRubyObject newException(ThreadContext context, RubyClass exceptionClass, IRubyObject message) {
-        return newException(context, exceptionClass, message.convertToString());
+    /**
+     * Construct a new RubyException object from the given exception class and message.
+     *
+     * @param context the current thread context
+     * @param exceptionClass the exception class
+     * @param args the arguments for the exception's constructor
+     * @return the new exception object
+     */
+    public static RubyException newException(ThreadContext context, RubyClass exceptionClass, IRubyObject... args) {
+        return (RubyException) exceptionClass.newInstance(context, args, Block.NULL_BLOCK);
     }
 
     @JRubyMethod
@@ -488,5 +503,10 @@ public class RubyException extends RubyObject {
         if (backtrace.backtraceData == null) {
             backtrace.backtraceData = context.runtime.getInstanceConfig().getTraceType().getIntegratedBacktrace(context, javaTrace);
         }
+    }
+
+    @Deprecated
+    public static IRubyObject newException(ThreadContext context, RubyClass exceptionClass, IRubyObject message) {
+        return newException(context, exceptionClass, message.convertToString());
     }
 }

--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -353,6 +353,17 @@ public class RubyException extends RubyObject {
 
     public void setCause(IRubyObject cause) {
         this.cause = cause;
+
+        Throwable t = toThrowable();
+        Object javaCause;
+
+        if (t.getCause() == null) {
+            if (cause instanceof RubyException) {
+                t.initCause(((RubyException) cause).toThrowable());
+            } else if (cause instanceof ConcreteJavaProxy && (javaCause = ((ConcreteJavaProxy) cause).getObject()) instanceof Throwable) {
+                t.initCause((Throwable) javaCause);
+            }
+        }
     }
 
     // NOTE: can not have IRubyObject as NativeException has getCause() returning Throwable

--- a/core/src/main/java/org/jruby/exceptions/Exception.java
+++ b/core/src/main/java/org/jruby/exceptions/Exception.java
@@ -27,6 +27,7 @@
 package org.jruby.exceptions;
 
 import org.jruby.RubyException;
+import org.jruby.javasupport.JavaUtil;
 
 /**
  * Represents a Ruby Exception as a throwable Java exception.
@@ -36,5 +37,19 @@ import org.jruby.RubyException;
 public class Exception extends RaiseException {
     public Exception(String message, RubyException exception) {
         super(message, exception);
+    }
+
+    @Override
+    public synchronized Throwable initCause(Throwable cause) {
+        Throwable t = super.initCause(cause);
+
+        // if init was successful, set Ruby exception's cause as well
+        if (cause instanceof Exception) {
+            getException().setCause(((Exception) cause).getException());
+        } else {
+            getException().setCause(JavaUtil.convertJavaToUsableRubyObject(getException().getRuntime(), cause));
+        }
+
+        return t;
     }
 }

--- a/core/src/test/java/org/jruby/exceptions/TestRaiseException.java
+++ b/core/src/test/java/org/jruby/exceptions/TestRaiseException.java
@@ -9,6 +9,7 @@ import org.jruby.RubyClass;
 import org.jruby.RubyException;
 import org.jruby.RubyObject;
 import org.jruby.RubyRuntimeAdapter;
+import org.jruby.RubyString;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.javasupport.JavaEmbedUtils;
 import org.jruby.runtime.Block;
@@ -361,6 +362,57 @@ public class TestRaiseException extends Base {
         public IRubyObject raise_from_nil(ThreadContext context) {
             throw RaiseException.from(context.runtime, context.runtime.getZeroDivisionError(), "raise_from_nil", context.nil);
         }
+    }
 
+    public void testNewRaiseExceptioin() {
+        Ruby ruby = Ruby.newInstance();
+
+        try {
+            throw ruby.newRaiseException(ruby.getException(), "blah");
+        } catch (Exception e) {
+            assertEquals("(Exception) blah", e.getMessage());
+        }
+
+        try {
+            throw ruby.newRaiseException(ruby.getException(), "blah");
+        } catch (Exception e) {
+            assertEquals("(Exception) blah", e.getMessage());
+        }
+
+        RubyArray backtrace = ruby.newEmptyArray();
+        try {
+            throw RaiseException.from(ruby, ruby.getException(), "blah", backtrace);
+        } catch (Exception e) {
+            assertEquals("(Exception) blah", e.getMessage());
+            assertEquals(backtrace, e.getException().backtrace());
+        }
+
+        RubyString message = ruby.newString("blah");
+        try {
+            throw RaiseException.from(ruby, ruby.getException(), message);
+        } catch (Exception e) {
+            assertEquals("(Exception) blah", e.getMessage());
+            assertEquals(message, e.getException().message(ruby.getCurrentContext()));
+        }
+
+        try {
+            throw RaiseException.from(ruby, "Exception", "blah");
+        } catch (Exception e) {
+            assertEquals("(Exception) blah", e.getMessage());
+        }
+
+        try {
+            throw RaiseException.from(ruby, "Exception", "blah", backtrace);
+        } catch (Exception e) {
+            assertEquals("(Exception) blah", e.getMessage());
+            assertEquals(backtrace, e.getException().backtrace());
+        }
+
+        try {
+            throw RaiseException.from(ruby, "Exception", message);
+        } catch (Exception e) {
+            assertEquals("(Exception) blah", e.getMessage());
+            assertEquals(message, e.getException().message(ruby.getCurrentContext()));
+        }
     }
 }


### PR DESCRIPTION
* Make a best effort to sync up `cause` between Java and Ruby.
* Provide more convenience forms of RaiseException.from that accept a String path to the exception class and varargs constructor parameters.

Fixes #6203.