### PR TITLE
Added checks to equalInternal to check for override of == method

### DIFF
--- a/core/src/main/java/org/jruby/RubyObject.java
+++ b/core/src/main/java/org/jruby/RubyObject.java
@@ -400,9 +400,19 @@ public class RubyObject extends RubyBasicObject {
 
     private static boolean fastNumEqualInternal(final ThreadContext context, final IRubyObject a, final IRubyObject b) {
         if (a instanceof RubyFixnum) {
-            if (b instanceof RubyFixnum) return ((RubyFixnum) a).fastEqual((RubyFixnum) b);
+            if (b instanceof RubyFixnum) {
+                if (!context.sites.Fixnum.op_eqq.isBuiltin(a)) {
+                    return context.sites.Fixnum.op_eqq.call(context, a, a, b).isTrue();
+                }
+                return ((RubyFixnum) a).fastEqual((RubyFixnum) b);
+            }
         } else if (a instanceof RubyFloat) {
-            if (b instanceof RubyFloat) return ((RubyFloat) a).fastEqual((RubyFloat) b);
+            if (b instanceof RubyFloat) {
+                if (!context.sites.Float.op_equal.isBuiltin(a)) {
+                    return context.sites.Float.op_equal.call(context, a, a, b).isTrue();
+                }
+                return ((RubyFloat) a).fastEqual((RubyFloat) b);
+            }
         }
         return invokedynamic(context, a, OP_EQUAL, b).isTrue();
     }

--- a/core/src/main/java/org/jruby/runtime/JavaSites.java
+++ b/core/src/main/java/org/jruby/runtime/JavaSites.java
@@ -250,6 +250,7 @@ public class JavaSites {
         public final CallSite op_le = new FunctionalCachingCallSite("<=");
         public final CallSite op_gt = new FunctionalCachingCallSite(">");
         public final CallSite op_lt = new FunctionalCachingCallSite("<");
+        public final CachingCallSite op_eqq = new FunctionalCachingCallSite("==");
         public final CachingCallSite basic_op_lt = new FunctionalCachingCallSite("<");
         public final CachingCallSite basic_op_gt = new FunctionalCachingCallSite(">");
         public final CallSite op_exp_complex = new FunctionalCachingCallSite("**");
@@ -298,7 +299,7 @@ public class JavaSites {
         public final CallSite op_le = new FunctionalCachingCallSite("<=");
         public final CallSite op_gt = new FunctionalCachingCallSite(">");
         public final CallSite op_lt = new FunctionalCachingCallSite("<");
-        public final CallSite op_equal = new FunctionalCachingCallSite("==");
+        public final CachingCallSite op_equal = new FunctionalCachingCallSite("==");
         public final RespondToCallSite respond_to_infinite = new RespondToCallSite("infinite?");
         public final CallSite infinite = new FunctionalCachingCallSite("infinite?");
     }


### PR DESCRIPTION
This change fixes a test in `test_array.rb`. The test in question is `test_count`.

The problem was that despite the `==` being overridden for the method was never called in preference to a fast equality i.e. checking the primitive values.

In the method there is a fast equals for both `RubyFixnum` and `RubyFloat` are tested so I provided a clause for both of them.