### PR TITLE
Implement Thread.each_caller_location

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -1899,6 +1899,11 @@ public class RubyThread extends RubyObject implements ExecutionContext {
                 (ctx, lev, len) -> WALKER.walk(getNativeThread().getStackTrace(), stream -> ctx.createCallerLocations(lev, len, stream)));
     }
 
+    @JRubyMethod(meta = true, omit = true)
+    public static IRubyObject each_caller_location(ThreadContext context, IRubyObject self, Block block) {
+        return ThreadContext.WALKER.walk(stream -> context.yieldCallerLocations(context, stream, 1, block));
+    }
+
     public boolean isReportOnException() {
         return reportOnException;
     }

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -857,6 +857,13 @@ public final class ThreadContext {
         return backTrace;
     }
 
+    public IRubyObject yieldCallerLocations(ThreadContext context, Stream<StackWalker.StackFrame> stackStream, int skip, Block block) {
+        runtime.incrementCallerCount();
+
+        // start at level 2 to skip each_caller_location and its caller
+        return TraceType.Gather.CALLER.getBacktraceData(this, stackStream).yieldBacktraceElements(context, skip, block);
+    }
+
     private RubyStackTraceElement[] getFullTrace(Integer length, Stream<StackWalker.StackFrame> stackStream) {
         if (length != null && length == 0) return RubyStackTraceElement.EMPTY_ARRAY;
         return TraceType.Gather.CALLER.getBacktraceData(this, stackStream).getBacktrace(runtime);


### PR DESCRIPTION
This passes all tests in https://github.com/ruby/ruby/pull/5445 except for the enumerator test, which shows it is tricky to get the "top" of the stack to match up.

See https://github.com/ruby/ruby/pull/5445

See https://bugs.ruby-lang.org/issues/16663