### PR TITLE
Fix raw and varargs backtrace elements

### DIFF
--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -886,7 +886,7 @@ public final class ThreadContext {
     public static String createRawBacktraceStringFromThrowable(final Throwable ex, final boolean color) {
         return WALKER.walk(ex.getStackTrace(), stream ->
             TraceType.printBacktraceJRuby(null,
-                    new BacktraceData(stream, Stream.empty(), true, false, false).getBacktraceWithoutRuby(),
+                    new BacktraceData(stream, Stream.empty(), true, true, false, false).getBacktraceWithoutRuby(),
                     ex.getClass().getName(),
                     ex.getLocalizedMessage(),
                     color));

--- a/core/src/main/java/org/jruby/runtime/backtrace/BacktraceData.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/BacktraceData.java
@@ -96,8 +96,7 @@ public class BacktraceData implements Serializable {
 
                     if (decodedName != null) {
                         // skip varargs frames if we just handled the method's regular frame
-                        if (type == FrameType.VARARGS_WRAPPER &&
-                                previousElement != null &&
+                        if (previousElement != null &&
                                 element.getMethodName().equals(previousElement.getMethodName() + JavaNameMangler.VARARGS_MARKER)) {
 
                             previousElement = null;

--- a/core/src/main/java/org/jruby/runtime/backtrace/BacktraceData.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/BacktraceData.java
@@ -21,13 +21,15 @@ public class BacktraceData implements Serializable {
     private final Stream<StackWalker.StackFrame> stackStream;
     private final Stream<BacktraceElement> rubyTrace;
     private final boolean fullTrace;
+    private final boolean rawTrace;
     private final boolean maskNative;
     private final boolean includeNonFiltered;
 
-    public BacktraceData(Stream<StackWalker.StackFrame> stackStream, Stream<BacktraceElement> rubyTrace, boolean fullTrace, boolean maskNative, boolean includeNonFiltered) {
+    public BacktraceData(Stream<StackWalker.StackFrame> stackStream, Stream<BacktraceElement> rubyTrace, boolean fullTrace, boolean rawTrace, boolean maskNative, boolean includeNonFiltered) {
         this.stackStream = stackStream;
         this.rubyTrace = rubyTrace;
         this.fullTrace = fullTrace;
+        this.rawTrace = rawTrace;
         this.maskNative = maskNative;
         this.includeNonFiltered = includeNonFiltered;
     }
@@ -35,6 +37,7 @@ public class BacktraceData implements Serializable {
     public static final BacktraceData EMPTY = new BacktraceData(
             Stream.empty(),
             Stream.empty(),
+            false,
             false,
             false,
             false);
@@ -84,38 +87,35 @@ public class BacktraceData implements Serializable {
             String methodName = element.getMethodName();
             String className = element.getClassName();
 
-            if (filename != null) {
+            // Only rewrite non-Java files when not in "raw" mode
+            if (!(rawTrace || filename == null || filename.endsWith(".java"))) {
+                List<String> mangledTuple = JavaNameMangler.decodeMethodTuple(methodName);
+                if (mangledTuple != null) {
+                    FrameType type = JavaNameMangler.decodeFrameTypeFromMangledName(mangledTuple.get(1));
+                    String decodedName = JavaNameMangler.decodeMethodName(type, mangledTuple);
 
-                // Don't process .java files
-                if (!filename.endsWith(".java")) {
-                    List<String> mangledTuple = JavaNameMangler.decodeMethodTuple(methodName);
-                    if (mangledTuple != null) {
-                        FrameType type = JavaNameMangler.decodeFrameTypeFromMangledName(mangledTuple.get(1));
-                        String decodedName = JavaNameMangler.decodeMethodName(type, mangledTuple);
+                    if (decodedName != null) {
+                        // skip varargs frames if we just handled the method's regular frame
+                        if (type == FrameType.VARARGS_WRAPPER &&
+                                previousElement != null &&
+                                element.getMethodName().equals(previousElement.getMethodName() + JavaNameMangler.VARARGS_MARKER)) {
 
-                        if (decodedName != null) {
-                            // skip varargs frames if we just handled the method's regular frame
-                            if (type == FrameType.VARARGS_WRAPPER &&
-                                    previousElement != null &&
-                                    element.getMethodName().equals(previousElement.getMethodName() + JavaNameMangler.VARARGS_MARKER)) {
-
-                                previousElement = null;
-                                continue;
-                            }
-
-                            // construct Ruby trace element
-                            RubyStackTraceElement rubyElement = new RubyStackTraceElement(className, decodedName, filename, line, false, type);
-
-                            // add duplicate if masking native and previous frame was native (Kernel#caller)
-                            if (maskNative && dupFrame) {
-                                dupFrame = false;
-                                trace.add(new RubyStackTraceElement(className, dupFrameName, filename, line, false, type));
-                            }
-                            trace.add(rubyElement);
-                            previousElement = element;
+                            previousElement = null;
                             continue;
-
                         }
+
+                        // construct Ruby trace element
+                        RubyStackTraceElement rubyElement = new RubyStackTraceElement(className, decodedName, filename, line, false, type);
+
+                        // add duplicate if masking native and previous frame was native (Kernel#caller)
+                        if (maskNative && dupFrame) {
+                            dupFrame = false;
+                            trace.add(new RubyStackTraceElement(className, dupFrameName, filename, line, false, type));
+                        }
+                        trace.add(rubyElement);
+                        previousElement = element;
+                        continue;
+
                     }
                 }
             }

--- a/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
@@ -171,6 +171,7 @@ public class TraceType {
                         stackStream,
                         Stream.empty(),
                         true,
+                        true,
                         false,
                         false);
             }
@@ -186,6 +187,7 @@ public class TraceType {
                         context.getBacktrace(),
                         true,
                         false,
+                        false,
                         false);
             }
         },
@@ -198,6 +200,7 @@ public class TraceType {
                 return new BacktraceData(
                         stackStream,
                         context.getBacktrace(),
+                        false,
                         false,
                         false,
                         true);
@@ -213,6 +216,7 @@ public class TraceType {
                         stackStream,
                         context.getBacktrace(),
                         false,
+                        false,
                         context.runtime.getInstanceConfig().getBacktraceMask(),
                         false);
             }
@@ -226,6 +230,7 @@ public class TraceType {
                 return new BacktraceData(
                         stackStream,
                         context.getBacktrace(),
+                        false,
                         false,
                         true,
                         false);

--- a/core/src/test/java/org/jruby/test/TestRuby.java
+++ b/core/src/test/java/org/jruby/test/TestRuby.java
@@ -124,7 +124,7 @@ public class TestRuby extends TestRubyBase {
             runtime.evalScriptlet("require 'tempfile'; file = Tempfile.open(['foo', '" + extensionSuffix + "']); file.close; require file.path");
             fail();
         } catch (RaiseException re) {
-            assertEquals(re.getException().getType(), runtime.getLoadError());
+            assertEquals(runtime.getLoadError(), re.getException().getType());
         }
     }
     


### PR DESCRIPTION
This is equivalent to #6877 backported to 9.2.