### PR TITLE
Update tests from MRI 2.6.8

### DIFF
--- a/test/mri/coverage/test_coverage.rb
+++ b/test/mri/coverage/test_coverage.rb
@@ -696,4 +696,16 @@ class TestCoverage < Test::Unit::TestCase
       }
     }
   end
+
+  def test_stop_wrong_peephole_optimization
+    result = {
+      :lines => [1, 1, 1, nil]
+    }
+    assert_coverage(<<~"end;", { lines: true }, result)
+      raise if 1 == 2
+      while true
+        break
+      end
+    end;
+  end
 end

--- a/test/mri/excludes/TestIO_Console.rb
+++ b/test/mri/excludes/TestIO_Console.rb
@@ -1,2 +1,3 @@
 # frozen_string_literal: false
 exclude :test_noctty, 'we return an IO.console even when not a TTY'
+exclude :test_getpass, 'our PTY library does not set a controlling terminal'

--- a/test/mri/io/console/test_io_console.rb
+++ b/test/mri/io/console/test_io_console.rb
@@ -7,41 +7,14 @@ rescue LoadError
 end
 
 class TestIO_Console < Test::Unit::TestCase
-  PATHS = $LOADED_FEATURES.grep(%r"/io/console(?:\.#{RbConfig::CONFIG['DLEXT']}|\.rb|/\w+\.rb)\z") {$`}
-  PATHS.uniq!
-
   # FreeBSD seems to hang on TTOU when running parallel tests
-  # tested on FreeBSD 11.x.
-  #
-  # Solaris gets stuck too, even in non-parallel mode.
-  # It occurs only in chkbuild.  It does not occur when running
-  # `make test-all` in SSH terminal.
-  #
-  # I suspect that it occurs only when having no TTY.
-  # (Parallel mode runs tests in child processes, so I guess
-  # they has no TTY.)
-  # But it does not occur in `make test-all > /dev/null`, so
-  # there should be an additional factor, I guess.
+  # tested on FreeBSD 11.x
   def set_winsize_setup
-    @old_ttou = trap(:TTOU, 'IGNORE') if RUBY_PLATFORM =~ /freebsd|solaris/i
+    @old_ttou = trap(:TTOU, 'IGNORE') if RUBY_PLATFORM =~ /freebsd/i
   end
 
   def set_winsize_teardown
     trap(:TTOU, @old_ttou) if defined?(@old_ttou) and @old_ttou
-  end
-
-  def test_failed_path
-    exceptions = %w[ENODEV ENOTTY EBADF ENXIO].map {|e|
-      Errno.const_get(e) if Errno.const_defined?(e)
-    }
-    exceptions.compact!
-    omit if exceptions.empty?
-    File.open(IO::NULL) do |f|
-      e = assert_raise(*exceptions) do
-        f.echo?
-      end
-      assert_include(e.message, IO::NULL)
-    end
   end
 end
 
@@ -65,15 +38,12 @@ defined?(PTY) and defined?(IO.console) and TestIO_Console.class_eval do
   end
 
   def test_raw_minchar
-    q = Thread::Queue.new
     helper {|m, s|
       len = 0
       assert_equal([nil, 0], [s.getch(min: 0), len])
       main = Thread.current
       go = false
       th = Thread.start {
-        q.pop
-        sleep 0.01 until main.stop?
         len += 1
         m.print("a")
         m.flush
@@ -83,8 +53,6 @@ defined?(PTY) and defined?(IO.console) and TestIO_Console.class_eval do
         m.flush
       }
       begin
-        sleep 0.1
-        q.push(1)
         assert_equal(["a", 1], [s.getch(min: 1), len])
         go = true
         assert_equal(["1", 11], [s.getch, len])
@@ -226,20 +194,11 @@ defined?(PTY) and defined?(IO.console) and TestIO_Console.class_eval do
   end
 
   def test_getpass
-    omit unless IO.method_defined?("getpass")
+    skip unless IO.method_defined?("getpass")
     run_pty("p IO.console.getpass('> ')") do |r, w|
       assert_equal("> ", r.readpartial(10))
       sleep 0.1
       w.print "asdf\n"
-      sleep 0.1
-      assert_equal("\r\n", r.gets)
-      assert_equal("\"asdf\"", r.gets.chomp)
-    end
-
-    run_pty("p IO.console.getpass('> ')") do |r, w|
-      assert_equal("> ", r.readpartial(10))
-      sleep 0.1
-      w.print "asdf\C-D\C-D"
       sleep 0.1
       assert_equal("\r\n", r.gets)
       assert_equal("\"asdf\"", r.gets.chomp)
@@ -322,79 +281,6 @@ defined?(PTY) and defined?(IO.console) and TestIO_Console.class_eval do
     set_winsize_teardown
   end
 
-  def test_cursor_position
-    run_pty("#{<<~"begin;"}\n#{<<~'end;'}") do |r, w, _|
-      begin;
-        con = IO.console
-        p con.cursor
-        con.cursor_down(3); con.puts
-        con.cursor_right(4); con.puts
-        con.cursor_left(2); con.puts
-        con.cursor_up(1); con.puts
-      end;
-      assert_equal("\e[6n", r.readpartial(5))
-      w.print("\e[12;34R"); w.flush
-      assert_equal([11, 33], eval(r.gets))
-      assert_equal("\e[3B", r.gets.chomp)
-      assert_equal("\e[4C", r.gets.chomp)
-      assert_equal("\e[2D", r.gets.chomp)
-      assert_equal("\e[1A", r.gets.chomp)
-    end
-  end
-
-  def assert_ctrl(expect, cc, r, w)
-    sleep 0.1
-    w.print cc
-    w.flush
-    result = EnvUtil.timeout(3) {r.gets}
-    assert_equal(expect, result.chomp)
-  end
-
-  def test_intr
-    run_pty("#{<<~"begin;"}\n#{<<~'end;'}") do |r, w, _|
-      begin;
-        require 'timeout'
-        STDOUT.puts `stty -a`.scan(/\b\w+ *= *\^.;/), ""
-        STDOUT.flush
-        con = IO.console
-        while c = con.getch
-          p c.ord
-          p con.getch(intr: false).ord
-          begin
-            p Timeout.timeout(1) {con.getch(intr: true)}.ord
-          rescue Timeout::Error, Interrupt => e
-            p e
-          end
-        end
-      end;
-      ctrl = {}
-      r.each do |l|
-        break unless /^(\w+) *= *\^(\\?.)/ =~ l
-        ctrl[$1] = eval("?\\C-#$2")
-      end
-      if cc = ctrl["intr"]
-        assert_ctrl("#{cc.ord}", cc, r, w)
-        assert_ctrl("#{cc.ord}", cc, r, w)
-        assert_ctrl("Interrupt", cc, r, w) unless /linux/ =~ RUBY_PLATFORM
-      end
-      if cc = ctrl["dsusp"]
-        assert_ctrl("#{cc.ord}", cc, r, w)
-        assert_ctrl("#{cc.ord}", cc, r, w)
-        assert_ctrl("#{cc.ord}", cc, r, w)
-      end
-      if cc = ctrl["lnext"]
-        assert_ctrl("#{cc.ord}", cc, r, w)
-        assert_ctrl("#{cc.ord}", cc, r, w)
-        assert_ctrl("#{cc.ord}", cc, r, w)
-      end
-      if cc = ctrl["stop"]
-        assert_ctrl("#{cc.ord}", cc, r, w)
-        assert_ctrl("#{cc.ord}", cc, r, w)
-        assert_ctrl("#{cc.ord}", cc, r, w)
-      end
-    end
-  end
-
   unless IO.console
     def test_close
       assert_equal(["true"], run_pty("IO.console.close; p IO.console.fileno >= 0"))
@@ -410,7 +296,7 @@ defined?(PTY) and defined?(IO.console) and TestIO_Console.class_eval do
   def helper
     m, s = PTY.open
   rescue RuntimeError
-    omit $!
+    skip $!
   else
     yield m, s
   ensure
@@ -419,11 +305,9 @@ defined?(PTY) and defined?(IO.console) and TestIO_Console.class_eval do
   end
 
   def run_pty(src, n = 1)
-    pend("PTY.spawn cannot control terminal on JRuby") if RUBY_ENGINE == 'jruby'
-    
-    r, w, pid = PTY.spawn(EnvUtil.rubybin, "-I#{TestIO_Console::PATHS.join(File::PATH_SEPARATOR)}", "-rio/console", "-e", src)
+    r, w, pid = PTY.spawn(EnvUtil.rubybin, "-rio/console", "-e", src)
   rescue RuntimeError
-    omit $!
+    skip $!
   else
     if block_given?
       yield r, w, pid
@@ -454,14 +338,10 @@ defined?(IO.console) and TestIO_Console.class_eval do
       s = IO.console.winsize
       assert_nothing_raised(TypeError) {IO.console.winsize = s}
       bug = '[ruby-core:82741] [Bug #13888]'
-      begin
-        IO.console.winsize = [s[0], s[1]+1]
-        assert_equal([s[0], s[1]+1], IO.console.winsize, bug)
-      rescue Errno::EINVAL    # Error if run on an actual console.
-      else
-        IO.console.winsize = s
-        assert_equal(s, IO.console.winsize, bug)
-      end
+      IO.console.winsize = [s[0], s[1]+1]
+      assert_equal([s[0], s[1]+1], IO.console.winsize, bug)
+      IO.console.winsize = s
+      assert_equal(s, IO.console.winsize, bug)
     ensure
       set_winsize_teardown
     end
@@ -482,10 +362,6 @@ defined?(IO.console) and TestIO_Console.class_eval do
     ensure
       IO.console(:close)
     end
-
-    def test_getch_timeout
-      assert_nil(IO.console.getch(intr: true, time: 0.1, min: 0))
-    end
   end
 end
 
@@ -495,7 +371,7 @@ defined?(IO.console) and TestIO_Console.class_eval do
     noctty = [EnvUtil.rubybin, "-e", "Process.daemon(true)"]
   when !(rubyw = RbConfig::CONFIG["RUBYW_INSTALL_NAME"]).empty?
     dir, base = File.split(EnvUtil.rubybin)
-    noctty = [File.join(dir, base.sub(RUBY_ENGINE, rubyw))]
+    noctty = [File.join(dir, base.sub(/ruby/, rubyw))]
   end
 
   if noctty
@@ -547,14 +423,14 @@ end
 
 TestIO_Console.class_eval do
   def test_stringio_getch
-    assert_ruby_status %w"--disable=gems -rstringio -rio/console", %q{
-      abort unless StringIO.method_defined?(:getch)
+    assert_separately %w"--disable=gems -rstringio -rio/console", %q{
+      assert_operator(StringIO, :method_defined?, :getch)
     }
-    assert_ruby_status %w"--disable=gems -rio/console -rstringio", %q{
-      abort unless StringIO.method_defined?(:getch)
+    assert_separately %w"--disable=gems -rio/console -rstringio", %q{
+      assert_operator(StringIO, :method_defined?, :getch)
     }
-    assert_ruby_status %w"--disable=gems -rstringio", %q{
-      abort if StringIO.method_defined?(:getch)
+    assert_separately %w"--disable=gems -rstringio", %q{
+      assert_not_operator(StringIO, :method_defined?, :getch)
     }
   end
 end

--- a/test/mri/json/json_addition_test.rb
+++ b/test/mri/json/json_addition_test.rb
@@ -5,7 +5,6 @@ require 'json/add/complex'
 require 'json/add/rational'
 require 'json/add/bigdecimal'
 require 'json/add/ostruct'
-require 'json/add/set'
 require 'date'
 
 class JSONAdditionTest < Test::Unit::TestCase
@@ -190,10 +189,5 @@ class JSONAdditionTest < Test::Unit::TestCase
     # XXX this won't work; o.foo = { :bar => true }
     o.foo = { 'bar' => true }
     assert_equal o, parse(JSON(o), :create_additions => true)
-  end
-
-  def test_set
-    s = Set.new([:a, :b, :c, :a])
-    assert_equal s, JSON.parse(JSON(s), :create_additions => true)
   end
 end

--- a/test/mri/json/json_common_interface_test.rb
+++ b/test/mri/json/json_common_interface_test.rb
@@ -27,15 +27,15 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
   end
 
   def test_parser
-    assert_match(/::Parser\z/, JSON.parser.name)
+    assert_match /::Parser\z/, JSON.parser.name
   end
 
   def test_generator
-    assert_match(/::Generator\z/, JSON.generator.name)
+    assert_match /::Generator\z/, JSON.generator.name
   end
 
   def test_state
-    assert_match(/::Generator::State\z/, JSON.state.name)
+    assert_match /::Generator::State\z/, JSON.state.name
   end
 
   def test_create_id
@@ -56,7 +56,7 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
   end
 
   def test_parse_bang
-    assert_equal [ 1, Infinity, 3, ], JSON.parse!('[ 1, Infinity, 3 ]')
+    assert_equal [ 1, NaN, 3, ], JSON.parse!('[ 1, NaN, 3 ]')
   end
 
   def test_generate
@@ -122,48 +122,5 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
   def test_JSON
     assert_equal @json, JSON(@hash)
     assert_equal @hash, JSON(@json)
-  end
-
-  def test_load_file
-    test_load_shared(:load_file)
-  end
-
-  def test_load_file!
-    test_load_shared(:load_file!)
-  end
-
-  def test_load_file_with_option
-    test_load_file_with_option_shared(:load_file)
-  end
-
-  def test_load_file_with_option!
-    test_load_file_with_option_shared(:load_file!)
-  end
-
-  private
-
-  def test_load_shared(method_name)
-    temp_file_containing(@json) do |filespec|
-      assert_equal JSON.public_send(method_name, filespec), @hash
-    end
-  end
-
-  def test_load_file_with_option_shared(method_name)
-    temp_file_containing(@json) do |filespec|
-      parsed_object = JSON.public_send(method_name, filespec, symbolize_names: true)
-      key_classes = parsed_object.keys.map(&:class)
-      assert_include(key_classes, Symbol)
-      assert_not_include(key_classes, String)
-    end
-  end
-
-  def temp_file_containing(text, file_prefix = '')
-    raise "This method must be called with a code block." unless block_given?
-
-    Tempfile.create(file_prefix) do |file|
-      file << text
-      file.close
-      yield file.path
-    end
   end
 end

--- a/test/mri/json/json_fixtures_test.rb
+++ b/test/mri/json/json_fixtures_test.rb
@@ -3,14 +3,13 @@ require 'test_helper'
 
 class JSONFixturesTest < Test::Unit::TestCase
   def setup
-    fixtures = File.join(File.dirname(__FILE__), 'fixtures/{fail,pass}*.json')
+    fixtures = File.join(File.dirname(__FILE__), 'fixtures/{fail,pass}.json')
     passed, failed = Dir[fixtures].partition { |f| f['pass'] }
     @passed = passed.inject([]) { |a, f| a << [ f, File.read(f) ] }.sort
     @failed = failed.inject([]) { |a, f| a << [ f, File.read(f) ] }.sort
   end
 
   def test_passing
-    verbose_bak, $VERBOSE = $VERBOSE, nil
     for name, source in @passed
       begin
         assert JSON.parse(source),
@@ -20,8 +19,6 @@ class JSONFixturesTest < Test::Unit::TestCase
         raise e
       end
     end
-  ensure
-    $VERBOSE = verbose_bak
   end
 
   def test_failing
@@ -31,10 +28,5 @@ class JSONFixturesTest < Test::Unit::TestCase
         JSON.parse(source)
       end
     end
-  end
-
-  def test_sanity
-    assert(@passed.size > 5)
-    assert(@failed.size > 20)
   end
 end

--- a/test/mri/json/json_generator_test.rb
+++ b/test/mri/json/json_generator_test.rb
@@ -40,14 +40,6 @@ class JSONGeneratorTest < Test::Unit::TestCase
 EOT
   end
 
-  def silence
-    v = $VERBOSE
-    $VERBOSE = nil
-    yield
-  ensure
-    $VERBOSE = v
-  end
-
   def test_generate
     json = generate(@hash)
     assert_equal(parse(@json2), parse(json))
@@ -63,11 +55,6 @@ EOT
   end
 
   def test_generate_pretty
-    json = pretty_generate({})
-    assert_equal(<<'EOT'.chomp, json)
-{
-}
-EOT
     json = pretty_generate(@hash)
     # hashes aren't (insertion) ordered on every ruby implementation
     # assert_equal(@json3, json)
@@ -142,14 +129,13 @@ EOT
   end
 
   def test_pretty_state
-    state = JSON.create_pretty_state
+    state = PRETTY_STATE_PROTOTYPE.dup
     assert_equal({
       :allow_nan             => false,
       :array_nl              => "\n",
       :ascii_only            => false,
       :buffer_initial_length => 1024,
       :depth                 => 0,
-      :escape_slash          => false,
       :indent                => "  ",
       :max_nesting           => 100,
       :object_nl             => "\n",
@@ -159,14 +145,13 @@ EOT
   end
 
   def test_safe_state
-    state = JSON::State.new
+    state = SAFE_STATE_PROTOTYPE.dup
     assert_equal({
       :allow_nan             => false,
       :array_nl              => "",
       :ascii_only            => false,
       :buffer_initial_length => 1024,
       :depth                 => 0,
-      :escape_slash          => false,
       :indent                => "",
       :max_nesting           => 100,
       :object_nl             => "",
@@ -176,14 +161,13 @@ EOT
   end
 
   def test_fast_state
-    state = JSON.create_fast_state
+    state = FAST_STATE_PROTOTYPE.dup
     assert_equal({
       :allow_nan             => false,
       :array_nl              => "",
       :ascii_only            => false,
       :buffer_initial_length => 1024,
       :depth                 => 0,
-      :escape_slash          => false,
       :indent                => "",
       :max_nesting           => 0,
       :object_nl             => "",
@@ -212,8 +196,12 @@ EOT
 
   def test_depth
     ary = []; ary << ary
+    assert_equal 0, JSON::SAFE_STATE_PROTOTYPE.depth
     assert_raise(JSON::NestingError) { generate(ary) }
+    assert_equal 0, JSON::SAFE_STATE_PROTOTYPE.depth
+    assert_equal 0, JSON::PRETTY_STATE_PROTOTYPE.depth
     assert_raise(JSON::NestingError) { JSON.pretty_generate(ary) }
+    assert_equal 0, JSON::PRETTY_STATE_PROTOTYPE.depth
     s = JSON.state.new
     assert_equal 0, s.depth
     assert_raise(JSON::NestingError) { ary.to_json(s) }
@@ -232,7 +220,7 @@ EOT
   end
 
   def test_gc
-    if respond_to?(:assert_in_out_err) && !(RUBY_PLATFORM =~ /java/)
+    if respond_to?(:assert_in_out_err)
       assert_in_out_err(%w[-rjson --disable-gems], <<-EOS, [], [])
         bignum_too_long_to_embed_as_string = 1234567890123456789012345
         expect = bignum_too_long_to_embed_as_string.to_s
@@ -368,10 +356,6 @@ EOT
     json = '["/"]'
     assert_equal json, generate(data)
     #
-    data = [ '/' ]
-    json = '["\/"]'
-    assert_equal json, generate(data, :escape_slash => true)
-    #
     data = ['"']
     json = '["\""]'
     assert_equal json, generate(data)
@@ -388,12 +372,6 @@ EOT
     end
     assert_nothing_raised(SystemStackError) do
       assert_equal '["foo"]', JSON.generate([s.new('foo')])
-    end
-  end
-
-  if defined?(Encoding)
-    def test_nonutf8_encoding
-      assert_equal("\"5\u{b0}\"", "5\xb0".force_encoding("iso-8859-1").to_json)
     end
   end
 end

--- a/test/mri/json/json_parser_test.rb
+++ b/test/mri/json/json_parser_test.rb
@@ -91,22 +91,22 @@ class JSONParserTest < Test::Unit::TestCase
     assert_raise(JSON::ParserError) { parse('+23') }
     assert_raise(JSON::ParserError) { parse('.23') }
     assert_raise(JSON::ParserError) { parse('023') }
-    assert_equal(23, parse('23'))
-    assert_equal(-23, parse('-23'))
-    assert_equal_float(3.141, parse('3.141'))
-    assert_equal_float(-3.141, parse('-3.141'))
-    assert_equal_float(3.141, parse('3141e-3'))
-    assert_equal_float(3.141, parse('3141.1e-3'))
-    assert_equal_float(3.141, parse('3141E-3'))
-    assert_equal_float(3.141, parse('3141.0E-3'))
-    assert_equal_float(-3.141, parse('-3141.0e-3'))
-    assert_equal_float(-3.141, parse('-3141e-3'))
+    assert_equal 23, parse('23')
+    assert_equal -23, parse('-23')
+    assert_equal_float 3.141, parse('3.141')
+    assert_equal_float -3.141, parse('-3.141')
+    assert_equal_float 3.141, parse('3141e-3')
+    assert_equal_float 3.141, parse('3141.1e-3')
+    assert_equal_float 3.141, parse('3141E-3')
+    assert_equal_float 3.141, parse('3141.0E-3')
+    assert_equal_float -3.141, parse('-3141.0e-3')
+    assert_equal_float -3.141, parse('-3141e-3')
     assert_raise(ParserError) { parse('NaN') }
     assert parse('NaN', :allow_nan => true).nan?
     assert_raise(ParserError) { parse('Infinity') }
-    assert_equal(1.0/0, parse('Infinity', :allow_nan => true))
+    assert_equal 1.0/0, parse('Infinity', :allow_nan => true)
     assert_raise(ParserError) { parse('-Infinity') }
-    assert_equal(-1.0/0, parse('-Infinity', :allow_nan => true))
+    assert_equal -1.0/0, parse('-Infinity', :allow_nan => true)
   end
 
   def test_parse_bigdecimals
@@ -218,17 +218,6 @@ class JSONParserTest < Test::Unit::TestCase
     end
   end
 
-  def test_freeze
-    assert_predicate parse('{}', :freeze => true), :frozen?
-    assert_predicate parse('[]', :freeze => true), :frozen?
-    assert_predicate parse('"foo"', :freeze => true), :frozen?
-
-    if string_deduplication_available?
-      assert_same(-'foo', parse('"foo"', :freeze => true))
-      assert_same(-'foo', parse('{"foo": 1}', :freeze => true).keys.first)
-    end
-  end
-
   def test_parse_comments
     json = <<EOT
 {
@@ -303,10 +292,6 @@ EOT
     #
     json = '["\\\'"]'
     data = ["'"]
-    assert_equal data, parse(json)
-
-    json = '["\/"]'
-    data = [ '/' ]
     assert_equal data, parse(json)
   end
 
@@ -478,16 +463,6 @@ EOT
   end
 
   private
-
-  def string_deduplication_available?
-    r1 = rand.to_s
-    r2 = r1.dup
-    begin
-      (-r1).equal?(-r2)
-    rescue NoMethodError
-      false # No String#-@
-    end
-  end
 
   def assert_equal_float(expected, actual, delta = 1e-2)
     Array === expected and expected = expected.first

--- a/test/mri/json/test_helper.rb
+++ b/test/mri/json/test_helper.rb
@@ -1,12 +1,12 @@
 case ENV['JSON']
 when 'pure'
-  $:.unshift File.join(__dir__, '../lib')
+  $:.unshift 'lib'
   require 'json/pure'
 when 'ext'
-  $:.unshift File.join(__dir__, '../ext'), File.join(__dir__, '../lib')
+  $:.unshift 'ext', 'lib'
   require 'json/ext'
 else
-  $:.unshift File.join(__dir__, '../ext'), File.join(__dir__, '../lib')
+  $:.unshift 'ext', 'lib'
   require 'json'
 end
 
@@ -14,4 +14,8 @@ require 'test/unit'
 begin
   require 'byebug'
 rescue LoadError
+end
+if ENV['START_SIMPLECOV'].to_i == 1
+  require 'simplecov'
+  SimpleCov.start
 end

--- a/test/mri/lib/envutil.rb
+++ b/test/mri/lib/envutil.rb
@@ -291,6 +291,7 @@ if defined?(RbConfig)
     end
     dir = File.dirname(ruby)
     CONFIG['bindir'] = dir
+    Gem::ConfigMap[:bindir] = dir if defined?(Gem::ConfigMap)
   end
 end
 

--- a/test/mri/lib/test/unit/assertions.rb
+++ b/test/mri/lib/test/unit/assertions.rb
@@ -519,10 +519,11 @@ EOT
         if defined? RubyVM::InstructionSequence
           RubyVM::InstructionSequence.compile(src, filename, filename, line)
         else
-          require 'jruby'
-          root = JRuby.parse(src, filename, false, line - 1)
-          runtime = JRuby::runtime
-          org.jruby.ir.IRBuilder.build_root(runtime.ir_manager, root)
+          src = <<-WRAPPED
+#{src}
+            BEGIN { throw :tag, :ok }
+          WRAPPED
+          assert_equal(:ok, catch(:tag) { eval(src, binding, filename, line)})
         end
       end
 

--- a/test/mri/net/http/test_https.rb
+++ b/test/mri/net/http/test_https.rb
@@ -44,8 +44,10 @@ class TestNetHTTPS < Test::Unit::TestCase
     http.request_get("/") {|res|
       assert_equal($test_net_http_data, res.body)
     }
-    assert_equal(CA_CERT.to_der, certs[0].to_der)
-    assert_equal(SERVER_CERT.to_der, certs[1].to_der)
+    # TODO: OpenSSL 1.1.1h seems to yield only SERVER_CERT; need to check the incompatibility
+    certs.zip([CA_CERT, SERVER_CERT]) do |actual, expected|
+      assert_equal(expected.to_der, actual.to_der)
+    end
   rescue SystemCallError
     skip $!
   end

--- a/test/mri/objspace/test_objspace.rb
+++ b/test/mri/objspace/test_objspace.rb
@@ -98,6 +98,8 @@ class TestObjSpace < Test::Unit::TestCase
     res = ObjectSpace.count_imemo_objects
     assert_not_empty(res)
     assert_not_nil(res[:imemo_cref])
+    assert_not_empty res.inspect
+
     arg = {}
     res = ObjectSpace.count_imemo_objects(arg)
     assert_not_empty(res)

--- a/test/mri/openssl/test_asn1.rb
+++ b/test/mri/openssl/test_asn1.rb
@@ -635,6 +635,11 @@ class  OpenSSL::TestASN1 < OpenSSL::TestCase
     assert_equal data, seq.entries
   end
 
+  def test_gc_stress
+    skip "very time consuming test"
+    assert_ruby_status(['--disable-gems', '-eGC.stress=true', '-erequire "openssl.so"'])
+  end
+
   private
 
   def B(ary)

--- a/test/mri/openssl/test_x509name.rb
+++ b/test/mri/openssl/test_x509name.rb
@@ -441,24 +441,10 @@ class OpenSSL::TestX509Name < OpenSSL::TestCase
     name0 = OpenSSL::X509::Name.new([["DC", "org"], ["DC", "ruby-lang"], ["CN", "bar.ruby-lang.org"]])
     name1 = OpenSSL::X509::Name.new([["DC", "org"], ["DC", "ruby-lang"], ["CN", "bar.ruby-lang.org"]])
     name2 = OpenSSL::X509::Name.new([["DC", "org"], ["DC", "ruby-lang"], ["CN", "baz.ruby-lang.org"]])
-    name3 = OpenSSL::X509::Name.new([["DC", "org"], ["DC", "ruby-lang"], ["CN", "bar.ruby-langg.org"]])
-    name4 = OpenSSL::X509::Name.new([["DC", "org"], ["DC", "ruby-lang"], ["CN", "bbz.ruby-lang.org"]])
     assert_equal true, name0 == name1
     assert_equal true, name0.eql?(name1)
-    assert_equal true, name1 == name0
-    assert_equal true, name1.eql?(name0)
     assert_equal false, name0 == name2
     assert_equal false, name0.eql?(name2)
-    assert_equal false, name2 == name0
-    assert_equal false, name2.eql?(name0)
-    assert_equal false, name0 == name3
-    assert_equal false, name0.eql?(name3)
-    assert_equal false, name3 == name0
-    assert_equal false, name3.eql?(name0)
-    assert_equal false, name0 == name4
-    assert_equal false, name0.eql?(name4)
-    assert_equal false, name4 == name0
-    assert_equal false, name4.eql?(name0)
   end
 
   def test_dup

--- a/test/mri/pathname/test_pathname.rb
+++ b/test/mri/pathname/test_pathname.rb
@@ -824,7 +824,7 @@ class TestPathname < Test::Unit::TestCase
       old = path.lstat.mode
       begin
         path.lchmod(0444)
-      rescue NotImplementedError
+      rescue NotImplementedError, Errno::EOPNOTSUPP
         next
       end
       assert_equal(0444, path.lstat.mode & 0777)

--- a/test/mri/psych/test_alias_and_anchor.rb
+++ b/test/mri/psych/test_alias_and_anchor.rb
@@ -19,7 +19,7 @@ module Psych
 - *id001
 - *id001
 EOYAML
-     result = Psych.unsafe_load yaml
+     result = Psych.load yaml
      result.each {|el| assert_same(result[0], el) }
    end
 
@@ -33,7 +33,7 @@ EOYAML
 - *id001
 EOYAML
 
-     result = Psych.unsafe_load yaml
+     result = Psych.load yaml
      result.each do |el|
       assert_same(result[0], el)
       assert_equal('test1', el.var1)
@@ -50,7 +50,7 @@ EOYAML
 - *id001
 - *id001
 EOYAML
-     result = Psych.unsafe_load yaml
+     result = Psych.load yaml
      result.each do |el|
       assert_same(result[0], el)
       assert_equal('test', el.var1)
@@ -62,7 +62,7 @@ EOYAML
      original = [o,o,o]
 
      yaml = Psych.dump original
-     result = Psych.unsafe_load yaml
+     result = Psych.load yaml
      result.each {|el| assert_same(result[0], el) }
    end
 
@@ -73,7 +73,7 @@ EOYAML
      original = [o,o,o]
 
      yaml = Psych.dump original
-     result = Psych.unsafe_load yaml
+     result = Psych.load yaml
      result.each do |el|
       assert_same(result[0], el)
       assert_equal('test1', el.var1)
@@ -87,7 +87,7 @@ EOYAML
      original = [o,o,o]
 
      yaml = Psych.dump original
-     result = Psych.unsafe_load yaml
+     result = Psych.load yaml
      result.each do |el|
       assert_same(result[0], el)
       assert_equal('test', el.var1)

--- a/test/mri/psych/test_array.rb
+++ b/test/mri/psych/test_array.rb
@@ -24,7 +24,7 @@ module Psych
     def test_another_subclass_with_attributes
       y = Y.new.tap {|o| o.val = 1}
       y << "foo" << "bar"
-      y = Psych.unsafe_load Psych.dump y
+      y = Psych.load Psych.dump y
 
       assert_equal %w{foo bar}, y
       assert_equal Y, y.class
@@ -42,13 +42,13 @@ module Psych
     end
 
     def test_subclass_with_attributes
-      y = Psych.unsafe_load Psych.dump Y.new.tap {|o| o.val = 1}
+      y = Psych.load Psych.dump Y.new.tap {|o| o.val = 1}
       assert_equal Y, y.class
       assert_equal 1, y.val
     end
 
     def test_backwards_with_syck
-      x = Psych.unsafe_load "--- !seq:#{X.name} []\n\n"
+      x = Psych.load "--- !seq:#{X.name} []\n\n"
       assert_equal X, x.class
     end
 

--- a/test/mri/psych/test_class.rb
+++ b/test/mri/psych/test_class.rb
@@ -7,13 +7,13 @@ module Psych
     end
 
     def test_cycle_anonymous_class
-      assert_raise(::TypeError) do
+      assert_raises(::TypeError) do
         assert_cycle(Class.new)
       end
     end
 
     def test_cycle_anonymous_module
-      assert_raise(::TypeError) do
+      assert_raises(::TypeError) do
         assert_cycle(Module.new)
       end
     end

--- a/test/mri/psych/test_coder.rb
+++ b/test/mri/psych/test_coder.rb
@@ -112,19 +112,9 @@ module Psych
       end
     end
 
-    class CustomEncode
-      def initialize(**opts)
-        @opts = opts
-      end
-
-      def encode_with(coder)
-        @opts.each { |k,v| coder.public_send :"#{k}=", v }
-      end
-    end
-
     def test_self_referential
       x = Referential.new
-      copy = Psych.unsafe_load Psych.dump x
+      copy = Psych.load Psych.dump x
       assert_equal copy, copy.a
     end
 
@@ -163,23 +153,23 @@ module Psych
     end
 
     def test_represent_map
-      thing = Psych.unsafe_load(Psych.dump(RepresentWithMap.new))
+      thing = Psych.load(Psych.dump(RepresentWithMap.new))
       assert_equal({ "string" => 'a', :symbol => 'b' }, thing.map)
     end
 
     def test_represent_sequence
-      thing = Psych.unsafe_load(Psych.dump(RepresentWithSeq.new))
+      thing = Psych.load(Psych.dump(RepresentWithSeq.new))
       assert_equal %w{ foo bar }, thing.seq
     end
 
     def test_represent_with_init
-      thing = Psych.unsafe_load(Psych.dump(RepresentWithInit.new))
+      thing = Psych.load(Psych.dump(RepresentWithInit.new))
       assert_equal 'bar', thing.str
     end
 
     def test_represent!
       assert_match(/foo/, Psych.dump(Represent.new))
-      assert_instance_of(Represent, Psych.unsafe_load(Psych.dump(Represent.new)))
+      assert_instance_of(Represent, Psych.load(Psych.dump(Represent.new)))
     end
 
     def test_scalar_coder
@@ -189,7 +179,7 @@ module Psych
 
     def test_load_dumped_tagging
       foo = InitApi.new
-      bar = Psych.unsafe_load(Psych.dump(foo))
+      bar = Psych.load(Psych.dump(foo))
       assert_equal false, bar.implicit
       assert_equal "!ruby/object:Psych::TestCoder::InitApi", bar.tag
       assert_equal Psych::Nodes::Mapping::BLOCK, bar.style
@@ -208,121 +198,10 @@ module Psych
 
     def test_dump_init_with
       foo = InitApi.new
-      bar = Psych.unsafe_load(Psych.dump(foo))
+      bar = Psych.load(Psych.dump(foo))
       assert_equal foo.a, bar.a
       assert_equal foo.b, bar.b
       assert_nil bar.c
-    end
-
-    def test_coder_style_map_default
-      foo = Psych.dump a: 1, b: 2
-      assert_equal foo, "---\n:a: 1\n:b: 2\n"
-    end
-
-    def test_coder_style_map_any
-      foo = Psych.dump CustomEncode.new \
-        map: {a: 1, b: 2},
-        style: Psych::Nodes::Mapping::ANY,
-        tag: nil
-      assert_equal foo, "---\n:a: 1\n:b: 2\n"
-    end
-
-    def test_coder_style_map_block
-      foo = Psych.dump CustomEncode.new \
-        map: {a: 1, b: 2},
-        style: Psych::Nodes::Mapping::BLOCK,
-        tag: nil
-      assert_equal foo, "---\n:a: 1\n:b: 2\n"
-    end
-
-    def test_coder_style_map_flow
-      foo = Psych.dump CustomEncode.new \
-        map: { a: 1, b: 2 },
-        style: Psych::Nodes::Mapping::FLOW,
-        tag: nil
-      assert_equal foo, "--- {! ':a': 1, ! ':b': 2}\n"
-    end
-
-    def test_coder_style_seq_default
-      foo = Psych.dump [ 1, 2, 3 ]
-      assert_equal foo, "---\n- 1\n- 2\n- 3\n"
-    end
-
-    def test_coder_style_seq_any
-      foo = Psych.dump CustomEncode.new \
-        seq: [ 1, 2, 3 ],
-        style: Psych::Nodes::Sequence::ANY,
-        tag: nil
-      assert_equal foo, "---\n- 1\n- 2\n- 3\n"
-    end
-
-    def test_coder_style_seq_block
-      foo = Psych.dump CustomEncode.new \
-        seq: [ 1, 2, 3 ],
-        style: Psych::Nodes::Sequence::BLOCK,
-        tag: nil
-      assert_equal foo, "---\n- 1\n- 2\n- 3\n"
-    end
-
-    def test_coder_style_seq_flow
-      foo = Psych.dump CustomEncode.new \
-        seq: [ 1, 2, 3 ],
-        style: Psych::Nodes::Sequence::FLOW,
-        tag: nil
-      assert_equal foo, "--- [1, 2, 3]\n"
-    end
-
-    def test_coder_style_scalar_default
-      foo = Psych.dump 'some scalar'
-      assert_equal foo, "--- some scalar\n"
-    end
-
-    def test_coder_style_scalar_any
-      foo = Psych.dump CustomEncode.new \
-        scalar: 'some scalar',
-        style: Psych::Nodes::Scalar::ANY,
-        tag: nil
-      assert_equal foo, "--- some scalar\n"
-    end
-
-    def test_coder_style_scalar_plain
-      foo = Psych.dump CustomEncode.new \
-        scalar: 'some scalar',
-        style: Psych::Nodes::Scalar::PLAIN,
-        tag: nil
-      assert_equal foo, "--- some scalar\n"
-    end
-
-    def test_coder_style_scalar_single_quoted
-      foo = Psych.dump CustomEncode.new \
-        scalar: 'some scalar',
-        style: Psych::Nodes::Scalar::SINGLE_QUOTED,
-        tag: nil
-      assert_equal foo, "--- ! 'some scalar'\n"
-    end
-
-    def test_coder_style_scalar_double_quoted
-      foo = Psych.dump CustomEncode.new \
-        scalar: 'some scalar',
-        style: Psych::Nodes::Scalar::DOUBLE_QUOTED,
-        tag: nil
-      assert_equal foo, %Q'--- ! "some scalar"\n'
-    end
-
-    def test_coder_style_scalar_literal
-      foo = Psych.dump CustomEncode.new \
-        scalar: 'some scalar',
-        style: Psych::Nodes::Scalar::LITERAL,
-        tag: nil
-      assert_equal foo, "--- ! |-\n  some scalar\n"
-    end
-
-    def test_coder_style_scalar_folded
-      foo = Psych.dump CustomEncode.new \
-        scalar: 'some scalar',
-        style: Psych::Nodes::Scalar::FOLDED,
-        tag: nil
-      assert_equal foo, "--- ! >-\n  some scalar\n"
     end
   end
 end

--- a/test/mri/psych/test_date_time.rb
+++ b/test/mri/psych/test_date_time.rb
@@ -22,7 +22,7 @@ module Psych
     def test_timezone_offset
       times = [Time.new(2017, 4, 13, 12, 0, 0, "+09:00"),
                Time.new(2017, 4, 13, 12, 0, 0, "-05:00")]
-      cycled = Psych::unsafe_load(Psych.dump times)
+      cycled = Psych::load(Psych.dump times)
       assert_match(/12:00:00 \+0900/, cycled.first.to_s)
       assert_match(/12:00:00 -0500/,  cycled.last.to_s)
     end
@@ -39,7 +39,7 @@ module Psych
     def test_datetime_timezone_offset
       times = [DateTime.new(2017, 4, 13, 12, 0, 0, "+09:00"),
                DateTime.new(2017, 4, 13, 12, 0, 0, "-05:00")]
-      cycled = Psych::unsafe_load(Psych.dump times)
+      cycled = Psych::load(Psych.dump times)
       assert_match(/12:00:00\+09:00/, cycled.first.to_s)
       assert_match(/12:00:00-05:00/,  cycled.last.to_s)
     end

--- a/test/mri/psych/test_deprecated.rb
+++ b/test/mri/psych/test_deprecated.rb
@@ -41,7 +41,7 @@ module Psych
     def test_recursive_quick_emit_encode_with
       qeew = QuickEmitterEncodeWith.new
       hash  = { :qe => qeew }
-      hash2 = Psych.unsafe_load Psych.dump hash
+      hash2 = Psych.load Psych.dump hash
       qe    = hash2[:qe]
 
       assert_equal qeew.name, qe.name
@@ -72,7 +72,7 @@ module Psych
     # receive the yaml_initialize call.
     def test_yaml_initialize_and_init_with
       hash  = { :yi => YamlInitAndInitWith.new }
-      hash2 = Psych.unsafe_load Psych.dump hash
+      hash2 = Psych.load Psych.dump hash
       yi    = hash2[:yi]
 
       assert_equal 'TGIF!', yi.name

--- a/test/mri/psych/test_document.rb
+++ b/test/mri/psych/test_document.rb
@@ -30,7 +30,7 @@ module Psych
     end
 
     def test_emit_bad_tag
-      assert_raise(RuntimeError) do
+      assert_raises(RuntimeError) do
         @doc.tag_directives = [['!']]
         @stream.yaml
       end

--- a/test/mri/psych/test_emitter.rb
+++ b/test/mri/psych/test_emitter.rb
@@ -40,7 +40,7 @@ module Psych
     end
 
     def test_start_stream_arg_error
-      assert_raise(TypeError) do
+      assert_raises(TypeError) do
         @emitter.start_stream 'asdfasdf'
       end
     end
@@ -56,7 +56,7 @@ module Psych
         [[], [nil,nil], false],
         [[1,1], [[nil, "tag:TALOS"]], 0],
       ].each do |args|
-        assert_raise(TypeError) do
+        assert_raises(TypeError) do
           @emitter.start_document(*args)
         end
       end
@@ -73,7 +73,7 @@ module Psych
         ['foo', nil, nil, false, true, :foo],
         [nil, nil, nil, false, true, 1],
       ].each do |args|
-        assert_raise(TypeError) do
+        assert_raises(TypeError) do
           @emitter.scalar(*args)
         end
       end
@@ -83,11 +83,11 @@ module Psych
       @emitter.start_stream Psych::Nodes::Stream::UTF8
       @emitter.start_document [], [], false
 
-      assert_raise(TypeError) do
+      assert_raises(TypeError) do
         @emitter.start_sequence(nil, Object.new, true, 1)
       end
 
-      assert_raise(TypeError) do
+      assert_raises(TypeError) do
         @emitter.start_sequence(nil, nil, true, :foo)
       end
     end

--- a/test/mri/psych/test_encoding.rb
+++ b/test/mri/psych/test_encoding.rb
@@ -63,7 +63,7 @@ module Psych
         # If the external encoding isn't utf8, utf16le, or utf16be, we cannot
         # process the file.
         File.open(t.path, 'r', :encoding => 'SHIFT_JIS') do |f|
-          assert_raise Psych::SyntaxError do
+          assert_raises Psych::SyntaxError do
             Psych.load(f)
           end
         end
@@ -121,7 +121,7 @@ module Psych
     def test_emit_alias
       @emitter.start_stream Psych::Parser::UTF8
       @emitter.start_document [], [], true
-      e = assert_raise(RuntimeError) do
+      e = assert_raises(RuntimeError) do
         @emitter.alias 'ドラえもん'.encode('EUC-JP')
       end
       assert_match(/alias value/, e.message)

--- a/test/mri/psych/test_exception.rb
+++ b/test/mri/psych/test_exception.rb
@@ -23,52 +23,38 @@ module Psych
       $VERBOSE = @orig_verbose
     end
 
-    def make_ex msg = 'oh no!'
-      begin
-        raise msg
-      rescue ::Exception => e
-        e
-      end
-    end
-
-    def test_backtrace
-      err     = make_ex
-      new_err = Psych.unsafe_load(Psych.dump(err))
-      assert_equal err.backtrace, new_err.backtrace
-    end
-
     def test_naming_exception
       err     = String.xxx rescue $!
-      new_err = Psych.unsafe_load(Psych.dump(err))
+      new_err = Psych.load(Psych.dump(err))
       assert_equal err.message, new_err.message
     end
 
     def test_load_takes_file
-      ex = assert_raise(Psych::SyntaxError) do
+      ex = assert_raises(Psych::SyntaxError) do
         Psych.load '--- `'
       end
       assert_nil ex.file
 
-      ex = assert_raise(Psych::SyntaxError) do
+      ex = assert_raises(Psych::SyntaxError) do
         Psych.load '--- `', filename: 'meow'
       end
       assert_equal 'meow', ex.file
 
       # deprecated interface
-      ex = assert_raise(Psych::SyntaxError) do
-        Psych.unsafe_load '--- `', 'deprecated'
+      ex = assert_raises(Psych::SyntaxError) do
+        Psych.load '--- `', 'deprecated'
       end
       assert_equal 'deprecated', ex.file
     end
 
     def test_psych_parse_stream_takes_file
-      ex = assert_raise(Psych::SyntaxError) do
+      ex = assert_raises(Psych::SyntaxError) do
         Psych.parse_stream '--- `'
       end
       assert_nil ex.file
       assert_match '(<unknown>)', ex.message
 
-      ex = assert_raise(Psych::SyntaxError) do
+      ex = assert_raises(Psych::SyntaxError) do
         Psych.parse_stream '--- `', filename: 'omg!'
       end
       assert_equal 'omg!', ex.file
@@ -76,19 +62,19 @@ module Psych
     end
 
     def test_load_stream_takes_file
-      ex = assert_raise(Psych::SyntaxError) do
+      ex = assert_raises(Psych::SyntaxError) do
         Psych.load_stream '--- `'
       end
       assert_nil ex.file
       assert_match '(<unknown>)', ex.message
 
-      ex = assert_raise(Psych::SyntaxError) do
+      ex = assert_raises(Psych::SyntaxError) do
         Psych.load_stream '--- `', filename: 'omg!'
       end
       assert_equal 'omg!', ex.file
 
       # deprecated interface
-      ex = assert_raise(Psych::SyntaxError) do
+      ex = assert_raises(Psych::SyntaxError) do
         Psych.load_stream '--- `', 'deprecated'
       end
       assert_equal 'deprecated', ex.file
@@ -99,7 +85,7 @@ module Psych
         t.binmode
         t.write '--- `'
         t.close
-        ex = assert_raise(Psych::SyntaxError) do
+        ex = assert_raises(Psych::SyntaxError) do
           Psych.parse_file t.path
         end
         assert_equal t.path, ex.file
@@ -111,46 +97,34 @@ module Psych
         t.binmode
         t.write '--- `'
         t.close
-        ex = assert_raise(Psych::SyntaxError) do
+        ex = assert_raises(Psych::SyntaxError) do
           Psych.load_file t.path
         end
         assert_equal t.path, ex.file
       }
     end
 
