### PR TITLE
Improve tagged pointer emulation

### DIFF
--- a/core/src/main/java/org/jruby/RubyFixnum.java
+++ b/core/src/main/java/org/jruby/RubyFixnum.java
@@ -155,7 +155,23 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
 
     @Override
     public IRubyObject equal_p(ThreadContext context, IRubyObject obj) {
-        return RubyBoolean.newBoolean(context, this == obj || eql(obj));
+        long value = this.value;
+
+        if (fixnumable(value)) {
+            return RubyBoolean.newBoolean(context, this == obj || eql(obj));
+        }
+
+        return super.equal_p(context, obj);
+    }
+
+    /**
+     * Determine whether the given long value is in fixnum range.
+     *
+     * @param value the value in question
+     * @return true if the value is in fixnum range, false otherwise
+     */
+    private static boolean fixnumable(long value) {
+        return value <= Long.MAX_VALUE / 2 && value >= Long.MIN_VALUE / 2;
     }
 
     @Override
@@ -1386,7 +1402,9 @@ public class RubyFixnum extends RubyInteger implements Constantizable {
 
     @Override
     public IRubyObject id() {
-        if (value <= Long.MAX_VALUE / 2 && value >= Long.MIN_VALUE / 2) {
+        long value = this.value;
+
+        if (fixnumable(value)) {
             return newFixnum(metaClass.runtime, 2 * value + 1);
         }
 

--- a/core/src/main/java/org/jruby/runtime/ObjectSpace.java
+++ b/core/src/main/java/org/jruby/runtime/ObjectSpace.java
@@ -76,8 +76,8 @@ public class ObjectSpace {
     }
 
     public static long calculateObjectId(Object object) {
-        // Fixnums get all the odd IDs, so we use identityHashCode * 2
-        return maxId.getAndIncrement() * 2;
+        // Fixnums get all the 0b01 id's, flonums get the 0b10 id's, so we use next ID * 4
+        return maxId.getAndIncrement() * 4;
     }
 
     public long createAndRegisterObjectId(IRubyObject rubyObject) {

--- a/core/src/main/java/org/jruby/util/Numeric.java
+++ b/core/src/main/java/org/jruby/util/Numeric.java
@@ -775,6 +775,28 @@ public class Numeric {
         return x instanceof RubyNumeric;
     }
 
+    /**
+     * Rotate the given long bits left.
+     *
+     * @param bits the bits to rotate
+     * @param rot how many bit positions to rotate
+     * @return the rotated value
+     */
+    public static long rotl(long bits, int rot) {
+        return (bits << (rot & 63)) | (bits >>> (-rot & 63));
+    }
+
+    /**
+     * Rotate the given long bits right.
+     *
+     * @param bits the bits to rotate
+     * @param rot how many bit positions to rotate
+     * @return the rotated value
+     */
+    public static long rotr(long bits, int rot) {
+        return (bits << (-rot & 63)) | (bits >>> (rot & 63));
+    }
+
     public static final class ComplexPatterns {
         public static final Regex comp_pat0, comp_pat1, comp_pat2, underscores_pat;
         static {


### PR DESCRIPTION
This commit improves the emulation of CRuby's fixnum and flonum tagged pointers.

Float emulation of flonum:

* Floats within flonum range will produce a flonum `object_id` that is reversible by ObjectSpace._id2ref.
* Float objects with equivalent values within flonum range are considered identical via `equal?`.
* RubyFloat.eql overrides the default RubyBasicObject.eql dynamic dispatch, as in RubyFixnum.

Fixnum emulation of fixnum:

* Fixnum objects with equivalent values within fixnum range *only* are considered identical via `equal?`. Previously all equivalent Fixnum objects were considered `equal?`.

Impact to existing behavior:

* Floats within range will now behave like flonums on CRuby rather than as independent objects.
* Fixnums outside of fixnum range will behave like independent objects for identity purposes.
* In order to accommodate the flonum IDs in `_id2ref`, non-fixnum non-flonum values are now modulo 4. This means we have halved the number of incremental object ID values available (Long.MAX_VALUE / 4 versus Long.MAX_VALUE / 2 for fixnum emulation alone).

See https://github.com/ruby/spec/pull/829 for some discussion of this.