### PR TITLE
Fixed failed test for `RubyArgsFile` / `ARGF`

### DIFF
--- a/core/src/main/java/org/jruby/RubyArgsFile.java
+++ b/core/src/main/java/org/jruby/RubyArgsFile.java
@@ -889,8 +889,7 @@ public class RubyArgsFile extends RubyObject {
             } else if(args.length >= 1) {
                 final int strLen = ((RubyString) str).getByteList().length();
                 if (strLen < len) {
-                    len -= strLen;
-                    args[0] = runtime.newFixnum(len);
+                    args[0] = runtime.newFixnum(len - strLen);
                     continue;
                 }
             }


### PR DESCRIPTION
Fixed problem where `RubyArgsFile` was not taking the correct amount of characters from the files passed to it.

The problem was that the len to be read was being incorrectly subtracted by the new length of the string to return.