### PR TITLE
Fixes #6748. Inconsistent encoding when calling #to_s on arrays.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,7 +24,7 @@ DO NOT MODIFIY - GENERATED CODE
     <build.lib.dir>test/target</build.lib.dir>
     <create.sources.jar>false</create.sources.jar>
     <dest.lib.dir>${lib.dir}</dest.lib.dir>
-    <install4j.executable>/Applications/install4j7/bin/install4jc</install4j.executable>
+    <install4j.executable>/Applications/install4j9/bin/install4jc</install4j.executable>
     <installer.gems>${jruby.win32ole.gem}</installer.gems>
     <jay.bin>jay</jay.bin>
     <jflex.bin>jflex</jflex.bin>

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -50,6 +50,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.RandomAccess;
+
+import org.jcodings.Encoding;
 import org.jcodings.specific.USASCIIEncoding;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
@@ -1670,7 +1672,8 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      */
     protected IRubyObject inspectAry(ThreadContext context) {
         final Ruby runtime = context.runtime;
-        RubyString str = RubyString.newStringLight(runtime, DEFAULT_INSPECT_STR_SIZE, USASCIIEncoding.INSTANCE);
+        Encoding encoding = runtime.getDefaultExternalEncoding();
+        RubyString str = RubyString.newStringLight(runtime, DEFAULT_INSPECT_STR_SIZE, encoding.isAsciiCompatible() ? encoding : USASCIIEncoding.INSTANCE);
         str.cat((byte) '[');
         boolean tainted = isTaint();
 
@@ -1680,11 +1683,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
             if (s.isTaint()) tainted = true;
             if (i > 0) {
                 ByteList bytes = str.getByteList();
-                bytes.ensure(2 + s.size() + 1);
                 bytes.append((byte) ',').append((byte) ' ');
-            }
-            else {
-                str.setEncoding(s.getEncoding());
             }
             str.cat19(s);
         }

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -84,6 +84,7 @@ import org.jruby.util.Pack;
 import org.jruby.util.RecursiveComparator;
 import org.jruby.util.TypeConverter;
 import org.jruby.util.cli.Options;
+import org.jruby.util.io.EncodingUtils;
 
 import static org.jruby.RubyEnumerator.SizeFn;
 import static org.jruby.RubyEnumerator.enumeratorize;
@@ -1672,8 +1673,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      */
     protected IRubyObject inspectAry(ThreadContext context) {
         final Ruby runtime = context.runtime;
-        Encoding encoding = runtime.getDefaultExternalEncoding();
-        RubyString str = RubyString.newStringLight(runtime, DEFAULT_INSPECT_STR_SIZE, encoding.isAsciiCompatible() ? encoding : USASCIIEncoding.INSTANCE);
+        RubyString str = RubyString.newStringLight(runtime, DEFAULT_INSPECT_STR_SIZE, USASCIIEncoding.INSTANCE);
         str.cat((byte) '[');
         boolean tainted = isTaint();
 
@@ -1684,6 +1684,8 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
             if (i > 0) {
                 ByteList bytes = str.getByteList();
                 bytes.append((byte) ',').append((byte) ' ');
+            } else {
+                EncodingUtils.encAssociateIndex(str, s.getEncoding());
             }
             str.cat19(s);
         }

--- a/core/src/main/java/org/jruby/specialized/RubyArrayOneObject.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArrayOneObject.java
@@ -10,6 +10,7 @@ import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.io.EncodingUtils;
 
 import static org.jruby.runtime.Helpers.arrayOf;
 