-    def test_safe_load_file_exception
-      Tempfile.create(['loadfile', 'yml']) {|t|
-        t.binmode
-        t.write '--- `'
-        t.close
-        ex = assert_raise(Psych::SyntaxError) do
-          Psych.safe_load_file t.path
-        end
-        assert_equal t.path, ex.file
-      }
-    end
-
     def test_psych_parse_takes_file
-      ex = assert_raise(Psych::SyntaxError) do
+      ex = assert_raises(Psych::SyntaxError) do
         Psych.parse '--- `'
       end
       assert_match '(<unknown>)', ex.message
       assert_nil ex.file
 
-      ex = assert_raise(Psych::SyntaxError) do
+      ex = assert_raises(Psych::SyntaxError) do
         Psych.parse '--- `', filename: 'omg!'
       end
       assert_match 'omg!', ex.message
 
       # deprecated interface
-      ex = assert_raise(Psych::SyntaxError) do
+      ex = assert_raises(Psych::SyntaxError) do
         Psych.parse '--- `', 'deprecated'
       end
       assert_match 'deprecated', ex.message
     end
 
     def test_attributes
-      e = assert_raise(Psych::SyntaxError) {
+      e = assert_raises(Psych::SyntaxError) {
         Psych.load '--- `foo'
       }
 
@@ -165,9 +139,8 @@ module Psych
     end
 
     def test_convert
-      w = Psych.unsafe_load(Psych.dump(@wups))
-      assert_equal @wups.message, w.message
-      assert_equal @wups.backtrace, w.backtrace
+      w = Psych.load(Psych.dump(@wups))
+      assert_equal @wups, w
       assert_equal 1, w.foo
       assert_equal 2, w.bar
     end

--- a/test/mri/psych/test_hash.rb
+++ b/test/mri/psych/test_hash.rb
@@ -6,18 +6,6 @@ module Psych
     class X < Hash
     end
 
-    class HashWithIvar < Hash
-      def initialize
-        @keys = []
-        super
-      end
-
-      def []=(k, v)
-        @keys << k
-        super(k, v)
-      end
-    end
-
     class HashWithCustomInit < Hash
       attr_reader :obj
       def initialize(obj)
@@ -36,14 +24,6 @@ module Psych
       @hash = { :a => 'b' }
     end
 
-    def test_hash_with_ivar
-      t1 = HashWithIvar.new
-      t1[:foo] = :bar
-      t2 = Psych.unsafe_load(Psych.dump(t1))
-      assert_equal t1, t2
-      assert_cycle t1
-    end
-
     def test_referenced_hash_with_ivar
       a = [1,2,3,4,5]
       t1 = [HashWithCustomInit.new(a)]
@@ -54,14 +34,14 @@ module Psych
     def test_custom_initialized
       a = [1,2,3,4,5]
       t1 = HashWithCustomInit.new(a)
-      t2 = Psych.unsafe_load(Psych.dump(t1))
+      t2 = Psych.load(Psych.dump(t1))
       assert_equal t1, t2
       assert_cycle t1
     end
 
     def test_custom_initialize_no_ivar
       t1 = HashWithCustomInitNoIvar.new(nil)
-      t2 = Psych.unsafe_load(Psych.dump(t1))
+      t2 = Psych.load(Psych.dump(t1))
       assert_equal t1, t2
       assert_cycle t1
     end
@@ -70,25 +50,25 @@ module Psych
       x = X.new
       x[:a] = 'b'
       x.instance_variable_set :@foo, 'bar'
-      dup = Psych.unsafe_load Psych.dump x
+      dup = Psych.load Psych.dump x
       assert_cycle x
       assert_equal 'bar', dup.instance_variable_get(:@foo)
       assert_equal X, dup.class
     end
 
     def test_load_with_class_syck_compatibility
-      hash = Psych.unsafe_load "--- !ruby/object:Hash\n:user_id: 7\n:username: Lucas\n"
+      hash = Psych.load "--- !ruby/object:Hash\n:user_id: 7\n:username: Lucas\n"
       assert_equal({ user_id: 7, username: 'Lucas'}, hash)
     end
 
     def test_empty_subclass
       assert_match "!ruby/hash:#{X}", Psych.dump(X.new)
-      x = Psych.unsafe_load Psych.dump X.new
+      x = Psych.load Psych.dump X.new
       assert_equal X, x.class
     end
 
     def test_map
-      x = Psych.unsafe_load "--- !map:#{X} { }\n"
+      x = Psych.load "--- !map:#{X} { }\n"
       assert_equal X, x.class
     end
 
@@ -102,7 +82,7 @@ module Psych
     end
 
     def test_ref_append
-      hash = Psych.unsafe_load(<<-eoyml)
+      hash = Psych.load(<<-eoyml)
 ---
 foo: &foo
   hello: world
@@ -110,20 +90,6 @@ bar:
   <<: *foo
 eoyml
       assert_equal({"foo"=>{"hello"=>"world"}, "bar"=>{"hello"=>"world"}}, hash)
-    end
-
-    def test_key_deduplication
-      unless String.method_defined?(:-@) && (-("a" * 20)).equal?((-("a" * 20)))
-        pend "This Ruby implementation doesn't support string deduplication"
-      end
-
-      hashes = Psych.load(<<-eoyml)
----
-- unique_identifier: 1
-- unique_identifier: 2
-eoyml
-
-      assert_same hashes[0].keys.first, hashes[1].keys.first
     end
   end
 end

--- a/test/mri/psych/test_marshalable.rb
+++ b/test/mri/psych/test_marshalable.rb
@@ -6,7 +6,7 @@ module Psych
   class TestMarshalable < TestCase
     def test_objects_defining_marshal_dump_and_marshal_load_can_be_dumped
       sd = SimpleDelegator.new(1)
-      loaded = Psych.unsafe_load(Psych.dump(sd))
+      loaded = Psych.load(Psych.dump(sd))
 
       assert_instance_of(SimpleDelegator, loaded)
       assert_equal(sd, loaded)
@@ -46,15 +46,7 @@ module Psych
 
     def test_init_with_takes_priority_over_marshal_methods
       obj = PsychCustomMarshalable.new(1)
-      loaded = Psych.unsafe_load(Psych.dump(obj))
-
-      assert(PsychCustomMarshalable === loaded)
-      assert_equal(2, loaded.foo)
-    end
-
-    def test_init_symbolize_names
-      obj = PsychCustomMarshalable.new(1)
-      loaded = Psych.unsafe_load(Psych.dump(obj), symbolize_names: true)
+      loaded = Psych.load(Psych.dump(obj))
 
       assert(PsychCustomMarshalable === loaded)
       assert_equal(2, loaded.foo)

--- a/test/mri/psych/test_merge_keys.rb
+++ b/test/mri/psych/test_merge_keys.rb
@@ -17,16 +17,6 @@ map:
       assert_equal hash, doc
     end
 
-    def test_merge_key_with_bare_hash_symbolized_names
-      doc = Psych.load <<-eodoc, symbolize_names: true
-map:
-  <<:
-    hello: world
-      eodoc
-      hash = { map: { hello: "world" } }
-      assert_equal hash, doc
-    end
-
     def test_roundtrip_with_chevron_key
       h = {}
       v = { 'a' => h, '<<' => h }
@@ -34,7 +24,7 @@ map:
     end
 
     def test_explicit_string
-      doc = Psych.unsafe_load <<-eoyml
+      doc = Psych.load <<-eoyml
 a: &me { hello: world }
 b: { !!str '<<': *me }
 eoyml
@@ -55,7 +45,7 @@ product:
   !ruby/object:#{Product.name}
   <<: *foo
       eoyml
-      hash = Psych.unsafe_load s
+      hash = Psych.load s
       assert_equal({"bar" => 10}, hash["foo"])
       product = hash["product"]
       assert_equal 10, product.bar
@@ -67,7 +57,7 @@ defaults: &defaults
 development:
   <<: *defaults
       eoyml
-      assert_equal({'<<' => nil }, Psych.unsafe_load(yaml)['development'])
+      assert_equal({'<<' => nil }, Psych.load(yaml)['development'])
     end
 
     def test_merge_array
@@ -77,7 +67,7 @@ foo: &hello
 baz:
   <<: *hello
       eoyml
-      assert_equal({'<<' => [1]}, Psych.unsafe_load(yaml)['baz'])
+      assert_equal({'<<' => [1]}, Psych.load(yaml)['baz'])
     end
 
     def test_merge_is_not_partial
@@ -89,9 +79,9 @@ foo: &hello
 baz:
   <<: [*hello, *default]
       eoyml
-      doc = Psych.unsafe_load yaml
+      doc = Psych.load yaml
       refute doc['baz'].key? 'hello'
-      assert_equal({'<<' => [[1], {"hello"=>"world"}]}, Psych.unsafe_load(yaml)['baz'])
+      assert_equal({'<<' => [[1], {"hello"=>"world"}]}, Psych.load(yaml)['baz'])
     end
 
     def test_merge_seq_nil
@@ -100,7 +90,7 @@ foo: &hello
 baz:
   <<: [*hello]
       eoyml
-      assert_equal({'<<' => [nil]}, Psych.unsafe_load(yaml)['baz'])
+      assert_equal({'<<' => [nil]}, Psych.load(yaml)['baz'])
     end
 
     def test_bad_seq_merge
@@ -109,7 +99,7 @@ defaults: &defaults [1, 2, 3]
 development:
   <<: *defaults
       eoyml
-      assert_equal({'<<' => [1,2,3]}, Psych.unsafe_load(yaml)['development'])
+      assert_equal({'<<' => [1,2,3]}, Psych.load(yaml)['development'])
     end
 
     def test_missing_merge_key
@@ -117,7 +107,7 @@ development:
 bar:
   << : *foo
       eoyml
-      exp = assert_raise(Psych::BadAlias) { Psych.load yaml }
+      exp = assert_raises(Psych::BadAlias) { Psych.load yaml }
       assert_match 'foo', exp.message
     end
 
@@ -134,7 +124,7 @@ bar:
       hash = {
         "foo" => { "hello" => "world"},
         "bar" => { "hello" => "world", "baz" => "boo" } }
-      assert_equal hash, Psych.unsafe_load(yaml)
+      assert_equal hash, Psych.load(yaml)
     end
 
     def test_multiple_maps
@@ -159,7 +149,7 @@ bar:
         'label' => 'center/big'
       }
 
