### PR TITLE
Do the read of the full file contents separately

### DIFF
--- a/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
+++ b/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
@@ -225,15 +225,21 @@ class LibrarySearcher {
 
         @Override
         public void load(Ruby runtime, boolean wrap) {
-            try (InputStream ris = resource.inputStream()) {
+            // Fully buffers file, so does not need to be closed
+            LoadServiceResourceInputStream ris = prepareInputStream(runtime);
 
-                if (runtime.getInstanceConfig().getCompileMode().shouldPrecompileAll()) {
-                    runtime.compileAndLoadFile(scriptName, ris, wrap);
-                } else {
-                    runtime.loadFile(scriptName, new LoadServiceResourceInputStream(ris), wrap);
-                }
-            } catch(IOException e) {
-                throw runtime.newLoadError("no such file to load -- " + searchName, searchName);
+            if (runtime.getInstanceConfig().getCompileMode().shouldPrecompileAll()) {
+                runtime.compileAndLoadFile(scriptName, ris, wrap);
+            } else {
+                runtime.loadFile(scriptName, ris, wrap);
+            }
+        }
+
+        private LoadServiceResourceInputStream prepareInputStream(Ruby runtime) {
+            try {
+                return new LoadServiceResourceInputStream(resource.inputStream());
+            } catch (IOException ioe) {
+                throw runtime.newLoadError("failure to load file: " + ioe.getLocalizedMessage(), searchName);
             }
         }
     }


### PR DESCRIPTION
This allows us to propagate IOException rather than wrongly
interpreting it as an error caused by the load of the file itself.
It still gets wrapped in a LoadError, but at least it does not
provide a misleading message.

Relates to #4194.