### PR TITLE
Do not cache non-"once" dregexp

### DIFF
--- a/core/src/main/java/org/jruby/ir/instructions/BuildDynRegExpInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/BuildDynRegExpInstr.java
@@ -106,17 +106,33 @@ public class BuildDynRegExpInstr extends NOperandResultBaseInstr {
 
     @Override
     public Object interpret(ThreadContext context, StaticScope currScope, DynamicScope currDynScope, IRubyObject self, Object[] temp) {
+        boolean once = options.isOnce();
+
         // FIXME (from RegexpNode.java): 1.9 should care about internal or external encoding and not kcode.
         // If we have a constant regexp string or if the regexp patterns asks for caching, cache the regexp
-        if (reCache.rubyRegexp == null || !options.isOnce() || context.runtime.getKCode() != reCache.rubyRegexp.getKCode()) {
-            RubyString[] pieces  = retrievePieces(context, self, currScope, currDynScope, temp);
-            RubyString   pattern = RubyRegexp.preprocessDRegexp(context, options, pieces);
-            RubyRegexp re = RubyRegexp.newDRegexp(context.runtime, pattern, options);
-            re.setLiteral();
+        if (
+                !once ||
+                 reCache.rubyRegexp == null ||
+                 context.runtime.getKCode() != reCache.rubyRegexp.getKCode()) {
+            
+            RubyRegexp re = buildRegexp(context, currScope, currDynScope, self, temp);
+
+            if (!once) {
+                return re;
+            }
+
             reCache.updateCache(options.isOnce(), re);
         }
 
         return reCache.rubyRegexp;
+    }
+
+    private RubyRegexp buildRegexp(ThreadContext context, StaticScope currScope, DynamicScope currDynScope, IRubyObject self, Object[] temp) {
+        RubyString[] pieces  = retrievePieces(context, self, currScope, currDynScope, temp);
+        RubyString   pattern = RubyRegexp.preprocessDRegexp(context, options, pieces);
+        RubyRegexp re = RubyRegexp.newDRegexp(context.runtime, pattern, options);
+        re.setLiteral();
+        return re;
     }
 
     @Override


### PR DESCRIPTION
The cache here serves as a cache for dynamic "once" regexps but
is also being used as the holder for non-"once" regexp. This leads
to a concurrency issue since a single field in this instruction is
used across threads and they may step on each other.

This patch avoids using the shared field for non-"once" dynamic
regexps. As a side effect, these instruction instances will not
be queriable for their last-built RubyRegexp, which also seems
appropriate if they are not a "once" dregexp.

Fixes #6992