### PR TITLE
Fixes to improve Java 11 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
         run: tool/maven-ci-script.sh
         env:
           PHASE: '-Pmain,test -Dinvoker.test=extended'
+      - name: test profile
+        run: tool/maven-ci-script.sh
+        env:
+          PHASE: '-Ptest'
 
   # Maven test suites that don't pass on Java 11
   maven-test-8:
@@ -74,10 +78,6 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: bootstrap
         run: mvn -Pbootstrap clean package
-      - name: test profile
-        run: tool/maven-ci-script.sh
-        env:
-          PHASE: '-Ptest'
       - name: jruby-jars profile
         run: tool/maven-ci-script.sh
         env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -134,6 +134,12 @@ matrix:
         - mvn clean package -Pbootstrap
         - jruby -S rake spec:ji
 
+    - name: JI specs jdk11
+      jdk: openjdk11
+      script:
+        - mvn clean package -Pbootstrap
+        - jruby -S rake spec:ji
+
     - name: Compiler specs
       script:
         - mvn clean package -Pbootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,12 @@ matrix:
         - mvn clean package -Pbootstrap
         - jruby -S rake spec:ruby:fast
 
+    - name: spec/ruby fast jdk11
+      jdk: openjdk11
+      script:
+        - mvn clean package -Pbootstrap
+        - jruby -S rake spec:ruby:fast
+
     - name: spec/ruby slow
       script:
         - mvn clean package -Pbootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,12 @@ matrix:
         - mvn clean package -Pbootstrap
         - jruby -S rake test:mri:core:jit
 
+    - name: MRI core jit jdk11
+      jdk: openjdk11
+      script:
+        - mvn clean package -Pbootstrap
+        - jruby -S rake test:mri:core:jit
+
     - name: MRI extra
       script:
         - mvn clean package -Pbootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -157,6 +157,13 @@ matrix:
         - jruby -S rake spec:compiler
       env: JRUBY_OPTS=-Xcompile.invokedynamic
 
+    - name: Compiler specs indy jdk11
+      jdk: openjdk11
+      script:
+        - mvn clean package -Pbootstrap
+        - jruby -S rake spec:compiler
+      env: JRUBY_OPTS=-Xcompile.invokedynamic
+
     - name: FFI specs
       script:
         - mvn clean package -Pbootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -175,6 +175,12 @@ matrix:
         - mvn clean package -Pbootstrap
         - jruby -S rake spec:ffi
 
+    - name: FFI specs jdk11
+      jdk: openjdk11
+      script:
+        - mvn clean package -Pbootstrap
+        - jruby -S rake spec:ffi
+
     - name: Regression specs
       script:
         - mvn clean package -Pbootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,12 @@ matrix:
         - mvn clean package -Pbootstrap
         - jruby -S rake test:jruby
 
+    - name: JRuby tests jit jdk11
+      jdk: openjdk11
+      script:
+        - mvn clean package -Pbootstrap
+        - jruby -S rake test:jruby
+
     - name: JRuby tests jit indy
       script:
         - mvn clean package -Pbootstrap

--- a/core/pom.rb
+++ b/core/pom.rb
@@ -235,6 +235,9 @@ project 'JRuby Core' do
             'jruby.home' =>  '${basedir}/..'
           },
           'argLine' =>  '-Xmx${jruby.test.memory} -Dfile.encoding=UTF-8 -Djava.awt.headless=true',
