### PR TITLE
Mark literal blocks escaped when passed through a super call

### DIFF
--- a/core/src/main/java/org/jruby/ir/instructions/ClassSuperInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ClassSuperInstr.java
@@ -9,6 +9,7 @@ import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
+import org.jruby.ir.operands.WrappedIRClosure;
 import org.jruby.ir.persistence.IRReaderDecoder;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.transformations.inlining.CloneInfo;
@@ -17,16 +18,22 @@ import org.jruby.runtime.*;
 import org.jruby.runtime.builtin.IRubyObject;
 
 public class ClassSuperInstr extends CallInstr {
+    private final boolean isLiteralBlock;
+
     // clone constructor
     protected ClassSuperInstr(IRScope scope, Variable result, Operand receiver, RubySymbol name, Operand[] args,
                               Operand closure, boolean potentiallyRefined, CallSite callSite, long callSiteId) {
         super(scope, Operation.CLASS_SUPER, CallType.SUPER, result, name, receiver, args, closure, potentiallyRefined, callSite, callSiteId);
+
+        isLiteralBlock = closure instanceof WrappedIRClosure;
     }
 
     // normal constructor
     public ClassSuperInstr(IRScope scope, Variable result, Operand definingModule, RubySymbol name, Operand[] args, Operand closure,
                            boolean isPotentiallyRefined) {
         super(scope, Operation.CLASS_SUPER, CallType.SUPER, result, name, definingModule, args, closure, isPotentiallyRefined);
+
+        isLiteralBlock = closure instanceof WrappedIRClosure;
     }
 
     public Operand getDefiningModule() {
@@ -82,7 +89,12 @@ public class ClassSuperInstr extends CallInstr {
     public Object interpret(ThreadContext context, StaticScope currScope, DynamicScope currDynScope, IRubyObject self, Object[] temp) {
         IRubyObject[] args = prepareArguments(context, self, currScope, currDynScope, temp);
         Block block = prepareBlock(context, self, currScope, currDynScope, temp);
-        return IRRuntimeHelpers.unresolvedSuper(context, self, args, block);
+
+        if (isLiteralBlock) {
+            return IRRuntimeHelpers.unresolvedSuperIter(context, self, args, block);
+        } else {
+            return IRRuntimeHelpers.unresolvedSuper(context, self, args, block);
+        }
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/UnresolvedSuperInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/UnresolvedSuperInstr.java
@@ -9,6 +9,7 @@ import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
+import org.jruby.ir.operands.WrappedIRClosure;
 import org.jruby.ir.persistence.IRReaderDecoder;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.transformations.inlining.CloneInfo;
@@ -24,6 +25,8 @@ import org.jruby.util.ByteList;
 // SSS FIXME: receiver is never used -- being passed in only to meet requirements of CallInstr
 
 public class UnresolvedSuperInstr extends CallInstr {
+    private final boolean isLiteralBlock;
+
     private static final ByteList DYNAMIC_SUPER_TARGET =
             new ByteList("-dynamic-super_target-".getBytes(), USASCIIEncoding.INSTANCE, false);
 
@@ -32,6 +35,8 @@ public class UnresolvedSuperInstr extends CallInstr {
                                 Operand closure, boolean isPotentiallyRefined, CallSite callSite, long callSiteId) {
         super(scope, op, CallType.SUPER, result, scope.getManager().getRuntime().newSymbol(DYNAMIC_SUPER_TARGET),
                 receiver, args, closure, isPotentiallyRefined, callSite, callSiteId);
+
+        isLiteralBlock = closure instanceof WrappedIRClosure;
     }
 
     // normal constructor
@@ -39,6 +44,8 @@ public class UnresolvedSuperInstr extends CallInstr {
                                 boolean isPotentiallyRefined) {
         super(scope, op, CallType.SUPER, result, scope.getManager().getRuntime().newSymbol(DYNAMIC_SUPER_TARGET),
                 receiver, args, closure, isPotentiallyRefined);
+
+        isLiteralBlock = closure instanceof WrappedIRClosure;
     }
 
     // specific instr constructor
@@ -100,7 +107,12 @@ public class UnresolvedSuperInstr extends CallInstr {
     public Object interpret(ThreadContext context, StaticScope currScope, DynamicScope currDynScope, IRubyObject self, Object[] temp) {
         IRubyObject[] args = prepareArguments(context, self, currScope, currDynScope, temp);
         Block block = prepareBlock(context, self, currScope, currDynScope, temp);
-        return IRRuntimeHelpers.unresolvedSuper(context, self, args, block);
+
+        if (isLiteralBlock) {
+            return IRRuntimeHelpers.unresolvedSuperIter(context, self, args, block);
+        } else {
+            return IRRuntimeHelpers.unresolvedSuper(context, self, args, block);
+        }
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/targets/InvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/InvocationCompiler.java
@@ -61,9 +61,10 @@ public interface InvocationCompiler {
      * @param name name of the method to invoke
      * @param arity arity of the arguments on the stack
      * @param hasClosure whether a block is passed
+     * @param literalClosure whether the block passed is a literal closure
      * @param splatmap a map of arguments to be splatted back into arg list
      */
-    void invokeInstanceSuper(String file, int line, String name, int arity, boolean hasClosure, boolean[] splatmap);
+    void invokeInstanceSuper(String file, int line, String name, int arity, boolean hasClosure, boolean literalClosure, boolean[] splatmap);
 
     /**
      * Invoke a superclass method from a class context.
@@ -75,9 +76,10 @@ public interface InvocationCompiler {
      * @param name name of the method to invoke
      * @param arity arity of the arguments on the stack
      * @param hasClosure whether a block is passed
+     * @param literalClosure whether the block passed is a literal closure
      * @param splatmap a map of arguments to be splatted back into arg list
      */
-    void invokeClassSuper(String file, int line, String name, int arity, boolean hasClosure, boolean[] splatmap);
+    void invokeClassSuper(String file, int line, String name, int arity, boolean hasClosure, boolean literalClosure, boolean[] splatmap);
 
     /**
      * Invoke a superclass method from an unresolved context.
@@ -89,9 +91,10 @@ public interface InvocationCompiler {
      * @param name name of the method to invoke
      * @param arity arity of the arguments on the stack
      * @param hasClosure whether a block is passed
+     * @param literalClosure whether the block passed is a literal closure
      * @param splatmap a map of arguments to be splatted back into arg list
      */
-    void invokeUnresolvedSuper(String file, int line, String name, int arity, boolean hasClosure, boolean[] splatmap);
+    void invokeUnresolvedSuper(String file, int line, String name, int arity, boolean hasClosure, boolean literalClosure, boolean[] splatmap);
 
     /**
      * Invoke a superclass method from a zsuper in a block.

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -1620,6 +1620,7 @@ public class JVMVisitor extends IRVisitor {
         }
 
         boolean hasClosure = closure != null;
+        boolean literalClosure = closure instanceof WrappedIRClosure;
         if (hasClosure) {
             m.loadContext();
             if (instr.isPotentiallyRefined()) m.loadStaticScope();
@@ -1633,13 +1634,13 @@ public class JVMVisitor extends IRVisitor {
 
         switch (operation) {
             case INSTANCE_SUPER:
-                m.getInvocationCompiler().invokeInstanceSuper(file, lastLine, name, args.length, hasClosure, splatMap);
+                m.getInvocationCompiler().invokeInstanceSuper(file, lastLine, name, args.length, hasClosure, literalClosure, splatMap);
                 break;
             case CLASS_SUPER:
-                m.getInvocationCompiler().invokeClassSuper(file, lastLine, name, args.length, hasClosure, splatMap);
+                m.getInvocationCompiler().invokeClassSuper(file, lastLine, name, args.length, hasClosure, literalClosure, splatMap);
                 break;
             case UNRESOLVED_SUPER:
-                m.getInvocationCompiler().invokeUnresolvedSuper(file, lastLine, name, args.length, hasClosure, splatMap);
+                m.getInvocationCompiler().invokeUnresolvedSuper(file, lastLine, name, args.length, hasClosure, literalClosure, splatMap);
                 break;
             case ZSUPER:
                 m.getInvocationCompiler().invokeZSuper(file, lastLine, name, args.length, hasClosure, splatMap);

--- a/core/src/main/java/org/jruby/ir/targets/indy/ClassSuperIterInvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/ClassSuperIterInvokeSite.java
@@ -1,0 +1,31 @@
+package org.jruby.ir.targets.indy;
+
+import org.jruby.RubyClass;
+import org.jruby.ir.runtime.IRRuntimeHelpers;
+import org.jruby.runtime.Block;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import java.lang.invoke.MethodType;
+
+/**
+* Created by headius on 10/23/14.
+*/
+public class ClassSuperIterInvokeSite extends ResolvedSuperInvokeSite {
+    public ClassSuperIterInvokeSite(MethodType type, String name, String splatmapString, String file, int line) {
+        super(type, name, splatmapString, file, line);
+    }
+
+    @Override
+    protected RubyClass getSuperClass(RubyClass definingModule) {
+        return definingModule.getMetaClass().getMetaClass().getSuperClass();
+    }
+
+    // FIXME: indy cached version was not doing splat mapping; revert to slow logic for now
+
+    public IRubyObject invoke(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass definingModule, IRubyObject[] args, Block block) throws Throwable {
+        // TODO: get rid of caller
+        // TODO: caching
+        return IRRuntimeHelpers.classSuperIterSplatArgs(context, self, superName, definingModule, args, block, splatMap);
+    }
+}

--- a/core/src/main/java/org/jruby/ir/targets/indy/IndyInvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/IndyInvocationCompiler.java
@@ -138,37 +138,40 @@ public class IndyInvocationCompiler implements InvocationCompiler {
         }
     }
 
-    public void invokeInstanceSuper(String file, int line, String name, int arity, boolean hasClosure, boolean[] splatmap) {
+    public void invokeInstanceSuper(String file, int line, String name, int arity, boolean hasClosure, boolean literalClosure, boolean[] splatmap) {
         if (arity > IRBytecodeAdapter.MAX_ARGUMENTS)
             throw new NotCompilableException("call to instance super has more than " + IRBytecodeAdapter.MAX_ARGUMENTS + " arguments");
 
         String splatmapString = IRRuntimeHelpers.encodeSplatmap(splatmap);
         if (hasClosure) {
-            compiler.adapter.invokedynamic("invokeInstanceSuper:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, RubyClass.class, JVM.OBJECT, arity, Block.class)), Bootstrap.invokeSuper(), splatmapString, file, line);
+            String operation = literalClosure ? "invokeInstanceSuperIter" : "invokeInstanceSuper";
+            compiler.adapter.invokedynamic(operation + ":" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, RubyClass.class, JVM.OBJECT, arity, Block.class)), Bootstrap.invokeSuper(), splatmapString, file, line);
         } else {
             compiler.adapter.invokedynamic("invokeInstanceSuper:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, RubyClass.class, JVM.OBJECT, arity)), Bootstrap.invokeSuper(), splatmapString, file, line);
         }
     }
 
-    public void invokeClassSuper(String file, int line, String name, int arity, boolean hasClosure, boolean[] splatmap) {
+    public void invokeClassSuper(String file, int line, String name, int arity, boolean hasClosure, boolean literalClosure, boolean[] splatmap) {
         if (arity > IRBytecodeAdapter.MAX_ARGUMENTS)
             throw new NotCompilableException("call to class super has more than " + IRBytecodeAdapter.MAX_ARGUMENTS + " arguments");
 
         String splatmapString = IRRuntimeHelpers.encodeSplatmap(splatmap);
         if (hasClosure) {
-            compiler.adapter.invokedynamic("invokeClassSuper:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, RubyClass.class, JVM.OBJECT, arity, Block.class)), Bootstrap.invokeSuper(), splatmapString, file, line);
+            String operation = literalClosure ? "invokeClassSuperIter" : "invokeClassSuper";
+            compiler.adapter.invokedynamic(operation + ":" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, RubyClass.class, JVM.OBJECT, arity, Block.class)), Bootstrap.invokeSuper(), splatmapString, file, line);
         } else {
             compiler.adapter.invokedynamic("invokeClassSuper:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, RubyClass.class, JVM.OBJECT, arity)), Bootstrap.invokeSuper(), splatmapString, file, line);
         }
     }
 
-    public void invokeUnresolvedSuper(String file, int line, String name, int arity, boolean hasClosure, boolean[] splatmap) {
+    public void invokeUnresolvedSuper(String file, int line, String name, int arity, boolean hasClosure, boolean literalClosure, boolean[] splatmap) {
         if (arity > IRBytecodeAdapter.MAX_ARGUMENTS)
             throw new NotCompilableException("call to unresolved super has more than " + IRBytecodeAdapter.MAX_ARGUMENTS + " arguments");
 
         String splatmapString = IRRuntimeHelpers.encodeSplatmap(splatmap);
         if (hasClosure) {
-            compiler.adapter.invokedynamic("invokeUnresolvedSuper:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, RubyClass.class, JVM.OBJECT, arity, Block.class)), Bootstrap.invokeSuper(), splatmapString, file, line);
+            String operation = literalClosure ? "invokeUnresolvedSuperIter" : "invokeUnresolvedSuper";
+            compiler.adapter.invokedynamic(operation + ":" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, RubyClass.class, JVM.OBJECT, arity, Block.class)), Bootstrap.invokeSuper(), splatmapString, file, line);
         } else {
             compiler.adapter.invokedynamic("invokeUnresolvedSuper:" + JavaNameMangler.mangleMethodName(name), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, RubyClass.class, JVM.OBJECT, arity)), Bootstrap.invokeSuper(), splatmapString, file, line);
         }

--- a/core/src/main/java/org/jruby/ir/targets/indy/InstanceSuperIterInvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/InstanceSuperIterInvokeSite.java
@@ -1,0 +1,31 @@
+package org.jruby.ir.targets.indy;
+
+import org.jruby.RubyClass;
+import org.jruby.ir.runtime.IRRuntimeHelpers;
+import org.jruby.runtime.Block;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import java.lang.invoke.MethodType;
+
+/**
+* Created by headius on 10/23/14.
+*/
+public class InstanceSuperIterInvokeSite extends ResolvedSuperInvokeSite {
+    public InstanceSuperIterInvokeSite(MethodType type, String name, String splatmapString, String file, int line) {
+        super(type, name, splatmapString, file, line);
+    }
+
+    @Override
+    protected RubyClass getSuperClass(RubyClass definingModule) {
+        return definingModule.getSuperClass();
+    }
+
+    // FIXME: indy cached version was not doing splat mapping; revert to slow logic for now
+
+    public IRubyObject invoke(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass definingModule, IRubyObject[] args, Block block) throws Throwable {
+        // TODO: get rid of caller
+        // TODO: caching
+        return IRRuntimeHelpers.instanceSuperIterSplatArgs(context, self, superName, definingModule, args, block, splatMap);
+    }
+}

--- a/core/src/main/java/org/jruby/ir/targets/indy/SuperInvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/SuperInvokeSite.java
@@ -50,11 +50,20 @@ public abstract class SuperInvokeSite extends SelfInvokeSite {
             case "invokeInstanceSuper":
                 site = new InstanceSuperInvokeSite(type, superName, splatmapString, file, line);
                 break;
+            case "invokeInstanceSuperIter":
+                site = new InstanceSuperIterInvokeSite(type, superName, splatmapString, file, line);
+                break;
             case "invokeClassSuper":
                 site = new ClassSuperInvokeSite(type, superName, splatmapString, file, line);
                 break;
+            case "invokeClassSuperIter":
+                site = new ClassSuperIterInvokeSite(type, superName, splatmapString, file, line);
+                break;
             case "invokeUnresolvedSuper":
                 site = new UnresolvedSuperInvokeSite(type, superName, splatmapString, file, line);
+                break;
+            case "invokeUnresolvedSuperIter":
+                site = new UnresolvedSuperIterInvokeSite(type, superName, splatmapString, file, line);
                 break;
             case "invokeZSuper":
                 site = new ZSuperInvokeSite(type, superName, splatmapString, file, line);

--- a/core/src/main/java/org/jruby/ir/targets/indy/UnresolvedSuperIterInvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/UnresolvedSuperIterInvokeSite.java
@@ -1,0 +1,28 @@
+package org.jruby.ir.targets.indy;
+
+import org.jruby.RubyClass;
+import org.jruby.ir.runtime.IRRuntimeHelpers;
+import org.jruby.runtime.Block;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import java.lang.invoke.MethodType;
+
+/**
+* Created by headius on 10/23/14.
+*/
+public class UnresolvedSuperIterInvokeSite extends SuperInvokeSite {
+    public UnresolvedSuperIterInvokeSite(MethodType type, String name, String splatmapString, String file, int line) {
+        super(type, name, splatmapString, file, line);
+    }
+
+    public IRubyObject invoke(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass definingModule, IRubyObject[] args, Block block) throws Throwable {
+        // TODO: get rid of caller
+        // TODO: caching
+        return IRRuntimeHelpers.unresolvedSuperIterSplatArgs(context, self, args, block, splatMap);
+    }
+
+    public IRubyObject fail(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass definingModule, IRubyObject[] args, Block block) throws Throwable {
+        return invoke(context, caller, self, definingModule, args, block);
+    }
+}

--- a/core/src/main/java/org/jruby/ir/targets/simple/NormalInvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/simple/NormalInvocationCompiler.java
@@ -285,25 +285,34 @@ public class NormalInvocationCompiler implements InvocationCompiler {
         invoke(file, line, scopeFieldName, call, arity);
     }
 
-    public void invokeInstanceSuper(String file, int line, String name, int arity, boolean hasClosure, boolean[] splatmap) {
+    public void invokeInstanceSuper(String file, int line, String name, int arity, boolean hasClosure, boolean literalClosure, boolean[] splatmap) {
         if (arity > IRBytecodeAdapter.MAX_ARGUMENTS)
             throw new NotCompilableException("call to instance super has more than " + IRBytecodeAdapter.MAX_ARGUMENTS + " arguments");
 
-        performSuper(file, line, name, arity, hasClosure, splatmap, "instanceSuper", "instanceSuperSplatArgs", false);
+        String noSplatMethod = literalClosure ? "instanceSuperIter" : "instanceSuper";
+        String splatMethod = literalClosure ? "instanceSuperIterSplatArgs" : "instanceSuperSplatArgs";
+
+        performSuper(file, line, name, arity, hasClosure, splatmap, noSplatMethod, splatMethod, false);
     }
 
-    public void invokeClassSuper(String file, int line, String name, int arity, boolean hasClosure, boolean[] splatmap) {
+    public void invokeClassSuper(String file, int line, String name, int arity, boolean hasClosure, boolean literalClosure, boolean[] splatmap) {
         if (arity > IRBytecodeAdapter.MAX_ARGUMENTS)
             throw new NotCompilableException("call to class super has more than " + IRBytecodeAdapter.MAX_ARGUMENTS + " arguments");
 
-        performSuper(file, line, name, arity, hasClosure, splatmap, "classSuper", "classSuperSplatArgs", false);
+        String noSplatMethod = literalClosure ? "classSuperIter" : "classSuper";
+        String splatMethod = literalClosure ? "classSuperIterSplatArgs" : "classSuperSplatArgs";
+
+        performSuper(file, line, name, arity, hasClosure, splatmap, noSplatMethod, splatMethod, false);
     }
 
-    public void invokeUnresolvedSuper(String file, int line, String name, int arity, boolean hasClosure, boolean[] splatmap) {
+    public void invokeUnresolvedSuper(String file, int line, String name, int arity, boolean hasClosure, boolean literalClosure, boolean[] splatmap) {
         if (arity > IRBytecodeAdapter.MAX_ARGUMENTS)
             throw new NotCompilableException("call to unresolved super has more than " + IRBytecodeAdapter.MAX_ARGUMENTS + " arguments");
 
-        performSuper(file, line, name, arity, hasClosure, splatmap, "unresolvedSuper", "unresolvedSuperSplatArgs", true);
+        String noSplatMethod = literalClosure ? "unresolvedSuperIter" : "unresolvedSuper";
+        String splatMethod = literalClosure ? "unresolvedSuperIterSplatArgs" : "unresolvedSuperSplatArgs";
+
+        performSuper(file, line, name, arity, hasClosure, splatmap, noSplatMethod, splatMethod, true);
     }
 
     public void invokeZSuper(String file, int line, String name, int arity, boolean hasClosure, boolean[] splatmap) {

--- a/spec/ruby/language/break_spec.rb
+++ b/spec/ruby/language/break_spec.rb
@@ -362,4 +362,22 @@ describe "Executing break from within a block" do
     bt2.three
     ScratchPad.recorded.should == [:two_ensure, :three_post, :three_ensure]
   end
+
+  it "works when passing through a super call" do
+    cls1 = Class.new { def foo; yield; end }
+    cls2 = Class.new(cls1) { def foo; super { break 1 }; end }
+
+    lambda do
+      cls2.new.foo.should == 1
+    end.should_not raise_error
+  end
+
+  it "raises LocalJumpError when converted into a proc during a a super call" do
+    cls1 = Class.new { def foo(&b); b; end }
+    cls2 = Class.new(cls1) { def foo; super { break 1 }.call; end }
+
+    lambda do
+      cls2.new.foo
+    end.should raise_error(LocalJumpError)
+  end
 end


### PR DESCRIPTION
Fix for #4695. See example case there (updated to work properly in comments).

Specs included. I put them in break specs because this is more testing behavior of break than of super.