### PR TITLE
[WiP] error info in ensure (avoids setting $! on RaiseException <init>)

### DIFF
--- a/core/src/main/java/org/jruby/Main.java
+++ b/core/src/main/java/org/jruby/Main.java
@@ -292,6 +292,9 @@ public class Main {
                     doRunFromMain(runtime, in, filename);
                 }
                 status = new Status();
+            } catch (RaiseException ex) {
+                runtime.getCurrentContext().setErrorInfo(ex.getException()); // set $! (accessible in at_exit blocks)
+                throw ex;
             } finally {
                 try {
                     runtime.tearDown();

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -786,11 +786,9 @@ public class RubyKernel {
                 throw new MainExitException(status, true);
             }
         } else {
-            if (message == null) {
-                throw runtime.newSystemExit(status);
-            } else {
-                throw runtime.newSystemExit(status, message);
-            }
+            RaiseException ex = message == null ? runtime.newSystemExit(status) : runtime.newSystemExit(status, message);
+            runtime.getCurrentContext().setErrorInfo(ex.getException()); // set $! (accessible in at_exit blocks)
+            throw ex;
         }
     }
 

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -787,7 +787,7 @@ public class RubyKernel {
             }
         } else {
             RaiseException ex = message == null ? runtime.newSystemExit(status) : runtime.newSystemExit(status, message);
-            runtime.getCurrentContext().setErrorInfo(ex.getException()); // set $! (accessible in at_exit blocks)
+            runtime.getCurrentContext().setErrorInfo(ex.getException()); // set $! (in case Kernel.exit called from at_exit)
             throw ex;
         }
     }

