### PR TITLE
Make sync and profiling method wrapper logic work with refinements

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -75,6 +75,7 @@ import org.jruby.internal.runtime.methods.AliasMethod;
 import org.jruby.internal.runtime.methods.AttrReaderMethod;
 import org.jruby.internal.runtime.methods.AttrWriterMethod;
 import org.jruby.internal.runtime.methods.DefineMethodMethod;
+import org.jruby.internal.runtime.methods.DelegatingDynamicMethod;
 import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.internal.runtime.methods.JavaMethod;
 import org.jruby.internal.runtime.methods.NativeCallMethod;
@@ -1534,6 +1535,11 @@ public class RubyModule extends RubyObject {
         RubyModule superClass;
 
         DynamicMethod method = entry.method;
+
+        // unwrap delegated methods so we can see them properly
+        if (method instanceof DelegatingDynamicMethod) {
+            method = ((DelegatingDynamicMethod) method).getDelegate();
+        }
 
         if (method instanceof RefinedWrapper){
             // original without refined flag


### PR DESCRIPTION
This PR will track work to make our two types of "transparent" delegating method wrappers compatible with refinements.

As described in #6547, the wrapper methods that the Synchronized module uses interfere with refinement logic due to the latter's dependence on its own wrapper. When the two are active at the same time, the method lookup process may fail to locate methods that are clearly there, due to not knowing how to access the original unwrapped method properly.

The first fix here is a one-off that pre-unwraps all DelegatingDynamicMethod wrappers before proceeding to the rest of the refined logic, but the issue is systemic; the synchronized wrappers cannot be perfectly transparent, and so they interfere with method table logic that depends on seeing the original method. An alternative solution is needed.

One such solution might be to move the synchronization logic to a specialized CacheEntry, that will provide the wrapper only when being used to invoke. All other accesses would continue to see the original method. This would avoid eagerly wrapping the retrieved method and hiding its true nature, but it would open up the possibility that the unsynchronized version would leak out and be invokable without synchronization further down the line.

The TruffleRuby equivalent to this eagerly replaces all methods with new methods that actively synchronize; they are normal methods, not wrappers, so refinements do not interfere with them. However this only affects methods defined on the class at the point at which the class is flipped to being synchronized; new methods will not be synchronized unless the switch is again flipped. This does not seem to be an acceptable alternative to adding synchronization at lookup or invocation time.