### PR TITLE
Allow reified classes to store instance variables in raw fields

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/util/JavaClassConfiguration.java
+++ b/core/src/main/java/org/jruby/javasupport/util/JavaClassConfiguration.java
@@ -50,6 +50,7 @@ public class JavaClassConfiguration implements Cloneable {
     public Map<Class<?>, Map<String, Object>> classAnnotations;
     public Map<String, List<Class<?>[]>> methodSignatures;
     public Map<String, Class<?>> fieldSignatures;
+    public List<DirectFieldConfiguration> requestedStorageVariables; // Variable to map to fields if we are ever reified
 
     public boolean callInitialize = true;
     public boolean allMethods = true;
@@ -93,6 +94,7 @@ public class JavaClassConfiguration implements Cloneable {
         if (classAnnotations != null) other.classAnnotations = new HashMap<>(classAnnotations); // TOOD: deep clone
         if (methodSignatures != null) other.methodSignatures = new HashMap<>(methodSignatures); // TOOD: deep clone
         if (fieldSignatures != null) other.fieldSignatures = new HashMap<>(fieldSignatures); // TOOD: deep clone
+        if (requestedStorageVariables != null) other.requestedStorageVariables = new ArrayList<>(requestedStorageVariables);
 
         return other;
     }
@@ -123,5 +125,19 @@ public class JavaClassConfiguration implements Cloneable {
 
         included.add(name);
         excluded.remove(name);
+    }
+    
+    public static class DirectFieldConfiguration {
+        public String name;
+        public Class<?> fieldType;
+        public Boolean unwrap;
+        public Class<?> unwrapType;
+        public DirectFieldConfiguration(String name, Class<?> fieldType, Boolean unwrap, Class<?> unwrapType) {
+            this.name = name;
+            this.fieldType = fieldType;
+            this.unwrap = unwrap;
+            this.unwrapType = unwrapType;
+        }
+        
     }
 }

--- a/core/src/main/java/org/jruby/runtime/ivars/FieldVariableAccessor.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/FieldVariableAccessor.java
@@ -58,11 +58,12 @@ public class FieldVariableAccessor extends VariableAccessor {
         super(realClass, name, index, classId);
 
         this.getter = getter;
+        this.setter = wrapSetter(setter);
+    }
 
