### PR TITLE
Don't double-slash path elements when canonicalizing

### DIFF
--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -2160,8 +2160,13 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         } else if (canonicalPath == null) {
             path = child;
         } else {
-            path = new StringBuilder(canonicalPath.length() + 1 + child.length()).
-                    append(canonicalPath).append('/').append(child);
+            // add a slash (if not already there) plus child and recurse)
+            int length = canonicalPath.length();
+            if (length > 0 && canonicalPath.charAt(length - 1) == '/') {
+                path = canonicalPath + child;
+            } else {
+                path = canonicalPath + "/" + child;
+            }
         }
 
         return canonicalize(path, remaining);

--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -2160,9 +2160,12 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         } else if (canonicalPath == null) {
             path = child;
         } else {
-            // add a slash (if not already there) plus child and recurse)
+            // add a slash (if not already there) plus child and recurse) (jruby/jruby#6045)
             int length = canonicalPath.length();
-            if (length > 0 && canonicalPath.charAt(length - 1) == '/') {
+            String canonPathString = canonicalPath.toString();
+            if (canonPathString.length() > 0 &&
+                    canonicalPath.charAt(length - 1) == '/' &&
+                    canonPathString.startsWith("uri:classloader:")) {
                 path = canonicalPath + child;
             } else {
                 path = canonicalPath + "/" + child;

--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -2146,11 +2146,13 @@ public class RubyFile extends RubyIO implements EncodingCapable {
             }
         } else if (child.equals("..")) {
             if (canonicalPath == null) throw new IllegalArgumentException("Cannot have .. at the start of an absolute path");
-            canonicalPath = canonicalPath.toString();
-            int lastDir = ((String) canonicalPath).lastIndexOf('/');
+            String canonicalPathString = canonicalPath.toString();
+            int lastDir = canonicalPathString.lastIndexOf('/');
             if (lastDir == -1) {
                 if (startsWithDriveLetterOnWindows(canonicalPath)) {
                     // do nothing, we should not delete the drive letter
+                } else if (isLocalURI(canonicalPathString)) {
+                    // do nothing, leave the URI bits alone
                 } else {
                     path = "";
                 }
@@ -2173,6 +2175,14 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         }
 
         return canonicalize(path, remaining);
+    }
+
+    private static boolean isLocalURI(String canonicalPathString) {
+        return startsWith("classpath:", canonicalPathString) ||
+                startsWith("classloader:", canonicalPathString) ||
+                startsWith("uri:classloader:", canonicalPathString) ||
+                startsWith("file:", canonicalPathString) ||
+                startsWith("jar:file", canonicalPathString);
     }
 
     private static StringBuilder appendSlash(final CharSequence canonicalPath) {

--- a/spec/java_integration/paths/uri_classloader_spec.rb
+++ b/spec/java_integration/paths/uri_classloader_spec.rb
@@ -2,7 +2,7 @@ require File.dirname(__FILE__) + "/../spec_helper"
 
 describe "uri:classloader path strings" do
   let(:many_slashes_path) { "uri:classloader:////foo/b.gemspec" }
-  let(:unc_like_path) { "uri:classloader://foo/b.gemspec" }
+  let(:unc_like_path) { "uri:classloader:/foo/b.gemspec" }
   let(:normal_path) { "uri:classloader:/foo/b.gemspec" }
 
   let(:sub_path) { "../../../vendor/jface/*.jar" }

--- a/spec/java_integration/paths/uri_classloader_spec.rb
+++ b/spec/java_integration/paths/uri_classloader_spec.rb
@@ -7,7 +7,7 @@ describe "uri:classloader path strings" do
 
   let(:sub_path) { "../../../vendor/jface/*.jar" }
   let(:base_path) { "uri:classloader:/gems/swt-4.6.1/lib/swt/full.rb" }
-  let(:resolved_path) { "uri:classloader://gems/swt-4.6.1/vendor/jface/*.jar" }
+  let(:resolved_path) { "uri:classloader:/gems/swt-4.6.1/vendor/jface/*.jar" }
   let(:resolved_path_win) { "uri:classloader:/gems/swt-4.6.1/vendor/jface/*.jar" }
   let(:windows) { RbConfig::CONFIG['host_os'] =~ /Windows|mswin/ }
 

--- a/test/jruby/test_file.rb
+++ b/test/jruby/test_file.rb
@@ -341,13 +341,9 @@ class TestFile < Test::Unit::TestCase
     def test_expand_path_with_uri_classloader_prefix
       assert_equal "uri:classloader:/foo/bar", File.expand_path("uri:classloader:/foo/bar")
       assert_equal "uri:classloader:/bar", File.expand_path("uri:classloader:/foo/../bar")
-      # uri:classloader:// and uri:classloader:/ are treated as equivalent as
-      # there is an internal normalization going on path which replace all // with /
-      assert_equal "uri:classloader://foo/bar/baz", File.expand_path("baz", "uri:classloader:/foo/bar")
+      assert_equal "uri:classloader:/foo/bar/baz", File.expand_path("baz", "uri:classloader:/foo/bar")
       assert_equal "uri:classloader:/foo/bar", File.expand_path("uri:classloader:/foo/bar", "uri:classloader:/baz/quux")
-      # uri:classloader:// and uri:classloader:/ are treated as equivalent as
-      # there is an internal normalization going on path which replace all // with /
-      assert_equal "uri:classloader://foo/bar", File.expand_path("../../foo/bar", "uri:classloader:/baz/quux")
+      assert_equal "uri:classloader:/foo/bar", File.expand_path("../../foo/bar", "uri:classloader:/baz/quux")
       assert_equal "uri:classloader:/foo/bar", File.expand_path("../../../foo/bar", "uri:classloader:/baz/quux")
     end if IS_JRUBY
 
@@ -367,8 +363,8 @@ class TestFile < Test::Unit::TestCase
     # GH-3176
     def test_expand_path_with_relative_reference_and_inside_uri_classloader
       Dir.chdir( 'uri:classloader:/') do
-        assert_equal 'uri:classloader://something/foo', File.expand_path('foo', 'something')
-        assert_equal 'uri:classloader://foo', File.expand_path('foo', '.')
+        assert_equal 'uri:classloader:/something/foo', File.expand_path('foo', 'something')
+        assert_equal 'uri:classloader:/foo', File.expand_path('foo', '.')
       end
     end if IS_JRUBY
 

--- a/test/jruby/test_pathname.rb
+++ b/test/jruby/test_pathname.rb
@@ -68,7 +68,7 @@ class TestPathname < Test::Unit::TestCase
 
   # GH-3150
   def test_expand_path_with_pathname_and_uri_path
-    assert_equal 'uri:classloader://foo', File.expand_path('foo', Pathname.new('uri:classloader:/'))
+    assert_equal 'uri:classloader:/foo', File.expand_path('foo', Pathname.new('uri:classloader:/'))
   end if defined?(JRUBY_VERSION)
 
 end

--- a/test/jruby/test_uri_classloader.rb
+++ b/test/jruby/test_uri_classloader.rb
@@ -84,4 +84,12 @@ class TestURIClassloader < Test::Unit::TestCase
       assert_equal cwd, `pwd`.chomp
     end
   end
+
+  # GH-6045: don't double up slashes when canonicalizing a URI path
+  def test_uri_expand_path_does_not_double_slash
+    assert_equal "uri:classloader:/foo/bar", File.expand_path("uri:classloader://foo/bar")
+    assert_equal "uri:classloader:/foo/bar", File.expand_path("uri:classloader:/foo/bar");
+    assert_equal "uri:classloader:/foo/bar", File.expand_path("foo/bar", "uri:classloader://")
+    assert_equal "uri:classloader:/foo/bar", File.expand_path("foo/bar", "uri:classloader:/")
+  end
 end


### PR DESCRIPTION
Fixes #6045