### PR TITLE
load all socket IP_ constants

### DIFF
--- a/core/src/main/java/org/jruby/ext/socket/RubySocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubySocket.java
@@ -101,6 +101,7 @@ public class RubySocket extends RubyBasicSocket {
         runtime.loadConstantSet(rb_mConstants, IPProto.class);
         runtime.loadConstantSet(rb_mConstants, Shutdown.class);
         runtime.loadConstantSet(rb_mConstants, TCP.class);
+        runtime.loadConstantSet(rb_mConstants, IP.class);
         runtime.loadConstantSet(rb_mConstants, NameInfo.class);
         runtime.loadConstantSet(rb_mConstants, SocketMessage.class);
 
@@ -124,14 +125,6 @@ public class RubySocket extends RubyBasicSocket {
 
         rb_mConstants.setConstant("AI_DEFAULT", runtime.newFixnum(AddressInfo.AI_DEFAULT));
         rb_mConstants.setConstant("AI_MASK", runtime.newFixnum(AddressInfo.AI_MASK));
-
-        // More constants needed by specs
-        rb_mConstants.setConstant("IP_MULTICAST_TTL", runtime.newFixnum(IP.IP_MULTICAST_TTL.value()));
-        rb_mConstants.setConstant("IP_MULTICAST_LOOP", runtime.newFixnum(IP.IP_MULTICAST_LOOP.value()));
-        rb_mConstants.setConstant("IP_ADD_MEMBERSHIP", runtime.newFixnum(IP.IP_ADD_MEMBERSHIP.value()));
-        rb_mConstants.setConstant("IP_MAX_MEMBERSHIPS", runtime.newFixnum(IP.IP_MAX_MEMBERSHIPS.value()));
-        rb_mConstants.setConstant("IP_DEFAULT_MULTICAST_LOOP", runtime.newFixnum(IP.IP_DEFAULT_MULTICAST_LOOP));
-        rb_mConstants.setConstant("IP_DEFAULT_MULTICAST_TTL", runtime.newFixnum(IP.IP_DEFAULT_MULTICAST_TTL));
 
         rb_cSocket.includeModule(rb_mConstants);
 


### PR DESCRIPTION
https://github.com/jnr/jnr-constants/blob/master/src/main/java/jnr/constants/platform/linux/IP.java

there's a risk that some of these constants don't have to be usable, so it could break feature checks like
```
if Socket.const_defined?(:Socket::IP_TTL)
  @sock.getsockopt(Socket::IPPROTO_IP, Socket::IP_TTL)
end
```

* to consider