### PR TITLE
Handle beginless ArithmeticSequence

### DIFF
--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -675,7 +675,9 @@ public class RubyRange extends RubyObject {
     }
 
     private IRubyObject stepEnumeratorize(ThreadContext context, IRubyObject step, String method) {
-        if (begin instanceof RubyNumeric && (end.isNil() || end instanceof RubyNumeric)) {
+        if ((begin instanceof RubyNumeric && (end.isNil() || end instanceof RubyNumeric)) ||
+                (end instanceof RubyNumeric && (begin.isNil() || end instanceof RubyNumeric))){
+            
             if (!(step instanceof RubyNumeric)) {
                 step = step.convertToInteger();
             }


### PR DESCRIPTION
Makes  things like `(..0).step(1)` (beginless) returns an instance of `Enumerator::ArithmeticSequence`.

