### PR TITLE
Only close temporary jars to avoid poisoning global jar file cache

### DIFF
--- a/core/src/main/java/org/jruby/util/JRubyClassLoader.java
+++ b/core/src/main/java/org/jruby/util/JRubyClassLoader.java
@@ -36,11 +36,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
+import java.net.JarURLConnection;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.jar.JarFile;
 
+import org.jruby.util.cli.Options;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
 
@@ -68,7 +74,7 @@ public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
 
     private static volatile File tempDir;
 
-    private final List<String> cachedJarPaths = Collections.synchronizedList(new ArrayList<String>());
+    private final Map<String, URL> cachedJarPaths = new ConcurrentHashMap<>();
 
     public JRubyClassLoader(ClassLoader parent) {
         super(parent);
@@ -98,13 +104,13 @@ public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
                     out.flush();
                     url = f.toURI().toURL();
 
-                    cachedJarPaths.add(URLUtil.getPath(url));
+                    cachedJarPaths.put(URLUtil.getPath(url), url);
                 }
             } catch (IOException e) {
                 throw new RuntimeException("BUG: we can not copy embedded jar to temp directory", e);
             }
         }
-        super.addURL( url );
+        super.addURL(url);
     }
 
     private static synchronized File getTempDir() {
@@ -159,21 +165,20 @@ public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
     }
 
     /**
-     * @deprecated use {@link #close()} instead
-     */
-    public void tearDown(boolean debug) {
-        close();
-    }
-
-    /**
      * Called when the parent runtime is torn down.
      */
     @Override
     public void close() {
-        try {
-            super.close();
+        if (Options.JI_CLOSE_CLASSLOADER.load()) {
+            // We no longer unconditionally close the classloader due to JDK issues with the open jar files it may be
+            // holding references to.
+            // See jruby/jruby#6218 and https://bugs.openjdk.java.net/browse/JDK-8246714
+            try {
+                super.close();
+            } catch (Exception ex) {
+                LOG.debug(ex);
+            }
         }
-        catch (Exception ex) { LOG.debug(ex); }
 
         try {
             // A hack to allow unloading all JDBC Drivers loaded by this classloader.
@@ -186,18 +191,31 @@ public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
     }
 
     protected void terminateJarIndexCacheEntries() {
-        for (String jarPath : cachedJarPaths){
+        cachedJarPaths.forEach((path, url) -> {
+            // close the jar file associated with the connection, since this might be cached by JDK
             try {
+                URLConnection connection = url.openConnection();
+
+                if (connection instanceof JarURLConnection) {
+                    JarFile jarFile = ((JarURLConnection) connection).getJarFile();
+
+                    try {
+                        jarFile.close();
+                    } catch (IOException ioe) {
+                        // ignore and proceed to delete the file
+                    }
+                }
+
                 // Remove reference from jar cache
-                JarResource.removeJarResource(jarPath);
+                JarResource.removeJarResource(path);
 
                 // Delete temp jar on disk
-                File jarFile = new File(jarPath);
+                File jarFile = new File(path);
                 jarFile.delete();
             } catch (Exception e) {
                 // keep trying to clean up other temp jars
             }
-        }
+        });
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -219,6 +219,7 @@ public class Options {
     public static final Option<Boolean> JI_AMBIGUOUS_CALLS_DEBUG = bool(JAVA_INTEGRATION, "ji.ambiguous.calls.debug", false, "Toggle verbose reporting of all ambiguous calls to Java objects");
     public static final Option<Boolean> AOT_LOADCLASSES = bool(JAVA_INTEGRATION, "aot.loadClasses", false, "Look for .class before .rb to load AOT-compiled code");
     public static final Option<Boolean> JI_LOAD_LAZY = bool(JAVA_INTEGRATION, "ji.load.lazy", true, "Load Java support (class extensions) lazily on demand or ahead of time.");
+    public static final Option<Boolean> JI_CLOSE_CLASSLOADER = bool(JAVA_INTEGRATION, "ji.close.classloader", false, "Close the JRubyClassLoader used by each runtime");
 
     public static final Option<Integer> PROFILE_MAX_METHODS = integer(PROFILING, "profile.max.methods", 100000, "Maximum number of methods to consider for profiling.");
 


### PR DESCRIPTION
This is another alternative fix for the issues reported in #6218
and diagnosed as a JDK bug in the following OpenJDK issue:

https://bugs.openjdk.java.net/browse/JDK-8246714

Rather than avoid the caching or leave all jar files open, this
patch takes a conservative approach. Temporary jar files that we
unpack must be deleted and should be closed even if globally
cached, since they will not conflict with other jar cache
consumers. Normal jars on the filesystem will remain unclosed, to
avoid impacting other consumers of the global jar cache.

This does mean that once a jar is opened by JRuby via our
classloader, it will not be closed until the process terminates.
Because this is a new behavior that may not be desirable in some
situations, this patch also adds a new property:

jruby.ji.close.classloader=true will close the per-runtime
classloader and any jar file instances it has cached, as before.
The default is "false" and in that case only the temporary jars
will be closed.

This fixes #6218