### PR TITLE
Fallback primitive numeric ops to object dispatch

### DIFF
--- a/core/src/main/java/org/jruby/ir/targets/simple/NormalInvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/simple/NormalInvokeSite.java
@@ -35,10 +35,17 @@ public class NormalInvokeSite extends InvokeSite {
 
     public static CallSite bootstrap(MethodHandles.Lookup lookup, String name, MethodType type, int closureInt, String file, int line) {
         boolean literalClosure = closureInt != 0;
-        String methodName = StringSupport.split(name, ':').get(1);
-        InvokeSite site = new NormalInvokeSite(type, JavaNameMangler.demangleMethodName(methodName), literalClosure, file, line);
+        String methodName = JavaNameMangler.demangleMethodName(StringSupport.split(name, ':').get(1));
 
-        return InvokeSite.bootstrap(site, lookup);
+        return newSite(lookup, methodName, type, literalClosure, file, line);
+    }
+
+    public static NormalInvokeSite newSite(MethodHandles.Lookup lookup, String methodName, MethodType type, boolean literalClosure, String file, int line) {
+        NormalInvokeSite site = new NormalInvokeSite(type, methodName, literalClosure, file, line);
+
+        InvokeSite.bootstrap(site, lookup);
+
+        return site;
     }
 
     @Override


### PR DESCRIPTION
Numeric operators with a literal long-ranged integer or double-ranged float on the RHS attempt to dispatch directly without an object, to avoid type-checking an incoming boxed Fixnum or Float object. However when the primitive type does not match the type of the LHS, we fell back to slow-path uncached invocation at indy call sites.

This patch instead falls back on "normal" invocation, currying the boxed number as the sole argument to a second call site's invoker. This allows these primitive numeric ops to fall back to fully optimizable object-based dispatch.