### PR TITLE
Update the implementation class of dedupMap to prevent the memory growth for #7229

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -5745,7 +5745,7 @@ public final class Ruby implements Constantizable {
      *
      * Access must be synchronized.
      */
-    private final ConcurrentHashMap<FStringEqual, WeakReference<RubyString>> dedupMap = new ConcurrentHashMap<>();
+    private final Map<FStringEqual, WeakReference<RubyString>> dedupMap = new ConcurrentWeakHashMap<>();
 
     private static final AtomicInteger RUNTIME_NUMBER = new AtomicInteger(0);
     private final int runtimeNumber = RUNTIME_NUMBER.getAndIncrement();

--- a/core/src/main/java/org/jruby/ir/operands/FrozenString.java
+++ b/core/src/main/java/org/jruby/ir/operands/FrozenString.java
@@ -103,6 +103,12 @@ public class FrozenString extends ImmutableLiteral<RubyString> implements String
         return IRRuntimeHelpers.newFrozenString(context, bytelist, coderange, file, line);
     }
 
+    // allways call createCacheObject (GH-7229)
+    @Override
+    public boolean isCached() {
+        return false;
+    }
+
     @Override
     public void visit(IRVisitor visitor) {
         visitor.FrozenString(this);


### PR DESCRIPTION
Using ConcurrentWeakHashMap class, I think frozen and dedup'd strings outside of the scope will be released.
This commit also overrides isChached of FrozenString class to avoid specific mri test failure.

See #7229