### PR TITLE
remove tainted spec

### DIFF
--- a/test/jruby/test_dir.rb
+++ b/test/jruby/test_dir.rb
@@ -381,11 +381,6 @@ class TestDir < Test::Unit::TestCase
     Dir.unlink utf8_dir rescue nil
   end
 
-  # JRUBY-5286
-  def test_pwd_tainted
-    assert Dir.pwd.tainted?
-  end
-
   if WINDOWS
     def test_chdir_slash_windows
       @orig_pwd = Dir.pwd

--- a/test/jruby/test_dup_clone_freeze.rb
+++ b/test/jruby/test_dup_clone_freeze.rb
@@ -1,26 +1,6 @@
 require 'test/unit'
 
-class TestDupCloneTaintFreeze < Test::Unit::TestCase
-
-  def test_taint_dup_still_tainted
-    assert(Module.new.taint.dup.tainted?)
-    assert(Class.new.taint.dup.tainted?)
-    assert(Object.new.taint.dup.tainted?)
-    assert(String.new.taint.dup.tainted?)
-    assert([].taint.dup.tainted?)
-    assert({}.taint.dup.tainted?)
-    assert(//.taint.dup.tainted?)
-  end
-
-  def test_taint_clone_still_tainted
-    assert(Module.new.taint.clone.tainted?)
-    assert(Class.new.taint.clone.tainted?)
-    assert(Object.new.taint.clone.tainted?)
-    assert(String.new.taint.clone.tainted?)
-    assert([].taint.clone.tainted?)
-    assert({}.taint.clone.tainted?)
-    assert(//.taint.clone.tainted?)
-  end
+class TestDupCloneFreeze < Test::Unit::TestCase
 
   def test_freeze_dup_not_frozen
     assert(!Module.new.freeze.dup.frozen?)

--- a/test/jruby/test_file.rb
+++ b/test/jruby/test_file.rb
@@ -1342,16 +1342,6 @@ class TestFile < Test::Unit::TestCase
     end
   end
 
-  # JRUBY-5286
-  def test_file_path_is_tainted
-    filename = 'test.txt'
-    io = File.new(filename, 'w')
-    assert io.path.tainted?
-  ensure
-    io.close
-    File.unlink(filename)
-  end
-
   # jruby/jruby#2331
   def test_classpath_realpath
     assert_equal("classpath:/java/lang/String.class", File.realpath("classpath:/java/lang/String.class"))

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -904,7 +904,7 @@ class TestHigherJavasupport < Test::Unit::TestCase
     index_of intern java_class java_object java_object= lastIndexOf last_index_of
     length matches notify notifyAll notify_all regionMatches region_matches replace
     replaceAll replaceFirst replace_all replace_first split startsWith starts_with
-    subSequence sub_sequence substring taint tainted? toCharArray toLowerCase
+    subSequence sub_sequence substring toCharArray toLowerCase
     toString toUpperCase to_char_array to_lower_case to_string
     to_upper_case trim wait]
 

--- a/test/jruby/test_pack.rb
+++ b/test/jruby/test_pack.rb
@@ -83,14 +83,4 @@ class TestPack < Test::Unit::TestCase
     assert_raises(ArgumentError) { [0].pack('CC') }
   end
 
-  # same as MRI's test_pack_infection
-  # except for 'P' and 'p' formats (aren't implemented)
-  def test_pack_infection
-    tainted_array_string = ["123456"]
-    tainted_array_string.first.taint
-    ['a', 'A', 'Z', 'B', 'b', 'H', 'h', 'u', 'M', 'm'].each do |f|
-      assert_predicate(tainted_array_string.pack(f), :tainted?)
-    end
-  end
-
 end


### PR DESCRIPTION
this PR removes jruby specific tests, since they aren't relevant anymore, see https://bugs.ruby-lang.org/issues/16131