### PR TITLE
Fixes #6692.  AIOOBE on evals overflowing closure ids.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
       name: MRI core int
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake test:mri:core:int
       env: JRUBY_OPTS='$JRUBY_OPTS -J-Xmx1G'
@@ -55,7 +55,7 @@ matrix:
     - name: MRI core fullint
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake test:mri:core:fullint
       env: JRUBY_OPTS='$JRUBY_OPTS -J-Xmx1G'
@@ -63,14 +63,14 @@ matrix:
     - name: MRI core jit
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake test:mri:core:jit
 
     - name: MRI extra
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake test:mri:extra
       env: JRUBY_OPTS='$JRUBY_OPTS -J-Xmx1G'
@@ -78,7 +78,7 @@ matrix:
     - name: MRI stdlib
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake test:mri:stdlib
       env: JRUBY_OPTS='$JRUBY_OPTS -J-Xmx1G'
@@ -86,14 +86,14 @@ matrix:
     - name: spec/ruby fast
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake spec:ruby:fast
 
     - name: spec/ruby slow
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake spec:ruby:slow
 
@@ -116,14 +116,14 @@ matrix:
     - name: JRuby tests jit
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake test:jruby
 
     - name: JRuby tests jit indy
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake test:jruby
       env: JRUBY_OPTS=-Xcompile.invokedynamic
@@ -131,42 +131,42 @@ matrix:
     - name: JRuby tests aot
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake test:jruby:aot
 
     - name: JRuby tests fullint
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake test:jruby:fullint
 
     - name: JRuby slow tests
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake test:slow_suites
 
     - name: JI specs
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake spec:ji
 
     - name: Compiler specs
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake spec:compiler
 
     - name: Compiler specs indy
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake spec:compiler
       env: JRUBY_OPTS=-Xcompile.invokedynamic
@@ -174,21 +174,21 @@ matrix:
     - name: FFI specs
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake spec:ffi
 
     - name: Regression specs
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake spec:regression
 
     - name: Regression specs jit
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake spec:regression
       env: JRUBY_OPTS=-Xjit.threshold=0
@@ -196,21 +196,21 @@ matrix:
     - name: JRuby specs
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake spec:jruby
 
     - name: jrubyc specs
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake spec:jrubyc
 
     - name: Profilers specs
       script:
         - mvn clean package -Pbootstrap
-        - gem install bundler
+        - gem install bundler --no-document
         - bundle install
         - jruby -S rake spec:profiler
 

--- a/core/src/main/java/org/jruby/ir/IRClosure.java
+++ b/core/src/main/java/org/jruby/ir/IRClosure.java
@@ -61,6 +61,7 @@ public class IRClosure extends IRScope {
         this.body = null;
     }
 
+    // Used by IREvalScript
     protected IRClosure(IRManager manager, IRScope lexicalParent, int lineNumber, StaticScope staticScope, int closureId, ByteList fullName) {
         super(manager, lexicalParent, null, lineNumber, staticScope);
 

--- a/core/src/main/java/org/jruby/ir/IRClosure.java
+++ b/core/src/main/java/org/jruby/ir/IRClosure.java
@@ -61,6 +61,13 @@ public class IRClosure extends IRScope {
         this.body = null;
     }
 
+    protected IRClosure(IRManager manager, IRScope lexicalParent, int lineNumber, StaticScope staticScope, int closureId, ByteList fullName) {
+        super(manager, lexicalParent, null, lineNumber, staticScope);
+
+        this.closureId = closureId;
+        super.setByteName(fullName);
+    }
+
     /** Used by cloning code for inlining */
     /* Inlining generates a new name and id and basic cloning will reuse the originals name */
     protected IRClosure(IRClosure c, IRScope lexicalParent, int closureId, ByteList fullName) {

--- a/core/src/main/java/org/jruby/ir/IREvalScript.java
+++ b/core/src/main/java/org/jruby/ir/IREvalScript.java
@@ -8,11 +8,13 @@ import org.jruby.util.ByteList;
 public class IREvalScript extends IRClosure {
     private String fileName;
 
-    private static final ByteList EVAL_ = new ByteList(new byte[] {'E', 'V', 'A', 'L', '_'});
+    private static final ByteList EVAL = new ByteList(new byte[] {'E', 'V', 'A', 'L'});
 
     public IREvalScript(IRManager manager, IRScope lexicalParent, String fileName,
             int lineNumber, StaticScope staticScope, EvalType evalType) {
-        super(manager, lexicalParent, lineNumber, staticScope, EVAL_);
+        // ALL eval scopes are not really closures and are always new scopes.  We should not reference an eval
+        // by a TemporaryClosureVariable ever.
+        super(manager, lexicalParent, lineNumber, staticScope, 0, EVAL);
 
         this.fileName = fileName;
 
@@ -28,6 +30,13 @@ public class IREvalScript extends IRClosure {
                 staticScope.setScopeType(s.getScopeType());
             }
         }
+    }
+
+    @Override
+    public int getNextClosureId() {
+        nextClosureIndex++;
+
+        return nextClosureIndex;
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/IRScope.java
+++ b/core/src/main/java/org/jruby/ir/IRScope.java
@@ -92,7 +92,7 @@ public abstract class IRScope implements ParseResult {
     private List<IRClosure> nestedClosures;
 
     // Index values to guarantee we don't assign same internal index twice
-    private int nextClosureIndex;
+    protected int nextClosureIndex;
 
     // List of all scopes this scope contains lexically.  This is not used
     // for execution, but is used during dry-runs for debugging.

--- a/tool/concurrent-ruby-travis.sh
+++ b/tool/concurrent-ruby-travis.sh
@@ -4,7 +4,7 @@ set -v -e
 # set up JRuby
 mvn clean package
 export PATH=`pwd`/bin:$PATH
-gem install bundler
+gem install bundler --no-document
 
 # prep for test
 git clone --depth=10 https://github.com/ruby-concurrency/concurrent-ruby.git


### PR DESCRIPTION
This has two pieces:
  1. Evals only live as a scope as long as they execute.  They should not
  be asking the lexical scope they are called in for an id.  This is likely
  a portion (or all) of the original reporters problem.

  2. Closures in evals should be given out scope ids relative to the eval.
  These were going to the eval and then the evals getScopeID would ask its
  lexical parent for an ID (which is the scope outside the eval).