### PR TITLE
Fix super chaining on Ruby subclasses of Java classes

### DIFF
--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -2021,7 +2021,7 @@ public class RubyClass extends RubyModule {
             if (supr == null) return;
 
             SkinnyMethodAdapter m = new SkinnyMethodAdapter(cw, ACC_SYNTHETIC | ACC_BRIDGE | ACC_PUBLIC,
-                    "__super$" + javaMethodName, sig(methodSignature), null, null);
+                    JavaProxyClass.generateSuperName(javaName, javaMethodName), sig(methodSignature), null, null);
             GeneratorAdapter ga = RealClassGenerator.makeGenerator(m);
             ga.loadThis();
             ga.loadArgs();

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -51,6 +51,12 @@ import org.jruby.ir.operands.Splat;
 import org.jruby.ir.operands.UndefinedValue;
 import org.jruby.ir.persistence.IRReader;
 import org.jruby.ir.persistence.IRReaderStream;
+import org.jruby.java.invokers.InstanceMethodInvoker;
+import org.jruby.java.invokers.RubyToJavaInvoker;
+import org.jruby.java.proxies.JavaProxy;
+import org.jruby.javasupport.JavaMethod;
+import org.jruby.javasupport.proxy.JavaProxyClass;
+import org.jruby.javasupport.proxy.JavaProxyMethod;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.Arity;
 import org.jruby.runtime.Binding;
@@ -1194,11 +1200,52 @@ public class IRRuntimeHelpers {
         CacheEntry entry = getSuperMethodEntry(id, definingModule);
         DynamicMethod method = entry.method;
 
+        if (method instanceof InstanceMethodInvoker && self instanceof JavaProxy) {
+            return javaProxySuper(
+                    context,
+                    (JavaProxy) self,
+                    id,
+                    (RubyClass) definingModule,
+                    args,
+                    (InstanceMethodInvoker) method);
+        }
+
         if (method.isUndefined()) {
             return Helpers.callMethodMissing(context, self, method.getVisibility(), id, CallType.SUPER, args, block);
         }
 
         return method.call(context, self, entry.sourceModule, id, args, block);
+    }
+
+    /**
+     * Perform a super invocation against a Java proxy, using proxy logic to locate and invoke the appropriate shim
+     * method.
+     *
+     * This duplicates some logic from InstanceMethodInvoker.call and JavaMethod.tryProxyInvocation in order to properly
+     * retrieve the superclass method from the caller's point of view. See GH-6718.
+     *
+     * @param context the current context
+     * @param self the proxy wrapper
+     * @param id the method name
+     * @param definingModule the module in which the calling method is defined
+     * @param args arguments to the call
+     * @param superMethod the invoker for the super method found using using Ruby super logic
+     * @return the result of invoking the super method via a shim method
+     */
+    private static IRubyObject javaProxySuper(ThreadContext context, JavaProxy self, String id, RubyClass definingModule, IRubyObject[] args, InstanceMethodInvoker superMethod) {
+        Object javaInvokee = self.getObject();
+
+        JavaMethod javaMethod = (JavaMethod) superMethod.findCallable(self, id, args, args.length);
+
+        // self is a Java subclass, need to do a bit more logic to dispatch the right method
+        JavaProxyClass jpc = JavaProxyClass.getProxyClass(context.runtime, definingModule);
+        JavaProxyMethod jpm;
+        Object[] newArgs = RubyToJavaInvoker.convertArguments(javaMethod, args);
+        if ((jpm = jpc.getMethod(id, javaMethod.getParameterTypes())) != null && jpm.hasSuperImplementation()) {
+            return javaMethod.invokeDirectSuperWithExceptionHandling(context, jpm.getSuperMethod(), javaInvokee, newArgs);
+        } else {
+            return javaMethod.invokeDirectWithExceptionHandling(context, javaMethod.getValue(), javaInvokee, newArgs);
+        }
     }
 
     @Interp

--- a/core/src/main/java/org/jruby/java/invokers/RubyToJavaInvoker.java
+++ b/core/src/main/java/org/jruby/java/invokers/RubyToJavaInvoker.java
@@ -400,7 +400,16 @@ public abstract class RubyToJavaInvoker<T extends JavaCallable> extends JavaMeth
         }
     }
 
