### PR TITLE
Tag work-in-process specs and add separate CI job for them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
 
     strategy:
       matrix:
-        target: ['test:mri:core:int', 'test:mri:extra', 'test:jruby:int', 'test:mri:stdlib', 'spec:ruby:slow', 'spec:ruby:debug', 'test:jruby:aot', 'test:slow_suites', 'spec:compiler', 'spec:regression', 'spec:jruby', 'spec:jrubyc', 'spec:profiler']
+        target: ['test:mri:core:int', 'test:mri:extra', 'test:jruby:int', 'test:mri:stdlib', 'spec:ruby:slow', 'spec:ruby:debug', 'spec:ruby:wip', 'test:jruby:aot', 'test:slow_suites', 'spec:compiler', 'spec:regression', 'spec:jruby', 'spec:jrubyc', 'spec:profiler']
       fail-fast: false
 
     name: rake ${{ matrix.target }} (Java 8)

--- a/rakelib/commands.rake
+++ b/rakelib/commands.rake
@@ -55,6 +55,7 @@ def mspec(mspec_options = {}, java_options = {}, &code)
   java_options[:dir] ||= BASE_DIR
   java_options[:maxmemory] ||= JRUBY_LAUNCH_MEMORY
 
+  mspec_options[:command] ||= 'ci'
   mspec_options[:compile_mode] ||= 'OFF'
   mspec_options[:jit_threshold] ||= 20
   mspec_options[:jit_max] ||= -1
@@ -84,7 +85,7 @@ def mspec(mspec_options = {}, java_options = {}, &code)
     # add . to load path so mspec config is found
     arg :line => "-I ."
 
-    arg :line => "#{MSPEC_BIN} ci"
+    arg :line => "#{MSPEC_BIN} #{ms[:command]}"
     arg :line => "-T -J-ea"
     arg :line => "-T -J-Djruby.launch.inproc=false"
     arg :line => "-T -J-Djruby.compile.mode=#{ms[:compile_mode]}"
@@ -100,6 +101,9 @@ def mspec(mspec_options = {}, java_options = {}, &code)
     arg :line => "-f #{ms[:format]}"
     arg :line => "--timeout #{ms[:timeout]}"
     arg :line => "-B #{ms[:spec_config]}" if ms[:spec_config]
+    (ms[:tags] || []).each do |tag|
+      arg :line => "-g #{tag}"
+    end
     arg :line => "#{ms[:spec_target]}" if ms[:spec_target]
   end
 end

--- a/rakelib/rubyspec.rake
+++ b/rakelib/rubyspec.rake
@@ -52,7 +52,7 @@ namespace :spec do
           :jruby_opts => "--debug"
   end
 
-  desc "Run specs for work-in-prorgess features"
+  desc "Run specs for work-in-progess features"
   task :'ruby:wip' do
     mspec :command => "run",
           :compile_mode => "OFF",

--- a/rakelib/rubyspec.rake
+++ b/rakelib/rubyspec.rake
@@ -52,6 +52,17 @@ namespace :spec do
           :jruby_opts => "--debug"
   end
 
+  desc "Run specs for work-in-prorgess features"
+  task :'ruby:wip' do
+    mspec :command => "run",
+          :compile_mode => "OFF",
+          :format => "s",
+          :spec_target => "spec/ruby",
+          :jruby_opts => "--dev",
+          :spec_config => "spec/jruby.mspec",
+          :tags => [:wip]
+  end
+
   desc "Run rubyspecs expected to pass"
   task :ci => ['spec:tagged']
 

--- a/spec/jruby.mspec
+++ b/spec/jruby.mspec
@@ -92,6 +92,10 @@ class MSpecScript
   get(:xtags) << 'hangs'
   get(:ci_xtags) << 'hangs'
 
+  # Specs we intend to pass but are still working on
+  get(:ci_xtags) << 'wip'
+
+  # Expected failures specific to a given Java version
   get(:ci_xtags) << "java#{ENV_JAVA['java.specification.version']}" # Java version
 
   unless $stdin.tty?

--- a/spec/tags/ruby/core/argf/gets_tags.txt
+++ b/spec/tags/ruby/core/argf/gets_tags.txt
@@ -1,1 +1,2 @@
 slow:ARGF.gets reads all lines of stdin
+wip:ARGF.gets reads the contents of the file with default encoding

--- a/spec/tags/ruby/core/argf/read_tags.txt
+++ b/spec/tags/ruby/core/argf/read_tags.txt
@@ -1,3 +1,4 @@
 slow:ARGF.read reads the contents of stdin
 slow:ARGF.read reads a number of bytes from stdin
 slow:ARGF.read reads the contents of one file and stdin
+wip:ARGF.read reads the contents of the file with default encoding

--- a/spec/tags/ruby/core/dir/element_reference_tags.txt
+++ b/spec/tags/ruby/core/dir/element_reference_tags.txt
@@ -1,2 +1,4 @@
 fails:Dir.[] raises an Encoding::CompatibilityError if the argument encoding is not compatible with US-ASCII
 fails:Dir.[] matches files with backslashes in their name
+wip:Dir.[] respects the order of {} expressions, expanding left most first
+wip:Dir.[] respects the optional nested {} expressions

--- a/spec/tags/ruby/core/dir/glob_tags.txt
+++ b/spec/tags/ruby/core/dir/glob_tags.txt
@@ -1,3 +1,5 @@
 fails:Dir.glob raises an Encoding::CompatibilityError if the argument encoding is not compatible with US-ASCII
 fails:Dir.glob recursively matches files and directories in nested dot subdirectory with 'nested/**/*' from the current directory and option File::FNM_DOTMATCH
 fails:Dir.glob matches files with backslashes in their name
+wip:Dir.glob respects the order of {} expressions, expanding left most first
+wip:Dir.glob respects the optional nested {} expressions

