### PR TITLE
#7225 make JarCache check interval configurable and raise default val…

### DIFF
--- a/core/src/main/java/org/jruby/util/JarCache.java
+++ b/core/src/main/java/org/jruby/util/JarCache.java
@@ -97,7 +97,7 @@ class JarCache {
          * <p>
          * NOTE: Getting the value is an expensive operation on Windows systems (see
          * {@link <a href="https://github.com/jruby/jruby/issues/6730}").
-         * Therefore a cached value is used with a maximum lifetime of {@link Options#JAR_CACHE_TTL} milliseconds.
+         * Therefore a cached value is used with a maximum lifetime of {@link Options#JAR_CACHE_UPDATE_CHECK_INTERVALL} milliseconds.
          *
          * @param jarPath The path to the JAR file.
          * @return The last modification timestamp.
@@ -107,7 +107,7 @@ class JarCache {
             if (lastModifiedExpiration != null && currentTimeMillis < lastModifiedExpiration) {
                 return lastModified;
             }
-            this.lastModifiedExpiration = currentTimeMillis + Options.JAR_CACHE_TTL.load();
+            this.lastModifiedExpiration = currentTimeMillis + Options.JAR_CACHE_UPDATE_CHECK_INTERVALL.load();
             return new File(jarPath).lastModified();
         }
 

--- a/core/src/main/java/org/jruby/util/JarCache.java
+++ b/core/src/main/java/org/jruby/util/JarCache.java
@@ -40,9 +40,9 @@ import static org.jruby.RubyFile.canonicalize;
 class JarCache {
 
     /**
-     * The timeout in milliseconds for caching the last modified timestamp of JAR files.
+     * The interval in milliseconds for checking the last modified timestamp of JAR files.
      */
-    private static final long LAST_MODIFIED_EXPIRATION_TIME_MILLISECONDS = 500;
+    private static final long LAST_MODIFIED_CHECK_INTERVALL_MILLISECONDS = Long.valueOf(System.getProperty("jruby.jarCache.lastModifiedCheckInterval", "750"));
 
     static class JarIndex {
         private static final String ROOT_KEY = "";
@@ -100,7 +100,7 @@ class JarCache {
          * <p>
          * NOTE: Getting the value is an expensive operation on Windows systems (see
          * {@link <a href="https://github.com/jruby/jruby/issues/6730}").
-         * Therefore a cached value is used with a maximum lifetime of {@link #LAST_MODIFIED_EXPIRATION_TIME_MILLISECONDS} milliseconds.
+         * Therefore a cached value is used with a maximum lifetime of {@link #LAST_MODIFIED_CHECK_INTERVALL_MILLISECONDS} milliseconds.
          *
          * @param jarPath The path to the JAR file.
          * @return The last modification timestamp.
@@ -110,7 +110,7 @@ class JarCache {
             if (lastModifiedExpiration != null && currentTimeMillis < lastModifiedExpiration) {
                 return lastModified;
             }
-            this.lastModifiedExpiration = currentTimeMillis + LAST_MODIFIED_EXPIRATION_TIME_MILLISECONDS;
+            this.lastModifiedExpiration = currentTimeMillis + LAST_MODIFIED_CHECK_INTERVALL_MILLISECONDS;
             return new File(jarPath).lastModified();
         }
 

--- a/core/src/main/java/org/jruby/util/JarCache.java
+++ b/core/src/main/java/org/jruby/util/JarCache.java
@@ -16,6 +16,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
+import org.jruby.util.cli.Options;
+
 import static org.jruby.RubyFile.canonicalize;
 
 /**
@@ -38,11 +40,6 @@ import static org.jruby.RubyFile.canonicalize;
  * associated spec locally.
  */
 class JarCache {
-
-    /**
-     * The interval in milliseconds for checking the last modified timestamp of JAR files.
-     */
-    private static final long LAST_MODIFIED_CHECK_INTERVALL_MILLISECONDS = Long.valueOf(System.getProperty("jruby.jarCache.lastModifiedCheckInterval", "750"));
 
     static class JarIndex {
         private static final String ROOT_KEY = "";
@@ -100,7 +97,7 @@ class JarCache {
          * <p>
          * NOTE: Getting the value is an expensive operation on Windows systems (see
          * {@link <a href="https://github.com/jruby/jruby/issues/6730}").
-         * Therefore a cached value is used with a maximum lifetime of {@link #LAST_MODIFIED_CHECK_INTERVALL_MILLISECONDS} milliseconds.
+         * Therefore a cached value is used with a maximum lifetime of {@link Options#JAR_CACHE_TTL} milliseconds.
          *
          * @param jarPath The path to the JAR file.
          * @return The last modification timestamp.
@@ -110,7 +107,7 @@ class JarCache {
             if (lastModifiedExpiration != null && currentTimeMillis < lastModifiedExpiration) {
                 return lastModified;
             }
-            this.lastModifiedExpiration = currentTimeMillis + LAST_MODIFIED_CHECK_INTERVALL_MILLISECONDS;
+            this.lastModifiedExpiration = currentTimeMillis + Options.JAR_CACHE_TTL.load();
             return new File(jarPath).lastModified();
         }
 

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -186,6 +186,7 @@ public class Options {
     public static final Option<Boolean> USE_FIXNUM_CACHE = bool(MISCELLANEOUS, "fixnum.cache", true, "Use a cache of low-valued Fixnum objects.");
     public static final Option<Integer> FIXNUM_CACHE_RANGE = integer(MISCELLANEOUS, "fixnum.cache.size", 256, "Values to retrieve from Fixnum cache, in the range -X..(X-1).");
     public static final Option<Boolean> PACKED_ARRAYS = bool(MISCELLANEOUS, "packed.arrays", true, "Toggle whether to use \"packed\" arrays for small tuples.");
+    public static final Option<Integer> JAR_CACHE_TTL = integer(MISCELLANEOUS, "jarcache.ttl", 750, "The time (ms) between checks if a JAR file containing resources has been updated.");
 
     public static final Option<Boolean> DEBUG_LOADSERVICE = bool(DEBUG, "debug.loadService", false, "Log require/load file searches.");
     public static final Option<Boolean> DEBUG_LOADSERVICE_TIMING = bool(DEBUG, "debug.loadService.timing", false, "Log require/load parse+evaluate times.");

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -186,7 +186,7 @@ public class Options {
     public static final Option<Boolean> USE_FIXNUM_CACHE = bool(MISCELLANEOUS, "fixnum.cache", true, "Use a cache of low-valued Fixnum objects.");
     public static final Option<Integer> FIXNUM_CACHE_RANGE = integer(MISCELLANEOUS, "fixnum.cache.size", 256, "Values to retrieve from Fixnum cache, in the range -X..(X-1).");
     public static final Option<Boolean> PACKED_ARRAYS = bool(MISCELLANEOUS, "packed.arrays", true, "Toggle whether to use \"packed\" arrays for small tuples.");
-    public static final Option<Integer> JAR_CACHE_TTL = integer(MISCELLANEOUS, "jarcache.ttl", 750, "The time (ms) between checks if a JAR file containing resources has been updated.");
+    public static final Option<Integer> JAR_CACHE_UPDATE_CHECK_INTERVALL = integer(MISCELLANEOUS, "jarcache.updateCheck.intervall", 750, "The time (ms) between checks if a JAR file containing resources has been updated.");
 
     public static final Option<Boolean> DEBUG_LOADSERVICE = bool(DEBUG, "debug.loadService", false, "Log require/load file searches.");
     public static final Option<Boolean> DEBUG_LOADSERVICE_TIMING = bool(DEBUG, "debug.loadService.timing", false, "Log require/load parse+evaluate times.");

--- a/core/src/test/java/org/jruby/util/JarCacheTest.java
+++ b/core/src/test/java/org/jruby/util/JarCacheTest.java
@@ -6,8 +6,7 @@ import org.junit.Test;
 import java.io.File;
 import java.net.URL;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.*;
 import static org.awaitility.Awaitility.waitAtMost;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
@@ -22,7 +21,7 @@ public class JarCacheTest {
     }
 
     /**
-     * Verifies that updating a JAR (i.e. change of last modification time) is recognized by the {@link JarCache} after at most 500ms.
+     * Verifies that updating a JAR (i.e. change of last modification time) is recognized by the {@link JarCache} after at most 1s.
      */
     @Test
     public void updateJar() {
@@ -33,7 +32,7 @@ public class JarCacheTest {
         assertNotNull(index);
 
         jarFile.setLastModified(System.currentTimeMillis() - MINUTES.toMillis(1));
-        waitAtMost(750, MILLISECONDS).untilAsserted(() -> {
+        waitAtMost(1, SECONDS).untilAsserted(() -> {
             JarCache.JarIndex updatedIndex = jarCache.getIndex(resource.getFile());
             assertNotSame(index, updatedIndex);
         });


### PR DESCRIPTION
- JarCache check interval is now configurable using the system property "jruby.jarCache.lastModifiedCheckInterval"
- The default value has been raised to 750ms