### PR TITLE
Handle possible ArithmeticException when extending byte store for String

### DIFF
--- a/core/src/main/java/org/jruby/util/ByteList.java
+++ b/core/src/main/java/org/jruby/util/ByteList.java
@@ -351,13 +351,21 @@ public class ByteList implements Comparable, CharSequence, Serializable {
 
     /**
      * Ensure that the bytelist is at least length bytes long.  Otherwise grow the backing store
-     * so that it is length bytes long
+     * so that it is at least length bytes long, but grow to 1.5 * length, if we're able
+     * to, to avoid thrashing.
      *
      * @param length to use to make sure ByteList is long enough
      */
     public void ensure(int length) {
         if (begin + length > bytes.length) {
-            byte[] tmp = new byte[Math.min(Integer.MAX_VALUE, length + (length >>> 1))];
+            int newLength;
+            try {
+                // Try to allocate 1.5 * length but that might take us outside the range of int
+                newLength = Math.addExact(length, length >>> 1);
+            } catch (ArithmeticException e) {
+                newLength = Integer.MAX_VALUE;
+            }
+            byte[] tmp = new byte[newLength];
             System.arraycopy(bytes, begin, tmp, 0, realSize);
             bytes = tmp;
             begin = 0;


### PR DESCRIPTION
I have a JRuby application that writes data into a `StringIO`. After a certain amount of data, the application throws a long winded exception with stack trace leading to `ByteList::ensure` with exception `Java::JavaLang::NegativeArraySizeException`.

It appears that the code attempts to extend the byte arrray beyond `Integer.MAX_VALUE` length which results in attempting to create a `byte[]` of negative length.

Relevant portion of stacktrace:

```
Java::JavaLang::NegativeArraySizeException:
--
org.jruby.util.ByteList.ensure(ByteList.java:344)
org.jruby.util.io.EncodingUtils.strBufCat(EncodingUtils.java:1712)
org.jruby.util.io.EncodingUtils.strBufCat(EncodingUtils.java:1697)
org.jruby.util.io.EncodingUtils.encCrStrBufCat(EncodingUtils.java:1820)
org.jruby.util.io.EncodingUtils.encStrBufCat(EncodingUtils.java:1718)
org.jruby.ext.stringio.StringIO.stringIOWrite(StringIO.java:1209)
org.jruby.ext.stringio.StringIO.write(StringIO.java:1170)
org.jruby.ext.stringio.StringIO$INVOKER$i$write.call(StringIO$INVOKER$i$write.gen)
```

This PR wraps the calculation in a try/catch and uses `Math.addExact` to catch a potential ArithmeticException. In the even that is does, we set the new allocation size to `Integer.MAX_VALUE`.

Retesting, I now get a more useful exception: `Java::JavaLang::OutOfMemoryError: Java heap space`.