### PR TITLE
Cache literal ranges constructed from immediate values

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -3031,6 +3031,15 @@ public class IRBuilder {
     }
 
     public Operand buildDot(final DotNode dotNode) {
+        Operand begin = build(dotNode.getBeginNode());
+        Operand end = build(dotNode.getEndNode());
+
+        if (begin instanceof ImmutableLiteral && end instanceof ImmutableLiteral) {
+            // endpoints are free of side effects, cache the range after creation
+            return new Range((ImmutableLiteral) begin, (ImmutableLiteral) end, dotNode.isExclusive());
+        }
+
+        // must be built every time
         return addResultInstr(new BuildRangeInstr(createTemporaryVariable(), build(dotNode.getBeginNode()),
                 build(dotNode.getEndNode()), dotNode.isExclusive()));
     }

--- a/core/src/main/java/org/jruby/ir/IRVisitor.java
+++ b/core/src/main/java/org/jruby/ir/IRVisitor.java
@@ -187,6 +187,7 @@ public abstract class IRVisitor {
     public void Nil(Nil nil) { error(nil); }
     public void NthRef(NthRef nthref) { error(nthref); }
     public void NullBlock(NullBlock nullblock) { error(nullblock); }
+    public void Range(Range range) { error(range); }
     public void Rational(Rational rational) { error(rational); }
     public void Regexp(Regexp regexp) { error(regexp); }
     public void Scope(Scope scope) { error(scope); }

--- a/core/src/main/java/org/jruby/ir/operands/Range.java
+++ b/core/src/main/java/org/jruby/ir/operands/Range.java
@@ -1,0 +1,82 @@
+package org.jruby.ir.operands;
+
+import org.jruby.RubyRange;
+import org.jruby.RubyRational;
+import org.jruby.ir.IRVisitor;
+import org.jruby.ir.persistence.IRReaderDecoder;
+import org.jruby.ir.persistence.IRWriterEncoder;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+/**
+ * Literal Range with literal endpoints.
+ */
+public class Range extends ImmutableLiteral {
+    private final ImmutableLiteral begin;
+    private final ImmutableLiteral end;
+    private final boolean exclusive;
+
+    public Range(ImmutableLiteral begin, ImmutableLiteral end, boolean exclusive) {
+        super();
+
+        this.begin = begin;
+        this.end = end;
+        this.exclusive = exclusive;
+    }
+
+    @Override
+    public OperandType getOperandType() {
+        return OperandType.RANGE;
+    }
+
+    @Override
+    public Object createCacheObject(ThreadContext context) {
+        IRubyObject begin = (IRubyObject) this.begin.cachedObject(context);
+        IRubyObject end = (IRubyObject) this.end.cachedObject(context);
+
+        if (exclusive) {
+            return RubyRange.newExclusiveRange(context, begin, end);
+        } else {
+            return RubyRange.newInclusiveRange(context, begin, end);
+        }
+    }
+
+    @Override
+    public void encode(IRWriterEncoder e) {
+        super.encode(e);
+        begin.encode(e);
+        end.encode(e);
+        e.encode(exclusive);
+    }
+
+    public static Range decode(IRReaderDecoder d) {
+        return new Range((ImmutableLiteral) d.decodeOperand(), (ImmutableLiteral) d.decodeOperand(), d.decodeBoolean());
+    }
+
+    @Override
+    public String toString() {
+        return "Range:" + begin + (exclusive ? "..." : "..") + end;
+    }
+
+    @Override
+    public void visit(IRVisitor visitor) {
+        visitor.Range(this);
+    }
+
+    public ImmutableLiteral getBegin() {
+        return begin;
+    }
+
+    public ImmutableLiteral getEnd() {
+        return end;
+    }
+
+    public boolean isExclusive() {
+        return exclusive;
+    }
+
+    @Override
+    public boolean isTruthyImmediate() {
+        return true;
+    }
+}

--- a/core/src/main/java/org/jruby/ir/persistence/IRReaderStream.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRReaderStream.java
@@ -530,6 +530,7 @@ public class IRReaderStream implements IRReaderDecoder, IRPersistenceValues {
             case NIL: return manager.getNil();
             case NTH_REF: return NthRef.decode(this);
             case NULL_BLOCK: return NullBlock.decode(this);
+            case RANGE: return Range.decode(this);
             case RATIONAL: return Rational.decode(this);
             case REGEXP: return Regexp.decode(this);
             case SCOPE_MODULE: return ScopeModule.decode(this);

--- a/core/src/main/java/org/jruby/ir/persistence/IRReaderStream.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRReaderStream.java
@@ -550,6 +550,6 @@ public class IRReaderStream implements IRReaderDecoder, IRPersistenceValues {
             case WRAPPED_IR_CLOSURE: return WrappedIRClosure.decode(this);
         }
 
-        return null;
+        throw new RuntimeException("failed to deserialize operand of type: " + type);
     }
 }

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -2684,6 +2684,14 @@ public class JVMVisitor extends IRVisitor {
     }
 
     @Override
