### PR TITLE
Fix platform type inititilization

### DIFF
--- a/core/src/main/java/org/jruby/platform/Platform.java
+++ b/core/src/main/java/org/jruby/platform/Platform.java
@@ -40,7 +40,6 @@ import org.jruby.runtime.Helpers;
  * Platform specific constants.
  */
 public abstract class Platform {
-    private static final Platform INSTANCE = initPlatform();
     public static Platform getPlatform() {
         return INSTANCE;
     }
@@ -131,6 +130,8 @@ public abstract class Platform {
     public static final boolean IS_GCJ = JVM.equals(GCJ);
     public static final boolean IS_J9 = JVM.equals(OPENJ9) || JVM.equals(IBM);
     public static final boolean IS_IBM = IS_J9;
+
+    private static final Platform INSTANCE = initPlatform();
 
     private static Platform initPlatform(){
         try {

--- a/core/src/test/java/org/jruby/platform/PlatformTest.java
+++ b/core/src/test/java/org/jruby/platform/PlatformTest.java
@@ -1,0 +1,41 @@
+package org.jruby.platform;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PlatformTest {
+    
+    private String osName;
+
+    @Before
+    public void setUp() {
+        osName = System.getProperty("os.name", "unknown").toLowerCase();
+    }
+
+    @Test
+    public void testIsMac() {
+        assumeTrue(osName.indexOf("mac") != -1);
+        assertTrue(Platform.getPlatform() instanceof UnixPlatform);
+    }
+    @Test
+    public void testIsWindows() {
+        assumeTrue(osName.indexOf("windows") != -1);
+        assertTrue(Platform.getPlatform() instanceof NTPlatform);
+    }
+
+    @Test
+    public void testIsSolaris() {
+        assumeTrue(osName.indexOf("sunos") != -1);
+        assertTrue(Platform.getPlatform() instanceof UnixPlatform);
+    }
+
+    @Test
+    public void testIsLinux() {
+        assumeTrue(osName.indexOf("linux") != -1);
+        assertTrue(Platform.getPlatform() instanceof UnixPlatform);
+    }
+}


### PR DESCRIPTION
Accidentally I found a bug in `Platform.initPlatform()`.  On Windows it returns `UnixPlatform` even though it has following logic:

```
    private static Platform initPlatform(){
        try {
            if (IS_WINDOWS)
                return new NTPlatform();
```

It turns out that ordering of static variables is matters.
When debugging it turns out that `Platform.OS` is null and IS_WINDOWS is not correctly computed.

Simplest solution is to just move `INSTANCE` below `OS` and `IS_WINDOWS`.
Tested on Oracle JDK 8 and Open JDK 11.