### PR TITLE
Test on JDK 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,8 @@ matrix:
         - bundle install
         - jruby -S rake test:mri:core:jit
 
-    - name: MRI core jit jdk14
-      jdk: openjdk14
+    - name: MRI core jit jdk16
+      jdk: openjdk16
       script:
         - mvn clean package -Pbootstrap
         - bundle install
@@ -99,8 +99,8 @@ matrix:
         - bundle install
         - jruby -S rake spec:ruby:fast
 
-    - name: spec/ruby fast jdk14
-      jdk: openjdk14
+    - name: spec/ruby fast jdk16
+      jdk: openjdk16
       script:
         - mvn clean package -Pbootstrap
         - bundle install
@@ -147,8 +147,8 @@ matrix:
         - bundle install
         - jruby -S rake test:jruby
 
-    - name: JRuby tests jit indy jdk14
-      jdk: openjdk14
+    - name: JRuby tests jit indy jdk16
+      jdk: openjdk16
       script:
         - export JRUBY_OPTS=-Xcompile.invokedynamic
         - mvn clean package -Pbootstrap
@@ -187,8 +187,8 @@ matrix:
         - bundle install
         - jruby -S rake spec:ji
 
-    - name: JI specs jdk14
-      jdk: openjdk14
+    - name: JI specs jdk16
+      jdk: openjdk16
       script:
         - mvn clean package -Pbootstrap
         - bundle install
@@ -222,8 +222,8 @@ matrix:
         - bundle install
         - jruby -S rake spec:compiler
 
-    - name: Compiler specs indy jdk14
-      jdk: openjdk14
+    - name: Compiler specs indy jdk16
+      jdk: openjdk16
       script:
         - export JRUBY_OPTS=-Xcompile.invokedynamic
         - mvn clean package -Pbootstrap


### PR DESCRIPTION
JDK 16 now has --illegal-access=deny by default. We should already
be good citizens and not dig around in unopened packages, but this
will help confirm and preserve that behavior.

Relates to #6721