### PR TITLE
getResource() should never be called with a starting slash when called on a classloader

### DIFF
--- a/core/src/main/java/org/jruby/ext/rbconfig/RbConfigLibrary.java
+++ b/core/src/main/java/org/jruby/ext/rbconfig/RbConfigLibrary.java
@@ -277,7 +277,7 @@ public class RbConfigLibrary implements Library {
         setConfig(context, CONFIG, "target_cpu", arch);
 
         String jrubyJarFile = "jruby.jar";
-        URL jrubyPropertiesUrl = Ruby.getClassLoader().getResource("/org/jruby/Ruby.class");
+        URL jrubyPropertiesUrl = Ruby.getClassLoader().getResource("org/jruby/Ruby.class");
         if (jrubyPropertiesUrl != null) {
             Pattern jarFile = Pattern.compile("jar:file:.*?([a-zA-Z0-9.\\-]+\\.jar)!" + "/org/jruby/Ruby.class");
             Matcher jarMatcher = jarFile.matcher(jrubyPropertiesUrl.toString());


### PR DESCRIPTION
Calling it with a slash might or might not work depending on the classloader.
A starting slash is only used when calling getResource() on a class.

JRuby using a "/" at the beginning cased an exception when running this inside the plugin class loader of IntelliJ (https://github.com/asciidoctor/asciidoctor-intellij-plugin/issues/664). 
I'd be happy if this could be included in an upcoming patch release, so I can remove a workaround in the IntelliJ AsciiDoc plugin.

See https://stackoverflow.com/questions/47900677/where-does-leading-slash-in-java-class-loader-getresource-leads-to for more information on slashes and classloaders. 