### PR TITLE
freeze module names

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2503,7 +2503,7 @@ public class RubyModule extends RubyObject {
 
     @JRubyMethod(name = "name")
     public IRubyObject name(ThreadContext context) {
-        return getBaseName() == null ? context.nil : rubyName().strDup(context.runtime);
+        return getBaseName() == null ? context.nil : rubyName();
     }
 
     @Deprecated


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/16150
```ruby
Module.name.frozen? => true
```