### PR TITLE
Upgrade RSpec to 3.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'rspec', '3.9.0'
-gem 'rspec-expectations', '3.9.2' # pinned to work around jruby/jruby#6452
+gem 'rspec', '3.10.0'


### PR DESCRIPTION
This avoids the issue reported in #6452 by moving past the broken rspec-expectations version (see rspec/rspec-expectations#1241).