### PR TITLE
Restore 9.2 collect signature and add more API

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -143,6 +143,11 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
     /**
      * Transform object into an Enumerator with the given size
      */
+    public static <T extends IRubyObject> RubyEnumerator enumWithSize(ThreadContext context, final T object, String method, IRubyObject[] args, SizeFn<T> sizeFn) {
+        Ruby runtime = context.runtime;
+        return new RubyEnumerator(runtime, runtime.getEnumerator(), object, runtime.fastNewSymbol(method), args, null, sizeFn);
+    }
+
     public static <T extends IRubyObject> IRubyObject enumeratorizeWithSize(ThreadContext context, final T object, String method, IRubyObject[] args, SizeFn<T> sizeFn) {
         Ruby runtime = context.runtime;
         return new RubyEnumerator(runtime, runtime.getEnumerator(), object, runtime.fastNewSymbol(method), args, null, sizeFn);
@@ -150,6 +155,10 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
 
     public static <T extends IRubyObject> IRubyObject enumeratorizeWithSize(ThreadContext context, T object, String method, SizeFn<T> sizeFn) {
         return enumeratorizeWithSize(context, object, method, NULL_ARRAY, sizeFn);
+    }
+
+    public static <T extends IRubyObject> RubyEnumerator enumWithSize(ThreadContext context, T object, String method, SizeFn<T> sizeFn) {
+        return enumWithSize(context, object, method, NULL_ARRAY, sizeFn);
     }
 
     public static IRubyObject enumeratorizeWithSize(ThreadContext context, IRubyObject object, String method, IRubyObject arg, IRubyObject size) {

--- a/core/src/main/java/org/jruby/specialized/RubyArrayOneObject.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArrayOneObject.java
@@ -264,8 +264,8 @@ public class RubyArrayOneObject extends RubyArraySpecialized {
     }
 
     @Override
-    public RubyArray collectCommon(ThreadContext context, Block block) {
-        if (!packed()) return super.collectCommon(context, block);
+    public RubyArray collectArray(ThreadContext context, Block block) {
+        if (!packed()) return super.collectArray(context, block);
 
         if (!block.isGiven()) return makeShared();
 

--- a/core/src/main/java/org/jruby/specialized/RubyArrayTwoObject.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArrayTwoObject.java
@@ -350,8 +350,8 @@ public class RubyArrayTwoObject extends RubyArraySpecialized {
     }
 
     @Override
-    public RubyArray collectCommon(ThreadContext context, Block block) {
-        if (!packed()) return super.collectCommon(context, block);
+    public RubyArray collectArray(ThreadContext context, Block block) {
+        if (!packed()) return super.collectArray(context, block);
 
         if (!block.isGiven()) return makeShared();
 


### PR DESCRIPTION
This addresses an issue found by jruby-openssl where we altered
the return value for a method in JRuby and broke backward compat
with JRuby 9.2 and earlier. Specifically we unintentionally caused
the RubyArray#collect(context, block) method to return IRubyObject
instead of RubyArray due to needing to return an enumerator for
some inputs.

As a result of this change, jruby-openssl compiled against the new
signature and became incompatible with JRuby 9.2.

This fix does not address the issue for JRuby 9.3.0 through 9.3.3,
which continue to have the bad signature. The restored signature
will remain through 9.3 and 9.4 maintenance at least, with two new
methods collectArray and collectEnum added to allow users to opt
into those specific paths. The Ruby-facing method is renamed to
rbCollect to indicate it is part of the Ruby interface for this
class.

See https://github.com/jruby/jruby-openssl/issues/245