### PR TITLE
Update wiki URLs to point directly to pages in warning messages

### DIFF
--- a/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
@@ -83,7 +83,7 @@ public class JRubyUtilLibrary implements Library {
         final Ruby runtime = recv.getRuntime();
         boolean enabled = arg.isTrue();
         if (enabled) {
-            runtime.getWarnings().warn("ObjectSpace impacts performance. See http://wiki.jruby.org/PerformanceTuning#dont-enable-objectspace");
+            runtime.getWarnings().warn("ObjectSpace impacts performance. See https://github.com/jruby/jruby/wiki/PerformanceTuning#dont-enable-objectspace");
         }
         runtime.setObjectSpaceEnabled(enabled);
         return runtime.newBoolean(enabled);

--- a/core/src/main/java/org/jruby/ext/socket/RubyServerSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyServerSocket.java
@@ -70,7 +70,7 @@ public class RubyServerSocket extends RubySocket {
     public IRubyObject listen(ThreadContext context, IRubyObject backlog) {
         context.runtime.getWarnings().warnOnce(
                 IRubyWarnings.ID.LISTEN_SERVER_SOCKET,
-                "pass backlog to #bind instead of #listen (http://wiki.jruby.org/ServerSocket)");
+                "pass backlog to #bind instead of #listen (https://github.com/jruby/jruby/wiki/ServerSocket)");
 
         return context.runtime.newFixnum(0);
     }

--- a/core/src/main/java/org/jruby/ext/socket/RubySocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubySocket.java
@@ -715,5 +715,5 @@ public class RubySocket extends RubyBasicSocket {
     protected Protocol soProtocol = Protocol.getProtocolByNumber(0);
 
     private static final String JRUBY_SERVER_SOCKET_ERROR =
-            "use ServerSocket for servers (http://wiki.jruby.org/ServerSocket)";
+            "use ServerSocket for servers (https://github.com/jruby/jruby/wiki/ServerSocket)";
 }// RubySocket

--- a/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
@@ -572,8 +572,8 @@ public class JavaProxy extends RubyObject {
         }
     }
 
-    private static final String NONPERSISTENT_IVAR_MESSAGE = "instance vars on non-persistent Java type {0} (http://wiki.jruby.org/Persistence)";
-    private static final String NONPERSISTENT_SINGLETON_MESSAGE = "singleton on non-persistent Java type {0} (http://wiki.jruby.org/Persistence)";
+    private static final String NONPERSISTENT_IVAR_MESSAGE = "instance vars on non-persistent Java type {0} (https://github.com/jruby/jruby/wiki/Persistence)";
+    private static final String NONPERSISTENT_SINGLETON_MESSAGE = "singleton on non-persistent Java type {0} (https://github.com/jruby/jruby/wiki/Persistence)";
 
     public static class ClassMethods {
 


### PR DESCRIPTION
While investigating an issue, https://github.com/socketry/falcon/issues/64, elsewhere, I found that in warnings emitted by JRuby, the direct link to a specific **wiki page link** had become **out of date**, and didn't point to the exact page anymore. It **just pointed to the start page**.

With this change, it does again point to the exact pages.

<details>

## TODO

Here are other files that need a change, please make that change, if you find that before I do. Have a nice day!

- [x] https://github.com/jruby/jruby/blob/a309a88614916621de4cc5dc3693f279dae58d0c/core/src/main/java/org/jruby/java/proxies/JavaProxy.java#L575
- [x] https://github.com/jruby/jruby/blob/a309a88614916621de4cc5dc3693f279dae58d0c/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java#L86
- [x] https://github.com/jruby/jruby/blob/df79d1f8b874fc0710c9f21d80e23b99ca72895d/core/src/main/java/org/jruby/ext/socket/RubySocket.java#L717


</details>