### PR TITLE
Revert "update surefire plugin"

### DIFF
--- a/pom.rb
+++ b/pom.rb
@@ -120,7 +120,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
 
     plugin :compiler, '3.8.1'
     plugin :shade, '3.2.4'
-    plugin :surefire, '3.0.0-M5'
+    plugin :surefire, '3.0.0-M2'
     plugin :plugin, '3.6.0'
     plugin( :invoker, '3.2.1',
             'properties' => { 'jruby.version' => '${project.version}',

--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,7 @@ DO NOT MODIFIY - GENERATED CODE
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>3.0.0-M2</version>
         </plugin>
         <plugin>
           <artifactId>maven-plugin-plugin</artifactId>


### PR DESCRIPTION
Reverts jruby/jruby#6788

I think this may have disabled tests, possibly due to this JUnit/Surefire conflict:

https://dzone.com/articles/why-your-junit-5-tests-are-not-running-under-maven

The latest JNR update (#6481) may have surfaced this issue by depending on a different version of JUnit and thereby letting tests run again.

The failures in that PR, then, might represent a valid regression that was hidden due to the tests not running.

Trying this reversion to see if we see tests running again on master, and if so whether they have the same failures as on the JNR update PR.