### PR TITLE
Fixes #6184. NullPointerException/"class is not compiled Ruby" for loop

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRScope.java
+++ b/core/src/main/java/org/jruby/ir/IRScope.java
@@ -358,6 +358,16 @@ public abstract class IRScope implements ParseResult {
         return lineNumber;
     }
 
+    public int countForLoops() {
+        int count = 0;
+        
+        for (IRScope current = this; current != null && !current.isTopLocalVariableScope(); current = current.getLexicalParent()) {
+            if (current instanceof IRFor) count++;
+        }
+
+        return count;
+    }
+
     /**
      * Returns the top level scope
      */

--- a/core/src/main/java/org/jruby/ir/operands/LocalVariable.java
+++ b/core/src/main/java/org/jruby/ir/operands/LocalVariable.java
@@ -121,7 +121,9 @@ public class LocalVariable extends Variable implements DepthCloneable {
     public void encode(IRWriterEncoder e) {
         super.encode(e);
         e.encode(getName());
-        e.encode(getScopeDepth());
+
+        int forCount = e.getCurrentScope().countForLoops();
+        e.encode(getScopeDepth() - forCount);
         // We do not encode location because we rebuild lvars from IRScope when being rebuilt
     }
 

--- a/core/src/main/java/org/jruby/ir/persistence/IRWriterAnalyzer.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRWriterAnalyzer.java
@@ -43,6 +43,11 @@ public class IRWriterAnalyzer implements IRWriterEncoder {
     }
 
     @Override
+    public IRScope getCurrentScope() {
+        return null;
+    }
+
+    @Override
     public void encode(ByteList value) {
     }
 

--- a/core/src/main/java/org/jruby/ir/persistence/IRWriterEncoder.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRWriterEncoder.java
@@ -23,6 +23,7 @@ import java.util.EnumSet;
  * input the the encoder which writes the file.
  */
 public interface IRWriterEncoder {
+    IRScope getCurrentScope();
 
     public void encode(ByteList bytelist);
     public void encode(Encoding encoding);

--- a/core/src/main/java/org/jruby/ir/persistence/IRWriterStream.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRWriterStream.java
@@ -13,6 +13,7 @@ import org.jruby.ir.IRScope;
 import org.jruby.ir.IRScopeType;
 import org.jruby.ir.Operation;
 import org.jruby.ir.instructions.Instr;
+import org.jruby.ir.operands.LocalVariable;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.OperandType;
 import org.jruby.parser.StaticScope;
@@ -52,6 +53,8 @@ public class IRWriterStream implements IRWriterEncoder, IRPersistenceValues {
     private final IRWriterAnalyzer analyzer;
     private Map<RubySymbol, Integer> constantMap = new HashMap();
 
+    // scope being encoded when instructions are being encoded.
+    IRScope currentScope = null;
     int headersOffset = -1;
 
     public IRWriterStream(OutputStream stream) {
@@ -79,6 +82,10 @@ public class IRWriterStream implements IRWriterEncoder, IRPersistenceValues {
      */
     public int getScopeInstructionOffset(IRScope scope) {
         return scopeInstructionOffsets.get(scope);
+    }
+
+    public IRScope getCurrentScope() {
+        return currentScope;
     }
 
     @Override
@@ -282,6 +289,7 @@ public class IRWriterStream implements IRWriterEncoder, IRPersistenceValues {
 
     @Override
     public void startEncodingScopeInstrs(IRScope scope) {
+        currentScope = scope;
         constantMap.clear();
         addScopeInstructionOffset(scope); // Record offset so we add this value to scope headers entry
         encode(scope.getInterpreterContext().getInstructions().length); // Allows us to right-size when reconstructing instr list.

--- a/spec/jrubyc/java/files/for.rb
+++ b/spec/jrubyc/java/files/for.rb
@@ -1,0 +1,13 @@
+$for_result = 0
+
+for i in [1, 2]
+  $for_result += i
+end
+
+$for_nested_result = 0
+for i in [1, 2]
+  for j in [3, 4]
+    2.times { $for_nested_result += j }
+  end
+end
+

--- a/spec/jrubyc/java/loading_spec.rb
+++ b/spec/jrubyc/java/loading_spec.rb
@@ -32,6 +32,12 @@ describe "JRuby::Compiler.compile_argv" do
     expect { DoubleRescue.re_raise }.to raise_error LoadError
   end
 
+  it "loads for.class" do
+    load File.join(FILES_DIR, 'for.class')
+    expect( $for_result ).to eql 3
+    expect( $for_nested_result ).to eql 28
+  end
+
   it "loads sample_block.class" do
     load File.join(FILES_DIR, 'sample_block.class')
 

--- a/spec/jrubyc/java/method_spec.rb
+++ b/spec/jrubyc/java/method_spec.rb
@@ -45,7 +45,7 @@ describe "A Ruby class generating a Java stub" do
           cls = generate("class Foo; def bar; end; end").classes[0]
 
           method = cls.methods[0]
-          method.should_not be nil
+          expect(method).to_not be nil
           method.name.should == "bar"
           method.constructor?.should == false
           method.java_signature.to_s.should == "Object bar()"


### PR DESCRIPTION
When using a "for" loop it will not compile of NPE.

Solution is to subtract the depths introduced by for loop scopes so when we decode the local variables our existing logic will then reintroduce the depth offsets of for those same 'for' loops.