### PR TITLE
Encoding experiments with file path negotiation

### DIFF
--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -171,7 +171,7 @@ public class RubyDir extends RubyObject implements Closeable {
 
         this.encoding = encoding;
 
-        String adjustedPath = RubyFile.adjustRootPathOnWindows(runtime, newPath.toString(), null);
+        String adjustedPath = RubyFile.getAdjustedPath(context, newPath);
         checkDirIsTwoSlashesOnWindows(getRuntime(), adjustedPath);
 
         this.dir = JRubyFile.createResource(context, adjustedPath);
@@ -352,7 +352,7 @@ public class RubyDir extends RubyObject implements Closeable {
 
         RubyString path = StringSupport.checkEmbeddedNulls(runtime, RubyFile.get_path(context, arg));
 
-        return entriesCommon(context, path.asJavaString(), runtime.getDefaultEncoding(), false);
+        return entriesCommon(context, path, runtime.getDefaultEncoding(), false);
     }
 
     @JRubyMethod(name = "entries", meta = true)
@@ -370,15 +370,16 @@ public class RubyDir extends RubyObject implements Closeable {
         }
         if (encoding == null) encoding = runtime.getDefaultEncoding();
 
-        return entriesCommon(context, path.asJavaString(), encoding, false);
+        return entriesCommon(context, path, encoding, false);
     }
 
