### PR TITLE
Fix Array#minmax with block

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -5543,7 +5543,7 @@ float_loop:
 
     @JRubyMethod
     public IRubyObject minmax(ThreadContext context, Block block) {
-        if (block.isGiven()) return Helpers.invokeSuper(context, this, block);
+        if (block.isGiven()) return RubyEnumerable.minmax(context, this, block);
 
         return RubyArray.newArray(context.runtime, callMethod("min"), callMethod("max"));
     }


### PR DESCRIPTION
This commit makes the following tests pass.
 * test_minmax in test/mri/ruby/test_array.rb
 * spec/ruby/core/array/minmax_spec.rb