### PR TITLE
Update Math#log when the argument is Bignum

### DIFF
--- a/spec/tags/ruby/core/math/log2_tags.txt
+++ b/spec/tags/ruby/core/math/log2_tags.txt
@@ -1,1 +1,0 @@
-fails:Math.log2 returns the natural logarithm of the argument


### PR DESCRIPTION
When the argument is Bignum, this logic parses the argument to generate 2 params(double value and shift bits) and avoids overflow.

This commit makes the following tests pass.
 * spec/ruby/core/math/log2_spec.rb