### PR TITLE
Fix uninitialized Enumerator::Chain#inspect

### DIFF
--- a/core/src/main/java/org/jruby/RubyChain.java
+++ b/core/src/main/java/org/jruby/RubyChain.java
@@ -130,7 +130,14 @@ public class RubyChain extends RubyObject {
         ByteList str = new ByteList();
         str.append('#').append('<');
         str.append(getMetaClass().getRealClass().getName().getBytes());
-        str.append(':').append(' ').append('[');
+        str.append(':').append(' ');
+
+        if (enums == null) {
+            str.append("uninitialized>".getBytes());
+            return RubyString.newStringLight(context.runtime, str);
+        }
+
+        str.append('[');
         for (int i = 0; i < enums.length - 1; i++) {
             str.append(RubyObject.inspect(context, enums[i]).getByteList());
             str.append(',').append(' ');


### PR DESCRIPTION
This commit makes the following tests pass.
 * spec/ruby/core/enumerator/chain/initialize_spec.rb