### PR TITLE
Check the retval of waitpid before errno

### DIFF
--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -916,7 +916,7 @@ public class RubyProcess {
 
         int res = pthreadKillable(context, ctx -> posix.waitpid(pid, status, flags));
 
-        raiseErrnoIfSet(runtime, ECHILD);
+        checkErrno(runtime, res, ECHILD);
 
         if (res > 0) {
             context.setLastExitStatus(RubyProcess.RubyStatus.newProcessStatus(runtime, status[0], res));
@@ -1023,7 +1023,7 @@ public class RubyProcess {
 
         int pid = pthreadKillable(context, ctx -> posix.wait(status));
 
-        raiseErrnoIfSet(runtime, ECHILD);
+        checkErrno(runtime, pid, ECHILD);
 
         context.setLastExitStatus(RubyProcess.RubyStatus.newProcessStatus(runtime, status[0], pid));
         return runtime.newFixnum(pid);


### PR DESCRIPTION
As described in #6477 it appears that a successful waitpid under
some circumstances is leaving errno set, either to 11 (EAGAIN) or
in some situation 2 (ENOENT). The reasons for this unsanitary
errno handling are not clear, but the logic in JRuby should at
least be checking for a -1 retval before assuming there was an
error. This commit makes that modification which should avoid the
error reported in #6477.

This constitutes a "fix" of sorts, but we still don't know why the
cicumstances in #6477 lead to this errno result.

Fixes #6477.