### PR TITLE
fix ArithmeticSequence#inspect

### DIFF
--- a/core/src/main/java/org/jruby/RubyArithmeticSequence.java
+++ b/core/src/main/java/org/jruby/RubyArithmeticSequence.java
@@ -393,10 +393,12 @@ public class RubyArithmeticSequence extends RubyObject {
                     }
                 }
 
+                int counter = 0;
                 while (argc > 0) {
-                    str.append(RubyObject.inspect(context, args[args.length - argc]).getByteList());
+                    str.append(RubyObject.inspect(context, args[counter]).getByteList());
                     str.append(',').append(' ');
-                    --argc;
+                    argc--;
+                    counter++;
                 }
                 
                 if (!kwds.isNil()) {

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -652,7 +652,7 @@ public class RubyRange extends RubyObject {
 
     @JRubyMethod(name = "step")
     public IRubyObject step(final ThreadContext context, final Block block) {
-        return block.isGiven() ? stepCommon(context, RubyFixnum.one(context.runtime), block) : step(context, context.runtime.newFixnum(1), block);
+        return block.isGiven() ? stepCommon(context, RubyFixnum.one(context.runtime), block) : step(context, context.runtime.getNil(), block);
     }
 
     @JRubyMethod(name = "step")
@@ -683,12 +683,8 @@ public class RubyRange extends RubyObject {
     private IRubyObject stepEnumeratorize(ThreadContext context, IRubyObject step, String method) {
         if ((begin instanceof RubyNumeric && (end.isNil() || end instanceof RubyNumeric)) ||
                 (end instanceof RubyNumeric && (begin.isNil() || end instanceof RubyNumeric))){
-            
-            if (!(step instanceof RubyNumeric)) {
-                step = step.convertToInteger();
-            }
 
-            if (((RubyNumeric) step).isZero()) {
+            if ((step instanceof RubyNumeric) && ((RubyNumeric) step).isZero()) {
                 throw context.runtime.newArgumentError("step can't be 0");
             }
 


### PR DESCRIPTION
This commit makes the following tests pass.
 * spec/ruby/core/enumerator/arithmetic_sequence/inspect_spec.rb
 * test_num_step_inspect and test_range_step_inspect in test/mri/ruby/test_arithmetic_sequence.rb