### PR TITLE
[fix][backport] Ensure copy_stream write sends all bytes read

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -4451,8 +4451,12 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
             if (n == -1) break;
 
+            // write buffer fully and then clear
             flipBuffer(buffer);
-            to.write(buffer);
+            long w = 0;
+            while (w < n) {
+                w += to.write(buffer);
+            }
             clearBuffer(buffer);
 
             transferred += n;


### PR DESCRIPTION
On target streams that may do partial reads, the logic here fails
to write all content read from the source stream. The return value
of Channel.write is never checked, but the total bytes written is
incremented, resulting in silently losing data.

The patch loops until all bytes have been written to the output
channel after each read.

CRuby does similar logic. We may need to add additional blocking
write or thread event checks here, in case the target stream
blocks during the write loop, but that will require the different
`transfer` paths to be expanded to support nonblocking IO
channels.

Fixes #6078