### PR TITLE
Use topSelf's class as scope's module

### DIFF
--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -1014,7 +1014,7 @@ public final class ThreadContext {
         Frame frame = getCurrentFrame();
         frame.setSelf(topSelf);
 
-        getCurrentStaticScope().setModule(objectClass);
+        getCurrentStaticScope().setModule(topSelf.getMetaClass());
     }
 
     public void preNodeEval(IRubyObject self) {


### PR DESCRIPTION
This appears to allow TOPLEVEL_BINDING to properly define methods on `main` rather than on `Object` as described in recent comments at #4845.