### PR TITLE
Remove redundant code

### DIFF
--- a/core/src/main/java/org/jruby/ir/instructions/LoadFrameClosureInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/LoadFrameClosureInstr.java
@@ -28,13 +28,7 @@ public class LoadFrameClosureInstr extends NoOperandResultBaseInstr implements F
     public Instr clone(CloneInfo info) {
         if (info instanceof SimpleCloneInfo) return new LoadFrameClosureInstr(info.getRenamedVariable(result));
 
-        // SSS FIXME: This code below is for inlining and is untested.
-
         InlineCloneInfo ii = (InlineCloneInfo) info;
-
-        // SSS FIXME: This is not strictly correct -- we have to wrap the block into an
-        // operand type that converts the static code block to a proc which is a closure.
-        if (ii.getCallClosure() instanceof WrappedIRClosure) return NopInstr.NOP;
 
         return new CopyInstr(ii.getRenamedVariable(result), ii.getCallClosure());
     }


### PR DESCRIPTION
To judge from #5384, there is redundant code in `LoadFrameClosureInstr#clone`.