### PR TITLE
Resolve symlinked java command to find home

### DIFF
--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -84,7 +84,7 @@ resolve_symlinks() {
 BASE_DIR="$(cd -P -- "$(dirname -- "$BASH_SOURCE")" >/dev/null && pwd -P)"
 SELF_PATH="$(resolve_symlinks "$BASE_DIR/$(basename -- "$BASH_SOURCE")")"
 
-JRUBY_HOME="${SELF_PATH%/*/*}"
+export JRUBY_HOME="${SELF_PATH%/*/*}"
 
 # ----- File paths for various options and files we'll process later ----------
 
@@ -129,19 +129,19 @@ esac
 # Determine where the java command is and ensure we have a good JAVA_HOME
 if [ -z "$JAVACMD" ] ; then
   if [ -z "$JAVA_HOME" ] ; then
-    JAVACMD="$(resolve_symlinks "$(command -v java)")"
-    JAVA_HOME="$(dirname "$(dirname "$JAVACMD")")"
+    export JAVACMD="$(resolve_symlinks "$(command -v java)")"
+    export JAVA_HOME="$(dirname "$(dirname "$JAVACMD")")"
   else
     if $cygwin; then
-      JAVACMD="$(cygpath -u "$JAVA_HOME")/bin/java"
+      export JAVACMD="$(cygpath -u "$JAVA_HOME")/bin/java"
     else
-      JAVACMD="$JAVA_HOME/bin/java"
+      export JAVACMD="$JAVA_HOME/bin/java"
     fi
   fi
 else
   expanded_javacmd="$(resolve_symlinks "$(command -v "$JAVACMD")")"
   if [ -z "$JAVA_HOME" ] && [ -x "$expanded_javacmd" ] ; then
-    JAVA_HOME="$(dirname "$(dirname "$expanded_javacmd")")"
+    export JAVA_HOME="$(dirname "$(dirname "$expanded_javacmd")")"
   fi
 fi
 

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -74,14 +74,15 @@ resolve_symlinks() {
     sym_base="$(cd -P -- "$(dirname -- "$cur_path")" >/dev/null && pwd -P)"
     cur_path="$(cd "$sym_base" && cd "$(dirname -- "$sym")" && pwd -P)/$(basename -- "$sym")"
   done
-  echo "$cur_path"
+  result="$cur_path"
 }
 
 # ----- Determine JRUBY_HOME based on this executable's path ------------------
 
 # get the absolute path of the executable
 BASE_DIR="$(cd -P -- "$(dirname -- "$BASH_SOURCE")" >/dev/null && pwd -P)"
-SELF_PATH="$(resolve_symlinks "$BASE_DIR/$(basename -- "$BASH_SOURCE")")"
+resolve_symlinks "$BASE_DIR/$(basename -- "$BASH_SOURCE")"
+SELF_PATH="$result"
 
 export JRUBY_HOME="${SELF_PATH%/*/*}"
 
@@ -128,7 +129,8 @@ esac
 # Determine where the java command is and ensure we have a good JAVA_HOME
 if [ -z "$JAVACMD" ] ; then
   if [ -z "$JAVA_HOME" ] ; then
-    export JAVACMD="$(resolve_symlinks "$(command -v java)")"
+    resolve_symlinks "$(command -v java)"
+    export JAVACMD="$result"
     export JAVA_HOME="$(dirname "$(dirname "$JAVACMD")")"
   else
     if $cygwin; then
@@ -138,7 +140,8 @@ if [ -z "$JAVACMD" ] ; then
     fi
   fi
 else
-  expanded_javacmd="$(resolve_symlinks "$(command -v "$JAVACMD")")"
+  resolve_symlinks "$(command -v "$JAVACMD")"
+  expanded_javacmd="$result"
   if [ -z "$JAVA_HOME" ] && [ -x "$expanded_javacmd" ] ; then
     export JAVA_HOME="$(dirname "$(dirname "$expanded_javacmd")")"
   fi

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -63,7 +63,6 @@ process_java_opts() {
 }
 
 # Resolve all symlinks in a chain
-unset resolve_symlinks
 resolve_symlinks() {
   cur_path="$1"
   while [ -h "$cur_path" ]; do

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -62,7 +62,7 @@ process_java_opts() {
   fi
 }
 
-# Resolve all symlinks in a chain using only POSIX features
+# Resolve all symlinks in a chain
 unset resolve_symlinks
 resolve_symlinks() {
   cur_path="$1"

--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -84,7 +84,7 @@ BASE_DIR="$(cd -P -- "$(dirname -- "$BASH_SOURCE")" >/dev/null && pwd -P)"
 resolve_symlinks "$BASE_DIR/$(basename -- "$BASH_SOURCE")"
 SELF_PATH="$result"
 
-export JRUBY_HOME="${SELF_PATH%/*/*}"
+JRUBY_HOME="${SELF_PATH%/*/*}"
 
 # ----- File paths for various options and files we'll process later ----------
 
@@ -130,22 +130,27 @@ esac
 if [ -z "$JAVACMD" ] ; then
   if [ -z "$JAVA_HOME" ] ; then
     resolve_symlinks "$(command -v java)"
-    export JAVACMD="$result"
-    export JAVA_HOME="$(dirname "$(dirname "$JAVACMD")")"
+    JAVACMD="$result"
+
+    # export separately from command execution
+    JAVA_HOME="$(dirname "$(dirname "$JAVACMD")")"
   else
     if $cygwin; then
-      export JAVACMD="$(cygpath -u "$JAVA_HOME")/bin/java"
+      JAVACMD="$(cygpath -u "$JAVA_HOME")/bin/java"
     else
-      export JAVACMD="$JAVA_HOME/bin/java"
+      JAVACMD="$JAVA_HOME/bin/java"
     fi
   fi
 else
   resolve_symlinks "$(command -v "$JAVACMD")"
   expanded_javacmd="$result"
   if [ -z "$JAVA_HOME" ] && [ -x "$expanded_javacmd" ] ; then
-    export JAVA_HOME="$(dirname "$(dirname "$expanded_javacmd")")"
+    JAVA_HOME="$(dirname "$(dirname "$expanded_javacmd")")"
   fi
 fi
+
+# Export discovered paths
+export JRUBY_HOME JAVACMD JAVA_HOME
 
 # Detect modularized Java
 if [ -f "$JAVA_HOME"/lib/modules ] || [ -f "$JAVA_HOME"/release ] && grep -q ^MODULES "$JAVA_HOME"/release; then

--- a/test/jruby/test_command_line_switches.rb
+++ b/test/jruby/test_command_line_switches.rb
@@ -354,7 +354,7 @@ class TestCommandLineSwitches < Test::Unit::TestCase
   def test_symlinked_java_resolves_home
     Dir.mktmpdir do |tmpdir|
       tmp_java = File.join(tmpdir, "java")
-      real_home = ENV['JAVA_HOME']
+      real_home = ENV_JAVA['java.home']
       real_java = File.join(real_home, 'bin', 'java')
 
       FileUtils.symlink real_java, tmp_java

--- a/test/jruby/test_command_line_switches.rb
+++ b/test/jruby/test_command_line_switches.rb
@@ -2,6 +2,7 @@ require 'test/unit'
 require 'test/jruby/test_helper'
 
 require 'fileutils'
+require 'tmpdir'
 
 class TestCommandLineSwitches < Test::Unit::TestCase
   include TestHelper
@@ -347,5 +348,27 @@ class TestCommandLineSwitches < Test::Unit::TestCase
     assert_equal 0, $?.exitstatus
   ensure
     ENV['RUBYOPT'] = rubyopt
+  end
+
+  # jruby/jruby#6637: symlinked `java` command interferes with JAVA_HOME determination
+  def test_symlinked_java_resolves_home
+    Dir.mktmpdir do |tmpdir|
+      tmp_java = File.join(tmpdir, "java")
+      real_home = ENV['JAVA_HOME']
+      real_java = File.join(real_home, 'bin', 'java')
+
+      FileUtils.symlink real_java, tmp_java
+
+      old_env = ENV.dup
+      ENV.delete "JAVA_HOME"
+      ENV["JAVACMD"] = tmp_java
+
+      found_home = jruby('-e "print ENV[\'JAVA_HOME\']"').chomp
+
+      assert_equal 0, $?.exitstatus
+      assert_equal real_home, found_home
+    ensure
+      ENV.replace(old_env)
+    end
   end
 end


### PR DESCRIPTION
This PR fixes #6637 by fully resolving any symlinks between the `java` command (found from `$JAVACMD` or `java` in PATH) before using that command's path to determine `$JAVA_HOME`.

The issue affects systems without `$JAVA_HOME` set, but that have a `java` command in PATH that resolves to a `$JAVA_HOME/bin/java` through a series of symlinks (e.g. CentOS).

This PR also exports `JRUBY_HOME`, `JAVACMD`, and `JAVA_HOME` so they will be seen by the JRuby process and subprocesses, avoiding recalculating this home or accidentally using a different JDK for additional JRuby launches.

I have added a test case for the symlink situation.