### PR TITLE
Expose Java's built-in monitor synchronization as a JRuby API

### DIFF
--- a/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
@@ -39,6 +39,7 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.javasupport.Java;
+import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.load.BasicLibraryService;
@@ -246,6 +247,106 @@ public class JRubyUtilLibrary implements Library {
             final RaiseException ex = runtime.newNameError("cannot load (ext) (" + className + ")", (String) null, e, true);
             ex.initCause(e); throw ex;
         }
+    }
+
+    /**
+     * Invoke the given block under synchronized lock, using standard Java synchronization.
+     *
+     * @param context the current context
+     * @param recv the JRuby module
+     * @param arg the object against which to synchronize
+     * @param block the block to execute
+     * @return the return value of the block
+     */
+    @JRubyMethod(name = "synchronized", module = true)
+    public static IRubyObject rbSynchronized(ThreadContext context, IRubyObject recv, IRubyObject arg, Block block) {
+        synchronized (arg) {
+            return block.call(context);
+        }
+    }
+
+    /**
+     * Wait for a locked object to notify, as in Object {@link #wait()}.
+     *
+     * @param context the current context
+     * @param recv the JRuby module
+     * @param arg the object to wait for
+     * @return the object given
+     * @throws InterruptedException if interrupted
+     */
+    @JRubyMethod(module = true)
+    public static IRubyObject wait(ThreadContext context, IRubyObject recv, IRubyObject arg) throws InterruptedException {
+        arg.wait();
+        return arg;
+    }
+
+    /**
+     * Wait for a locked object to notify, as in Object {@link #wait(long)}.
+     *
+     * The object given must be locked using JRuby.synchronized or a similar Java monitor-based locking mechanism.
+     *
+     * @param context the current context
+     * @param recv the JRuby module
+     * @param arg the object to wait for
+     * @param timeoutMillis the time in millis to wait (converted using #to_int)
+     * @return the object given
+     * @throws InterruptedException if interrupted
+     */
+    @JRubyMethod(module = true)
+    public static IRubyObject wait(ThreadContext context, IRubyObject recv, IRubyObject arg, IRubyObject timeoutMillis) throws InterruptedException {
+        arg.wait(timeoutMillis.convertToInteger().getLongValue());
+        return arg;
+    }
+
+    /**
+     * Wait for a locked object to notify, as in Object {@link #wait(long, int)}.
+     *
+     * The object given must be locked using JRuby.synchronized or a similar Java monitor-based locking mechanism.
+     *
+     * @param context the current context
+     * @param recv the JRuby module
+     * @param arg the object to wait for
+     * @param timeoutMillis the time in millis to wait (converted using #to_int)
+     * @param timeoutNanos the time in nanos to wait (converted using #to_int, and truncated to a signed 32-bit integer)
+     * @return the object given
+     * @throws InterruptedException if interrupted
+     */
+    @JRubyMethod(module = true)
+    public static IRubyObject wait(ThreadContext context, IRubyObject recv, IRubyObject arg, IRubyObject timeoutMillis, IRubyObject timeoutNanos) throws InterruptedException {
+        arg.wait(timeoutMillis.convertToInteger().getLongValue(), timeoutNanos.convertToInteger().getIntValue());
+        return arg;
+    }
+
+    /**
+     * Notify one waiter on a locked object, as in Object {@link #notify()}
+     *
+     * The object given must be locked using JRuby.synchronized or a similar Java monitor-based locking mechanism.
+     *
+     * @param context the current context
+     * @param recv the JRuby module
+     * @param arg the object to notify
+     * @return the object given
+     */
+    @JRubyMethod(module = true)
+    public static IRubyObject notify(ThreadContext context, IRubyObject recv, IRubyObject arg) {
+        arg.notify();
+        return arg;
+    }
+
+    /**
+     * Notify all waiters on a locked object, as in Object {@link #notifyAll()}
+     *
+     * The object given must be locked using JRuby.synchronized or a similar Java monitor-based locking mechanism.
+     *
+     * @param context the current context
+     * @param recv the JRuby module
+     * @param arg the object to notify
+     * @return the object given
+     */
+    @JRubyMethod(name = "notify_all", module = true)
+    public static IRubyObject notifyAll(ThreadContext context, IRubyObject recv, IRubyObject arg) {
+        arg.notifyAll();
+        return arg;
     }
 
     @Deprecated // since 9.2 only loaded with require 'core_ext/string.rb'

