### PR TITLE
Fixes #6564. Passing **kw to def with no args should work

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -42,6 +42,8 @@ import static org.jruby.ir.instructions.Instr.EMPTY_OPERANDS;
 import static org.jruby.ir.instructions.RuntimeHelperCall.Methods.*;
 
 import static org.jruby.ir.operands.ScopeModule.*;
+import static org.jruby.runtime.CallType.FUNCTIONAL;
+import static org.jruby.runtime.CallType.NORMAL;
 
 // This class converts an AST into a bunch of IR instructions
 
@@ -1088,14 +1090,13 @@ public class IRBuilder {
 
     // Wrap call in a rescue handler that catches the IRBreakJump
     private void receiveBreakException(Operand block, final CallInstr callInstr) {
-        receiveBreakException(block, new CodeBlock() { public Operand run() { addInstr(callInstr); return callInstr.getResult(); } });
+        receiveBreakException(block, () -> addResultInstr(callInstr));
     }
 
-    public Operand buildCall(Variable result, CallNode callNode, Label lazyLabel, Label endLabel) {
-        Node receiverNode = callNode.getReceiverNode();
-        RubySymbol name = callNode.getName();
+    public Operand buildCall(Variable aResult, CallNode callNode, Label lazyLabel, Label endLabel) {
+        RubySymbol name = methodName = callNode.getName();
 
-        methodName = name;
+        Node receiverNode = callNode.getReceiverNode();
 
         // Frozen string optimization: check for "string".freeze
         String id = name.idString(); // ID Str ok here since it is 7bit check.
@@ -1122,7 +1123,7 @@ public class IRBuilder {
             receiver = buildWithOrder(receiverNode, callNode.containsVariableAssignment());
         }
 
-        if (result == null) result = createTemporaryVariable();
+        final Variable result = aResult == null ? createTemporaryVariable() : aResult;
 
         // obj["string"] optimization for Hash
         ArrayNode argsAry;
@@ -1139,28 +1140,43 @@ public class IRBuilder {
             return result;
         }
 
-        if (callNode.isLazy()) {
-            addInstr(new BNilInstr(lazyLabel, receiver));
-        }
+        if (callNode.isLazy()) addInstr(new BNilInstr(lazyLabel, receiver));
 
         HashNode keywordArgs = getPossibleKeywordArgument(callNode.getArgsNode());
-
-        CallInstr callInstr;
-        Operand block;
         if (keywordArgs != null) {
             Operand[] args = buildCallArgsExcept(callNode.getArgsNode(), keywordArgs);
-            List<KeyValuePair<Operand, Operand>> kwargs = buildKeywordArguments(keywordArgs);
-            block = setupCallClosure(callNode.getIterNode());
-            callInstr = CallInstr.createWithKwargs(scope, CallType.NORMAL, result, name, receiver, args, block, kwargs);
+
+            if (keywordArgs.hasOnlyRestKwargs()) {  // {**k}, {**{}, **k}, etc...
+                Variable splatValue = buildRestKeywordArgs(keywordArgs);
+                Variable test = addResultInstr(new RuntimeHelperCall(createTemporaryVariable(), IS_HASH_EMPTY, new Operand[] { splatValue }));
+                Operand block = setupCallClosure(callNode.getIterNode());
+
+                determineIfWeNeedLineNumber(callNode); // buildOperand for fcall was papered over by args operand building so we check once more.
+                if_else(test, manager.getTrue(),
+                        () -> receiveBreakException(block,
+                                determineIfProcNew(receiverNode,
+                                        CallInstr.create(scope, NORMAL, result, name, receiver, args, block))),
+                        () -> receiveBreakException(block,
+                                determineIfProcNew(receiverNode,
+                                        CallInstr.create(scope, NORMAL, result, name, receiver, addArg(args, splatValue), block))));
+            } else {  // {a: 1, b: 2}
+                List<KeyValuePair<Operand, Operand>> kwargs = buildKeywordArguments(keywordArgs);
+                Operand block = setupCallClosure(callNode.getIterNode());
+
+                determineIfWeNeedLineNumber(callNode); // buildOperand for fcall was papered over by args operand building so we check once more.
+                receiveBreakException(block,
+                        determineIfProcNew(receiverNode,
+                                CallInstr.createWithKwargs(scope, NORMAL, result, name, receiver, args, block, kwargs)));
+            }
         } else {
             Operand[] args = setupCallArgs(callNode.getArgsNode());
-            block = setupCallClosure(callNode.getIterNode());
-            callInstr = CallInstr.create(scope, result, name, receiver, args, block);
-        }
+            Operand block = setupCallClosure(callNode.getIterNode());
 
-        determineIfWeNeedLineNumber(callNode);
-        determineIfProcNew(receiverNode, name, callInstr);
-        receiveBreakException(block, callInstr);
+            determineIfWeNeedLineNumber(callNode);
+            receiveBreakException(block,
+                    determineIfProcNew(receiverNode,
+                            CallInstr.create(scope, result, name, receiver, args, block)));
+        }
 
         if (compileLazyLabel) {
             addInstr(new JumpInstr(endLabel));
@@ -1175,17 +1191,19 @@ public class IRBuilder {
     private List<KeyValuePair<Operand, Operand>> buildKeywordArguments(HashNode keywordArgs) {
         List<KeyValuePair<Operand, Operand>> kwargs = new ArrayList<>();
         for (KeyValuePair<Node, Node> pair: keywordArgs.getPairs()) {
-            kwargs.add(new KeyValuePair<Operand, Operand>((Symbol) build(pair.getKey()), build(pair.getValue())));
+            kwargs.add(new KeyValuePair<>(build(pair.getKey()), build(pair.getValue())));
         }
         return kwargs;
     }
 
-    private void determineIfProcNew(Node receiverNode, RubySymbol name, CallInstr callInstr) {
+    private CallInstr determineIfProcNew(Node receiverNode, CallInstr callInstr) {
         // This is to support the ugly Proc.new with no block, which must see caller's frame
-        if (CommonByteLists.NEW_METHOD.equals(name.getBytes()) &&
+        if (CommonByteLists.NEW_METHOD.equals(callInstr.getName().getBytes()) &&
                 receiverNode instanceof ConstNode && ((ConstNode)receiverNode).getName().idString().equals("Proc")) {
             callInstr.setProcNew(true);
         }
+
+        return callInstr;
     }
 
     /*
@@ -1207,7 +1225,7 @@ public class IRBuilder {
 
             if (lastNode instanceof HashNode) {
                 HashNode hash = (HashNode) lastNode;
-                if (hash.hasOnlySymbolKeys() && !hash.isEmpty()) return (HashNode) lastNode;
+                if (hash.isMaybeKwargs()) return (HashNode) lastNode;
             }
         }
 
@@ -1643,7 +1661,11 @@ public class IRBuilder {
     }
 
     interface CodeBlock {
-        public Operand run();
+        Operand run();
+    }
+
+    interface VoidCodeBlock {
+        void run();
     }
 
     private Operand protectCodeWithRescue(CodeBlock protectedCode, CodeBlock rescueBlock) {
@@ -2692,7 +2714,7 @@ public class IRBuilder {
         boolean debuggingFrozenStringLiteral = manager.getInstanceConfig().isDebuggingFrozenStringLiteral();
         addInstr(new BuildCompoundStringInstr(stringResult, pieces, node.getEncoding(), estimatedSize, false, debuggingFrozenStringLiteral, getFileName(), node.getLine()));
 
-        return addResultInstr(CallInstr.create(scope, CallType.FUNCTIONAL, result, manager.getRuntime().newSymbol("`"), Self.SELF, new Operand[] { stringResult }, null));
+        return addResultInstr(CallInstr.create(scope, FUNCTIONAL, result, manager.getRuntime().newSymbol("`"), Self.SELF, new Operand[] { stringResult }, null));
     }
 
     /* ****************************************************************
@@ -2824,26 +2846,67 @@ public class IRBuilder {
         return manager.getFalse();
     }
 
-    public Operand buildFCall(Variable result, FCallNode fcallNode) {
-        Node      callArgsNode = fcallNode.getArgsNode();
+    /**
+     * Generate if testVariable NEQ testValue { ifBlock } else { elseBlock }.
+     *
+     * @param testVariable what we will test against testValue
+     * @param testValue what we want to testVariable to NOT be equal to.
+     * @param ifBlock the code if test values do NOT match
+     * @param elseBlock the code to execute otherwise.
+     */
+    private void if_else(Operand testVariable, Operand testValue, VoidCodeBlock ifBlock, VoidCodeBlock elseBlock) {
+        Label elseLabel = getNewLabel();
+        Label endLabel = getNewLabel();
 
-        methodName = fcallNode.getName();
+        addInstr(BNEInstr.create(elseLabel, testVariable, testValue));
+        ifBlock.run();
+        addInstr(new JumpInstr(endLabel));
 
-        if (result == null) result = createTemporaryVariable();
+        addInstr(new LabelInstr(elseLabel));
+        elseBlock.run();
+        addInstr(new LabelInstr(endLabel));
+    }
+
+    private Variable buildRestKeywordArgs(HashNode keywordArgs) {
+        Variable splatValue = copyAndReturnValue(new Hash(new ArrayList<>()));
+        for (KeyValuePair<Node, Node> pair: keywordArgs.getPairs()) {
+            Operand splat = buildWithOrder(pair.getValue(), keywordArgs.containsVariableAssignment());
+            addInstr(new RuntimeHelperCall(splatValue, MERGE_KWARGS, new Operand[] { splatValue, splat }));
+        }
+
+        return splatValue;
+    }
+
+    public Operand buildFCall(Variable aResult, FCallNode fcallNode) {
+        RubySymbol name = methodName = fcallNode.getName();
+
+        Node callArgsNode = fcallNode.getArgsNode();
+        final Variable result = aResult == null ? createTemporaryVariable() : aResult;
 
         HashNode keywordArgs = getPossibleKeywordArgument(fcallNode.getArgsNode());
-
-        CallInstr callInstr;
-        Operand block;
         if (keywordArgs != null) {
             Operand[] args = buildCallArgsExcept(fcallNode.getArgsNode(), keywordArgs);
-            List<KeyValuePair<Operand, Operand>> kwargs = buildKeywordArguments(keywordArgs);
-            block = setupCallClosure(fcallNode.getIterNode());
-            callInstr = CallInstr.createWithKwargs(scope, CallType.FUNCTIONAL, result, fcallNode.getName(), buildSelf(), args, block, kwargs);
+
+            if (keywordArgs.hasOnlyRestKwargs()) {  // {**k}, {**{}, **k}, etc...
+                Variable splatValue = buildRestKeywordArgs(keywordArgs);
+                Variable test = addResultInstr(new RuntimeHelperCall(createTemporaryVariable(), IS_HASH_EMPTY, new Operand[] { splatValue }));
+                Operand block = setupCallClosure(fcallNode.getIterNode());
+
+                determineIfWeNeedLineNumber(fcallNode); // buildOperand for fcall was papered over by args operand building so we check once more.
+                if_else(test, manager.getTrue(),
+                        () -> receiveBreakException(block, CallInstr.create(scope, FUNCTIONAL, result, name, buildSelf(), args, block)),
+                        () -> receiveBreakException(block, CallInstr.create(scope, FUNCTIONAL, result, name, buildSelf(), addArg(args, splatValue), block)));
+            } else {  // {a: 1, b: 2}
+                List<KeyValuePair<Operand, Operand>> kwargs = buildKeywordArguments(keywordArgs);
+                Operand block = setupCallClosure(fcallNode.getIterNode());
+
+                determineIfWeNeedLineNumber(fcallNode); // buildOperand for fcall was papered over by args operand building so we check once more.
+                receiveBreakException(block, CallInstr.createWithKwargs(scope, FUNCTIONAL, result, name, buildSelf(), args, block, kwargs));
+            }
         } else {
             Operand[] args = setupCallArgs(callArgsNode);
             determineIfMaybeRefined(fcallNode.getName(), args);
-            block = setupCallClosure(fcallNode.getIterNode());
+            Operand block = setupCallClosure(fcallNode.getIterNode());
 
             // We will stuff away the iters AST source into the closure in the hope we can convert
             // this closure to a method.
@@ -2857,11 +2920,9 @@ public class IRBuilder {
                 }
             }
 
-            callInstr = CallInstr.create(scope, CallType.FUNCTIONAL, result, fcallNode.getName(), buildSelf(), args, block);
+            determineIfWeNeedLineNumber(fcallNode); // buildOperand for fcall was papered over by args operand building so we check once more.
+            receiveBreakException(block, CallInstr.create(scope, FUNCTIONAL, result, name, buildSelf(), args, block));
         }
-
-        determineIfWeNeedLineNumber(fcallNode); // buildOperand for fcall was papered over by args operand building so we check once more.
-        receiveBreakException(block, callInstr);
 
         return result;
     }
@@ -3275,7 +3336,7 @@ public class IRBuilder {
         Variable readerValue = createTemporaryVariable();
         Variable writerValue = createTemporaryVariable();
         Node receiver = opAsgnNode.getReceiverNode();
-        CallType callType = receiver instanceof SelfNode ? CallType.FUNCTIONAL : CallType.NORMAL;
+        CallType callType = receiver instanceof SelfNode ? FUNCTIONAL : CallType.NORMAL;
 
         // get attr
         Operand  v1 = build(opAsgnNode.getReceiverNode());
@@ -3455,7 +3516,7 @@ public class IRBuilder {
 
     private Operand buildOpElementAsgnWith(OpElementAsgnNode opElementAsgnNode, Boolean truthy) {
         Node receiver = opElementAsgnNode.getReceiverNode();
-        CallType callType = receiver instanceof SelfNode ? CallType.FUNCTIONAL : CallType.NORMAL;
+        CallType callType = receiver instanceof SelfNode ? FUNCTIONAL : CallType.NORMAL;
         Operand array = buildWithOrder(receiver, opElementAsgnNode.containsVariableAssignment());
         Label endLabel = getNewLabel();
         Variable elt = createTemporaryVariable();
@@ -3476,7 +3537,7 @@ public class IRBuilder {
     // a[i] *= n, etc.  anything that is not "a[i] &&= .. or a[i] ||= .."
     public Operand buildOpElementAsgnWithMethod(OpElementAsgnNode opElementAsgnNode) {
         Node receiver = opElementAsgnNode.getReceiverNode();
-        CallType callType = receiver instanceof SelfNode ? CallType.FUNCTIONAL : CallType.NORMAL;
+        CallType callType = receiver instanceof SelfNode ? FUNCTIONAL : CallType.NORMAL;
         Operand array = buildWithOrder(receiver, opElementAsgnNode.containsVariableAssignment());
         Operand[] argList = setupCallArgs(opElementAsgnNode.getArgsNode());
         Operand block = setupCallClosure(opElementAsgnNode.getBlockNode());
@@ -4067,7 +4128,7 @@ public class IRBuilder {
     }
 
     public Operand buildXStr(XStrNode node) {
-        return addResultInstr(CallInstr.create(scope, CallType.FUNCTIONAL, createTemporaryVariable(),
+        return addResultInstr(CallInstr.create(scope, FUNCTIONAL, createTemporaryVariable(),
                 manager.getRuntime().newSymbol("`"), Self.SELF,
                 new Operand[] { new FrozenString(node.getValue(), node.getCodeRange(), scope.getFile(), node.getLine()) }, null));
     }

--- a/core/src/main/java/org/jruby/ir/instructions/RuntimeHelperCall.java
+++ b/core/src/main/java/org/jruby/ir/instructions/RuntimeHelperCall.java
@@ -26,7 +26,7 @@ public class RuntimeHelperCall extends NOperandResultBaseInstr {
         HANDLE_PROPAGATED_BREAK, HANDLE_NONLOCAL_RETURN, HANDLE_BREAK_AND_RETURNS_IN_LAMBDA,
         IS_DEFINED_BACKREF, IS_DEFINED_NTH_REF, IS_DEFINED_GLOBAL, IS_DEFINED_INSTANCE_VAR,
         IS_DEFINED_CLASS_VAR, IS_DEFINED_SUPER, IS_DEFINED_METHOD, IS_DEFINED_CALL,
-        IS_DEFINED_CONSTANT_OR_METHOD, MERGE_KWARGS;
+        IS_DEFINED_CONSTANT_OR_METHOD, MERGE_KWARGS, IS_HASH_EMPTY;
 
         public static Methods fromOrdinal(int value) {
             return value < 0 || value >= values().length ? null : values()[value];
@@ -159,6 +159,8 @@ public class RuntimeHelperCall extends NOperandResultBaseInstr {
             case MERGE_KWARGS:
                 return IRRuntimeHelpers.mergeKeywordArguments(context, (IRubyObject) arg1,
                         (IRubyObject) getArgs()[1].retrieve(context, self, currScope, currDynScope, temp));
+            case IS_HASH_EMPTY:
+                return IRRuntimeHelpers.isHashEmpty(context, (IRubyObject) arg1);
         }
 
         throw new RuntimeException("Unknown IR runtime helper method: " + helperMethod + "; INSTR: " + this);

--- a/core/src/main/java/org/jruby/ir/operands/Hash.java
+++ b/core/src/main/java/org/jruby/ir/operands/Hash.java
@@ -109,6 +109,10 @@ public class Hash extends Operand {
         return new Hash(newPairs, isKWArgsHash);
     }
 
+    public boolean isKeywordRest() {
+        return isKWArgsHash && pairs.length > 0 && pairs[0].getKey().equals(Symbol.KW_REST_ARG_DUMMY);
+    }
+
     @Override
     public Object retrieve(ThreadContext context, IRubyObject self, StaticScope currScope, DynamicScope currDynScope, Object[] temp) {
         Ruby runtime = context.runtime;
@@ -116,7 +120,7 @@ public class Hash extends Operand {
         KeyValuePair<Operand, Operand>[] pairs = this.pairs;
         int index = 0;
 
-        if (isKWArgsHash && pairs.length > 0 && pairs[0].getKey().equals(Symbol.KW_REST_ARG_DUMMY)) {
+        if (isKeywordRest()) {
             // Dup the rest args hash and use that as the basis for inserting the non-rest args
             hash = ((RubyHash) pairs[0].getValue().retrieve(context, self, currScope, currDynScope, temp)).dupFast(context);
             // Skip the first pair

--- a/core/src/main/java/org/jruby/ir/operands/Hash.java
+++ b/core/src/main/java/org/jruby/ir/operands/Hash.java
@@ -116,7 +116,7 @@ public class Hash extends Operand {
         KeyValuePair<Operand, Operand>[] pairs = this.pairs;
         int index = 0;
 
-        if (isKWArgsHash && pairs[0].getKey().equals(Symbol.KW_REST_ARG_DUMMY)) {
+        if (isKWArgsHash && pairs.length > 0 && pairs[0].getKey().equals(Symbol.KW_REST_ARG_DUMMY)) {
             // Dup the rest args hash and use that as the basis for inserting the non-rest args
             hash = ((RubyHash) pairs[0].getValue().retrieve(context, self, currScope, currDynScope, temp)).dupFast(context);
             // Skip the first pair

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -661,6 +661,11 @@ public class IRRuntimeHelpers {
         }
     }
 
+    public static IRubyObject isHashEmpty(ThreadContext context, IRubyObject hashArg) {
+        return hashArg instanceof RubyHash && ((RubyHash) hashArg).size() == 0 ?
+                context.tru : context.fals;
+    }
+
     private static class DivvyKeywordsVisitor extends RubyHash.VisitorWithState {
         RubyHash syms;
         RubyHash others;

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -2568,9 +2568,9 @@ public class JVMVisitor extends IRVisitor {
 
     @Override
     public void Hash(Hash hash) {
+        boolean kwargs = hash.isKeywordRest();
         List<KeyValuePair<Operand, Operand>> pairs = hash.getPairs();
         Iterator<KeyValuePair<Operand, Operand>> iter = pairs.iterator();
-        boolean kwargs = hash.isKWArgsHash && pairs.get(0).getKey() == Symbol.KW_REST_ARG_DUMMY;
 
         jvmMethod().loadContext();
         if (kwargs) {

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -2237,6 +2237,12 @@ public class JVMVisitor extends IRVisitor {
                 jvmAdapter().invokestatic(p(IRRuntimeHelpers.class), "mergeKeywordArguments", sig(IRubyObject.class, ThreadContext.class, IRubyObject.class, IRubyObject.class));
                 jvmStoreLocal(runtimehelpercall.getResult());
                 break;
+            case IS_HASH_EMPTY:
+                jvmMethod().loadContext();
+                visit(runtimehelpercall.getArgs()[0]);
+                jvmAdapter().invokestatic(p(IRRuntimeHelpers.class), "isHashEmpty", sig(IRubyObject.class, ThreadContext.class, IRubyObject.class));
+                jvmStoreLocal(runtimehelpercall.getResult());
+                break;
             default:
                 throw new NotCompilableException("Unknown IR runtime helper method: " + runtimehelpercall.getHelperMethod() + "; INSTR: " + this);
         }

--- a/spec/tags/ruby/language/method_tags.txt
+++ b/spec/tags/ruby/language/method_tags.txt
@@ -1,2 +1,0 @@
-fails:A method assigns local variables from method parameters for definition 'def m() end'
-fails:A method assigns local variables from method parameters for definition 'def m(*a) a end'


### PR DESCRIPTION
This fixes the problem reported in #6564.

It introduces a problem by not passing:
```ruby
def bar(a)
  puts "BAR #{a}"
end

a = {}
bar(**a)
```

In Ruby 2.6 this will receive the empty hash as parameter 'a' in 'bar'.  In Ruby 3.0 this will be an arity mismatch.  I opted to break 2.6 compatibility because bar(**{}, **{}) will arity error (which is inconsistent) and 3.0 corrects this inconsistency.  I am comfortable with encouraging people to not expect this behaviour.  Anyone doing this will need to update their library/application anyways.

The mechanics of the fix is to look at any **a passed at the callsite and if it is empty we will not pass it along.  If it is not empty we do.  This is option number 2 in #6564.  Not ideal in that we add some more interpreted logic for callsites with **a and it will generate more bytecode as well.  It is ideal in that it did not require us to rewrite all keyword argument processing.   Later work (like the other two options discussed in the issue) can eventually end up removing this.

As a note of other futures: 
  1. if_else in IRBuilder probably can be reused as a helper in other places.
  2. I am thinking about making a new instruction java_call which will allow arbitrary Java calls but can then probably eliminate multiple RuntimeHelperInstr.  This is a potentially a big hole in wanting to display against receivers and making static calls.  The operations will be the same as RuntimeHelperInstr.

