### PR TITLE
Fix detection of modularized java in mybinder environments

### DIFF
--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -160,7 +160,7 @@ else
 fi
 
 # Detect modularized Java
-if [ -f "$JAVA_HOME"/lib/modules ] || [ -f "$JAVA_HOME"/release ] && grep -q ^MODULES "$JAVA_HOME"/release; then
+if ([ -f "$JAVA_HOME"/release ] && [ grep -q ^MODULES "$JAVA_HOME"/release ]) || [ -f "$JAVA_HOME"/lib/modules ]; then
   use_modules=1
 fi
 


### PR DESCRIPTION
When using JRUBY in a mybinder.org container you get the following error due to an unconventional $JAVA_HOME path (`/srv/conda/envs/notebook`):

`grep: /srv/conda/envs/notebook/release: No such file or directory`

I think I did a decent proof within a small mybinder environment here, the steps can be replicated by running the jupyter notebook but the gist is that I added parenthesis around the last two conditions to force order of evaluation. I also reversed order so bash would evaluate my new expression first, which it does fine. Seems to work from my tests:
[jruby-mybinder](https://github.com/Ifiht/jruby-mybinder)
