### PR TITLE
Only define static field constant when inner class collides

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -773,14 +773,13 @@ public class Java implements Library {
 
         final RubyModule parentModule; final String className;
 
-        if ( fullName.indexOf('$') != -1 ) { // inner classes must be nested
-            Class<?> declaringClass = clazz.getDeclaringClass();
-            if ( declaringClass == null ) {
-                // no containing class for a $ class; treat it as internal and don't define a constant
-                return;
-            }
-            parentModule = getProxyClass(runtime, JavaClass.get(runtime, declaringClass));
-            className = clazz.getSimpleName();
+        if ( fullName.indexOf('$') != -1 ) {
+            /*
+             We don't want to define an inner class constant here, because it may conflict with static fields.
+             Instead, we defer that constant definition to the declaring class's proxy initialization, which will deal
+             with naming conflicts appropriately. See GH-6196.
+             */
+            return;
         }
         else {
             final int endPackage = fullName.lastIndexOf('.');

--- a/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
@@ -95,7 +95,7 @@ public class MethodGatherer {
 
     private Map<String, NamedInstaller> staticInstallers = Collections.EMPTY_MAP;
     private Map<String, NamedInstaller> instanceInstallers = Collections.EMPTY_MAP;
-    final List<ConstantField> constantFields = new ArrayList<>();
+    private Map<String, ConstantField> constantFields = Collections.EMPTY_MAP;
     final Ruby runtime;
 
     MethodGatherer(final Ruby runtime, final Class superClass) {
@@ -334,6 +334,16 @@ public class MethodGatherer {
             final String simpleName = JavaClass.getSimpleName(clazz);
             if ( simpleName.length() == 0 ) continue;
 
+            if (constantFields.containsKey(simpleName)) {
+                /*
+                 If we already have a static final field of the same name, don't define the inner class constant.
+                 Typically this is used for singleton patterns where the field is an instance of the inner class, and
+                 in languages like Kotlin the class itself is not what users intend to access. See GH-6196.
+                 */
+                runtime.getWarnings().warning("inner class \"" + javaClass.getName() + "::" + simpleName + "\" conflicts with field of same name");
+                continue;
+            }
+
             final RubyModule innerProxy = Java.getProxyClass(runtime, JavaClass.get(runtime, clazz));
 
             if ( IdUtil.isConstant(simpleName) ) {
@@ -424,7 +434,7 @@ public class MethodGatherer {
     }
 
     protected void installConstants(final RubyModule proxy) {
-        constantFields.forEach(field -> field.install(proxy));
+        constantFields.forEach((name, field) -> field.install(proxy));
     }
 
     protected void installClassMethods(final RubyModule proxy) {
@@ -535,7 +545,7 @@ public class MethodGatherer {
 
             boolean constant = isPublic && isStatic && isFinal && Character.isUpperCase(field.getName().charAt(0));
             if (constant) {
-                constantFields.add(new ConstantField(field));
+                addConstantField(field);
 
                 // If we already are adding it as a constant, make the accessors warn about deprecated behavior.
                 // See jruby/jruby#5730.
@@ -548,6 +558,14 @@ public class MethodGatherer {
                 addField(getInstanceInstallersForWrite(), instanceNames, field, isFinal, false, false);
             }
         }
+    }
+
+    private void addConstantField(Field field) {
+        Map<String, ConstantField> constantFields = this.constantFields;
+        if (constantFields == Collections.EMPTY_MAP) {
+            constantFields = this.constantFields = new HashMap<>();
+        }
+        constantFields.put(field.getName(), new ConstantField(field));
     }
 
     void setupMethods(Class<?> javaClass) {

--- a/spec/java_integration/fixtures/InnerClasses.java
+++ b/spec/java_integration/fixtures/InnerClasses.java
@@ -96,4 +96,10 @@ public class InnerClasses {
 
     public static interface CapsInnerSerial extends CapsInnerInterface, Serializable {}
 
+    public static class ConflictsWithStaticFinalField {
+        public boolean ok() { return true; }
+    }
+
+    public static final ConflictsWithStaticFinalField ConflictsWithStaticFinalField = new ConflictsWithStaticFinalField();
+
 }

--- a/spec/java_integration/interfaces/java8_methods_spec.rb
+++ b/spec/java_integration/interfaces/java8_methods_spec.rb
@@ -219,17 +219,6 @@ describe "an interface (Java 8+)" do
     expect( output.index('ambiguous') ).to be nil
   end
 
-  def with_stderr_captured
-    stderr = $stderr; require 'stringio'
-    begin
-      $stderr = StringIO.new
-      yield
-      $stderr.string
-    ensure
-      $stderr = stderr
-    end
-  end
-
   def javac_compile(files)
     compiler = javax.tools.ToolProvider.getSystemJavaCompiler
     fmanager = compiler.getStandardFileManager(nil, nil, nil)

--- a/spec/java_integration/spec_helper.rb
+++ b/spec/java_integration/spec_helper.rb
@@ -69,3 +69,15 @@ RSpec::Matchers.define :have_strings_or_symbols do |*strings|
     end.join("\n")
   end
 end
+
+def with_stderr_captured
+  stderr = $stderr; require 'stringio'
+  begin
+    $stderr = StringIO.new
+    yield
+    $stderr.string
+  ensure
+    $stderr = stderr
+  end
+end
+

--- a/spec/java_integration/types/retrieval_spec.rb
+++ b/spec/java_integration/types/retrieval_spec.rb
@@ -206,4 +206,14 @@ describe "A Java class with inner classes" do
     end.not_to raise_error
     expect(CapsInnerClass).to eq(InnerClasses::CapsInnerClass)
   end
+
+  describe "with static final fields of the same name" do
+    it "defines a constant pointing at the field" do
+      err = with_stderr_captured do
+        expect(InnerClasses::ConflictsWithStaticFinalField.ok()).to be true
+      end
+
+      err.should be_empty
+    end
+  end
 end


### PR DESCRIPTION
This commit makes two changes to fix #6196:

* When both an inner class and a static final field have the same
  name, only define the field. Typically this is used for a
  singleton pattern where the field points at a singleton instance
  of the inner class, as with Kotlin companion classes. Since we
  can't define both, we prefer the field.
* Do not define the inner class constant as a side effect of
  initializing that class's proxy, like we do for package
  constants for normal classes. Defer that constant definition to
  the initialization of the declaring class, which will make the
  decision whether to define (or not) the constant at that point.

If both the field and the class are needed, it's still possible to
import the inner class under a specific name using `java_import`:

```ruby
java_import("OuterClass$InnerClass") { "MyWeirdInnerClass" }
MyWeirdInnerClass.whatever()
```