### PR TITLE
Update SecureRandom#random_number when argument is non-numeric

### DIFF
--- a/core/src/main/java/org/jruby/RubyRandom.java
+++ b/core/src/main/java/org/jruby/RubyRandom.java
@@ -443,7 +443,7 @@ public class RubyRandom extends RubyRandomBase {
             RandomType rnd = tryGetRandomType(context, self);
             IRubyObject v = randRandom(context, self, rnd, arg0);
             if (v.isNil()) v = randRandom(context, self, rnd);
-            checkRandomNumber(context, v, arg0);
+            else if (v == context.fals) invalidArgument(context, arg0);
             return v;
         }
 

--- a/core/src/main/java/org/jruby/RubyRandomBase.java
+++ b/core/src/main/java/org/jruby/RubyRandomBase.java
@@ -270,7 +270,7 @@ public class RubyRandomBase extends RubyObject {
         }
     }
 
-    private static void invalidArgument(ThreadContext context, IRubyObject arg0) {
+    static void invalidArgument(ThreadContext context, IRubyObject arg0) {
         throw context.runtime.newArgumentError("invalid argument - " + arg0);
     }
 

--- a/spec/tags/ruby/library/securerandom/random_number_tags.txt
+++ b/spec/tags/ruby/library/securerandom/random_number_tags.txt
@@ -1,3 +1,2 @@
 wip:SecureRandom.random_number generates a random (potentially bignum) integer value for bignum argument
 wip:SecureRandom.random_number generates a random value in given (float) range limits
-wip:SecureRandom.random_number raises ArgumentError if the argument is non-numeric


### PR DESCRIPTION
When argument is non-numeric, SecureRandom#random_number should throw ArgumentError.