### PR TITLE
Use line number of scope for initial backtrace

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRBodyMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRBodyMethod.java
@@ -70,7 +70,7 @@ public class InterpretedIRBodyMethod extends InterpretedIRMethod {
 
     private IRubyObject interpretWithBacktrace(InterpreterContext ic, ThreadContext context, IRubyObject self, String name, Block block) {
         try {
-            ThreadContext.pushBacktrace(context, name, ic.getFileName(), context.getLine());
+            ThreadContext.pushBacktrace(context, name, ic.getFileName(), ic.getLine());
             return ic.getEngine().interpret(context, null, self, ic, getImplementationClass().getMethodLocation(), name, block);
         } finally {
             ThreadContext.popBacktrace(context);

--- a/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
@@ -77,7 +77,7 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
     private IRubyObject INTERPRET_METHOD(ThreadContext context, InterpreterContext ic, RubyModule implClass,
                                          IRubyObject self, String name, IRubyObject[] args, Block block) {
         try {
-            ThreadContext.pushBacktrace(context, name, ic.getFileName(), context.getLine());
+            ThreadContext.pushBacktrace(context, name, ic.getFileName(), ic.getLine());
 
             if (ic.hasExplicitCallProtocol()) {
                 return ic.getEngine().interpret(context, null, self, ic, implClass, name, args, block);
@@ -113,7 +113,7 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
     private IRubyObject INTERPRET_METHOD(ThreadContext context, InterpreterContext ic, RubyModule implClass,
                                          IRubyObject self, String name, Block block) {
         try {
-            ThreadContext.pushBacktrace(context, name, ic.getFileName(), context.getLine());
+            ThreadContext.pushBacktrace(context, name, ic.getFileName(), ic.getLine());
 
             if (ic.hasExplicitCallProtocol()) {
                 return ic.getEngine().interpret(context, null, self, ic, implClass, name, block);
@@ -149,7 +149,7 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
     private IRubyObject INTERPRET_METHOD(ThreadContext context, InterpreterContext ic, RubyModule implClass,
                                          IRubyObject self, String name, IRubyObject arg1, Block block) {
         try {
-            ThreadContext.pushBacktrace(context, name, ic.getFileName(), context.getLine());
+            ThreadContext.pushBacktrace(context, name, ic.getFileName(), ic.getLine());
 
             if (ic.hasExplicitCallProtocol()) {
                 return ic.getEngine().interpret(context, null, self, ic, implClass, name, arg1, block);
@@ -185,7 +185,7 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
     private IRubyObject INTERPRET_METHOD(ThreadContext context, InterpreterContext ic, RubyModule implClass,
                                          IRubyObject self, String name, IRubyObject arg1, IRubyObject arg2,  Block block) {
         try {
-            ThreadContext.pushBacktrace(context, name, ic.getFileName(), context.getLine());
+            ThreadContext.pushBacktrace(context, name, ic.getFileName(), ic.getLine());
 
             if (ic.hasExplicitCallProtocol()) {
                 return ic.getEngine().interpret(context, null, self, ic, implClass, name, arg1, arg2, block);
@@ -221,7 +221,7 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
     private IRubyObject INTERPRET_METHOD(ThreadContext context, InterpreterContext ic, RubyModule implClass,
                                          IRubyObject self, String name, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3, Block block) {
         try {
-            ThreadContext.pushBacktrace(context, name, ic.getFileName(), context.getLine());
+            ThreadContext.pushBacktrace(context, name, ic.getFileName(), ic.getLine());
 
             if (ic.hasExplicitCallProtocol()) {
                 return ic.getEngine().interpret(context, null, self, ic, implClass, name, arg1, arg2, arg3, block);

--- a/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
@@ -76,7 +76,7 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
     private IRubyObject INTERPRET_METHOD(ThreadContext context, InterpreterContext ic, RubyModule implClass,
                                                IRubyObject self, String name, IRubyObject[] args, Block block) {
         try {
-            ThreadContext.pushBacktrace(context, name, ic.getFileName(), context.getLine());
+            ThreadContext.pushBacktrace(context, name, ic.getFileName(), ic.getLine());
 
             if (ic.hasExplicitCallProtocol()) {
                 return ic.getEngine().interpret(context, null, self, ic, implClass, name, args, block);
@@ -111,7 +111,7 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
     private IRubyObject INTERPRET_METHOD(ThreadContext context, InterpreterContext ic, RubyModule implClass,
                                                IRubyObject self, String name, Block block) {
         try {
-            ThreadContext.pushBacktrace(context, name, ic.getFileName(), context.getLine());
+            ThreadContext.pushBacktrace(context, name, ic.getFileName(), ic.getLine());
 
             if (ic.hasExplicitCallProtocol()) {
                 return ic.getEngine().interpret(context, null, self, ic, implClass, name, block);
@@ -146,7 +146,7 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
     private IRubyObject INTERPRET_METHOD(ThreadContext context, InterpreterContext ic, RubyModule implClass,
                                                IRubyObject self, String name, IRubyObject arg1, Block block) {
         try {
-            ThreadContext.pushBacktrace(context, name, ic.getFileName(), context.getLine());
+            ThreadContext.pushBacktrace(context, name, ic.getFileName(), ic.getLine());
 
             if (ic.hasExplicitCallProtocol()) {
                 return ic.getEngine().interpret(context, null, self, ic, implClass, name, arg1, block);
@@ -181,7 +181,7 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
     private IRubyObject INTERPRET_METHOD(ThreadContext context, InterpreterContext ic, RubyModule implClass,
                                                IRubyObject self, String name, IRubyObject arg1, IRubyObject arg2,  Block block) {
         try {
-            ThreadContext.pushBacktrace(context, name, ic.getFileName(), context.getLine());
+            ThreadContext.pushBacktrace(context, name, ic.getFileName(), ic.getLine());
 
             if (ic.hasExplicitCallProtocol()) {
                 return ic.getEngine().interpret(context, null, self, ic, implClass, name, arg1, arg2, block);
@@ -216,7 +216,7 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
     private IRubyObject INTERPRET_METHOD(ThreadContext context, InterpreterContext ic, RubyModule implClass,
                                                IRubyObject self, String name, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3, Block block) {
         try {
-            ThreadContext.pushBacktrace(context, name, ic.getFileName(), context.getLine());
+            ThreadContext.pushBacktrace(context, name, ic.getFileName(), ic.getLine());
 
             if (ic.hasExplicitCallProtocol()) {
                 return ic.getEngine().interpret(context, null, self, ic, implClass, name, arg1, arg2, arg3, block);

--- a/core/src/main/java/org/jruby/ir/instructions/DefineClassInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/DefineClassInstr.java
@@ -90,7 +90,7 @@ public class DefineClassInstr extends TwoOperandResultBaseInstr implements Fixed
         if (!hasExplicitCallProtocol) pre(ic, context, clazz, null, clazz);
 
         try {
-            ThreadContext.pushBacktrace(context, id, ic.getFileName(), context.getLine());
+            ThreadContext.pushBacktrace(context, id, ic.getFileName(), ic.getLine());
             return ic.getEngine().interpret(context, null, clazz, ic, clazz.getMethodLocation(), id, Block.NULL_BLOCK);
         } finally {
             body.cleanupAfterExecution();

--- a/core/src/main/java/org/jruby/ir/instructions/DefineModuleInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/DefineModuleInstr.java
@@ -77,7 +77,7 @@ public class DefineModuleInstr extends OneOperandResultBaseInstr implements Fixe
         if (!hasExplicitCallProtocol) pre(ic, context, clazz, null, clazz);
 
         try {
-            ThreadContext.pushBacktrace(context, id, ic.getFileName(), context.getLine());
+            ThreadContext.pushBacktrace(context, id, ic.getFileName(), ic.getLine());
             return ic.getEngine().interpret(context, null, clazz, ic, clazz.getMethodLocation(), id, Block.NULL_BLOCK);
         } finally {
             body.cleanupAfterExecution();

--- a/core/src/main/java/org/jruby/ir/interpreter/Interpreter.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/Interpreter.java
@@ -92,7 +92,7 @@ public class Interpreter extends IRTranslator<IRubyObject, IRubyObject> {
     public static IRubyObject INTERPRET_ROOT(ThreadContext context, IRubyObject self,
            InterpreterContext ic, RubyModule clazz, String name) {
         try {
-            ThreadContext.pushBacktrace(context, name, ic.getFileName(), context.getLine());
+            ThreadContext.pushBacktrace(context, name, ic.getFileName(), ic.getLine());
             return ic.getEngine().interpret(context, null, self, ic, clazz, name, IRubyObject.NULL_ARRAY, Block.NULL_BLOCK);
         } finally {
             ThreadContext.popBacktrace(context);
@@ -102,7 +102,7 @@ public class Interpreter extends IRTranslator<IRubyObject, IRubyObject> {
     public static IRubyObject INTERPRET_EVAL(ThreadContext context, IRubyObject self,
            InterpreterContext ic, RubyModule clazz, IRubyObject[] args, String name, Block blockArg) {
         try {
-            ThreadContext.pushBacktrace(context, name, ic.getFileName(), context.getLine());
+            ThreadContext.pushBacktrace(context, name, ic.getFileName(), ic.getLine());
             return ic.getEngine().interpret(context, null, self, ic, clazz, name, args, blockArg);
         } finally {
             ThreadContext.popBacktrace(context);
@@ -112,7 +112,7 @@ public class Interpreter extends IRTranslator<IRubyObject, IRubyObject> {
     public static IRubyObject INTERPRET_BLOCK(ThreadContext context, Block block, IRubyObject self,
             InterpreterContext ic, IRubyObject[] args, String name, Block blockArg) {
         try {
-            ThreadContext.pushBacktrace(context, name, ic.getFileName(), context.getLine());
+            ThreadContext.pushBacktrace(context, name, ic.getFileName(), ic.getLine());
             return ic.getEngine().interpret(context, block, self, ic, null, name, args, blockArg);
         } finally {
             ThreadContext.popBacktrace(context);

--- a/core/src/main/java/org/jruby/ir/interpreter/InterpreterContext.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/InterpreterContext.java
@@ -171,6 +171,10 @@ public class InterpreterContext {
         return scope.getFile();
     }
 
+    public int getLine() {
+        return scope.getLine();
+    }
+
     public RubySymbol getName() {
         return scope.getManager().getRuntime().newSymbol(scope.getId());
     }


### PR DESCRIPTION
This code previously used the current line from context, which
would be the line of the caller invocation.

Fixes #6768