### PR TITLE
[deps] bump jruby-openssl to latest (0.12.2)

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -23,7 +23,7 @@ default_gems = [
     ['ipaddr', '1.2.0'],
     ['jar-dependencies', '${jar-dependencies.version}'],
     ['jruby-readline', '1.3.7'],
-    ['jruby-openssl', '0.11.0'],
+    ['jruby-openssl', '0.12.2'],
     ['json', '${json.version}'],
     ['psych', '3.2.0'],
     ['racc', '1.5.2'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -138,7 +138,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>jruby-openssl</artifactId>
-      <version>0.11.0</version>
+      <version>0.12.2</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -359,7 +359,7 @@ DO NOT MODIFIY - GENERATED CODE
           <include>specifications/ipaddr-1.2.0*</include>
           <include>specifications/jar-dependencies-${jar-dependencies.version}*</include>
           <include>specifications/jruby-readline-1.3.7*</include>
-          <include>specifications/jruby-openssl-0.11.0*</include>
+          <include>specifications/jruby-openssl-0.12.2*</include>
           <include>specifications/json-${json.version}*</include>
           <include>specifications/psych-3.2.0*</include>
           <include>specifications/racc-1.5.2*</include>
@@ -382,7 +382,7 @@ DO NOT MODIFIY - GENERATED CODE
           <include>gems/ipaddr-1.2.0*/**/*</include>
           <include>gems/jar-dependencies-${jar-dependencies.version}*/**/*</include>
           <include>gems/jruby-readline-1.3.7*/**/*</include>
-          <include>gems/jruby-openssl-0.11.0*/**/*</include>
+          <include>gems/jruby-openssl-0.12.2*/**/*</include>
           <include>gems/json-${json.version}*/**/*</include>
           <include>gems/psych-3.2.0*/**/*</include>
           <include>gems/racc-1.5.2*/**/*</include>
@@ -405,7 +405,7 @@ DO NOT MODIFIY - GENERATED CODE
           <include>cache/ipaddr-1.2.0*</include>
           <include>cache/jar-dependencies-${jar-dependencies.version}*</include>
           <include>cache/jruby-readline-1.3.7*</include>
-          <include>cache/jruby-openssl-0.11.0*</include>
+          <include>cache/jruby-openssl-0.12.2*</include>
           <include>cache/json-${json.version}*</include>
           <include>cache/psych-3.2.0*</include>
           <include>cache/racc-1.5.2*</include>


### PR DESCRIPTION
0.12 improves compatibility it also dropped the previous openssl/*.rb file duplication

- https://github.com/jruby/jruby-openssl/releases/tag/v0.12.1
- https://github.com/jruby/jruby-openssl/releases/tag/v0.12.2