### PR TITLE
Update doCoerce function

### DIFF
--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -516,30 +516,21 @@ public class RubyNumeric extends RubyObject {
         return callCoerced(context, site, other, false);
     }
 
-    // beneath are rewritten coercions that reflect MRI logic, the aboves are used only by RubyBigDecimal
-
-    /** coerce_body
-     *
-     */
-    protected final IRubyObject coerceBody(ThreadContext context, IRubyObject other) {
-        return sites(context).coerce.call(context, other, other, this);
-    }
-
     /** do_coerce
      *
      */
     protected final RubyArray doCoerce(ThreadContext context, IRubyObject other, boolean err) {
-        if (!sites(context).respond_to_coerce.respondsTo(context, other, other)) {
+        IRubyObject ary = getMetaClass(other).finvokeChecked(context, other, sites(context).coerce_checked, this);
+
+        if (ary == null) {
             if (err) {
                 coerceFailed(context, other);
             }
             return null;
         }
         final IRubyObject $ex = context.getErrorInfo();
-        final IRubyObject result;
 
-        result = coerceBody(context, other);
-        return coerceResult(context.runtime, result, err);
+        return coerceResult(context.runtime, ary, err);
     }
 
     private static RubyArray coerceResult(final Ruby runtime, final IRubyObject result, final boolean err) {

--- a/core/src/main/java/org/jruby/runtime/JavaSites.java
+++ b/core/src/main/java/org/jruby/runtime/JavaSites.java
@@ -178,6 +178,7 @@ public class JavaSites {
     public static class NumericSites {
         public final RespondToCallSite respond_to_coerce = new RespondToCallSite("coerce");
         public final CallSite coerce = new FunctionalCachingCallSite("coerce");
+        public final CheckedSites coerce_checked = new CheckedSites("coerce");
         public final CallSite op_cmp = new FunctionalCachingCallSite("<=>");
         public final CachingCallSite op_minus = new FunctionalCachingCallSite("-");
         public final CallSite op_quo = new FunctionalCachingCallSite("/");


### PR DESCRIPTION
This commit fixes 'TypeError: TestTimeout::Seconds can't be coerced into Float' error in test/jruby/test_timeout.rb .

See https://github.com/jruby/jruby/runs/7591269856?check_suite_focus=true#step:7:243 .