### PR TITLE
allow ObjectSpace._id2ref to work for objects with finalizer

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -1312,12 +1312,11 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
             // must also register this object in ObjectSpace, so that future
             // calls to undefine_finalizer, which takes an object symbol, can
             // locate the object properly. See JRUBY-4839.
-            long id = getObjectId();
-            IRubyObject fixnumId = id();
+            final long id = getObjectId();
 
             getRuntime().getObjectSpace().registerObjectId(id, this);
 
-            finalizer = new Finalizer(fixnumId);
+            finalizer = new Finalizer(getRuntime().newFixnum(id));
             setInternalVariable("__finalizer__", finalizer);
             getRuntime().addFinalizer(finalizer);
         }

--- a/core/src/main/java/org/jruby/RubyObjectSpace.java
+++ b/core/src/main/java/org/jruby/RubyObjectSpace.java
@@ -118,12 +118,10 @@ public class RubyObjectSpace {
             }
             return runtime.newFloat(d);
         } else {
+            IRubyObject object = runtime.getObjectSpace().id2ref(longId);
+            if (object != null) return object;
             if (runtime.isObjectSpaceEnabled()) {
-                IRubyObject object = runtime.getObjectSpace().id2ref(longId);
-                if (object == null) {
-                    return runtime.getNil();
-                }
-                return object;
+                return runtime.getNil();
             } else {
                 runtime.getWarnings().warn("ObjectSpace is disabled; _id2ref only supports immediates, pass -X+O to enable");
                 throw runtime.newRangeError(String.format("0x%016x is not id value", longId));


### PR DESCRIPTION
this is pretty much a low hanging fruit that allows the following to work (with `-O` as well):
`bin/jruby -v -e "obj = [1]; ObjectSpace.define_finalizer(obj, lambda { |_| }); p obj.object_id; p ObjectSpace._id2ref obj.object_id"`

... since internally the `define_finalizer` call assigns the `object_id` to the object.

maybe it's not a good idea, but seemed useful as well as dangerous, allowing to potentially de-reference an object in the finalizer: 
`ObjectSpace.define_finalizer(obj, lambda { |id| obj = ObjectSpace._id2ref(id)  })`