### PR TITLE
Cache package after acquisition

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/ext/Kernel.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/Kernel.java
@@ -54,6 +54,7 @@ public final class Kernel {
     }
 
     private static final class JavaPackageMethod extends JavaMethod.JavaMethodZero {
+        private IRubyObject pkg;
 
         JavaPackageMethod(RubyModule implClass, String name) {
             super(implClass, PUBLIC, name);
@@ -61,7 +62,11 @@ public final class Kernel {
 
         @Override
         public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name) {
-            return get_pkg(context, name);
+            IRubyObject pkg = this.pkg;
+            if (pkg == null) {
+                this.pkg = pkg = get_pkg(context, name);
+            }
+            return pkg;
         }
     }
 


### PR DESCRIPTION
Improves performance of these accesses by 10x:

Before:

```
$ rvm jruby-9.2.16.0 do jruby -e "loop { t = Time.now; i = 0; while i < 10_000_000; i+=1; java; java; java; java; java; end; puts Time.now - t }"
4.378078
4.057417
```

After:

```
$ jruby -e "loop { t = Time.now; i = 0; while i < 10_000_000; i+=1; java; java; java; java; java; end; puts Time.now - t }"
0.49563
0.451077
0.558907
```