### PR TITLE
Fix failing TestM17N#test_setbyte_range

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -4171,8 +4171,10 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     @JRubyMethod
     public IRubyObject setbyte(ThreadContext context, IRubyObject index, IRubyObject val) {
         int i = RubyNumeric.num2int(index);
-        int b = RubyNumeric.num2int(val);
         int normalizedIndex = checkIndexForRef(i, value.getRealSize());
+        RubyInteger v = val.convertToInteger();
+        IRubyObject w = v.modulo(context, (long)256);
+        int b = RubyNumeric.num2int(w) & 0xff;
 
         modify19();
         value.getUnsafeBytes()[normalizedIndex] = (byte)b;

--- a/test/mri/excludes/TestM17N.rb
+++ b/test/mri/excludes/TestM17N.rb
@@ -1,4 +1,3 @@
 exclude :test_nonascii_method_name, "lexer is not pulling mbc characters off the wire correctly"
-exclude :test_setbyte_range, "unfinished in initial 2.6 work, #6161"
 exclude :test_str_dump, "unfinished in initial 2.6 work, #6161"
 exclude :test_symbol, "management of differently-encoded symbols is not right"


### PR DESCRIPTION
This fixes failing [TestM17N#test_setbyte_range](https://github.com/jruby/jruby/blob/master/test/mri/ruby/test_m17n.rb#L1534-L1542) .

And sample.rb produces the same output.

#### sample.rb from TestM17N#test_setbyte_range

```
s = "\xE3\x81\x82\xE3\x81\x84".dup.force_encoding("UTF-8")
s.setbyte(0, 0x4f7574206f6620636861722072616e6765)
p s
```
#### MRI 2.6.6

```
% ruby -v sample.rb
ruby 2.6.6p146 (2020-03-31 revision 67876) [x86_64-darwin19]
"e\x81\x82い"
```

#### This PR
```
% ruby -v sample.rb
jruby 9.3.0.0-SNAPSHOT (2.6.5) 2020-09-03 ffffffffff OpenJDK 64-Bit Server VM 11.0.2+9 on 11.0.2+9 +jit [darwin-x86_64]
"e\x81\x82い"
```
