### PR TITLE
[feat] support RubyString#split for Java (exts)

### DIFF
--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -1495,11 +1495,11 @@ public class RubyRational extends RubyNumeric {
             IRubyObject de = match.at(3);
             IRubyObject re = match.post_match(context);
             
-            RubyArray a = nu.split(RubyRegexp.newDummyRegexp(runtime, Numeric.RationalPatterns.an_e_pat), context, false);
+            RubyArray a = nu.split(context, RubyRegexp.newDummyRegexp(runtime, Numeric.RationalPatterns.an_e_pat), false);
             RubyString ifp = (RubyString)a.eltInternal(0);
             IRubyObject exp = a.size() != 2 ? nil : a.eltInternal(1);
             
-            a = ifp.split(RubyRegexp.newDummyRegexp(runtime, Numeric.RationalPatterns.a_dot_pat), context, false);
+            a = ifp.split(context, RubyRegexp.newDummyRegexp(runtime, Numeric.RationalPatterns.a_dot_pat), false);
             IRubyObject ip = a.eltInternal(0);
             IRubyObject fp = a.size() != 2 ? nil : a.eltInternal(1);
             

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -4374,7 +4374,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return splitCommon(context, spat, false, value.realSize(), 0, useBackref);
     }
 
-    final RubyArray split(IRubyObject spat, ThreadContext context, boolean useBackref) {
+    final RubyArray split(ThreadContext context, RubyRegexp spat, boolean useBackref) {
         return splitCommon(context, spat, false, value.realSize(), 0, useBackref);
     }
 

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -4374,6 +4374,53 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return splitCommon(context, spat, false, value.realSize(), 0, useBackref);
     }
 
+    /**
+     * Split for ext (Java) callers (does not write $~).
+     * @param delimiter
+     * @return splited entries
+     */
+    public RubyArray split(RubyRegexp delimiter) {
+        return doSplit(delimiter, 0);
+    }
+
+    /**
+     * Split for ext (Java) callers (does not write $~).
+     * @param delimiter
+     * @param limit
+     * @return splited entries
+     */
+    public RubyArray split(RubyRegexp delimiter, int limit) {
+        return doSplit(delimiter, limit);
+    }
+
+    /**
+     * Split for ext (Java) callers (does not write $~).
+     * @param delimiter
+     * @return splited entries
+     */
+    public RubyArray split(RubyString delimiter) {
+        return doSplit(delimiter, 0);
+    }
+
+    /**
+     * Split for ext (Java) callers (does not write $~).
+     * @param delimiter
+     * @param limit
+     * @return splited entries
+     */
+    public RubyArray split(RubyString delimiter, int limit) {
+        return doSplit(delimiter, limit);
+    }
+
+    private RubyArray doSplit(IRubyObject delimiter, final int limit) {
+        ThreadContext context = getRuntime().getCurrentContext();
+        if (limit == 1) {
+            Ruby runtime = context.runtime;
+            return isEmpty() ? runtime.newEmptyArray() : runtime.newArray(this.strDup(runtime));
+        }
+        return splitCommon(context, delimiter, limit > 0, limit, 1, false);
+    }
+
     final RubyArray split(ThreadContext context, RubyRegexp spat, boolean useBackref) {
         return splitCommon(context, spat, false, value.realSize(), 0, useBackref);
     }

--- a/core/src/test/java/org/jruby/test/TestRubyString.java
+++ b/core/src/test/java/org/jruby/test/TestRubyString.java
@@ -31,7 +31,11 @@ package org.jruby.test;
 
 import org.jcodings.specific.UTF8Encoding;
 import org.jruby.Ruby;
+import org.jruby.RubyArray;
+import org.jruby.RubyRegexp;
 import org.jruby.RubyString;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.util.ByteList;
 
 /**
  * Test case for functionality in RubyArray
@@ -55,5 +59,25 @@ public class TestRubyString extends Base {
     public void testNewUnicodeString() throws Exception {
         RubyString str = RubyString.newUnicodeString(runtime, "hello");
         assertEquals(UTF8Encoding.INSTANCE, str.getByteList().getEncoding());
+    }
+
+    public void testSplit() throws RaiseException {
+        RubyString str = RubyString.newString(runtime, "JRuby is so awesome!");
+        RubyArray res = str.split(runtime.newString(" "));
+        assertEquals(4, res.size());
+        assertEquals("JRuby", res.get(0));
+        res = str.split(runtime.newString(" "), 2);
+        assertEquals(2, res.size());
+        assertEquals("JRuby", res.get(0));
+        assertEquals("is so awesome!", res.get(1));
+
+        RubyRegexp pat = RubyRegexp.newRegexp(runtime, ByteList.create("[ie]s"));
+        res = str.split(pat);
+        assertEquals(3, res.size());
+        assertEquals("JRuby ", res.get(0));
+        assertEquals(" so aw", res.get(1));
+        assertEquals("ome!", res.get(2));
+        res = str.split(pat, 4);
+        assertEquals(3, res.size());
     }
 }


### PR DESCRIPTION
currently, there's no easy way to do a `RubyString#split` from a Java extension (due split writing a back-ref for the frame).
the idea here is to provide a "strongly" typed API that Java consumers could leverage wout shooting themselves in the :foot: 