### PR TITLE
Provide direct byte[] read and write for RubyIO

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1548,26 +1548,24 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
      * @return the count of bytes written
      */
     public int write(ThreadContext context, byte[] bytes, int start, int length, Encoding encoding, boolean nosync) {
-        Ruby runtime = context.runtime;
-        OpenFile fptr;
-        int n;
-
         if (length == 0) return 0;
 
-        fptr = getOpenFileChecked();
+        OpenFile fptr = getOpenFileChecked();
 
         boolean locked = fptr.lock();
         try {
             fptr = getOpenFileChecked();
             fptr.checkWritable(context);
 
-            n = fptr.fwrite(context, bytes, start, length, encoding, nosync);
-            if (n == -1) throw runtime.newErrnoFromErrno(fptr.errno(), fptr.getPath());
+            int n = fptr.fwrite(context, bytes, start, length, encoding, nosync);
+
+            if (n == -1) throw context.runtime.newErrnoFromErrno(fptr.errno(), fptr.getPath());
+
+            return n;
         } finally {
             if (locked) fptr.unlock();
         }
 
-        return n;
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1573,6 +1573,64 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return n;
     }
 
+    /**
+     * Same as {@link #write(ThreadContext, byte[], int, int, Encoding, boolean)} but context will be retrieved.
+     *
+     * Heavy use should retrieve context once and call the original method to avoid thread-local overhead.
+     *
+     * @param bytes the bytes to write
+     * @param start start offset for writing
+     * @param length length to write
+     * @param encoding encoding of the bytes (will not be verified)
+     * @param nosync whether to write without syncing
+     * @return the count of bytes written
+     */
+    public int write(byte[] bytes, int start, int length, Encoding encoding, boolean nosync) {
+        return write(getRuntime().getCurrentContext(), bytes, start, length, encoding, nosync);
+    }
+
+    /**
+     * Same as {@link #write(ThreadContext, byte[], int, int, Encoding, boolean)} but context will be retrieved and
+     * nosync defaults to false.
+     *
+     * Heavy use should retrieve context once and call the original method to avoid thread-local overhead.
+     *
+     * @param bytes the bytes to write
+     * @param start start offset for writing
+     * @param length length to write
+     * @param encoding encoding of the bytes (will not be verified)
+     * @return the count of bytes written
+     */
+    public int write(byte[] bytes, int start, int length, Encoding encoding) {
+        return write(bytes, start, length, encoding, false);
+    }
+
+
+    /**
+     * Same as {@link #write(ThreadContext, byte[], int, int, Encoding, boolean)} but context will be retrieved nosync
+     * defaults to false, and the entire byte array will be written.
+     *
+     * Heavy use should retrieve context once and call the original method to avoid thread-local overhead.
+     *
+     * @param bytes the bytes to write
+     * @param encoding encoding of the bytes (will not be verified)
+     * @return the count of bytes written
+     */
+    public int write(byte[] bytes, Encoding encoding) {
+        return write(bytes, 0, bytes.length, encoding);
+    }
+
+    /**
+     * Same as {@link #write(ThreadContext, byte)} but context will be retrieved.
+     *
+     * Heavy use should retrieve context once and call the original method to avoid thread-local overhead.
+     *
+     * @param bite the byte to write, as an int
+     */
+    public void write(int bite) {
+        write(getRuntime().getCurrentContext(), (byte) bite);
+    }
+
     /** rb_io_addstr
      *
      */

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1346,7 +1346,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
             }
 
             ByteList strByteList = ((RubyString) str).getByteList();
-            n = OpenFile.writeInternal(context, fptr, fptr.fd(), strByteList.unsafeBytes(), strByteList.begin(), strByteList.getRealSize());
+            n = OpenFile.writeInternal(context, fptr, strByteList.unsafeBytes(), strByteList.begin(), strByteList.getRealSize());
 
             if (n == -1) throw runtime.newErrnoFromErrno(fptr.errno(), fptr.getPath());
         } finally {

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1422,14 +1422,23 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         }
     }
 
