### PR TITLE
Do not install bundler during travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ matrix:
       name: MRI core int
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake test:mri:core:int
       env: JRUBY_OPTS='$JRUBY_OPTS -J-Xmx1G'
@@ -55,7 +54,6 @@ matrix:
     - name: MRI core jit
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake test:mri:core:fullint
       env: JRUBY_OPTS='$JRUBY_OPTS -J-Xmx1G'
@@ -64,7 +62,6 @@ matrix:
       jdk: openjdk11
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake test:mri:core:jit
 
@@ -72,14 +69,12 @@ matrix:
       jdk: openjdk14
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake test:mri:core:jit
 
     - name: MRI extra
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake test:mri:extra
       env: JRUBY_OPTS='$JRUBY_OPTS -J-Xmx1G'
@@ -87,7 +82,6 @@ matrix:
     - name: MRI stdlib
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake test:mri:stdlib
       env: JRUBY_OPTS='$JRUBY_OPTS -J-Xmx1G'
@@ -95,7 +89,6 @@ matrix:
     - name: spec/ruby fast
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake spec:ruby:fast
 
@@ -103,7 +96,6 @@ matrix:
       jdk: openjdk11
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake spec:ruby:fast
 
@@ -111,14 +103,12 @@ matrix:
       jdk: openjdk14
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake spec:ruby:fast
 
     - name: spec/ruby slow
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake spec:ruby:slow
 
@@ -139,7 +129,6 @@ matrix:
     - name: JRuby tests int
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake test:jruby:int
 
@@ -147,7 +136,6 @@ matrix:
       jdk: openjdk11
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake test:jruby
       env: JRUBY_OPTS=-Xcompile.invokedynamic
@@ -156,7 +144,6 @@ matrix:
       jdk: openjdk14
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake test:jruby
       env: JRUBY_OPTS=-Xcompile.invokedynamic
@@ -164,7 +151,6 @@ matrix:
     - name: JRuby tests jit indy
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake test:jruby
       env: JRUBY_OPTS=-Xcompile.invokedynamic
@@ -172,21 +158,18 @@ matrix:
     - name: JRuby tests aot
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake test:jruby:aot
 
     - name: JRuby slow tests
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake test:slow_suites
 
     - name: JI specs
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake spec:ji
 
@@ -194,7 +177,6 @@ matrix:
       jdk: openjdk11
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake spec:ji
 
@@ -202,14 +184,12 @@ matrix:
       jdk: openjdk14
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake spec:ji
 
     - name: JI specs indy
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake spec:ji
       env: JRUBY_OPTS=-Xcompile.invokedynamic
@@ -217,14 +197,12 @@ matrix:
     - name: Compiler specs
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake spec:compiler
 
     - name: Compiler specs indy
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake spec:compiler
       env: JRUBY_OPTS=-Xcompile.invokedynamic
@@ -233,7 +211,6 @@ matrix:
       jdk: openjdk11
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake spec:compiler
       env: JRUBY_OPTS=-Xcompile.invokedynamic
@@ -242,7 +219,6 @@ matrix:
       jdk: openjdk14
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake spec:compiler
       env: JRUBY_OPTS=-Xcompile.invokedynamic
@@ -250,7 +226,6 @@ matrix:
     - name: FFI specs
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake spec:ffi
 
@@ -258,21 +233,18 @@ matrix:
       jdk: openjdk11
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake spec:ffi
 
     - name: Regression specs
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake spec:regression
 
     - name: Regression specs jit
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake spec:regression
       env: JRUBY_OPTS=-Xjit.threshold=0
@@ -280,21 +252,18 @@ matrix:
     - name: JRuby specs
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake spec:jruby
 
     - name: jrubyc specs
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake spec:jrubyc
 
     - name: Profilers specs
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
         - bundle install
         - jruby -S rake spec:profiler
 


### PR DESCRIPTION
Bundler is included as a default gem in 9.3+ so it is already
available.