--- a/core/src/main/java/org/jruby/exceptions/RaiseException.java
+++ b/core/src/main/java/org/jruby/exceptions/RaiseException.java
@@ -200,7 +200,6 @@ public class RaiseException extends JumpException {
         context.runtime.incrementExceptionCount();
         if (RubyInstanceConfig.LOG_EXCEPTIONS) TraceType.logException(exception);
 
-        doSetLastError(context);
         doCallEventHook(context);
 
         if (backtrace == null) {
@@ -263,10 +262,6 @@ public class RaiseException extends JumpException {
         if (context.runtime.hasEventHooks()) {
             context.runtime.callEventHooks(context, RubyEvent.RAISE, context.getFile(), context.getLine(), context.getFrameName(), context.getFrameKlazz());
         }
-    }
-
-    private void doSetLastError(final ThreadContext context) {
-        context.setErrorInfo(exception); // $!
     }
 
     /**

--- a/core/src/main/java/org/jruby/internal/runtime/GlobalVariable.java
+++ b/core/src/main/java/org/jruby/internal/runtime/GlobalVariable.java
@@ -31,6 +31,7 @@
 package org.jruby.internal.runtime;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.jruby.Ruby;
 import org.jruby.RubyProc;
@@ -72,13 +73,13 @@ public final class GlobalVariable {
         return scope;
     }
 
-    public ArrayList getTraces() {
+    public List<IRubyObject> getTraces() {
         return traces;
     }
 
     public void addTrace(RubyProc command) {
         if (traces == null) {
-            traces = new ArrayList<IRubyObject>();
+            traces = new ArrayList<>(2);
         }
         traces.add(command);
     }

--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -2885,9 +2885,9 @@ public class IRBuilder {
 
         // Now emit the ensure body's stashed instructions
         if (ensureNode != null) {
-            Variable exc2 = createTemporaryVariable();
-            addInstr(new ReceiveRubyExceptionInstr(exc2));
-            addInstr(new RestoreErrorInfoInstr(exc2));
+//            Variable exc2 = createTemporaryVariable();
+//            addInstr(new ReceiveRubyExceptionInstr(exc2));
+//            addInstr(new RestoreErrorInfoInstr(exc2));
             ebi.emitBody(this);
         }
 

--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -2840,9 +2840,7 @@ public class IRBuilder {
 
         // Record $! save var if we had a non-empty rescue node.
         // $! will be restored from it where required.
-        if (ensureBodyNode instanceof RescueNode) {
-            ebi.savedGlobalException = savedGlobalException;
-        }
+        ebi.savedGlobalException = savedGlobalException;
 
         ensureBodyBuildStack.push(ebi);
         Operand ensureRetVal = ensureNode == null ? manager.getNil() : build(ensureNode);
@@ -2887,6 +2885,9 @@ public class IRBuilder {
 
         // Now emit the ensure body's stashed instructions
         if (ensureNode != null) {
+            Variable exc2 = createTemporaryVariable();
+            addInstr(new ReceiveRubyExceptionInstr(exc2));
+            addInstr(new RestoreErrorInfoInstr(exc2));
             ebi.emitBody(this);
         }
 

--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -2839,7 +2839,7 @@ public class IRBuilder {
 
         // Record $! save var if we had a non-empty rescue node.
         // $! will be restored from it where required.
-        ebi.savedGlobalException = savedGlobalException;
+        if (ensureBodyNode instanceof RescueNode) ebi.savedGlobalException = savedGlobalException;
 
         ensureBodyBuildStack.push(ebi);
         Operand ensureRetVal = ensureNode == null ? manager.getNil() : build(ensureNode);
@@ -2884,8 +2884,6 @@ public class IRBuilder {
 
         // Now emit the ensure body's stashed instructions
         if (ensureNode != null) {
-            //Variable exc2 = createTemporaryVariable();
-            //addInstr(new ReceiveRubyExceptionInstr(exc2));
             addInstr(new RestoreErrorInfoInstr(exc));
             addInstr(new LabelInstr(ebi.start));
             ebi.emitBody(this);

--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -222,7 +222,6 @@ public class IRBuilder {
         }
 
         public void emitBody(IRBuilder b) {
-            b.addInstr(new LabelInstr(start));
             for (Instr i: instrs) {
                 b.addInstr(i);
             }
@@ -2885,9 +2884,10 @@ public class IRBuilder {
 
         // Now emit the ensure body's stashed instructions
         if (ensureNode != null) {
-//            Variable exc2 = createTemporaryVariable();
-//            addInstr(new ReceiveRubyExceptionInstr(exc2));
-//            addInstr(new RestoreErrorInfoInstr(exc2));
+            //Variable exc2 = createTemporaryVariable();
+            //addInstr(new ReceiveRubyExceptionInstr(exc2));
+            addInstr(new RestoreErrorInfoInstr(exc));
+            addInstr(new LabelInstr(ebi.start));
             ebi.emitBody(this);
         }
 

--- a/core/src/main/java/org/jruby/ir/instructions/ThrowExceptionInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ThrowExceptionInstr.java
@@ -47,11 +47,11 @@ public class ThrowExceptionInstr extends OneOperandInstr implements FixedArityIn
 
         Object excObj = getException().retrieve(context, self, currScope, currDynScope, temp);
 
-        if (excObj instanceof IRubyObject) {
-            RubyKernel.raise(context, context.runtime.getKernel(), new IRubyObject[] {(IRubyObject)excObj}, Block.NULL_BLOCK);
-        } else if (excObj instanceof Throwable) { // java exception -- avoid having to add 'throws' clause everywhere!
-            Helpers.throwException((Throwable)excObj);
+        if (excObj instanceof Throwable) {
+            excObj = Helpers.wrapJavaException(context.runtime, (Throwable) excObj); // IRubyObject
         }
+
+        RubyKernel.raise(context, self, new IRubyObject[] {(IRubyObject) excObj}, Block.NULL_BLOCK);
 
         // should never get here
         throw new RuntimeException("Control shouldn't have reached here in ThrowEx");

--- a/core/src/main/java/org/jruby/ir/instructions/ThrowExceptionInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ThrowExceptionInstr.java
@@ -54,7 +54,7 @@ public class ThrowExceptionInstr extends OneOperandInstr implements FixedArityIn
         RubyKernel.raise(context, self, new IRubyObject[] {(IRubyObject) excObj}, Block.NULL_BLOCK);
 
         // should never get here
-        throw new RuntimeException("Control shouldn't have reached here in ThrowEx");
+        throw new AssertionError("Control shouldn't have reached here in ThrowEx");
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/defined/RestoreErrorInfoInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/defined/RestoreErrorInfoInstr.java
@@ -8,6 +8,7 @@ import org.jruby.ir.instructions.OneOperandInstr;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.persistence.IRReaderDecoder;
 import org.jruby.ir.persistence.IRWriterEncoder;
+import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.DynamicScope;
@@ -40,7 +41,7 @@ public class RestoreErrorInfoInstr extends OneOperandInstr implements FixedArity
 
     @Override
     public Object interpret(ThreadContext context, StaticScope currScope, DynamicScope currDynScope, IRubyObject self, Object[] temp) {
-        context.setErrorInfo((IRubyObject) getArg().retrieve(context, self, currScope, currDynScope, temp));
+        IRRuntimeHelpers.setErrorInfoGlobalVariable(context, getArg().retrieve(context, self, currScope, currDynScope, temp));
 
         return null;
     }

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -31,6 +31,7 @@ import org.jruby.RubyRegexp;
 import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.jruby.common.IRubyWarnings;
+import org.jruby.exceptions.JumpException;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.Unrescuable;
 import org.jruby.ext.coverage.CoverageData;
@@ -448,10 +449,15 @@ public class IRRuntimeHelpers {
 
     @JIT
     public static void setErrorInfoGlobalVariable(ThreadContext context, Object exception) {
-        if (exception instanceof Throwable) {
+        if (exception instanceof RaiseException) {
+            exception = ((RaiseException) exception).getException();
+        } else if (exception instanceof Throwable && !(exception instanceof JumpException)) {
             exception = Helpers.wrapJavaException(context.runtime, (Throwable) exception);
         }
-        setErrorInfoGlobalVariable(context, (IRubyObject) exception);
+
+        if (exception instanceof IRubyObject) {
+            setErrorInfoGlobalVariable(context, (IRubyObject) exception);
+        }
     }
 
     public static void setErrorInfoGlobalVariable(ThreadContext context, IRubyObject exception) {

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -446,6 +446,14 @@ public class IRRuntimeHelpers {
         return false;
     }
 
+    @JIT
+    public static void setErrorInfoGlobalVariable(ThreadContext context, Object exception) {
+        if (exception instanceof Throwable) {
+            exception = Helpers.wrapJavaException(context.runtime, (Throwable) exception);
+        }
+        setErrorInfoGlobalVariable(context, (IRubyObject) exception);
+    }
+
     public static void setErrorInfoGlobalVariable(ThreadContext context, IRubyObject exception) {
         context.runtime.getGlobalVariables().set("$!", exception);
     }

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -2467,7 +2467,8 @@ public class JVMVisitor extends IRVisitor {
     public void RestoreErrorInfoInstr(RestoreErrorInfoInstr restoreerrorinfoinstr) {
         jvmMethod().loadContext();
         visit(restoreerrorinfoinstr.getArg());
-        jvmAdapter().invokevirtual(p(ThreadContext.class), "setErrorInfo", sig(IRubyObject.class, IRubyObject.class));
+        // jvmAdapter().invokevirtual(p(ThreadContext.class), "setErrorInfo", sig(IRubyObject.class, IRubyObject.class));
+        jvmAdapter().invokestatic(p(IRRuntimeHelpers.class), "setErrorInfoGlobalVariable", sig(Void.TYPE, ThreadContext.class, Object.class));
         jvmAdapter().pop();
     }
 

--- a/core/src/test/java/org/jruby/exceptions/TestRaiseException.java
+++ b/core/src/test/java/org/jruby/exceptions/TestRaiseException.java
@@ -406,6 +406,22 @@ public class TestRaiseException extends Base {
         }
     }
 
+    public void testPreviousRaisedNotConsideredCause() {
+        try {
+            runtime.evalScriptlet("raise 'foo'");
+            fail("expected to throw");
+        } catch (StandardError ex1) {
+            assertNull("ex1 has a cause", ex1.getCause());
+        }
+
+        try {
+            runtime.evalScriptlet("raise 'bar'");
+            fail("expected to throw");
+        } catch (StandardError ex2) {
+            assertNull("ex2 has a cause: " + ex2.getCause(), ex2.getCause());
+        }
+    }
+
     private static String printStackTrace(final Throwable ex) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ex.printStackTrace(new PrintStream(baos));

--- a/test/jruby/test_exception.rb
+++ b/test/jruby/test_exception.rb
@@ -125,4 +125,36 @@ class TestException < Test::Unit::TestCase
     assert_nil $!
   end
 
+  def test_exception_rescue_java(previous_error = nil)
+    begin
+      raise java.lang.IllegalStateException.new('from java')
+    rescue
+      assert_equal "from java", $!.message
+    ensure
+      assert_same previous_error, $!
+    end
+    assert_same previous_error, $!
+
+    begin
+      java.util.ArrayList.new.get(1)
+      raise 'foo'
+    rescue RuntimeError
+      fail 'should not rescue here' if $!
+    rescue java.lang.RuntimeException
+      assert_instance_of java.lang.IndexOutOfBoundsException, $!
+    end
+    assert_same previous_error, $!
+
+    begin
+      begin
+        java.util.ArrayList.new.addAll(nil)
+      ensure
+        assert_instance_of java.lang.NullPointerException, $!
+      end
+    rescue java.lang.NullPointerException
+      # pass
+    end
+    assert_same previous_error, $!
+  end if defined? JRUBY_VERSION
+
 end

--- a/test/jruby/test_exception.rb
+++ b/test/jruby/test_exception.rb
@@ -2,8 +2,10 @@ require 'test/unit'
 
 class TestException < Test::Unit::TestCase
 
+  class AnError < RuntimeError; end
+
   def raise_an_error
-    raise "an error"
+    raise AnError
   end
 
   def rescue_an_error
@@ -41,4 +43,86 @@ class TestException < Test::Unit::TestCase
       assert_equal(e.cause.cause.message, "error 1")
     end
   end
+
+  def test_exception_no_rescue_ensure
+    begin
+      raise_no_rescue_and_ensure!
+    rescue NotImplementedError
+      # pass
+    end
+    assert_nil $!
+  end
+
+  def raise_no_rescue_and_ensure!
+    begin
+      raise NotImplementedError
+    rescue
+      fail 'not expected'
+    ensure
+      assert_instance_of NotImplementedError, $!
+    end
+    assert_nil $!
+  end
+
+  def test_exception_rescue(previous_error = nil)
+    begin
+      raise TypeError, "duck"
+    rescue
+      assert_equal "duck", $!.message
+    ensure
+      assert_same previous_error, $!
+    end
+    assert_same previous_error, $!
+
+    begin
+      raise 'foo'
+    rescue TypeError
+      fail 'should not rescue here' if $!
+    rescue RuntimeError
+      assert_instance_of RuntimeError, $!
+    end
+    assert_same previous_error, $!
+
+    begin
+      raise_an_error
+    rescue AnError
+      # pass
+    end
+    assert_same previous_error, $!
+  end
+
+  def test_exception_rescue_nested
+    begin
+      raise_no_rescue_and_ensure!
+    rescue NotImplementedError => e
+      test_exception_rescue(e)
+      assert_instance_of NotImplementedError, $!
+    end
+    assert_nil $!
+
+    begin
+      raise_no_rescue_and_ensure!
+    rescue NotImplementedError
+      test_exception_rescue $!
+      assert_instance_of NotImplementedError, $!
+    ensure
+      assert_nil $!
+    end
+    assert_nil $!
+
+    begin
+      begin
+        raise_no_rescue_and_ensure!
+      ensure
+        prev = $!
+        assert_instance_of NotImplementedError, $!
+        test_exception_rescue(prev)
+        assert_same prev, $!
+      end
+    rescue NotImplementedError
+      # pass
+    end
+    assert_nil $!
+  end
+
 end


### PR DESCRIPTION
**NOTE**: mostly an (unfinished) experiment, likely won't be shipped ...

For a long time JRuby did the `$!` assignment, as well as other logic such as executing a :raise trace, when `new RaiseException()` was called.

This worked but in most cases, at least the `$!` setting part, wasn't necessary.
There are IR instructions that handle setting/restoring `$!`.

- add extra `$!` setting due ensure blocks (rescue blocks already set `$!` - which was previously redundant)
- add trace instructions for `:raise` in IR
- one place `$!` still needs manual care is when `Kernel.exit` is called

~~Second part of the PR is making sure `$!` is correct in ensure, which JRuby seems to have been missing in terms of compatibility.~~

*initially this came up from https://github.com/jruby/jruby/issues/6972*