### PR TITLE
Handle modification during delete_if iteration

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -2808,12 +2808,12 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         modify();
 
         final Ruby runtime = context.runtime;
-        final int len = realLength; final int beg = begin;
+        final int beg = begin;
 
         int len0 = 0, len1 = 0;
         try {
             int i1, i2;
-            for (i1 = i2 = 0; i1 < len; len0 = ++i1) {
+            for (i1 = i2 = 0; i1 < realLength; len0 = ++i1) {
                 final IRubyObject[] values = this.values;
                 // Do not coarsen the "safe" check, since it will misinterpret AIOOBE from the yield
                 // See JRUBY-5434
@@ -2828,7 +2828,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
             return (i1 == i2) ? context.nil : this;
         }
         finally {
-            selectBangEnsure(runtime, len, beg, len0, len1);
+            selectBangEnsure(runtime, realLength, beg, len0, len1);
         }
     }
 

--- a/test/jruby/test_array.rb
+++ b/test/jruby/test_array.rb
@@ -188,4 +188,20 @@ class TestArray < Test::Unit::TestCase
     assert(!(a == a))
   end
 
+  # This is unspecified behavior, and has no tests in the ruby/spec or CRuby
+  # suites. Since we are attempting to match CRuby behavior here, we will test
+  # this in our own suite. See jruby/jruby#6371.
+  def test_delete_if_with_modification
+    rules = [1, 2, 3, 4, 5]
+    iters = []
+    rules.delete_if do |rule|
+      iters << rule
+      rules.insert(1, 2) if rule == 1
+      true
+    end
+
+    assert_equal([1,2,2,3,4,5], iters)
+    assert_equal([], rules)
+  end
+
 end


### PR DESCRIPTION
In #6371 we saw that adding elements to the array while doing a `delete_if` iteration would end up skipping later elements. This was due to us memoizing the initial length of the array; elements added during iteration did not increase this length, so we would stop iterating prematurely.

The fix here matches CRuby, acquiring the array's new length for each iteration.

A test is provided in the JRuby suite but not in ruby/spec, due to the unspecified nature of this behavior.