-    private static RubyArray entriesCommon(ThreadContext context, String path, Encoding encoding, final boolean childrenOnly) {
+    private static RubyArray entriesCommon(ThreadContext context, IRubyObject path, Encoding encoding, final boolean childrenOnly) {
         Ruby runtime = context.runtime;
-        String adjustedPath = RubyFile.adjustRootPathOnWindows(runtime, path, null);
+
+        String adjustedPath = RubyFile.getAdjustedPath(context, path);
         checkDirIsTwoSlashesOnWindows(runtime, adjustedPath);
 
-        FileResource directory = JRubyFile.createResource(context, path);
+        FileResource directory = JRubyFile.createResource(context, adjustedPath);
         String[] files = getEntries(context, directory, adjustedPath);
 
         RubyArray result = RubyArray.newArray(runtime, files.length);
@@ -462,7 +463,7 @@ public class RubyDir extends RubyObject implements Closeable {
      */
     @JRubyMethod(name = "children")
     public IRubyObject children(ThreadContext context) {
-        return entriesCommon(context, path.asJavaString(), encoding, true);
+        return entriesCommon(context, path, encoding, true);
     }
     
     @JRubyMethod(name = "children", meta = true)
@@ -481,7 +482,7 @@ public class RubyDir extends RubyObject implements Closeable {
         }
         if (encoding == null) encoding = context.runtime.getDefaultEncoding();
 
-        return entriesCommon(context, RubyFile.get_path(context, arg).asJavaString(), encoding, true);
+        return entriesCommon(context, arg, encoding, true);
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyEncoding.java
+++ b/core/src/main/java/org/jruby/RubyEncoding.java
@@ -292,6 +292,17 @@ public class RubyEncoding extends RubyObject implements Constantizable {
         return bytes;
     }
 
+    /**
+     * Decode the range of bytes specified as UTF-8 content.
+     *
+     * This will attempt to use a zero-allocation decoder if the content length is shorter than {@link #CHAR_THRESHOLD}
+     * bytes, and otherwise will used cached decoders to avoid reallocating Charset-related objects.
+     *
+     * @param bytes the byte array
+     * @param start start of content
+     * @param length length of content
+     * @return a decoded String based on UTF-8 bytes
+     */
     public static String decodeUTF8(byte[] bytes, int start, int length) {
         if (length > CHAR_THRESHOLD) {
             return UTF8.decode(ByteBuffer.wrap(bytes, start, length)).toString();
@@ -299,18 +310,37 @@ public class RubyEncoding extends RubyObject implements Constantizable {
         return getUTF8Coder().decode(bytes, start, length).toString();
     }
 
-    public static String decodeISO(byte[] bytes, int start, int length) {
+    /**
+     * Decode the range of bytes specified as "raw" binary content, as in ISO-8859-1 or ASCII-8BIT encodings.
+     *
+     * This will attempt to use a zero-allocation decoder if the content length is shorter than {@link #CHAR_THRESHOLD}
+     * bytes, and otherwise will used cached decoders to avoid reallocating Charset-related objects.
+     *
+     * @param bytes the byte array
+     * @param start start of content
+     * @param length length of content
+     * @return a decoded String based on raw bytes
+     */
+    public static String decodeRaw(byte[] bytes, int start, int length) {
         if (length > CHAR_THRESHOLD) {
-            return new String(decodeISOLoop(bytes, start, length));
+            return new String(decodeRawLoop(bytes, start, length));
         }
-        return getISOCoder().decode(bytes, start, length);
+        return getRawCoder().decode(bytes, start, length);
     }
 
-    public static String decodeISO(ByteList byteList) {
-        return decodeISO(byteList.unsafeBytes(), byteList.begin(), byteList.realSize());
+    /**
+     * Decode the specified bytelist as "raw" binary content.
+     *
+     * This is the same as calling {@link #decodeRaw(byte[], int, int)} with the contents of byteList.
+     *
+     * @param byteList
+     * @return a decoded string based on raw bytes
+     */
+    public static String decodeRaw(ByteList byteList) {
+        return decodeRaw(byteList.unsafeBytes(), byteList.begin(), byteList.realSize());
     }
 
-    private static char[] decodeISOLoop(byte[] s, int start, int length) {
+    private static char[] decodeRawLoop(byte[] s, int start, int length) {
         char[] chars = new char[length];
         for (int i = 0; i < length; i++) {
             chars[i] = (char) (s[i + start] & 0xFF);
@@ -333,6 +363,9 @@ public class RubyEncoding extends RubyObject implements Constantizable {
     /** The maximum number of characters we can encode/decode in our cached buffers */
     private static final int CHAR_THRESHOLD = 1024;
 
+    /**
+     * A cached decoder for UTF-8 bytes.
+     */
     private static class UTF8Coder {
         private final CharsetEncoder encoder = UTF8.newEncoder();
         private final CharsetDecoder decoder = UTF8.newDecoder();
@@ -390,7 +423,10 @@ public class RubyEncoding extends RubyObject implements Constantizable {
 
     }
 
-    private static class ISOCoder {
+    /**
+     * A cached decoder object to decode bytes as raw binary (ISO-8859-1 or ASCII-8BIT) content.
+     */
+    private static class RawCoder {
         private final char[] charBuffer = new char[CHAR_THRESHOLD];
 
         public final String decode(byte[] bytes, int start, int length) {
@@ -404,11 +440,16 @@ public class RubyEncoding extends RubyObject implements Constantizable {
     }
 
     /**
-     * UTF8Coder wrapped in a SoftReference to avoid possible ClassLoader leak.
+     * Thread-local UTF8Coder wrapped in a SoftReference to avoid possible ClassLoader leak.
      * See JRUBY-6522
      */
     private static final ThreadLocal<SoftReference<UTF8Coder>> UTF8_CODER = new ThreadLocal<>();
-    private static final ThreadLocal<SoftReference<ISOCoder>> ISO_CODER = new ThreadLocal<>();
+
+    /**
+     * Thread-local RawCoder wrapped in a SoftReference to avoid possible ClassLoader leak.
+     * See JRUBY-6522
+     */
+    private static final ThreadLocal<SoftReference<RawCoder>> RAW_CODER = new ThreadLocal<>();
 
     private static UTF8Coder getUTF8Coder() {
         UTF8Coder coder;
@@ -421,12 +462,12 @@ public class RubyEncoding extends RubyObject implements Constantizable {
         return coder;
     }
 
-    private static ISOCoder getISOCoder() {
-        ISOCoder coder;
-        SoftReference<ISOCoder> ref = ISO_CODER.get();
+    private static RawCoder getRawCoder() {
+        RawCoder coder;
+        SoftReference<RawCoder> ref = RAW_CODER.get();
         if (ref == null || (coder = ref.get()) == null) {
-            coder = new ISOCoder();
-            ISO_CODER.set(new SoftReference<>(coder));
+            coder = new RawCoder();
+            RAW_CODER.set(new SoftReference<>(coder));
         }
 
         return coder;
@@ -620,5 +661,21 @@ public class RubyEncoding extends RubyObject implements Constantizable {
         if (context.runtime.isVerbose()) context.runtime.getWarnings().warning("setting Encoding.default_internal");
         EncodingUtils.rbEncSetDefaultInternal(context, encoding);
         return encoding;
+    }
+
+    /**
+     * @deprecated use {@link #decodeRaw(byte[], int, int)}
+     */
+    @Deprecated
+    public static String decodeISO(byte[] bytes, int start, int length) {
+        return decodeRaw(bytes, start, length);
+    }
+
+    /**
+     * @deprecated use {@link #decodeRaw(ByteList)}
+     */
+    @Deprecated
+    public static String decodeISO(ByteList byteList) {
+        return decodeRaw(byteList);
     }
 }

--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -1739,8 +1739,8 @@ public class RubyFile extends RubyIO implements EncodingCapable {
                 (wd != null && wd.getByteList().getEncoding() == ASCIIEncoding.INSTANCE)) {
             // use raw bytes if either are encoded as "binary"
             useISO = true;
-            relativePath = RubyEncoding.decodeISO(pathByteList);
-            cwd = wd == null ? null : RubyEncoding.decodeISO(wdByteList);
+            relativePath = RubyEncoding.decodeRaw(pathByteList);
+            cwd = wd == null ? null : RubyEncoding.decodeRaw(wdByteList);
         } else {
             // use characters assuming the string is properly encoded
             relativePath = path.toString();

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -64,7 +64,6 @@ import org.jruby.runtime.encoding.MarshalEncoding;
 import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.runtime.opto.OptoFactory;
 import org.jruby.util.ByteList;
-import org.jruby.util.ByteListHelper;
 import org.jruby.util.IdUtil;
 import org.jruby.util.PerlHash;
 import org.jruby.util.SipHashInline;
@@ -181,7 +180,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
     public final String toString() {
         String decoded = decodedString;
         if (decoded == null) {
-            decodedString = decoded = RubyEncoding.decodeISO(symbolBytes);
+            decodedString = decoded = RubyEncoding.decodeRaw(symbolBytes);
         }
         return decoded;
     }
@@ -1014,7 +1013,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
             if (symbol == null) {
                 bytes = bytes.dup();
                 symbol = createSymbol(
-                        RubyEncoding.decodeISO(bytes),
+                        RubyEncoding.decodeRaw(bytes),
                         bytes,
                         hash,
                         hard);

--- a/core/src/main/java/org/jruby/ir/targets/indy/IndyValueCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/IndyValueCompiler.java
@@ -63,31 +63,31 @@ public class IndyValueCompiler implements ValueCompiler {
 
     public void pushString(ByteList bl, int cr) {
         compiler.loadContext();
-        compiler.adapter.invokedynamic("string", sig(RubyString.class, ThreadContext.class), Bootstrap.string(), RubyEncoding.decodeISO(bl), bl.getEncoding().toString(), cr);
+        compiler.adapter.invokedynamic("string", sig(RubyString.class, ThreadContext.class), Bootstrap.string(), RubyEncoding.decodeRaw(bl), bl.getEncoding().toString(), cr);
     }
 
     public void pushFrozenString(ByteList bl, int cr, String file, int line) {
         compiler.loadContext();
-        compiler.adapter.invokedynamic("frozen", sig(RubyString.class, ThreadContext.class), Bootstrap.fstring(), RubyEncoding.decodeISO(bl), bl.getEncoding().toString(), cr, file, line);
+        compiler.adapter.invokedynamic("frozen", sig(RubyString.class, ThreadContext.class), Bootstrap.fstring(), RubyEncoding.decodeRaw(bl), bl.getEncoding().toString(), cr, file, line);
     }
 
     public void pushByteList(ByteList bl) {
-        compiler.adapter.invokedynamic("bytelist", sig(ByteList.class), Bootstrap.bytelist(), RubyEncoding.decodeISO(bl), bl.getEncoding().toString());
+        compiler.adapter.invokedynamic("bytelist", sig(ByteList.class), Bootstrap.bytelist(), RubyEncoding.decodeRaw(bl), bl.getEncoding().toString());
     }
 
     public void pushRegexp(ByteList source, int options) {
         compiler.loadContext();
-        compiler.adapter.invokedynamic("regexp", sig(RubyRegexp.class, ThreadContext.class), RegexpObjectSite.BOOTSTRAP, RubyEncoding.decodeISO(source), source.getEncoding().toString(), options);
+        compiler.adapter.invokedynamic("regexp", sig(RubyRegexp.class, ThreadContext.class), RegexpObjectSite.BOOTSTRAP, RubyEncoding.decodeRaw(source), source.getEncoding().toString(), options);
     }
 
     public void pushSymbol(final ByteList bytes) {
         compiler.loadContext();
-        compiler.adapter.invokedynamic("symbol", sig(JVM.OBJECT, ThreadContext.class), SymbolObjectSite.BOOTSTRAP, RubyEncoding.decodeISO(bytes), bytes.getEncoding().toString());
+        compiler.adapter.invokedynamic("symbol", sig(JVM.OBJECT, ThreadContext.class), SymbolObjectSite.BOOTSTRAP, RubyEncoding.decodeRaw(bytes), bytes.getEncoding().toString());
     }
 
     public void pushSymbolProc(final ByteList bytes) {
         compiler.loadContext();
-        compiler.adapter.invokedynamic("symbolProc", sig(JVM.OBJECT, ThreadContext.class), SymbolProcObjectSite.BOOTSTRAP, RubyEncoding.decodeISO(bytes), bytes.getEncoding().toString());
+        compiler.adapter.invokedynamic("symbolProc", sig(JVM.OBJECT, ThreadContext.class), SymbolProcObjectSite.BOOTSTRAP, RubyEncoding.decodeRaw(bytes), bytes.getEncoding().toString());
     }
 
     public void pushEncoding(Encoding encoding) {

--- a/core/src/main/java/org/jruby/util/TypeConverter.java
+++ b/core/src/main/java/org/jruby/util/TypeConverter.java
@@ -44,7 +44,6 @@ import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ClassIndex;
-import org.jruby.RubyNil;
 import org.jruby.runtime.JavaSites;
 import org.jruby.runtime.JavaSites.TypeConverterSites;
 import org.jruby.runtime.ThreadContext;
@@ -533,7 +532,7 @@ public class TypeConverter {
         // grab it's string representation without calling a method which properly encodes
         // the string.
         if (obj instanceof RubyString) {
-            return RubyEncoding.decodeISO(((RubyString) obj).getByteList()).intern();
+            return RubyEncoding.decodeRaw(((RubyString) obj).getByteList()).intern();
         }
         return obj.asJavaString().intern();
     }


### PR DESCRIPTION
This PR holds some experiments in making file path negotiation (expand_path, fnmatch) work properly with strings that are encoded as "binary" or "ASCII-8BIT".

In these cases it appears we should largely ignore the encoding of the characters and treat it as raw bytes, since it's not possible for us to guess the encoding. However some of the logic in these methods uses Java strings, and therefore needs to be decoded into UTF-16 characters. We will need to balance the binary cases with the properly-encoded cases as best we can, or otherwise rewrite this logic altogether to use only the raw byte form.