### PR TITLE
Limit Date.parse input length and make interruptible

### DIFF
--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -154,7 +154,7 @@ public class Options {
     public static final Option<Boolean> USE_FIXNUM_CACHE = bool(MISCELLANEOUS, "fixnum.cache", true, "Use a cache of low-valued Fixnum objects.");
     public static final Option<Integer> FIXNUM_CACHE_RANGE = integer(MISCELLANEOUS, "fixnum.cache.size", 256, "Values to retrieve from Fixnum cache, in the range -X..(X-1).");
     public static final Option<Boolean> PACKED_ARRAYS = bool(MISCELLANEOUS, "packed.arrays", true, "Toggle whether to use \"packed\" arrays for small tuples.");
-    public static final Option<Boolean> REGEXP_INTERRUPTIBLE = bool(MISCELLANEOUS, "regexp.interruptible", false, "Allow regexp operations to be interuptible from Ruby.");
+    public static final Option<Boolean> REGEXP_INTERRUPTIBLE = bool(MISCELLANEOUS, "regexp.interruptible", true, "Allow regexp operations to be interuptible from Ruby.");
 
     public static final Option<Boolean> DEBUG_LOADSERVICE = bool(DEBUG, "debug.loadService", false, "Log require/load file searches.");
     public static final Option<Boolean> DEBUG_LOADSERVICE_TIMING = bool(DEBUG, "debug.loadService.timing", false, "Log require/load parse+evaluate times.");

--- a/lib/ruby/stdlib/date.rb
+++ b/lib/ruby/stdlib/date.rb
@@ -483,28 +483,28 @@ class Date
   # Day Number day 0.
   #
   # +sg+ specifies the Day of Calendar Reform.
-  def self.parse(str='-4712-01-01', comp=true, sg=ITALY)
-    elem = _parse(str, comp)
+  def self.parse(str='-4712-01-01', comp=true, sg=ITALY, limit: 128)
+    elem = _parse(str, comp, limit: limit)
     new_by_frags(elem, sg)
   end
 
-  def self.iso8601(str='-4712-01-01', sg=ITALY) # :nodoc:
-    elem = _iso8601(str)
+  def self.iso8601(str='-4712-01-01', sg=ITALY, limit: 128) # :nodoc:
+    elem = _iso8601(str, limit: limit)
     new_by_frags(elem, sg)
   end
 
-  def self.rfc3339(str='-4712-01-01T00:00:00+00:00', sg=ITALY) # :nodoc:
-    elem = _rfc3339(str)
+  def self.rfc3339(str='-4712-01-01T00:00:00+00:00', sg=ITALY, limit: 128) # :nodoc:
+    elem = _rfc3339(str, limit: limit)
     new_by_frags(elem, sg)
   end
 
-  def self.xmlschema(str='-4712-01-01', sg=ITALY) # :nodoc:
-    elem = _xmlschema(str)
+  def self.xmlschema(str='-4712-01-01', sg=ITALY, limit: 128) # :nodoc:
+    elem = _xmlschema(str, limit: limit)
     new_by_frags(elem, sg)
   end
 
-  def self.rfc2822(str='Mon, 1 Jan -4712 00:00:00 +0000', sg=ITALY) # :nodoc:
-    elem = _rfc2822(str)
+  def self.rfc2822(str='Mon, 1 Jan -4712 00:00:00 +0000', sg=ITALY, limit: 128) # :nodoc:
+    elem = _rfc2822(str, limit: limit)
     new_by_frags(elem, sg)
   end
   class << self; alias_method :rfc822, :rfc2822 end
@@ -514,8 +514,8 @@ class Date
     new_by_frags(elem, sg)
   end
 
-  def self.jisx0301(str='-4712-01-01', sg=ITALY) # :nodoc:
-    elem = _jisx0301(str)
+  def self.jisx0301(str='-4712-01-01', sg=ITALY, limit: 128) # :nodoc:
+    elem = _jisx0301(str, limit: limit)
     new_by_frags(elem, sg)
   end
 
@@ -730,28 +730,28 @@ class DateTime < Date
   # Day Number day 0.
   #
   # +sg+ specifies the Day of Calendar Reform.
-  def self.parse(str='-4712-01-01T00:00:00+00:00', comp=true, sg=ITALY)
-    elem = _parse(str, comp)
+  def self.parse(str='-4712-01-01T00:00:00+00:00', comp=true, sg=ITALY, limit: 128)
+    elem = _parse(str, comp, limit: limit)
     new_by_frags(elem, sg)
   end
 
-  def self.iso8601(str='-4712-01-01T00:00:00+00:00', sg=ITALY) # :nodoc:
-    elem = _iso8601(str)
+  def self.iso8601(str='-4712-01-01T00:00:00+00:00', sg=ITALY, limit: 128) # :nodoc:
+    elem = _iso8601(str, limit: limit)
     new_by_frags(elem, sg)
   end
 
-  def self.rfc3339(str='-4712-01-01T00:00:00+00:00', sg=ITALY) # :nodoc:
-    elem = _rfc3339(str)
+  def self.rfc3339(str='-4712-01-01T00:00:00+00:00', sg=ITALY, limit: 128) # :nodoc:
+    elem = _rfc3339(str, limit: limit)
     new_by_frags(elem, sg)
   end
 
-  def self.xmlschema(str='-4712-01-01T00:00:00+00:00', sg=ITALY) # :nodoc:
-    elem = _xmlschema(str)
+  def self.xmlschema(str='-4712-01-01T00:00:00+00:00', sg=ITALY, limit: 128) # :nodoc:
+    elem = _xmlschema(str, limit: limit)
     new_by_frags(elem, sg)
   end
 
-  def self.rfc2822(str='Mon, 1 Jan -4712 00:00:00 +0000', sg=ITALY) # :nodoc:
-    elem = _rfc2822(str)
+  def self.rfc2822(str='Mon, 1 Jan -4712 00:00:00 +0000', sg=ITALY, limit: 128) # :nodoc:
+    elem = _rfc2822(str, limit: limit)
     new_by_frags(elem, sg)
   end
   class << self; alias_method :rfc822, :rfc2822 end
@@ -761,8 +761,8 @@ class DateTime < Date
     new_by_frags(elem, sg)
   end
 
-  def self.jisx0301(str='-4712-01-01T00:00:00+00:00', sg=ITALY) # :nodoc:
-    elem = _jisx0301(str)
+  def self.jisx0301(str='-4712-01-01T00:00:00+00:00', sg=ITALY, limit: 128) # :nodoc:
+    elem = _jisx0301(str, limit: limit)
     new_by_frags(elem, sg)
   end
 

--- a/lib/ruby/stdlib/date/format.rb
+++ b/lib/ruby/stdlib/date/format.rb
@@ -601,7 +601,18 @@ class Date
   private_class_method :set_zone
 
   def self.check_limit(str, limit)
-    return if limit.nil?
+    return if str.nil?
+
+    if String === str
+      # ok
+    elsif Symbol === str
+      str = str.to_s
+    else
+      raise TypeError.new("no implicit conversion of #{str.class} into String") unless str.respond_to?(:to_str)
+      str = str.to_str
+    end
+
+    limit = 2 ** 64 if limit.nil?
 
     slen = str.length
     if slen > limit

--- a/lib/ruby/stdlib/date/format.rb
+++ b/lib/ruby/stdlib/date/format.rb
@@ -326,7 +326,9 @@ class Date
 
   private_class_method :_parse_iso2, :_parse_jis, :_parse_vms, :_parse_ddd
 
-  def self._parse(str, comp=true)
+  def self._parse(str, comp=true, limit: 128)
+    check_limit(str, limit)
+
     if str.kind_of?(::String)
       # no-op
     elsif str.respond_to?(:to_str)
@@ -338,7 +340,9 @@ class Date
     return _parse_impl(str, :_comp => comp)
   end
 
-  def self._iso8601(str) # :nodoc:
+  def self._iso8601(str, limit: 128) # :nodoc:
+    check_limit(str, limit)
+
     h = {}
     if m = match(/\A\s*
       (?:
@@ -457,7 +461,9 @@ class Date
     h
   end
 
-  def self._rfc3339(str) # :nodoc:
+  def self._rfc3339(str, limit: 128) # :nodoc:
+    check_limit(str, limit)
+
     if /\A\s*-?\d{4}-\d{2}-\d{2} # allow minus, anyway
         (t|\s)
         \d{2}:\d{2}:\d{2}(\.\d+)?
@@ -468,7 +474,9 @@ class Date
     end
   end
 
-  def self._xmlschema(str) # :nodoc:
+  def self._xmlschema(str, limit: 128) # :nodoc:
+    check_limit(str, limit)
+
     if m = match(/\A\s*(-?\d{4,})(?:-(\d{2})(?:-(\d{2}))?)?
         (?:t
           (\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?)?
@@ -518,7 +526,9 @@ class Date
     end
   end
 
-  def self._rfc2822(str) # :nodoc:
+  def self._rfc2822(str, limit: 128) # :nodoc:
+    check_limit(str, limit)
+
     if m = match(/\A\s*(?:(?:#{Format::ABBR_DAYS.keys.join('|')})\s*,\s+)?
         \d{1,2}\s+
         (?:#{Format::ABBR_MONTHS.keys.join('|')})\s+
@@ -567,7 +577,9 @@ class Date
     end
   end
 
-  def self._jisx0301(str) # :nodoc:
+  def self._jisx0301(str, limit: 128) # :nodoc:
+    check_limit(str, limit)
+
     if /\A\s*[mtsh]?\d{2}\.\d{2}\.\d{2}
         (t
         (\d{2}:\d{2}(:\d{2}([,.]\d*)?)?
@@ -587,6 +599,16 @@ class Date
     hash[:offset] = zone_to_diff(zone)
   end
   private_class_method :set_zone
+
+  def self.check_limit(str, limit)
+    return if limit.nil?
+
+    slen = str.length
+    if slen > limit
+      raise ArgumentError.new("string length #{slen} exceeds the limit #{limit}")
+    end
+  end
+  private_class_method :check_limit
 
 end
 

--- a/test/jruby.index
+++ b/test/jruby.index
@@ -113,3 +113,5 @@ jruby/test_reified_variables
 jruby/compiler/test_jrubyc
 jruby/test_load_compiled_ruby
 jruby/test_load_compiled_ruby_class_from_classpath
+
+jruby/test_date_parse_limit

--- a/test/jruby/test_date_parse_limit.rb
+++ b/test/jruby/test_date_parse_limit.rb
@@ -1,0 +1,34 @@
+require 'test/unit'
+require 'date'
+require 'timeout'
+
+class TestDateOverflow < Test::Unit::TestCase
+  def test_length_limit
+    assert_raise(ArgumentError) { Date._parse("1" * 1000) }
+    assert_raise(ArgumentError) { Date._iso8601("1" * 1000) }
+    assert_raise(ArgumentError) { Date._rfc3339("1" * 1000) }
+    assert_raise(ArgumentError) { Date._xmlschema("1" * 1000) }
+    assert_raise(ArgumentError) { Date._rfc2822("1" * 1000) }
+    assert_raise(ArgumentError) { Date._rfc822("1" * 1000) }
+    assert_raise(ArgumentError) { Date._jisx0301("1" * 1000) }
+
+    assert_raise(ArgumentError) { Date.parse("1" * 1000) }
+    assert_raise(ArgumentError) { Date.iso8601("1" * 1000) }
+    assert_raise(ArgumentError) { Date.rfc3339("1" * 1000) }
+    assert_raise(ArgumentError) { Date.xmlschema("1" * 1000) }
+    assert_raise(ArgumentError) { Date.rfc2822("1" * 1000) }
+    assert_raise(ArgumentError) { Date.rfc822("1" * 1000) }
+    assert_raise(ArgumentError) { Date.jisx0301("1" * 1000) }
+
+    assert_raise(ArgumentError) { DateTime.parse("1" * 1000) }
+    assert_raise(ArgumentError) { DateTime.iso8601("1" * 1000) }
+    assert_raise(ArgumentError) { DateTime.rfc3339("1" * 1000) }
+    assert_raise(ArgumentError) { DateTime.xmlschema("1" * 1000) }
+    assert_raise(ArgumentError) { DateTime.rfc2822("1" * 1000) }
+    assert_raise(ArgumentError) { DateTime.rfc822("1" * 1000) }
+    assert_raise(ArgumentError) { DateTime.jisx0301("1" * 1000) }
+
+    assert_raise(ArgumentError) { Date._parse("Jan " + "9" * 1000000) }
+    assert_raise(Timeout::Error) { Timeout.timeout(1) { Date._parse("Jan " + "9" * 1000000, limit: nil) } }
+  end
+end

--- a/test/mri/excludes/JSONAdditionTest.rb
+++ b/test/mri/excludes/JSONAdditionTest.rb
@@ -1,0 +1,1 @@
+exclude :test_utc_datetime, "broken test patch from json that Ruby kwargs rejects"


### PR DESCRIPTION
Excessively long input to the various Date parsing methods can cause the calling thread to run for a long time, perhaps tying it up indefinitely. This PR incorporates to changes similar to those in ruby/date@3959acc.

* Add a limit option to the affected Date parse methods (see commit above for the list).
* Make all regexp matches interruptible by default. This can be disabled using the JRuby property `regexp.interruptible=false` in .jruby_opts, with `-Xregexp.interruptible=false` on the command line, or by setting the JVM property `jruby.regexp.interruptible=false`
* Add the same test as CRuby under our JRuby test suite, since no spec was added by ruby-core and we are not merging updated tests for this release.

This patch differs from #6951 in that it enables interruptible Regexp matches *globally*, since this appears to now be the case in CRuby. This also simplifies the PR and avoids modifying the Java code.

The pure-Ruby workaround from #6951 applies here, and manually enabling the `regexp.interruptible` property would bring a patched 9.3.1 or 9.3.0 install up to compliance with the test added here. No rebuild of JRuby is needed in this case.

cc @jordansissel, @rsim