### PR TITLE
Ruby3.1: Add String#unpack1 with offset

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -6400,6 +6400,22 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @JRubyMethod
     public RubyArray unpack(ThreadContext context, IRubyObject obj, IRubyObject opt, Block block) {
+        long offset = unpackOffset(context, opt);
+        return Pack.unpackWithBlock(context, this, stringValue(obj).value, offset, block);
+    }
+
+    @JRubyMethod
+    public IRubyObject unpack1(ThreadContext context, IRubyObject obj, Block block) {
+        return Pack.unpack1WithBlock(context, this, stringValue(obj).value, block);
+    }
+
+    @JRubyMethod
+    public IRubyObject unpack1(ThreadContext context, IRubyObject obj, IRubyObject opt, Block block) {
+        long offset = unpackOffset(context, opt);
+        return Pack.unpack1WithBlock(context, this, stringValue(obj).value, offset, block);
+    }
+
+    private static long unpackOffset(ThreadContext context, IRubyObject opt) {
         if (!(opt instanceof RubyHash)) throw context.runtime.newArgumentError(2, 1);
 
         RubyHash options = (RubyHash) opt;
@@ -6411,12 +6427,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         }
         // FIXME: keyword arg processing incomplete.  We need a better system.
 
-        return Pack.unpackWithBlock(context, this, stringValue(obj).value, offset, block);
-    }
-
-    @JRubyMethod
-    public IRubyObject unpack1(ThreadContext context, IRubyObject obj, Block block) {
-        return Pack.unpack1WithBlock(context, this, stringValue(obj).value, block);
+        return offset;
     }
 
     @Deprecated // not used

--- a/core/src/main/java/org/jruby/util/Pack.java
+++ b/core/src/main/java/org/jruby/util/Pack.java
@@ -896,6 +896,10 @@ public class Pack {
     }
 
     public static IRubyObject unpack1WithBlock(ThreadContext context, RubyString encoded, ByteList formatString, Block block) {
+        return unpack1WithBlock(context, encoded, formatString, 0, block);
+    }
+
+    public static IRubyObject unpack1WithBlock(ThreadContext context, RubyString encoded, ByteList formatString, long offset, Block block) {
         int formatLength = formatString.realSize();
 
         // Strict m0 is commmonly used in cookie handling so it has a fast path.
@@ -911,7 +915,7 @@ public class Pack {
             }
         }
 
-        return unpackInternal(context, encoded, formatString, UNPACK_1, 0, block);
+        return unpackInternal(context, encoded, formatString, UNPACK_1, offset, block);
     }
 
     private static IRubyObject unpackInternal(ThreadContext context, RubyString encoded, ByteList formatString, int mode, long offset, Block block) {

--- a/spec/tags/ruby/core/string/unpack1_tags.txt
+++ b/spec/tags/ruby/core/string/unpack1_tags.txt
@@ -1,2 +1,0 @@
-wip:String#unpack1 starts unpacking from the given offset
-wip:String#unpack1 returns nil if the offset is at the end of the string


### PR DESCRIPTION
This commit adds String#unpack1 with offset but String#unpack with offset is already implmented.
See #7015