### PR TITLE
Detect modules more robustly

### DIFF
--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -54,7 +54,7 @@ process_java_opts() {
 
     # On Java 9+, add an @argument for the given file.
     # On earlier versions the file contents will be read and expanded on the Java command line.
-    if [ "$is_java9" ]; then
+    if [ "$use_modules" ]; then
       java_opts_from_files="$java_opts_from_files @$java_opts_file"
     else
       java_opts_from_files="$java_opts_from_files $(cat "$java_opts_file")"
@@ -140,17 +140,17 @@ else
   fi
 fi
 
-# Detect Java 9+ by the presence of a jmods directory in JAVA_HOME
-if [ -d "$JAVA_HOME"/jmods ]; then
-  is_java9=1
+# Detect modularized Java
+if [ -f ${JAVA_HOME}/lib/modules ] || [ -f ${JAVA_HOME}/release ] && grep -q ^MODULES ${JAVA_HOME}/release; then
+  use_modules=1
 fi
 
 add_log "  JAVACMD: $JAVACMD"
 add_log "  JAVA_HOME: $JAVA_HOME"
 
-if [ "$is_java9" ]; then
+if [ "$use_modules" ]; then
   add_log
-  add_log "Detected Java modules at $JAVA_HOME/jmods"
+  add_log "Detected Java modules at $JAVA_HOME"
 fi
 
 # ----- Process .java_opts files ----------------------------------------------
@@ -384,7 +384,7 @@ fi
 
 # ----- Module and Class Data Sharing flags for Java 9+ -----------------------
 
-if [ "$is_java9" ]; then
+if [ "$use_modules" ]; then
   # Use module path instead of classpath for the jruby libs
   classpath_args=(--module-path "$JRUBY_CP" -classpath "$CP$CP_DELIMITER$CLASSPATH")
 


### PR DESCRIPTION
Detecting module support based on the existence of the jmods
directory was fragile for at least two reasons:

* The jmods directory is only present in some builds of the JDK
  (not JRE) that can be used to jlink new runtime environments.
* Some distributions of the JDK may omit or relocate this
  directory, such as Nix's version (#6608).

Instead we detect modules using two other mechanisms that should
reliably work on all modularized Java runtimes:

* Check for JAVA_HOME/lib/modules, generated by the jlink process.
* Check for a JAVA_HOME/release file with a MODULES entry.

See https://stackoverflow.com/questions/66601929 for a summary of
detection mechanism.

Fixes #6608.

jruby-launcher will need a matching update.