### PR TITLE
Avoid ClassCastException when super class is a Java Map for #7219

### DIFF
--- a/core/src/main/java/org/jruby/java/codegen/RealClassGenerator.java
+++ b/core/src/main/java/org/jruby/java/codegen/RealClassGenerator.java
@@ -68,6 +68,7 @@ import org.jruby.exceptions.RaiseException;
 import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.java.proxies.ConcreteJavaProxy;
 import org.jruby.java.proxies.ConcreteJavaProxy.SplitCtorData;
+import org.jruby.java.proxies.MapJavaProxy;
 import org.jruby.javasupport.Java.JCreateMethod;
 import org.jruby.javasupport.Java.JCtorCache;
 import org.jruby.javasupport.JavaConstructor;
@@ -1084,6 +1085,12 @@ public abstract class RealClassGenerator {
      */
     public static String makeConcreteConstructorProxy(ClassWriter cw, PositionAware initPosition, boolean hasRuby,
             ConcreteJavaReifier cjr, Class[] ctorTypes, boolean nested) {
+        Class clazz;
+        if (Map.class.isAssignableFrom(cjr.reifiedParent)) {
+            clazz = MapJavaProxy.class;
+        } else {
+            clazz = ConcreteJavaProxy.class;
+        }
         String sig = hasRuby ? sig(void.class, cjr.join(ctorTypes, Ruby.class, RubyClass.class))
                 : sig(void.class, ctorTypes);
         SkinnyMethodAdapter m = new SkinnyMethodAdapter(cw, ACC_PUBLIC, "<init>", sig, null, null);
@@ -1105,11 +1112,11 @@ public abstract class RealClassGenerator {
         m.aload(0); // uninitialized this
 
         //// new ConcreteJavaProxy(ruby, rubyClass);
-        m.newobj(p(ConcreteJavaProxy.class));
+        m.newobj(p(clazz));
         m.dup(); // rubyobject
         m.aload(rubyIndex); // ruby
         m.aload(rubyClassIndex); // rubyclass
-        m.invokespecial(p(ConcreteJavaProxy.class), "<init>", sig(void.class, Ruby.class, RubyClass.class));
+        m.invokespecial(p(clazz), "<init>", sig(void.class, Ruby.class, RubyClass.class));
 
         if (nested) m.iconst_1();
         else m.iconst_0(); // called from subclass?

--- a/core/src/main/java/org/jruby/java/proxies/ConcreteJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ConcreteJavaProxy.java
@@ -30,6 +30,7 @@ import static org.jruby.runtime.Visibility.PUBLIC;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
 
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
@@ -268,7 +269,13 @@ public class ConcreteJavaProxy extends JavaProxy {
 
             Constructor<? extends ReifiedJavaProxy> withBlock;
             try {
-                withBlock = reified.getConstructor(new Class[] { ConcreteJavaProxy.class, IRubyObject[].class,
+                Class _clazz;
+                if (Map.class.isAssignableFrom(reified)) {
+                    _clazz = MapJavaProxy.class;
+                } else {
+                    _clazz = ConcreteJavaProxy.class;
+                }
+                withBlock = reified.getConstructor(new Class[] { _clazz, IRubyObject[].class,
                         Block.class, Ruby.class, RubyClass.class });
             } catch (SecurityException | NoSuchMethodException e) {
                 // ignore, don't install

--- a/spec/regression/GH-7219_map_java_proxy_spec.rb
+++ b/spec/regression/GH-7219_map_java_proxy_spec.rb
@@ -1,0 +1,12 @@
+describe "MapJavaProxy" do
+  class A < java.util.concurrent.ConcurrentHashMap
+  end
+
+  class B < java.util.HashMap
+  end
+  
+  it "does not raise ClassCastException" do
+    A.new["test"].should be_nil
+    B.new["test"].should be_nil
+  end
+end


### PR DESCRIPTION
This commit uses checking class's type in several parts to avoid ClassCastException.

#7219