### PR TITLE
Fix system with chdir hanging

### DIFF
--- a/core/src/main/java/org/jruby/util/io/PopenExecutor.java
+++ b/core/src/main/java/org/jruby/util/io/PopenExecutor.java
@@ -1884,7 +1884,7 @@ public class PopenExecutor {
 
             newArgv[0] = newString(runtime, "sh");
             newArgv[1] = newString(runtime, "-c");
-            newArgv[2] = newString(runtime, "cd -- \"$1\"; shift; exec \"$@\"");
+            newArgv[2] = newString(runtime, "cd -- \"$1\"; shift; \"$@\"");
             newArgv[3] = newString(runtime, "sh");
             newArgv[4] = newString(runtime, eargp.chdir_dir);
 


### PR DESCRIPTION
It seems like the change in #6226 (backported as #6568) to use `exec` to run the subcommand after doing an `sh` to `chdir` may be causing `system` with `chdir` to hang under some circumstances (#6579).

This PR removes the exec, which should put us back to the old behavior other than how we handle the actual command args by evaluating `"$@"`.

cc @mrnoname1000 for assistance