### PR TITLE
Use method location for includes/prepends

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -3605,7 +3605,8 @@ public class RubyModule extends RubyObject {
         // In the current logic, if we getService here we know that module is not an
         // IncludedModuleWrapper, so there's no need to fish out the delegate. But just
         // in case the logic should change later, let's do it anyway
-        RubyClass wrapper = new IncludedModuleWrapper(getRuntime(), insertAbove.getSuperClass(), moduleToInclude);
+        RubyModule methodLocation = moduleToInclude.getMethodLocation();
+        RubyClass wrapper = new IncludedModuleWrapper(getRuntime(), insertAbove.getSuperClass(), methodLocation);
 
         // if the insertion point is a class, update subclass lists
         if (insertAbove instanceof RubyClass) {
@@ -3624,7 +3625,7 @@ public class RubyModule extends RubyObject {
         insertAbove = insertAbove.getSuperClass();
 
         if (isRefinement()) {
-            moduleToInclude.getMethods().forEach((name, method) -> addRefinedMethodEntry(name, method));
+            methodLocation.getMethods().forEach((name, method) -> addRefinedMethodEntry(name, method));
             wrapper.setFlag(INCLUDED_INTO_REFINEMENT, true);
         }
 


### PR DESCRIPTION
When we want to include a given module, we should be retrieving
its method location. This avoids prepends, which we will mine out
during the normal process of walking all modules included or
prepended into the source module.

Fixes #6924