### PR TITLE
Fix Math.ldexp for #7234

### DIFF
--- a/core/src/main/java/org/jruby/RubyMath.java
+++ b/core/src/main/java/org/jruby/RubyMath.java
@@ -500,8 +500,15 @@ public class RubyMath {
      */
     @JRubyMethod(name = "ldexp", required = 2, module = true, visibility = Visibility.PRIVATE)
     public static RubyFloat ldexp(ThreadContext context, IRubyObject recv, IRubyObject mantissa, IRubyObject exponent) {
-        return RubyFloat.newFloat(context.runtime, 
-                RubyNumeric.num2dbl(context, mantissa) * Math.pow(2.0, RubyNumeric.num2int(exponent)));
+        double m = RubyNumeric.num2dbl(context, mantissa);
+        int e = RubyNumeric.num2int(exponent);
+
+        if (e > 1023) {
+            // avoid overflow. Math.power(2.0, 1024) is greater than Math.MAX_VALUE.
+            return RubyFloat.newFloat(context.runtime, m * Math.pow(2.0, e - 1023) * Math.pow(2.0, 1023));
+        }
+
+        return RubyFloat.newFloat(context.runtime, m * Math.pow(2.0, e));
     }
 
     public static RubyFloat ldexp19(ThreadContext context, IRubyObject recv, IRubyObject mantissa, IRubyObject exponent) {

--- a/spec/regression/GH-7234_math_ldexp_spec.rb
+++ b/spec/regression/GH-7234_math_ldexp_spec.rb
@@ -1,0 +1,8 @@
+describe "Math.ldexp" do
+
+  it "returns correct value that closes to the max value of double type" do
+    Math.ldexp(0.5122058490966879, 1024).should == 9.207889385574391e+307
+    Math.ldexp(0.9999999999999999, 1024).should == 1.7976931348623157e+308
+    Math.ldexp(0.99999999999999999, 1024).should == Float::INFINITY
+  end
+end


### PR DESCRIPTION
When the exponent is greater than 1023, This commit avoids overflow by converting Math.pow(2.0, exponent) into Math.pow(2.0, exponent-1023) * Math.pow(2.0, 1023).
Because Math.pow(2.0, 1024) is evaluated to INFINITY(overflow).

#7234