### PR TITLE
Remove wip tag of Numeric#clone

### DIFF
--- a/spec/tags/ruby/core/numeric/clone_tags.txt
+++ b/spec/tags/ruby/core/numeric/clone_tags.txt
@@ -1,1 +1,0 @@
-wip:Numeric#clone does not change frozen status if passed freeze: nil

--- a/spec/tags/ruby/core/numeric/step_tags.txt
+++ b/spec/tags/ruby/core/numeric/step_tags.txt
@@ -1,8 +1,0 @@
-fails:Numeric#step with positional args when step is a String with self and stop as Floats raises an  when step is a numeric representation
-fails:Numeric#step with positional args when step is a String with self and stop as Floats raises an  with step as an alphanumeric string
-fails:Numeric#step with positional args when no block is given returned Enumerator size when step is a String with self and stop as Floats raises an  when step is a numeric representation
-fails:Numeric#step with positional args when no block is given returned Enumerator size when step is a String with self and stop as Floats raises an  with step as an alphanumeric string
-fails:Numeric#step with keyword arguments when step is a String with self and stop as Floats raises an  when step is a numeric representation
-fails:Numeric#step with keyword arguments when step is a String with self and stop as Floats raises an  with step as an alphanumeric string
-fails:Numeric#step with keyword arguments when no block is given returned Enumerator size when step is a String with self and stop as Floats raises an  when step is a numeric representation
-fails:Numeric#step with keyword arguments when no block is given returned Enumerator size when step is a String with self and stop as Floats raises an  with step as an alphanumeric string


### PR DESCRIPTION
I think this Numeric#clone failure fixed by eb078adb48fac335d53a4781f43b52f1fc2f2868 commit.
And I confirm all Numeric's rspecs work.