### PR TITLE
Run security specs

### DIFF
--- a/spec/jruby.mspec
+++ b/spec/jruby.mspec
@@ -4,6 +4,9 @@ require 'rbconfig'
 require 'java'
 require 'jruby'
 
+# Inherit from the default configuration
+load "#{__dir__}/ruby/default.mspec"
+
 # Some non-deterministic specs assume a GC will actually fire.  For spec
 # runs we change our noop version of GC.start to requesting we actually
 # perform a GC on the JVM.
@@ -21,29 +24,11 @@ SPEC_DIR = File.join(File.dirname(__FILE__), 'ruby') unless defined?(SPEC_DIR)
 TAGS_DIR = File.join(File.dirname(__FILE__), 'tags') unless defined?(TAGS_DIR)
 
 class MSpecScript
+  set :prefix, 'spec/ruby'
+
   jruby = RbConfig::CONFIG['ruby_install_name'] + RbConfig::CONFIG['EXEEXT']
   jruby = File.expand_path("../../bin/#{jruby}", __FILE__)
   set :target, jruby
-
-  # Command Line specs
-  set :command_line, [
-    SPEC_DIR + '/command_line',
-  ]
-
-  # Language features specs
-  set :language, [
-    SPEC_DIR + '/language',
-  ]
-
-  # Core library specs
-  set :core, [
-    SPEC_DIR + '/core',
-  ]
-
-  # Standard library specs
-  set :library, [
-    SPEC_DIR + '/library',
-  ]
 
   slow_specs = [
       SPEC_DIR + '/core/process',
@@ -116,8 +101,6 @@ class MSpecScript
 
   # This set of files is run by mspec ci
   set :ci_files, get(:language) + get(:core) + get(:command_line) + get(:library)
-
-  set :backtrace_filter, /mspec\//
 
   set :tags_patterns, [
                         [%r(^.*/language/),     TAGS_DIR + '/ruby/language/'],

--- a/spec/jruby.mspec
+++ b/spec/jruby.mspec
@@ -46,7 +46,8 @@ class MSpecScript
       SPEC_DIR + '/library/net/http',
       # This requires --debug which slows down or changes other spec results
       SPEC_DIR + '/core/tracepoint',
-      *get(:command_line)
+      *get(:command_line),
+      *get(:security),
   ]
 
   set :fast, [
@@ -100,13 +101,14 @@ class MSpecScript
   end
 
   # This set of files is run by mspec ci
-  set :ci_files, get(:language) + get(:core) + get(:command_line) + get(:library)
+  set :ci_files, get(:language) + get(:core) + get(:command_line) + get(:library) + get(:security)
 
   set :tags_patterns, [
                         [%r(^.*/language/),     TAGS_DIR + '/ruby/language/'],
                         [%r(^.*/core/),         TAGS_DIR + '/ruby/core/'],
                         [%r(^.*/command_line/), TAGS_DIR + '/ruby/command_line/'],
                         [%r(^.*/library/),      TAGS_DIR + '/ruby/library/'],
+                        [%r(^.*/security/),     TAGS_DIR + '/ruby/security/'],
                         [/_spec.rb$/,       '_tags.txt']
                       ]
 end

--- a/spec/tags/ruby/security/cve_2011_4815_tags.txt
+++ b/spec/tags/ruby/security/cve_2011_4815_tags.txt
@@ -1,0 +1,5 @@
+fails:Integer#hash with a small value resists CVE-2011-4815 by having different hash codes in different processes
+fails:Integer#hash with a large value resists CVE-2011-4815 by having different hash codes in different processes
+fails:Float#hash resists CVE-2011-4815 by having different hash codes in different processes
+fails:Rational#hash resists CVE-2011-4815 by having different hash codes in different processes
+fails:Complex#hash resists CVE-2011-4815 by having different hash codes in different processes

--- a/spec/tags/ruby/security/cve_2017_17742_tags.txt
+++ b/spec/tags/ruby/security/cve_2017_17742_tags.txt
@@ -1,0 +1,2 @@
+fails:WEBrick resists CVE-2017-17742 for a response splitting headers
+fails:WEBrick resists CVE-2017-17742 for a response splitting cookie headers

--- a/spec/tags/ruby/security/cve_2018_16396_tags.txt
+++ b/spec/tags/ruby/security/cve_2018_16396_tags.txt
@@ -1,0 +1,1 @@
+fails:Array#pack resists CVE-2018-16396 by tainting output based on input

--- a/spec/tags/ruby/security/cve_2018_8778_tags.txt
+++ b/spec/tags/ruby/security/cve_2018_8778_tags.txt
@@ -1,0 +1,1 @@
+fails:String#unpack resists CVE-2018-8778 by raising an exception when a position indicator is larger than a native integer


### PR DESCRIPTION
* Inherit from the default MSpec configuration
* Run security specs

[`security/` specs](https://github.com/ruby/spec/commits/master/security) exist since a while in ruby/spec but it seems JRuby didn't run them in CI yet.