### PR TITLE
Align StringIO compatibility with CRuby

### DIFF
--- a/test/mri/excludes/TestStringIO.rb
+++ b/test/mri/excludes/TestStringIO.rb
@@ -1,2 +1,3 @@
 exclude :test_overflow, "unusual subprocess test trying to overflow some value"
+exclude :test_write_encoding_conversion, "Encoding negotiation fails to reject UTF-8 => Windows-31J"
 exclude :test_write_integer_overflow, "JVM does not support > 32bit signed array offsets, so our StringIO cannot either"


### PR DESCRIPTION
Most of the fixes here are of the following types:

* Encoding handling in StringIO construction
* Proper checking for open/closed/read/write
* Style fixes to arity-split more methods

The three remaining excludes are as follows:

* Two that test overflow conditions that are different or not
  relevant on JRuby's JVM-based String
* One where we fail to reject trancoding UTF-8 to Windows-31J,
  somewhere in mixed-encoding negotiation logic

This is in preparation for moving StringIO out to the gem in https://github.com/ruby/stringio/pull/21.