### PR TITLE
Improve concurrency of $~ adjacent methods

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -41,6 +41,7 @@
 package org.jruby;
 
 import org.jcodings.specific.UTF8Encoding;
+import org.jruby.anno.FrameField;
 import org.jruby.anno.TypePopulator;
 import org.jruby.ast.ArrayNode;
 import org.jruby.ast.BlockNode;
@@ -72,6 +73,7 @@ import org.jruby.management.Caches;
 import org.jruby.management.InlineStats;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.JavaSites;
+import org.jruby.runtime.MethodIndex;
 import org.jruby.runtime.invokedynamic.InvokeDynamicSupport;
 import org.jruby.util.CommonByteLists;
 import org.jruby.util.JavaNameMangler;
@@ -577,6 +579,7 @@ public final class Ruby implements Constantizable {
 
     private void initKernelGsub(RubyModule kernel) {
         if (this.config.getKernelGsubDefined()) {
+            MethodIndex.addMethodReadFields("gsub", FrameField.LASTLINE, FrameField.BACKREF);
             kernel.addMethod("gsub", new JavaMethod(kernel, Visibility.PRIVATE, "gsub") {
 
                 @Override

--- a/core/src/main/java/org/jruby/RubyArgsFile.java
+++ b/core/src/main/java/org/jruby/RubyArgsFile.java
@@ -40,6 +40,7 @@ import jnr.posix.FileStat;
 import jnr.posix.util.Platform;
 
 import static org.jruby.RubyEnumerator.enumeratorize;
+import static org.jruby.anno.FrameField.LASTLINE;
 import static org.jruby.runtime.Visibility.PRIVATE;
 
 import org.jruby.anno.FrameField;
@@ -325,7 +326,7 @@ public class RubyArgsFile extends RubyObject {
     /** Read a line.
      *
      */
-    @JRubyMethod(name = "gets", optional = 1, writes = FrameField.LASTLINE)
+    @JRubyMethod(name = "gets", optional = 1, writes = LASTLINE)
     public static IRubyObject gets(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         return context.setLastLine(argf_getline(context, recv, args));
     }
@@ -333,7 +334,7 @@ public class RubyArgsFile extends RubyObject {
     /** Read a line.
      *
      */
-    @JRubyMethod(name = "readline", optional = 1)
+    @JRubyMethod(name = "readline", optional = 1, writes = LASTLINE)
     public static IRubyObject readline(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         IRubyObject line = gets(context, recv, args);
 

--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -882,12 +882,20 @@ public class RubyGlobal {
 
         @Override
         public IRubyObject get() {
-            return Helpers.getBackref(runtime.getCurrentContext());
+            return runtime.getCurrentContext().getBackRef();
         }
 
         @Override
         public IRubyObject set(IRubyObject value) {
-            Helpers.setBackref(runtime.getCurrentContext(), value);
+            ThreadContext context = runtime.getCurrentContext();
+            if (value.isNil()) {
+                context.clearBackRef();
+            } else if (value instanceof RubyMatchData) {
+                context.setBackRef((RubyMatchData) value);
+            } else {
+                throw runtime.newTypeError(value, runtime.getMatchData());
+            }
+
             return value;
         }
     }

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -106,6 +106,7 @@ import static com.headius.backport9.buffer.Buffers.clearBuffer;
 import static com.headius.backport9.buffer.Buffers.flipBuffer;
 import static com.headius.backport9.buffer.Buffers.limitBuffer;
 import static org.jruby.RubyEnumerator.enumeratorize;
+import static org.jruby.anno.FrameField.LASTLINE;
 import static org.jruby.runtime.Visibility.*;
 import static org.jruby.util.RubyStringBuilder.str;
 import static org.jruby.util.RubyStringBuilder.types;
@@ -1735,7 +1736,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     /** Print some objects to the stream.
      *
      */
-    @JRubyMethod(rest = true, reads = FrameField.LASTLINE)
+    @JRubyMethod(rest = true, reads = LASTLINE)
     public IRubyObject print(ThreadContext context, IRubyObject[] args) {
         return print(context, this, args);
     }
@@ -2449,25 +2450,25 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
      */
 
     // rb_io_gets_m
-    @JRubyMethod(name = "gets", writes = FrameField.LASTLINE)
+    @JRubyMethod(name = "gets", writes = LASTLINE)
     public IRubyObject gets(ThreadContext context) {
         return Getline.getlineCall(context, GETLINE, this, getReadEncoding(context));
     }
 
     // rb_io_gets_m
-    @JRubyMethod(name = "gets", writes = FrameField.LASTLINE)
+    @JRubyMethod(name = "gets", writes = LASTLINE)
     public IRubyObject gets(ThreadContext context, IRubyObject arg) {
         return Getline.getlineCall(context, GETLINE, this, getReadEncoding(context), arg);
     }
 
     // rb_io_gets_m
-    @JRubyMethod(name = "gets", writes = FrameField.LASTLINE)
+    @JRubyMethod(name = "gets", writes = LASTLINE)
     public IRubyObject gets(ThreadContext context, IRubyObject rs, IRubyObject limit_arg) {
         return Getline.getlineCall(context, GETLINE, this, getReadEncoding(context), rs, limit_arg);
     }
 
     // rb_io_gets_m
-    @JRubyMethod(name = "gets", writes = FrameField.LASTLINE)
+    @JRubyMethod(name = "gets", writes = LASTLINE)
     public IRubyObject gets(ThreadContext context, IRubyObject rs, IRubyObject limit_arg, IRubyObject opt) {
         return Getline.getlineCall(context, GETLINE, this, getReadEncoding(context), rs, limit_arg, opt);
     }
@@ -2815,7 +2816,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     /** Read a line.
      *
      */
-    @JRubyMethod(name = "readline", writes = FrameField.LASTLINE)
+    @JRubyMethod(name = "readline", writes = LASTLINE)
     public IRubyObject readline(ThreadContext context) {
         IRubyObject line = gets(context);
 
@@ -2824,7 +2825,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return line;
     }
 
-    @JRubyMethod(name = "readline", writes = FrameField.LASTLINE)
+    @JRubyMethod(name = "readline", writes = LASTLINE)
     public IRubyObject readline(ThreadContext context, IRubyObject separator) {
         IRubyObject line = gets(context, separator);
 
@@ -3673,14 +3674,14 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     // rb_io_s_foreach
     private static IRubyObject foreachInternal(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
-        Ruby runtime = context.runtime;
-
         IRubyObject opt = ArgsUtil.getOptionsArg(context.runtime, args);
         RubyIO io = openKeyArgs(context, recv, args, opt);
-        if (io == context.nil) return io;
+        IRubyObject nil = context.nil;
+
+        if (io == nil) return io;
 
         // replace arg with coerced opts
-        if (opt != context.nil) args[args.length - 1] = opt;
+        if (opt != nil) args[args.length - 1] = opt;
 
         // io_s_foreach, roughly
         try {
@@ -3700,14 +3701,13 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
             }
         } finally {
             io.close();
-            context.setLastLine(context.nil);
-            runtime.getGlobalVariables().clear("$_");
+            context.setLastLine(nil);
         }
 
-        return context.nil;
+        return nil;
     }
 
-    @JRubyMethod(name = "foreach", required = 1, optional = 3, meta = true)
+    @JRubyMethod(name = "foreach", required = 1, optional = 3, meta = true, writes = LASTLINE)
     public static IRubyObject foreach(final ThreadContext context, IRubyObject recv, IRubyObject[] args, final Block block) {
         if (!block.isGiven()) return enumeratorize(context.runtime, recv, "foreach", args);
 

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -2268,8 +2268,8 @@ public class RubyKernel {
         return ((RubyBasicObject) self).nil_p(context);
     }
 
-    // Reads and writes backref due to decendant calls ending up in Regexp#=~
-    @JRubyMethod(name = "=~", reads = FrameField.BACKREF, writes = FrameField.BACKREF)
+    // Writes backref due to decendant calls ending up in Regexp#=~
+    @JRubyMethod(name = "=~", writes = FrameField.BACKREF)
     public static IRubyObject op_match(ThreadContext context, IRubyObject self, IRubyObject arg) {
         context.runtime.getWarnings().warn(ID.DEPRECATED_METHOD,
             "deprecated Object#=~ is called on " + ((RubyBasicObject) self).type() +
@@ -2277,8 +2277,8 @@ public class RubyKernel {
         return ((RubyBasicObject) self).op_match(context, arg);
     }
 
-    // Reads and writes backref due to decendant calls ending up in Regexp#=~
-    @JRubyMethod(name = "!~", reads = FrameField.BACKREF, writes = FrameField.BACKREF)
+    // Writes backref due to decendant calls ending up in Regexp#=~
+    @JRubyMethod(name = "!~", writes = FrameField.BACKREF)
     public static IRubyObject op_not_match(ThreadContext context, IRubyObject self, IRubyObject arg) {
         return ((RubyBasicObject) self).op_not_match(context, arg);
     }

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -2989,7 +2989,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
             return subBangCommon(context, mBeg, mEnd, repl, tuFlags | repl.flags);
         }
-        return context.setBackRef(context.nil);
+        return context.clearBackRef();
     }
 
     private IRubyObject subBangIter(ThreadContext context, RubyRegexp regexp, RubyHash hash, Block block) {
@@ -3024,7 +3024,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
             return subBangCommon(context, mBeg, mEnd, repl, tuFlags | repl.flags);
         }
-        return context.setBackRef(context.nil);
+        return context.clearBackRef();
     }
 
     private IRubyObject subBangNoIter(ThreadContext context, IRubyObject arg0, RubyString repl) {
@@ -3046,7 +3046,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
             return subBangCommon(context, mBeg, mEnd, repl, repl.flags);
         }
-        return context.setBackRef(context.nil);
+        return context.clearBackRef();
     }
 
     private IRubyObject subBangNoIter(ThreadContext context, RubyRegexp regexp, RubyString repl) {
@@ -3057,7 +3057,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
             return subBangCommon(context, match.begin, match.end, repl, repl.flags);
         }
-        return context.setBackRef(context.nil);
+        return context.clearBackRef();
     }
 
     /**
@@ -3257,7 +3257,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         int beg = StringSupport.index(getByteList(), pattern.getByteList(), 0, patternEnc);
         int begz;
         if (beg < 0) {
-            if (useBackref) context.setBackRef(context.nil);
+            if (useBackref) context.clearBackRef();
             return bang ? context.nil : strDup(runtime); /* bang: true, no match, no substitution */
         }
 
@@ -3340,7 +3340,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
         int beg = RubyRegexp.matcherSearch(context, matcher, spBeg, spBeg + spLen, Option.NONE);
         if (beg < 0) {
-            if (useBackref) context.setBackRef(context.nil);
+            if (useBackref) context.clearBackRef();
             return bang ? context.nil : strDup(runtime); /* bang: true, no match, no substitution */
         }
 
@@ -3423,7 +3423,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         if (pos < 0) {
             pos += strLength();
             if (pos < 0) {
-                if (arg0 instanceof RubyRegexp) context.setBackRef(context.nil);
+                if (arg0 instanceof RubyRegexp) context.clearBackRef();
                 return context.nil;
             }
         }
@@ -3534,7 +3534,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         if (pos < 0) {
             pos += length;
             if (pos < 0) {
-                if (arg0 instanceof RubyRegexp) context.setBackRef(context.nil);
+                if (arg0 instanceof RubyRegexp) context.clearBackRef();
                 return context.nil;
             }
         }
@@ -4508,7 +4508,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
         if (len > 0 && (limit || len > beg || lim < 0)) result.append(makeShared(runtime, beg, len - beg));
 
-        if (useBackref) context.setBackRef(nil);
+        if (useBackref) context.clearBackRef();
 
         return result;
     }
@@ -4751,7 +4751,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
                     setBackRefString(context, str, beg, strPattern).infectBy(pattern);
                 }
                 else {
-                    context.setBackRef(context.nil);
+                    context.clearBackRef();
                 }
             }
             return beg;

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1677,7 +1677,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      *
      */
 
-    @JRubyMethod(name = "=~", reads = BACKREF, writes = BACKREF)
+    @JRubyMethod(name = "=~", writes = BACKREF)
     @Override
     public IRubyObject op_match(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyRegexp) return ((RubyRegexp) other).op_match(context, this);
@@ -1696,14 +1696,14 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return match19(context, pattern, Block.NULL_BLOCK);
     }
 
-    @JRubyMethod(name = "match", required = 1, reads = BACKREF)
+    @JRubyMethod(name = "match", required = 1, writes = BACKREF)
     public IRubyObject match19(ThreadContext context, IRubyObject pattern, Block block) {
         RubyRegexp coercedPattern = getPattern(context.runtime, pattern);
         IRubyObject result = sites(context).match.call(context, coercedPattern, coercedPattern, this);
         return block.isGiven() && result != context.nil ? block.yield(context, result) : result;
     }
 
-    @JRubyMethod(name = "match", reads = BACKREF)
+    @JRubyMethod(name = "match", writes = BACKREF)
     public IRubyObject match19(ThreadContext context, IRubyObject pattern, IRubyObject pos, Block block) {
         RubyRegexp coercedPattern = getPattern(context.runtime, pattern);
         IRubyObject result = sites(context).match.call(context, coercedPattern, coercedPattern, this, pos);
@@ -2913,21 +2913,21 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      *
      */
 
-    @JRubyMethod(name = "sub", reads = BACKREF, writes = BACKREF)
+    @JRubyMethod(name = "sub", writes = BACKREF)
     public IRubyObject sub(ThreadContext context, IRubyObject arg0, Block block) {
         RubyString str = strDup(context.runtime);
         str.sub_bang(context, arg0, block);
         return str;
     }
 
-    @JRubyMethod(name = "sub", reads = BACKREF, writes = BACKREF)
+    @JRubyMethod(name = "sub", writes = BACKREF)
     public IRubyObject sub(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Block block) {
         RubyString str = strDup(context.runtime);
         str.sub_bang(context, arg0, arg1, block);
         return str;
     }
 
-    @JRubyMethod(name = "sub!", reads = BACKREF, writes = BACKREF)
+    @JRubyMethod(name = "sub!", writes = BACKREF)
     public IRubyObject sub_bang(ThreadContext context, IRubyObject arg0, Block block) {
         Ruby runtime = context.runtime;
         frozenCheck();
@@ -2936,7 +2936,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         throw runtime.newArgumentError(1, 2);
     }
 
-    @JRubyMethod(name = "sub!", reads = BACKREF, writes = BACKREF)
+    @JRubyMethod(name = "sub!", writes = BACKREF)
     public IRubyObject sub_bang(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Block block) {
         Ruby runtime = context.runtime;
         IRubyObject hash = TypeConverter.convertToTypeWithCheck(context, arg1, runtime.getHash(), sites(context).to_hash_checked);
@@ -3189,7 +3189,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return gsub_bang(context, arg0, arg1, block);
     }
 
-    @JRubyMethod(name = "gsub", reads = BACKREF, writes = BACKREF)
+    @JRubyMethod(name = "gsub", writes = BACKREF)
     public IRubyObject gsub(ThreadContext context, IRubyObject arg0, Block block) {
         if (!block.isGiven()) return enumeratorize(context.runtime, this, "gsub", arg0);
 
@@ -3197,12 +3197,12 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     }
 
-    @JRubyMethod(name = "gsub", reads = BACKREF, writes = BACKREF)
+    @JRubyMethod(name = "gsub", writes = BACKREF)
     public IRubyObject gsub(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Block block) {
         return gsubImpl(context, arg0, arg1, block, false);
     }
 
-    @JRubyMethod(name = "gsub!", reads = BACKREF, writes = BACKREF)
+    @JRubyMethod(name = "gsub!", writes = BACKREF)
     public IRubyObject gsub_bang(ThreadContext context, IRubyObject arg0, Block block) {
         checkFrozen();
 
@@ -3211,7 +3211,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return gsubCommon(context, block, null, null, arg0, true, 0);
     }
 
-    @JRubyMethod(name = "gsub!", reads = BACKREF, writes = BACKREF)
+    @JRubyMethod(name = "gsub!", writes = BACKREF)
     public IRubyObject gsub_bang(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Block block) {
         checkFrozen();
 
@@ -3447,12 +3447,12 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     /** rb_str_index_m
      *
      */
-    @JRubyMethod(name = "index", reads = BACKREF, writes = BACKREF)
+    @JRubyMethod(name = "index", writes = BACKREF)
     public IRubyObject index(ThreadContext context, IRubyObject arg0) {
         return indexCommon19(context, arg0, 0);
     }
 
-    @JRubyMethod(name = "index", reads = BACKREF, writes = BACKREF)
+    @JRubyMethod(name = "index", writes = BACKREF)
     public IRubyObject index(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
         int pos = RubyNumeric.num2int(arg1);
         if (pos < 0) {
@@ -3559,12 +3559,12 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     /** rb_str_rindex_m
      *
      */
-    @JRubyMethod(name = "rindex", reads = BACKREF, writes = BACKREF)
+    @JRubyMethod(name = "rindex", writes = BACKREF)
     public IRubyObject rindex(ThreadContext context, IRubyObject arg0) {
         return rindexCommon(context, arg0, strLength());
     }
 
-    @JRubyMethod(name = "rindex", reads = BACKREF, writes = BACKREF)
+    @JRubyMethod(name = "rindex", writes = BACKREF)
     public IRubyObject rindex(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
         int pos = RubyNumeric.num2int(arg1);
         int length = strLength();
@@ -3985,7 +3985,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     /** rb_str_slice_bang
      *
      */
-    @JRubyMethod(name = "slice!", reads = BACKREF, writes = BACKREF)
+    @JRubyMethod(name = "slice!", writes = BACKREF)
     public IRubyObject slice_bang(ThreadContext context, IRubyObject arg0) {
         IRubyObject result = op_aref19(context, arg0);
         if (result.isNil()) {
@@ -3996,7 +3996,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return result;
     }
 
-    @JRubyMethod(name = "slice!", reads = BACKREF, writes = BACKREF)
+    @JRubyMethod(name = "slice!", writes = BACKREF)
     public IRubyObject slice_bang(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
         IRubyObject result = op_aref(context, arg0, arg1);
         if (result.isNil()) {

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -4531,7 +4531,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         int end, beg = 0;
         boolean lastNull = false;
         int start = beg;
-        while ((end = pattern.search(context, this, start, false)) >= 0) {
+        while ((end = pattern.searchString(context, this, start, false)) >= 0) {
             RubyMatchData match = context.getLocalMatch();
             if (start == end && match.begin(0) == match.end(0)) {
                 if (len == 0) {
@@ -4540,6 +4540,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
                 } else if (lastNull) {
                     result.append(makeShared(runtime, beg, StringSupport.length(enc, bytes, ptr + beg, ptr + len)));
                     beg = start;
+                } else {
                     if ((ptr + start) == ptr + len) {
                         start++;
                     } else {

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -2973,7 +2973,10 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
             final int mLen = pattern.size();
             final int mEnd = mBeg + mLen;
             final RubyMatchData match = new RubyMatchData(runtime);
+
             match.initMatchData(this, mBeg, pattern);
+
+            // set backref for user
             context.setBackRef(match);
 
             IRubyObject subStr = makeShared(runtime, mBeg, mLen);
@@ -2989,6 +2992,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
             return subBangCommon(context, mBeg, mEnd, repl, tuFlags | repl.flags);
         }
+
+        // set backref for user
         return context.clearBackRef();
     }
 
@@ -3006,6 +3011,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         if (RubyRegexp.matcherSearch(context, matcher, begin, range, Option.NONE) >= 0) {
             RubyMatchData match = RubyRegexp.createMatchData(context, this, matcher, pattern);
             match.regexp = regexp;
+
+            // set backref for user
             context.setBackRef(match);
 
             final int mBeg = matcher.getBegin(), mEnd = matcher.getEnd();
@@ -3024,6 +3031,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
             return subBangCommon(context, mBeg, mEnd, repl, tuFlags | repl.flags);
         }
+
+        // set backref for user
         return context.clearBackRef();
     }
 
@@ -3040,12 +3049,18 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         if (mBeg > -1) {
             final int mEnd = mBeg + pattern.size();
             final RubyMatchData match = new RubyMatchData(context.runtime);
+
             match.initMatchData(this, mBeg, pattern);
+
+            // set backref for user
             context.setBackRef(match);
+
             repl = RubyRegexp.regsub(context, repl, this, REPL_MOCK_REGEX, null, mBeg, mEnd);
 
             return subBangCommon(context, mBeg, mEnd, repl, repl.flags);
         }
+
+        // set backref for user
         return context.clearBackRef();
     }
 
@@ -3053,10 +3068,14 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         RubyMatchData match = subBangMatch(context, regexp, repl);
         if (match != null) {
             repl = RubyRegexp.regsub(context, repl, this, regexp.pattern, match.regs, match.begin, match.end);
+
+            // set backref for user
             context.setBackRef(match);
 
             return subBangCommon(context, match.begin, match.end, repl, repl.flags);
         }
+
+        // set backref for user
         return context.clearBackRef();
     }
 
@@ -3257,7 +3276,9 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         int beg = StringSupport.index(getByteList(), pattern.getByteList(), 0, patternEnc);
         int begz;
         if (beg < 0) {
+            // set backref for user
             if (useBackref) context.clearBackRef();
+
             return bang ? context.nil : strDup(runtime); /* bang: true, no match, no substitution */
         }
 
@@ -3282,7 +3303,9 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
                     match = new RubyMatchData(runtime);
                     match.initMatchData(this, begz, pattern);
 
+                    // set backref for user
                     if (useBackref) context.setBackRef(match);
+
                     val = objAsString(context, block.yield(context, pattern.strDup(runtime)));
                 }
                 modifyCheck(spBytes, spLen, str_enc);
@@ -3310,10 +3333,14 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
         if (useBackref) {
             if (match != null) { // block given
+                // set backref for user
                 context.setBackRef(match);
             } else {
                 match = new RubyMatchData(runtime);
+
                 match.initMatchData(this, begz, pattern);
+
+                // set backref for user
                 context.setBackRef(match);
             }
         }
@@ -3340,7 +3367,9 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
         int beg = RubyRegexp.matcherSearch(context, matcher, spBeg, spBeg + spLen, Option.NONE);
         if (beg < 0) {
+            // set backref for user
             if (useBackref) context.clearBackRef();
+
             return bang ? context.nil : strDup(runtime); /* bang: true, no match, no substitution */
         }
 
@@ -3365,7 +3394,10 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
                 } else {            // block given
                     match = RubyRegexp.createMatchData(context, this, matcher, pattern);
                     match.regexp = regexp;
+
+                    // set backref for user
                     if (useBackref) context.setBackRef(match);
+
                     val = objAsString(context, block.yield(context, substr));
                 }
                 modifyCheck(spBytes, spLen, str_enc);
@@ -3392,11 +3424,14 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         if (spLen > offset) dest.cat(spBytes, cp, spLen - offset, str_enc);
 
         if (useBackref) {
+            // set backref for user
             if (match != null) { // block given
                 context.setBackRef(match);
             } else {
                 match = RubyRegexp.createMatchData(context, this, matcher, pattern);
+
                 match.regexp = regexp;
+
                 context.setBackRef(match);
             }
         }
@@ -3423,7 +3458,9 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         if (pos < 0) {
             pos += strLength();
             if (pos < 0) {
+                // set backref for user
                 if (arg0 instanceof RubyRegexp) context.clearBackRef();
+
                 return context.nil;
             }
         }
@@ -3534,7 +3571,9 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         if (pos < 0) {
             pos += length;
             if (pos < 0) {
+                // set backref for user
                 if (arg0 instanceof RubyRegexp) context.clearBackRef();
+
                 return context.nil;
             }
         }
@@ -3752,7 +3791,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     /** rb_str_aref, rb_str_aref_m
      *
      */
-    @JRubyMethod(name = {"[]", "slice"}, reads = BACKREF, writes = BACKREF)
+    @JRubyMethod(name = {"[]", "slice"}, writes = BACKREF)
     public IRubyObject op_aref(ThreadContext context, IRubyObject arg) {
         Ruby runtime = context.runtime;
         if (arg instanceof RubyFixnum) {
@@ -3779,7 +3818,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return op_aref(runtime, RubyNumeric.num2int(arg));
     }
 
-    @JRubyMethod(name = {"[]", "slice"}, reads = BACKREF, writes = BACKREF)
+    @JRubyMethod(name = {"[]", "slice"}, writes = BACKREF)
     public IRubyObject op_aref(ThreadContext context, IRubyObject arg1, IRubyObject arg2) {
         Ruby runtime = context.runtime;
         if (arg1 instanceof RubyRegexp) return subpat(context, (RubyRegexp) arg1, arg2);
@@ -3816,12 +3855,12 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     private void subpatSet(ThreadContext context, RubyRegexp regexp, IRubyObject backref, IRubyObject repl) {
         Ruby runtime = context.runtime;
 
-        int result = regexp.search(context, this, 0, false);
+        int result = regexp.searchString(context, this, 0, false);
 
         if (result < 0) throw runtime.newIndexError("regexp not matched");
 
         // this cast should be ok, since nil matchdata will be < 0 above
-        RubyMatchData match = (RubyMatchData)context.getBackRef();
+        RubyMatchData match = context.getLocalMatch();
 
         int nth = backref == null ? 0 : subpatSetCheck(runtime, match.backrefNumber(context.runtime, backref), match.regs);
 
@@ -3839,25 +3878,42 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         // TODO: keep cr
         replaceInternal(start, end - start, replStr); // TODO: rb_str_splice_0
         associateEncoding(enc);
+
+        // set backref for user
+        context.setBackRef(match);
     }
 
     private IRubyObject subpat(ThreadContext context, RubyRegexp regex, IRubyObject backref) {
-        int result = regex.search(context, this, 0, false);
+        int result = regex.searchString(context, this, 0, false);
 
         if (result >= 0) {
-            RubyMatchData match = (RubyMatchData)context.getBackRef();
+            RubyMatchData match = context.getLocalMatch();
+
+            // set backref for user
+            context.setBackRef(match);
+
             return RubyRegexp.nth_match(match.backrefNumber(context.runtime, backref), match);
         }
+
+        context.clearBackRef();
 
         return context.nil;
     }
 
     private IRubyObject subpat(ThreadContext context, RubyRegexp regex) {
-        int result = regex.search(context, this, 0, false);
+        int result = regex.searchString(context, this, 0, false);
 
         if (result >= 0) {
-            return RubyRegexp.nth_match(0, context.getBackRef());
+            RubyMatchData match = context.getLocalMatch();
+
+            // set backref for user
+            context.setBackRef(match);
+
+            return RubyRegexp.nth_match(0, match);
         }
+
+        // set backref for user
+        context.clearBackRef();
 
         return context.nil;
     }
@@ -3865,7 +3921,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     /** rb_str_aset, rb_str_aset_m
      *
      */
-    @JRubyMethod(name = "[]=", reads = BACKREF)
+    @JRubyMethod(name = "[]=", writes = BACKREF)
     public IRubyObject op_aset(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
         if (arg0 instanceof RubyFixnum) {
             return op_aset(context, RubyNumeric.fix2int((RubyFixnum)arg0), arg1);
@@ -3902,7 +3958,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return arg1;
     }
 
-    @JRubyMethod(name = "[]=", reads = BACKREF)
+    @JRubyMethod(name = "[]=", writes = BACKREF)
     public IRubyObject op_aset(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
         if (arg0 instanceof RubyRegexp) {
             subpatSet(context, (RubyRegexp)arg0, arg1, arg2);
@@ -4461,24 +4517,21 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      * Call regexpSplit using a thread-local backref holder to avoid cross-thread pollution.
      */
     private RubyArray regexSplit(ThreadContext context, RubyRegexp pattern, boolean limit, int lim, int i, boolean useBackref) {
-        RubyArray result;
-
-        IRubyObject nil = context.nil;
-
         Ruby runtime = context.runtime;
+
+        RubyArray result = runtime.newArray();
 
         int ptr = value.getBegin();
         int len = value.getRealSize();
         byte[] bytes = value.getUnsafeBytes();
-
-        result = runtime.newArray();
         Encoding enc = value.getEncoding();
+
         boolean captures = pattern.getPattern().numberOfCaptures() != 0;
 
         int end, beg = 0;
         boolean lastNull = false;
         int start = beg;
-        while ((end = pattern.search(context, this, start, false, false)) >= 0) {
+        while ((end = pattern.search(context, this, start, false)) >= 0) {
             RubyMatchData match = context.getLocalMatch();
             if (start == end && match.begin(0) == match.end(0)) {
                 if (len == 0) {
@@ -4508,6 +4561,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
         if (len > 0 && (limit || len > beg || lim < 0)) result.append(makeShared(runtime, beg, len - beg));
 
+        // set backref for user
         if (useBackref) context.clearBackRef();
 
         return result;
@@ -4661,7 +4715,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     /** rb_str_scan
      *
      */
-    @JRubyMethod(name = "scan", reads = BACKREF, writes = BACKREF)
+    @JRubyMethod(name = "scan", writes = BACKREF)
     public IRubyObject scan(ThreadContext context, IRubyObject pat, Block block) {
         final RubyString str = this;
 
@@ -4679,7 +4733,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
                 if (ary == null) ary = context.runtime.newArray(4);
                 ary.append(result);
             }
-            if (last >= 0) patternSearch(context, pat, str, last, true);
+            if (last >= 0) patternSearch(context, pat, str, last);
             return ary == null ? context.runtime.newEmptyArray() : ary;
         }
 
@@ -4692,7 +4746,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
             block.yieldSpecific(context, result);
             str.modifyCheck(pBytes, len);
         }
-        if (last >= 0) patternSearch(context, pat, str, last, true);
+        if (last >= 0) patternSearch(context, pat, str, last);
         return this;
     }
 
@@ -4705,8 +4759,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     // MRI: scan_once
     private static IRubyObject scanOnce(ThreadContext context, RubyString str, IRubyObject pat, int[] startp) {
-        if (patternSearch(context, pat, str, startp[0], true) >= 0) {
-            final RubyMatchData match = (RubyMatchData) context.getBackRef();
+        if (patternSearch(context, pat, str, startp[0]) >= 0) {
+            final RubyMatchData match = context.getLocalMatch();
             final int matchEnd = match.end(0);
             if (match.begin(0) == matchEnd) {
                 Encoding enc = str.getEncoding();
@@ -4740,36 +4794,41 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     }
 
     // MRI: rb_pat_search
-    private static int patternSearch(ThreadContext context,
-        final IRubyObject pattern, RubyString str, final int pos,
-        final boolean setBackrefStr) {
+    private static int patternSearch(ThreadContext context, final IRubyObject pattern, RubyString str, final int pos) {
         if (pattern instanceof RubyString) {
             final RubyString strPattern = (RubyString) pattern;
             final int beg = str.strseqIndex(strPattern, pos, true);
-            if (setBackrefStr) {
-                if (beg >= 0) {
-                    setBackRefString(context, str, beg, strPattern).infectBy(pattern);
-                }
-                else {
-                    context.clearBackRef();
-                }
+            if (beg >= 0) {
+                context.setLocalMatch(setBackRefString(context, str, beg, strPattern));
+            } else {
+                context.clearLocalMatch();
+
+                // set backref for user
+                context.clearBackRef();
             }
             return beg;
         }
-        return ((RubyRegexp) pattern).search(context, str, pos, false);
+
+        int result = ((RubyRegexp) pattern).searchString(context, str, pos, false);
+
+        // set backref for user
+        if (result >= 0) {
+            context.setBackRef(context.getLocalMatch());
+        } else {
+            context.clearBackRef();
+        }
+
+        return result;
     }
 
     // MRI: rb_backref_set_string
     private static RubyMatchData setBackRefString(ThreadContext context, RubyString str, int pos, RubyString pattern) {
-        final IRubyObject m = context.getBackRef();
-        final RubyMatchData match;
-        if (m.isNil() || ((RubyMatchData) m).used()) {
-            match = new RubyMatchData(context.runtime);
-        } else {
-            match = (RubyMatchData) m;
-        }
-        match.initMatchData(str, pos, pattern); // MRI: match_set_string
+        final RubyMatchData match = RubyRegexp.createMatchData(context, str, pos, pattern);
+
+        match.infectBy(pattern);
+
         context.setBackRef(match);
+
         return match;
     }
 
@@ -5152,7 +5211,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return RubyArray.newArrayMayCopy(runtime, this.strDup(runtime), newEmptyString(runtime, enc), newEmptyString(runtime, enc));
     }
 
-    @JRubyMethod(name = "rpartition", reads = BACKREF, writes = BACKREF)
+    @JRubyMethod(name = "rpartition", writes = BACKREF)
     public IRubyObject rpartition(ThreadContext context, IRubyObject arg) {
         Ruby runtime = context.runtime;
         final int pos;
@@ -5161,7 +5220,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
             IRubyObject tmp = rindex(context, arg);
             if (tmp.isNil()) return rpartitionMismatch(runtime);
             pos = tmp.convertToInteger().getIntValue();
-            sep = (RubyString) RubyRegexp.nth_match(0, (RubyMatchData) context.getBackRef());
+            sep = (RubyString)RubyRegexp.nth_match(0, context.getLocalMatchOrNil());
         } else {
             IRubyObject tmp = arg.checkStringType();
             if (tmp.isNil()) throw runtime.newTypeError("type mismatch: " + arg.getMetaClass().getName() + " given");

--- a/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
+++ b/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
@@ -294,7 +294,7 @@ public class RubyPathname extends RubyObject {
         return context.runtime.newString("#<Pathname:" + getPath() + ">");
     }
 
-    @JRubyMethod(required = 1, optional = 1, reads = BACKREF, writes = BACKREF)
+    @JRubyMethod(required = 1, optional = 1, writes = BACKREF)
     public IRubyObject sub(ThreadContext context, IRubyObject[] args, Block block) {
         IRubyObject result = sites(context).sub.call(context, this, getPath(), args, block);
         return newInstance(context, result);

--- a/core/src/main/java/org/jruby/ext/stringio/StringIO.java
+++ b/core/src/main/java/org/jruby/ext/stringio/StringIO.java
@@ -1365,7 +1365,7 @@ public class StringIO extends RubyObject implements EncodingCapable, DataType {
             return self;
         }
 
-        @JRubyMethod(name = "print", rest = true)
+        @JRubyMethod(name = "print", rest = true, writes = FrameField.LASTLINE)
         public static IRubyObject print(ThreadContext context, IRubyObject self, IRubyObject[] args) {
             return RubyIO.print(context, self, args);
         }

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -2948,6 +2948,6 @@ public class Helpers {
 
     @Deprecated
     public static IRubyObject backref(ThreadContext context) {
-        return RubyRegexp.getBackRef(context);
+        return context.getBackRef();
     }
 }

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -827,12 +827,6 @@ public class Helpers {
 
     public static Block getBlockFromBlockPassBody(IRubyObject proc, Block currentBlock) {
         return getBlockFromBlockPassBody(proc.getRuntime(), proc, currentBlock);
-
-    }
-
-    @Deprecated
-    public static IRubyObject backref(ThreadContext context) {
-        return RubyRegexp.getBackRef(context);
     }
 
     @Deprecated
@@ -1674,27 +1668,6 @@ public class Helpers {
 
     public static IRubyObject getLastLine(Ruby runtime, ThreadContext context) {
         return context.getLastLine();
-    }
-
-    public static IRubyObject setBackref(ThreadContext context, IRubyObject value) {
-        if (!(value instanceof RubyMatchData) && value != context.nil) {
-            throw context.runtime.newTypeError(value, context.runtime.getMatchData());
-        }
-        return context.setBackRef(value);
-    }
-
-    @Deprecated
-    public static IRubyObject setBackref(Ruby runtime, ThreadContext context, IRubyObject value) {
-        return setBackref(context, value);
-    }
-
-    public static IRubyObject getBackref(ThreadContext context) {
-        return RubyRegexp.getBackRef(context);
-    }
-
-    @Deprecated
-    public static IRubyObject getBackref(Ruby runtime, ThreadContext context) {
-        return RubyRegexp.getBackRef(context);
     }
 
     public static RubyArray arrayValue(IRubyObject value) {
@@ -2960,5 +2933,21 @@ public class Helpers {
     @Deprecated
     public static IRubyObject invokeFrom(ThreadContext context, IRubyObject caller, IRubyObject self, String name, CallType callType) {
         return self.getMetaClass().invokeFrom(context, callType, caller, self, name, IRubyObject.NULL_ARRAY, Block.NULL_BLOCK);
+    }
+
+    @Deprecated
+    public static IRubyObject setBackref(Ruby runtime, ThreadContext context, IRubyObject value) {
+        if (!value.isNil() && !(value instanceof RubyMatchData)) throw runtime.newTypeError(value, runtime.getMatchData());
+        return context.setBackRef(value);
+    }
+
+    @Deprecated
+    public static IRubyObject getBackref(Ruby runtime, ThreadContext context) {
+        return context.getBackRef();
+    }
+
+    @Deprecated
+    public static IRubyObject backref(ThreadContext context) {
+        return RubyRegexp.getBackRef(context);
     }
 }

--- a/core/src/main/java/org/jruby/runtime/MethodIndex.java
+++ b/core/src/main/java/org/jruby/runtime/MethodIndex.java
@@ -268,11 +268,11 @@ public class MethodIndex {
         if (needsScope) SCOPE_AWARE_METHODS.addAll(names);
     }
 
-    public static void addMethodReadFields(String name, FrameField[] reads) {
+    public static void addMethodReadFields(String name, FrameField... reads) {
         addMethodReadFieldsPacked(FrameField.pack(reads), name);
     }
 
-    public static void addMethodWriteFields(String name, FrameField[] write) {
+    public static void addMethodWriteFields(String name, FrameField... write) {
         addMethodWriteFieldsPacked(FrameField.pack(write), name);
     }
 

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -44,6 +44,7 @@ import org.jruby.RubyArray;
 import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyContinuation;
+import org.jruby.RubyMatchData;
 import org.jruby.RubyProc;
 import org.jruby.exceptions.CatchThrow;
 import org.jruby.RubyInstanceConfig;
@@ -164,6 +165,8 @@ public final class ThreadContext {
     private RubyModule privateConstantReference;
 
     public final JavaSites sites;
+
+    private RubyMatchData matchData;
 
     @SuppressWarnings("deprecation")
     public SecureRandom getSecureRandom() {
@@ -1369,5 +1372,38 @@ public final class ThreadContext {
     public Encoding[] encodingHolder() {
         if (encodingHolder == null) encodingHolder = new Encoding[1];
         return encodingHolder;
+    }
+
+    /**
+     * Set the thread-local MatchData specific to this context. This is different from the frame backref since frames
+     * may be shared by several executing contexts at once (see jruby/jruby#4868).
+     *
+     * @param localMatch the new thread-local MatchData or null
+     */
+    public void setLocalMatch(RubyMatchData localMatch) {
+        matchData = localMatch;
+    }
+
+    /**
+     * Get the thread-local MatchData specific to this context. This is different from the frame backref since frames
+     * may be shared by several executing contexts at once (see jruby/jruby#4868).
+     *
+     * @return the current thread-local MatchData, or null if none
+     */
+    public RubyMatchData getLocalMatch() {
+        return matchData;
+    }
+
+    /**
+     * Get the thread-local MatchData specific to this context or nil if none.
+     *
+     * @see #getLocalMatch()
+     *
+     * @return the current thread-local MatchData, or nil if none
+     */
+    public IRubyObject getLocalMatchOrNil() {
+        RubyMatchData matchData = this.matchData;
+        if (matchData != null) return matchData;
+        return nil;
     }
 }

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -564,12 +564,23 @@ public final class ThreadContext {
     }
 
     /**
-     * Set the $~ (backref) "global" to the given value.
+     * Set the $~ (backref) "global" to nil.
+     *
+     * @return nil
+     */
+    public IRubyObject clearBackRef() {
+        return getCurrentFrame().setBackRef(nil);
+    }
+
+    /**
+     * Set the $~ (backref) "global" to the given RubyMatchData value. The value will be marked as "in use" since it
+     * can now be seen across threads that share the current frame.
      *
      * @param match the value to set
      * @return the value passed in
      */
-    public IRubyObject setBackRef(IRubyObject match) {
+    public IRubyObject setBackRef(RubyMatchData match) {
+        match.use();
         return getCurrentFrame().setBackRef(match);
     }
 
@@ -1405,5 +1416,10 @@ public final class ThreadContext {
         RubyMatchData matchData = this.matchData;
         if (matchData != null) return matchData;
         return nil;
+    }
+
+    @Deprecated
+    public IRubyObject setBackRef(IRubyObject match) {
+        return getCurrentFrame().setBackRef(match);
     }
 }

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -573,6 +573,23 @@ public final class ThreadContext {
     }
 
     /**
+     * Update the current frame's backref using the current thread-local match, or clear it if that match is null.
+     *
+     * @return The current match, or nil
+     */
+    public IRubyObject updateBackref() {
+        RubyMatchData match = matchData;
+
+        if (match == null) {
+            return clearBackRef();
+        }
+
+        match.use();
+
+        return getCurrentFrame().setBackRef(match);
+    }
+
+    /**
      * Set the $~ (backref) "global" to the given RubyMatchData value. The value will be marked as "in use" since it
      * can now be seen across threads that share the current frame.
      *
@@ -1396,6 +1413,15 @@ public final class ThreadContext {
     }
 
     /**
+     * Set the thread-local MatchData specific to this context to null.
+     *
+     * @see #setLocalMatch(RubyMatchData)
+     */
+    public void clearLocalMatch() {
+        matchData = null;
+    }
+
+    /**
      * Get the thread-local MatchData specific to this context. This is different from the frame backref since frames
      * may be shared by several executing contexts at once (see jruby/jruby#4868).
      *
@@ -1420,6 +1446,8 @@ public final class ThreadContext {
 
     @Deprecated
     public IRubyObject setBackRef(IRubyObject match) {
-        return getCurrentFrame().setBackRef(match);
+        if (match.isNil()) return clearBackRef();
+
+        return setBackRef((RubyMatchData) match);
     }
 }


### PR DESCRIPTION
This PR seeks to improve the concurrency characteristics of methods that read or write the "frame global" backref variable `$~`.

As seen in #6640 the concurrency issues surrounding backref (#4868) can in some cases lead to internal race conditions we must avoid. In that issue, the frame backref was used during the execution of the main `split` loop, leading to two threads stepping on each other.

The work here will move all internal usage of backref (as an "out of band" data-passing mechanism) to a context-local (essentially thread-local) field, only propagating the resulting match to the frame backref at the end of the method as appropriate. This will essentially eliminate data races surrounding `$~` within our own code. The remaining race will be in user code that opts into consuming this variable.