### PR TITLE
Socket fixes for GHA CI

### DIFF
--- a/core/src/main/java/org/jruby/util/io/Sockaddr.java
+++ b/core/src/main/java/org/jruby/util/io/Sockaddr.java
@@ -105,9 +105,9 @@ public class Sockaddr {
     }
 
     public static UnixSocketAddress addressFromSockaddr_un(ThreadContext context, ByteList bl) {
-        String pathStr = pathFromSockaddr_un(context, bl.bytes());
+        RubyString pathStr = pathFromSockaddr_un(context, bl.bytes());
 
-        return new UnixSocketAddress(new File(pathStr));
+        return new UnixSocketAddress(new File(pathStr.toString()));
     }
 
     public static IRubyObject packSockaddrFromAddress(ThreadContext context, InetSocketAddress sock) {
@@ -306,8 +306,7 @@ public class Sockaddr {
             throw runtime.newArgumentError("not an AF_UNIX sockaddr");
         }
 
-        String filename = pathFromSockaddr_un(context, val.bytes());
-        return context.runtime.newString(filename);
+        return pathFromSockaddr_un(context, val.bytes());
     }
 
     public static void writeSockaddrHeader(AddressFamily family, DataOutputStream ds) throws IOException {
@@ -377,13 +376,13 @@ public class Sockaddr {
         return ((high & 0xFF) << 8) + (low & 0xFF);
     }
 
-    private static String pathFromSockaddr_un(ThreadContext context, byte[] raw) {
+    private static RubyString pathFromSockaddr_un(ThreadContext context, byte[] raw) {
         int end = 2;
         for (; end < raw.length; end++) {
             if (raw[end] == 0) break;
         }
 
-        return new String(raw, 2, (end - 2));
+        return RubyString.newString(context.runtime, raw, 2, (end - 2));
     }
 
     // sizeof(sockaddr_un) on Linux

--- a/spec/tags/ruby/library/socket/basicsocket/local_address_tags.txt
+++ b/spec/tags/ruby/library/socket/basicsocket/local_address_tags.txt
@@ -1,2 +1,3 @@
 fails:BasicSocket#local_address using TCPSocket uses 0 as the protocol
 fails:BasicSocket#local_address using UDPSocket uses 0 as the protocol
+fails:BasicSocket#local_address using IPv6 uses 0 as the protocol

--- a/spec/tags/ruby/library/socket/basicsocket/recv_nonblock_tags.txt
+++ b/spec/tags/ruby/library/socket/basicsocket/recv_nonblock_tags.txt
@@ -1,1 +1,2 @@
 fails:Socket::BasicSocket#recv_nonblock using IPv4 using a connected but not bound socket raises Errno::ENOTCONN
+fails:Socket::BasicSocket#recv_nonblock using IPv6 using a connected but not bound socket raises Errno::ENOTCONN

--- a/spec/tags/ruby/library/socket/basicsocket/recvmsg_nonblock_tags.txt
+++ b/spec/tags/ruby/library/socket/basicsocket/recvmsg_nonblock_tags.txt
@@ -47,3 +47,4 @@ fails:BasicSocket#recvmsg_nonblock using IPv6 using a connected socket with data
 fails:BasicSocket#recvmsg_nonblock using IPv4 using a disconnected socket using a bound socket without any data available returns :wait_readable with exception: false
 fails:BasicSocket#recvmsg_nonblock using IPv6 using a disconnected socket using a bound socket without any data available returns :wait_readable with exception: false
 fails:BasicSocket#recvmsg_nonblock using IPv4 using a connected but not bound socket raises Errno::ENOTCONN
+fails:BasicSocket#recvmsg_nonblock using IPv6 using a connected but not bound socket raises Errno::ENOTCONN

--- a/spec/tags/ruby/library/socket/basicsocket/remote_address_tags.txt
+++ b/spec/tags/ruby/library/socket/basicsocket/remote_address_tags.txt
@@ -1,2 +1,3 @@
 fails:BasicSocket#remote_address using TCPSocket uses 0 as the protocol
 fails:BasicSocket#remote_address using UDPSocket uses 0 as the protocol
+fails:BasicSocket#remote_address using IPv6 uses 0 as the protocol

--- a/spec/tags/ruby/library/socket/socket/listen_tags.txt
+++ b/spec/tags/ruby/library/socket/socket/listen_tags.txt
@@ -1,10 +1,7 @@
-fails:Socket#listen verifies we can listen for incoming connections
-fails:Socket#listen using IPv4 using a DGRAM socket raises Errno::EOPNOTSUPP
-fails:Socket#listen using IPv4 using a STREAM socket returns 0
-fails:Socket#listen using IPv4 using a STREAM socket raises when the given argument can't be coerced to a Fixnum
-fails:Socket#listen using IPv6 using a DGRAM socket raises Errno::EOPNOTSUPP
-fails:Socket#listen using IPv6 using a STREAM socket returns 0
-fails:Socket#listen using IPv6 using a STREAM socket raises when the given argument can't be coerced to a Fixnum
-fails:Socket#listen using IPv4 using a STREAM socket raises when the given argument can't be coerced to an Integer
-fails:Socket#listen using IPv6 using a STREAM socket raises when the given argument can't be coerced to an Integer
-fails:Socket#listen using IPv4 using a DGRAM socket raises Errno::EOPNOTSUPP or Errno::EACCES
+fails(must use ServerSocket to get server functions):Socket#listen verifies we can listen for incoming connections
+fails(must use ServerSocket to get server functions):Socket#listen using IPv4 using a DGRAM socket raises Errno::EOPNOTSUPP or Errno::EACCES
+fails(must use ServerSocket to get server functions):Socket#listen using IPv4 using a STREAM socket returns 0
+fails(must use ServerSocket to get server functions):Socket#listen using IPv4 using a STREAM socket raises when the given argument can't be coerced to an Integer
+fails(must use ServerSocket to get server functions):Socket#listen using IPv6 using a DGRAM socket raises Errno::EOPNOTSUPP or Errno::EACCES
+fails(must use ServerSocket to get server functions):Socket#listen using IPv6 using a STREAM socket returns 0
+fails(must use ServerSocket to get server functions):Socket#listen using IPv6 using a STREAM socket raises when the given argument can't be coerced to an Integer


### PR DESCRIPTION
We have a few failures with IPv6 that have escaped notice due to not running in Travis CI. When they failed locally we probably ignored those failures assuming we did not have IPv6 set up properly.

This PR will include some fixes and some tags for IPv6-related failures we now see when running CI on GitHub Actions.

* Set IPv6-related constants to nil when unavailable: CRuby has complicated logic for defining socket-related constants and query methods, but I believe this is a rough match for how they filter out IPv6-related constants when IPv6 is not available. This is checked by e.g. MRI tests and rubyspec to skip or alter IPv6-related tests.
* Preserve multibyte strings in UNIX address: The path was being round-tripped through Java incorrectly, mangling multibyte characters.
* Update Socket#listen tags for IPv6: none of these specs work because JRuby cannot support both client and server behaviors in Socket. JDK Socket APIs require that we choose server or client at creation time, and it cannot be changed later. This prevents us from supporting `listen` unless you instantiate ServerSocket. All the IPv4 specs were tagged but some IPv6 specs were untagged.
* Update BasicSocket tags for IPv6: Equivalent tags already existed for the IPv4 versions but we those did not run on Travis.