### PR TITLE
Avoid interning tainted strings

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1166,7 +1166,7 @@ public class RubyHash extends RubyObject implements Map {
 
     // MRI: rb_hash_key_str
     private static RubyString hashKeyString(Ruby runtime, RubyString key) {
-        if (key.isBare(runtime)) {
+        if (!key.isTaint() && key.isBare(runtime)) {
             return runtime.freezeAndDedupString(key);
         }
 

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -6996,10 +6996,10 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     }
 
     /**
-     * Is this a "bare" string, i.e. has no instance vars and class == String.
+     * Is this a "bare" string, i.e. not tainted, has no instance vars, and class == String.
      */
     public boolean isBare(Ruby runtime) {
-        return !hasInstanceVariables() && metaClass == runtime.getString();
+        return !isTaint() && !hasInstanceVariables() && metaClass == runtime.getString();
     }
 
     private static StringSites sites(ThreadContext context) {


### PR DESCRIPTION
* Check for tainting in Hash string key negotiation.
* Check for tainting during deduplication and skip interning if
  tainted.

Fixes #7018