### PR TITLE
Update did_you_mean

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -31,7 +31,7 @@ default_gems = [
 ]
 
 bundled_gems = [
-    ['did_you_mean', '1.2.0'],
+    ['did_you_mean', '1.2.1'],
     ['minitest', '${minitest.version}'],
     ['net-telnet', '0.1.1'],
     ['power_assert', '${power_assert.version}'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -203,7 +203,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>did_you_mean</artifactId>
-      <version>1.2.0</version>
+      <version>1.2.1</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -350,9 +350,9 @@ DO NOT MODIFIY - GENERATED CODE
           <include>cache/webrick*1.6.1.gem</include>
           <include>gems/webrick*1.6.1/**</include>
           <include>specifications/webrick*1.6.1.gemspec</include>
-          <include>cache/did_you_mean*1.2.0.gem</include>
-          <include>gems/did_you_mean*1.2.0/**</include>
-          <include>specifications/did_you_mean*1.2.0.gemspec</include>
+          <include>cache/did_you_mean*1.2.1.gem</include>
+          <include>gems/did_you_mean*1.2.1/**</include>
+          <include>specifications/did_you_mean*1.2.1.gemspec</include>
           <include>cache/minitest*${minitest.version}.gem</include>
           <include>gems/minitest*${minitest.version}/**</include>
           <include>specifications/minitest*${minitest.version}.gemspec</include>


### PR DESCRIPTION
This updates the did_you_mean gem to version 1.2.1 to remove the CC BY-NC-SA yaml content reported in #6471.

The latest version is 1.4.0 but we have not decided whether to make that leap in a minor release of 9.2.