### PR TITLE
Ruby 2.7: Add Enumerator::Lazy#eager

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -182,6 +182,7 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
     }
 
     // used internally to create lazy without block (from Enumerator/Enumerable)
+    // and used internally to create enum from Enumerator::Lazy#eager
     @JRubyMethod(name = "__from", meta = true, required = 2, optional = 2, visibility = PRIVATE)
     public static IRubyObject __from(ThreadContext context, IRubyObject klass, IRubyObject[] args) {
         // Lazy.__from(enum, method, *args, size)

--- a/core/src/main/ruby/jruby/kernel/enumerator.rb
+++ b/core/src/main/ruby/jruby/kernel/enumerator.rb
@@ -419,6 +419,10 @@ class Enumerator
       end
     end
 
+    def eager
+      Enumerator.send :__from, self, :each, [], self.size
+    end
+
     protected
     def __set_inspect(method, args = nil, receiver = nil)
       @method = method


### PR DESCRIPTION
To create an Enumerator instance with size, this implementation
uses __from method insted of Enumerator.new .

And this commit makes the following tests pass.
 * spec/ruby/core/enumerator/lazy/eager_spec.rb

For #6464