### PR TITLE
Fixes #6993.  Evals cause memory leak.

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRScope.java
+++ b/core/src/main/java/org/jruby/ir/IRScope.java
@@ -182,7 +182,12 @@ public abstract class IRScope implements ParseResult {
     }
 
     private void setupLexicalContainment() {
-        if (lexicalParent != null) lexicalParent.addChildScope(this);
+        // evals are transient and are not usable in persistance or analysis (unless
+        // the analysis was for the eval itself but in that case we would do this
+        // differently).
+        if (!(this instanceof IREvalScript)) {
+            if (lexicalParent != null) lexicalParent.addChildScope(this);
+        }
     }
 
     public int getScopeId() {
@@ -493,7 +498,7 @@ public abstract class IRScope implements ParseResult {
 
         boolean usesEval = usesEval();
 
-        for (IRScope child : getLexicalScopes()) {
+        for (IRScope child : getClosures()) {
             usesEval |= child.anyUsesEval();
         }
 


### PR DESCRIPTION
This makes two changes.  The first is to not record evals
as lexical children.  In IR we actually only use lexical
children for IR persistence (and AOT compilation).  We would
never persist a live eval instance.

This leads to the second change.  anyUsesEval was using lexicalChildren
to detect for evals when trying to perform AOT compilation (which we
do not allow).  This is better served by getClosures as we really
only care about "soft" scopes containing an eval (e.g. we don't
care if a method contains and eval if we are trying to AOT a module
scope (hard scope change) but we do care about a closure in a method
containing an eval (soft scope change)).