### PR TITLE
Update Enumerable#grep for edge case

### DIFF
--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -820,6 +820,12 @@ public class RubyClass extends RubyModule {
         return method.call(context, self, entry.sourceModule, name, arg0, arg1, arg2);
     }
 
+    // MRI: rb_method_basic_definition_p
+    public boolean checkMethodBasicDefinition(String name) {
+        DynamicMethod method = searchMethod(name);
+        return method != null && method.isBuiltin();
+    }
+
     private void dumpReifiedClass(String dumpDir, String javaPath, byte[] classBytes) {
         if (dumpDir != null) {
             if (dumpDir.length() == 0) dumpDir = ".";

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -573,7 +573,7 @@ public class RubyEnumerable {
                     return ctx.nil;
                 }
             });
-        } else if (pattern instanceof RubyRegexp) {
+        } else if ((pattern instanceof RubyRegexp) && pattern.getMetaClass().checkMethodBasicDefinition("===")) {
             callEach(context, each, self, Signature.ONE_REQUIRED, new BlockCallback() {
                 public IRubyObject call(ThreadContext ctx, IRubyObject[] args, Block unused) {
                     return call(ctx, packEnumValues(ctx, args), unused);


### PR DESCRIPTION
In mri 3.1.0, enum_grep0 function in enum.c uses 'rb_method_basic_definition_p' macro to check === is defined as basic method.
As far as I see, the current master does not have any funtions equivalent to 'rb_method_basic_definition_p'.
Therefore I add checkMethodBasicDefinition to RubyClass.

This makes the following tests pass.
 * test_grep_optimization in test/mri/ruby/test_enum.rb