### PR TITLE
Fix KeyError behavior with no arguments

### DIFF
--- a/core/src/main/java/org/jruby/RubyKeyError.java
+++ b/core/src/main/java/org/jruby/RubyKeyError.java
@@ -11,11 +11,6 @@
  * implied. See the License for the specific language governing
  * rights and limitations under the License.
  *
-<<<<<<< HEAD
- * Copyright (C) 2017 Miguel Landaeta <miguel@miguel.cc>
- *
-=======
->>>>>>> master
  * Alternatively, the contents of this file may be used under the terms of
  * either of the GNU General Public License Version 2 or later (the "GPL"),
  * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
@@ -80,6 +75,11 @@ public class RubyKeyError extends RubyIndexError {
     }
 
     @JRubyMethod
+    public IRubyObject initialize(ThreadContext context) {
+        return context.nil;
+    }
+
+    @JRubyMethod
     public IRubyObject initialize(ThreadContext context, IRubyObject message, IRubyObject kwargs) {
         IRubyObject[] receiverKey = ArgsUtil.extractKeywordArgs(context, kwargs, VALID_KEYS);
 
@@ -90,8 +90,8 @@ public class RubyKeyError extends RubyIndexError {
         IRubyObject receiver;
         IRubyObject key;
         if (receiverKey == null) {
-            receiver = context.nil;
-            key = context.nil;
+            receiver = null;
+            key = null;
         } else {
             receiver = receiverKey[0];
             key = receiverKey[1];
@@ -115,11 +115,17 @@ public class RubyKeyError extends RubyIndexError {
 
     @JRubyMethod
     public IRubyObject receiver() {
+        if (receiver == null) {
+            throw getRuntime().newArgumentError("no receiver is available");
+        }
         return receiver;
     }
 
     @JRubyMethod
     public IRubyObject key() {
+        if (key == null) {
+            throw getRuntime().newArgumentError("no key is available");
+        }
         return key;
     }
 }

--- a/test/mri.core.index
+++ b/test/mri.core.index
@@ -51,6 +51,7 @@ ruby/test_integer_comb.rb
 ruby/test_io.rb
 ruby/test_io_m17n.rb
 ruby/test_iterator.rb
+ruby/test_key_error.rb
 ruby/test_lambda.rb
 ruby/test_lazy_enumerator.rb
 ruby/test_literal.rb


### PR DESCRIPTION
After JRuby 9.3, attempting to raise a KeyError with no arguments would
fail with an ArgumentError. This commit fixes this behavior to match
MRI, and updates the `key` and `receiver` methods to raise if they are
unset.

Prior to this, the relevant MRI tests for this functionality were not
running in CI, and when ran manually 3 tests were failing. Add the
`test_key_error.rb` file to the `mri.code` suite. After this change, all
tests from `test_key_error.rb` pass.

Fixes #6860.

Relevant MRI code: https://github.com/ruby/ruby/blob/09863a4cd8eb40b34b310083d8cdda899ab5bcc1/error.c#L2096-L2121