### PR TITLE
Restore quotes around module detection JAVA_HOME

### DIFF
--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -141,7 +141,7 @@ else
 fi
 
 # Detect modularized Java
-if [ -f ${JAVA_HOME}/lib/modules ] || [ -f ${JAVA_HOME}/release ] && grep -q ^MODULES ${JAVA_HOME}/release; then
+if [ -f "$JAVA_HOME"/lib/modules ] || [ -f "$JAVA_HOME"/release ] && grep -q ^MODULES "$JAVA_HOME"/release; then
   use_modules=1
 fi
 


### PR DESCRIPTION
See https://github.com/jruby/jruby/pull/6615#pullrequestreview-623982563

The quoting around `$JAVA_HOME` was inadvertently removed while fixing module detection in #6615. The review linked above points out that this causes problems when the JDK is installed in a path with spaces. This is not common on unixy environments, and the bash script is not used on Windows where it is more common, but the regression is real.

This PR restores the quoting around `$JAVA_HOME` to fix the issue.