### PR TITLE
Fixes #6870. Missing keywords after a second proc call (full/JIT).

### DIFF
--- a/core/src/main/java/org/jruby/ir/passes/AddCallProtocolInstructions.java
+++ b/core/src/main/java/org/jruby/ir/passes/AddCallProtocolInstructions.java
@@ -121,7 +121,7 @@ public class AddCallProtocolInstructions extends CompilerPass {
                 Signature sig = ((IRClosure)fic.getScope()).getSignature();
                 if (sig.isNoArguments()) {
                     prologueBB.addInstr(PrepareNoBlockArgsInstr.INSTANCE);
-                } else if (sig.isOneArgument()) { // no kwargs and just a single required argument
+                } else if (sig.isOneArgument() && !sig.hasKwargs()) { // no kwargs and just a single required argument
                     prologueBB.addInstr(PrepareSingleBlockArgInstr.INSTANCE);
                 } else {
                     prologueBB.addInstr(PrepareBlockArgsInstr.INSTANCE);


### PR DESCRIPTION
Entertainingly the comment on the fixed line specifies what the line
should have said.  The new signature logic must explicitly check for
no kwargs.