### PR TITLE
fix ArithmeticSequence#first when begin param is nil.

### DIFF
--- a/core/src/main/java/org/jruby/RubyArithmeticSequence.java
+++ b/core/src/main/java/org/jruby/RubyArithmeticSequence.java
@@ -176,6 +176,9 @@ public class RubyArithmeticSequence extends RubyObject {
         boolean x;
 
         if (num == null) {
+            if (b.isNil()) {
+                return context.nil;
+            }
             if (!e.isNil()) {
                 IRubyObject zero = int2fix(runtime, 0);
                 CallSite op_cmp = sites(context).op_cmp;


### PR DESCRIPTION
This commit makes the following test pass.
 * test_first in test/mri/ruby/test_arithmetic_sequence.rb