### PR TITLE
[aarch64] fix unrecognized command -m64 for native extensions

### DIFF
--- a/core/src/main/java/org/jruby/ext/rbconfig/RbConfigLibrary.java
+++ b/core/src/main/java/org/jruby/ext/rbconfig/RbConfigLibrary.java
@@ -424,8 +424,11 @@ public class RbConfigLibrary implements Library {
         String ldflags = ""; // + soflags;
         String dldflags = "";
         String ldsharedflags = " -shared ";
+        String arch = getArchitecture();
+        String archflags = "";
 
-        String archflags = " -m" + (IS_64_BIT ? "64" : "32");
+        if (arch.equals("x86_64") || arch.equals("i386"))
+            archflags += " -m" + (IS_64_BIT ? "64" : "32");
 
         String hdr_dir = newFile(normalizedHome, "lib/native/include/").getPath();
 
@@ -440,7 +443,7 @@ public class RbConfigLibrary implements Library {
         } else if (Platform.IS_MAC) {
             ldsharedflags = " -dynamic -bundle -undefined dynamic_lookup ";
             cflags = " -DTARGET_RT_MAC_CFM=0 " + cflags;
-            archflags = " -arch " + getArchitecture();
+            archflags = " -arch " + arch;
             cppflags = " -D_XOPEN_SOURCE -D_DARWIN_C_SOURCE " + cppflags;
             setConfig(context, mkmfHash, "DLEXT", "bundle");
 	        setConfig(context, mkmfHash, "EXEEXT", "");


### PR DESCRIPTION
jruby 9.4.0.0-SNAPSHOT (3.1.0) 2022-03-10 0b09e5447d OpenJDK 64-Bit Server VM 25.292-b10 on 1.8.0_292-8u292-b10-0ubuntu1~20.04-b10 +jit [linux-aarch64]

```
Fetching sassc-2.4.0.gem
Building native extensions. This could take a while...
ERROR:  Error installing sassc:
        ERROR: Failed to build gem native extension.

    current directory: /home/jruby/lib/ruby/gems/shared/gems/sassc-2.4.0/ext
/home/jruby/bin/jruby -I /home/jruby/lib/ruby/stdlib -r ./siteconf20220310-9324-qbakp6.rb extconf.rb
creating Makefile

current directory: /home/jruby/lib/ruby/gems/shared/gems/sassc-2.4.0/ext
make DESTDIR\= clean

current directory: /home/jruby/lib/ruby/gems/shared/gems/sassc-2.4.0/ext
make DESTDIR\=
compiling ./libsass/src/ast.cpp
c++: error: unrecognized command line option '-m64'
make: *** [Makefile:196: ast.o] Error 1
```