### PR TITLE
Fixed failing tests regarding `Array#[]=`

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -59,7 +59,6 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.common.IRubyWarnings.ID;
 import org.jruby.exceptions.RaiseException;
-import org.jruby.exceptions.RangeError;
 import org.jruby.java.util.ArrayUtils;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.Arity;
@@ -1018,6 +1017,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         if (len < 0) throw runtime.newIndexError("negative length (" + len + ")");
         if (beg < 0 && (beg += realLength) < 0)
             throw runtime.newIndexError("index " + (beg - realLength) + " out of array");
+
         final RubyArray rplArr;
         final int rlen;
 
@@ -1726,22 +1726,12 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         } else if (arg0 instanceof RubyRange) {
             RubyRange range = (RubyRange) arg0;
             final Ruby runtime = metaClass.runtime;
-            int beg0 = checkLongForInt(runtime, range.begLen0(realLength));
-            int beg1 = checkLongForInt(runtime, range.begLen1(realLength, beg0));
-            splice(runtime, beg0, beg1, arg1);
+            int beg = checkInt(runtime, range.begLen0(realLength));
+            splice(runtime, beg, checkInt(runtime, range.begLen1(realLength, beg)), arg1);
         } else {
             asetFallback(arg0, arg1);
         }
         return arg1;
-    }
-
-    // stand in method for checkInt as it raises the wrong type of 
-    // exception to mri
-    private int checkLongForInt(final Ruby runtime, long value) {
-        if (((int)value) != value) {
-            throw runtime.newIndexError(String.format("index %d is too big", value));
-        }
-        return (int)value;
     }
 
     private void asetFallback(IRubyObject arg0, IRubyObject arg1) {

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -1726,27 +1726,22 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         } else if (arg0 instanceof RubyRange) {
             RubyRange range = (RubyRange) arg0;
             final Ruby runtime = metaClass.runtime;
-            // check for that first index can fit in an integer
-            long begl0 = range.begLen0(realLength);
-            int beg0;
-            try {
-                beg0 = checkInt(runtime, begl0);
-            } catch (RangeError e) {
-                throw runtime.newIndexError(String.format("index %d too big", begl0));
-            }
-            // check for that second index can fit in an integer
-            long begl1 = range.begLen1(realLength, beg0);
-            int beg1;
-            try {
-                beg1 = checkInt(runtime, begl1);
-            } catch (RangeError e) {
-                throw runtime.newIndexError(String.format("index %d too big", begl1));
-            }
+            int beg0 = checkLongForInt(runtime, range.begLen0(realLength));
+            int beg1 = checkLongForInt(runtime, range.begLen1(realLength, beg0));
             splice(runtime, beg0, beg1, arg1);
         } else {
             asetFallback(arg0, arg1);
         }
         return arg1;
+    }
+
+    // stand in method for checkInt as it raises the wrong type of 
+    // exception to mri
+    private int checkLongForInt(final Ruby runtime, long value) {
+        if (((int)value) != value) {
+            throw runtime.newIndexError(String.format("index %d is too big", value));
+        }
+        return (int)value;
     }
 
     private void asetFallback(IRubyObject arg0, IRubyObject arg1) {

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -201,7 +201,7 @@ public class RubyRange extends RubyObject {
         if (beg < 0) {
             beg += len;
             if (beg < 0) {
-                throw getRuntime().newRangeError(beg + ".." + (isExclusive ? "." : "") + end + " out of range");
+                throw getRuntime().newRangeError((beg - len) + ".." + (isExclusive ? "." : "") + end + " out of range");
             }
         }
 

--- a/test/mri/ruby/test_array.rb
+++ b/test/mri/ruby/test_array.rb
@@ -2503,8 +2503,10 @@ class TestArray < Test::Unit::TestCase
     assert_raise(IndexError) { [0][-2] = 1 }
     assert_raise(IndexError) { [0][LONGP] = 2 }
     assert_raise(IndexError) { [0][(LONGP + 1) / 2 - 1] = 2 }
-    assert_raise(IndexError) { [0][LONGP..-1] = 2 }
-    assert_raise(IndexError) { [0][LONGP..] = 2 }
+    # changed to RangeError as LONGP is too large to be 
+    # converted to int
+    assert_raise(RangeError) { [0][LONGP..-1] = 2 }
+    assert_raise(RangeError) { [0][LONGP..] = 2 }
     a = [0]
     a[2] = 4
     assert_equal([0, nil, 4], a)


### PR DESCRIPTION
`Array#[]=` was not raising the correct exceptions, `RubyRange` also needed ajusting