-      assert_equal hash, Psych.unsafe_load(yaml)[4]
+      assert_equal hash, Psych.load(yaml)[4]
     end
 
     def test_override
@@ -185,7 +175,7 @@ bar:
         'label' => 'center/big'
       }
 
-      assert_equal hash, Psych.unsafe_load(yaml)[4]
+      assert_equal hash, Psych.load(yaml)[4]
     end
   end
 end

--- a/test/mri/psych/test_object.rb
+++ b/test/mri/psych/test_object.rb
@@ -28,7 +28,7 @@ module Psych
 
     def test_tag_round_trip
       tag   = Tagged.new
-      tag2  = Psych.unsafe_load(Psych.dump(tag))
+      tag2  = Psych.load(Psych.dump(tag))
       assert_equal tag.baz, tag2.baz
       assert_instance_of(Tagged, tag2)
     end
@@ -36,7 +36,7 @@ module Psych
     def test_cyclic_references
       foo = Foo.new(nil)
       foo.parent = foo
-      loaded = Psych.unsafe_load Psych.dump foo
+      loaded = Psych.load Psych.dump foo
 
       assert_instance_of(Foo, loaded)
       assert_equal loaded, loaded.parent

--- a/test/mri/psych/test_object_references.rb
+++ b/test/mri/psych/test_object_references.rb
@@ -34,16 +34,12 @@ module Psych
     def assert_reference_trip obj
       yml = Psych.dump([obj, obj])
       assert_match(/\*-?\d+/, yml)
