### PR TITLE
Fix handling of ENXIO error during resource open

### DIFF
--- a/core/src/main/java/org/jruby/util/RegularFileResource.java
+++ b/core/src/main/java/org/jruby/util/RegularFileResource.java
@@ -335,22 +335,10 @@ class RegularFileResource implements FileResource {
                 throw new ResourceException.FileIsDirectory(absolutePath());
             case ENOTDIR:
                 throw new ResourceException.FileIsNotDirectory(absolutePath());
-            case EMFILE:
             default:
-                throw new InternalIOException(errno.description());
+                throw new ResourceException.ErrnoException(errno, absolutePath());
 
         }
-    }
-
-    static class InternalIOException extends IOException {
-
-        InternalIOException(final String message) {
-            super(message);
-        }
-
-        @Override
-        public Throwable fillInStackTrace() { return this; }
-
     }
 
 }

--- a/core/src/main/java/org/jruby/util/ResourceException.java
+++ b/core/src/main/java/org/jruby/util/ResourceException.java
@@ -1,5 +1,6 @@
 package org.jruby.util;
 
+import jnr.constants.platform.Errno;
 import org.jruby.Ruby;
 import org.jruby.exceptions.RaiseException;
 
@@ -22,13 +23,22 @@ public abstract class ResourceException extends IOException {
         super(message, cause);
     }
 
-    abstract static class ErrnoException extends ResourceException {
+    public static class ErrnoException extends ResourceException {
         private final String path;
         private final String errnoClass;
+        private final Errno errno;
 
         protected ErrnoException(String errnoClass, String path) {
             super(errnoClass + ": " + path);
+            this.errno = Errno.valueOf(errnoClass);
             this.errnoClass = errnoClass;
+            this.path = path;
+        }
+
+        protected ErrnoException(Errno errno, String path) {
+            super(errno.name() + ": " + path);
+            this.errno = errno;
+            this.errnoClass = errno.name();
             this.path = path;
         }
 
@@ -42,6 +52,10 @@ public abstract class ResourceException extends IOException {
 
         public String getPath() {
             return path;
+        }
+
+        public Errno getErrno() {
+            return errno;
         }
     }
 

--- a/core/src/main/java/org/jruby/util/io/PosixShim.java
+++ b/core/src/main/java/org/jruby/util/io/PosixShim.java
@@ -449,6 +449,8 @@ public class PosixShim {
             setErrno(Errno.EACCES);
         } catch (ResourceException.TooManySymlinks e) {
             setErrno(Errno.ELOOP);
+        } catch (ResourceException.ErrnoException e) {
+            setErrno(e.getErrno());
         } catch (ResourceException ex) {
             throw ex.newRaiseException(runtime);
         } catch (Exception ex) {


### PR DESCRIPTION
This triggered a failure in the io/wait tests when it expected a
nonblocking write-only open call against an unread fifo to raise
ENXIO. We instead raised one of our internal anonymous errors,
preventing the logic in this test from retrying:

https://github.com/ruby/io-wait/blob/0c73ebcf5d75b0568405f5863eefaffba0ec7a0e/test/io/wait/test_io_wait_uncommon.rb#L23

The changes here promote all unraised errno exceptions to use
ErrnoException, which propagates the errno object as well as the
name and path. This allows upstream error handling to raise the
proper Ruby error.