### PR TITLE
update jar-dependencies gem hooks

### DIFF
--- a/lib/ruby/stdlib/rubygems/defaults/jruby.rb
+++ b/lib/ruby/stdlib/rubygems/defaults/jruby.rb
@@ -100,6 +100,12 @@ rescue LoadError
 end
 
 begin
-  require 'jar_install_post_install_hook'
+  Gem.post_install do |gem_installer|
+    # defer this require until the post-install hook is actually called
+    # since otherwise Bundler will not be able to activate any other
+    # version of jar-dependencies than the pre-packaged default gem.
+    require "jars/post_install_hook"
+    Jars.post_install_hook(gem_installer)
+  end
 rescue LoadError
 end

--- a/pom.rb
+++ b/pom.rb
@@ -71,7 +71,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
               'jruby-launcher.version' => '1.1.6',
               'ant.version' => '1.9.8',
               'asm.version' => '9.2',
-              'jar-dependencies.version' => '0.4.1',
+              'jar-dependencies.version' => '0.4.2',
               'jffi.version' => '1.3.9',
               'joda.time.version' => '2.10.10' )
 

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@ DO NOT MODIFIY - GENERATED CODE
     <invoker.skip>true</invoker.skip>
     <its.j2ee>j2ee*/pom.xml</its.j2ee>
     <its.osgi>osgi*/pom.xml</its.osgi>
-    <jar-dependencies.version>0.4.1</jar-dependencies.version>
+    <jar-dependencies.version>0.4.2</jar-dependencies.version>
     <jffi.version>1.3.9</jffi.version>
     <joda.time.version>2.10.10</joda.time.version>
     <jruby-launcher.version>1.1.6</jruby-launcher.version>


### PR DESCRIPTION
fixes #7262, but requires https://github.com/mkristian/jar-dependencies to have a new release first.