-      begin
-        data = Psych.load yml
-      rescue Psych::DisallowedClass
-        data = Psych.unsafe_load yml
-      end
+      data = Psych.load yml
       assert_equal data.first.object_id, data.last.object_id
     end
 
     def test_float_references
-      data = Psych.unsafe_load <<-eoyml
+      data = Psych.load <<-eoyml
 ---\s
 - &name 1.2
 - *name
@@ -53,7 +49,7 @@ module Psych
     end
 
     def test_binary_references
-      data = Psych.unsafe_load <<-eoyml
+      data = Psych.load <<-eoyml
 ---
 - &name !binary |-
   aGVsbG8gd29ybGQh
@@ -64,7 +60,7 @@ module Psych
     end
 
     def test_regexp_references
-      data = Psych.unsafe_load <<-eoyml
+      data = Psych.load <<-eoyml
 ---\s
 - &name !ruby/regexp /pattern/i
 - *name

--- a/test/mri/psych/test_omap.rb
+++ b/test/mri/psych/test_omap.rb
@@ -4,7 +4,7 @@ require_relative 'helper'
 module Psych
   class TestOmap < TestCase
     def test_parse_as_map
-      o = Psych.unsafe_load "--- !!omap\na: 1\nb: 2"
+      o = Psych.load "--- !!omap\na: 1\nb: 2"
       assert_kind_of Psych::Omap, o
       assert_equal 1, o['a']
       assert_equal 2, o['b']
@@ -14,7 +14,7 @@ module Psych
       map = Psych::Omap.new
       map['foo'] = 'bar'
       map['self'] = map
-      assert_equal(map, Psych.unsafe_load(Psych.dump(map)))
+      assert_equal(map, Psych.load(Psych.dump(map)))
     end
 
     def test_keys

--- a/test/mri/psych/test_parser.rb
+++ b/test/mri/psych/test_parser.rb
@@ -63,7 +63,7 @@ module Psych
 
         parser = Psych::Parser.new klass.new
         2.times {
-          assert_raise(RuntimeError, method.to_s) do
+          assert_raises(RuntimeError, method.to_s) do
             parser.parse yaml
           end
         }
@@ -77,7 +77,7 @@ module Psych
     end
 
     def test_filename
-      ex = assert_raise(Psych::SyntaxError) do
+      ex = assert_raises(Psych::SyntaxError) do
         @parser.parse '--- `', 'omg!'
       end
       assert_match 'omg!', ex.message
@@ -180,7 +180,7 @@ module Psych
       def o.external_encoding; nil end
       def o.read len; self end
 
-      assert_raise(TypeError) do
+      assert_raises(TypeError) do
         @parser.parse o
       end
     end
@@ -193,23 +193,23 @@ module Psych
     end
 
     def test_syntax_error
-      assert_raise(Psych::SyntaxError) do
+      assert_raises(Psych::SyntaxError) do
         @parser.parse("---\n\"foo\"\n\"bar\"\n")
       end
     end
 
     def test_syntax_error_twice
-      assert_raise(Psych::SyntaxError) do
+      assert_raises(Psych::SyntaxError) do
         @parser.parse("---\n\"foo\"\n\"bar\"\n")
       end
 
-      assert_raise(Psych::SyntaxError) do
+      assert_raises(Psych::SyntaxError) do
         @parser.parse("---\n\"foo\"\n\"bar\"\n")
       end
     end
 
     def test_syntax_error_has_path_for_string
-      e = assert_raise(Psych::SyntaxError) do
+      e = assert_raises(Psych::SyntaxError) do
         @parser.parse("---\n\"foo\"\n\"bar\"\n")
       end
       assert_match '(<unknown>):', e.message
@@ -219,7 +219,7 @@ module Psych
       io = StringIO.new "---\n\"foo\"\n\"bar\"\n"
       def io.path; "hello!"; end
 
-      e = assert_raise(Psych::SyntaxError) do
+      e = assert_raises(Psych::SyntaxError) do
         @parser.parse(io)
       end
       assert_match "(#{io.path}):", e.message

--- a/test/mri/psych/test_psych.rb
+++ b/test/mri/psych/test_psych.rb
@@ -16,7 +16,7 @@ class TestPsych < Psych::TestCase
   end
 
   def test_line_width_invalid
-    assert_raise(ArgumentError) { Psych.dump('x', { :line_width => -2 }) }
+    assert_raises(ArgumentError) { Psych.dump('x', { :line_width => -2 }) }
   end
 
   def test_line_width_no_limit
@@ -61,7 +61,7 @@ class TestPsych < Psych::TestCase
   end
 
   def test_load_argument_error
-    assert_raise(TypeError) do
+    assert_raises(TypeError) do
       Psych.load nil
     end
   end
@@ -75,7 +75,7 @@ class TestPsych < Psych::TestCase
   end
 
   def test_parse_raises_on_bad_input
-    assert_raise(Psych::SyntaxError) { Psych.parse("--- `") }
+    assert_raises(Psych::SyntaxError) { Psych.parse("--- `") }
   end
 
   def test_parse_with_fallback
@@ -83,8 +83,8 @@ class TestPsych < Psych::TestCase
   end
 
   def test_non_existing_class_on_deserialize
-    e = assert_raise(ArgumentError) do
-      Psych.unsafe_load("--- !ruby/object:NonExistent\nfoo: 1")
+    e = assert_raises(ArgumentError) do
+      Psych.load("--- !ruby/object:NonExistent\nfoo: 1")
     end
     assert_equal 'undefined class/module NonExistent', e.message
   end
@@ -125,25 +125,12 @@ class TestPsych < Psych::TestCase
     assert_equal %w{ foo bar }, docs
   end
 
-  def test_load_stream_freeze
-    docs = Psych.load_stream("--- foo\n...\n--- bar\n...", freeze: true)
-    assert_equal %w{ foo bar }, docs
-    docs.each do |string|
-      assert_predicate string, :frozen?
-    end
-  end
-
-  def test_load_stream_symbolize_names
-    docs = Psych.load_stream("---\nfoo: bar", symbolize_names: true)
-    assert_equal [{foo: 'bar'}], docs
-  end
-
   def test_load_stream_default_fallback
     assert_equal [], Psych.load_stream("")
   end
 
   def test_load_stream_raises_on_bad_input
-    assert_raise(Psych::SyntaxError) { Psych.load_stream("--- `") }
+    assert_raises(Psych::SyntaxError) { Psych.load_stream("--- `") }
   end
 
   def test_parse_stream
@@ -175,7 +162,7 @@ class TestPsych < Psych::TestCase
   end
 
   def test_parse_stream_raises_on_bad_input
-    assert_raise(Psych::SyntaxError) { Psych.parse_stream("--- `") }
+    assert_raises(Psych::SyntaxError) { Psych.parse_stream("--- `") }
   end
 
   def test_add_builtin_type
@@ -205,45 +192,29 @@ class TestPsych < Psych::TestCase
     assert_equal({ 'hello' => 'world' }, got)
   end
 
-  def test_load_freeze
-    data = Psych.load("--- {foo: ['a']}", freeze: true)
-    assert_predicate data, :frozen?
-    assert_predicate data['foo'], :frozen?
-    assert_predicate data['foo'].first, :frozen?
-  end
-
-  def test_load_freeze_deduplication
-    unless String.method_defined?(:-@) && (-("a" * 20)).equal?((-("a" * 20)))
-      pend "This Ruby implementation doesn't support string deduplication"
-    end
-
-    data = Psych.load("--- ['a']", freeze: true)
-    assert_same 'a', data.first
-  end
-
   def test_load_default_fallback
-    assert_equal false, Psych.unsafe_load("")
+    assert_equal false, Psych.load("")
   end
 
   def test_load_with_fallback
-    assert_equal 42, Psych.load("", filename: "file", fallback: 42)
+    assert_equal 42, Psych.load("", "file", fallback: 42)
   end
 
   def test_load_with_fallback_nil_or_false
-    assert_nil Psych.load("", filename: "file", fallback: nil)
-    assert_equal false, Psych.load("", filename: "file", fallback: false)
+    assert_nil Psych.load("", "file", fallback: nil)
+    assert_equal false, Psych.load("", "file", fallback: false)
   end
 
   def test_load_with_fallback_hash
-    assert_equal Hash.new, Psych.load("", filename: "file", fallback: Hash.new)
+    assert_equal Hash.new, Psych.load("", "file", fallback: Hash.new)
   end
 
   def test_load_with_fallback_for_nil
-    assert_nil Psych.unsafe_load("--- null", "file", fallback: 42)
+    assert_nil Psych.load("--- null", "file", fallback: 42)
   end
 
   def test_load_with_fallback_for_false
-    assert_equal false, Psych.unsafe_load("--- false", "file", fallback: 42)
+    assert_equal false, Psych.load("--- false", "file", fallback: 42)
   end
 
   def test_load_file
@@ -255,30 +226,9 @@ class TestPsych < Psych::TestCase
     }
   end
 
-  def test_load_file_freeze
-    Tempfile.create(['yikes', 'yml']) {|t|
-      t.binmode
-      t.write('--- hello world')
-      t.close
-
-      object = Psych.load_file(t.path, freeze: true)
-      assert_predicate object, :frozen?
-    }
-  end
-
-  def test_load_file_symbolize_names
-    Tempfile.create(['yikes', 'yml']) {|t|
-      t.binmode
-      t.write("---\nfoo: bar")
-      t.close
-
-      assert_equal({foo: 'bar'}, Psych.load_file(t.path, symbolize_names: true))
-    }
-  end
-
   def test_load_file_default_fallback
     Tempfile.create(['empty', 'yml']) {|t|
-      assert_equal false, Psych.unsafe_load_file(t.path)
+      assert_equal false, Psych.load_file(t.path)
     }
   end
 
@@ -319,18 +269,6 @@ class TestPsych < Psych::TestCase
     }
   end
 
