### PR TITLE
Try not to canonicalize load names before parse

### DIFF
--- a/core/src/main/java/org/jruby/runtime/load/ExternalScript.java
+++ b/core/src/main/java/org/jruby/runtime/load/ExternalScript.java
@@ -40,23 +40,22 @@ import static org.jruby.RubyFile.canonicalize;
 
 public class ExternalScript implements Library {
     private final LoadServiceResource resource;
+    private final String loadName;
     
-    public ExternalScript(LoadServiceResource resource, String name) {
+    public ExternalScript(LoadServiceResource resource, String loadName) {
         this.resource = resource;
+        this.loadName = loadName;
     }
 
     public void load(Ruby runtime, boolean wrap) {
         InputStream in = null;
         try {
             in = resource.getInputStream();
-            String name = resource.getName();
 
             if (runtime.getInstanceConfig().getCompileMode().shouldPrecompileAll()) {
-                runtime.compileAndLoadFile(name, in, wrap);
+                runtime.compileAndLoadFile(loadName, in, wrap);
             } else {
-                name = CompiledScriptLoader.getFilenameFromPathAndName(resource.getPath(), name, resource.isAbsolute());
-
-                runtime.loadFile(name, new LoadServiceResourceInputStream(in), wrap);
+                runtime.loadFile(loadName, new LoadServiceResourceInputStream(in), wrap);
             }
         } catch (IOException e) {
             throw runtime.newIOErrorFromException(e);


### PR DESCRIPTION
In #5662 we see that the eventual source name used by e.g. `__FILE__` should not be the canonicalized name, and should reflect the original load name more closely. On Windows, 8.3 names should not be expanded to full paths, and on unix, symlinks should not be replaced with their referees.

This is an experiment to see if a simple change might get the original paths where we want them.