### PR TITLE
update error message

### DIFF
--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -1871,7 +1871,7 @@ CLASSDEF
       fail 'expected to raise'
     rescue ArgumentError => e
       msg = e.message
-      assert msg.start_with?("wrong number of arguments calling `length` (given 1, expected 0)"), msg
+      assert msg.start_with?("`length': wrong number of arguments (given 1, expected 0)"), msg
     end
 
     begin # array proxy class


### PR DESCRIPTION
fixes a failure according to https://github.com/jruby/jruby/pull/7158
```
Failure: test_raised_errors_on_array_proxy(TestHigherJavasupport):
  `length': wrong number of arguments (given 1, expected 0).
  <false> is not true.
/home/runner/work/jruby/jruby/test/jruby/test_higher_javasupport.rb:1874:in `test_raised_errors_on_array_proxy'
     1871:       fail 'expected to raise'
     1872:     rescue ArgumentError => e
     1873:       msg = e.message
  => 1874:       assert msg.start_with?("wrong number of arguments calling `length` (given 1, expected 0)"), msg
     1875:     end
     1876: 
     1877:     begin # array proxy class
```

