### PR TITLE
Clear errinfo after each finalizer runs

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -1968,7 +1968,12 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
 
         private void callFinalizer(IRubyObject finalizer) {
             ThreadContext context = finalizer.getRuntime().getCurrentContext();
-            sites(context).call.call(context, finalizer, finalizer, id);
+            try {
+                sites(context).call.call(context, finalizer, finalizer, id);
+            } finally {
+                // clear last error so it is not seen by future finalizers
+                context.setErrorInfo(context.nil);
+            }
         }
     }
 


### PR DESCRIPTION
In #7267 we had a report of endless exception cause processing
that turned out to be triggered by a bad finalizer (that allowed
an exception to bubble out) stacking up causes from previous calls
of that finalizer.

The fix here mimics what CRuby does: where they reset the errinfo
to what it was prior to the finalizer running (because CRuby's GC
often/usually runs on the current user thread), we simply clear it
after each finalizer has run (because the JDK runs finalizers on
a separate thread, as will our future non-JVM-finalizer version of
this logic).

No spec is provided yet due to the difficulty of testing
GC-triggered events across VMs. See https://github.com/ruby/spec/issues/935
for more details.

Fixes #7267