--- a/spec/tags/ruby/core/dir/read_tags.txt
+++ b/spec/tags/ruby/core/dir/read_tags.txt
@@ -1,0 +1,1 @@
+wip:Dir#read returns all directory entries even when encoding conversion will fail

--- a/spec/tags/ruby/core/encoding/list_tags.txt
+++ b/spec/tags/ruby/core/encoding/list_tags.txt
@@ -1,0 +1,1 @@
+wip:Encoding.list includes CESU-8 encoding

--- a/spec/tags/ruby/core/enumerator/new_tags.txt
+++ b/spec/tags/ruby/core/enumerator/new_tags.txt
@@ -1,0 +1,1 @@
+wip:Enumerator.new no block given raises

--- a/spec/tags/ruby/core/exception/frozen_error_tags.txt
+++ b/spec/tags/ruby/core/exception/frozen_error_tags.txt
@@ -1,0 +1,2 @@
+wip:FrozenError.new should take optional receiver argument
+wip:FrozenError#receiver should return frozen object that modification was attempted on

--- a/spec/tags/ruby/core/exception/no_method_error_tags.txt
+++ b/spec/tags/ruby/core/exception/no_method_error_tags.txt
@@ -1,1 +1,2 @@
 fails:NoMethodError#dup copies the name, arguments and receiver
+wip:NoMethodError#message uses #name to display the receiver if it is a class or a module

--- a/spec/tags/ruby/core/fiber/blocking_tags.txt
+++ b/spec/tags/ruby/core/fiber/blocking_tags.txt
@@ -1,0 +1,12 @@
+wip:Fiber.blocking? root Fiber of the main thread returns false
+wip:Fiber.blocking? root Fiber of the main thread returns false for blocking: false
+wip:Fiber.blocking? root Fiber of a new thread returns false
+wip:Fiber.blocking? root Fiber of a new thread returns false for blocking: false
+wip:Fiber.blocking? when fiber is blocking root Fiber of the main thread returns 1 for blocking: true
+wip:Fiber.blocking? when fiber is blocking root Fiber of a new thread returns 1 for blocking: true
+wip:Fiber#blocking? root Fiber of the main thread returns false
+wip:Fiber#blocking? root Fiber of the main thread returns false for blocking: false
+wip:Fiber#blocking? root Fiber of a new thread returns false
+wip:Fiber#blocking? root Fiber of a new thread returns false for blocking: false
+wip:Fiber#blocking? when fiber is blocking root Fiber of the main thread returns true for blocking: true
+wip:Fiber#blocking? when fiber is blocking root Fiber of a new thread returns true for blocking: true

--- a/spec/tags/ruby/core/fiber/raise_tags.txt
+++ b/spec/tags/ruby/core/fiber/raise_tags.txt
@@ -1,0 +1,26 @@
+wip:Fiber#raise aborts execution
+wip:Fiber#raise accepts an exception that implements to_hash
+wip:Fiber#raise allows the message parameter to be a hash
+wip:Fiber#raise raises RuntimeError if no exception class is given
+wip:Fiber#raise raises a given Exception instance
+wip:Fiber#raise raises a RuntimeError if string given
+wip:Fiber#raise passes no arguments to the constructor when given only an exception class
+wip:Fiber#raise raises a TypeError when passed a non-Exception object
+wip:Fiber#raise raises a TypeError when passed true
+wip:Fiber#raise raises a TypeError when passed false
+wip:Fiber#raise raises a TypeError when passed nil
+wip:Fiber#raise re-raises a previously rescued exception without overwriting the backtrace
+wip:Fiber#raise allows Exception, message, and backtrace parameters
+wip:Fiber#raise raises RuntimeError by default
+wip:Fiber#raise raises FiberError if Fiber is not born
+wip:Fiber#raise raises FiberError if Fiber is dead
+wip:Fiber#raise accepts error class
+wip:Fiber#raise accepts error message
+wip:Fiber#raise does not accept array of backtrace information only
+wip:Fiber#raise does not accept integer
+wip:Fiber#raise accepts error class with error message
+wip:Fiber#raise accepts error class with with error message and backtrace information
+wip:Fiber#raise does not accept only error message and backtrace information
+wip:Fiber#raise raises a FiberError if invoked from a different Thread
+wip:Fiber#raise kills Fiber
+wip:Fiber#raise transfers and raises on a transferring fiber

--- a/spec/tags/ruby/core/fiber/resume_tags.txt
+++ b/spec/tags/ruby/core/fiber/resume_tags.txt
@@ -1,0 +1,1 @@
+wip:Fiber#resume raises a FiberError if the Fiber tries to resume itself

--- a/spec/tags/ruby/core/fiber/yield_tags.txt
+++ b/spec/tags/ruby/core/fiber/yield_tags.txt
@@ -1,0 +1,1 @@
+wip:Fiber.yield raises a FiberError if called from the root Fiber

--- a/spec/tags/ruby/core/file/dirname_tags.txt
+++ b/spec/tags/ruby/core/file/dirname_tags.txt
@@ -1,0 +1,2 @@
+wip:File.dirname returns all the components of filename except the last parts by the level
+wip:File.dirname returns the same string if the level is 0

--- a/spec/tags/ruby/core/file/extname_tags.txt
+++ b/spec/tags/ruby/core/file/extname_tags.txt
@@ -1,0 +1,1 @@
+wip:File.extname returns the extension for edge cases

--- a/spec/tags/ruby/core/file/stat/inspect_tags.txt
+++ b/spec/tags/ruby/core/file/stat/inspect_tags.txt
@@ -1,0 +1,1 @@
+wip:File::Stat#inspect produces a nicely formatted description of a File::Stat object

--- a/spec/tags/ruby/core/gc/measure_total_time_tags.txt
+++ b/spec/tags/ruby/core/gc/measure_total_time_tags.txt
@@ -1,0 +1,1 @@
+wip:GC.measure_total_time can set and get a boolean value

