### PR TITLE
[refactor] move include_package into Java

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -3712,7 +3712,7 @@ public class RubyModule extends RubyObject {
             RubySymbol sym = (RubySymbol) name;
 
             if (!sym.validConstantName()) {
-                throw runtime.newNameError(str(runtime, "wrong constant name", ids(runtime, sym)), sym);
+                throw runtime.newNameError(str(runtime, "wrong constant name ", ids(runtime, sym)), sym);
             }
 
             String id = sym.idString();
@@ -3813,7 +3813,7 @@ public class RubyModule extends RubyObject {
         int sep = name.indexOf("::");
         // symbol form does not allow ::
         if (symbol instanceof RubySymbol && sep != -1) {
-            throw runtime.newNameError("wrong constant name", fullName);
+            throw runtime.newNameError("wrong constant name ", fullName);
         }
 
         RubyModule mod = this;

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -228,6 +228,7 @@ public class Java implements Library {
         }
     }
 
+    @Deprecated
     public static IRubyObject create_proxy_class(
             IRubyObject self,
             IRubyObject name,
@@ -952,8 +953,12 @@ public class Java implements Library {
     }
 
     public static Class getJavaClass(final Ruby runtime, final String className) throws RaiseException {
+        return getJavaClass(runtime, className, true);
+    }
+
+    public static Class getJavaClass(final Ruby runtime, final String className, boolean initialize) throws RaiseException {
         try {
-            return loadJavaClass(runtime, className);
+            return loadJavaClass(runtime, className, initialize);
         } catch (ClassNotFoundException ex) {
             throw initCause(runtime.newNameError("Java class " + className + " not found", className, ex), ex);
         }

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -109,6 +109,7 @@ public class Java implements Library {
         JavaPackage.createJavaPackageClass(runtime, Java);
 
         org.jruby.javasupport.ext.Kernel.define(runtime);
+        org.jruby.javasupport.ext.Module.define(runtime);
 
         org.jruby.javasupport.ext.JavaLang.define(runtime);
         org.jruby.javasupport.ext.JavaLangReflect.define(runtime);
@@ -238,15 +239,19 @@ public class Java implements Library {
             throw runtime.newTypeError(module, runtime.getModule());
         }
 
-        final RubyModule proxyClass = get_proxy_class(self, javaClass);
-        final String constName = name.asJavaString();
-        IRubyObject existing = ((RubyModule) module).getConstantNoConstMissing(constName);
+        return setProxyClass(runtime, (RubyModule) module, name.asJavaString(), resolveJavaClassArgument(runtime, javaClass));
+    }
+
+    public static RubyModule setProxyClass(final Ruby runtime, final RubyModule target,
+                                           final String constName, final Class<?> javaClass) {
+        final RubyModule proxyClass = getProxyClass(runtime, javaClass);
+        IRubyObject existing = target.getConstantNoConstMissing(constName);
 
         if ( existing != null && existing != RubyBasicObject.UNDEF && existing != proxyClass ) {
-            runtime.getWarnings().warn("replacing " + existing + " with " + proxyClass + " in constant '" + constName + " on class/module " + module);
+            runtime.getWarnings().warn("replacing " + existing + " with " + proxyClass + " in constant '" + constName + " on class/module " + target);
         }
 
-        ((RubyModule) module).setConstantQuiet(name.asJavaString(), proxyClass);
+        target.setConstantQuiet(constName, proxyClass);
         return proxyClass;
     }
 

--- a/core/src/main/java/org/jruby/javasupport/JavaPackage.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaPackage.java
@@ -96,6 +96,10 @@ public class JavaPackage extends RubyModule {
         this.packageName = packageName.toString();
     }
 
+    public String getPackageName() {
+        return packageName;
+    }
+
     // NOTE: name is Ruby name not pkg.name ~ maybe it should be just like with JavaClass?
 
     @JRubyMethod(name = "package_name", alias = "to_s")

--- a/core/src/main/java/org/jruby/javasupport/JavaUtilities.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtilities.java
@@ -40,11 +40,13 @@ public class JavaUtilities {
         return Java.get_proxy_class(recv, arg0);
     }
 
+    @Deprecated // no longer used
     @JRubyMethod(module = true, visibility = Visibility.PRIVATE)
     public static IRubyObject create_proxy_class(IRubyObject recv, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
         return Java.create_proxy_class(recv, arg0, arg1, arg2);
     }
 
+    @Deprecated // no longer used
     @JRubyMethod(module = true, visibility = Visibility.PRIVATE)
     public static IRubyObject get_java_class(IRubyObject recv, IRubyObject arg0) {
         final Ruby runtime = recv.getRuntime();
@@ -68,7 +70,7 @@ public class JavaUtilities {
         return RubyBoolean.newBoolean(context, validJavaIdentifier(javaName));
     }
 
-    private static boolean validJavaIdentifier(final String javaName) {
+    public static boolean validJavaIdentifier(final String javaName) {
         for (String frag : StringSupport.split(javaName, '.')) {
             if (frag.length() == 0) return false;
             if (!Character.isJavaIdentifierStart(frag.codePointAt(0))) return false;

--- a/core/src/main/java/org/jruby/javasupport/ext/Module.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/Module.java
@@ -1,0 +1,153 @@
+/***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2021 The JRuby Team
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+package org.jruby.javasupport.ext;
+
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.RubyModule;
+import org.jruby.RubySymbol;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.exceptions.NameError;
+import org.jruby.internal.runtime.methods.JavaMethod;
+import org.jruby.javasupport.Java;
+import org.jruby.javasupport.JavaPackage;
+import org.jruby.runtime.Block;
+import org.jruby.runtime.Helpers;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.jruby.runtime.Visibility.PRIVATE;
+import static org.jruby.runtime.Visibility.PUBLIC;
+
+/**
+ * Module Java extensions, namely java_import and include_package.
+ *
+ * @author kares
+ */
+public class Module {
+
+    public static void define(final Ruby runtime) {
+        final RubyClass Module = runtime.getModule();
+        Module.defineAnnotatedMethods(Module.class);
+    }
+
+    @JRubyMethod(required = 2, visibility = PRIVATE)
+    public static IRubyObject java_alias(final ThreadContext context, final IRubyObject self, IRubyObject new_id, IRubyObject old_id) {
+        final IncludedPackages includedPackages = getIncludedPackages(context, (RubyModule) self);
+        if (!(new_id instanceof RubySymbol)) {
+            throw context.runtime.newTypeError(new_id, "Symbol");
+        }
+        if (!(old_id instanceof RubySymbol)) {
+            throw context.runtime.newTypeError(old_id, "Symbol");
+        }
+
+        includedPackages.javaAliases.put((RubySymbol) new_id, (RubySymbol) old_id);
+        return old_id;
+    }
+
+    @JRubyMethod(required = 1, visibility = PRIVATE)
+    public static IRubyObject include_package(final ThreadContext context, final IRubyObject self, IRubyObject pkg) {
+        String packageName;
+        if (pkg instanceof JavaPackage) {
+            packageName = ((JavaPackage) pkg).getPackageName();
+        } else if (pkg.respondsTo("package_name")) {
+            packageName = pkg.callMethod(context, "package_name").convertToString().asJavaString();
+        } else {
+            packageName = pkg.convertToString().asJavaString();
+        }
+
+        final IncludedPackages includedPackages = getIncludedPackages(context, (RubyModule) self);
+        return includedPackages.packages.add(packageName) ? pkg : context.nil;
+    }
+
+    private static IncludedPackages getIncludedPackages(final ThreadContext context, final RubyModule target) {
+        IncludedPackages includedPackages = (IncludedPackages) target.getInternalVariable("includedPackages");
+        if (includedPackages == null) {
+            target.setInternalVariable("includedPackages", includedPackages = new IncludedPackages());
+            ConstMissingMethod method = new ConstMissingMethod(target, includedPackages); // def self.const_missing(constant) :
+            Helpers.addInstanceMethod(target.getSingletonClass(), context.runtime.newSymbol("const_missing"), method, PUBLIC, context, context.runtime);
+        }
+        return includedPackages;
+    }
+
+    private static class IncludedPackages {
+
+        final Collection<String> packages;
+        final Map<RubySymbol, RubySymbol> javaAliases;
+
+        IncludedPackages() {
+            packages = new LinkedHashSet<>(8);
+            javaAliases = new HashMap<>(4);
+        }
+
+    }
+
+    private static final class ConstMissingMethod extends JavaMethod.JavaMethodOne {
+
+        private final IncludedPackages includedPackages;
+
+        ConstMissingMethod(RubyModule implClass, IncludedPackages includedPackages) {
+            super(implClass, PUBLIC, "const_missing");
+            this.includedPackages = includedPackages;
+        }
+
+        @Override
+        public IRubyObject call(final ThreadContext context, final IRubyObject self, final RubyModule clazz,
+                                final String name, final IRubyObject constant) {
+            final Ruby runtime = context.runtime;
+            final String realName = includedPackages.javaAliases.getOrDefault(constant, (RubySymbol) constant).idString();
+
+            Class<?> foundClass = null;
+            for (String packageName : includedPackages.packages) {
+                try {
+                    foundClass = Java.loadJavaClass(runtime, packageName + '.' + realName);
+                    break;
+                } catch (ClassNotFoundException ignore) {
+                    // continue try next package
+                }
+            }
+
+            if (foundClass == null) {
+                try {
+                    return Helpers.invokeSuper(context, self, constant, Block.NULL_BLOCK);
+                } catch (NameError e) { // super didn't find anything either, raise a (new) NameError
+                    throw runtime.newNameError(constant + " not found in packages: " + includedPackages.packages.stream().collect(Collectors.joining(", ")), constant);
+                }
+            }
+            return Java.setProxyClass(runtime, (RubyModule) self, realName, foundClass);
+        }
+
+    }
+
+}

--- a/core/src/main/ruby/jruby/java/core_ext.rb
+++ b/core/src/main/ruby/jruby/java/core_ext.rb
@@ -1,5 +1,4 @@
 # Extensions to Ruby classes
 
 # These are loads so they don't pollute LOADED_FEATURES
-# load 'jruby/java/core_ext/module.rb'
 load 'jruby/java/core_ext/object.rb'

--- a/core/src/main/ruby/jruby/java/core_ext.rb
+++ b/core/src/main/ruby/jruby/java/core_ext.rb
@@ -1,5 +1,5 @@
 # Extensions to Ruby classes
 
 # These are loads so they don't pollute LOADED_FEATURES
-load 'jruby/java/core_ext/module.rb'
+# load 'jruby/java/core_ext/module.rb'
 load 'jruby/java/core_ext/object.rb'

--- a/core/src/main/ruby/jruby/java/core_ext/module.rb
+++ b/core/src/main/ruby/jruby/java/core_ext/module.rb
@@ -68,52 +68,11 @@ class Module
     end
   end
 
-  ##
   # Includes a Java package into this class/module. The Java classes in the
   # package will become available in this class/module, unless a constant
   # with the same name as a Java class is already defined.
-  #
   def include_package(package)
-    package = package.package_name if package.respond_to?(:package_name)
-
-    if defined? @included_packages
-      @included_packages << package
-      return
-    end
-
-    @included_packages = [ package ]
-    @java_aliases ||= {}
-
-    def self.const_missing(constant)
-      real_name = @java_aliases[constant] || constant
-
-      java_class = nil
-      last_error = nil
-
-      @included_packages.each do |package|
-          begin
-            java_class = JavaUtilities.get_java_class("#{package}.#{real_name}")
-          rescue NameError
-            # we only rescue NameError, since other errors should bubble out
-            last_error = $!
-          end
-          break if java_class
-      end
-
-      if java_class
-        return JavaUtilities.create_proxy_class(constant, java_class, self)
-      else
-        # try to chain to super's const_missing
-        begin
-          return super
-        rescue NameError
-          # super didn't find anything either, raise our Java error
-          raise NameError.new("#{constant} not found in packages #{@included_packages.join(', ')}; last error: #{last_error.message}")
-        end
-      end
-    end
-    nil
-  end
+  end if false
 
   # Imports the package specified by +package_name+, first by trying to scan JAR resources
   # for the file in question, and failing that by adding a const_missing hook
@@ -123,10 +82,6 @@ class Module
       return java_import(package_name, &block)
     end
     include_package(package_name, &block)
-  end
-
-  def java_alias(new_id, old_id)
-    (@java_aliases ||= {})[new_id] = old_id
   end
 
 end

--- a/core/src/main/ruby/jruby/java/core_ext/module.rb
+++ b/core/src/main/ruby/jruby/java/core_ext/module.rb
@@ -8,80 +8,19 @@ class Module
   #   java_import java.lang.System, java.lang.Thread
   #   java_import [java.lang.System, java.lang.Thread]
   #
-  def java_import(*import_classes)
-    import_classes.flatten!
-
-    import_classes.map do |import_class|
-      case import_class
-      when String
-        unless JavaUtilities.valid_java_identifier?(import_class)
-          raise ArgumentError.new "not a valid Java identifier: #{import_class}"
-        end
-        raise ArgumentError.new "must use Java style name: #{import_class}" if import_class.include?('::')
-        import_class = JavaUtilities.get_proxy_class(import_class)
-      when Java::JavaPackage
-        raise ArgumentError.new "java_import does not work for Java packages (try include_package instead)"
-      when Module
-        unless import_class.respond_to? :java_class
-          raise ArgumentError.new "not a Java class or interface: #{import_class}"
-        end
-      else
-        raise ArgumentError.new "invalid Java class or interface: #{import_class} (of type #{import_class.class})"
-      end
-
-      java_class = import_class.java_class
-      class_name = java_class.simple_name
-
-      if block_given?
-        package = java_class.package
-
-        # package can be nil if it's default or no package was defined by the classloader
-        if package
-          package_name = package.name
-        elsif m = java_class.canonical_name.match(/(.*)\.[^.]$/)
-          package_name = m[1]
-        else
-          package_name = ""
-        end
-
-        constant = yield(package_name, class_name)
-      else
-        constant = class_name
-
-        # Inner classes are separated with $, get last element
-        if m = constant.match(/\$([^$])$/)
-          constant = m[1]
-        end
-      end
-
-      begin
-        if !const_defined?(constant) || const_get(constant) != import_class
-          const_set(constant, import_class)
-        end
-      rescue NameError => e
-        ex = e.exception("cannot import Java class #{java_class.name.inspect} as `#{constant}' : #{e.message}")
-        ex.set_backtrace e.backtrace
-        raise ex
-      end
-
-      import_class
-    end
+  def java_import(*classes)
   end
 
   # Includes a Java package into this class/module. The Java classes in the
   # package will become available in this class/module, unless a constant
   # with the same name as a Java class is already defined.
   def include_package(package)
-  end if false
+  end
 
   # Imports the package specified by +package_name+, first by trying to scan JAR resources
   # for the file in question, and failing that by adding a const_missing hook
   # to try that package when constants are missing.
-  def import(package_name, &block)
-    if package_name.respond_to?(:java_class) || (String === package_name && package_name.split(/\./).last =~ /^[A-Z]/)
-      return java_import(package_name, &block)
-    end
-    include_package(package_name, &block)
+  def import(package_or_class, &block)
   end
 
-end
+end if false # only here for doc -> implementation at org.jruby.javasupport.ext.Module

--- a/core/src/main/ruby/jruby/java/java_ext.rb
+++ b/core/src/main/ruby/jruby/java/java_ext.rb
@@ -1,8 +1,1 @@
 # Extensions to Java classes
-
-# These are loads so they don't pollute LOADED_FEATURES
-# load 'jruby/java/java_ext/java.lang.rb' - moved to native
-# load 'jruby/java/java_ext/java.util.rb' - moved to native
-# load 'jruby/java/java_ext/java.util.regex.rb' - moved to native
-# load 'jruby/java/java_ext/java.io.rb'  - moved to native
-# load 'jruby/java/java_ext/java.net.rb'  - moved to native

--- a/spec/java_integration/packages/include_spec.rb
+++ b/spec/java_integration/packages/include_spec.rb
@@ -3,25 +3,26 @@ require File.dirname(__FILE__) + "/../spec_helper"
 describe "jar with dependecies" do
   it "carries its error messages along to Ruby exception when one of its classes is imported" do
     begin
-      module Fixtures
+      mod = Module.new do
         import 'java_integration.fixtures.ThrowExceptionOnCreate'
       end
-
-      Fixtures::ThrowExceptionOnCreate.new
-    rescue
-      expect($!.message).to match(/cannot link Java class java_integration\.fixtures\.ThrowExceptionOnCreate .?java.lang.NoClassDefFoundError: junit.framework.Test.?/)
+      mod::ThrowExceptionOnCreate
+      fail 'expected to raise'
+    rescue NameError
+      expect($!.message).to eql 'cannot link Java class java_integration.fixtures.ThrowExceptionOnCreate (java.lang.NoClassDefFoundError: junit/framework/Test)'
     end
   end
 
   it "carries its error messages along to Ruby exception when it's included as package" do
     begin
-      module Fixtures
+      mod = Module.new do
         include_package 'java_integration.fixtures'
       end
-
-      Fixtures::ThrowExceptionOnCreate.new
-    rescue
-      expect($!.message).to match(/cannot link Java class java_integration\.fixtures\.ThrowExceptionOnCreate .?java.lang.NoClassDefFoundError: junit.framework.Test.?/)
+      mod::ThrowExceptionOnCreate
+      fail 'expected to raise'
+    rescue NameError => e
+      # NOTE: include_package no longer rescues (and re-wraps) all NameErrors (in JRuby 9.2 this was part of a message of another NameError)
+      expect(e.message).to eql 'cannot link Java class java_integration.fixtures.ThrowExceptionOnCreate (java.lang.NoClassDefFoundError: junit/framework/Test)'
     end
   end
 end

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -58,17 +58,22 @@ class TestHigherJavasupport < Test::Unit::TestCase
     assert_equal("java.util.ArrayList", org.jruby.test.TestHelper.getClassName(ArrayList))
   end
 
-  @@include_java_lang = Proc.new {
+  class IncludePackageTest < Test::Unit::TestCase
+
+    @@include_java_lang = Proc.new {
       include_package "java.lang"
       java_alias :JavaInteger, :Integer
-  }
+    }
 
-  def test_java_class_loading_and_class_name_collisions
-    assert_raises(NameError) { System }
-    @@include_java_lang.call
-    assert_nothing_raised { System }
-    assert_equal(10, JavaInteger.new(10).intValue)
-    assert_raises(NoMethodError) { Integer.new(10) }
+    def test_java_class_loading_and_class_name_collisions
+      assert_raises(NameError) { VirtualMachineError }
+      @@include_java_lang.call
+      assert_nothing_raised { VirtualMachineError }
+      assert_equal(10, JavaInteger.new(10).intValue)
+      assert_nothing_raised { Integer.to_s }
+      assert_raises(NoMethodError) { Integer.new(10) }
+    end
+
   end
 
   def test_java_alias_prior_to_import


### PR DESCRIPTION
also `java_import` was moved to not have these in 2 places (could ditch the whole JI *module.rb* ext file)

the motivation for the move is to have predictable include_package behavior e.g. on Java linking errors.
previously w `include_package`, all `NameError` where rescued and loop continued attempting to load a class with the next package -> effectively creating a weird set of errors where the real cause is unknown e.g. https://github.com/cheald/manticore/issues/87

the changes here make sure only `ClassNotFoundException` is a valid error to continue the loop, alll other `NameError` instances (e.g. caused by `LinkageError`) will be raised promptly.
