### PR TITLE
jrubyc: make valid java code when using annotations in java_signature

### DIFF
--- a/lib/ruby/stdlib/jruby/compiler/java_class.rb
+++ b/lib/ruby/stdlib/jruby/compiler/java_class.rb
@@ -610,7 +610,7 @@ JAVA
     end
 
     def annotations_string
-      annotations.map { |anno| "@#{anno}" }.join("\n")
+      (annotations.map { |anno| "@#{anno}" } + java_signature.modifiers.select(&:annotation?).map(&:to_s)).join("\n    ")
     end
 
     def conversion_string(var_names)
@@ -644,9 +644,7 @@ JAVA
         visibility_str = visibility || 'public'
       end
 
-      annotations = java_signature.modifiers.select(&:annotation?).map(&:to_s).join(' ')
-
-      "#{annotations}#{visibility_str}#{static_str}#{final_str}#{abstract_str}#{strictfp_str}#{native_str}#{synchronized_str}"
+      "#{visibility_str}#{static_str}#{final_str}#{abstract_str}#{strictfp_str}#{native_str}#{synchronized_str}"
     end
 
     def typed_args

--- a/spec/jrubyc/java/annotation_spec.rb
+++ b/spec/jrubyc/java/annotation_spec.rb
@@ -32,4 +32,12 @@ describe "A Ruby class generating a Java stub" do
       expect( method.to_s ).to match /@java\.lang\.SuppressWarnings\(name = "blah"\)\s+public Object bar/n
     end
   end
+
+  describe "with an annotated method, java_signature style" do
+    it "generates an annotation in the Java source" do
+      cls = generate("class Foo; java_signature '@java.lang.SuppressWarnings(name = \"blah\") public Object bar()'; def bar; end; end").classes[0]
+
+      expect( cls.to_s ).to match /@java\.lang\.SuppressWarnings\(name="blah"\)\s+public Object bar/n
+    end
+  end
 end


### PR DESCRIPTION
### Setup

```rb
 require 'java'
java_import 'javax.ws.rs.Path'
java_import 'javax.ws.rs.GET'
java_import 'javax.ws.rs.Produces'

java_package 'com.headius.demo.jersey'
class HelloWorld

  java_signature "@GET public java.lang.String cliched_message2()"
  def cliched_message2
    "Hello World"
  end
end
```

### Expected jrubyc --java output
```txt
...
@GET public java.lang.String cliched_message2() {
...
```
### Actual jrubyc --java output prior to this PR

```txt
...
@GETpublic java.lang.String cliched_message2() {
...
```
Note no space

This PR fixes the space and formats all annotations alike