### PR TITLE
Work around EPERM fstat error for inotify under WSL

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -916,11 +916,9 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
                 }
             }
         } else {
-            ChannelFD descriptor = runtime.getFilenoUtil().getWrapperFromFileno(fileno);
+            fd = runtime.getFilenoUtil().getWrapperFromFileno(fileno);
 
-            if (descriptor == null) throw runtime.newErrnoEBADFError();
-
-            fd = descriptor;
+            if (fd == null) throw runtime.newErrnoEBADFError();
         }
 
         if (!fd.ch.isOpen()) {

--- a/core/src/main/java/org/jruby/util/io/ChannelFD.java
+++ b/core/src/main/java/org/jruby/util/io/ChannelFD.java
@@ -171,8 +171,15 @@ public class ChannelFD implements Closeable {
 
         if (chNative != null) {
             // we have an ENXIO channel, but need to know if it's a regular file to skip selection
-            FileStat stat = posix.fstat(chNative.getFD());
-            if (stat.isFile()) {
+            boolean isFile = false;
+            try {
+                isFile = posix.fstat(chNative.getFD()).isFile();
+            } catch (Exception e) {
+                // If fstat doesn't work, it is unlikely to be a normal file.
+                // See GH-6129, inotify fd raises EPERM when calling fstat under WSL
+            }
+
+            if (isFile) {
                 chSelect = null;
                 isNativeFile = true;
             }


### PR DESCRIPTION
The `fstat` system call raises EPERM when run against an inotify file descriptor under Windows Subsystem for Linux, as reported in #6129.

Rails uses inotify support via rb-inotify, which recently started using `IO.new` to wrap the inotify file descriptor. Our logic for `IO.new` tries to use `fstat` in two places, which causes rb-inotify to fail.

There are updates to WSL that purport to improve inotify support, but I have been unable to find a rig that works properly.

This PR makes the following changes in an attempt to deal with the issue:

* When checking for fd liveness in FilenoUtil, we prefer `fcntl` except on Windows (which only has `fstat`). This means we use `fcntl` under WSL, avoiding the EPERM.
* Ignore any exception raised when using `fstat` to determine the file type, which we do to skip using selection logic against normal files. The logic I added assumes if we can't `fstat` it is probably not a normal file.

The second fix is mildly hacky but our fstat there was already hacky.

This allows the reduced script from #6129 to run properly and may fix #6129 sufficiently well.