### PR TITLE
Make Pathname#inspect behave like other Ruby implementations (fixes #6519)

### DIFF
--- a/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
+++ b/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
@@ -298,7 +298,7 @@ public class RubyPathname extends RubyObject {
 
     @JRubyMethod
     public IRubyObject inspect(ThreadContext context) {
-        return context.runtime.newString("<Pathname:" + getPath() + ">");
+        return context.runtime.newString("#<Pathname:" + getPath() + ">");
     }
 
     @JRubyMethod(required = 1, optional = 1, reads = BACKREF, writes = BACKREF)


### PR DESCRIPTION
Opening a PR to verify if the tests pass via CI, because I haven't been quickly able to run the tests locally.

I also wonder if I need to "sync" the Ruby specs (see #6519 and https://github.com/ruby/spec/pull/822), or add something in the test suite for this.