### PR TITLE
Reconfigure some CI builds and add JDK14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,12 +50,6 @@ matrix:
         - jruby -S rake test:mri:core:int
       env: JRUBY_OPTS='$JRUBY_OPTS -J-Xmx1G'
 
-    - name: MRI core fullint
-      script:
-        - mvn clean package -Pbootstrap
-        - jruby -S rake test:mri:core:fullint
-      env: JRUBY_OPTS='$JRUBY_OPTS -J-Xmx1G'
-
     - name: MRI core jit
       script:
         - mvn clean package -Pbootstrap
@@ -63,6 +57,12 @@ matrix:
 
     - name: MRI core jit jdk11
       jdk: openjdk11
+      script:
+        - mvn clean package -Pbootstrap
+        - jruby -S rake test:mri:core:jit
+
+    - name: MRI core jit jdk14
+      jdk: openjdk14
       script:
         - mvn clean package -Pbootstrap
         - jruby -S rake test:mri:core:jit
@@ -88,6 +88,11 @@ matrix:
       jdk: openjdk11
       script:
         - mvn clean package -Pbootstrap
+
+    - name: spec/ruby fast jdk14
+      jdk: openjdk14
+      script:
+        - mvn clean package -Pbootstrap
         - jruby -S rake spec:ruby:fast
 
     - name: spec/ruby slow
@@ -109,16 +114,24 @@ matrix:
     - name: concurrent ruby
       script: tool/concurrent-ruby-travis.sh
 
-    - name: JRuby tests jit
+    - name: JRuby tests int
       script:
         - mvn clean package -Pbootstrap
-        - jruby -S rake test:jruby
+        - jruby -S rake test:jruby:int
 
-    - name: JRuby tests jit jdk11
+    - name: JRuby tests jit indy jdk11
       jdk: openjdk11
       script:
         - mvn clean package -Pbootstrap
         - jruby -S rake test:jruby
+      env: JRUBY_OPTS=-Xcompile.invokedynamic
+
+    - name: JRuby tests jit indy jdk14
+      jdk: openjdk14
+      script:
+        - mvn clean package -Pbootstrap
+        - jruby -S rake test:jruby
+      env: JRUBY_OPTS=-Xcompile.invokedynamic
 
     - name: JRuby tests jit indy
       script:
@@ -130,11 +143,6 @@ matrix:
       script:
         - mvn clean package -Pbootstrap
         - jruby -S rake test:jruby:aot
-
-    - name: JRuby tests fullint
-      script:
-        - mvn clean package -Pbootstrap
-        - jruby -S rake test:jruby:fullint
 
     - name: JRuby slow tests
       script:
@@ -152,6 +160,12 @@ matrix:
         - mvn clean package -Pbootstrap
         - jruby -S rake spec:ji
 
+    - name: JI specs jdk14
+      jdk: openjdk14
+      script:
+        - mvn clean package -Pbootstrap
+        - jruby -S rake spec:ji
+
     - name: Compiler specs
       script:
         - mvn clean package -Pbootstrap
@@ -165,6 +179,13 @@ matrix:
 
     - name: Compiler specs indy jdk11
       jdk: openjdk11
+      script:
+        - mvn clean package -Pbootstrap
+        - jruby -S rake spec:compiler
+      env: JRUBY_OPTS=-Xcompile.invokedynamic
+
+    - name: Compiler specs indy jdk14
+      jdk: openjdk14
       script:
         - mvn clean package -Pbootstrap
         - jruby -S rake spec:compiler

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,7 @@ matrix:
       jdk: openjdk11
       script:
         - mvn clean package -Pbootstrap
+        - jruby -S rake spec:ruby:fast
 
     - name: spec/ruby fast jdk14
       jdk: openjdk14

--- a/bin/.dev_mode.java_opts
+++ b/bin/.dev_mode.java_opts
@@ -1,5 +1,6 @@
 -XX:+TieredCompilation
 -XX:TieredStopAtLevel=1
+-XX:-PrintWarnings
 -Djruby.compile.mode=OFF
 -Djruby.compile.invokedynamic=false
 -Djnr.ffi.asm.enabled=false

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -3883,9 +3883,11 @@ public final class Ruby implements Constantizable {
 
     private final static Pattern ADDR_NOT_AVAIL_PATTERN = Pattern.compile("assign.*address");
 
-    public RaiseException newErrnoEADDRFromBindException(BindException be) {
-		return newErrnoEADDRFromBindException(be, null);
-	}
+    public RaiseException newErrnoFromBindException(BindException be, String contextMessage) {
+        Errno errno = Helpers.errnoFromException(be);
+
+        return newErrnoFromErrno(errno, contextMessage);
+    }
 
     public RaiseException newErrnoEADDRFromBindException(BindException be, String contextMessage) {
         String msg = be.getMessage();
@@ -5708,6 +5710,11 @@ public final class Ruby implements Constantizable {
                     + "If you need this option please set it manually as a JVM property.\n"
                     + "Use JAVA_OPTS=-Djava.net.preferIPv4Stack=true OR prepend -J as a JRuby option.");
         }
+    }
+
+    @Deprecated
+    public RaiseException newErrnoEADDRFromBindException(BindException be) {
+        return newErrnoEADDRFromBindException(be, null);
     }
 
 }

--- a/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
@@ -737,6 +737,10 @@ public class RubyBasicSocket extends RubyIO {
         return RubyArray.newArray(runtime, ret0, ret1, ret2, ret3);
     }
 
