### PR TITLE
Remove env shebang on Linux

### DIFF
--- a/lib/ruby/stdlib/rubygems/defaults/jruby.rb
+++ b/lib/ruby/stdlib/rubygems/defaults/jruby.rb
@@ -18,13 +18,15 @@ module Gem
     end
   end
 
-  def self.platform_defaults
-    return {
-        'install' => '--env-shebang',
-        'update' => '--env-shebang',
-        'setup' => '--env-shebang',
-        'pristine' => '--env-shebang'
-    }
+  unless RbConfig::CONFIG['host_os'].match? /linux/
+    def self.platform_defaults
+      return {
+          'install' => '--env-shebang',
+          'update' => '--env-shebang',
+          'setup' => '--env-shebang',
+          'pristine' => '--env-shebang'
+      }
+    end
   end
 
   # Default home directory path to be used if an alternate value is not


### PR DESCRIPTION
As of a later Linux 2.6 release (2.6.27.something) the kernel now
recognizes when another script is used as the shebang command and
properly runs that script rather than the binary that script needs
to launch (e.g. putting a bash script in the shebang line will run
the script, rather than bash). Because of that improvement, we no
longer need to use "env shebangs" on Linux, since the bin/jruby
shell script will launch correctly.

This change was released in late 2008, so any 2.6 kernels past
that date work properly. Linux 2.4 was EOL in 2011, so all up-to-
date Linux installs after that date should be on a 2.6 or higher
Kernel, very likely after the fix was landed. And 2.6 itself was
EOL in 2016, so all up-to-date Linux installs after that date will
certainly have the fix. We believe it is now safe for us to drop
the requirement that RubyGems install bin scripts using the env
shebang on Linux.

Note that this is still necessary for most other *nix environments
including the BSDs, Solaris, AIX, HP/UX, and so on.