### PR TITLE
UNIX datagram socket support

### DIFF
--- a/core/src/main/java/org/jruby/ext/socket/SocketType.java
+++ b/core/src/main/java/org/jruby/ext/socket/SocketType.java
@@ -28,6 +28,7 @@ package org.jruby.ext.socket;
 
 import jnr.constants.platform.Sock;
 import jnr.constants.platform.SocketOption;
+import jnr.unixsocket.UnixDatagramChannel;
 import jnr.unixsocket.UnixServerSocketChannel;
 import jnr.unixsocket.UnixSocketAddress;
 import jnr.unixsocket.UnixSocketChannel;
@@ -260,6 +261,9 @@ public enum SocketType {
             return SERVER;
 
         } else if (channel instanceof DatagramChannel) {
+            return DATAGRAM;
+
+        } else if (channel instanceof UnixDatagramChannel) {
             return DATAGRAM;
 
         } else if (channel instanceof UnixSocketChannel) {

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
 
 import jnr.constants.platform.Errno;
+import jnr.enxio.channels.NativeException;
 import org.jruby.*;
 import org.jruby.ast.ArgsNode;
 import org.jruby.ast.ArgumentNode;
@@ -261,6 +262,8 @@ public class Helpers {
             return errnoFromMessage(dnee);
         } catch (BindException be) {
             return errnoFromMessage(be);
+        } catch (NativeException ne) {
+            return ((NativeException) ne).getErrno();
         } catch (IOException ioe) {
             String message = ioe.getMessage();
             // Raised on Windows for process launch with missing file


### PR DESCRIPTION
Unix datagram sockets have never been properly wired up. In addition, datagram send and receive have not been hooked up for RubySocket, which makes it impossible to construct and use a UNIX DGRAM socket via the Socket class. This PR will fix all that for #6504.