+          'environmentVariables' => {
+              'JDK_JAVA_OPTIONS' => '--add-modules java.scripting'
+          },
           includes: [
               'org/jruby/test/**/*Test*.java',
               'org/jruby/embed/**/*Test*.java',

--- a/core/pom.rb
+++ b/core/pom.rb
@@ -73,7 +73,7 @@ project 'JRuby Core' do
 
   jar 'me.qmx.jitescript:jitescript:0.4.1', :exclusions => ['org.ow2.asm:asm-all']
 
-  jar 'com.headius:backport9:1.7'
+  jar 'com.headius:backport9:1.8'
 
   jar 'javax.annotation:javax.annotation-api:1.3.1', scope: 'compile'
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -249,7 +249,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>com.headius</groupId>
       <artifactId>backport9</artifactId>
-      <version>1.7</version>
+      <version>1.8</version>
     </dependency>
     <dependency>
       <groupId>javax.annotation</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -570,6 +570,9 @@ DO NOT MODIFIY - GENERATED CODE
             <jruby.home>${basedir}/..</jruby.home>
           </systemProperties>
           <argLine>-Xmx${jruby.test.memory} -Dfile.encoding=UTF-8 -Djava.awt.headless=true</argLine>
+          <environmentVariables>
+            <JDK_JAVA_OPTIONS>--add-modules java.scripting</JDK_JAVA_OPTIONS>
+          </environmentVariables>
           <includes>
             <include>org/jruby/test/**/*Test*.java</include>
             <include>org/jruby/embed/**/*Test*.java</include>

--- a/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
@@ -1,5 +1,6 @@
 package org.jruby.javasupport.binding;
 
+import com.headius.backport9.modules.Modules;
 import org.jruby.Ruby;
 import org.jruby.RubyModule;
 import org.jruby.internal.runtime.methods.JavaMethod;
@@ -166,7 +167,7 @@ public class MethodGatherer {
         // same name+signature as subclass methods (see JRUBY-3130)
         for ( Class<?> klass = javaClass; klass != null; klass = klass.getSuperclass() ) {
             // only add class's methods if it's public (JIRA issue JRUBY-4799)
-            if (Modifier.isPublic(klass.getModifiers())) {
+            if (Modifier.isPublic(klass.getModifiers()) && Modules.isExported(klass, Java.class)) {
                 // for each class, scan declared methods for new signatures
                 try {
                     // add methods, including static if this is the actual class,

--- a/pom.rb
+++ b/pom.rb
@@ -129,7 +129,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
 
     plugin :compiler, '3.3'
     plugin :shade, '3.1.0'
-    plugin :surefire, '2.15'
+    plugin :surefire, '3.0.0-M2'
     plugin :plugin, '3.2'
     plugin( :invoker, '1.8',
             'properties' => { 'jruby.version' => '${project.version}',

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@ DO NOT MODIFIY - GENERATED CODE
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.15</version>
+          <version>3.0.0-M2</version>
         </plugin>
         <plugin>
           <artifactId>maven-plugin-plugin</artifactId>

--- a/spec/java_integration/fixtures/JavaFields.java
+++ b/spec/java_integration/fixtures/JavaFields.java
@@ -52,6 +52,8 @@ public class JavaFields {
     public Boolean trueObjField = Boolean.TRUE;
     public Boolean falseObjField = Boolean.FALSE;
 
+    private final int privateIntField = 1;
+
     Object field1 = this;
     Object[] aryField2 = new Object[] { this };
 

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -917,7 +917,27 @@ class TestHigherJavasupport < Test::Unit::TestCase
     assert_equal(0, a.size)
   end
 
+  def test_open_reflected_field
+    java_fields = Java::JavaClass.for_name('java_integration.fixtures.JavaFields')
+    begin
+      java_fields.field('privateIntField')
+      fail('value field is not public!')
+    rescue NameError => e
+      assert e
+    end
+    value_field = java_fields.declared_field('privateIntField')
+    assert_equal false, value_field.static?
+    assert_equal false, value_field.public?
+    assert_equal true, value_field.final?
+    assert_equal false, value_field.accessible?
+    value_field.accessible = true
+    assert_equal 1, value_field.value( java_fields.constructor.new_instance )
+    assert_equal 'int', value_field.value_type
+  end
+
   def test_reflected_field
+    skip if JAVA_9
+
     j_integer = Java::JavaClass.for_name('java.lang.Integer')
     begin
       j_integer.field('value')


### PR DESCRIPTION
This PR will fix issues preventing some of our test suites from passing on Java 11, in order to help move toward full compatibility in the presence of Java modules.

This PR is based on 9.3 but most fixes should be mergeable to 9.2, and we may want to consider some or all of them for 9.2.12.