+    protected static String bindContextMessage(IRubyObject host, int port) {
+        return "bind(2) for " + host.inspect() + " port " + port;
+    }
+
     @Deprecated
     public IRubyObject recv(IRubyObject[] args) {
         return recv(getRuntime().getCurrentContext(), args);

--- a/core/src/main/java/org/jruby/ext/socket/RubyTCPServer.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyTCPServer.java
@@ -103,7 +103,11 @@ public class RubyTCPServer extends RubyTCPSocket {
 
                 break;
             case 1:
+                _host = context.nil;
                 _port = args[0];
+                break;
+            default:
+                throw runtime.newArgumentError(args.length, 1, 2);
         }
 
         int port = SocketUtils.getPortFrom(context, _port);
@@ -124,7 +128,7 @@ public class RubyTCPServer extends RubyTCPSocket {
             throw SocketUtils.sockerr(runtime, "initialize: name or service not known");
 
         } catch(BindException e) {
-            throw runtime.newErrnoEADDRFromBindException(e);
+            throw runtime.newErrnoFromBindException(e, bindContextMessage(_host, port));
 
         } catch(SocketException e) {
             String msg = e.getMessage();

--- a/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
@@ -205,17 +205,17 @@ public class RubyUDPSocket extends RubyIPSocket {
             throw SocketUtils.sockerr(runtime, "bind: name or service not known");
         }
         catch (BindException e) {
-            throw runtime.newErrnoEADDRFromBindException(e);
+            throw runtime.newErrnoFromBindException(e, bindContextMessage(host, port));
         }
         catch (AlreadyBoundException e) {
-            throw runtime.newErrnoEINVALError("bind(2) for " + host.inspect() + " port " + port);
+            throw runtime.newErrnoEINVALError(bindContextMessage(host, port));
         }
         catch (SocketException e) {
             final String message = e.getMessage();
             if ( message != null ) {
                 switch ( message ) {
                     case "Permission denied" :
-                        throw runtime.newErrnoEACCESError("bind(2) for " + host.inspect() + " port " + port);
+                        throw runtime.newErrnoEACCESError(bindContextMessage(host, port));
                 }
             }
             throw sockerr(runtime, "bind: name or service not known", e);

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -5,6 +5,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Array;
 
+import java.net.BindException;
 import java.net.PortUnreachableException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.charset.Charset;
@@ -261,16 +262,17 @@ public class Helpers {
         } catch (AccessDeniedException ade) {
             return Errno.EACCES;
         } catch (DirectoryNotEmptyException dnee) {
-            switch (dnee.getMessage()) {
-                case "File exists":
-                    return Errno.EEXIST;
-                case "Directory not empty":
-                    return Errno.ENOTEMPTY;
-            }
+            return errnoFromMessage(dnee);
+        } catch (BindException be) {
+            return errnoFromMessage(be);
         } catch (Throwable t2) {
             // fall through
         }
 
+        return errnoFromMessage(t);
+    }
+
+    private static Errno errnoFromMessage(Throwable t) {
         final String errorMessage = t.getMessage();
 
         if (errorMessage != null) {

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -303,6 +303,8 @@ public class Helpers {
                     return Errno.ENETUNREACH;
                 case "Address already in use":
                     return Errno.EADDRINUSE;
+                case "Cannot assign requested address":
+                    return Errno.EADDRNOTAVAIL;
                 case "No space left on device":
                     return Errno.ENOSPC;
                 case "Message too large": // Alpine Linux
@@ -317,8 +319,8 @@ public class Helpers {
                 case "permission denied":
                 case "Permission denied":
                     return Errno.EACCES;
-                case "Protocol family unavailable":
-                    return Errno.EADDRNOTAVAIL;
+                case "Protocol family not supported":
+                    return Errno.EPFNOSUPPORT;
             }
         }
         return null;

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -61,7 +61,8 @@ namespace :test do
 
   compile_flags = {
     :default => :int,
-    :int => ["-X-C"],
+    # interpreter is set to threshold=1 to encourage full builds to run for code called twice
+    :int => ["-X-C", "-Xjit.threshold=1", "-Xjit.background=false"],
     # Note: jit.background=false is implied by jit.threshold=0, but we add it here to be sure
     :fullint => ["-X-C", "-Xjit.threshold=0", "-Xjit.background=false"],
     :jit => ["-Xjit.threshold=0", "-Xjit.background=false", get_meta_size.call()],
@@ -80,7 +81,8 @@ namespace :test do
 
   namespace :mri do
     jruby_opts = {
-        int: "--dev",
+        # interpreter is set to threshold=1 to encourage full builds to run for code called twice
+        int: "--dev -Xjit.threshold=1 -Xjit.background=false",
         fullint: "-X-C -Xjit.threshold=0 -Xjit.background=false",
         jit: "-Xjit.threshold=0 -Xjit.background=false",
         aot: "-X+C -Xjit.background=false #{get_meta_size.call()}"


### PR DESCRIPTION
This PR makes a few changes to our Travis CI runs:

* Modify the "int" builds to encourage a full build for code called twice, using threshold=1 and jit.background=false.
* Remove "fullint" builds from JRuby and MRI suites.
* Add indy flag to a few JDK11 builds.
* Duplicate some of the JDK11 builds for JDK14. These builds should be kept up with latest OpenJDK release (so move to 15 this fall).