### PR TITLE
Try to make the package module more "real"

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/JavaPackage.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaPackage.java
@@ -59,11 +59,8 @@ import static org.jruby.runtime.Visibility.PRIVATE;
 public class JavaPackage extends RubyModule {
 
     static RubyModule createJavaPackageClass(final Ruby runtime, final RubyModule Java) {
-        RubyClass superClass = new BlankSlateWrapper(runtime, runtime.getModule(), runtime.getKernel());
-        RubyClass JavaPackage = RubyClass.newClass(runtime, superClass);
-        JavaPackage.setMetaClass(runtime.getModule());
+        RubyClass JavaPackage = RubyClass.newClass(runtime, runtime.getModule());
         JavaPackage.setAllocator(ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR);
-        ((MetaClass) JavaPackage.makeMetaClass(superClass)).setAttached(JavaPackage);
 
         JavaPackage.setBaseName("JavaPackage");
 


### PR DESCRIPTION
Our package modules are weirdly structured to try to have as blank
a method table as possible, but this ends up producing objects
that look like classes or modules but do not behave as such. This
commit removes some of the sneakier bits of this structure and
makes Java package modules simply extend Module, so they do not
trip up reflective tools like Sorbet as reported in #6242.

This change may need further refinement to ensure that valid
package names shadowed by Module methods can still be accessed.