### PR TITLE
Fix a warning when loading date.rb

### DIFF
--- a/lib/ruby/stdlib/date.rb
+++ b/lib/ruby/stdlib/date.rb
@@ -425,7 +425,7 @@ class Date
   end
   private_class_method :valid_date_frags?
 
-  def self.valid_time_frags? (elem) # :nodoc:
+  def self.valid_time_frags?(elem) # :nodoc:
     h, min, s = elem.values_at(:hour, :min, :sec)
     _valid_time?(h, min, s)
   end


### PR DESCRIPTION
`jruby -v`: jruby 9.4.0.0-SNAPSHOT (3.1.0) 2022-01-15 a0b853cb09 OpenJDK 64-Bit Server VM 11.0.13+8-Ubuntu-0ubuntu1.21.10 on 11.0.13+8-Ubuntu-0ubuntu1.21.10 +jit [linux-x86_64]

Running `require 'date'` with jruby head results in a warning:

```
jruby -e 'require "date"'
```

> /tmp/jruby/stdlib/rubygems/core_ext/kernel_require.rb:85: warning: parentheses after method name is interpreted as an argument list, not a decomposed argument

The warning is caused by the space before the parenthesis in the definition of `self.valid_time_frags?`. This pull request removes the space.