### PR TITLE
Update stdlib

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -55,10 +55,10 @@ DO NOT MODIFIY - GENERATED CODE
     <test.results.dir>${build.dir}/test-results</test.results.dir>
     <tzdata.scope>provided</tzdata.scope>
     <tzdata.version>2019c</tzdata.version>
-    <version.ruby>2.6.5</version.ruby>
+    <version.ruby>2.6.8</version.ruby>
     <version.ruby.major>2.6</version.ruby.major>
     <version.ruby.minor>0</version.ruby.minor>
-    <version.ruby.revision>67812</version.ruby.revision>
+    <version.ruby.revision>67951</version.ruby.revision>
   </properties>
   <dependencies>
     <dependency>

--- a/default.build.properties
+++ b/default.build.properties
@@ -28,8 +28,8 @@ rake.args=
 install4j.executable=/Applications/install4j9/bin/install4jc
 
 # Ruby versions
-version.ruby=2.6.5
+version.ruby=2.6.8
 version.ruby.major=2.6
 version.ruby.minor=0
-version.ruby.revision=67812
+version.ruby.revision=67951
 

--- a/lib/ruby/stdlib/net/ftp.rb
+++ b/lib/ruby/stdlib/net/ftp.rb
@@ -97,6 +97,10 @@ module Net
     # When +true+, the connection is in passive mode.  Default: +true+.
     attr_accessor :passive
 
+    # When +true+, use the IP address in PASV responses.  Otherwise, it uses
+    # the same IP address for the control connection.  Default: +false+.
+    attr_accessor :use_pasv_ip
+
     # When +true+, all traffic to and from the server is written
     # to +$stdout+.  Default: +false+.
     attr_accessor :debug_mode
@@ -205,6 +209,9 @@ module Net
     #                          handshake.
     #                          See Net::FTP#ssl_handshake_timeout for
     #                          details.  Default: +nil+.
+    # use_pasv_ip::  When +true+, use the IP address in PASV responses.
+    #                Otherwise, it uses the same IP address for the control
+    #                connection.  Default: +false+.
     # debug_mode::  When +true+, all traffic to and from the server is
     #               written to +$stdout+.  Default: +false+.
     #
@@ -267,6 +274,7 @@ module Net
       @open_timeout = options[:open_timeout]
       @ssl_handshake_timeout = options[:ssl_handshake_timeout]
       @read_timeout = options[:read_timeout] || 60
+      @use_pasv_ip = options[:use_pasv_ip] || false
       if host
         connect(host, options[:port] || FTP_PORT)
         if options[:username]
@@ -1332,7 +1340,12 @@ module Net
         raise FTPReplyError, resp
       end
       if m = /\((?<host>\d+(,\d+){3}),(?<port>\d+,\d+)\)/.match(resp)
-        return parse_pasv_ipv4_host(m["host"]), parse_pasv_port(m["port"])
+        if @use_pasv_ip
+          host = parse_pasv_ipv4_host(m["host"])
+        else
+          host = @bare_sock.remote_address.ip_address
+        end
+        return host, parse_pasv_port(m["port"])
       else
         raise FTPProtoError, resp
       end

--- a/lib/ruby/stdlib/net/http/response.rb
+++ b/lib/ruby/stdlib/net/http/response.rb
@@ -262,12 +262,13 @@ class Net::HTTPResponse
 
       begin
         yield inflate_body_io
+        success = true
       ensure
-        orig_err = $!
         begin
           inflate_body_io.finish
         rescue => err
-          raise orig_err || err
+          # Ignore #finish's error if there is an exception from yield
+          raise err if success
         end
       end
     when 'none', 'identity' then

--- a/lib/ruby/stdlib/net/imap.rb
+++ b/lib/ruby/stdlib/net/imap.rb
@@ -1215,12 +1215,14 @@ module Net
       end
       resp = @tagged_responses.delete(tag)
       case resp.name
+      when /\A(?:OK)\z/ni
+        return resp
       when /\A(?:NO)\z/ni
         raise NoResponseError, resp
       when /\A(?:BAD)\z/ni
         raise BadResponseError, resp
       else
-        return resp
+        raise UnknownResponseError, resp
       end
     end
 
@@ -3714,6 +3716,10 @@ module Net
     # that the client is not being allowed to login, or has been timed
     # out due to inactivity.
     class ByeResponseError < ResponseError
+    end
+
+    # Error raised upon an unknown response from the server.
+    class UnknownResponseError < ResponseError
     end
 
     RESPONSE_ERRORS = Hash.new(ResponseError)

