### PR TITLE
Update Struct.new to raise ArgumentError when there is a duplcate member

### DIFF
--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -33,6 +33,7 @@
 
 package org.jruby;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -240,6 +241,7 @@ public class RubyStruct extends RubyObject {
             keywordInit = ret != null && ret.isTrue();
         }
 
+        Set<IRubyObject> tmpMemberSet = new HashSet<IRubyObject>();
         for (int i = (name == null && !nilName) ? 0 : 1; i < argc; i++) {
             IRubyObject arg = args[i];
             RubySymbol sym;
@@ -249,6 +251,11 @@ public class RubyStruct extends RubyObject {
                 sym = runtime.newSymbol(arg.convertToString().getByteList());
             } else {
                 sym = runtime.newSymbol(arg.asJavaString());
+            }
+            if (tmpMemberSet.contains(sym)) {
+                throw runtime.newArgumentError("duplicate member: " + sym);
+            } else {
+                tmpMemberSet.add(sym);
             }
 
             member.append(sym);

--- a/spec/tags/ruby/core/struct/new_tags.txt
+++ b/spec/tags/ruby/core/struct/new_tags.txt
@@ -1,2 +1,0 @@
-fails:Struct.new raises ArgumentError when there is a duplicate member
-fails:Struct.new keyword_init: true option raises when there is a duplicate member


### PR DESCRIPTION
This commit makes the following tests pass.
 * spec/ruby/core/struct/new_spec.rb