### PR TITLE
Push a frame for init_dup/clone for super

### DIFF
--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -307,18 +307,16 @@ public class RubySet extends RubyObject implements Set {
 
     }
 
-    @JRubyMethod
+    @JRubyMethod(frame = true)
     public IRubyObject initialize_dup(ThreadContext context, IRubyObject orig) {
-        RubyClass superClass = orig.getMetaClass().getSuperClass();
-        sites(context).initialize_dup_super.call(context, this, this, superClass, "initialize_dup", orig);
+        sites(context).initialize_dup_super.call(context, this, this, orig);
         setHash((RubyHash) (((RubySet) orig).hash).dup(context));
         return this;
     }
 
-    @JRubyMethod
+    @JRubyMethod(frame = true)
     public IRubyObject initialize_clone(ThreadContext context, IRubyObject orig) {
-        RubyClass superClass = orig.getMetaClass().getSuperClass();
-        sites(context).initialize_clone_super.call(context, this, this, superClass, "initialize_clone", orig);
+        sites(context).initialize_clone_super.call(context, this, this, orig);
         setHash((RubyHash) (((RubySet) orig).hash).rbClone(context));
         return this;
     }


### PR DESCRIPTION
We can't blindly get the current object's class's superclass
because the object's class may be multiple descendants below the
Set class, causing super calls to super back into a lower point
in the hierarchy. This is the cause of #6958.

The fix here is to request a frame be pushed for Set#init_dup and
init_clone so that we can redispatch from the proper point in the
hierarchy. This also properly uses SuperCallSite, passing in the
class from which to super. The original code was flawed in two
ways:

* It always acquired the superclass via object.class.superclass,
  which does not work for a two-deep descendant of Set.
* It passed the superclass in for the frame class, which allowed
  the flawed logic to work for one level deep. It is broken for
  two levels deep or no levels deep because it passes the wrong
  frame class.

This was not found during testing of #6910 because the original
example only has one descendant.