### PR TITLE
addrinfo - inspect hostname

### DIFF
--- a/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
+++ b/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
@@ -283,6 +283,11 @@ public class Addrinfo extends RubyObject {
         } else if (protocol != null && protocol.getProto() != 0) {
             val.append(" ").append(String.format("UNKNOWN PROTOCOL(%d)", protocol.getProto()));
         }
+
+        String inspectName = inspectname();
+        if (inspectName != null) {
+            val.append(" (").append(inspectName).append(")");
+        }
        
         return context.runtime.newString(String.format(base, val.toString()));
     }
@@ -673,6 +678,16 @@ public class Addrinfo extends RubyObject {
 
         if (in.isLoopbackAddress()) return "::1";
         return SocketUtilsIPV6.getIPV6Address(in.getHostAddress());
+    }
+
+    private String inspectname() {
+        if (socketAddress instanceof InetSocketAddress) {
+            return getInetSocketAddress().getAddress().getHostName();
+        } else if (socketAddress instanceof UnixSocketAddress) {
+            return getUnixSocketAddress().path();
+        } else {
+            return null;
+        }
     }
 
     private static InetAddress getRubyInetAddress(IRubyObject node) {

--- a/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
+++ b/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
@@ -682,12 +682,14 @@ public class Addrinfo extends RubyObject {
 
     private String inspectname() {
         if (socketAddress instanceof InetSocketAddress) {
-            return getInetSocketAddress().getAddress().getHostName();
+            InetAddress address = getInetSocketAddress().getAddress();
+            if (!address.toString().startsWith("/")) { // contains hostname
+                return address.getHostName();
+            }
         } else if (socketAddress instanceof UnixSocketAddress) {
             return getUnixSocketAddress().path();
-        } else {
-            return null;
         }
+        return null;
     }
 
     private static InetAddress getRubyInetAddress(IRubyObject node) {

--- a/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
+++ b/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
@@ -285,7 +285,7 @@ public class Addrinfo extends RubyObject {
         }
 
         String inspectName = inspectname();
-        if (inspectName != null) {
+        if (inspectName != null && interfaceLink == false) {
             val.append(" (").append(inspectName).append(")");
         }
        
@@ -686,8 +686,6 @@ public class Addrinfo extends RubyObject {
             if (!address.toString().startsWith("/")) { // contains hostname
                 return address.getHostName();
             }
-        } else if (socketAddress instanceof UnixSocketAddress) {
-            return getUnixSocketAddress().path();
         }
         return null;
     }


### PR DESCRIPTION
as requested in https://github.com/jruby/jruby/pull/6829

before
```
[#<Addrinfo: 216.58.201.78:80 TCP>]
```
after
```
[#<Addrinfo: 216.58.201.78:80 TCP (google.com)>]
```

some parts are still missing or they may behave differently, for instance:
```
ruby -rsocket -e "p Addrinfo.getaddrinfo('localhost', 80, :INET, :STREAM, Socket::IPPROTO_TCP, Socket::AI_CANONNAME)"
[#<Addrinfo: 127.0.0.1:80 TCP DESKTOP-U60MURJ (localhost)>]
```