### PR TITLE
embed fix

### DIFF
--- a/core/src/main/java/org/jruby/embed/variable/Argv.java
+++ b/core/src/main/java/org/jruby/embed/variable/Argv.java
@@ -169,11 +169,12 @@ public class Argv extends AbstractVariable {
         // ARGV constant should be only one
         if ( vars.containsKey(name) ) {
             BiVariable var = vars.getVariable(topSelf, name);
-            var.setRubyObject(argv);
+            if (var != null) {
+                var.setRubyObject(argv);
+                return;
+            }
         }
-        else {
-            vars.update(name, new Argv(topSelf, name, argv));
-        }
+        vars.update(name, new Argv(topSelf, name, argv));
     }
 
     // ARGV appears to require special treatment, leaving javaType intact


### PR DESCRIPTION
```
[ERROR] org.jruby.embed.jsr223.JRubyEngineTest.testARGV  Time elapsed: 0.271 s  <<< ERROR!
javax.script.ScriptException: java.lang.NullPointerException: Cannot invoke "org.jruby.embed.variable.BiVariable.setRubyObject(org.jruby.runtime.builtin.IRubyObject)" because "var" is null
        at org.jruby.embed.jsr223.JRubyEngineTest.testARGV(JRubyEngineTest.java:740)
Caused by: java.lang.NullPointerException: Cannot invoke "org.jruby.embed.variable.BiVariable.setRubyObject(org.jruby.runtime.builtin.IRubyObject)" because "var" is null
        at org.jruby.embed.jsr223.JRubyEngineTest.testARGV(JRubyEngineTest.java:740)
```