### PR TITLE
Allow false autorelease to set unmanaged = true

### DIFF
--- a/core/src/main/java/org/jruby/ext/ffi/jffi/AllocatedNativeMemoryIO.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/AllocatedNativeMemoryIO.java
@@ -94,7 +94,7 @@ final class AllocatedNativeMemoryIO extends BoundedNativeMemoryIO implements All
     }
 
     public void setAutoRelease(boolean autorelease) {
-        if (autorelease && !allocation.released) {
+        if (!allocation.released) {
             allocation.unmanaged = !autorelease;
         }
     }


### PR DESCRIPTION
This appears to be long-broken logic for setting autorelease to false, since the only value that will change the unmanaged bit is passing autorelease = true. The change here allows toggling both ways.

This may not have been seen before because this version of MemoryIO is only used when the requested size is greater than 256 bytes, and typically structs are smaller than that. In #6284, as well as #6310 and sass/sassc-ruby#208, we have reports of a double free, and sassc itself uses autorelease on a potentially large value here:

https://github.com/sass/sassc-ruby/blob/4bd764f568ad312a78181d7a3187f3715388e33e/lib/sassc/native.rb#L54-L58