--- a/spec/tags/ruby/core/gc/stat_tags.txt
+++ b/spec/tags/ruby/core/gc/stat_tags.txt
@@ -3,3 +3,5 @@ fails:GC.stat increases major_gc_count after GC is run
 fails:GC.stat provides some number for heap_free_slots
 fails:GC.stat provides some number for total_allocated_objects
 fails:GC.stat the values are all Integer since rb_gc_stat() returns size_t
+wip:GC.stat raises an error if argument is not nil, a symbol, or a hash
+wip:GC.stat raises an error if an unknown key is given

--- a/spec/tags/ruby/core/gc/total_time_tags.txt
+++ b/spec/tags/ruby/core/gc/total_time_tags.txt
@@ -1,0 +1,2 @@
+wip:GC.total_time returns an Integer
+wip:GC.total_time increases as collections are run

--- a/spec/tags/ruby/core/hash/deconstruct_keys_tags.txt
+++ b/spec/tags/ruby/core/hash/deconstruct_keys_tags.txt
@@ -1,0 +1,1 @@
+wip:Hash#deconstruct_keys requires one argument

--- a/spec/tags/ruby/core/hash/each_pair_tags.txt
+++ b/spec/tags/ruby/core/hash/each_pair_tags.txt
@@ -1,0 +1,1 @@
+wip:Hash#each_pair always yields an Array of 2 elements, even when given a callable of arity 2

--- a/spec/tags/ruby/core/hash/each_tags.txt
+++ b/spec/tags/ruby/core/hash/each_tags.txt
@@ -1,0 +1,1 @@
+wip:Hash#each always yields an Array of 2 elements, even when given a callable of arity 2

--- a/spec/tags/ruby/core/hash/transform_keys_tags.txt
+++ b/spec/tags/ruby/core/hash/transform_keys_tags.txt
@@ -1,0 +1,1 @@
+wip:Hash#transform_keys! returns the processed keys and non evaluated keys if we break from the block

--- a/spec/tags/ruby/core/integer/chr_tags.txt
+++ b/spec/tags/ruby/core/integer/chr_tags.txt
@@ -1,0 +1,1 @@
+wip:Integer#chr with an encoding argument returns a String encoding self interpreted as a codepoint in the CESU-8 encoding

--- a/spec/tags/ruby/core/integer/left_shift_tags.txt
+++ b/spec/tags/ruby/core/integer/left_shift_tags.txt
@@ -1,3 +1,7 @@
 fails:Integer#<< (with n << m) fixnum returns 0 when m < 0 and m is a Bignum
 fails:Integer#<< (with n << m) bignum returns 0 when m < 0 and m is a Bignum
 fails:Integer#<< (with n << m) fixnum calls #to_int to convert the argument to an Integer
+wip:Integer#<< (with n << m) when m is a bignum or larger than int returns -1 when m < 0 and n < 0
+wip:Integer#<< (with n << m) when m is a bignum or larger than int returns 0 when m < 0 and n >= 0
+wip:Integer#<< (with n << m) when m is a bignum or larger than int returns 0 when m > 0 bignum and n == 0
+wip:Integer#<< (with n << m) when m is a bignum or larger than int raises NoMemoryError when m > 0 and n != 0

--- a/spec/tags/ruby/core/integer/right_shift_tags.txt
+++ b/spec/tags/ruby/core/integer/right_shift_tags.txt
@@ -1,0 +1,4 @@
+wip:Integer#>> (with n >> m) when m is a bignum or larger than int returns -1 when m > 0 and n < 0
+wip:Integer#>> (with n >> m) when m is a bignum or larger than int returns 0 when m > 0 and n >= 0
+wip:Integer#>> (with n >> m) when m is a bignum or larger than int returns 0 when m < 0 bignum and n == 0
+wip:Integer#>> (with n >> m) when m is a bignum or larger than int raises NoMemoryError when m < 0 and n != 0

--- a/spec/tags/ruby/core/io/for_fd_tags.txt
+++ b/spec/tags/ruby/core/io/for_fd_tags.txt
@@ -3,3 +3,5 @@ fails:IO.for_fd raises an error if passed conflicting binary/text mode two ways
 windows:IO.for_fd raises an Errno::EINVAL if the new mode is not compatible with the descriptor's current mode
 fails:IO.for_fd ignores the :encoding option when the :external_encoding option is present
 fails:IO.for_fd ignores the :encoding option when the :internal_encoding option is present
+wip:IO.for_fd raises ArgumentError for nil options
+wip:IO.for_fd raises ArgumentError if passed a hash for mode and nil for options

--- a/spec/tags/ruby/core/io/new_tags.txt
+++ b/spec/tags/ruby/core/io/new_tags.txt
@@ -4,3 +4,5 @@ windows:IO.new ingores the :encoding option when the :internal_encoding option i
 windows:IO.new raises an Errno::EINVAL if the new mode is not compatible with the descriptor's current mode
 fails:IO.new ignores the :encoding option when the :external_encoding option is present
 fails:IO.new ignores the :encoding option when the :internal_encoding option is present
+wip:IO.new raises ArgumentError for nil options
+wip:IO.new raises ArgumentError if passed a hash for mode and nil for options

--- a/spec/tags/ruby/core/io/nonblock_tags.txt
+++ b/spec/tags/ruby/core/io/nonblock_tags.txt
@@ -1,0 +1,2 @@
+wip:IO#nonblock? returns true for pipe by default
+wip:IO#nonblock? returns true for socket by default

--- a/spec/tags/ruby/core/io/open_tags.txt
+++ b/spec/tags/ruby/core/io/open_tags.txt
@@ -4,3 +4,5 @@ windows:IO.open ingores the :encoding option when the :internal_encoding option 
 windows:IO.open raises an Errno::EINVAL if the new mode is not compatible with the descriptor's current mode
 fails:IO.open ignores the :encoding option when the :external_encoding option is present
 fails:IO.open ignores the :encoding option when the :internal_encoding option is present
