### PR TITLE
6730 jar cache slowing down startup time 9.2

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -60,6 +60,7 @@ project 'JRuby Core' do
   jar 'com.jcraft:jzlib:1.1.3'
   jar 'com.martiansoftware:nailgun-server:0.9.1'
   jar 'junit:junit', :scope => 'test'
+  jar 'org.awaitility:awaitility', :scope => 'test'
   jar 'org.apache.ant:ant:${ant.version}', :scope => 'provided'
   jar 'org.osgi:org.osgi.core:5.0.0', :scope => 'provided'
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -200,6 +200,11 @@ DO NOT MODIFIY - GENERATED CODE
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
       <version>${ant.version}</version>

--- a/core/src/main/java/org/jruby/util/JarCache.java
+++ b/core/src/main/java/org/jruby/util/JarCache.java
@@ -17,25 +17,31 @@ import java.util.jar.JarFile;
 import static org.jruby.RubyFile.canonicalize;
 
 /**
-  * Instances of JarCache provides jar index information.
+ * Instances of JarCache provides jar index information.
+ *
+ * <p>
+ * Implementation is threadsafe.
   *
-  * <p>
-  *     Implementation is threadsafe.
+ * Since loading index information is O(jar-entries) we cache the snapshot in a WeakHashMap.
+ * The implementation pays attention to lastModified timestamp of the jar and will invalidate
+ * the cache entry if jar has been updated since the snapshot calculation.
+ * </p>
   *
-  *     Since loading index information is O(jar-entries) we cache the snapshot in a WeakHashMap.
-  *     The implementation pays attention to lastModified timestamp of the jar and will invalidate
-  *     the cache entry if jar has been updated since the snapshot calculation.
-  * </p>
+ * ******************************************************************************************
+ * DANGER DANGER DANGER DANGER DANGER DANGER DANGER DANGER DANGER DANGER DANGER DANGER DANGER
+ * ******************************************************************************************
   *
-  * ******************************************************************************************
-  * DANGER DANGER DANGER DANGER DANGER DANGER DANGER DANGER DANGER DANGER DANGER DANGER DANGER
-  * ******************************************************************************************
-  *
-  * The spec for this cache is disabled currently for #2655, because of last-modified time
-  * oddities on CloudBees. Please be cautious modifying this code and make sure you run the
-  * associated spec locally.
-  */
+ * The spec for this cache is disabled currently for #2655, because of last-modified time
+ * oddities on CloudBees. Please be cautious modifying this code and make sure you run the
+ * associated spec locally.
+ */
 class JarCache {
+
+    /**
+     * The timeout in milliseconds for caching the last modified timestamp of JAR files.
+     */
+    private static final long LAST_MODIFIED_EXPIRATION_TIME_MILLISECONDS = 500;
+
     static class JarIndex {
         private static final String ROOT_KEY = "";
 
@@ -87,12 +93,22 @@ class JarCache {
             this.cachedDirEntries = Collections.unmodifiableMap(cachedDirEntries);
         }
 
+        /**
+         * Determines the last modification timestamp of a file.
+         * <p>
+         * NOTE: Getting the value is an expensive operation on Windows systems (see
+         * {@link <a href="https://github.com/jruby/jruby/issues/6730}").
+         * Therefore a cached value is used with a maximum lifetime of {@link #LAST_MODIFIED_EXPIRATION_TIME_MILLISECONDS} milliseconds.
+         *
+         * @param jarPath The path to the JAR file.
+         * @return The last modification timestamp.
+         */
         private long getLastModified(String jarPath) {
             long currentTimeMillis = System.currentTimeMillis();
             if (lastModifiedExpiration != null && currentTimeMillis < lastModifiedExpiration) {
                 return lastModified;
             }
-            this.lastModifiedExpiration = currentTimeMillis + 500;
+            this.lastModifiedExpiration = currentTimeMillis + LAST_MODIFIED_EXPIRATION_TIME_MILLISECONDS;
             return new File(jarPath).lastModified();
         }
 
@@ -111,7 +127,8 @@ class JarCache {
         public void release() {
             try {
                 jar.close();
-            } catch (IOException ioe) { }
+            } catch (IOException ioe) {
+            }
         }
 
         public boolean isValid() {
@@ -163,15 +180,14 @@ class JarCache {
         }
     }
 
-    public boolean remove(String jarPath){
+    public boolean remove(String jarPath) {
         String cacheKey = jarPath;
 
         synchronized (indexCache) {
             JarIndex index = indexCache.get(cacheKey);
-            if (index == null){
+            if (index == null) {
                 return false;
-            }
-            else{
+            } else {
                 index.release();
                 indexCache.remove(cacheKey);
                 return true;

--- a/core/src/test/java/org/jruby/util/JarCacheTest.java
+++ b/core/src/test/java/org/jruby/util/JarCacheTest.java
@@ -1,0 +1,42 @@
+package org.jruby.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URL;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.awaitility.Awaitility.waitAtMost;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+
+public class JarCacheTest {
+
+    private JarCache jarCache ;
+
+    @Before
+    public void setUp() throws Exception {
+        this.jarCache = new JarCache();
+    }
+
+    /**
+     * Verifies that updating a JAR (i.e. change of last modification time) is recognized by the {@link JarCache} after at most 500ms.
+     */
+    @Test
+    public void updateJar() {
+        URL resource = Thread.currentThread().getContextClassLoader().getResource("foobar.jar");
+        File jarFile = new File(resource.getFile());
+        jarFile.setLastModified(System.currentTimeMillis() - MINUTES.toMillis(2));
+        JarCache.JarIndex index = jarCache.getIndex(resource.getFile());
+        assertNotNull(index);
+
+        jarFile.setLastModified(System.currentTimeMillis() - MINUTES.toMillis(1));
+        waitAtMost(500, MILLISECONDS).untilAsserted(() -> {
+            JarCache.JarIndex updatedIndex = jarCache.getIndex(resource.getFile());
+            assertNotSame(index, updatedIndex);
+        });
+    }
+
+}

--- a/core/src/test/java/org/jruby/util/JarCacheTest.java
+++ b/core/src/test/java/org/jruby/util/JarCacheTest.java
@@ -33,7 +33,7 @@ public class JarCacheTest {
         assertNotNull(index);
 
         jarFile.setLastModified(System.currentTimeMillis() - MINUTES.toMillis(1));
-        waitAtMost(500, MILLISECONDS).untilAsserted(() -> {
+        waitAtMost(750, MILLISECONDS).untilAsserted(() -> {
             JarCache.JarIndex updatedIndex = jarCache.getIndex(resource.getFile());
             assertNotSame(index, updatedIndex);
         });

--- a/pom.rb
+++ b/pom.rb
@@ -90,6 +90,9 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
     jar( 'junit:junit:4.12',
          :scope => 'test' )
 
+    jar( 'org.awaitility:awaitility:4.1.0',
+         :scope => 'test' )
+
     plugin( 'org.apache.felix:maven-bundle-plugin:4.2.1',
             'instructions' => {
               'Export-Package' =>  'org.jruby.*;version=${project.version}',

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,12 @@ DO NOT MODIFIY - GENERATED CODE
         <version>4.12</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility</artifactId>
+        <version>4.1.0</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <repositories>


### PR DESCRIPTION
* PR for #6730 , targeting `jruby-9.2`
* Last moficiation timestamp for JAR files is cached for at most 500ms now
* Added a simple unit test for verification that updated JAR is picked up (using Awaitility as a test dependency, hope you don't mind that I introduced it) 