### PR TITLE
Fix yielding to methods that take two params from Hash#each

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1513,7 +1513,11 @@ public class RubyHash extends RubyObject implements Map {
     private static final VisitorWithState<Block> YieldKeyValueArrayVisitor = new VisitorWithState<Block>() {
         @Override
         public void visit(ThreadContext context, RubyHash self, IRubyObject key, IRubyObject value, int index, Block block) {
-            block.yield(context, context.runtime.newArray(key, value));
+            if (block.getSignature().arityValue() > 1) {
+                block.yieldSpecific(context, key, value);
+            } else {
+                block.yield(context, context.runtime.newArray(key, value));
+            }
         }
     };
 

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -2439,16 +2439,11 @@ public class Helpers {
     // . Array with multiple values and NO rest should extract args if there are more than one argument
 
     static IRubyObject[] restructureBlockArgs(ThreadContext context,
-        IRubyObject value, Signature signature, Block.Type type, boolean needsSplat) {
+        IRubyObject value, Signature signature, Block.Type type) {
 
         if (!type.checkArity && signature == Signature.NO_ARGUMENTS) return IRubyObject.NULL_ARRAY;
 
         if (value == null) return IRubyObject.NULL_ARRAY;
-
-        if (needsSplat) {
-            IRubyObject ary = Helpers.aryToAry(context, value);
-            if (ary instanceof RubyArray) return ((RubyArray) ary).toJavaArrayMaybeUnsafe();
-        }
 
         return new IRubyObject[] { value };
     }

--- a/core/src/main/java/org/jruby/runtime/MethodBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/MethodBlockBody.java
@@ -64,7 +64,7 @@ public class MethodBlockBody extends ContextAwareBlockBody {
 
     @Override
     protected IRubyObject doYield(ThreadContext context, Block block, IRubyObject value) {
-        IRubyObject[] realArgs = Helpers.restructureBlockArgs(context, value, getSignature(), block.type, false);
+        IRubyObject[] realArgs = Helpers.restructureBlockArgs(context, value, getSignature(), block.type);
         return entry.method.call(context, receiver, entry.sourceModule, originName, realArgs, Block.NULL_BLOCK);
     }
 

--- a/spec/tags/ruby/core/enumerable/collect_tags.txt
+++ b/spec/tags/ruby/core/enumerable/collect_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#collect yields 2 arguments for a Hash

--- a/spec/tags/ruby/core/enumerable/map_tags.txt
+++ b/spec/tags/ruby/core/enumerable/map_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#map yields 2 arguments for a Hash

--- a/spec/tags/ruby/core/hash/each_pair_tags.txt
+++ b/spec/tags/ruby/core/hash/each_pair_tags.txt
@@ -1,1 +1,0 @@
-fails:Hash#each_pair yields 2 values and not an Array of 2 elements when given a callable of arity 2

--- a/spec/tags/ruby/core/hash/each_tags.txt
+++ b/spec/tags/ruby/core/hash/each_tags.txt
@@ -1,1 +1,0 @@
-fails:Hash#each yields 2 values and not an Array of 2 elements when given a callable of arity 2


### PR DESCRIPTION
This fixes issue #5896 by always splatting out the arguments if possible.

I was surprised that `Helpers.restructureBlockArgs()` is only used here. Not sure why this is a special case.

Overall I'm not 100% sure about this fix. But since I couldn't get the tests to all run locally I'm opening up this PR in hopes that CI can reveal issues or someone here can tell me what I'm missing.