### PR TITLE
Do not optimize case with null value to switch

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -1188,24 +1188,26 @@ public class IRBuilder {
     }
 
     public Operand buildCase(CaseNode caseNode) {
-        // scan all cases to see if we have a homogeneous literal case/when
-        NodeType seenType = null;
-        for (Node aCase : caseNode.getCases().children()) {
-            WhenNode whenNode = (WhenNode)aCase;
-            NodeType exprNodeType = whenNode.getExpressionNodes().getNodeType();
+        if (caseNode.getCaseNode() != null) {
+            // scan all cases to see if we have a homogeneous literal case/when
+            NodeType seenType = null;
+            for (Node aCase : caseNode.getCases().children()) {
+                WhenNode whenNode = (WhenNode) aCase;
+                NodeType exprNodeType = whenNode.getExpressionNodes().getNodeType();
 
-            if (seenType == null) {
-                seenType = exprNodeType;
-            } else if (seenType != exprNodeType) {
-                seenType = null;
-                break;
+                if (seenType == null) {
+                    seenType = exprNodeType;
+                } else if (seenType != exprNodeType) {
+                    seenType = null;
+                    break;
+                }
             }
-        }
 
-        if (seenType != null) {
-            switch (seenType) {
-                case FIXNUMNODE:
-                    return buildFixnumCase(caseNode);
+            if (seenType != null) {
+                switch (seenType) {
+                    case FIXNUMNODE:
+                        return buildFixnumCase(caseNode);
+                }
             }
         }
 

--- a/core/src/main/java/org/jruby/ir/instructions/BSwitchInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/BSwitchInstr.java
@@ -31,6 +31,9 @@ public class BSwitchInstr extends MultiBranchInstr {
         // We depend on the jump table being sorted, so ensure that's the case here
         assert jumpsAreSorted(jumps);
 
+        // Switch cases must not have an empty "case" value (GH-6440)
+        assert operand != null : "Switch cases must not have an empty \"case\" value";
+
         this.jumps = jumps;
         this.operand = operand;
         this.rubyCase = rubyCase;

--- a/spec/ruby/language/case_spec.rb
+++ b/spec/ruby/language/case_spec.rb
@@ -424,4 +424,13 @@ describe "The 'case'-construct with no target expression" do
       :called
     end.should == :called
   end
+
+  # Homogeneous cases are often optimized to avoid === using a jump table, and should be tested separately.
+  # See https://github.com/jruby/jruby/issues/6440
+  it "handles homogeneous cases" do
+    case
+    when 1; 'foo'
+    when 2; 'bar'
+    end.should == 'foo'
+  end
 end


### PR DESCRIPTION
Optimized Fixnum switch is only possible when we have a `case`
value and the `when` values are all int-ranged literal numbers.
The NPE in #6440 was due to us also trying to optimize homogeneous
int case/when even if the case value was null (omitted in source).

This patch limits the optimized switch generation to situations
where we have a non-null `case` value.

Fixes #6440.