### PR TITLE
restore api compatibility with nio4r

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -2227,6 +2227,11 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         enterSleep();
     }
 
+    @Deprecated
+    public void beforeBlockingCall() {
+        beforeBlockingCall(metaClass.runtime.getCurrentContext());
+    }
+
     public void afterBlockingCall() {
         exitSleep();
         pollThreadEvents();


### PR DESCRIPTION
introduced by https://github.com/jruby/jruby/commit/84ece2bba5ee9824fefb9f805df6314298154764

blockingThreadPoll was a public API and nio4r / puma use the method at https://github.com/socketry/nio4r/blob/master/ext/nio4r/org/nio4r/Selector.java#L237