### PR TITLE
Use the wide versions of these functions always

### DIFF
--- a/lib/ruby/stdlib/win32/registry.rb
+++ b/lib/ruby/stdlib/win32/registry.rb
@@ -235,11 +235,11 @@ For detail, see the MSDN[http://msdn.microsoft.com/library/en-us/sysinfo/base/pr
         %w/RegEnumKeyExW    LLPPLLLP     L/,
         %w/RegQueryValueExW LPLPPP       L/,
         %w/RegSetValueExW   LPLLPL       L/,
-        %w/RegDeleteValue   LP           L/,
-        %w/RegDeleteKey     LP           L/,
+        %w/RegDeleteValueW   LP           L/,
+        %w/RegDeleteKeyW     LP           L/,
         %w/RegFlushKey      L            L/,
         %w/RegCloseKey      L            L/,
-        %w/RegQueryInfoKey  LPPPPPPPPPPP L/,
+        %w/RegQueryInfoKeyW  LPPPPPPPPPPP L/,
       ].each do |fn|
         const_set fn[0].intern, Win32API.new('advapi32.dll', *fn)
       end


### PR DESCRIPTION
The two delete functions were modified to be wide in CRuby in
response to https://bugs.ruby-lang.org/issues/10820 seven years
ago. The query function was mentioned here but not updated to be
wide. I am unsure how CRuby is locating the appropriate `A` or `W`
function given the bare name, but since we have largely forked
this file and always want to use the wide version, this change
seems appropriate.

Fixes #7106