### PR TITLE
Ruby 3.1: Update Array#each_slice to return a receiver

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -2008,7 +2008,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
             window.realLength = realLength;
             block.yield(context, window);
         }
-        return context.nil;
+        return this;
     }
 
     @JRubyMethod


### PR DESCRIPTION
For #7015 

e.g. ` [1, 2, 3].each_slice(2){} =>  [1, 2, 3]`