### PR TITLE
Fixes #6428: Date._strptime raises Java exception on invalid argument

### DIFF
--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -1685,7 +1685,8 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod(meta = true)
     public static IRubyObject _strptime(ThreadContext context, IRubyObject self, IRubyObject string, IRubyObject format) {
-        format = TypeConverter.checkStringType(context.runtime, format);
+        string = string.convertToString();
+        format = format.convertToString();
         return parse(context, string, ((RubyString) format).decodeString());
     }
 

--- a/test/jruby/test_time.rb
+++ b/test/jruby/test_time.rb
@@ -213,4 +213,10 @@ class TestTimeNilOps < Test::Unit::TestCase
     end
   end
 
+  def test_strptime_type_error
+    assert_raise(TypeError) { Time.strptime(0, '%Y-%m-%d') }
+    assert_raise(TypeError) { Time.strptime(nil, '%Y-%m-%d') }
+    assert_raise(TypeError) { Time.strptime('2020-01-01', 0) }
+    assert_raise(TypeError) { Time.strptime('2020-01-01', nil) }
+  end
 end


### PR DESCRIPTION
Fixes #6428