### PR TITLE
Remove the require lock on LoadError

### DIFF
--- a/core/src/main/java/org/jruby/runtime/load/LoadService.java
+++ b/core/src/main/java/org/jruby/runtime/load/LoadService.java
@@ -68,6 +68,7 @@ import org.jruby.RubyThread;
 import org.jruby.ast.executable.Script;
 import org.jruby.exceptions.CatchThrow;
 import org.jruby.exceptions.JumpException;
+import org.jruby.exceptions.LoadError;
 import org.jruby.exceptions.MainExitException;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.StandardError;
@@ -461,6 +462,11 @@ public class LoadService {
                 destroyLock = true;
 
                 return state;
+            } catch (LoadError le) {
+                // LoadError should be considered a completed load and remove the lock
+                destroyLock = true;
+
+                throw le;
             } catch (StandardError se) {
                 // standard error, consider file not loaded
                 destroyLock = false;


### PR DESCRIPTION
Leaving this lock in place indicates to later feature tests that
the file was never loaded, incorrectly causing autoload constant
lookups to fail to load the file a second time. Instead, we
always remove any lock set up for the require so the feature does
not look like it is still in the process of loading.

See #7070

This is a WIP and we will see how it handles tests. I believe I originally added the `destroyLock` logic to form fit behavior to some spec, but I cannot remember which spec behavior led me to doing this. It seems wrong now to leave the lock in place under any circumstances, since it will interfere with future attempts to load that file (the case in #7070).