### PR TITLE
Also use shell for commands with a space

### DIFF
--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1664,7 +1664,7 @@ public class RubyKernel {
     }
 
     @JRubyMethod(name = "system", required = 1, rest = true, module = true, visibility = PRIVATE)
-    public static IRubyObject system(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+    public static IRubyObject    system(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         final Ruby runtime = context.runtime;
         boolean needChdir = !runtime.getCurrentDirectory().equals(runtime.getPosix().getcwd());
 

--- a/lib/ruby/stdlib/jruby/open3_windows.rb
+++ b/lib/ruby/stdlib/jruby/open3_windows.rb
@@ -63,7 +63,7 @@ module Open3
       env = {}
     end
 
-    if cmd.size == 1 && ShellLauncher.shouldUseShell(cmd[0])
+    if cmd.size == 1 && (cmd[0] =~ / / || ShellLauncher.shouldUseShell(cmd[0]))
       cmd = [RbConfig::CONFIG['SHELL'], JRuby::Util::ON_WINDOWS ? '/c' : '-c', cmd[0]]
     end
 


### PR DESCRIPTION
This duplicates some logic in ShellLauncher but that other logic
splits the command line and tries to pass it as multiple args.
This way works ok and may be more reliable for Open3 cases, plus
it skips all the heinous logic in ShellLauncher.

Fixes #6678