### PR TITLE
Always treat non-full IC as not having protocol

### DIFF
--- a/core/src/main/java/org/jruby/runtime/InterpretedIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/InterpretedIRBlockBody.java
@@ -76,7 +76,6 @@ public class InterpretedIRBlockBody extends IRBlockBody implements Compilable<In
 
             ic = closure.getInterpreterContext();
             interpreterContext = ic;
-            fullInterpreterContext = interpreterContext;
         }
         return ic;
     }
@@ -93,19 +92,19 @@ public class InterpretedIRBlockBody extends IRBlockBody implements Compilable<In
 
     @Override
     public boolean canCallDirect() {
-        return interpreterContext != null && interpreterContext.hasExplicitCallProtocol();
+        return fullInterpreterContext != null && fullInterpreterContext.hasExplicitCallProtocol();
     }
 
     @Override
     protected IRubyObject callDirect(ThreadContext context, Block block, IRubyObject[] args, Block blockArg) {
-        InterpreterContext ic = ensureInstrsReady(); // so we get debugging output
-        return Interpreter.INTERPRET_BLOCK(context, block, null, ic, args, block.getBinding().getMethod(), blockArg);
+        ensureInstrsReady(); // so we get debugging output
+        return Interpreter.INTERPRET_BLOCK(context, block, null, fullInterpreterContext, args, block.getBinding().getMethod(), blockArg);
     }
 
     @Override
     protected IRubyObject yieldDirect(ThreadContext context, Block block, IRubyObject[] args, IRubyObject self) {
-        InterpreterContext ic = ensureInstrsReady(); // so we get debugging output
-        return Interpreter.INTERPRET_BLOCK(context, block, self, ic, args, block.getBinding().getMethod(), Block.NULL_BLOCK);
+        ensureInstrsReady(); // so we get debugging output
+        return Interpreter.INTERPRET_BLOCK(context, block, self, fullInterpreterContext, args, block.getBinding().getMethod(), Block.NULL_BLOCK);
     }
 
     @Override
@@ -113,11 +112,6 @@ public class InterpretedIRBlockBody extends IRBlockBody implements Compilable<In
         if (callCount >= 0) promoteToFullBuild(context);
 
         InterpreterContext ic = ensureInstrsReady();
-
-        // Update interpreter context for next time this block is executed
-        // This ensures that if we had determined canCallDirect() is false
-        // based on the old IC, we continue to execute with it.
-        interpreterContext = fullInterpreterContext;
 
         Binding binding = block.getBinding();
         Visibility oldVis = binding.getFrame().getVisibility();


### PR DESCRIPTION
The logic here used to go to interpreterContext to check for the
call protocol logic. The hasExplicitCallProtocol method returns a
cached value acquired from the encapsulated scope, via its flags.
However the enum of flags in IRScope may be mutated concurrently,
leading to a situation where we have seen the scope flip to having
call protocols installed, but the InterpreterContext in hand is
still the one without protocol instructions. As a result, we may
start interpreting using an unoptimized IR along the "direct" path
which does not push any scope state. This lead to the AIOOB
reported later in #6282.

The NPE reported in #6282 has not reproduced for me on the
jruby-9.2 branch, and may have been fixed through other means, but
this modified logic should also help any such cases that remain.
Instead of overwriting the two InterpreterContext fields, the non-
full version will always remain the non-full version, and the full
version will only be set into that field. Once set, neither are
ever cleared or re-set to a new value, avoiding a transient null
in the instructionContext field.

I ran the new reproduction from #6282 for a few hours and saw no
errors. Adding a test that guarantees this is fixed may be
difficult, but I believe we've got it here.

This logic will be overhauled for 9.3, so we'll go with this
workaround for now and call it fixed.

Fixes #6282.