### PR TITLE
Accept numeric host

### DIFF
--- a/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
+++ b/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
@@ -12,8 +12,10 @@ import jnr.netdb.Service;
 import jnr.unixsocket.UnixSocketAddress;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
+import org.jruby.RubyBignum;
 import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
+import org.jruby.RubyInteger;
 import org.jruby.RubyObject;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyMethod;
@@ -667,6 +669,23 @@ public class Addrinfo extends RubyObject {
 
     private static InetAddress getRubyInetAddress(IRubyObject node) {
         try {
+            if (node instanceof RubyInteger) {
+                byte[] bytes;
+                if (node instanceof RubyBignum) {
+                    // IP6 addresses will be 16 bytes wide
+                    bytes = ((RubyBignum) node).getBigIntegerValue().toByteArray();
+                } else {
+                    long i = node.convertToInteger().getIntValue() & 0xFFFFL;
+
+                    bytes = new byte[]{
+                            (byte) ((i >> 24) & 0xFF),
+                            (byte) ((i >> 16) & 0xFF),
+                            (byte) ((i >> 8) & 0xFF),
+                            (byte) (i & 0xFF),
+                    };
+                }
+                return SocketUtils.getRubyInetAddress(bytes);
+            }
             return SocketUtils.getRubyInetAddress(node.convertToString().toString());
         } catch (UnknownHostException uhe) {
             return null;

--- a/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
+++ b/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
@@ -464,8 +464,11 @@ public class SocketUtils {
             return specialAddress;
         } else {
             return InetAddress.getByName(addressString);
-
         }
+    }
+
+    public static InetAddress getRubyInetAddress(byte[] addressBytes) throws UnknownHostException {
+        return InetAddress.getByAddress(addressBytes);
     }
     
     private static InetAddress specialAddress(String addressString) throws UnknownHostException {


### PR DESCRIPTION
Numeric hosts can be converted to a byte sequence for address
lookup.

Fixes #3883