### PR TITLE
Fixes #6540. difference with block keyword arguments.

### DIFF
--- a/core/src/main/java/org/jruby/ir/passes/AddCallProtocolInstructions.java
+++ b/core/src/main/java/org/jruby/ir/passes/AddCallProtocolInstructions.java
@@ -124,7 +124,7 @@ public class AddCallProtocolInstructions extends CompilerPass {
                     prologueBB.addInstr(PrepareNoBlockArgsInstr.INSTANCE);
                 } else {
                     if (sig.isFixed()) {
-                        if (arityValue == 1) {
+                        if (arityValue == 1 && !sig.hasKwargs()) {
                             prologueBB.addInstr(PrepareSingleBlockArgInstr.INSTANCE);
                         } else {
                             prologueBB.addInstr(PrepareBlockArgsInstr.INSTANCE);

--- a/core/src/main/java/org/jruby/runtime/BlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/BlockBody.java
@@ -266,7 +266,7 @@ public abstract class BlockBody {
             if (args.length == 1) {
                 // Convert value to arg-array, unwrapping where necessary
                 args = IRRuntimeHelpers.convertValueIntoArgArray(context, args[0], signature, args[0] instanceof RubyArray && type == Block.Type.NORMAL);
-            } else if (signature.arityValue() == 1 && !signature.restKwargs()) {
+            } else if (signature.arityValue() == 1 && !signature.hasKwargs()) {
                 // discard excess arguments
                 args = args.length == 0 ? context.runtime.getSingleNilArray() : new IRubyObject[] { args[0] };
             }

--- a/spec/ruby/core/proc/shared/call.rb
+++ b/spec/ruby/core/proc/shared/call.rb
@@ -49,6 +49,9 @@ describe :proc_call_on_proc_or_lambda, shared: true do
 
     a = proc {|x| x}.send(@method, 1, 2, 3)
     a.should == 1
+
+    a = proc {|x:| x}.send(@method, 2, x: 1)
+    a.should == 1
   end
 
   it "will call #to_ary on argument and return self if return is nil" do


### PR DESCRIPTION
Our call logic was only using first incoming args[0] is arity was 1
and there is no kwrest(**a).  This should be arity of 1 and the lack of
 presence of any kwargs at all.

Intuitively, we know if we have kwargs at the callsite and the block
accepts kwargs...we should pass them forward.

We also know that procs will pass any extra args to the proc whether
the proc is defined to accept them or not.  As opposed to lambdas which
would error because you are passing the wrong number.

So I feel pretty good about this fix but I am very leery on landing this
the day before a release.  Blocks are tricky internally in Ruby.