### PR TITLE
Fixes #6242. Sorbet srb init crashes

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -108,7 +108,7 @@ public class Java implements Library {
     public void load(Ruby runtime, boolean wrap) {
         final RubyModule Java = createJavaModule(runtime);
 
-        JavaPackage.createJavaPackageClass(runtime, Java);
+        runtime.getJavaSupport().setJavaPackageClass(JavaPackage.createJavaPackageClass(runtime, Java));
 
         org.jruby.javasupport.ext.Kernel.define(runtime);
         org.jruby.javasupport.ext.Module.define(runtime);

--- a/core/src/main/java/org/jruby/javasupport/JavaPackage.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaPackage.java
@@ -58,7 +58,7 @@ import static org.jruby.runtime.Visibility.PRIVATE;
 @JRubyClass(name="Java::JavaPackage", parent="Module")
 public class JavaPackage extends RubyModule {
 
-    static RubyModule createJavaPackageClass(final Ruby runtime, final RubyModule Java) {
+    static RubyClass createJavaPackageClass(final Ruby runtime, final RubyModule Java) {
         RubyClass superClass = new BlankSlateWrapper(runtime, runtime.getModule(), runtime.getKernel());
         RubyClass JavaPackage = RubyClass.newClass(runtime, superClass);
         JavaPackage.setMetaClass(runtime.getModule());
@@ -66,9 +66,7 @@ public class JavaPackage extends RubyModule {
         ((MetaClass) JavaPackage.makeMetaClass(superClass)).setAttached(JavaPackage);
 
         JavaPackage.setBaseName("JavaPackage");
-
         JavaPackage.setParent(Java);
-        Java.setConstant("JavaPackage", JavaPackage); // Java::JavaPackage
         // JavaPackage.setReifiedClass(JavaPackage.class);
 
         JavaPackage.defineAnnotatedMethods(JavaPackage.class);

--- a/core/src/main/java/org/jruby/javasupport/JavaSupport.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupport.java
@@ -148,7 +148,7 @@ public abstract class JavaSupport {
     public abstract RubyClass getJavaClassClass();
 
     public abstract RubyClass getJavaPackageClass();
-    public abstract void setJavaPackageClass(RubyClass javaPackageClass);
+    abstract void setJavaPackageClass(RubyClass javaPackageClass);
 
     public abstract RubyModule getJavaInterfaceTemplate();
 

--- a/core/src/main/java/org/jruby/javasupport/JavaSupport.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupport.java
@@ -147,7 +147,8 @@ public abstract class JavaSupport {
 
     public abstract RubyClass getJavaClassClass();
 
-    public abstract RubyClass getJavaPackageClass() ;
+    public abstract RubyClass getJavaPackageClass();
+    public abstract void setJavaPackageClass(RubyClass javaPackageClass);
 
     public abstract RubyModule getJavaInterfaceTemplate();
 

--- a/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupportImpl.java
@@ -218,9 +218,11 @@ public class JavaSupportImpl extends JavaSupport {
     }
 
     public RubyClass getJavaPackageClass() {
-        RubyClass clazz;
-        if ((clazz = javaPackageClass) != null) return clazz;
-        return javaPackageClass = getJavaModule().getClass("JavaPackage");
+        return javaPackageClass;
+    }
+
+    public void setJavaPackageClass(RubyClass javaPackageClass) {
+        this.javaPackageClass = javaPackageClass;
     }
 
     public RubyModule getJavaInterfaceTemplate() {

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -1079,31 +1079,24 @@ class TestHigherJavasupport < Test::Unit::TestCase
   end if ALLOW_UPPERCASE_PACKAGE_NAMES
 
   def test_package_class
+    # Java::JavaPackage is now not directly accessible as a normal constant but it still exists.
+    # We can still test by asking for the name of the class
+    java_package = "Java::JavaPackage"
     assert org.jruby.class.is_a?(Class)
-    assert_equal org.jruby.class, Java::JavaPackage
-    assert_equal Java::OrgJrubyJavasupport.class, Java::JavaPackage
+    assert_equal org.jruby.class.name, java_package
+    assert_equal Java::OrgJrubyJavasupport.class.name, java_package
 
     assert org.jruby.singleton_class.is_a?(Class)
     assert_not_equal org.jruby.singleton_class, org.jruby.class
     assert_not_equal org.jruby.singleton_class, org.jruby.javasupport.singleton_class
-
-    # really to avoid unexpected outcomes for Class instances :
-
-    assert Java::JavaPackage.is_a?(Module)
-    # can not make it a Module instance "only", really
-    if Java::JavaPackage.is_a?(Class)
-      assert_equal Module, Java::JavaPackage.superclass
-    end
   end
 
   def test_package_name_colliding_with_name_method
     assert_equal 'Java::OrgJrubyJavasupport', org.jruby.javasupport.name
     assert_equal true, org.jruby.javasupport.respond_to?(:name)
-    assert org.jruby.javasupport.test.is_a?(Java::JavaPackage)
 
     assert_equal 'Java::OrgJrubyJavasupportTest', org.jruby.javasupport.test.name
     # we can use :: to access the name package :
-    assert Java::OrgJrubyJavasupportTestName.is_a?(Java::JavaPackage)
     assert Java::OrgJrubyJavasupportTestName::Sample
   end
 
@@ -1461,12 +1454,10 @@ CLASSDEF
 
   # JRUBY-781
   def test_that_classes_beginning_with_small_letter_can_be_referenced
-    assert_equal Java::JavaPackage, org.jruby.test.smallLetterClazz.class
     assert org.jruby.test.smallLetterClazz.is_a?(Module)
     assert ! org.jruby.test.smallLetterClazz.is_a?(Class)
     
     assert_equal Class, org.jruby.test.smallLetterClass.class
-    assert ! org.jruby.test.smallLetterClass.is_a?(Java::JavaPackage)
   end
 
   Module.send :remove_method, :attr


### PR DESCRIPTION
The fix here is to not register JavaPackage as a constant of Java.
This prevents srb from finding it via constants.  So the problem class
is never seen.

Note: I think in the scenario of walking ObjectSpace we can still run
across this but that may be another issue to deal with when we experience it.

The explanation of what is wrong is that JavaPackage is in fact a Class but
due to how we want it to behave we set its metaclass to Module.  When srb
retrieves an UnboundMethod off of Class that method cannot be bound to this
type because it says "nope I am a module" (even though it is actually a class).