### PR TITLE
Do not stack causes for exceptions raised out of embedding APIs

### DIFF
--- a/core/src/main/java/org/jruby/embed/internal/EmbedEvalUnitImpl.java
+++ b/core/src/main/java/org/jruby/embed/internal/EmbedEvalUnitImpl.java
@@ -124,6 +124,9 @@ public class EmbedEvalUnitImpl implements EmbedEvalUnit {
             return ret;
         }
         catch (RaiseException e) {
+            // Exception is about to be propagated out to Java, so clear $!
+            runtime.getCurrentContext().setErrorInfo(runtime.getNil());
+
             // handle exits as simple script termination
             if ( e.getException() instanceof RubySystemExit ) {
                 return ((RubySystemExit) e.getException()).status();

--- a/core/src/main/java/org/jruby/embed/jsr223/JRubyEngine.java
+++ b/core/src/main/java/org/jruby/embed/jsr223/JRubyEngine.java
@@ -42,6 +42,8 @@ import javax.script.ScriptEngineFactory;
 import javax.script.ScriptException;
 import javax.script.SimpleBindings;
 import javax.script.SimpleScriptContext;
+
+import org.jruby.Ruby;
 import org.jruby.embed.EmbedEvalUnit;
 import org.jruby.embed.ScriptingContainer;
 import org.jruby.exceptions.NoMethodError;
@@ -274,6 +276,11 @@ public class JRubyEngine implements Compilable, Invocable, ScriptEngine {
 
             ScriptException se = new ScriptException("Error during evaluation of Ruby in " + file + " at line " + line + ": " + e.getMessage());
             se.initCause(e);
+
+            // Exception is about to be propagated out to Java, so clear $!
+            Ruby runtime = e.getException().getRuntime();
+            runtime.getCurrentContext().setErrorInfo(runtime.getNil());
+
             return se;
         }
 

--- a/core/src/test/java/org/jruby/embed/jsr223/JRubyEngineTest.java
+++ b/core/src/test/java/org/jruby/embed/jsr223/JRubyEngineTest.java
@@ -827,6 +827,38 @@ public class JRubyEngineTest extends BaseTest {
         assertNotNull( getVarMap(instance).getVariable("ARGV") );
     }
 
+    @Test
+    public void testRaiseDoesNotStackCause()
+            throws Exception
+    {
+        try
+        {
+            final ScriptEngine _jruby1 = new JRubyEngineFactory().getScriptEngine();
+            _jruby1.eval("raise 'foo'");
+        }
+        catch (Exception _e)
+        {
+            try (ByteArrayOutputStream _bos = new ByteArrayOutputStream();
+                 PrintStream _s = new PrintStream(_bos))
+            {
+                assertFalse("stack contains bar: " + _bos.toString(), _bos.toString().contains("bar"));
+            }
+        }
+        try
+        {
+            final ScriptEngine _jruby2 = new JRubyEngineFactory().getScriptEngine();
+            _jruby2.eval("raise 'bar'");
+        }
+        catch (Exception _e)
+        {
+            try (ByteArrayOutputStream _bos = new ByteArrayOutputStream();
+                 PrintStream _s = new PrintStream(_bos))
+            {
+                assertFalse("stack contains foo: " + _bos.toString(), _bos.toString().contains("foo"));
+            }
+        }
+    }
+
     private static BiVariableMap getVarMap(final ScriptEngine engine) {
         return ((JRubyEngine) engine).container.getVarMap();
     }


### PR DESCRIPTION
This fixes #7187 by clearing the current in-flight exception once it is raised out of Ruby into Java. This prevents endless stacking of `cause` exceptions, but breaks the ability to query `$!` from the consumer side of the embedding APIs.

Note that only one of the two fixes is necessary to resolve #7187. One affects both ScriptingContainer and javax.script, and the other affects only the latter.