+wip:IO.open raises ArgumentError for nil options
+wip:IO.open raises ArgumentError if passed a hash for mode and nil for options

--- a/spec/tags/ruby/core/io/ungetc_tags.txt
+++ b/spec/tags/ruby/core/io/ungetc_tags.txt
@@ -1,1 +1,2 @@
 windows:IO#ungetc adjusts the stream position
+wip:IO#ungetc raises TypeError if passed nil

--- a/spec/tags/ruby/core/io/write_tags.txt
+++ b/spec/tags/ruby/core/io/write_tags.txt
@@ -1,3 +1,4 @@
 windows:IO.write doesn't truncate the file and writes the given string if an offset is given
 windows:IO.write doesn't truncate and writes at the given offset after passing empty opts
 windows:IO#write on Windows normalizes line endings in text mode
+wip:IO#write on STDOUT raises SignalException SIGPIPE if the stream is closed instead of Errno::EPIPE like other IOs

--- a/spec/tags/ruby/core/kernel/Complex_tags.txt
+++ b/spec/tags/ruby/core/kernel/Complex_tags.txt
@@ -1,0 +1,1 @@
+wip:Kernel.Complex() when passed exception: false and [Numeric] returns a complex number

--- a/spec/tags/ruby/core/kernel/__dir___tags.txt
+++ b/spec/tags/ruby/core/kernel/__dir___tags.txt
@@ -1,1 +1,2 @@
 fails:Kernel#__dir__ when used in eval with a given filename returns File.dirname(filename)
+wip:Kernel#__dir__ when used in eval with top level binding returns nil

--- a/spec/tags/ruby/core/kernel/clone_tags.txt
+++ b/spec/tags/ruby/core/kernel/clone_tags.txt
@@ -1,0 +1,7 @@
+wip:Kernel#clone with freeze: nil copies frozen state from the original, like #clone without arguments
+wip:Kernel#clone with freeze: nil copies frozen?
+wip:Kernel#clone with freeze: true freezes the copy even if the original was not frozen
+wip:Kernel#clone with freeze: true calls #initialize_clone with kwargs freeze: true
+wip:Kernel#clone with freeze: true calls #initialize_clone with kwargs freeze: true even if #initialize_clone only takes a single argument
+wip:Kernel#clone with freeze: false calls #initialize_clone with kwargs freeze: false
+wip:Kernel#clone with freeze: false calls #initialize_clone with kwargs freeze: false even if #initialize_clone only takes a single argument

--- a/spec/tags/ruby/core/kernel/initialize_clone_tags.txt
+++ b/spec/tags/ruby/core/kernel/initialize_clone_tags.txt
@@ -1,0 +1,1 @@
+wip:Kernel#initialize_clone accepts a :freeze keyword argument for obj.clone(freeze: value)

--- a/spec/tags/ruby/core/kernel/instance_variables_tags.txt
+++ b/spec/tags/ruby/core/kernel/instance_variables_tags.txt
@@ -1,0 +1,1 @@
+wip:Kernel#instance_variables regular objects returns the instances variables in the order declared

--- a/spec/tags/ruby/core/kernel/lambda_tags.txt
+++ b/spec/tags/ruby/core/kernel/lambda_tags.txt
@@ -1,1 +1,2 @@
 fails:Kernel.lambda does not create lambda-style Procs when captured with #method
+wip:Kernel.lambda when called without a literal block warns when proc isn't a lambda

--- a/spec/tags/ruby/core/kernel/rand_tags.txt
+++ b/spec/tags/ruby/core/kernel/rand_tags.txt
@@ -1,1 +1,2 @@
 fails:Kernel.rand returns nil when range is backwards
+wip:Kernel#rand returns nil when range is backwards

--- a/spec/tags/ruby/core/kernel/require_tags.txt
+++ b/spec/tags/ruby/core/kernel/require_tags.txt
@@ -6,3 +6,5 @@ fails:Kernel.require ($LOADED_FEATURES) with symlinks does not canonicalize the 
 fails:Kernel.require ($LOADED_FEATURES) with symlinks in the required feature and $LOAD_PATH canonicalizes the entry in $LOAD_PATH but not the filename passed to #require
 fails:Kernel#require ($LOADED_FEATURES) unicode_normalize is part of core and not $LOADED_FEATURES
 fails:Kernel.require ($LOADED_FEATURES) unicode_normalize is part of core and not $LOADED_FEATURES
+wip:Kernel#require ($LOADED_FEATURES) complex, enumerator, rational, thread, ruby2_keywords are already required
+wip:Kernel.require ($LOADED_FEATURES) complex, enumerator, rational, thread, ruby2_keywords are already required

--- a/spec/tags/ruby/core/kernel/warn_tags.txt
+++ b/spec/tags/ruby/core/kernel/warn_tags.txt
@@ -1,2 +1,5 @@
 fails:Kernel#warn :uplevel keyword argument does not prepend caller information if line number is too big
 fails:Kernel#warn :uplevel keyword argument does not prepend caller information if the uplevel argument is too large
+wip:Kernel#warn calls Warning.warn with category: nil if Warning.warn accepts keyword arguments
+wip:Kernel#warn calls Warning.warn with given category keyword converted to a symbol
+wip:Kernel#warn :uplevel keyword argument raises if :category keyword is not nil and not convertible to symbol

--- a/spec/tags/ruby/core/marshal/restore_tags.txt
+++ b/spec/tags/ruby/core/marshal/restore_tags.txt
@@ -2,3 +2,4 @@ fails:Marshal.restore for a Symbol loads a binary encoded Symbol
 fails:Marshal.restore for an Object raises ArgumentError if the object from an 'o' stream is not dumpable as 'o' type user class
 fails:Marshal.restore for a wrapped C pointer raises ArgumentError when the local class is a regular object ERROR
 
+wip:Marshal.restore for a wrapped C pointer raises ArgumentError when the local class is a regular object

