### PR TITLE
Fix Rational#round and Update Rational#marshal_dump

### DIFF
--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -1115,9 +1115,6 @@ public class RubyRational extends RubyNumeric {
         Ruby runtime = context.runtime;
 
         opts = ArgsUtil.getOptionsArg(runtime, opts);
-        if (!opts.isNil()) {
-            n = context.nil;
-        }
 
         RoundingMode mode = RubyNumeric.getRoundingMode(context, opts);
 

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -1413,7 +1413,7 @@ public class RubyRational extends RubyNumeric {
     /** nurat_marshal_dump
      * 
      */
-    @JRubyMethod(name = "marshal_dump")
+    @JRubyMethod(name = "marshal_dump", visibility = Visibility.PRIVATE)
     public IRubyObject marshal_dump(ThreadContext context) {
         RubyArray dump = context.runtime.newArray(num, den);
         if (hasVariables()) dump.syncVariables(this);

--- a/spec/tags/ruby/core/rational/comparison_tags.txt
+++ b/spec/tags/ruby/core/rational/comparison_tags.txt
@@ -1,1 +1,0 @@
-fails:Rational#<=> when passed an Object that responds to #coerce rescues exception (StandardError and subclasses) raised in other#coerce and returns nil

--- a/spec/tags/ruby/core/rational/divide_tags.txt
+++ b/spec/tags/ruby/core/rational/divide_tags.txt
@@ -1,1 +1,0 @@
-fails:Rational#/ rescues exception (StandardError and subclasses) raised in other#coerce and raises TypeError

--- a/spec/tags/ruby/core/rational/exponent_tags.txt
+++ b/spec/tags/ruby/core/rational/exponent_tags.txt
@@ -1,6 +1,0 @@
-critical(hangs):Rational#** when passed Bignum returns positive Infinity when self is > 1
-critical(hangs):Rational#** when passed Bignum returns 0.0 when self is > 1 and the exponent is negative
-critical(hangs):Rational#** when passed Bignum returns positive Infinity when self < -1
-critical(hangs):Rational#** when passed Bignum returns 0.0 when self is < -1 and the exponent is negative
-fails:Rational#** when passed Bignum returns positive Infinity when self is > 1
-fails:Rational#** when passed Bignum returns 0.0 when self is > 1 and the exponent is negative

--- a/spec/tags/ruby/core/rational/marshal_dump_tags.txt
+++ b/spec/tags/ruby/core/rational/marshal_dump_tags.txt
@@ -1,1 +1,0 @@
-fails:Rational#marshal_dump is a private method

--- a/spec/tags/ruby/core/rational/minus_tags.txt
+++ b/spec/tags/ruby/core/rational/minus_tags.txt
@@ -1,1 +1,0 @@
-fails:Rational#- rescues exception (StandardError and subclasses) raised in other#coerce and raises TypeError

--- a/spec/tags/ruby/core/rational/multiply_tags.txt
+++ b/spec/tags/ruby/core/rational/multiply_tags.txt
@@ -1,1 +1,0 @@
-fails:Rational#* rescues exception (StandardError and subclasses) raised in other#coerce and raises TypeError

--- a/spec/tags/ruby/core/rational/plus_tags.txt
+++ b/spec/tags/ruby/core/rational/plus_tags.txt
@@ -1,1 +1,0 @@
-fails:Rational#+ rescues exception (StandardError and subclasses) raised in other#coerce and raises TypeError

--- a/spec/tags/ruby/core/rational/round_tags.txt
+++ b/spec/tags/ruby/core/rational/round_tags.txt
@@ -1,1 +1,0 @@
-fails:Rational#round with half option returns a Rational when the precision is greater than 0


### PR DESCRIPTION
1. This PR deletes unnecessary condition expression to fix Rational#round .
2. This PR updates Rational#marshal_dump to private method.
3. This PR also cleans up tags of Rational's rspecs.