### PR TITLE
Fix Bignum#<= for edge case

### DIFF
--- a/core/src/main/java/org/jruby/runtime/JavaSites.java
+++ b/core/src/main/java/org/jruby/runtime/JavaSites.java
@@ -281,6 +281,10 @@ public class JavaSites {
         public final CheckedSites checked_op_or = new CheckedSites("|");
         public final CheckedSites checked_op_xor = new CheckedSites("^");
         public final CallSite op_cmp = new FunctionalCachingCallSite("<=>");
+        public final CallSite op_ge = new FunctionalCachingCallSite(">=");
+        public final CallSite op_le = new FunctionalCachingCallSite("<=");
+        public final CallSite op_gt = new FunctionalCachingCallSite(">");
+        public final CallSite op_lt = new FunctionalCachingCallSite("<");
         public final CallSite fdiv = new FunctionalCachingCallSite("fdiv");
         public final CachingCallSite basic_op_lt = new FunctionalCachingCallSite("<");
         public final CachingCallSite basic_op_gt = new FunctionalCachingCallSite(">");

--- a/spec/tags/ruby/core/integer/chr_tags.txt
+++ b/spec/tags/ruby/core/integer/chr_tags.txt
@@ -1,1 +1,0 @@
-wip:Integer#chr with an encoding argument returns a String encoding self interpreted as a codepoint in the CESU-8 encoding

--- a/spec/tags/ruby/core/integer/lte_tags.txt
+++ b/spec/tags/ruby/core/integer/lte_tags.txt
@@ -1,1 +1,0 @@
-fails:Integer#<= bignum returns false if compares with near float

--- a/spec/tags/ruby/core/integer/zero_tags.txt
+++ b/spec/tags/ruby/core/integer/zero_tags.txt
@@ -1,1 +1,0 @@
-fails:Integer#zero? Integer#zero? uses Numeric#zero?


### PR DESCRIPTION
This commit also updates #<, #<=, #> and #>= by porting from mri.
The following test will pass.
 * spec/ruby/core/integer/lte_spec.rb