### PR TITLE
Return only inflated content from Zlib.inflate

### DIFF
--- a/core/src/main/java/org/jruby/ext/zlib/JZlibInflate.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibInflate.java
@@ -67,14 +67,12 @@ public class JZlibInflate extends ZStream {
         JZlibInflate inflate = (JZlibInflate) klass.allocate();
         inflate.init(JZlib.DEF_WBITS);
 
-        IRubyObject result;
         try {
-            inflate.append(string.convertToString().getByteList());
+            return inflate.inflate(context, string, Block.NULL_BLOCK);
         } finally {
-            result = inflate.finish(context, Block.NULL_BLOCK);
+            inflate.finish(context, Block.NULL_BLOCK);
             inflate.close();
         }
-        return result;
     }
 
     @JRubyMethod(name = "initialize", optional = 1, visibility = PRIVATE)

--- a/spec/tags/ruby/library/zlib/deflate/deflate_tags.txt
+++ b/spec/tags/ruby/library/zlib/deflate/deflate_tags.txt
@@ -1,7 +1,5 @@
 fails:Zlib::Deflate.deflate deflates chunked data
 fails:Zlib::Deflate#deflate without break deflates chunked data
 fails:Zlib::Deflate#deflate without break deflates chunked data with final chunk
-fails:Zlib::Deflate#deflate without break deflates chunked data without errors
 fails:Zlib::Deflate#deflate with break deflates only first chunk
 fails:Zlib::Deflate#deflate with break deflates chunked data with final chunk
-fails:Zlib::Deflate#deflate with break deflates chunked data without errors


### PR DESCRIPTION
Fixes #6606

Need to investigate the surrounding logic, since it no longer matches CRuby and this patch is a bit of a best guess at what is intended. The basic issue was that we were appending extra bytes on the input to the decompressed output. CRuby, on the other hand, just ensures the input buffer contains only those extra bytes, allowing you to pass the same input to inflate repeatedly to get multiple compressed chunks out of it.

We do not support this behavior, and the related test does not pass (this PR neither fixes nor breaks any CRuby zlib tests, as far as I could see).