### PR TITLE
Fixes #7237. Java::JavaLang::NullPointerException in org.jruby.ir.ins…

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -312,7 +312,7 @@ public class IRBuilder {
     protected final List<Instr> instructions;
     protected List<Object> argumentDescriptions;
     protected int coverageMode;
-    private boolean executesOnce = true;
+    protected boolean executesOnce = true;
     private int temporaryVariableIndex = -1;
     private boolean needsYieldBlock = false;
 

--- a/core/src/main/java/org/jruby/ir/IRMethod.java
+++ b/core/src/main/java/org/jruby/ir/IRMethod.java
@@ -198,8 +198,9 @@ public class IRMethod extends IRScope {
     private synchronized void buildMethodImpl() {
         if (hasBeenBuilt()) return;
 
-        IRBuilder.topIRBuilder(getManager(), this).
-                defineMethodInner(defNode, getLexicalParent(), getCoverageMode()); // sets interpreterContext
+        IRBuilder builder = IRBuilder.topIRBuilder(getManager(), this);
+        builder.executesOnce = false; // set up so nested things (modules+) which think it could execute once knows it cannot (it is in a method).
+        builder.defineMethodInner(defNode, getLexicalParent(), getCoverageMode()); // sets interpreterContext
         this.defNode = null;
     }
 


### PR DESCRIPTION
…tructions.DefineClassInstr.INTERPRET_CLASS

define_method -> real method should mark the builder as execute_once = false since it nor any child scopes can execute only once.