### PR TITLE
Fix test_greek_capital_gap failure.

### DIFF
--- a/core/src/main/java/org/jruby/util/StringSupport.java
+++ b/core/src/main/java/org/jruby/util/StringSupport.java
@@ -1540,7 +1540,13 @@ public final class StringSupport {
 
     // MRI: enc_succ_alnum_char
     private static NeighborChar succAlnumChar(Encoding enc, byte[]bytes, int p, int len, byte[]carry, int carryP) {
+        NeighborChar ret;
         byte save[] = new byte[org.jcodings.Config.ENC_CODE_TO_MBC_MAXLEN];
+
+        /* skip 03A2, invalid char between GREEK CAPITAL LETTERS */
+        int tryCounter;
+        final int maxGaps = 1;
+
         int c = enc.mbcToCode(bytes, p, p + len);
 
         final int cType;
@@ -1553,10 +1559,12 @@ public final class StringSupport {
         }
 
         System.arraycopy(bytes, p, save, 0, len);
-        NeighborChar ret = succChar(enc, bytes, p, len);
-        if (ret == NeighborChar.FOUND) {
-            c = enc.mbcToCode(bytes, p, p + len);
-            if (enc.isCodeCType(c, cType)) return NeighborChar.FOUND;
+        for (tryCounter = 0; tryCounter <= maxGaps; ++tryCounter) {
+            ret = succChar(enc, bytes, p, len);
+            if (ret == NeighborChar.FOUND) {
+                c = enc.mbcToCode(bytes, p, p + len);
+                if (enc.isCodeCType(c, cType)) return NeighborChar.FOUND;
+            }
         }
 
         System.arraycopy(save, 0, bytes, p, len);

--- a/test/mri/excludes/TestM17N.rb
+++ b/test/mri/excludes/TestM17N.rb
@@ -1,4 +1,3 @@
-exclude :test_greek_capital_gap, "needs investigation #4303"
 exclude :test_nonascii_method_name, "lexer is not pulling mbc characters off the wire correctly"
 exclude :test_setbyte_range, "unfinished in initial 2.6 work, #6161"
 exclude :test_str_dump, "unfinished in initial 2.6 work, #6161"


### PR DESCRIPTION
Ported from MRI 2.3.
See [https://github.com/ruby/ruby/commit/9d502cf9a44d3934742d076f184574ef5b89702a#diff-7a2f2c7dfe0bf61d38272aeaf68ac768]().