### PR TITLE
Add an option to turn off "foo".freeze optz

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -31,6 +31,7 @@ import org.jruby.util.ByteList;
 import org.jruby.util.CommonByteLists;
 import org.jruby.util.DefinedMessage;
 import org.jruby.util.KeyValuePair;
+import org.jruby.util.cli.Options;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -1112,12 +1113,14 @@ public class IRBuilder {
         RubySymbol name = methodName = callNode.getName();
 
         Node receiverNode = callNode.getReceiverNode();
+        String id = name.idString(); // ID Str ok here since compared strings are all 7-bit.
 
-        // Frozen string optimization: check for "string".freeze
-        String id = name.idString(); // ID Str ok here since it is 7bit check.
-        if (receiverNode instanceof StrNode && (id.equals("freeze") || id.equals("-@"))) {
-            StrNode asString = (StrNode) receiverNode;
-            return new FrozenString(asString.getValue(), asString.getCodeRange(), scope.getFile(), asString.getLine());
+        if (Options.IR_STRING_FREEZE.load()) {
+            // Frozen string optimization: check for "string".freeze
+            if (receiverNode instanceof StrNode && (id.equals("freeze") || id.equals("-@"))) {
+                StrNode asString = (StrNode) receiverNode;
+                return new FrozenString(asString.getValue(), asString.getCodeRange(), scope.getFile(), asString.getLine());
+            }
         }
 
         boolean compileLazyLabel = false;

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -115,6 +115,7 @@ public class Options {
     public static final Option<Boolean>  IR_PRINT_ALL = bool(IR, "ir.print.all", false, "Enable ir.print and include IR executed during JRuby's boot phase.");
     public static final Option<Boolean>  IR_PRINT = bool(IR, "ir.print", IR_PRINT_ALL.load(), "Print the final IR to be run before starting to execute each body of code.");
     public static final Option<Boolean>  IR_PRINT_COLOR = bool(IR, "ir.print.color", false, "Print the final IR with color highlighting.");
+    public static final Option<Boolean>  IR_STRING_FREEZE = bool(IR, "ir.string.freeze", true, "Compile \"foo\".freeze as a constant frozen string value instead of a call.");
 
     public static final Option<Boolean> NATIVE_ENABLED = bool(NATIVE, "native.enabled", true, "Enable/disable native code, including POSIX features and C exts.");
     public static final Option<Boolean> NATIVE_VERBOSE = bool(NATIVE, "native.verbose", false, "Enable verbose logging of native extension loading.");


### PR DESCRIPTION
Officially, the .freeze optimization should still see when the
freeze method is replaced and actually call it, but the use cases
for this are so rare (we know of zero) we are instead just adding
an option to turn off the optimization.

This is a workaround for the missing behavior described in #2156.