-  def test_safe_load_file_with_permitted_classe
-    Tempfile.create(['false', 'yml']) {|t|
-      t.binmode
-      t.write("--- !ruby/range\nbegin: 0\nend: 42\nexcl: false\n")
-      t.close
-      assert_equal 0..42, Psych.safe_load_file(t.path, permitted_classes: [Range])
-      assert_raise(Psych::DisallowedClass) {
-        Psych.safe_load_file(t.path)
-      }
-    }
-  end
-
   def test_parse_file
     Tempfile.create(['yikes', 'yml']) {|t|
       t.binmode
@@ -347,9 +285,9 @@ class TestPsych < Psych::TestCase
   end
 
   def test_degenerate_strings
-    assert_equal false, Psych.unsafe_load('    ')
+    assert_equal false, Psych.load('    ')
     assert_equal false, Psych.parse('   ')
-    assert_equal false, Psych.unsafe_load('')
+    assert_equal false, Psych.load('')
     assert_equal false, Psych.parse('')
   end
 
@@ -371,18 +309,17 @@ class TestPsych < Psych::TestCase
     yaml = <<-eoyml
 foo:
   bar: baz
-  1: 2
 hoge:
   - fuga: piyo
     eoyml
 
     result = Psych.load(yaml)
-    assert_equal result, { "foo" => { "bar" => "baz", 1 => 2 }, "hoge" => [{ "fuga" => "piyo" }] }
+    assert_equal result, { "foo" => { "bar" => "baz"}, "hoge" => [{ "fuga" => "piyo" }] }
 
     result = Psych.load(yaml, symbolize_names: true)
-    assert_equal result, { foo: { bar: "baz", 1 => 2 }, hoge: [{ fuga: "piyo" }] }
+    assert_equal result, { foo: { bar: "baz" }, hoge: [{ fuga: "piyo" }] }
 
     result = Psych.safe_load(yaml, symbolize_names: true)
-    assert_equal result, { foo: { bar: "baz", 1 => 2 }, hoge: [{ fuga: "piyo" }] }
+    assert_equal result, { foo: { bar: "baz" }, hoge: [{ fuga: "piyo" }] }
   end
 end

--- a/test/mri/psych/test_ractor.rb
+++ b/test/mri/psych/test_ractor.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+require_relative 'helper'
+
+class TestPsychRactor < Test::Unit::TestCase
+  def test_ractor_round_trip
+    assert_ractor(<<~RUBY, require_relative: 'helper')
+      obj = {foo: [42]}
+      obj2 = Ractor.new(obj) do |obj|
+        Psych.unsafe_load(Psych.dump(obj))
+      end.take
+      assert_equal obj, obj2
+    RUBY
+  end
+
+  def test_not_shareable
+    # There's no point in making these frozen / shareable
+    # and the C-ext disregards begin frozen
+    assert_ractor(<<~RUBY, require_relative: 'helper')
+      parser = Psych::Parser.new
+      emitter = Psych::Emitter.new(nil)
+      assert_raise(Ractor::Error) { Ractor.make_shareable(parser) }
+      assert_raise(Ractor::Error) { Ractor.make_shareable(emitter) }
+    RUBY
+  end
+
+  def test_ractor_config
+    # Config is ractor-local
+    # Test is to make sure it works, even though usage is probably very low.
+    # The methods are not documented and might be deprecated one day
+    assert_ractor(<<~RUBY, require_relative: 'helper')
+      r = Ractor.new do
+        Psych.add_builtin_type 'omap' do |type, val|
+          val * 2
+        end
+        Psych.load('--- !!omap hello')
+      end.take
+      assert_equal 'hellohello', r
+      assert_equal 'hello', Psych.load('--- !!omap hello')
+    RUBY
+  end
+
+  def test_ractor_constants
+    assert_ractor(<<~RUBY, require_relative: 'helper')
+      r = Ractor.new do
+        Psych.libyaml_version.join('.') == Psych::LIBYAML_VERSION
+      end.take
+      assert_equal true, r
+    RUBY
+  end
+end if defined?(Ractor)

--- a/test/mri/psych/test_safe_load.rb
+++ b/test/mri/psych/test_safe_load.rb
@@ -22,7 +22,7 @@ module Psych
     def test_no_recursion
       x = []
       x << x
-      assert_raise(Psych::BadAlias) do
+      assert_raises(Psych::BadAlias) do
         Psych.safe_load Psych.dump(x)
       end
     end
@@ -37,7 +37,7 @@ module Psych
 
     def test_permitted_symbol
       yml = Psych.dump :foo
-      assert_raise(Psych::DisallowedClass) do
+      assert_raises(Psych::DisallowedClass) do
         Psych.safe_load yml
       end
       assert_equal(
@@ -54,15 +54,15 @@ module Psych
     end
 
     def test_symbol
-      assert_raise(Psych::DisallowedClass) do
+      assert_raises(Psych::DisallowedClass) do
         assert_safe_cycle :foo
       end
-      assert_raise(Psych::DisallowedClass) do
+      assert_raises(Psych::DisallowedClass) do
         Psych.safe_load '--- !ruby/symbol foo', permitted_classes: []
       end
 
       # deprecated interface
-      assert_raise(Psych::DisallowedClass) do
+      assert_raises(Psych::DisallowedClass) do
         Psych.safe_load '--- !ruby/symbol foo', []
       end
 
@@ -75,16 +75,16 @@ module Psych
     end
 
     def test_foo
-      assert_raise(Psych::DisallowedClass) do
+      assert_raises(Psych::DisallowedClass) do
         Psych.safe_load '--- !ruby/object:Foo {}', permitted_classes: [Foo]
       end
 
       # deprecated interface
-      assert_raise(Psych::DisallowedClass) do
+      assert_raises(Psych::DisallowedClass) do
         Psych.safe_load '--- !ruby/object:Foo {}', [Foo]
       end
 
-      assert_raise(Psych::DisallowedClass) do
+      assert_raises(Psych::DisallowedClass) do
         assert_safe_cycle Foo.new
       end
       assert_kind_of(Foo, Psych.safe_load(Psych.dump(Foo.new), permitted_classes: [Foo]))
@@ -96,7 +96,7 @@ module Psych
     X = Struct.new(:x)
     def test_struct_depends_on_sym
       assert_safe_cycle(X.new, permitted_classes: [X, Symbol])
-      assert_raise(Psych::DisallowedClass) do
+      assert_raises(Psych::DisallowedClass) do
         cycle X.new, permitted_classes: [X]
       end
     end
@@ -107,14 +107,14 @@ module Psych
   foo: bar
                       eoyml
 
-      assert_raise(Psych::DisallowedClass) do
+      assert_raises(Psych::DisallowedClass) do
         Psych.safe_load(<<-eoyml, permitted_classes: [Struct])
 --- !ruby/struct
   foo: bar
                       eoyml
       end
 
-      assert_raise(Psych::DisallowedClass) do
+      assert_raises(Psych::DisallowedClass) do
         Psych.safe_load(<<-eoyml, permitted_classes: [Symbol])
 --- !ruby/struct
   foo: bar
@@ -128,14 +128,14 @@ module Psych
   foo: bar
                       eoyml
 
-      assert_raise(Psych::DisallowedClass) do
+      assert_raises(Psych::DisallowedClass) do
         Psych.safe_load(<<-eoyml, [Struct])
 --- !ruby/struct
   foo: bar
                       eoyml
       end
 
-      assert_raise(Psych::DisallowedClass) do
+      assert_raises(Psych::DisallowedClass) do
         Psych.safe_load(<<-eoyml, [Symbol])
 --- !ruby/struct
   foo: bar
@@ -152,7 +152,7 @@ module Psych
     end
 
     def test_safe_load_raises_on_bad_input
-      assert_raise(Psych::SyntaxError) { Psych.safe_load("--- `") }
+      assert_raises(Psych::SyntaxError) { Psych.safe_load("--- `") }
     end
 
     private

--- a/test/mri/psych/test_scalar_scanner.rb
+++ b/test/mri/psych/test_scalar_scanner.rb
@@ -113,25 +113,5 @@ module Psych
     def test_scan_strings_starting_with_underscores
       assert_equal "_100", ss.tokenize('_100')
     end
-
-    def test_scan_int_commas_and_underscores
-      # NB: This test is to ensure backward compatibility with prior Psych versions,
-      # not to test against any actual YAML specification.
-      assert_equal 123_456_789, ss.tokenize('123_456_789')
-      assert_equal 123_456_789, ss.tokenize('123,456,789')
-      assert_equal 123_456_789, ss.tokenize('1_2,3,4_5,6_789')
-      assert_equal 123_456_789, ss.tokenize('1_2,3,4_5,6_789_')
-
-      assert_equal 0b010101010, ss.tokenize('0b010101010')
-      assert_equal 0b010101010, ss.tokenize('0b0,1_0,1_,0,1_01,0')
-
-      assert_equal 01234567, ss.tokenize('01234567')
-      assert_equal 01234567, ss.tokenize('0_,,,1_2,_34567')
-
-      assert_equal 0x123456789abcdef, ss.tokenize('0x123456789abcdef')
-      assert_equal 0x123456789abcdef, ss.tokenize('0x12_,34,_56,_789abcdef')
-      assert_equal 0x123456789abcdef, ss.tokenize('0x_12_,34,_56,_789abcdef')
-      assert_equal 0x123456789abcdef, ss.tokenize('0x12_,34,_56,_789abcdef__')
-    end
   end
 end

--- a/test/mri/psych/test_serialize_subclasses.rb
+++ b/test/mri/psych/test_serialize_subclasses.rb
@@ -17,7 +17,7 @@ module Psych
 
     def test_some_object
       so = SomeObject.new('foo', [1,2,3])
-      assert_equal so, Psych.unsafe_load(Psych.dump(so))
+      assert_equal so, Psych.load(Psych.dump(so))
     end
 
     class StructSubclass < Struct.new(:foo)
@@ -33,7 +33,7 @@ module Psych
 
     def test_struct_subclass
       so = StructSubclass.new('foo', [1,2,3])
-      assert_equal so, Psych.unsafe_load(Psych.dump(so))
+      assert_equal so, Psych.load(Psych.dump(so))
     end
   end
 end

--- a/test/mri/psych/test_set.rb
+++ b/test/mri/psych/test_set.rb
@@ -21,7 +21,7 @@ module Psych
     ###
     # FIXME: Syck should also support !!set as shorthand
     def test_load_from_yaml
-      loaded = Psych.unsafe_load(<<-eoyml)
+      loaded = Psych.load(<<-eoyml)
 --- !set
 foo: bar
 bar: baz
@@ -30,11 +30,11 @@ bar: baz
     end
 
     def test_loaded_class
-      assert_instance_of(Psych::Set, Psych.unsafe_load(Psych.dump(@set)))
+      assert_instance_of(Psych::Set, Psych.load(Psych.dump(@set)))
     end
 
     def test_set_shorthand
-      loaded = Psych.unsafe_load(<<-eoyml)
+      loaded = Psych.load(<<-eoyml)
 --- !!set
 foo: bar
 bar: baz

--- a/test/mri/psych/test_string.rb
+++ b/test/mri/psych/test_string.rb
@@ -104,7 +104,7 @@ module Psych
     end
 
     def test_string_subclass_with_anchor
-      y = Psych.unsafe_load <<-eoyml
+      y = Psych.load <<-eoyml
 ---
 body:
   string: &70121654388580 !ruby/string
@@ -116,7 +116,7 @@ body:
     end
 
     def test_self_referential_string
-      y = Psych.unsafe_load <<-eoyml
+      y = Psych.load <<-eoyml
 ---
 string: &70121654388580 !ruby/string
   str: ! 'foo'
@@ -129,32 +129,32 @@ string: &70121654388580 !ruby/string
     end
 
     def test_another_subclass_with_attributes
-      y = Psych.unsafe_load Psych.dump Y.new("foo").tap {|o| o.val = 1}
+      y = Psych.load Psych.dump Y.new("foo").tap {|o| o.val = 1}
       assert_equal "foo", y
       assert_equal Y, y.class
       assert_equal 1, y.val
     end
 
     def test_backwards_with_syck
-      x = Psych.unsafe_load "--- !str:#{X.name} foo\n\n"
+      x = Psych.load "--- !str:#{X.name} foo\n\n"
       assert_equal X, x.class
       assert_equal 'foo', x
     end
 
     def test_empty_subclass
       assert_match "!ruby/string:#{X}", Psych.dump(X.new)
-      x = Psych.unsafe_load Psych.dump X.new
+      x = Psych.load Psych.dump X.new
       assert_equal X, x.class
     end
 
     def test_empty_character_subclass
       assert_match "!ruby/string:#{Z}", Psych.dump(Z.new)
-      x = Psych.unsafe_load Psych.dump Z.new
+      x = Psych.load Psych.dump Z.new
       assert_equal Z, x.class
     end
 
     def test_subclass_with_attributes
-      y = Psych.unsafe_load Psych.dump Y.new.tap {|o| o.val = 1}
+      y = Psych.load Psych.dump Y.new.tap {|o| o.val = 1}
       assert_equal Y, y.class
       assert_equal 1, y.val
     end

--- a/test/mri/psych/test_struct.rb
+++ b/test/mri/psych/test_struct.rb
@@ -22,7 +22,7 @@ module Psych
       ss = StructSubclass.new(nil, 'foo')
       ss.foo = ss
 
-      loaded = Psych.unsafe_load(Psych.dump(ss))
+      loaded = Psych.load(Psych.dump(ss))
       assert_instance_of(StructSubclass, loaded.foo)
 
       assert_equal(ss, loaded)
@@ -30,14 +30,14 @@ module Psych
 
     def test_roundtrip
       thing = PsychStructWithIvar.new('bar')
-      struct = Psych.unsafe_load(Psych.dump(thing))
+      struct = Psych.load(Psych.dump(thing))
 
       assert_equal 'hello', struct.bar
       assert_equal 'bar', struct.foo
     end
 
     def test_load
-      obj = Psych.unsafe_load(<<-eoyml)
+      obj = Psych.load(<<-eoyml)
 --- !ruby/struct:PsychStructWithIvar
 :foo: bar
 :@bar: hello

--- a/test/mri/psych/test_tainted.rb
+++ b/test/mri/psych/test_tainted.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+require_relative 'helper'
+
+module Psych
+  class TestStringTainted < TestCase
+    class Tainted < Handler
+      attr_reader :tc
+
+      def initialize tc
+        @tc = tc
+      end
+
+      def start_document version, tags, implicit
+        tags.flatten.each do |tag|
+          assert_taintedness tag
+        end
+      end
+
+      def alias name
+        assert_taintedness name
+      end
+
+      def scalar value, anchor, tag, plain, quoted, style
+        assert_taintedness value
+        assert_taintedness tag if tag
+        assert_taintedness anchor if anchor
+      end
+
+      def start_sequence anchor, tag, implicit, style
+        assert_taintedness tag if tag
+        assert_taintedness anchor if anchor
+      end
+
+      def start_mapping anchor, tag, implicit, style
+        assert_taintedness tag if tag
+        assert_taintedness anchor if anchor
+      end
+
+      def assert_taintedness thing, message = "'#{thing}' should be tainted"
+        tc.assert thing.tainted?, message
+      end
+    end
+
+    class Untainted < Tainted
+      def assert_taintedness thing, message = "'#{thing}' should not be tainted"
+        tc.assert !thing.tainted?, message
+      end
+    end
+
+
+    def setup
+      handler = Tainted.new self
+      @parser = Psych::Parser.new handler
+    end
+
+    def test_tags_are_tainted
+      assert_taintedness "%TAG !yaml! tag:yaml.org,2002:\n---\n!yaml!str \"foo\""
+    end
+
+    def test_alias
+      assert_taintedness  "--- &ponies\n- foo\n- *ponies"
+    end
+
+    def test_scalar
+      assert_taintedness "--- ponies"
+    end
+
+    def test_anchor
+      assert_taintedness "--- &hi ponies"
+    end
+
+    def test_scalar_tag
+      assert_taintedness "--- !str ponies"
+    end
+
+    def test_seq_start_tag
+      assert_taintedness "--- !!seq [ a ]"
+    end
+
+    def test_seq_start_anchor
+      assert_taintedness "--- &zomg [ a ]"
+    end
+
+    def test_seq_mapping_tag
+      assert_taintedness "--- !!map { a: b }"
+    end
+
+    def test_seq_mapping_anchor
+      assert_taintedness "--- &himom { a: b }"
+    end
+
+    def assert_taintedness string
+      @parser.parse string.dup.taint
+    end
+  end
+
+  class TestStringUntainted < TestStringTainted
+    def setup
+      handler = Untainted.new self
+      @parser = Psych::Parser.new handler
+    end
+
+    def assert_taintedness string
+      @parser.parse string
+    end
+  end
+
+  class TestStringIOUntainted < TestStringTainted
+    def setup
+      handler = Untainted.new self
+      @parser = Psych::Parser.new handler
+    end
+
+    def assert_taintedness string
+      @parser.parse StringIO.new(string)
+    end
+  end
+
+  class TestIOTainted < TestStringTainted
+    def assert_taintedness string
+      Tempfile.create(['something', 'yml']) {|t|
+        t.binmode
+        t.write string
+        t.close
+        File.open(t.path, 'r:bom|utf-8') { |f|
+          @parser.parse f
+        }
+      }
+    end
+  end
+end

--- a/test/mri/psych/test_yaml.rb
+++ b/test/mri/psych/test_yaml.rb
@@ -17,7 +17,7 @@ class Psych_Unit_Tests < Psych::TestCase
     end
 
     def test_y_method
-      assert_raise(NoMethodError) do
+      assert_raises(NoMethodError) do
         OpenStruct.new.y 1
       end
     end
@@ -573,7 +573,7 @@ EOY
 	end
 
 	def test_spec_root_mapping
-		y = Psych::unsafe_load( <<EOY
+		y = Psych::load( <<EOY
 # This stream is an example of a top-level mapping.
 invoice : 34843
 date    : 2001-01-23
@@ -1034,7 +1034,6 @@ EOY
     end
 
 	def test_ruby_struct
-		Struct.send(:remove_const, :MyBookStruct) if Struct.const_defined?(:MyBookStruct)
 		# Ruby structures
 		book_struct = Struct::new( "MyBookStruct", :author, :title, :year, :isbn )
 		assert_to_yaml(
@@ -1077,7 +1076,7 @@ EOY
 
 		# Read Psych dumped by the ruby 1.8.3.
 		assert_to_yaml( Rational(1, 2), "!ruby/object:Rational 1/2\n" )
-		assert_raise( ArgumentError ) { Psych.unsafe_load("!ruby/object:Rational INVALID/RATIONAL\n") }
+		assert_raises( ArgumentError ) { Psych.load("!ruby/object:Rational INVALID/RATIONAL\n") }
 	end
 
 	def test_ruby_complex
@@ -1089,7 +1088,7 @@ EOY
 
 		# Read Psych dumped by the ruby 1.8.3.
 		assert_to_yaml( Complex(3, 4), "!ruby/object:Complex 3+4i\n" )
-		assert_raise( ArgumentError ) { Psych.unsafe_load("!ruby/object:Complex INVALID+COMPLEXi\n") }
+		assert_raises( ArgumentError ) { Psych.load("!ruby/object:Complex INVALID+COMPLEXi\n") }
 	end
 
 	def test_emitting_indicators
@@ -1209,7 +1208,7 @@ EOY
     def test_circular_references
         a = []; a[0] = a; a[1] = a
         inspect_str = "[[...], [...]]"
-        assert_equal( inspect_str, Psych::unsafe_load(Psych.dump(a)).inspect )
+        assert_equal( inspect_str, Psych::load(Psych.dump(a)).inspect )
     end
 
     #
@@ -1264,11 +1263,11 @@ EOY
     end
 
     def test_date_out_of_range
-      Psych::unsafe_load('1900-01-01T00:00:00+00:00')
+      Psych::load('1900-01-01T00:00:00+00:00')
     end
 
     def test_normal_exit
-      Psych.unsafe_load("2000-01-01 00:00:00.#{"0"*1000} +00:00\n")
+      Psych.load("2000-01-01 00:00:00.#{"0"*1000} +00:00\n")
       # '[ruby-core:13735]'
     end
 

--- a/test/mri/psych/test_yaml_special_cases.rb
+++ b/test/mri/psych/test_yaml_special_cases.rb
@@ -13,7 +13,7 @@ module Psych
 
     def test_empty_string
       s = ""
-      assert_equal false, Psych.unsafe_load(s)
+      assert_equal false, Psych.load(s)
       assert_equal [], Psych.load_stream(s)
       assert_equal false, Psych.parse(s)
       assert_equal [], Psych.parse_stream(s).transform
@@ -58,8 +58,8 @@ module Psych
 
     def test_NaN
       s = ".NaN"
-      assert Psych.load(s).nan?
-      assert Psych.load_stream(s).first.nan?
+      assert Float::NAN, Psych.load(s).nan?
+      assert [Float::NAN], Psych.load_stream(s).first.nan?
       assert Psych.parse(s).transform.nan?
       assert Psych.parse_stream(s).transform.first.nan?
       assert Psych.safe_load(s).nan?

--- a/test/mri/psych/test_yamlstore.rb
+++ b/test/mri/psych/test_yamlstore.rb
@@ -4,22 +4,7 @@ require 'yaml/store'
 require 'tmpdir'
 
 module Psych
-  class YAML::Store
-    alias :old_load :load
-
-    def load(content)
-      table = YAML.load(content, fallback: false)
-      if table == false
-        {}
-      else
-        table
-      end
-    end
-  end
-
-  unless defined?(Psych::Store)
-    Psych::Store = YAML::Store
-  end
+  Psych::Store = YAML::Store unless defined?(Psych::Store)
 
   class YAMLStoreTest < TestCase
     def setup
@@ -39,61 +24,61 @@ module Psych
 
     def test_opening_new_file_in_readonly_mode_should_result_in_empty_values
       @yamlstore.transaction(true) do
-        assert_nil @yamlstore["foo"]
-        assert_nil @yamlstore["bar"]
+        assert_nil @yamlstore[:foo]
+        assert_nil @yamlstore[:bar]
       end
     end
 
     def test_opening_new_file_in_readwrite_mode_should_result_in_empty_values
       @yamlstore.transaction do
-        assert_nil @yamlstore["foo"]
-        assert_nil @yamlstore["bar"]
+        assert_nil @yamlstore[:foo]
+        assert_nil @yamlstore[:bar]
       end
     end
 
     def test_data_should_be_loaded_correctly_when_in_readonly_mode
       @yamlstore.transaction do
-        @yamlstore["foo"] = "bar"
+        @yamlstore[:foo] = "bar"
       end
       @yamlstore.transaction(true) do
-        assert_equal "bar", @yamlstore["foo"]
+        assert_equal "bar", @yamlstore[:foo]
       end
     end
 
     def test_data_should_be_loaded_correctly_when_in_readwrite_mode
       @yamlstore.transaction do
-        @yamlstore["foo"] = "bar"
+        @yamlstore[:foo] = "bar"
       end
       @yamlstore.transaction do
-        assert_equal "bar", @yamlstore["foo"]
+        assert_equal "bar", @yamlstore[:foo]
       end
     end
 
     def test_changes_after_commit_are_discarded
       @yamlstore.transaction do
-        @yamlstore["foo"] = "bar"
+        @yamlstore[:foo] = "bar"
         @yamlstore.commit
-        @yamlstore["foo"] = "baz"
+        @yamlstore[:foo] = "baz"
       end
       @yamlstore.transaction(true) do
-        assert_equal "bar", @yamlstore["foo"]
+        assert_equal "bar", @yamlstore[:foo]
       end
     end
 
     def test_changes_are_not_written_on_abort
       @yamlstore.transaction do
-        @yamlstore["foo"] = "bar"
+        @yamlstore[:foo] = "bar"
         @yamlstore.abort
       end
       @yamlstore.transaction(true) do
-        assert_nil @yamlstore["foo"]
+        assert_nil @yamlstore[:foo]
       end
     end
 
     def test_writing_inside_readonly_transaction_raises_error
-      assert_raise(PStore::Error) do
+      assert_raises(PStore::Error) do
         @yamlstore.transaction(true) do
-          @yamlstore["foo"] = "bar"
+          @yamlstore[:foo] = "bar"
         end
       end
     end

--- a/test/mri/psych/visitors/test_to_ruby.rb
+++ b/test/mri/psych/visitors/test_to_ruby.rb
@@ -20,13 +20,12 @@ module Psych
       end
 
       def test_tz_00_00_loads_without_error
-        assert Psych.unsafe_load('1900-01-01T00:00:00+00:00')
+        assert Psych.load('1900-01-01T00:00:00+00:00')
       end
 
       def test_legacy_struct
-        Struct.send(:remove_const, :AWESOME) if Struct.const_defined?(:AWESOME)
         foo = Struct.new('AWESOME', :bar)
-        assert_equal foo.new('baz'), Psych.unsafe_load(<<-eoyml)
+        assert_equal foo.new('baz'), Psych.load(<<-eoyml)
 !ruby/struct:AWESOME
   bar: baz
         eoyml

--- a/test/mri/psych/visitors/test_yaml_tree.rb
+++ b/test/mri/psych/visitors/test_yaml_tree.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'psych/helper'
-require 'delegate'
 
 module Psych
   module Visitors
@@ -8,7 +7,7 @@ module Psych
       class TestDelegatorClass < Delegator
         def initialize(obj); super; @obj = obj; end
         def __setobj__(obj); @obj = obj; end
-        def __getobj__; @obj if defined?(@obj); end
+        def __getobj__; @obj; end
       end
 
       class TestSimpleDelegatorClass < SimpleDelegator
@@ -63,19 +62,19 @@ module Psych
 
       def test_struct_anon
         s = Struct.new(:foo).new('bar')
-        obj =  Psych.unsafe_load(Psych.dump(s))
+        obj =  Psych.load(Psych.dump(s))
         assert_equal s.foo, obj.foo
       end
 
       def test_override_method
         s = Struct.new(:method).new('override')
-        obj =  Psych.unsafe_load(Psych.dump(s))
+        obj =  Psych.load(Psych.dump(s))
         assert_equal s.method, obj.method
       end
 
       def test_exception
         ex = Exception.new 'foo'
-        loaded = Psych.unsafe_load(Psych.dump(ex))
+        loaded = Psych.load(Psych.dump(ex))
 
         assert_equal ex.message, loaded.message
         assert_equal ex.class, loaded.class
@@ -89,7 +88,7 @@ module Psych
 
       def test_time
         t = Time.now
-        assert_equal t, Psych.unsafe_load(Psych.dump(t))
+        assert_equal t, Psych.load(Psych.dump(t))
       end
 
       def test_date
@@ -128,11 +127,11 @@ module Psych
       end
 
       def test_anon_class
-        assert_raise(TypeError) do
+        assert_raises(TypeError) do
           @v.accept Class.new
         end
 
-        assert_raise(TypeError) do
+        assert_raises(TypeError) do
           Psych.dump(Class.new)
         end
       end

--- a/test/mri/rdoc/test_rdoc_rdoc.rb
+++ b/test/mri/rdoc/test_rdoc_rdoc.rb
@@ -420,6 +420,18 @@ class TestRDocRDoc < RDoc::TestCase
     end
   end
 
+  def test_remove_unparseable_CVE_2021_31799
+    skip 'for Un*x platforms' if Gem.win_platform?
+    temp_dir do
+      file_list = ['| touch evil.txt && echo tags']
+      file_list.each do |f|
+        FileUtils.touch f
+      end
+      assert_equal file_list, @rdoc.remove_unparseable(file_list)
+      assert_equal file_list, Dir.children('.')
+    end
+  end
+
   def test_setup_output_dir
     Dir.mktmpdir {|d|
       path = File.join d, 'testdir'

--- a/test/mri/resolv/test_dns.rb
+++ b/test/mri/resolv/test_dns.rb
@@ -128,6 +128,119 @@ class TestResolvDNS < Test::Unit::TestCase
     }
   end
 
+  def test_query_ipv4_duplicate_responses
+    begin
+      OpenSSL
+    rescue LoadError
+      skip 'autoload problem. see [ruby-dev:45021][Bug #5786]'
+    end if defined?(OpenSSL)
+
+    with_udp('127.0.0.1', 0) {|u|
+      _, server_port, _, server_address = u.addr
+      begin
+        client_thread = Thread.new {
+          Resolv::DNS.open(:nameserver_port => [[server_address, server_port]], :search => ['bad1.com', 'bad2.com', 'good.com'], ndots: 5) {|dns|
+            dns.getaddress("example")
+          }
+        }
+        server_thread = Thread.new {
+          3.times do
+            msg, (_, client_port, _, client_address) = Timeout.timeout(5) {u.recvfrom(4096)}
+            id, flags, qdcount, ancount, nscount, arcount = msg.unpack("nnnnnn")
+
+            qr =     (flags & 0x8000) >> 15
+            opcode = (flags & 0x7800) >> 11
+            aa =     (flags & 0x0400) >> 10
+            tc =     (flags & 0x0200) >> 9
+            rd =     (flags & 0x0100) >> 8
+            ra =     (flags & 0x0080) >> 7
+            z =      (flags & 0x0070) >> 4
+            rcode =   flags & 0x000f
+            rest = msg[12..-1]
+
+            questions = msg.bytes[12..-1]
+            labels = []
+            idx = 0
+            while idx < questions.length-5
+              size = questions[idx]
+              labels << questions[idx+1..idx+size].pack('c*')
+              idx += size+1
+            end
+            hostname = labels.join('.')
+
+            if hostname == "example.good.com"
+              id = id
+              qr = 1
+              opcode = opcode
+              aa = 0
+              tc = 0
+              rd = rd
+              ra = 1
+              z = 0
+              rcode = 0
+              qdcount = 1
+              ancount = 1
+              nscount = 0
+              arcount = 0
+              word2 = (qr << 15) |
+                      (opcode << 11) |
+                      (aa << 10) |
+                      (tc << 9) |
+                      (rd << 8) |
+                      (ra << 7) |
+                      (z << 4) |
+                      rcode
+              msg = [id, word2, qdcount, ancount, nscount, arcount].pack("nnnnnn")
+              msg << questions.pack('c*')
+              type = 1
+              klass = 1
+              ttl = 3600
+              rdlength = 4
+              rdata = [52,0,2,1].pack("CCCC")
+              rr = [0xc00c, type, klass, ttl, rdlength, rdata].pack("nnnNna*")
+              msg << rr
+              rdata = [52,0,2,2].pack("CCCC")
+              rr = [0xc00c, type, klass, ttl, rdlength, rdata].pack("nnnNna*")
+              msg << rr
+
+              u.send(msg, 0, client_address, client_port)
+            else
+              id = id
+              qr = 1
+              opcode = opcode
+              aa = 0
+              tc = 0
+              rd = rd
+              ra = 1
+              z = 0
+              rcode = 3
+              qdcount = 1
+              ancount = 0
+              nscount = 0
+              arcount = 0
+              word2 = (qr << 15) |
+                      (opcode << 11) |
+                      (aa << 10) |
+                      (tc << 9) |
+                      (rd << 8) |
+                      (ra << 7) |
+                      (z << 4) |
+                      rcode
+              msg = [id, word2, qdcount, ancount, nscount, arcount].pack("nnnnnn")
+              msg << questions.pack('c*')
+
+              u.send(msg, 0, client_address, client_port)
+              u.send(msg, 0, client_address, client_port)
+            end
+          end
+        }
+        result, _ = assert_join_threads([client_thread, server_thread])
+        assert_instance_of(Resolv::IPv4, result)
+        assert_equal("52.0.2.1", result.to_s)
+      end
+    }
+  end
+
   def test_query_ipv4_address_timeout
     with_udp('127.0.0.1', 0) {|u|
       _, port , _, host = u.addr

--- a/test/mri/rexml/parse/test_document_type_declaration.rb
+++ b/test/mri/rexml/parse/test_document_type_declaration.rb
@@ -5,17 +5,187 @@ require "rexml/document"
 module REXMLTests
   class TestParseDocumentTypeDeclaration < Test::Unit::TestCase
     private
-    def xml(internal_subset)
-      <<-XML
-<!DOCTYPE r SYSTEM "urn:x-rexml:test" [
-#{internal_subset}
-]>
+    def parse(doctype)
+      REXML::Document.new(<<-XML).doctype
+#{doctype}
 <r/>
       XML
     end
 
-    def parse(internal_subset)
-      REXML::Document.new(xml(internal_subset)).doctype
+    class TestName < self
+      def test_valid
+        doctype = parse(<<-DOCTYPE)
+<!DOCTYPE r>
+        DOCTYPE
+        assert_equal("r", doctype.name)
+      end
+
+      def test_garbage_plus_before_name_at_line_start
+        exception = assert_raise(REXML::ParseException) do
+          parse(<<-DOCTYPE)
+<!DOCTYPE +
+r SYSTEM "urn:x-rexml:test" [
+]>
+          DOCTYPE
+        end
+        assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed DOCTYPE: invalid name
+Line: 5
+Position: 51
+Last 80 unconsumed characters:
++ r SYSTEM "urn:x-rexml:test" [ ]>  <r/> 
+        DETAIL
+      end
+    end
+
+    class TestExternalID < self
+      class TestSystem < self
+        def test_left_bracket_in_system_literal
+          doctype = parse(<<-DOCTYPE)
+<!DOCTYPE r SYSTEM "urn:x-rexml:[test" [
+]>
+          DOCTYPE
+          assert_equal([
+                         "r",
+                         "SYSTEM",
+                         nil,
+                         "urn:x-rexml:[test",
+                       ],
+                       [
+                         doctype.name,
+                         doctype.external_id,
+                         doctype.public,
+                         doctype.system,
+                       ])
+        end
+
+        def test_greater_than_in_system_literal
+          doctype = parse(<<-DOCTYPE)
+<!DOCTYPE r SYSTEM "urn:x-rexml:>test" [
+]>
+          DOCTYPE
+          assert_equal([
+                         "r",
+                         "SYSTEM",
+                         nil,
+                         "urn:x-rexml:>test",
+                       ],
+                       [
+                         doctype.name,
+                         doctype.external_id,
+                         doctype.public,
+                         doctype.system,
+                       ])
+        end
+
+        def test_no_literal
+          exception = assert_raise(REXML::ParseException) do
+            parse(<<-DOCTYPE)
+<!DOCTYPE r SYSTEM>
+            DOCTYPE
+          end
+          assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed DOCTYPE: system literal is missing
+Line: 3
+Position: 26
+Last 80 unconsumed characters:
+ SYSTEM>  <r/> 
+          DETAIL
+        end
+
+        def test_garbage_after_literal
+          exception = assert_raise(REXML::ParseException) do
+            parse(<<-DOCTYPE)
+<!DOCTYPE r SYSTEM 'r.dtd'x'>
+            DOCTYPE
+          end
+          assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed DOCTYPE: garbage after external ID
+Line: 3
+Position: 36
+Last 80 unconsumed characters:
+x'>  <r/> 
+          DETAIL
+        end
+
+        def test_single_quote
+          doctype = parse(<<-DOCTYPE)
+<!DOCTYPE r SYSTEM 'r".dtd'>
+          DOCTYPE
+          assert_equal("r\".dtd", doctype.system)
+        end
+
+        def test_double_quote
+          doctype = parse(<<-DOCTYPE)
+<!DOCTYPE r SYSTEM "r'.dtd">
+          DOCTYPE
+          assert_equal("r'.dtd", doctype.system)
+        end
+      end
+
+      class TestPublic < self
+        class TestPublicIDLiteral < self
+          def test_content_double_quote
+            exception = assert_raise(REXML::ParseException) do
+              parse(<<-DOCTYPE)
+<!DOCTYPE r PUBLIC 'double quote " is invalid' "r.dtd">
+              DOCTYPE
+            end
+            assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed DOCTYPE: invalid public ID literal
+Line: 3
+Position: 62
+Last 80 unconsumed characters:
+ PUBLIC 'double quote " is invalid' "r.dtd">  <r/> 
+            DETAIL
+          end
+
+          def test_single_quote
+            doctype = parse(<<-DOCTYPE)
+<!DOCTYPE r PUBLIC 'public-id-literal' "r.dtd">
+            DOCTYPE
+            assert_equal("public-id-literal", doctype.public)
+          end
+
+          def test_double_quote
+            doctype = parse(<<-DOCTYPE)
+<!DOCTYPE r PUBLIC "public'-id-literal" "r.dtd">
+            DOCTYPE
+            assert_equal("public'-id-literal", doctype.public)
+          end
+        end
+
+        class TestSystemLiteral < self
+          def test_garbage_after_literal
+            exception = assert_raise(REXML::ParseException) do
+              parse(<<-DOCTYPE)
+<!DOCTYPE r PUBLIC 'public-id-literal' 'system-literal'x'>
+              DOCTYPE
+            end
+            assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed DOCTYPE: garbage after external ID
+Line: 3
+Position: 65
+Last 80 unconsumed characters:
+x'>  <r/> 
+           DETAIL
+          end
+
+          def test_single_quote
+            doctype = parse(<<-DOCTYPE)
+<!DOCTYPE r PUBLIC "public-id-literal" 'system"-literal'>
+            DOCTYPE
+            assert_equal("system\"-literal", doctype.system)
+          end
+
+          def test_double_quote
+            doctype = parse(<<-DOCTYPE)
+<!DOCTYPE r PUBLIC "public-id-literal" "system'-literal">
+            DOCTYPE
+            assert_equal("system'-literal", doctype.system)
+          end
+        end
+      end
     end
 
     class TestMixed < self
@@ -44,6 +214,15 @@ module REXMLTests
         INTERNAL_SUBSET
         assert_equal([REXML::NotationDecl, REXML::AttlistDecl],
                      doctype.children.collect(&:class))
+      end
+
+      private
+      def parse(internal_subset)
+        super(<<-DOCTYPE)
+<!DOCTYPE r SYSTEM "urn:x-rexml:test" [
+#{internal_subset}
+]>
+        DOCTYPE
       end
     end
   end

--- a/test/mri/rexml/parse/test_element.rb
+++ b/test/mri/rexml/parse/test_element.rb
@@ -33,6 +33,32 @@ Last 80 unconsumed characters:
 
         DETAIL
       end
+
+      def test_garbage_less_than_before_root_element_at_line_start
+        exception = assert_raise(REXML::ParseException) do
+          parse("<\n<x/>")
+        end
+        assert_equal(<<-DETAIL.chomp, exception.to_s)
+malformed XML: missing tag start
+Line: 2
+Position: 6
+Last 80 unconsumed characters:
+< <x/>
+        DETAIL
+      end
+
+      def test_garbage_less_than_slash_before_end_tag_at_line_start
+        exception = assert_raise(REXML::ParseException) do
+          parse("<x></\n</x>")
+        end
+        assert_equal(<<-DETAIL.chomp, exception.to_s)
+Missing end tag for 'x'
+Line: 2
+Position: 10
+Last 80 unconsumed characters:
+</ </x>
+        DETAIL
+      end
     end
   end
 end

--- a/test/mri/rexml/parse/test_notation_declaration.rb
+++ b/test/mri/rexml/parse/test_notation_declaration.rb
@@ -23,10 +23,100 @@ module REXMLTests
         doctype = parse("<!NOTATION name PUBLIC 'urn:public-id'>")
         assert_equal("name", doctype.notation("name").name)
       end
+
+      def test_no_name
+        exception = assert_raise(REXML::ParseException) do
+          parse(<<-INTERNAL_SUBSET)
+<!NOTATION>
+          INTERNAL_SUBSET
+        end
+        assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed notation declaration: name is missing
+Line: 5
+Position: 72
+Last 80 unconsumed characters:
+ <!NOTATION>  ]> <r/> 
+        DETAIL
+      end
+
+      def test_invalid_name
+        exception = assert_raise(REXML::ParseException) do
+          parse(<<-INTERNAL_SUBSET)
+<!NOTATION '>
+          INTERNAL_SUBSET
+        end
+        assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed notation declaration: invalid name
+Line: 5
+Position: 74
+Last 80 unconsumed characters:
+'>  ]> <r/> 
+        DETAIL
+      end
+
+      def test_no_id_type
+        exception = assert_raise(REXML::ParseException) do
+          parse(<<-INTERNAL_SUBSET)
+<!NOTATION name>
+          INTERNAL_SUBSET
+        end
+        assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed notation declaration: invalid ID type
+Line: 5
+Position: 77
+Last 80 unconsumed characters:
+>  ]> <r/> 
+        DETAIL
+      end
+
+      def test_invalid_id_type
+        exception = assert_raise(REXML::ParseException) do
+          parse(<<-INTERNAL_SUBSET)
+<!NOTATION name INVALID>
+          INTERNAL_SUBSET
+        end
+        assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed notation declaration: invalid ID type
+Line: 5
+Position: 85
+Last 80 unconsumed characters:
+ INVALID>  ]> <r/> 
+        DETAIL
+      end
     end
 
     class TestExternalID < self
       class TestSystem < self
+        def test_no_literal
+          exception = assert_raise(REXML::ParseException) do
+            parse(<<-INTERNAL_SUBSET)
+<!NOTATION name SYSTEM>
+            INTERNAL_SUBSET
+          end
+          assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed notation declaration: system literal is missing
+Line: 5
+Position: 84
+Last 80 unconsumed characters:
+ SYSTEM>  ]> <r/> 
+          DETAIL
+        end
+
+        def test_garbage_after_literal
+          exception = assert_raise(REXML::ParseException) do
+            parse(<<-INTERNAL_SUBSET)
+<!NOTATION name SYSTEM 'system-literal'x'>
+            INTERNAL_SUBSET
+          end
+          assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed notation declaration: garbage before end >
+Line: 5
+Position: 103
+Last 80 unconsumed characters:
+x'>  ]> <r/> 
+          DETAIL
+        end
+
         def test_single_quote
           doctype = parse(<<-INTERNAL_SUBSET)
 <!NOTATION name SYSTEM 'system-literal'>
@@ -44,6 +134,21 @@ module REXMLTests
 
       class TestPublic < self
         class TestPublicIDLiteral < self
+          def test_content_double_quote
+            exception = assert_raise(REXML::ParseException) do
+              parse(<<-INTERNAL_SUBSET)
+<!NOTATION name PUBLIC 'double quote " is invalid' "system-literal">
+              INTERNAL_SUBSET
+            end
+            assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed notation declaration: invalid public ID literal
+Line: 5
+Position: 129
+Last 80 unconsumed characters:
+ PUBLIC 'double quote " is invalid' "system-literal">  ]> <r/> 
+            DETAIL
+          end
+
           def test_single_quote
             doctype = parse(<<-INTERNAL_SUBSET)
 <!NOTATION name PUBLIC 'public-id-literal' "system-literal">
@@ -60,6 +165,21 @@ module REXMLTests
         end
 
         class TestSystemLiteral < self
+          def test_garbage_after_literal
+            exception = assert_raise(REXML::ParseException) do
+              parse(<<-INTERNAL_SUBSET)
+<!NOTATION name PUBLIC 'public-id-literal' 'system-literal'x'>
+              INTERNAL_SUBSET
+            end
+            assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed notation declaration: garbage before end >
+Line: 5
+Position: 123
+Last 80 unconsumed characters:
+x'>  ]> <r/> 
+           DETAIL
+          end
+
           def test_single_quote
             doctype = parse(<<-INTERNAL_SUBSET)
 <!NOTATION name PUBLIC "public-id-literal" 'system-literal'>
@@ -94,6 +214,67 @@ module REXMLTests
           assert_equal(["public-name", "system-name"],
                        doctype.notations.collect(&:name))
         end
+      end
+    end
+
+    class TestPublicID < self
+      def test_no_literal
+        exception = assert_raise(REXML::ParseException) do
+          parse(<<-INTERNAL_SUBSET)
+<!NOTATION name PUBLIC>
+          INTERNAL_SUBSET
+        end
+        assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed notation declaration: public ID literal is missing
+Line: 5
+Position: 84
+Last 80 unconsumed characters:
+ PUBLIC>  ]> <r/> 
+        DETAIL
+      end
+
+      def test_literal_content_double_quote
+        exception = assert_raise(REXML::ParseException) do
+          parse(<<-INTERNAL_SUBSET)
+<!NOTATION name PUBLIC 'double quote " is invalid in PubidLiteral'>
+          INTERNAL_SUBSET
+        end
+        assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed notation declaration: invalid public ID literal
+Line: 5
+Position: 128
+Last 80 unconsumed characters:
+ PUBLIC 'double quote \" is invalid in PubidLiteral'>  ]> <r/> 
+        DETAIL
+      end
+
+      def test_garbage_after_literal
+        exception = assert_raise(REXML::ParseException) do
+          parse(<<-INTERNAL_SUBSET)
+<!NOTATION name PUBLIC 'public-id-literal'x'>
+          INTERNAL_SUBSET
+        end
+        assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed notation declaration: garbage before end >
+Line: 5
+Position: 106
+Last 80 unconsumed characters:
+x'>  ]> <r/> 
+        DETAIL
+      end
+
+      def test_literal_single_quote
+        doctype = parse(<<-INTERNAL_SUBSET)
+<!NOTATION name PUBLIC 'public-id-literal'>
+        INTERNAL_SUBSET
+        assert_equal("public-id-literal", doctype.notation("name").public)
+      end
+
+      def test_literal_double_quote
+        doctype = parse(<<-INTERNAL_SUBSET)
+<!NOTATION name PUBLIC "public-id-literal">
+        INTERNAL_SUBSET
+        assert_equal("public-id-literal", doctype.notation("name").public)
       end
     end
   end

