### PR TITLE
Do not merge extra env with current env

### DIFF
--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1703,12 +1703,6 @@ public class RubyKernel {
             return runtime.getFalse();
         }
 
-        // else old JDK logic
-        if (args[0] instanceof RubyHash) {
-            runtime.getENV().merge_bang(context, (RubyHash) args[0], Block.NULL_BLOCK);
-            // drop the first element for calling systemCommon()
-            args = ArraySupport.newCopy(args, 1, args.length - 1);
-        }
         int resultCode = systemCommon(context, recv, args);
         switch (resultCode) {
             case 0: return runtime.getTrue();


### PR DESCRIPTION
The env hash is now peeled off during processing of the argument
array in ShellLauncher, so this is no longer needed and was not
correct in the first place (should have used a dup of ENV at
best.)

Fixes #6554