### PR TITLE
Fix Integer#times for big integer

### DIFF
--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -337,11 +337,11 @@ public abstract class RubyInteger extends RubyNumeric {
             IRubyObject i = RubyFixnum.zero(runtime);
             RubyFixnum one = RubyFixnum.one(runtime);
             while (true) {
-                if (!sites(context).op_lt.call(context, i, i, this).isTrue()) {
+                if (!((RubyInteger) i).op_lt(context, this).isTrue()) {
                     break;
                 }
                 block.yield(context, i);
-                i = sites(context).op_plus.call(context, i, i, one);
+                i = ((RubyInteger) i).op_plus(context, one);
             }
             return this;
         } else {


### PR DESCRIPTION
This patch relates to https://bugs.ruby-lang.org/issues/18377

The results of TestInteger#test_times_bignum_redefine_plus_lt are below.

- jruby-head
```
  1) Failure:
TestInteger#test_times_bignum_redefine_plus_lt [/Users/kiichi/IdeaProjects/jruby/test/mri/ruby/test_integer.rb:323]:
[ruby-core:106361].
<false> expected but was
<true>.
```

- jruby-head + this PR
```
  1) Failure:
TestInteger#test_times_bignum_redefine_plus_lt [/Users/kiichi/IdeaProjects/jruby/test/mri/ruby/test_integer.rb:303]:
assert_separately failed with error message
pid 21910 exit 0
| -:21: warning: method redefined; discarding old +
| -:23: warning: method redefined; discarding old <
```

It still fails because of some warning messages, but I believe this patch works.