### PR TITLE
Unsupported process waits warn and noop

### DIFF
--- a/core/src/main/java/org/jruby/common/IRubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/IRubyWarnings.java
@@ -100,7 +100,8 @@ public interface IRubyWarnings {
         GC_STRESS_UNIMPLEMENTED,
         GC_ENABLE_UNIMPLEMENTED,
         GC_DISABLE_UNIMPLEMENTED,
-        RATIONAL_OUT_OF_RANGE,;
+        RATIONAL_OUT_OF_RANGE,
+        PROCESS_WAIT_UNAVAILABLE;
 
         public String getID() {
             return name();


### PR DESCRIPTION
When running without native support, we cannot do any of the pid-
based waits. However in many instances it may be more damaging to
raise a hard error for the unimplemented logic rather than just
warning and doing nothing. This commit changes the logic of these
methods to report not implemented and warn rather than failing
outright. The methods are also marked as not implemented in case
code checks this (though I have no such examples).