### PR TITLE
Remove long-deprecated import method for JI

### DIFF
--- a/core/src/main/ruby/jruby/java/core_ext/object.rb
+++ b/core/src/main/ruby/jruby/java/core_ext/object.rb
@@ -1,16 +1,3 @@
-class Object
-  # :nodoc:
-  # @deprecated
-  unless respond_to?(:import)
-    def import(*import_classes, &block)
-      warn "import is deprecated; use java_import", uplevel: 1
-      Object.send :java_import, *import_classes, &block
-    end
-    private :import
-  end
-
-end
-
 # @see Module.java_import
 def java_import(*import_classes, &block)
   Object.send :java_import, *import_classes, &block


### PR DESCRIPTION
This method has been deprecated for many years and it's time to
remove it.

Relates to #6976