--- a/spec/tags/ruby/core/method/inspect_tags.txt
+++ b/spec/tags/ruby/core/method/inspect_tags.txt
@@ -1,0 +1,3 @@
+wip:Method#inspect returns a String containing method arguments
+wip:Method#inspect returns a String containing the Module containing the method if object has a singleton class but method is not defined in the singleton class
+wip:Method#inspect shows the metaclass and the owner for a Module instance method retrieved from a class

--- a/spec/tags/ruby/core/method/to_s_tags.txt
+++ b/spec/tags/ruby/core/method/to_s_tags.txt
@@ -1,0 +1,3 @@
+wip:Method#to_s returns a String containing method arguments
+wip:Method#to_s returns a String containing the Module containing the method if object has a singleton class but method is not defined in the singleton class
+wip:Method#to_s shows the metaclass and the owner for a Module instance method retrieved from a class

--- a/spec/tags/ruby/core/module/autoload_tags.txt
+++ b/spec/tags/ruby/core/module/autoload_tags.txt
@@ -1,2 +1,4 @@
 fails(conflicting state changes for failed load and autoload):Module#autoload does not remove the constant from Module#constants if load raises a RuntimeError and keeps it as an autoload
 hangs(incompatible locking in autoload):Module#autoload during the autoload before the constant is assigned returns nil in autoload thread and returns the path in other threads for Module#autoload?
+wip:Module#autoload removes the constant from Module#constants if the loaded file does not define it
+wip:Module#autoload after autoloading searches for the constant like the original lookup looks up in parent scope after failed autoload

--- a/spec/tags/ruby/core/module/deprecate_constant_tags.txt
+++ b/spec/tags/ruby/core/module/deprecate_constant_tags.txt
@@ -1,0 +1,1 @@
+wip:Module#deprecate_constant when accessing the deprecated module does not warn if Warning[:deprecated] is false

--- a/spec/tags/ruby/core/module/prepend_tags.txt
+++ b/spec/tags/ruby/core/module/prepend_tags.txt
@@ -1,0 +1,1 @@
+wip:Module#prepend uses only new module when dupping the module

