### PR TITLE
Avoid using URL.openStream due to JDK cache

### DIFF
--- a/core/src/main/java/org/jruby/embed/internal/EmbedRubyRuntimeAdapterImpl.java
+++ b/core/src/main/java/org/jruby/embed/internal/EmbedRubyRuntimeAdapterImpl.java
@@ -37,6 +37,7 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.net.URL;
+import java.net.URLConnection;
 
 import org.jruby.Ruby;
 import org.jruby.RubyInstanceConfig.CompileMode;
@@ -130,7 +131,9 @@ public class EmbedRubyRuntimeAdapterImpl implements EmbedRubyRuntimeAdapter {
                     if (loc != null) {
                         filename = LoadService.classpathFilenameFromURL(filename, loc, true);
                         try {
-                            istream = loc.openStream();
+                            URLConnection connection = loc.openConnection();
+                            connection.setUseCaches(false);
+                            istream = connection.getInputStream();
                         } catch (IOException ioe) {
                             istream = null; // as in getClassLoader.getResourceAsStream
                         }

--- a/core/src/main/java/org/jruby/embed/jsr223/ServiceFinder.java
+++ b/core/src/main/java/org/jruby/embed/jsr223/ServiceFinder.java
@@ -33,6 +33,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -73,8 +74,10 @@ class ServiceFinder<T> {
             URL url = null;
             try {
                 url = urls.nextElement();
+                URLConnection connection = url.openConnection();
+                connection.setUseCaches(false);
                 BufferedReader reader =
-                        new BufferedReader(new InputStreamReader(url.openStream(), encoding));
+                        new BufferedReader(new InputStreamReader(connection.getInputStream(), encoding));
                 String line;
                 while ((line = reader.readLine()) != null) {
                     if ((line = deleteComments(line)) != null) {

--- a/core/src/main/java/org/jruby/embed/osgi/OSGiScriptingContainer.java
+++ b/core/src/main/java/org/jruby/embed/osgi/OSGiScriptingContainer.java
@@ -32,6 +32,7 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.net.URLConnection;
 
 import org.jruby.embed.EmbedEvalUnit;
 import org.jruby.embed.EvalFailedException;
@@ -120,7 +121,9 @@ public class OSGiScriptingContainer extends ScriptingContainer {
         addToClassPath(bundle);
         InputStream istream = null;
         try {
-            istream = new BufferedInputStream(url.openStream());
+            URLConnection connection = url.openConnection();
+            connection.setUseCaches(false);
+            istream = new BufferedInputStream(connection.getInputStream());
             return this.runScriptlet(istream, getFilename(bundle, path));
         } catch (IOException ioe) {
             throw new EvalFailedException(ioe);
@@ -143,8 +146,9 @@ public class OSGiScriptingContainer extends ScriptingContainer {
     public EmbedEvalUnit parse(Bundle bundle, String path, int... lines) throws IOException {
         URL url = bundle.getEntry(path);
         InputStream istream = null;
-        try {
-            istream = new BufferedInputStream(url.openStream());
+        try {URLConnection connection = url.openConnection();
+            connection.setUseCaches(false);
+            istream = new BufferedInputStream(connection.getInputStream());
             return super.parse(istream, getFilename(bundle, path));
         } catch (IOException ioe) {
             throw new EvalFailedException(ioe);

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaNet.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaNet.java
@@ -39,6 +39,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URLConnection;
 
 import static org.jruby.javasupport.JavaUtil.unwrapIfJavaObject;
 import static org.jruby.runtime.Visibility.PUBLIC;
@@ -67,7 +68,9 @@ public abstract class JavaNet {
             java.net.URL url = unwrapIfJavaObject(self);
             final InputStream stream; final RubyIO io;
             try {
-                stream = url.openStream();
+                URLConnection connection = url.openConnection();
+                connection.setUseCaches(false);
+                stream = connection.getInputStream();
                 io = JavaIo.to_io(context, stream, null);
 
                 if ( block.isGiven() ) {

--- a/core/src/main/java/org/jruby/runtime/load/LoadService.java
+++ b/core/src/main/java/org/jruby/runtime/load/LoadService.java
@@ -41,6 +41,7 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLConnection;
 import java.security.AccessControlException;
 import java.util.HashMap;
 import java.util.List;

--- a/core/src/main/java/org/jruby/runtime/load/LoadServiceResource.java
+++ b/core/src/main/java/org/jruby/runtime/load/LoadServiceResource.java
@@ -38,6 +38,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 
@@ -82,11 +83,10 @@ public class LoadServiceResource {
 
     public InputStream getInputStream() throws IOException {
         if (resource != null) {
-            InputStream is = resource.openStream();
-            try {
+            URLConnection connection = resource.openConnection();
+            connection.setUseCaches(false);
+            try (InputStream is = connection.getInputStream()){
                 return new LoadServiceResourceInputStream(is);
-            } finally {
-                is.close();
             }
         }
         byte[] bytes = new byte[(int)path.length()];

--- a/core/src/main/java/org/jruby/util/JRubyClassLoader.java
+++ b/core/src/main/java/org/jruby/util/JRubyClassLoader.java
@@ -37,6 +37,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -84,8 +85,11 @@ public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
             try {
                 File f = File.createTempFile("jruby", new File(url.getFile()).getName(), getTempDir());
 
+                URLConnection connection = url.openConnection();
+                connection.setUseCaches(false);
+
                 try (FileOutputStream fileOut = new FileOutputStream(f);
-                     InputStream urlIn = url.openStream()) {
+                     InputStream urlIn = connection.getInputStream()) {
 
                     OutputStream out = new BufferedOutputStream(fileOut);
                     InputStream in = new BufferedInputStream(urlIn);

--- a/core/src/test/java/org/jruby/javasupport/test/RubyTestCase.java
+++ b/core/src/test/java/org/jruby/javasupport/test/RubyTestCase.java
@@ -34,6 +34,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.net.URLConnection;
 
 import junit.framework.TestCase;
 
@@ -55,7 +56,9 @@ public class RubyTestCase extends TestCase {
         if (url == null) {
             throw new NullPointerException("url was null");
         }
-        InputStream in = url.openStream();
+        URLConnection connection = url.openConnection();
+        connection.setUseCaches(false);
+        InputStream in = connection.getInputStream();
         NormalizedFile f = (NormalizedFile)NormalizedFile.createTempFile("rtc", ".rb");
         FileOutputStream out = new FileOutputStream(f);
 


### PR DESCRIPTION
The caching done by OpenJDK's jar connection logic appears to be
sensitive to heavy concurrent use. When requesting that a URL open
a stream on itself, the default behavior is for it to use an
internal cache of previously opened jar files. A map from the URL
to the JarFile is maintained, where JarFile eventually bottoms out
in an open ZipFile.

Unfortunately URLClassLoader uses the same cache to reuse open jar
files, while also adding those files to its list of closables.
When the URLClassLoader itself is closed, all closables are
closed, which may end up closing a cached JarFile.

So if different URLClassLoader instances are used to access the
same jar files, it is likely that a shared JarFile instance will
be used and eventually closed, triggering errors.

This commit alters our use of URL.openStream to always instead
open a URLConnection and then disable caching before proceeding to
actually open the stream. This avoids the use of cached jar files,
ensuring we don't hit this bug.

A similar change will likely also need to be done for all places
where we do ClassLoader.getResourceAsStream, since if the
classloader is a URLClassLoader it will backend on this same cache
and once again eat the poison pill.

Part of, and possibly sufficient for, issue #6218.