### PR TITLE
Always encode gethostname result as UTF-8

### DIFF
--- a/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
+++ b/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
@@ -33,6 +33,7 @@ import jnr.constants.platform.SocketLevel;
 import jnr.constants.platform.SocketOption;
 import jnr.netdb.Protocol;
 import jnr.netdb.Service;
+import org.jcodings.specific.ASCIIEncoding;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyClass;
@@ -80,12 +81,12 @@ public class SocketUtils {
         Ruby runtime = context.runtime;
 
         try {
-            return RubyString.newInternalFromJavaExternal(context.runtime, InetAddress.getLocalHost().getHostName());
+            return RubyString.newString(context.runtime, InetAddress.getLocalHost().getHostName());
 
         } catch(UnknownHostException e) {
 
             try {
-                return RubyString.newInternalFromJavaExternal(context.runtime, InetAddress.getByAddress(new byte[]{0, 0, 0, 0}).getHostName());
+                return RubyString.newString(context.runtime, InetAddress.getByAddress(new byte[]{0, 0, 0, 0}).getHostName());
 
             } catch(UnknownHostException e2) {
                 throw sockerr(runtime, "gethostname: name or service not known");


### PR DESCRIPTION
Our gethostname backends on the JDK's socket API, which always
returns a decoded character string. Rather than try to pretend
that this decoding has not happened and stuff the string back into
a "binary" ASCII-8BIT string, we instead always normalize the
encoding to UTF-8, the default encoding for Ruby strings now.

Fixes #6156