### PR TITLE
Update rubygems to 3.2.29 and bundler to 2.2.29

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -17,8 +17,8 @@ end
 default_gems = [
     # treat RGs update special:
     # - we do not want bin/update_rubygems or bin/gem overrides
-    ['rubygems-update', '3.2.14', { bin: false }],
-    ['bundler', '2.2.14'],
+    ['rubygems-update', '3.2.29', { bin: false }],
+    ['bundler', '2.2.29'],
     ['cmath', '1.0.0'],
     ['csv', '3.1.2'],
     ['e2mmap', '0.1.0'],


### PR DESCRIPTION
In March 2021 PR https://github.com/jruby/jruby/pull/6533 added support for RubyGems to 3.2 and Bundler 2.2 but pinned the versions that were released at the time.
This PR was merged into the 9.3.0.0, but this jruby release only happened in September, meaning that JRuby 9.3.0.0 ships with older versions of bundler compared even to JRuby 9.2.