### PR TITLE
[deps] bump jruby-openssl to latest (0.12.2)

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -30,7 +30,7 @@ default_gems = [
     ['io-console', '0.5.9'],
     ['jar-dependencies', '0.4.1'],
     ['jruby-readline', '1.3.7'],
-    ['jruby-openssl', '0.11.0'],
+    ['jruby-openssl', '0.12.2'],
     ['json', '2.5.1'],
     ['logger', '1.3.0'],
     ['matrix', '0.3.0'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -203,7 +203,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>jruby-openssl</artifactId>
-      <version>0.11.0</version>
+      <version>0.12.2</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -572,7 +572,7 @@ DO NOT MODIFIY - GENERATED CODE
           <include>specifications/io-console-0.5.9*</include>
           <include>specifications/jar-dependencies-0.4.1*</include>
           <include>specifications/jruby-readline-1.3.7*</include>
-          <include>specifications/jruby-openssl-0.11.0*</include>
+          <include>specifications/jruby-openssl-0.12.2*</include>
           <include>specifications/json-2.5.1*</include>
           <include>specifications/logger-1.3.0*</include>
           <include>specifications/matrix-0.3.0*</include>
@@ -611,7 +611,7 @@ DO NOT MODIFIY - GENERATED CODE
           <include>gems/io-console-0.5.9*/**/*</include>
           <include>gems/jar-dependencies-0.4.1*/**/*</include>
           <include>gems/jruby-readline-1.3.7*/**/*</include>
-          <include>gems/jruby-openssl-0.11.0*/**/*</include>
+          <include>gems/jruby-openssl-0.12.2*/**/*</include>
           <include>gems/json-2.5.1*/**/*</include>
           <include>gems/logger-1.3.0*/**/*</include>
           <include>gems/matrix-0.3.0*/**/*</include>
@@ -650,7 +650,7 @@ DO NOT MODIFIY - GENERATED CODE
           <include>cache/io-console-0.5.9*</include>
           <include>cache/jar-dependencies-0.4.1*</include>
           <include>cache/jruby-readline-1.3.7*</include>
-          <include>cache/jruby-openssl-0.11.0*</include>
+          <include>cache/jruby-openssl-0.12.2*</include>
           <include>cache/json-2.5.1*</include>
           <include>cache/logger-1.3.0*</include>
           <include>cache/matrix-0.3.0*</include>


### PR DESCRIPTION
0.12 improves compatibility it also dropped the previous openssl/*.rb file duplication

- https://github.com/jruby/jruby-openssl/releases/tag/v0.12.1
- https://github.com/jruby/jruby-openssl/releases/tag/v0.12.2