### PR TITLE
Do not pollute CP with annotation-api

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -75,7 +75,7 @@ project 'JRuby Base' do
 
   jar 'com.headius:backport9:1.10'
 
-  jar 'jakarta.annotation:jakarta.annotation-api:2.0.0', scope: 'compile'
+  jar 'jakarta.annotation:jakarta.annotation-api:2.0.0', scope: 'provided'
 
   plugin_management do
     plugin( 'org.eclipse.m2e:lifecycle-mapping:1.0.0',

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -238,7 +238,7 @@ DO NOT MODIFIY - GENERATED CODE
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
       <version>2.0.0</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
https://github.com/jruby/jruby/issues/6514#issuecomment-752748414:
> We only use the API at build time for our annotation processor

Unfortunately, current `compile` scope used propagates to client project (it isn't _compile-time-only_) and is placed on project's classpath. I can't switch annotation api in the project, but I'd like to consider JRuby upgrade.

I've built and used jruby-core 9.3.0.0-SNAPSHOT to verify that this change would work as I expect it. (I used published snapshot in first place and learnt that it conflicts with the project.)