### PR TITLE
Update and fix failures in ostruct tests

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -1682,7 +1682,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         return singleton_method_undefined(context, recv, symbolId, block);
     }
 
-    @JRubyMethod(name = "method_missing", rest = true, module = true, visibility = PRIVATE)
+    @JRubyMethod(name = "method_missing", rest = true, module = true, omit = true, visibility = PRIVATE)
     public static IRubyObject method_missing(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         Visibility lastVis = context.getLastVisibility();
         CallType lastCallType = context.getLastCallType();

--- a/test/mri/excludes/TC_OpenStruct.rb
+++ b/test/mri/excludes/TC_OpenStruct.rb
@@ -1,2 +1,2 @@
-exclude :test_method_missing, "depends on __callee__ which is broken"
-exclude :test_to_h_with_block, "test is newer than the released ostruct 0.1.0 (https://github.com/ruby/ostruct/issues/31)"
+exclude :test_each_pair, "Bug in each_pair in ostruct 0.5.4 (https://github.com/ruby/ostruct/pull/45)"
+exclude :test_initialize, "Bug in each_pair in ostruct 0.5.4 (https://github.com/ruby/ostruct/pull/45)"

--- a/test/mri/ostruct/test_ostruct.rb
+++ b/test/mri/ostruct/test_ostruct.rb
@@ -406,4 +406,10 @@ class TC_OpenStruct < Test::Unit::TestCase
     o2 = Marshal.load(Marshal.dump(o))
     assert_equal o, o2
   end
+
+  def test_class
+    os = OpenStruct.new(class: 'my-class', method: 'post')
+    assert_equal('my-class', os.class)
+    assert_equal(OpenStruct, os.class!)
+  end
 end


### PR DESCRIPTION
This updates ostruct tests and fixes one of the resulting failures.

The two existing excludes were resolved:

* test_method_missing depends on the native method_missing not appearing in NoMethodError backtrace. Fixed by `omit = true` in the JRuby method_missing binding, which is a new change.
* test_to_h_with_block was likely fixed by updating ostruct.

Two new failures are due to ruby/ostruct#41 and will be fixed by ruby/ostruct#45: test_each_pair, test_initialize
