### PR TITLE
use ENOTSUP from errno

### DIFF
--- a/core/src/main/java/org/jruby/util/RegularFileResource.java
+++ b/core/src/main/java/org/jruby/util/RegularFileResource.java
@@ -335,6 +335,8 @@ class RegularFileResource implements FileResource {
                 throw new ResourceException.FileIsDirectory(absolutePath());
             case ENOTDIR:
                 throw new ResourceException.FileIsNotDirectory(absolutePath());
+            case ENOTSUP:
+                throw new ResourceException.NotSupported(absolutePath());
             case EMFILE:
             default:
                 throw new InternalIOException(errno.description());

--- a/core/src/main/java/org/jruby/util/ResourceException.java
+++ b/core/src/main/java/org/jruby/util/ResourceException.java
@@ -73,6 +73,10 @@ public abstract class ResourceException extends IOException {
         public TooManySymlinks(String path) { super("ELOOP", path); }
     }
 
+    public static class NotSupported extends ErrnoException {
+        public NotSupported(String path) { super("ENOTSUP", path); }
+    }
+
     @Deprecated
     public static class IOError extends ResourceException {
         private final IOException ioe;

--- a/core/src/main/java/org/jruby/util/io/PosixShim.java
+++ b/core/src/main/java/org/jruby/util/io/PosixShim.java
@@ -449,6 +449,8 @@ public class PosixShim {
             setErrno(Errno.EACCES);
         } catch (ResourceException.TooManySymlinks e) {
             setErrno(Errno.ELOOP);
+        } catch (ResourceException.NotSupported e) {
+            setErrno(Errno.ENOTSUP);
         } catch (ResourceException ex) {
             throw ex.newRaiseException(runtime);
         } catch (Exception ex) {


### PR DESCRIPTION
fixes a failure on aarch64
```
File.open creates an unnamed temporary file with File::TMPFILE ERROR
IOError: Operation not supported
org/jruby/RubyIO.java:1224:in `sysopen'
org/jruby/RubyFile.java:362:in `initialize'
org/jruby/RubyClass.java:906:in `new'
org/jruby/RubyIO.java:1146:in `open'
/home/travis/build/jruby/jruby/spec/ruby/core/file/open_spec.rb:519:in `block in <main>'
org/jruby/RubyBasicObject.java:2663:in `instance_exec'
org/jruby/RubyArray.java:4661:in `all?'
org/jruby/RubyArray.java:1865:in `each'
/home/travis/build/jruby/jruby/spec/ruby/core/file/open_spec.rb:7:in `<main>'
org/jruby/RubyKernel.java:1052:in `load'
org/jruby/RubyBasicObject.java:2663:in `instance_exec'
org/jruby/RubyArray.java:1865:in `each'
```

now raises ```Errno::EOPNOTSUPP: Operation not supported``` which matches the expected exception on CRuby