### PR TITLE
Allow ulong range values to coerce to long bits

### DIFF
--- a/core/src/main/java/org/jruby/RubyBignum.java
+++ b/core/src/main/java/org/jruby/RubyBignum.java
@@ -199,12 +199,19 @@ public class RubyBignum extends RubyInteger {
      * This is here because for C extensions ulong can hold different values without throwing a RangeError
      */
     public static long big2ulong(RubyBignum value) {
+        Ruby runtime = value.getRuntime();
+
         BigInteger big = value.getValue();
 
-        if (big.compareTo(LONG_MIN) <= 0 || big.compareTo(ULONG_MAX) > 0) {
-            throw value.getRuntime().newRangeError("bignum too big to convert into `ulong'");
+        return big2ulong(runtime, big);
+    }
+
+    public static long big2ulong(Ruby runtime, BigInteger big) {
+        if (big.compareTo(BigInteger.ZERO) < 0 || big.compareTo(ULONG_MAX) > 0) {
+            throw runtime.newRangeError("bignum out of range for `ulong'");
         }
-        return value.getValue().longValue();
+
+        return big.longValue();
     }
 
     /** rb_big2dbl

--- a/core/src/main/java/org/jruby/ext/ffi/Util.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Util.java
@@ -80,7 +80,7 @@ public final class Util {
     public static final long uint64Value(IRubyObject parameter) {
         final long value = parameter instanceof RubyBignum
                 ? ((RubyBignum) parameter).getValue().longValue()
-                :longValue(parameter);
+                :ulongValue(parameter);
         return value;
     }
 
@@ -115,6 +115,10 @@ public final class Util {
         } else {
             return (int) longValue(obj);
         }
+    }
+
+    public static final long ulongValue(IRubyObject parameter) {
+        return RubyNumeric.num2ulong(parameter);
     }
 
     public static final IRubyObject newSigned8(Ruby runtime, byte value) {


### PR DESCRIPTION
This adds ulong versions of the numeric-to-long conversion methods
that allow ulong-ranged values to be coerced to a Java long.
Callers must take care to use the resulting long correctly, since
Java will always see it as signed.

Added primarily to support ulong use cases in FFI, and fixes #6376
and a test commented out due to jnr/jffi#87.

The tests in question can be enabled via the following patch:

```diff
diff --git a/spec/ffi/struct_spec.rb b/spec/ffi/struct_spec.rb
index 70e60c15a9..b5e262a04a 100644
--- a/spec/ffi/struct_spec.rb
+++ b/spec/ffi/struct_spec.rb
@@ -365,17 +365,17 @@ module StructSpecsStructTests
     int_field_test(:int, [ 0, 0x7fffffff, -0x80000000, -1 ])
     int_field_test(:uint, [ 0, 0x7fffffff, 0x80000000, 0xffffffff ])
     int_field_test(:long_long, [ 0, 0x7fffffffffffffff, -0x8000000000000000, -1 ])
-    if RUBY_ENGINE != 'jruby' # https://github.com/jnr/jffi/issues/87
+    # if RUBY_ENGINE != 'jruby' # https://github.com/jnr/jffi/issues/87
       int_field_test(:ulong_long, [ 0, 0x7fffffffffffffff, 0x8000000000000000, 0xffffffffffffffff ])
-    end
+    # end
     if FFI::Platform::LONG_SIZE == 32
       int_field_test(:long, [ 0, 0x7fffffff, -0x80000000, -1 ])
       int_field_test(:ulong, [ 0, 0x7fffffff, 0x80000000, 0xffffffff ])
     else
       int_field_test(:long, [ 0, 0x7fffffffffffffff, -0x8000000000000000, -1 ])
-      if RUBY_ENGINE != 'jruby' # https://github.com/jruby/jruby/issues/6376
+      # if RUBY_ENGINE != 'jruby' # https://github.com/jruby/jruby/issues/6376
         int_field_test(:ulong, [ 0, 0x7fffffffffffffff, 0x8000000000000000, 0xffffffffffffffff ])
-      end
+      # end
     end
 
     it ":float field r/w" do
```