### PR TITLE
Java class reopened to add a super call should dispatch normally

### DIFF
--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -57,6 +57,7 @@ import org.jruby.java.proxies.JavaProxy;
 import org.jruby.javasupport.JavaMethod;
 import org.jruby.javasupport.proxy.JavaProxyClass;
 import org.jruby.javasupport.proxy.JavaProxyMethod;
+import org.jruby.javasupport.proxy.ReifiedJavaProxy;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.Arity;
 import org.jruby.runtime.Binding;
@@ -1237,15 +1238,20 @@ public class IRRuntimeHelpers {
 
         JavaMethod javaMethod = (JavaMethod) superMethod.findCallable(self, id, args, args.length);
 
-        // self is a Java subclass, need to do a bit more logic to dispatch the right method
-        JavaProxyClass jpc = JavaProxyClass.getProxyClass(context.runtime, definingModule);
-        JavaProxyMethod jpm;
         Object[] newArgs = RubyToJavaInvoker.convertArguments(javaMethod, args);
-        if ((jpm = jpc.getMethod(id, javaMethod.getParameterTypes())) != null && jpm.hasSuperImplementation()) {
-            return javaMethod.invokeDirectSuperWithExceptionHandling(context, jpm.getSuperMethod(), javaInvokee, newArgs);
-        } else {
-            return javaMethod.invokeDirectWithExceptionHandling(context, javaMethod.getValue(), javaInvokee, newArgs);
+
+        JavaProxyClass jpc = JavaProxyClass.getProxyClass(context.runtime, definingModule);
+
+        if (jpc != null) {
+            // self is a Java subclass, need to do a bit more logic to dispatch the right method
+            JavaProxyMethod jpm = jpc.getMethod(id, javaMethod.getParameterTypes());
+
+            if (jpm != null && jpm.hasSuperImplementation()) {
+                return javaMethod.invokeDirectSuperWithExceptionHandling(context, jpm.getSuperMethod(), javaInvokee, newArgs);
+            }
         }
+
+        return javaMethod.invokeDirectWithExceptionHandling(context, javaMethod.getValue(), javaInvokee, newArgs);
     }
 
     @Interp

--- a/spec/java_integration/fixtures/ClassWithSimpleMethod.java
+++ b/spec/java_integration/fixtures/ClassWithSimpleMethod.java
@@ -1,0 +1,12 @@
+package java_integration.fixtures;
+
+/**
+ * Reopened Java subclasses should super normally into the parent class, not using reified subclass logic.
+ *
+ * See jruby/jruby#6968
+ */
+public class ClassWithSimpleMethod {
+    public String foo(String s) {
+        return "foo" + s;
+    }
+}

--- a/spec/java_integration/fixtures/SubclassOfClassWithSimpleMethod.java
+++ b/spec/java_integration/fixtures/SubclassOfClassWithSimpleMethod.java
@@ -1,0 +1,12 @@
+package java_integration.fixtures;
+
+/**
+ * Reopened Java subclasses should super normally into the parent class, not using reified subclass logic.
+ *
+ * See jruby/jruby#6968
+ */
+public class SubclassOfClassWithSimpleMethod extends ClassWithSimpleMethod {
+    public String foo(String s) {
+        return "foo" + s;
+    }
+}

--- a/spec/java_integration/methods/dispatch_spec.rb
+++ b/spec/java_integration/methods/dispatch_spec.rb
@@ -4,6 +4,7 @@ java_import "java_integration.fixtures.ClassWithVarargs"
 java_import "java_integration.fixtures.ClassWithPrimitiveVarargs"
 java_import "java_integration.fixtures.CoreTypeMethods"
 java_import "java_integration.fixtures.StaticMethodSelection"
+java_import "java_integration.fixtures.SubclassOfClassWithSimpleMethod"
 java_import "java_integration.fixtures.UsesSingleMethodInterface"
 
 describe "Non-overloaded static Java methods" do
@@ -446,5 +447,20 @@ if TestHelper::JAVA_9
         end.not_to raise_error
       end
     end
+  end
+end
+
+# Reopened Java subclasses should super normally into the parent class, not using reified subclass logic.
+# See jruby/jruby#6968
+describe "A normal Java class reopened to call a super method on its Java parent class" do
+  class SubclassOfClassWithSimpleMethod
+    def foo(s)
+      super(s + 'baz')
+    end
+  end
+
+  it 'calls method defined in Java superclass of reopened class with super()' do
+    obj = SubclassOfClassWithSimpleMethod.new
+    expect(obj.foo('bar')).to eq('foobarbaz')
   end
 end


### PR DESCRIPTION
The logic here was falling into the reified Ruby < Java subclass logic when trying to super out of a reopened normal Java class. When in such a situation, we should detect that we are not in a Ruby subclass of a Java class and not try to use that logic, which depends on additional structures not present on normal proxied Java classes

Fixes #6968.