### PR TITLE
Explicitly use public visibility for define_singleton_method

### DIFF
--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1453,7 +1453,7 @@ public class RubyKernel {
         return context.nil;
     }
 
-    @JRubyMethod(required = 1, optional = 1, reads = VISIBILITY)
+    @JRubyMethod(required = 1, optional = 1)
     public static IRubyObject define_singleton_method(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         if (args.length == 0) {
             throw context.runtime.newArgumentError(0, 1);
@@ -1471,9 +1471,9 @@ public class RubyKernel {
                     throw context.runtime.newTypeError("can't bind singleton method to a different class");
                 }
             }
-            return singleton_class.define_method(context, args[0], args[1], block);
+            return singleton_class.defineMethodFromCallable(context, args[0], args[1], PUBLIC);
         } else {
-            return singleton_class.define_method(context, args[0], block);
+            return singleton_class.defineMethodFromBlock(context, args[0], block, PUBLIC);
         }
     }
 

--- a/spec/ruby/core/kernel/define_singleton_method_spec.rb
+++ b/spec/ruby/core/kernel/define_singleton_method_spec.rb
@@ -96,4 +96,17 @@ describe "Kernel#define_singleton_method" do
       o.define(:foo) { raise "not used" }
     }.should raise_error(ArgumentError)
   end
+
+  it "always defines the method with public visibility" do
+    cls = Class.new
+    def cls.define(name, &block)
+      private
+      define_singleton_method(name, &block)
+    end
+
+    -> {
+      cls.define(:foo) { :ok }
+      cls.foo.should == :ok
+    }.should_not raise_error(NoMethodError)
+  end
 end


### PR DESCRIPTION
This PR makes public visibility the only visiblity for `define_singleton_method` methods, and adds a spec testing a simple case of this.

This is a bit of an open question, since in CRuby `define_singleton_method` ends up producing public methods nearly all of the time due to a quirk in how the frame's visibility is accessed.

There's at least one edge case where `define_singleton_method` **does** obey the frame visibility, but it requires calling `define_singleton_method` from within a scope rooted on the destination singleton class. I would argue this is a peculiar-enough edge case that it should be made to explicitly use public visibility in all cases.

See https://github.com/ruby/ostruct/issues/40 for a related issue, where we warn about aliasing `define_singleton_method` due to its rarely-used ability to source visibility from the caller's scope.

See https://bugs.ruby-lang.org/issues/18561 for my CRuby issue to codify this behavior and eliminate the edge cases.