### PR TITLE
WIP: remove broken enc check

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -6292,10 +6292,6 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     public RubySymbol intern() {
         final Ruby runtime = getRuntime();
 
-        if (scanForCodeRange() == CR_BROKEN) {
-            throw runtime.newEncodingError("invalid symbol in encoding " + getEncoding() + " :" + inspect());
-        }
-
         RubySymbol symbol = runtime.getSymbolTable().getSymbol(value);
         if (symbol.getBytes() == value) shareLevel = SHARE_LEVEL_BYTELIST;
         return symbol;


### PR DESCRIPTION
interning a string should be in ideal case just a simple lookup = extremely fast

however, scanForCodeRange is pretty expensive. This check should be moved to the SymbolTable and test it only if the string wasn't interned yet (this is what CRuby does)

let's see if removing it breaks any test...