### PR TITLE
Update IO.new, IO.open and IO.for_fd to raise ArgumentError for some edge cases

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1009,6 +1009,15 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     public IRubyObject initialize(ThreadContext context, IRubyObject fileNumber, IRubyObject modeValue, IRubyObject options, Block unused) {
         int fileno = RubyNumeric.fix2int(fileNumber);
 
+        // TODO: MRI has a method name in ArgumentError. 
+        // e.g. `for_fd': wrong number of arguments (given 3, expected 1..2)
+        if (modeValue != null && !modeValue.isNil() && !(modeValue instanceof RubyInteger) && !(modeValue instanceof RubyString)) {
+            throw context.runtime.newArgumentError(3, 1, 2);
+        }
+        if (options == null || options.isNil()) {
+            throw context.runtime.newArgumentError(3, 1, 2);
+        }
+
         return initializeCommon(context, fileno, modeValue, options);
     }
 

--- a/spec/tags/ruby/core/io/for_fd_tags.txt
+++ b/spec/tags/ruby/core/io/for_fd_tags.txt
@@ -3,5 +3,3 @@ fails:IO.for_fd raises an error if passed conflicting binary/text mode two ways
 windows:IO.for_fd raises an Errno::EINVAL if the new mode is not compatible with the descriptor's current mode
 fails:IO.for_fd ignores the :encoding option when the :external_encoding option is present
 fails:IO.for_fd ignores the :encoding option when the :internal_encoding option is present
-wip:IO.for_fd raises ArgumentError for nil options
-wip:IO.for_fd raises ArgumentError if passed a hash for mode and nil for options

--- a/spec/tags/ruby/core/io/new_tags.txt
+++ b/spec/tags/ruby/core/io/new_tags.txt
@@ -4,5 +4,3 @@ windows:IO.new ingores the :encoding option when the :internal_encoding option i
 windows:IO.new raises an Errno::EINVAL if the new mode is not compatible with the descriptor's current mode
 fails:IO.new ignores the :encoding option when the :external_encoding option is present
 fails:IO.new ignores the :encoding option when the :internal_encoding option is present
-wip:IO.new raises ArgumentError for nil options
-wip:IO.new raises ArgumentError if passed a hash for mode and nil for options

--- a/spec/tags/ruby/core/io/open_tags.txt
+++ b/spec/tags/ruby/core/io/open_tags.txt
@@ -4,5 +4,3 @@ windows:IO.open ingores the :encoding option when the :internal_encoding option 
 windows:IO.open raises an Errno::EINVAL if the new mode is not compatible with the descriptor's current mode
 fails:IO.open ignores the :encoding option when the :external_encoding option is present
 fails:IO.open ignores the :encoding option when the :internal_encoding option is present
-wip:IO.open raises ArgumentError for nil options
-wip:IO.open raises ArgumentError if passed a hash for mode and nil for options


### PR DESCRIPTION
For instance, IO.for_fd(IO.sysopen("tmp.rb"), "w", nil) shoud raise "`for_fd': wrong number of arguments (given 3, expected 1..2) (ArgumentError)".
This commit also decreases wip tag in rspecs.