### PR TITLE
Provide a collector for indy varargs boxing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -206,6 +206,14 @@ matrix:
         - bundle install
         - jruby -S rake spec:ji
 
+      - name: JI specs indy
+        script:
+          - mvn clean package -Pbootstrap
+          - gem install bundler
+          - bundle install
+          - jruby -S rake spec:ji
+        env: JRUBY_OPTS=-Xcompile.invokedynamic
+
     - name: Compiler specs
       script:
         - mvn clean package -Pbootstrap

--- a/core/pom.rb
+++ b/core/pom.rb
@@ -55,7 +55,7 @@ project 'JRuby Base' do
   jar 'org.jruby.jcodings:jcodings:1.0.55'
   jar 'org.jruby:dirgra:0.3'
 
-  jar 'com.headius:invokebinder:1.11'
+  jar 'com.headius:invokebinder:1.12'
   jar 'com.headius:options:1.5'
 
   jar 'com.jcraft:jzlib:1.1.3'

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -165,7 +165,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>com.headius</groupId>
       <artifactId>invokebinder</artifactId>
-      <version>1.11</version>
+      <version>1.12</version>
     </dependency>
     <dependency>
       <groupId>com.headius</groupId>

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -140,6 +140,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     private static final byte[] SCRUB_REPL_UTF32LE = new byte[]{(byte)0xFD, (byte)0xFF, (byte)0x00, (byte)0x00};
     private static final byte[] FORCE_ENCODING_BYTES = ".force_encoding(\"".getBytes();
 
+    public static RubyString[] NULL_ARRAY = {};
+
     private volatile int shareLevel = SHARE_LEVEL_NONE;
 
     private ByteList value;

--- a/core/src/main/java/org/jruby/ir/targets/indy/Bootstrap.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/Bootstrap.java
@@ -661,7 +661,7 @@ public class Bootstrap {
                             site.name(),
                             self.getRuntime().newSymbol(site.methodName))
                     .insert(0, "method", DynamicMethod.class, method)
