### PR TITLE
Remove to_hash from HashMap proxy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
 gem 'rspec', '3.9.0'
-gem 'rspec-expectations', '3.9.2' # pinned to work around jruby/jruby#6452

--- a/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
@@ -457,9 +457,9 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
     /** rb_hash_to_hash
      *
      */
-    @JRubyMethod(name = { "to_hash", "to_h" })
-    public RubyHash to_hash(ThreadContext context) {
-        return getOrCreateRubyHashMap(context.runtime).to_hash(context);
+    @JRubyMethod(name = { "to_h" })
+    public RubyHash to_h(ThreadContext context) {
+        return getOrCreateRubyHashMap(context.runtime).to_h(context);
     }
 
     /** rb_hash_aset


### PR DESCRIPTION
This addresses #6452 by removing `to_hash` coercion from our HashMap proxy, which avoids it being coerced to keyword arguments. It causes new Java integration failures in specs that expect the `to_hash` behavior, and I have left those failures intact as a demonstration of what will be lost by removing this behavior.