-    protected T findCallable(IRubyObject self, String name, IRubyObject[] args, final int arity) {
+    /**
+     * Find the matching callable object given the target proxy wrapper, method name, arguments, and actual arity.
+     *
+     * @param self the proxy wrapper
+     * @param name the method name
+     * @param args the arguments
+     * @param arity the actual arity
+     * @return a suitable callable, or else raises an argument or name error
+     */
+    public T findCallable(IRubyObject self, String name, IRubyObject[] args, final int arity) {
         switch (arity) {
             case 0:
                 return findCallableArityZero(self, name);

--- a/core/src/main/java/org/jruby/javasupport/JavaMethod.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaMethod.java
@@ -405,7 +405,7 @@ public class JavaMethod extends JavaCallable {
         }
     }
 
-    private IRubyObject invokeDirectSuperWithExceptionHandling(ThreadContext context, Method method, Object javaInvokee, Object... arguments) {
+    public IRubyObject invokeDirectSuperWithExceptionHandling(ThreadContext context, Method method, Object javaInvokee, Object... arguments) {
         // super calls from proxies must use reflected method
         // FIXME: possible to make handles do the superclass call?
         try {
@@ -422,7 +422,7 @@ public class JavaMethod extends JavaCallable {
         }
     }
 
-    private IRubyObject invokeDirectWithExceptionHandling(ThreadContext context, Method method, Object javaInvokee, Object[] arguments) {
+    public IRubyObject invokeDirectWithExceptionHandling(ThreadContext context, Method method, Object javaInvokee, Object[] arguments) {
         try {
             Object result = method.invoke(javaInvokee, arguments);
             return convertReturn(context.runtime, result);

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyClass.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyClass.java
@@ -408,13 +408,13 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
             methodsWithName.add(proxyMethod);
         }
         catch (ClassNotFoundException e) {
-            throw new InternalError(e.getMessage());
+            throw new InternalError(e.getMessage(), e);
         }
         catch (SecurityException e) {
-            throw new InternalError(e.getMessage());
+            throw new InternalError(e.getMessage(), e);
         }
         catch (NoSuchMethodException e) {
-            throw new InternalError(e.getMessage());
+            throw new InternalError(e.getMessage(), e);
         }
     }
 

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyClass.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyClass.java
@@ -70,6 +70,7 @@ import org.jruby.javasupport.*;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ClassDefiningClassLoader;
+import org.jruby.util.JavaNameMangler;
 
 import static org.jruby.javasupport.JavaClass.EMPTY_CLASS_ARRAY;
 import static org.jruby.javasupport.JavaCallable.inspectParameterTypes;
@@ -393,7 +394,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
             Method method = proxy.getDeclaredMethod(name, paramTypes);
             Method superMethod = null;
             if ( hasSuper ) {
-                superMethod = proxy.getDeclaredMethod("__super$" + name, paramTypes);
+                superMethod = proxy.getDeclaredMethod(generateSuperName(proxy.getName(), name), paramTypes);
             }
 
             JavaProxyMethod proxyMethod = new ProxyMethodImpl(getRuntime(), this, method, superMethod);
@@ -415,6 +416,17 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
         catch (NoSuchMethodException e) {
             throw new InternalError(e.getMessage());
         }
+    }
+
+    /**
+     * Generate a "super" stub for the given proxy class name and super method name.
+     *
+     * @param className the proxy class name
+     * @param superName the super method name
+     * @return a unique stub method name for the given proxy class and super method
+     */
+    public static String generateSuperName(String className, String superName) {
+        return "__super$" + JavaNameMangler.mangleMethodName(className) + "$" + superName;
     }
 
     private static Class[] parse(final ClassLoader loader, String desc) throws ClassNotFoundException {

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyClass.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyClass.java
@@ -30,6 +30,26 @@
 
 package org.jruby.javasupport.proxy;
 
+import org.jruby.Ruby;
+import org.jruby.RubyArray;
+import org.jruby.RubyClass;
+import org.jruby.RubyFixnum;
+import org.jruby.RubyModule;
+import org.jruby.RubyObject;
+import org.jruby.RubyString;
+import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.internal.runtime.AbstractIRMethod;
+import org.jruby.internal.runtime.methods.DynamicMethod;
+import org.jruby.java.proxies.ConcreteJavaProxy.NewMethodReified;
+import org.jruby.java.proxies.ConcreteJavaProxy.StaticJCreateMethod;
+import org.jruby.javasupport.Java;
+import org.jruby.javasupport.JavaObject;
+import org.jruby.javasupport.JavaUtil;
+import org.jruby.runtime.ObjectAllocator;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.JavaNameMangler;
+
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -37,43 +57,14 @@ import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
-import java.util.Collection;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
-import org.jruby.Ruby;
-import org.jruby.RubyArray;
-import org.jruby.RubyClass;
-import org.jruby.RubyFixnum;
-import org.jruby.RubyModule;
-import org.jruby.RubyObject;
-import org.jruby.RubyNil;
-import org.jruby.RubyString;
-import org.jruby.anno.JRubyClass;
-import org.jruby.anno.JRubyMethod;
-import org.jruby.exceptions.RaiseException;
-import org.jruby.internal.runtime.AbstractIRMethod;
-import org.jruby.internal.runtime.methods.*;
-import org.jruby.java.codegen.Reified;
-import org.jruby.java.proxies.ConcreteJavaProxy.*;
-import org.jruby.java.proxies.JavaProxy;
-import org.jruby.javasupport.*;
-import org.jruby.runtime.ObjectAllocator;
-import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.util.ClassDefiningClassLoader;
-import org.jruby.util.JavaNameMangler;
-
-import static org.jruby.javasupport.JavaClass.EMPTY_CLASS_ARRAY;
 import static org.jruby.javasupport.JavaCallable.inspectParameterTypes;
+import static org.jruby.javasupport.JavaClass.EMPTY_CLASS_ARRAY;
 
 /**
  * Generalized proxy for classes and interfaces.

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyClass.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyClass.java
@@ -412,6 +412,9 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
     /**
      * Generate a "super" stub for the given proxy class name and super method name.
      *
+     * This name is intended to be unique to this class and method in order to allow jumping into the super chain at any
+     * point in the hierarchy, bypassing the default behavior of virtual and reflective calls.
+     *
      * @param className the proxy class name
      * @param superName the super method name
      * @return a unique stub method name for the given proxy class and super method

--- a/spec/java_integration/fixtures/concrete_subclass_overrides.rb
+++ b/spec/java_integration/fixtures/concrete_subclass_overrides.rb
@@ -1,0 +1,65 @@
+class Child1Override < java.lang.Object
+  def toString
+    "child1 #{super}"
+  end
+end
+
+class Child1NoOverride < java.lang.Object
+end
+
+class Child1OverrideChild2Override < Child1Override
+  def toString
+    "child2 #{super}"
+  end
+end
+
+class Child1OverrideChild2NoOverride < Child1Override
+end
+
+class Child1NoOverrideChild2Override < Child1NoOverride
+  def toString
+    "child2 #{super}"
+  end
+end
+
+class Child1NoOverrideChild2NoOverride < Child1NoOverride
+end
+
+class Child1OverrideChild2OverrideChild3Override < Child1OverrideChild2Override
+  def toString
+    "child3 #{super}"
+  end
+end
+
+class Child1OverrideChild2OverrideChild3NoOverride < Child1OverrideChild2Override
+end
+
+class Child1OverrideChild2NoOverrideChild3Override < Child1OverrideChild2NoOverride
+  def toString
+    "child3 #{super}"
+  end
+end
+
+class Child1OverrideChild2NoOverrideChild3NoOverride < Child1OverrideChild2NoOverride
+end
+
+class Child1NoOverrideChild2NoOverride < Child1NoOverride
+end
+
+class Child1NoOverrideChild2OverrideChild3Override < Child1NoOverrideChild2Override
+  def toString
+    "child3 #{super}"
+  end
+end
+
+class Child1NoOverrideChild2OverrideChild3NoOverride < Child1NoOverrideChild2Override
+end
+
+class Child1NoOverrideChild2NoOverrideChild3Override < Child1NoOverrideChild2NoOverride
+  def toString
+    "child3 #{super}"
+  end
+end
+
+class Child1NoOverrideChild2NoOverrideChild3NoOverride < Child1NoOverrideChild2NoOverride
+end

--- a/spec/java_integration/methods/super_on_concrete_subclass_spec.rb
+++ b/spec/java_integration/methods/super_on_concrete_subclass_spec.rb
@@ -1,39 +1,23 @@
-require File.dirname(__FILE__) + "/../spec_helper"
+require_relative "../fixtures/concrete_subclass_overrides"
 
 # See GH-6718
-describe "A Java method overidden by a Ruby subclass" do
-  it "can dispatch to the super method" do
-    class Parent < java.lang.Object
-      def toString
-        "parent #{super}"
-      end
-    end
+describe "A Java method from a parent class overridden by its Ruby descendants" do
+  it "invokes all overrides followed by the Java method" do
+    expect(Child1Override.new.toString).to match(/^child1/)
+    expect(Child1NoOverride.new.toString).not_to match(/^child1/)
 
-    expect(Parent.new.toString).to match(/^parent/)
+    expect(Child1OverrideChild2Override.new.toString).to match(/^child2 child1/)
+    expect(Child1OverrideChild2NoOverride.new.toString).to match(/^child1/)
+    expect(Child1NoOverrideChild2Override.new.toString).to match(/^child2/)
+    expect(Child1NoOverrideChild2NoOverride.new.toString).not_to match(/child/)
 
-    class Child < Parent
-    end
-
-    expect(Child.new.toString).to match(/^parent/)
-  end
-
-  describe "and further overridden by a second Ruby subclass" do
-    it "can dispatch to both super methods" do
-      class Parent < java.lang.Object
-        def toString
-          "parent #{super}"
-        end
-      end
-
-      expect(Parent.new.toString).to match(/^parent/)
-
-      class Child < Parent
-        def toString
-          "child #{super}"
-        end
-      end
-
-      expect(Child.new.toString).to match(/^child parent/)
-    end
+    expect(Child1OverrideChild2OverrideChild3Override.new.toString).to match(/^child3 child2 child1/)
+    expect(Child1OverrideChild2NoOverrideChild3Override.new.toString).to match(/^child3 child1/)
+    expect(Child1NoOverrideChild2OverrideChild3Override.new.toString).to match(/^child3 child2/)
+    expect(Child1NoOverrideChild2NoOverrideChild3Override.new.toString).to match(/child3/)
+    expect(Child1OverrideChild2OverrideChild3NoOverride.new.toString).to match(/^child2 child1/)
+    expect(Child1OverrideChild2NoOverrideChild3NoOverride.new.toString).to match(/^child1/)
+    expect(Child1NoOverrideChild2OverrideChild3NoOverride.new.toString).to match(/^child2/)
+    expect(Child1NoOverrideChild2NoOverrideChild3NoOverride.new.toString).not_to match(/child/)
   end
 end

--- a/spec/java_integration/methods/super_on_concrete_subclass_spec.rb
+++ b/spec/java_integration/methods/super_on_concrete_subclass_spec.rb
@@ -1,0 +1,39 @@
+require File.dirname(__FILE__) + "/../spec_helper"
+
+# See GH-6718
+describe "A Java method overidden by a Ruby subclass" do
+  it "can dispatch to the super method" do
+    class Parent < java.lang.Object
+      def toString
+        "parent #{super}"
+      end
+    end
+
+    expect(Parent.new.toString).to match(/^parent/)
+
+    class Child < Parent
+    end
+
+    expect(Child.new.toString).to match(/^parent/)
+  end
+
+  describe "and further overridden by a second Ruby subclass" do
+    it "can dispatch to both super methods" do
+      class Parent < java.lang.Object
+        def toString
+          "parent #{super}"
+        end
+      end
+
+      expect(Parent.new.toString).to match(/^parent/)
+
+      class Child < Parent
+        def toString
+          "child #{super}"
+        end
+      end
+
+      expect(Child.new.toString).to match(/^child parent/)
+    end
+  end
+end


### PR DESCRIPTION
The issue here was that we super calls would sometimes fall back on reflective invocation when more than one subclass was involved. This had the effect of restarting the invocation chain back at the bottom of the hierarchy (from the self object's class) due to the nature of reflective invocation (it always calls the lowest override).

The fix here pulls the super invocation logic back from within the Java integration guts and into the Ruby-level super logic, so we can look up an appropriate super shim method to invoke at the proper level.

This fix will need to be refined in the future, using some of the following ideas:

* Rewrite such supers to be a different instruction. We should be able to detect this in the same way we detect super in the initialize methods of Ruby/Java subclasses. Alternatively make the check into a boolean, but this keeps some unnecessary overhead when the super invocation does not involve a Ruby/Java subclass.
* Restructure JI invocation to be able to handle this case, by passing through the `definingModule` from which the super call should originate. This was not possible using the standard `DynamicMethod` call paths, but enhancement may be possible.
* Improve the caching of this and other forms of super, which may inform a better design.

Includes simple test cases for the examples in #6718.

Fixes #6718.