### PR TITLE
remove redundant Process.uid patch on windows

### DIFF
--- a/lib/ruby/stdlib/rubygems/defaults/jruby.rb
+++ b/lib/ruby/stdlib/rubygems/defaults/jruby.rb
@@ -87,14 +87,6 @@ class Gem::Specification
 end
 ## END JAR FILES
 
-if (Gem::win_platform?)
-  module Process
-    def self.uid
-      0
-    end
-  end
-end
-
 # Check for jruby_native and load it if present. jruby_native
 # indicates the native launcher is installed and will override
 # env-shebang and possibly other options.


### PR DESCRIPTION
have cleaned up unused parts in RG's *defaults/jruby.rb*, this is the only questionable piece.

WindowsPOSIX impl already `return 0` from `Process.uid` the patch should not be needed, 
the only place RGs uses `Process.uid` is for the cache check: https://github.com/rubygems/rubygems/blob/v3.0.6/lib/rubygems/source.rb#L120 which should not matter.

was thinking maybe this is there simply as a desired side-effect? https://github.com/jruby/jruby/commit/8a898fb50edc3af78c5832c484b3af5774384040