### PR TITLE
Implement most of Fiber#raise

### DIFF
--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -905,6 +905,12 @@ public class RubyClass extends RubyModule {
         return obj;
     }
 
+    public IRubyObject newInstance(ThreadContext context, IRubyObject arg0) {
+        IRubyObject obj = allocate();
+        baseCallSites[CS_IDX_INITIALIZE].call(context, obj, obj, arg0);
+        return obj;
+    }
+
     @JRubyMethod(name = "new", forward = true)
     public IRubyObject newInstance(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Block block) {
         IRubyObject obj = allocate();

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -875,15 +875,13 @@ public class RubyKernel {
     }
     public static IRubyObject raise(ThreadContext context, IRubyObject self, IRubyObject arg0) {
         final Ruby runtime = context.runtime;
-        int argc = 1;
-        boolean forceCause = false;
 
         // semi extract_raise_opts :
         IRubyObject cause;
         if (arg0 instanceof RubyHash) {
             RubyHash opt = (RubyHash) arg0;
             RubySymbol key;
-            if (!opt.isEmpty() && (opt.has_key_p(context, key = runtime.newSymbol("cause")) == runtime.getTrue())) {
+            if (!opt.isEmpty() && (opt.has_key_p(context, runtime.newSymbol("cause")) == runtime.getTrue())) {
                 throw runtime.newArgumentError("only cause is given with no arguments");
             }
         }
@@ -903,7 +901,7 @@ public class RubyKernel {
             printExceptionSummary(runtime, raise.getException());
         }
 
-        if (forceCause || argc > 0 && raise.getException().getCause() == null && cause != raise.getException()) {
+        if (raise.getException().getCause() == null && cause != raise.getException()) {
             raise.getException().setCause(cause);
         }
 

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -1478,7 +1478,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         if (!isAlive()) return context.nil;
 
 
-        pendingInterruptEnqueue(prepareRaiseException(context, args, Block.NULL_BLOCK));
+        pendingInterruptEnqueue(prepareRaiseException(context, args));
         interrupt();
 
         if (currentThread == this) {
@@ -1488,8 +1488,10 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         return context.nil;
     }
 
-    private IRubyObject prepareRaiseException(ThreadContext context, IRubyObject[] args, Block block) {
+    public static IRubyObject prepareRaiseException(ThreadContext context, IRubyObject[] args) {
         final Ruby runtime = context.runtime;
+        IRubyObject errorInfo = context.getErrorInfo();
+
         if (args.length == 0) {
             if (errorInfo.isNil()) {
                 // We force RaiseException here to populate backtrace
@@ -1504,7 +1506,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         final RubyException exception;
         if (args.length == 1) {
             if (arg instanceof RubyString) {
-                tmp = runtime.getRuntimeError().newInstance(context, args, block);
+                tmp = runtime.getRuntimeError().newInstance(context, args, Block.NULL_BLOCK);
             }
             else if (arg instanceof ConcreteJavaProxy ) {
                 return arg;
@@ -1532,7 +1534,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
             exception.set_backtrace(args[2]);
         }
 
-        IRubyObject cause = context.getErrorInfo();
+        IRubyObject cause = errorInfo;
         if (cause != exception) {
             exception.setCause(cause);
         }

--- a/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
+++ b/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
@@ -99,10 +99,10 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
     public IRubyObject resume(ThreadContext context, IRubyObject[] values) {
         Ruby runtime = context.runtime;
 
+        if (!alive()) throw runtime.newFiberError("dead fiber called");
+
         final FiberData data = this.data;
         if (data.prev != null || data.transferred) throw runtime.newFiberError("double resume");
-        
-        if (!alive()) throw runtime.newFiberError("dead fiber called");
         
         FiberData currentFiberData = context.getFiber().data;
         

--- a/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
+++ b/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
@@ -295,14 +295,7 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
 
         FiberRequest val = new FiberRequest(exception, RequestType.RAISE);
 
-        if (currentFiberData.prev != null) {
-            // new fiber should answer to current prev and this fiber is marked as transferred
-            data.prev = currentFiberData.prev;
-            currentFiberData.prev = null;
-            currentFiberData.transferred = true;
-        } else {
-            data.prev = context.getFiber();
-        }
+        data.prev = context.getFiber();
 
         FiberRequest result = null;
         try {

--- a/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
+++ b/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
@@ -136,7 +136,7 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
             throw ((RubyException) result.data).toThrowable();
         }
 
-        return result.data;
+        return processResultData(context, result);
     }
 
     @JRubyMethod(rest = true)
@@ -275,7 +275,7 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
             throw ((RubyException) result.data).toThrowable();
         }
 
-        return result.data;
+        return processResultData(context, result);
     }
     public IRubyObject raise(ThreadContext context, IRubyObject exception) {
         Ruby runtime = context.runtime;
@@ -312,7 +312,7 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
             throw ((RubyException) result.data).toThrowable();
         }
 
-        return result.data;
+        return processResultData(context, result);
     }
     
     @JRubyMethod(meta = true)
@@ -333,6 +333,10 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
             throw ((RubyException) result.data).toThrowable();
         }
 
+        return processResultData(context, result);
+    }
+
+    private static IRubyObject processResultData(ThreadContext context, FiberRequest result) {
         IRubyObject data = result.data;
 
         if (data == RubyBasicObject.NEVER) return context.nil;
@@ -358,7 +362,7 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
             throw ((RubyException) result.data).toThrowable();
         }
 
-        return result.data;
+        return processResultData(context, result);
     }
 
     private static FiberData verifyCurrentFiber(ThreadContext context, Ruby runtime) {

--- a/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
+++ b/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
@@ -340,7 +340,11 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
             throw ((RubyException) result.data).toThrowable();
         }
 
-        return result.data;
+        IRubyObject data = result.data;
+
+        if (data == RubyBasicObject.NEVER) return context.nil;
+
+        return data;
     }
 
     @JRubyMethod(meta = true, rest = true)

--- a/spec/tags/ruby/core/fiber/raise_tags.txt
+++ b/spec/tags/ruby/core/fiber/raise_tags.txt
@@ -1,4 +1,3 @@
 wip:Fiber#raise re-raises a previously rescued exception without overwriting the backtrace
 wip:Fiber#raise raises FiberError if Fiber is not born
-fails:Fiber#raise allows extra keyword arguments for compatibility
 fails:Fiber#raise does not allow message and extra keyword arguments

--- a/spec/tags/ruby/core/fiber/raise_tags.txt
+++ b/spec/tags/ruby/core/fiber/raise_tags.txt
@@ -1,28 +1,4 @@
-wip:Fiber#raise aborts execution
-wip:Fiber#raise accepts an exception that implements to_hash
-wip:Fiber#raise allows the message parameter to be a hash
-wip:Fiber#raise raises RuntimeError if no exception class is given
-wip:Fiber#raise raises a given Exception instance
-wip:Fiber#raise raises a RuntimeError if string given
-wip:Fiber#raise passes no arguments to the constructor when given only an exception class
-wip:Fiber#raise raises a TypeError when passed a non-Exception object
-wip:Fiber#raise raises a TypeError when passed true
-wip:Fiber#raise raises a TypeError when passed false
-wip:Fiber#raise raises a TypeError when passed nil
 wip:Fiber#raise re-raises a previously rescued exception without overwriting the backtrace
-wip:Fiber#raise allows Exception, message, and backtrace parameters
-wip:Fiber#raise raises RuntimeError by default
 wip:Fiber#raise raises FiberError if Fiber is not born
-wip:Fiber#raise raises FiberError if Fiber is dead
-wip:Fiber#raise accepts error class
-wip:Fiber#raise accepts error message
-wip:Fiber#raise does not accept array of backtrace information only
-wip:Fiber#raise does not accept integer
-wip:Fiber#raise accepts error class with error message
-wip:Fiber#raise accepts error class with with error message and backtrace information
-wip:Fiber#raise does not accept only error message and backtrace information
-wip:Fiber#raise raises a FiberError if invoked from a different Thread
-wip:Fiber#raise kills Fiber
-wip:Fiber#raise transfers and raises on a transferring fiber
 fails:Fiber#raise allows extra keyword arguments for compatibility
 fails:Fiber#raise does not allow message and extra keyword arguments

--- a/spec/tags/ruby/core/fiber/yield_tags.txt
+++ b/spec/tags/ruby/core/fiber/yield_tags.txt
@@ -1,1 +1,0 @@
-wip:Fiber.yield raises a FiberError if called from the root Fiber


### PR DESCRIPTION
This implements Fiber#raise by introducing a new transfer mechanism, FiberRequest, which can be used to do the raise safely on the Fiber side rather than trying to force it through thread mechanism. No specs regressed and nearly all Fiber#raise specs now pass, but I have not investigated the performance impact of this additional carrier object yet.