--- a/test/mri/rexml/parse/test_processing_instruction.rb
+++ b/test/mri/rexml/parse/test_processing_instruction.rb
@@ -20,6 +20,25 @@ Last 80 unconsumed characters:
 <??>
         DETAIL
       end
+
+      def test_garbage_text
+        # TODO: This should be parse error.
+        # Create test/parse/test_document.rb or something and move this to it.
+        doc = parse(<<-XML)
+x<?x y
+<!--?><?x -->?>
+<r/>
+        XML
+        pi = doc.children[1]
+        assert_equal([
+                       "x",
+                       "y\n<!--",
+                     ],
+                     [
+                       pi.target,
+                       pi.content,
+                     ])
+      end
     end
   end
 end

--- a/test/mri/rexml/parser/test_ultra_light.rb
+++ b/test/mri/rexml/parser/test_ultra_light.rb
@@ -16,7 +16,6 @@ class TestUltraLightParser < Test::Unit::TestCase
                        nil,
                        [:entitydecl, "name", "value"]
                      ],
-                     [:text, "\n"],
                      [:start_element, :parent, "root", {}],
                      [:text, "\n"],
                    ],

--- a/test/mri/rexml/test_core.rb
+++ b/test/mri/rexml/test_core.rb
@@ -1,4 +1,4 @@
-# coding: binary
+# coding: utf-8
 # frozen_string_literal: false
 
 require_relative "rexml_test_utils"
