### PR TITLE
Update Struct#eql? and #== to handle recursive structures correctly

### DIFF
--- a/core/src/main/java/org/jruby/runtime/JavaSites.java
+++ b/core/src/main/java/org/jruby/runtime/JavaSites.java
@@ -52,6 +52,7 @@ public class JavaSites {
     public final FiberSites Fiber = new FiberSites();
     public final MonitorSites Monitor = new MonitorSites();
     public final SetSites Set = new SetSites();
+    public final StructSites Struct = new StructSites();
 
     public static class BasicObjectSites {
         public final CallSite respond_to = new FunctionalCachingCallSite("respond_to?");
@@ -302,6 +303,11 @@ public class JavaSites {
         public final CachingCallSite op_equal = new FunctionalCachingCallSite("==");
         public final RespondToCallSite respond_to_infinite = new RespondToCallSite("infinite?");
         public final CallSite infinite = new FunctionalCachingCallSite("infinite?");
+    }
+
+    public static class StructSites {
+        public final CallSite op_equal = new FunctionalCachingCallSite("==");
+        public final CallSite eql = new FunctionalCachingCallSite("eql?");
     }
 
     public static class TimeSites {

--- a/core/src/main/java/org/jruby/util/RecursiveComparator.java
+++ b/core/src/main/java/org/jruby/util/RecursiveComparator.java
@@ -5,6 +5,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.RubyHash;
 import org.jruby.RubyArray;
+import org.jruby.RubyStruct;
 import org.jruby.Ruby;
 import org.jruby.runtime.invokedynamic.MethodNames;
 
@@ -26,7 +27,8 @@ public class RecursiveComparator {
             Set<Pair> seen;
 
             if (a instanceof RubyHash && b instanceof RubyHash ||
-                a instanceof RubyArray && b instanceof RubyArray) {
+                a instanceof RubyArray && b instanceof RubyArray ||
+                a instanceof RubyStruct && b instanceof RubyStruct) {
 
                 RecursiveComparator.Pair pair = new RecursiveComparator.Pair(a, b);
 
@@ -50,6 +52,10 @@ public class RecursiveComparator {
             if (a instanceof RubyArray) {
                 RubyArray array = (RubyArray) a;
                 return array.compare(context, (CallSite) invokable, b);
+            }
+            if (a instanceof RubyStruct) {
+                RubyStruct struct = (RubyStruct) a;
+                return struct.compare(context, (CallSite) invokable, b);
             }
             return ((CallSite) invokable).call(context, a, a, b);
         }

--- a/spec/tags/ruby/core/struct/eql_tags.txt
+++ b/spec/tags/ruby/core/struct/eql_tags.txt
@@ -1,1 +1,0 @@
-fails:Struct#eql? handles recursive structures by returning false if a difference can be found

--- a/spec/tags/ruby/core/struct/equal_value_tags.txt
+++ b/spec/tags/ruby/core/struct/equal_value_tags.txt
@@ -1,1 +1,0 @@
-fails:Struct#== handles recursive structures by returning false if a difference can be found


### PR DESCRIPTION
This commit makes the following tests pass.
 * spec/ruby/core/struct/eql_spec.rb
 * spec/ruby/core/struct/equal_value_spec.rb