### PR TITLE
Fixes #7102. ArgumentError re-splatting empty keyword arguments

### DIFF
--- a/core/src/main/java/org/jruby/ObjectFlags.java
+++ b/core/src/main/java/org/jruby/ObjectFlags.java
@@ -31,5 +31,6 @@ public interface ObjectFlags {
     int MATCH_BUSY = registry.newFlag(RubyMatchData.class);
 
     int COMPARE_BY_IDENTITY_F = registry.newFlag(RubyHash.class);
+    int KEYWORD_REST_ARGUMENTS_F = registry.newFlag(RubyHash.class);
     int PROCDEFAULT_HASH_F = registry.newFlag(RubyHash.class);
 }

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -117,6 +117,7 @@ public class RubyHash extends RubyObject implements Map {
     public static final int DEFAULT_INSPECT_STR_SIZE = 20;
 
     public static final int COMPARE_BY_IDENTITY_F = ObjectFlags.COMPARE_BY_IDENTITY_F;
+    public static final int KEYWORD_REST_ARGUMENTS_F = ObjectFlags.KEYWORD_REST_ARGUMENTS_F;
 
     public static RubyClass createHashClass(Ruby runtime) {
         RubyClass hashc = runtime.defineClass("Hash", runtime.getObject(), RubyHash::new);
@@ -2524,6 +2525,14 @@ public class RubyHash extends RubyObject implements Map {
         } else {
             flags &= ~COMPARE_BY_IDENTITY_F;
         }
+    }
+
+    public boolean isKeywordRestArguments() {
+        return (flags & KEYWORD_REST_ARGUMENTS_F) != 0;
+    }
+
+    public void setKeywordRestArguments(boolean value) {
+        setFlag(KEYWORD_REST_ARGUMENTS_F, value);
     }
 
     private class BaseSet extends AbstractSet {


### PR DESCRIPTION
Went with marking incoming key word rest arguments getting marked with
a flag indicating that it is a kwrest.  The flag is removed once we
enter check_arity helper.  A kwrest is transient and isolated from the
call site to the method which recieves it.  So there is no opportunity
for more than one thread to see this or other shenanigans like that.

This also is the general direction of Ruby 3 where we (and MRI) mark
kwargs hashes with a flag.  We seem to fail there as well so we might
actually need this new flag there (since kw and kwrest will have different
behavior when passed to a method like the one attached to #7102).