### PR TITLE
Ruby3.0: Remove Time#succ

### DIFF
--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -871,7 +871,6 @@ public class RubyRange extends RubyObject {
     }
 
     private static boolean discreteObject(ThreadContext context, IRubyObject obj) {
-        if (obj instanceof RubyTime) return false;
         return sites(context).respond_to_succ.respondsTo(context, obj, obj, false);
     }
 

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -544,14 +544,6 @@ public class RubyTime extends RubyObject {
         return this;
     }
 
-    @JRubyMethod
-    public RubyTime succ() {
-        RubyTime time = newTime(getRuntime(), dt.plusSeconds(1));
-        time.setIsTzRelative(isTzRelative);
-        time.setZoneObject(zone);
-        return time;
-    }
-
     @JRubyMethod(name = {"gmtime", "utc", "to_time"})
     public RubyTime gmtime() {
         return adjustTimeZone(getRuntime(), DateTimeZone.UTC, false);


### PR DESCRIPTION
This commit removes Time#succ . And this commit updates the discreteObject
function in RubyRange to fix failing spec/ruby/core/range/each_spec.rb .
The discreteObject function does not need to check the type of arg because of Time#succ is deleted.

See https://bugs.ruby-lang.org/issues/17039