### PR TITLE
Fix failing test Array#rindex

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -2624,6 +2624,8 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      *
      */
     public IRubyObject rindex(ThreadContext context, IRubyObject obj) {
+        unpack();
+        
         Ruby runtime = context.runtime;
         int i = realLength;
 

--- a/test/mri/ruby/test_array.rb
+++ b/test/mri/ruby/test_array.rb
@@ -2574,10 +2574,8 @@ class TestArray < Test::Unit::TestCase
     assert_raise(StopIteration) { e.next }
 
     o = Object.new
-    class << o; self; end.class_eval do
-      define_method(:==) {|x| a.clear; false }
-    end
     a = [nil, o]
+    o.define_singleton_method(:==) { |x| a.clear; false }
     assert_equal(nil, a.rindex(0))
   end
 

--- a/test/mri/ruby/test_array.rb
+++ b/test/mri/ruby/test_array.rb
@@ -2574,8 +2574,10 @@ class TestArray < Test::Unit::TestCase
     assert_raise(StopIteration) { e.next }
 
     o = Object.new
+    class << o; self; end.class_eval do
+      define_method(:==) {|x| a.clear; false }
+    end
     a = [nil, o]
-    o.define_singleton_method(:==) { |x| a.clear; false }
     assert_equal(nil, a.rindex(0))
   end
 


### PR DESCRIPTION
Fixed issue with `Array#rindex`  test failing. Using `unpack` to deal with concurrency error and `Object#define_singleton_method` to replace `class_eval` which seemed to not be working