### PR TITLE
Use Gemfile to install rspec for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,40 +47,54 @@ matrix:
       name: MRI core int
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake test:mri:core:int
       env: JRUBY_OPTS='$JRUBY_OPTS -J-Xmx1G'
 
     - name: MRI core fullint
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake test:mri:core:fullint
       env: JRUBY_OPTS='$JRUBY_OPTS -J-Xmx1G'
 
     - name: MRI core jit
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake test:mri:core:jit
 
     - name: MRI extra
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake test:mri:extra
       env: JRUBY_OPTS='$JRUBY_OPTS -J-Xmx1G'
 
     - name: MRI stdlib
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake test:mri:stdlib
       env: JRUBY_OPTS='$JRUBY_OPTS -J-Xmx1G'
 
     - name: spec/ruby fast
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake spec:ruby:fast
 
     - name: spec/ruby slow
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake spec:ruby:slow
 
     - env: COMMAND=test/check_versions.sh
@@ -102,74 +116,102 @@ matrix:
     - name: JRuby tests jit
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake test:jruby
 
     - name: JRuby tests jit indy
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake test:jruby
       env: JRUBY_OPTS=-Xcompile.invokedynamic
 
     - name: JRuby tests aot
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake test:jruby:aot
 
     - name: JRuby tests fullint
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake test:jruby:fullint
 
     - name: JRuby slow tests
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake test:slow_suites
 
     - name: JI specs
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake spec:ji
 
     - name: Compiler specs
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake spec:compiler
 
     - name: Compiler specs indy
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake spec:compiler
       env: JRUBY_OPTS=-Xcompile.invokedynamic
 
     - name: FFI specs
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake spec:ffi
 
     - name: Regression specs
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake spec:regression
 
     - name: Regression specs jit
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake spec:regression
       env: JRUBY_OPTS=-Xjit.threshold=0
 
     - name: JRuby specs
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake spec:jruby
 
     - name: jrubyc specs
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake spec:jrubyc
 
     - name: Profilers specs
       script:
         - mvn clean package -Pbootstrap
+        - gem install bundler
+        - bundle install
         - jruby -S rake spec:profiler
 
     - env: PHASE='-Pdist'

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'rspec', '3.9.0'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,8 +7,6 @@ strategy:
   matrix:
     linux:
       imageName: 'Ubuntu-16.04'
-    windows:
-      imageName: 'windows-2019'
 
 trigger:
 - master

--- a/test/pom.rb
+++ b/test/pom.rb
@@ -36,7 +36,6 @@ project 'JRuby Integration Tests' do
   jar( 'org.jruby:requireTest:1.0',
        :scope => 'system',
        :systemPath => '${project.basedir}/jruby/requireTest-1.0.jar' )
-  gem 'rspec', '${rspec.version}'
 
   overrides do
     plugin( 'org.eclipse.m2e:lifecycle-mapping:1.0.0',


### PR DESCRIPTION
Something changed on rubygems.org that's causing the mavengem plugin to produce "marshal data too short" errors. While we investigate, remove rspec from -Pbootstrap mavengems and instead use bundler to install it in CI.

See https://github.com/torquebox/jruby-maven-plugins/issues/107