### PR TITLE
Expand env-shebang to setup and pristine

### DIFF
--- a/lib/ruby/stdlib/rubygems/defaults/jruby.rb
+++ b/lib/ruby/stdlib/rubygems/defaults/jruby.rb
@@ -20,7 +20,9 @@ module Gem
   def self.platform_defaults
     return {
         'install' => '--env-shebang',
-        'update' => '--env-shebang'
+        'update' => '--env-shebang',
+        'setup' => '--env-shebang',
+        'pristine' => '--env-shebang'
     }
   end
 


### PR DESCRIPTION
The setup command is used when upgrading RubyGems, and pristine
is a clean reinstall. Neither honor the settings for "install" or
"update" so we need to force them too.

See rubygems/rubygems#4404