--- a/spec/tags/ruby/core/module/refine_tags.txt
+++ b/spec/tags/ruby/core/module/refine_tags.txt
@@ -5,3 +5,6 @@ fails(not implemented, jruby/jruby#6161):Module#refine for methods accessed indi
 fails(not implemented, jruby/jruby#6161):Module#refine for methods accessed indirectly is honored by Kernel#public_send
 fails(not implemented, jruby/jruby#6161):Module#refine for methods accessed indirectly is honored by Kernel#respond_to?
 fails:Module#refine when super is called in a refinement looks in the lexical scope refinements before other active refinements
+wip:Module#refine for methods accessed indirectly is honored by Kernel#method
+wip:Module#refine for methods accessed indirectly is honored by Kernel#public_method
+wip:Module#refine for methods accessed indirectly is honored by Kernel#instance_method

--- a/spec/tags/ruby/core/numeric/clone_tags.txt
+++ b/spec/tags/ruby/core/numeric/clone_tags.txt
@@ -1,0 +1,1 @@
+wip:Numeric#clone does not change frozen status if passed freeze: nil

--- a/spec/tags/ruby/core/objectspace/define_finalizer_tags.txt
+++ b/spec/tags/ruby/core/objectspace/define_finalizer_tags.txt
@@ -1,3 +1,6 @@
 fails:ObjectSpace.define_finalizer calls finalizer at exit even if it is self-referencing
 fails:ObjectSpace.define_finalizer raises ArgumentError trying to define a finalizer on a non-reference
 fails:ObjectSpace.define_finalizer calls a finalizer defined in a finalizer running at exit
+wip:ObjectSpace.define_finalizer warns if the finalizer has the object as the receiver
+wip:ObjectSpace.define_finalizer warns if the finalizer is a method bound to the receiver
+wip:ObjectSpace.define_finalizer warns if the finalizer was a block in the receiver

--- a/spec/tags/ruby/core/proc/inspect_tags.txt
+++ b/spec/tags/ruby/core/proc/inspect_tags.txt
@@ -4,3 +4,4 @@ fails:Proc#inspect for a proc created with lambda has a binary encoding
 fails:Proc#inspect for a proc created with proc has a binary encoding
 fails:Proc#inspect for a proc created with UnboundMethod#to_proc has a binary encoding
 fails:Proc#inspect for a proc created with Symbol#to_proc has a binary encoding
+wip:Proc#inspect for a proc created with proc returns a description including file and line number

--- a/spec/tags/ruby/core/proc/ruby2_keywords_tags.txt
+++ b/spec/tags/ruby/core/proc/ruby2_keywords_tags.txt
@@ -1,0 +1,2 @@
+wip:Proc#ruby2_keywords marks the final hash argument as keyword hash
+wip:Proc#ruby2_keywords applies to the underlying method and applies across duplication

--- a/spec/tags/ruby/core/proc/source_location_tags.txt
+++ b/spec/tags/ruby/core/proc/source_location_tags.txt
@@ -1,1 +1,4 @@
 fails:Proc#source_location returns the first line of a multi-line proc (i.e. the line containing 'proc do')
+wip:Proc#source_location works even if the proc was created on the same line
+wip:Proc#source_location returns the location of the proc's body; not necessarily the proc itself
+wip:Proc#source_location sets the last value to an Integer representing the line on which the proc was defined

--- a/spec/tags/ruby/core/proc/to_s_tags.txt
+++ b/spec/tags/ruby/core/proc/to_s_tags.txt
@@ -4,3 +4,4 @@ fails:Proc#to_s for a proc created with lambda has a binary encoding
 fails:Proc#to_s for a proc created with proc has a binary encoding
 fails:Proc#to_s for a proc created with UnboundMethod#to_proc has a binary encoding
 fails:Proc#to_s for a proc created with Symbol#to_proc has a binary encoding
+wip:Proc#to_s for a proc created with proc returns a description including file and line number

--- a/spec/tags/ruby/core/process/clock_gettime_tags.txt
+++ b/spec/tags/ruby/core/process/clock_gettime_tags.txt
@@ -1,0 +1,5 @@
+wip:Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_PROCESS_CPUTIME_ID
+wip:Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_THREAD_CPUTIME_ID
+wip:Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_MONOTONIC_RAW
+wip:Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_MONOTONIC_RAW_APPROX
+wip:Process.clock_gettime supports the platform clocks mentioned in the documentation CLOCK_UPTIME_RAW and CLOCK_UPTIME_RAW_APPROX

--- a/spec/tags/ruby/core/process/status/wait_tags.txt
+++ b/spec/tags/ruby/core/process/status/wait_tags.txt
@@ -1,0 +1,10 @@
+wip:Process::Status.wait returns a status with pid -1 if there are no child processes
+wip:Process::Status.wait returns a status with its child pid
+wip:Process::Status.wait should not set $? to the Process::Status
+wip:Process::Status.wait should not change the value of $?
+wip:Process::Status.wait waits for any child process if no pid is given
+wip:Process::Status.wait waits for a specific child if a pid is given
+wip:Process::Status.wait coerces the pid to an Integer
+wip:Process::Status.wait waits for a child whose process group ID is that of the calling process
+wip:Process::Status.wait doesn't block if no child is available when WNOHANG is used
+wip:Process::Status.wait always accepts flags=0

--- a/spec/tags/ruby/core/queue/initialize_tags.txt
+++ b/spec/tags/ruby/core/queue/initialize_tags.txt
@@ -1,0 +1,3 @@
+wip:Queue#initialize adds all elements of the passed Enumerable to self
+wip:Queue#initialize uses #to_a on the provided Enumerable
+wip:Queue#initialize raises if the provided Enumerable does not respond to #to_a

--- a/spec/tags/ruby/core/range/dup_tags.txt
+++ b/spec/tags/ruby/core/range/dup_tags.txt
@@ -1,0 +1,1 @@
+wip:Range#dup creates an unfrozen range

--- a/spec/tags/ruby/core/range/each_tags.txt
+++ b/spec/tags/ruby/core/range/each_tags.txt
@@ -1,0 +1,1 @@
+wip:Range#each supports Time objects that respond to #succ

--- a/spec/tags/ruby/core/string/length_tags.txt
+++ b/spec/tags/ruby/core/string/length_tags.txt
@@ -1,0 +1,1 @@
+wip:String#length adds 1 (and not 2) for a incomplete surrogate in UTF-16

--- a/spec/tags/ruby/core/string/size_tags.txt
+++ b/spec/tags/ruby/core/string/size_tags.txt
@@ -1,0 +1,1 @@
+wip:String#size adds 1 (and not 2) for a incomplete surrogate in UTF-16

--- a/spec/tags/ruby/core/string/split_tags.txt
+++ b/spec/tags/ruby/core/string/split_tags.txt
@@ -1,0 +1,2 @@
+wip:String#split with String doesn't split on non-ascii whitespace
+wip:String#split with String when $; is not nil warns

--- a/spec/tags/ruby/core/string/uminus_tags.txt
+++ b/spec/tags/ruby/core/string/uminus_tags.txt
@@ -1,0 +1,1 @@
+wip:String#-@ interns the provided string if it is frozen

--- a/spec/tags/ruby/core/string/unpack1_tags.txt
+++ b/spec/tags/ruby/core/string/unpack1_tags.txt
@@ -1,0 +1,2 @@
+wip:String#unpack1 starts unpacking from the given offset
+wip:String#unpack1 returns nil if the offset is at the end of the string

--- a/spec/tags/ruby/core/string/valid_encoding_tags.txt
+++ b/spec/tags/ruby/core/string/valid_encoding_tags.txt
@@ -1,0 +1,1 @@
+wip:String#valid_encoding? returns true for IBM720 encoding self is valid in

--- a/spec/tags/ruby/core/struct/deconstruct_keys_tags.txt
+++ b/spec/tags/ruby/core/struct/deconstruct_keys_tags.txt
@@ -1,0 +1,1 @@
+wip:Struct#deconstruct_keys requires one argument

--- a/spec/tags/ruby/core/symbol/to_proc_tags.txt
+++ b/spec/tags/ruby/core/symbol/to_proc_tags.txt
@@ -1,1 +1,2 @@
 fails:Symbol#to_proc produces a proc with source location nil
+wip:Symbol#to_proc produces a Proc with arity -2

--- a/spec/tags/ruby/core/thread/backtrace/location/absolute_path_tags.txt
+++ b/spec/tags/ruby/core/thread/backtrace/location/absolute_path_tags.txt
@@ -4,3 +4,4 @@ fails:Thread::Backtrace::Location#absolute_path canonicalization returns a canon
 fails:Thread::Backtrace::Location#absolute_path canonicalization returns a canonical path without symlinks, even when __FILE__ is removed
 fails:Thread::Backtrace::Location#absolute_path returns an absolute path when using a relative main script path
 fails:Thread::Backtrace::Location#absolute_path when used in a core method returns nil
+wip:Thread::Backtrace::Location#absolute_path when used in eval with a given filename returns nil with absolute_path

--- a/spec/tags/ruby/core/thread/ignore_deadlock_tags.txt
+++ b/spec/tags/ruby/core/thread/ignore_deadlock_tags.txt
@@ -1,0 +1,2 @@
+wip:Thread.ignore_deadlock returns false by default
+wip:Thread.ignore_deadlock= changes the value of Thread.ignore_deadlock

--- a/spec/tags/ruby/core/thread/inspect_tags.txt
+++ b/spec/tags/ruby/core/thread/inspect_tags.txt
@@ -1,1 +1,2 @@
 fails:Thread#inspect has a binary encoding
+wip:Thread#inspect returns a description including file and line number

--- a/spec/tags/ruby/core/warning/element_set_tags.txt
+++ b/spec/tags/ruby/core/warning/element_set_tags.txt
@@ -1,0 +1,1 @@
+wip:Warning.[]= :experimental emits and suppresses warnings for :experimental

--- a/spec/tags/ruby/core/warning/warn_tags.txt
+++ b/spec/tags/ruby/core/warning/warn_tags.txt
@@ -1,0 +1,2 @@
+wip:Warning.warn is called by Kernel.warn with nil category keyword
+wip:Warning.warn is called by Kernel.warn with given category keyword converted to a symbol

--- a/spec/tags/ruby/language/class_variable_tags.txt
+++ b/spec/tags/ruby/language/class_variable_tags.txt
@@ -1,0 +1,2 @@
+wip:Accessing a class variable raises a RuntimeError when accessed from the toplevel scope (not in some module or class)
+wip:Accessing a class variable raises a RuntimeError when a class variable is overtaken in an ancestor class

--- a/spec/tags/ruby/language/comment_tags.txt
+++ b/spec/tags/ruby/language/comment_tags.txt
@@ -1,0 +1,1 @@
+wip:The comment can be placed between fluent dot now

--- a/spec/tags/ruby/language/constants_tags.txt
+++ b/spec/tags/ruby/language/constants_tags.txt
@@ -8,3 +8,5 @@ fails(2.3 feature):Constant resolution within a singleton class (class << obj) a
 fails:Module#private_constant marked constants in a module cannot be reopened as a module from scope where constant would be private
 fails:Module#private_constant marked constants in a module cannot be reopened as a class from scope where constant would be private
 fails:Allowed characters does not allow not ASCII upcased characters at the beginning
+wip:Literal (A::X) constant resolution uses the module or class #name to craft the error message
+wip:Module#private_constant marked constants remain private even when updated

--- a/spec/tags/ruby/language/heredoc_tags.txt
+++ b/spec/tags/ruby/language/heredoc_tags.txt
@@ -1,0 +1,1 @@
+wip:Heredoc string raises SyntaxError if quoted HEREDOC identifier is ending not on same line

--- a/spec/tags/ruby/language/pattern_matching_tags.txt
+++ b/spec/tags/ruby/language/pattern_matching_tags.txt
@@ -1,0 +1,2 @@
+wip:Pattern matching find pattern can be nested
+wip:Pattern matching find pattern can nest hash and array patterns

--- a/spec/tags/ruby/language/predefined_tags.txt
+++ b/spec/tags/ruby/language/predefined_tags.txt
@@ -2,3 +2,7 @@ fails:Global variable $0 raises a TypeError when not given an object that can be
 fails:Global variable $0 actually sets the program name
 windows:The predefined global constant ARGV contains Strings encoded in locale Encoding
 fails:Predefined global $! in bodies without ensure should be cleared when an exception is rescued even when a non-local return is present
+wip:Predefined global $, warns if assigned non-nil
+wip:$LOAD_PATH.resolve_feature_path returns what will be loaded without actual loading, .rb file
+wip:$LOAD_PATH.resolve_feature_path returns what will be loaded without actual loading, .so file
+wip:$LOAD_PATH.resolve_feature_path return nil if feature cannot be found

--- a/spec/tags/ruby/language/return_tags.txt
+++ b/spec/tags/ruby/language/return_tags.txt
@@ -1,1 +1,2 @@
 fails:The return keyword at top level within a block within a class is allowed
+wip:The return keyword at top level return with argument warns but does not affect exit status

--- a/spec/tags/ruby/language/send_tags.txt
+++ b/spec/tags/ruby/language/send_tags.txt
@@ -1,2 +1,3 @@
 fails:Invoking a method expands the Array elements from the splat after executing the arguments and block if no other arguments follow the splat
 fails:Invoking a private getter method does not permit self as a receiver
+wip:Invoking a private getter method permits self as a receiver

--- a/spec/tags/ruby/language/string_tags.txt
+++ b/spec/tags/ruby/language/string_tags.txt
@@ -1,0 +1,1 @@
+wip:Ruby String interpolation creates a non-frozen String when # frozen-string-literal: true is used

--- a/spec/tags/ruby/library/cgi/escapeHTML_tags.txt
+++ b/spec/tags/ruby/library/cgi/escapeHTML_tags.txt
@@ -1,0 +1,1 @@
+wip:CGI.escapeHTML escapes invalid encoding

--- a/spec/tags/ruby/library/cgi/unescapeHTML_tags.txt
+++ b/spec/tags/ruby/library/cgi/unescapeHTML_tags.txt
@@ -1,0 +1,1 @@
+wip:CGI.unescapeHTML unescapes invalid encoding

--- a/spec/tags/ruby/library/coverage/result_tags.txt
+++ b/spec/tags/ruby/library/coverage/result_tags.txt
@@ -1,0 +1,1 @@
+wip:Coverage.result second Coverage.start give exception

--- a/spec/tags/ruby/library/date/strftime_tags.txt
+++ b/spec/tags/ruby/library/date/strftime_tags.txt
@@ -1,0 +1,1 @@
+wip:Date#strftime should be able to show the commercial week

--- a/spec/tags/ruby/library/datetime/strftime_tags.txt
+++ b/spec/tags/ruby/library/datetime/strftime_tags.txt
@@ -1,0 +1,1 @@
+wip:DateTime#strftime should be able to show the commercial week

--- a/spec/tags/ruby/library/delegate/delegator/frozen_tags.txt
+++ b/spec/tags/ruby/library/delegate/delegator/frozen_tags.txt
@@ -1,0 +1,1 @@
+wip:Delegator when frozen creates a frozen clone

--- a/spec/tags/ruby/library/fiber/current_tags.txt
+++ b/spec/tags/ruby/library/fiber/current_tags.txt
@@ -1,0 +1,1 @@
+wip:Fiber.current returns the current Fiber when called from a Fiber that transferred to another

--- a/spec/tags/ruby/library/fiber/resume_tags.txt
+++ b/spec/tags/ruby/library/fiber/resume_tags.txt
@@ -1,0 +1,2 @@
+wip:Fiber#resume can work with Fiber#transfer
+wip:Fiber#resume raises a FiberError if the Fiber attempts to resume a resuming fiber

--- a/spec/tags/ruby/library/fiber/transfer_tags.txt
+++ b/spec/tags/ruby/library/fiber/transfer_tags.txt
@@ -3,3 +3,6 @@ critical(hangs):Fiber#transfer raises a FiberError when transferring to a Fiber 
 unstable(intermittent):Fiber#transfer raises a LocalJumpError if the block includes a return statement
 fails:Fiber#transfer can be invoked from the same Fiber it transfers control to
 windows(hangs):Fiber#transfer raises a FiberError if the Fiber is dead
+wip(hangs on MacOS):Fiber#transfer can be invoked from the root Fiber
+wip:Fiber#transfer transfers control from one Fiber to another when called from a Fiber
+wip:Fiber#transfer can not transfer control to a Fiber that has suspended by Fiber.yield

--- a/spec/tags/ruby/library/pp/pp_tags.txt
+++ b/spec/tags/ruby/library/pp/pp_tags.txt
@@ -1,0 +1,1 @@
+wip:PP.pp correctly prints a Hash

--- a/spec/tags/ruby/library/rbconfig/unicode_emoji_version_tags.txt
+++ b/spec/tags/ruby/library/rbconfig/unicode_emoji_version_tags.txt
@@ -1,0 +1,1 @@
+wip:RbConfig::CONFIG['UNICODE_EMOJI_VERSION'] is 13.1 for Ruby 3.1

--- a/spec/tags/ruby/library/rbconfig/unicode_version_tags.txt
+++ b/spec/tags/ruby/library/rbconfig/unicode_version_tags.txt
@@ -1,1 +1,2 @@
 fails:RbConfig::CONFIG['UNICODE_VERSION'] is 10.0.0 for Ruby 2.5
+wip:RbConfig::CONFIG['UNICODE_VERSION'] is 13.0.0 for Ruby 3.1

--- a/spec/tags/ruby/library/ripper/lex_tags.txt
+++ b/spec/tags/ruby/library/ripper/lex_tags.txt
@@ -1,0 +1,1 @@
+wip:Ripper.lex lexes a simple method declaration

--- a/spec/tags/ruby/library/securerandom/random_number_tags.txt
+++ b/spec/tags/ruby/library/securerandom/random_number_tags.txt
@@ -1,0 +1,3 @@
+wip:SecureRandom.random_number generates a random (potentially bignum) integer value for bignum argument
+wip:SecureRandom.random_number generates a random value in given (float) range limits
+wip:SecureRandom.random_number raises ArgumentError if the argument is non-numeric

--- a/spec/tags/ruby/library/set/sortedset/sortedset_tags.txt
+++ b/spec/tags/ruby/library/set/sortedset/sortedset_tags.txt
@@ -1,0 +1,1 @@
+wip:SortedSet raises error including message that it has been extracted from the set stdlib

--- a/spec/tags/ruby/library/socket/socket/getservbyname_tags.txt
+++ b/spec/tags/ruby/library/socket/socket/getservbyname_tags.txt
@@ -1,0 +1,1 @@
+wip:Socket#getservbyname raises a SocketError when the service or port is invalid

--- a/spec/tags/ruby/library/socket/tcpserver/initialize_tags.txt
+++ b/spec/tags/ruby/library/socket/tcpserver/initialize_tags.txt
@@ -1,2 +1,3 @@
 fails:TCPServer#initialize with a single Fixnum argument sets the hostname to 0.0.0.0
 fails:TCPServer#initialize with a single String argument containing a numeric value sets the hostname to 0.0.0.0
+wip:TCPServer#initialize with a single String argument containing a non numeric value raises SocketError

--- a/spec/tags/ruby/library/socket/tcpsocket/initialize_tags.txt
+++ b/spec/tags/ruby/library/socket/tcpsocket/initialize_tags.txt
@@ -1,0 +1,4 @@
+wip:TCPSocket#initialize raises Errno::ETIMEDOUT with :connect_timeout when no server is listening on the given address
+wip:TCPSocket#initialize with a running server connects to a server when passed connect_timeout argument
+wip:TCPSocket#initialize using IPv4 when a server is listening on the given address raises SocketError when the port number is a non numeric String
+wip:TCPSocket#initialize using IPv6 when a server is listening on the given address raises SocketError when the port number is a non numeric String

--- a/spec/tags/ruby/library/socket/tcpsocket/open_tags.txt
+++ b/spec/tags/ruby/library/socket/tcpsocket/open_tags.txt
@@ -1,0 +1,2 @@
+wip:TCPSocket.open raises Errno::ETIMEDOUT with :connect_timeout when no server is listening on the given address
+wip:TCPSocket.open with a running server connects to a server when passed connect_timeout argument

--- a/spec/tags/ruby/library/socket/udpsocket/send_tags.txt
+++ b/spec/tags/ruby/library/socket/udpsocket/send_tags.txt
@@ -1,2 +1,3 @@
 hangs:UDPSocket#send using IPv4 using a connected socket with an explicit destination address sends the data to the given address instead
 hangs:UDPSocket#send using IPv6 using a connected socket with an explicit destination address sends the data to the given address instead
+wip(hangs on MacOS):UDPSocket#send sends data in ad hoc mode (with port given as a String)


### PR DESCRIPTION
The `wip` tag will mark specs we are currently working on and hoping to support for the next release. The `spec:ruby:wip` task will run only these tags, or you can specify it with `mspec run -g wip`.

The goal here is to get the baseline spec CI runs back to green, so we can detect regressions.