### PR TITLE
Fix spec:ji on GHA

### DIFF
--- a/spec/java_integration/ant/ant_spec.rb
+++ b/spec/java_integration/ant/ant_spec.rb
@@ -137,9 +137,10 @@ end
 describe Ant, '.ant' do
   it "prefers $ANT_HOME to $PATH" do
     if ENV['ANT_HOME']
-      hide_ant_from_path
-      expect { Ant.ant(:basedir => File.join(File.dirname(__FILE__), '..', '..', '..')) }.
+      with_hidden_ant_path do
+        expect { Ant.ant(:basedir => File.join(File.dirname(__FILE__), '..', '..', '..')) }.
         to_not raise_error
+      end
     else
       skip '$ANT_HOME is not set'
     end

--- a/spec/java_integration/ant_spec_helper.rb
+++ b/spec/java_integration/ant_spec_helper.rb
@@ -118,12 +118,14 @@ class Rake::Ant
   end
 end
 
-def hide_ant_from_path
-  env=[]
-  ENV['PATH'].split(File::PATH_SEPARATOR).each do |dir|
-    if ! File.executable?(File.join(dir, 'ant'))
-      env << dir
-    end
-  end
-  ENV['PATH'] = env.join(File::PATH_SEPARATOR)
+def with_hidden_ant_path
+  original_env_path = ENV['PATH']
+  hidden_path = ENV['PATH'].split(File::PATH_SEPARATOR).reject { |dir|
+    File.executable?(File.join(dir, 'ant'))
+  }.join(File::PATH_SEPARATOR)
+  ENV['PATH'] = hidden_path
+
+  yield
+ensure
+  ENV['PATH'] = original_env_path
 end

--- a/spec/java_integration/utilities/jar_glob_spec.rb
+++ b/spec/java_integration/utilities/jar_glob_spec.rb
@@ -19,14 +19,14 @@ describe 'Dir globs (Dir.glob and Dir.[])' do
     begin
       FileUtils.rm_rf 'glob_test'
     rescue Errno::ENOENT; end
-    
+
     FileUtils.mkdir_p 'glob_target'
     File.open('glob_target/bar.txt', 'w') {|file| file << 'Some text.'}
     `jar -cf glob-test.jar glob_target/bar.txt`
     FileUtils.mkdir_p 'glob_test'
     FileUtils.cp "glob-test.jar", 'glob_test/'
   end
-  
+
   after :all do
     FileUtils.rm    'glob_target/bar.txt',     :force => true
     FileUtils.rmdir 'glob_target'
@@ -39,7 +39,7 @@ describe 'Dir globs (Dir.glob and Dir.[])' do
     end
     FileUtils.rmdir 'glob_test'
   end
-  
+
   it "finds the contents inside a jar with Dir.[] in a dir inside the jar" do
     FileUtils.cd('glob_test') do
       expect(Dir["file:#{File.expand_path(Dir.pwd)}/glob-test.jar!/glob_target/**/*"]).to have_jar_entries([
@@ -47,7 +47,7 @@ describe 'Dir globs (Dir.glob and Dir.[])' do
       ])
     end
   end
-  
+
   it "finds the contents inside a jar with Dir.glob in a dir inside the jar" do
     FileUtils.cd('glob_test') do
       expect(Dir.glob("file:#{File.expand_path(Dir.pwd)}/glob-test.jar!/glob_target/**/*")).to have_jar_entries([
@@ -66,7 +66,7 @@ describe 'Dir globs (Dir.glob and Dir.[])' do
       ])
     end
   end
-    
+
   it "finds the contents inside a jar with Dir.glob at the root of the jar" do
     FileUtils.cd('glob_test') do
       expect(Dir.glob("file:#{File.expand_path(Dir.pwd)}/glob-test.jar!/**/*")).to have_jar_entries([
@@ -108,7 +108,7 @@ describe 'Dir globs (Dir.glob and Dir.[])' do
     sleep 2
 
     # This should delete the /glob_target and /glob_target/bar.txt entries
-    `jar uf #{jar_path} glob_target/bar.txt`
+    `zip -d #{jar_path} glob_target/bar.txt`
 
     puts File.mtime(jar_path)
 
@@ -201,9 +201,8 @@ describe "Dir.glob and Dir[] with multiple magic modifiers" do
   end
 
   it "iterates over directories when there are more than one magic modifier" do
-    FileUtils.cd('jruby-4396') do      
+    FileUtils.cd('jruby-4396') do
       Dir.glob("file:#{File.expand_path(Dir.pwd)}/top.jar!top/dir2/**/*/**").size.should == 6
     end
   end
 end
-


### PR DESCRIPTION
A spec in ji/ant/ant_spec.rb was changing ENV['PATH'] under certain
circumstances, which resulted in the shells spawned by backtick being
unable to find common programs like `zip` or `which`. Fix that, and restore
`jar_glob_spec.rb`'s use of `zip -d`.