@@ -135,13 +136,13 @@ public class RubyArrayOneObject extends RubyArraySpecialized {
         if (!packed()) return super.inspectAry(context);
 
         final Ruby runtime = context.runtime;
-        Encoding encoding = runtime.getDefaultExternalEncoding();
-        RubyString str = RubyString.newStringLight(runtime, DEFAULT_INSPECT_STR_SIZE, encoding.isAsciiCompatible() ? encoding : USASCIIEncoding.INSTANCE);
+        RubyString str = RubyString.newStringLight(runtime, DEFAULT_INSPECT_STR_SIZE, USASCIIEncoding.INSTANCE);
         str.cat((byte) '[');
         boolean tainted = isTaint();
 
         RubyString s = inspect(context, value);
         if (s.isTaint()) tainted = true;
+        EncodingUtils.encAssociateIndex(str, s.getEncoding());
         str.cat19(s);
 
         str.cat((byte) ']');

--- a/core/src/main/java/org/jruby/specialized/RubyArrayOneObject.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArrayOneObject.java
@@ -1,5 +1,6 @@
 package org.jruby.specialized;
 
+import org.jcodings.Encoding;
 import org.jcodings.specific.USASCIIEncoding;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
@@ -134,13 +135,13 @@ public class RubyArrayOneObject extends RubyArraySpecialized {
         if (!packed()) return super.inspectAry(context);
 
         final Ruby runtime = context.runtime;
-        RubyString str = RubyString.newStringLight(runtime, DEFAULT_INSPECT_STR_SIZE, USASCIIEncoding.INSTANCE);
+        Encoding encoding = runtime.getDefaultExternalEncoding();
+        RubyString str = RubyString.newStringLight(runtime, DEFAULT_INSPECT_STR_SIZE, encoding.isAsciiCompatible() ? encoding : USASCIIEncoding.INSTANCE);
         str.cat((byte) '[');
         boolean tainted = isTaint();
 
         RubyString s = inspect(context, value);
         if (s.isTaint()) tainted = true;
-        else str.setEncoding(s.getEncoding());
         str.cat19(s);
 
         str.cat((byte) ']');

--- a/core/src/main/java/org/jruby/specialized/RubyArrayTwoObject.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArrayTwoObject.java
@@ -1,5 +1,6 @@
 package org.jruby.specialized;
 
+import org.jcodings.Encoding;
 import org.jcodings.specific.USASCIIEncoding;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
@@ -150,22 +151,20 @@ public class RubyArrayTwoObject extends RubyArraySpecialized {
         if (!packed()) return super.inspectAry(context);
 
         final Ruby runtime = context.runtime;
-        RubyString str = RubyString.newStringLight(runtime, DEFAULT_INSPECT_STR_SIZE, USASCIIEncoding.INSTANCE);
+        Encoding encoding = runtime.getDefaultExternalEncoding();
+        RubyString str = RubyString.newStringLight(runtime, DEFAULT_INSPECT_STR_SIZE, encoding.isAsciiCompatible() ? encoding : USASCIIEncoding.INSTANCE);
         str.cat((byte) '[');
         boolean tainted = isTaint();
 
         RubyString s1 = inspect(context, car);
         RubyString s2 = inspect(context, cdr);
         if (s1.isTaint()) tainted = true;
-        else str.setEncoding(s1.getEncoding());
         str.cat19(s1);
 
         ByteList bytes = str.getByteList();
-        bytes.ensure(2 + s2.size() + 1);
         bytes.append((byte) ',').append((byte) ' ');
 
         if (s2.isTaint()) tainted = true;
-        else str.setEncoding(s2.getEncoding());
         str.cat19(s2);
 
         str.cat((byte) ']');

--- a/core/src/main/java/org/jruby/specialized/RubyArrayTwoObject.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArrayTwoObject.java
@@ -15,6 +15,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.invokedynamic.MethodNames;
 import org.jruby.util.ByteList;
+import org.jruby.util.io.EncodingUtils;
 
 import static org.jruby.runtime.Helpers.arrayOf;
 import static org.jruby.runtime.Helpers.invokedynamic;
@@ -151,14 +152,14 @@ public class RubyArrayTwoObject extends RubyArraySpecialized {
         if (!packed()) return super.inspectAry(context);
 
         final Ruby runtime = context.runtime;
-        Encoding encoding = runtime.getDefaultExternalEncoding();
-        RubyString str = RubyString.newStringLight(runtime, DEFAULT_INSPECT_STR_SIZE, encoding.isAsciiCompatible() ? encoding : USASCIIEncoding.INSTANCE);
+        RubyString str = RubyString.newStringLight(runtime, DEFAULT_INSPECT_STR_SIZE, USASCIIEncoding.INSTANCE);
         str.cat((byte) '[');
         boolean tainted = isTaint();
 
         RubyString s1 = inspect(context, car);
         RubyString s2 = inspect(context, cdr);
         if (s1.isTaint()) tainted = true;
+        EncodingUtils.encAssociateIndex(str, s1.getEncoding());
         str.cat19(s1);
 
         ByteList bytes = str.getByteList();

--- a/core/src/main/java/org/jruby/util/io/EncodingUtils.java
+++ b/core/src/main/java/org/jruby/util/io/EncodingUtils.java
@@ -816,8 +816,7 @@ public class EncodingUtils {
         if (((EncodingCapable)obj).getEncoding() == encidx) {
             return obj;
         }
-        if (obj instanceof RubyString &&
-                ! CodeRangeSupport.isCodeRangeAsciiOnly((RubyString) obj) ||
+        if (obj instanceof RubyString && !CodeRangeSupport.isCodeRangeAsciiOnly((RubyString) obj) ||
                 encAsciicompat(encidx)) {
             ((RubyString)obj).clearCodeRange();
         }


### PR DESCRIPTION
The main problem with the original code was that we would:

```java
    str.setEncoding(s.getEncoding());
```

Where s is an inspected element of the array.  MRI will call
rb_enc_associate which may setEncoding but might not.  In fact,
rb_enc_associate has a lot of logic which I don't really understand.
What I mean by that is that we call str.cat19 which will also do the
appropriate encoding negotiation of building up the result inspect
string.  Why add this extra method into the mix?

I opted to just let cat19 do its thing and spec:ruby:fast passed.

A second change I made was to make the inspect string use default_external
unless it is an encoding which does not support ascii (which is needed since
inspect is adding ascii like '[').  In the non-ascii case we just default to
US-ASCII.  Thankfully spec/ruby already has specs for this.