### PR TITLE
Force backref/lastline writes to captured frame into thread-local

### DIFF
--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -535,7 +535,7 @@ public final class ThreadContext {
         Frame frame = stack[index];
 
         // if the frame was captured, we must replace it but not clear
-        if (frame.captured) {
+        if (frame.isCaptured()) {
             stack[index] = new Frame();
         } else {
             frame.clear();


### PR DESCRIPTION
Traditionally the $~ and $_ variables have been frame-local but not thread-local, meaning that if the frame is uprooted by capturing a block, that frame-local storage is shared across threads. That leads to issues like #3031, which has been present in JRuby and CRuby both for at least the past 15 years.

This patch attempts to make writes to backref or lastline on a captured frame become thread-local without losing the direct access for simple single-thread accesses.

We already track whether a frame has been captured in order to eagerly raise LocalJumpError for any non-local breaks or returns that may originate from that block. This also turns out to be useful for knowing that the block and its associated frame are now potentially visible across threads. We reuse this flag to make backref and lastline safe to read and write across threads.

Once a block has been captured, the frame is marked captured, and subsequent writes will switch to using a ThreadLocal. Reads will continue to return the direct value as long as it is not a ThreadLocal, and otherwise will return the thread-local value. The ThreadLocal itself will have an initial value for each thread equal to the value at the time when the first captured write happens.

I believe this allows all current expectations about behavior to work properly, with minimal added overhead:

* For uncaptured reads, the nonvolatile read is now volatile and there's a type-check and cast to IRubyObject.
* For captured reads, the nonvolatile read is now volatile, the IRubyObject type-check will fail, a ThreadLocal type-check will succeed, and a thread-local get will be performed.
* For uncaptured writes, the captured flag will be found to be false before performing a direct write. Since captured can only be set by the thread that owned the frame originally, until captured a thread can freely write directly to the field.
* For captured writes, the 'captured' flag will be found to be true before proceeding to set the existing thread-local or atomically switch to using a new thread-local.

The primary performance issue will most likely be due to the creation of a ThreadLocal at the moment of the first captured write. For code sharing procs across threads, this overhead is unavoidable (and the existing behavior is just a bug that has not been found yet). However for code using procs alongside backref or lastline but only on a single thread, this may be a substantial performance hit with no behavioral improvement.