### PR TITLE
Deprecate public APIs referencing Joda Time

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -188,6 +188,7 @@ import java.lang.ref.WeakReference;
 import java.net.BindException;
 import java.nio.charset.Charset;
 import java.security.SecureRandom;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -4594,8 +4595,13 @@ public final class Ruby implements Constantizable {
         return fiberExecutor;
     }
 
+    @Deprecated
     public Map<String, DateTimeZone> getTimezoneCache() {
         return timeZoneCache;
+    }
+
+    public Map<String, ZoneId> getZoneIdCache() {
+        return zoneIdCache;
     }
 
     @Deprecated
@@ -5624,6 +5630,7 @@ public final class Ruby implements Constantizable {
     private final ConcurrentWeakHashMap<RubyModule, Object> allModules = new ConcurrentWeakHashMap<>(128);
 
     private final Map<String, DateTimeZone> timeZoneCache = new HashMap<>();
+    private final Map<String, ZoneId> zoneIdCache = new HashMap<>();
     /**
      * A list of "external" finalizers (the ones, registered via ObjectSpace),
      * weakly referenced, to be executed on tearDown.

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -208,7 +208,7 @@ public class RubyModule extends RubyObject {
      *
      * @param classIndex the ClassIndex for this type
      */
-    @SuppressWarnings("deprecated")
+    @SuppressWarnings("deprecation")
     void setClassIndex(ClassIndex classIndex) {
         this.classIndex = classIndex;
         this.index = classIndex.ordinal();

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -2194,7 +2194,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         }
     }
 
