### PR TITLE
Use cached UTF8 single-char bytelists here

### DIFF
--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -38,6 +38,7 @@ package org.jruby;
 import org.jcodings.Encoding;
 import org.jcodings.specific.ASCIIEncoding;
 import org.jcodings.specific.USASCIIEncoding;
+import org.jcodings.specific.UTF8Encoding;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.ast.util.ArgsUtil;
@@ -368,6 +369,51 @@ public abstract class RubyInteger extends RubyNumeric {
 
     static ByteList singleCharByteList(final byte index) {
         return SINGLE_CHAR_BYTELISTS[index & 0xFF];
+    }
+
+    static final ByteList[] SINGLE_CHAR_UTF8_BYTELISTS;
+    static {
+        SINGLE_CHAR_UTF8_BYTELISTS = new ByteList[128];
+        for (int i = 0; i < 128; i++) {
+            ByteList bytes = new ByteList(new byte[] { (byte) i }, false);
+            SINGLE_CHAR_UTF8_BYTELISTS[i] = bytes;
+            bytes.setEncoding(UTF8Encoding.INSTANCE);
+        }
+    }
+
+    /**
+     * Return a low ASCII single-character bytelist with UTF-8 encoding, using cached values.
+     *
+     * The resulting ByteList should not be modified.
+     *
+     * @param index the byte
+     * @return a cached single-character ByteList
+     */
+    public static ByteList singleCharUTF8ByteList(final byte index) {
+        return SINGLE_CHAR_UTF8_BYTELISTS[index & 0xFF];
+    }
+
+    /**
+     * Return a single-character ByteList, possibly cached, corresponding to the given byte and encoding.
+     *
+     * Note this will return high ASCII non-UTF8 characters as ASCII-8BIT, rather than US-ASCII.
+     *
+     * @param b the byte
+     * @param enc the encoding
+     * @return a new single-character RubyString
+     */
+    public static RubyString singleCharString(Ruby runtime, byte b, RubyClass meta, Encoding enc) {
+        ByteList bytes;
+        if (enc == USASCIIEncoding.INSTANCE) {
+            bytes = singleCharByteList(b);
+        } else if ((b & 0xFF) < 0x80 && enc == RubyString.UTF8) {
+            bytes = singleCharUTF8ByteList(b);
+        } else {
+            return new RubyString(runtime, meta, new ByteList(new byte[]{b}, enc));
+        }
+
+        // use shared for cached bytelists
+        return RubyString.newStringShared(runtime, meta, bytes);
     }
 
     /** int_chr

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -887,12 +887,15 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         if (len == 0) {
             shared = newEmptyString(runtime, meta, enc);
         } else if (len == 1) {
-            // as with the 1.8 makeShared, don't bother sharing for substrings that are a single byte
-            // to get a good speed boost in a number of common scenarios (note though that unlike 1.8,
-            // we can't take advantage of SINGLE_CHAR_BYTELISTS since our encoding may not be ascii, but the
-            // single byte copy is pretty much negligible)
-            ByteList bytes = new ByteList(new byte[] { (byte) value.get(index) }, enc);
-            shared = new RubyString(runtime, meta, bytes, enc);
+            byte b = (byte) value.get(index);
+
+            // only use cache for low ASCII bytes
+            if ((b & 0xFF) < 0x80) {
+                shared = RubyInteger.singleCharString(runtime, b, meta, enc);
+            } else {
+                ByteList bytes = new ByteList(new byte[]{(byte) value.get(index)}, enc);
+                shared = new RubyString(runtime, meta, bytes);
+            }
         } else {
             if (shareLevel == SHARE_LEVEL_NONE) shareLevel = SHARE_LEVEL_BUFFER;
             shared = new RubyString(runtime, meta, value.makeShared(index, len));
@@ -3652,6 +3655,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         } else {
             len = StringSupport.offset(enc, bytes, p, end, len);
         }
+
         return makeShared(runtime, p - s, len);
     }
 


### PR DESCRIPTION
This logic would always create a new byte[], ByteList, and
RubyString when pulling single-byte characters from a multi-byte
string. This change allows it to use cached ByteList (and byte[])
for those cases if the encoding is UTF-8.