### PR TITLE
Skip prepend wrappers in each_object(Module)

### DIFF
--- a/core/src/main/java/org/jruby/RubyObjectSpace.java
+++ b/core/src/main/java/org/jruby/RubyObjectSpace.java
@@ -145,7 +145,7 @@ public class RubyObjectSpace {
             final ArrayList<IRubyObject> modules = new ArrayList<>(96);
             runtime.eachModule((module) -> {
                     if (rubyClass.isInstance(module)) {
-                        if (!(module instanceof IncludedModule)) {
+                        if (!(module instanceof IncludedModule || module instanceof PrependedModule)) {
                             // do nothing for included wrappers or singleton classes
                             modules.add(module); // store the module to avoid concurrent modification exceptions
                         }


### PR DESCRIPTION
We were skipping include wrappers, but not prepend wrappers. That resulted in us trying to use a PrependedModule wrapper as a real module, which of course it is not.

This logic was never updated after prepend was added, so the bug has been present for some time.

Fixes #6896