### PR TITLE
Fix Dir.glob with cases

### DIFF
--- a/core/src/main/java/org/jruby/util/Dir.java
+++ b/core/src/main/java/org/jruby/util/Dir.java
@@ -750,9 +750,34 @@ public class Dir {
             if (cwd == null) cwd = "C:";
             cwd = cwd + "/";
         }
+
         FileResource file = JRubyFile.createResource(runtime, cwd, fileName);
+
         if (file.exists()) {
-            return func.call(bytes, begin, end - begin, enc, arg);
+            byte[] newBytes;
+            
+            // get the real filename (case-sensitive)
+            if(file.isFile() && cwd != null) {
+                String path = file.isSymLink() ? file.absolutePath() : file.canonicalPath();
+
+                // compensate for missing slash
+                if (fileName.endsWith("/")) {
+                    path += "/";
+                }
+
+                if(fileName.contains("./")) {
+                    newBytes = ("./" + path.substring((path.length() - end + 2))).getBytes();
+                } else {
+                    int tempBegin = path.length() - fileName.length();
+                    newBytes = path.substring(tempBegin).getBytes();
+                }
+
+                end = newBytes.length;
+            } else {
+                newBytes = bytes;
+            }
+
+            return func.call(newBytes, begin, end - begin, enc, arg);
         }
 
         return 0;

--- a/spec/tags/ruby/core/dir/glob_tags.txt
+++ b/spec/tags/ruby/core/dir/glob_tags.txt
@@ -1,4 +1,3 @@
-fails(JRUBY-5667):Dir.glob splits the string on \0 if there is only one string given
 fails:Dir.glob raises an Encoding::CompatibilityError if the argument encoding is not compatible with US-ASCII
 fails:Dir.glob splits the string on \0 if there is only one string given and warns
 fails:Dir.glob recursively matches files and directories in nested dot subdirectory with 'nested/**/*' from the current directory and option File::FNM_DOTMATCH

--- a/test/mri/excludes/TestDir.rb
+++ b/test/mri/excludes/TestDir.rb
@@ -1,6 +1,5 @@
 exclude :test_chdir, "uses user.home as a fallback home path"
 exclude :test_glob, '\0 delimiter is not handled'
-exclude :test_glob_cases, "fails to return files with their correct casing (#2150)"
 exclude :test_glob_gc_for_fd, "tweaks rlimit and never restores it, depends on GC effects"
 exclude :test_glob_too_may_open_files, "our glob does not appear to open files, and so the expected EMFILE does not happen"
 exclude :test_home, "uses user.home as a fallback home path"


### PR DESCRIPTION
Hi,

This PR updates the `addToResultIfExists` Java method in order to handle the correct file name in the file system. It should close this issue: https://github.com/jruby/jruby/issues/2150.

**note:** This is my attempt to achieve my first contribution to JRuby, so any feedback here would be great.

Thanks

