### PR TITLE
Fix inconsistency in #5837

### DIFF
--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -1039,7 +1039,12 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
 
             if (symbol == null) {
                 bytes = bytes.dup();
-                return createSymbol(bytes.toString(), bytes, handler, hash, hard);
+                return createSymbol(
+                        RubyEncoding.decodeRaw(bytes),
+                        bytes,
+                        handler,
+                        hash,
+                        hard);
             }
 
             handler.accept(symbol, false);


### PR DESCRIPTION
In #5837, only `getSymbol(ByteList bytes, boolean hard)` method was modified, and its similar method, `getSymbol(ByteList bytes, ObjBooleanConsumer<RubySymbol> handler, boolean hard)` was not modified.
I think the method has a potential bug, so I fixed it.