--- a/spec/java_integration/utilities/jruby_util_spec.rb
+++ b/spec/java_integration/utilities/jruby_util_spec.rb
@@ -1,0 +1,97 @@
+require File.dirname(__FILE__) + "/../spec_helper"
+require 'jruby/util'
+
+describe "JRuby::Util.synchronized" do
+  it "locks the Java object monitor for the given object while the block is active" do
+    o = Object.new
+    expect(java.lang.Thread.holds_lock(o)).to eq(false)
+    JRuby::Util.synchronized(o) do
+      expect(java.lang.Thread.holds_lock(o)).to eq(true)
+    end
+    expect(java.lang.Thread.holds_lock(o)).to eq(false)
+  end
+end
+
+describe "JRuby::Util.wait" do
+  it "raises IllegalMonitorStateException if the object's monitor is not held" do
+    o = Object.new
+    expect { JRuby::Util.wait(o) }.to raise_error(java.lang.IllegalMonitorStateException)
+  end
+
+  it "yields the lock when called against a locked object" do
+    result = []
+    o = Object.new
+    t = nil
+    JRuby::Util.synchronized(o) do
+      result << :outer_before
+      Thread.new do
+        JRuby::Util.synchronized(o) do
+          result << :inner_before
+          JRuby::Util.notify(o)
+          result << :inner_after
+        end
+      end
+      result << :outer_before_wait
+      JRuby::Util.wait(o)
+      result << :outer_after_wait
+    end
+
+    expect(result).to eq([:outer_before, :outer_before_wait, :inner_before, :inner_after, :outer_after_wait])
+  end
+
+  it "waits the specified time millis and then reacquires the lock" do
+    o = Object.new
+    JRuby::Util.synchronized(o) do
+      t = Time.now
+      JRuby::Util.wait(o, 500)
+      expect(Time.now - t).to satisfy {|n| n >= 0.5}
+    end
+  end
+
+  it "waits the specified time millis and nanos and then reacquires the lock" do
+    o = Object.new
+    JRuby::Util.synchronized(o) do
+      t = Time.now
+      100.times { JRuby::Util.wait(o, 0, 999_999) }
+      expect(Time.now - t).to satisfy {|n| n >= 0.1}
+    end
+  end
+end
+
+describe "JRuby::Util.notify_all" do
+  it "raises IllegalMonitorStateException if the object's monitor is not held" do
+    o = Object.new
+    expect {JRuby::Util.notify_all(o) }.to raise_error(java.lang.IllegalMonitorStateException)
+  end
+
+  it "notifies all waiters" do
+    result = []
+    o = Object.new
+    threads = nil
+    JRuby::Util.synchronized(o) do
+      threads = 2.times.map {|i|
+        Thread.new do
+          JRuby::Util.synchronized(o) do
+            result << :waiting
+            JRuby::Util.wait(o)
+            result << :woke
+          end
+        end
+      }
+    end
+    Thread.pass until result == [:waiting, :waiting]
+    JRuby::Util.synchronized(o) do
+      JRuby::Util.notify_all(o)
+    end
+    threads.each(&:join)
+    expect(result).to eq([:waiting, :waiting, :woke, :woke])
+  end
+end
+
+# Other functionality tested above in wait examples
+describe "JRuby::Util.notify" do
+  it "raises IllegalMonitorStateException if the object's monitor is not held" do
+    o = Object.new
+    expect {JRuby::Util.notify(o) }.to raise_error(java.lang.IllegalMonitorStateException)
+  end
+end


### PR DESCRIPTION
I'm not sure why we've never done this before, but since there's
really no way to synchronize against an object's Java monitor from
Ruby this API seems like a gap in JRuby. Here I've added the
following JRuby utility functions:

* JRuby.synchronized(arg) {} which works like Java's synchronized
  statement
* JRuby.wait(arg [, millis [, nanos]]) like Object.wait
* JRuby.notify(arg) and notifyAll(arg) like Object.notify[All]

This question came up in the JRuby chat, and it seems like a
useful and appropriate addition to the JRuby module.