### PR TITLE
Fix calling primitive varargs and add tests

### DIFF
--- a/core/src/main/java/org/jruby/java/invokers/RubyToJavaInvoker.java
+++ b/core/src/main/java/org/jruby/java/invokers/RubyToJavaInvoker.java
@@ -312,7 +312,7 @@ public abstract class RubyToJavaInvoker<T extends JavaCallable> extends JavaMeth
 
         final Class<?> compType = varArrayType.getComponentType();
         final Object varArgs = Array.newInstance(compType, varCount);
-        if (varArrayType.isPrimitive()) {
+        if (compType.isPrimitive()) {
             for (int i = 0; i < varCount; i++) {
                 Array.set(varArgs, i, args[varStart + i].toJava(compType));
             }

--- a/spec/java_integration/fixtures/ClassWithPrimitiveVarargs.java
+++ b/spec/java_integration/fixtures/ClassWithPrimitiveVarargs.java
@@ -1,0 +1,48 @@
+package java_integration.fixtures;
+
+import java.util.Arrays;
+
+public class ClassWithPrimitiveVarargs {
+    private String constructor;
+    public ClassWithPrimitiveVarargs(int... args) {
+        constructor = "0: " + Arrays.toString(args);
+    }
+    public ClassWithPrimitiveVarargs(String a, int... args) {
+        constructor = "1: " + Arrays.toString(args);
+    }
+    public ClassWithPrimitiveVarargs(String a, String b, int... args) {
+        constructor = "2: " + Arrays.toString(args);
+    }
+    public ClassWithPrimitiveVarargs(String a, String b, String c, int... args) {
+        constructor = "3: " + Arrays.toString(args);
+    }
+    public String getConstructor() {
+        return constructor;
+    }
+
+    public static String primitiveVarargsStatic(int... args) {
+        return "0: " + Arrays.toString(args);
+    }
+    public static String primitiveVarargsStatic(String a, int... args) {
+        return "1: " + Arrays.toString(args);
+    }
+    public static String primitiveVarargsStatic(String a, String b, int... args) {
+        return "2: " + Arrays.toString(args);
+    }
+    public static String primitiveVarargsStatic(String a, String b, String c, int... args) {
+        return "3: " + Arrays.toString(args);
+    }
+
+    public String primitiveVarargs(int... args) {
+        return "0: " + Arrays.toString(args);
+    }
+    public String primitiveVarargs(String a, int... args) {
+        return "1: " + Arrays.toString(args);
+    }
+    public String primitiveVarargs(String a, String b, int... args) {
+        return "2: " + Arrays.toString(args);
+    }
+    public String primitiveVarargs(String a, String b, String c, int... args) {
+        return "3: " + Arrays.toString(args);
+    }
+}

--- a/spec/java_integration/methods/dispatch_spec.rb
+++ b/spec/java_integration/methods/dispatch_spec.rb
@@ -1,6 +1,7 @@
 require File.dirname(__FILE__) + "/../spec_helper"
 
 java_import "java_integration.fixtures.ClassWithVarargs"
+java_import "java_integration.fixtures.ClassWithPrimitiveVarargs"
 java_import "java_integration.fixtures.CoreTypeMethods"
 java_import "java_integration.fixtures.StaticMethodSelection"
 java_import "java_integration.fixtures.UsesSingleMethodInterface"
@@ -259,6 +260,148 @@ describe "A class with varargs static methods" do
     expect(ClassWithVarargs.varargs_static('foo', [1,2,3].to_java)).to eq("1: [1, 2, 3]")
     expect(ClassWithVarargs.varargs_static('foo', 'bar', [1,2,3].to_java)).to eq("2: [1, 2, 3]")
     expect(ClassWithVarargs.varargs_static('foo', 'bar', 'baz', [1,2,3].to_java)).to eq("3: [1, 2, 3]")
+  end
+end
+
+describe "A class with primitive varargs constructors" do
+  it "should be called with the most exact overload" do
+    obj = ClassWithPrimitiveVarargs.new()
+    expect(obj.constructor).to eq("0: []")
+    obj = ClassWithPrimitiveVarargs.new(1)
+    expect(obj.constructor).to eq("0: [1]")
+    obj = ClassWithPrimitiveVarargs.new(1,2)
+    expect(obj.constructor).to eq("0: [1, 2]")
+    obj = ClassWithPrimitiveVarargs.new(1,2,3)
+    expect(obj.constructor).to eq("0: [1, 2, 3]")
+    obj = ClassWithPrimitiveVarargs.new(1,2,3,4)
+    expect(obj.constructor).to eq("0: [1, 2, 3, 4]")
+
+    obj = ClassWithPrimitiveVarargs.new('foo', 1)
+    expect(obj.constructor).to eq("1: [1]")
+    obj = ClassWithPrimitiveVarargs.new('foo', 1, 2)
+    expect(obj.constructor).to eq("1: [1, 2]")
+    obj = ClassWithPrimitiveVarargs.new('foo', 1, 2, 3)
+    expect(obj.constructor).to eq("1: [1, 2, 3]")
+    obj = ClassWithPrimitiveVarargs.new('foo', 1, 2, 3, 4)
+    expect(obj.constructor).to eq("1: [1, 2, 3, 4]")
+
+    obj = ClassWithPrimitiveVarargs.new('foo', 'bar', 1)
+    expect(obj.constructor).to eq("2: [1]")
+    obj = ClassWithPrimitiveVarargs.new('foo', 'bar', 1, 2)
+    expect(obj.constructor).to eq("2: [1, 2]")
+    obj = ClassWithPrimitiveVarargs.new('foo', 'bar', 1, 2, 3)
+    expect(obj.constructor).to eq("2: [1, 2, 3]")
+    obj = ClassWithPrimitiveVarargs.new('foo', 'bar', 1, 2, 3, 4)
+    expect(obj.constructor).to eq("2: [1, 2, 3, 4]")
+
+    obj = ClassWithPrimitiveVarargs.new('foo', 'bar', 'baz', 1)
+    expect(obj.constructor).to eq("3: [1]")
+    obj = ClassWithPrimitiveVarargs.new('foo', 'bar', 'baz', 1, 2)
+    expect(obj.constructor).to eq("3: [1, 2]")
+    obj = ClassWithPrimitiveVarargs.new('foo', 'bar', 'baz', 1, 2, 3)
+    expect(obj.constructor).to eq("3: [1, 2, 3]")
+    obj = ClassWithPrimitiveVarargs.new('foo', 'bar', 'baz', 1, 2, 3, 4)
+    expect(obj.constructor).to eq("3: [1, 2, 3, 4]")
+
+    #skip("needs better type-driven ranking of overloads") do
+    obj = ClassWithPrimitiveVarargs.new('foo')
+    expect(obj.constructor).to eq("1: []")
+
+    obj = ClassWithPrimitiveVarargs.new('foo', 'bar')
+    expect(obj.constructor).to eq("2: []")
+
+    obj = ClassWithPrimitiveVarargs.new('foo', 'bar', 'baz')
+    expect(obj.constructor).to eq("3: []")
+    #end
+  end
+
+  it "should be callable with an array" do
+    expect(ClassWithPrimitiveVarargs.new([1,2,3].to_java(:int)).constructor).to eq("0: [1, 2, 3]")
+    expect(ClassWithPrimitiveVarargs.new('foo', [1,2,3].to_java(:int)).constructor).to eq("1: [1, 2, 3]")
+    expect(ClassWithPrimitiveVarargs.new('foo', 'bar', [1,2,3].to_java(:int)).constructor).to eq("2: [1, 2, 3]")
+    expect(ClassWithPrimitiveVarargs.new('foo', 'bar', 'baz', [1,2,3].to_java(:int)).constructor).to eq("3: [1, 2, 3]")
+  end
+end
+
+describe "A class with primitive varargs instance methods" do
+  it "should be called with the most exact overload" do
+    obj = ClassWithPrimitiveVarargs.new(1)
+
+    expect(obj.primitive_varargs()).to eq("0: []");
+    expect(obj.primitive_varargs(1)).to eq("0: [1]");
+    expect(obj.primitive_varargs(1,2)).to eq("0: [1, 2]");
+    expect(obj.primitive_varargs(1,2,3)).to eq("0: [1, 2, 3]");
+    expect(obj.primitive_varargs(1,2,3,4)).to eq("0: [1, 2, 3, 4]");
+
+    expect(obj.primitive_varargs('foo', 1)).to eq("1: [1]");
+    expect(obj.primitive_varargs('foo', 1, 2)).to eq("1: [1, 2]");
+    expect(obj.primitive_varargs('foo', 1, 2, 3)).to eq("1: [1, 2, 3]");
+    expect(obj.primitive_varargs('foo', 1, 2, 3, 4)).to eq("1: [1, 2, 3, 4]");
+
+    expect(obj.primitive_varargs('foo', 'bar', 1)).to eq("2: [1]");
+    expect(obj.primitive_varargs('foo', 'bar', 1, 2)).to eq("2: [1, 2]");
+    expect(obj.primitive_varargs('foo', 'bar', 1, 2, 3)).to eq("2: [1, 2, 3]");
+    expect(obj.primitive_varargs('foo', 'bar', 1, 2, 3, 4)).to eq("2: [1, 2, 3, 4]");
+
+    expect(obj.primitive_varargs('foo', 'bar', 'baz', 1)).to eq("3: [1]");
+    expect(obj.primitive_varargs('foo', 'bar', 'baz', 1, 2)).to eq("3: [1, 2]");
+    expect(obj.primitive_varargs('foo', 'bar', 'baz', 1, 2, 3)).to eq("3: [1, 2, 3]");
+    expect(obj.primitive_varargs('foo', 'bar', 'baz', 1, 2, 3, 4)).to eq("3: [1, 2, 3, 4]");
+
+    #skip("needs better type-driven ranking of overloads") do
+    expect(obj.primitive_varargs('foo')).to eq("1: []")
+    expect(obj.primitive_varargs('foo', 'bar')).to eq("2: []")
+    expect(obj.primitive_varargs('foo', 'bar', 'baz')).to eq("3: []")
+    #end
+  end
+
+  it "should be callable with an array" do
+    obj = ClassWithPrimitiveVarargs.new(1)
+    expect(obj.primitive_varargs([1,2,3].to_java(:int))).to eq("0: [1, 2, 3]")
+    expect(obj.primitive_varargs('foo', [1,2,3].to_java(:int))).to eq("1: [1, 2, 3]")
+    expect(obj.primitive_varargs('foo', 'bar', [1,2,3].to_java(:int))).to eq("2: [1, 2, 3]")
+    expect(obj.primitive_varargs('foo', 'bar', 'baz', [1,2,3].to_java(:int))).to eq("3: [1, 2, 3]")
+  end
+end
+
+describe "A class with primitive varargs static methods" do
+  it "should be called with the most exact overload" do
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static()).to eq("0: []");
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static(1)).to eq("0: [1]");
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static(1,2)).to eq("0: [1, 2]");
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static(1,2,3)).to eq("0: [1, 2, 3]");
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static(1,2,3,4)).to eq("0: [1, 2, 3, 4]");
+
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo', 1)).to eq("1: [1]");
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo', 1, 2)).to eq("1: [1, 2]");
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo', 1, 2, 3)).to eq("1: [1, 2, 3]");
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo', 1, 2, 3, 4)).to eq("1: [1, 2, 3, 4]");
+
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo', 'bar', 1)).to eq("2: [1]");
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo', 'bar', 1, 2)).to eq("2: [1, 2]");
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo', 'bar', 1, 2, 3)).to eq("2: [1, 2, 3]");
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo', 'bar', 1, 2, 3, 4)).to eq("2: [1, 2, 3, 4]");
+
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo', 'bar', 'baz', 1)).to eq("3: [1]");
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo', 'bar', 'baz', 1, 2)).to eq("3: [1, 2]");
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo', 'bar', 'baz', 1, 2, 3)).to eq("3: [1, 2, 3]");
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo', 'bar', 'baz', 1, 2, 3, 4)).to eq("3: [1, 2, 3, 4]");
+
+    #skip("needs better type-driven ranking of overloads") do
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo')).to eq("1: []")
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo', 'bar')).to eq("2: []")
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo', 'bar', 'baz')).to eq("3: []")
+    #end
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo'.to_java)).to eq("1: []")
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo'.to_java, 'bar')).to eq("2: []")
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo'.to_java, 'bar'.to_java)).to eq("2: []")
+  end
+
+  it "should be callable with an array" do
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static([1,2,3].to_java(:int))).to eq("0: [1, 2, 3]")
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo', [1,2,3].to_java(:int))).to eq("1: [1, 2, 3]")
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo', 'bar', [1,2,3].to_java(:int))).to eq("2: [1, 2, 3]")
+    expect(ClassWithPrimitiveVarargs.primitive_varargs_static('foo', 'bar', 'baz', [1,2,3].to_java(:int))).to eq("3: [1, 2, 3]")
   end
 end
 


### PR DESCRIPTION
An optimization to use direct array sets for object components
accidentally caused us to do the same logic for primitive
components. This fixes that regression and adds specs for calling
primitive varargs methods.

Fixes #6830