### PR TITLE
Fixes to allow WIP suite to run to completion

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -3911,6 +3911,10 @@ public final class Ruby implements Constantizable {
         return newRaiseException(getErrno().getClass("EAFNOSUPPORT"), message);
     }
 
+    public RaiseException newErrnoETIMEDOUTError() {
+        return newRaiseException(getErrno().getClass("ETIMEDOUT"), "Broken pipe");
+    }
+
     public RaiseException newErrnoFromLastPOSIXErrno() {
         RubyClass errnoClass = getErrno(getPosix().errno());
         if (errnoClass == null) errnoClass = systemCallError;

--- a/rakelib/rubyspec.rake
+++ b/rakelib/rubyspec.rake
@@ -57,7 +57,7 @@ namespace :spec do
     mspec :command => "run",
           :compile_mode => "OFF",
           :format => "s",
-          :spec_target => "spec/ruby",
+          :spec_target => ":ci_files",
           :jruby_opts => "--dev",
           :spec_config => "spec/jruby.mspec",
           :tags => [:wip]

--- a/spec/ruby/library/socket/fixtures/classes.rb
+++ b/spec/ruby/library/socket/fixtures/classes.rb
@@ -118,14 +118,14 @@ module SocketSpecs
 
         socket.send data, 0
       ensure
-        socket.close
+        socket.close unless socket.closed?
       end
     end
 
     def shutdown
       log "SpecTCPServer shutting down"
+      @server.close unless @server.closed?
       @thread.join
-      @server.close
     end
 
     def log(message)

--- a/spec/ruby/library/socket/udpsocket/send_spec.rb
+++ b/spec/ruby/library/socket/udpsocket/send_spec.rb
@@ -16,13 +16,14 @@ describe "UDPSocket#send" do
           retry
         end
       ensure
-        @server.close if !@server.closed?
+        @server.close unless @server.closed?
       end
     end
     Thread.pass while @server_thread.status and !@port
   end
 
   after :each do
+    @server.close unless @server.closed
     @server_thread.join
   end
 

--- a/spec/tags/ruby/core/argf/gets_tags.txt
+++ b/spec/tags/ruby/core/argf/gets_tags.txt
@@ -1,2 +1,1 @@
 slow:ARGF.gets reads all lines of stdin
-wip:ARGF.gets reads the contents of the file with default encoding

--- a/spec/tags/ruby/core/argf/read_tags.txt
+++ b/spec/tags/ruby/core/argf/read_tags.txt
@@ -1,4 +1,3 @@
 slow:ARGF.read reads the contents of stdin
 slow:ARGF.read reads a number of bytes from stdin
 slow:ARGF.read reads the contents of one file and stdin
-wip:ARGF.read reads the contents of the file with default encoding

--- a/spec/tags/ruby/library/socket/tcpsocket/initialize_tags.txt
+++ b/spec/tags/ruby/library/socket/tcpsocket/initialize_tags.txt
@@ -1,4 +1,2 @@
-wip:TCPSocket#initialize raises Errno::ETIMEDOUT with :connect_timeout when no server is listening on the given address
-wip:TCPSocket#initialize with a running server connects to a server when passed connect_timeout argument
 wip:TCPSocket#initialize using IPv4 when a server is listening on the given address raises SocketError when the port number is a non numeric String
 wip:TCPSocket#initialize using IPv6 when a server is listening on the given address raises SocketError when the port number is a non numeric String

--- a/spec/tags/ruby/library/socket/tcpsocket/open_tags.txt
+++ b/spec/tags/ruby/library/socket/tcpsocket/open_tags.txt
@@ -1,2 +1,0 @@
-wip:TCPSocket.open raises Errno::ETIMEDOUT with :connect_timeout when no server is listening on the given address
-wip:TCPSocket.open with a running server connects to a server when passed connect_timeout argument


### PR DESCRIPTION
The fixes here, mostly in TCPSocket and related specs, allow the "work in progress" set of specs to run to completion, so contributors can see what remains there to be implemented.

Note that running individual sections of specs may still hang; notably, the root Fiber transfer spec hangs when running just the library specs, but does not hang in the full run (and even passes). There are interactions between the specs at play here. This PR only gets the complete suite running.

See also the fixes here to improve shutdown of TCPSocket and UDPSocket tests by closing the server before joining it (ruby/spec#925).