### PR TITLE
Consider both "argument scope" and lambda as return jump target

### DIFF
--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -179,7 +179,9 @@ public class IRRuntimeHelpers {
 
             // We hit a method boundary (actual method or a define_method closure) or we exit out of a script/file.
             if (scopeType.isMethodType() ||                              // Contained within a method
-                    scopeType.isBlock() && staticScope.isArgumentScope() ||  // Contained within define_method closure
+                    scopeType.isBlock() && (
+                            staticScope.isArgumentScope() ||  // Contained within define_method closure
+                            current.isLambda()) ||
                     scopeType == IRScopeType.SCRIPT_BODY) {              // (2.5+) Contained within a script
                 return current;
             }

--- a/core/src/main/java/org/jruby/runtime/DynamicScope.java
+++ b/core/src/main/java/org/jruby/runtime/DynamicScope.java
@@ -28,6 +28,7 @@
 package org.jruby.runtime;
 
 import org.jruby.EvalType;
+import org.jruby.ir.IRScopeType;
 import org.jruby.ir.JIT;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -569,6 +570,24 @@ public abstract class DynamicScope implements Cloneable {
 
     public boolean isLambda() {
         return lambda;
+    }
+
+    /**
+     * A DynamicScope is the target of a non-local return if it is one of the following:
+     *
+     * * A method scope
+     * * A top-level script scope
+     * * A block scope that is either marked as the argument scope (define_method) or a lambda
+     *
+     * @return true if this scope is the nearest return scope, false otherwise
+     */
+    public boolean isReturnTarget() {
+        StaticScope staticScope = this.staticScope;
+        IRScopeType scopeType = staticScope.getScopeType();
+
+        return scopeType.isMethodType() ||                              // Contained within a method
+                scopeType == IRScopeType.SCRIPT_BODY ||
+                scopeType.isBlock() && (staticScope.isArgumentScope() || lambda);  // Contained within define_method closure
     }
 
     @Deprecated

--- a/rakelib/rubyspec.rake
+++ b/rakelib/rubyspec.rake
@@ -38,7 +38,7 @@ namespace :spec do
   desc "Run slow specs"
   task :'ruby:slow' do
     mspec :compile_mode => "OFF",
-          :format => MSPEC_FORMAT,
+          :format => "s",
           :spec_target => ":slow",
           :jruby_opts => "-I. --dev --debug"
   end


### PR DESCRIPTION
In the logic to look for a valid return target, we find a lambda, via `IRRuntimeHelpers.initiateNonLocalReturn` calling `getContainingLambda`. However when we later try to detect if the return jump should propagate as a LocalJumpError (because its target scope is no longer active) we do not do this same search for a lambda (see `IRRuntimeHelpers.checkForLJE`). This inconsistency causes the errors from #6350, because we incorrectly detect the target as the lambda, but do the detection against its parent scope and raise an IRReturnJump with an improper target scope. This jump then bubbles all the way off the stack and never becomes a LocalJumpError.

In CRuby, when the lambda becomes inactive, the return target moves to the containing return target scope. This means a given return can potentially have two different targets, depending on whether its containing lambda is still on the stack or not.

I believe the appropriate behavior in both cases from #6350 is to raise LocalJumpError immediately. In each case, the return target for the proc should be the lambda, but the lambda is no longer active. The return target should not change to the containing scope, because that's not the proper return target.

The change here adds the lambda logic to the LJE check, so that it sees the lambda return target is no longer active and eagerly raises the LJE.

We will need to reconcile this difference with CRuby, but since this is such an obscure case I doubt it will affect real-world code.

Fixes #6350.