### PR TITLE
Fixes #7184. Double splat operator with empty hash works differently …

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -1163,17 +1163,12 @@ public class IRBuilder {
 
             if (keywordArgs.hasOnlyRestKwargs()) {  // {**k}, {**{}, **k}, etc...
                 Variable splatValue = buildRestKeywordArgs(keywordArgs);
-                Variable test = addResultInstr(new RuntimeHelperCall(createTemporaryVariable(), IS_HASH_EMPTY, new Operand[] { splatValue }));
                 Operand block = setupCallClosure(callNode.getIterNode());
 
                 determineIfWeNeedLineNumber(callNode); // buildOperand for fcall was papered over by args operand building so we check once more.
-                if_else(test, manager.getTrue(),
-                        () -> receiveBreakException(block,
-                                determineIfProcNew(receiverNode,
-                                        CallInstr.create(scope, NORMAL, result, name, receiver, args, block))),
-                        () -> receiveBreakException(block,
-                                determineIfProcNew(receiverNode,
-                                        CallInstr.create(scope, NORMAL, result, name, receiver, addArg(args, splatValue), block))));
+                receiveBreakException(block,
+                        determineIfProcNew(receiverNode,
+                                CallInstr.create(scope, NORMAL, result, name, receiver, addArg(args, splatValue), block)));
             } else {  // {a: 1, b: 2}
                 List<KeyValuePair<Operand, Operand>> kwargs = buildKeywordArguments(keywordArgs);
                 Operand block = setupCallClosure(callNode.getIterNode());
@@ -2957,13 +2952,10 @@ public class IRBuilder {
 
             if (keywordArgs.hasOnlyRestKwargs()) {  // {**k}, {**{}, **k}, etc...
                 Variable splatValue = buildRestKeywordArgs(keywordArgs);
-                Variable test = addResultInstr(new RuntimeHelperCall(createTemporaryVariable(), IS_HASH_EMPTY, new Operand[] { splatValue }));
                 Operand block = setupCallClosure(fcallNode.getIterNode());
 
                 determineIfWeNeedLineNumber(fcallNode); // buildOperand for fcall was papered over by args operand building so we check once more.
-                if_else(test, manager.getTrue(),
-                        () -> receiveBreakException(block, CallInstr.create(scope, FUNCTIONAL, result, name, buildSelf(), args, block)),
-                        () -> receiveBreakException(block, CallInstr.create(scope, FUNCTIONAL, result, name, buildSelf(), addArg(args, splatValue), block)));
+                receiveBreakException(block, CallInstr.create(scope, FUNCTIONAL, result, name, buildSelf(), addArg(args, splatValue), block));
             } else {  // {a: 1, b: 2}
                 List<KeyValuePair<Operand, Operand>> kwargs = buildKeywordArguments(keywordArgs);
                 Operand block = setupCallClosure(fcallNode.getIterNode());

--- a/spec/tags/ruby/language/method_tags.txt
+++ b/spec/tags/ruby/language/method_tags.txt
@@ -1,0 +1,1 @@
+fails:A method assigns local variables from method parameters for definition 'def m(*a) a end'


### PR DESCRIPTION
…in JRuby 9.3 and MRI 2.6