### PR TITLE
Timezone fixes for 2.6 logic

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -2038,7 +2038,7 @@ public class RubyTime extends RubyObject {
         long t;
 
         if (time instanceof RubyTime) {
-            return ((RubyTime) time).getDateTime().getMillis();
+            return ((RubyTime) time).getDateTime().withZoneRetainFields(DateTimeZone.UTC).getMillis();
         } else if (time instanceof RubyStruct) {
             t = ((RubyStruct) time).aref(context.runtime.newSymbol("to_i")).convertToInteger().getLongValue();
         } else {


### PR DESCRIPTION
This contains one or more fixes for timezone handling in 2.6 compatibility.

See #6488, which these fixes are intended to resolve.