### PR TITLE
Revert ostruct tests/specs due to reverted gem

### DIFF
--- a/spec/tags/ruby/library/openstruct/to_h_tags.txt
+++ b/spec/tags/ruby/library/openstruct/to_h_tags.txt
@@ -1,0 +1,5 @@
+fails(reverted ostruct due to https://github.com/ruby/ostruct/issues/30):OpenStruct#to_h with block converts [key, value] pairs returned by the block to a hash
+fails(reverted ostruct due to https://github.com/ruby/ostruct/issues/30):OpenStruct#to_h with block raises ArgumentError if block returns longer or shorter array
+fails(reverted ostruct due to https://github.com/ruby/ostruct/issues/30):OpenStruct#to_h with block raises TypeError if block returns something other than Array
+fails(reverted ostruct due to https://github.com/ruby/ostruct/issues/30):OpenStruct#to_h with block coerces returned pair to Array with #to_ary
+fails(reverted ostruct due to https://github.com/ruby/ostruct/issues/30):OpenStruct#to_h with block does not coerce returned pair to Array with #to_a

--- a/test/mri/excludes/TC_OpenStruct.rb
+++ b/test/mri/excludes/TC_OpenStruct.rb
@@ -1,1 +1,2 @@
 exclude :test_method_missing, "depends on __callee__ which is broken"
+exclude :test_to_h_with_block, "test is newer than the released ostruct 0.1.0 (https://github.com/ruby/ostruct/issues/31)"


### PR DESCRIPTION
See https://github.com/ruby/ostruct/issues/30 for the ostruct issue that caused us to revert to an earlier gem. This PR reverts the test and tags the specs that do not pass on the older version of ostruct.

See also #6831.