### PR TITLE
Include overriding classes in backtrace mapping

### DIFF
--- a/core/src/main/java/org/jruby/AbstractRubyMethod.java
+++ b/core/src/main/java/org/jruby/AbstractRubyMethod.java
@@ -33,6 +33,7 @@
 
 package org.jruby;
 
+import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.internal.runtime.methods.AliasMethod;
 import org.jruby.internal.runtime.methods.DynamicMethod;
@@ -48,6 +49,7 @@ import org.jruby.runtime.marshal.DataType;
  * @see RubyMethod
  * @see RubyUnboundMethod
  */
+@JRubyClass(name = {"Method", "UnboundMethod"}, overrides = {RubyMethod.class, RubyUnboundMethod.class})
 public abstract class AbstractRubyMethod extends RubyObject implements DataType {
     protected RubyModule implementationModule;
     protected String methodName;

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -2953,19 +2953,18 @@ public final class Ruby implements Constantizable {
     }
 
     public void addBoundMethod(String className, String methodName, String rubyName) {
-        Map<String, String> javaToRuby = boundMethods.get(className);
-        if (javaToRuby == null) boundMethods.put(className, javaToRuby = new HashMap<>());
-        javaToRuby.put(methodName, rubyName);
+        Map<String, String> javaToRuby = boundMethods.computeIfAbsent(className, s -> new HashMap<>());
+        javaToRuby.putIfAbsent(methodName, rubyName);
     }
 
     public void addBoundMethods(String className, String... tuples) {
-        Map<String, String> javaToRuby = boundMethods.get(className);
-        if (javaToRuby == null) boundMethods.put(className, javaToRuby = new HashMap<>(tuples.length / 2 + 1, 1));
+        Map<String, String> javaToRuby = boundMethods.computeIfAbsent(className, s -> new HashMap<>());
         for (int i = 0; i < tuples.length; i += 2) {
-            javaToRuby.put(tuples[i], tuples[i+1]);
+            javaToRuby.putIfAbsent(tuples[i], tuples[i+1]);
         }
     }
 
+    // Used by generated populators
     public void addBoundMethods(int tuplesIndex, String... classNamesAndTuples) {
         Map<String, String> javaToRuby = new HashMap<>((classNamesAndTuples.length - tuplesIndex) / 2 + 1, 1);
         for (int i = tuplesIndex; i < classNamesAndTuples.length; i += 2) {

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -2966,6 +2966,22 @@ public final class Ruby implements Constantizable {
         }
     }
 
+    public void addBoundMethods(int tuplesIndex, String... classNamesAndTuples) {
+        Map<String, String> javaToRuby = new HashMap<>((classNamesAndTuples.length - tuplesIndex) / 2 + 1, 1);
+        for (int i = tuplesIndex; i < classNamesAndTuples.length; i += 2) {
+            javaToRuby.put(classNamesAndTuples[i], classNamesAndTuples[i+1]);
+        }
+
+        for (int i = 0; i < tuplesIndex; i++) {
+            String className = classNamesAndTuples[i];
+            if (boundMethods.containsKey(className)) {
+                boundMethods.get(className).putAll(javaToRuby);
+            } else {
+                boundMethods.put(className, new HashMap<>(javaToRuby));
+            }
+        }
+    }
+
     @Deprecated // no longer used -> except for IndyBinder
     public void addBoundMethodsPacked(String className, String packedTuples) {
         List<String> names = StringSupport.split(packedTuples, ';');

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -82,6 +82,7 @@ import org.jruby.util.Pack;
 import org.jruby.util.RecursiveComparator;
 import org.jruby.util.TypeConverter;
 import org.jruby.util.cli.Options;
+import org.jruby.util.collections.StringArraySet;
 
 import static org.jruby.RubyEnumerator.SizeFn;
 import static org.jruby.RubyEnumerator.enumeratorize;
@@ -102,7 +103,8 @@ import static org.jruby.util.RubyStringBuilder.types;
  * all users must synchronize externally with writers.
  *
  */
-@JRubyClass(name="Array", include = { "Enumerable" })
+@JRubyClass(name="Array", include = { "Enumerable" },
+        overrides = {RubyArrayOneObject.class, RubyArrayTwoObject.class, StringArraySet.class})
 public class RubyArray<T extends IRubyObject> extends RubyObject implements List, RandomAccess {
     public static final int DEFAULT_INSPECT_STR_SIZE = 10;
 

--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -66,7 +66,7 @@ import static org.jruby.util.Numeric.f_lcm;
  *
  * @author  jpetersen
  */
-@JRubyClass(name="Integer", parent="Numeric")
+@JRubyClass(name="Integer", parent="Numeric", overrides = {RubyFixnum.class, RubyBignum.class})
 public abstract class RubyInteger extends RubyNumeric {
 
     public static RubyClass createIntegerClass(Ruby runtime) {

--- a/core/src/main/java/org/jruby/anno/AnnotationBinder.java
+++ b/core/src/main/java/org/jruby/anno/AnnotationBinder.java
@@ -261,8 +261,8 @@ public class AnnotationBinder extends AbstractProcessor {
     private void addSubclassNames(List<CharSequence> classAndSubs, JRubyClass classAnno) {
         // all implementer classes specified in annotation
         try {
-            for (int i = 0; i < classAnno.implementers().length; i++) {
-                classAndSubs.add(classAnno.implementers()[i].getCanonicalName());
+            for (int i = 0; i < classAnno.overrides().length; i++) {
+                classAndSubs.add(classAnno.overrides()[i].getCanonicalName());
             }
         } catch (MirroredTypesException mte) {
             for (TypeMirror tm : mte.getTypeMirrors()) {

--- a/core/src/main/java/org/jruby/anno/AnnotationBinder.java
+++ b/core/src/main/java/org/jruby/anno/AnnotationBinder.java
@@ -207,8 +207,8 @@ public class AnnotationBinder extends AbstractProcessor {
             CharSequence primaryName = getActualQualifiedName(cd);
             classNames.add(primaryName);
 
-            List<CharSequence> classAndSubs = new ArrayList<>();
-            classAndSubs.add(cd.getQualifiedName());
+            List<String> classAndSubs = new ArrayList<>();
+            classAndSubs.add(cd.getQualifiedName().toString());
 
             JRubyClass classAnno = cd.getAnnotation(JRubyClass.class);
             if (classAnno != null) {
@@ -258,12 +258,10 @@ public class AnnotationBinder extends AbstractProcessor {
         }
     }
 
-    private void addSubclassNames(List<CharSequence> classAndSubs, JRubyClass classAnno) {
+    public void addSubclassNames(List<String> classAndSubs, JRubyClass classAnno) {
         // all implementer classes specified in annotation
         try {
-            for (int i = 0; i < classAnno.overrides().length; i++) {
-                classAndSubs.add(classAnno.overrides()[i].getCanonicalName());
-            }
+            AnnotationHelper.addSubclassNames(classAndSubs, classAnno);
         } catch (MirroredTypesException mte) {
             for (TypeMirror tm : mte.getTypeMirrors()) {
                 classAndSubs.add(((TypeElement) types.asElement(tm)).getQualifiedName().toString());

--- a/core/src/main/java/org/jruby/anno/AnnotationHelper.java
+++ b/core/src/main/java/org/jruby/anno/AnnotationHelper.java
@@ -114,5 +114,11 @@ public class AnnotationHelper {
             }
         }
     }
+
+    public static void addSubclassNames(List<String> classAndSubs, JRubyClass classAnno) {
+        for (int i = 0; i < classAnno.overrides().length; i++) {
+            classAndSubs.add(classAnno.overrides()[i].getCanonicalName());
+        }
+    }
 }
 

--- a/core/src/main/java/org/jruby/anno/JRubyClass.java
+++ b/core/src/main/java/org/jruby/anno/JRubyClass.java
@@ -46,5 +46,5 @@ public @interface JRubyClass {
     //This parameter should only be used to point out if something is a Module instead of a Class
     String parent() default "Object";
     String[] include() default {};
-    Class[] implementers() default {};
+    Class[] overrides() default {};
 }

--- a/core/src/main/java/org/jruby/anno/JRubyClass.java
+++ b/core/src/main/java/org/jruby/anno/JRubyClass.java
@@ -46,4 +46,5 @@ public @interface JRubyClass {
     //This parameter should only be used to point out if something is a Module instead of a Class
     String parent() default "Object";
     String[] include() default {};
+    Class[] implementers() default {};
 }

--- a/core/src/main/java/org/jruby/anno/JRubyMethod.java
+++ b/core/src/main/java/org/jruby/anno/JRubyMethod.java
@@ -101,6 +101,11 @@ public @interface JRubyMethod {
      */
     boolean notImplemented() default false;
 
+    /**
+     * A list of classes that implement an abstract JRubyMethod, for backtrace purposes.
+     */
+    Class[] implementers() default {};
+
     @Deprecated
     boolean scope() default false;
 


### PR DESCRIPTION
This PR will fix #5200 by also adding subclasses' bound methods to the mapping table, in one way or another. The initial logic adds a JRubyMethod.implementers list of subclasses to include in the mapping table, but it is fairly naive and does not check if the method is actually overridden. The fix provided would be sufficient, but requires at least one annotation in a given native class to specify a list of implementers to include.

If other experiments don't pan out, we can go with this, but I will try to refine this to only include the actually-overridden methods, and ideally to not require an explicit list of classes.