### PR TITLE
 Fix string literals in other encodings which should be utf-8 encoding

### DIFF
--- a/core/src/main/java/org/jruby/lexer/yacc/HeredocTerm.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/HeredocTerm.java
@@ -176,11 +176,12 @@ public class HeredocTerm extends StrTerm {
                 tok.append('#');
             }
 
+            boolean encodingDetermined[] = new boolean[] { false };
             // MRI has extra pointer which makes our code look a little bit more strange in comparison
             do {
                 lexer.pushback(c);
 
-                if ((c = new StringTerm(flags, '\0', '\n', lexer.getRubySourceline()).parseStringIntoBuffer(lexer, tok, lexer.getEncoding())) == EOF) {
+                if ((c = new StringTerm(flags, '\0', '\n', lexer.getRubySourceline()).parseStringIntoBuffer(lexer, tok, lexer.getEncoding(), encodingDetermined)) == EOF) {
                     if (lexer.eofp) return error(lexer, len, str, eos);
                     return restore(lexer);
                 }

--- a/core/src/main/java/org/jruby/lexer/yacc/StringTerm.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/StringTerm.java
@@ -66,12 +66,6 @@ public class StringTerm extends StrTerm {
         return flags;
     }
 
-    protected ByteList createByteList(RubyLexer lexer) {
-        ByteList bytelist = new ByteList(15);
-        bytelist.setEncoding(lexer.getEncoding());
-        return bytelist;
-    }
-
     private int endFound(RubyLexer lexer) throws IOException {
         if ((flags & STR_FUNC_QWORDS) != 0) {
             flags |= STR_FUNC_TERM;
@@ -129,8 +123,8 @@ public class StringTerm extends StrTerm {
             lexer.pushback(c);
             return ' ';
         }
-        
-        ByteList buffer = createByteList(lexer);
+
+        ByteList buffer = new ByteList(15);
         lexer.newtok(true);
         if ((flags & STR_FUNC_EXPAND) != 0 && c == '#') {
             int token = lexer.peekVariableName(RubyParser.tSTRING_DVAR, RubyParser.tSTRING_DBEG);
@@ -161,9 +155,9 @@ public class StringTerm extends StrTerm {
         boolean expand = (flags & STR_FUNC_EXPAND) != 0;
         boolean escape = (flags & STR_FUNC_ESCAPE) != 0;
         boolean regexp = (flags & STR_FUNC_REGEXP) != 0;
-        boolean symbol = (flags & STR_FUNC_SYMBOL) != 0;
         boolean indent = (flags & STR_FUNC_INDENT) != 0;
         boolean hasNonAscii = false;
+        boolean encodingDetermined[] = new boolean[] { false };
         int c;
 
         while ((c = lexer.nextc()) != EOF) {
@@ -219,7 +213,7 @@ public class StringTerm extends StrTerm {
                     if (regexp) {
                         lexer.readUTFEscapeRegexpLiteral(buffer);
                     } else {
-                        lexer.readUTFEscape(buffer, true, symbol);
+                        lexer.readUTFEscape(buffer, true, encodingDetermined);
                     }
 
                     if (hasNonAscii && buffer.getEncoding() != encoding) {
@@ -276,8 +270,10 @@ public class StringTerm extends StrTerm {
                 }
             } else if (!lexer.isASCII(c)) {
 nonascii:       hasNonAscii = true; // Label for comparison with MRI only.
-
-                if (buffer.getEncoding() != encoding) {
+                if (!encodingDetermined[0]) {
+                    encodingDetermined[0] = true;
+                    buffer.setEncoding(lexer.getEncoding());
+                } else if (buffer.getEncoding() != encoding) {
                     mixedEscape(lexer, buffer.getEncoding(), encoding);
                     continue;
                 }
@@ -295,14 +291,19 @@ nonascii:       hasNonAscii = true; // Label for comparison with MRI only.
 
             if ((c & 0x80) != 0) {
                 hasNonAscii = true;
-                if (buffer.getEncoding() != encoding) {
+
+                if (!encodingDetermined[0]) {
+                    encodingDetermined[0] = true;
+                    buffer.setEncoding(lexer.getEncoding());
+                } else if (buffer.getEncoding() != encoding) {
                     mixedEscape(lexer, buffer.getEncoding(), encoding);
                     continue;
                 }
             }
             buffer.append(c);
         }
-        
+        if (!encodingDetermined[0]) buffer.setEncoding(lexer.getEncoding());
+
         return c;
     }
 

--- a/core/src/main/java/org/jruby/lexer/yacc/StringTerm.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/StringTerm.java
@@ -125,6 +125,7 @@ public class StringTerm extends StrTerm {
         }
 
         ByteList buffer = new ByteList(15);
+
         lexer.newtok(true);
         if ((flags & STR_FUNC_EXPAND) != 0 && c == '#') {
             int token = lexer.peekVariableName(RubyParser.tSTRING_DVAR, RubyParser.tSTRING_DBEG);
@@ -135,8 +136,9 @@ public class StringTerm extends StrTerm {
         }
         lexer.pushback(c); // pushback API is deceptive here...we are just pushing index back one and not pushing c back necessarily.
 
+        boolean encodingDetermined[] = new boolean[] { false };
 
-        if (parseStringIntoBuffer(lexer, buffer, lexer.getEncoding()) == EOF) {
+        if (parseStringIntoBuffer(lexer, buffer, lexer.getEncoding(), encodingDetermined) == EOF) {
             lexer.setRubySourceline(startLine);
             lexer.compile_error("unterminated " + ((flags & STR_FUNC_REGEXP) != 0 ? "regexp" : "string") +  " meets end of file");
         }
@@ -150,14 +152,13 @@ public class StringTerm extends StrTerm {
     }
 
     // mri: parser_tokadd_string
-    public int parseStringIntoBuffer(RubyLexer lexer, ByteList buffer, Encoding encoding) throws IOException {
+    public int parseStringIntoBuffer(RubyLexer lexer, ByteList buffer, Encoding encoding, boolean[] encodingDetermined) throws IOException {
         boolean qwords = (flags & STR_FUNC_QWORDS) != 0;
         boolean expand = (flags & STR_FUNC_EXPAND) != 0;
         boolean escape = (flags & STR_FUNC_ESCAPE) != 0;
         boolean regexp = (flags & STR_FUNC_REGEXP) != 0;
         boolean indent = (flags & STR_FUNC_INDENT) != 0;
         boolean hasNonAscii = false;
-        boolean encodingDetermined[] = new boolean[] { false };
         int c;
 
         while ((c = lexer.nextc()) != EOF) {

--- a/shaded/src/main/java/Nothing.java
+++ b/shaded/src/main/java/Nothing.java
@@ -1,6 +1,0 @@
-// Not part of our sources but we put this in so docs will generate a jar to
-// satisy sonatype requirements.  There must be a way to solve this purely
-// through Maven but we did not figure that out yet.
-
-public class Nothing {
-}


### PR DESCRIPTION
 We have the test of time just created a new string using the lexers
 encoding.  This worked until I fixed the last known issues in the
 parser reporting errors with mixed strings (like binary data + UTF-8
 escapes).  This is not a valid string and the parser should error out.

 Unfortunately, by setting the lex encoding right away we are not in a
 position of knowing whether the string should just have that encoding
 or whether we are in a new string where we have not yet figured out
 what encoding it should be.

 Case in point.  #6832.  It is evaling as a Window-31J string BUT the
 literal string is only utf-8 escapes.  It should resolve as being
 UTF-8 yet it errors because it sees the escapes and then errors out
 thinking it is already a windows-31J string.

 The solution is to emulate how MRI does this by indicating that we
 have not yet determined the encoding for the string and then if nothing
 special happens during the processing we just set it to the lex encoding.