### PR TITLE
Fix #6859.  respond_to? regression with refinements.

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -2066,7 +2066,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
 
     final RubyBoolean respond_to_p(ThreadContext context, IRubyObject methodName, final boolean includePrivate) {
         final String name = methodName.asJavaString();
-        if (getMetaClass().respondsToMethod(name, !includePrivate)) return context.tru;
+        if (getMetaClass().respondsToMethod(name, !includePrivate, context.getCurrentStaticScope())) return context.tru;
         // MRI (1.9) always passes down a symbol when calling respond_to_missing?
         if ( ! (methodName instanceof RubySymbol) ) methodName = context.runtime.newSymbol(name);
         IRubyObject respond = sites(context).respond_to_missing.call(context, this, this, methodName, RubyBoolean.newBoolean(context, includePrivate));

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1566,7 +1566,6 @@ public class RubyModule extends RubyObject {
         CacheEntry entry = searchWithCache(id, cacheUndef);
 
         if (entry.method.isRefined()) {
-            if (refinedScope == null) refinedScope = getRuntime().getCurrentContext().getCurrentStaticScope();
             // FIXME: We walk up scopes to look for refinements, while MRI seems to copy from parent to child on push
             // CON: Walk improved to only walk up to nearest refined scope, since methods/classes/modules will copy parent's
             for (; refinedScope != null; refinedScope = refinedScope.getEnclosingScope()) {
@@ -2276,6 +2275,10 @@ public class RubyModule extends RubyObject {
         DynamicMethod method = searchMethod(name);
 
         return !method.isUndefined() && !(checkVisibility && method.getVisibility() == PRIVATE);
+    }
+
+    public boolean respondsToMethod(String name, boolean checkVisibility, StaticScope scope) {
+        return Helpers.respondsToMethod(searchWithRefinements(name, scope).method, checkVisibility);
     }
 
     public boolean respondsToMethod(String name, boolean checkVisibility) {

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1566,6 +1566,7 @@ public class RubyModule extends RubyObject {
         CacheEntry entry = searchWithCache(id, cacheUndef);
 
         if (entry.method.isRefined()) {
+            if (refinedScope == null) refinedScope = getRuntime().getCurrentContext().getCurrentStaticScope();
             // FIXME: We walk up scopes to look for refinements, while MRI seems to copy from parent to child on push
             // CON: Walk improved to only walk up to nearest refined scope, since methods/classes/modules will copy parent's
             for (; refinedScope != null; refinedScope = refinedScope.getEnclosingScope()) {


### PR DESCRIPTION
respond_to? calls searchMethod and that code path ends up passing
the static scope as null.  RubyModule.searchWithCache notices we
are dealing with a refined method yet it has no static scope so it
just passes by the refinement logic.

The fix is to get current static scope based on the notion current
is the lexical location anything would be searching at the moment.
Getting current context as the fix is a little undesirable but pushing
context through all these paths would be a big change.