### PR TITLE
Fix Array#slice with Enumerator::ArithmeticSequence

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -1303,6 +1303,11 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
             aseqEnd = tmp;
         }
 
+        if (step < -1 || step > 1) {
+            int [] ret = RubyRange.newRange(context, aseqBeg, aseqEnd, aseqExcl).begLenInt((int)len, 1);
+            if (ret != null && (ret[0] > len || ret[1] > len)) throw runtime.newRangeError(arg0.inspect(context) + " out of range");
+        }
+
         if (aseqBeg.isNil()) {
             beg = 0;
         } else {


### PR DESCRIPTION
If ArithmeticSequince range outsides of array, Array#slice becomes to throw RangeError.
This commit makes the following tests pass.
 * spec/ruby/core/array/minmax_spec.rb
 * spec/ruby/core/array/element_reference_spec.rb

#6878