### PR TITLE
Fix interrupt handling in synchronize

### DIFF
--- a/lib/ruby/stdlib/monitor.rb
+++ b/lib/ruby/stdlib/monitor.rb
@@ -230,11 +230,15 @@ module MonitorMixin
   def mon_synchronize
     # Prevent interrupt on handling interrupts; for example timeout errors
     # it may break locking state.
-    Thread.handle_interrupt(Exception => :never){ mon_enter }
-    begin
-      yield
-    ensure
-      Thread.handle_interrupt(EXCEPTION_NEVER){ mon_exit }
+    Thread.handle_interrupt(EXCEPTION_NEVER) do
+      mon_enter
+      begin
+        Thread.handle_interrupt(EXCEPTION_IMMEDIATE) do
+          yield
+        end
+      ensure
+        mon_exit
+      end
     end
   end
   alias synchronize mon_synchronize


### PR DESCRIPTION
The logic in MonitorMixin#mon_synchronize is broken as described
in ruby/monitor#2 due to the improper use of handle_interrupt.
This patch fixes the issue by ensuring the entire body of the
method is protected from interrupts except for the yield to the
incoming block. This avoids the ensure being interrupted, leaving
the monitor locked.

Fixes #6526