### PR TITLE
Disable rlimit features on Windows

### DIFF
--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -105,10 +105,17 @@ public class RubyProcess {
         process_sys.defineAnnotatedMethods(Sys.class);
 
         runtime.loadConstantSet(process, jnr.constants.platform.PRIO.class);
-        runtime.loadConstantSet(process, jnr.constants.platform.RLIM.class);
-        for (RLIMIT r : RLIMIT.values()) {
-            if (!r.defined()) continue;
-            process.defineConstant(r.name(), runtime.newFixnum(r.intValue()));
+
+        if (Platform.IS_WINDOWS) {
+            // mark rlimit methods as not implemented and skip defining the constants (GH-6491)
+            process.getSingletonClass().retrieveMethod("getrlimit").setNotImplemented(true);
+            process.getSingletonClass().retrieveMethod("setrlimit").setNotImplemented(true);
+        } else {
+            runtime.loadConstantSet(process, jnr.constants.platform.RLIM.class);
+            for (RLIMIT r : RLIMIT.values()) {
+                if (!r.defined()) continue;
+                process.defineConstant(r.name(), runtime.newFixnum(r.intValue()));
+            }
         }
 
         process.defineConstant("WNOHANG", runtime.newFixnum(1));
@@ -626,6 +633,15 @@ public class RubyProcess {
     @JRubyMethod(name = "setrlimit", module = true, visibility = PRIVATE)
     public static IRubyObject setrlimit(ThreadContext context, IRubyObject recv, IRubyObject resource, IRubyObject rlimCur, IRubyObject rlimMax) {
         Ruby runtime = context.runtime;
+
+        if (Platform.IS_WINDOWS) {
+            throw runtime.newNotImplementedError("Process#setrlimit is not implemented on Windows");
+        }
+
+        if (!runtime.getPosix().isNative()) {
+            runtime.getWarnings().warn("Process#setrlimit not supported on this platform");
+            return context.nil;
+        }
 
         RLimit rlim = runtime.getPosix().getrlimit(0);
 
@@ -1293,7 +1309,11 @@ public class RubyProcess {
         return getrlimit(context.runtime, arg);
     }
     public static IRubyObject getrlimit(Ruby runtime, IRubyObject arg) {
-        if (!runtime.getPosix().isNative() || Platform.IS_WINDOWS) {
+        if (Platform.IS_WINDOWS) {
+            throw runtime.newNotImplementedError("Process#getrlimit is not implemented on Windows");
+        }
+
+        if (!runtime.getPosix().isNative()) {
             runtime.getWarnings().warn("Process#getrlimit not supported on this platform");
             return runtime.newFixnum(Long.MAX_VALUE);
         }

--- a/spec/ruby/core/process/constants_spec.rb
+++ b/spec/ruby/core/process/constants_spec.rb
@@ -60,4 +60,26 @@ describe "Process::Constants" do
       Process::RLIMIT_AS.should == 10
     end
   end
+
+  platform_is :windows do
+    it "does not define RLIMIT constants" do
+      %i[
+          RLIMIT_CPU
+          RLIMIT_FSIZE
+          RLIMIT_DATA
+          RLIMIT_STACK
+          RLIMIT_CORE
+          RLIMIT_RSS
+          RLIMIT_NPROC
+          RLIMIT_NOFILE
+          RLIMIT_MEMLOCK
+          RLIMIT_AS
+          RLIM_INFINITY
+          RLIM_SAVED_MAX
+          RLIM_SAVED_CUR
+      ].each do |const|
+        Process.const_defined?(const).should be_false
+      end
+    end
+  end
 end

--- a/spec/ruby/core/process/getrlimit_spec.rb
+++ b/spec/ruby/core/process/getrlimit_spec.rb
@@ -11,8 +11,8 @@ platform_is :aix do
   Process.getrlimit(:DATA)
 end
 
-platform_is_not :windows do
-  describe "Process.getrlimit" do
+describe "Process.getrlimit" do
+  platform_is_not :windows do
     it "returns a two-element Array of Integers" do
       result = Process.getrlimit Process::RLIMIT_CORE
       result.size.should == 2
@@ -86,6 +86,15 @@ platform_is_not :windows do
 
         Process.getrlimit(obj).should == Process.getrlimit(@resource)
       end
+    end
+  end
+
+  platform_is :windows do
+    it "is not implemented" do
+      Process.respond_to?(:getrlimit).should be_false
+      lambda do
+        Process.getrlimit(nil)
+      end.should raise_error NotImplementedError
     end
   end
 end

--- a/spec/ruby/core/process/setrlimit_spec.rb
+++ b/spec/ruby/core/process/setrlimit_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  describe "Process.setrlimit" do
+describe "Process.setrlimit" do
+  platform_is_not :windows do
     context "when passed an Object" do
       before do
         @resource = Process::RLIMIT_CORE
@@ -227,6 +227,15 @@ platform_is_not :windows do
 
         Process.setrlimit(obj, @limit, @max).should be_nil
       end
+    end
+  end
+
+  platform_is :windows do
+    it "is not implemented" do
+      Process.respond_to?(:setrlimit).should be_false
+      lambda do
+        Process.setrlimit(nil, nil)
+      end.should raise_error NotImplementedError
     end
   end
 end


### PR DESCRIPTION
See #6491 and https://github.com/rubygems/rubygems/issues/4129 for discussions of this issue.

We *could* also do this disabling when running on a platform that does not support our FFI, but that would increase the compatibility gap on such platforms.