### PR TITLE
Avoid NullPointerException in Symbol operand

### DIFF
--- a/core/src/main/java/org/jruby/ir/operands/Symbol.java
+++ b/core/src/main/java/org/jruby/ir/operands/Symbol.java
@@ -1,6 +1,7 @@
 package org.jruby.ir.operands;
 
 import org.jcodings.Encoding;
+import org.jcodings.specific.UTF8Encoding;
 import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.jruby.ir.IRVisitor;
@@ -29,6 +30,8 @@ public class Symbol extends ImmutableLiteral implements Stringable {
     }
 
     public ByteList getBytes() {
+        if (symbol == null) return ByteList.EMPTY_BYTELIST;
+
         return symbol.getBytes();
     }
 
@@ -36,7 +39,7 @@ public class Symbol extends ImmutableLiteral implements Stringable {
         return symbol;
     }
 
-    public String getString() { return symbol.idString(); }
+    public String getString() { return symbol == null ? null : symbol.idString(); }
 
     @Override
     public Object createCacheObject(ThreadContext context) {
@@ -49,6 +52,8 @@ public class Symbol extends ImmutableLiteral implements Stringable {
     }
 
     public Encoding getEncoding() {
+        if (symbol == null) return UTF8Encoding.INSTANCE;
+
         return symbol.getEncoding();
     }
 


### PR DESCRIPTION
Hello team,

I've been doing some reverse engineering work on a JRuby application and while dumping the IR using some code I wrote that uses [`IRDumper`](https://github.com/jruby/jruby/blob/master/core/src/main/java/org/jruby/ir/persistence/IRDumper.java) I hit a few `NullPointerException`s.

I see `getString` is already fixed in 9.3.x but the rest was missing.

I wasn't sure what was the best way to contribute this PR. Should I open `master` first and then backport to `jruby-9.3` and `jruby-9.2`?