-    /** io_write_m
+    /**
+     * Ruby method IO#write(str), equivalent to io_write_m.
      *
+     * @param context the current context
+     * @param str the string to write
      */
     @JRubyMethod(name = "write", required = 1)
     public IRubyObject write(ThreadContext context, IRubyObject str) {
         return write(context, str, false);
     }
 
+    /**
+     * Ruby method IO#write(str, ...), equivalent to io_write_m.
+     *
+     * @param context the current context
+     * @param args the strings to write
+     */
     @JRubyMethod(name = "write", rest = true)
     public IRubyObject write(ThreadContext context, IRubyObject[] args) {
         long acc = 0l;
@@ -1441,12 +1450,29 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return RubyFixnum.newFixnum(context.runtime, acc);
     }
 
+    /**
+     * Write a single byte to this IO's write target.
+     *
+     * @param context the current context
+     * @param ch the byte to write, as an int
+     * @return the count of bytes written
+     */
     public final IRubyObject write(ThreadContext context, int ch) {
         RubyString str = RubyString.newStringShared(context.runtime, RubyInteger.singleCharByteList((byte) ch));
         return write(context, str, false);
     }
 
-    // io_write
+
+    /**
+     * Write the given range of bytes to this IO's write target.
+     *
+     * Equivalent to io_write.
+     *
+     * @param context the current context
+     * @param str the string to write
+     * @param nosync whether to write without syncing
+     * @return the count of bytes written
+     */
     public IRubyObject write(ThreadContext context, IRubyObject str, boolean nosync) {
         Ruby runtime = context.runtime;
         OpenFile fptr;
@@ -1480,12 +1506,37 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return RubyFixnum.newFixnum(runtime, n);
     }
 
-    // io_write_m with source bytes
+    /**
+     * Write the given range of bytes to this IO.
+     *
+     * Equivalent to io_write_m with source bytes and no digging out any wrapped write IO (bytes will be written to this
+     * IO.
+     *
+     * @param context the current context
+     * @param bytes the bytes to write
+     * @param start start offset for writing
+     * @param length length to write
+     * @param encoding encoding of the bytes (will not be verified)
+     * @return the count of bytes written
+     */
     public IRubyObject write(ThreadContext context,  byte[] bytes, int start, int length, Encoding encoding) {
         return write(context, bytes, start, length, encoding, false);
     }
 
-    // io_write with source bytes
+    /**
+     * Write the given range of bytes to this IO.
+     *
+     * Equivalent to io_write with source bytes and no digging out any wrapped write IO (bytes will be written to this
+     * IO.
+     *
+     * @param context the current context
+     * @param bytes the bytes to write
+     * @param start start offset for writing
+     * @param length length to write
+     * @param encoding encoding of the bytes (will not be verified)
+     * @param nosync whether to write without syncing
+     * @return the count of bytes written
+     */
     public IRubyObject write(ThreadContext context, byte[] bytes, int start, int length, Encoding encoding, boolean nosync) {
         Ruby runtime = context.runtime;
         OpenFile fptr;

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1462,6 +1462,19 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return write(context, str, false);
     }
 
+    /**
+     * Write a single byte to this IO's write target but do not return the number of bytes written (it will be 1).
+     *
+     * This version does not dig out any wrapped write IO (bytes will be written to this IO).
+     *
+     * @param context the current context
+     * @param ch the byte to write, as an int
+     */
+    public final void write(ThreadContext context, byte ch) {
+        ByteList bytes = RubyInteger.singleCharByteList(ch);
+
+        write(context, bytes.unsafeBytes(), bytes.begin(), bytes.realSize(), bytes.getEncoding(), false);
+    }
 
     /**
      * Write the given range of bytes to this IO's write target.
@@ -1510,7 +1523,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
      * Write the given range of bytes to this IO.
      *
      * Equivalent to io_write_m with source bytes and no digging out any wrapped write IO (bytes will be written to this
-     * IO.
+     * IO).
      *
      * @param context the current context
      * @param bytes the bytes to write
@@ -1519,7 +1532,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
      * @param encoding encoding of the bytes (will not be verified)
      * @return the count of bytes written
      */
