### PR TITLE
Reduce frame overhead for leaf blocks

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRVisitor.java
+++ b/core/src/main/java/org/jruby/ir/IRVisitor.java
@@ -76,6 +76,7 @@ public abstract class IRVisitor {
     public void LoadLocalVarInstr(LoadLocalVarInstr loadlocalvarinstr) { error(loadlocalvarinstr); }
     public void LoadImplicitClosure(LoadImplicitClosureInstr loadimplicitclosureinstr) { error(loadimplicitclosureinstr); }
     public void LoadFrameClosure(LoadFrameClosureInstr loadframeclosureinstr) { error(loadframeclosureinstr); }
+    public void LoadBlockImplicitClosure(LoadBlockImplicitClosureInstr loadblockimplicitclosureinstr) { error(loadblockimplicitclosureinstr); }
     public void MatchInstr(MatchInstr matchInstr) { error(matchInstr); }
     public void ModuleVersionGuardInstr(ModuleVersionGuardInstr moduleversionguardinstr) { error(moduleversionguardinstr); }
     public void NonlocalReturnInstr(NonlocalReturnInstr nonlocalreturninstr) { error(nonlocalreturninstr); }

--- a/core/src/main/java/org/jruby/ir/Operation.java
+++ b/core/src/main/java/org/jruby/ir/Operation.java
@@ -56,6 +56,7 @@ public enum Operation {
     /** Instruction to reify an passed-in block to a Proc for def foo(&b) */
     REIFY_CLOSURE(0),
     LOAD_FRAME_CLOSURE(0),
+    LOAD_BLOCK_IMPLICIT_CLOSURE(0),
 
     /* By default, call instructions cannot be deleted even if their results
      * aren't used by anyone unless we know more about what the call is,

--- a/core/src/main/java/org/jruby/ir/instructions/LoadBlockImplicitClosureInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/LoadBlockImplicitClosureInstr.java
@@ -1,0 +1,59 @@
+package org.jruby.ir.instructions;
+
+import org.jruby.ir.IRFlags;
+import org.jruby.ir.IRScope;
+import org.jruby.ir.IRVisitor;
+import org.jruby.ir.Operation;
+import org.jruby.ir.operands.Variable;
+import org.jruby.ir.operands.WrappedIRClosure;
+import org.jruby.ir.persistence.IRReaderDecoder;
+import org.jruby.ir.transformations.inlining.CloneInfo;
+import org.jruby.ir.transformations.inlining.InlineCloneInfo;
+import org.jruby.ir.transformations.inlining.SimpleCloneInfo;
+
+import java.util.EnumSet;
+
+import static org.jruby.ir.IRFlags.REQUIRES_BLOCK;
+
+/**
+ * Load the block passed to this scope via the on-heap frame (or similar cross-call structure).
+ * This is typically used to access the "yieldable" target for blocks and evals. Only used
+ * when within a scope that will use an on-heap frame.
+ */
+public class LoadBlockImplicitClosureInstr extends NoOperandResultBaseInstr implements FixedArityInstr {
+    public LoadBlockImplicitClosureInstr(Variable result) {
+        super(Operation.LOAD_BLOCK_IMPLICIT_CLOSURE, result);
+
+        assert result != null : "LoadFrameClosureInstr result is null";
+    }
+
+    @Override
+    public Instr clone(CloneInfo info) {
+        if (info instanceof SimpleCloneInfo) return new LoadBlockImplicitClosureInstr(info.getRenamedVariable(result));
+
+        // SSS FIXME: This code below is for inlining and is untested.
+
+        InlineCloneInfo ii = (InlineCloneInfo) info;
+
+        // SSS FIXME: This is not strictly correct -- we have to wrap the block into an
+        // operand type that converts the static code block to a proc which is a closure.
+        if (ii.getCallClosure() instanceof WrappedIRClosure) return NopInstr.NOP;
+
+        return new CopyInstr(ii.getRenamedVariable(result), ii.getCallClosure());
+    }
+
+    // encode is from ResultBase since this has no other state.
+    public static LoadBlockImplicitClosureInstr decode(IRReaderDecoder d) {
+        return new LoadBlockImplicitClosureInstr(d.decodeVariable());
+    }
+
+    @Override
+    public boolean computeScopeFlags(IRScope scope, EnumSet<IRFlags> flags) {
+        return super.computeScopeFlags(scope, flags);
+    }
+
+    @Override
+    public void visit(IRVisitor visitor) {
+        visitor.LoadBlockImplicitClosure(this);
+    }
+}

--- a/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
@@ -531,6 +531,10 @@ public class InterpreterEngine {
 
             case LOAD_FRAME_CLOSURE:
                 setResult(temp, currDynScope, instr, context.getFrameBlock());
+                break;
+
+            case LOAD_BLOCK_IMPLICIT_CLOSURE:
+                setResult(temp, currDynScope, instr, Helpers.getImplicitBlockFromBlockBinding(block));
                 return;
 
             // ---------- All the rest ---------

--- a/core/src/main/java/org/jruby/ir/interpreter/StartupInterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/StartupInterpreterEngine.java
@@ -162,9 +162,15 @@ public class StartupInterpreterEngine extends InterpreterEngine {
             case CHECK_FOR_LJE:
                 ((CheckForLJEInstr) instr).check(context, currDynScope, block);
                 break;
+
             case LOAD_FRAME_CLOSURE:
                 setResult(temp, currDynScope, instr, context.getFrameBlock());
+                break;
+
+            case LOAD_BLOCK_IMPLICIT_CLOSURE:
+                setResult(temp, currDynScope, instr, Helpers.getImplicitBlockFromBlockBinding(block));
                 return;
+
             // ---------- All the rest ---------
             default:
                 setResult(temp, currDynScope, instr, instr.interpret(context, currScope, currDynScope, self, temp));

--- a/core/src/main/java/org/jruby/ir/persistence/IRReaderStream.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRReaderStream.java
@@ -306,6 +306,7 @@ public class IRReaderStream implements IRReaderDecoder, IRPersistenceValues {
             case LAMBDA: return BuildLambdaInstr.decode(this);
             case LEXICAL_SEARCH_CONST: return LexicalSearchConstInstr.decode(this);
             case LOAD_FRAME_CLOSURE: return LoadFrameClosureInstr.decode(this);
+            case LOAD_BLOCK_IMPLICIT_CLOSURE: return LoadBlockImplicitClosureInstr.decode(this);
             case LOAD_IMPLICIT_CLOSURE: return LoadImplicitClosureInstr.decode(this);
             case LINE_NUM: return LineNumberInstr.decode(this);
             case MASGN_OPT: return OptArgMultipleAsgnInstr.decode(this);

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -1704,6 +1704,13 @@ public class JVMVisitor extends IRVisitor {
     }
 
     @Override
+    public void LoadBlockImplicitClosure(LoadBlockImplicitClosureInstr loadblockimplicitclosureinstr) {
+        jvmMethod().loadSelfBlock();
+        jvmMethod().invokeHelper("getImplicitBlockFromBlockBinding", Block.class, Block.class);
+        jvmStoreLocal(loadblockimplicitclosureinstr.getResult());
+    }
+
+    @Override
     public void MatchInstr(MatchInstr matchInstr) {
         compileCallCommon(jvmMethod(), matchInstr);
     }

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -820,6 +820,11 @@ public class Helpers {
         return ((RubyProc) proc).getBlock();
     }
 
+    @JIT
+    public static Block getImplicitBlockFromBlockBinding(Block block) {
+        return block.getFrame().getBlock();
+    }
+
     public static Block getBlockFromBlockPassBody(IRubyObject proc, Block currentBlock) {
         return getBlockFromBlockPassBody(proc.getRuntime(), proc, currentBlock);
 


### PR DESCRIPTION
* Avoid retrieving the implicit block from the frame if it is not
  needed for a yield.
* When the implicit block is needed, load it directly from the
  block binding rather than from the frame stack, avoiding pushing
  the frame.

This speeds up leaf blocks that do not otherwise need a pushed
frame by many times... up to 30x for a simple block with no yield.