@@ -995,7 +995,7 @@ EOL
       document.write(s)
 
       ## XML Doctype
-      str = '<!DOCTYPE foo "bar">'
+      str = '<!DOCTYPE foo SYSTEM "bar">'
       source  = REXML::Source.new(str)
       doctype = REXML::DocType.new(source)
       document.add(doctype)

--- a/test/mri/rexml/test_doctype.rb
+++ b/test/mri/rexml/test_doctype.rb
@@ -18,12 +18,6 @@ module REXMLTests
       @doc_type_system = REXML::Document.new(xml_system).doctype
 
       @pubid = "TEST_ID"
-      xml_public = <<-XML
-      <!DOCTYPE root PUBLIC "#{@pubid}">
-      <root/>
-      XML
-      @doc_type_public = REXML::Document.new(xml_public).doctype
-
       xml_public_system = <<-XML
       <!DOCTYPE root PUBLIC "#{@pubid}" "#{@sysid}">
       <root/>
@@ -35,11 +29,9 @@ module REXMLTests
       assert_equal([
                      nil,
                      @pubid,
-                     @pubid,
                    ],
                    [
                      @doc_type_system.public,
-                     @doc_type_public.public,
                      @doc_type_public_system.public,
                    ])
     end
@@ -58,12 +50,10 @@ module REXMLTests
     def test_system
       assert_equal([
                      @sysid,
-                     nil,
                      @sysid,
                    ],
                    [
                      @doc_type_system.system,
-                     @doc_type_public.system,
                      @doc_type_public_system.system,
                    ])
     end

--- a/test/mri/ripper/test_parser_events.rb
+++ b/test/mri/ripper/test_parser_events.rb
@@ -1498,4 +1498,10 @@ class TestRipper::ParserEvents < Test::Unit::TestCase
     assert_warn("") {fmt, = warn("\r;")}
     assert_match(/encountered/, fmt)
   end
+
+  def test_warn_mismatched_indentations
+    fmt, tokend, tokbeg, line = assert_warning("") {break warn("if true\n  end\n")}
+    assert_match(/mismatched indentations/, fmt)
+    assert_equal(["if", "end", 1], [tokbeg, tokend, line])
+  end
 end if ripper_test

--- a/test/mri/ruby/test_arithmetic_sequence.rb
+++ b/test/mri/ruby/test_arithmetic_sequence.rb
@@ -254,6 +254,11 @@ class TestArithmeticSequence < Test::Unit::TestCase
                           '[ruby-core:90648] [Bug #15444]')
   end
 
+  def test_last_bug17218
+    seq = (1.0997r .. 1.1r).step(0.0001r)
+    assert_equal([1.0997r, 1.0998r, 1.0999r, 1.1r], seq.to_a, '[ruby-core:100312] [Bug #17218]')
+  end
+
   def test_slice
     seq = 1.step(10, 2)
     assert_equal([[1, 3, 5], [7, 9]], seq.each_slice(3).to_a)

--- a/test/mri/ruby/test_ast.rb
+++ b/test/mri/ruby/test_ast.rb
@@ -269,4 +269,15 @@ class TestAst < Test::Unit::TestCase
     assert_equal(:LIT, body.type)
     assert_equal([1], body.children)
   end
+
+  def test_op_asgn2
+    node = RubyVM::AbstractSyntaxTree.parse("struct.field += foo")
+    _, _, body = *node.children
+    assert_equal(:OP_ASGN2, body.type)
+    recv, _, mid, op, value = body.children
+    assert_equal(:VCALL, recv.type)
+    assert_equal(:field, mid)
+    assert_equal(:+, op)
+    assert_equal(:VCALL, value.type)
+  end
 end

--- a/test/mri/ruby/test_autoload.rb
+++ b/test/mri/ruby/test_autoload.rb
@@ -42,8 +42,10 @@ p Foo::Bar
     require 'tmpdir'
     Dir.mktmpdir('autoload') {|tmpdir|
       tmpfile = tmpdir + '/foo.rb'
+      tmpfile2 = tmpdir + '/bar.rb'
       a = Module.new do
         autoload :X, tmpfile
+        autoload :Y, tmpfile2
       end
       b = Module.new do
         include a
@@ -52,6 +54,10 @@ p Foo::Bar
       assert_equal(true, b.const_defined?(:X))
       assert_equal(tmpfile, a.autoload?(:X), bug4565)
       assert_equal(tmpfile, b.autoload?(:X), bug4565)
+      assert_equal(true, a.const_defined?("Y"))
+      assert_equal(true, b.const_defined?("Y"))
+      assert_equal(tmpfile2, a.autoload?("Y"))
+      assert_equal(tmpfile2, b.autoload?("Y"))
     }
   end
 

--- a/test/mri/ruby/test_defined.rb
+++ b/test/mri/ruby/test_defined.rb
@@ -23,40 +23,80 @@ class TestDefined < Test::Unit::TestCase
     return !defined?(yield)
   end
 
-  def test_defined
+  def test_defined_global_variable
     $x = nil
 
     assert(defined?($x))		# global variable
     assert_equal('global-variable', defined?($x))# returns description
+  end
 
+  def test_defined_local_variable
     assert_nil(defined?(foo))		# undefined
     foo=5
     assert(defined?(foo))		# local variable
+  end
 
+  def test_defined_constant
     assert(defined?(Array))		# constant
     assert(defined?(::Array))		# toplevel constant
     assert(defined?(File::Constants))	# nested constant
+  end
+
+  def test_defined_public_method
     assert(defined?(Object.new))	# method
     assert(defined?(Object::new))	# method
-    assert(!defined?(Object.print))	# private method
-    assert(defined?(1 == 2))		# operator expression
+  end
 
+  def test_defined_private_method
+    assert(!defined?(Object.print))	# private method
+  end
+
+  def test_defined_operator
+    assert(defined?(1 == 2))		# operator expression
+  end
+
+  def test_defined_protected_method
     f = Foo.new
     assert_nil(defined?(f.foo))         # protected method
     f.bar(f) { |v| assert(v) }
+    f.bar(Class.new(Foo).new) { |v| assert(v, "inherited protected method") }
+  end
+
+  def test_defined_undefined_method
+    f = Foo.new
     assert_nil(defined?(f.quux))        # undefined method
+  end
+
+  def test_defined_undefined_argument
+    f = Foo.new
     assert_nil(defined?(f.baz(x)))      # undefined argument
     x = 0
     assert(defined?(f.baz(x)))
     assert_nil(defined?(f.quux(x)))
     assert(defined?(print(x)))
     assert_nil(defined?(quux(x)))
+  end
+
+  def test_defined_attrasgn
+    f = Foo.new
     assert(defined?(f.attr = 1))
     f.attrasgn_test { |v| assert(v) }
+  end
 
+  def test_defined_undef
+    x = Object.new
+    def x.foo; end
+    assert(defined?(x.foo))
+    x.instance_eval {undef :foo}
+    assert(!defined?(x.foo), "undefed method should not be defined?")
+  end
+
+  def test_defined_yield
     assert(defined_test)		# not iterator
     assert(!defined_test{})	        # called as iterator
+  end
 
