### PR TITLE
Use non-range cover logic for eqq and include

### DIFF
--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -846,7 +846,7 @@ public class RubyRange extends RubyObject {
         if (iterable
                 || !TypeConverter.convertToTypeWithCheck(context, begin, runtime.getInteger(), to_int_checked).isNil()
                 || !TypeConverter.convertToTypeWithCheck(context, end, runtime.getInteger(), to_int_checked).isNil()) {
-            return cover_p(context, val);
+            return RubyBoolean.newBoolean(context, rangeIncludes(context, val));
         } else if ((begin instanceof RubyString) || (end instanceof RubyString)) {
             if ((begin instanceof RubyString) && (end instanceof RubyString)) {
                 if (useStringCover) {
@@ -888,7 +888,7 @@ public class RubyRange extends RubyObject {
     public IRubyObject eqq_p(ThreadContext context, IRubyObject obj) {
         IRubyObject result = includeCommon(context, obj, true);
         if (result != UNDEF) return result;
-        return callMethod(context, "cover?", obj);
+        return RubyBoolean.newBoolean(context, rangeIncludes(context, obj));
     }
 
     @JRubyMethod(name = "cover?")


### PR DESCRIPTION
This code has for years mistakenly dispatched to the full cover?
logic, which considers intersecting ranges as being covered. The
logic in CRuby, however, only uses a small part of the cover logic
that does not accept ranges. The naming of the methods (in CRuby
it's r_cover_p, and in JRuby that got mapped to the full cover_p
method instead of the equivalent rangeInclude method) probably
was confusing, or early in JRuby development CRuby's r_cover_p and
our cover_p were equivalent and that changed over time in CRuby.

This also eliminates a dynamic dispatch to `cover?` that does not
exist in CRuby.

Fixes #7137