### PR TITLE
Use normalized URI for glob

### DIFF
--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -300,11 +300,18 @@ public class RubyDir extends RubyObject implements Closeable {
         String base = globOptions(context, args, flags);
         List<ByteList> dirs;
 
-        if (base != null && !base.isEmpty() && !(JRubyFile.createResource(context, base).exists())){
+        if (base == null || base.isEmpty()) {
+            base = runtime.getCurrentDirectory();
+        }
+
+        // createResource will normalize URLs (see GH-6421)
+        FileResource resource = JRubyFile.createResource(context, base);
+
+        if (!(resource.exists())){
             dirs = new ArrayList<ByteList>();
         } else {
             IRubyObject tmp = args[0].checkArrayType();
-            String dir = base == null || base.isEmpty() ? runtime.getCurrentDirectory() : base;
+            String dir = resource.absolutePath();
 
             if (tmp.isNil()) {
                 dirs = Dir.push_glob(runtime, dir, globArgumentAsByteList(context, args[0]), flags[0]);

--- a/core/src/main/java/org/jruby/util/JRubyFile.java
+++ b/core/src/main/java/org/jruby/util/JRubyFile.java
@@ -98,7 +98,9 @@ public class JRubyFile extends JavaSecuredFile {
 
         if (pathname.indexOf(':') > 0) { // scheme-oriented resources
             if (pathname.startsWith("classpath:")) {
-                pathname = "uri:classloader:/" + pathname.substring(10);
+                String subpath = pathname.substring(10);
+                String slash = subpath.charAt(0) == '/' ? "" : "/";
+                pathname = "uri:classloader:" + slash + subpath;
             }
 
             // replace is needed for maven/jruby-complete/src/it/app_using_classpath_uri to work


### PR DESCRIPTION
The Dir.glob logic did not use the normalized URI form when calling glob internals, and since those internals do not support "classpath:" it ended up raising an IllegalArgumentException as reported in #6421.

This change should be benign, but my concern lies in having to call "getAbsolutePath" to get the normalized URI back.

This may be worth including in 9.2.14.