### PR TITLE
Fix 6924

### DIFF
--- a/core/src/main/java/org/jruby/IncludedModuleWrapper.java
+++ b/core/src/main/java/org/jruby/IncludedModuleWrapper.java
@@ -62,9 +62,13 @@ public class IncludedModuleWrapper extends IncludedModule {
      * @param origin the actual module not a wrapper from a prepend or include.
      */
     public IncludedModuleWrapper(Ruby runtime, RubyClass superClass, RubyModule origin) {
+        this(runtime, superClass, origin, origin); // FIXME: include passes in methodLocation but refinements calls this several places.  Determined what we should really be passing.
+    }
+
+    public IncludedModuleWrapper(Ruby runtime, RubyClass superClass, RubyModule origin, RubyModule methodsHolder) {
         super(runtime, superClass, origin);
         origin.addIncludingHierarchy(this);
-        methods = origin.getMethodLocation().getMethodsForWrite();
+        methods = methodsHolder.getMethodsForWrite();
     }
 
     /**

--- a/core/src/main/java/org/jruby/IncludedModuleWrapper.java
+++ b/core/src/main/java/org/jruby/IncludedModuleWrapper.java
@@ -56,12 +56,15 @@ import org.jruby.runtime.builtin.Variable;
  * @see org.jruby.RubyModule
  */
 public class IncludedModuleWrapper extends IncludedModule {
+    /**
+     * @param runtime the runtime
+     * @param superClass the superclass
+     * @param origin the actual module not a wrapper from a prepend or include.
+     */
     public IncludedModuleWrapper(Ruby runtime, RubyClass superClass, RubyModule origin) {
         super(runtime, superClass, origin);
         origin.addIncludingHierarchy(this);
-        // FIXME: Is this ok if we are including a prepended module?
-        methods = origin.getMethodsForWrite();
-        //cachedMethods = origin.cachedMethods;
+        methods = origin.getMethodLocation().getMethodsForWrite();
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -3605,7 +3605,7 @@ public class RubyModule extends RubyObject {
         // In the current logic, if we getService here we know that module is not an
         // IncludedModuleWrapper, so there's no need to fish out the delegate. But just
         // in case the logic should change later, let's do it anyway
-        RubyClass wrapper = new IncludedModuleWrapper(getRuntime(), insertAbove.getSuperClass(), moduleToInclude);
+        RubyClass wrapper = new IncludedModuleWrapper(getRuntime(), insertAbove.getSuperClass(), moduleToInclude, moduleToInclude.getMethodLocation());
 
         // if the insertion point is a class, update subclass lists
         if (insertAbove instanceof RubyClass) {
@@ -3624,7 +3624,7 @@ public class RubyModule extends RubyObject {
         insertAbove = insertAbove.getSuperClass();
 
         if (isRefinement()) {
-            moduleToInclude.getMethods().forEach((name, method) -> addRefinedMethodEntry(name, method));
+            wrapper.getMethods().forEach((name, method) -> addRefinedMethodEntry(name, method));
             wrapper.setFlag(INCLUDED_INTO_REFINEMENT, true);
         }
 


### PR DESCRIPTION
Fixes #6924.

Including modules after a prepend needs the new locations for methods.
    
IncludedModuleWrapper takes the real module (e.g. Enumerable) but if
the module has been prepended then all the methods get moved to a
PrependedModule.  getMethodLocation returns that prependedmodule instance.
