### PR TITLE
Changes to how non-local break is propagated

### DIFF
--- a/core/src/main/java/org/jruby/RubyMethod.java
+++ b/core/src/main/java/org/jruby/RubyMethod.java
@@ -224,7 +224,7 @@ public class RubyMethod extends AbstractRubyMethod {
         int line = getLine(); // getLine adds 1 to 1-index but we need to reset to 0-index internally
         body = new MethodBlockBody(runtime.getStaticScopeFactory().getDummyScope(), signature, entry, argsDesc,
                 receiver, originModule, originName, getFilename(), line == -1 ? -1 : line - 1);
-        Block b = MethodBlockBody.createMethodBlock(body);
+        Block b = MethodBlockBody.createMethodBlock(context, body);
         
         return RubyProc.newProc(runtime, b, Block.Type.LAMBDA);
     }

--- a/core/src/main/java/org/jruby/ir/runtime/IRBreakJump.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRBreakJump.java
@@ -2,25 +2,21 @@ package org.jruby.ir.runtime;
 
 import org.jruby.exceptions.Unrescuable;
 import org.jruby.runtime.DynamicScope;
+import org.jruby.runtime.Frame;
 import org.jruby.runtime.builtin.IRubyObject;
 
 public class IRBreakJump extends IRJump implements Unrescuable {
-    public final DynamicScope scopeToReturnTo;
+    public final Frame frameToReturnTo;
     public final IRubyObject breakValue;
     public boolean breakInEval;
 
-    private IRBreakJump(DynamicScope scopeToReturnTo, IRubyObject rv, boolean breakInEval) {
-        this.scopeToReturnTo = scopeToReturnTo;
+    private IRBreakJump(Frame frameToReturnTo, IRubyObject rv, boolean breakInEval) {
+        this.frameToReturnTo = frameToReturnTo;
         this.breakValue = rv;
         this.breakInEval = breakInEval;
     }
 
-    @Deprecated
-    public static IRBreakJump create(DynamicScope scopeToReturnTo, IRubyObject rv) {
-        return new IRBreakJump(scopeToReturnTo, rv, false);
-    }
-
-    public static IRBreakJump create(DynamicScope scopeToReturnTo, IRubyObject rv, boolean breakInEval) {
-        return new IRBreakJump(scopeToReturnTo, rv, breakInEval);
+    public static IRBreakJump create(Frame frameToReturnTo, IRubyObject rv, boolean breakInEval) {
+        return new IRBreakJump(frameToReturnTo, rv, breakInEval);
     }
 }

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -217,12 +217,14 @@ public class IRRuntimeHelpers {
         // paths so that ensures are run, frames/scopes are popped from runtime stacks, etc.
         if (inLambda(block.type)) throw new IRWrappedLambdaReturnValue(breakValue, true);
 
-        if (block.isEscaped()) {
+        Frame targetFrame = block.getFrame();
+
+        if (block.isEscaped() || targetFrame.getThreadID() != context.threadID) {
             throw Helpers.newLocalJumpErrorForBreak(context.runtime, breakValue);
         }
 
         // Raise a break jump so we can bubble back down the stack to the appropriate place to break from.
-        throw IRBreakJump.create(block.getFrame(), breakValue, scope.getStaticScope().getScopeType().isEval()); // weirdly evals are impld as closures...yes yes.
+        throw IRBreakJump.create(targetFrame, breakValue, scope.getStaticScope().getScopeType().isEval()); // weirdly evals are impld as closures...yes yes.
     }
 
     // Are we within the scope where we want to return the value we are passing down the stack?

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -212,21 +212,17 @@ public class IRRuntimeHelpers {
 
     // FIXME: When we recompile lambdas we can eliminate this binary code path and we can emit as a NONLOCALRETURN directly.
     @JIT
-    public static IRubyObject initiateBreak(ThreadContext context, DynamicScope dynScope, IRubyObject breakValue, Block block) throws RuntimeException {
+    public static IRubyObject initiateBreak(ThreadContext context, DynamicScope scope, IRubyObject breakValue, Block block) throws RuntimeException {
         // Wrap the return value in an exception object and push it through the break exception
         // paths so that ensures are run, frames/scopes are popped from runtime stacks, etc.
         if (inLambda(block.type)) throw new IRWrappedLambdaReturnValue(breakValue, true);
-
-        IRScopeType scopeType = ensureScopeIsClosure(context, dynScope);
-
-        DynamicScope parentScope = dynScope.getParentScope();
 
         if (block.isEscaped()) {
             throw Helpers.newLocalJumpErrorForBreak(context.runtime, breakValue);
         }
 
         // Raise a break jump so we can bubble back down the stack to the appropriate place to break from.
-        throw IRBreakJump.create(parentScope, breakValue, scopeType.isEval()); // weirdly evals are impld as closures...yes yes.
+        throw IRBreakJump.create(block.getFrame(), breakValue, scope.getStaticScope().getScopeType().isEval()); // weirdly evals are impld as closures...yes yes.
     }
 
     // Are we within the scope where we want to return the value we are passing down the stack?
@@ -279,7 +275,7 @@ public class IRRuntimeHelpers {
 
             bj.breakInEval = false;
             throw bj;
-        } else if (bj.scopeToReturnTo == dynScope) {
+        } else if (bj.frameToReturnTo == context.getCurrentFrame()) {
             // Done!! Hurray!
             if (isDebug()) System.out.println("---> Break reached target in scope: " + dynScope);
             return bj.breakValue;

--- a/core/src/main/java/org/jruby/runtime/Binding.java
+++ b/core/src/main/java/org/jruby/runtime/Binding.java
@@ -307,12 +307,4 @@ public class Binding {
     public BacktraceElement getBacktrace() {
         return new BacktraceElement(method, filename, line);
     }
-
-    @Deprecated
-    public static final Binding DUMMY =
-            new Binding(
-                    RubyBasicObject.NEVER,
-                    // Can't use Frame.DUMMY because of circular static init seeing it before it's assigned
-                    new Frame(),
-                    Visibility.PUBLIC);
 }

--- a/core/src/main/java/org/jruby/runtime/Block.java
+++ b/core/src/main/java/org/jruby/runtime/Block.java
@@ -89,7 +89,7 @@ public class Block implements FunctionOneOrTwoOrThree<ThreadContext, IRubyObject
     /**
      * All Block variables should either refer to a real block or this NULL_BLOCK.
      */
-    public static final Block NULL_BLOCK = new Block(BlockBody.NULL_BODY, new Binding(null, new Frame(), Visibility.PUBLIC));
+    public static final Block NULL_BLOCK = new Block(BlockBody.NULL_BODY, new Binding(null, new Frame(null), Visibility.PUBLIC));
 
     static {
         // Ensure dummy frame is updated with NULL_BLOCK since it may clinit first.

--- a/core/src/main/java/org/jruby/runtime/Frame.java
+++ b/core/src/main/java/org/jruby/runtime/Frame.java
@@ -91,18 +91,23 @@ public final class Frame {
     /** whether this frame has been captured into a binding **/
     boolean captured;
 
+    /** the ID object for the thread that created this frame **/
+    final Object threadID;
+
     /**
      * Empty constructor, since Frame objects are pre-allocated and updated
      * when needed.
      */
-    public Frame() {
+    public Frame(Object threadID) {
+        this.threadID = threadID;
     }
 
     /**
      * Used only by static init to avoid accessing NULL_BLOCK before initialized.
      * @param nullBlock
      */
-    private Frame(Block nullBlock) {
+    private Frame(Object threadID, Block nullBlock) {
+        this.threadID = threadID;
         this.block = nullBlock;
     }
 
@@ -113,6 +118,7 @@ public final class Frame {
     private Frame(Frame frame) {
         assert frame.block != null;
 
+        this.threadID = frame.threadID;
         this.self = frame.self;
         this.name = frame.name;
         this.klazz = frame.klazz;
@@ -235,18 +241,6 @@ public final class Frame {
     }
 
     /**
-     * Clone this frame for use in backtraces only (avoiding long-lived
-     * references to other elements.
-     *
-     * @return A new frame with identical backtrace information to this frame
-     */
-    public Frame duplicateForBacktrace() {
-        Frame backtraceFrame = new Frame();
-        backtraceFrame.name = name;
-        return backtraceFrame;
-    }
-
-    /**
      * Return class that we are calling against
      *
      * @return The class we are calling against
@@ -358,6 +352,10 @@ public final class Frame {
         return captured;
     }
 
+    public Object getThreadID() {
+        return threadID;
+    }
+
     /* (non-Javadoc)
      * @see java.lang.Object#toString()
      */
@@ -372,7 +370,4 @@ public final class Frame {
 
         return sb.toString();
     }
-
-    @Deprecated
-    public static final Frame DUMMY = new Frame();
 }

--- a/core/src/main/java/org/jruby/runtime/MethodBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/MethodBlockBody.java
@@ -30,10 +30,10 @@ public class MethodBlockBody extends ContextAwareBlockBody {
         this.line = line;
     }
 
-    public static Block createMethodBlock(MethodBlockBody body) {
+    public static Block createMethodBlock(ThreadContext context, MethodBlockBody body) {
         DynamicMethod method = body.entry.method;
         RubyModule module = method.getImplementationClass();
-        Frame frame = new Frame();
+        Frame frame = new Frame(context.threadID);
 
         frame.setKlazz(module);
         frame.setName(method.getName());

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -168,6 +168,8 @@ public final class ThreadContext {
 
     private RubyMatchData matchData;
 
+    public final Object threadID = new Object();
+
     @SuppressWarnings("deprecation")
     public SecureRandom getSecureRandom() {
         SecureRandom secureRandom = this.secureRandom;
@@ -227,7 +229,7 @@ public final class ThreadContext {
         Frame[] stack = frameStack;
         int length = stack.length;
         for (int i = 0; i < length; i++) {
-            stack[i] = new Frame();
+            stack[i] = new Frame(threadID);
         }
         BacktraceElement[] stack2 = backtrace;
         int length2 = stack2.length;
@@ -321,7 +323,7 @@ public final class ThreadContext {
         System.arraycopy(frameStack, 0, newFrameStack, 0, frameStack.length);
 
         for (int i = frameStack.length; i < newSize; i++) {
-            newFrameStack[i] = new Frame();
+            newFrameStack[i] = new Frame(threadID);
         }
 
         return newFrameStack;
@@ -505,7 +507,7 @@ public final class ThreadContext {
 
         // if the frame was captured, we must replace it but not clear
         if (frame.isCaptured()) {
-            stack[index] = new Frame();
+            stack[index] = new Frame(threadID);
         } else {
             frame.clearFrameForBackref();
         }
@@ -535,7 +537,7 @@ public final class ThreadContext {
 
         // if the frame was captured, we must replace it but not clear
         if (frame.captured) {
-            stack[index] = new Frame();
+            stack[index] = new Frame(threadID);
         } else {
             frame.clear();
         }


### PR DESCRIPTION
This is an experiment to change how we propagate non-local breaks (i.e. within a closure or eval) to address #7009 and allow detecting that the target frame is not part of the current thread (and therefore should be a LocalJumpError right away).

The strategy is as follows:

* Switch non-local break to target a Frame, rather than a DynamicScope.
* Add a thread ID field to Frame that will be set at create time and used to identify the source thread.
* Compare the thread ID field at break-throw time to know whether the break has a valid target on the current thread.