### PR TITLE
Module check mishandles bash operator precedence

### DIFF
--- a/bin/jruby.bash
+++ b/bin/jruby.bash
@@ -213,8 +213,8 @@ else
   fi
 fi
 
-# Detect modularized Java
-if [ -f "$JAVA_HOME"/lib/modules ] || [ -f "$JAVA_HOME"/release ] && grep -q ^MODULES "$JAVA_HOME"/release; then
+# Detect modularized Java if modules file is present or a MODULES line appears in release
+if [ -f "$JAVA_HOME"/lib/modules ] || ([ -f "$JAVA_HOME"/release ] && grep -q ^MODULES "$JAVA_HOME"/release); then
   use_modules=1
 fi
 


### PR DESCRIPTION
This fixes the issue described in #6789 where a nonexistent `release` file gets grepped even though we do an existence check. The problem here is that in bash, unlike in C or Java, the `||` and `&&` operators have the same precedence, which means they will be evaluated from left to right. In the environment described by @lfiht in  #6789, where only the `modules` file exists, this leads to an error as the `grep` command tries to read the non-existent `release` file.