### PR TITLE
Do not bind methods from classes that are not exported

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -73,7 +73,7 @@ project 'JRuby Core' do
 
   jar 'me.qmx.jitescript:jitescript:0.4.1', :exclusions => ['org.ow2.asm:asm-all']
 
-  jar 'com.headius:backport9:1.7'
+  jar 'com.headius:backport9:1.8'
 
   jar 'javax.annotation:javax.annotation-api:1.3.1', scope: 'compile'
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -249,7 +249,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>com.headius</groupId>
       <artifactId>backport9</artifactId>
-      <version>1.7</version>
+      <version>1.8</version>
     </dependency>
     <dependency>
       <groupId>javax.annotation</groupId>

--- a/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
@@ -1,5 +1,6 @@
 package org.jruby.javasupport.binding;
 
+import com.headius.backport9.modules.Modules;
 import org.jruby.Ruby;
 import org.jruby.RubyModule;
 import org.jruby.internal.runtime.methods.JavaMethod;
@@ -166,7 +167,7 @@ public class MethodGatherer {
         // same name+signature as subclass methods (see JRUBY-3130)
         for ( Class<?> klass = javaClass; klass != null; klass = klass.getSuperclass() ) {
             // only add class's methods if it's public (JIRA issue JRUBY-4799)
-            if (Modifier.isPublic(klass.getModifiers())) {
+            if (Modifier.isPublic(klass.getModifiers()) && Modules.isExported(klass, Java.class)) {
                 // for each class, scan declared methods for new signatures
                 try {
                     // add methods, including static if this is the actual class,


### PR DESCRIPTION
This cherry-picks the fix for #6287 for 9.2.12.