### PR TITLE
Fix typo to combine flags in the parser singleton class rule

### DIFF
--- a/core/src/main/java/org/jruby/parser/RubyParser.y
+++ b/core/src/main/java/org/jruby/parser/RubyParser.y
@@ -1558,7 +1558,7 @@ primary         : literal
                     support.setIsInClass($<Boolean>4.booleanValue());
                 }
                 | k_class tLSHFT expr {
-                    $$ = new Integer((support.isInClass() ? 2 : 0) & (support.isInDef() ? 1 : 0));
+                    $$ = new Integer((support.isInClass() ? 2 : 0) | (support.isInDef() ? 1 : 0));
                     support.setInDef(false);
                     support.setIsInClass(false);
                     support.pushLocalScope();


### PR DESCRIPTION
See https://github.com/ruby/ruby/blob/46a5d1b4a63f624f2c5c5b6f710cc1a176c88b02/parse.y#L2585

I'm not sure how to regenerate the parser (and ripper maybe), could you do it?