### PR TITLE
Add more travis platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -305,3 +305,4 @@ addons:
   apt:
     packages:
       - haveged
+      - ant

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
 
 before_install:
   - unset _JAVA_OPTIONS
-  - rm ~/.m2/settings.xml
+  - rm -f ~/.m2/settings.xml
   - export MAVEN_SKIP_RC=true
   - export MAVEN_OPTS="-Xmn64M -Xmx512M -XX:CompressedClassSpaceSize=96M"
   - export JAVA_OPTS="$JAVA_OPTS -XX:CompressedClassSpaceSize=96M"
@@ -25,6 +25,7 @@ before_script:
   - echo $HOME
   - echo $JAVA_OPTS
   - echo $MAVEN_OPTS
+  - 'export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")'
 
 jdk:
   - openjdk8
@@ -43,6 +44,27 @@ matrix:
   fast_finish: true
 
   include:
+    - name: JRuby tests jit ARM64
+      jdk: openjdk11
+      arch: arm64
+      script:
+        - ./mvnw clean package -Pbootstrap
+        - jruby -S rake test:jruby
+
+    - name: JRuby tests jit PPC64LE
+      jdk: openjdk11
+      arch: ppc64le
+      script:
+        - ./mvnw clean package -Pbootstrap
+        - jruby -S rake test:jruby
+
+    - name: JRuby tests jit S390X
+      jdk: openjdk11
+      arch: s390x
+      script:
+        - ./mvnw clean package -Pbootstrap
+        - jruby -S rake test:jruby
+
     - stage: test
       name: MRI core int
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,26 +44,6 @@ matrix:
   fast_finish: true
 
   include:
-    - name: JRuby tests jit ARM64
-      jdk: openjdk11
-      arch: arm64
-      script:
-        - ./mvnw clean package -Pbootstrap
-        - jruby -S rake test:jruby
-
-    - name: JRuby tests jit PPC64LE
-      jdk: openjdk11
-      arch: ppc64le
-      script:
-        - ./mvnw clean package -Pbootstrap
-        - jruby -S rake test:jruby
-
-    - name: JRuby tests jit S390X
-      jdk: openjdk11
-      arch: s390x
-      script:
-        - ./mvnw clean package -Pbootstrap
-        - jruby -S rake test:jruby
 
     - stage: test
       name: MRI core int
@@ -161,6 +141,35 @@ matrix:
         - mvn clean package -Pbootstrap
         - jruby -S rake test:jruby
       env: JRUBY_OPTS=-Xcompile.invokedynamic
+
+    - name: JRuby tests jit indy jdk11 ARM64
+      jdk: openjdk11
+      arch: arm64
+      script:
+        - ./mvnw clean package -Pbootstrap
+        - jruby -S rake test:jruby
+      env: JRUBY_OPTS=-Xcompile.invokedynamic
+
+    - name: spec/ruby fast jdk11 ARM64
+      jdk: openjdk11
+      arch: arm64
+      script:
+        - ./mvnw clean package -Pbootstrap
+        - jruby -S rake spec:ruby:fast
+
+    - name: JRuby tests jit PPC64LE
+      jdk: openjdk11
+      arch: ppc64le
+      script:
+        - ./mvnw clean package -Pbootstrap
+        - jruby -S rake test:jruby
+
+    - name: JRuby tests jit S390X
+      jdk: openjdk11
+      arch: s390x
+      script:
+        - ./mvnw clean package -Pbootstrap
+        - jruby -S rake test:jruby
 
     - name: JRuby tests aot
       script:
@@ -268,6 +277,8 @@ matrix:
   allow_failures:
     - env: PHASE='-Pjruby_complete_jar_extended -Dinvoker.skip=true'
     - name: concurrent ruby # temporary, see ruby-concurrency/concurrent-ruby#862
+    - name: JRuby tests jit PPC64LE
+    - name: JRuby tests jit S390X
 
 script: tool/maven-ci-script.sh
 


### PR DESCRIPTION
Travis now supports (in an experimental way) three additional hardware platforms: `arm64`, `ppc64le`, and `s390x`. I will use this PR to try out some of our suites on those platforms and keep the ones that work.