### PR TITLE
More agressively kill dead code

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRManager.java
+++ b/core/src/main/java/org/jruby/ir/IRManager.java
@@ -62,7 +62,7 @@ public class IRManager {
 
     private int dummyMetaClassCount = 0;
     private final IRModuleBody object;
-    private final Nil nil = new Nil();
+    private final Nil nil = Nil.NIL;
     private final Boolean tru = new Boolean(true);
     private final Boolean fals = new Boolean(false);
     private final StandardError standardError = new StandardError();

--- a/core/src/main/java/org/jruby/ir/instructions/BFalseInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/BFalseInstr.java
@@ -2,6 +2,7 @@ package org.jruby.ir.instructions;
 
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
+import org.jruby.ir.operands.Boolean;
 import org.jruby.ir.operands.Label;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.persistence.IRReaderDecoder;
@@ -23,6 +24,17 @@ public class BFalseInstr extends OneOperandBranchInstr implements FixedArityInst
 
     public static BFalseInstr decode(IRReaderDecoder d) {
         return new BFalseInstr(d.decodeLabel(), d.decodeOperand());
+    }
+
+    @Override
+    public Instr simplifyBranch() {
+        if (getArg1() instanceof Boolean && ((Boolean) getArg1()).isFalse()) {
+            return new JumpInstr(getJumpTarget());
+        } else if (getArg1().isTruthyImmediate()) {
+            return NopInstr.NOP;
+        } else {
+            return super.simplifyBranch();
+        }
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/BNEInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/BNEInstr.java
@@ -3,6 +3,7 @@ package org.jruby.ir.instructions;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
 import org.jruby.ir.operands.Boolean;
+import org.jruby.ir.operands.ImmutableLiteral;
 import org.jruby.ir.operands.Label;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.UndefinedValue;
@@ -28,6 +29,16 @@ public class BNEInstr extends TwoOperandBranchInstr implements FixedArityInstr {
     @Override
     public Instr clone(CloneInfo ii) {
         return new BNEInstr(ii.getRenamedLabel(getJumpTarget()), getArg1().cloneForInlining(ii), getArg2().cloneForInlining(ii));
+    }
+
+    // FIXME: Add !op_equal logic here for various immutable literal types
+    @Override
+    public Instr simplifyBranch() {
+        if (getArg1().equals(getArg2())) {
+            return NopInstr.NOP;
+        } else {
+            return super.simplifyBranch();
+        }
     }
 
     public static BNEInstr decode(IRReaderDecoder d) {

--- a/core/src/main/java/org/jruby/ir/instructions/BNilInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/BNilInstr.java
@@ -2,7 +2,9 @@ package org.jruby.ir.instructions;
 
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
+import org.jruby.ir.operands.ImmutableLiteral;
 import org.jruby.ir.operands.Label;
+import org.jruby.ir.operands.Nil;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.persistence.IRReaderDecoder;
 import org.jruby.ir.transformations.inlining.CloneInfo;
@@ -19,6 +21,17 @@ public class BNilInstr extends OneOperandBranchInstr  implements FixedArityInstr
     @Override
     public Instr clone(CloneInfo ii) {
         return new BNilInstr(ii.getRenamedLabel(getJumpTarget()), getArg1().cloneForInlining(ii));
+    }
+
+    @Override
+    public Instr simplifyBranch() {
+        if (getArg1().equals(Nil.NIL)) {
+            return new JumpInstr(getJumpTarget());
+        } else if (getArg1() instanceof ImmutableLiteral) {
+            return NopInstr.NOP;
+        } else {
+            return super.simplifyBranch();
+        }
     }
 
     public static BNilInstr decode(IRReaderDecoder d) {

--- a/core/src/main/java/org/jruby/ir/instructions/BTrueInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/BTrueInstr.java
@@ -2,6 +2,7 @@ package org.jruby.ir.instructions;
 
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
+import org.jruby.ir.operands.Boolean;
 import org.jruby.ir.operands.Label;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.persistence.IRReaderDecoder;
@@ -19,6 +20,17 @@ public class BTrueInstr extends OneOperandBranchInstr implements FixedArityInstr
     @Override
     public Instr clone(CloneInfo ii) {
         return new BTrueInstr(ii.getRenamedLabel(getJumpTarget()), getArg1().cloneForInlining(ii));
+    }
+
+    @Override
+    public Instr simplifyBranch() {
+        if (getArg1().isTruthyImmediate()) {
+            return new JumpInstr(getJumpTarget());
+        } else if (getArg1().isFalseyImmediate()) {
+            return NopInstr.NOP;
+        } else {
+            return super.simplifyBranch();
+        }
     }
 
     public static BTrueInstr decode(IRReaderDecoder d) {

--- a/core/src/main/java/org/jruby/ir/instructions/BUndefInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/BUndefInstr.java
@@ -2,7 +2,9 @@ package org.jruby.ir.instructions;
 
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
+import org.jruby.ir.operands.ImmutableLiteral;
 import org.jruby.ir.operands.Label;
+import org.jruby.ir.operands.Nil;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.UndefinedValue;
 import org.jruby.ir.persistence.IRReaderDecoder;
@@ -20,6 +22,17 @@ public class BUndefInstr extends OneOperandBranchInstr  implements FixedArityIns
     @Override
     public Instr clone(CloneInfo ii) {
         return new BUndefInstr(ii.getRenamedLabel(getJumpTarget()), getArg1().cloneForInlining(ii));
+    }
+
+    @Override
+    public Instr simplifyBranch() {
+        if (getArg1().equals(UndefinedValue.UNDEFINED)) {
+            return new JumpInstr(getJumpTarget());
+        } else if (getArg1() instanceof ImmutableLiteral) {
+            return NopInstr.NOP;
+        } else {
+            return super.simplifyBranch();
+        }
     }
 
     public static BUndefInstr decode(IRReaderDecoder d) {

--- a/core/src/main/java/org/jruby/ir/instructions/BranchInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/BranchInstr.java
@@ -9,4 +9,8 @@ public abstract class BranchInstr extends Instr implements JumpTargetInstr {
     }
 
     public abstract Label getJumpTarget();
+
+    public Instr simplifyBranch() {
+        return this;
+    }
 }

--- a/core/src/main/java/org/jruby/ir/operands/Nil.java
+++ b/core/src/main/java/org/jruby/ir/operands/Nil.java
@@ -12,6 +12,8 @@ import org.jruby.runtime.ThreadContext;
  * way I got lazy and removed protected.
  */
 public class Nil extends ImmutableLiteral {
+    public static Nil NIL = new Nil();
+
     public Nil() {
         super();
     }

--- a/core/src/main/java/org/jruby/ir/passes/LocalOptimizationPass.java
+++ b/core/src/main/java/org/jruby/ir/passes/LocalOptimizationPass.java
@@ -1,6 +1,7 @@
 package org.jruby.ir.passes;
 
 import org.jruby.ir.Operation;
+import org.jruby.ir.instructions.BranchInstr;
 import org.jruby.ir.instructions.CopyInstr;
 import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.instructions.ResultInstr;
@@ -8,6 +9,7 @@ import org.jruby.ir.interpreter.FullInterpreterContext;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.representations.BasicBlock;
+import org.jruby.ir.representations.CFG;
 
 import java.util.*;
 
@@ -24,9 +26,18 @@ public class LocalOptimizationPass extends CompilerPass {
 
     @Override
     public Object execute(FullInterpreterContext fic, Object... data) {
-        for (BasicBlock b: fic.getCFG().getBasicBlocks()) {
-            runLocalOptsOnBasicBlock(fic, b);
+        boolean reexamineCFG = false;
+        CFG cfg = fic.getCFG();
+
+        for (BasicBlock bb: cfg.getBasicBlocks()) {
+            if (runLocalOptsOnBasicBlock(fic, bb)) {
+                reexamineCFG = true;
+                cfg.fixupEdges(bb);
+            }
         }
+
+        // If we changed any edges we can potentially remove some whole BBs!
+        if (reexamineCFG) fic.getCFG().optimize();
 
         // LVA information is no longer valid after this pass
         // Currently, we don't run this after LVA, but just in case ...
@@ -59,6 +70,11 @@ public class LocalOptimizationPass extends CompilerPass {
 
         // Simplify instruction and record mapping between target variable and simplified value
         Operand val = instr.simplifyAndGetResult(fic.getScope(), valueMap);
+
+        // A branch may no longer need to be a branch (e.g. b_true(true, label) -> jump(label)).
+        if (instr instanceof BranchInstr) {
+            instr = ((BranchInstr) instr).simplifyBranch();
+        }
 
         // Variable dst = (instr instanceof ResultInstr) ? ((ResultInstr) instr).getResult() : null;
         // System.out.println("AFTER: " + instr + "; dst = " + dst + "; val = " + val);
@@ -137,7 +153,8 @@ public class LocalOptimizationPass extends CompilerPass {
         }
     }
 
-    public static void runLocalOptsOnBasicBlock(FullInterpreterContext fic, BasicBlock b) {
+    public static boolean runLocalOptsOnBasicBlock(FullInterpreterContext fic, BasicBlock b) {
+        boolean reexamineCFG = false;  // If we changed something which changes flow we need to update CFG.
         ListIterator<Instr> instrs = b.getInstrs().listIterator();
         // Reset value map if this instruction is the start/end of a basic block
         Map<Operand,Operand> valueMap = new HashMap<>();
@@ -146,8 +163,10 @@ public class LocalOptimizationPass extends CompilerPass {
             Instr instr = instrs.next();
             Instr newInstr = optInstr(fic, instr, valueMap, simplificationMap);
             if (newInstr.isDead()) {
+                if (newInstr != instr && instr.getOperation().endsBasicBlock()) reexamineCFG = true;
                 instrs.remove();
             } else if (newInstr != instr) {
+                if (instr.getOperation().endsBasicBlock()) reexamineCFG = true;
                 instrs.set(newInstr);
             }
 
@@ -170,5 +189,7 @@ public class LocalOptimizationPass extends CompilerPass {
                 simplificationMap = new HashMap<>();
             }
         }
+
+        return reexamineCFG;
     }
 }

--- a/core/src/main/java/org/jruby/ir/representations/CFG.java
+++ b/core/src/main/java/org/jruby/ir/representations/CFG.java
@@ -347,11 +347,11 @@ public class CFG {
             // We assume branches will not turn into other branches so we ignore this
         } else if (bb.getLastInstr() instanceof JumpTargetInstr) { // this is really a jump branch already covered
             for (Edge<BasicBlock> edge: getOutgoingEdges(bb)) {
-                if (edge.getType() == EdgeType.FALL_THROUGH) removeEdge(bb, edge.getDestination().getData());
+                if (edge.getType() == EdgeType.FALL_THROUGH) graph.removeEdge(edge);
             }
         } else {
             for (Edge<BasicBlock> edge: getOutgoingEdges(bb)) {
-                if (edge.getType() == EdgeType.REGULAR) removeEdge(bb, edge.getDestination().getData());
+                if (edge.getType() == EdgeType.REGULAR) graph.removeEdge(edge);
             }
         }
     }
@@ -524,6 +524,7 @@ public class CFG {
         graph.removeVertexFor(b);
         bbMap.remove(b.getLabel());
         rescuerMap.remove(b);
+        returnBBs.remove(b);
     }
 
     /**

--- a/core/src/main/java/org/jruby/ir/representations/CFG.java
+++ b/core/src/main/java/org/jruby/ir/representations/CFG.java
@@ -43,6 +43,9 @@ public class CFG {
     /** Exit BB */
     private BasicBlock exitBB;
 
+    /** List of bbs that have a 'return' instruction */
+    List<BasicBlock> returnBBs = new ArrayList<>();
+
     /** BB that traps all exception-edges out of the cfg where we could add any cleanup/ensure code (ex: pop frames, etc.) */
     private BasicBlock globalEnsureBB;
 
@@ -212,9 +215,6 @@ public class CFG {
         // Map of label & basic blocks which are waiting for a bb with that label
         Map<Label, List<BasicBlock>> forwardRefs = new HashMap<>();
 
-        // List of bbs that have a 'return' instruction
-        List<BasicBlock> returnBBs = new ArrayList<>();
-
         // List of bbs that have a 'throw' instruction
         List<BasicBlock> exceptionBBs = new ArrayList<>();
 
@@ -335,9 +335,25 @@ public class CFG {
         // System.out.println("\nGraph:\n" + toStringGraph());
         // System.out.println("\nInstructions:\n" + toStringInstrs());
 
-        optimize(returnBBs); // remove useless cfg edges & orphaned bbs
+        optimize(); // remove useless cfg edges & orphaned bbs
 
         return graph;
+    }
+
+    // A branch may have become something else...let's fix up the CFG
+    public void fixupEdges(BasicBlock bb) {
+        Instr lastInstr = bb.getLastInstr();
+        if (lastInstr instanceof BranchInstr) {
+            // We assume branches will not turn into other branches so we ignore this
+        } else if (bb.getLastInstr() instanceof JumpTargetInstr) { // this is really a jump branch already covered
+            for (Edge<BasicBlock> edge: getOutgoingEdges(bb)) {
+                if (edge.getType() == EdgeType.FALL_THROUGH) removeEdge(bb, edge.getDestination().getData());
+            }
+        } else {
+            for (Edge<BasicBlock> edge: getOutgoingEdges(bb)) {
+                if (edge.getType() == EdgeType.REGULAR) removeEdge(bb, edge.getDestination().getData());
+            }
+        }
     }
 
     private void addEdge(BasicBlock src, Label targetLabel, Map<Label, List<BasicBlock>> forwardRefs) {
@@ -551,7 +567,7 @@ public class CFG {
         }
     }
 
-    public void optimize(List<BasicBlock> returnBBs) {
+    public void optimize() {
         // Propagate returns backwards where possible.
         // If:
         // - there is an edge from BB: x -> r, and

--- a/core/src/main/java/org/jruby/ir/transformations/inlining/CFGInliner.java
+++ b/core/src/main/java/org/jruby/ir/transformations/inlining/CFGInliner.java
@@ -310,6 +310,7 @@ public class CFGInliner {
         // Optimize cfg by merging straight-line bbs (just one piece of what CFG.optimize does)
         //cfg.collapseStraightLineBBs();
 
+        /*
         // FIXME: This probably is too much work here. Decide between this and just collapsing straight line BBs
         // FIXME: If we do keep this we should maybe internalize calculating these in CFG itself.
         List<BasicBlock> returnBBs = new ArrayList<>();
@@ -318,7 +319,8 @@ public class CFGInliner {
                 if (instr.getOperation().isReturn()) returnBBs.add(basicBlock);
             }
         }
-        cfg.optimize(returnBBs);
+        cfg.optimize(returnBBs);*/
+        cfg.optimize();
 
         addMissingJumps();
 


### PR DESCRIPTION
LocalOptimizationPass will propagate values.  For example:

```ruby
_tmp = true
unless _tmp
 puts "Never"
end
```

In this case by the end of this pass we will see a BB end with a
b_false(true, some_label).  This clearly cannot happen.  If we eliminate
this instr then we should also be able to lop off the bb(s) representing
whatever is within the unless conditional.  In this snippet the entire
snippet should be dead code except _tmp = true.

To fix this I added simplifyBranch to BranchInstr.  This gives us the
ability to swap out a branch with a noop or a jump (in case where something
is unconditionally true).

After we replace the instr with a new one we need to reexamine the basicblock
it is in and correct any edge placement.