-    @SuppressWarnings("deprecated")
+    @SuppressWarnings("deprecation")
     public synchronized void interrupt() {
         setInterrupt();
 

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -175,7 +175,7 @@ public class RubyTime extends RubyObject {
         ZoneId cachedZone = runtime.getZoneIdCache().get(zone);
         if (cachedZone != null) return cachedZone;
 
-        ZoneId dtz = JodaConverters.jodaToJavaTimeZone(parseTZString(runtime, zone));
+        ZoneId dtz = JodaConverters.jodaToJavaTimeZone(getTimeZoneFromTZString(runtime, zone));
         runtime.getZoneIdCache().put(zone, dtz);
         return dtz;
     }
@@ -359,7 +359,11 @@ public class RubyTime extends RubyObject {
         ZoneId cachedZone = runtime.getZoneIdCache().get(strOffset);
         if (cachedZone != null) return cachedZone;
 
-        ZoneId zone = JodaConverters.jodaToJavaTimeZone(getTimeZoneFromUtcOffset(context, arg));
+        DateTimeZone dtz = getTimeZoneFromUtcOffset(context, arg);
+
+        if (dtz == null) return null;
+
+        ZoneId zone = JodaConverters.jodaToJavaTimeZone(dtz);
 
         runtime.getZoneIdCache().put(strOffset, zone);
 

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -51,6 +51,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.*;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
+import org.jruby.util.time.JodaConverters;
 
 import java.io.Serializable;
 import java.time.*;
@@ -130,14 +131,14 @@ public class RubyDate extends RubyObject {
         this(runtime, klass, defaultDateTime);
     }
 
-    public RubyDate(Ruby runtime, RubyClass klass, DateTime dt) {
+    public RubyDate(Ruby runtime, RubyClass klass, ZonedDateTime zdt) {
         super(runtime, klass);
 
-        this.dt = dt; // assuming of = 0 (UTC)
+        this.dt = JodaConverters.javaToJodaDateTime(zdt); // assuming of = 0 (UTC)
     }
 
-    public RubyDate(Ruby runtime, DateTime dt) {
-        this(runtime, getDate(runtime), dt);
+    public RubyDate(Ruby runtime, ZonedDateTime zdt) {
+        this(runtime, getDate(runtime), zdt);
     }
 
     RubyDate(Ruby runtime, RubyClass klass, DateTime dt, int off, long start) {
@@ -189,16 +190,6 @@ public class RubyDate extends RubyObject {
     // to be overriden by RubyDateTime
     RubyDate newInstance(final ThreadContext context, final DateTime dt, int off, long start, long subNum, long subDen) {
         return new RubyDate(context.runtime, getMetaClass(), dt, off, start, subNum, subDen);
-    }
-
-    /**
-     * @note since <code>Date.new</code> is a <code>civil</code> alias, this won't ever get used
-     * @deprecated kept due AR-JDBC (uses RubyClass.newInstance(...) to 'fast' allocate a Date instance)
-     */
-    @JRubyMethod(visibility = Visibility.PRIVATE)
-    public RubyDate initialize(ThreadContext context, IRubyObject dt) {
-        this.dt = (DateTime) JavaUtil.unwrapJavaValue(dt);
-        return this;
     }
 
     @JRubyMethod(visibility = Visibility.PRIVATE)
@@ -433,25 +424,8 @@ public class RubyDate extends RubyObject {
         return civilImpl(context, (RubyClass) self, args[0], args[1], args[2], sg);
     }
 
-    public static DateTime civilDate(ThreadContext context, final int y, final int m, final int d, final Chronology chronology) {
-        DateTime dt;
-        try {
-            if (d >= 0) { // let d == 0 fail (raise 'invalid date')
-                dt = new DateTime(y, m, d, 0, 0, chronology);
-            }
-            else {
-                dt = new DateTime(y, m, 1, 0, 0, chronology);
-                long ms = dt.getMillis();
-                int last = chronology.dayOfMonth().getMaximumValue(ms);
-                ms = chronology.dayOfMonth().set(ms, last + d + 1); // d < 0 (d == -1 -> d == 31)
-                dt = dt.withMillis(ms);
-            }
-        }
-        catch (IllegalArgumentException ex) {
-            debug(context, "invalid date", ex);
-            throw context.runtime.newArgumentError("invalid date");
-        }
-        return dt;
+    public static ZonedDateTime civilZonedDateTime(ThreadContext context, final int y, final int m, final int d, final Chronology chronology) {
+        return JodaConverters.jodaToJavaDateTime(civilDate(context, y, m, d, chronology));
     }
 
     // NOTE: no Bignum special care since JODA does not support 'huge' years anyway
@@ -749,7 +723,7 @@ public class RubyDate extends RubyObject {
         return RubyDate._valid_civil_p(context, null, args);
     }
 
-    public DateTime getDateTime() { return dt; }
+    public ZonedDateTime getZonedDateTime() { return JodaConverters.jodaToJavaDateTime(dt); }
 
     @Override
     public boolean equals(Object other) {
@@ -2589,5 +2563,53 @@ public class RubyDate extends RubyObject {
 
         return super.toJava(target);
     }
+
+    @Deprecated
+    public RubyDate(Ruby runtime, RubyClass klass, DateTime dt) {
+        super(runtime, klass);
+
+        this.dt = dt; // assuming of = 0 (UTC)
+    }
+
+    @Deprecated
+    public RubyDate(Ruby runtime, DateTime dt) {
+        this(runtime, getDate(runtime), dt);
+    }
+
+    /**
+     * @note since <code>Date.new</code> is a <code>civil</code> alias, this won't ever get used
+     * @deprecated kept due AR-JDBC (uses RubyClass.newInstance(...) to 'fast' allocate a Date instance)
+     */
+    @Deprecated
+    @JRubyMethod(visibility = Visibility.PRIVATE)
+    public RubyDate initialize(ThreadContext context, IRubyObject dt) {
+        this.dt = (DateTime) JavaUtil.unwrapJavaValue(dt);
+        return this;
+    }
+
+    @Deprecated
+    public static DateTime civilDate(ThreadContext context, final int y, final int m, final int d, final Chronology chronology) {
+        DateTime dt;
+        try {
+            if (d >= 0) { // let d == 0 fail (raise 'invalid date')
+                dt = new DateTime(y, m, d, 0, 0, chronology);
+            }
+            else {
+                dt = new DateTime(y, m, 1, 0, 0, chronology);
+                long ms = dt.getMillis();
+                int last = chronology.dayOfMonth().getMaximumValue(ms);
+                ms = chronology.dayOfMonth().set(ms, last + d + 1); // d < 0 (d == -1 -> d == 31)
+                dt = dt.withMillis(ms);
+            }
+        }
+        catch (IllegalArgumentException ex) {
+            debug(context, "invalid date", ex);
+            throw context.runtime.newArgumentError("invalid date");
+        }
+        return dt;
+    }
+
+    @Deprecated
+    public DateTime getDateTime() { return dt; }
 
 }

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -277,6 +277,7 @@ public class RubyDate extends RubyObject {
     /**
      * @deprecated internal Date.new!
      */
+    @Deprecated
     @JRubyMethod(name = "new!", meta = true, visibility = Visibility.PRIVATE)
     public static RubyDate new_(ThreadContext context, IRubyObject self) {
         if (self == getDateTime(context.runtime)) {
@@ -288,6 +289,7 @@ public class RubyDate extends RubyObject {
     /**
      * @deprecated internal Date.new!
      */
+    @Deprecated
     @JRubyMethod(name = "new!", meta = true, visibility = Visibility.PRIVATE)
     public static RubyDate new_(ThreadContext context, IRubyObject self, IRubyObject ajd) {
         if (ajd instanceof JavaProxy) { // backwards - compatibility with JRuby's date.rb
@@ -705,6 +707,7 @@ public class RubyDate extends RubyObject {
         return new RubyDate(context.runtime, (RubyClass) self, todayDate(context, chrono), 0, start);
     }
 
+    @Deprecated
     private static DateTime todayDate(final ThreadContext context, final Chronology chrono) {
         org.joda.time.LocalDate today = new org.joda.time.LocalDate(RubyTime.getLocalTimeZone(context.runtime));
         return new DateTime(today.getYear(), today.getMonthOfYear(), today.getDayOfMonth(), 0, 0, chrono);
@@ -1476,6 +1479,7 @@ public class RubyDate extends RubyObject {
         return jd_to_ajd(context, jd, fr, of_sec);
     }
 
+    @Deprecated
     public static Chronology getChronology(ThreadContext context, final long sg, final int off) {
         final DateTimeZone zone;
         if (off == 0) {
@@ -1494,6 +1498,7 @@ public class RubyDate extends RubyObject {
         return getChronology(context, sg, zone);
     }
 
+    @Deprecated
     static Chronology getChronology(ThreadContext context, final long sg, final DateTimeZone zone) {
         if (sg == ITALY) return GJChronology.getInstance(zone);
         if (sg == JULIAN) return JulianChronology.getInstance(zone);
@@ -1611,11 +1616,13 @@ public class RubyDate extends RubyObject {
     @JRubyMethod
     public RubyDate to_date() { return this; }
 
+    @SuppressWarnings("deprecation")
     @JRubyMethod
     public RubyDateTime to_datetime(ThreadContext context) {
         return new RubyDateTime(context.runtime, getDateTime(context.runtime), dt.withTimeAtStartOfDay(), off, start);
     }
 
+    @SuppressWarnings("deprecation")
     @JRubyMethod // Time.local(year, mon, mday)
     public RubyTime to_time(ThreadContext context) {
         final Ruby runtime = context.runtime;
@@ -1635,6 +1642,7 @@ public class RubyDate extends RubyObject {
         return strftime(context, RubyString.newStringLight(context.runtime, DEFAULT_FORMAT_BYTES));
     }
 
+    @SuppressWarnings("deprecation")
     @JRubyMethod // alias_method :format, :strftime
     public RubyString strftime(ThreadContext context, IRubyObject fmt) {
         RubyRational subMillis = this.subMillisNum == 0 ? null :

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -51,6 +51,7 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
+import org.jruby.util.time.JodaConverters;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -83,14 +84,12 @@ public class RubyDateTime extends RubyDate {
         this(runtime, klass, defaultDateTime);
     }
 
-    public RubyDateTime(Ruby runtime, RubyClass klass, DateTime dt) {
-        super(runtime, klass, dt);
-
-        this.off = dt.getZone().getOffset(dt.getMillis()) / 1000;
+    public RubyDateTime(Ruby runtime, RubyClass klass, ZonedDateTime zdt) {
+        this(runtime, klass, JodaConverters.javaToJodaDateTime(zdt));
     }
 
-    public RubyDateTime(Ruby runtime, DateTime dt) {
-        this(runtime, getDateTime(runtime), dt);
+    public RubyDateTime(Ruby runtime, ZonedDateTime zdt) {
+        this(runtime, JodaConverters.javaToJodaDateTime(zdt));
     }
 
     public RubyDateTime(Ruby runtime, long millis, Chronology chronology) {
@@ -590,6 +589,18 @@ public class RubyDateTime extends RubyDate {
         }
 
         return super.toJava(target);
+    }
+
+    @Deprecated
+    public RubyDateTime(Ruby runtime, RubyClass klass, DateTime dt) {
+        super(runtime, klass, dt);
+
+        this.off = dt.getZone().getOffset(dt.getMillis()) / 1000;
+    }
+
+    @Deprecated
+    public RubyDateTime(Ruby runtime, DateTime dt) {
+        this(runtime, getDateTime(runtime), dt);
     }
 
 }

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -92,6 +92,7 @@ public class RubyDateTime extends RubyDate {
         this(runtime, JodaConverters.javaToJodaDateTime(zdt));
     }
 
+    @Deprecated
     public RubyDateTime(Ruby runtime, long millis, Chronology chronology) {
         super(runtime, getDateTime(runtime), new DateTime(millis, chronology));
     }
@@ -104,6 +105,7 @@ public class RubyDateTime extends RubyDate {
         super(context, klass, ajd, rest, off, start);
     }
 
+    @Deprecated
     private RubyDateTime(Ruby runtime, RubyClass klass, DateTime dt, int off) {
         super(runtime, klass);
 
@@ -111,6 +113,7 @@ public class RubyDateTime extends RubyDate {
         this.off = off;
     }
 
+    @Deprecated
     RubyDateTime(Ruby runtime, RubyClass klass, DateTime dt, int off, long start) {
         super(runtime, klass);
 
@@ -118,6 +121,7 @@ public class RubyDateTime extends RubyDate {
         this.off = off; this.start = start;
     }
 
+    @Deprecated
     RubyDateTime(Ruby runtime, RubyClass klass, DateTime dt, int off, long start, long subMillisNum, long subMillisDen) {
         super(runtime, klass);
 
@@ -126,6 +130,7 @@ public class RubyDateTime extends RubyDate {
         this.subMillisNum = subMillisNum; this.subMillisDen = subMillisDen;
     }
 
+    @Deprecated
     RubyDateTime(ThreadContext context, RubyClass klass, IRubyObject ajd, Chronology chronology, int off) {
         super(context, klass, ajd, chronology, off);
     }
@@ -169,6 +174,7 @@ public class RubyDateTime extends RubyDate {
         return new RubyDateTime(context.runtime, (RubyClass) self, civilImpl(context, year, month), 0);
     }
 
+    @SuppressWarnings("deprecation")
     @JRubyMethod(name = "civil", alias = "new", meta = true, optional = 8)
     public static RubyDateTime civil(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         // year=-4712, month=1, mday=1,
@@ -424,7 +430,7 @@ public class RubyDateTime extends RubyDate {
      #
      # +sg+ specifies the Day of Calendar Reform.
      **/
-
+    @SuppressWarnings("deprecation")
     @JRubyMethod(meta = true)
     public static RubyDateTime now(ThreadContext context, IRubyObject self) { // sg=ITALY
         final DateTimeZone zone = RubyTime.getLocalTimeZone(context.runtime);
@@ -436,6 +442,7 @@ public class RubyDateTime extends RubyDate {
         return new RubyDateTime(context.runtime, (RubyClass) self, dt, off, ITALY);
     }
 
+    @SuppressWarnings("deprecation")
     @JRubyMethod(meta = true)
     public static RubyDateTime now(ThreadContext context, IRubyObject self, IRubyObject sg) {
         final long start = val2sg(context, sg);
@@ -495,6 +502,7 @@ public class RubyDateTime extends RubyDate {
     @JRubyMethod
     public RubyDateTime to_datetime() { return this; }
 
+    @SuppressWarnings("deprecation")
     @JRubyMethod // Time.new(year, mon, mday, hour, min, sec + sec_fraction, (@of * 86400.0))
     public RubyTime to_time(ThreadContext context) {
         final Ruby runtime = context.runtime;

--- a/core/src/main/java/org/jruby/ext/date/TimeExt.java
+++ b/core/src/main/java/org/jruby/ext/date/TimeExt.java
@@ -54,6 +54,7 @@ public abstract class TimeExt {
     @JRubyMethod
     public static RubyTime to_time(IRubyObject self) { return (RubyTime) self; }
 
+    @SuppressWarnings("deprecation")
     @JRubyMethod(name = "to_date")
     public static RubyDate to_date(ThreadContext context, IRubyObject self) {
         final DateTime dt = ((RubyTime) self).getDateTime();
@@ -61,6 +62,7 @@ public abstract class TimeExt {
         return new RubyDate(context, getDate(context.runtime), jd_to_ajd(context, jd), CHRONO_ITALY_UTC, 0);
     }
 
+    @SuppressWarnings("deprecation")
     @JRubyMethod(name = "to_datetime")
     public static RubyDateTime to_datetime(ThreadContext context, IRubyObject self) {
         final RubyTime time = (RubyTime) self;

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
@@ -313,6 +313,7 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
         return getRuntime().getNil();
     }
 
+    @SuppressWarnings("deprecation")
     @JRubyMethod(name = "mtime=", required = 1)
     public IRubyObject set_mtime(IRubyObject arg) {
         if (arg instanceof RubyTime) {

--- a/core/src/main/java/org/jruby/ext/zlib/RubyGzipFile.java
+++ b/core/src/main/java/org/jruby/ext/zlib/RubyGzipFile.java
@@ -48,6 +48,8 @@ import org.jruby.util.ByteList;
 import org.jruby.util.io.EncodingUtils;
 import org.jruby.util.io.IOEncodable;
 
+import java.time.ZonedDateTime;
+
 /**
  *
  */
@@ -135,7 +137,7 @@ public class RubyGzipFile extends RubyObject implements IOEncodable {
     
     public RubyGzipFile(Ruby runtime, RubyClass type) {
         super(runtime, type);
-        mtime = RubyTime.newTime(runtime, new DateTime());
+        mtime = RubyTime.newTime(runtime, ZonedDateTime.now());
         enc = null;
         enc2 = null;
     }

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaTime.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaTime.java
@@ -38,6 +38,9 @@ import org.jruby.anno.JRubyModule;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import java.time.Instant;
+import java.time.ZonedDateTime;
+
 import static org.jruby.javasupport.JavaUtil.unwrapIfJavaObject;
 
 /**
@@ -75,7 +78,7 @@ public class JavaTime {
             long millis = val.getEpochSecond() * 1000 + (nano / 1_000_000);
             nano = nano % 1_000_000;
             final Ruby runtime = context.runtime;
-            return RubyTime.newTime(runtime, new DateTime(millis, RubyTime.getLocalTimeZone(runtime)), nano);
+            return RubyTime.newTime(runtime, java.time.ZonedDateTime.ofInstant(java.time.Instant.ofEpochMilli(millis), RubyTime.getLocalZoneId(runtime)), nano);
         }
 
     }
@@ -88,6 +91,7 @@ public class JavaTime {
             return proxy;
         }
 
+        @SuppressWarnings("deprecation")
         @JRubyMethod(name = "to_time")
         public static IRubyObject to_time(ThreadContext context, IRubyObject self) {
             java.time.LocalDateTime val = unwrapIfJavaObject(self);
@@ -114,6 +118,7 @@ public class JavaTime {
             return proxy;
         }
 
+        @SuppressWarnings("deprecation")
         @JRubyMethod(name = "to_time")
         public static IRubyObject to_time(ThreadContext context, IRubyObject self) {
             java.time.OffsetDateTime val = unwrapIfJavaObject(self);
@@ -158,6 +163,7 @@ public class JavaTime {
 
     }
 
+    @Deprecated
     private static RubyTime toTime(final Ruby runtime,
                                    int year, int month, int day, int hour, int min, int sec, int nano,
                                    DateTimeZone zone) {
@@ -180,6 +186,7 @@ public class JavaTime {
      * @param id
      * @return a (joda) date-time zone from Java time's zone id
      */
+    @Deprecated
     private static DateTimeZone convertZone(final String id) {
         if ("Z".equals(id)) { // special Java time case JODA does not handle (for UTC)
             return DateTimeZone.UTC;

--- a/core/src/main/java/org/jruby/util/RubyDateFormatter.java
+++ b/core/src/main/java/org/jruby/util/RubyDateFormatter.java
@@ -35,6 +35,7 @@ package org.jruby.util;
 import java.text.DateFormat;
 import java.text.DateFormatSymbols;
 import java.text.ParsePosition;
+import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
@@ -51,6 +52,7 @@ import org.jruby.RubyString;
 import org.jruby.RubyTime;
 import org.jruby.lexer.StrftimeLexer;
 import org.jruby.runtime.ThreadContext;
+import org.jruby.util.time.JodaConverters;
 
 import static org.jruby.util.CommonByteLists.*;
 import static org.jruby.util.RubyDateFormatter.FieldType.*;
@@ -415,14 +417,14 @@ public class RubyDateFormatter {
     }
 
     /** Convenience method when using no pattern caching */
-    public RubyString compileAndFormat(ByteList pattern, boolean dateLibrary, DateTime dt, long nsec, RubyNumeric sub_millis) {
+    public RubyString compileAndFormat(ByteList pattern, boolean dateLibrary, ZonedDateTime zdt, long nsec, RubyNumeric sub_millis) {
         compilePattern(pattern, dateLibrary);
-        RubyString out = format(compiledPattern, dt, nsec, sub_millis);
+        RubyString out = format(compiledPattern, JodaConverters.javaToJodaDateTime(zdt), nsec, sub_millis);
         return out;
     }
 
-    public RubyString format(Token[] compiledPattern, DateTime dt, long nsec, RubyNumeric sub_millis) {
-        return runtime.newString(formatToByteList(compiledPattern, dt, nsec, sub_millis));
+    public RubyString format(Token[] compiledPattern, ZonedDateTime zdt, long nsec, RubyNumeric sub_millis) {
+        return runtime.newString(formatToByteList(compiledPattern, JodaConverters.javaToJodaDateTime(zdt), nsec, sub_millis));
     }
 
     private ByteList formatToByteList(Token[] compiledPattern, DateTime dt, long nsec, RubyNumeric sub_millis) {
@@ -728,6 +730,18 @@ public class RubyDateFormatter {
      */
     public Date parse(String source, ParsePosition pos) {
         throw new UnsupportedOperationException();
+    }
+
+    @Deprecated
+    public RubyString format(Token[] compiledPattern, DateTime dt, long nsec, RubyNumeric sub_millis) {
+        return runtime.newString(formatToByteList(compiledPattern, dt, nsec, sub_millis));
+    }
+
+    @Deprecated
+    public RubyString compileAndFormat(ByteList pattern, boolean dateLibrary, DateTime dt, long nsec, RubyNumeric sub_millis) {
+        compilePattern(pattern, dateLibrary);
+        RubyString out = format(compiledPattern, dt, nsec, sub_millis);
+        return out;
     }
 
 }

--- a/core/src/main/java/org/jruby/util/RubyDateFormatter.java
+++ b/core/src/main/java/org/jruby/util/RubyDateFormatter.java
@@ -427,6 +427,7 @@ public class RubyDateFormatter {
         return runtime.newString(formatToByteList(compiledPattern, JodaConverters.javaToJodaDateTime(zdt), nsec, sub_millis));
     }
 
+    @Deprecated
     private ByteList formatToByteList(Token[] compiledPattern, DateTime dt, long nsec, RubyNumeric sub_millis) {
         RubyTimeOutputFormatter formatter = RubyTimeOutputFormatter.DEFAULT_FORMATTER;
         final ByteList output = new ByteList(27, patternEncoding); // Typical length produced by logger by default

--- a/core/src/main/java/org/jruby/util/time/JodaConverters.java
+++ b/core/src/main/java/org/jruby/util/time/JodaConverters.java
@@ -1,5 +1,9 @@
 package org.jruby.util.time;
 
+import org.joda.time.tz.FixedDateTimeZone;
+
+import java.time.ZoneId;
+
 /**
  * The JodaConverters class contains static methods for org.joda.time.* and java.time.* conversion.
  *
@@ -194,7 +198,9 @@ public class JodaConverters {
 	 * @return Java 8 ZoneId
 	 */
 	public static java.time.ZoneId jodaToJavaTimeZone( org.joda.time.DateTimeZone timeZone ) {
-		return java.time.ZoneId.of( timeZone.getID() );
+		return timeZone.isFixed() ?
+				java.time.ZoneOffset.ofTotalSeconds(timeZone.toTimeZone().getRawOffset() / 1000) :
+				java.time.ZoneId.of( timeZone.getID(), ZoneId.SHORT_IDS );
 	}
 
 	/**

--- a/core/src/main/java/org/jruby/util/time/JodaConverters.java
+++ b/core/src/main/java/org/jruby/util/time/JodaConverters.java
@@ -1,0 +1,256 @@
+package org.jruby.util.time;
+
+/**
+ * The JodaConverters class contains static methods for org.joda.time.* and java.time.* conversion.
+ *
+ * Borrowed from 'timeywimey' library at https://github.com/meetup/timeywimey (MIT license)
+ *
+ * @author Sak Lee
+ * @version 0.1.0
+ * @since 2016-05-16
+ */
+public class JodaConverters {
+	private static int milliToNanoConst = 1000000;
+
+	/* ************************ *
+	 * Classes without timezone *
+	 * ************************ */
+
+	/**
+	 * Converts Joda-Time LocalDate to Java 8 equivalent.
+	 *
+	 * @param localDate Joda-Time LocalDate
+	 * @return Java 8 LocalDate
+	 */
+	public static java.time.LocalDate jodaToJavaLocalDate( org.joda.time.LocalDate localDate ) {
+		return java.time.LocalDate.of( localDate.getYear(), localDate.getMonthOfYear(), localDate.getDayOfMonth() );
+	}
+
+	/**
+	 * Converts Java 8 LocalDate to Joda-Time equivalent.
+	 *
+	 * @param localDate Java 8 LocalDate
+	 * @return Joda-Time LocalDate
+	 */
+	public static org.joda.time.LocalDate javaToJodaLocalDate( java.time.LocalDate localDate ) {
+		return new org.joda.time.LocalDate( localDate.getYear(), localDate.getMonthValue(), localDate.getDayOfMonth() );
+	}
+
+	/**
+	 * Converts Joda-Time LocalTime to Java 8 equivalent.
+	 *
+	 * @param localTime Joda-Time LocalTime
+	 * @return Java 8 LocalTime
+	 */
+	public static java.time.LocalTime jodaToJavaLocalTime( org.joda.time.LocalTime localTime ) {
+		return java.time.LocalTime.of(
+				localTime.getHourOfDay(),
+				localTime.getMinuteOfHour(),
+				localTime.getSecondOfMinute(),
+				localTime.getMillisOfSecond() * milliToNanoConst );
+	}
+
+	/**
+	 * Converts Java 8 LocalTime to Joda-Time equivalent.
+	 * <p>
+	 * This is a potentially lossy operation. Any time info below millis unit are deleted.
+	 *
+	 * @param localTime Java 8 LocalTime
+	 * @return Joda-Time LocalTime
+	 */
+	public static org.joda.time.LocalTime javaToJodaLocalTime( java.time.LocalTime localTime ) {
+		return new org.joda.time.LocalTime(
+				localTime.getHour(),
+				localTime.getMinute(),
+				localTime.getSecond(),
+				localTime.getNano() / milliToNanoConst );
+	}
+
+	/**
+	 * Converts Joda-Time LocalDateTime to Java 8 equivalent.
+	 *
+	 * @param localDateTime Joda-Time LocalDateTime
+	 * @return Java 8 LocalDateTime
+	 */
+	public static java.time.LocalDateTime jodaToJavaLocalDateTime( org.joda.time.LocalDateTime localDateTime ) {
+		return java.time.LocalDateTime.of(
+				localDateTime.getYear(),
+				localDateTime.getMonthOfYear(),
+				localDateTime.getDayOfMonth(),
+				localDateTime.getHourOfDay(),
+				localDateTime.getMinuteOfHour(),
+				localDateTime.getSecondOfMinute(),
+				localDateTime.getMillisOfSecond() * milliToNanoConst );
+	}
+
+	/**
+	 * Converts Java 8 LocalDateTime to Joda-Time equivalent.
+	 * <p>
+	 * This is a potentially lossy operation. Any time info below millis unit are lost.
+	 *
+	 * @param localDateTime Java 8 LocalDateTime
+	 * @return Joda-Time LocalDateTime
+	 */
+	public static org.joda.time.LocalDateTime javaToJodaLocalDateTime( java.time.LocalDateTime localDateTime ) {
+		return new org.joda.time.LocalDateTime(
+				localDateTime.getYear(),
+				localDateTime.getMonthValue(),
+				localDateTime.getDayOfMonth(),
+				localDateTime.getHour(),
+				localDateTime.getMinute(),
+				localDateTime.getSecond(),
+				localDateTime.getNano() / milliToNanoConst );
+	}
+
+	/**
+	 * Converts Joda-Time MonthDay to Java 8 equivalent.
+	 *
+	 * @param monthDay Joda-Time MonthDay
+	 * @return Java 8 MonthDay
+	 */
+	public static java.time.MonthDay jodaToJavaMonthDay( org.joda.time.MonthDay monthDay ) {
+		return java.time.MonthDay.of( monthDay.getMonthOfYear(), monthDay.getDayOfMonth() );
+	}
+
+	/**
+	 * Converts Java 8 MonthDay to Joda-Time equivalent.
+	 *
+	 * @param monthDay Java 8 MonthDay
+	 * @return Joda-Time MonthDay
+	 */
+	public static org.joda.time.MonthDay javaToJodaMonthDay( java.time.MonthDay monthDay ) {
+		return new org.joda.time.MonthDay( monthDay.getMonthValue(), monthDay.getDayOfMonth() );
+	}
+
+	/**
+	 * Converts Joda-Time YearMonth to Java 8 equivalent.
+	 *
+	 * @param yearMonth Joda-Time YearMonth
+	 * @return Java 8 YearMonth
+	 */
+	public static java.time.YearMonth jodaToJavaYearMonth( org.joda.time.YearMonth yearMonth ) {
+		return java.time.YearMonth.of( yearMonth.getYear(), yearMonth.getMonthOfYear() );
+	}
+
+	/**
+	 * Converts Java 8 YearMonth to Joda-Time equivalent.
+	 *
+	 * @param yearMonth Java 8 YearMonth
+	 * @return Joda-Time YearMonth
+	 */
+	public static org.joda.time.YearMonth javaToJodaYearMonth( java.time.YearMonth yearMonth ) {
+		return new org.joda.time.YearMonth( yearMonth.getYear(), yearMonth.getMonthValue() );
+	}
+
+
+	/* ****************************** *
+	 * Class with timezone or instant *
+	 * ****************************** */
+
+	/**
+	 * Converts Joda-Time DateTime to Java 8 equivalent.
+	 *
+	 * @param dateTime Joda-Time DateTime
+	 * @return Java 8 ZonedDateTime
+	 */
+	public static java.time.ZonedDateTime jodaToJavaDateTime( org.joda.time.DateTime dateTime ) {
+		return jodaToJavaInstant( dateTime.toInstant() ).atZone( jodaToJavaTimeZone( dateTime.getZone() ) );
+	}
+
+	/**
+	 * Converts Java 8 ZonedDateTime to Joda-Time equivalent.
+	 *
+	 * @param dateTime Java 8 ZonedDateTime
+	 * @return Joda-Time DateTime
+	 */
+	public static org.joda.time.DateTime javaToJodaDateTime( java.time.ZonedDateTime dateTime ) {
+		return new org.joda.time.DateTime( javaToJodaInstant( dateTime.toInstant() ), javaToJodaTimeZone( dateTime.getZone() ) );
+	}
+
+	/**
+	 * Converts Joda-Time Instant to Java 8 equivalent.
+	 *
+	 * @param instant Joda-Time Instant
+	 * @return Java 8 Instant
+	 */
+	public static java.time.Instant jodaToJavaInstant( org.joda.time.Instant instant ) {
+		return java.time.Instant.ofEpochMilli( instant.getMillis() );
+	}
+
+	/**
+	 * Converts Java 8 Instant to Joda-Time equivalent.
+	 *
+	 * @param instant Java 8 Instant
+	 * @return Joda-Time Instant
+	 */
+	public static org.joda.time.Instant javaToJodaInstant( java.time.Instant instant ) {
+		return new org.joda.time.Instant( instant.toEpochMilli() );
+	}
+
+	/**
+	 * Converts Joda-Time DateTimeZone to Java 8 equivalent.
+	 *
+	 * @param timeZone Joda-Time DateTimeZone
+	 * @return Java 8 ZoneId
+	 */
+	public static java.time.ZoneId jodaToJavaTimeZone( org.joda.time.DateTimeZone timeZone ) {
+		return java.time.ZoneId.of( timeZone.getID() );
+	}
+
+	/**
+	 * Converts Java 8 ZoneId to Joda-Time equivalent.
+	 *
+	 * @param timeZone Java 8 ZoneId
+	 * @return Joda-Time DateTimeZone
+	 */
+	public static org.joda.time.DateTimeZone javaToJodaTimeZone( java.time.ZoneId timeZone ) {
+		return org.joda.time.DateTimeZone.forID( timeZone.getId() );
+	}
+
+
+	/* ************** *
+	 * Amount of Time *
+	 * ************** */
+
+	/**
+	 * Converts Joda-Time Duration to Java 8 equivalent.
+	 *
+	 * @param duration Joda-Time Duration
+	 * @return Java 8 Duration
+	 */
+	public static java.time.Duration jodaToJavaDuration( org.joda.time.Duration duration ) {
+		return java.time.Duration.ofMillis( duration.getMillis() );
+	}
+
+	/**
+	 * Converts Java 8 Duration to Joda-Time equivalent.
+	 *
+	 * @param duration Java 8 Duration
+	 * @return Joda-Time Duration
+	 */
+	public static org.joda.time.Duration javaToJodaDuration( java.time.Duration duration ) {
+		return org.joda.time.Duration.millis( duration.toMillis() );
+	}
+
+	/**
+	 * Converts Joda-Time Period to Java 8 equivalent.
+	 * <p>
+	 * This is a potentially lossy operation. Any time info below day unit are lost.
+	 *
+	 * @param period Joda-Time Period
+	 * @return Java 8 Period
+	 */
+	public static java.time.Period jodaToJavaPeriod( org.joda.time.Period period ) {
+		return java.time.Period.of( period.getYears(), period.getMonths(), period.getDays() );
+	}
+
+	/**
+	 * Converts Java 8 Period to Joda-Time equivalent.
+	 *
+	 * @param period Java 8 Period
+	 * @return Joda-Time Period
+	 */
+	public static org.joda.time.Period javaToJodaPeriod( java.time.Period period ) {
+		return new org.joda.time.Period( period.getYears(), period.getMonths(), 0, period.getDays(), 0, 0, 0, 0 );
+	}
+}

--- a/core/src/main/java/org/jruby/util/time/TimeArgs.java
+++ b/core/src/main/java/org/jruby/util/time/TimeArgs.java
@@ -16,6 +16,8 @@ import org.jruby.runtime.JavaSites;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.function.Function;
 
 public class TimeArgs {
@@ -102,6 +104,7 @@ public class TimeArgs {
         this.dst = dst;
     }
 
+    @Deprecated
     public void initializeTime(ThreadContext context, RubyTime time, DateTimeZone dtz) {
         Ruby runtime = context.runtime;
 
@@ -204,6 +207,11 @@ public class TimeArgs {
 
         time.setDateTime(dt);
         time.setNSec(nanos);
+    }
+
+    @SuppressWarnings("deprecation")
+    public void initializeTime(ThreadContext context, RubyTime time, ZoneId dtz) {
+        initializeTime(context, time, JodaConverters.javaToJodaTimeZone(dtz));
     }
 
     private static int parseYear(ThreadContext context, IRubyObject _year) {


### PR DESCRIPTION
This will be a series of commits to deprecate and replace all public APIs referencing classes from the Joda Time library and providing new versions based on java.time.

We will need to maintain these deprecated methods for a while before we can remove them and Joda Time from JRuby.

Some helpful guides:

* Mapping joda to java.time types, but not much help on how to convert: https://blog.joda.org/2014/11/converting-from-joda-time-to-javatime.html
* timeywimey a tiny library for converting some joda types to and from java.time: https://github.com/meetup/timeywimey