### PR TITLE
Fixes #7218. Empty rescue block returns exception object instead of nil.

### DIFF
--- a/core/src/main/java/org/jruby/parser/RubyParser.java
+++ b/core/src/main/java/org/jruby/parser/RubyParser.java
@@ -3710,7 +3710,7 @@ states[456] = (ParserSupport support, RubyLexer lexer, Object yyVal, ProductionS
 states[459] = (ParserSupport support, RubyLexer lexer, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
                     Node node;
                     if (((Node)yyVals[-3+yyTop].value) != null) {
-                        node = support.appendToBlock(node_assign(((Node)yyVals[-3+yyTop].value), new GlobalVarNode(((Integer)yyVals[-5+yyTop].value), support.symbolID(lexer.DOLLAR_BANG))), ((Node)yyVals[-1+yyTop].value));
+                        node = support.appendToBlock(node_assign(((Node)yyVals[-3+yyTop].value), new GlobalVarNode(((Integer)yyVals[-5+yyTop].value), support.symbolID(lexer.DOLLAR_BANG))), support.makeNullNil(((Node)yyVals[-1+yyTop].value)));
                         if (((Node)yyVals[-1+yyTop].value) != null) {
                             node.setLine(((Integer)yyVals[-5+yyTop].value));
                         }

--- a/core/src/main/java/org/jruby/parser/RubyParser.y
+++ b/core/src/main/java/org/jruby/parser/RubyParser.y
@@ -2041,7 +2041,7 @@ cases           : opt_else | case_body
 opt_rescue      : keyword_rescue exc_list exc_var then compstmt opt_rescue {
                     Node node;
                     if ($3 != null) {
-                        node = support.appendToBlock(node_assign($3, new GlobalVarNode($1, support.symbolID(lexer.DOLLAR_BANG))), $5);
+                        node = support.appendToBlock(node_assign($3, new GlobalVarNode($1, support.symbolID(lexer.DOLLAR_BANG))), support.makeNullNil($5));
                         if ($5 != null) {
                             node.setLine($1);
                         }


### PR DESCRIPTION
The fix was an error in our parser.  When we get exception variables in
a rescue statement we will make effectively '_e = $!' and then append
whatever is actually in the body of the exception body.  In MRI's case
it ends up being 'nil'.  In our case it was 'null'.  Our impl thinks it
is smart and realizes nothing is happening and what should you append
if it is null anyways and just left the body as only '_e = $!'.  We
needed '_e = $!; nil'.

Trivial fix is to make sure any null return from compstmt in this grammar
production will always just be nil.  Impact from this change should only
effect the case when a rescue body is empty and in the precence of an
exception variable.  What we did was wrong.  I see no risk.