### PR TITLE
Update Kernel#send, #public_send and BasicObject#send to raise correct error message

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -1638,7 +1638,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
 
     @JRubyMethod(name = "__send__", omit = true)
     public IRubyObject send(ThreadContext context, IRubyObject arg0, Block block) {
-        String name = RubySymbol.objectToSymbolString(arg0);
+        String name = RubySymbol.checkID(arg0);
 
         StaticScope staticScope = context.getCurrentStaticScope();
 
@@ -1646,7 +1646,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     }
     @JRubyMethod(name = "__send__", omit = true)
     public IRubyObject send(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Block block) {
-        String name = RubySymbol.objectToSymbolString(arg0);
+        String name = RubySymbol.checkID(arg0);
 
         StaticScope staticScope = context.getCurrentStaticScope();
 
@@ -1654,7 +1654,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     }
     @JRubyMethod(name = "__send__", omit = true)
     public IRubyObject send(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
-        String name = RubySymbol.objectToSymbolString(arg0);
+        String name = RubySymbol.checkID(arg0);
 
         StaticScope staticScope = context.getCurrentStaticScope();
 
@@ -1662,7 +1662,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     }
     @JRubyMethod(name = "__send__", required = 1, rest = true, omit = true)
     public IRubyObject send(ThreadContext context, IRubyObject[] args, Block block) {
-        String name = RubySymbol.objectToSymbolString(args[0]);
+        String name = RubySymbol.checkID(args[0]);
 
         StaticScope staticScope = context.getCurrentStaticScope();
 

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1994,7 +1994,7 @@ public class RubyKernel {
             throw context.runtime.newArgumentError("no method name given");
         }
 
-        String name = RubySymbol.objectToSymbolString(args[0]);
+        String name = RubySymbol.checkID(args[0]);
 
         final int length = args.length - 1;
         args = ( length == 0 ) ? IRubyObject.NULL_ARRAY : ArraySupport.newCopy(args, 1, length);

--- a/spec/tags/ruby/core/basicobject/__send___tags.txt
+++ b/spec/tags/ruby/core/basicobject/__send___tags.txt
@@ -1,1 +1,0 @@
-fails:BasicObject#__send__ raises a TypeError if the method name is not a string or symbol

--- a/spec/tags/ruby/core/kernel/public_send_tags.txt
+++ b/spec/tags/ruby/core/kernel/public_send_tags.txt
@@ -1,1 +1,0 @@
-fails:Kernel#public_send raises a TypeError if the method name is not a string or symbol

--- a/spec/tags/ruby/core/kernel/send_tags.txt
+++ b/spec/tags/ruby/core/kernel/send_tags.txt
@@ -1,1 +1,0 @@
-fails:Kernel#send raises a TypeError if the method name is not a string or symbol


### PR DESCRIPTION
This commit uses the checkID method instead of the objectToSymbolString method.