### PR TITLE
Copy 9.3 socket implementation to 9.2

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -4359,9 +4359,11 @@ public final class Ruby implements Constantizable {
 
     public <E extends Enum<E>> void loadConstantSet(RubyModule module, Class<E> enumClass) {
         for (E e : EnumSet.allOf(enumClass)) {
-            Constant c = (Constant) e;
-            if (c.defined() && Character.isUpperCase(c.name().charAt(0))) {
-                module.setConstant(c.name(), newFixnum(c.intValue()));
+            if (e instanceof Constant) {
+                Constant c = (Constant) e;
+                if (c.defined() && Character.isUpperCase(c.name().charAt(0))) {
+                    module.setConstant(c.name(), newFixnum(c.intValue()));
+                }
             }
         }
     }

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -4360,14 +4360,14 @@ public final class Ruby implements Constantizable {
     public <E extends Enum<E>> void loadConstantSet(RubyModule module, Class<E> enumClass) {
         for (E e : EnumSet.allOf(enumClass)) {
             Constant c = (Constant) e;
-            if (Character.isUpperCase(c.name().charAt(0))) {
+            if (c.defined() && Character.isUpperCase(c.name().charAt(0))) {
                 module.setConstant(c.name(), newFixnum(c.intValue()));
             }
         }
     }
     public void loadConstantSet(RubyModule module, String constantSetName) {
         for (Constant c : ConstantSet.getConstantSet(constantSetName)) {
-            if (Character.isUpperCase(c.name().charAt(0))) {
+            if (c.defined() && Character.isUpperCase(c.name().charAt(0))) {
                 module.setConstant(c.name(), newFixnum(c.intValue()));
             }
         }

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -4357,16 +4357,28 @@ public final class Ruby implements Constantizable {
         return checkpointInvalidator;
     }
 
-    public <E extends Enum<E>> void loadConstantSet(RubyModule module, Class<E> enumClass) {
-        for (E e : EnumSet.allOf(enumClass)) {
-            if (e instanceof Constant) {
-                Constant c = (Constant) e;
-                if (c.defined() && Character.isUpperCase(c.name().charAt(0))) {
-                    module.setConstant(c.name(), newFixnum(c.intValue()));
+    /**
+     * Define all constants from the given jnr-constants enum which are defined on the current platform.
+     *
+     * @param module the module in which we want to define the constants
+     * @param enumClass the enum class of the constants to define
+     * @param <C> the enum type, which must implement {@link Constant}.
+     */
+    public <C extends Enum<C> & Constant> void loadConstantSet(RubyModule module, Class<C> enumClass) {
+        for (C constant : EnumSet.allOf(enumClass)) {
+            String name = constant.name();
+            if (constant.defined() && Character.isUpperCase(name.charAt(0))) {
+                    module.setConstant(name, newFixnum(constant.intValue()));
                 }
-            }
         }
     }
+
+    /**
+     * Define all constants from the named jnr-constants set which are defined on the current platform.
+     *
+     * @param module the module in which we want to define the constants
+     * @param constantSetName the name of the constant set from which to get the constants
+     */
     public void loadConstantSet(RubyModule module, String constantSetName) {
         for (Constant c : ConstantSet.getConstantSet(constantSetName)) {
             if (c.defined() && Character.isUpperCase(c.name().charAt(0))) {

--- a/core/src/main/java/org/jruby/ext/socket/Ifaddr.java
+++ b/core/src/main/java/org/jruby/ext/socket/Ifaddr.java
@@ -1,5 +1,12 @@
 package org.jruby.ext.socket;
 
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.RubyObject;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -7,14 +14,6 @@ import java.net.InterfaceAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.UnknownHostException;
-
-import org.jruby.Ruby;
-import org.jruby.RubyClass;
-import org.jruby.RubyObject;
-import org.jruby.anno.JRubyMethod;
-import org.jruby.runtime.ObjectAllocator;
-import org.jruby.runtime.ThreadContext;
-import org.jruby.runtime.builtin.IRubyObject;
 
 /**
  *
@@ -40,11 +39,7 @@ public class Ifaddr extends RubyObject {
         RubyClass ifaddr = runtime.getClass("Socket").defineClassUnder(
                 "Ifaddr",
                 runtime.getData(),
-                new ObjectAllocator() {
-                    public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
-                        return new Ifaddr(runtime, klazz);
-                    }
-                });
+                Ifaddr::new);
         ifaddr.defineAnnotatedMethods(Ifaddr.class);
     }
 

--- a/core/src/main/java/org/jruby/ext/socket/MulticastStateManager.java
+++ b/core/src/main/java/org/jruby/ext/socket/MulticastStateManager.java
@@ -31,10 +31,9 @@ package org.jruby.ext.socket;
 import jnr.constants.platform.IP;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.MulticastSocket;
-import java.net.InetAddress;
-
 import java.util.ArrayList;
 
 

--- a/core/src/main/java/org/jruby/ext/socket/Option.java
+++ b/core/src/main/java/org/jruby/ext/socket/Option.java
@@ -7,22 +7,19 @@ import jnr.constants.platform.SocketLevel;
 import jnr.constants.platform.SocketOption;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
+import org.jruby.RubyNumeric;
 import org.jruby.RubyObject;
 import org.jruby.RubyString;
-import org.jruby.RubyNumeric;
 import org.jruby.anno.JRubyMethod;
-import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.runtime.Visibility;
 import org.jruby.util.ByteList;
 import org.jruby.util.Pack;
 import org.jruby.util.Sprintf;
 import org.jruby.util.TypeConverter;
 
 import java.nio.ByteBuffer;
-import java.text.NumberFormat;
 import java.util.Locale;
 
 public class Option extends RubyObject {
@@ -30,11 +27,7 @@ public class Option extends RubyObject {
         RubyClass addrinfo = runtime.getClass("Socket").defineClassUnder(
                 "Option",
                 runtime.getObject(),
-                new ObjectAllocator() {
-                    public IRubyObject allocate(Ruby runtime, RubyClass klazz) {
-                        return new Option(runtime, klazz);
-                    }
-                });
+                Option::new);
 
         addrinfo.defineAnnotatedMethods(Option.class);
     }

--- a/core/src/main/java/org/jruby/ext/socket/RubyIPSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyIPSocket.java
@@ -30,17 +30,13 @@
 package org.jruby.ext.socket;
 
 import org.jruby.Ruby;
-import org.jruby.RubyArray;
 import org.jruby.RubyClass;
-import org.jruby.RubySymbol;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.Arity;
-import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.TypeConverter;
-import org.jruby.util.io.BadDescriptorException;
 import org.jruby.util.io.Sockaddr;
 
 import java.net.InetSocketAddress;
@@ -51,17 +47,11 @@ import java.net.InetSocketAddress;
 @JRubyClass(name="IPSocket", parent="BasicSocket")
 public class RubyIPSocket extends RubyBasicSocket {
     static void createIPSocket(Ruby runtime) {
-        RubyClass rb_cIPSocket = runtime.defineClass("IPSocket", runtime.getClass("BasicSocket"), IPSOCKET_ALLOCATOR);
+        RubyClass rb_cIPSocket = runtime.defineClass("IPSocket", runtime.getClass("BasicSocket"), RubyIPSocket::new);
 
         rb_cIPSocket.defineAnnotatedMethods(RubyIPSocket.class);
         rb_cIPSocket.undefineMethod("initialize");
     }
-
-    private static ObjectAllocator IPSOCKET_ALLOCATOR = new ObjectAllocator() {
-        public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-            return new RubyIPSocket(runtime, klass);
-        }
-    };
 
     public RubyIPSocket(Ruby runtime, RubyClass type) {
         super(runtime, type);

--- a/core/src/main/java/org/jruby/ext/socket/RubyServerSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyServerSocket.java
@@ -35,7 +35,6 @@ import org.jruby.RubyFixnum;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.common.IRubyWarnings;
-import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.io.ChannelFD;
@@ -58,16 +57,10 @@ import java.nio.channels.SocketChannel;
 @JRubyClass(name="Socket", parent="BasicSocket", include="Socket::Constants")
 public class RubyServerSocket extends RubySocket {
     static void createServerSocket(Ruby runtime) {
-        RubyClass rb_cSocket = runtime.defineClass("ServerSocket", runtime.getClass("Socket"), SERVER_SOCKET_ALLOCATOR);
+        RubyClass rb_cSocket = runtime.defineClass("ServerSocket", runtime.getClass("Socket"), RubyServerSocket::new);
 
         rb_cSocket.defineAnnotatedMethods(RubyServerSocket.class);
     }
-
-    private static ObjectAllocator SERVER_SOCKET_ALLOCATOR = new ObjectAllocator() {
-        public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-            return new RubyServerSocket(runtime, klass);
-        }
-    };
 
     public RubyServerSocket(Ruby runtime, RubyClass type) {
         super(runtime, type);

--- a/core/src/main/java/org/jruby/ext/socket/RubySocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubySocket.java
@@ -28,8 +28,40 @@
 
 package org.jruby.ext.socket;
 
+import jnr.constants.platform.AddressFamily;
+import jnr.constants.platform.AddressInfo;
+import jnr.constants.platform.Errno;
+import jnr.constants.platform.INAddr;
+import jnr.constants.platform.IP;
+import jnr.constants.platform.IPProto;
+import jnr.constants.platform.NameInfo;
+import jnr.constants.platform.ProtocolFamily;
+import jnr.constants.platform.Shutdown;
+import jnr.constants.platform.Sock;
+import jnr.constants.platform.SocketLevel;
+import jnr.constants.platform.SocketMessage;
+import jnr.constants.platform.SocketOption;
+import jnr.constants.platform.TCP;
+import jnr.netdb.Protocol;
+import jnr.unixsocket.UnixSocketAddress;
+import jnr.unixsocket.UnixSocketChannel;
+import org.jruby.Ruby;
+import org.jruby.RubyArray;
+import org.jruby.RubyBoolean;
+import org.jruby.RubyClass;
+import org.jruby.RubyFixnum;
+import org.jruby.RubyModule;
+import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.runtime.Helpers;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.Visibility;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.io.ChannelFD;
+import org.jruby.util.io.Sockaddr;
+
 import java.io.IOException;
-import java.net.ConnectException;
 import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
 import java.net.InterfaceAddress;
@@ -44,46 +76,10 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ConnectionPendingException;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.SelectableChannel;
+import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.Enumeration;
 import java.util.regex.Pattern;
-
-import jnr.constants.platform.AddressFamily;
-import jnr.constants.platform.AddressInfo;
-import jnr.constants.platform.Errno;
-import jnr.constants.platform.INAddr;
-import jnr.constants.platform.IP;
-import jnr.constants.platform.IPProto;
-import jnr.constants.platform.NameInfo;
-import jnr.constants.platform.ProtocolFamily;
-import jnr.constants.platform.Shutdown;
-import jnr.constants.platform.Sock;
-import jnr.constants.platform.SocketLevel;
-import jnr.constants.platform.SocketOption;
-import jnr.constants.platform.SocketMessage;
-import jnr.constants.platform.TCP;
-import jnr.netdb.Protocol;
-import jnr.unixsocket.UnixSocketAddress;
-import jnr.unixsocket.UnixSocketChannel;
-
-import org.jruby.Ruby;
-import org.jruby.RubyArray;
-import org.jruby.RubyBoolean;
-import org.jruby.RubyClass;
-import org.jruby.RubyFixnum;
-import org.jruby.RubyModule;
-import org.jruby.anno.JRubyClass;
-import org.jruby.anno.JRubyMethod;
-import org.jruby.exceptions.RaiseException;
-import org.jruby.runtime.Helpers;
-import org.jruby.runtime.ObjectAllocator;
-import org.jruby.runtime.ThreadContext;
-import org.jruby.runtime.Visibility;
-import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.util.io.ChannelFD;
-import org.jruby.util.io.Sockaddr;
-
-import static org.jruby.runtime.Helpers.arrayOf;
 
 /**
  * @author <a href="mailto:ola.bini@ki.se">Ola Bini</a>
@@ -91,7 +87,7 @@ import static org.jruby.runtime.Helpers.arrayOf;
 @JRubyClass(name="Socket", parent="BasicSocket", include="Socket::Constants")
 public class RubySocket extends RubyBasicSocket {
     static void createSocket(Ruby runtime) {
-        RubyClass rb_cSocket = runtime.defineClass("Socket", runtime.getClass("BasicSocket"), SOCKET_ALLOCATOR);
+        RubyClass rb_cSocket = runtime.defineClass("Socket", runtime.getClass("BasicSocket"), RubySocket::new);
 
         RubyModule rb_mConstants = rb_cSocket.defineModuleUnder("Constants");
         // we don't have to define any that we don't support; see socket.c
@@ -117,14 +113,14 @@ public class RubySocket extends RubyBasicSocket {
         rb_mConstants.setConstant("IPPORT_RESERVED", RubyFixnum.newFixnum(runtime, 1024));
         rb_mConstants.setConstant("IPPORT_USERRESERVED", RubyFixnum.newFixnum(runtime, 5000));
 
-        rb_mConstants.setConstant("AI_PASSIVE", runtime.newFixnum(1));
-        rb_mConstants.setConstant("AI_CANONNAME", runtime.newFixnum(2));
-        rb_mConstants.setConstant("AI_NUMERICHOST", runtime.newFixnum(4));
-        rb_mConstants.setConstant("AI_ALL", runtime.newFixnum(256));
-        rb_mConstants.setConstant("AI_V4MAPPED_CFG", runtime.newFixnum(512));
-        rb_mConstants.setConstant("AI_ADDRCONFIG", runtime.newFixnum(1024));
-        rb_mConstants.setConstant("AI_V4MAPPED", runtime.newFixnum(2048));
-        rb_mConstants.setConstant("AI_NUMERICSERV", runtime.newFixnum(4096));
+        rb_mConstants.setConstant("AI_PASSIVE", runtime.newFixnum(AddressInfo.AI_PASSIVE));
+        rb_mConstants.setConstant("AI_CANONNAME", runtime.newFixnum(AddressInfo.AI_CANONNAME));
+        rb_mConstants.setConstant("AI_NUMERICHOST", runtime.newFixnum(AddressInfo.AI_NUMERICHOST));
+        rb_mConstants.setConstant("AI_ALL", runtime.newFixnum(AddressInfo.AI_ALL));
+        rb_mConstants.setConstant("AI_V4MAPPED_CFG", runtime.newFixnum(AddressInfo.AI_V4MAPPED_CFG));
+        rb_mConstants.setConstant("AI_ADDRCONFIG", runtime.newFixnum(AddressInfo.AI_ADDRCONFIG));
+        rb_mConstants.setConstant("AI_V4MAPPED", runtime.newFixnum(AddressInfo.AI_V4MAPPED));
+        rb_mConstants.setConstant("AI_NUMERICSERV", runtime.newFixnum(AddressInfo.AI_NUMERICSERV));
 
         rb_mConstants.setConstant("AI_DEFAULT", runtime.newFixnum(AddressInfo.AI_DEFAULT));
         rb_mConstants.setConstant("AI_MASK", runtime.newFixnum(AddressInfo.AI_MASK));
@@ -141,13 +137,6 @@ public class RubySocket extends RubyBasicSocket {
 
         rb_cSocket.defineAnnotatedMethods(RubySocket.class);
     }
-
-    private static ObjectAllocator SOCKET_ALLOCATOR = new ObjectAllocator() {
-        @Override
-        public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-            return new RubySocket(runtime, klass);
-        }
-    };
 
     public RubySocket(Ruby runtime, RubyClass type) {
         super(runtime, type);
@@ -288,8 +277,8 @@ public class RubySocket extends RubyBasicSocket {
                 }
             }
         }
-        catch (SocketException|RuntimeException ex) {
-            if ( ex instanceof RaiseException ) throw (RaiseException) ex;
+        catch (SocketException | RuntimeException ex) {
+            if ( ex instanceof RaiseException) throw (RaiseException) ex;
             throw SocketUtils.sockerr_with_trace(context.runtime, "getifaddrs: " + ex.toString(), ex.getStackTrace());
         }
         return list;
@@ -505,91 +494,90 @@ public class RubySocket extends RubyBasicSocket {
     }
 
     private IRubyObject doConnectNonblock(ThreadContext context, SocketAddress addr, boolean ex) {
+        Ruby runtime = context.runtime;
+
         Channel channel = getChannel();
 
         if ( ! (channel instanceof SelectableChannel) ) {
-            throw context.runtime.newErrnoENOPROTOOPTError();
+            throw runtime.newErrnoENOPROTOOPTError();
         }
 
-        SelectableChannel selectable = (SelectableChannel) channel;
-        synchronized (selectable.blockingLock()) {
-            boolean oldBlocking = selectable.isBlocking();
-            try {
-                selectable.configureBlocking(false);
+        boolean result = tryConnect(context, runtime, channel, addr, ex, false);
 
-                try {
-                    return doConnect(context, addr, ex);
-
-                } finally {
-                    selectable.configureBlocking(oldBlocking);
-                }
-
-            }
-            catch (ClosedChannelException e) {
-                throw context.runtime.newErrnoECONNREFUSEDError();
-            }
-            catch (IOException e) {
-                throw sockerr(context.runtime, "connect(2): name or service not known", e);
-            }
+        if ( !result ) {
+            if (!ex) return runtime.newSymbol("wait_writable");
+            throw runtime.newErrnoEINPROGRESSWritableError();
         }
+
+        return runtime.newFixnum(0);
     }
 
     protected IRubyObject doConnect(ThreadContext context, SocketAddress addr, boolean ex) {
         Ruby runtime = context.runtime;
         Channel channel = getChannel();
 
-        try {
-            boolean result = true;
-            if (channel instanceof SocketChannel) {
-                SocketChannel socket = (SocketChannel) channel;
+        tryConnect(context, runtime, channel, addr, ex, true);
 
-                if (socket.isConnectionPending()) {
-                    // connection initiated but not finished
-                    result = socket.finishConnect();
-                } else {
-                    result = socket.connect(addr);
+        return runtime.newFixnum(0);
+    }
+
+    private boolean tryConnect(ThreadContext context, Ruby runtime, Channel channel, SocketAddress addr, boolean ex, boolean blocking) {
+        SelectableChannel selectable = (SelectableChannel) channel;
+        try {
+            synchronized (selectable.blockingLock()) {
+                boolean oldBlocking = selectable.isBlocking();
+                try {
+                    selectable.configureBlocking(false);
+
+                    while (true) {
+                        boolean result = true;
+                        if (channel instanceof SocketChannel) {
+                            SocketChannel socket = (SocketChannel) channel;
+
+                            if (socket.isConnectionPending()) {
+                                // connection initiated but not finished
+                                result = socket.finishConnect();
+                            } else {
+                                result = socket.connect(addr);
+                            }
+                        } else if (channel instanceof UnixSocketChannel) {
+                            result = ((UnixSocketChannel) channel).connect((UnixSocketAddress) addr);
+
+                        } else if (channel instanceof DatagramChannel) {
+                            ((DatagramChannel) channel).connect(addr);
+                        } else {
+                            throw runtime.newErrnoENOPROTOOPTError();
+                        }
+
+                        if (!blocking || result) return result;
+
+                        while (!context.getThread().select(channel, this, SelectionKey.OP_CONNECT)) {
+                            context.pollThreadEvents();
+                        }
+                    }
+                } finally {
+                    selectable.configureBlocking(oldBlocking);
                 }
             }
-            else if (channel instanceof UnixSocketChannel) {
-                result = ((UnixSocketChannel) channel).connect((UnixSocketAddress) addr);
-
-            }
-            else if (channel instanceof DatagramChannel) {
-                ((DatagramChannel)channel).connect(addr);
-            }
-            else {
-                throw runtime.newErrnoENOPROTOOPTError();
-            }
-
-            if ( ! result ) {
-                if (!ex) return runtime.newSymbol("wait_writable");
-                throw runtime.newErrnoEINPROGRESSWritableError();
-            }
-        }
-        catch (AlreadyConnectedException e) {
-            if (!ex) return runtime.newFixnum(0);
+        } catch (ClosedChannelException e) {
+            throw context.runtime.newErrnoECONNREFUSEDError();
+        } catch (AlreadyConnectedException e) {
+            if (!ex) return false;
             throw runtime.newErrnoEISCONNError();
-        }
-        catch (ConnectionPendingException e) {
+        } catch (ConnectionPendingException e) {
             throw runtime.newErrnoEINPROGRESSWritableError();
-        }
-        catch (UnknownHostException e) {
+        } catch (UnknownHostException e) {
             throw SocketUtils.sockerr(runtime, "connect(2): unknown host");
-        }
-        catch (SocketException e) {
+        } catch (SocketException e) {
             // Subclasses of SocketException all indicate failure to connect, which leaves the channel closed.
             // At this point the socket channel is no longer usable, so we clean up.
             getOpenFile().cleanup(runtime, true);
             throw buildSocketException(runtime, e, "connect(2)", addr);
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             throw sockerr(runtime, "connect(2): name or service not known", e);
-        }
-        catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             throw sockerr(runtime, e.getMessage(), e);
         }
-
-        return runtime.newFixnum(0);
     }
 
     protected void doBind(ThreadContext context, SocketAddress iaddr) {
@@ -628,7 +616,7 @@ public class RubySocket extends RubyBasicSocket {
     }
 
     static RaiseException buildSocketException(final Ruby runtime, final SocketException ex,
-        final String caller, final SocketAddress addr) {
+                                               final String caller, final SocketAddress addr) {
 
         final Errno errno = Helpers.errnoFromException(ex);
         final String callerWithAddr = caller + " for " + formatAddress(addr);

--- a/core/src/main/java/org/jruby/ext/socket/RubyTCPServer.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyTCPServer.java
@@ -28,17 +28,6 @@
 
 package org.jruby.ext.socket;
 
-import java.io.IOException;
-import java.net.BindException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
-import java.net.SocketException;
-import java.nio.channels.SelectionKey;
-import java.nio.channels.Selector;
-import java.nio.channels.ServerSocketChannel;
-import java.nio.channels.SocketChannel;
-
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyFixnum;
@@ -47,13 +36,22 @@ import org.jruby.RubyThread;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.Block;
-import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
-
 import org.jruby.util.io.FilenoUtil;
 import org.jruby.util.io.SelectorFactory;
+
+import java.io.IOException;
+import java.net.BindException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
 import java.nio.channels.spi.SelectorProvider;
 
 /**
@@ -63,18 +61,12 @@ import java.nio.channels.spi.SelectorProvider;
 public class RubyTCPServer extends RubyTCPSocket {
     static void createTCPServer(Ruby runtime) {
         RubyClass rb_cTCPServer = runtime.defineClass(
-                "TCPServer", runtime.getClass("TCPSocket"), TCPSERVER_ALLOCATOR);
+                "TCPServer", runtime.getClass("TCPSocket"), RubyTCPServer::new);
 
         rb_cTCPServer.defineAnnotatedMethods(RubyTCPServer.class);
 
         runtime.getObject().setConstant("TCPserver",rb_cTCPServer);
     }
-
-    private static ObjectAllocator TCPSERVER_ALLOCATOR = new ObjectAllocator() {
-        public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-            return new RubyTCPServer(runtime, klass);
-        }
-    };
 
     public RubyTCPServer(Ruby runtime, RubyClass type) {
         super(runtime, type);

--- a/core/src/main/java/org/jruby/ext/socket/RubyTCPSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyTCPSocket.java
@@ -30,49 +30,39 @@
 
 package org.jruby.ext.socket;
 
-import static jnr.constants.platform.AddressFamily.*;
-
-import java.io.IOException;
-
-import java.net.BindException;
-import java.net.ConnectException;
-import java.net.Inet4Address;
-import java.net.Inet6Address;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.NoRouteToHostException;
-import java.net.Socket;
-import java.net.UnknownHostException;
-
-import java.nio.channels.ClosedChannelException;
-import java.nio.channels.SelectableChannel;
-import java.nio.channels.SelectionKey;
-import java.nio.channels.SocketChannel;
-
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.Block;
-import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import java.io.IOException;
+import java.net.BindException;
+import java.net.ConnectException;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.NoRouteToHostException;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.SocketChannel;
+
+import static jnr.constants.platform.AddressFamily.AF_INET;
+import static jnr.constants.platform.AddressFamily.AF_INET6;
+
 public class RubyTCPSocket extends RubyIPSocket {
     static void createTCPSocket(Ruby runtime) {
-        RubyClass rb_cTCPSocket = runtime.defineClass("TCPSocket", runtime.getClass("IPSocket"), TCPSOCKET_ALLOCATOR);
+        RubyClass rb_cTCPSocket = runtime.defineClass("TCPSocket", runtime.getClass("IPSocket"), RubyTCPSocket::new);
 
         rb_cTCPSocket.defineAnnotatedMethods(RubyTCPSocket.class);
 
         runtime.getObject().setConstant("TCPsocket",rb_cTCPSocket);
     }
-
-    private static ObjectAllocator TCPSOCKET_ALLOCATOR = new ObjectAllocator() {
-        public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-            return new RubyTCPSocket(runtime, klass);
-        }
-    };
 
     public RubyTCPSocket(Ruby runtime, RubyClass type) {
         super(runtime, type);
@@ -80,7 +70,7 @@ public class RubyTCPSocket extends RubyIPSocket {
 
 
     private SocketChannel attemptConnect(ThreadContext context, IRubyObject host, String localHost, int localPort,
-                                String remoteHost, int remotePort) throws IOException {
+                                         String remoteHost, int remotePort) throws IOException {
         for (InetAddress address: InetAddress.getAllByName(remoteHost)) {
             // This is a bit convoluted because (1) SocketChannel.bind is only in jdk 7 and
             // (2) Socket.getChannel() seems to return null in some cases

--- a/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
@@ -29,29 +29,6 @@
 
 package org.jruby.ext.socket;
 
-import java.io.IOException;
-import java.net.BindException;
-import java.net.ConnectException;
-import java.net.Inet4Address;
-import java.net.Inet6Address;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.NoRouteToHostException;
-import java.net.PortUnreachableException;
-import java.net.ProtocolFamily;
-import java.net.SocketException;
-import java.net.MulticastSocket;
-import java.net.StandardProtocolFamily;
-import java.net.UnknownHostException;
-import java.net.DatagramPacket;
-import java.nio.ByteBuffer;
-import java.nio.channels.AlreadyBoundException;
-import java.nio.channels.Channel;
-import java.nio.channels.DatagramChannel;
-import java.nio.channels.IllegalBlockingModeException;
-import java.nio.channels.NotYetConnectedException;
-import java.nio.channels.UnsupportedAddressTypeException;
-
 import jnr.constants.platform.AddressFamily;
 import jnr.netdb.Service;
 import org.jruby.Ruby;
@@ -67,12 +44,34 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.Block;
-import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 import org.jruby.util.io.Sockaddr;
+
+import java.io.IOException;
+import java.net.BindException;
+import java.net.ConnectException;
+import java.net.DatagramPacket;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.MulticastSocket;
+import java.net.NoRouteToHostException;
+import java.net.PortUnreachableException;
+import java.net.ProtocolFamily;
+import java.net.SocketException;
+import java.net.StandardProtocolFamily;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.nio.channels.AlreadyBoundException;
+import java.nio.channels.Channel;
+import java.nio.channels.DatagramChannel;
+import java.nio.channels.IllegalBlockingModeException;
+import java.nio.channels.NotYetConnectedException;
+import java.nio.channels.UnsupportedAddressTypeException;
 
 import static org.jruby.runtime.Helpers.extractExceptionOnlyArg;
 
@@ -82,8 +81,10 @@ import static org.jruby.runtime.Helpers.extractExceptionOnlyArg;
 @JRubyClass(name="UDPSocket", parent="IPSocket")
 public class RubyUDPSocket extends RubyIPSocket {
 
+    public static final double RECV_BUFFER_COPY_SCALE = 1.5;
+
     static void createUDPSocket(Ruby runtime) {
-        RubyClass rb_cUDPSocket = runtime.defineClass("UDPSocket", runtime.getClass("IPSocket"), UDPSOCKET_ALLOCATOR);
+        RubyClass rb_cUDPSocket = runtime.defineClass("UDPSocket", runtime.getClass("IPSocket"), RubyUDPSocket::new);
 
         rb_cUDPSocket.includeModule(runtime.getClass("Socket").getConstant("Constants"));
 
@@ -91,13 +92,6 @@ public class RubyUDPSocket extends RubyIPSocket {
 
         runtime.getObject().setConstant("UDPsocket", rb_cUDPSocket);
     }
-
-    private static ObjectAllocator UDPSOCKET_ALLOCATOR = new ObjectAllocator() {
-
-        public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-            return new RubyUDPSocket(runtime, klass);
-        }
-    };
 
     public RubyUDPSocket(Ruby runtime, RubyClass type) {
         super(runtime, type);
@@ -163,7 +157,7 @@ public class RubyUDPSocket extends RubyIPSocket {
             }
             else if (host instanceof RubyFixnum) {
                 // passing in something like INADDR_ANY
-                int intAddr = 0;
+                int intAddr;
                 if (host instanceof RubyInteger) {
                     intAddr = RubyNumeric.fix2int(host);
                 } else if (host instanceof RubyString) {
@@ -294,7 +288,7 @@ public class RubyUDPSocket extends RubyIPSocket {
     }
 
     private static IRubyObject recvfrom_nonblock(RubyBasicSocket socket, ThreadContext context,
-        IRubyObject length, IRubyObject flags, IRubyObject str, boolean exception) {
+                                                 IRubyObject length, IRubyObject flags, IRubyObject str, boolean exception) {
         final Ruby runtime = context.runtime;
 
         try {
@@ -581,12 +575,12 @@ public class RubyUDPSocket extends RubyIPSocket {
     }
 
     private static IRubyObject doReceive(RubyBasicSocket socket, final Ruby runtime, final boolean non_block,
-        int length) throws IOException {
+                                         int length) throws IOException {
         return doReceive(socket, runtime, non_block, length, null);
     }
 
     protected static IRubyObject doReceive(RubyBasicSocket socket, final Ruby runtime, final boolean non_block,
-        int length, ReceiveTuple tuple) throws IOException {
+                                           int length, ReceiveTuple tuple) throws IOException {
         DatagramChannel channel = (DatagramChannel) socket.getChannel();
 
         ByteBuffer buf = ByteBuffer.allocate(length);
@@ -602,7 +596,9 @@ public class RubyUDPSocket extends RubyIPSocket {
             }
         }
 
-        RubyString result = runtime.newString(new ByteList(buf.array(), 0, buf.position(), false));
+        // return a string from the buffer, copying if the buffer size is > 1.5 * data size
+        ByteList bl = new ByteList(buf.array(), 0, buf.position(), buf.limit() > buf.position() * RECV_BUFFER_COPY_SCALE);
+        RubyString result = runtime.newString(bl);
 
         if (tuple != null) {
             tuple.result = result;
@@ -613,7 +609,7 @@ public class RubyUDPSocket extends RubyIPSocket {
     }
 
     private static IRubyObject doReceiveMulticast(RubyBasicSocket socket, final Ruby runtime, final boolean non_block,
-        int length, ReceiveTuple tuple) throws IOException {
+                                                  int length, ReceiveTuple tuple) throws IOException {
         DatagramPacket recv = new DatagramPacket(new byte[length], length);
 
         try {

--- a/core/src/main/java/org/jruby/ext/socket/RubyUNIXServer.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUNIXServer.java
@@ -37,7 +37,6 @@ import org.jruby.RubyClass;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.Helpers;
-import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -49,14 +48,8 @@ import java.nio.channels.SelectionKey;
 
 @JRubyClass(name="UNIXServer", parent="UNIXSocket")
 public class RubyUNIXServer extends RubyUNIXSocket {
-    private static ObjectAllocator UNIXSERVER_ALLOCATOR = new ObjectAllocator() {
-        public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-            return new RubyUNIXServer(runtime, klass);
-        }
-    };
-
     static void createUNIXServer(Ruby runtime) {
-        RubyClass rb_cUNIXServer = runtime.defineClass("UNIXServer", runtime.getClass("UNIXSocket"), UNIXSERVER_ALLOCATOR);
+        RubyClass rb_cUNIXServer = runtime.defineClass("UNIXServer", runtime.getClass("UNIXSocket"), RubyUNIXServer::new);
 
         runtime.getObject().setConstant("UNIXserver", rb_cUNIXServer);
         

--- a/core/src/main/java/org/jruby/ext/socket/RubyUNIXSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUNIXSocket.java
@@ -33,52 +33,45 @@ import jnr.constants.platform.OpenFlags;
 import jnr.constants.platform.SocketLevel;
 import jnr.constants.platform.SocketOption;
 import jnr.ffi.LastError;
+import jnr.posix.CmsgHdr;
+import jnr.posix.MsgHdr;
+import jnr.posix.POSIX;
 import jnr.unixsocket.UnixServerSocket;
 import jnr.unixsocket.UnixServerSocketChannel;
 import jnr.unixsocket.UnixSocketAddress;
 import jnr.unixsocket.UnixSocketChannel;
-import jnr.posix.CmsgHdr;
-import jnr.posix.MsgHdr;
-import jnr.posix.POSIX;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
+import org.jruby.RubyFixnum;
+import org.jruby.RubyIO;
 import org.jruby.RubyNumeric;
 import org.jruby.RubyString;
-import org.jruby.RubyIO;
-import org.jruby.RubyFixnum;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.Helpers;
-import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 import org.jruby.util.StringSupport;
+import org.jruby.util.io.FilenoUtil;
 import org.jruby.util.io.ModeFlags;
 import org.jruby.util.io.OpenFile;
-import org.jruby.util.io.FilenoUtil;
 
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.nio.channels.Channel;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.Channel;
 
 import static com.headius.backport9.buffer.Buffers.flipBuffer;
 
 
 @JRubyClass(name="UNIXSocket", parent="BasicSocket")
 public class RubyUNIXSocket extends RubyBasicSocket {
-    private static ObjectAllocator UNIXSOCKET_ALLOCATOR = new ObjectAllocator() {
-        public IRubyObject allocate(Ruby runtime, RubyClass klass) {
-            return new RubyUNIXSocket(runtime, klass);
-        }
-    };
-
     static void createUNIXSocket(Ruby runtime) {
-        RubyClass rb_cUNIXSocket = runtime.defineClass("UNIXSocket", runtime.getClass("BasicSocket"), UNIXSOCKET_ALLOCATOR);
+        RubyClass rb_cUNIXSocket = runtime.defineClass("UNIXSocket", runtime.getClass("BasicSocket"), RubyUNIXSocket::new);
         runtime.getObject().setConstant("UNIXsocket", rb_cUNIXSocket);
 
         rb_cUNIXSocket.defineAnnotatedMethods(RubyUNIXSocket.class);

--- a/core/src/main/java/org/jruby/ext/socket/SocketLibrary.java
+++ b/core/src/main/java/org/jruby/ext/socket/SocketLibrary.java
@@ -1,9 +1,10 @@
 package org.jruby.ext.socket;
 
-import java.io.IOException;
 import org.jruby.Ruby;
 import org.jruby.platform.Platform;
 import org.jruby.runtime.load.Library;
+
+import java.io.IOException;
 
 /**
  *

--- a/core/src/main/java/org/jruby/ext/socket/SocketType.java
+++ b/core/src/main/java/org/jruby/ext/socket/SocketType.java
@@ -28,7 +28,6 @@ package org.jruby.ext.socket;
 
 import jnr.constants.platform.Sock;
 import jnr.constants.platform.SocketOption;
-import jnr.unixsocket.UnixServerSocketChannel;
 import jnr.unixsocket.UnixSocketAddress;
 import jnr.unixsocket.UnixSocketChannel;
 

--- a/test/jruby/test_socket.rb
+++ b/test/jruby/test_socket.rb
@@ -71,6 +71,12 @@ class SocketTest < Test::Unit::TestCase
     end
   end
 
+  if RbConfig::CONFIG['target_os'] == 'linux'
+    def test_not_available_constant
+      assert !Socket.const_defined?(:TCP_KEEPALIVE)
+    end
+  end
+
   #JRUBY-3827
   def test_nil_hostname_and_passive_returns_inaddr_any
     assert_nothing_raised do


### PR DESCRIPTION
This is a wholesale duplication of the 9.3 (master at time of
writing) socket implementation into 9.2 to pick up all recent
improvements in the socket library.

This should address #6541 and other socket issues fixed on master.