### PR TITLE
Do lazy instruction deserialization against dup'ed reader

### DIFF
--- a/core/src/main/java/org/jruby/ir/persistence/IRReader.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRReader.java
@@ -45,7 +45,7 @@ public class IRReader implements IRPersistenceValues {
             int instructionsOffset = file.decodeInt();
             int poolOffset = file.decodeInt();
 
-            scope.allocateInterpreterContext(() -> file.decodeInstructionsAt(scope, poolOffset, instructionsOffset));
+            scope.allocateInterpreterContext(() -> file.dup().decodeInstructionsAt(scope, poolOffset, instructionsOffset));
         }
 
         return firstScope; // topmost scope;

--- a/core/src/main/java/org/jruby/ir/persistence/IRReaderDecoder.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRReaderDecoder.java
@@ -71,4 +71,11 @@ public interface IRReaderDecoder {
 
     public TemporaryVariableType decodeTemporaryVariableType();
     public ByteList getFilename();
+
+    /**
+     * Duplicate this decoder to isolate any state changes.
+     *
+     * @return An identical decoder that's isolated from the original
+     */
+    public IRReaderDecoder dup();
 }


### PR DESCRIPTION
Instruction reading is done lazily to avoid the cost of
deserializing method bodies that will never be called. However the
buffer associated with the original file was being shared across
all of these lazy deserializations, causing concurrency issues.

This patch modifies the lazy deserialization lambda to operate
against a duplicate of the original reader, isolating its changes
in a separate buffer and avoiding the concurrency issues.

Fixes #6210