### PR TITLE
Add Kotlin Integration tests for Companion objects

### DIFF
--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -30,6 +30,9 @@ namespace :test do
     java_home = [ ENV_JAVA['java.home'], File.join(ENV_JAVA['java.home'], '..') ] # in case of jdk/jre
     javac = java_home.map { |home| File.expand_path('bin/javac', home) }.find { |javac| File.exist?(javac) } || 'javac'
     sh "#{javac} -cp #{classpath} -d test/target/test-classes #{Dir['spec/java_integration/fixtures/**/*.java'].to_a.join(' ')}"
+    # TODO: What about environments without this installed?
+    kotlinc = 'kotlinc'
+    sh "#{kotlinc} -cp #{classpath} -include-runtime -d test/target/test-classes/kotlin_fixtures.jar #{Dir['spec/java_integration/fixtures/**/*.kt'].to_a.join(' ')}"
   end
 
   short_tests = ['jruby', 'mri']

--- a/spec/java_integration/fixtures/CompanionObjects.kt
+++ b/spec/java_integration/fixtures/CompanionObjects.kt
@@ -1,0 +1,21 @@
+package java_integration.fixtures;
+
+public class CompanionObject {
+    companion object {
+        const val COMPANION_CONST = "Constant"
+
+	val value = "Value"
+
+	@JvmStatic
+	val jvmStaticValue = "JvmStaticValue"
+
+        fun companionMethod(): String {
+            return "Method"
+        }
+
+        @JvmStatic
+        fun jvmStaticMethod(): String {
+            return "JvmStaticMethod"
+        }
+    }
+}

--- a/spec/java_integration/fixtures/NamedCompanionObjects.kt
+++ b/spec/java_integration/fixtures/NamedCompanionObjects.kt
@@ -1,0 +1,21 @@
+package java_integration.fixtures;
+
+public class NamedCompanionObject {
+    companion object Factory {
+        const val COMPANION_CONST = "Constant"
+
+	val value = "Value"
+
+	@JvmStatic
+	val jvmStaticValue = "JvmStaticValue"
+
+        fun companionMethod(): String {
+            return "Method"
+        }
+
+        @JvmStatic
+        fun jvmStaticMethod(): String {
+            return "JvmStaticMethod"
+        }
+    }
+}

--- a/spec/java_integration/kotlin/companion_spec.rb
+++ b/spec/java_integration/kotlin/companion_spec.rb
@@ -1,0 +1,79 @@
+require File.dirname(__FILE__) + "/../spec_helper"
+require "kotlin_fixtures.jar"
+
+java_import "java_integration.fixtures.CompanionObject"
+java_import "java_integration.fixtures.NamedCompanionObject"
+
+describe "Kotlin Companion objects" do
+  describe "unnamed companion objects" do
+    it "exposes constants on the parent class" do
+      expect(CompanionObject::COMPANION_CONST).to eq("Constant")
+    end
+
+    it "exposes values on the companion object" do
+      expect(CompanionObject::Companion.value).to eq("Value")
+    end
+
+    it "exposes @JvmStatic values on the parent class" do
+      expect(CompanionObject.jvm_static_value).to eq("JvmStaticValue")
+    end
+
+    it "exposes @JvmStatic values on the companion object" do
+      expect(CompanionObject::Companion.jvm_static_value).to eq("JvmStaticValue")
+    end
+
+    it "exposes non-@JvmStatic methods on the companion object" do
+      expect(CompanionObject::Companion.companion_method).to eq("Method")
+    end
+
+    it "does not expose non-@JvmStatic methods on the companion object" do
+      expect do
+        CompanionObject.companion_method
+      end.to raise_error(NameError)
+    end
+
+    it "exposes @JvmStatic methods on the parent class" do
+      expect(CompanionObject.jvmStaticMethod).to eq("JvmStaticMethod")
+    end
+
+    it "exposes @JvmStatic methods on the companion object" do
+      expect(CompanionObject::Companion.jvmStaticMethod).to eq("JvmStaticMethod")
+    end
+  end
+
+  describe "named companion objects" do
+    it "exposes constants on the parent class" do
+      expect(NamedCompanionObject::COMPANION_CONST).to eq("Constant")
+    end
+
+    it "exposes values on the companion object" do
+      expect(NamedCompanionObject::Factory.value).to eq("Value")
+    end
+
+    it "exposes @JvmStatic values on the parent class" do
+      expect(NamedCompanionObject.jvm_static_value).to eq("JvmStaticValue")
+    end
+
+    it "exposes @JvmStatic values on the companion object" do
+      expect(NamedCompanionObject::Factory.jvm_static_value).to eq("JvmStaticValue")
+    end
+
+    it "exposes non-@JvmStatic methods on the companion object" do
+      expect(NamedCompanionObject::Factory.companion_method).to eq("Method")
+    end
+
+    it "does not expose non-@JvmStatic methods on the companion object" do
+      expect do
+        NamedCompanionObject.companion_method
+      end.to raise_error(NameError)
+    end
+
+    it "exposes @JvmStatic methods on the parent class" do
+      expect(NamedCompanionObject.jvmStaticMethod).to eq("JvmStaticMethod")
+    end
+
+    it "exposes @JvmStatic methods on the companion object" do
+      expect(NamedCompanionObject::Factory.jvmStaticMethod).to eq("JvmStaticMethod")
+    end
+  end
+end


### PR DESCRIPTION
This starts a Kotlin integration spec.  The integration of Kotlin into
the build still needs a bit of work, but if you have `kotlinc` installed
in your path, you can compile the fixtures and run the tests with

```
jruby -S rake test:compile
jruby bin/rspec spec/java_integration/kotlin
```