### PR TITLE
Add thread polling on backedges of Range#each loop

### DIFF
--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -230,6 +230,7 @@ public abstract class RubyInteger extends RubyNumeric {
             long i;
             for (i = from; i < to; i++) {
                 block.yield(context, nil);
+                context.pollThreadEvents();
             }
             if (i <= to) {
                 block.yield(context, nil);
@@ -239,6 +240,7 @@ public abstract class RubyInteger extends RubyNumeric {
             long i;
             for (i = from; i < to; i++) {
                 block.yield(context, RubyFixnum.newFixnum(runtime, i));
+                context.pollThreadEvents();
             }
             if (i <= to) {
                 block.yield(context, RubyFixnum.newFixnum(runtime, i));

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -1160,6 +1160,7 @@ public class RubyNumeric extends RubyObject {
         if (inf) {
             for (;; i += diff) {
                 block.yield(context, RubyFixnum.newFixnum(runtime, i));
+                context.pollThreadEvents();
             }
         } else {
             // We must avoid integer overflows in "i += step".
@@ -1169,6 +1170,7 @@ public class RubyNumeric extends RubyObject {
                 if (end > tov) tov = end;
                 for (; i >= tov; i += diff) {
                     block.yield(context, RubyFixnum.newFixnum(runtime, i));
+                    context.pollThreadEvents();
                 }
                 if (i >= end) {
                     block.yield(context, RubyFixnum.newFixnum(runtime, i));
@@ -1178,6 +1180,7 @@ public class RubyNumeric extends RubyObject {
                 if (end < tov) tov = end;
                 for (; i <= tov; i += diff) {
                     block.yield(context, RubyFixnum.newFixnum(runtime, i));
+                    context.pollThreadEvents();
                 }
                 if (i <= end) {
                     block.yield(context, RubyFixnum.newFixnum(runtime, i));
@@ -1201,12 +1204,14 @@ public class RubyNumeric extends RubyObject {
             RubyFloat value = RubyFloat.newFloat(runtime, beg);
             for (;;) {
                 block.yield(context, value);
+                context.pollThreadEvents();
             }
         } else {
             for (i=0; i<n; i++) {
                 double d = i*unit+beg;
                 if (unit >= 0 ? end < d : d < end) d = end;
                 block.yield(context, RubyFloat.newFloat(runtime, d));
+                context.pollThreadEvents();
             }
         }
     }
@@ -1217,12 +1222,14 @@ public class RubyNumeric extends RubyObject {
         if (inf) {
             for (;; i = sites(context).op_plus.call(context, i, i, step)) {
                 block.yield(context, i);
+                context.pollThreadEvents();
             }
         } else {
             CallSite cmpSite = desc ? sites(context).op_lt : sites(context).op_gt;
 
             for (; !cmpSite.call(context, i, i, to).isTrue(); i = sites(context).op_plus.call(context, i, i, step)) {
                 block.yield(context, i);
+                context.pollThreadEvents();
             }
         }
     }
@@ -1330,11 +1337,13 @@ public class RubyNumeric extends RubyObject {
                 /* if unit is infinity, i*unit+beg is NaN */
                 if (n > 0) {
                     block.yield(context, dbl2num(context.runtime, beg));
+                    context.pollThreadEvents();
                 }
             } else if (unit == 0) {
                 IRubyObject val = dbl2num(context.runtime, beg);
                 for (;;) {
                     block.yield(context, val);
+                    context.pollThreadEvents();
                 }
             } else {
                 for (long i=0; i < n; i++) {
@@ -1343,6 +1352,7 @@ public class RubyNumeric extends RubyObject {
                         d = end;
                     }
                     block.yield(context, dbl2num(context.runtime, d));
+                    context.pollThreadEvents();
                 }
             }
 

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -504,6 +504,7 @@ public class RubyRange extends RubyObject {
             while (rangeLt(context, v, end) != null) {
                 callback.doCall(context, v);
                 v = v.callMethod(context, "succ");
+                context.pollThreadEvents();
             }
         } else {
             IRubyObject c;
@@ -513,6 +514,7 @@ public class RubyRange extends RubyObject {
                     break;
                 }
                 v = v.callMethod(context, "succ");
+                context.pollThreadEvents();
             }
         }
     }
@@ -601,6 +603,7 @@ public class RubyRange extends RubyObject {
                 } else {
                     for (IRubyObject beg = begin;; beg = beg.callMethod(context, "succ")) {
                         block.yield(context, beg);
+                        context.pollThreadEvents();
                     }
                 }
             }

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -4072,6 +4072,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
                 if (!excl && c == e) break;
                 c++;
                 if (excl && c == e) break;
+                context.pollThreadEvents();
             }
             return this;
         } else if (isAscii && ASCII.isDigit(value.getUnsafeBytes()[value.getBegin()]) && ASCII.isDigit(end.value.getUnsafeBytes()[end.value.getBegin()])) {
@@ -4082,6 +4083,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
             while (s < send) {
                 if (!ASCII.isDigit(bytes[s] & 0xff)) return uptoCommonNoDigits(context, end, excl, block, asSymbol);
                 s++;
+                context.pollThreadEvents();
             }
             s = end.value.getBegin();
             send = s + end.value.getRealSize();
@@ -4090,6 +4092,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
             while (s < send) {
                 if (!ASCII.isDigit(bytes[s] & 0xff)) return uptoCommonNoDigits(context, end, excl, block, asSymbol);
                 s++;
+                context.pollThreadEvents();
             }
 
             IRubyObject b = stringToInum(10);
@@ -4109,6 +4112,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
                     RubyString str = RubyString.newStringNoCopy(runtime, to, USASCIIEncoding.INSTANCE, CR_7BIT);
                     block.yield(context, asSymbol ? runtime.newSymbol(str.toString()) : str);
                     bl++;
+                    context.pollThreadEvents();
                 }
             } else {
                 StringSites sites = sites(context);
@@ -4121,6 +4125,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
                     RubyString str = RubyString.newStringNoCopy(runtime, to, USASCIIEncoding.INSTANCE, CR_7BIT);
                     block.yield(context, asSymbol ? runtime.newSymbol(str.toString()) : str);
                     b = sites.succ.call(context, b, b);
+                    context.pollThreadEvents();
                 }
             }
             return this;
@@ -4146,6 +4151,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
             current = next.convertToString();
             if (excl && current.op_equal(context, end).isTrue()) break;
             if (current.getByteList().length() > end.getByteList().length() || current.getByteList().length() == 0) break;
+            context.pollThreadEvents();
         }
         return this;
     }
@@ -4173,6 +4179,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
                     current = RubyString.newStringNoCopy(runtime, to, USASCIIEncoding.INSTANCE, CR_7BIT);
                     block.yield(context, current);
                     bl++;
+                    context.pollThreadEvents();
                 }
 
                 argsArr.eltSetOk(1, RubyFixnum.newFixnum(runtime, bl));
@@ -4188,6 +4195,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
             if (next == null) break;
             current = next.convertToString();
             if (current.getByteList().length() == 0) break;
+            context.pollThreadEvents();
         }
 
         return this;


### PR DESCRIPTION
There are several forms of loops here but none had any explicit
thread polling, which led to #7279 and timeout events not firing
during trivial Range#each loops. This commit adds polling to all
loops reachable from Range#each, which fixees #7279 and other
untested cases.

This does, however, come with a performance hit; the related thread
state must be checked after each loop. These could be improved in
the future by using a safe point mechanism like SwitchPoint, or by
porting these functions to Ruby which gets backedge thread polling
via the IR.

Fixes #7279