### PR TITLE
[fix] Date/DateTime loosing offset on marshal

### DIFF
--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -1395,7 +1395,7 @@ public class RubyDate extends RubyObject {
         final Ruby runtime = context.runtime;
         return context.runtime.newArrayNoCopy(new IRubyObject[] {
                 ajd(context),
-                RubyFixnum.newFixnum(runtime, off),
+                RubyRational.newRationalCanonicalize(context, off, DAY_IN_SECONDS),
                 RubyFixnum.newFixnum(runtime, start)
         });
     }

--- a/test/jruby/test_date.rb
+++ b/test/jruby/test_date.rb
@@ -912,6 +912,14 @@ class TestDate < Test::Unit::TestCase
     assert_equal(-1199, dt.year)
   end
 
+  def test_marshaling_keeps_offset
+    dt = DateTime.now
+    offset = dt.offset
+    dt2 = Marshal.load(Marshal.dump(dt))
+    assert_equal(offset, dt2.offset)
+    assert_equal(dt, dt2)
+  end
+
   def test_marshaling_with_active_support_like_calculation # GH-5188
     time = ActiveSupport.time_advance(Time.now, days: 1)
     date = time.to_date


### PR DESCRIPTION
This is a regression since `Date`/`DateTime` where moved to native in 9.2.
In JRuby 9.1 we used to store the offset as it's returned by `Date#offset` (usually a `Rational`), 
however on the native side we now store `* DAYS_IN_SECONDS` an an integer.

The change here restores 9.1 behaviour.

resolves GH-6385