### PR TITLE
Mimic CRuby's numeric hashing

### DIFF
--- a/core/src/main/java/org/jruby/RubyBignum.java
+++ b/core/src/main/java/org/jruby/RubyBignum.java
@@ -41,6 +41,7 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.common.IRubyWarnings.ID;
 import org.jruby.runtime.ClassIndex;
+import org.jruby.runtime.Helpers;
 import org.jruby.runtime.JavaSites;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -1043,12 +1044,17 @@ public class RubyBignum extends RubyInteger {
      */
     @Override
     public RubyFixnum hash() {
-        return metaClass.runtime.newFixnum(value.hashCode());
+        Ruby runtime = metaClass.runtime;
+        return RubyFixnum.newFixnum(runtime, bigHash(runtime, value));
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return (int) bigHash(getRuntime(), value);
+    }
+
+    private static long bigHash(Ruby runtime, BigInteger value) {
+        return Helpers.multAndMix(runtime.getHashSeedK0(), value.hashCode());
     }
 
     /** rb_big_to_f

--- a/core/src/main/java/org/jruby/RubyFixnum.java
+++ b/core/src/main/java/org/jruby/RubyFixnum.java
@@ -44,6 +44,7 @@ import org.jruby.compiler.Constantizable;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.CallSite;
 import org.jruby.runtime.ClassIndex;
+import org.jruby.runtime.Helpers;
 import org.jruby.runtime.JavaSites;
 import org.jruby.runtime.Signature;
 import org.jruby.runtime.ThreadContext;
@@ -248,12 +249,17 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
 
     @Override
     public RubyFixnum hash() {
-        return newFixnum(metaClass.runtime, hashCode());
+        Ruby runtime = metaClass.runtime;
+        return newFixnum(runtime, fixHash(runtime, value));
     }
 
     @Override
     public final int hashCode() {
-        return (int) (value ^ value >>> 32);
+        return (int) fixHash(getRuntime(), value);
+    }
+
+    private static long fixHash(Ruby runtime, long value) {
+        return Helpers.multAndMix(runtime.getHashSeedK0(), value);
     }
 
     /*  ================

--- a/core/src/main/java/org/jruby/RubyFloat.java
+++ b/core/src/main/java/org/jruby/RubyFloat.java
@@ -48,6 +48,7 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.runtime.ClassIndex;
+import org.jruby.runtime.Helpers;
 import org.jruby.runtime.JavaSites.FloatSites;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
@@ -667,14 +668,19 @@ public class RubyFloat extends RubyNumeric {
     @JRubyMethod(name = "hash")
     @Override
     public RubyFixnum hash() {
-        return metaClass.runtime.newFixnum( hashCode() );
+        Ruby runtime = metaClass.runtime;
+        return RubyFixnum.newFixnum(runtime, floatHash(runtime, value));
     }
 
     @Override
     public final int hashCode() {
+        return (int) floatHash(getRuntime(), value);
+    }
+
+    private static long floatHash(Ruby runtime, double value) {
         final double val = value == 0.0 ? -0.0 : value;
-        final long l = Double.doubleToLongBits(val);
-        return (int) ( l ^ l >>> 32 );
+        long hashLong = Double.doubleToLongBits(val);
+        return Helpers.multAndMix(runtime.getHashSeedK0(), hashLong);
     }
 
     /** flo_fo

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -2592,6 +2592,17 @@ public class Helpers {
         return (RubyFixnum) hval;
     }
 
+    // MRI: mult_and_mix, roughly since we have no uint64 type
+    public static long multAndMix(long seed, long hash) {
+        long hm1 = seed >> 32, hm2 = hash >> 32;
+        long lm1 = seed, lm2 = hash;
+        long v64_128 = hm1 * hm2;
+        long v32_96 = hm1 * lm2 + lm1 * hm2;
+        long v1_32 = lm1 * lm2;
+
+        return (v64_128 + (v32_96 >> 32)) ^ ((v32_96 << 32) + v1_32);
+    }
+
     public static long murmurCombine(long h, long i)
     {
         long v = 0;


### PR DESCRIPTION
This PR makes changes to RubyFixnum, RubyBignum, and RubyFloat hashing to incorporate the per-runtime random seed, in an effort to mimic CRuby's fixes for CVE-2011-4815.

This CVE was part of a flurry of "hashDOS" fixes that happened in the early 2010s to address poor hash use by application frameworks like Rails. Because untrusted data from web requests was blindly used for internal hashing, these frameworks could be DOS'ed by predicting the hashes of strings and other data and tricking Ruby into putting all elements in the same linear-scanned hash box.

The change here roughly mimics the CRuby logic for combining a random seed with the 64-bit long representation of these core numeric types, which in turn propagates that randomness to the composite types like Complex and Rational.

We may want to make this randomization optional, since we have had requests like #590 to allow users to opt into repeatable hashing.

This PR can safely merge to master.

See #6304 for the security specs failing without this change. This PR addresses all the failing numeric hash security specs.