### PR TITLE
Handle errors in Process.detach properly

### DIFF
--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -1461,10 +1461,13 @@ public class RubyProcess {
 
     @JRubyMethod(name = "detach", required = 1, module = true, visibility = PRIVATE)
     public static IRubyObject detach(ThreadContext context, IRubyObject recv, IRubyObject arg) {
-        final int pid = (int)arg.convertToInteger().getLongValue();
+        final long pid = arg.convertToInteger().getLongValue();
         Ruby runtime = context.runtime;
 
         BlockCallback callback = (ctx, args, block) -> {
+            // push a dummy frame to avoid AIOOB if an exception fires
+            ctx.pushFrame();
+
             while (waitpid(ctx.runtime, pid, 0) == 0) {}
 
             return last_status(ctx, recv);

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -699,7 +699,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         return rubyThread;
     }
 
-    protected static RubyThread startWaiterThread(final Ruby runtime, int pid, Block block) {
+    protected static RubyThread startWaiterThread(final Ruby runtime, long pid, Block block) {
         final IRubyObject waiter = runtime.getProcess().getConstantAt("Waiter"); // Process::Waiter
         final RubyThread rubyThread = new RubyThread(runtime, (RubyClass) waiter);
         rubyThread.op_aset(runtime.newSymbol("pid"), runtime.newFixnum(pid));


### PR DESCRIPTION
The rb_waitpid function in CRuby does not actually trigger an
exception raise when the waitpid errors, leaving that to callers
to decide. Because ours did so, any errors during the
Process.detach call to waitpid would trigger the raise event hook
and unfix #6466.

This change moves the errno check outside of our rb_waitpid
equivalent, making it safe to use in the Process.detach thread.

Fixes #6466 again.