### PR TITLE
[test] spawn+detach raising (previous) posix error

### DIFF
--- a/core/src/test/java/org/jruby/test/TestProcessSpawn.java
+++ b/core/src/test/java/org/jruby/test/TestProcessSpawn.java
@@ -1,0 +1,20 @@
+package org.jruby.test;
+
+import org.jruby.RubyArray;
+import org.jruby.exceptions.RaiseException;
+
+public class TestProcessSpawn extends TestRubyBase {
+
+    public void testSpawnAndDetach() throws RaiseException {
+        runtime.evalScriptlet("require 'open3'; require 'jruby'");
+        Object result = runtime.evalScriptlet("Kernel.spawn('non-existent-cmd') rescue nil");
+        int errno = runtime.getPosix().errno();
+        assertTrue("expected > 0 got: " + errno, errno > 0);
+        String cmd = "echo foo";
+        // should not raise ENOENT: No such file or directory
+        result = runtime.evalScriptlet("out_err, status = Open3.capture2e('" + cmd + "'); [out_err, status.to_i]");
+        // ["foo\n", #<Process::Status: pid 3839850 exit 0>]
+        assertEquals(0, ((Number) ((RubyArray) result).get(1)).intValue());
+    }
+
+}


### PR DESCRIPTION
test-case similar to the behavior on #6477 except it would constantly raise `ENOENT` (before the #6489 fix)

*NOTE: seen this at Logstash's https://github.com/elastic/logstash/pull/12519, interestingly a test run would only fail when using the gradle test worker but not from a cli `jruby -S rspec` (which I haven't figured out why)*
