### PR TITLE
Simplify detached process thread logic

### DIFF
--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -1443,15 +1443,10 @@ public class RubyProcess {
         final int pid = (int)arg.convertToInteger().getLongValue();
         Ruby runtime = context.runtime;
 
-        BlockCallback callback = new BlockCallback() {
-            @Override
-            public IRubyObject call(ThreadContext context, IRubyObject[] args, Block block) {
-                int[] status = new int[1];
-                Ruby runtime = context.runtime;
-                int result = checkErrno(runtime, runtime.getPosix().waitpid(pid, status, 0));
+        BlockCallback callback = (ctx, args, block) -> {
+            while (waitpid(ctx.runtime, pid, 0) == 0) {}
 
-                return RubyStatus.newProcessStatus(runtime, status[0], pid);
-            }
+            return last_status(ctx, recv);
         };
 
         return RubyThread.startWaiterThread(


### PR DESCRIPTION
In #6466 we see that the thread from a Process::detach is raising
an error when the waitpid fails with an error. This does not
appear to match the logic in MRI and also breaks if there is a
"raise" hook installed in the system.

This change should better match MRI logic for the detach thread
and avoid the hook issue reported in #6466. It does not address a
separate bug in the trace hook logic when no Ruby frames are
available.