### PR TITLE
Fix #6864. include? on an String Range always returns true.

### DIFF
--- a/c.diff
+++ b/c.diff
@@ -1,0 +1,20 @@
+diff --git a/core/src/main/java/org/jruby/ir/IREvalScript.java b/core/src/main/java/org/jruby/ir/IREvalScript.java
+index 3fbfc9e7ca1..6f7a926cb65 100644
+--- a/core/src/main/java/org/jruby/ir/IREvalScript.java
++++ b/core/src/main/java/org/jruby/ir/IREvalScript.java
+@@ -8,6 +8,15 @@ import org.jruby.util.ByteList;
+ public class IREvalScript extends IRClosure {
+     private String fileName;
+ 
++    public int getNextClosureId() {
++        nextClosureIndex++;
++
++        return nextClosureIndex;
++    }
++
++    // Index values to guarantee we don't assign same internal index twice
++    private int nextClosureIndex;
++
+     private static final ByteList EVAL_ = new ByteList(new byte[] {'E', 'V', 'A', 'L', '_'});
+ 
+     public IREvalScript(IRManager manager, IRScope lexicalParent, String fileName,

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -6971,7 +6971,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
                             beg,
                             beg.getMetaClass(),
                             Signature.ONE_ARGUMENT,
-                            new IncludeUpToCallback(beg),
+                            new IncludeUpToCallback(val),
                             context), false);
         } catch (JumpException.SpecialJump e) {
             return context.tru;

--- a/spec/regression/GH-6864_spec.rb
+++ b/spec/regression/GH-6864_spec.rb
@@ -1,0 +1,11 @@
+require 'rspec'
+
+# JRuby has separate codepaths for 1 char and >1 char.
+describe "A Range of strings >1 char long" do
+  it "works" do
+    expect(('01'..'10').include?('01')).to be true
+    expect(('01'..'10').include?('02')).to be true
+    expect(('01'..'10').include?('10')).to be true
+    expect(('01'..'10').include?('test')).to be false
+  end
+end


### PR DESCRIPTION
Looks like during a refactoring strings >1 char passed beg as
test value instead of the actual test value.