### PR TITLE
Move Monitor to native

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -58,6 +58,7 @@ import org.jruby.exceptions.SystemExit;
 import org.jruby.ext.jruby.JRubyUtilLibrary;
 import org.jruby.ext.thread.ConditionVariable;
 import org.jruby.ext.thread.Mutex;
+import org.jruby.ext.thread.Queue;
 import org.jruby.ext.thread.SizedQueue;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.IRScriptBody;
@@ -478,10 +479,13 @@ public final class Ruby implements Constantizable {
 
         // Initialize exceptions
         initExceptions();
-        Mutex.setup(this);
-        ConditionVariable.setup(this);
-        org.jruby.ext.thread.Queue.setup(this);
-        SizedQueue.setup(this);
+
+        // Thread library utilities
+        mutexClass = Mutex.setup(threadClass, objectClass);
+        conditionVariableClass = ConditionVariable.setup(threadClass, objectClass);
+        queueClass = Queue.setup(threadClass, objectClass);
+        closedQueueError = Queue.setupError(queueClass, stopIteration, objectClass);
+        sizedQueueClass = SizedQueue.setup(threadClass, queueClass, objectClass);
 
         fiberClass = new ThreadFiberLibrary().createFiberClass(this);
 
@@ -2224,6 +2228,26 @@ public final class Ruby implements Constantizable {
 
     public void setLocation(RubyClass location) {
         this.locationClass = location;
+    }
+
+    public RubyClass getMutex() {
+        return mutexClass;
+    }
+
+    public RubyClass getConditionVariable() {
+        return conditionVariableClass;
+    }
+
+    public RubyClass getQueue() {
+        return queueClass;
+    }
+
+    public RubyClass getClosedQueueError() {
+        return closedQueueError;
+    }
+
+    public RubyClass getSizedQueueClass() {
+        return sizedQueueClass;
     }
 
     public RubyModule getWarning() {
@@ -5327,6 +5351,11 @@ public final class Ruby implements Constantizable {
     private final RubyClass dummyClass;
     private final RubyClass randomClass;
     private final RubyClass dataClass;
+    private final RubyClass mutexClass;
+    private final RubyClass conditionVariableClass;
+    private final RubyClass queueClass;
+    private final RubyClass closedQueueError;
+    private final RubyClass sizedQueueClass;
 
     private RubyClass tmsStruct;
     private RubyClass passwdStruct;

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -2298,7 +2298,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         synchronized (recv) {
             mutex = (Mutex) recv.getConstantNoConstMissing(MUTEX_FOR_THREAD_EXCLUSIVE, false, false);
             if (mutex == null) {
-                mutex = Mutex.newInstance(context, context.runtime.getThread().getClass("Mutex"), NULL_ARRAY, Block.NULL_BLOCK);
+                mutex = Mutex.newInstance(context, context.runtime.getMutex(), NULL_ARRAY, Block.NULL_BLOCK);
                 recv.setConstant(MUTEX_FOR_THREAD_EXCLUSIVE, mutex, true);
             }
             return mutex;

--- a/core/src/main/java/org/jruby/ext/monitor/Monitor.java
+++ b/core/src/main/java/org/jruby/ext/monitor/Monitor.java
@@ -1,0 +1,141 @@
+package org.jruby.ext.monitor;
+
+import org.jruby.Ruby;
+import org.jruby.RubyBoolean;
+import org.jruby.RubyClass;
+import org.jruby.RubyObject;
+import org.jruby.RubyThread;
+import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.ext.thread.Mutex;
+import org.jruby.runtime.Block;
+import org.jruby.runtime.JavaSites;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+@JRubyClass(name = "Monitor")
+public class Monitor extends RubyObject {
+    private final Mutex mutex;
+    private volatile RubyThread owner;
+    private volatile long count;
+
+    public Monitor(Ruby runtime, RubyClass klass) {
+        super(runtime, klass);
+
+        mutex = new Mutex(runtime, runtime.getMutex());
+    }
+
+    public static void createMonitorClass(Ruby runtime) {
+        RubyClass cMonitor = runtime.defineClass("Monitor", runtime.getObject(), Monitor::new);
+
+        cMonitor.defineAnnotatedMethods(Monitor.class);
+    }
+
+    @JRubyMethod
+    public RubyBoolean try_enter(ThreadContext context) {
+        if (!ownedByCurrentThread(context)) {
+            if (!mutex.tryLock(context)) {
+                return context.fals;
+            }
+            owner = context.getThread();
+            count = 0;
+        }
+
+        count++;
+
+        return context.tru;
+    }
+
+    @JRubyMethod
+    public IRubyObject enter(ThreadContext context) {
+        if (!ownedByCurrentThread(context)) {
+            mutex.lock(context);
+            owner = context.getThread();
+            count = 0;
+        }
+
+        count++;
+
+        return context.nil;
+    }
+
+    @JRubyMethod
+    public IRubyObject exit(ThreadContext context) {
+        mon_check_owner(context);
+
+        if (count <= 0) throw context.runtime.newRuntimeError("monitor_exit: count:" + count + "\n");
+
+        count--;
+
+        if (count == 0) {
+            owner = null;
+            mutex.unlock(context);
+        }
+
+        return context.nil;
+    }
+
+    @JRubyMethod
+    public IRubyObject synchronize(ThreadContext context, Block block) {
+        enter(context);
+        try {
+            return block.yieldSpecific(context);
+        } finally {
+            exit(context);
+        }
+    }
+
+    @JRubyMethod(name = "mon_locked?")
+    public IRubyObject mon_locked_p(ThreadContext context) {
+        return mutex.locked_p(context);
+    }
+
+    @JRubyMethod
+    public IRubyObject mon_check_owner(ThreadContext context) {
+        checkOwner(context);
+
+        return context.nil;
+    }
+
+    @JRubyMethod(name = "mon_owned?")
+    public RubyBoolean mon_owned_p(ThreadContext context) {
+        return RubyBoolean.newBoolean(context, ownedByCurrentThread(context));
+    }
+
+    @JRubyMethod
+    public IRubyObject wait_for_cond(ThreadContext context, IRubyObject cond, IRubyObject timeout) {
+        long count = exitForCondition();
+
+        try {
+            sites(context).wait.call(context, cond, cond, mutex, timeout);
+
+            return context.tru;
+        } finally {
+            this.owner = context.getThread();
+            this.count = count;
+        }
+    }
+
+    private boolean ownedByCurrentThread(ThreadContext context) {
+        return owner == context.getThread();
+    }
+
+    private void checkOwner(ThreadContext context) {
+        if (!ownedByCurrentThread(context)) {
+            throw context.runtime.newThreadError("current thread not owner");
+        }
+    }
+
+    private long exitForCondition() {
+        long cnt = count;
+
+        owner = null;
+        count = 0;
+
+        return cnt;
+    }
+
+    private static JavaSites.MonitorSites sites(ThreadContext context) {
+        return context.sites.Monitor;
+    }
+}

--- a/core/src/main/java/org/jruby/ext/monitor/MonitorLibrary.java
+++ b/core/src/main/java/org/jruby/ext/monitor/MonitorLibrary.java
@@ -1,0 +1,47 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2016 Karol Bucek
+ * 
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby.ext.monitor;
+
+import org.jruby.Ruby;
+import org.jruby.ext.set.EnumerableExt;
+import org.jruby.ext.set.RubySet;
+import org.jruby.ext.set.RubySortedSet;
+import org.jruby.runtime.load.Library;
+
+public final class MonitorLibrary implements Library {
+
+    public void load(Ruby runtime, boolean wrap) {
+        MonitorLibrary.load(runtime);
+    }
+
+    public static void load(Ruby runtime) {
+        Monitor.createMonitorClass(runtime);
+    }
+
+}

--- a/core/src/main/java/org/jruby/ext/thread/ConditionVariable.java
+++ b/core/src/main/java/org/jruby/ext/thread/ConditionVariable.java
@@ -60,20 +60,20 @@ public class ConditionVariable extends RubyObject {
         super(runtime, type);
     }
 
-    public static void setup(Ruby runtime) {
+    public static RubyClass setup(RubyClass threadClass, RubyClass objectClass) {
         RubyClass cConditionVariable =
-                runtime.getThread().defineClassUnder(
+                threadClass.defineClassUnder(
                         "ConditionVariable",
-                        runtime.getObject(),
-                        (r, klass) -> new ConditionVariable(r, klass));
+                        objectClass,
+                        ConditionVariable::new);
 
         cConditionVariable.undefineMethod("initialize_copy");
-
         cConditionVariable.setReifiedClass(ConditionVariable.class);
-
         cConditionVariable.defineAnnotatedMethods(ConditionVariable.class);
 
-        runtime.getObject().setConstant("ConditionVariable", cConditionVariable);
+        objectClass.setConstant("ConditionVariable", cConditionVariable);
+
+        return cConditionVariable;
     }
 
     @JRubyMethod(name = "wait")

--- a/core/src/main/java/org/jruby/ext/thread/Mutex.java
+++ b/core/src/main/java/org/jruby/ext/thread/Mutex.java
@@ -62,16 +62,15 @@ public class Mutex extends RubyObject implements DataType {
         super(runtime, type);
     }
 
-    public static void setup(Ruby runtime) {
-        RubyClass cMutex = runtime.getThread().defineClassUnder("Mutex", runtime.getObject(), new ObjectAllocator() {
+    public static RubyClass setup(RubyClass threadClass, RubyClass objectClass) {
+        RubyClass cMutex = threadClass.defineClassUnder("Mutex", objectClass, Mutex::new);
 
-            public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-                return new Mutex(runtime, klass);
-            }
-        });
         cMutex.setReifiedClass(Mutex.class);
         cMutex.defineAnnotatedMethods(Mutex.class);
-        runtime.getObject().setConstant("Mutex", cMutex);
+
+        objectClass.setConstant("Mutex", cMutex);
+
+        return cMutex;
     }
 
     @JRubyMethod(name = "locked?")

--- a/core/src/main/java/org/jruby/ext/thread/Mutex.java
+++ b/core/src/main/java/org/jruby/ext/thread/Mutex.java
@@ -75,15 +75,23 @@ public class Mutex extends RubyObject implements DataType {
 
     @JRubyMethod(name = "locked?")
     public RubyBoolean locked_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, lock.isLocked());
+        return RubyBoolean.newBoolean(context, isLocked());
+    }
+
+    public boolean isLocked() {
+        return lock.isLocked();
     }
 
     @JRubyMethod
     public RubyBoolean try_lock(ThreadContext context) {
+        return RubyBoolean.newBoolean(context, tryLock(context));
+    }
+
+    public boolean tryLock(ThreadContext context) {
         if (lock.isHeldByCurrentThread()) {
-            return context.fals;
+            return false;
         }
-        return RubyBoolean.newBoolean(context, context.getThread().tryLock(lock));
+        return context.getThread().tryLock(lock);
     }
 
     @JRubyMethod
@@ -110,7 +118,7 @@ public class Mutex extends RubyObject implements DataType {
 
     @JRubyMethod
     public IRubyObject unlock(ThreadContext context) {
-        if (!lock.isLocked()) {
+        if (!isLocked()) {
             throw context.runtime.newThreadError("Mutex is not locked");
         }
         if (!lock.isHeldByCurrentThread()) {

--- a/core/src/main/java/org/jruby/ext/thread/SizedQueue.java
+++ b/core/src/main/java/org/jruby/ext/thread/SizedQueue.java
@@ -60,16 +60,15 @@ public class SizedQueue extends Queue {
         initialize(runtime.getCurrentContext(), runtime.newFixnum(max));
     }
 
-    public static void setup(Ruby runtime) {
-        RubyClass cSizedQueue = runtime.getThread().defineClassUnder("SizedQueue", runtime.getClass("Queue"), new ObjectAllocator() {
+    public static RubyClass setup(RubyClass threadClass, RubyClass queueClass, RubyClass objectClass) {
+        RubyClass cSizedQueue = threadClass.defineClassUnder("SizedQueue", queueClass, SizedQueue::new);
 
-            public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-                return new SizedQueue(runtime, klass);
-            }
-        });
         cSizedQueue.setReifiedClass(SizedQueue.class);
         cSizedQueue.defineAnnotatedMethods(SizedQueue.class);
-        runtime.getObject().setConstant("SizedQueue", cSizedQueue);
+
+        objectClass.setConstant("SizedQueue", cSizedQueue);
+
+        return cSizedQueue;
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/runtime/JavaSites.java
+++ b/core/src/main/java/org/jruby/runtime/JavaSites.java
@@ -49,6 +49,7 @@ public class JavaSites {
     public final RaiseExceptionSites RaiseException = new RaiseExceptionSites();
     public final ConditionVariableSites ConditionVariable = new ConditionVariableSites();
     public final FiberSites Fiber = new FiberSites();
+    public final MonitorSites Monitor = new MonitorSites();
 
     public static class BasicObjectSites {
         public final CallSite respond_to = new FunctionalCachingCallSite("respond_to?");
@@ -508,6 +509,10 @@ public class JavaSites {
         public final CachingCallSite peek = new FunctionalCachingCallSite("peek");
         public final CachingCallSite next = new FunctionalCachingCallSite("next");
         public final CallSite each = new FunctionalCachingCallSite("each");
+    }
+
+    public static class MonitorSites {
+        public final CachingCallSite wait = new FunctionalCachingCallSite("wait");
     }
 
     public static class CheckedSites {

--- a/lib/ruby/stdlib/monitor.rb
+++ b/lib/ruby/stdlib/monitor.rb
@@ -17,7 +17,7 @@
 # structure.
 #
 # You can read more about the general principles on the Wikipedia page for
-# Monitors[http://en.wikipedia.org/wiki/Monitor_%28synchronization%29]
+# Monitors[https://en.wikipedia.org/wiki/Monitor_%28synchronization%29]
 #
 # == Examples
 #
@@ -86,10 +86,15 @@
 # This Class is implemented as subclass of Array which includes the
 # MonitorMixin module.
 #
-module MonitorMixin
-  EXCEPTION_NEVER = {Exception => :never}.freeze
-  EXCEPTION_IMMEDIATE = {Exception => :immediate}.freeze
 
+case RUBY_ENGINE
+when 'jruby'
+  JRuby::Util.load_ext("org.jruby.ext.monitor.MonitorLibrary")
+else
+  require 'monitor.so'
+end
+
+module MonitorMixin
   #
   # FIXME: This isn't documented in Nutshell.
   #
@@ -97,8 +102,6 @@ module MonitorMixin
   # above calls while_wait and signal, this class should be documented.
   #
   class ConditionVariable
-    class Timeout < Exception; end
-
     #
     # Releases the lock held in the associated monitor and waits; reacquires the lock on wakeup.
     #
@@ -106,18 +109,8 @@ module MonitorMixin
     # even if no other thread doesn't signal.
     #
     def wait(timeout = nil)
-      Thread.handle_interrupt(EXCEPTION_NEVER) do
-        @monitor.__send__(:mon_check_owner)
-        count = @monitor.__send__(:mon_exit_for_cond)
-        begin
-          Thread.handle_interrupt(EXCEPTION_IMMEDIATE) do
-            @cond.wait(@monitor.instance_variable_get(:@mon_mutex), timeout)
-          end
-          return true
-        ensure
-          @monitor.__send__(:mon_enter_for_cond, count)
-        end
-      end
+      @monitor.mon_check_owner
+      @monitor.wait_for_cond(@cond, timeout)
     end
 
     #
@@ -142,7 +135,7 @@ module MonitorMixin
     # Wakes up the first thread in line waiting for this lock.
     #
     def signal
-      @monitor.__send__(:mon_check_owner)
+      @monitor.mon_check_owner
       @cond.signal
     end
 
@@ -150,7 +143,7 @@ module MonitorMixin
     # Wakes up all threads waiting for this lock.
     #
     def broadcast
-      @monitor.__send__(:mon_check_owner)
+      @monitor.mon_check_owner
       @cond.broadcast
     end
 
@@ -171,15 +164,7 @@ module MonitorMixin
   # Attempts to enter exclusive section.  Returns +false+ if lock fails.
   #
   def mon_try_enter
-    if @mon_owner != Thread.current
-      unless @mon_mutex.try_lock
-        return false
-      end
-      @mon_owner = Thread.current
-      @mon_count = 0
-    end
-    @mon_count += 1
-    return true
+    @mon_data.try_enter
   end
   # For backward compatibility
   alias try_mon_enter mon_try_enter
@@ -188,12 +173,7 @@ module MonitorMixin
   # Enters exclusive section.
   #
   def mon_enter
-    if @mon_owner != Thread.current
-      @mon_mutex.lock
-      @mon_owner = Thread.current
-      @mon_count = 0
-    end
-    @mon_count += 1
+    @mon_data.enter
   end
 
   #
@@ -201,25 +181,21 @@ module MonitorMixin
   #
   def mon_exit
     mon_check_owner
-    @mon_count -=1
-    if @mon_count == 0
-      @mon_owner = nil
-      @mon_mutex.unlock
-    end
+    @mon_data.exit
   end
 
   #
   # Returns true if this monitor is locked by any thread
   #
   def mon_locked?
-    @mon_mutex.locked?
+    @mon_data.mon_locked?
   end
 
   #
   # Returns true if this monitor is locked by current thread.
   #
   def mon_owned?
-    @mon_mutex.locked? && @mon_owner == Thread.current
+    @mon_data.mon_owned?
   end
 
   #
@@ -227,28 +203,21 @@ module MonitorMixin
   # section automatically when the block exits.  See example under
   # +MonitorMixin+.
   #
-  def mon_synchronize
-    # Prevent interrupt on handling interrupts; for example timeout errors
-    # it may break locking state.
-    Thread.handle_interrupt(EXCEPTION_NEVER) do
-      mon_enter
-      begin
-        Thread.handle_interrupt(EXCEPTION_IMMEDIATE) do
-          yield
-        end
-      ensure
-        mon_exit
-      end
-    end
+  def mon_synchronize(&b)
+    @mon_data.synchronize(&b)
   end
   alias synchronize mon_synchronize
 
   #
   # Creates a new MonitorMixin::ConditionVariable associated with the
-  # receiver.
+  # Monitor object.
   #
   def new_cond
-    return ConditionVariable.new(self)
+    unless defined?(@mon_data)
+      mon_initialize
+      @mon_initialized_by_new_cond = true
+    end
+    return ConditionVariable.new(@mon_data)
   end
 
   private
@@ -256,7 +225,7 @@ module MonitorMixin
   # Use <tt>extend MonitorMixin</tt> or <tt>include MonitorMixin</tt> instead
   # of this constructor.  Have look at the examples above to understand how to
   # use this module.
-  def initialize(*args)
+  def initialize(*)
     super
     mon_initialize
   end
@@ -264,31 +233,19 @@ module MonitorMixin
   # Initializes the MonitorMixin after being included in a class or when an
   # object has been extended with the MonitorMixin
   def mon_initialize
-    if defined?(@mon_mutex) && @mon_mutex_owner_object_id == object_id
-      raise ThreadError, "already initialized"
+    if defined?(@mon_data)
+      if defined?(@mon_initialized_by_new_cond)
+        return # already initialized.
+      elsif @mon_data_owner_object_id == self.object_id
+        raise ThreadError, "already initialized"
+      end
     end
-    @mon_mutex = Thread::Mutex.new
-    @mon_mutex_owner_object_id = object_id
-    @mon_owner = nil
-    @mon_count = 0
+    @mon_data = ::Monitor.new
+    @mon_data_owner_object_id = self.object_id
   end
 
   def mon_check_owner
-    if @mon_owner != Thread.current
-      raise ThreadError, "current thread not owner"
-    end
-  end
-
-  def mon_enter_for_cond(count)
-    @mon_owner = Thread.current
-    @mon_count = count
-  end
-
-  def mon_exit_for_cond
-    count = @mon_count
-    @mon_owner = nil
-    @mon_count = 0
-    return count
+    @mon_data.mon_check_owner
   end
 end
 
@@ -303,12 +260,17 @@ end
 #   end
 #
 class Monitor
-  include MonitorMixin
-  alias try_enter try_mon_enter
-  alias enter mon_enter
-  alias exit mon_exit
-end
+  def new_cond
+    ::MonitorMixin::ConditionVariable.new(self)
+  end
 
+  # for compatibility
+  alias try_mon_enter try_enter
+  alias mon_try_enter try_enter
+  alias mon_enter enter
+  alias mon_exit exit
+  alias mon_synchronize synchronize
+end
 
 # Documentation comments:
 #  - All documentation comes from Nutshell.
@@ -325,8 +287,3 @@ end
 #    directly in the RDoc output.
 #  - in short, it may be worth changing the code layout in this file to make the
 #    documentation easier
-
-# Local variables:
-# mode: Ruby
-# tab-width: 8
-# End:


### PR DESCRIPTION
See https://github.com/ruby/ruby/pull/2576 which did the same for CRuby 2.7.

This eliminates the need for the monitor.rb fixes in #6527 and ruby/monitor#2, plus synchronize will perform significantly better than the nested block implementation.

This may be safe to include in 9.3 even though the compatibility level is 2.6.