### PR TITLE
Fall back on old regexp BindException mapping

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -3770,7 +3770,12 @@ public final class Ruby implements Constantizable {
     public RaiseException newErrnoFromBindException(BindException be, String contextMessage) {
         Errno errno = Helpers.errnoFromException(be);
 
-        return newErrnoFromErrno(errno, contextMessage);
+        if (errno != null) {
+            return newErrnoFromErrno(errno, contextMessage);
+        }
+
+        // Messages may differ so revert to old behavior (jruby/jruby#6322)
+        return newErrnoEADDRFromBindException(be, contextMessage);
     }
 
     public RaiseException newErrnoEADDRFromBindException(BindException be, String contextMessage) {


### PR DESCRIPTION
On some platforms, the expected BindException messages may differ,
so we need to fall back to the regexp match to make sure we do not
raise a SystemCallError.

Fixes #6322