### PR TITLE
Update Resolv to the latest MRI version

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -33,7 +33,7 @@ default_gems = [
     ['debug', '0.2.1'],
     ['delegate', '0.2.0'],
     ['did_you_mean', '1.6.1'],
-    ['digest', '3.1.0'], 
+    ['digest', '3.1.0'],
     ['drb', '2.1.0'],
     ['english', '0.7.1'],
     ['erb', '2.2.3'],
@@ -53,7 +53,7 @@ default_gems = [
     # https://github.com/ruby/io-nonblock/issues/4
     # ['io-nonblock', '0.1.0'],
     ['io-wait', '0.2.3'],
-    ['ipaddr', '1.2.3'],
+    ['ipaddr', '1.2.4'],
     ['irb', '1.4.1'],
     ['jar-dependencies', '0.4.1'],
     ['jruby-readline', '1.3.7'],
@@ -334,7 +334,7 @@ project 'JRuby Lib Setup' do
 
         # copy bin files if the gem has any
         copy_gem_executables.call(spec, gem_home) if options[:bin]
-        
+
         # TODO: try avoiding these binstub of gems - should use a full gem location
         spec.executables.each do |f|
           bin = Dir.glob(File.join( gems, "#{gem_name}*", spec.bindir ))[0]

--- a/lib/ruby/stdlib/resolv.rb
+++ b/lib/ruby/stdlib/resolv.rb
@@ -2468,7 +2468,7 @@ class Resolv
     Regex_8HexLinkLocal = /\A
       [Ff][Ee]80
       (?::[0-9A-Fa-f]{1,4}){7}
-      %[0-9A-Za-z]+
+      %[-0-9A-Za-z._~]+
       \z/x
 
     ##
@@ -2482,7 +2482,7 @@ class Resolv
         |
         :((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)
       )?
-      :[0-9A-Fa-f]{1,4}%[0-9A-Za-z.]+
+      :[0-9A-Fa-f]{1,4}%[-0-9A-Za-z._~]+
       \z/x
 
     ##

--- a/test/mri/resolv/test_addr.rb
+++ b/test/mri/resolv/test_addr.rb
@@ -28,6 +28,10 @@ class TestResolvAddr < Test::Unit::TestCase
     assert_match(Resolv::IPv6::Regex, "FE80:2:3:4:5:6:7:8%EM1", bug17112)
     assert_match(Resolv::IPv6::Regex, "FE80::20D:3AFF:FE7D:9760%ETH0", bug17112)
     assert_match(Resolv::IPv6::Regex, "FE80::1%EM1", bug17112)
+
+    bug17524 = "[ruby-core:101992]"
+    assert_match(Resolv::IPv6::Regex, "FE80::20D:3AFF:FE7D:9760%ruby_3.0.0-1", bug17524)
+    assert_match(Resolv::IPv6::Regex, "fe80::1%ruby_3.0.0-1", bug17524)
   end
 
   def test_valid_socket_ip_address_list


### PR DESCRIPTION
This will fix the IPv6 parsing when the address has local zone id e.g. `fe80::861e:a3ff:fea5:dd27%en0` where `%en0` is a zone id

Extra links: 
* MRI issue - [resolv: add some more characters in IPv6 link local zone id](https://bugs.ruby-lang.org/issues/17524)

Example: 

```ruby
resolv = Resolv.new([
  Resolv::Hosts.new
])

resolv.getaddress('google.com')
```

leads to

```
Traceback (most recent call last):
       16: from org/jruby/RubyArray.java:1865:in `each'
       15: from /Users/vidok/.rbenv/versions/jruby-9.3.3.0/lib/ruby/stdlib/resolv.rb:122:in `block in each_address'
       14: from /Users/vidok/.rbenv/versions/jruby-9.3.3.0/lib/ruby/stdlib/resolv.rb:410:in `each_address'
       13: from /Users/vidok/.rbenv/versions/jruby-9.3.3.0/lib/ruby/stdlib/resolv.rb:513:in `each_resource'
       12: from /Users/vidok/.rbenv/versions/jruby-9.3.3.0/lib/ruby/stdlib/resolv.rb:523:in `fetch_resource'
       11: from /Users/vidok/.rbenv/versions/jruby-9.3.3.0/lib/ruby/stdlib/resolv.rb:1121:in `resolv'
       10: from org/jruby/RubyArray.java:1865:in `each'
        9: from /Users/vidok/.rbenv/versions/jruby-9.3.3.0/lib/ruby/stdlib/resolv.rb:1123:in `block in resolv'
        8: from org/jruby/RubyArray.java:1865:in `each'
        7: from /Users/vidok/.rbenv/versions/jruby-9.3.3.0/lib/ruby/stdlib/resolv.rb:1124:in `block in resolv'
        6: from org/jruby/RubyArray.java:1865:in `each'
        5: from /Users/vidok/.rbenv/versions/jruby-9.3.3.0/lib/ruby/stdlib/resolv.rb:1126:in `block in resolv'
        4: from /Users/vidok/.rbenv/versions/jruby-9.3.3.0/lib/ruby/stdlib/resolv.rb:528:in `block in fetch_resource'
        3: from /Users/vidok/.rbenv/versions/jruby-9.3.3.0/lib/ruby/stdlib/resolv.rb:774:in `sender'
        2: from org/jruby/RubyClass.java:886:in `new'
        1: from /Users/vidok/.rbenv/versions/jruby-9.3.3.0/lib/ruby/stdlib/ipaddr.rb:598:in `initialize'
IPAddr::InvalidAddressError (invalid address: fe80::861e:a3ff:fea5:dd27%en0)
```

so both `ipaddr` and `resolv` need to be upgraded