### PR TITLE
Use java_home command on MacOS

### DIFF
--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -131,11 +131,18 @@ esac
 # Determine where the java command is and ensure we have a good JAVA_HOME
 if [ -z "$JAVACMD" ] ; then
   if [ -z "$JAVA_HOME" ] ; then
-    resolve_symlinks "$(command -v java)"
-    JAVACMD="$result"
+    if [ -x "/usr/libexec/java_home" ] ; then
+      # use java_home command when none is set (on MacOS)
+      JAVA_HOME="$(/usr/libexec/java_home)"
+      JAVACMD="$JAVA_HOME"/bin/java
+    else
+      # Linux and others have a chain of symlinks
+      resolve_symlinks "$(command -v java)"
+      JAVACMD="$result"
 
-    # export separately from command execution
-    JAVA_HOME="$(dirname "$(dirname "$JAVACMD")")"
+      # export separately from command execution
+      JAVA_HOME="$(dirname "$(dirname "$JAVACMD")")"
+    fi
   else
     if $cygwin; then
       JAVACMD="$(cygpath -u "$JAVA_HOME")/bin/java"


### PR DESCRIPTION
When no JAVA_HOME env is set on MacOS, we do not properly detect
the actual JDK install location. The default `java` command is an
executable in /usr/bin/java that launches the default installed
JDK (usually the highest version). Since it is not a simlink the
logic we use on Linux to dig out the real JAVA_HOME does not work.

This patch uses the `java_home` command when no JAVA_HOME is set.
This command is only available on MacOS as far as I know, though
similar commands exist on other platforms.

Fixes #6726.

The same change needs to go into jruby-launcher.