### PR TITLE
Compile splatted rescue as splat

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -3890,9 +3890,7 @@ public class IRBuilder {
                 for (int i = 0; i < exceptionNodes.length; i++) {
                     outputExceptionCheck(build(exceptionNodes[i]), exc, caughtLabel);
                 }
-            } else if (exceptionList instanceof SplatNode) { // splatnode, catch
-                outputExceptionCheck(build(((SplatNode)exceptionList).getValue()), exc, caughtLabel);
-            } else { // argscat/argspush
+            } else { // splat/argscat/argspush
                 outputExceptionCheck(build(exceptionList), exc, caughtLabel);
             }
         } else {


### PR DESCRIPTION
Allows coercing non-array to array of exception types.