### PR TITLE
Fix String#length for an imcomplete surrogate in UTF-16

### DIFF
--- a/core/src/main/java/org/jruby/util/StringSupport.java
+++ b/core/src/main/java/org/jruby/util/StringSupport.java
@@ -535,7 +535,11 @@ public final class StringSupport {
                 p += cl;
             } else {
                 cr = CR_BROKEN;
-                p++;
+                if (p + enc.minLength() <= end) {
+                    p += enc.minLength();
+                } else {
+                    p = end;
+                }
             }
         }
         return pack(c, cr == 0 ? CR_7BIT : cr);

--- a/spec/tags/ruby/core/string/length_tags.txt
+++ b/spec/tags/ruby/core/string/length_tags.txt
@@ -1,1 +1,0 @@
-wip:String#length adds 1 (and not 2) for a incomplete surrogate in UTF-16

--- a/spec/tags/ruby/core/string/size_tags.txt
+++ b/spec/tags/ruby/core/string/size_tags.txt
@@ -1,1 +1,0 @@
-wip:String#size adds 1 (and not 2) for a incomplete surrogate in UTF-16


### PR DESCRIPTION
This commit updates the strLengthWithCodeRangeNonAsciiCompatible function to fix String#length for edge case.