### PR TITLE
update jruby-openssl to 0.10.5

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -21,7 +21,7 @@ default_gems = [
     ['ipaddr', '1.2.0'],
     ['jar-dependencies', '${jar-dependencies.version}'],
     ['jruby-readline', '1.3.7'],
-    ['jruby-openssl', '0.10.4'],
+    ['jruby-openssl', '0.10.5'],
     ['json', '${json.version}'],
     ['psych', '3.2.0'],
     ['rake-ant', '1.0.4'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -112,7 +112,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>jruby-openssl</artifactId>
-      <version>0.10.4</version>
+      <version>0.10.5</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -329,9 +329,9 @@ DO NOT MODIFIY - GENERATED CODE
           <include>cache/jruby-readline*1.3.7.gem</include>
           <include>gems/jruby-readline*1.3.7/**</include>
           <include>specifications/jruby-readline*1.3.7.gemspec</include>
-          <include>cache/jruby-openssl*0.10.4.gem</include>
-          <include>gems/jruby-openssl*0.10.4/**</include>
-          <include>specifications/jruby-openssl*0.10.4.gemspec</include>
+          <include>cache/jruby-openssl*0.10.5.gem</include>
+          <include>gems/jruby-openssl*0.10.5/**</include>
+          <include>specifications/jruby-openssl*0.10.5.gemspec</include>
           <include>cache/json*${json.version}.gem</include>
           <include>gems/json*${json.version}/**</include>
           <include>specifications/json*${json.version}.gemspec</include>


### PR DESCRIPTION
expected to avoid left-over reflection warnings on Java 9+

https://github.com/jruby/jruby-openssl/releases/tag/v0.10.5