### PR TITLE
Merge 9.2 for JNR update and Symbol fix

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -43,11 +43,11 @@ project 'JRuby Base' do
 
   # exclude jnr-ffi to avoid problems with shading and relocation of the asm packages
   jar 'com.github.jnr:jnr-netdb:1.2.0', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-enxio:0.32.12', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-unixsocket:0.38.15', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-posix:3.1.14', :exclusions => ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-enxio:0.32.13', :exclusions => ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-unixsocket:0.38.16', :exclusions => ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-posix:3.1.15', :exclusions => ['com.github.jnr:jnr-ffi']
   jar 'com.github.jnr:jnr-constants:0.10.3', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-ffi:2.2.10'
+  jar 'com.github.jnr:jnr-ffi:2.2.11'
   jar 'com.github.jnr:jffi:${jffi.version}'
   jar 'com.github.jnr:jffi:${jffi.version}:native'
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -90,7 +90,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-enxio</artifactId>
-      <version>0.32.12</version>
+      <version>0.32.13</version>
       <exclusions>
         <exclusion>
           <artifactId>jnr-ffi</artifactId>
@@ -101,7 +101,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-unixsocket</artifactId>
-      <version>0.38.15</version>
+      <version>0.38.16</version>
       <exclusions>
         <exclusion>
           <artifactId>jnr-ffi</artifactId>
@@ -112,7 +112,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
-      <version>3.1.14</version>
+      <version>3.1.15</version>
       <exclusions>
         <exclusion>
           <artifactId>jnr-ffi</artifactId>
@@ -134,7 +134,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-ffi</artifactId>
-      <version>2.2.10</version>
+      <version>2.2.11</version>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>

--- a/core/src/main/java/org/jruby/ir/operands/Symbol.java
+++ b/core/src/main/java/org/jruby/ir/operands/Symbol.java
@@ -1,6 +1,7 @@
 package org.jruby.ir.operands;
 
 import org.jcodings.Encoding;
+import org.jcodings.specific.UTF8Encoding;
 import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.jruby.ir.IRVisitor;
@@ -29,6 +30,8 @@ public class Symbol extends ImmutableLiteral implements Stringable {
     }
 
     public ByteList getBytes() {
+        if (symbol == null) return ByteList.EMPTY_BYTELIST;
+
         return symbol.getBytes();
     }
 
@@ -49,6 +52,8 @@ public class Symbol extends ImmutableLiteral implements Stringable {
     }
 
     public Encoding getEncoding() {
+        if (symbol == null) return UTF8Encoding.INSTANCE;
+
         return symbol.getEncoding();
     }
 

--- a/pom.rb
+++ b/pom.rb
@@ -72,7 +72,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
               'ant.version' => '1.9.8',
               'asm.version' => '9.2',
               'jar-dependencies.version' => '0.4.1',
-              'jffi.version' => '1.3.8',
+              'jffi.version' => '1.3.9',
               'joda.time.version' => '2.10.10' )
 
   plugin_management do

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ DO NOT MODIFIY - GENERATED CODE
     <its.j2ee>j2ee*/pom.xml</its.j2ee>
     <its.osgi>osgi*/pom.xml</its.osgi>
     <jar-dependencies.version>0.4.1</jar-dependencies.version>
-    <jffi.version>1.3.8</jffi.version>
+    <jffi.version>1.3.9</jffi.version>
     <joda.time.version>2.10.10</joda.time.version>
     <jruby-launcher.version>1.1.6</jruby-launcher.version>
     <jruby.basedir>${project.basedir}</jruby.basedir>


### PR DESCRIPTION
Pulls in recent work on variadic function calls to improve support for Apple Silicon plus an unmerged Symbol operand fix from 9.2.

* #6978
* https://github.com/jnr/jffi/pull/121
* https://github.com/jnr/jnr-ffi/pull/292
* https://github.com/jnr/jnr-posix/pull/174