### PR TITLE
[fix] [ji] empty char array inspect

### DIFF
--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -580,10 +580,12 @@ public final class ArrayJavaProxy extends JavaProxy {
     // NOTE: special case as we want to inspect like a Character wrapper e.g. ['', 'a']
     private static RubyString inspectCharArrayPart(final Ruby runtime, final StringBuilder buffer, final char[] ary, final int len) {
         buffer.append('[');
-        for (int i = 0; ; i++) {
-            inspectCharValue(buffer, ary[i]);
-            if (i == len - 1) break;
-            buffer.append(", ");
+        if (len > 0) {
+            for (int i = 0; ; i++) {
+                inspectCharValue(buffer, ary[i]);
+                if (i == len - 1) break;
+                buffer.append(", ");
+            }
         }
         buffer.append(']');
         return RubyString.newString(runtime, buffer.append('>'));

--- a/spec/java_integration/types/array_spec.rb
+++ b/spec/java_integration/types/array_spec.rb
@@ -281,6 +281,9 @@ describe "A Java primitive Array of type" do
 
       arr = Java::char[2].new; arr[1] = 'ō' # null char + multi-byte char
       expect(arr.inspect).to eql "#<Java::char[2]: ['\u0000', 'ō']>"
+
+      arr = ''.to_java.to_char_array
+      expect(arr.inspect).to eql "#<Java::char[0]: []>"
     end
 
     it 'handles equality to another array' do


### PR DESCRIPTION
ended up being broken with the JI `inspect` support added in 9.3

this only concerns empty `char[]` : 

```
>> ''.to_java.toCharArray
Traceback (most recent call last):
       16: from org.jruby.internal.runtime.methods.CompiledIRMethod.call(CompiledIRMethod.java:139)
       15: from org.jruby.ir.targets.indy.InvokeSite.invoke(InvokeSite.java:208)
       14: from org.jruby.RubyProc$INVOKER$i$call.call(RubyProc$INVOKER$i$call.gen)
       13: from org.jruby.RubyProc.call(RubyProc.java:272)
       12: from org.jruby.runtime.Block.call(Block.java:147)
       11: from org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:66)
       10: from org.jruby.runtime.MixedModeIRBlockBody.commonYieldPath(MixedModeIRBlockBody.java:136)
        9: from org.jruby.ir.interpreter.Interpreter.INTERPRET_BLOCK(Interpreter.java:116)
        8: from org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72)
        7: from org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:345)
        6: from org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:144)
        5: from org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:351)
        4: from org.jruby.java.proxies.ArrayJavaProxy$INVOKER$i$0$0$inspect.call(ArrayJavaProxy$INVOKER$i$0$0$inspect.gen)
        3: from org.jruby.java.proxies.ArrayJavaProxy.inspect(ArrayJavaProxy.java:507)
        2: from org.jruby.java.proxies.ArrayJavaProxy.inspectPrimitiveArray(ArrayJavaProxy.java:562)
        1: from org.jruby.java.proxies.ArrayJavaProxy.inspectCharArrayPart(ArrayJavaProxy.java:584)
Java::JavaLang::ArrayIndexOutOfBoundsException (Index 0 out of bounds for length 0)

```