### PR TITLE
Add an option for specifying the nested jar temp location

### DIFF
--- a/core/src/main/java/org/jruby/util/JRubyClassLoader.java
+++ b/core/src/main/java/org/jruby/util/JRubyClassLoader.java
@@ -113,7 +113,7 @@ public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
     private static synchronized File getTempDir() {
         if (tempDir != null) return tempDir;
 
-        tempDir = new File(systemTmpDir(), tempDirName());
+        tempDir = new File(tempDir(), tempDirName());
         if (tempDir.mkdirs()) {
             Runtime.getRuntime().addShutdownHook(new Thread() {
                 public void run() {
@@ -151,13 +151,23 @@ public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
         }
     }
 
-    private static String systemTmpDir() {
+    private static String tempDir() {
+        // try JRuby-specific option first
+        String jrubyTmpdir = Options.JI_NESTED_JAR_TMPDIR.load();
+
+        if (jrubyTmpdir != null) {
+            return jrubyTmpdir;
+        }
+
+        // fall back on Java tmpdir if available
         try {
             return System.getProperty("java.io.tmpdir");
         }
         catch (SecurityException ex) {
             LOG.warn("could not access 'java.io.tmpdir' will use working directory", ex);
         }
+
+        // give up and just use current dir
         return "";
     }
 

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -218,6 +218,7 @@ public class Options {
     public static final Option<Boolean> AOT_LOADCLASSES = bool(JAVA_INTEGRATION, "aot.loadClasses", false, "Look for .class before .rb to load AOT-compiled code");
     public static final Option<Boolean> JI_LOAD_LAZY = bool(JAVA_INTEGRATION, "ji.load.lazy", true, "Load Java support (class extensions) lazily on demand or ahead of time.");
     public static final Option<Boolean> JI_CLOSE_CLASSLOADER = bool(JAVA_INTEGRATION, "ji.close.classloader", true, "Close the JRubyClassLoader used by each runtime");
+    public static final Option<String> JI_NESTED_JAR_TMPDIR = string(JAVA_INTEGRATION, "ji.nested.jar.tmpdir", "Use specified dir as a base for unpacking nested jar files.");
 
     public static final Option<Integer> PROFILE_MAX_METHODS = integer(PROFILING, "profile.max.methods", 100000, "Maximum number of methods to consider for profiling.");
 


### PR DESCRIPTION
This allows customizing the temp jar unpacking independently of the java.io.tmpdir location.

See #6314 and probably others related to temp locations with varying permissions.