### PR TITLE
Undo shared-buffer optimizations from #6557

### DIFF
--- a/core/src/main/java/org/jruby/util/IOChannel.java
+++ b/core/src/main/java/org/jruby/util/IOChannel.java
@@ -94,24 +94,33 @@ public abstract class IOChannel implements Channel {
         return returnValue;
     }
 
+    /**
+     * Perform a write to the given IO-like object, using the given call site, and passing the contents of the given
+     * buffer.
+     *
+     * The buffer and its contents should not be referenced beyond the method's return.
+     *
+     * @param runtime the current runtime
+     * @param io the target IO-like object
+     * @param write the call site for making dynamic `write` calls
+     * @param src the data to write
+     * @return the amount of data reported written by the dynamic `write` call
+     */
     protected static int write(Ruby runtime, IRubyObject io, CallSite write, ByteBuffer src) {
-        RubyString string;
+        ByteList buffer;
         int position = src.position();
         int remaining = src.remaining();
 
-        // wrap buffer contents with String
+        // copy buffer contents to a ByteList
         if (src.hasArray()) {
-            // wrap heap src with shared string to prevent target from modifying our buffer (GH-4903)
-            string = RubyString.newStringShared(runtime, src.array(), position, remaining);
+            buffer = new ByteList(src.array(), src.position(), remaining, true);
         } else {
-            // copy native src to heap bytes to use in string
-            byte[] bytes = new byte[remaining];
-            src.duplicate().get(bytes);
-            string = RubyString.newStringNoCopy(runtime, bytes);
+            buffer = new ByteList(remaining);
+            buffer.append(src, remaining);
         }
 
         // call write with new String based on this ByteList
-        IRubyObject written = write.call(runtime.getCurrentContext(), io, io, string);
+        IRubyObject written = write.call(runtime.getCurrentContext(), io, io, RubyString.newStringLight(runtime, buffer));
         int wrote = written.convertToInteger().getIntValue();
 
         // set source position to match bytes written

--- a/core/src/test/java/org/jruby/util/TestIOChannel.java
+++ b/core/src/test/java/org/jruby/util/TestIOChannel.java
@@ -1,0 +1,37 @@
+package org.jruby.util;
+
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.ext.stringio.StringIO;
+import org.jruby.runtime.Block;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+public class TestIOChannel {
+    Ruby runtime;
+
+    @Before
+    public void setup() {
+        runtime = Ruby.newInstance();
+        runtime.evalScriptlet("class MyO; def write(str); @str = str; str.length; end; end");
+    }
+
+    @Test
+    public void testBufferReuse() throws Exception {
+        ThreadContext context = runtime.getCurrentContext();
+        IRubyObject myo = runtime.getClass("MyO").newInstance(context, Block.NULL_BLOCK);
+        IOChannel.IOWritableByteChannel ioc = new IOChannel.IOWritableByteChannel(myo);
+        ByteBuffer buf = ByteBuffer.wrap(new byte[] {(byte) 'f', (byte) 'o', (byte) 'o'});
+        ioc.write(buf);
+
+        IRubyObject written = myo.getInstanceVariables().getInstanceVariable("@str");
+        Assert.assertEquals("foo", written.toString());
+        buf.put(0, (byte)'b');
+        Assert.assertEquals("foo", written.toString());
+    }
+}


### PR DESCRIPTION
The "optimizations" in #6557 were overzealous:

* The incoming ByteBuffer and its contents should not be
  referenced past the end of the call, as was done here by
  returning a String that directly wraps the buffer's underlying
  array.
* The copy of bytes out of the native buffer is essentially the
  same as calling #duplicate, so this is just unnecessary double-
  copying.

Fixes #6767.