### PR TITLE
Initial support for lightweight generators

### DIFF
--- a/core/src/main/ruby/jruby/kernel.rb
+++ b/core/src/main/ruby/jruby/kernel.rb
@@ -14,6 +14,9 @@ rescue Exception # java.lang.ProcessBuilder not available
   # leave old backtick logic in place
 end unless JRuby::Util.native_posix? # native POSIX uses new logic for back-quote
 
+# Generators for Enumerator#next
+load 'jruby/kernel/jruby/generators.rb'
+
 # These are loads so they don't pollute LOADED_FEATURES
 load 'jruby/kernel/signal.rb'
 load 'jruby/kernel/kernel.rb'

--- a/core/src/main/ruby/jruby/kernel/jruby/generators.rb
+++ b/core/src/main/ruby/jruby/kernel/jruby/generators.rb
@@ -1,0 +1,137 @@
+module JRuby
+  # Base generator with unimplemented methods for children to fill in
+  class AbstractGenerator
+    def initialize(object, method, args, feed_value)
+      @object = object
+      @method = method
+      @args = args
+      @feed_value = feed_value
+    end
+
+    def next?
+      raise NotImplementedError
+    end
+
+    def next
+      raise NotImplementedError
+    end
+
+    def rewind
+      raise NotImplementedError
+    end
+
+    def reset
+      raise NotImplementedError
+    end
+
+    def result
+      raise NotImplementedError
+    end
+  end
+
+  # Array#each generator using a cursor
+  class ArrayEachGenerator < AbstractGenerator
+    def initialize(array, feed_value)
+      super(array, nil, nil, feed_value)
+
+      @index = 0
+    end
+
+    def next?
+      @index < @object.size
+    end
+
+    def next
+      feed_value = @feed_value.use_value
+
+      return feed_value unless feed_value.nil?
+
+      index = @index
+      object = @object
+
+      raise StopIteration.new("iteration reached an end") if index > object.size
+
+      val = object.at(index)
+      @index = index + 1
+
+      val
+    end
+
+    def rewind
+      @index = 0
+    end
+    alias reset rewind
+
+    def result
+      next? ? nil : self
+    end
+  end
+
+  # Fiber-based internal iteration generator
+  class FiberGenerator
+    class State
+      attr_reader :to_proc
+      attr_accessor :done, :result
+
+      def initialize(object, method, args, feed_value)
+        @to_proc = proc do
+          @result = object.__send__ method, *args do |*vals|
+            ret = Fiber.yield(*vals)
+            val = feed_value.use_value
+            ret = val unless val.nil?
+            ret
+          end
+
+          @done = true
+        end
+      end
+
+    end
+    private_constant :State
+
+    def initialize(obj, method, args, feed_value)
+      @state = State.new(obj, method, args, feed_value)
+      @fiber = nil
+      rewind
+    end
+
+    def result
+      @state.result
+    end
+
+    def next?
+      !@state.done
+    end
+
+    def next
+      reset unless @fiber&.__alive__
+
+      val = @fiber.resume
+
+      raise StopIteration, 'iteration has ended' if @state.done
+
+      val
+    end
+
+    def rewind
+      fiber, @fiber = @fiber, nil
+      fiber.send(:__finalize__) if fiber&.__alive__
+      @state.done = false
+    end
+
+    def reset
+      @state.done = false
+      @state.result = nil
+      @fiber = Fiber.new(&@state)
+    end
+  end
+end
+
+class Array
+  # Use fiberless generator for simple :each cases
+  def to_generator(method, args, feed_value)
+    if method == :each && args.length == 0
+      return JRuby::ArrayEachGenerator.new(self, feed_value)
+    end
+  end
+end


### PR DESCRIPTION
This adds a simple lightweight generator for Array#each and starts
the process of making a formal to_generator method that classes
can implement to do external iteration.

The use of Fiber for internal iteration allows all such cases to
work, but leads to a lot of thread creation that cannot easily
handle large numbers of enumerators. In addition, these fiber
threads frequently will get hard referenced and stuck alive,
leading to thread leaks such as in #6004. We can provide non-fiber
external iteration for many of the most common use cases, such as
Array#each, while also providing a protocol for users to add their
own generators returned by to_generator.

See #6006 for further discussion.