### PR TITLE
Always pass filename into AOT root scope creation

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -999,7 +999,9 @@ public final class Ruby implements Constantizable {
                 System.err.println("found class " + scriptClass.getName() + " for " + filename);
             }
 
-            return Compiler.getScriptFromClass(scriptClass);
+            Script script = Compiler.getScriptFromClass(scriptClass);
+
+            script.setFilename(filename);
         } catch (ClassNotFoundException cnfe) {
             // ignore and proceed to parse and execute
             if (Options.COMPILE_CACHE_CLASSES_LOGGING.load()) {
@@ -2553,7 +2555,7 @@ public final class Ruby implements Constantizable {
 
         try {
             // Get IR from .ir file
-            return IRReader.load(getIRManager(), new IRReaderStream(getIRManager(), IRFileExpert.getIRPersistedFile(file), new ByteList(file.getBytes())));
+            return IRReader.load(getIRManager(), new IRReaderStream(getIRManager(), IRFileExpert.getIRPersistedFile(file), file));
         } catch (IOException e) {
             // FIXME: What is something actually throws IOException
             return (ParseResult) parseFileAndGetAST(in, file, scope, lineNumber, false);
@@ -2574,7 +2576,7 @@ public final class Ruby implements Constantizable {
         if (!RubyInstanceConfig.IR_READING) return (ParseResult) parseFileFromMainAndGetAST(in, file, scope);
 
         try {
-            return IRReader.load(getIRManager(), new IRReaderStream(getIRManager(), IRFileExpert.getIRPersistedFile(file), new ByteList(file.getBytes())));
+            return IRReader.load(getIRManager(), new IRReaderStream(getIRManager(), IRFileExpert.getIRPersistedFile(file), file));
         } catch (IOException ex) {
             if (config.isVerbose()) {
                 LOG.info(ex);

--- a/core/src/main/java/org/jruby/ir/Compiler.java
+++ b/core/src/main/java/org/jruby/ir/Compiler.java
@@ -91,7 +91,7 @@ public class Compiler extends IRTranslator<ScriptAndCode, ClassDefiningClassLoad
         MethodHandle scriptHandle;
 
         try {
-            Method scriptMethod = compiled.getMethod("run", ThreadContext.class, IRubyObject.class, boolean.class);
+            Method scriptMethod = compiled.getMethod("run", ThreadContext.class, IRubyObject.class, String.class, boolean.class);
             scriptHandle = MethodHandles.publicLookup().unreflect(scriptMethod);
         } catch (Throwable t) {
             throw new NotCompilableException("failed to load script from class" + compiled.getName(), t);
@@ -101,7 +101,7 @@ public class Compiler extends IRTranslator<ScriptAndCode, ClassDefiningClassLoad
             @Override
             public IRubyObject __file__(ThreadContext context, IRubyObject self, IRubyObject[] args, Block block) {
                 try {
-                    return (IRubyObject) scriptHandle.invokeWithArguments(context, self, false);
+                    return (IRubyObject) scriptHandle.invokeWithArguments(context, self, filename, false);
                 } catch (Throwable t) {
                     Helpers.throwException(t);
                     return null; // not reached
@@ -111,7 +111,7 @@ public class Compiler extends IRTranslator<ScriptAndCode, ClassDefiningClassLoad
             @Override
             public IRubyObject load(ThreadContext context, IRubyObject self, boolean wrap) {
                 try {
-                    return (IRubyObject) scriptHandle.invokeWithArguments(context, self, wrap);
+                    return (IRubyObject) scriptHandle.invokeWithArguments(context, self, filename, wrap);
                 } catch (IRBreakJump bj) {
                     throw IRException.BREAK_LocalJumpError.getException(context.runtime);
                 } catch (Throwable t) {

--- a/core/src/main/java/org/jruby/ir/persistence/IRReader.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRReader.java
@@ -95,7 +95,7 @@ public class IRReader implements IRPersistenceValues {
         ByteList name = null;
         IRScope parent = null;
         if (type == IRScopeType.SCRIPT_BODY) {
-            file = decoder.decodeString();
+            file = decoder.getFilename();
             if (RubyInstanceConfig.IR_READING_DEBUG) System.out.println("decodeScopeHeader: script file = " + file);
         } else {
             name = decoder.decodeByteList();
@@ -122,12 +122,11 @@ public class IRReader implements IRPersistenceValues {
     private static StaticScope decodeStaticScope(IRReaderDecoder decoder, StaticScope parentScope) {
         StaticScope.Type type = decoder.decodeStaticScopeType();
         if (RubyInstanceConfig.IR_READING_DEBUG) System.out.println("decodeStaticScope: type = " + type);
-        String file = decoder.decodeString();
         String[] ids = decoder.decodeStringArray();
         int firstKeywordIndex = decoder.decodeInt();
         if (RubyInstanceConfig.IR_READING_DEBUG) System.out.println("decodeStaticScope: keyword index = " + firstKeywordIndex);
 
-        StaticScope scope = StaticScopeFactory.newStaticScope(parentScope, type, file, ids, firstKeywordIndex);
+        StaticScope scope = StaticScopeFactory.newStaticScope(parentScope, type, decoder.getFilename(), ids, firstKeywordIndex);
 
         Signature signature = decoder.decodeSignature();
         scope.setSignature(signature);

--- a/core/src/main/java/org/jruby/ir/persistence/IRReaderDecoder.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRReaderDecoder.java
@@ -73,7 +73,7 @@ public interface IRReaderDecoder {
     public IRScope decodeScope();
 
     public TemporaryVariableType decodeTemporaryVariableType();
-    public ByteList getFilename();
+    public String getFilename();
 
     /**
      * Duplicate this decoder to isolate any state changes.

--- a/core/src/main/java/org/jruby/ir/persistence/IRReaderStream.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRReaderStream.java
@@ -50,18 +50,18 @@ public class IRReaderStream implements IRReaderDecoder, IRPersistenceValues {
     private final List<IRScope> scopes;
     private IRScope currentScope; // FIXME: This is not thread-safe and more than a little gross
     /** Filename to use for the script */
-    private final ByteList filename;
+    private final String filename;
     private RubySymbol[] constantPool;
 
-    public IRReaderStream(IRManager manager, byte[] bytes, ByteList filename) {
+    public IRReaderStream(IRManager manager, byte[] bytes, String filename) {
         this(ByteBuffer.wrap(bytes), manager, new ArrayList<>(), null, filename, null);
     }
 
-    public IRReaderStream(IRManager manager, File file, ByteList filename) {
+    public IRReaderStream(IRManager manager, File file, String filename) {
         this(readingIntoBuffer(file), manager, new ArrayList<>(), null, filename, null);
     }
 
-    private IRReaderStream(ByteBuffer buf, IRManager manager, List<IRScope> scopes, IRScope currentScope, ByteList filename, RubySymbol[] constantPool) {
+    private IRReaderStream(ByteBuffer buf, IRManager manager, List<IRScope> scopes, IRScope currentScope, String filename, RubySymbol[] constantPool) {
         this.buf = buf;
         this.manager = manager;
         this.scopes = scopes;
@@ -84,7 +84,7 @@ public class IRReaderStream implements IRReaderDecoder, IRPersistenceValues {
     }
 
     @Override
-    public ByteList getFilename() {
+    public String getFilename() {
         return filename;
     }
 

--- a/core/src/main/java/org/jruby/ir/persistence/IRWriter.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRWriter.java
@@ -74,8 +74,7 @@ public class IRWriter {
 
         if (RubyInstanceConfig.IR_WRITING_DEBUG) System.out.println("NAME = " + scope.getId());
         if (scope instanceof IRScriptBody) {
-            if (shouldLog(file)) System.out.println("persistScopeHeader: file = " + scope.getFile());
-            file.encode(scope.getFile());
+            // filename comes in at load time, to allow for precompilation and relocating sources
         } else {
 
             if (shouldLog(file)) System.out.println("persistScopeHeader: id   = " + scope.getId());
@@ -95,7 +94,6 @@ public class IRWriter {
         file.encode(staticScope.getType());
         // This naively looks like a bug because these represent id's and not properly encoded names BUT all of those
         // symbols for these ids will be created when IRScope loads the LocalVariable versions of these...so this is ok.
-        file.encode(staticScope.getFile());
         file.encode(staticScope.getVariables());
         file.encode(staticScope.getFirstKeywordIndex());
         file.encode(staticScope.getSignature());

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1955,7 +1955,7 @@ public class IRRuntimeHelpers {
     @JIT
     public static IRScope decodeScopeFromBytes(Ruby runtime, byte[] scopeBytes, String filename) {
         try {
-            return IRReader.load(runtime.getIRManager(), new IRReaderStream(runtime.getIRManager(), scopeBytes, new ByteList(filename.getBytes())));
+            return IRReader.load(runtime.getIRManager(), new IRReaderStream(runtime.getIRManager(), scopeBytes, filename));
         } catch (IOException ioe) {
             // should not happen for bytes
             return null;

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -399,22 +399,22 @@ public class JVMVisitor extends IRVisitor {
                 jvm.cls(),
                 Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
                 "run",
-                sig(IRubyObject.class, ThreadContext.class, IRubyObject.class, boolean.class), null, null);
+                sig(IRubyObject.class, ThreadContext.class, IRubyObject.class, String.class, boolean.class), null, null);
         method.start();
 
         // save self class
         method.aload(1);
         method.invokeinterface(p(IRubyObject.class), "getMetaClass", sig(RubyClass.class));
-        method.astore(3);
+        method.astore(4);
 
         // instantiate script scope
         registerScopeField(script, scopeField);
 
         // FIXME: duplicated from IRBytecodeAdapter6
         method.getstatic(clsName, scopeField, ci(StaticScope.class));
-        method.astore(4);
+        method.astore(5);
 
-        method.aload(4);
+        method.aload(5);
 
         org.objectweb.asm.Label after = new org.objectweb.asm.Label();
         method.ifnonnull(after);
@@ -422,22 +422,22 @@ public class JVMVisitor extends IRVisitor {
             method.ldc(staticScopeDescriptorMap.get(scopeField));
             method.aconst_null();
             method.invokestatic(p(Helpers.class), "restoreScope", sig(StaticScope.class, String.class, StaticScope.class));
-            method.astore(4);
+            method.astore(5);
 
             // set scope's module
-            method.aload(4);
+            method.aload(5);
             method.aload(0);
             method.getfield(p(ThreadContext.class), "runtime", ci(Ruby.class));
             method.invokevirtual(p(Ruby.class), "getObject", sig(RubyClass.class));
             method.invokevirtual(p(StaticScope.class), "setModule", sig(void.class, RubyModule.class));
 
             // set scope's filename
-            method.aload(4);
-            method.ldc(script.getFile());
+            method.aload(5);
+            method.aload(2);
             method.invokevirtual(p(StaticScope.class), "setFile", sig(void.class, String.class));
 
             // wrapping logic for load
-            method.iload(2);
+            method.iload(3);
 
             org.objectweb.asm.Label nowrap = new org.objectweb.asm.Label();
             method.iffalse(nowrap);
@@ -445,29 +445,29 @@ public class JVMVisitor extends IRVisitor {
                 method.aload(0);
                 method.getfield(p(ThreadContext.class), "runtime", ci(Ruby.class));
                 method.aload(1); // self
-                method.aload(4);
+                method.aload(5);
                 method.invokevirtual(p(Ruby.class), "setupWrappedToplevel", sig(StaticScope.class, IRubyObject.class, StaticScope.class));
-                method.astore(4); // update to new scope
+                method.astore(5); // update to new scope
 
                 // set scope's filename
-                method.aload(4);
-                method.ldc(script.getFile());
+                method.aload(5);
+                method.aload(2);
                 method.invokevirtual(p(StaticScope.class), "setFile", sig(void.class, String.class));
             }
             method.label(nowrap);
 
-            method.aload(4);
+            method.aload(5);
             method.putstatic(clsName, scopeField, ci(StaticScope.class));
         }
         method.label(after);
 
         // execute script method
         method.aload(0); // context
-        method.aload(4); // static scope
+        method.aload(5); // static scope
         method.aload(1); // self
         method.aconst_null(); // args
         method.getstatic(p(Block.class), "NULL_BLOCK", ci(Block.class)); // block
-        method.aload(3); // self class
+        method.aload(4); // self class
         method.aconst_null(); // call name
 
         method.invokestatic(clsName, scopeName, sig(signature.type().returnType(), signature.type().parameterArray()));

--- a/spec/compiler/general_spec.rb
+++ b/spec/compiler/general_spec.rb
@@ -54,7 +54,7 @@ module PersistenceSpecUtils
     writer = org.jruby.ir.persistence.IRWriterStream.new(baos)
     org.jruby.ir.persistence.IRWriter.persist(writer, method)
 
-    reader = org.jruby.ir.persistence.IRReaderStream.new(manager, baos.to_byte_array, org.jruby.util.ByteList.new(filename.to_java.getBytes))
+    reader = org.jruby.ir.persistence.IRReaderStream.new(manager, baos.to_byte_array, filename.to_java)
     method = org.jruby.ir.persistence.IRReader.load(manager, reader)
 
     # interpret


### PR DESCRIPTION
The filename from which a script is loaded can change after that
script has been AOT compiled to either serialized IR or JVM
bytecode formats. Previous commits broke this dynamic filename
handling by hardcoding the filename into the serialized IR and JVM
bytecode, causing #7211.

This commit reinstates the dynamic filename by passing it through
from load logic to the root scope creation, and removing the
hardcoded filenames produced by both AOT forms.

Note that one path has always been broken and remains broken: the
JVM `main` entry point provided to run a script directly as a Java
class. There is no way to reliably determine the real path of the
main class, so it continues to hardcode the original filename
(which is similar to javac embedding the original filename of a
compiled Java source file).

Fixes #7211