-                    .collect("args", "arg.*", Helpers.constructObjectArrayHandle(site.arity));
+                    .collect("args", "arg.*", Helpers.constructObjectArrayHandle(site.arity + 1));
         } else {
             SmartHandle fold = SmartBinder.from(
                     site.signature

--- a/core/src/main/java/org/jruby/ir/targets/indy/Bootstrap.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/Bootstrap.java
@@ -54,6 +54,7 @@ import java.math.BigInteger;
 import static java.lang.invoke.MethodHandles.*;
 import static java.lang.invoke.MethodType.methodType;
 import static org.jruby.runtime.Helpers.arrayOf;
+import static org.jruby.runtime.Helpers.constructObjectArrayHandle;
 import static org.jruby.runtime.invokedynamic.InvokeDynamicSupport.findStatic;
 import static org.jruby.runtime.invokedynamic.InvokeDynamicSupport.findVirtual;
 import static org.jruby.util.CodegenUtils.p;
@@ -597,7 +598,7 @@ public class Bootstrap {
                         if (!blockGiven) mh = insertArguments(mh, mh.type().parameterCount() - 1, Block.NULL_BLOCK);
 
                         mh = SmartBinder.from(lookup(), siteToDyncall)
-                                .collect("args", "arg.*")
+                                .collect("args", "arg.*", Helpers.constructObjectArrayHandle(site.arity))
                                 .invoke(mh)
                                 .handle();
                     }
@@ -636,7 +637,7 @@ public class Bootstrap {
                 .insert(0, "method", DynamicMethod.class, method);
 
         if (site.arity > 3) {
-            binder = binder.collect("args", "arg.*");
+            binder = binder.collect("args", "arg.*", constructObjectArrayHandle(site.arity));
         }
 
         if (Options.INVOKEDYNAMIC_LOG_BINDING.load()) {
@@ -660,7 +661,7 @@ public class Bootstrap {
                             site.name(),
                             self.getRuntime().newSymbol(site.methodName))
                     .insert(0, "method", DynamicMethod.class, method)
-                    .collect("args", "arg.*");
+                    .collect("args", "arg.*", Helpers.constructObjectArrayHandle(site.arity));
         } else {
             SmartHandle fold = SmartBinder.from(
                     site.signature
@@ -837,7 +838,7 @@ public class Bootstrap {
                     mh = specific;
                 } else {
                     mh = (MethodHandle) compiledIRMethod.getHandle();
-                    binder = binder.collect("args", "arg.*");
+                    binder = binder.collect("args", "arg.*", Helpers.constructObjectArrayHandle(site.arity));
                 }
             }
 
@@ -898,7 +899,7 @@ public class Bootstrap {
                     } else {
                         // 1 or more args, collect into []
                         binder = SmartBinder.from(lookup(), site.signature)
-                                .collect("args", "arg.*");
+                                .collect("args", "arg.*", Helpers.constructObjectArrayHandle(site.arity));
                     }
                 }
 

--- a/core/src/main/java/org/jruby/ir/targets/indy/DRegexpObjectSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/DRegexpObjectSite.java
@@ -4,6 +4,7 @@ import com.headius.invokebinder.Binder;
 import com.headius.invokebinder.SmartBinder;
 import org.jruby.RubyRegexp;
 import org.jruby.RubyString;
+import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.util.RegexpOptions;
 import org.objectweb.asm.Handle;
@@ -60,7 +61,7 @@ public class DRegexpObjectSite extends ConstructObjectSite {
         // "once" deregexp must be handled on the call side
         return SmartBinder
                 .from(RubyRegexp.class, argNames, argTypes)
-                .collect("parts", "part.*")
+                .collect("parts", "part.*", Helpers.constructRubyStringArrayHandle(argNames.length - 1))
                 .binder();
     }
 

--- a/core/src/main/java/org/jruby/ir/targets/indy/InvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/InvokeSite.java
@@ -341,7 +341,7 @@ public abstract class InvokeSite extends MutableCallSite {
                 binder = binder.insert(argOffset, "args", IRubyObject.NULL_ARRAY);
             } else {
                 binder = binder
-                        .collect("args", "arg[0-9]+");
+                        .collect("args", "arg[0-9]+", Helpers.constructObjectArrayHandle(arity));
             }
         }
 

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -3,6 +3,9 @@ package org.jruby.runtime;
 import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.Array;
 
 import java.net.BindException;
@@ -32,6 +35,7 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import com.headius.invokebinder.Binder;
 import jnr.constants.platform.Errno;
 import org.jruby.*;
 import org.jruby.ast.ArgsNode;
@@ -64,6 +68,7 @@ import org.jruby.runtime.callsite.CacheEntry;
 import org.jruby.runtime.invokedynamic.MethodNames;
 import org.jruby.util.ArraySupport;
 import org.jruby.util.ByteList;
+import org.jruby.util.CodegenUtils;
 import org.jruby.util.MurmurHash;
 import org.jruby.util.TypeConverter;
 
@@ -78,6 +83,7 @@ import static org.jruby.RubyBasicObject.getMetaClass;
 import static org.jruby.runtime.Visibility.PRIVATE;
 import static org.jruby.runtime.Visibility.PROTECTED;
 import static org.jruby.runtime.invokedynamic.MethodNames.EQL;
+import static org.jruby.util.CodegenUtils.params;
 import static org.jruby.util.CodegenUtils.sig;
 import static org.jruby.util.RubyStringBuilder.str;
 import static org.jruby.util.RubyStringBuilder.ids;
@@ -94,6 +100,8 @@ import org.jruby.util.io.EncodingUtils;
 public class Helpers {
 
     public static final Pattern SEMICOLON_PATTERN = Pattern.compile(";");
+
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
 
     public static RubyClass getSingletonClass(Ruby runtime, IRubyObject receiver) {
         if (receiver instanceof RubyFixnum || receiver instanceof RubySymbol) {
@@ -1297,6 +1305,106 @@ public class Helpers {
 
     public static IRubyObject[] constructObjectArray(IRubyObject one, IRubyObject two, IRubyObject three, IRubyObject four, IRubyObject five, IRubyObject six, IRubyObject seven, IRubyObject eight, IRubyObject nine, IRubyObject ten) {
         return new IRubyObject[] {one, two, three, four, five, six, seven, eight, nine, ten};
+    }
+
+    private static final MethodHandle[] constructObjectArrayHandles = new MethodHandle[11];
+
+    public static MethodHandle constructObjectArrayHandle(int size) {
+        if (size < 0) throw new IllegalArgumentException("illegal size: " + size);
+
+        if (size > 10) {
+            return Binder
+                    .from(IRubyObject[].class, params(IRubyObject.class, size))
+                    .collect(0, IRubyObject[].class).identity();
+        }
+
+        MethodHandle handle = constructObjectArrayHandles[size];
+
+        if (handle == null) {
+            try {
+                if (size == 0) {
+                    handle = Binder.from(IRubyObject[].class).getStatic(LOOKUP, IRubyObject.class, "NULL_ARRAY");
+                } else {
+                    handle = MethodHandles.publicLookup().findStatic(Helpers.class, "constructObjectArray", MethodType.methodType(IRubyObject[].class, CodegenUtils.params(IRubyObject.class, size)));
+                }
+
+                constructObjectArrayHandles[size] = handle;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        return handle;
+    }
+    
+    public static RubyString[] constructRubyStringArray(RubyString one) {
+        return new RubyString[] {one};
+    }
+
+    public static RubyString[] constructRubyStringArray(RubyString one, RubyString two) {
+        return new RubyString[] {one, two};
+    }
+
+    public static RubyString[] constructRubyStringArray(RubyString one, RubyString two, RubyString three) {
+        return new RubyString[] {one, two, three};
+    }
+
+    public static RubyString[] constructRubyStringArray(RubyString one, RubyString two, RubyString three, RubyString four) {
+        return new RubyString[] {one, two, three, four};
+    }
+
+    public static RubyString[] constructRubyStringArray(RubyString one, RubyString two, RubyString three, RubyString four, RubyString five) {
+        return new RubyString[] {one, two, three, four, five};
+    }
+
+    public static RubyString[] constructRubyStringArray(RubyString one, RubyString two, RubyString three, RubyString four, RubyString five, RubyString six) {
+        return new RubyString[] {one, two, three, four, five, six};
+    }
+
+    public static RubyString[] constructRubyStringArray(RubyString one, RubyString two, RubyString three, RubyString four, RubyString five, RubyString six, RubyString seven) {
+        return new RubyString[] {one, two, three, four, five, six, seven};
+    }
+
+    public static RubyString[] constructRubyStringArray(RubyString one, RubyString two, RubyString three, RubyString four, RubyString five, RubyString six, RubyString seven, RubyString eight) {
+        return new RubyString[] {one, two, three, four, five, six, seven, eight};
+    }
+
+    public static RubyString[] constructRubyStringArray(RubyString one, RubyString two, RubyString three, RubyString four, RubyString five, RubyString six, RubyString seven, RubyString eight, RubyString nine) {
+        return new RubyString[] {one, two, three, four, five, six, seven, eight, nine};
+    }
+
+    public static RubyString[] constructRubyStringArray(RubyString one, RubyString two, RubyString three, RubyString four, RubyString five, RubyString six, RubyString seven, RubyString eight, RubyString nine, RubyString ten) {
+        return new RubyString[] {one, two, three, four, five, six, seven, eight, nine, ten};
+    }
+
+    private static final MethodHandle[] constructRubyStringArrayHandles = new MethodHandle[11];
+
+    public static MethodHandle constructRubyStringArrayHandle(int size) {
+        if (size < 0) throw new IllegalArgumentException("illegal size: " + size);
+
+        if (size > 10) {
+            return Binder
+                    .from(RubyString[].class, params(RubyString.class, size))
+                    .collect(0, RubyString[].class).identity();
+        }
+
+        MethodHandle handle = constructRubyStringArrayHandles[size];
+
+        if (handle == null) {
+            try {
+                if (size == 0) {
+                    handle = Binder.from(RubyString[].class).getStatic(LOOKUP, RubyString.class, "NULL_ARRAY");
+                } else {
+                    handle = MethodHandles.publicLookup().findStatic(Helpers.class, "constructRubyStringArray", MethodType.methodType(RubyString[].class, CodegenUtils.params(RubyString.class, size)));
+                }
+
+                constructRubyStringArrayHandles[size] = handle;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        return handle;
     }
 
     public static RubyArray constructRubyArray(Ruby runtime, IRubyObject one) {

--- a/spec/compiler/general_spec.rb
+++ b/spec/compiler/general_spec.rb
@@ -1250,6 +1250,7 @@ modes.each do |mode|
     end
 
     it "handles method_missing dispatch forms" do
+      run('obj = Class.new { def method_missing(name, *args); puts :here; [name, *args]; end }.new; obj.foo()') {|x| expect(x).to eq([:foo])}
       run('obj = Class.new { def method_missing(name, *args); [name, *args]; end }.new; obj.foo(1)') {|x| expect(x).to eq([:foo, 1])}
       run('obj = Class.new { def method_missing(name, *args); [name, *args]; end }.new; obj.foo(1,2,3,4)') {|x| expect(x).to eq([:foo, 1, 2, 3, 4])}
       run('obj = Class.new { def method_missing(name, *args); [name, *args]; end }.new; ary = 1.upto(4).to_a; obj.foo(*ary)') {|x| expect(x).to eq([:foo, 1, 2, 3, 4])}


### PR DESCRIPTION
It turns out that MethodHandle.asCollector is very slow for
subclasses of Object[] due to double-allocation and double-copying
done by the OpenJDK logic. To avoid this overhead, we use 10-wide
overloads of our own collector utility functions and pass to
Binder.collect, which now supports the
MethodHandles.collectArguments decorator.

Fixes #6628