### PR TITLE
Fix String#split with String doesn't split on non-ascii whitespace

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -4575,7 +4575,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
             }
 
             if (skip) {
-                if (enc.isSpace(c)) {
+                // MRI uses rb_isspace
+                if (ASCII.isSpace(c)) {
                     b = p - ptr;
                 } else {
                     e = p - ptr;
@@ -4583,7 +4584,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
                     if (limit && lim <= i) break;
                 }
             } else {
-                if (enc.isSpace(c)) {
+                // MRI uses rb_isspace
+                if (ASCII.isSpace(c)) {
                     result.append(makeSharedString(runtime, b, e - b));
                     skip = true;
                     b = p - ptr;

--- a/spec/tags/ruby/core/string/split_tags.txt
+++ b/spec/tags/ruby/core/string/split_tags.txt
@@ -1,2 +1,1 @@
-wip:String#split with String doesn't split on non-ascii whitespace
 wip:String#split with String when $; is not nil warns


### PR DESCRIPTION
This commit uses the isSpace function of ASCIIEncoding same as MRI uses rb_ispace function.
And this commit fixes String#split for edge case.