### PR TITLE
Fixes for Windows native exec

### DIFF
--- a/core/src/main/java/org/jruby/util/ShellLauncher.java
+++ b/core/src/main/java/org/jruby/util/ShellLauncher.java
@@ -1182,13 +1182,7 @@ public class ShellLauncher {
             execArgs = new String[3];
             execArgs[0] = shell;
             execArgs[1] = shell.endsWith("sh") ? "-c" : "/c";
-
-            if (Platform.IS_WINDOWS) {
-                // that's how MRI does it too
-                execArgs[2] = "\"" + cmdline + "\"";
-            } else {
-                execArgs[2] = cmdline;
-            }
+            execArgs[2] = cmdline;
         }
 
         public void verifyExecutableForDirect() {

--- a/core/src/main/java/org/jruby/util/ShellLauncher.java
+++ b/core/src/main/java/org/jruby/util/ShellLauncher.java
@@ -1171,7 +1171,7 @@ public class ShellLauncher {
 
         public void verifyExecutableForShell() {
             String cmdline = rawArgs[0].toString().trim();
-            if (doExecutableSearch && shouldVerifyPathExecutable(cmdline) && !cmdBuiltin) {
+            if (doExecutableSearch && args.length == rawArgs.length && shouldVerifyPathExecutable(cmdline) && !cmdBuiltin) {
                 verifyExecutable();
                 // replace cmdline with found executable
                 cmdline = executableFile.getAbsolutePath();

--- a/core/src/main/java/org/jruby/util/ShellLauncher.java
+++ b/core/src/main/java/org/jruby/util/ShellLauncher.java
@@ -1173,6 +1173,8 @@ public class ShellLauncher {
             String cmdline = rawArgs[0].toString().trim();
             if (doExecutableSearch && shouldVerifyPathExecutable(cmdline) && !cmdBuiltin) {
                 verifyExecutable();
+                // replace cmdline with found executable
+                cmdline = executableFile.getAbsolutePath();
             }
 
             // now, prepare the exec args
@@ -1648,7 +1650,7 @@ public class ShellLauncher {
     }
 
     private static String getShell(Ruby runtime) {
-        return RbConfigLibrary.jrubyShell();
+        return findPathExecutable(runtime, RbConfigLibrary.jrubyShell()).getAbsolutePath();
     }
 
     public static boolean shouldUseShell(String command) {

--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -146,6 +146,12 @@ project 'JRuby Lib Setup' do
 
     log 'install gems unless already installed'
     ENV_JAVA['jars.skip'] = 'true'
+
+    # force Ruby command to "jruby" for the generated Windows bat files since we install using 9.1.17.0 jar file
+    Gem.singleton_class.send(:define_method, :ruby) do
+      File.join(global_bin, "jruby#{RbConfig::CONFIG['EXEEXT']}")
+    end
+
     ctx.project.artifacts.select do |a|
       a.group_id == 'rubygems' || a.group_id == 'org.jruby.gems'
     end.each do |a|

--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -120,9 +120,6 @@ project 'JRuby Lib Setup' do
     stdlib_dir = File.join( ruby_dir, 'stdlib' )
     jruby_home = ctx.project.parent.basedir.to_pathname
 
-    # bin location for global binstubs
-    global_bin = File.join( jruby_home, "bin" )
-
     FileUtils.mkdir_p( default_specs )
 
     # have an empty openssl.rb so we do not run in trouble with not having
@@ -146,6 +143,9 @@ project 'JRuby Lib Setup' do
 
     log 'install gems unless already installed'
     ENV_JAVA['jars.skip'] = 'true'
+
+    # bin location for global binstubs
+    global_bin = File.join( jruby_home, "bin" )
 
     # force Ruby command to "jruby" for the generated Windows bat files since we install using 9.1.17.0 jar file
     Gem.singleton_class.send(:define_method, :ruby) do

--- a/test/jruby/test_exec.rb
+++ b/test/jruby/test_exec.rb
@@ -1,0 +1,17 @@
+require 'test/unit'
+require 'rbconfig'
+require 'tempfile'
+
+class TestExec < Test::Unit::TestCase
+  if RbConfig::CONFIG['host_os'] =~ /Windows|mswin/
+    # GH-6745
+    def test_exec_finds_bat_files_on_windows
+      Tempfile.open([__method__.to_s, ".bat"]) do |f|
+        path = File.dirname(f)
+        f.write "@echo hello"
+        f.flush
+        assert_equal "hello\n", `jruby -e "exec '#{f.path.gsub(".bat", "")}'"`
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR contains various small fixes for the native `exec` support on Windows, mostly relating to finding the full paths to cmd.exe and the .exe/.com/.bat/.cmd executables that go with a given command.

See #6745.