### PR TITLE
Add rubyspec back to M1 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     
     strategy:
       matrix:
-        target: ['spec:ffi']
+        target: ['spec:ffi', 'spec:ruby:fast']
         java-version: ['11']
       fail-fast: false
 


### PR DESCRIPTION
Now that the merge mess has been fixed (CI was running against gha_on_m1 merged to master, rather than 9.3) we will try this job again.