### PR TITLE
Only drop block for non-JI native calls

### DIFF
--- a/core/src/main/java/org/jruby/ir/targets/indy/Bootstrap.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/Bootstrap.java
@@ -691,7 +691,9 @@ public class Bootstrap {
         boolean wantsBlock = true;
         if (method instanceof NativeCallMethod) {
             DynamicMethod.NativeCall nativeCall = ((NativeCallMethod) method).getNativeCall();
-            if (nativeCall != null) {
+            // if it is a non-JI native call and does not want block, drop it
+            // JI calls may lazily convert blocks to an interface type (jruby/jruby#7246)
+            if (nativeCall != null && !nativeCall.isJava()) {
                 Class[] nativeSignature = nativeCall.getNativeSignature();
 
                 // no args or last arg not a block, do no pass block


### PR DESCRIPTION
Java calls may lazily convert incoming blocks to match an
interface type, which cannot be detected by this naive signature
check. We skip JI calls here to allow them to do the extra type
conversion.

Fixes #7246