### PR TITLE
Update WEBrick to 1.6.0

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -27,7 +27,7 @@ default_gems = [
     ['rake-ant', '1.0.4'],
     ['rdoc', '${rdoc.version}'],
     ['scanf', '1.0.0'],
-    ['webrick', '1.4.2'],
+    ['webrick', '1.6.0'],
 ]
 
 bundled_gems = [

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -190,7 +190,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>webrick</artifactId>
-      <version>1.4.2</version>
+      <version>1.6.0</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -347,9 +347,9 @@ DO NOT MODIFIY - GENERATED CODE
           <include>cache/scanf*1.0.0.gem</include>
           <include>gems/scanf*1.0.0/**</include>
           <include>specifications/scanf*1.0.0.gemspec</include>
-          <include>cache/webrick*1.4.2.gem</include>
-          <include>gems/webrick*1.4.2/**</include>
-          <include>specifications/webrick*1.4.2.gemspec</include>
+          <include>cache/webrick*1.6.0.gem</include>
+          <include>gems/webrick*1.6.0/**</include>
+          <include>specifications/webrick*1.6.0.gemspec</include>
           <include>cache/did_you_mean*1.2.0.gem</include>
           <include>gems/did_you_mean*1.2.0/**</include>
           <include>specifications/did_you_mean*1.2.0.gemspec</include>


### PR DESCRIPTION
This updates our shipped webrick to 1.6.0.

See #6304 for two security spec failures that this addresses.

There seems to be no other released version of webrick that has all the relevant CVE fixes. The versions shipped with CRuby do not correspond to any released version of webrick.