-    public IRubyObject write(ThreadContext context,  byte[] bytes, int start, int length, Encoding encoding) {
+    public int write(ThreadContext context,  byte[] bytes, int start, int length, Encoding encoding) {
         return write(context, bytes, start, length, encoding, false);
     }
 
@@ -1537,12 +1550,12 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
      * @param nosync whether to write without syncing
      * @return the count of bytes written
      */
-    public IRubyObject write(ThreadContext context, byte[] bytes, int start, int length, Encoding encoding, boolean nosync) {
+    public int write(ThreadContext context, byte[] bytes, int start, int length, Encoding encoding, boolean nosync) {
         Ruby runtime = context.runtime;
         OpenFile fptr;
-        long n;
+        int n;
 
-        if (length == 0) return RubyFixnum.zero(runtime);
+        if (length == 0) return 0;
 
         fptr = getOpenFileChecked();
 
@@ -1557,7 +1570,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
             if (locked) fptr.unlock();
         }
 
-        return RubyFixnum.newFixnum(runtime, n);
+        return n;
     }
 
     /** rb_io_addstr

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -3784,13 +3784,13 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
         POSIX posix = runtime.getNativePosix();
 
-        if (!(posix instanceof Linux)) {
-            return context.nil;
-        }
-
         RubyIO io = GetWriteIO();
 
         fptr = io.getOpenFileChecked();
+
+        if (!(posix instanceof Linux)) {
+            return context.nil;
+        }
 
         int fd = fptr.fd().realFileno;
 

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -3281,7 +3281,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
      * @param buffer the target buffer
      * @param start start offset in target buffer
      * @param len count of bytes to read
-     * @return the number of bytes actually read
+     * @return the number of bytes actually read or -1 for EOF
      */
     public int read(ThreadContext context, byte[] buffer, int start, int len) {
         checkLength(context, len);
@@ -3291,7 +3291,12 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         try {
             fptr.checkByteReadable(context);
 
-            return doRead(context, fptr, buffer, start, len);
+            len = doRead(context, fptr, buffer, start, len);
+
+            // Java convention
+            if (len == 0) return -1;
+
+            return len;
         } finally {
             if (locked) fptr.unlock();
         }

--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -382,7 +382,7 @@ public abstract class RubyInteger extends RubyNumeric {
     @Deprecated
     public static final ByteList[] SINGLE_CHAR_BYTELISTS19 = SINGLE_CHAR_BYTELISTS;
 
-    static ByteList singleCharByteList(final byte index) {
+    public static ByteList singleCharByteList(final byte index) {
         return SINGLE_CHAR_BYTELISTS[index & 0xFF];
     }
 

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -1628,7 +1628,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     }
 
     /**
-     * Execute an interruptible write operation with the given byte range and data object.
+     * Execute an interruptible read or write operation with the given byte range and data object.
      *
      * @param context the current context
      * @param data a data object
@@ -1640,10 +1640,10 @@ public class RubyThread extends RubyObject implements ExecutionContext {
      * @return the number of bytes written
      * @throws InterruptedException
      */
-    public <Data> int executeWriteTask(
+    public <Data> int executeReadWrite(
             ThreadContext context,
             Data data, byte[] bytes, int start, int length,
-            WriteTask<Data> task) throws InterruptedException {
+            ReadWrite<Data> task) throws InterruptedException {
         Status oldStatus = STATUS.get(this);
         try {
             this.unblockArg = data;
@@ -1663,7 +1663,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         }
     }
 
-    public interface WriteTask<Data> extends Unblocker<Data> {
+    public interface ReadWrite<Data> extends Unblocker<Data> {
         public int run(ThreadContext context, Data data, byte[] bytes, int start, int length) throws InterruptedException;
         public void wakeup(RubyThread thread, Data data);
     }

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -1255,7 +1255,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
                 result.catString(Integer.toString(line + 1));
             }
             result.cat(' ');
-            result.catString(status.toString().toLowerCase());
+            result.catString(getStatus().toString().toLowerCase());
             result.cat('>');
             return result;
         }
@@ -1673,7 +1673,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     }
 
     public void exitSleep() {
-        if (status != Status.ABORTING) {
+        if (getStatus() != Status.ABORTING) {
             STATUS.set(this, Status.RUN);
         }
     }

--- a/core/src/main/java/org/jruby/util/ByteList.java
+++ b/core/src/main/java/org/jruby/util/ByteList.java
@@ -96,6 +96,20 @@ public class ByteList implements Comparable, CharSequence, Serializable {
     }
 
     /**
+     * Creates a new instance of Bytelist with a pre-allocated size and specified encoding.
+     *
+     * See {@link #ByteList(int)}
+     *
+     * @param size to preallocate the bytelist to
+     * @param enc encoding to set
+     */
+    public ByteList(int size, Encoding enc) {
+        bytes = new byte[size];
+        realSize = 0;
+        encoding = safeEncoding(enc);
+    }
+
+    /**
      * Create a new instance of ByteList with the bytes supplied using the specified encoding.
      *
      * Important: bytes is used as the initial backing store for the bytelist.  Over time as the

--- a/core/src/main/java/org/jruby/util/IOOutputStream.java
+++ b/core/src/main/java/org/jruby/util/IOOutputStream.java
@@ -111,14 +111,12 @@ public class IOOutputStream extends OutputStream {
     public void write(final int bite) throws IOException {
         ThreadContext context = runtime.getCurrentContext();
 
-        RubyString str = RubyString.newStringLight(runtime, new ByteList(new byte[]{(byte) bite}, encoding, false));
-
         RubyIO realIO = this.realIO;
         if (realIO != null) {
-            realIO.write(context, str);
+            realIO.write(context, bite);
         } else {
             IRubyObject io = this.io;
-            writeAdapter.call(context, io, io, str);
+            writeAdapter.call(context, io, io, RubyString.newStringShared(runtime, new ByteList(new byte[]{(byte) bite}, encoding, false)));
         }
     }
 
@@ -131,14 +129,12 @@ public class IOOutputStream extends OutputStream {
     public void write(final byte[] b,final int off, final int len) throws IOException {
         ThreadContext context = runtime.getCurrentContext();
 
-        RubyString str = RubyString.newStringLight(runtime, new ByteList(b, off, len, encoding, false));
-
         RubyIO realIO = this.realIO;
         if (realIO != null) {
-            realIO.write(context, str);
+            realIO.write(context, b, off, len, encoding);
         } else {
             IRubyObject io = this.io;
-            writeAdapter.call(context, io, io, str);
+            writeAdapter.call(context, io, io, RubyString.newStringLight(runtime, new ByteList(b, off, len, encoding, false)));
         }
     }
     

--- a/core/src/main/java/org/jruby/util/IOOutputStream.java
+++ b/core/src/main/java/org/jruby/util/IOOutputStream.java
@@ -69,19 +69,7 @@ public class IOOutputStream extends OutputStream {
         this.runtime = io.getRuntime();
 
         // If we can get a real IO from the object, we can do fast writes
-        RubyIO realIO = null;
-        if (io instanceof RubyIO) {
-            RubyIO tmpIO = (RubyIO) io;
-            if (fastWritable(tmpIO)) {
-                tmpIO = tmpIO.GetWriteIO();
-
-                // recheck write IO for IOness
-                if (tmpIO == io || fastWritable(tmpIO)) {
-                    realIO = tmpIO;
-                }
-            }
-        }
-        this.realIO = realIO;
+        RubyIO realIO = this.realIO = getRealIO(io);
 
         if (realIO == null || verifyCanWrite) {
             final String site;
@@ -101,6 +89,22 @@ public class IOOutputStream extends OutputStream {
             writeAdapter = null; // won't be used
         }
         this.encoding = encoding;
+    }
+
+    protected RubyIO getRealIO(IRubyObject io) {
+        RubyIO realIO = null;
+        if (io instanceof RubyIO) {
+            RubyIO tmpIO = (RubyIO) io;
+            if (fastWritable(tmpIO)) {
+                tmpIO = tmpIO.GetWriteIO();
+
+                // recheck write IO for IOness
+                if (tmpIO == io || fastWritable(tmpIO)) {
+                    realIO = tmpIO;
+                }
+            }
+        }
+        return realIO;
     }
 
     protected boolean fastWritable(RubyIO io) {


### PR DESCRIPTION
This PR tracks work to address #6589 by adding allocation-free RubyIO read and write paths.