### PR TITLE
Fix failling TestUTF16#test_regexp_union

### DIFF
--- a/core/src/main/java/org/jruby/RubyRegexp.java
+++ b/core/src/main/java/org/jruby/RubyRegexp.java
@@ -851,9 +851,10 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
             Encoding hasAsciiCompatFixed = null;
             Encoding hasAsciiIncompat = null;
 
+            byte [] verticalVarBytes = new byte[]{'|'};
             for (int i = 0; i < args.length; i++) {
                 IRubyObject e = args[i];
-                if (i > 0) source.cat((byte)'|');
+                if (i > 0) source.catAscii(verticalVarBytes, 0, 1);
                 IRubyObject v = TypeConverter.convertToTypeWithCheck(e, runtime.getRegexp(), "to_regexp");
                 final Encoding enc; final ByteList re;
                 if (v != context.nil) {

--- a/test/mri/excludes/TestUTF16.rb
+++ b/test/mri/excludes/TestUTF16.rb
@@ -1,2 +1,1 @@
-exclude :test_regexp_union, "needs investigation"
 exclude :test_sym_eq, "needs investigation"


### PR DESCRIPTION
This fixes failling [TestUTF16#test_regexp_union](https://github.com/jruby/jruby/blob/master/test/mri/ruby/enc/test_utf16.rb#L275-L277) .