### PR TITLE
Make sure locks are added immediately after acquisition

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -2166,6 +2166,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
             @Override
             public Object run(ThreadContext context, Lock reentrantLock) throws InterruptedException {
                 reentrantLock.lockInterruptibly();
+                heldLocks.add(lock);
                 return reentrantLock;
             }
 
@@ -2174,7 +2175,6 @@ public class RubyThread extends RubyObject implements ExecutionContext {
                 thread.getNativeThread().interrupt();
             }
         });
-        heldLocks.add(lock);
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -2211,7 +2211,12 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     public void unlockAll() {
         assert Thread.currentThread() == getNativeThread();
         for (Lock lock : heldLocks) {
-            lock.unlock();
+            try {
+                lock.unlock();
+            } catch (IllegalMonitorStateException imse) {
+                // don't allow a bad lock to prevent others from unlocking
+                getRuntime().getWarnings().warn("BUG: attempted to unlock a non-acquired lock " + lock + " in thread " + toString());
+            }
         }
     }
 

--- a/spec/regression/GH-6405_race_in_interruptible_lock_acquisition.rb
+++ b/spec/regression/GH-6405_race_in_interruptible_lock_acquisition.rb
@@ -1,0 +1,33 @@
+# Acquired locks must go into the thread's lock list, so they are released when the thread terminates.
+# The following code simulates threads attempting to lock at the same time another thread (main) is
+# trying to kill them. This led to the regression behind #6405 and #6326 where the kill event would
+# interrupt the thread before it had added the locked lock to its lock list, resulting in it remaining
+# locked forever.
+describe "A Thread that acquires a lock immediately before being killed" do
+  it "releases that lock when killed" do
+    def rand_sleep
+      sleep(rand / 500)
+    end
+
+    mutex = Mutex.new
+    200.times do
+      ts = 3.times.map do
+        Thread.new do
+          rand_sleep
+          mutex.synchronize { rand_sleep }
+        end
+      end
+      3.times do
+        rand_sleep
+        ts.sample.kill
+      end
+
+      # lock in main thread to force some threads to wait
+      mutex.synchronize {}
+
+      ts.each(&:join)
+    end
+
+    expect(mutex).to_not be_locked
+  end
+end


### PR DESCRIPTION
There's a race doing the lock add after the executeTask, since a thread event could interrupt the flow and bypass that logic. A finally would not be appropriate, since an interrupted attempt to acquire the lock would then stil add it. Instead we just move the lock add immediately after lockInterruptibly. If we reach this point, the lock is locked by the current thread, and must be added.

I am looking over the rest of the lock management code in Thread to see if there's other places that could be a risk, but this appears to fix the issue reported in #6405 and probably fixes the issue in #6326.