+  def test_defined_matchdata
     /a/ =~ ''
     assert_equal nil, defined?($&)
     assert_equal nil, defined?($`)
@@ -85,12 +125,16 @@ class TestDefined < Test::Unit::TestCase
     assert_equal 'global-variable', defined?($+)
     assert_equal 'global-variable', defined?($1)
     assert_equal nil, defined?($2)
+  end
 
+  def test_defined_literal
     assert_equal("nil", defined?(nil))
     assert_equal("true", defined?(true))
     assert_equal("false", defined?(false))
     assert_equal("expression", defined?(1))
+  end
 
+  def test_defined_empty_paren_expr
     bug8224 = '[ruby-core:54024] [Bug #8224]'
     (1..3).each do |level|
       expr = "("*level+")"*level

--- a/test/mri/ruby/test_enum.rb
+++ b/test/mri/ruby/test_enum.rb
@@ -730,6 +730,19 @@ class TestEnumerable < Test::Unit::TestCase
     assert_equal([2,1,3,2,1], @obj.reverse_each.to_a)
   end
 
+  def test_reverse_each_memory_corruption
+    bug16354 = '[ruby-dev:50867]'
+    assert_normal_exit %q{
+      size = 1000
+      (0...size).reverse_each do |i|
+        i.inspect
+        ObjectSpace.each_object(Array) do |a|
+          a.clear if a.length == size
+        end
+      end
+    }, bug16354
+  end
+
   def test_chunk
     e = [].chunk {|elt| true }
     assert_equal([], e.to_a)

--- a/test/mri/ruby/test_env.rb
+++ b/test/mri/ruby/test_env.rb
@@ -440,6 +440,8 @@ class TestEnv < Test::Unit::TestCase
     ENV["foo"] = "xxx"
     ENV.replace({"foo"=>"bar", "baz"=>"qux"})
     check(ENV.to_hash.to_a, [%w(foo bar), %w(baz qux)])
+    ENV.replace({"Foo"=>"Bar", "Baz"=>"Qux"})
+    check(ENV.to_hash.to_a, [%w(Foo Bar), %w(Baz Qux)])
   end
 
   def test_update

--- a/test/mri/ruby/test_exception.rb
+++ b/test/mri/ruby/test_exception.rb
@@ -842,6 +842,26 @@ end.join
     }
   end
 
+  def test_cause_exception_in_cause_message
+    assert_in_out_err([], "#{<<~"begin;"}\n#{<<~'end;'}") do |outs, errs, status|
+      begin;
+        exc = Class.new(StandardError) do
+          def initialize(obj, cnt)
+            super(obj)
+            @errcnt = cnt
+          end
+          def to_s
+            return super if @errcnt <= 0
+            @errcnt -= 1
+            raise "xxx"
+          end
+        end.new("ok", 10)
+        raise "[Bug #17033]", cause: exc
+      end;
+      assert_equal(1, errs.count {|m| m.include?("[Bug #17033]")}, proc {errs.pretty_inspect})
+    end
+  end
+
   def test_anonymous_message
     assert_in_out_err([], "raise Class.new(RuntimeError), 'foo'", [], /foo\n/)
   end

--- a/test/mri/ruby/test_gc.rb
+++ b/test/mri/ruby/test_gc.rb
@@ -383,11 +383,6 @@ class TestGc < Test::Unit::TestCase
     end;
   end
 
-  def test_gc_stress_at_startup
-    skip # it'll be fixed later
-    assert_in_out_err([{"RUBY_DEBUG"=>"gc_stress"}], '', [], [], '[Bug #15784]', success: true)
-  end
-
   def test_gc_disabled_start
     begin
       disabled = GC.disable

--- a/test/mri/ruby/test_hash.rb
+++ b/test/mri/ruby/test_hash.rb
@@ -1733,4 +1733,62 @@ class TestHash < Test::Unit::TestCase
       super
     end
   end
+
+  def test_ar2st
+    # insert
+    obj = Object.new
+    obj.instance_variable_set(:@h, h = {})
+    def obj.hash
+      10.times{|i| @h[i] = i}
+      0
+    end
+    def obj.inspect
+      'test'
+    end
+    h[obj] = true
+    assert_equal '{0=>0, 1=>1, 2=>2, 3=>3, 4=>4, 5=>5, 6=>6, 7=>7, 8=>8, 9=>9, test=>true}', h.inspect
+
+    # delete
+    obj = Object.new
+    obj.instance_variable_set(:@h, h = {})
+    def obj.hash
+      10.times{|i| @h[i] = i}
+      0
+    end
+    def obj.inspect
+      'test'
+    end
+    def obj.eql? other
+      other.class == Object
+    end
+    obj2 = Object.new
+    def obj2.hash
+      0
+    end
+
+    h[obj2] = true
+    h.delete obj
+    assert_equal '{0=>0, 1=>1, 2=>2, 3=>3, 4=>4, 5=>5, 6=>6, 7=>7, 8=>8, 9=>9}', h.inspect
+
+    # lookup
+    obj = Object.new
+    obj.instance_variable_set(:@h, h = {})
+    def obj.hash
+      10.times{|i| @h[i] = i}
+      0
+    end
+    def obj.inspect
+      'test'
+    end
+    def obj.eql? other
+      other.class == Object
+    end
+    obj2 = Object.new
+    def obj2.hash
+      0
+    end
+
+    h[obj2] = true
+    assert_equal true, h[obj]
+  end
 end

--- a/test/mri/ruby/test_integer.rb
+++ b/test/mri/ruby/test_integer.rb
@@ -595,6 +595,9 @@ class TestInteger < Test::Unit::TestCase
       failures << n  unless root*root <= n && (root+1)*(root+1) > n
     end
     assert_empty(failures, bug13440)
+
+    x = 0xffff_ffff_ffff_ffff
+    assert_equal(x, Integer.sqrt(x ** 2), "[ruby-core:95453]")
   end
 
   def test_fdiv

--- a/test/mri/ruby/test_io.rb
+++ b/test/mri/ruby/test_io.rb
@@ -3374,7 +3374,7 @@ __END__
       }
 
       IO.select(tempfiles)
-    }, bug8080, timeout: 100
+    }, bug8080, timeout: 50
   end if defined?(Process::RLIMIT_NOFILE)
 
   def test_read_32bit_boundary

--- a/test/mri/ruby/test_keyword.rb
+++ b/test/mri/ruby/test_keyword.rb
@@ -520,12 +520,6 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal(:ok, m.f(*a, **o), '[ruby-core:83638] [Bug #10856]')
 
     o = {a: 42}
-    assert_warning(/splat keyword/, 'splat to mandatory') do
-      assert_equal({a: 42}, m.f1(**o))
-    end
-    assert_warning(/splat keyword/) do
-      assert_equal({a: 42}, m.f2(**o), '[ruby-core:82280] [Bug #13791]')
-    end
     assert_warning('', 'splat to kwrest') do
       assert_equal({a: 42}, m.f3(**o))
     end

--- a/test/mri/ruby/test_marshal.rb
+++ b/test/mri/ruby/test_marshal.rb
@@ -779,4 +779,48 @@ class TestMarshal < Test::Unit::TestCase
     obj = Bug14314.new(foo: 42)
     assert_equal obj, Marshal.load(Marshal.dump(obj))
   end
+
+  class Bug15968
+    attr_accessor :bar, :baz
+
+    def initialize
+      self.bar = Bar.new(self)
+    end
+
+    class Bar
+      attr_accessor :foo
+
+      def initialize(foo)
+        self.foo = foo
+      end
+
+      def marshal_dump
+        if self.foo.baz
+          self.foo.remove_instance_variable(:@baz)
+        else
+          self.foo.baz = :problem
+        end
+        {foo: self.foo}
+      end
+
+      def marshal_load(data)
+        self.foo = data[:foo]
+      end
+    end
+  end
+
+  def test_marshal_dump_adding_instance_variable
+    obj = Bug15968.new
+    assert_raise_with_message(RuntimeError, /instance variable added/) do
+      Marshal.dump(obj)
+    end
+  end
+
+  def test_marshal_dump_removing_instance_variable
+    obj = Bug15968.new
+    obj.baz = :Bug15968
+    assert_raise_with_message(RuntimeError, /instance variable removed/) do
+      Marshal.dump(obj)
+    end
+  end
 end

--- a/test/mri/ruby/test_module.rb
+++ b/test/mri/ruby/test_module.rb
@@ -294,8 +294,11 @@ class TestModule < Test::Unit::TestCase
   end
 
   def test_nested_get
-    assert_equal Other, Object.const_get([self.class, Other].join('::'))
+    assert_equal Other, Object.const_get([self.class, 'Other'].join('::'))
     assert_equal User::USER, self.class.const_get([User, 'USER'].join('::'))
+    assert_raise(NameError) {
+      Object.const_get([self.class.name, 'String'].join('::'))
+    }
   end
 
   def test_nested_get_symbol
@@ -328,6 +331,7 @@ class TestModule < Test::Unit::TestCase
     assert_send([Object, :const_defined?, [self.class.name, 'Other'].join('::')])
     assert_send([self.class, :const_defined?, 'User::USER'])
     assert_not_send([self.class, :const_defined?, 'User::Foo'])
+    assert_not_send([Object, :const_defined?, [self.class.name, 'String'].join('::')])
   end
 
   def test_nested_defined_symbol

--- a/test/mri/ruby/test_notimp.rb
+++ b/test/mri/ruby/test_notimp.rb
@@ -13,11 +13,11 @@ class TestNotImplement < Test::Unit::TestCase
 
   def test_respond_to_lchmod
     assert_include(File.methods, :lchmod)
-    if /linux/ =~ RUBY_PLATFORM
-      assert_equal(false, File.respond_to?(:lchmod))
-    end
-    if /freebsd/ =~ RUBY_PLATFORM
+    case RUBY_PLATFORM
+    when /freebsd/, /linux-musl/
       assert_equal(true, File.respond_to?(:lchmod))
+    when /linux/
+      assert_equal(false, File.respond_to?(:lchmod))
     end
   end
 
@@ -57,9 +57,14 @@ class TestNotImplement < Test::Unit::TestCase
         File.open(f, "w") {}
         File.symlink f, g
         newmode = 0444
-        File.lchmod newmode, "#{d}/g"
-        snew = File.lstat(g)
-        assert_equal(newmode, snew.mode & 0777)
+        begin
+          File.lchmod newmode, "#{d}/g"
+        rescue Errno::EOPNOTSUPP
+          skip $!
+        else
+          snew = File.lstat(g)
+          assert_equal(newmode, snew.mode & 0777)
+        end
       }
     end
   end

--- a/test/mri/ruby/test_parse.rb
+++ b/test/mri/ruby/test_parse.rb
@@ -1198,6 +1198,12 @@ x = __ENCODING__
     assert_valid_syntax('let () { m(a) do; end }')
   end
 
+  def test_void_value_in_command_rhs
+    w = "void value expression"
+    ex = assert_syntax_error("x = return 1", w)
+    assert_equal(1, ex.message.scan(w).size, "same #{w.inspect} warning should be just once")
+  end
+
 =begin
   def test_past_scope_variable
     assert_warning(/past scope/) {catch {|tag| eval("BEGIN{throw tag}; tap {a = 1}; a")}}

--- a/test/mri/ruby/test_process.rb
+++ b/test/mri/ruby/test_process.rb
@@ -2387,6 +2387,15 @@ EOS
     r.close if r
   end if defined?(fork)
 
+  def test_rescue_exec_fail
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      assert_raise(Errno::ENOENT) do
+        exec("", in: "")
+      end
+    end;
+  end
+
   def test_many_args
     bug11418 = '[ruby-core:70251] [Bug #11418]'
     assert_in_out_err([], <<-"end;", ["x"]*256, [], bug11418, timeout: 60)

--- a/test/mri/ruby/test_rational.rb
+++ b/test/mri/ruby/test_rational.rb
@@ -598,6 +598,13 @@ class Rational_Test < Test::Unit::TestCase
     assert_nothing_raised(TypeError, '[Bug #5020] [ruby-dev:44088]') do
       Rational(1,2).coerce(Complex(1,1))
     end
+
+    assert_raise(ZeroDivisionError) do
+      1 / 0r.coerce(0+0i)[0]
+    end
+    assert_raise(ZeroDivisionError) do
+      1 / 0r.coerce(0.0+0i)[0]
+    end
   end
 
   class ObjectX

--- a/test/mri/ruby/test_regexp.rb
+++ b/test/mri/ruby/test_regexp.rb
@@ -161,6 +161,10 @@ class TestRegexp < Test::Unit::TestCase
     s = "foo"
     s[/(?<bar>o)/, "bar"] = "baz"
     assert_equal("fbazo", s)
+
+    /.*/ =~ "abc"
+    "a".sub("a", "")
+    assert_raise(IndexError) {Regexp.last_match(:_id)}
   end
 
   def test_named_capture_with_nul
@@ -214,6 +218,17 @@ class TestRegexp < Test::Unit::TestCase
   def test_assign_named_capture_to_reserved_word
     /(?<nil>.)/ =~ "a"
     assert_not_include(local_variables, :nil, "[ruby-dev:32675]")
+
+    def (obj = Object.new).test(s, nil: :ng)
+      /(?<nil>.)/ =~ s
+      binding.local_variable_get(:nil)
+    end
+    assert_equal("b", obj.test("b"))
+
+    tap do |nil: :ng|
+      /(?<nil>.)/ =~ "c"
+      assert_equal("c", binding.local_variable_get(:nil))
+    end
   end
 
   def test_assign_named_capture_to_const

--- a/test/mri/ruby/test_settracefunc.rb
+++ b/test/mri/ruby/test_settracefunc.rb
@@ -3,21 +3,17 @@ require 'test/unit'
 
 class TestSetTraceFunc < Test::Unit::TestCase
   def setup
-    if defined?(RubyVM)
-      @original_compile_option = RubyVM::InstructionSequence.compile_option
-      RubyVM::InstructionSequence.compile_option = {
-        :trace_instruction => true,
-        :specialized_instruction => false
-      }
-    end
+    @original_compile_option = RubyVM::InstructionSequence.compile_option
+    RubyVM::InstructionSequence.compile_option = {
+      :trace_instruction => true,
+      :specialized_instruction => false
+    }
     @target_thread = Thread.current
   end
 
   def teardown
     set_trace_func(nil)
-    if defined?(RubyVM)
-      RubyVM::InstructionSequence.compile_option = @original_compile_option
-    end
+    RubyVM::InstructionSequence.compile_option = @original_compile_option
     @target_thread = nil
   end
 

--- a/test/mri/ruby/test_struct.rb
+++ b/test/mri/ruby/test_struct.rb
@@ -92,6 +92,10 @@ module TestStruct
     assert_equal([:utime, :stime, :cutime, :cstime], Process.times.members)
   end
 
+  def test_struct_new_with_empty_hash
+    assert_equal({:a=>1}, Struct.new(:a, {}).new({:a=>1}).a)
+  end
+
   def test_struct_new_with_keyword_init
     @Struct.new("KeywordInitTrue", :a, :b, keyword_init: true)
     @Struct.new("KeywordInitFalse", :a, :b, keyword_init: false)

--- a/test/mri/ruby/test_syntax.rb
+++ b/test/mri/ruby/test_syntax.rb
@@ -958,10 +958,8 @@ eom
     assert_warn(/literal in condition/) do
       eval('1 if //')
     end
-    if RUBY_ENGINE != 'jruby'
-      assert_warn(/literal in condition/) do
-        eval('1 if true..false')
-      end
+    assert_warn(/literal in condition/) do
+      eval('1 if true..false')
     end
     assert_warning(/literal in condition/) do
       eval('1 if 1')
@@ -979,10 +977,8 @@ eom
     assert_warn('') do
       eval('1 if !//')
     end
-    if RUBY_ENGINE != 'jruby'
-      assert_warn('') do
-        eval('1 if !(true..false)')
-      end
+    assert_warn('') do
+      eval('1 if !(true..false)')
     end
     assert_warning('') do
       eval('1 if !1')
@@ -1269,6 +1265,15 @@ eom
     assert_nil obj.test
   end
 
+  def test_assignment_return_in_loop
+    obj = Object.new
+    def obj.test
+      x = nil
+      _y = (return until x unless x)
+    end
+    assert_nil obj.test, "[Bug #16695]"
+  end
+
   def test_method_call_location
     line = __LINE__+5
     e = assert_raise(NoMethodError) do
@@ -1308,6 +1313,12 @@ eom
   def test_command_with_cmd_brace_block
     assert_valid_syntax('obj.foo (1) {}')
     assert_valid_syntax('obj::foo (1) {}')
+  end
+
+  def test_value_expr_in_condition
+    mesg = /void value expression/
+    assert_syntax_error("tap {a = (true ? next : break)}", mesg)
+    assert_valid_syntax("tap {a = (true ? true : break)}")
   end
 
   private

--- a/test/mri/ruby/test_thread.rb
+++ b/test/mri/ruby/test_thread.rb
@@ -305,7 +305,7 @@ class TestThread < Test::Unit::TestCase
       s += 1
     end
     Thread.pass until t.stop?
-    # sleep 1 if RubyVM::MJIT.enabled? # t.stop? behaves unexpectedly with --jit-wait
+    sleep 1 if RubyVM::MJIT.enabled? # t.stop? behaves unexpectedly with --jit-wait
     assert_equal(1, s)
     t.wakeup
     Thread.pass while t.alive?
@@ -1332,7 +1332,7 @@ q.pop
     opts = { timeout: 5, timeout_error: nil }
 
     # prevent SIGABRT from slow shutdown with MJIT
-    # opts[:reprieve] = 3 if RubyVM::MJIT.enabled?
+    opts[:reprieve] = 3 if RubyVM::MJIT.enabled?
 
     assert_normal_exit(<<-_end, '[Bug #8996]', opts)
       Thread.report_on_exception = false

--- a/test/mri/ruby/test_time.rb
+++ b/test/mri/ruby/test_time.rb
@@ -851,6 +851,13 @@ class TestTime < Test::Unit::TestCase
     assert_equal(8192, Time.now.strftime('%8192z').size)
   end
 
+  def test_strftime_wide_precision
+    t2000 = get_t2000
+    s = t2000.strftime("%28c")
+    assert_equal(28, s.size)
+    assert_equal(t2000.strftime("%c"), s.strip)
+  end
+
   def test_strfimte_zoneoffset
     t2000 = get_t2000
     t = t2000.getlocal("+09:00:00")
@@ -1099,6 +1106,14 @@ class TestTime < Test::Unit::TestCase
       assert_equal(min, t.min)
       assert_equal(sec, t.sec)
     }
+  end
+
+  def test_getlocal_utc_offset
+    t = Time.gm(2000)
+    assert_equal [00, 30, 21, 31, 12, 1999], t.getlocal("-02:30").to_a[0, 6]
+    assert_equal [00, 00,  9,  1,  1, 2000], t.getlocal("+09:00").to_a[0, 6]
+    assert_equal [20, 29, 21, 31, 12, 1999], t.getlocal("-02:30:40").to_a[0, 6]
+    assert_equal [35, 10,  9,  1,  1, 2000], t.getlocal("+09:10:35").to_a[0, 6]
   end
 
   def test_getlocal_nil

--- a/test/mri/ruby/test_time_tz.rb
+++ b/test/mri/ruby/test_time_tz.rb
@@ -156,6 +156,12 @@ class TestTimeTZ < Test::Unit::TestCase
     }
   end
 
+  def test_asia_kuala_lumpur
+    with_tz(tz="Asia/Kuala_Lumpur") {
+      assert_time_constructor(tz, "1933-01-01 00:20:00 +0720", :local, [1933])
+    }
+  end
+
   def test_canada_newfoundland
     with_tz(tz="America/St_Johns") {
       assert_time_constructor(tz, "2007-11-03 23:00:59 -0230", :new, [2007,11,3,23,0,59,:dst])
@@ -542,6 +548,8 @@ module TestTimeTZ::WithTZ
     m, s = (4000-utc_offset).divmod(60)
     h, m = m.divmod(60)
     assert_equal(time_class.utc(2018, 9, 1, 12+h, m, s), t)
+    assert_equal(6, t.wday)
+    assert_equal(244, t.yday)
   end
 
   def subtest_at(time_class, tz, tzarg, tzname, abbr, utc_offset)
@@ -650,6 +658,16 @@ else
     def tz
       @tz ||= TZInfo::Timezone.get(tzname)
     end
+  end
+
+  def test_fractional_second
+    x = Object.new
+    def x.local_to_utc(t); t + 8*3600; end
+    def x.utc_to_local(t); t - 8*3600; end
+
+    t1 = Time.new(2020,11,11,12,13,14.124r, '-08:00')
+    t2 = Time.new(2020,11,11,12,13,14.124r, x)
+    assert_equal(t1, t2)
   end
 end
 

--- a/test/mri/ruby/test_transcode.rb
+++ b/test/mri/ruby/test_transcode.rb
@@ -2161,6 +2161,14 @@ class TestTranscode < Test::Unit::TestCase
     assert_equal("U+3042", "\u{3042}".encode("US-ASCII", fallback: fallback.method(:escape)))
   end
 
+  def test_fallback_aref
+    fallback = Object.new
+    def fallback.[](x)
+      "U+%.4X" % x.unpack("U")
+    end
+    assert_equal("U+3042", "\u{3042}".encode("US-ASCII", fallback: fallback))
+  end
+
   bug8940 = '[ruby-core:57318] [Bug #8940]'
   %w[UTF-32 UTF-16].each do |enc|
     define_method("test_pseudo_encoding_inspect(#{enc})") do

--- a/test/mri/rubygems/test_bundled_ca.rb
+++ b/test/mri/rubygems/test_bundled_ca.rb
@@ -51,13 +51,16 @@ if ENV["CI"] || ENV["TEST_SSL"]
       assert_https('rubygems.org')
     end
 
-    def test_accessing_fastly
-      assert_https('rubygems.global.ssl.fastly.net')
+    def test_accessing_www_rubygems
+      assert_https('www.rubygems.org')
+    end
+
+    def test_accessing_staging
+      assert_https('staging.rubygems.org')
     end
 
     def test_accessing_new_index
-      assert_https('fastly.rubygems.org')
+      assert_https('index.rubygems.org')
     end
-
   end
 end

--- a/test/mri/rubygems/test_gem_package.rb
+++ b/test/mri/rubygems/test_gem_package.rb
@@ -563,42 +563,6 @@ class TestGemPackage < Gem::Package::TarTestCase
     end
   end
 
-  def test_extract_symlink_parent_doesnt_delete_user_dir
-    skip if RUBY_VERSION <= "1.8.7"
-
-    package = Gem::Package.new @gem
-
-    # Extract into a subdirectory of @destination; if this test fails it writes
-    # a file outside destination_subdir, but we want the file to remain inside
-    # @destination so it will be cleaned up.
-    destination_subdir = File.join @destination, 'subdir'
-    FileUtils.mkdir_p destination_subdir
-
-    destination_user_dir = File.join @destination, 'user'
-    destination_user_subdir = File.join destination_user_dir, 'dir'
-    FileUtils.mkdir_p destination_user_subdir
-
-    tgz_io = util_tar_gz do |tar|
-      tar.add_symlink 'link', destination_user_dir, 16877
-      tar.add_symlink 'link/dir', '.', 16877
-    end
-
-    e = assert_raises(Gem::Package::PathError, Errno::EACCES) do
-      package.extract_tar_gz tgz_io, destination_subdir
-    end
-
-    assert_path_exists destination_user_subdir
-
-    if Gem::Package::PathError === e
-      assert_equal("installing into parent path #{destination_user_subdir} of " +
-                  "#{destination_subdir} is not allowed", e.message)
-    elsif win_platform?
-      skip "symlink - must be admin with no UAC on Windows"
-    else
-      raise e
-    end
-  end
-
   def test_extract_tar_gz_directory
     package = Gem::Package.new @gem
 

--- a/test/mri/scanf/test_scanfio.rb
+++ b/test/mri/scanf/test_scanfio.rb
@@ -17,12 +17,5 @@ class TestScanfIO < Test::Unit::TestCase
   ensure
     fh.close
   end
-
-  def test_pipe_scanf
-    r, w = IO.pipe
-    w.write('a')
-    w.close
-    assert_equal([], r.scanf('a'))
-  end
 end
 

--- a/test/mri/socket/test_socket.rb
+++ b/test/mri/socket/test_socket.rb
@@ -380,11 +380,10 @@ class TestSocket < Test::Unit::TestCase
             in6_ifreq = [ifr_name,ai.to_sockaddr].pack('a16A*')
             s.ioctl(ulSIOCGIFFLAGS, in6_ifreq)
             next true if in6_ifreq.unpack('A16L1').last & ulIFF_POINTOPOINT != 0
-          else
-            ifconfig ||= `/sbin/ifconfig`
-            next true if ifconfig.scan(/^(\w+):(.*(?:\n\t.*)*)/).find do|ifname, value|
-              value.include?(ai.ip_address) && value.include?('POINTOPOINT')
-            end
+          end
+          ifconfig ||= `/sbin/ifconfig`
+          next true if ifconfig.scan(/^(\w+):(.*(?:\n\t.*)*)/).find do |_ifname, value|
+            value.include?(ai.ip_address) && value.include?('POINTOPOINT')
           end
         end
         false

--- a/test/mri/test_pp.rb
+++ b/test/mri/test_pp.rb
@@ -195,14 +195,14 @@ class PPFileStatTest < Test::Unit::TestCase
 end
 
 if defined?(RubyVM)
-  class PPAbstractSyntaxTree < Test::Unit::TestCase
-    AST = RubyVM::AbstractSyntaxTree
-    def test_literal
-      ast = AST.parse("1")
-      expected = "(SCOPE@1:0-1:1 tbl: [] args: nil body: (LIT@1:0-1:1 1))"
-      assert_equal(expected, PP.singleline_pp(ast, ''.dup), ast)
-    end
+class PPAbstractSyntaxTree < Test::Unit::TestCase
+  AST = RubyVM::AbstractSyntaxTree
+  def test_literal
+    ast = AST.parse("1")
+    expected = "(SCOPE@1:0-1:1 tbl: [] args: nil body: (LIT@1:0-1:1 1))"
+    assert_equal(expected, PP.singleline_pp(ast, ''.dup), ast)
   end
+end
 end
 
 end

--- a/test/mri/test_rbconfig.rb
+++ b/test/mri/test_rbconfig.rb
@@ -51,4 +51,13 @@ class TestRbConfig < Test::Unit::TestCase
       assert_match(/\$\(sitearch|\$\(rubysitearchprefix\)/, val, "#{key} #{bug7823}")
     end
   end
+
+  if /darwin/ =~ RUBY_PLATFORM
+    def test_sdkroot
+      assert_separately([{"SDKROOT" => "$(prefix)/SDKRoot"}], "#{<<~"begin;"}\n#{<<~'end;'}")
+      begin;
+        assert_equal RbConfig::CONFIG["prefix"]+"/SDKRoot", RbConfig::CONFIG["SDKROOT"]
+      end;
+    end
+  end
 end

--- a/test/mri/test_syslog.rb
+++ b/test/mri/test_syslog.rb
@@ -113,7 +113,7 @@ class TestSyslog < Test::Unit::TestCase
   end
 
   def syslog_line_regex(ident, message)
-    /(?:^| )#{Regexp.quote(ident)}(?:\[([1-9][0-9]*)\])?(?: |[: ].* )#{Regexp.quote(message)}$/
+    /(?:^| )#{Regexp.quote(ident)}(?:\[([1-9][0-9]*)\])?(?: | ([1-9][0-9]*) - - ||[: ].* )#{Regexp.quote(message)}$/
   end
 
   def test_log
@@ -168,8 +168,9 @@ class TestSyslog < Test::Unit::TestCase
         end
         m = re.match(line)
         assert_not_nil(m)
-        assert_not_nil(m[1])
-        assert_equal(pid, m[1].to_i)
+        output_pid = m[1] || m[2]
+        assert_not_nil(output_pid)
+        assert_equal(pid, output_pid.to_i)
       }
     }
   end

--- a/test/mri/uri/test_ldap.rb
+++ b/test/mri/uri/test_ldap.rb
@@ -95,6 +95,10 @@ class TestLDAP < Test::Unit::TestCase
       u.select(:scheme, :host, :not_exist, :port)
     end
   end
+
+  def test_parse_invalid_uri
+    assert_raise(URI::InvalidURIError) {URI.parse("ldap:https://example.com")}
+  end
 end
 
 

--- a/test/mri/webrick/test_httpproxy.rb
+++ b/test/mri/webrick/test_httpproxy.rb
@@ -213,7 +213,7 @@ class TestWEBrickHTTPProxy < Test::Unit::TestCase
         end
       end
     end
-  end
+  end if RUBY_VERSION >= '2.5'
 
   def make_certificate(key, cn)
     subject = OpenSSL::X509::Name.parse("/DC=org/DC=ruby-lang/CN=#{cn}")

--- a/test/mri/webrick/test_httpserver.rb
+++ b/test/mri/webrick/test_httpserver.rb
@@ -253,7 +253,7 @@ class TestWEBrickHTTPServer < Test::Unit::TestCase
       server.virtual_host(WEBrick::HTTPServer.new(vhost_config))
 
       Thread.pass while server.status != :Running
-      sleep 1 if RubyVM::MJIT.enabled? # server.status behaves unexpectedly with --jit-wait
+      sleep 1 if defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled? # server.status behaves unexpectedly with --jit-wait
       assert_equal(1, started, log.call)
       assert_equal(0, stopped, log.call)
       assert_equal(0, accepted, log.call)

--- a/test/mri/webrick/test_server.rb
+++ b/test/mri/webrick/test_server.rb
@@ -65,7 +65,7 @@ class TestWEBrickServer < Test::Unit::TestCase
     }
     TestWEBrick.start_server(Echo, config){|server, addr, port, log|
       true while server.status != :Running
-      sleep 1 if RubyVM::MJIT.enabled? # server.status behaves unexpectedly with --jit-wait
+      sleep 1 if defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled? # server.status behaves unexpectedly with --jit-wait
       assert_equal(1, started, log.call)
       assert_equal(0, stopped, log.call)
       assert_equal(0, accepted, log.call)


### PR DESCRIPTION
These are not all passing, due to a combination of unfixed features in JRuby and modifications to CRuby tests that require e.g. RubyVM features we do not support. This PR will track fixes, test modifications, or excludes to get green on the latest 2.6 suite.