### PR TITLE
Reduce backref usage in split

### DIFF
--- a/core/src/main/java/org/jruby/RubyRegexp.java
+++ b/core/src/main/java/org/jruby/RubyRegexp.java
@@ -86,6 +86,8 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
     private ByteList str = ByteList.EMPTY_BYTELIST;
     private RegexpOptions options;
 
+    private static final ThreadLocal<IRubyObject[]> TL_HOLDER = ThreadLocal.withInitial(() -> new IRubyObject[1]);
+
     public static final int ARG_ENCODING_FIXED     =   ReOptions.RE_FIXED;
     public static final int ARG_ENCODING_NONE      =   ReOptions.RE_NONE;
 
@@ -1820,6 +1822,16 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
     private static IRubyObject regOperand(IRubyObject str, boolean check) {
         if (str instanceof RubySymbol) return ((RubySymbol) str).to_s();
         return check ? str.convertToString() : str.checkStringType();
+    }
+
+    static void clearThreadHolder(IRubyObject[] holder) {
+        holder[0] = null;
+    }
+
+    static IRubyObject[] getThreadHolder(IRubyObject nil) {
+        IRubyObject[] holder = TL_HOLDER.get();
+        holder[0] = nil;
+        return holder;
     }
 
     @Deprecated

--- a/spec/ruby/core/string/split_spec.rb
+++ b/spec/ruby/core/string/split_spec.rb
@@ -425,6 +425,16 @@ describe "String#split with Regexp" do
     ->{ broken_str.split(/\r\n|\r|\n/) }.should raise_error(ArgumentError)
   end
 
+  # See https://bugs.ruby-lang.org/issues/12689 and https://github.com/jruby/jruby/issues/4868
+  it "allows concurrent Regexp calls in a shared context" do
+    str = 'a,b,c,d,e'
+
+    p = proc { str.split(/,/) }
+    results = 10.times.map { Thread.new { x = nil; 100.times { x = p.call }; x } }.map(&:value)
+
+    results.should == [%w[a b c d e]] * 10
+  end
+
   ruby_version_is "2.6" do
     it "yields each split substrings if a block is given" do
       a = []


### PR DESCRIPTION
String#split appears to do nothing with the context backref slot
except using it to receive the MatchData from a regexp match and
eventually clearing it to nil. This patch sets up a thread-local
IRubyObject[] holder to use for that out value and avoids using
the context backref at all except for clearing it at the end.

This fixes #6160 by avoiding all reads of the context backref. It
may still cause problems for other backref-reading functions that
run concurrently and see the clearing to nil unexpectedly.