### PR TITLE
Fixed tests in RubyTime failing with to_a

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -956,7 +956,11 @@ public class RubyTime extends RubyObject {
             sec(), min(), hour(),
             mday(), month(), year(),
             wday(), yday(), isdst(),
-            dt.getZone().getShortName(dt.getMillis()));
+            getTimezoneShortName());
+    }
+
+    private RubyString getTimezoneShortName() {
+        return RubyString.newString(getRuntime(), dt.getZone().getShortName(dt.getMillis()));
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -45,6 +45,7 @@ import org.joda.time.*;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.tz.FixedDateTimeZone;
+import org.jruby.Ruby;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.ast.util.ArgsUtil;
@@ -956,11 +957,11 @@ public class RubyTime extends RubyObject {
             sec(), min(), hour(),
             mday(), month(), year(),
             wday(), yday(), isdst(),
-            getTimezoneShortName());
+            getTimezoneShortName(context.runtime));
     }
 
-    private RubyString getTimezoneShortName() {
-        return RubyString.newString(getRuntime(), dt.getZone().getShortName(dt.getMillis()));
+    private RubyString getTimezoneShortName(Ruby runtime) {
+        return RubyString.newString(runtime, dt.getZone().getShortName(dt.getMillis()));
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -951,7 +951,12 @@ public class RubyTime extends RubyObject {
     @JRubyMethod
     @Override
     public RubyArray to_a(ThreadContext context) {
-        return RubyArray.newArrayNoCopy(context.runtime, sec(), min(), hour(), mday(), month(), year(), wday(), yday(), isdst(), zone());
+        return RubyArray.newArrayNoCopy(
+            context.runtime,
+            sec(), min(), hour(),
+            mday(), month(), year(),
+            wday(), yday(), isdst(),
+            dt.getZone().getShortName(dt.getMillis()));
     }
 
     @JRubyMethod


### PR DESCRIPTION
Fixes a few tests that were failing in master.

`Time#to_a` returns its timezone as the short name only. `Time#to_s` seems to have a different interpretation of this using something of the form `GMT-06:00` but the spec expected `CST`

To fix this I just changed how `Time#to_a` receives it's timezone.