### PR TITLE
Fix Enumerable#grep and Enumerable#grep_v with Regexp

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -580,7 +580,9 @@ public class RubyEnumerable {
                 }
                 @Override
                 public IRubyObject call(ThreadContext ctx, IRubyObject arg, Block unused) {
-                    if (((RubyRegexp) pattern).match_p(ctx, arg).isTrue() == isPresent) {
+                    IRubyObject converted = arg instanceof RubySymbol ? arg : TypeConverter.checkStringType(ctx.runtime, arg);
+
+                    if (((RubyRegexp) pattern).match_p(ctx, converted).isTrue() == isPresent) {
                         synchronized (result) { result.append(arg); }
                     }
                     return ctx.nil;


### PR DESCRIPTION
Enumerable#grep(_v) with block handles non-string elements correctly.
The following tests pass.
 * spec/ruby/core/enumerable/grep_spec
 * spec/ruby/core/enumerable/grep_v_spec.rb

#6878