### PR TITLE
Update buildDot function to fix failing TestRange#test_evaluation_order

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -3135,8 +3135,7 @@ public class IRBuilder {
         }
 
         // must be built every time
-        return addResultInstr(new BuildRangeInstr(createTemporaryVariable(), build(dotNode.getBeginNode()),
-                build(dotNode.getEndNode()), dotNode.isExclusive()));
+        return addResultInstr(new BuildRangeInstr(createTemporaryVariable(), begin, end, dotNode.isExclusive()));
     }
 
     private int dynamicPiece(Operand[] pieces, int i, Node pieceNode) {


### PR DESCRIPTION
This commit avoids to evaluating beginNode and endNode twice in buildDot function.
e.g.
 arr = [1,2]
 (arr.shift)..(arr.shift) should be (1)..(2) , not be (nil)..(nil) .

The following tests pass.
 * test_evaluation_order in test/mri/ruby/test_range.rb