### PR TITLE
Prefer the native thread status

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -1775,11 +1775,16 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     }
 
     private Status getStatus() {
-        Status status = STATUS.get(this);
+        Status statusFromNative = nativeStatus();
+        Status statusFromRuby = Status.NATIVE;
 
-        if (status != Status.NATIVE) return status;
+        if (statusFromNative == Status.RUN) {
+            statusFromRuby = STATUS.get(this);
+        }
 
-        return nativeStatus();
+        if (statusFromRuby != Status.NATIVE) return statusFromRuby;
+
+        return statusFromNative;
     }
 
     private Status nativeStatus() {


### PR DESCRIPTION
The native status of a thread will be more accurate when the
thread is in a blocking or sleeping state, since we often cannot
detect these states before making calls into Java libraries. The
status we manage on our own is only set when calling through our
own blocking call wrappers, which are not present for blocking
calls made directly to Java.

The logic here uses the native status if it is anything other
than "new" or "run". Only if the native thread appears to be
runnable do we fall back on the Ruby thread status we maintain.

This appears to fix #7032 but it is unknown what other impact it
may have.