### PR TITLE
Update jnr and asm

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -41,11 +41,11 @@ project 'JRuby Core' do
 
   # exclude jnr-ffi to avoid problems with shading and relocation of the asm packages
   jar 'com.github.jnr:jnr-netdb:1.2.0', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-enxio:0.32.6', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-unixsocket:0.38.8', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-posix:3.1.7', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-constants:0.10.2', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-ffi:2.2.4'
+  jar 'com.github.jnr:jnr-enxio:0.32.10', :exclusions => ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-unixsocket:0.38.12', :exclusions => ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-posix:3.1.11', :exclusions => ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-constants:0.10.3', :exclusions => ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-ffi:2.2.8'
   jar 'com.github.jnr:jffi:${jffi.version}'
   jar 'com.github.jnr:jffi:${jffi.version}:native'
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -96,7 +96,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-enxio</artifactId>
-      <version>0.32.6</version>
+      <version>0.32.10</version>
       <exclusions>
         <exclusion>
           <artifactId>jnr-ffi</artifactId>
@@ -107,7 +107,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-unixsocket</artifactId>
-      <version>0.38.8</version>
+      <version>0.38.12</version>
       <exclusions>
         <exclusion>
           <artifactId>jnr-ffi</artifactId>
@@ -118,7 +118,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
-      <version>3.1.7</version>
+      <version>3.1.11</version>
       <exclusions>
         <exclusion>
           <artifactId>jnr-ffi</artifactId>
@@ -129,7 +129,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-constants</artifactId>
-      <version>0.10.2</version>
+      <version>0.10.3</version>
       <exclusions>
         <exclusion>
           <artifactId>jnr-ffi</artifactId>
@@ -140,7 +140,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-ffi</artifactId>
-      <version>2.2.4</version>
+      <version>2.2.8</version>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>

--- a/pom.rb
+++ b/pom.rb
@@ -82,8 +82,8 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
               'jar-dependencies.version' => '0.4.1',
               'jruby-launcher.version' => '1.1.6',
               'ant.version' => '1.9.8',
-              'asm.version' => '9.0',
-              'jffi.version' => '1.3.3',
+              'asm.version' => '9.2',
+              'jffi.version' => '1.3.6',
               'joda.time.version' => '2.10.5' )
 
   plugin_management do

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@ DO NOT MODIFIY - GENERATED CODE
   </distributionManagement>
   <properties>
     <ant.version>1.9.8</ant.version>
-    <asm.version>9.0</asm.version>
+    <asm.version>9.2</asm.version>
     <base.java.version>1.8</base.java.version>
     <base.javac.version>1.8</base.javac.version>
     <github.global.server>github</github.global.server>
@@ -113,7 +113,7 @@ DO NOT MODIFIY - GENERATED CODE
     <its.j2ee>j2ee*/pom.xml</its.j2ee>
     <its.osgi>osgi*/pom.xml</its.osgi>
     <jar-dependencies.version>0.4.1</jar-dependencies.version>
-    <jffi.version>1.3.3</jffi.version>
+    <jffi.version>1.3.6</jffi.version>
     <joda.time.version>2.10.5</joda.time.version>
     <jruby-launcher.version>1.1.6</jruby-launcher.version>
     <jruby.basedir>${project.basedir}</jruby.basedir>


### PR DESCRIPTION
* asm to 9.2, to match jnr-ffi's update.
* jffi 1.3.6: https://github.com/jnr/jffi/milestone/28?closed=1
* jnr-ffi 2.2.8: https://github.com/jnr/jnr-ffi/milestone/37?closed=1
* jnr-constants 0.10.3: https://github.com/jnr/jnr-constants/milestone/22?closed=1
* jnr-posix 3.1.11: only dep updates
* jnr-enxio 0.32.10: only dep updates
* jnr-unixsocket 0.38.12: only dep updates