### PR TITLE
Backport JarCache soft reference fix

### DIFF
--- a/core/src/main/java/org/jruby/util/JarResource.java
+++ b/core/src/main/java/org/jruby/util/JarResource.java
@@ -86,8 +86,8 @@ abstract class JarResource implements FileResource, DummyResourceStat.FileResour
         return null;
     }
 
-    public static boolean removeJarResource(String jarPath){
-        return jarCache.remove(jarPath);
+    public static void removeJarResource(String jarPath){
+        jarCache.remove(jarPath);
     }
 
     private final CharSequence jarPrefix;


### PR DESCRIPTION
This PR backports #6268 to 9.2 to fix the evacuation of the cache (due to weakly referenced-keys that immediately get dereferenced).

This backport will make it easier to incorporate other improvements from @DirkMahler for #6730.