### PR TITLE
[ji] eliminate JavaClass usage in favor of Java wrappers

### DIFF
--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -1841,8 +1841,8 @@ public class RubyClass extends RubyModule {
             if (reifiedClass == null) reifyWithAncestors(); // possibly auto-reify
             // Class requested; try java_class or else return nearest reified class
             final ThreadContext context = runtime.getCurrentContext();
-            IRubyObject javaClass = JavaClass.java_class(context, this);
-            if ( ! javaClass.isNil() ) return javaClass.toJava(target);
+            Class<?> javaClass = JavaClass.getJavaClassIfProxy(context, this);
+            if (javaClass != null) return (T) javaClass;
 
             Class reifiedClass = nearestReifiedClass(this);
             if ( reifiedClass != null ) return target.cast(reifiedClass);

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -5165,8 +5165,8 @@ public class RubyModule extends RubyObject {
     public <T> T toJava(Class<T> target) {
         if (target == Class.class) { // try java_class for proxy modules
             final ThreadContext context = metaClass.runtime.getCurrentContext();
-            IRubyObject javaClass = JavaClass.java_class(context, this);
-            if ( ! javaClass.isNil() ) return javaClass.toJava(target);
+            Class<?> javaClass = JavaClass.getJavaClassIfProxy(context, this);
+            if (javaClass != null) return (T) javaClass;
         }
 
         return super.toJava(target);

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
@@ -100,6 +100,19 @@ public class JRubyUtilLibrary implements Library {
     }
 
     /**
+     * Loads a (Java) class.
+     * @param context
+     * @param recv
+     * @param name the class name
+     * @return Java class (wrapper) or raises a NameError if loading fails or class is not found
+     */
+    @JRubyMethod(meta = true)
+    public static IRubyObject load_java_class(ThreadContext context, IRubyObject recv, IRubyObject name) {
+        Class<?> klass = Java.getJavaClass(context.runtime, name.convertToString().asJavaString());
+        return Java.getInstance(context.runtime, klass);
+    }
+
+    /**
      * @note class_loader_resources alias exists since 9.2
      * @param context
      * @param recv

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
@@ -217,7 +217,7 @@ public class JRubyUtilLibrary implements Library {
     }
 
     private static boolean loadExtension(final Ruby runtime, final String className) {
-        Class<?> clazz = runtime.getJavaSupport().loadJavaClassQuiet(className);
+        Class<?> clazz = Java.getJavaClass(runtime, className);
         // 1. BasicLibraryService interface
         if (BasicLibraryService.class.isAssignableFrom(clazz)) {
             try {

--- a/core/src/main/java/org/jruby/java/addons/ClassJavaAddons.java
+++ b/core/src/main/java/org/jruby/java/addons/ClassJavaAddons.java
@@ -2,17 +2,16 @@ package org.jruby.java.addons;
 
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
+import org.jruby.RubyModule;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.java.proxies.JavaProxy;
 import org.jruby.javasupport.Java;
-import org.jruby.javasupport.JavaClass;
 import org.jruby.javasupport.proxy.JavaProxyClass;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import java.lang.reflect.Field;
-import java.util.Collection;
 import java.util.Set;
 
 /**
@@ -25,15 +24,11 @@ public abstract class ClassJavaAddons {
     public static IRubyObject java_class(ThreadContext context, final IRubyObject self) {
         Class reifiedClass = RubyClass.nearestReifiedClass((RubyClass) self);
         if ( reifiedClass == null ) return context.nil;
-        // TODO: java_class is used for different things with Java proxy modules/classes
         return asJavaClass(context.runtime, reifiedClass);
     }
 
-    private static IRubyObject asJavaClass(final Ruby runtime, final Class<?> reifiedClass) {
-        // TODO: java_class is used for different things with Java proxy modules/classes
-        // returning a JavaClass here would break stuff - simply needs to get through ...
-        // return JavaClass.get(context.runtime, reifiedClass);
-        return Java.getInstance(runtime, reifiedClass);
+    private static JavaProxy asJavaClass(final Ruby runtime, final Class<?> reifiedClass) {
+        return (JavaProxy) Java.getInstance(runtime, reifiedClass);
     }
 
     @JRubyMethod(name = "become_java!", required = 0)
@@ -68,7 +63,7 @@ public abstract class ClassJavaAddons {
 
         Class<?> reifiedClass = klass.getReifiedClass();
         if (reifiedClass == null) { // java proxies can't be reified, but they deserve field accessors too
-            reifiedClass = JavaProxyClass.getProxyClass(context.getRuntime(), klass).getJavaClass();
+            reifiedClass = JavaProxyClass.getProxyClass(context.runtime, klass).getJavaClass();
         }
         if (reifiedClass == null) {
             throw context.runtime.newTypeError("requested class " + klass.getName() + " was not reifiable");

--- a/core/src/main/java/org/jruby/java/addons/KernelJavaAddons.java
+++ b/core/src/main/java/org/jruby/java/addons/KernelJavaAddons.java
@@ -29,7 +29,7 @@ public class KernelJavaAddons {
     public static IRubyObject to_java(ThreadContext context, final IRubyObject fromObject, final IRubyObject type) {
         if ( type.isNil() ) return to_java(context, fromObject);
 
-        final Class targetType = resolveTargetType(context, type);
+        final Class targetType = Java.resolveClassType(context, type);
         if ( fromObject instanceof RubyArray ) {
             return toJavaArray(context.runtime, targetType, (RubyArray) fromObject);
         }
@@ -108,12 +108,6 @@ public class KernelJavaAddons {
     public static IRubyObject java_field(IRubyObject recv, IRubyObject[] args) {
         // empty stub for now
         return recv.getRuntime().getNil();
-    }
-
-    private static Class<?> resolveTargetType(ThreadContext context, IRubyObject type) {
-        RubyModule proxyClass = Java.resolveType(context.runtime, type);
-        if ( proxyClass == null ) throw context.runtime.newTypeError("unable to convert to type: " + type);
-        return JavaClass.getJavaClass(context, proxyClass);
     }
 
 }

--- a/core/src/main/java/org/jruby/java/addons/KernelJavaAddons.java
+++ b/core/src/main/java/org/jruby/java/addons/KernelJavaAddons.java
@@ -2,12 +2,10 @@ package org.jruby.java.addons;
 
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
-import org.jruby.RubyModule;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.java.proxies.ArrayJavaProxy;
 import org.jruby.java.util.ArrayUtils;
 import org.jruby.javasupport.Java;
-import org.jruby.javasupport.JavaClass;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;

--- a/core/src/main/java/org/jruby/java/addons/KernelJavaAddons.java
+++ b/core/src/main/java/org/jruby/java/addons/KernelJavaAddons.java
@@ -1,32 +1,71 @@
 package org.jruby.java.addons;
 
+import org.jruby.Ruby;
 import org.jruby.RubyArray;
+import org.jruby.RubyModule;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.java.proxies.ArrayJavaProxy;
+import org.jruby.java.util.ArrayUtils;
 import org.jruby.javasupport.Java;
 import org.jruby.javasupport.JavaClass;
+import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+
+import java.lang.reflect.Array;
 
 public class KernelJavaAddons {
 
     @JRubyMethod
     public static IRubyObject to_java(ThreadContext context, final IRubyObject fromObject) {
+        final Ruby runtime = context.runtime;
         if ( fromObject instanceof RubyArray ) {
-            final JavaClass targetType = context.runtime.getJavaSupport().getObjectJavaClass();
-            return targetType.javaArrayFromRubyArray(context, (RubyArray) fromObject);
+            return toJavaArray(runtime, Object.class, (RubyArray) fromObject);
         }
-        return Java.getInstance(context.runtime, fromObject.toJava(Object.class));
+        return Java.getInstance(runtime, fromObject.toJava(Object.class));
     }
 
     @JRubyMethod
     public static IRubyObject to_java(ThreadContext context, final IRubyObject fromObject, final IRubyObject type) {
         if ( type.isNil() ) return to_java(context, fromObject);
 
-        final JavaClass targetType = resolveTargetType(context, type);
+        final Class targetType = resolveTargetType(context, type);
         if ( fromObject instanceof RubyArray ) {
-            return targetType.javaArrayFromRubyArray(context, (RubyArray) fromObject);
+            return toJavaArray(context.runtime, targetType, (RubyArray) fromObject);
         }
-        return Java.getInstance(context.runtime, fromObject.toJava(targetType.javaClass()));
+        return Java.getInstance(context.runtime, fromObject.toJava(targetType));
+    }
+
+    static ArrayJavaProxy toJavaArray(final Ruby runtime, final Class<?> type, final RubyArray fromArray) {
+        final Object newArray = toJavaArrayInternal(runtime, type, fromArray);
+        return new ArrayJavaProxy(runtime, Java.getProxyClassForObject(runtime, newArray), newArray, JavaUtil.getJavaConverter(type));
+    }
+
+    private static Object toJavaArrayInternal(final Ruby runtime, final Class<?> type, final RubyArray fromArray) {
+        final Object newArray = Array.newInstance(type, fromArray.size());
+
+        if (type.isArray()) {
+            // if it's an array of arrays, recurse with the component type
+            for ( int i = 0; i < fromArray.size(); i++ ) {
+                final Class<?> nestedType = type.getComponentType();
+                final IRubyObject element = fromArray.eltInternal(i);
+                final Object nestedArray;
+                if ( element instanceof RubyArray ) { // recurse
+                    nestedArray = toJavaArrayInternal(runtime, nestedType, (RubyArray) element);
+                }
+                else if ( type.isInstance(element) ) {
+                    nestedArray = element;
+                }
+                else { // still try (nested) toJava conversion :
+                    nestedArray = element.toJava(type);
+                }
+                ArrayUtils.setWithExceptionHandlingDirect(runtime, newArray, i, nestedArray);
+            }
+        } else {
+            ArrayUtils.copyDataToJavaArrayDirect(fromArray, newArray);
+        }
+
+        return newArray;
     }
 
     @JRubyMethod(rest = true)
@@ -71,10 +110,10 @@ public class KernelJavaAddons {
         return recv.getRuntime().getNil();
     }
 
-    static JavaClass resolveTargetType(ThreadContext context, IRubyObject type) {
-        JavaClass javaType = JavaClass.resolveType(context, type);
-        if ( javaType == null ) throw context.runtime.newTypeError("unable to convert to type: " + type);
-        return javaType;
+    private static Class<?> resolveTargetType(ThreadContext context, IRubyObject type) {
+        RubyModule proxyClass = Java.resolveType(context.runtime, type);
+        if ( proxyClass == null ) throw context.runtime.newTypeError("unable to convert to type: " + type);
+        return JavaClass.getJavaClass(context, proxyClass);
     }
 
 }

--- a/core/src/main/java/org/jruby/java/invokers/MethodInvoker.java
+++ b/core/src/main/java/org/jruby/java/invokers/MethodInvoker.java
@@ -16,7 +16,7 @@ public abstract class MethodInvoker extends RubyToJavaInvoker {
 
     @Override
     protected final JavaCallable createCallable(Ruby runtime, Member member) {
-        return new JavaMethod(runtime, (Method) member);
+        return JavaMethod.create(runtime, (Method) member);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -490,8 +490,7 @@ public final class ArrayJavaProxy extends JavaProxy {
     @JRubyMethod(name = "component_type")
     public IRubyObject component_type(ThreadContext context) {
         Class<?> componentType = getObject().getClass().getComponentType();
-        final JavaClass javaClass = JavaClass.get(context.runtime, componentType);
-        return Java.getProxyClass(context.runtime, javaClass);
+        return Java.getProxyClass(context.runtime, componentType);
     }
 
     private static final byte[] END_BRACKET_COLON_SPACE = new byte[] { ']', ':', ' ' };

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -52,7 +52,7 @@ public final class ArrayJavaProxy extends JavaProxy {
         return arrayJavaProxy;
     }
 
-    static ArrayJavaProxy newArray(final Ruby runtime, final Class<?> elementType, final int... dimensions) {
+    public static ArrayJavaProxy newArray(final Ruby runtime, final Class<?> elementType, final int... dimensions) {
         final Object array;
         try {
             array = Array.newInstance(elementType, dimensions);

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxyCreator.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxyCreator.java
@@ -37,8 +37,8 @@ public class ArrayJavaProxyCreator extends RubyObject {
         return arrayJavaProxyCreator;
     }
 
-    ArrayJavaProxyCreator(final ThreadContext context, JavaClass elementType, final IRubyObject[] sizes) {
-        this(context.runtime, elementType.javaClass());
+    ArrayJavaProxyCreator(final ThreadContext context, Class<?> elementType, final IRubyObject[] sizes) {
+        this(context.runtime, elementType);
         assert sizes.length > 0;
         aggregateDimensions(sizes);
     }

--- a/core/src/main/java/org/jruby/java/proxies/InterfaceJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/InterfaceJavaProxy.java
@@ -52,8 +52,7 @@ public class InterfaceJavaProxy extends JavaProxy {
         public static IRubyObject initialize(ThreadContext context, IRubyObject self, IRubyObject javaClassName, Block block) {
             Ruby runtime = context.runtime;
 
-            Class<?> klass = Java.getJavaClass(runtime, javaClassName.asJavaString());
-            self.getInstanceVariables().setInstanceVariable("@java_class", Java.getProxyClass(runtime, klass));
+            JavaProxy.setJavaClass(self, Java.getJavaClass(runtime, javaClassName.asJavaString()));
             self.getInstanceVariables().setInstanceVariable("@block", RubyProc.newProc(runtime, block, block.type));
 
             self.getInternalVariables().getInternalVariable("@block");

--- a/core/src/main/java/org/jruby/java/proxies/InterfaceJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/InterfaceJavaProxy.java
@@ -9,6 +9,7 @@ import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyProc;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.javasupport.Java;
 import org.jruby.javasupport.JavaClass;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ObjectAllocator;
@@ -51,7 +52,8 @@ public class InterfaceJavaProxy extends JavaProxy {
         public static IRubyObject initialize(ThreadContext context, IRubyObject self, IRubyObject javaClassName, Block block) {
             Ruby runtime = context.runtime;
 
-            self.getInstanceVariables().setInstanceVariable("@java_class", JavaClass.forNameVerbose(runtime, javaClassName.asJavaString()));
+            Class<?> klass = Java.getJavaClass(runtime, javaClassName.asJavaString());
+            self.getInstanceVariables().setInstanceVariable("@java_class", Java.getProxyClass(runtime, klass));
             self.getInstanceVariables().setInstanceVariable("@block", RubyProc.newProc(runtime, block, block.type));
 
             self.getInternalVariables().getInternalVariable("@block");

--- a/core/src/main/java/org/jruby/java/proxies/JavaInterfaceTemplate.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaInterfaceTemplate.java
@@ -22,6 +22,7 @@ import org.jruby.internal.runtime.methods.JavaMethod.JavaMethodZero;
 import org.jruby.javasupport.Java;
 import org.jruby.javasupport.JavaClass;
 import org.jruby.javasupport.JavaObject;
+import org.jruby.javasupport.JavaUtil;
 import org.jruby.javasupport.JavaUtilities;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.Arity;
@@ -38,12 +39,15 @@ public class JavaInterfaceTemplate {
         RubyModule JavaInterfaceTemplate = runtime.defineModule("JavaInterfaceTemplate");
 
         RubyClass singleton = JavaInterfaceTemplate.getSingletonClass();
-        singleton.addReadAttribute(context, "java_class");
         singleton.defineAnnotatedMethods(JavaInterfaceTemplate.class);
-
         JavaInterfaceTemplate.defineAnnotatedMethods(JavaProxy.ClassMethods.class);
 
         return JavaInterfaceTemplate;
+    }
+
+    @JRubyMethod
+    public static IRubyObject java_class(final IRubyObject self) {
+        return JavaProxy.getJavaClass((RubyModule) self);
     }
 
     @Deprecated // not used - should go away in >= 9.2
@@ -59,9 +63,9 @@ public class JavaInterfaceTemplate {
         }
 
         final RubyModule targetModule = (RubyModule) clazz;
-        final JavaClass javaClass = getJavaClassForInterface(self);
-
-        final Method[] javaInstanceMethods = javaClass.javaClass().getMethods();
+        final IRubyObject javaClass = JavaProxy.getJavaClass((RubyModule) self);
+        Class<?> klass = JavaUtil.unwrapJavaObject(javaClass);
+        final Method[] javaInstanceMethods = klass.getMethods();
         final DynamicMethod dummyMethodImpl = new DummyMethodImpl(targetModule);
 
         for (int i = 0; i < javaInstanceMethods.length; i++) {
@@ -107,7 +111,7 @@ public class JavaInterfaceTemplate {
         final Ruby runtime = context.runtime;
         checkAlreadyReified(clazz, runtime);
 
-        final JavaClass javaClass = getJavaClassForInterface(self);
+        final IRubyObject javaClass = JavaProxy.getJavaClass((RubyModule) self);
         RubyArray javaInterfaces;
         if ( ! clazz.hasInstanceVariable("@java_interfaces") ) {
             javaInterfaces = RubyArray.newArray(runtime, javaClass);
@@ -154,7 +158,7 @@ public class JavaInterfaceTemplate {
             // list of interfaces we implement
             singleton.addReadAttribute(context, "java_interfaces");
 
-            if ( ( ! Java.NEW_STYLE_EXTENSION && clazz.getSuperClass().getRealClass().hasInstanceVariable("@java_class") )
+            if ( ( ! Java.NEW_STYLE_EXTENSION && JavaProxy.getJavaClass(clazz.getSuperClass().getRealClass()) != null )
                 || RubyInstanceConfig.INTERFACES_USE_PROXY ) {
                 // superclass is a Java class...use old style impl for now
 
@@ -515,9 +519,6 @@ public class JavaInterfaceTemplate {
 
     }
 
-    private static JavaClass getJavaClassForInterface(final IRubyObject module) {
-        return (JavaClass) module.getInstanceVariables().getInstanceVariable("@java_class");
-    }
 
     private static RubyArray getJavaInterfaces(final IRubyObject clazz) {
         return (RubyArray) clazz.getInstanceVariables().getInstanceVariable("@java_interfaces");

--- a/core/src/main/java/org/jruby/java/proxies/JavaInterfaceTemplate.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaInterfaceTemplate.java
@@ -258,7 +258,7 @@ public class JavaInterfaceTemplate {
             else {
                 javaClass = self.getClass(); // NOTE what is this for?
             }
-            return JavaClass.get(context.runtime, javaClass);
+            return Java.getInstance(context.runtime, javaClass);
         }
 
     }

--- a/core/src/main/java/org/jruby/java/util/ArrayUtils.java
+++ b/core/src/main/java/org/jruby/java/util/ArrayUtils.java
@@ -7,6 +7,7 @@ import org.jruby.RubyClass;
 import org.jruby.RubyFixnum;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.java.proxies.ArrayJavaProxy;
+import org.jruby.javasupport.Java;
 import org.jruby.javasupport.JavaArray;
 import org.jruby.javasupport.JavaClass;
 import org.jruby.javasupport.JavaUtil;
@@ -47,7 +48,7 @@ public class ArrayUtils {
 
     public static ArrayJavaProxy newProxiedArray(Ruby runtime, Class<?> componentType, JavaUtil.JavaConverter converter, int size) {
         final Object array = Array.newInstance(componentType, size);
-        RubyClass proxyClass = JavaClass.get(runtime, array.getClass()).getProxyClass();
+        RubyClass proxyClass = (RubyClass) Java.getProxyClass(runtime, array.getClass());
         return new ArrayJavaProxy(runtime, proxyClass, array, converter);
     }
 

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -334,6 +334,10 @@ public class Java implements Library {
         return null;
     }
 
+    public static Class<?> unwrapClassProxy(final IRubyObject self) {
+        return (Class) ((JavaProxy) self).getObject();
+    }
+
     public static RubyClass getProxyClassForObject(Ruby runtime, Object object) {
         return (RubyClass) getProxyClass(runtime, object.getClass());
     }

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -356,16 +356,16 @@ public class Java implements Library {
             return null;
         }
 
-        JavaClass klass; // handle legacy JavaClass
+        Class<?> klass; // handle legacy JavaClass
         if (type instanceof JavaClass) {
-            klass = (JavaClass) type;
+            klass = ((JavaClass) type).javaClass();
         } else if (type instanceof RubyModule) { // assuming a proxy module/class e.g. to_java(java.lang.String)
-            klass = JavaClass.getJavaClassIfProxyImpl(runtime.getCurrentContext(), (RubyModule) type);
+            klass = JavaClass.getJavaClassIfProxy(runtime.getCurrentContext(), (RubyModule) type);
             if (klass == null) return null;
         } else {
             return null;
         }
-        return getProxyClass(runtime, klass.javaClass());
+        return getProxyClass(runtime, klass);
     }
 
     private static Class resolveShortClassName(final String name) {

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -292,18 +292,18 @@ public class Java implements Library {
     }
 
     public static RubyModule get_interface_module(final Ruby runtime, IRubyObject javaClassObject) {
-        JavaClass javaClass; String javaName;
+        Class<?> javaClass; String javaName;
         if ( javaClassObject instanceof RubyString ) {
-            javaClass = JavaClass.forNameVerbose(runtime, javaClassObject.asJavaString());
+            javaClass = Java.getJavaClass(runtime, javaClassObject.asJavaString());
         }
         else if ( javaClassObject instanceof JavaClass ) {
-            javaClass = (JavaClass) javaClassObject;
+            javaClass = ((JavaClass) javaClassObject).javaClass();
         }
         else if ( (javaName = unwrapJavaString(javaClassObject)) != null ) {
-            javaClass = JavaClass.forNameVerbose(runtime, javaName);
+            javaClass = Java.getJavaClass(runtime, javaName);
         }
         else {
-            throw runtime.newArgumentError("expected JavaClass, got " + javaClassObject);
+            throw runtime.newArgumentError("expected a Java class, got " + javaClassObject.inspect());
         }
         return getInterfaceModule(runtime, javaClass);
     }

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -959,7 +959,6 @@ public class Java implements Library {
     }
 
     static Class loadJavaClass(final Ruby runtime, final String className, boolean initialize) throws ClassNotFoundException, RaiseException {
-        final Class<?> clazz;
         try { // loadJavaClass here to handle things like LinkageError through
             synchronized (Java.class) {
                 // a circular load might potentially dead-lock when loading concurrently
@@ -1509,7 +1508,7 @@ public class Java implements Library {
         String implClassName = Constants.GENERATED_PACKAGE;
         if (clazz.getBaseName() == null) {
             // no-name class, generate a bogus name for it
-            implClassName += "anon_class" + Math.abs(System.identityHashCode(clazz)) + '_' + Math.abs(interfacesHashCode);
+            implClassName += "Class0x" + Integer.toHexString(System.identityHashCode(clazz)) + '_' + Math.abs(interfacesHashCode);
         } else {
             implClassName += StringSupport.replaceAll(clazz.getName(), "::", "$$").toString() + '_' + Math.abs(interfacesHashCode);
         }

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -946,7 +946,7 @@ public class Java implements Library {
         try {
             return loadJavaClass(runtime, className);
         } catch (ClassNotFoundException ex) {
-            throw initCause(runtime.newNameError("cannot load Java class " + className, className, ex), ex);
+            throw initCause(runtime.newNameError("Java class " + className + " not found", className, ex), ex);
         }
     }
 

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -135,14 +135,15 @@ public class Java implements Library {
 
         runtime.setJavaProxyClassFactory(JavaProxyClassFactory.createFactory());
 
-        // TODO: these are still used internally with Ruby 2 Java invocation:
-        JavaMethod.createJavaMethodClass(runtime, Java);
-        JavaConstructor.createJavaConstructorClass(runtime, Java);
         // (legacy) JavaClass compatibility:
         Java.setConstant("JavaClass", getProxyClass(runtime, java.lang.Class.class));
         Java.deprecateConstant(runtime, "JavaClass");
         Java.setConstant("JavaField", getProxyClass(runtime, java.lang.reflect.Field.class));
         Java.deprecateConstant(runtime, "JavaField");
+        Java.setConstant("JavaMethod", getProxyClass(runtime, java.lang.reflect.Method.class));
+        Java.deprecateConstant(runtime, "JavaMethod");
+        Java.setConstant("JavaConstructor", getProxyClass(runtime, java.lang.reflect.Constructor.class));
+        Java.deprecateConstant(runtime, "JavaConstructor");
 
         // modify ENV_JAVA to be a read/write version
         final Map systemProperties = new SystemPropertiesMap();

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -289,6 +289,7 @@ public class Java implements Library {
         return runtime.getNil();
     }
 
+    @Deprecated
     public static RubyModule getInterfaceModule(final Ruby runtime, final JavaClass javaClass) {
         return getInterfaceModule(runtime, javaClass.javaClass());
     }
@@ -347,13 +348,16 @@ public class Java implements Library {
             klass = resolveShortClassName(className);
             if (klass == null) klass = getJavaClass(runtime, className);
         } else {
-            klass = resolveClassTypeInternal(runtime, type);
+            klass = resolveClassType(runtime, type);
+            if (klass == null) {
+                throw runtime.newTypeError("expected a Java class, got: " + type);
+            }
         }
         return getProxyClass(runtime, klass);
     }
 
     // this should handle the type returned from Class#java_class
-    static Class<?> resolveClassTypeInternal(final Ruby runtime, final IRubyObject type) {
+    static Class<?> resolveClassType(final Ruby runtime, final IRubyObject type) {
         if (type instanceof JavaProxy) { // due Class#java_class wrapping
             final Object wrapped = ((JavaProxy) type).getObject();
             if (wrapped instanceof Class) return (Class) wrapped;

--- a/core/src/main/java/org/jruby/javasupport/JavaAccessibleObject.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaAccessibleObject.java
@@ -139,6 +139,7 @@ public abstract class JavaAccessibleObject extends RubyObject {
     // for our purposes, Accessibles are also Members, and vice-versa,
     // so we'll include Member methods here.
     @JRubyMethod
+    @SuppressWarnings("deprecation")
     public IRubyObject declaring_class() {
         Class<?> clazz = ((Member) accessibleObject()).getDeclaringClass();
         if ( clazz != null ) return JavaClass.get(getRuntime(), clazz);

--- a/core/src/main/java/org/jruby/javasupport/JavaAccessibleObject.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaAccessibleObject.java
@@ -39,6 +39,7 @@ import org.jruby.RubyFixnum;
 import org.jruby.RubyObject;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 public abstract class JavaAccessibleObject extends RubyObject {
@@ -69,25 +70,25 @@ public abstract class JavaAccessibleObject extends RubyObject {
     }
 
     @JRubyMethod
-    public RubyFixnum hash() {
-        return getRuntime().newFixnum(hashCode());
+    public RubyFixnum hash(ThreadContext context) {
+        return context.runtime.newFixnum(hashCode());
     }
 
     @JRubyMethod(name = {"==", "eql?"})
-    public RubyBoolean op_equal(final IRubyObject other) {
-        return RubyBoolean.newBoolean(getRuntime(), equals(other));
+    public RubyBoolean op_equal(ThreadContext context, final IRubyObject other) {
+        return RubyBoolean.newBoolean(context.runtime, equals(other));
     }
 
     @JRubyMethod(name = "equal?")
-    public RubyBoolean same(final IRubyObject other) {
+    public RubyBoolean same(ThreadContext context, final IRubyObject other) {
         final boolean same = other instanceof JavaAccessibleObject && same((JavaAccessibleObject) other);
-        return same ? getRuntime().getTrue() : getRuntime().getFalse();
+        return same ? context.runtime.getTrue() : context.runtime.getFalse();
     }
 
     @JRubyMethod(name = "accessible?")
     @Deprecated
-    public RubyBoolean isAccessible() {
-        return RubyBoolean.newBoolean(getRuntime(), accessibleObject().isAccessible());
+    public RubyBoolean isAccessible(ThreadContext context) {
+        return RubyBoolean.newBoolean(context.runtime, accessibleObject().isAccessible());
     }
 
     @JRubyMethod(name = "accessible=")
@@ -98,72 +99,80 @@ public abstract class JavaAccessibleObject extends RubyObject {
 
     @SuppressWarnings("unchecked")
     @JRubyMethod
-    public IRubyObject annotation(final IRubyObject annoClass) {
-        if ( ! ( annoClass instanceof JavaClass ) ) {
-            throw getRuntime().newTypeError(annoClass, getRuntime().getJavaSupport().getJavaClassClass());
+    public IRubyObject annotation(ThreadContext context, final IRubyObject annoClass) {
+        final Class annotation;
+        if (annoClass instanceof RubyClass && ((RubyClass) annoClass).getJavaProxy()) {
+            annotation = ((RubyClass) annoClass).getJavaClass();
+        } else if (annoClass instanceof JavaClass) {
+            annotation = ((JavaClass) annoClass).javaClass();
+        } else {
+            throw context.runtime.newTypeError("expected a Java (proxy) class, got: " + annoClass);
         }
-        final Class annotation = ((JavaClass) annoClass).javaClass();
-        return Java.getInstance(getRuntime(), accessibleObject().getAnnotation(annotation));
+        return Java.getInstance(context.runtime, accessibleObject().getAnnotation(annotation));
     }
 
     @JRubyMethod
-    public IRubyObject annotations() {
-        return Java.getInstance(getRuntime(), accessibleObject().getAnnotations());
+    public IRubyObject annotations(ThreadContext context) {
+        return Java.getInstance(context.runtime, accessibleObject().getAnnotations());
     }
 
     @JRubyMethod(name = "annotations?")
-    public RubyBoolean annotations_p() {
-        return getRuntime().newBoolean(accessibleObject().getAnnotations().length > 0);
+    public RubyBoolean annotations_p(ThreadContext context) {
+        return context.runtime.newBoolean(accessibleObject().getAnnotations().length > 0);
     }
 
     @JRubyMethod
-    public IRubyObject declared_annotations() {
-        return Java.getInstance(getRuntime(), accessibleObject().getDeclaredAnnotations());
+    public IRubyObject declared_annotations(ThreadContext context) {
+        return Java.getInstance(context.runtime, accessibleObject().getDeclaredAnnotations());
     }
 
     @JRubyMethod(name = "declared_annotations?")
-    public RubyBoolean declared_annotations_p() {
-        return getRuntime().newBoolean(accessibleObject().getDeclaredAnnotations().length > 0);
+    public RubyBoolean declared_annotations_p(ThreadContext context) {
+        return context.runtime.newBoolean(accessibleObject().getDeclaredAnnotations().length > 0);
     }
 
     @SuppressWarnings("unchecked")
     @JRubyMethod(name = "annotation_present?")
-    public IRubyObject annotation_present_p(final IRubyObject annoClass) {
-        if ( ! ( annoClass instanceof JavaClass ) ) {
-            throw getRuntime().newTypeError(annoClass, getRuntime().getJavaSupport().getJavaClassClass());
+    public IRubyObject annotation_present_p(ThreadContext context, final IRubyObject annoClass) {
+        final Class annotation;
+        if (annoClass instanceof RubyClass && ((RubyClass) annoClass).getJavaProxy()) {
+            annotation = ((RubyClass) annoClass).getJavaClass();
+        } else if (annoClass instanceof JavaClass) {
+            annotation = ((JavaClass) annoClass).javaClass();
+        } else {
+            throw context.runtime.newTypeError("expected a Java (proxy) class, got: " + annoClass);
         }
-        final Class annotation = ((JavaClass) annoClass).javaClass();
-        return getRuntime().newBoolean( accessibleObject().isAnnotationPresent(annotation) );
+        return context.runtime.newBoolean( accessibleObject().isAnnotationPresent(annotation) );
     }
 
     // for our purposes, Accessibles are also Members, and vice-versa,
     // so we'll include Member methods here.
     @JRubyMethod
     @SuppressWarnings("deprecation")
-    public IRubyObject declaring_class() {
+    public IRubyObject declaring_class(ThreadContext context) {
         Class<?> clazz = ((Member) accessibleObject()).getDeclaringClass();
-        if ( clazz != null ) return JavaClass.get(getRuntime(), clazz);
-        return getRuntime().getNil();
+        if ( clazz != null ) return Java.getProxyClass(context.runtime, clazz);
+        return context.runtime.getNil();
     }
 
     @JRubyMethod
-    public IRubyObject modifiers() {
-        return getRuntime().newFixnum(((Member) accessibleObject()).getModifiers());
+    public IRubyObject modifiers(ThreadContext context) {
+        return context.runtime.newFixnum(((Member) accessibleObject()).getModifiers());
     }
 
     @JRubyMethod
-    public IRubyObject name() {
-        return getRuntime().newString(((Member) accessibleObject()).getName());
+    public IRubyObject name(ThreadContext context) {
+        return context.runtime.newString(((Member) accessibleObject()).getName());
     }
 
     @JRubyMethod(name = "synthetic?")
-    public IRubyObject synthetic_p() {
-        return getRuntime().newBoolean(((Member) accessibleObject()).isSynthetic());
+    public IRubyObject synthetic_p(ThreadContext context) {
+        return context.runtime.newBoolean(((Member) accessibleObject()).isSynthetic());
     }
 
     @JRubyMethod(name = {"to_s", "to_string"})
-    public RubyString to_string() {
-        return getRuntime().newString( toString() );
+    public RubyString to_string(ThreadContext context) {
+        return context.runtime.newString( toString() );
     }
 
     @Override

--- a/core/src/main/java/org/jruby/javasupport/JavaAccessibleObject.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaAccessibleObject.java
@@ -36,16 +36,19 @@ import org.jruby.Ruby;
 import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyFixnum;
-import org.jruby.RubyObject;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
-public abstract class JavaAccessibleObject extends RubyObject {
+public abstract class JavaAccessibleObject {
 
     protected JavaAccessibleObject(Ruby runtime, RubyClass rubyClass) {
-        super(runtime, rubyClass);
+        this(runtime, rubyClass, false);
+    }
+
+    JavaAccessibleObject(Ruby runtime, RubyClass rubyClass, boolean objectSpace) {
+        // super(runtime, rubyClass, objectSpace);
     }
 
     public static void registerRubyMethods(Ruby runtime, RubyClass result) {
@@ -178,15 +181,6 @@ public abstract class JavaAccessibleObject extends RubyObject {
     @Override
     public String toString() {
         return accessibleObject().toString();
-    }
-
-    @Override
-    public <T> T toJava(Class<T> target) {
-        AccessibleObject accessibleObject = accessibleObject();
-        if (target.isAssignableFrom(accessibleObject.getClass())) {
-            return target.cast(accessibleObject);
-        }
-        return super.toJava(target);
     }
 
 }

--- a/core/src/main/java/org/jruby/javasupport/JavaCallable.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaCallable.java
@@ -94,11 +94,13 @@ public abstract class JavaCallable extends JavaAccessibleObject implements Param
     }
 
     @JRubyMethod(name = { "argument_types", "parameter_types" })
+    @SuppressWarnings("deprecation")
     public final RubyArray parameter_types() {
         return toRubyArray(getRuntime(), getParameterTypes());
     }
 
     @JRubyMethod
+    @SuppressWarnings("deprecation")
     public RubyArray exception_types() {
         return toRubyArray(getRuntime(), getExceptionTypes());
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaCallable.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaCallable.java
@@ -89,55 +89,55 @@ public abstract class JavaCallable extends JavaAccessibleObject implements Param
     protected abstract String nameOnInspection();
 
     @JRubyMethod
-    public final RubyFixnum arity() {
-        return getRuntime().newFixnum(getArity());
+    public final RubyFixnum arity(ThreadContext context) {
+        return context.runtime.newFixnum(getArity());
     }
 
     @JRubyMethod(name = { "argument_types", "parameter_types" })
     @SuppressWarnings("deprecation")
-    public final RubyArray parameter_types() {
-        return toRubyArray(getRuntime(), getParameterTypes());
+    public final RubyArray parameter_types(ThreadContext context) {
+        return toRubyArray(context.runtime, getParameterTypes());
     }
 
     @JRubyMethod
     @SuppressWarnings("deprecation")
-    public RubyArray exception_types() {
-        return toRubyArray(getRuntime(), getExceptionTypes());
+    public RubyArray exception_types(ThreadContext context) {
+        return toRubyArray(context.runtime, getExceptionTypes());
     }
 
     @JRubyMethod
-    public IRubyObject generic_parameter_types() {
-        return Java.getInstance(getRuntime(), getGenericParameterTypes());
+    public IRubyObject generic_parameter_types(ThreadContext context) {
+        return Java.getInstance(context.runtime, getGenericParameterTypes());
     }
 
     @JRubyMethod
-    public IRubyObject generic_exception_types() {
-        return Java.getInstance(getRuntime(), getGenericExceptionTypes());
+    public IRubyObject generic_exception_types(ThreadContext context) {
+        return Java.getInstance(context.runtime, getGenericExceptionTypes());
     }
 
     @JRubyMethod
-    public IRubyObject parameter_annotations() {
-        return Java.getInstance(getRuntime(), getParameterAnnotations());
+    public IRubyObject parameter_annotations(ThreadContext context) {
+        return Java.getInstance(context.runtime, getParameterAnnotations());
     }
 
     @JRubyMethod(name = "varargs?")
-    public RubyBoolean varargs_p() {
-        return getRuntime().newBoolean(isVarArgs());
+    public RubyBoolean varargs_p(ThreadContext context) {
+        return context.runtime.newBoolean(isVarArgs());
     }
 
     @JRubyMethod
-    public RubyString to_generic_string() {
-        return getRuntime().newString(toGenericString());
+    public RubyString to_generic_string(ThreadContext context) {
+        return context.runtime.newString(toGenericString());
     }
 
     @JRubyMethod(name = "public?")
-    public RubyBoolean public_p() {
-        return RubyBoolean.newBoolean(getRuntime(), Modifier.isPublic(getModifiers()));
+    public RubyBoolean public_p(ThreadContext context) {
+        return RubyBoolean.newBoolean(context.runtime, Modifier.isPublic(getModifiers()));
     }
 
-    protected final void checkArity(final int length) {
+    protected final void checkArity(ThreadContext context, final int length) {
         if ( length != getArity() ) {
-            throw getRuntime().newArgumentError(length, getArity());
+            throw context.runtime.newArgumentError(length, getArity());
         }
     }
 
@@ -165,32 +165,32 @@ public abstract class JavaCallable extends JavaAccessibleObject implements Param
     }
 
     protected final IRubyObject handleInvocationTargetEx(ThreadContext context, InvocationTargetException ex) {
-        return handleThrowable(context, ex.getTargetException());
+        return handleThrowable(context, ex.getTargetException()); // NOTE: we no longer unwrap
     }
 
-    final IRubyObject handleIllegalAccessEx(final IllegalAccessException ex, Member target) throws RaiseException {
-        throw getRuntime().newTypeError("illegal access on '" + target.getName() + "': " + ex.getMessage());
+    final IRubyObject handleIllegalAccessEx(ThreadContext context, final IllegalAccessException ex, Member target) throws RaiseException {
+        throw context.runtime.newTypeError("illegal access on '" + target.getName() + "': " + ex.getMessage());
     }
 
-    final IRubyObject handleIllegalAccessEx(final IllegalAccessException ex, Constructor target)  throws RaiseException {
-        throw getRuntime().newTypeError("illegal access on constructor for type '" + target.getDeclaringClass().getSimpleName() + "': " + ex.getMessage());
+    final IRubyObject handleIllegalAccessEx(ThreadContext context, final IllegalAccessException ex, Constructor target)  throws RaiseException {
+        throw context.runtime.newTypeError("illegal access on constructor for type '" + target.getDeclaringClass().getSimpleName() + "': " + ex.getMessage());
     }
 
-    final IRubyObject handlelIllegalArgumentEx(final IllegalArgumentException ex, Method target, Object... arguments) throws RaiseException {
+    final IRubyObject handlelIllegalArgumentEx(ThreadContext context, final IllegalArgumentException ex, Method target, Object... arguments) throws RaiseException {
         final StringBuilder msg = new StringBuilder(64);
         msg.append("for method ").append( target.getDeclaringClass().getSimpleName() )
            .append('.').append( target.getName() );
         msg.append(" expected "); dumpParameterTypes(msg);
         msg.append("; got: "); dumpArgTypes(arguments, msg);
         msg.append("; error: ").append( ex.getMessage() );
-        throw getRuntime().newTypeError( msg.toString() );
+        throw context.runtime.newTypeError( msg.toString() );
     }
 
-    final IRubyObject handlelIllegalArgumentEx(final IllegalArgumentException ex, Constructor target, Object... arguments) throws RaiseException {
-        return handlelIllegalArgumentEx(ex, target, true, arguments);
+    final IRubyObject handlelIllegalArgumentEx(ThreadContext context, final IllegalArgumentException ex, Constructor target, Object... arguments) throws RaiseException {
+        return handlelIllegalArgumentEx(context, ex, target, true, arguments);
     }
 
-    final IRubyObject handlelIllegalArgumentEx(final IllegalArgumentException ex, Constructor target, final boolean targetInfo, Object... arguments) throws RaiseException {
+    final IRubyObject handlelIllegalArgumentEx(ThreadContext context, final IllegalArgumentException ex, Constructor target, final boolean targetInfo, Object... arguments) throws RaiseException {
         final StringBuilder msg = new StringBuilder(64);
         if ( targetInfo ) {
             msg.append("for constructor of type ").append( target.getDeclaringClass().getSimpleName() );
@@ -198,7 +198,7 @@ public abstract class JavaCallable extends JavaAccessibleObject implements Param
         msg.append(" expected "); dumpParameterTypes(msg);
         msg.append("; got: "); dumpArgTypes(arguments, msg);
         msg.append("; error: ").append( ex.getMessage() );
-        throw getRuntime().newTypeError( msg.toString() );
+        throw context.runtime.newTypeError( msg.toString() );
     }
 
     private void dumpParameterTypes(final StringBuilder str) {

--- a/core/src/main/java/org/jruby/javasupport/JavaCallable.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaCallable.java
@@ -60,7 +60,7 @@ public abstract class JavaCallable extends JavaAccessibleObject implements Param
 
     private static final boolean REWRITE_JAVA_TRACE = Options.REWRITE_JAVA_TRACE.load();
 
-    public JavaCallable(Ruby runtime, RubyClass rubyClass, Class<?>[] parameterTypes) {
+    protected JavaCallable(Ruby runtime, RubyClass rubyClass, Class<?>[] parameterTypes) {
         super(runtime, rubyClass);
         this.parameterTypes = parameterTypes;
     }
@@ -82,11 +82,6 @@ public abstract class JavaCallable extends JavaAccessibleObject implements Param
     public abstract Annotation[][] getParameterAnnotations();
     public abstract boolean isVarArgs();
     public abstract String toGenericString();
-
-    /**
-     * @return the name used in the head of the string returned from inspect()
-     */
-    protected abstract String nameOnInspection();
 
     @JRubyMethod
     public final RubyFixnum arity(ThreadContext context) {

--- a/core/src/main/java/org/jruby/javasupport/JavaClass.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaClass.java
@@ -44,12 +44,9 @@ import org.jruby.RubyClass;
 import org.jruby.RubyInteger;
 import org.jruby.RubyModule;
 import org.jruby.RubyString;
-import org.jruby.RubySymbol;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.RaiseException;
-import org.jruby.java.addons.ClassJavaAddons;
-import org.jruby.java.proxies.ArrayJavaProxy;
 import org.jruby.java.proxies.ConcreteJavaProxy;
 import org.jruby.java.proxies.JavaProxy;
 import org.jruby.java.util.ArrayUtils;
@@ -72,7 +69,7 @@ import java.lang.reflect.Modifier;
 import static org.jruby.RubyModule.undefinedMethodMessage;
 import static org.jruby.util.RubyStringBuilder.ids;
 
-@JRubyClass(name="Java::JavaClass", parent="Java::JavaObject", include = "Comparable")
+// @JRubyClass(name="Java::JavaClass", parent="Java::JavaObject", include = "Comparable")
 public class JavaClass extends JavaObject {
 
     public static final Class[] EMPTY_CLASS_ARRAY = new Class[0];
@@ -471,7 +468,7 @@ public class JavaClass extends JavaObject {
     public IRubyObject enclosing_constructor() {
         Constructor<?> ctor = javaClass().getEnclosingConstructor();
         if (ctor != null) {
-            return new JavaConstructor(getRuntime(), ctor);
+            return Java.getInstance(getRuntime(), ctor);
         }
         return getRuntime().getNil();
     }
@@ -480,7 +477,7 @@ public class JavaClass extends JavaObject {
     public IRubyObject enclosing_method() {
         Method meth = javaClass().getEnclosingMethod();
         if (meth != null) {
-            return new JavaMethod(getRuntime(), meth);
+            return Java.getInstance(getRuntime(), meth);
         }
         return getRuntime().getNil();
     }
@@ -601,7 +598,7 @@ public class JavaClass extends JavaObject {
         for ( int i = 0; i < methods.length; i++ ) {
             final Method method = methods[i];
             if ( isStatic == Modifier.isStatic(method.getModifiers()) ) {
-                result.append( new JavaMethod(runtime, method) );
+                result.append(Java.getInstance(runtime, method));
             }
         }
         return result;
@@ -688,6 +685,7 @@ public class JavaClass extends JavaObject {
     }
 
     @JRubyMethod
+    @SuppressWarnings("deprecation")
     public RubyArray classes() {
         return toRubyArray(getRuntime(), javaClass().getClasses());
     }
@@ -735,7 +733,7 @@ public class JavaClass extends JavaObject {
     private static RubyArray buildConstructors(final Ruby runtime, Constructor<?>[] constructors) {
         RubyArray result = RubyArray.newArray(runtime, constructors.length);
         for ( int i = 0; i < constructors.length; i++ ) {
-            result.append( new JavaConstructor(runtime, constructors[i]) );
+            result.append(Java.getInstance(runtime, constructors[i]));
         }
         return result;
     }
@@ -847,7 +845,7 @@ public class JavaClass extends JavaObject {
     private static RubyArray buildFieldResults(final Ruby runtime, Field[] fields) {
         RubyArray result = runtime.newArray( fields.length );
         for ( int i = 0; i < fields.length; i++ ) {
-            result.append( new JavaField(runtime, fields[i]) );
+            result.append(Java.getInstance(runtime, fields[i]));
         }
         return result;
     }
@@ -895,6 +893,7 @@ public class JavaClass extends JavaObject {
     }
 
     @JRubyMethod
+    @SuppressWarnings("deprecation")
     public RubyArray interfaces() {
         return toRubyArray(getRuntime(), javaClass().getInterfaces());
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaClass.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaClass.java
@@ -104,10 +104,6 @@ public class JavaClass extends JavaObject {
         return (RubyClass) Java.getProxyClass(getRuntime(), javaClass());
     }
 
-    private static Class<?> unwrapClassProxy(final IRubyObject self) {
-        return (Class) ((JavaProxy) self).getObject();
-    }
-
     private static IRubyObject addProxyExtender(final ThreadContext context, final Class<?> klass, final IRubyObject extender) {
         if ( ! extender.respondsTo("extend_proxy") ) {
             throw context.runtime.newTypeError("proxy extender must have an extend_proxy method");
@@ -122,7 +118,7 @@ public class JavaClass extends JavaObject {
             addProxyExtender(context, ((JavaClass) self).javaClass(), extender);
         } else {
             // NOTE: used by java.lang.Class as a JavaClass compatiblity layer
-            addProxyExtender(context, unwrapClassProxy(self), extender);
+            addProxyExtender(context, Java.unwrapClassProxy(self), extender);
         }
         return context.nil;
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaClass.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaClass.java
@@ -135,10 +135,6 @@ public class JavaClass extends JavaObject {
         return RubyArray.newArrayMayCopy(runtime, javaClasses);
     }
 
-    public static RubyClass createJavaClassClass(final Ruby runtime, final RubyModule Java) {
-        return createJavaClassClass(runtime, Java, Java.getClass("JavaObject"));
-    }
-
     static RubyClass createJavaClassClass(final Ruby runtime, final RubyModule Java, final RubyClass JavaObject) {
         // TODO: Determine if a real allocator is needed here. Do people want to extend
         // JavaClass? Do we want them to do that? Can you Class.new(JavaClass)? Should you be able to?
@@ -230,12 +226,9 @@ public class JavaClass extends JavaObject {
         return proxyClass == null ? null : get(context.runtime, getJavaClass(context, proxyClass));
     }
 
+    @Deprecated
     public static JavaClass forNameVerbose(Ruby runtime, String className) {
-        Class<?> klass = null; // "boolean".length() == 7
-        if (className.length() < 8 && Character.isLowerCase(className.charAt(0))) {
-            // one word type name that starts lower-case...it may be a primitive type
-            klass = JavaUtil.getPrimitiveClass(className);
-        }
+        Class<?> klass = null;
         synchronized (JavaClass.class) {
             if (klass == null) {
                 klass = runtime.getJavaSupport().loadJavaClassVerbose(className);

--- a/core/src/main/java/org/jruby/javasupport/JavaClass.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaClass.java
@@ -217,7 +217,8 @@ public class JavaClass extends JavaObject {
      * @param type
      * @return Java proxy class, Java reified class or nil
      */
-    public static IRubyObject java_class(final ThreadContext context, final RubyModule type) {
+    @Deprecated
+    public static IRubyObject java_class(final ThreadContext context, final RubyModule type) { // TODO avoid callers!
         IRubyObject java_class = type.getInstanceVariable("@java_class");
         if ( java_class == null ) { // || java_class.isNil()
             if ( type.respondsTo("java_class") ) { // NOTE: quite bad since built-in Ruby classes will return
@@ -254,6 +255,7 @@ public class JavaClass extends JavaObject {
         }
     }
 
+    @Deprecated // no longer used
     public static JavaClass forNameQuiet(Ruby runtime, String className) {
         synchronized (JavaClass.class) {
             Class<?> klass = runtime.getJavaSupport().loadJavaClassQuiet(className);

--- a/core/src/main/java/org/jruby/javasupport/JavaConstructor.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaConstructor.java
@@ -198,47 +198,47 @@ public class JavaConstructor extends JavaCallable {
     }
 
     @JRubyMethod
-    public IRubyObject type_parameters() {
-        return Java.getInstance(getRuntime(), constructor.getTypeParameters());
+    public IRubyObject type_parameters(ThreadContext context) {
+        return Java.getInstance(context.runtime, constructor.getTypeParameters());
     }
 
     @JRubyMethod
-    public IRubyObject return_type() {
-        return getRuntime().getNil();
+    public IRubyObject return_type(ThreadContext context) {
+        return context.runtime.getNil();
     }
 
     @JRubyMethod
     @SuppressWarnings("deprecation")
-    public IRubyObject declaring_class() {
-        return JavaClass.get(getRuntime(), getDeclaringClass());
+    public IRubyObject declaring_class(ThreadContext context) {
+        return Java.getProxyClass(context.runtime, getDeclaringClass());
     }
 
     @JRubyMethod(rest = true)
-    public final IRubyObject new_instance(final IRubyObject[] args) {
-        checkArity(args.length);
+    public final IRubyObject new_instance(ThreadContext context, final IRubyObject[] args) {
+        checkArity(context, args.length);
 
-        return newInstanceExactArity( convertArguments(args) );
+        return newInstanceExactArity(context, convertArguments(args));
     }
 
-    public final IRubyObject new_instance(final Object[] arguments) {
-        checkArity(arguments.length);
+    public final IRubyObject new_instance(ThreadContext context, final Object[] arguments) {
+        checkArity(context, arguments.length);
 
-        return newInstanceExactArity(arguments);
+        return newInstanceExactArity(context, arguments);
     }
 
-    private IRubyObject newInstanceExactArity(Object[] arguments) {
+    private IRubyObject newInstanceExactArity(ThreadContext context, Object[] arguments) {
         try {
             Object result = constructor.newInstance(arguments);
             return JavaObject.wrap(getRuntime(), result);
         }
         catch (IllegalArgumentException iae) {
-            return handlelIllegalArgumentEx(iae, constructor, false, arguments);
+            return handlelIllegalArgumentEx(context, iae, constructor, false, arguments);
         }
         catch (IllegalAccessException iae) {
             throw getRuntime().newTypeError("illegal access");
         }
         catch (InvocationTargetException ite) {
-            getRuntime().getJavaSupport().handleNativeException(ite.getTargetException(), constructor);
+            getRuntime().getJavaSupport().handleNativeException(ite.getTargetException(), constructor); // NOTE: we no longer unwrap
             // not reached
             assert false;
             return null;
@@ -249,14 +249,14 @@ public class JavaConstructor extends JavaCallable {
     }
 
     public Object newInstanceDirect(ThreadContext context, Object... arguments) {
-        checkArity(arguments.length);
+        checkArity(context, arguments.length);
 
         try {
             return constructor.newInstance(arguments);
         } catch (IllegalArgumentException iae) {
-            return handlelIllegalArgumentEx(iae, constructor, arguments);
+            return handlelIllegalArgumentEx(context, iae, constructor, arguments);
         } catch (IllegalAccessException iae) {
-            return handleIllegalAccessEx(iae, constructor);
+            return handleIllegalAccessEx(context, iae, constructor);
         } catch (InvocationTargetException ite) {
             return handleInvocationTargetEx(context, ite);
         } catch (Throwable t) {
@@ -265,14 +265,14 @@ public class JavaConstructor extends JavaCallable {
     }
 
     public Object newInstanceDirect(ThreadContext context) {
-        checkArity(0);
+        checkArity(context, 0);
 
         try {
             return constructor.newInstance();
         } catch (IllegalArgumentException iae) {
-            return handlelIllegalArgumentEx(iae, constructor);
+            return handlelIllegalArgumentEx(context, iae, constructor);
         } catch (IllegalAccessException iae) {
-            return handleIllegalAccessEx(iae, constructor);
+            return handleIllegalAccessEx(context, iae, constructor);
         } catch (InvocationTargetException ite) {
             return handleInvocationTargetEx(context, ite);
         } catch (Throwable t) {
@@ -281,14 +281,14 @@ public class JavaConstructor extends JavaCallable {
     }
 
     public Object newInstanceDirect(ThreadContext context, Object arg0) {
-        checkArity(1);
+        checkArity(context, 1);
 
         try {
             return constructor.newInstance(arg0);
         } catch (IllegalArgumentException iae) {
-            return handlelIllegalArgumentEx(iae, constructor, arg0);
+            return handlelIllegalArgumentEx(context, iae, constructor, arg0);
         } catch (IllegalAccessException iae) {
-            return handleIllegalAccessEx(iae, constructor);
+            return handleIllegalAccessEx(context, iae, constructor);
         } catch (InvocationTargetException ite) {
             return handleInvocationTargetEx(context, ite);
         } catch (Throwable t) {
@@ -297,14 +297,14 @@ public class JavaConstructor extends JavaCallable {
     }
 
     public Object newInstanceDirect(ThreadContext context, Object arg0, Object arg1) {
-        checkArity(2);
+        checkArity(context, 2);
 
         try {
             return constructor.newInstance(arg0, arg1);
         } catch (IllegalArgumentException iae) {
-            return handlelIllegalArgumentEx(iae, constructor, arg0, arg1);
+            return handlelIllegalArgumentEx(context, iae, constructor, arg0, arg1);
         } catch (IllegalAccessException iae) {
-            return handleIllegalAccessEx(iae, constructor);
+            return handleIllegalAccessEx(context, iae, constructor);
         } catch (InvocationTargetException ite) {
             return handleInvocationTargetEx(context, ite);
         } catch (Throwable t) {
@@ -313,14 +313,14 @@ public class JavaConstructor extends JavaCallable {
     }
 
     public Object newInstanceDirect(ThreadContext context, Object arg0, Object arg1, Object arg2) {
-        checkArity(3);
+        checkArity(context, 3);
 
         try {
             return constructor.newInstance(arg0, arg1, arg2);
         } catch (IllegalArgumentException iae) {
-            return handlelIllegalArgumentEx(iae, constructor, arg0, arg1, arg2);
+            return handlelIllegalArgumentEx(context, iae, constructor, arg0, arg1, arg2);
         } catch (IllegalAccessException iae) {
-            return handleIllegalAccessEx(iae, constructor);
+            return handleIllegalAccessEx(context, iae, constructor);
         } catch (InvocationTargetException ite) {
             return handleInvocationTargetEx(context, ite);
         } catch (Throwable t) {
@@ -329,14 +329,14 @@ public class JavaConstructor extends JavaCallable {
     }
 
     public Object newInstanceDirect(ThreadContext context, Object arg0, Object arg1, Object arg2, Object arg3) {
-        checkArity(4);
+        checkArity(context, 4);
 
         try {
             return constructor.newInstance(arg0, arg1, arg2, arg3);
         } catch (IllegalArgumentException iae) {
-            return handlelIllegalArgumentEx(iae, constructor, arg0, arg1, arg2, arg3);
+            return handlelIllegalArgumentEx(context, iae, constructor, arg0, arg1, arg2, arg3);
         } catch (IllegalAccessException iae) {
-            return handleIllegalAccessEx(iae, constructor);
+            return handleIllegalAccessEx(context, iae, constructor);
         } catch (InvocationTargetException ite) {
             return handleInvocationTargetEx(context, ite);
         } catch (Throwable t) {

--- a/core/src/main/java/org/jruby/javasupport/JavaConstructor.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaConstructor.java
@@ -44,15 +44,12 @@ import java.lang.reflect.Type;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
-import org.jruby.RubyString;
-import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
-@Deprecated
-@JRubyClass(name="Java::JavaConstructor")
+// @JRubyClass(name="Java::JavaConstructor")
 public class JavaConstructor extends JavaCallable {
 
     private final Constructor<?> constructor;
@@ -74,8 +71,8 @@ public class JavaConstructor extends JavaCallable {
         return result;
     }
 
-    public JavaConstructor(Ruby runtime, Constructor<?> constructor) {
-        super(runtime, runtime.getJavaSupport().getJavaConstructorClass(), constructor.getParameterTypes());
+    JavaConstructor(Ruby runtime, Constructor<?> constructor) {
+        super(runtime, null, constructor.getParameterTypes());
         this.constructor = constructor;
         //this.objectConverter = JavaUtil.getJavaConverter(constructor.getDeclaringClass());
     }
@@ -129,21 +126,6 @@ public class JavaConstructor extends JavaCallable {
     @Override
     public final int hashCode() {
         return constructor.hashCode();
-    }
-
-    @Override // not-used
-    protected String nameOnInspection() {
-        return getType().toString();
-    }
-
-    @JRubyMethod
-    public RubyString inspect() {
-        StringBuilder str = new StringBuilder();
-        str.append("#<");
-        str.append( getType().toString() );
-        inspectParameterTypes(str, this);
-        str.append('>');
-        return RubyString.newString(getRuntime(), str);
     }
 
     //@Override
@@ -229,22 +211,22 @@ public class JavaConstructor extends JavaCallable {
     private IRubyObject newInstanceExactArity(ThreadContext context, Object[] arguments) {
         try {
             Object result = constructor.newInstance(arguments);
-            return JavaObject.wrap(getRuntime(), result);
+            return JavaObject.wrap(context.runtime, result);
         }
         catch (IllegalArgumentException iae) {
             return handlelIllegalArgumentEx(context, iae, constructor, false, arguments);
         }
         catch (IllegalAccessException iae) {
-            throw getRuntime().newTypeError("illegal access");
+            throw context.runtime.newTypeError("illegal access");
         }
         catch (InvocationTargetException ite) {
-            getRuntime().getJavaSupport().handleNativeException(ite.getTargetException(), constructor); // NOTE: we no longer unwrap
+            context.runtime.getJavaSupport().handleNativeException(ite.getTargetException(), constructor); // NOTE: we no longer unwrap
             // not reached
             assert false;
             return null;
         }
         catch (InstantiationException ie) {
-            throw getRuntime().newTypeError("can't make instance of " + constructor.getDeclaringClass().getName());
+            throw context.runtime.newTypeError("can't make instance of " + constructor.getDeclaringClass().getName());
         }
     }
 

--- a/core/src/main/java/org/jruby/javasupport/JavaConstructor.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaConstructor.java
@@ -51,6 +51,7 @@ import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
+@Deprecated
 @JRubyClass(name="Java::JavaConstructor")
 public class JavaConstructor extends JavaCallable {
 

--- a/core/src/main/java/org/jruby/javasupport/JavaConstructor.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaConstructor.java
@@ -207,6 +207,7 @@ public class JavaConstructor extends JavaCallable {
     }
 
     @JRubyMethod
+    @SuppressWarnings("deprecation")
     public IRubyObject declaring_class() {
         return JavaClass.get(getRuntime(), getDeclaringClass());
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaField.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaField.java
@@ -108,6 +108,7 @@ public class JavaField extends JavaAccessibleObject {
     }
 
     @JRubyMethod(name = "type")
+    @SuppressWarnings("deprecation")
     public IRubyObject field_type() {
         return JavaClass.get(getRuntime(), field.getType());
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaField.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaField.java
@@ -50,6 +50,7 @@ import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
+@Deprecated
 @JRubyClass(name="Java::JavaField")
 public class JavaField extends JavaAccessibleObject {
 

--- a/core/src/main/java/org/jruby/javasupport/JavaField.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaField.java
@@ -43,7 +43,6 @@ import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.RubyString;
-import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ObjectAllocator;
@@ -51,7 +50,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 @Deprecated
-@JRubyClass(name="Java::JavaField")
+// @JRubyClass(name="Java::JavaField")
 public class JavaField extends JavaAccessibleObject {
 
     private final Field field;
@@ -84,34 +83,34 @@ public class JavaField extends JavaAccessibleObject {
     }
 
     @JRubyMethod
-    public RubyString value_type() {
-        return getRuntime().newString(field.getType().getName());
+    public RubyString value_type(ThreadContext context) {
+        return context.runtime.newString(field.getType().getName());
     }
 
     @JRubyMethod(name = "public?")
-    public RubyBoolean public_p() {
-        return getRuntime().newBoolean(Modifier.isPublic(field.getModifiers()));
+    public RubyBoolean public_p(ThreadContext context) {
+        return context.runtime.newBoolean(Modifier.isPublic(field.getModifiers()));
     }
 
     @JRubyMethod(name = "static?")
-    public RubyBoolean static_p() {
-        return getRuntime().newBoolean(Modifier.isStatic(field.getModifiers()));
+    public RubyBoolean static_p(ThreadContext context) {
+        return context.runtime.newBoolean(Modifier.isStatic(field.getModifiers()));
     }
 
     @JRubyMethod(name = "enum_constant?")
-    public RubyBoolean enum_constant_p() {
-        return getRuntime().newBoolean(field.isEnumConstant());
+    public RubyBoolean enum_constant_p(ThreadContext context) {
+        return context.runtime.newBoolean(field.isEnumConstant());
     }
 
     @JRubyMethod
-    public RubyString to_generic_string() {
-        return getRuntime().newString(field.toGenericString());
+    public RubyString to_generic_string(ThreadContext context) {
+        return context.runtime.newString(field.toGenericString());
     }
 
     @JRubyMethod(name = "type")
     @SuppressWarnings("deprecation")
-    public IRubyObject field_type() {
-        return JavaClass.get(getRuntime(), field.getType());
+    public IRubyObject field_type(ThreadContext context) {
+        return JavaClass.get(context.runtime, field.getType());
     }
 
     @JRubyMethod
@@ -120,7 +119,7 @@ public class JavaField extends JavaAccessibleObject {
 
         final Object javaObject;
         if ( ! Modifier.isStatic( field.getModifiers() ) ) {
-            javaObject = unwrapJavaObject(object);
+            javaObject = unwrapJavaObject(context, object);
         }
         else {
             javaObject = null;
@@ -135,10 +134,10 @@ public class JavaField extends JavaAccessibleObject {
     }
 
     @JRubyMethod
-    public IRubyObject set_value(IRubyObject object, IRubyObject value) {
+    public IRubyObject set_value(ThreadContext context, IRubyObject object, IRubyObject value) {
         final Object javaObject;
         if ( ! Modifier.isStatic( field.getModifiers() ) ) {
-            javaObject = unwrapJavaObject(object);
+            javaObject = unwrapJavaObject(context, object);
         }
         else {
             javaObject = null;
@@ -149,53 +148,53 @@ public class JavaField extends JavaAccessibleObject {
             field.set(javaObject, javaValue);
         }
         catch (IllegalAccessException iae) {
-            throw getRuntime().newTypeError("illegal access on setting variable: " + iae.getMessage());
+            throw context.runtime.newTypeError("illegal access on setting variable: " + iae.getMessage());
         }
         catch (IllegalArgumentException iae) {
-            throw getRuntime().newTypeError("wrong type for " + field.getType().getName() + ": " +
+            throw context.runtime.newTypeError("wrong type for " + field.getType().getName() + ": " +
                     ( javaValue == null ? null : javaValue.getClass().getName() ) );
         }
         return value;
     }
 
     @JRubyMethod(name = "final?")
-    public RubyBoolean final_p() {
-        return getRuntime().newBoolean(Modifier.isFinal(field.getModifiers()));
+    public RubyBoolean final_p(ThreadContext context) {
+        return context.runtime.newBoolean(Modifier.isFinal(field.getModifiers()));
     }
 
     @JRubyMethod
-    public IRubyObject static_value() {
+    public IRubyObject static_value(ThreadContext context) {
         try {
-            return convertToRuby( getRuntime(), field.get(null) );
+            return convertToRuby( context.runtime, field.get(null) );
         }
         catch (IllegalAccessException iae) {
-            throw getRuntime().newTypeError("illegal static value access: " + iae.getMessage());
+            throw context.runtime.newTypeError("illegal static value access: " + iae.getMessage());
         }
     }
 
     @JRubyMethod
-    public IRubyObject set_static_value(IRubyObject value) {
+    public IRubyObject set_static_value(ThreadContext context, IRubyObject value) {
         if ( ! ( value instanceof JavaObject ) ) {
-            throw getRuntime().newTypeError("not a java object:" + value);
+            throw context.runtime.newTypeError("not a java object:" + value);
         }
         final Object javaValue = convertValueToJava(value);
         try {
             field.set(null, javaValue);
         }
         catch (IllegalAccessException iae) {
-            throw getRuntime().newTypeError(
+            throw context.runtime.newTypeError(
                                 "illegal access on setting static variable: " + iae.getMessage());
         }
         catch (IllegalArgumentException iae) {
-            throw getRuntime().newTypeError("wrong type for " + field.getType().getName() + ": " +
+            throw context.runtime.newTypeError("wrong type for " + field.getType().getName() + ": " +
                     ( javaValue == null ? null : javaValue.getClass().getName() ) );
         }
         return value;
     }
 
     @JRubyMethod
-    public RubyString name() {
-        return getRuntime().newString(field.getName());
+    public RubyString name(ThreadContext context) {
+        return context.runtime.newString(field.getName());
     }
 
     @Override
@@ -203,10 +202,10 @@ public class JavaField extends JavaAccessibleObject {
         return field;
     }
 
-    private Object unwrapJavaObject(final IRubyObject object) throws RaiseException {
+    private Object unwrapJavaObject(ThreadContext context, final IRubyObject object) throws RaiseException {
         Object javaObject = JavaUtil.unwrapJavaValue(object);
         if ( javaObject == null ) {
-            throw getRuntime().newTypeError("not a java object: " + object);
+            throw context.runtime.newTypeError("not a java object: " + object);
         }
         return javaObject;
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaMethod.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaMethod.java
@@ -199,24 +199,24 @@ public class JavaMethod extends JavaCallable {
 
     @JRubyMethod
     @Override
-    public RubyString name() {
-        return getRuntime().newString(method.getName());
+    public RubyString name(ThreadContext context) {
+        return context.runtime.newString(method.getName());
     }
 
     @JRubyMethod(name = "public?")
     @Override
-    public RubyBoolean public_p() {
-        return getRuntime().newBoolean(Modifier.isPublic(method.getModifiers()));
+    public RubyBoolean public_p(ThreadContext context) {
+        return context.runtime.newBoolean(Modifier.isPublic(method.getModifiers()));
     }
 
     @JRubyMethod(name = "final?")
-    public RubyBoolean final_p() {
-        return getRuntime().newBoolean(Modifier.isFinal(method.getModifiers()));
+    public RubyBoolean final_p(ThreadContext context) {
+        return context.runtime.newBoolean(Modifier.isFinal(method.getModifiers()));
     }
 
     @JRubyMethod(rest = true)
     public IRubyObject invoke(ThreadContext context, IRubyObject[] args) {
-        checkArity(args.length - 1);
+        checkArity(context, args.length - 1);
 
         final IRubyObject invokee = args[0];
         final Object[] arguments = convertArguments(args, 1);
@@ -262,7 +262,7 @@ public class JavaMethod extends JavaCallable {
 
     @JRubyMethod(rest = true)
     public IRubyObject invoke_static(ThreadContext context, IRubyObject[] args) {
-        checkArity(args.length);
+        checkArity(context, args.length);
 
         final Object[] arguments = convertArguments(args, 0);
         return invokeWithExceptionHandling(context, method, null, arguments);
@@ -270,23 +270,23 @@ public class JavaMethod extends JavaCallable {
 
     @JRubyMethod
     @SuppressWarnings("deprecation")
-    public IRubyObject return_type() {
+    public IRubyObject return_type(ThreadContext context) {
         Class<?> klass = method.getReturnType();
 
         if (klass.equals(void.class)) {
-            return getRuntime().getNil();
+            return context.runtime.getNil();
         }
-        return JavaClass.get(getRuntime(), klass);
+        return Java.getProxyClass(context.runtime, klass);
     }
 
     @JRubyMethod
-    public IRubyObject type_parameters() {
-        return Java.getInstance(getRuntime(), method.getTypeParameters());
+    public IRubyObject type_parameters(ThreadContext context) {
+        return Java.getInstance(context.runtime, method.getTypeParameters());
     }
 
     public IRubyObject invokeDirect(ThreadContext context, Object javaInvokee, Object[] args) {
-        checkArity(args.length);
-        checkInstanceof(javaInvokee);
+        checkArity(context, args.length);
+        checkInstanceof(context.runtime, javaInvokee);
 
         if (mightBeProxy(javaInvokee)) {
             return tryProxyInvocation(context, javaInvokee, args);
@@ -298,7 +298,7 @@ public class JavaMethod extends JavaCallable {
     public IRubyObject invokeDirect(ThreadContext context, Object javaInvokee) {
         assert method.getDeclaringClass().isInstance(javaInvokee);
 
-        checkArity(0);
+        checkArity(context, 0);
 
         if (mightBeProxy(javaInvokee)) {
             return tryProxyInvocation(context, javaInvokee);
@@ -310,7 +310,7 @@ public class JavaMethod extends JavaCallable {
     public IRubyObject invokeDirect(ThreadContext context, Object javaInvokee, Object arg0) {
         assert method.getDeclaringClass().isInstance(javaInvokee);
 
-        checkArity(1);
+        checkArity(context, 1);
 
         if (mightBeProxy(javaInvokee)) {
             return tryProxyInvocation(context, javaInvokee, arg0);
@@ -322,7 +322,7 @@ public class JavaMethod extends JavaCallable {
     public IRubyObject invokeDirect(ThreadContext context, Object javaInvokee, Object arg0, Object arg1) {
         assert method.getDeclaringClass().isInstance(javaInvokee);
 
-        checkArity(2);
+        checkArity(context, 2);
 
         if (mightBeProxy(javaInvokee)) {
             return tryProxyInvocation(context, javaInvokee, arg0, arg1);
@@ -334,7 +334,7 @@ public class JavaMethod extends JavaCallable {
     public IRubyObject invokeDirect(ThreadContext context, Object javaInvokee, Object arg0, Object arg1, Object arg2) {
         assert method.getDeclaringClass().isInstance(javaInvokee);
 
-        checkArity(3);
+        checkArity(context, 3);
 
         if (mightBeProxy(javaInvokee)) {
             return tryProxyInvocation(context, javaInvokee, arg0, arg1, arg2);
@@ -346,7 +346,7 @@ public class JavaMethod extends JavaCallable {
     public IRubyObject invokeDirect(ThreadContext context, Object javaInvokee, Object arg0, Object arg1, Object arg2, Object arg3) {
         assert method.getDeclaringClass().isInstance(javaInvokee);
 
-        checkArity(4);
+        checkArity(context, 4);
 
         if (mightBeProxy(javaInvokee)) {
             return tryProxyInvocation(context, javaInvokee, arg0, arg1, arg2, arg3);
@@ -356,49 +356,49 @@ public class JavaMethod extends JavaCallable {
     }
 
     public IRubyObject invokeStaticDirect(ThreadContext context, Object[] args) {
-        checkArity(args.length);
+        checkArity(context, args.length);
         return invokeDirectWithExceptionHandling(context, method, null, args);
     }
 
     public IRubyObject invokeStaticDirect(ThreadContext context) {
-        checkArity(0);
+        checkArity(context, 0);
         return invokeDirectWithExceptionHandling(context, method, null);
     }
 
     public IRubyObject invokeStaticDirect(ThreadContext context, Object arg0) {
-        checkArity(1);
+        checkArity(context, 1);
         return invokeDirectWithExceptionHandling(context, method, null, arg0);
     }
 
     public IRubyObject invokeStaticDirect(ThreadContext context, Object arg0, Object arg1) {
-        checkArity(2);
+        checkArity(context, 2);
         return invokeDirectWithExceptionHandling(context, method, null, arg0, arg1);
     }
 
     public IRubyObject invokeStaticDirect(ThreadContext context, Object arg0, Object arg1, Object arg2) {
-        checkArity(3);
+        checkArity(context, 3);
         return invokeDirectWithExceptionHandling(context, method, null, arg0, arg1, arg2);
     }
 
     public IRubyObject invokeStaticDirect(ThreadContext context, Object arg0, Object arg1, Object arg2, Object arg3) {
-        checkArity(4);
+        checkArity(context, 4);
         return invokeDirectWithExceptionHandling(context, method, null, arg0, arg1, arg2, arg3);
     }
 
-    private void checkInstanceof(Object javaInvokee) throws RaiseException {
+    private void checkInstanceof(final Ruby runtime, Object javaInvokee) throws RaiseException {
         if (!method.getDeclaringClass().isInstance(javaInvokee)) {
-            throw getRuntime().newTypeError("invokee not instance of method's class (" + "got" + javaInvokee.getClass().getName() + " wanted " + method.getDeclaringClass().getName() + ")");
+            throw runtime.newTypeError("invokee not instance of method's class (" + "got" + javaInvokee.getClass().getName() + " wanted " + method.getDeclaringClass().getName() + ")");
         }
     }
 
     private IRubyObject invokeWithExceptionHandling(ThreadContext context, Method method, Object javaInvokee, Object[] arguments) {
         try {
             Object result = method.invoke(javaInvokee, arguments);
-            return returnConverter.convert(getRuntime(), result);
+            return returnConverter.convert(context.runtime, result);
         } catch (IllegalArgumentException iae) {
-            return handlelIllegalArgumentEx(iae, method, arguments);
+            return handlelIllegalArgumentEx(context, iae, method, arguments);
         } catch (IllegalAccessException iae) {
-            return handleIllegalAccessEx(iae, method);
+            return handleIllegalAccessEx(context, iae, method);
         } catch (InvocationTargetException ite) {
             return handleInvocationTargetEx(context, ite);
         } catch (Throwable t) {
@@ -411,11 +411,11 @@ public class JavaMethod extends JavaCallable {
         // FIXME: possible to make handles do the superclass call?
         try {
             Object result = method.invoke(javaInvokee, arguments);
-            return convertReturn(result);
+            return convertReturn(context.runtime, result);
         } catch (IllegalArgumentException iae) {
-            return handlelIllegalArgumentEx(iae, method, arguments);
+            return handlelIllegalArgumentEx(context, iae, method, arguments);
         } catch (IllegalAccessException iae) {
-            return handleIllegalAccessEx(iae, method);
+            return handleIllegalAccessEx(context, iae, method);
         } catch (InvocationTargetException ite) {
             return handleInvocationTargetEx(context, ite);
         } catch (Throwable t) {
@@ -426,11 +426,11 @@ public class JavaMethod extends JavaCallable {
     private IRubyObject invokeDirectWithExceptionHandling(ThreadContext context, Method method, Object javaInvokee, Object[] arguments) {
         try {
             Object result = method.invoke(javaInvokee, arguments);
-            return convertReturn(result);
+            return convertReturn(context.runtime, result);
         } catch (IllegalArgumentException iae) {
-            return handlelIllegalArgumentEx(iae, method, arguments);
+            return handlelIllegalArgumentEx(context, iae, method, arguments);
         } catch (IllegalAccessException iae) {
-            return handleIllegalAccessEx(iae, method);
+            return handleIllegalAccessEx(context, iae, method);
         } catch (InvocationTargetException ite) {
             return handleInvocationTargetEx(context, ite);
         } catch (Throwable t) {
@@ -441,11 +441,11 @@ public class JavaMethod extends JavaCallable {
     private IRubyObject invokeDirectWithExceptionHandling(ThreadContext context, Method method, Object javaInvokee) {
         try {
             Object result = method.invoke(javaInvokee);
-            return convertReturn(result);
+            return convertReturn(context.runtime, result);
         } catch (IllegalArgumentException iae) {
-            return handlelIllegalArgumentEx(iae, method);
+            return handlelIllegalArgumentEx(context, iae, method);
         } catch (IllegalAccessException iae) {
-            return handleIllegalAccessEx(iae, method);
+            return handleIllegalAccessEx(context, iae, method);
         } catch (InvocationTargetException ite) {
             return handleInvocationTargetEx(context, ite);
         } catch (Throwable t) {
@@ -456,11 +456,11 @@ public class JavaMethod extends JavaCallable {
     private IRubyObject invokeDirectWithExceptionHandling(ThreadContext context, Method method, Object javaInvokee, Object arg0) {
         try {
             Object result = method.invoke(javaInvokee, arg0);
-            return convertReturn(result);
+            return convertReturn(context.runtime, result);
         } catch (IllegalArgumentException iae) {
-            return handlelIllegalArgumentEx(iae, method, arg0);
+            return handlelIllegalArgumentEx(context, iae, method, arg0);
         } catch (IllegalAccessException iae) {
-            return handleIllegalAccessEx(iae, method);
+            return handleIllegalAccessEx(context, iae, method);
         } catch (InvocationTargetException ite) {
             return handleInvocationTargetEx(context, ite);
         } catch (Throwable t) {
@@ -471,11 +471,11 @@ public class JavaMethod extends JavaCallable {
     private IRubyObject invokeDirectWithExceptionHandling(ThreadContext context, Method method, Object javaInvokee, Object arg0, Object arg1) {
         try {
             Object result = method.invoke(javaInvokee, arg0, arg1);
-            return convertReturn(result);
+            return convertReturn(context.runtime, result);
         } catch (IllegalArgumentException iae) {
-            return handlelIllegalArgumentEx(iae, method, arg0, arg1);
+            return handlelIllegalArgumentEx(context, iae, method, arg0, arg1);
         } catch (IllegalAccessException iae) {
-            return handleIllegalAccessEx(iae, method);
+            return handleIllegalAccessEx(context, iae, method);
         } catch (InvocationTargetException ite) {
             return handleInvocationTargetEx(context, ite);
         } catch (Throwable t) {
@@ -486,11 +486,11 @@ public class JavaMethod extends JavaCallable {
     private IRubyObject invokeDirectWithExceptionHandling(ThreadContext context, Method method, Object javaInvokee, Object arg0, Object arg1, Object arg2) {
         try {
             Object result = method.invoke(javaInvokee, arg0, arg1, arg2);
-            return convertReturn(result);
+            return convertReturn(context.runtime, result);
         } catch (IllegalArgumentException iae) {
-            return handlelIllegalArgumentEx(iae, method, arg0, arg1, arg2);
+            return handlelIllegalArgumentEx(context, iae, method, arg0, arg1, arg2);
         } catch (IllegalAccessException iae) {
-            return handleIllegalAccessEx(iae, method);
+            return handleIllegalAccessEx(context, iae, method);
         } catch (InvocationTargetException ite) {
             return handleInvocationTargetEx(context, ite);
         } catch (Throwable t) {
@@ -501,11 +501,11 @@ public class JavaMethod extends JavaCallable {
     private IRubyObject invokeDirectWithExceptionHandling(ThreadContext context, Method method, Object javaInvokee, Object arg0, Object arg1, Object arg2, Object arg3) {
         try {
             Object result = method.invoke(javaInvokee, arg0, arg1, arg2, arg3);
-            return convertReturn(result);
+            return convertReturn(context.runtime, result);
         } catch (IllegalArgumentException iae) {
-            return handlelIllegalArgumentEx(iae, method, arg0, arg1, arg2, arg3);
+            return handlelIllegalArgumentEx(context, iae, method, arg0, arg1, arg2, arg3);
         } catch (IllegalAccessException iae) {
-            return handleIllegalAccessEx(iae, method);
+            return handleIllegalAccessEx(context, iae, method);
         } catch (InvocationTargetException ite) {
             return handleInvocationTargetEx(context, ite);
         } catch (Throwable t) {
@@ -513,13 +513,13 @@ public class JavaMethod extends JavaCallable {
         }
     }
 
-    private IRubyObject convertReturn(Object result) {
+    private IRubyObject convertReturn(Ruby runtime, Object result) {
         if (result != null && result.getClass() != boxedReturnType) {
             // actual type does not exactly match method return type, re-get converter
             // FIXME: when the only autoconversions are primitives, this won't be needed
-            return JavaUtil.convertJavaToUsableRubyObject(getRuntime(), result);
+            return JavaUtil.convertJavaToUsableRubyObject(runtime, result);
         }
-        return JavaUtil.convertJavaToUsableRubyObjectWithConverter(getRuntime(), result, returnConverter);
+        return JavaUtil.convertJavaToUsableRubyObjectWithConverter(runtime, result, returnConverter);
     }
 
     //@Override

--- a/core/src/main/java/org/jruby/javasupport/JavaMethod.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaMethod.java
@@ -268,6 +268,7 @@ public class JavaMethod extends JavaCallable {
     }
 
     @JRubyMethod
+    @SuppressWarnings("deprecation")
     public IRubyObject return_type() {
         Class<?> klass = method.getReturnType();
 

--- a/core/src/main/java/org/jruby/javasupport/JavaMethod.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaMethod.java
@@ -65,6 +65,7 @@ import static org.jruby.util.CodegenUtils.getBoxType;
 import static org.jruby.util.CodegenUtils.prettyParams;
 import static org.jruby.util.RubyStringBuilder.ids;
 
+@Deprecated
 @JRubyClass(name="Java::JavaMethod")
 public class JavaMethod extends JavaCallable {
 

--- a/core/src/main/java/org/jruby/javasupport/JavaObject.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaObject.java
@@ -236,9 +236,14 @@ public class JavaObject extends RubyObject {
         return getRuntime().newString(getJavaClass().getName());
     }
 
-    @JRubyMethod
+    @Deprecated
     public JavaClass java_class() {
         return JavaClass.get(getRuntime(), getJavaClass());
+    }
+
+    @JRubyMethod
+    public IRubyObject get_java_class() {
+        return Java.getInstance(getRuntime(), getJavaClass());
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/javasupport/JavaPackage.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaPackage.java
@@ -187,8 +187,7 @@ public class JavaPackage extends RubyModule {
 
     RubyModule relativeJavaProxyClass(final Ruby runtime, final IRubyObject name) {
         final String fullName = packageRelativeName( name.toString() ).toString();
-        final JavaClass javaClass = JavaClass.forNameVerbose(runtime, fullName);
-        return Java.getProxyClass(runtime, javaClass);
+        return Java.getProxyClass(runtime, Java.getJavaClass(runtime, fullName));
     }
 
     @JRubyMethod(name = "respond_to?")
@@ -306,7 +305,7 @@ public class JavaPackage extends RubyModule {
             final String subPackageName = JavaPackage.buildPackageName(pkg, name).toString();
 
             final Ruby runtime = pkg.getRuntime();
-            JavaClass javaClass = JavaClass.forNameVerbose(runtime, subPackageName);
+            Class<?> javaClass = Java.getJavaClass(runtime, subPackageName);
             return (RubyClass) Java.getProxyClass(runtime, javaClass);
         }
 
@@ -314,7 +313,7 @@ public class JavaPackage extends RubyModule {
             final String subPackageName = JavaPackage.buildPackageName(pkg, name).toString();
 
             final Ruby runtime = pkg.getRuntime();
-            JavaClass javaClass = JavaClass.forNameVerbose(runtime, subPackageName);
+            Class<?> javaClass = Java.getJavaClass(runtime, subPackageName);
             return Java.getInterfaceModule(runtime, javaClass);
         }
 

--- a/core/src/main/java/org/jruby/javasupport/JavaProxyMethods.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaProxyMethods.java
@@ -47,7 +47,7 @@ public class JavaProxyMethods {
     
     @JRubyMethod
     public static IRubyObject java_class(ThreadContext context, IRubyObject recv) {
-        return recv.getMetaClass().getRealClass().getInstanceVariable("@java_class");
+        return JavaProxy.getJavaClass(recv.getMetaClass().getRealClass());
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/javasupport/JavaSupport.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupport.java
@@ -137,8 +137,10 @@ public abstract class JavaSupport {
 
     public abstract RubyClass getJavaObjectClass();
 
+    @Deprecated
     public abstract JavaClass getObjectJavaClass();
 
+    @Deprecated
     public abstract void setObjectJavaClass(JavaClass objectJavaClass);
 
     public abstract RubyClass getJavaArrayClass();
@@ -162,6 +164,7 @@ public abstract class JavaSupport {
 
     public abstract RubyClass getArrayProxyClass();
 
+    @Deprecated
     public abstract RubyClass getJavaFieldClass();
 
     public abstract RubyClass getJavaMethodClass();

--- a/core/src/main/java/org/jruby/javasupport/JavaSupport.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupport.java
@@ -167,8 +167,10 @@ public abstract class JavaSupport {
     @Deprecated
     public abstract RubyClass getJavaFieldClass();
 
+    @Deprecated
     public abstract RubyClass getJavaMethodClass();
 
+    @Deprecated
     public abstract RubyClass getJavaConstructorClass();
 
     public abstract RubyClass getJavaProxyConstructorClass();

--- a/core/src/main/java/org/jruby/javasupport/JavaSupport.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupport.java
@@ -47,8 +47,12 @@ import java.util.Map;
 import java.util.Set;
 
 public abstract class JavaSupport {
-    public abstract Class loadJavaClass(String className) throws ClassNotFoundException;
 
+    public Class loadJavaClass(String className) throws ClassNotFoundException {
+        return loadJavaClass(className, true);
+    }
+
+    public abstract Class loadJavaClass(String className, boolean initialize) throws ClassNotFoundException;
     public abstract Class loadJavaClassVerbose(String className);
 
     public abstract Class loadJavaClassQuiet(String className);
@@ -61,7 +65,10 @@ public abstract class JavaSupport {
 
     public abstract ObjectProxyCache<IRubyObject,RubyClass> getObjectProxyCache();
 
+    @Deprecated
     public abstract Map<String, JavaClass> getNameClassMap();
+
+    public abstract Map<String, RubyModule> getNameClassCache();
 
     @Deprecated
     public abstract Object getJavaObjectVariable(Object o, int i);

--- a/core/src/main/java/org/jruby/javasupport/JavaSupport.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupport.java
@@ -68,8 +68,6 @@ public abstract class JavaSupport {
     @Deprecated
     public abstract Map<String, JavaClass> getNameClassMap();
 
-    public abstract Map<String, RubyModule> getNameClassCache();
-
     @Deprecated
     public abstract Object getJavaObjectVariable(Object o, int i);
 

--- a/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
@@ -40,25 +40,20 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.ReentrantLock;
 
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.Unrescuable;
-import org.jruby.javasupport.ext.JavaExtensions;
 import org.jruby.runtime.Helpers;
 import org.jruby.util.ArraySupport;
-import org.jruby.util.Loader;
 import org.jruby.util.collections.ClassValue;
 import org.jruby.javasupport.binding.AssignedName;
 import org.jruby.javasupport.proxy.JavaProxyClass;
 import org.jruby.javasupport.util.ObjectProxyCache;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.WeakIdentityHashMap;
-import org.jruby.util.collections.ClassValueCalculator;
 
 import static org.jruby.javasupport.Java.initCause;
 
@@ -198,14 +193,16 @@ public class JavaSupportImpl extends JavaSupport {
         return javaProxyConstructorClass = getJavaModule().getClass("JavaProxyConstructor");
     }
 
+    @Deprecated // no longer used
     public JavaClass getObjectJavaClass() {
         JavaClass clazz;
         if ((clazz = objectJavaClass) != null) return clazz;
         return objectJavaClass = JavaClass.get(runtime, Object.class);
     }
 
+    @Deprecated
     public void setObjectJavaClass(JavaClass objectJavaClass) {
-        this.objectJavaClass = objectJavaClass;
+        // noop
     }
 
     public RubyClass getJavaArrayClass() {

--- a/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
@@ -106,9 +106,6 @@ public class JavaSupportImpl extends JavaSupport {
     private RubyClass mapJavaProxy;
     private RubyClass javaProxyConstructorClass;
 
-    private final Map<String, JavaClass> nameClassMap = new HashMap<String, JavaClass>(64);
-    private final Map<String, RubyModule> nameClassCache = new HashMap<>(64);
-
     public JavaSupportImpl(final Ruby runtime) {
         this.runtime = runtime;
 
@@ -221,11 +218,7 @@ public class JavaSupportImpl extends JavaSupport {
     // of constants table.)
 
     public Map<String, JavaClass> getNameClassMap() {
-        return nameClassMap;
-    }
-
-    public Map<String, RubyModule> getNameClassCache() {
-        return nameClassCache;
+        return Collections.emptyMap();
     }
 
     public RubyModule getJavaModule() {

--- a/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
@@ -103,26 +103,8 @@ public class JavaSupportImpl extends JavaSupport {
         this.instanceAssignedNames = ClassValue.newInstance(klass -> new HashMap<>(8, 1));
     }
 
-    public Class loadJavaClass(String className) throws ClassNotFoundException {
-        return loadJavaClass(className, true);
-    }
-
-    public Class loadJavaClass(String className, boolean initialize) throws ClassNotFoundException {
-        Class<?> primitiveClass;
-        if ((primitiveClass = JavaUtil.getPrimitiveClass(className)) == null) {
-            if (!Ruby.isSecurityRestricted()) {
-                for (Loader loader : runtime.getInstanceConfig().getExtraLoaders()) {
-                    try {
-                        return loader.loadClass(className);
-                    } catch (ClassNotFoundException ignored) { /* continue */ }
-                }
-                return Class.forName(className, initialize, runtime.getJRubyClassLoader());
-            }
-            return Class.forName(className, initialize, JavaSupport.class.getClassLoader());
-        }
-        return primitiveClass;
-    }
-
+    @Override
+    @Deprecated
     public Class loadJavaClassVerbose(String className) {
         try {
             return loadJavaClass(className);
@@ -138,6 +120,8 @@ public class JavaSupportImpl extends JavaSupport {
         }
     }
 
+    @Override
+    @Deprecated
     public Class loadJavaClassQuiet(String className) {
         try {
             return loadJavaClass(className);

--- a/core/src/main/java/org/jruby/javasupport/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtil.java
@@ -233,7 +233,7 @@ public class JavaUtil {
         RubyClass procClass = rubyObject.getMetaClass();
 
         // Extend the interfaces into the proc's class. This creates a singleton class to connect up the Java proxy.
-        final RubyModule ifaceModule = Java.getInterfaceModule(runtime, JavaClass.get(runtime, targetType));
+        final RubyModule ifaceModule = Java.getInterfaceModule(runtime, targetType);
         if ( ! ifaceModule.isInstance(rubyObject) ) {
             ifaceModule.callMethod(context, "extend_object", rubyObject);
             ifaceModule.callMethod(context, "extended", rubyObject);

--- a/core/src/main/java/org/jruby/javasupport/JavaUtilities.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtilities.java
@@ -1,5 +1,6 @@
 package org.jruby.javasupport;
 
+import org.jruby.Ruby;
 import org.jruby.RubyBoolean;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyModule;
@@ -46,7 +47,9 @@ public class JavaUtilities {
 
     @JRubyMethod(module = true, visibility = Visibility.PRIVATE)
     public static IRubyObject get_java_class(IRubyObject recv, IRubyObject arg0) {
-        return Java.get_java_class(recv, arg0);
+        final Ruby runtime = recv.getRuntime();
+        Class<?> javaClass = Java.getJavaClass(runtime, arg0.asJavaString());
+        return Java.getInstance(runtime, javaClass);
     }
 
     @JRubyMethod(module = true, visibility = Visibility.PRIVATE)

--- a/core/src/main/java/org/jruby/javasupport/binding/Initializer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/Initializer.java
@@ -3,6 +3,7 @@ package org.jruby.javasupport.binding;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
+import org.jruby.java.proxies.JavaProxy;
 import org.jruby.javasupport.JavaSupport;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
@@ -72,7 +73,7 @@ public abstract class Initializer {
     }
 
     private static void setJavaClassFor(final Class<?> javaClass, final RubyModule proxy) {
-        proxy.setInstanceVariable("@java_class", proxy.getRuntime().getJavaSupport().getJavaClassFromCache(javaClass));
+        JavaProxy.setJavaClass(proxy, javaClass);
         proxy.dataWrapStruct(javaClass);
     }
 

--- a/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
@@ -348,7 +348,7 @@ public class MethodGatherer {
                 continue;
             }
 
-            final RubyModule innerProxy = Java.getProxyClass(runtime, JavaClass.get(runtime, clazz));
+            final RubyModule innerProxy = Java.getProxyClass(runtime, clazz);
 
             if ( IdUtil.isConstant(simpleName) ) {
                 if (proxy.getConstantAt(simpleName) == null) {

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -692,7 +692,9 @@ public abstract class JavaLang {
 
             JavaCallable callable = JavaClass.getMatchingCallable(context.runtime, klass, methodName, argumentTypes);
 
-            if ( callable != null ) return callable;
+            if ( callable != null ) {
+                return Java.getInstance(context.runtime, callable.accessibleObject()); // a JavaMethod or JavaConstructor like
+            }
 
             final Ruby runtime = context.runtime;
             throw runtime.newNameError(undefinedMethodMessage(runtime, ids(runtime, methodName), ids(runtime, klass.getName()), false), methodName);

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -483,7 +483,7 @@ public abstract class JavaLang {
         @JRubyMethod(name = "ruby_class")
         public static IRubyObject proxy_class(final ThreadContext context, final IRubyObject self) {
             final java.lang.Class klass = unwrapJavaObject(self);
-            return context.runtime.getJavaSupport().getProxyClassFromCache(klass);
+            return Java.getProxyClass(context.runtime, klass);
         }
 
         @JRubyMethod

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -33,9 +33,13 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyModule;
 import org.jruby.internal.runtime.methods.JavaMethod;
+import org.jruby.java.proxies.ArrayJavaProxy;
+import org.jruby.javasupport.Java;
+import org.jruby.javasupport.JavaCallable;
 import org.jruby.javasupport.JavaClass;
 import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
+import org.jruby.runtime.Helpers;
 import org.jruby.runtime.JavaInternalBlockBody;
 import org.jruby.runtime.Signature;
 import org.jruby.runtime.ThreadContext;
@@ -43,14 +47,19 @@ import org.jruby.runtime.backtrace.TraceType;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.RubyStringBuilder;
 
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
+import static org.jruby.RubyModule.undefinedMethodMessage;
 import static org.jruby.javasupport.JavaUtil.convertJavaToUsableRubyObject;
 import static org.jruby.javasupport.JavaUtil.isJavaObject;
 import static org.jruby.javasupport.JavaUtil.unwrapIfJavaObject;
 import static org.jruby.javasupport.JavaUtil.unwrapJavaObject;
 import static org.jruby.runtime.Visibility.PUBLIC;
 import static org.jruby.util.Inspector.*;
+import static org.jruby.util.RubyStringBuilder.ids;
 
 /**
  * Java::JavaLang package extensions.
@@ -462,6 +471,12 @@ public abstract class JavaLang {
         static RubyClass define(final Ruby runtime, final RubyClass proxy) {
             proxy.includeModule( runtime.getComparable() ); // include Comparable
             proxy.defineAnnotatedMethods(Class.class);
+            // JavaClass facade (compatibility) :
+            proxy.defineAlias("resource", "get_resource");
+            proxy.defineAlias("declared_field", "get_declared_field");
+            proxy.defineAlias("field", "get_field");
+            proxy.defineAlias("annotation", "get_annotation");
+            proxy.defineAlias("annotation_present?", "is_annotation_present");
             return proxy;
         }
 
@@ -622,6 +637,126 @@ public abstract class JavaLang {
         public static IRubyObject static_p(final IRubyObject self) {
             final java.lang.Class klass = unwrapJavaObject(self);
             return JavaLangReflect.isStatic(self, klass.getModifiers());
+        }
+
+        // JavaClass facade (compatibility) :
+
+        @JRubyMethod(required = 1)
+        public static IRubyObject extend_proxy(final ThreadContext context, IRubyObject self, IRubyObject extender) {
+            return JavaClass.extend_proxy(context, self, extender);
+        }
+
+        //@JRubyMethod(name = "simple_name") // (legacy) compatibility with JavaClass
+        //public static IRubyObject simple_name(final ThreadContext context, final IRubyObject self) {
+        //    final java.lang.Class klass = unwrapJavaObject(self);
+        //    return context.runtime.newString(JavaClass.getSimpleName(klass));
+        //}
+
+        @JRubyMethod(required = 1, rest = true)
+        public static IRubyObject java_method(ThreadContext context, IRubyObject self, final IRubyObject[] args) {
+            final java.lang.Class klass = unwrapJavaObject(self);
+
+            final java.lang.String methodName = args[0].asJavaString();
+            try {
+                java.lang.Class<?>[] argumentTypes = JavaClass.getArgumentTypes(context, args, 1);
+                final Method method = klass.getMethod(methodName, argumentTypes);
+                return Java.getInstance(context.runtime, method); // a JavaMethod like
+            } catch (NoSuchMethodException e) {
+                final Ruby runtime = context.runtime;
+                throw runtime.newNameError(undefinedMethodMessage(runtime, ids(runtime, methodName), ids(runtime, klass.getName()), false), methodName);
+            }
+        }
+
+        @JRubyMethod(required = 1, rest = true)
+        public static IRubyObject declared_method(ThreadContext context, IRubyObject self, final IRubyObject[] args) {
+            final java.lang.Class klass = unwrapJavaObject(self);
+
+            final java.lang.String methodName = args[0].asJavaString();
+            try {
+                java.lang.Class<?>[] argumentTypes = JavaClass.getArgumentTypes(context, args, 1);
+                final Method method = klass.getDeclaredMethod(methodName, argumentTypes);
+                return Java.getInstance(context.runtime, method); // a JavaMethod like
+            } catch (NoSuchMethodException e) {
+                Helpers.throwException(e); // NOTE: this is mostly a get_declared_method alias
+                return null; // never reached
+            }
+        }
+
+        @JRubyMethod(required = 1, rest = true)
+        public static IRubyObject declared_method_smart(ThreadContext context, IRubyObject self, final IRubyObject[] args) {
+            final java.lang.Class klass = unwrapJavaObject(self);
+
+            final java.lang.String methodName = args[0].asJavaString();
+
+            java.lang.Class<?>[] argumentTypes = JavaClass.getArgumentTypes(context, args, 1);
+
+            JavaCallable callable = JavaClass.getMatchingCallable(context.runtime, klass, methodName, argumentTypes);
+
+            if ( callable != null ) return callable;
+
+            final Ruby runtime = context.runtime;
+            throw runtime.newNameError(undefinedMethodMessage(runtime, ids(runtime, methodName), ids(runtime, klass.getName()), false), methodName);
+        }
+
+        @JRubyMethod(rest = true)
+        public static IRubyObject constructor(ThreadContext context, IRubyObject self, IRubyObject[] args) {
+            final java.lang.Class klass = unwrapJavaObject(self);
+            try {
+                java.lang.Class<?>[] parameterTypes = JavaClass.getArgumentTypes(context, args, 0);
+                Constructor<?> constructor = klass.getConstructor(parameterTypes);
+                return Java.getInstance(context.runtime, constructor); // JavaConstructor like
+            } catch (NoSuchMethodException e) {
+                Helpers.throwException(e); // NOTE: this is mostly a get_constructor alias
+                return null; // never reached
+            }
+        }
+
+        @JRubyMethod(rest = true)
+        public static IRubyObject declared_constructor(ThreadContext context, IRubyObject self, IRubyObject[] args) {
+            final java.lang.Class klass = unwrapJavaObject(self);
+            try {
+                java.lang.Class<?>[] parameterTypes = JavaClass.getArgumentTypes(context, args, 0);
+                Constructor<?> constructor = klass.getDeclaredConstructor(parameterTypes);
+                return Java.getInstance(context.runtime, constructor); // JavaConstructor like
+            } catch (NoSuchMethodException e) {
+                Helpers.throwException(e); // NOTE: this is mostly a get_declared_constructor alias
+                return null; // never reached
+            }
+        }
+
+        @JRubyMethod
+        public static IRubyObject array_class(ThreadContext context, IRubyObject self) {
+            final java.lang.Class klass = unwrapJavaObject(self);
+            final java.lang.Class<?> arrayClass = Array.newInstance(klass, 0).getClass();
+            return Java.getInstance(context.runtime, arrayClass);
+        }
+
+        @JRubyMethod(required = 1)
+        public static IRubyObject new_array(ThreadContext context, IRubyObject self, IRubyObject length) {
+            final java.lang.Class klass = unwrapJavaObject(self);
+
+            if (length instanceof RubyInteger) { // one-dimensional array
+                int len = ((RubyInteger) length).getIntValue();
+                return ArrayJavaProxy.newArray(context.runtime, klass, len);
+            }
+            if (length instanceof RubyArray) { // n-dimensional array
+                IRubyObject[] aryLengths = ((RubyArray) length).toJavaArrayMaybeUnsafe();
+                final int len = aryLengths.length;
+                if (len == 0) {
+                    throw context.runtime.newArgumentError("empty dimensions specifier for java array");
+                }
+                final int[] dimensions = new int[len];
+                for (int i = len; --i >= 0; ) {
+                    IRubyObject dimLength = aryLengths[i];
+                    if (!( dimLength instanceof RubyInteger)) {
+                        throw context.runtime.newTypeError(dimLength, context.runtime.getInteger());
+                    }
+                    dimensions[i] = ((RubyInteger) dimLength).getIntValue();
+                }
+                return ArrayJavaProxy.newArray(context.runtime, klass, dimensions);
+            }
+
+            throw context.runtime.newArgumentError("invalid length or dimensions specifier for java array - must be Integer or Array of Integer");
         }
 
     }

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLangReflect.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLangReflect.java
@@ -31,15 +31,20 @@ package org.jruby.javasupport.ext;
 import org.jruby.*;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.java.proxies.JavaProxy;
+import org.jruby.javasupport.JavaObject;
+import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
 
 import static org.jruby.javasupport.JavaUtil.convertArguments;
 import static org.jruby.javasupport.JavaUtil.convertJavaToUsableRubyObject;
-import static org.jruby.javasupport.JavaUtil.unwrapJavaObject;
+import static org.jruby.javasupport.JavaUtil.unwrapIfJavaObject;
 
 /**
  * Java::JavaLangReflect package extensions.
@@ -69,7 +74,7 @@ public abstract class JavaLangReflect {
 
         @JRubyMethod // alias argument_types parameter_types
         public static IRubyObject argument_types(final ThreadContext context, final IRubyObject self) {
-            final java.lang.reflect.Constructor thiz = unwrapJavaObject(self);
+            final java.lang.reflect.Constructor thiz = JavaUtil.unwrapJavaObject(self);
             return convertJavaToUsableRubyObject(context.runtime, thiz.getParameterTypes());
         }
 
@@ -77,7 +82,7 @@ public abstract class JavaLangReflect {
 
         @JRubyMethod
         public static IRubyObject inspect(final ThreadContext context, final IRubyObject self) {
-            final java.lang.reflect.AccessibleObject thiz = unwrapJavaObject(self);
+            final java.lang.reflect.AccessibleObject thiz = JavaUtil.unwrapJavaObject(self);
             return RubyString.newString(context.runtime, thiz.toString());
         }
 
@@ -85,31 +90,31 @@ public abstract class JavaLangReflect {
 
         @JRubyMethod(name = "public?")
         public static IRubyObject public_p(final IRubyObject self) {
-            final java.lang.reflect.Constructor thiz = unwrapJavaObject(self);
+            final java.lang.reflect.Constructor thiz = JavaUtil.unwrapJavaObject(self);
             return isPublic(self, thiz.getModifiers());
         }
 
         @JRubyMethod(name = "protected?")
         public static IRubyObject protected_p(final IRubyObject self) {
-            final java.lang.reflect.Constructor thiz = unwrapJavaObject(self);
+            final java.lang.reflect.Constructor thiz = JavaUtil.unwrapJavaObject(self);
             return isProtected(self, thiz.getModifiers());
         }
 
         @JRubyMethod(name = "private?")
         public static IRubyObject private_p(final IRubyObject self) {
-            final java.lang.reflect.Constructor thiz = unwrapJavaObject(self);
+            final java.lang.reflect.Constructor thiz = JavaUtil.unwrapJavaObject(self);
             return isPrivate(self, thiz.getModifiers());
         }
 
         @JRubyMethod(name = "final?")
         public static IRubyObject final_p(final IRubyObject self) {
-            final java.lang.reflect.Constructor thiz = unwrapJavaObject(self);
+            final java.lang.reflect.Constructor thiz = JavaUtil.unwrapJavaObject(self);
             return isFinal(self, thiz.getModifiers());
         }
 
         @JRubyMethod(name = "static?")
         public static IRubyObject static_p(final IRubyObject self) {
-            final java.lang.reflect.Constructor thiz = unwrapJavaObject(self);
+            final java.lang.reflect.Constructor thiz = JavaUtil.unwrapJavaObject(self);
             return isStatic(self, thiz.getModifiers());
         }
 
@@ -125,22 +130,43 @@ public abstract class JavaLangReflect {
 
         @JRubyMethod
         public static IRubyObject return_type(final ThreadContext context, final IRubyObject self) {
-            final java.lang.reflect.Method thiz = unwrapJavaObject(self);
+            final java.lang.reflect.Method thiz = JavaUtil.unwrapJavaObject(self);
             return convertJavaToUsableRubyObject(context.runtime, thiz.getReturnType());
         }
 
         @JRubyMethod // alias argument_types parameter_types
         public static IRubyObject argument_types(final ThreadContext context, final IRubyObject self) {
-            final java.lang.reflect.Method thiz = unwrapJavaObject(self);
+            final java.lang.reflect.Method thiz = JavaUtil.unwrapJavaObject(self);
             return convertJavaToUsableRubyObject(context.runtime, thiz.getParameterTypes());
         }
 
         @JRubyMethod(rest = true)
-        public static IRubyObject invoke_static(final ThreadContext context, final IRubyObject self, final IRubyObject[] args) {
-            final java.lang.reflect.Method thiz = unwrapJavaObject(self);
-            final Object[] javaArgs = convertArguments(args, thiz.getParameterTypes());
+        public static IRubyObject invoke(final ThreadContext context, final IRubyObject self, final IRubyObject[] args) {
+            final java.lang.reflect.Method method = JavaUtil.unwrapJavaObject(self);
+            // NOTE: (legacy) JavaMethod compat - also worked with no arguments
+            final Object target;
+            final Object[] javaArgs;
+            if (args.length == 0) {
+                target = null;
+                javaArgs = new Object[0];
+            } else {
+                target = unwrapJavaObject(args[0]);
+                javaArgs = convertArguments(args, method.getParameterTypes(), 1);
+            }
             try {
-                return convertJavaToUsableRubyObject(context.runtime, thiz.invoke(null, javaArgs));
+                return convertJavaToUsableRubyObject(context.runtime, method.invoke(target, javaArgs));
+            }
+            catch (IllegalAccessException|InvocationTargetException e) {
+                Helpers.throwException(e); return null;
+            }
+        }
+
+        @JRubyMethod(rest = true)
+        public static IRubyObject invoke_static(final ThreadContext context, final IRubyObject self, final IRubyObject[] args) {
+            final java.lang.reflect.Method method = JavaUtil.unwrapJavaObject(self);
+            final Object[] javaArgs = convertArguments(args, method.getParameterTypes());
+            try {
+                return convertJavaToUsableRubyObject(context.runtime, method.invoke(null, javaArgs));
             }
             catch (IllegalAccessException|InvocationTargetException e) {
                 Helpers.throwException(e); return null;
@@ -151,13 +177,13 @@ public abstract class JavaLangReflect {
 
         @JRubyMethod
         public static IRubyObject inspect(final ThreadContext context, final IRubyObject self) {
-            final java.lang.reflect.AccessibleObject thiz = unwrapJavaObject(self);
+            final java.lang.reflect.AccessibleObject thiz = JavaUtil.unwrapJavaObject(self);
             return RubyString.newString(context.runtime, thiz.toString());
         }
 
         @JRubyMethod(name = "abstract?")
         public static IRubyObject abstract_p(final IRubyObject self) {
-            final java.lang.reflect.Field thiz = unwrapJavaObject(self);
+            final java.lang.reflect.Field thiz = JavaUtil.unwrapJavaObject(self);
             return isAbstract(self, thiz.getModifiers());
         }
 
@@ -165,31 +191,31 @@ public abstract class JavaLangReflect {
 
         @JRubyMethod(name = "public?")
         public static IRubyObject public_p(final IRubyObject self) {
-            final java.lang.reflect.Method thiz = unwrapJavaObject(self);
+            final java.lang.reflect.Method thiz = JavaUtil.unwrapJavaObject(self);
             return isPublic(self, thiz.getModifiers());
         }
 
         @JRubyMethod(name = "protected?")
         public static IRubyObject protected_p(final IRubyObject self) {
-            final java.lang.reflect.Method thiz = unwrapJavaObject(self);
+            final java.lang.reflect.Method thiz = JavaUtil.unwrapJavaObject(self);
             return isProtected(self, thiz.getModifiers());
         }
 
         @JRubyMethod(name = "private?")
         public static IRubyObject private_p(final IRubyObject self) {
-            final java.lang.reflect.Method thiz = unwrapJavaObject(self);
+            final java.lang.reflect.Method thiz = JavaUtil.unwrapJavaObject(self);
             return isPrivate(self, thiz.getModifiers());
         }
 
         @JRubyMethod(name = "final?")
         public static IRubyObject final_p(final IRubyObject self) {
-            final java.lang.reflect.Method thiz = unwrapJavaObject(self);
+            final java.lang.reflect.Method thiz = JavaUtil.unwrapJavaObject(self);
             return isFinal(self, thiz.getModifiers());
         }
 
         @JRubyMethod(name = "static?")
         public static IRubyObject static_p(final IRubyObject self) {
-            final java.lang.reflect.Method thiz = unwrapJavaObject(self);
+            final java.lang.reflect.Method thiz = JavaUtil.unwrapJavaObject(self);
             return isStatic(self, thiz.getModifiers());
         }
 
@@ -205,15 +231,17 @@ public abstract class JavaLangReflect {
 
         @JRubyMethod // alias value_type name
         public static IRubyObject value_type(final ThreadContext context, final IRubyObject self) {
-            final java.lang.reflect.Field field = unwrapJavaObject(self);
+            final java.lang.reflect.Field field = JavaUtil.unwrapJavaObject(self);
             return convertJavaToUsableRubyObject(context.runtime, field.getName());
         }
 
         @JRubyMethod // alias value get
         public static IRubyObject value(final ThreadContext context, final IRubyObject self, final IRubyObject obj) {
-            final java.lang.reflect.Field field = unwrapJavaObject(self);
+            final java.lang.reflect.Field field = JavaUtil.unwrapJavaObject(self);
+            // NOTE: (legacy) JavaField compat - also worked when setting a static value
+            final Object target = Modifier.isStatic(field.getModifiers()) ? null : unwrapJavaObject(obj);
             try {
-                return convertJavaToUsableRubyObject(context.runtime, field.get(unwrapJavaObject(obj)));
+                return convertJavaToUsableRubyObject(context.runtime, field.get(target));
             }
             catch (IllegalAccessException e) {
                 Helpers.throwException(e); return null;
@@ -223,10 +251,12 @@ public abstract class JavaLangReflect {
         @JRubyMethod // alias set_value set
         public static IRubyObject set_value(final ThreadContext context, final IRubyObject self, final IRubyObject obj,
             final IRubyObject value) {
-            final java.lang.reflect.Field field = unwrapJavaObject(self);
+            final java.lang.reflect.Field field = JavaUtil.unwrapJavaObject(self);
+            // NOTE: (legacy) JavaField compat - also worked when setting a static value
+            final Object target = Modifier.isStatic(field.getModifiers()) ? null : unwrapJavaObject(obj);
+            final Object javaValue = convertValueToJava(field, value);
             try {
-                final Object val = value.toJava(field.getType());
-                field.set(unwrapJavaObject(obj), val);
+                field.set(target, javaValue);
             }
             catch (IllegalAccessException e) {
                 Helpers.throwException(e); return null;
@@ -236,7 +266,7 @@ public abstract class JavaLangReflect {
 
         @JRubyMethod
         public static IRubyObject static_value(final ThreadContext context, final IRubyObject self) {
-            final java.lang.reflect.Field field = unwrapJavaObject(self);
+            final java.lang.reflect.Field field = JavaUtil.unwrapJavaObject(self);
             try {
                 return convertJavaToUsableRubyObject(context.runtime, field.get(null));
             }
@@ -247,10 +277,10 @@ public abstract class JavaLangReflect {
 
         @JRubyMethod
         public static IRubyObject set_static_value(final ThreadContext context, final IRubyObject self, final IRubyObject value) {
-            final java.lang.reflect.Field field = unwrapJavaObject(self);
+            final java.lang.reflect.Field field = JavaUtil.unwrapJavaObject(self);
+            final Object javaValue = convertValueToJava(field, value);
             try {
-                final Object val = value.toJava(field.getType());
-                field.set(null, val);
+                field.set(null, javaValue);
             }
             catch (IllegalAccessException e) {
                 Helpers.throwException(e); return null;
@@ -261,8 +291,8 @@ public abstract class JavaLangReflect {
         //
 
         @JRubyMethod
-        public static IRubyObject inspect(final ThreadContext context, final IRubyObject self) {
-            final java.lang.reflect.AccessibleObject thiz = unwrapJavaObject(self);
+        public static IRubyObject inspect(final ThreadContext context, final IRubyObject self) { // TODO
+            final java.lang.reflect.AccessibleObject thiz = JavaUtil.unwrapJavaObject(self);
             return RubyString.newString(context.runtime, thiz.toString());
         }
 
@@ -270,34 +300,44 @@ public abstract class JavaLangReflect {
 
         @JRubyMethod(name = "public?")
         public static IRubyObject public_p(final IRubyObject self) {
-            final java.lang.reflect.Field thiz = unwrapJavaObject(self);
+            final java.lang.reflect.Field thiz = JavaUtil.unwrapJavaObject(self);
             return isPublic(self, thiz.getModifiers());
         }
 
         @JRubyMethod(name = "protected?")
         public static IRubyObject protected_p(final IRubyObject self) {
-            final java.lang.reflect.Field thiz = unwrapJavaObject(self);
+            final java.lang.reflect.Field thiz = JavaUtil.unwrapJavaObject(self);
             return isProtected(self, thiz.getModifiers());
         }
 
         @JRubyMethod(name = "private?")
         public static IRubyObject private_p(final IRubyObject self) {
-            final java.lang.reflect.Field thiz = unwrapJavaObject(self);
+            final java.lang.reflect.Field thiz = JavaUtil.unwrapJavaObject(self);
             return isPrivate(self, thiz.getModifiers());
         }
 
         @JRubyMethod(name = "final?")
         public static IRubyObject final_p(final IRubyObject self) {
-            final java.lang.reflect.Field thiz = unwrapJavaObject(self);
+            final java.lang.reflect.Field thiz = JavaUtil.unwrapJavaObject(self);
             return isFinal(self, thiz.getModifiers());
         }
 
         @JRubyMethod(name = "static?")
         public static IRubyObject static_p(final IRubyObject self) {
-            final java.lang.reflect.Field thiz = unwrapJavaObject(self);
+            final java.lang.reflect.Field thiz = JavaUtil.unwrapJavaObject(self);
             return isStatic(self, thiz.getModifiers());
         }
 
+    }
+
+    private static Object unwrapJavaObject(final IRubyObject object) {
+        return JavaUtil.unwrapJavaValue(object);
+    }
+
+    private static Object convertValueToJava(final java.lang.reflect.Field field, IRubyObject value) {
+        Object val = value.dataGetStruct();
+        if (val instanceof JavaObject) value = (IRubyObject) val;
+        return value.toJava(field.getType());
     }
 
     static RubyBoolean isAbstract(final IRubyObject self, final int mod) {

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLangReflect.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLangReflect.java
@@ -31,20 +31,20 @@ package org.jruby.javasupport.ext;
 import org.jruby.*;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
-import org.jruby.exceptions.RaiseException;
-import org.jruby.java.proxies.JavaProxy;
 import org.jruby.javasupport.JavaObject;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.RubyStringBuilder;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 
 import static org.jruby.javasupport.JavaUtil.convertArguments;
 import static org.jruby.javasupport.JavaUtil.convertJavaToUsableRubyObject;
-import static org.jruby.javasupport.JavaUtil.unwrapIfJavaObject;
+import static org.jruby.util.Inspector.GT;
+import static org.jruby.util.Inspector.inspectPrefix;
 
 /**
  * Java::JavaLangReflect package extensions.
@@ -54,9 +54,31 @@ import static org.jruby.javasupport.JavaUtil.unwrapIfJavaObject;
 public abstract class JavaLangReflect {
 
     public static void define(final Ruby runtime) {
+        JavaExtensions.put(runtime, java.lang.reflect.AccessibleObject.class, (proxyClass) -> AccessibleObject.define(runtime, (RubyClass) proxyClass));
         JavaExtensions.put(runtime, java.lang.reflect.Constructor.class, (proxyClass) -> Constructor.define(runtime, (RubyClass) proxyClass));
         JavaExtensions.put(runtime, java.lang.reflect.Field.class, (proxyClass) -> Field.define(runtime, (RubyClass) proxyClass));
         JavaExtensions.put(runtime, java.lang.reflect.Method.class, (proxyClass) -> Method.define(runtime, (RubyClass) proxyClass));
+    }
+
+    @JRubyClass(name = "Java::JavaLangReflect::AccessibleObject")
+    public static class AccessibleObject {
+
+        static RubyClass define(final Ruby runtime, final RubyClass proxy) {
+            proxy.defineAnnotatedMethods(AccessibleObject.class);
+            return proxy;
+        }
+
+        @JRubyMethod
+        public static IRubyObject inspect(final ThreadContext context, final IRubyObject self) {
+            final java.lang.reflect.AccessibleObject obj = JavaUtil.unwrapJavaObject(self);
+
+            RubyString buf = inspectPrefix(context, self.getMetaClass());
+            RubyStringBuilder.cat(context.runtime, buf, ' ');
+            RubyStringBuilder.cat(context.runtime, buf, obj.toString());
+            RubyStringBuilder.cat(context.runtime, buf, GT); // >
+
+            return buf;
+        }
     }
 
     @JRubyClass(name = "Java::JavaLangReflect::Constructor")
@@ -76,14 +98,6 @@ public abstract class JavaLangReflect {
         public static IRubyObject argument_types(final ThreadContext context, final IRubyObject self) {
             final java.lang.reflect.Constructor thiz = JavaUtil.unwrapJavaObject(self);
             return convertJavaToUsableRubyObject(context.runtime, thiz.getParameterTypes());
-        }
-
-        //
-
-        @JRubyMethod
-        public static IRubyObject inspect(final ThreadContext context, final IRubyObject self) {
-            final java.lang.reflect.AccessibleObject thiz = JavaUtil.unwrapJavaObject(self);
-            return RubyString.newString(context.runtime, thiz.toString());
         }
 
         // JavaUtilities::ModifiedShortcuts :
@@ -174,12 +188,6 @@ public abstract class JavaLangReflect {
         }
 
         //
-
-        @JRubyMethod
-        public static IRubyObject inspect(final ThreadContext context, final IRubyObject self) {
-            final java.lang.reflect.AccessibleObject thiz = JavaUtil.unwrapJavaObject(self);
-            return RubyString.newString(context.runtime, thiz.toString());
-        }
 
         @JRubyMethod(name = "abstract?")
         public static IRubyObject abstract_p(final IRubyObject self) {
@@ -286,14 +294,6 @@ public abstract class JavaLangReflect {
                 Helpers.throwException(e); return null;
             }
             return context.nil;
-        }
-
-        //
-
-        @JRubyMethod
-        public static IRubyObject inspect(final ThreadContext context, final IRubyObject self) { // TODO
-            final java.lang.reflect.AccessibleObject thiz = JavaUtil.unwrapJavaObject(self);
-            return RubyString.newString(context.runtime, thiz.toString());
         }
 
         // JavaUtilities::ModifiedShortcuts :

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLangReflect.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLangReflect.java
@@ -229,10 +229,10 @@ public abstract class JavaLangReflect {
             return proxy;
         }
 
-        @JRubyMethod // alias value_type name
+        @JRubyMethod
         public static IRubyObject value_type(final ThreadContext context, final IRubyObject self) {
             final java.lang.reflect.Field field = JavaUtil.unwrapJavaObject(self);
-            return convertJavaToUsableRubyObject(context.runtime, field.getName());
+            return convertJavaToUsableRubyObject(context.runtime, field.getType().getName());
         }
 
         @JRubyMethod // alias value get

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyClass.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyClass.java
@@ -643,7 +643,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
                     RubyArray interfaces = (RubyArray) var;
                     for (int i = interfaces.size(); --i >= 0; ) {
                         IRubyObject iface = interfaces.eltInternal(i);
-                        Class interfaceClass = ((JavaClass) iface).javaClass();
+                        Class<?> interfaceClass = Java.unwrapClassProxy(iface);
                         if (!interfaceClass.isInterface()) {
                             throw runtime.newTypeError("invalid java interface defined for proxy (or ancestor): " +
                                     ancestor + ": " + iface + " (not an interface)");
@@ -705,8 +705,8 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
     }
 
     @JRubyMethod
-    public RubyObject superclass() {
-        return JavaClass.get(getRuntime(), getSuperclass());
+    public IRubyObject superclass() {
+        return Java.getInstance(getRuntime(), getSuperclass());
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyClass.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyClass.java
@@ -60,6 +60,7 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.internal.runtime.methods.DynamicMethod;
+import org.jruby.java.proxies.JavaProxy;
 import org.jruby.javasupport.*;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -375,7 +376,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
 
         @JRubyMethod
         public RubyArray argument_types() {
-            return toRubyArray(getParameterTypes());
+            return toClassArray(getRuntime(), getParameterTypes());
         }
 
         @JRubyMethod(name = "super?")
@@ -607,7 +608,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
         // intentionally overridden, except those from Kernel, Java, and JavaProxyMethods, as well as Enumerable.
         // TODO: may want to exclude other common mixins?
 
-        JavaClass javaClass = null;
+        Class<?> javaClass = null;
         HashSet<String> names = new HashSet<>(); // need names ordered for key generation later
         Collection<Class<?>> interfaceList = new LinkedHashSet<>(8);
 
@@ -616,24 +617,20 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
             RubyModule ancestor = (RubyModule) ancestorObject;
             if (ancestor instanceof RubyClass) {
                 if (skipRemainingClasses) continue;
-                // we only collect methods and interfaces for
-                // user-defined proxy classes.
+                // we only collect methods and interfaces for user-defined proxy classes
                 if (!ancestor.getInstanceVariables().hasInstanceVariable("@java_proxy_class")) {
                     skipRemainingClasses = true;
                     continue;
                 }
 
-                // get JavaClass if this is the new proxy class; verify it
-                // matches if this is a superclass proxy.
-                IRubyObject var = ancestor.getInstanceVariables().getInstanceVariable("@java_class");
-                if ( ! (var instanceof JavaClass) ) {
-                    if (var == null) {
-                        throw runtime.newTypeError("no java_class defined for proxy (or ancestor): " + ancestor);
-                    }
-                    throw runtime.newTypeError("invalid java_class defined for proxy (or ancestor): " + ancestor + ": " + var);
+                // get JavaClass if this is the new proxy class; verify it matches if this is a superclass proxy.
+                IRubyObject var = JavaProxy.getJavaClass(ancestor);
+                if (var == null) {
+                    throw runtime.newTypeError("no java_class defined for proxy (or ancestor): " + ancestor);
                 }
-                if (javaClass == null) javaClass = (JavaClass) var;
-                else if (javaClass != var) {
+                if (javaClass == null) {
+                    javaClass = JavaUtil.unwrapJavaObject(var);
+                } else if (javaClass != JavaUtil.unwrapJavaObject(var)) {
                     throw runtime.newTypeError("java_class defined for " + clazz + " (" + javaClass +
                             ") does not match java_class for ancestor " + ancestor + " (" + var + ")");
                 }
@@ -693,7 +690,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
         Class<?>[] interfaces = interfaceList.isEmpty() ? EMPTY_CLASS_ARRAY : interfaceList.toArray(new Class<?>[interfaceList.size()]);
 
         try {
-            return newProxyClass(runtime, javaClass.javaClass(), interfaces, names, clazz.getFieldSignatures(), clazz.getMethodSignatures(), clazz);
+            return newProxyClass(runtime, javaClass, interfaces, names, clazz.getFieldSignatures(), clazz.getMethodSignatures(), clazz);
         }
         catch (RaiseException e) {
             throw e;
@@ -719,12 +716,12 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
 
     @JRubyMethod
     public RubyArray interfaces() {
-        return toRubyArray(getInterfaces());
+        return toClassArray(getRuntime(), getInterfaces());
     }
 
     @JRubyMethod
     public final RubyArray constructors() {
-        return toRubyArray( getConstructors() );
+        return toRubyArray(getConstructors());
     }
 
     public final String nameOnInspection() {

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyConstructor.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyConstructor.java
@@ -157,7 +157,7 @@ public class JavaProxyConstructor extends JavaProxyReflectionObject implements P
 
     @JRubyMethod
     public final RubyArray argument_types() {
-        return toRubyArray(getParameterTypes());
+        return toClassArray(getRuntime(), getParameterTypes());
     }
 
     @JRubyMethod(rest = true)

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyReflectionObject.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyReflectionObject.java
@@ -37,6 +37,7 @@ import org.jruby.RubyObject;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.javasupport.Java;
 import org.jruby.javasupport.JavaClass;
 import org.jruby.javasupport.JavaObject;
 import org.jruby.runtime.ThreadContext;
@@ -157,8 +158,12 @@ public class JavaProxyReflectionObject extends RubyObject {
         return RubyArray.newArrayMayCopy(getRuntime(), elements);
     }
 
-    final RubyArray toRubyArray(final Class<?>[] classes) {
-        return JavaClass.toRubyArray(getRuntime(), classes);
+    static RubyArray toClassArray(final Ruby runtime, final Class<?>[] classes) {
+        IRubyObject[] javaClasses = new IRubyObject[classes.length];
+        for ( int i = classes.length; --i >= 0; ) {
+            javaClasses[i] = Java.getProxyClass(runtime, classes[i]);
+        }
+        return RubyArray.newArrayMayCopy(runtime, javaClasses);
     }
 
 }

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyReflectionObject.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyReflectionObject.java
@@ -126,8 +126,8 @@ public class JavaProxyReflectionObject extends RubyObject {
     }
 
     @JRubyMethod
-    public JavaClass java_class() {
-        return JavaClass.get(getRuntime(), getJavaClass());
+    public IRubyObject java_class() {
+        return Java.getInstance(getRuntime(), getJavaClass());
     }
 
     @JRubyMethod

--- a/core/src/test/java/org/jruby/javasupport/TestJava.java
+++ b/core/src/test/java/org/jruby/javasupport/TestJava.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Method;
 
 import org.jruby.*;
 import org.jruby.exceptions.RaiseException;
+import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.junit.Test;
 
@@ -100,16 +101,17 @@ public class TestJava extends junit.framework.TestCase {
     @Test
     public void testJavaConstructorExceptionHandling() throws Exception {
         final Ruby runtime = Ruby.newInstance();
+        ThreadContext context = runtime.getCurrentContext();
         JavaConstructor constructor = JavaConstructor.create(runtime,
                 ThrowingConstructor.class.getDeclaredConstructor(Integer.class)
         );
-        assert constructor.new_instance(new IRubyObject[] { runtime.newFixnum(0) }) != null;
+        assertNotNull(constructor.new_instance(context, new IRubyObject[] { runtime.newFixnum(0) }));
 
-        assert constructor.new_instance(new Object[] { 1 }) != null;
+        assertNotNull(constructor.new_instance(context, new Object[] { 1 }));
 
         try {
-            constructor.new_instance(new Object[0]);
-            assert false;
+            constructor.new_instance(context, new Object[0]);
+            assertTrue("raise exception expected", false);
         }
         catch (RaiseException ex) {
             assertEquals("(ArgumentError) wrong number of arguments (given 0, expected 1)", ex.getMessage());
@@ -119,8 +121,8 @@ public class TestJava extends junit.framework.TestCase {
         }
 
         try {
-            constructor.new_instance(new Object[] { -1 });
-            assert false;
+            constructor.new_instance(context, new Object[] { -1 });
+            assertTrue("raise exception expected", false);
         }
         catch (IllegalStateException ex) {
             assertEquals("param == -1", ex.getMessage());
@@ -130,8 +132,8 @@ public class TestJava extends junit.framework.TestCase {
         }
 
         try {
-            constructor.new_instance(new Object[] { null }); // new IllegalStateException() null cause message
-            assert false;
+            constructor.new_instance(context, new Object[] { null }); // new IllegalStateException() null cause message
+            assertTrue("raise exception expected", false);
         }
         catch (IllegalStateException ex) {
             assertEquals(null, ex.getMessage());

--- a/core/src/test/java/org/jruby/javasupport/TestJavaClass.java
+++ b/core/src/test/java/org/jruby/javasupport/TestJavaClass.java
@@ -1,6 +1,5 @@
 package org.jruby.javasupport;
 
-import org.jruby.runtime.builtin.IRubyObject;
 import org.junit.Test;
 
 import org.jruby.*;
@@ -8,6 +7,7 @@ import org.jruby.*;
 public class TestJavaClass extends junit.framework.TestCase {
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testGet() {
         Ruby runtime = Ruby.newInstance();
         requireJava(runtime);

--- a/spec/java_integration/addons/class_spec.rb
+++ b/spec/java_integration/addons/class_spec.rb
@@ -1,0 +1,50 @@
+require File.dirname(__FILE__) + "/../spec_helper"
+require 'java'
+
+describe "A Java class" do
+  it "has a name" do
+    klass = java.lang.String.java_class.to_java
+    expect(klass.name).to eq('java.lang.String')
+  end
+
+  it "improves to_s with canonical name" do
+    klass = Java::boolean[1].new.java_class.to_java
+    expect(klass.name).to eq('[Z')
+    expect(klass.to_s).to eq('boolean[]')
+  end
+
+  it "returns name for anonymous class with to_s" do
+    obj = java.util.function.Function.identity
+    klass = obj.java_class.to_java
+    expect(klass.name).to start_with('java.util.function.Function$')
+    expect(klass.to_s).to start_with('java.util.function.Function$')
+  end
+
+  context 'java_class' do
+    it "is the proxy wrapper for Java type" do
+      obj = java.lang.Integer.new(0)
+      expect( obj.java_class ).to equal java.lang.Class.forName('java.lang.Integer')
+      expect( obj.java_class ).to equal java.lang.Integer.java_class
+    end
+
+    it "is the target for Java class proxy" do
+      expect( java.lang.Integer.java_class ).to be java.lang.Class.forName('java.lang.Integer')
+      expect( java.lang.Runnable.java_class ).to eql java.lang.Class.forName('java.lang.Runnable')
+    end
+
+    it "is infered for Ruby interface impl" do
+      obj = Proc.new { Thread.pass }.to_java java.lang.Runnable
+      expect( obj.java_class ).not_to eql java.lang.Runnable.java_class
+      expect( obj.java_class.interfaces ).to include(java.lang.Runnable.java_class)
+    end
+
+    it "is the Java proxy class for Ruby sub-classed Java" do
+      klass = Class.new(java.util.ArrayList)
+      list = klass.new([1, 2])
+      java.util.Collections.swap(list, 0, 1)
+      # NOTE: this isn't accurate/consistent but it's compatible with JRuby 9.2
+      expect( list.java_class ).to eql java.lang.Class.forName('java.util.ArrayList')
+    end
+  end
+
+end

--- a/spec/java_integration/fixtures/PublicConstructor.java
+++ b/spec/java_integration/fixtures/PublicConstructor.java
@@ -1,6 +1,27 @@
 package java_integration.fixtures;
 
 public class PublicConstructor {
+
+  public int i;
+  public Object v;
+
   public PublicConstructor() {
+  }
+
+  public PublicConstructor(int i) {
+    this.i = i;
+  }
+
+  public PublicConstructor(Object v) {
+    this.v = v;
+  }
+
+  public PublicConstructor(Object i, Object v) {
+    this.i = ((Long) i).intValue();
+    this.v = v;
+  }
+
+  public Class vClass() {
+    return v.getClass();
   }
 }

--- a/spec/java_integration/module/java_import_spec.rb
+++ b/spec/java_integration/module/java_import_spec.rb
@@ -7,7 +7,7 @@ describe "java_import" do
       Module.new do
         java_import('does.not.Exist')
       end
-    end.to raise_error(NameError, /cannot load Java class.*?does.not.Exist.*?/)
+    end.to raise_error(NameError, /Java class .?does.not.Exist.? not found/)
   end
 
   it "should receive an array with the imported classes" do

--- a/spec/java_integration/packages/include_spec.rb
+++ b/spec/java_integration/packages/include_spec.rb
@@ -9,7 +9,7 @@ describe "jar with dependecies" do
 
       Fixtures::ThrowExceptionOnCreate.new
     rescue
-      expect($!.message).to match(/cannot link Java class java_integration\.fixtures\.ThrowExceptionOnCreate, probable missing dependency: junit.framework.Test/)
+      expect($!.message).to match(/cannot link Java class java_integration\.fixtures\.ThrowExceptionOnCreate .?java.lang.NoClassDefFoundError: junit.framework.Test.?/)
     end
   end
 
@@ -21,7 +21,7 @@ describe "jar with dependecies" do
 
       Fixtures::ThrowExceptionOnCreate.new
     rescue
-      expect($!.message).to match(/cannot link Java class java_integration\.fixtures\.ThrowExceptionOnCreate, probable missing dependency: junit.framework.Test/)
+      expect($!.message).to match(/cannot link Java class java_integration\.fixtures\.ThrowExceptionOnCreate .?java.lang.NoClassDefFoundError: junit.framework.Test.?/)
     end
   end
 end

--- a/spec/java_integration/reflection/constructor_spec.rb
+++ b/spec/java_integration/reflection/constructor_spec.rb
@@ -1,0 +1,24 @@
+require File.dirname(__FILE__) + "/../spec_helper"
+
+java_import 'java_integration.fixtures.PublicConstructor'
+
+describe "A JavaConstructor" do
+  it "should instantiate" do
+    ctor = PublicConstructor.java_class.declared_constructor
+    expect { ctor.new_instance }.not_to raise_error
+  end
+
+  it "should instantiate using specified ctor" do
+    ctor = PublicConstructor.java_class.declared_constructor Java::int
+    instance = ctor.new_instance 42
+    expect( instance.i ).to eq 42
+  end
+
+  it "should convert to Java" do
+    ctor = PublicConstructor.java_class.constructor java.lang.Object, java.lang.Object
+    instance = ctor.new_instance 42, "str"
+    expect( instance.i ).to eq 42
+    expect( instance.v ).to eq 'str'
+    expect( instance.vClass ).to be java.lang.String.java_class
+  end
+end

--- a/spec/java_integration/reflection/field_spec.rb
+++ b/spec/java_integration/reflection/field_spec.rb
@@ -13,14 +13,6 @@ describe "A JavaClass" do
     expect(PublicField.java_class.declared_field(:strField)).not_to eq(nil)
     expect(PackageField.java_class.declared_field(:strField)).not_to eq(nil)
   end
-
-  it "should provide a look up for a fields using a Ruby formatted name" do
-    skip "worked in JRuby 9.2 but compatibility was broken purposefully"
-    expect(PrivateField.java_class.declared_field(:str_field)).not_to eq(nil)
-    expect(ProtectedField.java_class.declared_field(:str_field)).not_to eq(nil)
-    expect(PublicField.java_class.declared_field(:str_field)).not_to eq(nil)
-    expect(PackageField.java_class.declared_field(:str_field)).not_to eq(nil)
-  end
 end
 
 describe "A JavaField" do

--- a/spec/java_integration/reflection/field_spec.rb
+++ b/spec/java_integration/reflection/field_spec.rb
@@ -15,6 +15,7 @@ describe "A JavaClass" do
   end
 
   it "should provide a look up for a fields using a Ruby formatted name" do
+    skip "worked in JRuby 9.2 but compatibility was broken purposefully"
     expect(PrivateField.java_class.declared_field(:str_field)).not_to eq(nil)
     expect(ProtectedField.java_class.declared_field(:str_field)).not_to eq(nil)
     expect(PublicField.java_class.declared_field(:str_field)).not_to eq(nil)
@@ -125,6 +126,11 @@ describe "A JavaField" do
 
         @field.set_value @obj.java_object, nil
         expect(@field.value(@obj.java_object)).to be_nil
+      end
+
+      it "should set/get value directly" do
+        @field.set_value @obj, "aaa"
+        expect( @field.value(@obj) ).to eq("aaa")
       end
     end
   end

--- a/spec/java_integration/reflection/method_spec.rb
+++ b/spec/java_integration/reflection/method_spec.rb
@@ -10,7 +10,7 @@ java_import 'java_integration.fixtures.PackageStaticMethod'
 describe "A JavaMethod" do
   describe "given a private Java class method" do
     before(:each) do
-      @method = PrivateStaticMethod.java_class.declared_method_smart :thePrivateMethod
+      @method = PrivateStaticMethod.java_class.declared_method :thePrivateMethod
       @method.accessible = true
     end
       
@@ -29,7 +29,7 @@ describe "A JavaMethod" do
   
   describe "given a protected Java class method" do
     before(:each) do
-      @method = ProtectedStaticMethod.java_class.declared_method_smart :theProtectedMethod
+      @method = ProtectedStaticMethod.java_class.declared_method :theProtectedMethod
       @method.accessible = true
     end
   
@@ -48,7 +48,7 @@ describe "A JavaMethod" do
   
   describe "given a package scope Java class method" do
     before(:each) do
-      @method = PackageStaticMethod.java_class.declared_method_smart :thePackageScopeMethod
+      @method = PackageStaticMethod.java_class.declared_method :thePackageScopeMethod
       @method.accessible = true    
     end
     
@@ -67,42 +67,42 @@ describe "A JavaMethod" do
 
   it "should provide the ability to invoke private Java instance methods on a Ruby object" do
     o = PrivateInstanceMethod.new
-    method = PrivateInstanceMethod.java_class.declared_method_smart :thePrivateMethod
+    method = PrivateInstanceMethod.java_class.declared_method :thePrivateMethod
     method.accessible = true
     expect { method.invoke(o) }.not_to raise_error
   end
   
   it "should provide the ability to invoke protected Java instance methods on a Ruby object" do
     o = ProtectedInstanceMethod.new
-    method = ProtectedInstanceMethod.java_class.declared_method_smart :theProtectedMethod
+    method = ProtectedInstanceMethod.java_class.declared_method :theProtectedMethod
     method.accessible = true
     expect { method.invoke(o) }.not_to raise_error
   end
   
   it "should provide the ability to invoke package scope Java instance methods on a Ruby object" do
     o = PackageInstanceMethod.new
-    method = PackageInstanceMethod.java_class.declared_method_smart :thePackageScopeMethod
+    method = PackageInstanceMethod.java_class.declared_method :thePackageScopeMethod
     method.accessible = true
     expect { method.invoke(o) }.not_to raise_error
   end
   
   it "should provide the ability to invoke private Java instance methods on a JavaObject" do
     o = PrivateInstanceMethod.new
-    method = PrivateInstanceMethod.java_class.declared_method_smart :thePrivateMethod
+    method = PrivateInstanceMethod.java_class.declared_method :thePrivateMethod
     method.accessible = true
     expect { method.invoke(o.java_object) }.not_to raise_error
   end
   
   it "should provide the ability to invoke protected Java instance methods on a JavaObject" do
     o = ProtectedInstanceMethod.new
-    method = ProtectedInstanceMethod.java_class.declared_method_smart :theProtectedMethod
+    method = ProtectedInstanceMethod.java_class.declared_method :theProtectedMethod
     method.accessible = true
     expect { method.invoke(o.java_object) }.not_to raise_error
   end
   
   it "should provide the ability to invoke package scope Java instance methods on a JavaObject" do
     o = PackageInstanceMethod.new
-    method = PackageInstanceMethod.java_class.declared_method_smart :thePackageScopeMethod
+    method = PackageInstanceMethod.java_class.declared_method :thePackageScopeMethod
     method.accessible = true
     expect { method.invoke(o.java_object) }.not_to raise_error
   end

--- a/spec/java_integration/reify/become_java_spec.rb
+++ b/spec/java_integration/reify/become_java_spec.rb
@@ -16,7 +16,8 @@ describe "JRuby class reification" do
       add_method_signature("run", [java.lang.Void::TYPE])
     end
     java_class = RubyRunnable.become_java!
-    expect(java_class.interfaces).to include(java.lang.Runnable.java_class)
+    interfaces = java_class.interfaces
+    expect( interfaces ).to include(java.lang.Runnable.java_class)
   end
 
   it "uses the nesting of the class for its package name" do

--- a/spec/java_integration/types/array_spec.rb
+++ b/spec/java_integration/types/array_spec.rb
@@ -8,26 +8,26 @@ describe "A Java primitive Array of type" do
   describe "boolean" do
     it "should be possible to create empty array" do
       arr = Java::boolean[0].new
-      expect(arr.java_class.to_s).to eq("[Z")
+      expect(arr.java_class.to_s).to eq("boolean[]")
       expect(arr).to be_empty
     end
 
     it "should be possible to create uninitialized single dimensional array" do
       arr = Java::boolean[10].new
-      expect(arr.java_class.to_s).to eq("[Z")
+      expect(arr.java_class.name).to eq("[Z")
       expect(arr).not_to be_empty
     end
 
     it "should be possible to create uninitialized multi dimensional array" do
       arr = Java::boolean[10,10].new
-      expect(arr.java_class.to_s).to eq("[[Z")
+      expect(arr.java_class.to_s).to eq("boolean[][]")
       expect(arr).not_to be_empty
     end
 
     it "should be possible to create primitive array from Ruby array" do
       # Check with symbol name
       arr = [true, false].to_java :boolean
-      expect(arr.java_class.to_s).to eq("[Z")
+      expect(arr.java_class.name).to eq("[Z")
 
       expect(arr.length).to eq(2)
 
@@ -37,7 +37,7 @@ describe "A Java primitive Array of type" do
 
       # Check with type
       arr = [true, false].to_java Java::boolean
-      expect(arr.java_class.to_s).to eq("[Z")
+      expect(arr.java_class.name).to eq("[Z")
 
       expect(arr.length).to eq(2)
 
@@ -78,26 +78,26 @@ describe "A Java primitive Array of type" do
   describe "byte" do
     it "should be possible to create empty array" do
       arr = Java::byte[0].new
-      expect(arr.java_class.to_s).to eq("[B")
+      expect(arr.java_class.name).to eq("[B")
       expect(arr).to be_empty
     end
 
     it "should be possible to create uninitialized single dimensional array" do
       arr = Java::byte[10].new
-      expect(arr.java_class.to_s).to eq("[B")
+      expect(arr.java_class.name).to eq("[B")
       expect(arr).not_to be_empty
     end
 
     it "should be possible to create uninitialized multi dimensional array" do
       arr = Java::byte[10,10].new
-      expect(arr.java_class.to_s).to eq("[[B")
+      expect(arr.java_class.name).to eq("[[B")
       expect(arr).not_to be_empty
     end
 
     it "should be possible to create primitive array from Ruby array" do
       # Check with symbol name
       arr = [1,2].to_java :byte
-      expect(arr.java_class.to_s).to eq("[B")
+      expect(arr.java_class.to_s).to eq("byte[]")
 
       expect(arr.length).to eq(2)
 
@@ -107,7 +107,7 @@ describe "A Java primitive Array of type" do
 
       # Check with type
       arr = [1,2].to_java Java::byte
-      expect(arr.java_class.to_s).to eq("[B")
+      expect(arr.java_class.to_s).to eq("byte[]")
 
       expect(arr.length).to eq(2)
 
@@ -212,26 +212,26 @@ describe "A Java primitive Array of type" do
   describe "char" do
     it "should be possible to create empty array" do
       arr = Java::char[0].new
-      expect(arr.java_class.to_s).to eq("[C")
+      expect(arr.java_class.to_s).to eq("char[]")
       expect(arr).to be_empty
     end
 
     it "should be possible to create uninitialized single dimensional array" do
       arr = Java::char[10].new
-      expect(arr.java_class.to_s).to eq("[C")
+      expect(arr.java_class.name).to eq("[C")
       expect(arr).not_to be_empty
     end
 
     it "should be possible to create uninitialized multi dimensional array" do
       arr = Java::char[10,10].new
-      expect(arr.java_class.to_s).to eq("[[C")
+      expect(arr.java_class.name).to eq("[[C")
       expect(arr).not_to be_empty
     end
 
     it "should be possible to create primitive array from Ruby array" do
       # Check with symbol name
       arr = [1,2].to_java :char
-      expect(arr.java_class.to_s).to eq("[C")
+      expect(arr.java_class.name).to eq("[C")
 
       expect(arr.length).to eq(2)
 
@@ -241,7 +241,7 @@ describe "A Java primitive Array of type" do
 
       # Check with type
       arr = [1,2].to_java Java::char
-      expect(arr.java_class.to_s).to eq("[C")
+      expect(arr.java_class.name).to eq("[C")
 
       expect(arr.length).to eq(2)
 
@@ -324,26 +324,26 @@ describe "A Java primitive Array of type" do
   describe "double" do
     it "should be possible to create empty array" do
       arr = Java::double[0].new
-      expect(arr.java_class.to_s).to eq("[D")
+      expect(arr.java_class.name).to eq("[D")
       expect(arr).to be_empty
     end
 
     it "should be possible to create uninitialized single dimensional array" do
       arr = Java::double[10].new
-      expect(arr.java_class.to_s).to eq("[D")
+      expect(arr.java_class.name).to eq("[D")
       expect(arr).not_to be_empty
     end
 
     it "should be possible to create uninitialized multi dimensional array" do
       arr = Java::double[10,10].new
-      expect(arr.java_class.to_s).to eq("[[D")
+      expect(arr.java_class.name).to eq("[[D")
       expect(arr).not_to be_empty
     end
 
     it "should be possible to create primitive array from Ruby array" do
       # Check with symbol name
       arr = [1.2,2.3].to_java :double
-      expect(arr.java_class.to_s).to eq("[D")
+      expect(arr.java_class.name).to eq("[D")
 
       expect(arr.length).to eq(2)
 
@@ -353,7 +353,7 @@ describe "A Java primitive Array of type" do
 
       # Check with type
       arr = [1.2,2.3].to_java Java::double
-      expect(arr.java_class.to_s).to eq("[D")
+      expect(arr.java_class.to_s).to eq("double[]")
 
       expect(arr.length).to eq(2)
 
@@ -428,26 +428,26 @@ describe "A Java primitive Array of type" do
   describe "float" do
     it "should be possible to create empty array" do
       arr = Java::float[0].new
-      expect(arr.java_class.to_s).to eq("[F")
+      expect(arr.java_class.to_s).to eq("float[]")
       expect(arr).to be_empty
     end
 
     it "should be possible to create uninitialized single dimensional array" do
       arr = Java::float[10].new
-      expect(arr.java_class.to_s).to eq("[F")
+      expect(arr.java_class.name).to eq("[F")
       expect(arr).not_to be_empty
     end
 
     it "should be possible to create uninitialized multi dimensional array" do
       arr = Java::float[10,10].new
-      expect(arr.java_class.to_s).to eq("[[F")
+      expect(arr.java_class.name).to eq("[[F")
       expect(arr).not_to be_empty
     end
 
     it "should be possible to create primitive array from Ruby array" do
       # Check with symbol name
       arr = [1.2,2.3].to_java :float
-      expect(arr.java_class.to_s).to eq("[F")
+      expect(arr.java_class.name).to eq("[F")
 
       expect(arr.length).to eq(2)
 
@@ -457,7 +457,7 @@ describe "A Java primitive Array of type" do
 
       # Check with type
       arr = [1.2,2.3].to_java Java::float
-      expect(arr.java_class.to_s).to eq("[F")
+      expect(arr.java_class.name).to eq("[F")
 
       expect(arr.length).to eq(2)
 
@@ -542,26 +542,26 @@ describe "A Java primitive Array of type" do
   describe "int" do
     it "should be possible to create empty array" do
       arr = Java::int[0].new
-      expect(arr.java_class.to_s).to eq("[I")
+      expect(arr.java_class.name).to eq("[I")
       expect(arr).to be_empty
     end
 
     it "should be possible to create uninitialized single dimensional array" do
       arr = Java::int[10].new
-      expect(arr.java_class.to_s).to eq("[I")
+      expect(arr.java_class.name).to eq("[I")
       expect(arr).not_to be_empty
     end
 
     it "should be possible to create uninitialized multi dimensional array" do
       arr = Java::int[10,10].new
-      expect(arr.java_class.to_s).to eq("[[I")
+      expect(arr.java_class.name).to eq("[[I")
       expect(arr).not_to be_empty
     end
 
     it "should be possible to create primitive array from Ruby array" do
       # Check with symbol name
       arr = [1,2].to_java :int
-      expect(arr.java_class.to_s).to eq("[I")
+      expect(arr.java_class.name).to eq("[I")
 
       expect(arr.length).to eq(2)
 
@@ -571,7 +571,7 @@ describe "A Java primitive Array of type" do
 
       # Check with type
       arr = [1,2].to_java Java::int
-      expect(arr.java_class.to_s).to eq("[I")
+      expect(arr.java_class.name).to eq("[I")
 
       expect(arr.length).to eq(2)
 
@@ -653,26 +653,26 @@ describe "A Java primitive Array of type" do
   describe "long" do
     it "should be possible to create empty array" do
       arr = Java::long[0].new
-      expect(arr.java_class.to_s).to eq("[J")
+      expect(arr.java_class.to_s).to eq("long[]")
       expect(arr).to be_empty
     end
 
     it "should be possible to create uninitialized single dimensional array" do
       arr = Java::long[10].new
-      expect(arr.java_class.to_s).to eq("[J")
+      expect(arr.java_class.name).to eq("[J")
       expect(arr).not_to be_empty
     end
 
     it "should be possible to create uninitialized multi dimensional array" do
       arr = Java::long[10,10].new
-      expect(arr.java_class.to_s).to eq("[[J")
+      expect(arr.java_class.name).to eq("[[J")
       expect(arr).not_to be_empty
     end
 
     it "should be possible to create primitive array from Ruby array" do
       # Check with symbol name
       arr = [1,2].to_java :long
-      expect(arr.java_class.to_s).to eq("[J")
+      expect(arr.java_class.name).to eq("[J")
 
       expect(arr.length).to eq(2)
 
@@ -682,7 +682,7 @@ describe "A Java primitive Array of type" do
 
       # Check with type
       arr = [1,2].to_java Java::long
-      expect(arr.java_class.to_s).to eq("[J")
+      expect(arr.java_class.name).to eq("[J")
 
       expect(arr.length).to eq(2)
 
@@ -767,26 +767,26 @@ describe "A Java primitive Array of type" do
   describe "short" do
     it "should be possible to create empty array" do
       arr = Java::short[0].new
-      expect(arr.java_class.to_s).to eq("[S")
+      expect(arr.java_class.name).to eq("[S")
       expect(arr).to be_empty
     end
 
     it "should be possible to create uninitialized single dimensional array" do
       arr = Java::short[10].new
-      expect(arr.java_class.to_s).to eq("[S")
+      expect(arr.java_class.name).to eq("[S")
       expect(arr).not_to be_empty
     end
 
     it "should be possible to create uninitialized multi dimensional array" do
       arr = Java::short[10,10].new
-      expect(arr.java_class.to_s).to eq("[[S")
+      expect(arr.java_class.to_s).to eq("short[][]")
       expect(arr).not_to be_empty
     end
 
     it "should be possible to create primitive array from Ruby array" do
       # Check with symbol name
       arr = [1,2].to_java :short
-      expect(arr.java_class.to_s).to eq("[S")
+      expect(arr.java_class.name).to eq("[S")
 
       expect(arr.length).to eq(2)
 
@@ -796,7 +796,7 @@ describe "A Java primitive Array of type" do
 
       # Check with type
       arr = [1,2].to_java Java::short
-      expect(arr.java_class.to_s).to eq("[S")
+      expect(arr.java_class.name).to eq("[S")
 
       expect(arr.length).to eq(2)
 
@@ -849,26 +849,26 @@ describe "A Java primitive Array of type" do
   describe "string" do
     it "should be possible to create empty array" do
       arr = java.lang.String[0].new
-      expect(arr.java_class.to_s).to eq("[Ljava.lang.String;")
+      expect(arr.java_class.to_s).to eq("java.lang.String[]")
       expect(arr).to be_empty
     end
 
     it "should be possible to create uninitialized single dimensional array" do
       arr = java.lang.String[10].new
-      expect(arr.java_class.to_s).to eq("[Ljava.lang.String;")
+      expect(arr.java_class.name).to eq("[Ljava.lang.String;")
       expect(arr).not_to be_empty
     end
 
     it "should be possible to create uninitialized multi dimensional array" do
       arr = java.lang.String[10,10].new
-      expect(arr.java_class.to_s).to eq("[[Ljava.lang.String;")
+      expect(arr.java_class.to_s).to eq("java.lang.String[][]")
       expect(arr).not_to be_empty
     end
 
     it "should be possible to create primitive array from Ruby array" do
       # Check with symbol name
       arr = ["foo", :bar].to_java :string
-      expect(arr.java_class.to_s).to eq("[Ljava.lang.String;")
+      expect(arr.java_class.name).to eq("[Ljava.lang.String;")
 
       expect(arr.length).to eq(2)
 
@@ -878,7 +878,7 @@ describe "A Java primitive Array of type" do
 
       # Check with type
       arr = ["foo", :bar].to_java java.lang.String
-      expect(arr.java_class.to_s).to eq("[Ljava.lang.String;")
+      expect(arr.java_class.name).to eq("[Ljava.lang.String;")
 
       expect(arr.length).to eq(2)
 
@@ -931,19 +931,19 @@ describe "A Java primitive Array of type" do
   describe "Object" do
     it "should be possible to create empty array" do
       arr = java.util.HashMap[0].new
-      expect(arr.java_class.to_s).to eq("[Ljava.util.HashMap;")
+      expect(arr.java_class.name).to eq("[Ljava.util.HashMap;")
       expect(arr).to be_empty
     end
 
     it "should be possible to create uninitialized single dimensional array" do
       arr = java.util.HashMap[10].new
-      expect(arr.java_class.to_s).to eq("[Ljava.util.HashMap;")
+      expect(arr.java_class.name).to eq("[Ljava.util.HashMap;")
       expect(arr).not_to be_empty
     end
 
     it "should be possible to create uninitialized multi dimensional array" do
       arr = java.util.HashMap[10,10].new
-      expect(arr.java_class.to_s).to eq("[[Ljava.util.HashMap;")
+      expect(arr.java_class.name).to eq("[[Ljava.util.HashMap;")
       expect(arr).not_to be_empty
     end
 
@@ -955,7 +955,7 @@ describe "A Java primitive Array of type" do
       h2["max"] = "foo"
 
       arr = [h1, h2].to_java java.util.HashMap
-      expect(arr.java_class.to_s).to eq("[Ljava.util.HashMap;")
+      expect(arr.java_class.name).to eq("[Ljava.util.HashMap;")
 
       expect(arr.length).to eq(2)
 
@@ -1064,19 +1064,19 @@ describe "A Java primitive Array of type" do
   describe "Class ref" do
     it "should be possible to create empty array" do
       arr = java.lang.Class[0].new
-      expect(arr.java_class.to_s).to eq("[Ljava.lang.Class;")
+      expect(arr.java_class.to_s).to eq("java.lang.Class[]")
       expect(arr).to be_empty
     end
 
     it "should be possible to create uninitialized single dimensional array" do
       arr = java.lang.Class[10].new
-      expect(arr.java_class.to_s).to eq("[Ljava.lang.Class;")
+      expect(arr.java_class.to_s).to eq("java.lang.Class[]")
       expect(arr).not_to be_empty
     end
 
     it "should be possible to create uninitialized multi dimensional array" do
       arr = java.lang.Class[10,10].new
-      expect(arr.java_class.to_s).to eq("[[Ljava.lang.Class;")
+      expect(arr.java_class.name).to eq("[[Ljava.lang.Class;")
       expect(arr).not_to be_empty
     end
 
@@ -1085,7 +1085,7 @@ describe "A Java primitive Array of type" do
         h2 = java.util.HashMap.java_class
 
         arr = [h1, h2].to_java java.lang.Class
-        expect(arr.java_class.to_s).to eq("[Ljava.lang.Class;")
+        expect(arr.java_class.name).to eq("[Ljava.lang.Class;")
 
         expect(arr.length).to eq(2)
 

--- a/spec/java_integration/types/construction_spec.rb
+++ b/spec/java_integration/types/construction_spec.rb
@@ -12,23 +12,23 @@ describe "A Java primitive Array of type" do
   describe "boolean" do 
     it "should be possible to create empty array" do 
       arr = Java::boolean[0].new
-      expect(arr.java_class.to_s).to eq("[Z")
+      expect(arr.java_class.name).to eq("[Z")
     end
     
     it "should be possible to create uninitialized single dimensional array" do 
       arr = Java::boolean[10].new
-      expect(arr.java_class.to_s).to eq("[Z")
+      expect(arr.java_class.name).to eq("[Z")
     end
     
     it "should be possible to create uninitialized multi dimensional array" do 
       arr = Java::boolean[10,10].new
-      expect(arr.java_class.to_s).to eq("[[Z")
+      expect(arr.java_class.name).to eq("[[Z")
     end
 
     it "should be possible to create primitive array from Ruby array" do 
       # Check with symbol name
       arr = [true, false].to_java :boolean
-      expect(arr.java_class.to_s).to eq("[Z")
+      expect(arr.java_class.name).to eq("[Z")
 
       expect(arr.length).to eq(2)
 
@@ -38,7 +38,7 @@ describe "A Java primitive Array of type" do
 
       # Check with type
       arr = [true, false].to_java Java::boolean
-      expect(arr.java_class.to_s).to eq("[Z")
+      expect(arr.java_class.name).to eq("[Z")
 
       expect(arr.length).to eq(2)
 
@@ -74,23 +74,23 @@ describe "A Java primitive Array of type" do
   describe "byte" do 
     it "should be possible to create empty array" do 
       arr = Java::byte[0].new
-      expect(arr.java_class.to_s).to eq("[B")
+      expect(arr.java_class.name).to eq("[B")
     end
     
     it "should be possible to create uninitialized single dimensional array" do 
       arr = Java::byte[10].new
-      expect(arr.java_class.to_s).to eq("[B")
+      expect(arr.java_class.name).to eq("[B")
     end
     
     it "should be possible to create uninitialized multi dimensional array" do 
       arr = Java::byte[10,10].new
-      expect(arr.java_class.to_s).to eq("[[B")
+      expect(arr.java_class.name).to eq("[[B")
     end
 
     it "should be possible to create primitive array from Ruby array" do 
       # Check with symbol name
       arr = [1,2].to_java :byte
-      expect(arr.java_class.to_s).to eq("[B")
+      expect(arr.java_class.name).to eq("[B")
 
       expect(arr.length).to eq(2)
 
@@ -100,7 +100,7 @@ describe "A Java primitive Array of type" do
 
       # Check with type
       arr = [1,2].to_java Java::byte
-      expect(arr.java_class.to_s).to eq("[B")
+      expect(arr.java_class.name).to eq("[B")
 
       expect(arr.length).to eq(2)
 
@@ -138,23 +138,23 @@ describe "A Java primitive Array of type" do
   describe "char" do 
     it "should be possible to create empty array" do 
       arr = Java::char[0].new
-      expect(arr.java_class.to_s).to eq("[C")
+      expect(arr.java_class.name).to eq("[C")
     end
     
     it "should be possible to create uninitialized single dimensional array" do 
       arr = Java::char[10].new
-      expect(arr.java_class.to_s).to eq("[C")
+      expect(arr.java_class.name).to eq("[C")
     end
     
     it "should be possible to create uninitialized multi dimensional array" do 
       arr = Java::char[10,10].new
-      expect(arr.java_class.to_s).to eq("[[C")
+      expect(arr.java_class.name).to eq("[[C")
     end
 
     it "should be possible to create primitive array from Ruby array" do 
       # Check with symbol name
       arr = [1,2].to_java :char
-      expect(arr.java_class.to_s).to eq("[C")
+      expect(arr.java_class.name).to eq("[C")
 
       expect(arr.length).to eq(2)
 
@@ -164,7 +164,7 @@ describe "A Java primitive Array of type" do
 
       # Check with type
       arr = [1,2].to_java Java::char
-      expect(arr.java_class.to_s).to eq("[C")
+      expect(arr.java_class.name).to eq("[C")
 
       expect(arr.length).to eq(2)
 
@@ -202,23 +202,23 @@ describe "A Java primitive Array of type" do
   describe "double" do 
     it "should be possible to create empty array" do 
       arr = Java::double[0].new
-      expect(arr.java_class.to_s).to eq("[D")
+      expect(arr.java_class.name).to eq("[D")
     end
     
     it "should be possible to create uninitialized single dimensional array" do 
       arr = Java::double[10].new
-      expect(arr.java_class.to_s).to eq("[D")
+      expect(arr.java_class.name).to eq("[D")
     end
     
     it "should be possible to create uninitialized multi dimensional array" do 
       arr = Java::double[10,10].new
-      expect(arr.java_class.to_s).to eq("[[D")
+      expect(arr.java_class.name).to eq("[[D")
     end
 
     it "should be possible to create primitive array from Ruby array" do 
       # Check with symbol name
       arr = [1.2,2.3].to_java :double
-      expect(arr.java_class.to_s).to eq("[D")
+      expect(arr.java_class.name).to eq("[D")
 
       expect(arr.length).to eq(2)
 
@@ -228,7 +228,7 @@ describe "A Java primitive Array of type" do
 
       # Check with type
       arr = [1.2,2.3].to_java Java::double
-      expect(arr.java_class.to_s).to eq("[D")
+      expect(arr.java_class.name).to eq("[D")
 
       expect(arr.length).to eq(2)
 
@@ -266,23 +266,23 @@ describe "A Java primitive Array of type" do
   describe "float" do 
     it "should be possible to create empty array" do 
       arr = Java::float[0].new
-      expect(arr.java_class.to_s).to eq("[F")
+      expect(arr.java_class.name).to eq("[F")
     end
     
     it "should be possible to create uninitialized single dimensional array" do 
       arr = Java::float[10].new
-      expect(arr.java_class.to_s).to eq("[F")
+      expect(arr.java_class.name).to eq("[F")
     end
     
     it "should be possible to create uninitialized multi dimensional array" do 
       arr = Java::float[10,10].new
-      expect(arr.java_class.to_s).to eq("[[F")
+      expect(arr.java_class.name).to eq("[[F")
     end
 
     it "should be possible to create primitive array from Ruby array" do 
       # Check with symbol name
       arr = [1.2,2.3].to_java :float
-      expect(arr.java_class.to_s).to eq("[F")
+      expect(arr.java_class.name).to eq("[F")
 
       expect(arr.length).to eq(2)
 
@@ -292,7 +292,7 @@ describe "A Java primitive Array of type" do
 
       # Check with type
       arr = [1.2,2.3].to_java Java::float
-      expect(arr.java_class.to_s).to eq("[F")
+      expect(arr.java_class.name).to eq("[F")
 
       expect(arr.length).to eq(2)
 
@@ -334,23 +334,23 @@ describe "A Java primitive Array of type" do
   describe "int" do 
     it "should be possible to create empty array" do 
       arr = Java::int[0].new
-      expect(arr.java_class.to_s).to eq("[I")
+      expect(arr.java_class.name).to eq("[I")
     end
     
     it "should be possible to create uninitialized single dimensional array" do 
       arr = Java::int[10].new
-      expect(arr.java_class.to_s).to eq("[I")
+      expect(arr.java_class.name).to eq("[I")
     end
     
     it "should be possible to create uninitialized multi dimensional array" do 
       arr = Java::int[10,10].new
-      expect(arr.java_class.to_s).to eq("[[I")
+      expect(arr.java_class.name).to eq("[[I")
     end
 
     it "should be possible to create primitive array from Ruby array" do 
       # Check with symbol name
       arr = [1,2].to_java :int
-      expect(arr.java_class.to_s).to eq("[I")
+      expect(arr.java_class.name).to eq("[I")
 
       expect(arr.length).to eq(2)
 
@@ -360,7 +360,7 @@ describe "A Java primitive Array of type" do
 
       # Check with type
       arr = [1,2].to_java Java::int
-      expect(arr.java_class.to_s).to eq("[I")
+      expect(arr.java_class.name).to eq("[I")
 
       expect(arr.length).to eq(2)
 
@@ -398,23 +398,23 @@ describe "A Java primitive Array of type" do
   describe "long" do 
     it "should be possible to create empty array" do 
       arr = Java::long[0].new
-      expect(arr.java_class.to_s).to eq("[J")
+      expect(arr.java_class.name).to eq("[J")
     end
     
     it "should be possible to create uninitialized single dimensional array" do 
       arr = Java::long[10].new
-      expect(arr.java_class.to_s).to eq("[J")
+      expect(arr.java_class.name).to eq("[J")
     end
     
     it "should be possible to create uninitialized multi dimensional array" do 
       arr = Java::long[10,10].new
-      expect(arr.java_class.to_s).to eq("[[J")
+      expect(arr.java_class.name).to eq("[[J")
     end
 
     it "should be possible to create primitive array from Ruby array" do 
       # Check with symbol name
       arr = [1,2].to_java :long
-      expect(arr.java_class.to_s).to eq("[J")
+      expect(arr.java_class.name).to eq("[J")
 
       expect(arr.length).to eq(2)
 
@@ -424,7 +424,7 @@ describe "A Java primitive Array of type" do
 
       # Check with type
       arr = [1,2].to_java Java::long
-      expect(arr.java_class.to_s).to eq("[J")
+      expect(arr.java_class.name).to eq("[J")
 
       expect(arr.length).to eq(2)
 
@@ -462,23 +462,23 @@ describe "A Java primitive Array of type" do
   describe "short" do 
     it "should be possible to create empty array" do 
       arr = Java::short[0].new
-      expect(arr.java_class.to_s).to eq("[S")
+      expect(arr.java_class.name).to eq("[S")
     end
     
     it "should be possible to create uninitialized single dimensional array" do 
       arr = Java::short[10].new
-      expect(arr.java_class.to_s).to eq("[S")
+      expect(arr.java_class.name).to eq("[S")
     end
     
     it "should be possible to create uninitialized multi dimensional array" do 
       arr = Java::short[10,10].new
-      expect(arr.java_class.to_s).to eq("[[S")
+      expect(arr.java_class.name).to eq("[[S")
     end
 
     it "should be possible to create primitive array from Ruby array" do 
       # Check with symbol name
       arr = [1,2].to_java :short
-      expect(arr.java_class.to_s).to eq("[S")
+      expect(arr.java_class.name).to eq("[S")
 
       expect(arr.length).to eq(2)
 
@@ -488,7 +488,7 @@ describe "A Java primitive Array of type" do
 
       # Check with type
       arr = [1,2].to_java Java::short
-      expect(arr.java_class.to_s).to eq("[S")
+      expect(arr.java_class.name).to eq("[S")
 
       expect(arr.length).to eq(2)
 
@@ -526,23 +526,23 @@ describe "A Java primitive Array of type" do
   describe "string" do 
     it "should be possible to create empty array" do 
       arr = java.lang.String[0].new
-      expect(arr.java_class.to_s).to eq("[Ljava.lang.String;")
+      expect(arr.java_class.name).to eq("[Ljava.lang.String;")
     end
     
     it "should be possible to create uninitialized single dimensional array" do 
       arr = java.lang.String[10].new
-      expect(arr.java_class.to_s).to eq("[Ljava.lang.String;")
+      expect(arr.java_class.name).to eq("[Ljava.lang.String;")
     end
     
     it "should be possible to create uninitialized multi dimensional array" do 
       arr = java.lang.String[10,10].new
-      expect(arr.java_class.to_s).to eq("[[Ljava.lang.String;")
+      expect(arr.java_class.name).to eq("[[Ljava.lang.String;")
     end
 
     it "should be possible to create primitive array from Ruby array" do 
       # Check with symbol name
       arr = ["foo","bar"].to_java :string
-      expect(arr.java_class.to_s).to eq("[Ljava.lang.String;")
+      expect(arr.java_class.name).to eq("[Ljava.lang.String;")
 
       expect(arr.length).to eq(2)
 
@@ -552,7 +552,7 @@ describe "A Java primitive Array of type" do
 
       # Check with type
       arr = ["foo","bar"].to_java java.lang.String
-      expect(arr.java_class.to_s).to eq("[Ljava.lang.String;")
+      expect(arr.java_class.name).to eq("[Ljava.lang.String;")
 
       expect(arr.length).to eq(2)
 
@@ -590,17 +590,17 @@ describe "A Java primitive Array of type" do
   describe "Object ref" do 
     it "should be possible to create empty array" do 
       arr = java.util.HashMap[0].new
-      expect(arr.java_class.to_s).to eq("[Ljava.util.HashMap;")
+      expect(arr.java_class.name).to eq("[Ljava.util.HashMap;")
     end
     
     it "should be possible to create uninitialized single dimensional array" do 
       arr = java.util.HashMap[10].new
-      expect(arr.java_class.to_s).to eq("[Ljava.util.HashMap;")
+      expect(arr.java_class.name).to eq("[Ljava.util.HashMap;")
     end
     
     it "should be possible to create uninitialized multi dimensional array" do 
       arr = java.util.HashMap[10,10].new
-      expect(arr.java_class.to_s).to eq("[[Ljava.util.HashMap;")
+      expect(arr.java_class.name).to eq("[[Ljava.util.HashMap;")
     end
 
     it "should be possible to create primitive array from Ruby array" do
@@ -611,7 +611,7 @@ describe "A Java primitive Array of type" do
       h2["max"] = "foo"
 
       arr = [h1, h2].to_java java.util.HashMap
-      expect(arr.java_class.to_s).to eq("[Ljava.util.HashMap;")
+      expect(arr.java_class.name).to eq("[Ljava.util.HashMap;")
 
       expect(arr.length).to eq(2)
 
@@ -676,17 +676,17 @@ describe "A Java primitive Array of type" do
   describe "Class ref" do 
     it "should be possible to create empty array" do 
       arr = java.lang.Class[0].new
-      expect(arr.java_class.to_s).to eq("[Ljava.lang.Class;")
+      expect(arr.java_class.name).to eq("[Ljava.lang.Class;")
     end
     
     it "should be possible to create uninitialized single dimensional array" do 
       arr = java.lang.Class[10].new
-      expect(arr.java_class.to_s).to eq("[Ljava.lang.Class;")
+      expect(arr.java_class.name).to eq("[Ljava.lang.Class;")
     end
     
     it "should be possible to create uninitialized multi dimensional array" do 
       arr = java.lang.Class[10,10].new
-      expect(arr.java_class.to_s).to eq("[[Ljava.lang.Class;")
+      expect(arr.java_class.name).to eq("[[Ljava.lang.Class;")
     end
 
     it "should be possible to create primitive array from Ruby array" do
@@ -694,7 +694,7 @@ describe "A Java primitive Array of type" do
         h2 = java.util.HashMap.java_class
 
         arr = [h1, h2].to_java java.lang.Class
-        expect(arr.java_class.to_s).to eq("[Ljava.lang.Class;")
+        expect(arr.java_class.name).to eq("[Ljava.lang.Class;")
 
         expect(arr.length).to eq(2)
 

--- a/spec/java_integration/types/retrieval_spec.rb
+++ b/spec/java_integration/types/retrieval_spec.rb
@@ -55,7 +55,8 @@ end
 describe "A JavaClass wrapper around a java.lang.Class" do
   it "provides a nice String output for inspect" do
     myclass = java.lang.String.java_class
-    expect(myclass.inspect).to eq("class java.lang.String")
+    expect( myclass ).to be_a java.lang.Class
+    expect(myclass.to_s).to eq("java.lang.String")
   end
 end
 

--- a/spec/java_integration/types/retrieval_spec.rb
+++ b/spec/java_integration/types/retrieval_spec.rb
@@ -16,16 +16,18 @@ describe "Kernel\#java_import" do
 end
 
 describe "Java::JavaClass.for_name" do
-  it "should return primitive classes for Java primitive type names" do
-    expect(Java::JavaClass.for_name("byte")).to eq(Java::byte.java_class)
-    expect(Java::JavaClass.for_name("boolean")).to eq(Java::boolean.java_class)
-    expect(Java::JavaClass.for_name("short")).to eq(Java::short.java_class)
-    expect(Java::JavaClass.for_name("char")).to eq(Java::char.java_class)
-    expect(Java::JavaClass.for_name("int")).to eq(Java::int.java_class)
-    expect(Java::JavaClass.for_name("long")).to eq(Java::long.java_class)
-    expect(Java::JavaClass.for_name("float")).to eq(Java::float.java_class)
-    expect(Java::JavaClass.for_name("double")).to eq(Java::double.java_class)
-  end
+  # NOTE: 'breaking compatibility' used to work for JavaClass, we could make it
+  # work for java.lang.Class by patching for_name but it's counter-intuitive.
+  # it "should return primitive classes for Java primitive type names" do
+  #   expect(Java::JavaClass.for_name("byte")).to eq(Java::byte.java_class)
+  #   expect(Java::JavaClass.for_name("boolean")).to eq(Java::boolean.java_class)
+  #   expect(Java::JavaClass.for_name("short")).to eq(Java::short.java_class)
+  #   expect(Java::JavaClass.for_name("char")).to eq(Java::char.java_class)
+  #   expect(Java::JavaClass.for_name("int")).to eq(Java::int.java_class)
+  #   expect(Java::JavaClass.for_name("long")).to eq(Java::long.java_class)
+  #   expect(Java::JavaClass.for_name("float")).to eq(Java::float.java_class)
+  #   expect(Java::JavaClass.for_name("double")).to eq(Java::double.java_class)
+  # end
 
   it "should return Java class from JRuby class-path" do
     expect(Java::JavaClass.for_name('java_integration.fixtures.Reflector')).to_not be nil

--- a/spec/java_integration/types/retrieval_spec.rb
+++ b/spec/java_integration/types/retrieval_spec.rb
@@ -18,19 +18,23 @@ end
 describe "Java::JavaClass.for_name" do
   # NOTE: 'breaking compatibility' used to work for JavaClass, we could make it
   # work for java.lang.Class by patching for_name but it's counter-intuitive.
-  # it "should return primitive classes for Java primitive type names" do
-  #   expect(Java::JavaClass.for_name("byte")).to eq(Java::byte.java_class)
-  #   expect(Java::JavaClass.for_name("boolean")).to eq(Java::boolean.java_class)
-  #   expect(Java::JavaClass.for_name("short")).to eq(Java::short.java_class)
-  #   expect(Java::JavaClass.for_name("char")).to eq(Java::char.java_class)
-  #   expect(Java::JavaClass.for_name("int")).to eq(Java::int.java_class)
-  #   expect(Java::JavaClass.for_name("long")).to eq(Java::long.java_class)
-  #   expect(Java::JavaClass.for_name("float")).to eq(Java::float.java_class)
-  #   expect(Java::JavaClass.for_name("double")).to eq(Java::double.java_class)
-  # end
+  it "should return primitive classes for Java primitive type names" do
+    class_for_name = -> (name) { JRuby.load_java_class(name) } # Java::JavaClass.for_name 'replacement'
+    expect(class_for_name.("byte")).to eq(Java::byte.java_class)
+    expect(class_for_name.("boolean")).to eq(Java::boolean.java_class)
+    expect(class_for_name.("short")).to eq(Java::short.java_class)
+    expect(class_for_name.("char")).to eq(Java::char.java_class)
+    expect(class_for_name.("int")).to eq(Java::int.java_class)
+    expect(class_for_name.("long")).to eq(Java::long.java_class)
+    expect(class_for_name.("float")).to eq(Java::float.java_class)
+    expect(class_for_name.("double")).to eq(Java::double.java_class)
+  end
 
+  # NOTE: breaking change in 9.3 with JavaClass being deprecated
   it "should return Java class from JRuby class-path" do
-    expect(Java::JavaClass.for_name('java_integration.fixtures.Reflector')).to_not be nil
+    # Java::JavaClass.for_name('java_integration.fixtures.Reflector') is now a :
+    # java.lang.Class.forName invocation
+    expect(JRuby.load_java_class('java_integration.fixtures.Reflector')).to_not be nil
   end
 
   it "should also accept Java string argument" do

--- a/test/DefaultPackageClass.java
+++ b/test/DefaultPackageClass.java
@@ -14,4 +14,7 @@ public class DefaultPackageClass {
         }
         return ((Comparable) o1).compareTo(o2);
     }
+
+    public static Class<?> returnLongClass() { return Long.class; }
+
 }

--- a/test/jruby/test_backtraces.rb
+++ b/test/jruby/test_backtraces.rb
@@ -15,19 +15,14 @@ class TestBacktraces < Test::Unit::TestCase
     assert_exception_backtrace(expectation, ex)
   end
 
-  import org.jruby.test.TestHelper
-
   def test_native_java_backtrace
-    # TestHelperException extends RuntimeException
-    TestHelper.throwTestHelperException
+    org.jruby.test.TestHelper.throwTestHelperException
     fail 'did no raise exception'
   rescue NativeException => ex
     assert_equal '#<NativeException: org.jruby.test.TestHelper$TestHelperException: null>', ex.inspect
     assert_equal 'org.jruby.test.TestHelper$TestHelperException: null', ex.message
     assert_not_nil ex.cause
     assert_instance_of org.jruby.test.TestHelper::TestHelperException, ex.cause
-
-    # ex.backtrace.each { |b| puts b.inspect }
 
     # starts with Java stack trace part :
     _throwTestHelperException = /org.jruby.test.TestHelper\.java:\d+:in `throwTestHelperException'/
@@ -51,7 +46,6 @@ class TestBacktraces < Test::Unit::TestCase
   end
 
   def test_native_java_backtrace2
-    # TestHelperException extends RuntimeException
     sample_class = java.lang.Class.for_name('org.jruby.javasupport.test.name.Sample')
     constructor = sample_class.constructor(Java::int)
     constructor.new_instance 0
@@ -69,13 +63,11 @@ class TestBacktraces < Test::Unit::TestCase
   end
 
   def test_java_backtrace
-    # TestHelperException extends RuntimeException
-    TestHelper.throwTestHelperException
+    org.jruby.test.TestHelper.throwTestHelperException
     fail 'did no raise exception'
   rescue java.lang.Exception => ex
+    # TestHelperException extends RuntimeException
     # assert_nil ex.message
-
-    # ex.backtrace.each { |b| puts b.inspect }
 
     _throwTestHelperException = /org.jruby.test.TestHelper.throwTestHelperException/
     assert_match _throwTestHelperException, ex.backtrace[0]

--- a/test/jruby/test_backtraces.rb
+++ b/test/jruby/test_backtraces.rb
@@ -52,7 +52,7 @@ class TestBacktraces < Test::Unit::TestCase
 
   def test_native_java_backtrace2
     # TestHelperException extends RuntimeException
-    sample_class = Java::JavaClass.for_name('org.jruby.javasupport.test.name.Sample')
+    sample_class = java.lang.Class.for_name('org.jruby.javasupport.test.name.Sample')
     constructor = sample_class.constructor(Java::int)
     constructor.new_instance 0
     begin

--- a/test/jruby/test_backtraces.rb
+++ b/test/jruby/test_backtraces.rb
@@ -53,9 +53,9 @@ class TestBacktraces < Test::Unit::TestCase
       constructor.new_instance(-1)
       fail 'did no raise exception'
     rescue NativeException => ex
-      assert_equal 'java.lang.IllegalStateException: param == -1', ex.message
-      assert_equal '#<NativeException: java.lang.IllegalStateException: param == -1>', ex.inspect
-      assert_instance_of java.lang.IllegalStateException, ex.cause
+      assert_equal 'java.lang.reflect.InvocationTargetException: param == -1', ex.message
+      assert_equal '#<NativeException: java.lang.reflect.InvocationTargetException: param == -1>', ex.inspect
+      assert_instance_of java.lang.reflect.InvocationTargetException, ex.cause
       # NOTE: backtrace will be messed in this case as long as there's filtering
       # clases org.jruby.javasupport.test.name.Sample "org.jruby.javasupport" prefix is considered internal
       # ex.backtrace.each { |b| puts "  #{b.inspect}" }

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -709,6 +709,16 @@ class TestHigherJavasupport < Test::Unit::TestCase
   def test_high_level_java_should_only_deal_with_proxies_and_not_low_level_java_class
     a = JString.new
     assert_equal Java::JavaLang::Class, a.getClass().class
+    assert Java::JavaLang::Class.equal? a.getClass().class
+    assert_equal java.lang.Class.object_id, Java::JavaLang::Class.object_id
+  end
+
+  def test_proxy_class_initialized_once
+    assert_equal java.lang.Class.object_id, Java::JavaLang::Class.object_id
+    assert_equal java.lang.String.object_id, Java::JavaLang::String.object_id
+    assert_equal Java::JavaIo::Serializable.object_id, java.io.Serializable.object_id
+    assert Java::JavaLang::Object.equal? java.lang.Object.new.class
+    assert Java::JavaLang::Object.equal? java.lang.Object
   end
 
   # We had a problem with accessing singleton class versus class earlier. Sanity check

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -680,17 +680,16 @@ class TestHigherJavasupport < Test::Unit::TestCase
   end
 
   def test_support_of_other_class_loaders
-    assert_helper_class = java.lang.Class.for_name("org.jruby.test.TestHelper")
-    assert_helper_class2 = java.lang.Class.forName("org.jruby.test.TestHelper")
-    assert(assert_helper_class.java_class == assert_helper_class2.java_class, "Successive calls return the same class")
-    method = assert_helper_class.java_method('loadAlternateClass')
-    alt_assert_helper_class = method.invoke_static()
+    loaded_class = JRuby::Util.load_java_class("org.jruby.test.AlternativelyLoaded")
+    assert_equal loaded_class, java.lang.Class.forName("org.jruby.test.AlternativelyLoaded")
+    method = loaded_class.java_method('loadAlternateClass')
+    alt_loaded_class = method.invoke_static() # loaded with a different class loader
+    assert_not_equal loaded_class, alt_loaded_class
 
-    constructor = alt_assert_helper_class.constructor();
-    alt_assert_helper = constructor.new_instance();
-    identityMethod = alt_assert_helper_class.java_method('identityTest')
-    identity = identityMethod.invoke(alt_assert_helper)
-    assert_equal("ABCDEFGH",  identity)
+    method = loaded_class.java_method('invokeIdentifyTest', java.lang.Class)
+    assert_equal"Original", method.invoke_static(loaded_class)
+
+    assert_equal"ABCDEFGH", method.invoke_static(alt_loaded_class)
   end
 
   module Foo

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -1006,10 +1006,10 @@ class TestHigherJavasupport < Test::Unit::TestCase
   #   Java::JavaProxyConstructor
   # end
 
-#  def test_java_class_equality
-#    long_class = java.lang.Long
-#    assert_equal long_class, Java::DefaultPackageClass.returnLongClass
-#  end
+  def test_java_class_equality
+    long_class = java.lang.Long.java_class
+    assert_equal long_class, Java::DefaultPackageClass.returnLongClass
+  end
 
   Properties = Java::java.util.Properties
 

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -9,7 +9,7 @@ end
 
 class TestHigherJavasupport < Test::Unit::TestCase
   include TestHelper
-  TestHelper = org.jruby.test.TestHelper
+
   JArray = ArrayList = java.util.ArrayList
   FinalMethodBaseTest = org.jruby.test.FinalMethodBaseTest
   Annotation = java.lang.annotation.Annotation
@@ -49,13 +49,13 @@ class TestHigherJavasupport < Test::Unit::TestCase
   def test_passing_a_java_class_auto_reifies
     assert_nil Klass2.to_java.getReifiedClass
     # previously TestHelper.getClassName(Klass2) returned 'org.jruby.RubyObject'
-    assert_equal 'rubyobj.TestHigherJavasupport.Klass2', TestHelper.getClassName(Klass2)
+    assert_equal 'rubyobj.TestHigherJavasupport.Klass2', org.jruby.test.TestHelper.getClassName(Klass2)
     assert_not_nil Klass2.to_java.getReifiedClass
     assert_not_nil Klass1.to_java.getReifiedClass
   end
 
   def test_java_passing_class
-    assert_equal("java.util.ArrayList", TestHelper.getClassName(ArrayList))
+    assert_equal("java.util.ArrayList", org.jruby.test.TestHelper.getClassName(ArrayList))
   end
 
   @@include_java_lang = Proc.new {
@@ -110,7 +110,7 @@ class TestHigherJavasupport < Test::Unit::TestCase
   end
 
   def test_dispatching_on_nil
-    sb = TestHelper.getInterfacedInstance()
+    sb = org.jruby.test.TestHelper.getInterfacedInstance()
     assert_equal(nil, sb.dispatchObject(nil))
   end
 

--- a/test/jruby/test_loading_builtin_libraries.rb
+++ b/test/jruby/test_loading_builtin_libraries.rb
@@ -41,16 +41,24 @@ class TestLoadingBuiltinLibraries < Test::Unit::TestCase
     pend "TODO: JRuby (still) self-reflects on Windows" if TestHelper::WINDOWS
 
     code  = "all = []; ObjectSpace.each_object(Module) { |mod| all << mod }; "
-    code += "p all.count { |m| m.is_a?(Java::JavaPackage) }; " # <= 3
+    code += "packages = all.select { |m| m.is_a?(Java::JavaPackage) }; "
+    code += "p packages.size; packages.each { |m| p m }; "
+    # TODO due ENV_JAVA we (still) load 3 Java packages
     # org.jruby.java.util (SystemPropertiesMap) and dependencies :
     # java.util (Map) implemented interface
     # java.lang (Object) super-class
-    code += "all.each { |m| m.inspect }; " # if self-reflecting this would fail (on RubyBasicObject.UNDEF)
+    # TODO since 9.3 also java.lang.Class and dependencies :
+    # java.lang.reflect (interfaces)
+    # java.io (Class implements java.io.Serializable)
+    #code += "all.select { |m| m.inspect.start_with? \"Java::\" }.each { |m| puts m.inspect };"
+    # self-reflecting this would fail (on RubyBasicObject.UNDEF)
+
+    expected_count = 5
 
     out = `#{RbConfig.ruby} -e '#{code}'`
     assert $?.success?, "JRuby self-reflected (JI) during boot!"
     pkg_count = out.strip.to_i
-    assert pkg_count <= 3 # due ENV_JAVA we (still) load 3 Java packages - see ^^^
+    assert pkg_count <= expected_count, "expected less than #{expected_count} packages but loaded: #{out}"
 
     requires = [ 'stringio',
                  'rbconfig',
@@ -91,9 +99,9 @@ class TestLoadingBuiltinLibraries < Test::Unit::TestCase
                  'yaml',
     ]
     requires = requires.map { |lib| "-r#{lib}" }.join(' ')
-    out = `#{RbConfig.ruby} #{requires} -e '#{code}'`
+    lib_out = `#{RbConfig.ruby} #{requires} -e '#{code}'`
     assert $?.success?, "a library self-reflected (JI) during boot!"
-    assert_equal pkg_count.to_s, out.strip
+    assert_equal out, lib_out
   end if defined? JRUBY_VERSION
 
 end

--- a/test/jruby/test_loading_builtin_libraries.rb
+++ b/test/jruby/test_loading_builtin_libraries.rb
@@ -101,7 +101,14 @@ class TestLoadingBuiltinLibraries < Test::Unit::TestCase
     requires = requires.map { |lib| "-r#{lib}" }.join(' ')
     lib_out = `#{RbConfig.ruby} #{requires} -e '#{code}'`
     assert $?.success?, "a library self-reflected (JI) during boot!"
-    assert_equal out, lib_out
+    assert_same_output_lines out, lib_out
   end if defined? JRUBY_VERSION
+
+  private
+
+  def assert_same_output_lines(expected, actual)
+    p expected.split("\n").sort
+    assert_equal expected.split("\n").sort, actual.split("\n").sort
+  end
 
 end

--- a/test/jruby/test_loading_builtin_libraries.rb
+++ b/test/jruby/test_loading_builtin_libraries.rb
@@ -53,7 +53,7 @@ class TestLoadingBuiltinLibraries < Test::Unit::TestCase
     #code += "all.select { |m| m.inspect.start_with? \"Java::\" }.each { |m| puts m.inspect };"
     # self-reflecting this would fail (on RubyBasicObject.UNDEF)
 
-    expected_count = 5
+    expected_count = 7 # 5 on JDK 11 TODO on Java 14 loads 2 more (Java::JavaLangInvoke, Java::JavaLangConstant)
 
     out = `#{RbConfig.ruby} -e '#{code}'`
     assert $?.success?, "JRuby self-reflected (JI) during boot!"

--- a/test/org/jruby/test/AlternateLoader.java
+++ b/test/org/jruby/test/AlternateLoader.java
@@ -1,0 +1,96 @@
+/*
+ **** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2004 David Corbin <dcorbin@users.sourceforge.net>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.test;
+
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.ByteArrayOutputStream;
+
+class AlternateLoader extends ClassLoader {
+
+    protected Class findModClass(String name) throws ClassNotFoundException {
+        byte[] classBytes = loadClassBytes(name);
+        replace(classBytes, "Original", "ABCDEFGH");
+        return defineClass(name, classBytes, 0, classBytes.length);
+    }
+    private void replace(byte[] classBytes, String find, String replaceWith) {
+        byte[] findBytes = find.getBytes();
+        byte[] replaceBytes = replaceWith.getBytes();
+        for (int i=0; i<classBytes.length; i++) {
+            boolean match = true;
+            for (int j=0; j<findBytes.length; j++) {
+                if (classBytes[i+j] != findBytes[j]) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) {
+                for (int j=0; j<findBytes.length; j++)
+                    classBytes[i+j] = replaceBytes[j];
+                return;
+            }
+        }
+    }
+    @Override
+    public Class loadClass(String name) throws ClassNotFoundException {
+        if (name.equals("org.jruby.test.AlternativelyLoaded"))
+            return findModClass(name);
+
+        return super.loadClass(name);
+    }
+    private byte[] loadClassBytes(String name) throws ClassNotFoundException {
+        InputStream stream = null;
+        try {
+            String fileName = name.replaceAll("\\.", "/");
+            fileName += ".class";
+            byte[] buf = new byte[1024];
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            int bytesRead = 0;
+            stream = getClass().getResourceAsStream("/" + fileName);
+            while ((bytesRead = stream.read(buf)) != -1) {
+                bytes.write(buf, 0, bytesRead);
+            }
+            return bytes.toByteArray();
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new ClassNotFoundException(e.getMessage(),e);
+        } finally {
+            if (stream != null)
+                try {
+                    stream.close();
+                } catch (IOException e1) {
+                    e1.printStackTrace();
+                }
+        }
+    }
+}

--- a/test/org/jruby/test/AlternativelyLoaded.java
+++ b/test/org/jruby/test/AlternativelyLoaded.java
@@ -1,0 +1,55 @@
+/*
+ **** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2002 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2004 David Corbin <dcorbin@users.sourceforge.net>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.test;
+
+import java.lang.reflect.Method;
+
+public class AlternativelyLoaded {
+
+    public String identityTest() {
+        return "Original";
+    }
+
+    public static Class loadAlternateClass() throws ClassNotFoundException {
+        AlternateLoader loader = new AlternateLoader();
+        Class klass = loader.loadClass("org.jruby.test.AlternativelyLoaded");
+        return klass;
+    }
+
+    public static Object invokeIdentifyTest(Class<?> klass) throws Exception {
+        Method method = klass.getMethod("identityTest");
+        Object instance = klass.newInstance();
+        return method.invoke(instance);
+    }
+
+}

--- a/test/org/jruby/test/TestHelper.java
+++ b/test/org/jruby/test/TestHelper.java
@@ -122,13 +122,6 @@ public class TestHelper {
         }
     }
 
-
-    public static Class loadAlternateClass() throws ClassNotFoundException {
-        AlternateLoader loader = new AlternateLoader();
-        Class klass = loader.loadClass("org.jruby.test.TestHelper");
-        return klass;
-    }
-
     /**
      * Used by JVM bytecode compiler tests to run compiled code
      */
@@ -173,63 +166,6 @@ public class TestHelper {
             return cl;
         }
 
-    }
-    private static class AlternateLoader extends ClassLoader {
-
-        protected Class findModClass(String name) throws ClassNotFoundException {
-           byte[] classBytes = loadClassBytes(name);
-           replace(classBytes, "Original", "ABCDEFGH");
-           return defineClass(name, classBytes, 0, classBytes.length);
-        }
-        private void replace(byte[] classBytes, String find, String replaceWith) {
-            byte[] findBytes = find.getBytes();
-            byte[] replaceBytes = replaceWith.getBytes();
-            for (int i=0; i<classBytes.length; i++) {
-                boolean match = true;
-                for (int j=0; j<findBytes.length; j++) {
-                    if (classBytes[i+j] != findBytes[j]) {
-                        match = false;
-                        break;
-                    }
-                }
-                if (match) {
-                    for (int j=0; j<findBytes.length; j++)
-                        classBytes[i+j] = replaceBytes[j];
-                    return;
-                }
-            }
-        }
-        @Override
-        public Class loadClass(String name) throws ClassNotFoundException {
-            if (name.equals("org.jruby.test.TestHelper"))
-                return findModClass(name);
-            return super.loadClass(name);
-        }
-        private byte[] loadClassBytes(String name) throws ClassNotFoundException {
-            InputStream stream = null;
-            try {
-                String fileName = name.replaceAll("\\.", "/");
-                fileName += ".class";
-                byte[] buf = new byte[1024];
-                ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-                int bytesRead = 0;
-                stream = getClass().getResourceAsStream("/" + fileName);
-                while ((bytesRead = stream.read(buf)) != -1) {
-                    bytes.write(buf, 0, bytesRead);
-                }
-                return bytes.toByteArray();
-            } catch (Exception e) {
-                e.printStackTrace();
-                throw new ClassNotFoundException(e.getMessage(),e);
-            } finally {
-                if (stream != null)
-                    try {
-                        stream.close();
-                    } catch (IOException e1) {
-                        e1.printStackTrace();
-                    }
-            }
-        }
     }
 
     private static class TestHelperException extends RuntimeException {


### PR DESCRIPTION
JRuby's Java integration has been using a custom `JavaClass` ruby class to represent a `java.lang.Class` instance.
However this isn't super easy to work with (personally I have always find it quite confusing given the existing complexity of proxy modules/classes) nor has been 100% consistent e.g. `obj.java_class` depending on the proxy type (interface impl, Java sub-class in Ruby) might have returned a proxy instead of the `JavaClass` instance (returned from `java.lang.String.java_class`).

The proposal here is to start returning `java.lang.Class` instance Java proxy wrappers everywhere (all `java_class` calls), for compatibility all of the custom `JavaClass` Ruby API is supported on `java.lang.Class` and others (there's  `JavaField`, `JavaConstructor` instances `JavaClass` methods where returning which will be 'emulated' using `java.lang.reflect.Field`, `java.lang.reflect.Constructor`).