### PR TITLE
Update webrick to 1.6.1

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -42,7 +42,7 @@ default_gems = [
     ['sync', '0.5.0'],
     ['thwait', '0.1.0'],
     ['tracer', '0.1.0'],
-    ['webrick', '1.6.0'],
+    ['webrick', '1.6.1'],
 ]
 
 bundled_gems = [

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -385,7 +385,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>webrick</artifactId>
-      <version>1.6.0</version>
+      <version>1.6.1</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -587,9 +587,9 @@ DO NOT MODIFIY - GENERATED CODE
           <include>cache/tracer*0.1.0.gem</include>
           <include>gems/tracer*0.1.0/**</include>
           <include>specifications/tracer*0.1.0.gemspec</include>
-          <include>cache/webrick*1.6.0.gem</include>
-          <include>gems/webrick*1.6.0/**</include>
-          <include>specifications/webrick*1.6.0.gemspec</include>
+          <include>cache/webrick*1.6.1.gem</include>
+          <include>gems/webrick*1.6.1/**</include>
+          <include>specifications/webrick*1.6.1.gemspec</include>
           <include>cache/did_you_mean*1.2.0.gem</include>
           <include>gems/did_you_mean*1.2.0/**</include>
           <include>specifications/did_you_mean*1.2.0.gemspec</include>


### PR DESCRIPTION
Upgrade webrick to 1.6.1 which fixes CVE-2020-25613