--- a/lib/ruby/stdlib/resolv.rb
+++ b/lib/ruby/stdlib/resolv.rb
@@ -697,13 +697,13 @@ class Resolv
           rescue DecodeError
             next # broken DNS message ignored
           end
-          if s = sender_for(from, msg)
+          if sender == sender_for(from, msg)
             break
           else
             # unexpected DNS message ignored
           end
         end
-        return msg, s.data
+        return msg, sender.data
       end
 
       def sender_for(addr, msg)

--- a/lib/ruby/stdlib/tmpdir.rb
+++ b/lib/ruby/stdlib/tmpdir.rb
@@ -90,7 +90,7 @@ class Dir
     }
     if block_given?
       begin
-        yield path
+        yield path.dup
       ensure
         unless base
           stat = File.stat(File.dirname(path))

--- a/lib/ruby/stdlib/uri/ldap.rb
+++ b/lib/ruby/stdlib/uri/ldap.rb
@@ -119,6 +119,7 @@ module URI
 
     # Private method to cleanup +dn+ from using the +path+ component attribute.
     def parse_dn
+      raise InvalidURIError, 'bad LDAP URL' unless @path
       @dn = @path[1..-1]
     end
     private :parse_dn

--- a/test/mri/net/ftp/test_ftp.rb
+++ b/test/mri/net/ftp/test_ftp.rb
@@ -61,7 +61,7 @@ class FTPTest < Test::Unit::TestCase
   end
 
   def test_parse227
-    ftp = Net::FTP.new
+    ftp = Net::FTP.new(nil, use_pasv_ip: true)
     host, port = ftp.send(:parse227, "227 Entering Passive Mode (192,168,0,1,12,34)")
     assert_equal("192.168.0.1", host)
     assert_equal(3106, port)
@@ -80,6 +80,14 @@ class FTPTest < Test::Unit::TestCase
     assert_raise(Net::FTPProtoError) do
       ftp.send(:parse227, "227 ) foo bar (")
     end
+
+    ftp = Net::FTP.new
+    sock = OpenStruct.new
+    sock.remote_address = OpenStruct.new
+    sock.remote_address.ip_address = "10.0.0.1"
+    ftp.instance_variable_set(:@bare_sock, sock)
+    host, port = ftp.send(:parse227, "227 Entering Passive Mode (192,168,0,1,12,34)")
+    assert_equal("10.0.0.1", host)
   end
 
   def test_parse228
@@ -2360,10 +2368,155 @@ EOF
     end
   end
 
