### PR TITLE
Backport string deduplication fixes from 9.3

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -4642,11 +4642,10 @@ public final class Ruby implements Constantizable {
      * @return the freeze-duped version of the string
      */
     public RubyString freezeAndDedupString(RubyString string) {
-        if (string.getMetaClass() != stringClass) {
+        if (!string.isBare(this)) {
             // never cache a non-natural String
-            RubyString duped = string.strDup(this);
-            duped.setFrozen(true);
-            return duped;
+            string.setFrozen(true);
+            return string;
         }
 
         // Populate thread-local wrapper

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -1403,6 +1403,16 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     }
 
     /**
+     * Check whether this object has any *set* instance variables unrelated to object_id, FFI, and ObjectSpace (which
+     * also use hidden ivar slots).
+     *
+     * @return true if there are set instance variables, false otherwise
+     */
+    protected boolean hasInstanceVariables() {
+        return metaClass.getVariableTableManager().hasInstanceVariables(this);
+    }
+
+    /**
      * Gets a list of all variables in this object.
      */
     @Override

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1165,7 +1165,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @JRubyMethod(name = "-@") // -'foo' returns frozen string
     public final IRubyObject minus_at(ThreadContext context) {
-        return context.runtime.freezeAndDedupString(this);
+        return isFrozen() ? this : context.runtime.freezeAndDedupString(this);
     }
 
     @JRubyMethod(name = "+@") // +'foo' returns modifiable string

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1165,7 +1165,13 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @JRubyMethod(name = "-@") // -'foo' returns frozen string
     public final IRubyObject minus_at(ThreadContext context) {
-        return isFrozen() ? this : context.runtime.freezeAndDedupString(this);
+        Ruby runtime = context.runtime;
+
+        RubyString str = this;
+
+        if (!str.isBare(runtime) && !str.isFrozen()) str = str.strDup(runtime);
+
+        return runtime.freezeAndDedupString(str);
     }
 
     @JRubyMethod(name = "+@") // +'foo' returns modifiable string
@@ -6691,6 +6697,13 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         int pp = nth(value.getEncoding(), value.unsafeBytes(), p, e, nth, singlebyte);
         if (pp == -1) return size;
         return pp - p;
+    }
+
+    /**
+     * Is this a "bare" string, i.e. has no instance vars and class == String.
+     */
+    private boolean isBare(Ruby runtime) {
+        return !hasVariables() && metaClass == runtime.getString();
     }
 
     private static StringSites sites(ThreadContext context) {

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -6694,10 +6694,10 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     }
 
     /**
-     * Is this a "bare" string, i.e. has no instance vars and class == String.
+     * Is this a "bare" string, i.e. not tainted, has no instance vars, and class == String.
      */
     public boolean isBare(Ruby runtime) {
-        return !hasInstanceVariables() && metaClass == runtime.getString();
+        return !isTaint() && !hasInstanceVariables() && metaClass == runtime.getString();
     }
 
     private static StringSites sites(ThreadContext context) {

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1165,13 +1165,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @JRubyMethod(name = "-@") // -'foo' returns frozen string
     public final IRubyObject minus_at(ThreadContext context) {
-        Ruby runtime = context.runtime;
-
-        RubyString str = this;
-
-        if (!str.isBare(runtime) && !str.isFrozen()) str = str.strDup(runtime);
-
-        return runtime.freezeAndDedupString(str);
+        return context.runtime.freezeAndDedupString(this);
     }
 
     @JRubyMethod(name = "+@") // +'foo' returns modifiable string
@@ -6702,7 +6696,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     /**
      * Is this a "bare" string, i.e. has no instance vars and class == String.
      */
-    private boolean isBare(Ruby runtime) {
+    public boolean isBare(Ruby runtime) {
         return !hasVariables() && metaClass == runtime.getString();
     }
 

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -6697,7 +6697,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      * Is this a "bare" string, i.e. has no instance vars and class == String.
      */
     public boolean isBare(Ruby runtime) {
-        return !hasVariables() && metaClass == runtime.getString();
+        return !hasInstanceVariables() && metaClass == runtime.getString();
     }
 
     private static StringSites sites(ThreadContext context) {

--- a/core/src/main/java/org/jruby/runtime/ivars/VariableTableManager.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/VariableTableManager.java
@@ -432,6 +432,22 @@ public class VariableTableManager {
                 (myVarTable = object.varTable) != null && myVarTable.length > hasObjectID + hasFFI + hasObjectspaceGroup;
     }
 
+    public boolean hasInstanceVariables(RubyBasicObject object) {
+        // we check both to exclude object_id
+        Object[] myVarTable;
+        if (fieldVariables > 0) return true;
+        if ((myVarTable = object.varTable) != null
+                && myVarTable.length > hasObjectID + hasFFI + hasObjectspaceGroup) {
+
+            for (int i = 0; i < myVarTable.length; i++) {
+                if (i == hasObjectID || i == hasFFI || i == hasObjectspaceGroup) continue;
+                if (myVarTable[i] != null) return true;
+            }
+        }
+
+        return false;
+    }
+
     public void serializeVariables(RubyBasicObject object, ObjectOutputStream oos) throws IOException {
         if (object.varTable != null) {
             Map<String, VariableAccessor> accessors = getVariableAccessorsForRead();


### PR DESCRIPTION
This PR combines the following commits, cherry-picked to the 9.2 branch:

* e963a579939720095cd2bdcf2d81d0ddad8a5979: added bareness-checking to `String#-@`.
* eb11c5de9d9f9e220c6166b440c484639384e291: bareness check reuse in string deuplication internals.
* 7c4edfb8ae7434d08598ee0c8aed9741a2fc76d1: only consider instance vars to make a string non-bare, and not internal vars.
* 59f08d59a52f99fd3f385b248d6ca319a941b458: from #7020 sans hash key duplication changes, check for taintedness in bareness checks.