+    public void Range(Range range) {
+        jvmMethod().getValueCompiler().pushRange(
+                () -> visit(range.getBegin()),
+                () -> visit(range.getEnd()),
+                range.isExclusive());
+    }
+
+    @Override
     public void Regexp(Regexp regexp) {
         jvmMethod().getValueCompiler().pushRegexp(regexp.getSource(), regexp.options.toEmbeddedOptions());
     }

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -2666,10 +2666,13 @@ public class JVMVisitor extends IRVisitor {
         switch (builtinClass.getType()) {
             case ARRAY:
                 jvmMethod().getValueCompiler().pushArrayClass();
+                return;
             case HASH:
                 jvmMethod().getValueCompiler().pushHashClass();
+                return;
             case OBJECT:
                 jvmMethod().getValueCompiler().pushObjectClass();
+                return;
             default:
                 throw new RuntimeException("BuiltinClass has unknown type");
         }

--- a/core/src/main/java/org/jruby/ir/targets/ValueCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/ValueCompiler.java
@@ -5,6 +5,7 @@ import org.jruby.ir.instructions.CallBase;
 import org.jruby.util.ByteList;
 
 import java.math.BigInteger;
+import java.util.function.Consumer;
 
 public interface ValueCompiler {
     /**
@@ -76,6 +77,17 @@ public interface ValueCompiler {
      * @param bl ByteList to push
      */
     void pushByteList(ByteList bl);
+
+    /**
+     * Build and save a literal range.
+     * <p>
+     * Stack required: context
+     *
+     * @param begin a runnable that will emit code for the begin value
+     * @param end a runnable that will emit code for the end value
+     * @param exclusive whether this is an exclusive range
+     */
+    void pushRange(Runnable begin, Runnable end, boolean exclusive);
 
     /**
      * Build and save a literal regular expression.

--- a/core/src/main/java/org/jruby/ir/targets/indy/IndyValueCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/IndyValueCompiler.java
@@ -5,6 +5,7 @@ import org.jruby.Ruby;
 import org.jruby.RubyBignum;
 import org.jruby.RubyClass;
 import org.jruby.RubyEncoding;
+import org.jruby.RubyRange;
 import org.jruby.RubyRegexp;
 import org.jruby.RubyString;
 import org.jruby.compiler.impl.SkinnyMethodAdapter;
@@ -23,6 +24,7 @@ import org.jruby.util.ByteList;
 import org.jruby.util.CodegenUtils;
 
 import java.math.BigInteger;
+import java.util.function.Consumer;
 
 import static org.jruby.util.CodegenUtils.ci;
 import static org.jruby.util.CodegenUtils.p;
@@ -87,6 +89,13 @@ public class IndyValueCompiler implements ValueCompiler {
 
     public void pushByteList(ByteList bl) {
         compiler.adapter.invokedynamic("bytelist", sig(ByteList.class), Bootstrap.bytelist(), RubyEncoding.decodeRaw(bl), bl.getEncoding().toString());
+    }
+
+    public void pushRange(Runnable begin, Runnable end, boolean exclusive) {
+        compiler.loadContext();
+        begin.run();
+        end.run();
+        compiler.adapter.invokedynamic("range", sig(RubyRange.class, ThreadContext.class, IRubyObject.class, IRubyObject.class), RangeObjectSite.BOOTSTRAP, exclusive ? 1 : 0);
     }
 
     public void pushRegexp(ByteList source, int options) {

--- a/core/src/main/java/org/jruby/ir/targets/indy/RangeObjectSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/RangeObjectSite.java
@@ -1,0 +1,39 @@
+package org.jruby.ir.targets.indy;
+
+import org.jruby.RubyRange;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.Opcodes;
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+import static org.jruby.util.CodegenUtils.p;
+import static org.jruby.util.CodegenUtils.sig;
+
+public class RangeObjectSite extends LazyObjectSite {
+    protected final boolean exclusive;
+
+    public RangeObjectSite(MethodType type, boolean exclusive) {
+        super(type);
+
+        this.exclusive = exclusive;
+    }
+
+    public static final Handle BOOTSTRAP = new Handle(
+            Opcodes.H_INVOKESTATIC,
+            p(RangeObjectSite.class),
+            "bootstrap",
+            sig(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class, int.class),
+            false);
+
+    public static CallSite bootstrap(MethodHandles.Lookup lookup, String name, MethodType type, int exclusive) {
+        return new RangeObjectSite(type, exclusive == 1 ? true : false).bootstrap(lookup);
+    }
+
+    public IRubyObject construct(ThreadContext context, IRubyObject begin, IRubyObject end) throws Throwable {
+        return RubyRange.newRange(context, begin, end, exclusive);
+    }
+}

--- a/core/src/main/java/org/jruby/ir/targets/simple/NormalValueCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/simple/NormalValueCompiler.java
@@ -9,6 +9,7 @@ import org.jruby.RubyEncoding;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
 import org.jruby.RubyProc;
+import org.jruby.RubyRange;
 import org.jruby.RubyRegexp;
 import org.jruby.RubyString;
 import org.jruby.RubySymbol;
@@ -40,6 +41,7 @@ import java.lang.invoke.MethodType;
 import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static org.jruby.util.CodegenUtils.ci;
 import static org.jruby.util.CodegenUtils.p;
@@ -122,6 +124,16 @@ public class NormalValueCompiler implements ValueCompiler {
             compiler.adapter.ldc(bl.toString());
             compiler.adapter.ldc(bl.getEncoding().toString());
             compiler.invokeIRHelper("newByteListFromRaw", sig(ByteList.class, Ruby.class, String.class, String.class));
+        });
+    }
+
+    public void pushRange(Runnable begin, Runnable end, boolean exclusive) {
+        cacheValuePermanentlyLoadContext("range", RubyRange.class, null, () -> {
+            compiler.loadContext();
+            begin.run();
+            end.run();
+            compiler.adapter.pushBoolean(exclusive);
+            compiler.adapter.invokestatic(p(RubyRange.class), "newRange", sig(RubyRange.class, ThreadContext.class, IRubyObject.class, IRubyObject.class, boolean.class));
         });
     }
 

--- a/spec/compiler/general_spec.rb
+++ b/spec/compiler/general_spec.rb
@@ -170,6 +170,7 @@ modes.each do |mode|
       run("a = {:foo => {:bar => 5.5}}; a") {|result| expect(result).to eq({:foo => {:bar => 5.5}}) }
       run("a = /foo/; a") {|result| expect(result).to eq(/foo/) }
       run("1..2") {|result| expect(result).to eq (1..2) }
+      run("1...2") {|result| expect(result).to eq (1...2) }
       run("1r") {|result| expect(result).to eq (Rational(1, 1))}
       run("1.1r") {|result| expect(result).to eq (Rational(11, 10))}
       run("1i") {|result| expect(result).to eq (Complex(0, 1))}


### PR DESCRIPTION
This adds logic in IR and JIT to cache the resulting Range object when a literal range is composed of other immediate literal values, like longs.

The first pass here is a simple introduction of logic to cache the resulting object, while still emitting code to create the input values. A more compact representation would not need to revisit the input value logic (even to check a cache) and would instead embed the values directly into the range, so it can be constructed and cached outside of IR/JIT output.