### PR TITLE
Update Kernel.#Complex to treat exception option correctly

### DIFF
--- a/spec/tags/ruby/core/kernel/Complex_tags.txt
+++ b/spec/tags/ruby/core/kernel/Complex_tags.txt
@@ -1,1 +1,0 @@
-wip:Kernel.Complex() when passed exception: false and [Numeric] returns a complex number


### PR DESCRIPTION
For instance, Complet(123, exception: false) should be Complex(123).
When exception option is not boolean, ArgumentError should be raised same as mri 3.1.2.

This commit also decreases wip tag in rspecs.