### PR TITLE
Eliminate JI-specific const replacement warning

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -247,13 +247,8 @@ public class Java implements Library {
     public static RubyModule setProxyClass(final Ruby runtime, final RubyModule target,
                                            final String constName, final Class<?> javaClass) {
         final RubyModule proxyClass = getProxyClass(runtime, javaClass);
-        IRubyObject existing = target.getConstantNoConstMissing(constName);
 
-        if ( existing != null && existing != RubyBasicObject.UNDEF && existing != proxyClass ) {
-            runtime.getWarnings().warn("replacing " + existing + " with " + proxyClass + " in constant '" + constName + " on class/module " + target);
-        }
-
-        target.setConstantQuiet(constName, proxyClass);
+        target.setConstant(constName, proxyClass);
         return proxyClass;
     }
 


### PR DESCRIPTION
This warning duplicates existing functionality intended to warn
when overwriting a constant, perhaps due to the more "magic"
nature of include_package and its open-ended behavior of assigning
constants to Java classes on demand. This feature is expected to
be used in places where you explicitly want the Java classes to be
preferred over classes further up in the hierarchy, so I believe
it makes sense to only warn if overwriting a constant that exists
on the target module directly.

Fixes #7185