### PR TITLE
Architecture tweaks for JRuby on M1

### DIFF
--- a/core/src/main/java/org/jruby/ext/rbconfig/RbConfigLibrary.java
+++ b/core/src/main/java/org/jruby/ext/rbconfig/RbConfigLibrary.java
@@ -103,6 +103,7 @@ public class RbConfigLibrary implements Library {
         String architecture = Platform.ARCH;
         if (architecture == null) architecture = "unknown";
         if ("amd64".equals(architecture)) architecture = "x86_64";
+        if ("aarch64".equals(architecture) && Platform.IS_MAC) architecture = "arm64";
 
         return architecture;
     }

--- a/core/src/main/java/org/jruby/util/cli/OutputStrings.java
+++ b/core/src/main/java/org/jruby/util/cli/OutputStrings.java
@@ -127,8 +127,8 @@ public class OutputStrings {
                 SafePropertyAccessor.getProperty("java.runtime.version", SafePropertyAccessor.getProperty("java.version", "Unknown version")),
                 Options.COMPILE_INVOKEDYNAMIC.load() ? " +indy" : "",
                 Options.COMPILE_MODE.load().shouldJIT() ? " +jit" : "",
-                RbConfigLibrary.getOSName(),
-                RbConfigLibrary.getArchitecture()
+                RbConfigLibrary.getArchitecture(),
+                RbConfigLibrary.getOSName()
         );
     }
 

--- a/spec/tags/ruby/library/socket/unixserver/accept_nonblock_tags.txt
+++ b/spec/tags/ruby/library/socket/unixserver/accept_nonblock_tags.txt
@@ -1,2 +1,2 @@
-darwin-aarch64:UNIXServer#accept_nonblock returns :wait_readable in exceptionless mode
-darwin-aarch64:UNIXServer#accept_nonblock without a client raises IO::WaitReadable
+darwin-arm64:UNIXServer#accept_nonblock returns :wait_readable in exceptionless mode
+darwin-arm64:UNIXServer#accept_nonblock without a client raises IO::WaitReadable


### PR DESCRIPTION
In https://github.com/sass/sassc-ruby/issues/231 it was reported that JRuby builds an improper `ARCH_FLAG` on MacOS/M1, using `aarch64` when it should use `arm64`. This PR fixes that.

This may be an appropriate change for other `aarch64` platforms depending on what the compiler wants, but I do not currently have a working Linux/aarch64 system on which to test it.

I also noticed that the `-v` output on JRuby reverses the arch and OS compared to CRuby, so this PR fixes that as well.

Two spec tags are updated to the new `arm64` arch name on `darwin`.