### PR TITLE
Fix date parse with week number

### DIFF
--- a/lib/ruby/stdlib/date.rb
+++ b/lib/ruby/stdlib/date.rb
@@ -406,7 +406,7 @@ class Date
       return jd
     end
 
-    if cwyear = elem[:cwyear] and cweek = elem[:cweek] and cwday = (elem[:cwday] || elem[:wday].nonzero? || 7) and
+    if cwyear = elem[:cwyear] and cweek = elem[:cweek] and cwday = (elem[:cwday] || 1 ) and
         jd = _valid_commercial?(cwyear, cweek, cwday, sg)
       return jd
     end

--- a/lib/ruby/stdlib/date.rb
+++ b/lib/ruby/stdlib/date.rb
@@ -406,7 +406,7 @@ class Date
       return jd
     end
 
-    if cwyear = elem[:cwyear] and cweek = elem[:cweek] and cwday = (elem[:cwday] || 1 ) and
+    if cwyear = elem[:cwyear] and cweek = elem[:cweek] and cwday = (elem[:cwday] || 1) and
         jd = _valid_commercial?(cwyear, cweek, cwday, sg)
       return jd
     end

--- a/spec/ruby/library/date/parse_spec.rb
+++ b/spec/ruby/library/date/parse_spec.rb
@@ -66,8 +66,13 @@ describe "Date#parse" do
   end
 
   it "parses YYYY-W## as year and week number and defaults to first day of week" do
-    d = Date.parse('2020-W09')
+    d = Date.parse('2020-W09') #9th week of the year assumes first day of the week.
     d.should == Date.civil(2020, 2, 24) #Mon. 2/24/2020. Week always starts with a Monday.
+  end
+
+  it "parses YYYY-W##-D# as year, week number and day number" do
+    d = Date.parse('2020-W09-7') #9th week of the year 7th (last) day of the week
+    d.should == Date.civil(2020, 3, 1) #Sun. 2/24/2020. Week always ends with a Sunday.
   end
 
   it "raises a TypeError trying to parse non-String-like object" do

--- a/spec/ruby/library/date/parse_spec.rb
+++ b/spec/ruby/library/date/parse_spec.rb
@@ -65,6 +65,11 @@ describe "Date#parse" do
     d.should == Date.civil(1910, 11, 1)
   end
 
+  it "parses YYYY-W## as year and week number and defaults to first day of week" do
+    d = Date.parse('2020-W09')
+    d.should == Date.civil(2020, 2, 24) #Mon. 2/24/2020. Week always starts with a Monday.
+  end
+
   it "raises a TypeError trying to parse non-String-like object" do
     -> { Date.parse(1) }.should raise_error(TypeError)
     -> { Date.parse(:invalid) }.should raise_error(TypeError)


### PR DESCRIPTION
I noticed that parsing a date string with a week number (https://en.wikipedia.org/wiki/ISO_week_date) in jruby will raise NoMethodError (undefined method `nonzero?' for nil:NilClass) I looked into it and have attempted a fix and included a couple unit tests.