### PR TITLE
fix failing TestM17N#test_utf_without_bom_valid

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -274,10 +274,10 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     public static int scanForCodeRange(final ByteList bytes) {
         Encoding enc = bytes.getEncoding();
-        if (enc.minLength() > 1 && enc.isDummy()) {
+        if (enc.minLength() > 1 && enc.isDummy() && EncodingUtils.getActualEncoding(enc, bytes).minLength() == 1) {
             return CR_BROKEN;
         }
-        return codeRangeScan(EncodingUtils.getActualEncoding(enc, bytes), bytes);
+        return codeRangeScan(enc, bytes);
     }
 
     final boolean singleByteOptimizable() {

--- a/test/mri/excludes/TestM17N.rb
+++ b/test/mri/excludes/TestM17N.rb
@@ -2,4 +2,3 @@ exclude :test_nonascii_method_name, "lexer is not pulling mbc characters off the
 exclude :test_setbyte_range, "unfinished in initial 2.6 work, #6161"
 exclude :test_str_dump, "unfinished in initial 2.6 work, #6161"
 exclude :test_symbol, "management of differently-encoded symbols is not right"
-exclude :test_utf_without_bom_valid, "needs investigation"


### PR DESCRIPTION
This fixes failling [TestM17N#test_utf_without_bom_valid](https://github.com/k77ch7/jruby/blob/master/test/mri/ruby/test_m17n.rb#L272-L277) . 