### PR TITLE
Fix failures in ruby/spec running with immediate jit mode

### DIFF
--- a/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/MixedModeIRBlockBody.java
@@ -113,8 +113,6 @@ public class MixedModeIRBlockBody extends IRBlockBody implements Compilable<Comp
 
     @Override
     protected IRubyObject commonYieldPath(ThreadContext context, Block block, Block.Type type, IRubyObject[] args, IRubyObject self, Block blockArg) {
-        if (callCount >= 0) promoteToFullBuild(context);
-
         InterpreterContext ic = ensureInstrsReady();
 
         Binding binding = block.getBinding();
@@ -139,6 +137,9 @@ public class MixedModeIRBlockBody extends IRBlockBody implements Compilable<Comp
         }
         finally {
             postYield(context, ic, binding, oldVis, prevFrame);
+
+            // trigger JIT on the trailing edge, so we make a best effort to not interpret again after jitting
+            if (callCount >= 0) promoteToFullBuild(context);
         }
     }
 

--- a/spec/jruby.mspec
+++ b/spec/jruby.mspec
@@ -92,19 +92,21 @@ class MSpecScript
 
   get(:ci_xtags) << HOST_OS
 
+  instance_config = JRuby.runtime.instance_config
+
   if WINDOWS
     # Some specs on Windows will fail in we launch JRuby via
     # ruby_exe() in-process (see core/argf/gets_spec.rb)
-    JRuby.runtime.instance_config.run_ruby_in_process = false
+    instance_config.run_ruby_in_process = false
 
     # exclude specs tagged with 'windows' keyword
     get(:ci_xtags) << 'windows'
   end
 
-  # If running specs with jit threshold = 1 or force (AOT) compile, additional tags
-  if JRuby.runtime.instance_config.compile_mode.to_s == "FORCE" ||
-      JRuby.runtime.instance_config.jit_threshold == 1
-    get(:ci_xtags) << 'compiler'
+  # If running specs with jit threshold = 0 or force (AOT) compile, additional tags
+  if instance_config.compile_mode.to_s == "FORCE" ||
+      instance_config.jit_threshold == 0
+    get(:ci_xtags) << 'jit'
   end
 
   # This set of files is run by mspec ci

--- a/spec/tags/ruby/core/binding/eval_tags.txt
+++ b/spec/tags/ruby/core/binding/eval_tags.txt
@@ -1,0 +1,5 @@
+jit(jit never pushes backtrace so file and line are from nearest interp scope, GH-6163):Binding#eval inherits __LINE__ from the enclosing scope
+jit(jit never pushes backtrace so file and line are from nearest interp scope, GH-6163):Binding#eval preserves __LINE__ across multiple calls to eval
+jit(jit never pushes backtrace so file and line are from nearest interp scope, GH-6163):Binding#eval preserves __LINE__ across multiple calls to eval
+jit(jit never pushes backtrace so file and line are from nearest interp scope, GH-6163):Binding#eval inherits __LINE__ from the enclosing scope even if the Binding is created with #send
+jit(jit never pushes backtrace so file and line are from nearest interp scope, GH-6163):Binding#eval inherits __FILE__ from the enclosing scope

--- a/spec/tags/ruby/core/binding/eval_tags.txt
+++ b/spec/tags/ruby/core/binding/eval_tags.txt
@@ -1,5 +1,5 @@
 jit(jit never pushes backtrace so file and line are from nearest interp scope, GH-6163):Binding#eval inherits __LINE__ from the enclosing scope
 jit(jit never pushes backtrace so file and line are from nearest interp scope, GH-6163):Binding#eval preserves __LINE__ across multiple calls to eval
-jit(jit never pushes backtrace so file and line are from nearest interp scope, GH-6163):Binding#eval preserves __LINE__ across multiple calls to eval
+jit(jit never pushes backtrace so file and line are from nearest interp scope, GH-6163):Binding#eval increments __LINE__ on each line of a multiline eval
 jit(jit never pushes backtrace so file and line are from nearest interp scope, GH-6163):Binding#eval inherits __LINE__ from the enclosing scope even if the Binding is created with #send
 jit(jit never pushes backtrace so file and line are from nearest interp scope, GH-6163):Binding#eval inherits __FILE__ from the enclosing scope

--- a/spec/tags/ruby/core/proc/new_tags.txt
+++ b/spec/tags/ruby/core/proc/new_tags.txt
@@ -1,0 +1,1 @@
+jit(never really worked, deprecated in 2.7):Proc.new with an associated block returns a new Proc instance from the block passed to the containing method

--- a/spec/tags/ruby/core/string/slice_tags.txt
+++ b/spec/tags/ruby/core/string/slice_tags.txt
@@ -1,1 +1,4 @@
 fails:String#slice with index, length returns nil if the offset falls outside of self
+jit(transition with threshold=0 may lose tainting, GH-6757):String#slice with Regexp always taints resulting strings when self or regexp is tainted
+jit(transition with threshold=0 may lose tainting, GH-6757):String#slice with Regexp, index always taints resulting strings when self or regexp is tainted
+jit(transition with threshold=0 may lose tainting, GH-6757):String#slice with Regexp, group always taints resulting strings when self or regexp is tainted

--- a/spec/tags/ruby/language/regexp_tags.txt
+++ b/spec/tags/ruby/language/regexp_tags.txt
@@ -1,0 +1,1 @@
+jit(transition from interpreter will cause a new regexp object to be created):Literal Regexps caches the Regexp object


### PR DESCRIPTION
See #6753 for the PR that initiated this work, by @ahorek. That PR has been superseded by this one, which includes the added jit job and will eventually contain all fixes to get that job green.