+  def test_ignore_pasv_ip
+    commands = []
+    binary_data = (0..0xff).map {|i| i.chr}.join * 4 * 3
+    server = create_ftp_server(nil, "127.0.0.1") { |sock|
+      sock.print("220 (test_ftp).\r\n")
+      commands.push(sock.gets)
+      sock.print("331 Please specify the password.\r\n")
+      commands.push(sock.gets)
+      sock.print("230 Login successful.\r\n")
+      commands.push(sock.gets)
+      sock.print("200 Switching to Binary mode.\r\n")
+      line = sock.gets
+      commands.push(line)
+      data_server = TCPServer.new("127.0.0.1", 0)
+      port = data_server.local_address.ip_port
+      sock.printf("227 Entering Passive Mode (999,0,0,1,%s).\r\n",
+                  port.divmod(256).join(","))
+      commands.push(sock.gets)
+      sock.print("150 Opening BINARY mode data connection for foo (#{binary_data.size} bytes)\r\n")
+      conn = data_server.accept
+      binary_data.scan(/.{1,1024}/nm) do |s|
+        conn.print(s)
+      end
+      conn.shutdown(Socket::SHUT_WR)
+      conn.read
+      conn.close
+      data_server.close
+      sock.print("226 Transfer complete.\r\n")
+    }
+    begin
+      begin
+        ftp = Net::FTP.new
+        ftp.passive = true
+        ftp.read_timeout *= 5 if defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled? # for --jit-wait
+        ftp.connect("127.0.0.1", server.port)
+        ftp.login
+        assert_match(/\AUSER /, commands.shift)
+        assert_match(/\APASS /, commands.shift)
+        assert_equal("TYPE I\r\n", commands.shift)
+        buf = ftp.getbinaryfile("foo", nil)
+        assert_equal(binary_data, buf)
+        assert_equal(Encoding::ASCII_8BIT, buf.encoding)
+        assert_equal("PASV\r\n", commands.shift)
+        assert_equal("RETR foo\r\n", commands.shift)
+        assert_equal(nil, commands.shift)
+      ensure
+        ftp.close if ftp
+      end
+    ensure
+      server.close
+    end
+  end
+
+  def test_use_pasv_ip
+    commands = []
+    binary_data = (0..0xff).map {|i| i.chr}.join * 4 * 3
+    server = create_ftp_server(nil, "127.0.0.1") { |sock|
+      sock.print("220 (test_ftp).\r\n")
+      commands.push(sock.gets)
+      sock.print("331 Please specify the password.\r\n")
+      commands.push(sock.gets)
+      sock.print("230 Login successful.\r\n")
+      commands.push(sock.gets)
+      sock.print("200 Switching to Binary mode.\r\n")
+      line = sock.gets
+      commands.push(line)
+      data_server = TCPServer.new("127.0.0.1", 0)
+      port = data_server.local_address.ip_port
+      sock.printf("227 Entering Passive Mode (127,0,0,1,%s).\r\n",
+                  port.divmod(256).join(","))
+      commands.push(sock.gets)
+      sock.print("150 Opening BINARY mode data connection for foo (#{binary_data.size} bytes)\r\n")
+      conn = data_server.accept
+      binary_data.scan(/.{1,1024}/nm) do |s|
+        conn.print(s)
+      end
+      conn.shutdown(Socket::SHUT_WR)
+      conn.read
+      conn.close
+      data_server.close
+      sock.print("226 Transfer complete.\r\n")
+    }
+    begin
+      begin
+        ftp = Net::FTP.new
+        ftp.passive = true
+        ftp.use_pasv_ip = true
+        ftp.read_timeout *= 5 if defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled? # for --jit-wait
+        ftp.connect("127.0.0.1", server.port)
+        ftp.login
+        assert_match(/\AUSER /, commands.shift)
+        assert_match(/\APASS /, commands.shift)
+        assert_equal("TYPE I\r\n", commands.shift)
+        buf = ftp.getbinaryfile("foo", nil)
+        assert_equal(binary_data, buf)
+        assert_equal(Encoding::ASCII_8BIT, buf.encoding)
+        assert_equal("PASV\r\n", commands.shift)
+        assert_equal("RETR foo\r\n", commands.shift)
+        assert_equal(nil, commands.shift)
+      ensure
+        ftp.close if ftp
+      end
+    ensure
+      server.close
+    end
+  end
+
+  def test_use_pasv_invalid_ip
+    commands = []
+    binary_data = (0..0xff).map {|i| i.chr}.join * 4 * 3
+    server = create_ftp_server(nil, "127.0.0.1") { |sock|
+      sock.print("220 (test_ftp).\r\n")
+      commands.push(sock.gets)
+      sock.print("331 Please specify the password.\r\n")
+      commands.push(sock.gets)
+      sock.print("230 Login successful.\r\n")
+      commands.push(sock.gets)
+      sock.print("200 Switching to Binary mode.\r\n")
+      line = sock.gets
+      commands.push(line)
+      sock.print("227 Entering Passive Mode (999,0,0,1,48,57).\r\n")
+      commands.push(sock.gets)
+    }
+    begin
+      begin
+        ftp = Net::FTP.new
+        ftp.passive = true
+        ftp.use_pasv_ip = true
+        ftp.read_timeout *= 5 if defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled? # for --jit-wait
+        ftp.connect("127.0.0.1", server.port)
+        ftp.login
+        assert_match(/\AUSER /, commands.shift)
+        assert_match(/\APASS /, commands.shift)
+        assert_equal("TYPE I\r\n", commands.shift)
+        assert_raise(SocketError) do
+          ftp.getbinaryfile("foo", nil)
+        end
+      ensure
+        ftp.close if ftp
+      end
+    ensure
+      server.close
+    end
+  end
+
   private
 
-  def create_ftp_server(sleep_time = nil)
-    server = TCPServer.new(SERVER_ADDR, 0)
+  def create_ftp_server(sleep_time = nil, addr = SERVER_ADDR)
+    server = TCPServer.new(addr, 0)
     @thread = Thread.start do
       if sleep_time
         sleep(sleep_time)


### PR DESCRIPTION
This updates our non-gem stdlib files to match CRuby 2.6.8, other than two unreleased changes in fileutils and rdoc.

See https://github.com/jruby/jruby/issues/6801 and https://github.com/jruby/jruby/pull/6795.

I also updated the appropriate Ruby version values to reflect CRuby 2.6.8.