### PR TITLE
Handle unrooted break jumps in Thread

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/RubyRunnable.java
+++ b/core/src/main/java/org/jruby/internal/runtime/RubyRunnable.java
@@ -35,7 +35,9 @@ import org.jruby.RubyThread;
 import org.jruby.exceptions.JumpException;
 import org.jruby.exceptions.MainExitException;
 import org.jruby.exceptions.ThreadKill;
+import org.jruby.ir.runtime.IRBreakJump;
 import org.jruby.runtime.Block;
+import org.jruby.runtime.Helpers;
 import org.jruby.runtime.RubyEvent;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -108,6 +110,8 @@ public class RubyRunnable implements ThreadedRunnable {
             } catch (MainExitException mee) {
                 // Someone called exit!, so we need to kill the main thread
                 runtime.getThreadService().getMainThread().kill();
+            } catch (IRBreakJump irbj) {
+                rubyThread.exceptionRaised(Helpers.newLocalJumpErrorForBreak(runtime, irbj.breakValue));
             } catch (Throwable t) {
                 rubyThread.exceptionRaised(t);
             } finally {

--- a/core/src/main/java/org/jruby/ir/operands/IRException.java
+++ b/core/src/main/java/org/jruby/ir/operands/IRException.java
@@ -5,7 +5,9 @@ import org.jruby.RubyLocalJumpError;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.persistence.IRReaderDecoder;
 import org.jruby.ir.persistence.IRWriterEncoder;
+import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.transformations.inlining.CloneInfo;
+import org.jruby.runtime.Helpers;
 
 import java.util.List;
 
@@ -68,7 +70,7 @@ public class IRException extends Operand {
     public RuntimeException getException(Ruby runtime) {
         switch (getType()) {
             case NEXT: return runtime.newLocalJumpError(getType(), null, "unexpected next");
-            case BREAK: return runtime.newLocalJumpError(getType(), null, "unexpected break");
+            case BREAK: return Helpers.newLocalJumpErrorForBreak(runtime, null);
             case RETURN: return runtime.newLocalJumpError(getType(), null, "unexpected return");
             case REDO: return runtime.newLocalJumpError(getType(), null, "unexpected redo");
             case RETRY: return runtime.newLocalJumpError(getType(), null, "retry outside of rescue not supported");

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -222,7 +222,7 @@ public class IRRuntimeHelpers {
         DynamicScope parentScope = dynScope.getParentScope();
 
         if (block.isEscaped()) {
-            throw context.runtime.newLocalJumpError(RubyLocalJumpError.Reason.BREAK, breakValue, "unexpected break");
+            throw Helpers.newLocalJumpErrorForBreak(context.runtime, breakValue);
         }
 
         // Raise a break jump so we can bubble back down the stack to the appropriate place to break from.

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -969,7 +969,11 @@ public class Helpers {
     }
 
     public static IRubyObject breakLocalJumpError(Ruby runtime, IRubyObject value) {
-        throw runtime.newLocalJumpError(RubyLocalJumpError.Reason.BREAK, value, "unexpected break");
+        throw newLocalJumpErrorForBreak(runtime, value);
+    }
+
+    public static RaiseException newLocalJumpErrorForBreak(Ruby runtime, IRubyObject breakValue) {
+        return runtime.newLocalJumpError(RubyLocalJumpError.Reason.BREAK, breakValue, "unexpected break");
     }
 
     public static IRubyObject[] concatObjectArrays(IRubyObject[] array, IRubyObject[] add) {


### PR DESCRIPTION
This PR will fix #7009 by converting the IRBreakJump into a LocalJumpError before it bubbles completely out of the thread.

Initial attempt at this allows the jump to bubble all the way to the top of RubyRunnable before getting converted, which does not exactly match CRuby behavior. In CRuby, the jump is an LJE immediately because they search the current thread for the target scope and raise LJE immediately if it is not present. We do not want to add such a search to our break instruction.