### PR TITLE
Unbreak CachingCallSite.isBuiltin

### DIFF
--- a/core/src/main/java/org/jruby/runtime/callsite/CachingCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/CachingCallSite.java
@@ -17,6 +17,7 @@ import static org.jruby.RubyBasicObject.getMetaClass;
 public abstract class CachingCallSite extends CallSite {
 
     protected CacheEntry cache = CacheEntry.NULL_CACHE;
+    @Deprecated
     protected CacheEntry builtinCache = CacheEntry.NULL_CACHE;
 
     public CachingCallSite(String methodName, CallType callType) {
@@ -289,7 +290,7 @@ public abstract class CachingCallSite extends CallSite {
     public boolean isBuiltin(IRubyObject self) {
         RubyClass selfType = getMetaClass(self);
         // This must be retrieved *once* to avoid racing with other threads.
-        CacheEntry cache = this.builtinCache;
+        CacheEntry cache = this.cache;
         if (cache.typeOk(selfType)) {
             return true;
         }


### PR DESCRIPTION
During the various deprecations and undeprecations of this method,
it was inadvertently broken due to switching to a cacheAndGet path
that does not set the builtinCache field. Since call sites used
for isBuiltin are usually *only* used for isBuiltin, I modified
this to just use the standard cache field.

Relates to #6628