### PR TITLE
Dig improvements

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -4930,6 +4930,23 @@ float_loop:
         return Pack.pack(context, this, obj.convertToString(), (RubyString) buffer);
     }
 
+    @JRubyMethod(name = "dig")
+    public IRubyObject dig(ThreadContext context, IRubyObject arg0) {
+        return at( arg0 );
+    }
+
+    @JRubyMethod(name = "dig")
+    public IRubyObject dig(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
+        final IRubyObject val = at( arg0 );
+        return RubyObject.dig1(context, val, arg1);
+    }
+
+    @JRubyMethod(name = "dig")
+    public IRubyObject dig(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
+        final IRubyObject val = at( arg0 );
+        return RubyObject.dig2(context, val, arg1, arg2);
+    }
+
     @JRubyMethod(name = "dig", required = 1, rest = true)
     public IRubyObject dig(ThreadContext context, IRubyObject[] args) {
         return dig(context, args, 0);

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -4949,12 +4949,8 @@ float_loop:
 
     @JRubyMethod(name = "dig", required = 1, rest = true)
     public IRubyObject dig(ThreadContext context, IRubyObject[] args) {
-        return dig(context, args, 0);
-    }
-
-    final IRubyObject dig(ThreadContext context, IRubyObject[] args, int idx) {
-        final IRubyObject val = at( args[idx++] );
-        return idx == args.length ? val : RubyObject.dig(context, val, args, idx);
+        final IRubyObject val = at( args[0] );
+        return args.length == 1 ? val : RubyObject.dig(context, val, args, 1);
     }
 
     private IRubyObject maxWithBlock(ThreadContext context, Block block) {

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -2198,6 +2198,23 @@ public class RubyHash extends RubyObject implements Map {
         return ifNone;
     }
 
+    @JRubyMethod(name = "dig")
+    public IRubyObject dig(ThreadContext context, IRubyObject arg0) {
+        return op_aref( context, arg0 );
+    }
+
+    @JRubyMethod(name = "dig")
+    public IRubyObject dig(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
+        final IRubyObject val = op_aref( context, arg0 );
+        return RubyObject.dig1(context, val, arg1);
+    }
+
+    @JRubyMethod(name = "dig")
+    public IRubyObject dig(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
+        final IRubyObject val = op_aref( context, arg0 );
+        return RubyObject.dig2(context, val, arg1, arg2);
+    }
+
     @JRubyMethod(name = "dig", required = 1, rest = true)
     public IRubyObject dig(ThreadContext context, IRubyObject[] args) {
         return dig(context, args, 0);

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -2217,12 +2217,8 @@ public class RubyHash extends RubyObject implements Map {
 
     @JRubyMethod(name = "dig", required = 1, rest = true)
     public IRubyObject dig(ThreadContext context, IRubyObject[] args) {
-        return dig(context, args, 0);
-    }
-
-    final IRubyObject dig(ThreadContext context, IRubyObject[] args, int idx) {
-        final IRubyObject val = op_aref( context, args[idx++] );
-        return idx == args.length ? val : RubyObject.dig(context, val, args, idx);
+        final IRubyObject val = op_aref(context, args[0] );
+        return args.length == 1 ? val : RubyObject.dig(context, val, args, 1);
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -780,12 +780,8 @@ public class RubyStruct extends RubyObject {
 
     @JRubyMethod(name = "dig", required = 1, rest = true)
     public IRubyObject dig(ThreadContext context, IRubyObject[] args) {
-        return dig(context, args, 0);
-    }
-
-    final IRubyObject dig(ThreadContext context, IRubyObject[] args, int idx) {
-        final IRubyObject val = arefImpl( args[idx++], true );
-        return idx == args.length ? val : RubyObject.dig(context, val, args, idx);
+        final IRubyObject val = arefImpl( args[0], true );
+        return args.length == 1 ? val : RubyObject.dig(context, val, args, 1);
     }
 
     public static void marshalTo(RubyStruct struct, MarshalStream output) throws java.io.IOException {

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -761,6 +761,23 @@ public class RubyStruct extends RubyObject {
         return result;
     }
 
+    @JRubyMethod(name = "dig")
+    public IRubyObject dig(ThreadContext context, IRubyObject arg0) {
+        return arefImpl( arg0, true );
+    }
+
+    @JRubyMethod(name = "dig")
+    public IRubyObject dig(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
+        final IRubyObject val = arefImpl( arg0, true );
+        return RubyObject.dig1(context, val, arg1);
+    }
+
+    @JRubyMethod(name = "dig")
+    public IRubyObject dig(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
+        final IRubyObject val = arefImpl( arg0, true );
+        return RubyObject.dig2(context, val, arg1, arg2);
+    }
+
     @JRubyMethod(name = "dig", required = 1, rest = true)
     public IRubyObject dig(ThreadContext context, IRubyObject[] args) {
         return dig(context, args, 0);


### PR DESCRIPTION
These are small improvements for the `dig` method:

* Arity-split up to three. These will be very common arities. We could split further in the future but with greatly diminishing returns.
* Make known types (Array, Hash, Struct) use an iterative algorithm to dig out successive values. This avoids recursion for known types.

This work was originally intended to fix #6628 but the performance issue there was primarily due to poor performance in MethodHandle.asCollector: #6630.

Benchmark numbers using just this branch improve for 1-3 arguments but then the indy numbers drastically fall off due to #6630 (see benchmark there).

No indy, before:
```
              dig-01     38.572M (± 4.8%) i/s -    195.184M in   5.072156s
              dig-02     40.883M (± 9.2%) i/s -    202.908M in   5.019322s
              dig-03     29.216M (± 6.0%) i/s -    147.446M in   5.067869s
              dig-04     24.229M (±14.5%) i/s -    116.700M in   5.008082s
              dig-05     21.963M (± 3.0%) i/s -    110.112M in   5.018112s
              dig-06     19.876M (± 3.9%) i/s -     99.521M in   5.014908s
              dig-07     17.807M (± 6.0%) i/s -     90.336M in   5.096993s
              dig-08     16.079M (± 5.5%) i/s -     80.465M in   5.021685s
              dig-09     14.032M (± 6.0%) i/s -     70.755M in   5.062774s
              dig-10     13.674M (± 4.9%) i/s -     69.170M in   5.070931s
```

Indy, before:
```
              dig-01     22.006M (± 7.5%) i/s -    109.948M in   5.026393s
              dig-02     20.545M (± 5.0%) i/s -    104.253M in   5.087895s
              dig-03     17.492M (± 7.7%) i/s -     88.326M in   5.083337s
              dig-04     15.416M (± 8.5%) i/s -     76.567M in   5.009796s
              dig-05     10.026M (±17.8%) i/s -     49.617M in   5.112008s
              dig-06      6.033M (±28.6%) i/s -     28.628M in   5.207503s
              dig-07      8.400M (±22.2%) i/s -     40.710M in   5.145922s
              dig-08      6.176M (±23.2%) i/s -     29.795M in   5.026196s
              dig-09      5.184M (±10.3%) i/s -     26.370M in   5.141858s
              dig-10      4.955M (± 7.4%) i/s -     24.656M in   5.004148s
```

No indy, after:
```
              dig-01     44.564M (±11.3%) i/s -    222.821M in   5.071922s
              dig-02     42.557M (±10.0%) i/s -    211.797M in   5.033207s
              dig-03     29.046M (±19.0%) i/s -    138.995M in   5.008805s
              dig-04     23.889M (±16.5%) i/s -    115.952M in   5.003884s
              dig-05     10.731M (±36.0%) i/s -     47.529M in   5.027489s
              dig-06     19.317M (±18.7%) i/s -     93.677M in   5.075702s
              dig-07     19.467M (±12.1%) i/s -     97.240M in   5.081109s
              dig-08     17.968M (± 9.0%) i/s -     88.934M in   5.000420s
              dig-09     16.856M (± 5.8%) i/s -     84.081M in   5.006363s
              dig-10     14.803M (± 8.0%) i/s -     74.603M in   5.072760s
```

Indy, after:
```
              dig-01     81.816M (±12.0%) i/s -    400.972M in   4.999073s
              dig-02     69.296M (± 7.5%) i/s -    348.541M in   5.060798s
              dig-03     55.133M (± 6.2%) i/s -    277.685M in   5.056766s
              dig-04     15.309M (±23.1%) i/s -     66.131M in   5.061833s
              dig-05     14.798M (± 6.9%) i/s -     74.706M in   5.073418s
              dig-06     14.220M (± 7.3%) i/s -     71.180M in   5.036140s
              dig-07     12.885M (± 5.4%) i/s -     64.917M in   5.052570s
              dig-08     12.701M (± 5.8%) i/s -     63.740M in   5.039548s
              dig-09     10.996M (± 8.0%) i/s -     55.575M in   5.088719s
              dig-10     10.494M (± 9.6%) i/s -     52.704M in   5.079754s
```