### PR TITLE
Fixes to get specs passing on Darwin and other things

### DIFF
--- a/core/src/main/java/org/jruby/RubySignal.java
+++ b/core/src/main/java/org/jruby/RubySignal.java
@@ -79,7 +79,8 @@ public class RubySignal {
         HashMap<String, Integer> signals = new HashMap<>();
         HashMap<Integer, String> signums = new HashMap<>();
 
-        for (Signal s : Signal.values()) {
+        Signal[] values = Signal.values();
+        for (Signal s : values) {
             // Skip signals not defined on this platform
             if (!s.defined()) continue;
 
@@ -91,8 +92,10 @@ public class RubySignal {
 
             // replace CLD with CHLD value
             int signo = s.intValue();
-            if (s == Signal.SIGCLD)
-                signo = Signal.SIGCHLD.intValue();
+            if (s == Signal.SIGCHLD || s == Signal.SIGCLD) {
+                // skip these because Ruby does them weirdly
+                continue;
+            }
 
             // omit unsupported signals
             if (signo >= 20000) continue;
@@ -104,6 +107,22 @@ public class RubySignal {
         // We always define KILL as 9 on Windows
         if (Platform.IS_WINDOWS) {
             signals.put("KILL", 9);
+        }
+
+        // map SIGCLD and SIGCHLD like Ruby
+        int CHLD;
+        if (Signal.SIGCLD.defined()) {
+            CHLD = Signal.SIGCLD.intValue();
+        } else if (Signal.SIGCHLD.defined()) {
+            CHLD = Signal.SIGCHLD.intValue();
+        } else {
+            CHLD = 0;
+        }
+
+        if (CHLD != 0) {
+            signals.put("CLD", CHLD);
+            signals.put("CHLD", CHLD);
+            signums.put(CHLD, "CHLD");
         }
 
         SIGNAME_MAP = Collections.unmodifiableMap(signals);

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -567,7 +567,6 @@ public class JVMVisitor extends IRVisitor {
         /* Compile the closure like a method */
         String name = JavaNameMangler.encodeScopeForBacktrace(closure) + '$' + methodIndex++;
 
-
         emitScope(closure, name, CLOSURE_SIGNATURE, false, print);
 
         Handle handle = new Handle(

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Array;
 import java.net.BindException;
 import java.net.PortUnreachableException;
 import java.nio.channels.ClosedChannelException;
+import java.nio.channels.NotYetConnectedException;
 import java.nio.charset.Charset;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.AtomicMoveNotSupportedException;
@@ -265,6 +266,8 @@ public class Helpers {
             return errnoFromMessage(dnee);
         } catch (BindException be) {
             return errnoFromMessage(be);
+        } catch (NotYetConnectedException nyce) {
+            return Errno.ENOTCONN;
         } catch (Throwable t2) {
             // fall through
         }

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -308,6 +308,7 @@ public class Helpers {
                 case "Address already in use":
                     return Errno.EADDRINUSE;
                 case "Cannot assign requested address":
+                case "Can't assign requested address":
                     return Errno.EADDRNOTAVAIL;
                 case "No space left on device":
                     return Errno.ENOSPC;

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.concurrent.Callable;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -330,18 +331,65 @@ public class Helpers {
     }
 
     /**
-     * Java does not give us enough information for specific error conditions
-     * so we are reduced to divining them through string matches...
+     * Construct an appropriate error (which may ultimately not be an IOError) for a given IOException.
      *
-     * TODO: Should ECONNABORTED get thrown earlier in the descriptor itself or is it ok to handle this late?
-     * TODO: Should we include this into Errno code somewhere do we can use this from other places as well?
+     * If this method is used on an exception which can't be translated to a Ruby error using {@link #newErrorFromException(Ruby, Exception)}
+     * then a RuntimeError will be returned, due to the unhandled exception type.
+     *
+     * @param runtime the current runtime
+     * @param ex the exception to translate into a Ruby error
+     * @return a RaiseException subtype instance appropriate for the given exception
      */
     public static RaiseException newIOErrorFromException(Ruby runtime, IOException ex) {
-        Errno errno = errnoFromException(ex);
+        return (RaiseException) newErrorFromException(runtime, ex, (t) -> runtime.newRuntimeError("unexpected Java exception: " + ex.toString()));
+    }
 
-        if (errno == null) throw runtime.newIOError(ex.getLocalizedMessage());
+    /**
+     * Return a Ruby-friendly Throwable for a given Throwable.
+     *
+     * The following translations will be attempted in order:
+     *
+     * <ul>
+     *     <li>if the Throwable is already a Ruby exception type, return it as-is</li>
+     *     <li>convert to a Ruby Errno exception via {@link #errnoFromException(Throwable)}</li>
+     *     <li>convert to a Ruby IOError if the exception is a java.io.IOException</li>
+     *     <li>using the provided function as a fallback transformation</li>
+     * </ul>
+     *
+     * @param runtime the current runtime
+     * @param t the exception to translate into a Ruby error
+     * @param els a fallback function if the exception cannot be translated
+     * @return a RaiseException subtype instance appropriate for the given exception
+     */
+    public static Throwable newErrorFromException(Ruby runtime, Throwable t, Function<Throwable, Throwable> els) {
+        if (t instanceof RaiseException) {
+            // already a Ruby-friendly Throwable
+            return t;
+        }
 
-        throw runtime.newErrnoFromErrno(errno, ex.getLocalizedMessage());
+        Errno errno = errnoFromException(t);
+
+        if (errno != null) {
+            return runtime.newErrnoFromErrno(errno, t.getLocalizedMessage());
+        } else if (t instanceof IOException) {
+            return runtime.newIOError(t.getLocalizedMessage());
+        }
+
+        return els.apply(t);
+    }
+
+    /**
+     * Throw an appropriate Ruby-friendly error or exception for a given Java exception.
+     *
+     * This method will first attempt to translate the exception into a Ruby error using {@link #newErrorFromException(Ruby, Throwable, Function)}.
+     *
+     * Failing that, it will raise the original Java exception as-is.
+     *
+     * @param runtime the current runtime
+     * @param t the exception to raise as an error, if appropriate, or as itself otherwise
+     */
+    public static void throwErrorFromException(Ruby runtime, Throwable t) {
+        throwException(newErrorFromException(runtime, t, (t0) -> t0));
     }
 
     public static RubyModule getNthScopeModule(StaticScope scope, int depth) {

--- a/core/src/main/java/org/jruby/util/io/PosixShim.java
+++ b/core/src/main/java/org/jruby/util/io/PosixShim.java
@@ -115,13 +115,9 @@ public class PosixShim {
             }
 
             return written;
-        }  catch (NotYetConnectedException nyce) {
-            setErrno(Errno.ENOTCONN);
-            error = nyce;
-            return -1;
-        } catch (IOException ioe) {
-            setErrno(Helpers.errnoFromException(ioe));
-            error = ioe;
+        }  catch (Exception e) {
+            setErrno(Helpers.errnoFromException(e));
+            error = e;
             return -1;
         }
     }

--- a/core/src/main/java/org/jruby/util/io/PosixShim.java
+++ b/core/src/main/java/org/jruby/util/io/PosixShim.java
@@ -6,6 +6,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channel;
 import java.nio.channels.Channels;
 import java.nio.channels.FileLock;
+import java.nio.channels.NotYetConnectedException;
 import java.nio.channels.OverlappingFileLockException;
 import java.nio.channels.Pipe;
 
@@ -114,6 +115,10 @@ public class PosixShim {
             }
 
             return written;
+        }  catch (NotYetConnectedException nyce) {
+            setErrno(Errno.ENOTCONN);
+            error = nyce;
+            return -1;
         } catch (IOException ioe) {
             setErrno(Helpers.errnoFromException(ioe));
             error = ioe;

--- a/spec/jruby.mspec
+++ b/spec/jruby.mspec
@@ -80,6 +80,8 @@ class MSpecScript
 
   get(:xtags) << 'critical'
   get(:ci_xtags) << 'critical'
+  get(:xtags) << 'hangs'
+  get(:ci_xtags) << 'hangs'
 
   get(:ci_xtags) << "java#{ENV_JAVA['java.specification.version']}" # Java version
 

--- a/spec/jruby.mspec
+++ b/spec/jruby.mspec
@@ -85,6 +85,10 @@ class MSpecScript
 
   get(:ci_xtags) << "java#{ENV_JAVA['java.specification.version']}" # Java version
 
+  if (ENV["TRAVIS"] == "true")
+    get(:ci_xtags) << "travis" # Failing only on Travis
+  end
+
   get(:ci_xtags) << RbConfig::CONFIG['host_os']
 
   if WINDOWS

--- a/spec/tags/ruby/library/socket/addrinfo/initialize_tags.txt
+++ b/spec/tags/ruby/library/socket/addrinfo/initialize_tags.txt
@@ -23,15 +23,8 @@ fails:Addrinfo#initialize with a sockaddr string with a family, socket type and 
 fails:Addrinfo#initialize with a sockaddr string with a family, socket type and protocol returns the specified socket type
 fails:Addrinfo#initialize with a sockaddr string with a family, socket type and protocol returns the specified protocol
 fails:Addrinfo#initialize with a sockaddr array without a family returns the Socket::UNSPEC pfamily
-fails:Addrinfo#initialize with a sockaddr array with a family given returns the Socket::UNSPEC pfamily
-fails:Addrinfo#initialize with a sockaddr array with a family and socket type returns the Socket::UNSPEC pfamily
 fails:Addrinfo#initialize with a sockaddr array with a family and socket type returns the 0 protocol
-fails:Addrinfo#initialize with a sockaddr array with a family, socket type and protocol returns the Socket::UNSPEC pfamily
 fails:Addrinfo#initialize with a sockaddr string without a family returns AF_INET as the default address family
-fails:Addrinfo#initialize with a sockaddr array without a family returns the Socket::PF_INET pfamily
-fails:Addrinfo#initialize with a sockaddr array with a valid IP address returns an Addrinfo with the correct IP
-fails:Addrinfo#initialize with a sockaddr array with a valid IP address returns an Addrinfo with the correct address family
-fails:Addrinfo#initialize with a sockaddr array with a valid IP address returns an Addrinfo with the correct protocol family
 fails:Addrinfo#initialize with a sockaddr array with an invalid IP address raises SocketError
 fails:Addrinfo#initialize with a sockaddr array with a family and socket type raises SocketError when using SOCK_RDM
 fails:Addrinfo#initialize using an Array with extra arguments with the AF_INET6 address family and an explicit protocol family raises SocketError when using any Socket constant except except AF_INET(6)/PF_INET(6)

--- a/spec/tags/ruby/library/socket/addrinfo/ip_tags.txt
+++ b/spec/tags/ruby/library/socket/addrinfo/ip_tags.txt
@@ -1,2 +1,0 @@
-fails:Addrinfo.ip using IPv4 sets the protocol family
-fails:Addrinfo.ip using IPv6 sets the protocol family

--- a/spec/tags/ruby/library/socket/basicsocket/connect_address_tags.txt
+++ b/spec/tags/ruby/library/socket/basicsocket/connect_address_tags.txt
@@ -3,5 +3,4 @@ fails:Socket#connect_address using a socket bound to 0.0.0.0 uses 127.0.0.1 as t
 fails:Socket#connect_address using a socket bound to 0.0.0.0 uses AF_INET as the address family
 fails:Socket#connect_address using a socket bound to 0.0.0.0 uses PF_INET as the address family
 fails:Socket#connect_address using a socket bound to 0.0.0.0 uses 0 as the protocol
-fails:Socket#connect_address using a socket bound to :: uses PF_INET6 as the address family
 fails:Socket#connect_address using a socket bound to :: uses 0 as the protocol

--- a/spec/tags/ruby/library/socket/basicsocket/do_not_reverse_lookup_tags.txt
+++ b/spec/tags/ruby/library/socket/basicsocket/do_not_reverse_lookup_tags.txt
@@ -1,2 +1,0 @@
-fails:BasicSocket#do_not_reverse_lookup for an TCPSocket.new socket is false when BasicSocket.do_not_reverse_lookup is false
-fails:BasicSocket#do_not_reverse_lookup for an TCPServer#accept socket is false when BasicSocket.do_not_reverse_lookup is false

--- a/spec/tags/ruby/library/socket/basicsocket/read_nonblock_tags.txt
+++ b/spec/tags/ruby/library/socket/basicsocket/read_nonblock_tags.txt
@@ -1,4 +1,0 @@
-fails:BasicSocket#read_nonblock using IPv4 receives data after it's ready
-fails:BasicSocket#read_nonblock using IPv4 does not set the IO in nonblock mode
-fails:BasicSocket#read_nonblock using IPv6 receives data after it's ready
-fails:BasicSocket#read_nonblock using IPv6 does not set the IO in nonblock mode

--- a/spec/tags/ruby/library/socket/basicsocket/recv_nonblock_tags.txt
+++ b/spec/tags/ruby/library/socket/basicsocket/recv_nonblock_tags.txt
@@ -1,4 +1,0 @@
-fails:Socket::BasicSocket#recv_nonblock raises an exception extending IO::WaitReadable if there's no data available
-fails:Socket::BasicSocket#recv_nonblock receives data after it's ready
-fails:Socket::BasicSocket#recv_nonblock allows an output buffer as third argument
-fails:Socket::BasicSocket#recv_nonblock does not block if there's no data available

--- a/spec/tags/ruby/library/socket/basicsocket/recv_nonblock_tags.txt
+++ b/spec/tags/ruby/library/socket/basicsocket/recv_nonblock_tags.txt
@@ -2,14 +2,3 @@ fails:Socket::BasicSocket#recv_nonblock raises an exception extending IO::WaitRe
 fails:Socket::BasicSocket#recv_nonblock receives data after it's ready
 fails:Socket::BasicSocket#recv_nonblock allows an output buffer as third argument
 fails:Socket::BasicSocket#recv_nonblock does not block if there's no data available
-fails:Socket::BasicSocket#recv_nonblock using IPv4 raises an exception extending IO::WaitReadable if there's no data available
-fails:Socket::BasicSocket#recv_nonblock using IPv4 receives data after it's ready
-fails:Socket::BasicSocket#recv_nonblock using IPv4 allows an output buffer as third argument
-fails:Socket::BasicSocket#recv_nonblock using IPv4 does not block if there's no data available
-fails:Socket::BasicSocket#recv_nonblock using IPv4 using an unbound socket raises an exception extending IO::WaitReadable
-fails:Socket::BasicSocket#recv_nonblock using IPv6 raises an exception extending IO::WaitReadable if there's no data available
-fails:Socket::BasicSocket#recv_nonblock using IPv6 receives data after it's ready
-fails:Socket::BasicSocket#recv_nonblock using IPv6 allows an output buffer as third argument
-fails:Socket::BasicSocket#recv_nonblock using IPv6 does not block if there's no data available
-fails:Socket::BasicSocket#recv_nonblock using IPv6 using an unbound socket raises an exception extending IO::WaitReadable
-fails:Socket::BasicSocket#recv_nonblock using IPv4 returns :wait_readable with exception: false

--- a/spec/tags/ruby/library/socket/basicsocket/recv_tags.txt
+++ b/spec/tags/ruby/library/socket/basicsocket/recv_tags.txt
@@ -1,16 +1,10 @@
 fails:BasicSocket#recv accepts flags to specify unusual receiving behaviour
 fails:BasicSocket#recv allows an output buffer as third argument
-fails:BasicSocket#recv using IPv4 using a bound socket with data available reads the given amount of bytes
-fails:BasicSocket#recv using IPv4 using a bound socket with data available reads the given amount of bytes when it exceeds the data size
-fails:BasicSocket#recv using IPv4 using a bound socket with data available blocks the caller when called twice without new data being available
+hangs:BasicSocket#recv using IPv4 using a bound socket with data available blocks the caller when called twice without new data being available
 fails:BasicSocket#recv using IPv4 using a bound socket with data available takes a peek at the data when using the MSG_PEEK flag
-fails:BasicSocket#recv using IPv6 using a bound socket with data available reads the given amount of bytes
-fails:BasicSocket#recv using IPv6 using a bound socket with data available reads the given amount of bytes when it exceeds the data size
-fails:BasicSocket#recv using IPv6 using a bound socket with data available blocks the caller when called twice without new data being available
+hangs:BasicSocket#recv using IPv6 using a bound socket with data available blocks the caller when called twice without new data being available
 fails:BasicSocket#recv using IPv6 using a bound socket with data available takes a peek at the data when using the MSG_PEEK flag
-fails:BasicSocket#recv receives a specified number of bytes of a message from another socket
-fails:BasicSocket#recv gets lines delimited with a custom separator
-fails:BasicSocket#recv using IPv4 using an unbound socket blocks the caller
-fails:BasicSocket#recv using IPv4 using a bound socket without any data available blocks the caller
-fails:BasicSocket#recv using IPv6 using an unbound socket blocks the caller
-fails:BasicSocket#recv using IPv6 using a bound socket without any data available blocks the caller
+hangs:BasicSocket#recv using IPv4 using an unbound socket blocks the caller
+hangs:BasicSocket#recv using IPv4 using a bound socket without any data available blocks the caller
+hangs:BasicSocket#recv using IPv6 using an unbound socket blocks the caller
+hangs:BasicSocket#recv using IPv6 using a bound socket without any data available blocks the caller

--- a/spec/tags/ruby/library/socket/basicsocket/recvmsg_nonblock_tags.txt
+++ b/spec/tags/ruby/library/socket/basicsocket/recvmsg_nonblock_tags.txt
@@ -45,3 +45,4 @@ fails:BasicSocket#recvmsg_nonblock using IPv6 using a connected socket with data
 fails:BasicSocket#recvmsg_nonblock using IPv6 using a connected socket with data available the returned Array the returned Addrinfo uses the correct socket type
 fails:BasicSocket#recvmsg_nonblock using IPv6 using a connected socket with data available the returned Array the returned Addrinfo raises when receiving the ip_port message
 fails:BasicSocket#recvmsg_nonblock using IPv4 using a disconnected socket using a bound socket without any data available returns :wait_readable with exception: false
+fails:BasicSocket#recvmsg_nonblock using IPv6 using a disconnected socket using a bound socket without any data available returns :wait_readable with exception: false

--- a/spec/tags/ruby/library/socket/basicsocket/recvmsg_tags.txt
+++ b/spec/tags/ruby/library/socket/basicsocket/recvmsg_tags.txt
@@ -19,7 +19,6 @@ fails:BasicSocket#recvmsg using IPv4 using a connected socket with data availabl
 fails:BasicSocket#recvmsg using IPv4 using a connected socket with data available the returned Array the returned Addrinfo returns 0 for the protocol family
 fails:BasicSocket#recvmsg using IPv4 using a connected socket with data available the returned Array the returned Addrinfo uses the correct socket type
 fails:BasicSocket#recvmsg using IPv4 using a connected socket with data available the returned Array the returned Addrinfo raises when receiving the ip_port message
-fails:BasicSocket#recvmsg using IPv6 using a disconnected socket using a bound socket without any data available blocks the caller
 fails:BasicSocket#recvmsg using IPv6 using a disconnected socket using a bound socket with data available returns an Array containing the data, an Addrinfo and the flags
 fails:BasicSocket#recvmsg using IPv6 using a disconnected socket using a bound socket with data available without a maximum message length reads all the available data
 fails:BasicSocket#recvmsg using IPv6 using a disconnected socket using a bound socket with data available with a maximum message length reads up to the maximum amount of bytes

--- a/spec/tags/ruby/library/socket/basicsocket/send_tags.txt
+++ b/spec/tags/ruby/library/socket/basicsocket/send_tags.txt
@@ -1,15 +1,9 @@
 fails:BasicSocket#send accepts flags to specify unusual sending behaviour
 fails:BasicSocket#send using IPv4 using a disconnected socket without a destination address raises Errno::EDESTADDRREQ
-fails:BasicSocket#send using IPv4 using a disconnected socket with a destination address as a String returns the amount of sent bytes
 fails:BasicSocket#send using IPv4 using a disconnected socket with a destination address as a String does not persist the connection after writing to the socket
-fails:BasicSocket#send using IPv4 using a disconnected socket with a destination address as an Addrinfo returns the amount of sent bytes
-fails:BasicSocket#send using IPv4 using a connected UDP socket with a destination address argument sends the message to the given address instead
-fails:BasicSocket#send using IPv4 using a connected UDP socket with a destination address argument does not persist the alternative connection after writing to the socket
+hangs:BasicSocket#send using IPv4 using a connected UDP socket with a destination address argument sends the message to the given address instead
 fails:BasicSocket#send using IPv4 using a connected TCP socket using the MSG_OOB flag sends an out-of-band message
 fails:BasicSocket#send using IPv6 using a disconnected socket without a destination address raises Errno::EDESTADDRREQ
-fails:BasicSocket#send using IPv6 using a disconnected socket with a destination address as a String returns the amount of sent bytes
 fails:BasicSocket#send using IPv6 using a disconnected socket with a destination address as a String does not persist the connection after writing to the socket
-fails:BasicSocket#send using IPv6 using a disconnected socket with a destination address as an Addrinfo returns the amount of sent bytes
-fails:BasicSocket#send using IPv6 using a connected UDP socket with a destination address argument sends the message to the given address instead
-fails:BasicSocket#send using IPv6 using a connected UDP socket with a destination address argument does not persist the alternative connection after writing to the socket
+hangs:BasicSocket#send using IPv6 using a connected UDP socket with a destination address argument sends the message to the given address instead
 fails:BasicSocket#send using IPv6 using a connected TCP socket using the MSG_OOB flag sends an out-of-band message

--- a/spec/tags/ruby/library/socket/basicsocket/write_nonblock_tags.txt
+++ b/spec/tags/ruby/library/socket/basicsocket/write_nonblock_tags.txt
@@ -1,4 +1,2 @@
-fails:BasicSocket#write_nonblock using IPv4 sends data
 fails:BasicSocket#write_nonblock using IPv4 does not set the IO in nonblock mode
-fails:BasicSocket#write_nonblock using IPv6 sends data
 fails:BasicSocket#write_nonblock using IPv6 does not set the IO in nonblock mode

--- a/spec/tags/ruby/library/socket/ipsocket/recvfrom_tags.txt
+++ b/spec/tags/ruby/library/socket/ipsocket/recvfrom_tags.txt
@@ -1,5 +1,4 @@
-fails(hangs):Socket::IPSocket#recvfrom using IPv4 allows specifying of flags when receiving data
-fails(hangs):Socket::IPSocket#recvfrom using IPv6 allows specifying of flags when receiving data
-fails:Socket::IPSocket#recvfrom using IPv4 returns an Array containing up to N bytes and address information
+hangs:Socket::IPSocket#recvfrom using IPv4 allows specifying of flags when receiving data
+hangs:Socket::IPSocket#recvfrom using IPv6 allows specifying of flags when receiving data
 fails:Socket::IPSocket#recvfrom using IPv6 returns an Array containing up to N bytes and address information
 fails:Socket::IPSocket#recvfrom using IPv6 using reverse lookups includes the hostname in the address Array

--- a/spec/tags/ruby/library/socket/socket/getaddrinfo_tags.txt
+++ b/spec/tags/ruby/library/socket/socket/getaddrinfo_tags.txt
@@ -8,3 +8,4 @@ fails:Socket.getaddrinfo without global reverse lookups performs a reverse looku
 fails:Socket.getaddrinfo without global reverse lookups performs a reverse lookup when the reverse_lookup argument is :hostname
 fails:Socket.getaddrinfo without global reverse lookups performs a reverse lookup when the reverse_lookup argument is :numeric
 fails:Socket.getaddrinfo without global reverse lookups accepts an Integer as the address family using IPv6
+travis(no IPv6 so spec ends up having no expectations):Socket.getaddrinfo accepts empty addresses for IPv6 non-passive sockets

--- a/spec/tags/ruby/library/socket/socket/getaddrinfo_tags.txt
+++ b/spec/tags/ruby/library/socket/socket/getaddrinfo_tags.txt
@@ -1,7 +1,6 @@
 windows:Socket#getaddrinfo accepts empty addresses for IPv6 passive sockets
 windows:Socket#getaddrinfo accepts empty addresses for IPv6 non-passive sockets
 fails:Socket#getaddrinfo accepts empty addresses for IPv6 non-passive sockets
-fails:Socket.getaddrinfo accepts empty addresses for IPv6 non-passive sockets
 fails:Socket.getaddrinfo without global reverse lookups accepts a Fixnum as the address family using IPv6
 fails:Socket.getaddrinfo without global reverse lookups accepts a Symbol as the address family using IPv6
 fails:Socket.getaddrinfo without global reverse lookups accepts a String as the address family using IPv6

--- a/spec/tags/ruby/library/socket/socket/gethostbyname_tags.txt
+++ b/spec/tags/ruby/library/socket/socket/gethostbyname_tags.txt
@@ -3,3 +3,5 @@ fails:Socket.gethostbyname the returned Array includes the hostname as the first
 fails:Socket.gethostbyname using an IPv4 address the returned Array includes the IP address as the first value
 fails:Socket.gethostbyname using an IPv6 address the returned Array includes the IP address as the first value
 fails:Socket.gethostbyname using an IPv6 address the returned Array includes the address type as the 3rd value
+darwin(macOS provides a hostname for the broadcast address):Socket.gethostbyname returns broadcast address info for '<broadcast>'
+darwin(macOS provides a hostname for the broadcast address):Socket.gethostbyname using <broadcast> as the input address the returned Array includes the broadcast address as the first value

--- a/spec/tags/ruby/library/socket/socket/gethostname_tags.txt
+++ b/spec/tags/ruby/library/socket/socket/gethostname_tags.txt
@@ -1,1 +1,0 @@
-fails:Socket.gethostname returns the host name

--- a/spec/tags/ruby/library/socket/socket/gethostname_tags.txt
+++ b/spec/tags/ruby/library/socket/socket/gethostname_tags.txt
@@ -1,0 +1,1 @@
+travis(reverses localhost to a travis hostname):Socket.gethostname returns the host name

--- a/spec/tags/ruby/library/socket/socket/recvfrom_tags.txt
+++ b/spec/tags/ruby/library/socket/socket/recvfrom_tags.txt
@@ -1,6 +1,6 @@
-fails(hangs):Socket#recvfrom using IPv4 using an unbound socket blocks the caller
-fails(hangs):Socket#recvfrom using IPv4 using a bound socket without any data available blocks the caller
-fails(hangs):Socket#recvfrom using IPv6 using an unbound socket blocks the caller
-fails(hangs):Socket#recvfrom using IPv6 using a bound socket without any data available blocks the caller
+hangs:Socket#recvfrom using IPv4 using an unbound socket blocks the caller
+hangs:Socket#recvfrom using IPv4 using a bound socket without any data available blocks the caller
+hangs:Socket#recvfrom using IPv6 using an unbound socket blocks the caller
+hangs:Socket#recvfrom using IPv6 using a bound socket without any data available blocks the caller
 fails:Socket#recvfrom using IPv4 using a bound socket with data available the returned Addrinfo uses 0 as the protocol
 fails:Socket#recvfrom using IPv6 using a bound socket with data available the returned Addrinfo uses 0 as the protocol

--- a/spec/tags/ruby/library/socket/socket/tcp_server_loop_tags.txt
+++ b/spec/tags/ruby/library/socket/socket/tcp_server_loop_tags.txt
@@ -1,1 +1,0 @@
-fails:Socket.tcp_server_loop when a connection is available yields a Socket and an Addrinfo

--- a/spec/tags/ruby/library/socket/socket/udp_server_loop_on_tags.txt
+++ b/spec/tags/ruby/library/socket/socket/udp_server_loop_on_tags.txt
@@ -1,2 +1,1 @@
 fails:Socket.udp_server_loop_on when a connection is available yields the message and a Socket::UDPSource
-fails(does not handle sporadic wakeups in IO.select):Socket.udp_server_loop_on when no connections are available blocks the caller

--- a/spec/tags/ruby/library/socket/socket/udp_server_loop_tags.txt
+++ b/spec/tags/ruby/library/socket/socket/udp_server_loop_tags.txt
@@ -1,2 +1,2 @@
 fails:Socket.udp_server_loop when no connections are available blocks the caller
-fails:Socket.udp_server_loop when a connection is available yields the message and a Socket::UDPSource
+hangs:Socket.udp_server_loop when a connection is available yields the message and a Socket::UDPSource

--- a/spec/tags/ruby/library/socket/tcpsocket/local_address_tags.txt
+++ b/spec/tags/ruby/library/socket/tcpsocket/local_address_tags.txt
@@ -1,3 +1,2 @@
 fails:TCPSocket#local_address using IPv4 using an explicit hostname the returned Addrinfo uses 0 as the protocol
 fails:TCPSocket#local_address using IPv6 using an explicit hostname the returned Addrinfo uses 0 as the protocol
-

--- a/spec/tags/ruby/library/socket/tcpsocket/partially_closable_tags.txt
+++ b/spec/tags/ruby/library/socket/tcpsocket/partially_closable_tags.txt
@@ -1,2 +1,0 @@
-fails:TCPSocket partial closability if the write end is closed then the other side can read past EOF without blocking
-fails:TCPSocket partial closability closing the write end ensures that the other side can read until EOF

--- a/spec/tags/ruby/library/socket/tcpsocket/remote_address_tags.txt
+++ b/spec/tags/ruby/library/socket/tcpsocket/remote_address_tags.txt
@@ -1,3 +1,2 @@
 fails:TCPSocket#remote_address using IPv4 using an explicit hostname the returned Addrinfo uses 0 as the protocol
 fails:TCPSocket#remote_address using IPv6 using an explicit hostname the returned Addrinfo uses 0 as the protocol
-

--- a/spec/tags/ruby/library/socket/udpsocket/send_tags.txt
+++ b/spec/tags/ruby/library/socket/udpsocket/send_tags.txt
@@ -1,2 +1,2 @@
-fails(hangs):UDPSocket#send using IPv4 using a connected socket with an explicit destination address sends the data to the given address instead
-fails(hangs):UDPSocket#send using IPv6 using a connected socket with an explicit destination address sends the data to the given address instead
+hangs:UDPSocket#send using IPv4 using a connected socket with an explicit destination address sends the data to the given address instead
+hangs:UDPSocket#send using IPv6 using a connected socket with an explicit destination address sends the data to the given address instead

--- a/spec/tags/ruby/library/socket/unixsocket/pair_tags.txt
+++ b/spec/tags/ruby/library/socket/unixsocket/pair_tags.txt
@@ -1,2 +1,0 @@
-fails:UNIXSocket#pair if the write end is closed then the other side can read past EOF without blocking
-fails:UNIXSocket#pair closing the write end ensures that the other side can read until EOF

--- a/spec/tags/ruby/library/socket/unixsocket/partially_closable_tags.txt
+++ b/spec/tags/ruby/library/socket/unixsocket/partially_closable_tags.txt
@@ -1,2 +1,0 @@
-fails:UNIXSocket partial closability if the write end is closed then the other side can read past EOF without blocking
-fails:UNIXSocket partial closability closing the write end ensures that the other side can read until EOF

--- a/spec/tags/ruby/library/socket/unixsocket/peeraddr_tags.txt
+++ b/spec/tags/ruby/library/socket/unixsocket/peeraddr_tags.txt
@@ -1,1 +1,0 @@
-fails:UNIXSocket#peeraddr returns the address family and path of the server end of the connection


### PR DESCRIPTION
This started out as a PR to get :fast specs passing on Darwin, but has expanded into fixing a few additional issues.

The bulk of the failing specs were from socket specs, mostly because there are special carve-outs for certain platforms and we did not have these tagged. Where possible, I've actually fixed the related specs on all platforms.

One failure was due to the JIT not using `<main>` for the method name of blocks at the root level of a script.

One failure was due to incorrectly managing the SIGCLD and SIGCHLD signals the way CRuby does.