### PR TITLE
[ji] "usable" inspect for core Java types

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -1699,8 +1699,8 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     @JRubyMethod(name = "inspect")
     public RubyString inspect(ThreadContext context) {
         final Ruby runtime = context.runtime;
-        if (realLength == 0) return RubyString.newStringShared(runtime, EMPTY_ARRAY_BYTES);
-        if (runtime.isInspecting(this)) return RubyString.newStringShared(runtime, RECURSIVE_ARRAY_BYTES);
+        if (realLength == 0) return RubyString.newStringShared(runtime, EMPTY_ARRAY_BL);
+        if (runtime.isInspecting(this)) return RubyString.newStringShared(runtime, RECURSIVE_ARRAY_BL);
 
         try {
             runtime.registerInspecting(this);

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -92,6 +92,7 @@ import static org.jruby.runtime.Helpers.arrayOf;
 import static org.jruby.runtime.Helpers.hashEnd;
 import static org.jruby.runtime.Helpers.murmurCombine;
 import static org.jruby.runtime.Visibility.PRIVATE;
+import static org.jruby.util.Inspector.*;
 import static org.jruby.util.RubyStringBuilder.str;
 import static org.jruby.util.RubyStringBuilder.types;
 
@@ -362,9 +363,6 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     private static final int TMPLOCK_ARR_F = 1 << 9;
     private static final int TMPLOCK_OR_FROZEN_ARR_F = TMPLOCK_ARR_F | FROZEN_F;
-
-    private static final ByteList EMPTY_ARRAY_BYTELIST = new ByteList(new byte[] { '[',']' }, USASCIIEncoding.INSTANCE);
-    private static final ByteList RECURSIVE_ARRAY_BYTELIST = new ByteList(new byte[] { '[','.','.','.',']' }, USASCIIEncoding.INSTANCE);
 
     private volatile boolean isShared = false;
 
@@ -1701,8 +1699,8 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     @JRubyMethod(name = "inspect")
     public RubyString inspect(ThreadContext context) {
         final Ruby runtime = context.runtime;
-        if (realLength == 0) return RubyString.newStringShared(runtime, EMPTY_ARRAY_BYTELIST);
-        if (runtime.isInspecting(this)) return RubyString.newStringShared(runtime, RECURSIVE_ARRAY_BYTELIST);
+        if (realLength == 0) return RubyString.newStringShared(runtime, EMPTY_ARRAY_BYTES);
+        if (runtime.isInspecting(this)) return RubyString.newStringShared(runtime, RECURSIVE_ARRAY_BYTES);
 
         try {
             runtime.registerInspecting(this);

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -74,9 +74,7 @@ import org.jruby.runtime.component.VariableEntry;
 import org.jruby.runtime.marshal.CoreObjectType;
 import org.jruby.util.ArraySupport;
 import org.jruby.util.ByteList;
-import org.jruby.util.ConvertBytes;
 import org.jruby.util.IdUtil;
-import org.jruby.util.Inspector;
 import org.jruby.util.TypeConverter;
 import org.jruby.util.unsafe.UnsafeHolder;
 
@@ -85,6 +83,7 @@ import static org.jruby.runtime.invokedynamic.MethodNames.OP_EQUAL;
 import static org.jruby.runtime.invokedynamic.MethodNames.OP_CMP;
 import static org.jruby.runtime.invokedynamic.MethodNames.EQL;
 import static org.jruby.runtime.invokedynamic.MethodNames.INSPECT;
+import static org.jruby.util.Inspector.*;
 import static org.jruby.util.RubyStringBuilder.ids;
 import static org.jruby.util.RubyStringBuilder.str;
 import static org.jruby.util.RubyStringBuilder.types;
@@ -1154,15 +1153,12 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     }
 
     private static final byte[] INSPECT_SPACE_DOT_DOT_DOT_GT = " ...>".getBytes();
-    private static final byte[] INSPECT_COMMA = ",".getBytes();
-    private static final byte[] INSPECT_SPACE = " ".getBytes();
     private static final byte[] INSPECT_EQUALS = "=".getBytes();
-    private static final byte[] INSPECT_GT = ">".getBytes();
 
     public final IRubyObject hashyInspect() {
         final Ruby runtime = getRuntime();
 
-        RubyString part = Inspector.inspectStart(runtime.getCurrentContext(), metaClass.getRealClass(), inspectHashCode());
+        RubyString part = inspectStart(runtime.getCurrentContext(), metaClass.getRealClass(), inspectHashCode());
 
         if (runtime.isInspecting(this)) {
             encStrBufCat(runtime, part, INSPECT_SPACE_DOT_DOT_DOT_GT);
@@ -1222,8 +1218,8 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
 
             IRubyObject obj = (IRubyObject) value;
 
-            if (!first) encStrBufCat(runtime, part, INSPECT_COMMA);
-            encStrBufCat(runtime, part, INSPECT_SPACE);
+            if (!first) encStrBufCat(runtime, part, COMMA);
+            encStrBufCat(runtime, part, SPACE);
             // FIXME: bytelist_love: EPICLY wrong but something in MRI gets around identifiers of arbitrary encoding.
             encStrBufCat(runtime, part, symbol.asString().encode(context, runtime.getEncodingService().convertEncodingToRubyEncoding(part.getEncoding())).asString().getByteList());
             encStrBufCat(runtime, part, INSPECT_EQUALS);
@@ -1231,7 +1227,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
 
             first = false;
         }
-        encStrBufCat(runtime, part, INSPECT_GT);
+        encStrBufCat(runtime, part, GT);
         part.setTaint(isTaint());
         return part;
     }

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -1158,7 +1158,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     public final IRubyObject hashyInspect() {
         final Ruby runtime = getRuntime();
 
-        RubyString part = inspectStart(runtime.getCurrentContext(), metaClass.getRealClass(), inspectHashCode());
+        RubyString part = inspectPrefix(runtime.getCurrentContext(), metaClass.getRealClass(), inspectHashCode());
 
         if (runtime.isInspecting(this)) {
             encStrBufCat(runtime, part, INSPECT_SPACE_DOT_DOT_DOT_GT);

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -76,6 +76,7 @@ import org.jruby.util.ArraySupport;
 import org.jruby.util.ByteList;
 import org.jruby.util.ConvertBytes;
 import org.jruby.util.IdUtil;
+import org.jruby.util.Inspector;
 import org.jruby.util.TypeConverter;
 import org.jruby.util.unsafe.UnsafeHolder;
 
@@ -1146,14 +1147,12 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      */
     @Override
     public IRubyObject inspect() {
-        if ((!isImmediate()) && !(this instanceof RubyModule) && hasVariables()) {
+        if (!isImmediate() && !(this instanceof RubyModule) && hasVariables()) {
             return hashyInspect();
         }
         return to_s();
     }
 
-    private static final byte[] INSPECT_POUND_LT = "#<".getBytes();
-    private static final byte[] INSPECT_COLON_ZERO_X = ":0x".getBytes();
     private static final byte[] INSPECT_SPACE_DOT_DOT_DOT_GT = " ...>".getBytes();
     private static final byte[] INSPECT_COMMA = ",".getBytes();
     private static final byte[] INSPECT_SPACE = " ".getBytes();
@@ -1162,12 +1161,8 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
 
     public final IRubyObject hashyInspect() {
         final Ruby runtime = getRuntime();
-        ByteList name = types(runtime, metaClass.getRealClass()).getByteList();
-        RubyString part = RubyString.newStringLight(runtime, 2 + name.length() + 3 + 8 + 1); // #<Object:0x5a1c0542>
-        encStrBufCat(runtime, part, INSPECT_POUND_LT);
-        encStrBufCat(runtime, part, name);
-        encStrBufCat(runtime, part, INSPECT_COLON_ZERO_X);
-        encStrBufCat(runtime, part, ConvertBytes.longToHexBytes(inspectHashCode()));
+
+        RubyString part = Inspector.inspectStart(runtime.getCurrentContext(), metaClass.getRealClass(), inspectHashCode());
 
         if (runtime.isInspecting(this)) {
             encStrBufCat(runtime, part, INSPECT_SPACE_DOT_DOT_DOT_GT);

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -909,8 +909,8 @@ public class RubyHash extends RubyObject implements Map {
     public IRubyObject inspect(ThreadContext context) {
         final Ruby runtime = context.runtime;
 
-        if (size() == 0) return RubyString.newStringShared(runtime, EMPTY_HASH_BYTES);
-        if (runtime.isInspecting(this)) return RubyString.newStringShared(runtime, RECURSIVE_HASH_BYTES);
+        if (size() == 0) return RubyString.newStringShared(runtime, EMPTY_HASH_BL);
+        if (runtime.isInspecting(this)) return RubyString.newStringShared(runtime, RECURSIVE_HASH_BL);
 
         try {
             runtime.registerInspecting(this);

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -59,9 +59,7 @@ import org.jruby.runtime.callsite.CachingCallSite;
 import org.jruby.runtime.marshal.MarshalStream;
 import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.util.ByteList;
-import org.jruby.util.Inspector;
 import org.jruby.util.RecursiveComparator;
-import org.jruby.util.RubyStringBuilder;
 import org.jruby.util.TypeConverter;
 
 import java.io.IOException;
@@ -75,8 +73,9 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
-import static org.jruby.runtime.Visibility.PRIVATE;
 import static org.jruby.RubyEnumerator.SizeFn;
+import static org.jruby.runtime.Visibility.PRIVATE;
+import static org.jruby.util.Inspector.*;
 
 // Design overview:
 //
@@ -902,9 +901,6 @@ public class RubyHash extends RubyObject implements Map {
     public IRubyObject inspect() {
         return inspect(metaClass.runtime.getCurrentContext());
     }
-
-    protected static final ByteList EMPTY_HASH_BYTES = new ByteList(new byte[] { '{','}' }, USASCIIEncoding.INSTANCE);
-    protected static final ByteList RECURSIVE_HASH_BYTES = new ByteList(new byte[] { '{','.','.','.','}' }, USASCIIEncoding.INSTANCE);
 
     /** rb_hash_inspect
      *

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -20,6 +20,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ConvertBytes;
 import org.jruby.util.RubyStringBuilder;
 
+import static org.jruby.javasupport.ext.JavaLang.Character.inspectCharValue;
 import static org.jruby.util.Inspector.*;
 
 public final class ArrayJavaProxy extends JavaProxy {
@@ -558,8 +559,8 @@ public final class ArrayJavaProxy extends JavaProxy {
                 /* if (componentClass == short.class) */ buffer.append(Arrays.toString((short[])getObject()));
                 break;
             case 'c':
-                /* if (componentClass == char.class) */ buffer.append(Arrays.toString((char[])getObject()));
-                break;
+                /* if (componentClass == char.class) */
+                return inspectCharArrayPart(runtime, buffer, (char[])getObject(), len);
             case 'i':
                 /* if (componentClass == int.class) */ buffer.append(Arrays.toString((int[])getObject()));
                 ///* if (componentClass == int.class) */ toString(buffer, (int[])getObject());
@@ -575,6 +576,18 @@ public final class ArrayJavaProxy extends JavaProxy {
                 break;
         }
         return RubyString.newUSASCIIString(runtime, buffer.append('>').toString());
+    }
+
+    // NOTE: special case as we want to inspect like a Character wrapper e.g. ['', 'a']
+    private static RubyString inspectCharArrayPart(final Ruby runtime, final StringBuilder buffer, final char[] ary, final int len) {
+        buffer.append('[');
+        for (int i = 0; ; i++) {
+            inspectCharValue(buffer, ary[i]);
+            if (i == len - 1) break;
+            buffer.append(", ");
+        }
+        buffer.append(']');
+        return RubyString.newString(runtime, buffer.append('>'));
     }
 
     // long[1, 2, 0]

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -517,9 +517,9 @@ public final class ArrayJavaProxy extends JavaProxy {
         RubyStringBuilder.cat(runtime, buf, END_BRACKET_COLON_SPACE); // ]:
 
         if (ary.length == 0) {
-            RubyStringBuilder.cat(runtime, buf, EMPTY_ARRAY_BYTES);
+            RubyStringBuilder.cat(runtime, buf, EMPTY_ARRAY_BL);
         } else if (runtime.isInspecting(ary)) {
-            RubyStringBuilder.cat(runtime, buf, RECURSIVE_ARRAY_BYTES);
+            RubyStringBuilder.cat(runtime, buf, RECURSIVE_ARRAY_BL);
         } else {
             try {
                 runtime.registerInspecting(ary);

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -633,41 +633,6 @@ public final class ArrayJavaProxy extends JavaProxy {
         return buffer.toString();
     }
 
-//    private static void toString(StringBuilder str, byte[] a) {
-//        int last = a.length - 1;
-//        if (last == -1) {
-//            str.append("[]"); return;
-//        }
-//
-//        int i = 0;
-//        str.append('[');
-//        while (true) {
-//            str.append(a[i++]);
-//            if (i == last) {
-//                str.append(']'); return;
-//            }
-//            str.append(", ");
-//        }
-//    }
-//
-//
-//    private static void toString(StringBuilder str, int[] a) {
-//        int last = a.length - 1;
-//        if (last == -1) {
-//            str.append("[]"); return;
-//        }
-//
-//        int i = 0;
-//        str.append('[');
-//        while (true) {
-//            str.append(a[i++]);
-//            if (i == last) {
-//                str.append(']'); return;
-//            }
-//            str.append(", ");
-//        }
-//    }
-
     @Override
     @JRubyMethod(name = "==")
     public RubyBoolean op_equal(ThreadContext context, IRubyObject other) {

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -492,10 +492,7 @@ public final class ArrayJavaProxy extends JavaProxy {
         return Java.getProxyClass(context.runtime, javaClass);
     }
 
-    private static final byte[] BEG_BRACKET = new byte[] { '[' };
-    private static final byte[] END_BRACKET_GT = new byte[] { ']', '>' };
-    private static final byte[] END_BRACKET_DOT_SPACE = new byte[] { ']', ':', ' ' };
-    private static final byte[] COMMA_SPACE = new byte[] { ',', ' ' };
+    private static final byte[] END_BRACKET_COLON_SPACE = new byte[] { ']', ':', ' ' };
 
     // #<Java::long[3]: [1, 2, 0]>
     // #<Java::int[0]: []>
@@ -513,22 +510,22 @@ public final class ArrayJavaProxy extends JavaProxy {
 
         RubyModule type = Java.getProxyClass(runtime, componentClass);
         RubyString buf = Inspector.inspectStart(context, type);
-        RubyStringBuilder.cat(runtime, buf, BEG_BRACKET); // [
+        RubyStringBuilder.cat(runtime, buf, Inspector.BEG_BRACKET); // [
         RubyStringBuilder.cat(runtime, buf, ConvertBytes.intToCharBytes(ary.length));
-        RubyStringBuilder.cat(runtime, buf, END_BRACKET_DOT_SPACE); // ]:
+        RubyStringBuilder.cat(runtime, buf, END_BRACKET_COLON_SPACE); // ]:
 
-        RubyStringBuilder.cat(runtime, buf, BEG_BRACKET); // [
+        RubyStringBuilder.cat(runtime, buf, Inspector.BEG_BRACKET); // [
         for (int i = 0; i < ary.length; i++) {
             RubyString s = JavaUtil.inspectObject(context, ary[i]);
             if (i > 0) {
-                RubyStringBuilder.cat(runtime, buf, COMMA_SPACE); // ,
+                RubyStringBuilder.cat(runtime, buf, Inspector.COMMA_SPACE); // ,
             } else {
                 buf.setEncoding(s.getEncoding());
             }
             buf.cat19(s);
         }
 
-        RubyStringBuilder.cat(runtime, buf, END_BRACKET_GT); // ]>
+        RubyStringBuilder.cat(runtime, buf, Inspector.END_BRACKET_GT); // ]>
         return buf;
     }
 

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -510,7 +510,7 @@ public final class ArrayJavaProxy extends JavaProxy {
         final Object[] ary = (Object[]) getObject();
 
         RubyModule type = Java.getProxyClass(runtime, componentClass);
-        RubyString buf = inspectStartType(context, type);
+        RubyString buf = inspectPrefixTypeOnly(context, type);
         RubyStringBuilder.cat(runtime, buf, BEG_BRACKET); // [
         RubyStringBuilder.cat(runtime, buf, ConvertBytes.intToCharBytes(ary.length));
         RubyStringBuilder.cat(runtime, buf, END_BRACKET_COLON_SPACE); // ]:

--- a/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
@@ -136,9 +136,9 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
             RubyStringBuilder.cat(runtime, buf, SPACE);
 
             if (size() == 0) {
-                RubyStringBuilder.cat(runtime, buf, EMPTY_HASH_BYTES);
+                RubyStringBuilder.cat(runtime, buf, EMPTY_HASH_BL);
             } else if (runtime.isInspecting(map)) {
-                RubyStringBuilder.cat(runtime, buf, RECURSIVE_HASH_BYTES);
+                RubyStringBuilder.cat(runtime, buf, RECURSIVE_HASH_BL);
             } else {
                 try {
                     runtime.registerInspecting(map);

--- a/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
@@ -461,12 +461,10 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         return (RubyProc) newProc;
     }
 
-    /** rb_hash_to_s
-     *
-     */
+    // NOTE: keep Map#to_s -> toString as with other Java types
     @JRubyMethod(name = "to_s")
     public IRubyObject to_s(ThreadContext context) {
-        return getOrCreateRubyHashMap(context.runtime).to_s(context);
+        return RubyString.newString(context.runtime, getMapObject().toString());
     }
 
     /** rb_hash_rehash

--- a/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
@@ -132,7 +132,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
             final Ruby runtime = context.runtime;
             final Map map = mapDelegate();
 
-            RubyString buf = inspectStart(context, receiver.getMetaClass());
+            RubyString buf = inspectPrefix(context, receiver.getMetaClass());
             RubyStringBuilder.cat(runtime, buf, SPACE);
 
             if (size() == 0) {

--- a/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
@@ -52,9 +52,10 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
-import org.jruby.util.Inspector;
 import org.jruby.util.RubyStringBuilder;
 import org.jruby.util.TypeConverter;
+
+import static org.jruby.util.Inspector.*;
 
 /**
  * A proxy for wrapping <code>java.util.Map</code> instances.
@@ -129,24 +130,25 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         @Override
         public IRubyObject inspect(ThreadContext context) {
             final Ruby runtime = context.runtime;
+            final Map map = mapDelegate();
 
-            RubyString buf = Inspector.inspectStart(context, receiver.getMetaClass());
-            RubyStringBuilder.cat(runtime, buf, Inspector.SPACE);
+            RubyString buf = inspectStart(context, receiver.getMetaClass());
+            RubyStringBuilder.cat(runtime, buf, SPACE);
 
             if (size() == 0) {
                 RubyStringBuilder.cat(runtime, buf, EMPTY_HASH_BYTES);
-            } else if (runtime.isInspecting(this)) {
+            } else if (runtime.isInspecting(map)) {
                 RubyStringBuilder.cat(runtime, buf, RECURSIVE_HASH_BYTES);
             } else {
                 try {
-                    runtime.registerInspecting(this);
+                    runtime.registerInspecting(map);
                     buf.cat19(inspectHash(context));
                 } finally {
-                    runtime.unregisterInspecting(this);
+                    runtime.unregisterInspecting(map);
                 }
             }
 
-            return RubyStringBuilder.cat(runtime, buf, Inspector.GT);
+            return RubyStringBuilder.cat(runtime, buf, GT);
         }
 
         @Override

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -116,6 +116,7 @@ public class Java implements Library {
         org.jruby.javasupport.ext.JavaUtil.define(runtime);
         org.jruby.javasupport.ext.JavaUtilRegex.define(runtime);
         org.jruby.javasupport.ext.JavaIo.define(runtime);
+        org.jruby.javasupport.ext.JavaNio.define(runtime);
         org.jruby.javasupport.ext.JavaNet.define(runtime);
         org.jruby.javasupport.ext.JavaMath.define(runtime);
         org.jruby.javasupport.ext.JavaTime.define(runtime);

--- a/core/src/main/java/org/jruby/javasupport/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtil.java
@@ -328,7 +328,7 @@ public class JavaUtil {
 
     public static RubyString inspectObject(ThreadContext context, Object obj) {
         if (!(obj instanceof IRubyObject)) {
-            obj = JavaUtil.convertJavaToRuby(context.runtime, obj);
+            obj = Java.getInstance(context.runtime, obj);
         }
         return RubyObject.inspect(context, (IRubyObject) obj);
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtil.java
@@ -326,6 +326,13 @@ public class JavaUtil {
         throw runtime.newTypeError(errorMessage);
     }
 
+    public static RubyString inspectObject(ThreadContext context, Object obj) {
+        if (!(obj instanceof IRubyObject)) {
+            obj = JavaUtil.convertJavaToRuby(context.runtime, obj);
+        }
+        return RubyObject.inspect(context, (IRubyObject) obj);
+    }
+
     /**
      * @param object
      * @note Returns null if not a wrapped Java value.

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -663,8 +663,8 @@ public abstract class JavaLang {
 
         @JRubyMethod(name = "inspect")
         public static IRubyObject inspect(final ThreadContext context, final IRubyObject self) {
-            // NOTE: we re-define java.lang.String#inspect thus these are "others" e.g. StringBuilder
-            java.lang.CharSequence str = self.toJava(java.lang.CharSequence.class);
+            // we re-define java.lang.String#inspect thus this is for StringBuilder etc.
+            java.lang.CharSequence str = unwrapIfJavaObject(self);
 
             RubyString buf = inspectPrefix(context, self.getMetaClass());
             RubyStringBuilder.cat(context.runtime, buf, SPACE);

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -255,10 +255,17 @@ public abstract class JavaLang {
             return message(context, self);
         }
 
-        @JRubyMethod
+        @JRubyMethod(name = "inspect")
         public static IRubyObject inspect(final ThreadContext context, final IRubyObject self) {
             java.lang.Throwable throwable = unwrapIfJavaObject(self);
-            return RubyString.newString(context.runtime, throwable.toString());
+
+            RubyString buf = inspectPrefix(context, self.getMetaClass());
+            RubyStringBuilder.cat(context.runtime, buf, SPACE);
+            final java.lang.String message = throwable.getMessage();
+            buf.catString(message == null ? "" : message);
+            RubyStringBuilder.cat(context.runtime, buf, GT); // >
+
+            return buf;
         }
 
         @JRubyMethod(name = "===", meta = true)
@@ -440,10 +447,10 @@ public abstract class JavaLang {
         @JRubyMethod(name = "inspect")
         public static IRubyObject inspect(final ThreadContext context, final IRubyObject self) {
             java.lang.Character c = (java.lang.Character) self.toJava(java.lang.Character.class);
-            return RubyString.newString(context.runtime, inspectCharValue(new StringBuilder(3), c));
+            return RubyString.newString(context.runtime, inspectCharValue(new java.lang.StringBuilder(3), c));
         }
 
-        public static StringBuilder inspectCharValue(final StringBuilder buf, final char c) {
+        public static java.lang.StringBuilder inspectCharValue(final java.lang.StringBuilder buf, final char c) {
             return buf.append('\'').append(c).append('\'');
         }
 

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -485,21 +485,25 @@ public abstract class JavaLang {
             return new RubyIO(context.runtime, klass.getResourceAsStream(resName)).read(context);
         }
 
-        @JRubyMethod // alias to_s name
+        @JRubyMethod // make to_s an improved class.name version
         public static IRubyObject to_s(final ThreadContext context, final IRubyObject self) {
-            final java.lang.Class klass = unwrapJavaObject(self);
-            return RubyString.newString(context.runtime, klass.getName());
+            return RubyString.newString(context.runtime, getClassName(self));
         }
 
         @JRubyMethod
         public static IRubyObject inspect(final ThreadContext context, final IRubyObject self) {
             // with 'type' - to be able to tell Java::JavaLang::Class apart
-            final java.lang.Class klass = unwrapJavaObject(self);
             RubyString buf = inspectPrefix(context, self.getMetaClass());
             RubyStringBuilder.cat(context.runtime, buf, SPACE);
-            buf.catString(klass.getCanonicalName());
+            buf.catString(getClassName(self));
             RubyStringBuilder.cat(context.runtime, buf, GT); // >
             return buf;
+        }
+
+        private static java.lang.String getClassName(final IRubyObject self) {
+            final java.lang.Class klass = unwrapJavaObject(self);
+            final java.lang.String name = klass.getCanonicalName();
+            return name == null ? klass.getName() : name;
         }
 
         @JRubyMethod(name = "annotations?")

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -439,7 +439,11 @@ public abstract class JavaLang {
         @JRubyMethod(name = "inspect")
         public static IRubyObject inspect(final ThreadContext context, final IRubyObject self) {
             java.lang.Character c = (java.lang.Character) self.toJava(java.lang.Character.class);
-            return RubyString.newString(context.runtime, "'" + c.toString() + "'");
+            return RubyString.newString(context.runtime, inspectCharValue(new StringBuilder(3), c));
+        }
+
+        public static StringBuilder inspectCharValue(final StringBuilder buf, final char c) {
+            return buf.append('\'').append(c).append('\'');
         }
 
     }

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -493,8 +493,13 @@ public abstract class JavaLang {
 
         @JRubyMethod
         public static IRubyObject inspect(final ThreadContext context, final IRubyObject self) {
+            // with 'type' - to be able to tell Java::JavaLang::Class apart
             final java.lang.Class klass = unwrapJavaObject(self);
-            return RubyString.newString(context.runtime, klass.toString());
+            RubyString buf = inspectPrefix(context, self.getMetaClass());
+            RubyStringBuilder.cat(context.runtime, buf, SPACE);
+            buf.catString(klass.getCanonicalName());
+            RubyStringBuilder.cat(context.runtime, buf, GT); // >
+            return buf;
         }
 
         @JRubyMethod(name = "annotations?")

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -76,6 +76,7 @@ public abstract class JavaLang {
         JavaExtensions.put(runtime, java.lang.CharSequence.class, (proxyClass) -> CharSequence.define(runtime, proxyClass));
         JavaExtensions.put(runtime, java.lang.String.class, (proxyClass) -> String.define(runtime, (RubyClass) proxyClass));
         JavaExtensions.put(runtime, java.lang.Enum.class, (proxyClass) -> proxyClass.defineAlias("inspect", "to_s"));
+        JavaExtensions.put(runtime, java.lang.Boolean.class, (proxyClass) -> proxyClass.defineAlias("inspect", "to_s"));
     }
 
     @JRubyModule(name = "Java::JavaLang::Iterable", include = "Enumerable")

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -75,6 +75,7 @@ public abstract class JavaLang {
         });
         JavaExtensions.put(runtime, java.lang.CharSequence.class, (proxyClass) -> CharSequence.define(runtime, proxyClass));
         JavaExtensions.put(runtime, java.lang.String.class, (proxyClass) -> String.define(runtime, (RubyClass) proxyClass));
+        JavaExtensions.put(runtime, java.lang.Enum.class, (proxyClass) -> proxyClass.defineAlias("inspect", "to_s"));
     }
 
     @JRubyModule(name = "Java::JavaLang::Iterable", include = "Enumerable")

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -649,7 +649,7 @@ public abstract class JavaLang {
             // NOTE: we re-define java.lang.String#inspect thus these are "others" e.g. StringBuilder
             java.lang.CharSequence str = self.toJava(java.lang.CharSequence.class);
 
-            RubyString buf = inspectStart(context, self.getMetaClass());
+            RubyString buf = inspectPrefix(context, self.getMetaClass());
             RubyStringBuilder.cat(context.runtime, buf, SPACE);
             buf.cat19(RubyString.newString(context.runtime, str).inspect());
             RubyStringBuilder.cat(context.runtime, buf, GT); // >
@@ -684,7 +684,7 @@ public abstract class JavaLang {
     static RubyString inspectJavaValue(final ThreadContext context, final IRubyObject self) {
         java.lang.Object obj = unwrapIfJavaObject(self);
 
-        RubyString buf = inspectStart(context, self.getMetaClass());
+        RubyString buf = inspectPrefix(context, self.getMetaClass());
         RubyStringBuilder.cat(context.runtime, buf, SPACE);
         RubyStringBuilder.cat(context.runtime, buf, obj.toString());
         RubyStringBuilder.cat(context.runtime, buf, GT); // >

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaNio.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaNio.java
@@ -1,0 +1,96 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2020 The JRuby Team
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby.javasupport.ext;
+
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.RubyModule;
+import org.jruby.RubyString;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.anno.JRubyModule;
+import org.jruby.internal.runtime.methods.JavaMethod;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.RubyStringBuilder;
+
+import static org.jruby.javasupport.JavaUtil.unwrapIfJavaObject;
+import static org.jruby.runtime.Visibility.PUBLIC;
+import static org.jruby.util.Inspector.GT;
+import static org.jruby.util.Inspector.SPACE;
+import static org.jruby.util.Inspector.inspectPrefix;
+
+/**
+ * <code>java.nio</code> package additions.
+ *
+ * @author kares
+ */
+public abstract class JavaNio {
+
+    public static void define(final Ruby runtime) {
+        JavaExtensions.put(runtime, java.nio.Buffer.class, (proxy) -> Buffer.define(runtime, (RubyClass) proxy));
+        // make sure it does not use CharSequence#inspect but rather a unified Buffer#inspect format:
+        JavaExtensions.put(runtime, java.nio.CharBuffer.class, (proxy) -> proxy.addMethod("inspect", new InspectBuffer(proxy)));
+    }
+
+    @JRubyModule(name = "Java::JavaNio::Buffer")
+    public static class Buffer {
+
+        static RubyModule define(final Ruby runtime, final RubyClass proxy) {
+            proxy.defineAnnotatedMethods(Buffer.class);
+            proxy.addMethod("inspect", new InspectBuffer(proxy));
+            return proxy;
+        }
+
+        @JRubyMethod(name = {"length", "size"})
+        public static IRubyObject length(final ThreadContext context, final IRubyObject self) {
+            java.nio.Buffer obj = self.toJava(java.nio.Buffer.class);
+            return context.runtime.newFixnum(obj.remaining()); // limit - position
+        }
+
+    }
+
+    private static final class InspectBuffer extends JavaMethod.JavaMethodZero {
+
+        InspectBuffer(RubyModule implClass) {
+            super(implClass, PUBLIC, "inspect");
+        }
+
+        @Override
+        public IRubyObject call(final ThreadContext context, final IRubyObject self, final RubyModule clazz, final java.lang.String name) {
+            java.nio.Buffer obj = unwrapIfJavaObject(self);
+
+            RubyString buf = inspectPrefix(context, self.getMetaClass(), System.identityHashCode(obj));
+            RubyStringBuilder.cat(context.runtime, buf, SPACE);
+            buf.catString("position=" + obj.position() + ", limit=" + obj.limit() + ", capacity=" + obj.capacity() + ", readOnly=" + obj.isReadOnly());
+            RubyStringBuilder.cat(context.runtime, buf, GT); // >
+            return buf;
+        }
+    }
+
+}

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaTime.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaTime.java
@@ -52,6 +52,9 @@ public class JavaTime {
         JavaExtensions.put(runtime, java.time.OffsetDateTime.class, (proxyClass) -> OffsetDateTime.define(runtime, proxyClass));
         JavaExtensions.put(runtime, java.time.LocalDateTime.class, (proxyClass) -> LocalDateTime.define(runtime, proxyClass));
         JavaExtensions.put(runtime, java.time.ZonedDateTime.class, (proxyClass) -> ZonedDateTime.define(runtime, proxyClass));
+        JavaExtensions.put(runtime, java.time.temporal.Temporal.class, (klass) -> {
+            klass.addMethod("inspect", new JavaLang.InspectValue(klass));
+        });
     }
 
     @JRubyModule(name = "Java::JavaTime::Instant")

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
@@ -264,7 +264,7 @@ public abstract class JavaUtil {
             RubyStringBuilder.cat(runtime, buf, Inspector.SPACE);
 
             if (runtime.isInspecting(coll)) {
-                RubyStringBuilder.cat(runtime, buf, RECURSIVE_ARRAY_BYTES);
+                RubyStringBuilder.cat(runtime, buf, RECURSIVE_ARRAY_BL);
             } else {
                 RubyStringBuilder.cat(runtime, buf, BEG_BRACKET); // [
                 try {

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
@@ -260,7 +260,7 @@ public abstract class JavaUtil {
             final Ruby runtime = context.runtime;
             final java.util.Collection coll = unwrapIfJavaObject(self);
 
-            RubyString buf = inspectStart(context, self.getMetaClass());
+            RubyString buf = inspectPrefix(context, self.getMetaClass());
             RubyStringBuilder.cat(runtime, buf, Inspector.SPACE);
 
             if (runtime.isInspecting(coll)) {

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaUtilRegex.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaUtilRegex.java
@@ -90,7 +90,7 @@ public abstract class JavaUtilRegex {
         public static IRubyObject inspect(final ThreadContext context, final IRubyObject self) {
             final java.util.regex.Pattern regex = unwrapJavaObject(self);
 
-            RubyString buf = inspectStart(context, self.getMetaClass());
+            RubyString buf = inspectPrefix(context, self.getMetaClass());
             RubyStringBuilder.cat(context.runtime, buf, SPACE);
             RubyStringBuilder.cat(context.runtime, buf, SLASH);
             RubyStringBuilder.cat(context.runtime, buf, regex.toString());

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaUtilRegex.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaUtilRegex.java
@@ -33,9 +33,11 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.RubyStringBuilder;
 
 import static org.jruby.javasupport.JavaUtil.convertJavaToUsableRubyObject;
 import static org.jruby.javasupport.JavaUtil.unwrapJavaObject;
+import static org.jruby.util.Inspector.*;
 
 /**
  * Java::JavaLangReflect package extensions.
@@ -84,9 +86,22 @@ public abstract class JavaUtilRegex {
             return RubyBoolean.newBoolean(context, i);
         }
 
+        @JRubyMethod(name = "inspect")
+        public static IRubyObject inspect(final ThreadContext context, final IRubyObject self) {
+            final java.util.regex.Pattern regex = unwrapJavaObject(self);
+
+            RubyString buf = inspectStart(context, self.getMetaClass());
+            RubyStringBuilder.cat(context.runtime, buf, SPACE);
+            RubyStringBuilder.cat(context.runtime, buf, SLASH);
+            RubyStringBuilder.cat(context.runtime, buf, regex.toString());
+            RubyStringBuilder.cat(context.runtime, buf, SLASH);
+            RubyStringBuilder.cat(context.runtime, buf, GT); // >
+            return buf;
+        }
+
         private static java.util.regex.Matcher matcher(final IRubyObject self, final IRubyObject str) {
             final java.util.regex.Pattern regex = unwrapJavaObject(self);
-            return regex.matcher((CharSequence) str.toJava(CharSequence.class));
+            return regex.matcher(str.toJava(CharSequence.class));
         }
 
     }

--- a/core/src/main/java/org/jruby/util/Inspector.java
+++ b/core/src/main/java/org/jruby/util/Inspector.java
@@ -20,6 +20,7 @@ public class Inspector {
     private static final byte[] COLON_ZERO_X = new byte[] { ':', '0', 'x' };
     public static final byte[] COLON = new byte[] { ':' };
     public static final byte[] SPACE = new byte[] { ' ' };
+    public static final byte[] SLASH = new byte[] { '/' };
     public static final byte[] COLON_SPACE = new byte[] { ':', ' ' };
     public static final byte[] GT = new byte[] { '>' };
     public static final byte[] COMMA_SPACE = new byte[] { ',', ' ' };

--- a/core/src/main/java/org/jruby/util/Inspector.java
+++ b/core/src/main/java/org/jruby/util/Inspector.java
@@ -5,7 +5,6 @@ import org.jruby.Ruby;
 import org.jruby.RubyModule;
 import org.jruby.RubyString;
 import org.jruby.runtime.ThreadContext;
-import org.jruby.runtime.builtin.IRubyObject;
 
 import static org.jruby.util.io.EncodingUtils.encStrBufCat;
 
@@ -30,23 +29,23 @@ public class Inspector {
     public static final byte[] END_BRACKET_GT = new byte[] { ']', '>' };
 
     // e.g.: #<Object:0x5a1c0542
-    public static RubyString inspectStart(final ThreadContext context, final RubyModule type, final int hash) {
+    public static RubyString inspectPrefix(final ThreadContext context, final RubyModule type, final int hash) {
         final Ruby runtime = context.runtime;
-        RubyString buf = inspectStartType(context, type);
+        RubyString buf = inspectPrefixTypeOnly(context, type);
         encStrBufCat(runtime, buf, COLON_ZERO_X); // :0x
         encStrBufCat(runtime, buf, ConvertBytes.longToHexBytes(hash));
         return buf;
     }
 
     // e.g. #<Java::JavaUtil::Vector:
-    public static RubyString inspectStart(final ThreadContext context, final RubyModule type) {
+    public static RubyString inspectPrefix(final ThreadContext context, final RubyModule type) {
         final Ruby runtime = context.runtime;
-        RubyString buf = inspectStartType(context, type);
+        RubyString buf = inspectPrefixTypeOnly(context, type);
         encStrBufCat(runtime, buf, COLON); // :
         return buf;
     }
 
-    public static RubyString inspectStartType(final ThreadContext context, final RubyModule type) {
+    public static RubyString inspectPrefixTypeOnly(final ThreadContext context, final RubyModule type) {
         RubyString name = RubyStringBuilder.types(context, type);
         // minimal: "#<Object:0x5a1c0542>"
         RubyString buf = RubyString.newStringLight(context.runtime, 2 + name.length() + 3 + 8 + 1, USASCIIEncoding.INSTANCE);

--- a/core/src/main/java/org/jruby/util/Inspector.java
+++ b/core/src/main/java/org/jruby/util/Inspector.java
@@ -10,11 +10,11 @@ import static org.jruby.util.io.EncodingUtils.encStrBufCat;
 
 public class Inspector {
 
-    public static final ByteList EMPTY_ARRAY_BYTES = new ByteList(new byte[] { '[',']' }, USASCIIEncoding.INSTANCE, false);
-    public static final ByteList RECURSIVE_ARRAY_BYTES = new ByteList(new byte[] { '[','.','.','.',']' }, USASCIIEncoding.INSTANCE, false);
+    public static final ByteList EMPTY_ARRAY_BL = new ByteList(new byte[] { '[',']' }, USASCIIEncoding.INSTANCE, false);
+    public static final ByteList RECURSIVE_ARRAY_BL = new ByteList(new byte[] { '[','.','.','.',']' }, USASCIIEncoding.INSTANCE, false);
 
-    public static final ByteList EMPTY_HASH_BYTES = new ByteList(new byte[] { '{','}' }, USASCIIEncoding.INSTANCE, false);
-    public static final ByteList RECURSIVE_HASH_BYTES = new ByteList(new byte[] { '{','.','.','.','}' }, USASCIIEncoding.INSTANCE, false);
+    public static final ByteList EMPTY_HASH_BL = new ByteList(new byte[] { '{','}' }, USASCIIEncoding.INSTANCE, false);
+    public static final ByteList RECURSIVE_HASH_BL = new ByteList(new byte[] { '{','.','.','.','}' }, USASCIIEncoding.INSTANCE, false);
 
     private static final byte[] COLON_ZERO_X = new byte[] { ':', '0', 'x' };
     public static final byte[] COLON = new byte[] { ':' };

--- a/core/src/main/java/org/jruby/util/Inspector.java
+++ b/core/src/main/java/org/jruby/util/Inspector.java
@@ -5,10 +5,17 @@ import org.jruby.Ruby;
 import org.jruby.RubyModule;
 import org.jruby.RubyString;
 import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
 
 import static org.jruby.util.io.EncodingUtils.encStrBufCat;
 
 public class Inspector {
+
+    public static final ByteList EMPTY_ARRAY_BYTES = new ByteList(new byte[] { '[',']' }, USASCIIEncoding.INSTANCE, false);
+    public static final ByteList RECURSIVE_ARRAY_BYTES = new ByteList(new byte[] { '[','.','.','.',']' }, USASCIIEncoding.INSTANCE, false);
+
+    public static final ByteList EMPTY_HASH_BYTES = new ByteList(new byte[] { '{','}' }, USASCIIEncoding.INSTANCE, false);
+    public static final ByteList RECURSIVE_HASH_BYTES = new ByteList(new byte[] { '{','.','.','.','}' }, USASCIIEncoding.INSTANCE, false);
 
     private static final byte[] COLON_ZERO_X = new byte[] { ':', '0', 'x' };
     public static final byte[] COLON = new byte[] { ':' };
@@ -17,6 +24,7 @@ public class Inspector {
     public static final byte[] GT = new byte[] { '>' };
     public static final byte[] COMMA_SPACE = new byte[] { ',', ' ' };
     public static final byte[] BEG_BRACKET = new byte[] { '[' };
+    public static final byte[] END_BRACKET = new byte[] { ']' };
     public static final byte[] END_BRACKET_GT = new byte[] { ']', '>' };
 
     // e.g.: #<Object:0x5a1c0542
@@ -36,7 +44,7 @@ public class Inspector {
         return buf;
     }
 
-    private static RubyString inspectStartType(final ThreadContext context, final RubyModule type) {
+    public static RubyString inspectStartType(final ThreadContext context, final RubyModule type) {
         RubyString name = RubyStringBuilder.types(context, type);
         // minimal: "#<Object:0x5a1c0542>"
         RubyString buf = RubyString.newStringLight(context.runtime, 2 + name.length() + 3 + 8 + 1, USASCIIEncoding.INSTANCE);

--- a/core/src/main/java/org/jruby/util/Inspector.java
+++ b/core/src/main/java/org/jruby/util/Inspector.java
@@ -11,7 +11,13 @@ import static org.jruby.util.io.EncodingUtils.encStrBufCat;
 public class Inspector {
 
     private static final byte[] COLON_ZERO_X = new byte[] { ':', '0', 'x' };
-    private static final byte[] COLON = new byte[] { ':' };
+    public static final byte[] COLON = new byte[] { ':' };
+    public static final byte[] SPACE = new byte[] { ' ' };
+    public static final byte[] COLON_SPACE = new byte[] { ':', ' ' };
+    public static final byte[] GT = new byte[] { '>' };
+    public static final byte[] COMMA_SPACE = new byte[] { ',', ' ' };
+    public static final byte[] BEG_BRACKET = new byte[] { '[' };
+    public static final byte[] END_BRACKET_GT = new byte[] { ']', '>' };
 
     // e.g.: #<Object:0x5a1c0542
     public static RubyString inspectStart(final ThreadContext context, final RubyModule type, final int hash) {

--- a/core/src/main/java/org/jruby/util/Inspector.java
+++ b/core/src/main/java/org/jruby/util/Inspector.java
@@ -23,6 +23,7 @@ public class Inspector {
     public static final byte[] SLASH = new byte[] { '/' };
     public static final byte[] COLON_SPACE = new byte[] { ':', ' ' };
     public static final byte[] GT = new byte[] { '>' };
+    public static final byte[] COMMA = new byte[] { ',' };
     public static final byte[] COMMA_SPACE = new byte[] { ',', ' ' };
     public static final byte[] BEG_BRACKET = new byte[] { '[' };
     public static final byte[] END_BRACKET = new byte[] { ']' };

--- a/core/src/main/java/org/jruby/util/Inspector.java
+++ b/core/src/main/java/org/jruby/util/Inspector.java
@@ -1,0 +1,41 @@
+package org.jruby.util;
+
+import org.jcodings.specific.USASCIIEncoding;
+import org.jruby.Ruby;
+import org.jruby.RubyModule;
+import org.jruby.RubyString;
+import org.jruby.runtime.ThreadContext;
+
+import static org.jruby.util.io.EncodingUtils.encStrBufCat;
+
+public class Inspector {
+
+    private static final byte[] COLON_ZERO_X = new byte[] { ':', '0', 'x' };
+    private static final byte[] COLON = new byte[] { ':' };
+
+    // e.g.: #<Object:0x5a1c0542
+    public static RubyString inspectStart(final ThreadContext context, final RubyModule type, final int hash) {
+        final Ruby runtime = context.runtime;
+        RubyString buf = inspectStartType(context, type);
+        encStrBufCat(runtime, buf, COLON_ZERO_X); // :0x
+        encStrBufCat(runtime, buf, ConvertBytes.longToHexBytes(hash));
+        return buf;
+    }
+
+    // e.g. #<Java::JavaUtil::Vector
+    public static RubyString inspectStart(final ThreadContext context, final RubyModule type) {
+        final Ruby runtime = context.runtime;
+        RubyString buf = inspectStartType(context, type);
+        encStrBufCat(runtime, buf, COLON); // :
+        return buf;
+    }
+
+    private static RubyString inspectStartType(final ThreadContext context, final RubyModule type) {
+        RubyString name = RubyStringBuilder.types(context, type);
+        // minimal: "#<Object:0x5a1c0542>"
+        RubyString buf = RubyString.newStringLight(context.runtime, 2 + name.length() + 3 + 8 + 1, USASCIIEncoding.INSTANCE);
+        buf.cat('#').cat('<').cat19(name);
+        return buf;
+    }
+
+}

--- a/core/src/main/java/org/jruby/util/Inspector.java
+++ b/core/src/main/java/org/jruby/util/Inspector.java
@@ -28,7 +28,7 @@ public class Inspector {
         return buf;
     }
 
-    // e.g. #<Java::JavaUtil::Vector
+    // e.g. #<Java::JavaUtil::Vector:
     public static RubyString inspectStart(final ThreadContext context, final RubyModule type) {
         final Ruby runtime = context.runtime;
         RubyString buf = inspectStartType(context, type);

--- a/core/src/main/java/org/jruby/util/RubyStringBuilder.java
+++ b/core/src/main/java/org/jruby/util/RubyStringBuilder.java
@@ -17,6 +17,11 @@ import static org.jruby.util.StringSupport.codePoint;
  * Helper methods to make Ruby Strings without the ceremony of manually building the string up.
   */
 public class RubyStringBuilder {
+
+    public static RubyString types(ThreadContext context, RubyModule type) {
+        return inspectIdentifierByteList(context.runtime, type.toRubyString(context).getByteList());
+    }
+
     public static RubyString types(Ruby runtime, RubyModule type) {
         ThreadContext context = runtime.getCurrentContext();
 
@@ -162,7 +167,7 @@ public class RubyStringBuilder {
     public static String str(Ruby runtime, IRubyObject value, String message) {
         RubyString buf = (RubyString) value.asString().dup();
 
-        catUTF8(runtime, buf, message);
+        cat(runtime, buf, message);
 
         return buf.toString();
     }
@@ -179,7 +184,7 @@ public class RubyStringBuilder {
         RubyString buf = runtime.newString(messageBegin);
 
         buf.cat19(value.asString());
-        catUTF8(runtime, buf, messageEnd);
+        cat(runtime, buf, messageEnd);
 
         return buf.toString();
     }
@@ -187,7 +192,7 @@ public class RubyStringBuilder {
     public static String str(Ruby runtime, IRubyObject value, String message, IRubyObject value2) {
         RubyString buf = (RubyString) value.asString().dup();
 
-        catUTF8(runtime, buf, message);
+        cat(runtime, buf, message);
         buf.cat19(value2.asString());
 
         return buf.toString();
@@ -196,9 +201,9 @@ public class RubyStringBuilder {
     public static String str(Ruby runtime, IRubyObject value, String message, IRubyObject value2, String message2) {
         RubyString buf = (RubyString) value.asString().dup();
 
-        catUTF8(runtime, buf, message);
+        cat(runtime, buf, message);
         buf.cat19(value2.asString());
-        catUTF8(runtime, buf, message2);
+        cat(runtime, buf, message2);
 
         return buf.toString();
     }
@@ -207,7 +212,7 @@ public class RubyStringBuilder {
         RubyString buf = runtime.newString(messageBegin);
 
         buf.cat19(value.asString());
-        catUTF8(runtime, buf, messageMiddle);
+        cat(runtime, buf, messageMiddle);
         buf.cat19(value2.asString());
 
         return buf.toString();
@@ -217,9 +222,9 @@ public class RubyStringBuilder {
         RubyString buf = runtime.newString(messageBegin);
 
         buf.cat19(value.asString());
-        catUTF8(runtime, buf, messageMiddle);
+        cat(runtime, buf, messageMiddle);
         buf.cat19(value2.asString());
-        catUTF8(runtime, buf, messageEnd);
+        cat(runtime, buf, messageEnd);
 
         return buf.toString();
     }
@@ -230,19 +235,30 @@ public class RubyStringBuilder {
         RubyString buf = runtime.newString(messageBegin);
 
         buf.cat19(value.asString());
-        catUTF8(runtime, buf, messageMiddle);
+        cat(runtime, buf, messageMiddle);
         buf.cat19(value2);
-        catUTF8(runtime, buf, messageMiddle2);
+        cat(runtime, buf, messageMiddle2);
         buf.cat19(value3.asString());
-        catUTF8(runtime, buf, messageMiddle3);
+        cat(runtime, buf, messageMiddle3);
         buf.cat19(value4);
-        catUTF8(runtime, buf, messageEnd);
+        cat(runtime, buf, messageEnd);
 
         return buf.toString();
     }
 
-    private static void catUTF8(final Ruby runtime, final RubyString str, final String value) {
+    public static RubyString cat(final Ruby runtime, final RubyString str, final String value) {
         EncodingUtils.encStrBufCat(runtime, str, value);
+        return str;
+    }
+
+    public static RubyString cat(final Ruby runtime, RubyString buf, int b) {
+        EncodingUtils.encStrBufCat(runtime, buf, new byte[] { (byte) b });
+        return buf;
+    }
+
+    public static RubyString cat(final Ruby runtime, RubyString buf, byte[] b) {
+        EncodingUtils.encStrBufCat(runtime, buf, b);
+        return buf;
     }
 
 }

--- a/core/src/main/java/org/jruby/util/RubyStringBuilder.java
+++ b/core/src/main/java/org/jruby/util/RubyStringBuilder.java
@@ -256,8 +256,13 @@ public class RubyStringBuilder {
         return buf;
     }
 
-    public static RubyString cat(final Ruby runtime, RubyString buf, byte[] b) {
-        EncodingUtils.encStrBufCat(runtime, buf, b);
+    public static RubyString cat(final Ruby runtime, RubyString buf, byte[] bytes) {
+        EncodingUtils.encStrBufCat(runtime, buf, bytes);
+        return buf;
+    }
+
+    public static RubyString cat(final Ruby runtime, RubyString buf, ByteList bytes) {
+        EncodingUtils.encStrBufCat(runtime, buf, bytes);
         return buf;
     }
 

--- a/spec/java_integration/addons/throwable_spec.rb
+++ b/spec/java_integration/addons/throwable_spec.rb
@@ -26,9 +26,12 @@ describe "A Java Throwable" do
     expect(ex.to_s).to eq ex.message
   end
 
-  it "implements inspect as toString" do
+  it "implements inspect to be Ruby-like" do
     ex = java.lang.Exception.new('hello')
-    expect(ex.inspect).to eq "java.lang.Exception: hello"
+    expect(ex.inspect).to eq '#<Java::JavaLang::Exception: hello>'
+
+    ex = java.lang.AssertionError.new
+    expect(ex.inspect).to eq '#<Java::JavaLang::AssertionError: >'
   end
 
   it "implements full_message" do
@@ -181,11 +184,10 @@ describe "Rescuing a Java exception using Exception" do
 
     it 'has Throwable extensions' do
       throwable = RubyThrowable.new 'foo'
-      expect( throwable.backtrace ).to_not be nil
       expect( throwable.backtrace ).to_not be_empty
 
       expect( throwable.message ).to eql 'foo'
-      expect( throwable.to_s ).to eql 'foo'
+      expect( throwable.inspect ).to eql '#<RubyThrowable: foo>'
     end
 
   end

--- a/spec/java_integration/types/array_spec.rb
+++ b/spec/java_integration/types/array_spec.rb
@@ -1132,12 +1132,11 @@ describe "A Java primitive Array of type" do
     end
 
     it "inspects to show type and contents" do
-      h1 = java.util.Set.java_class
-      h2 = java.util.HashMap.java_class
-      h3 = java.lang.ref.SoftReference.java_class
+      h1 = java.util.Map::Entry.java_class
+      h2 = Java::jnr::posix::Times.java_class
 
-      arr = [h1, h2, h3].to_java java.lang.Class
-      expect(arr.inspect).to match(/^\#<Java::JavaLang::Class\[3\]: \[interface java\.util\.Set, class java\.util\.HashMap, class java\.lang\.ref\.SoftReference\]>$/)
+      arr = [h1, h2].to_java java.lang.Class
+      expect(arr.inspect).to match(/^\#<Java::JavaLang::Class\[2\]: \[#<Java::JavaLang::Class: java.util.Map.Entry>, #<Java::JavaLang::Class: jnr.posix.Times>]>$/)
     end
   end
 end

--- a/spec/java_integration/types/array_spec.rb
+++ b/spec/java_integration/types/array_spec.rb
@@ -71,7 +71,7 @@ describe "A Java primitive Array of type" do
 
     it "inspects to show type and contents" do
       arr = [false, true, false].to_java :boolean
-      expect(arr.inspect).to match(/^boolean\[false, true, false\]@[0-9a-f]+$/)
+      expect(arr.inspect).to eql '#<Java::boolean[3]: [false, true, false]>'
     end
   end
 
@@ -152,8 +152,8 @@ describe "A Java primitive Array of type" do
     end
 
     it "inspects to show type and contents" do
-      arr = [1, 2, 3].to_java :byte
-      expect(arr.inspect).to match(/^byte\[1, 2, 3\]@[0-9a-f]+$/)
+      arr = [1, 2, -128].to_java :byte
+      expect(arr.inspect).to eql '#<Java::byte[3]: [1, 2, -128]>'
     end
 
     it 'handles equality to another array' do
@@ -276,8 +276,8 @@ describe "A Java primitive Array of type" do
     end
 
     it "inspects to show type and contents" do
-      arr = [100, 101, 102].to_java :char
-      expect(arr.inspect).to match(/^char\[d, e, f\]@[0-9a-f]+$/)
+      arr = [100, 101, 225].to_java :char
+      expect(arr.inspect).to eql '#<Java::char[3]: [d, e, á]>'
     end
 
     it 'handles equality to another array' do
@@ -402,7 +402,7 @@ describe "A Java primitive Array of type" do
 
     it "inspects to show type and contents" do
       arr = [1.0, 1.1, 1.2].to_java :double
-      expect(arr.inspect).to match(/^double\[1\.0, 1\.1, 1\.2\]@[0-9a-f]+$/)
+      expect(arr.inspect).to eql '#<Java::double[3]: [1.0, 1.1, 1.2]>'
     end
 
     it "detects element using include?" do
@@ -515,7 +515,7 @@ describe "A Java primitive Array of type" do
 
     it "inspects to show type and contents" do
       arr = [1.0, 1.1, 1.2].to_java :float
-      expect(arr.inspect).to match(/^float\[1\.0, 1\.1, 1\.2\]@[0-9a-f]+$/)
+      expect(arr.inspect).to eql '#<Java::float[3]: [1.0, 1.1, 1.2]>'
     end
 
     it "detects element using include?" do
@@ -624,7 +624,7 @@ describe "A Java primitive Array of type" do
 
     it "inspects to show type and contents" do
       arr = [13, 42, 120].to_java :int
-      expect(arr.inspect).to match(/^int\[13, 42, 120\]@[0-9a-f]+$/)
+      expect(arr.inspect).to eql '#<Java::int[3]: [13, 42, 120]>'
     end
 
     it "detects element using include?" do
@@ -728,8 +728,8 @@ describe "A Java primitive Array of type" do
     end
 
     it "inspects to show type and contents" do
-      arr = [13, 42, 120].to_java :long
-      expect(arr.inspect).to match(/^long\[13, 42, 120\]@[0-9a-f]+$/)
+      arr = [13, 42, 120000000000].to_java :long
+      expect(arr.inspect).to eql '#<Java::long[3]: [13, 42, 120000000000]>'
     end
 
     it "clones" do
@@ -829,7 +829,7 @@ describe "A Java primitive Array of type" do
 
     it "inspects to show type and contents" do
       arr = [13, 42, 120].to_java :short
-      expect(arr.inspect).to match(/^short\[13, 42, 120\]@[0-9a-f]+$/)
+      expect(arr.inspect).to eql '#<Java::short[3]: [13, 42, 120]>'
     end
 
     it "dups" do
@@ -910,8 +910,8 @@ describe "A Java primitive Array of type" do
     end
 
     it "inspects to show type and contents" do
-      arr = ['foo', 'bar', 'baz'].to_java :string
-      expect(arr.inspect).to match(/^java.lang.String\[foo, bar, baz\]@[0-9a-f]+$/)
+      arr = ['foo', 'bar', 'bar'].to_java :string
+      expect(arr.inspect).to eql '#<Java::JavaLang::String[3]: ["foo", "bar", "bar"]>'
     end
 
     it "dups" do
@@ -1029,10 +1029,17 @@ describe "A Java primitive Array of type" do
     end
 
     it "inspects to show type and contents" do
-      jobject = java.lang.Object
-      arr = [jobject.new, jobject.new, jobject.new].to_java :object
-      expect(arr.inspect).to match(/^java.lang.Object\[java\.lang\.Object@[0-9a-f]+, java\.lang\.Object@[0-9a-f]+, java\.lang\.Object@[0-9a-f]+\]@[0-9a-f]+$/)
+      arr = [java.lang.Object.new, Object.new].to_java :object
+      expect(arr.inspect).to start_with '#<Java::JavaLang::Object[2]: '
+      expect(arr.inspect).to match(/\[#<Java::JavaLang::Object:0x[0-9a-f]+>, #<Object:0x[0-9a-f]+>]>$/)
     end
+  end
+
+  it "inspects a Boolean wrapper like a primitive" do
+    arr = java.lang.Boolean[3].new
+    arr[0] = java.lang.Boolean::TRUE
+    arr[1] = java.lang.Boolean.new(false)
+    expect(arr.inspect).to eql '#<Java::JavaLang::Boolean[3]: [true, false, nil]>'
   end
 
   describe "Class ref" do

--- a/spec/java_integration/types/array_spec.rb
+++ b/spec/java_integration/types/array_spec.rb
@@ -277,7 +277,10 @@ describe "A Java primitive Array of type" do
 
     it "inspects to show type and contents" do
       arr = [100, 101, 225].to_java :char
-      expect(arr.inspect).to eql '#<Java::char[3]: [d, e, á]>'
+      expect(arr.inspect).to eql "#<Java::char[3]: ['d', 'e', 'á']>"
+
+      arr = Java::char[2].new; arr[1] = 'ō' # null char + multi-byte char
+      expect(arr.inspect).to eql "#<Java::char[2]: ['\u0000', 'ō']>"
     end
 
     it 'handles equality to another array' do
@@ -1040,6 +1043,22 @@ describe "A Java primitive Array of type" do
     arr[0] = java.lang.Boolean::TRUE
     arr[1] = java.lang.Boolean.new(false)
     expect(arr.inspect).to eql '#<Java::JavaLang::Boolean[3]: [true, false, nil]>'
+  end
+
+  it "inspects a Character wrapper Ruby style" do
+    arr = java.lang.Character[3].new
+
+    c = java.lang.Character.new(48)
+    expect( c.to_s ).to eql '0'
+    expect( c.inspect ).to eql "'0'"
+    arr[0] = c
+
+    c = java.lang.Character.new(0)
+    expect( c.to_s ).to eql "\u0000"
+    expect( c.inspect ).to eql "'\u0000'"
+    arr[1] = c
+
+    expect(arr.inspect).to eql "#<Java::JavaLang::Character[3]: ['0', '\u0000', nil]>"
   end
 
   describe "Class ref" do

--- a/spec/java_integration/types/array_spec.rb
+++ b/spec/java_integration/types/array_spec.rb
@@ -1137,7 +1137,7 @@ describe "A Java primitive Array of type" do
       h3 = java.lang.ref.SoftReference.java_class
 
       arr = [h1, h2, h3].to_java java.lang.Class
-      expect(arr.inspect).to match(/^java\.lang\.Class\[interface java\.util\.Set, class java\.util\.HashMap, class java\.lang\.ref\.SoftReference\]@[0-9a-f]+$/)
+      expect(arr.inspect).to match(/^\#<Java::JavaLang::Class\[3\]: \[interface java\.util\.Set, class java\.util\.HashMap, class java\.lang\.ref\.SoftReference\]>$/)
     end
   end
 end

--- a/spec/java_integration/types/inspect_spec.rb
+++ b/spec/java_integration/types/inspect_spec.rb
@@ -14,6 +14,9 @@ describe "java.lang.Class" do
 
     klass = Java::short[0].new.java_class.to_java
     expect(klass.inspect).to eq '#<Java::JavaLang::Class: short[]>'
+
+    klass = Java::java.lang.Double[1].new.java_class.to_java
+    expect(klass.inspect).to eq '#<Java::JavaLang::Class: java.lang.Double[]>'
   end
 end
 

--- a/spec/java_integration/types/inspect_spec.rb
+++ b/spec/java_integration/types/inspect_spec.rb
@@ -30,3 +30,19 @@ describe "java.lang.StringBuilder" do
     expect(str.inspect).to eq '#<Java::JavaLang::StringBuilder: "bar">'
   end
 end
+
+describe "java.nio.CharSequence" do # implements CharSequence
+  it "inspects as other Buffer impls" do
+    buf = java.nio.CharBuffer.allocate(12)
+    buf.append('a'); buf.put('b')
+    expect(buf.inspect).to match /#<Java::JavaNio::HeapCharBuffer:.*? position=2, limit=12, capacity=12, readOnly=false>/
+  end
+end
+
+describe "java.nio.ByteBuffer" do
+  it "inspects as other Buffer impls" do
+    buf = java.nio.ByteBuffer.allocateDirect(8)
+    buf.put(1)
+    expect(buf.inspect).to match /#<Java::JavaNio::DirectByteBuffer:.*? position=1, limit=8, capacity=8, readOnly=false>/
+  end
+end

--- a/spec/java_integration/types/inspect_spec.rb
+++ b/spec/java_integration/types/inspect_spec.rb
@@ -6,3 +6,13 @@ describe "A Java object's builtin inspect method" do
     expect(o.inspect).to match(/\#<Java::JavaLang::Object:0x[0-9a-f]+>/)
   end
 end
+
+describe "java.lang.Class" do
+  it "produces Ruby-style inspect" do
+    klass = java.lang.String.java_class.to_java
+    expect(klass.inspect).to eq '#<Java::JavaLang::Class: java.lang.String>'
+
+    klass = Java::short[0].new.java_class.to_java
+    expect(klass.inspect).to eq '#<Java::JavaLang::Class: short[]>'
+  end
+end

--- a/spec/java_integration/types/inspect_spec.rb
+++ b/spec/java_integration/types/inspect_spec.rb
@@ -16,3 +16,17 @@ describe "java.lang.Class" do
     expect(klass.inspect).to eq '#<Java::JavaLang::Class: short[]>'
   end
 end
+
+describe "java.lang.String" do
+  it "inspects like a Ruby string" do
+    str = java.lang.String.new 'foo'
+    expect(str.inspect).to eq '"foo"'
+  end
+end
+
+describe "java.lang.StringBuilder" do
+  it "inspects with Ruby type" do
+    str = java.lang.StringBuilder.new 'bar'
+    expect(str.inspect).to eq '#<Java::JavaLang::StringBuilder: "bar">'
+  end
+end

--- a/spec/java_integration/types/map_spec.rb
+++ b/spec/java_integration/types/map_spec.rb
@@ -81,7 +81,6 @@ describe "a java.util.Map instance" do
     h = java.util.HashMap.new
     test_ok(h.kind_of? java.util.Map)
     h.put(1, 2); h.put(3, 4); h.put(5, 6)
-    test_equal({1=>2, 3=>4, 5=>6}, eval(h.inspect))
     test_equal(4, h[3])
     test_equal(nil, h[10])
 
@@ -167,18 +166,18 @@ describe "a java.util.Map instance" do
       test_equal({"a"=>100, "b"=>254, "c"=>300}, h1.ruby_merge(h2))
     end
     test_equal({"a"=>100, "b"=>454, "c"=>300}, h1.ruby_merge(h2) { |k, o, n| o+n })
-    test_equal("{\"a\"=>100, \"b\"=>200}", h1.inspect)
+    expect( h1.inspect ).to include "{\"a\"=>100, \"b\"=>200}"
 
     h1.merge!(h2) { |k, o, n| o }
-    test_equal("{\"a\"=>100, \"b\"=>200, \"c\"=>300}", h1.inspect)
+    test_equal('#<Java::JavaUtil::LinkedHashMap: {"a"=>100, "b"=>200, "c"=>300}>', h1.inspect)
     test_equal(Java::JavaUtil::LinkedHashMap, h1.class)
 
     h.clear
     h.put(1, 100); h.put(2, 200); h.put(3, 300)
     test_equal({1=>100, 2=>200}, h.reject { |k, v| k > 2 })
-    test_equal("{1=>100, 2=>200, 3=>300}", h.inspect)
+    expect( h.inspect ).to include "{1=>100, 2=>200, 3=>300}"
     test_equal({1=>100, 2=>200}, h.reject! { |k, v| k > 2 })
-    test_equal("{1=>100, 2=>200}", h.inspect)
+    expect( h.inspect ).to include "{1=>100, 2=>200}"
 
     # Java 8 adds a replace method to Map that takes a key and value
     test_equal({"c"=>300, "d"=>400, "e"=>500}, h.ruby_replace({"c"=>300, "d"=>400, "e"=>500}))
@@ -215,7 +214,7 @@ describe "a java.util.Map instance" do
 
     h2 = {"b"=>254, "c"=>300}
     test_equal({"a"=>100, "b"=>200, "c"=>300}, h.update(h2) { |k, o, n| o })
-    test_equal("{\"a\"=>100, \"b\"=>200, \"c\"=>300}", h.inspect)
+    expect( h.inspect ).to include "{\"a\"=>100, \"b\"=>200, \"c\"=>300}"
     test_equal(Java::JavaUtil::LinkedHashMap, h.class)
     test_equal([100, 200], h.values_at("a", "b"))
     test_equal([100, 200, nil], h.values_at("a", "b", "z"))
@@ -366,7 +365,7 @@ describe "a java.util.Map instance" do
     map['_internal_1'] = 1
     map['_internal_2'] = 2
     expect( map.size() ).to eql 2
-    expect( map.inspect ).to eql '{}'
+    expect( map.inspect ).to eql '#<Java::Java_integrationFixtures::InternalMap: {}>'
     yielded = {}
     map.each { |key, val| yielded[key] = val }
     expect(yielded).to be_empty

--- a/spec/java_integration/types/map_spec.rb
+++ b/spec/java_integration/types/map_spec.rb
@@ -201,7 +201,8 @@ describe "a java.util.Map instance" do
     test_equal(Java::JavaUtil::LinkedHashMap, h.class)
     test_equal(Hash, rh.class)
 
-    test_equal("{\"a\"=>20, \"d\"=>10, \"c\"=>30, \"b\"=>0, \"e\"=>20}", h.to_s)
+    test_equal("{a=20, d=10, c=30, b=0, e=20}", h.to_s)
+    test_equal(h.toString, h.to_s)
 
     test_ok(h.all? { |k, v| k.length == 1 })
     test_ok(!h.all? { |k, v| v > 100 })


### PR DESCRIPTION
This is, I believe, my 3rd attempt on Java types having usable `inspect` (last one [2 years ago](https://github.com/jruby/jruby/pull/5219) actually got reverted).

It's frustrating working with Java integration out-of-the-box (unless you alias all `alias inspect to_s`).
For example a rspec failure on a Java type will not get you anything useful: `#<Java::JavaTime::Instant:0xeded048>`

Even with a simple `inspect` -> `toString` alias (a previous attempt) I still find myself figuring out types manually.
e.g. `"[]"` is it an empty Ruby Array instance or a Java collection instance?

The proposal here would be to define simple inspect (Java#toString) on intermediate Java types: primitives, strings, enums (and maybe BigInteger/BigDecimal). This is already a compromise as sometimes it's useful to know it's a Java (`java.lang.String`) but since these are 'Ruby' convertible (`to_str`, `to_int`) it kind of makes sense to not go verbose.

The format is not set in stone - aligning all requires some format changes on Java arrays and Maps. 

JRuby obviously can not cover everything out there, but should be able to provide a nice experience with Java SDK types.
Loading too much won't be an issue - JI extensions already load lazily on first occurence of the type in Ruby scripted Java
(should refactor these further to not even initialize Java classes but use class names instead).

The default would be either a reflective (might require unlocking ALL for field reflection) or a bean-style inspect attempt.
Having an optional `reflective_inspect`, even if it isn't a default for generic Java objects, around would be really helpful for `jirb` sessions poking around Java APIs.

Current status:

```diff
1,20c1,21
< #<Java::JavaLang::String:0x4ad896f7>
> "fó\"bař\""
< #<Java::JavaLang::Character:0x7d61468c>
> 'c'
< #<Java::JavaLang::Float:0x4b98225c>
> 10.01
< #<Java::JavaMath::BigInteger:0x3c488b34>
> 1111111111111111111
< #<Java::JavaUtilConcurrent::TimeUnit:0x3866c96e>
> SECONDS
< byte[0, 127, -128]@5c76fce4
> #<Java::byte[3]: [0, 127, -128]>
< float[]@5aab5b31
> #<Java::float[0]: []>
< java.lang.String[bar]@5408d4b3
> #<Java::JavaLang::String[1]: ["bar"]>
< #<Java::JavaTime::Instant:0xeded048>
> #<Java::JavaTime::Instant: 2020-12-14T05:19:14.785116Z>
< #<Java::JavaTime::LocalDateTime:0x655621fd>
> #<Java::JavaTime::LocalDateTime: 2020-12-14T06:19:14.790763>
< #<Java::JavaTime::LocalDate:0xfcd0e8d>
> #<Java::JavaTime::LocalDate: 2020-12-14>
< #<Java::JavaTime::Year:0x1a4083f6>
> #<Java::JavaTime::Year: 2020>
< #<Java::JavaUtil::Date:0x44abdb1f>
> #<Java::JavaUtil::Date: Mon Dec 14 06:19:14 CET 2020>
< #<Java::JavaSql::Time:0x7cd1ec54>
> #<Java::JavaSql::Time: 01:00:00>
< #<Java::JavaUtilRegex::Pattern:0x6d420cdd>
> #<Java::JavaUtilRegex::Pattern: /.*?/>
< #<Java::JavaUtil::ArrayList:0x78128dd0>
> #<Java::JavaUtil::ArrayList: [:symbol]>
< #<Java::JavaUtil::Arrays::ArrayList:0x28dd81ad>
> #<Java::JavaUtil::Arrays::ArrayList: [[#<Java::JavaLang::StringBuilder: "str">], #<Java::JavaTime::LocalDateTime: 2020-12-14T06:19:14.841896>, #<Foo:0x3a5e2525 @foo=true>]>
< #<Java::JavaUtil::HashSet:0x5c9a4f3b>
> #<Java::JavaUtil::HashSet: [0, 1, 2]>
< #<Java::JavaUtilConcurrent::LinkedBlockingDeque:0x6f24ce45>
> #<Java::JavaUtilConcurrent::LinkedBlockingDeque: [1, "2"]>
< {2=>"val2", 10=>"val1"}
> #<Java::JavaUtilConcurrent::ConcurrentHashMap: {2=>"val2", 10=>"val1"}>
```