### PR TITLE
Update SecureRandom#random_number with a float range limit

### DIFF
--- a/core/src/main/java/org/jruby/util/Random.java
+++ b/core/src/main/java/org/jruby/util/Random.java
@@ -159,8 +159,16 @@ public class Random {
     }
 
     public double genrandReal() {
-        int a = genrandInt32() >>> 5;
-        int b = genrandInt32() >>> 6;
+        int a = genrandInt32();
+        int b = genrandInt32();
+        return intPairToRealExclusive(a, b);
+    }
+
+    // TODO: check the latest mri's int_pair_to_real_exclusive in random.c
+    // This implementation is until mri 2.7.x
+    public static double intPairToRealExclusive(int a, int b) {
+        a >>>= 5;
+        b >>>= 6;
         return (a * 67108864.0 + b) * (1.0 / 9007199254740992.0);
     }
 
@@ -175,7 +183,7 @@ public class Random {
 
     // c: ldexp((a<< 32)|b) * ((1<<53)+1) >> 64, -53)
     // TODO: not enough prec...
-    private double intPairToRealInclusive(int a, int b) {
+    public static double intPairToRealInclusive(int a, int b) {
         BigInteger c = BigInteger.valueOf(a & 0xffffffffL);
         BigInteger d = BigInteger.valueOf(b & 0xffffffffL);
         return c.shiftLeft(32).or(d).multiply(INTPAIR_CONST).shiftRight(64).doubleValue()

--- a/spec/tags/ruby/core/random/random_number_tags.txt
+++ b/spec/tags/ruby/core/random/random_number_tags.txt
@@ -1,2 +1,0 @@
-fails:Random.random_number returns a Float if no max argument is passed
-fails:Random.random_number returns an Integer if an Integer argument is passed

--- a/spec/tags/ruby/library/securerandom/random_number_tags.txt
+++ b/spec/tags/ruby/library/securerandom/random_number_tags.txt
@@ -1,2 +1,1 @@
 wip:SecureRandom.random_number generates a random (potentially bignum) integer value for bignum argument
-wip:SecureRandom.random_number generates a random value in given (float) range limits

--- a/spec/tags/ruby/library/securerandom/random_number_tags.txt
+++ b/spec/tags/ruby/library/securerandom/random_number_tags.txt
@@ -1,1 +1,0 @@
-wip:SecureRandom.random_number generates a random (potentially bignum) integer value for bignum argument


### PR DESCRIPTION
When random variable is null, this logic calls objRandomBytes function against the self obj to generate a random double value from 8 bytes same as mri 3.1.x.

And this  cleans up tags because securerandom and rand all spec pass.