### PR TITLE
Remove teardown hook to allow hard shutdown

### DIFF
--- a/core/src/main/java/org/jruby/Main.java
+++ b/core/src/main/java/org/jruby/Main.java
@@ -276,18 +276,6 @@ public class Main {
         final Ruby runtime = _runtime;
         final AtomicBoolean didTeardown = new AtomicBoolean();
 
-        if (runtime != null && config.isHardExit()) {
-            // we're the command-line JRuby, and should set a shutdown hook for
-            // teardown.
-            Runtime.getRuntime().addShutdownHook(new Thread() {
-                public void run() {
-                    if (didTeardown.compareAndSet(false, true)) {
-                        runtime.tearDown();
-                    }
-                }
-            });
-        }
-
         try {
             if (runtime != null) {
                 doSetContextClassLoader(runtime);
@@ -304,7 +292,7 @@ public class Main {
                 return doRunFromMain(runtime, in, filename);
             }
         } finally {
-            if (runtime != null && didTeardown.compareAndSet(false, true)) {
+            if (runtime != null) {
                 runtime.tearDown();
             }
         }


### PR DESCRIPTION
This is a cherry-pick of the crucial commit from #6213 that
should also fix #6379, where users reported that at_exit and
other "clean shutdown" hooks were improperly running during a
"hard shutdown" using `exit!`.

See c941c41 for the original commit and https://github.com/jruby/jruby/issues/6379#issuecomment-694328219 for a discussion of this fix.