+    protected MethodHandle wrapSetter(MethodHandle setter) {
         // mix frozen check into setter
-        setter = MethodHandles.foldArguments(setter, ENSURE_SETTABLE.asType(setter.type()));
-        
-        this.setter = setter;
+        return MethodHandles.foldArguments(setter, ENSURE_SETTABLE.asType(setter.type()));
     }
 
     public MethodHandle getGetter() {

--- a/core/src/main/java/org/jruby/runtime/ivars/RawFieldVariableAccessor.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/RawFieldVariableAccessor.java
@@ -1,0 +1,198 @@
+/*
+ ***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ * 
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby.runtime.ivars;
+
+import com.headius.invokebinder.Binder;
+
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.java.proxies.ConcreteJavaProxy;
+import org.jruby.javasupport.JavaUtil;
+import org.jruby.runtime.Helpers;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.specialized.RubyObjectSpecializer;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+
+/**
+ * A variable accessor that accesses a reified java field directly (Storing java objects that may not be IRubyObjects
+ */
+public class RawFieldVariableAccessor extends FieldVariableAccessor {
+    /**
+     * Construct a new RawFieldVariableAccessor for the given "real" class,
+     * variable name, variable index, class ID, and field offset
+     * 
+     * @param realClass the "real" class
+     * @param unwrapInSet if the setter should unwrap ruby objects for java use use
+     * @param toJava the variable's java type
+     * @param name the variable's name
+     * @param index the variable's index
+     * @param classId the class's ID
+     * @param getter the getter handle for the field
+     * @param setter the setter handle for the field
+     */
+    public RawFieldVariableAccessor(RubyClass realClass, boolean unwrapInSet, Class<?> toJava, Class<?> returnType, String name, int index, int classId, MethodHandle getter, MethodHandle setter) {
+        super(realClass, name, index, classId, wrapGetter(getter, realClass, returnType), wrapSetter(setter, realClass, unwrapInSet, toJava, returnType));
+
+    }
+    
+    @Override
+    protected MethodHandle wrapSetter(MethodHandle setter) {
+
+        // using java_field + ivar storage is an advanced use of jruby for integrating with the jvm more tightly.
+        // JVM semantics take precedence over ruby semantics in such usage
+        
+        // reified concrete classes are never frozen, though non-concrete are. However, we can't freeze fields, and to prevent more 
+        // nonsense like @foo= throwing and self.foo= not throwing, when you configure this accessor we use JVM semantics instead of Ruby semantics
+        
+        return setter; // no frozen check
+    }
+    
+    protected static MethodHandle wrapSetter(MethodHandle setter, RubyClass realClass,boolean unwrap, Class<?> toJava, Class<?> basetype)
+    {
+        // this method is simple, but we must repeat almost everthing 3 times because the arguments change each configuration for the setters
+        try {
+            // accepts objects, yay, just need to check if we are proxied
+            if (!unwrap)
+            {
+                if (realClass.getIsReifiedExtendedJavaClass() == Boolean.TRUE)
+                {
+                    MethodHandle cjpUnwrap = Binder
+                            .from(realClass.getReifiedClass(), ConcreteJavaProxy.class, Object.class)
+                            .dropLast()
+                            .cast(Object.class, ConcreteJavaProxy.class)
+                            .invokeVirtual(RubyObjectSpecializer.LOOKUP, "unwrap");
+                    MethodHandle wrapperSetter = 
+                            Binder
+                            .from(Object.class, realClass.getReifiedClass(), ConcreteJavaProxy.class, Object.class)
+                            .permute(0,2)
+                            .cast(void.class, realClass.getReifiedClass(), basetype)
+                            .invoke(setter);
+                    MethodHandle temp = MethodHandles.foldArguments(wrapperSetter, cjpUnwrap);
+                    return temp;
+                }
+                else
+                return setter;
+            }
+            // have to unwrap the type for java
+            else
+            {
+                // check if we are proxied
+                if (realClass.getIsReifiedExtendedJavaClass() == Boolean.TRUE)
+                {
+                    // we are given a ConcreteJavaProxy, must unwrap first
+                    MethodHandle cjpUnwrap = Binder
+                            .from(realClass.getReifiedClass(), ConcreteJavaProxy.class, Object.class)
+                            .dropLast()
+                            .cast(Object.class, ConcreteJavaProxy.class)
+                            .invokeVirtual(RubyObjectSpecializer.LOOKUP, "unwrap");
+    
+                    MethodHandle wrapperSetConvert = 
+                            Binder
+                            .from(Object.class, realClass.getReifiedClass(), ConcreteJavaProxy.class, Object.class)
+                            .dropFirst(2)
+                            .cast(Object.class, IRubyObject.class)
+                            .insert(1, toJava)
+                            .invokeVirtual(RubyObjectSpecializer.LOOKUP, "toJava");
+                    
+                    MethodHandle wrapperSetter = 
+                            Binder
+                            .from(Object.class, Object.class, realClass.getReifiedClass(), ConcreteJavaProxy.class, Object.class)
+                            .permute(1,0)
+                            .cast(void.class, realClass.getReifiedClass(), basetype)
+                            .invoke(setter);
+    
+                    MethodHandle temp = MethodHandles.foldArguments(wrapperSetter, wrapperSetConvert);
+                    temp = MethodHandles.foldArguments(temp, cjpUnwrap);
+                    return temp;
+                }
+                else
+                {
+    
+                    MethodHandle wrapperSetConvert = 
+                            Binder
+                            .from(Object.class, realClass.getReifiedClass(), Object.class)
+                            .dropFirst()
+                            .cast(Object.class, IRubyObject.class)
+                            .insert(1, toJava)
+                            .invokeVirtual(RubyObjectSpecializer.LOOKUP, "toJava");
+                    
+                    MethodHandle wrapperSetter = 
+                            Binder
+                            .from(Object.class, Object.class, realClass.getReifiedClass(), Object.class)
+                            .permute(1,0)
+                            .cast(void.class, realClass.getReifiedClass(), basetype)
+                            .invoke(setter);
+    
+                    MethodHandle temp = MethodHandles.foldArguments(wrapperSetter, wrapperSetConvert);
+                    return temp;
+                }
+            }
+            
+        } catch (NoSuchMethodException |IllegalAccessException e) {
+            RaiseException r = Ruby.getGlobalRuntime().newRuntimeError("JRuby bug detected. Please file an issue if not already filed. Raw Field Accessor Setter gave errors: " + e.getMessage());
+            r.initCause(e);
+            throw r;
+        }
+    }
+    
+    protected static MethodHandle wrapGetter(MethodHandle getter, RubyClass realClass, Class<?> basetype) {
+
+        // getter much shorter as we dont need to juggle arguments
+        try {
+            MethodHandle wrapperGet = 
+                    Binder
+                    .from(IRubyObject.class, basetype)
+                    .cast(IRubyObject.class, Object.class)
+                    .insert(0, realClass.getRuntime())
+                    .invokeStatic(RubyObjectSpecializer.LOOKUP, JavaUtil.class, "convertJavaToUsableRubyObject");
+            
+            MethodHandle temp = MethodHandles.filterReturnValue(getter, wrapperGet);
+            
+            if (realClass.getIsReifiedExtendedJavaClass() == Boolean.TRUE)
+            {
+                // we are given a ConcreteJavaProxy, must unwrap first
+                MethodHandle cjpUnwrap = Binder
+                        .from(realClass.getReifiedClass(), Object.class)
+                        .cast(Object.class, ConcreteJavaProxy.class)
+                        .invokeVirtual(RubyObjectSpecializer.LOOKUP, "unwrap");
+    
+                temp = MethodHandles.filterReturnValue(cjpUnwrap, temp);
+            }
+        
+            return temp;
+            
+        } catch (NoSuchMethodException |IllegalAccessException e) {
+            RaiseException r = Ruby.getGlobalRuntime().newRuntimeError("JRuby bug detected. Please file an issue if not already filed. Raw Field Accessor getter gave errors: " + e.getMessage());
+            r.initCause(e);
+            throw r;
+        }
+    }
+}

--- a/core/src/main/java/org/jruby/runtime/ivars/VariableTableManager.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/VariableTableManager.java
@@ -31,15 +31,21 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.lang.invoke.MethodHandle;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.jruby.Ruby;
 import org.jruby.RubyBasicObject;
 import org.jruby.RubyClass;
+import org.jruby.java.codegen.Reified;
+import org.jruby.javasupport.util.JavaClassConfiguration;
+import org.jruby.javasupport.util.JavaClassConfiguration.DirectFieldConfiguration;
 import org.jruby.runtime.ObjectSpace;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.specialized.RubyObjectSpecializer;
 import org.jruby.util.ArraySupport;
 import org.jruby.util.cli.Options;
 import org.jruby.util.unsafe.UnsafeHolder;
@@ -169,6 +175,51 @@ public class VariableTableManager {
     }
 
     /**
+     * This is internal API, don't call this directly if you aren't in the JRuby codebase, it may change
+     * Request that the listed ivars (no @ in name) have field storage when we are reified
+     */
+    public synchronized void requestFieldStorage(String name, Class<?> fieldType,  Boolean unwrap, Class<?> toType) {
+        DirectFieldConfiguration config = new JavaClassConfiguration.DirectFieldConfiguration(name, fieldType, unwrap, toType);
+        if (realClass.getReifiedClass() != null)
+            requestFieldStorage(config);
+        else {
+            if (realClass.getClassConfig().requestedStorageVariables == null)
+                realClass.getClassConfig().requestedStorageVariables = new ArrayList<>();
+            realClass.getClassConfig().requestedStorageVariables.add(config);
+        }
+    }
+
+    /**
+     * Actually requests field storage for the ivar once we are reified
+     * This is internal API, don't call this directly if you aren't in the JRuby codebase, it may change
+     */
+    public void requestFieldStorage(DirectFieldConfiguration config) {
+        try {
+            Class<? extends Reified> reifiedClass = realClass.getReifiedClass();
+            Class<?> fieldType = reifiedClass.getField(config.name).getType();
+            if (fieldType != config.fieldType)
+                throw realClass.getClassRuntime().newTypeError("java_field " + config.name + " has incorrectly specified types for @ivar mapping");
+            
+            // by default, unwrap if it's not assignable to IRO
+            boolean unwrap = config.unwrap == null ? !fieldType.isAssignableFrom(IRubyObject.class) : config.unwrap.booleanValue();
+            Class<?> unwrapType = config.unwrapType == null ? fieldType : config.unwrapType;
+            if (unwrap && !fieldType.isAssignableFrom(unwrapType))
+                throw realClass.getClassRuntime().newTypeError("java_field " + config.name + " has incorrectly specified unwrap type for @ivar mapping: type is incompatible");
+            
+            getVariableAccessorForJavaMappedVar("@" + config.name,
+                    unwrap,
+                    fieldType,
+                    unwrapType,
+                    RubyObjectSpecializer.LOOKUP.findGetter(reifiedClass, config.name, fieldType),
+                    RubyObjectSpecializer.LOOKUP.findSetter(reifiedClass, config.name, fieldType));
+        } catch (NoSuchFieldException e) {
+            throw realClass.getClassRuntime().newNameError("java_field " + config.name + " was marked for @ivar mapping, but wasn't found (was the class reifed already?)", config.name);
+        } catch (IllegalAccessException e) {
+            throw realClass.getClassRuntime().newSecurityError("Error in accessing java_field " +config.name+ ": " + e.getMessage());
+        }
+    }
+
+    /**
      * Get the variable accessor for the given name with intent to use it for
      * writing.
      *
@@ -176,29 +227,26 @@ public class VariableTableManager {
      * @return an accessor appropriate for writing
      */
     public VariableAccessor getVariableAccessorForWrite(String name) {
-        VariableAccessor ivarAccessor = variableAccessors.get(name);
-        if (ivarAccessor == null) {
-
-            synchronized (realClass) {
-                Map<String, VariableAccessor> myVariableAccessors = variableAccessors;
-                ivarAccessor = myVariableAccessors.get(name);
-
-                if (ivarAccessor == null) {
-                    // allocate a new accessor and populate a new table
-                    ivarAccessor = allocateVariableAccessor(name);
-                    Map<String, VariableAccessor> newVariableAccessors = new HashMap<String, VariableAccessor>(myVariableAccessors.size() + 1);
-
-                    newVariableAccessors.putAll(myVariableAccessors);
-                    newVariableAccessors.put(name, ivarAccessor);
-
-                    variableAccessors = newVariableAccessors;
-                }
-            }
-        }
-        return ivarAccessor;
+        return getVariableAccessorWithBuilder(name, makeTableVariableAccessorBuilder(name));
     }
 
-    public VariableAccessor getVariableAccessorForVar(String name, MethodHandle getter, MethodHandle setter) {
+    public VariableAccessor getVariableAccessorForRubyVar(String name, MethodHandle getter, MethodHandle setter) {
+        return getVariableAccessorWithBuilder(name, makeRubyFieldAccessorBuilder(name, getter, setter));
+    }
+    
+    public VariableAccessor getVariableAccessorForJavaMappedVar(String name, boolean unwrap, Class<?> unwrapType, Class<?> fieldType, MethodHandle getter, MethodHandle setter) {
+        return getVariableAccessorWithBuilder(name, makeRawFieldAccessorBuilder(name, unwrap, unwrapType, fieldType, getter, setter));
+    }
+    
+    /**
+     * Get the variable accessor for the given name, or if it doesn't exist, create it 
+     * with the provided builder.
+     *
+     * @param name the name of the variable
+     * @param defaultAccessorBuilder a builder to use if the accessor doesn't exist yet
+     * @return an accessor
+     */
+    VariableAccessor getVariableAccessorWithBuilder(String name, Function<Integer, VariableAccessor> defaultAccessorBuilder) {
         VariableAccessor ivarAccessor = variableAccessors.get(name);
         if (ivarAccessor == null) {
 
@@ -208,7 +256,7 @@ public class VariableTableManager {
 
                 if (ivarAccessor == null) {
                     // allocate a new accessor and populate a new table
-                    ivarAccessor = allocateVariableAccessorForVar(name, getter, setter);
+                    ivarAccessor = allocateVariableAccessors(name, defaultAccessorBuilder);
                     Map<String, VariableAccessor> newVariableAccessors = new HashMap<String, VariableAccessor>(myVariableAccessors.size() + 1);
 
                     newVariableAccessors.putAll(myVariableAccessors);
@@ -560,45 +608,63 @@ public class VariableTableManager {
      * @param name the name of the variable
      * @return the new VariableAccessor
      */
-    synchronized final VariableAccessor allocateVariableAccessor(String name) {
-        int id = realClass.id;
-
-        final String[] myVariableNames = variableNames;
-        final int newIndex = myVariableNames.length;
-
-        VariableAccessor newVariableAccessor;
+    final VariableAccessor allocateVariableAccessor(String name) {
+        return allocateVariableAccessors(name, makeTableVariableAccessorBuilder(name));
+    }
+    
+    /**
+     * Makes a standard table accessor builder. Pass this into getVariableAccessorWithBuilder
+     */
+    final Function<Integer, VariableAccessor> makeTableVariableAccessorBuilder(String name) {
         if (Options.VOLATILE_VARIABLES.load()) {
             if (UnsafeHolder.U == null) {
-                newVariableAccessor = new SynchronizedVariableAccessor(realClass, name, newIndex, id);
+                return (newIndex) -> new SynchronizedVariableAccessor(realClass, name, newIndex, realClass.id);
             } else {
-                newVariableAccessor = new StampedVariableAccessor(realClass, name, newIndex, id);
+                return (newIndex) -> new StampedVariableAccessor(realClass, name, newIndex, realClass.id);
             }
         } else {
             if (UnsafeHolder.U == null) {
-                newVariableAccessor = new NonvolatileVariableAccessor(realClass, name, newIndex, id);
+                return (newIndex) -> new NonvolatileVariableAccessor(realClass, name, newIndex, realClass.id);
             } else {
                 // We still need safe updating of the vartable, so we fall back on sync here too.
-                newVariableAccessor = new StampedVariableAccessor(realClass, name, newIndex, id);
+                return (newIndex) -> new StampedVariableAccessor(realClass, name, newIndex, realClass.id);
             }
         }
-
-        final String[] newVariableNames = new String[newIndex + 1];
-        ArraySupport.copy(myVariableNames, 0, newVariableNames, 0, newIndex);
-        newVariableNames[newIndex] = name;
-        variableNames = newVariableNames;
-
-        return newVariableAccessor;
     }
 
-    synchronized final VariableAccessor allocateVariableAccessorForVar(String name, MethodHandle getter, MethodHandle setter) {
-        int id = realClass.id;
+    /**
+     * Makes a raw field accessor builder for reified classes with java_field. Pass this into getVariableAccessorWithBuilder
+     */
+    final Function<Integer, VariableAccessor> makeRawFieldAccessorBuilder(String name, boolean unwrap,Class<?> unwrapType, Class<?> fieldType, MethodHandle getter, MethodHandle setter)
+    {
+        return (newIndex) -> {
+            fieldVariables += 1;
+            return new RawFieldVariableAccessor(realClass, unwrap, unwrapType, fieldType, name, newIndex, realClass.id, getter, setter);
+        };
+    }
+
+    /**
+     * Makes an IRubyObject field accessor builder for reified classes. Pass this into getVariableAccessorWithBuilder
+     */
+    final Function<Integer, VariableAccessor> makeRubyFieldAccessorBuilder(String name, MethodHandle getter, MethodHandle setter)
+    {
+        return (newIndex) -> {
+            fieldVariables += 1;
+            return new FieldVariableAccessor(realClass, name, newIndex, realClass.id, getter, setter);
+        };
+    }
+
+    /**
+     * Allocation helper to map variables to names
+     */
+    synchronized final VariableAccessor allocateVariableAccessors(String name, Function<Integer, VariableAccessor> builder) {
 
         final String[] myVariableNames = variableNames;
         final int newIndex = myVariableNames.length;
 
-        fieldVariables += 1;
+        VariableAccessor newVariableAccessor = builder.apply(newIndex);
 
-        VariableAccessor newVariableAccessor = new FieldVariableAccessor(realClass, name, newIndex, id, getter, setter);
+        fieldVariables += 1;
 
         final String[] newVariableNames = new String[newIndex + 1];
         ArraySupport.copy(myVariableNames, 0, newVariableNames, 0, newIndex);

--- a/core/src/main/java/org/jruby/specialized/RubyObjectSpecializer.java
+++ b/core/src/main/java/org/jruby/specialized/RubyObjectSpecializer.java
@@ -138,7 +138,7 @@ public class RubyObjectSpecializer {
 
             // TODO: this just ends up reifying the first N variables it finds, which may not be the most valuable
             for (String name : foundVariables) {
-                klass.getVariableTableManager().getVariableAccessorForVar(
+                klass.getVariableTableManager().getVariableAccessorForRubyVar(
                         name,
                         LOOKUP.findGetter(cna.cls, "var" + offset, Object.class),
                         LOOKUP.findSetter(cna.cls, "var" + offset, Object.class));

--- a/lib/ruby/stdlib/jruby/core_ext/class.rb
+++ b/lib/ruby/stdlib/jruby/core_ext/class.rb
@@ -156,14 +156,35 @@ class Class
   ##
   # java_field will take the argument and create a java field as defined
   # with the name, the Java type, and the annotation signatures.
+  #
+  # For advanced JVM integration, you can bind it to the corresponding instance
+  # variable via instance_variable: true. This changes the semantics of the
+  # corresponding variable to JVM semantics (freeze is not honored, @var.equals?(@var) may be false, etc)
   # 
   # :call-seq:
   #   java_field '@FXML int foo'
   #   java_field 'org.foo.Bar bar'
-  def java_field(signature_source)
+  def java_field(signature_source, instance_variable: false, to_java: nil)
     signature = JRuby::JavaSignature.parse "#{signature_source}()"
 
     add_field_signature signature.name, signature.return_type
+    
+    if instance_variable # request @ivar field binding
+      opts = {unwrap: nil, type: signature.return_type}
+      unless to_java == nil
+        if to_java == false
+          opts[:unwrap] = false
+        elsif to_java.is_a? Java::JavaLang::Class or to_java.is_a? Class
+          opts[:unwrap] = true
+          opts[:type] = to_java
+        else
+          raise ArgumentError, "to_java must be either false, or a valid java class"
+        end
+      end
+      JRuby.reference0(self).variable_table_manager.request_field_storage(signature.name, signature.return_type, opts[:unwrap], opts[:type])
+    elsif to_java != nil
+      raise ArgumentError, "to_java only affects java_field when instance_variable is true"
+    end
 
     annotations = signature.annotations
     add_field_annotation signature.name, annotations if annotations
@@ -258,7 +279,6 @@ class Class
   def java_annotation(anno)
     warn "java_annotation is deprecated. Use java_signature '@#{anno} ...' instead. Called from: #{caller.first}"
   end
-  
 
   def add_field_signature(name, type)
     self_r = JRuby.reference0(self)

--- a/spec/java_integration/reify/become_java_spec.rb
+++ b/spec/java_integration/reify/become_java_spec.rb
@@ -453,6 +453,98 @@ describe "JRuby class reification" do
         expect(fields).to eq(%w(ruby rubyClass foo bar baz zot intField byteField shortField floatField doubleField))
       end
     end
+    
+    context "ivar using backing field" do
+      let(:fields) { proc {
+        java_field "java.lang.String stringField", instance_variable: true
+        java_field "java.lang.Thread.State enumField", instance_variable: true
+        java_field "java.util.Date dateField", instance_variable: true
+        java_field "java.lang.Object objField", instance_variable: true
+        java_field "int intField", instance_variable: true
+        java_field "boolean booleanField", instance_variable: true
+        java_field "double doubleField", instance_variable: true
+      }}
+      it "allows reads and writes to the java fields" do
+        subject
+        instance = klass.new
+        test_values = {
+          :@stringField=>[nil, "A String", "A different string"], 
+          :@enumField=>[nil, Java::java.lang.Thread::State::TIMED_WAITING, Java::java.lang.Thread::State::TERMINATED], 
+          :@dateField=>[nil, Java::java.util.Date.new(12345678),Java::java.util.Date.new(87654321)], 
+          :@objField=>[nil, Java::java.util.Date.new(12345678),Java::java.util.Date.new(87654321)], #tests not unwrapping
+          :@intField=>[0, 122448,-98765], 
+          :@booleanField=>[false, true, false], 
+          :@doubleField=>[0.0,6.28,-2.71828]
+        }
+        test_values.each do |var_sym, value|
+          m_get = var_sym.to_s[1..-1].to_sym # strip "@"
+          m_set = :"#{m_get}="
+
+          # check the default jvm values
+          expect(instance.instance_variable_get(var_sym)).to eq(value.first)
+          expect(instance.instance_variable_get(var_sym)).to eq(instance.send(m_get))
+          expect(instance.class.java_class.get_field(m_get.to_s).get(instance)).to eq(value.first)
+
+          # now set via ivar, and check again
+          instance.instance_variable_set(var_sym, value[1])
+          expect(instance.instance_variable_get(var_sym)).to eq(value[1])
+          expect(instance.send(m_get)).to eq(value[1])
+          expect(instance.class.java_class.get_field(m_get.to_s).get(instance)).to eq(value[1])
+
+          # now set via field, and check again
+          instance.send(m_set, value[2])
+          expect(instance.instance_variable_get(var_sym)).to eq(value[2])
+          expect(instance.send(m_get)).to eq(value[2])
+          expect(instance.class.java_class.get_field(m_get.to_s).get(instance)).to eq(value[2])
+        end
+      end
+    end
+    context "ivar using backing field (concrete java extension)" do
+      let(:klass) { Class.new(java.lang.Object, &fields) }
+      let(:fields) { proc {
+        java_field "java.lang.String stringField", instance_variable: true
+        java_field "java.lang.Thread.State enumField", instance_variable: true
+        java_field "java.util.Date dateField", instance_variable: true
+        java_field "java.lang.Object objField", instance_variable: true
+        java_field "int intField", instance_variable: true
+        java_field "boolean booleanField", instance_variable: true
+        java_field "double doubleField", instance_variable: true
+      }}
+      it "allows reads and writes to the java fields" do
+        subject
+        instance = klass.new
+        test_values = {
+          :@stringField=>[nil, "A String", "A different string"], 
+          :@enumField=>[nil, Java::java.lang.Thread::State::TIMED_WAITING, Java::java.lang.Thread::State::TERMINATED], 
+          :@dateField=>[nil, Java::java.util.Date.new(12345678),Java::java.util.Date.new(87654321)], 
+          :@objField=>[nil, Java::java.util.Date.new(12345678),Java::java.util.Date.new(87654321)], #tests not unwrapping
+          :@intField=>[0, 122448,-98765], 
+          :@booleanField=>[false, true, false], 
+          :@doubleField=>[0.0,6.28,-2.71828]
+        }
+        test_values.each do |var_sym, value|
+          m_get = var_sym.to_s[1..-1].to_sym # strip "@"
+          m_set = :"#{m_get}="
+
+          # check the default jvm values
+          expect(instance.instance_variable_get(var_sym)).to eq(value.first)
+          expect(instance.instance_variable_get(var_sym)).to eq(instance.send(m_get))
+          expect(instance.class.java_class.get_field(m_get.to_s).get(instance)).to eq(value.first)
+
+          # now set via ivar, and check again
+          instance.instance_variable_set(var_sym, value[1])
+          expect(instance.instance_variable_get(var_sym)).to eq(value[1])
+          expect(instance.send(m_get)).to eq(value[1])
+          expect(instance.class.java_class.get_field(m_get.to_s).get(instance)).to eq(value[1])
+
+          # now set via field, and check again
+          instance.send(m_set, value[2])
+          expect(instance.instance_variable_get(var_sym)).to eq(value[2])
+          expect(instance.send(m_get)).to eq(value[2])
+          expect(instance.class.java_class.get_field(m_get.to_s).get(instance)).to eq(value[2])
+        end
+      end
+    end
   end
 
 end


### PR DESCRIPTION
This is principally for making Java integration produce more idomatic Ruby. This allows users to configure a class to store specific ivars in a field of a reified class. This is principally for JRubyFX at this point in time, as that framwork sets java fields on a provided class. 

Still a WIP. Notable things that need to be done:

- [x] Find a good configuration name
- [x] pick exception types
- [x] deduplicate some code
- [x] Write tests
- [ ] Document weird nonsense like `@foo.equals?(@foo)` being false for some types (ex: j.l.String)
- [ ] Document weird nonsense like `@foo=` being frozen, but `self.foo=` not
- [x] Deal with clones and parents

Quick working demo:

```rb
require 'java'
require 'jruby/core_ext'

class BackedClass
   java_field "java.lang.String testfield" # define the field to be reified
   headius_definitely_approved_this_ivar_configuration_method_name :@testfield # now mark it used for ivar storage

	def testread
		puts "Ruby R #{@testfield.inspect}"
	end
	def testwrite(v)
		puts "Ruby W #{v}"
		@testfield = v
	end
	def testjavaread
		puts "Java R #{self.class.java_class.get_field("testfield").get(self).inspect}"
	end
	def testjavawrite(v)
		self.class.java_class.get_field("testfield").set(self, v)
		puts "Java W #{v}"
	end
	become_java!
end

o = BackedClass.new
o.testjavaread
o.testread
o.testjavawrite("Java says hi")
o.testjavaread
o.testread
o.testwrite("Ruby strings are better!")
o.testjavaread
o.testread

```

Now outputs:
```txt
Java R nil
Ruby R nil
Java W Java says hi
Java R "Java says hi"
Ruby R "Java says hi"
Ruby W Ruby strings are better!
Java R "Ruby strings are better!"
Ruby R "Ruby strings are better!"
```


