### PR TITLE
Better warnings for deprecated java_import forms

### DIFF
--- a/core/src/main/ruby/jruby/java/core_ext/object.rb
+++ b/core/src/main/ruby/jruby/java/core_ext/object.rb
@@ -1,13 +1,13 @@
 class Object
   # :nodoc:
   # @deprecated
-  def java_import(*import_classes, &block)
-    warn "calling java_import on a non-Module object is deprecated"
-    Object.send :java_import, *import_classes, &block
+  unless respond_to?(:import)
+    def import(*import_classes, &block)
+      warn "import is deprecated; use java_import", uplevel: 1
+      Object.send :java_import, *import_classes, &block
+    end
+    private :import
   end
-  private :java_import
-
-  alias :import :java_import unless respond_to?(:import)
 
 end
 


### PR DESCRIPTION
* import in any context: warn of deprecation, recommend
  java_import instead.
* java_import from a non-module object: removed deprecated
  definition since it was being overwritten by toplevel
  definition and lazy import is a good use case to support.
* java_import from toplevel: works without warning.

Fixes https://github.com/jruby/jruby/issues/6976

```
$ jruby -e 'java_import java.lang.System; p System'
Java::JavaLang::System

$ jruby -e 'import java.lang.System; p System'
-e:1: warning: import is deprecated; use java_import
Java::JavaLang::System

$ jruby -e 'class X; def foo; java_import java.lang.System; p System; end; end; X.new.foo'
Java::JavaLang::System
```