### PR TITLE
Fix included_modules method to not return wrapped modules

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2569,7 +2569,7 @@ public class RubyModule extends RubyObject {
 
         for (RubyModule p = getSuperClass(); p != null; p = p.getSuperClass()) {
             if (p.isIncluded()) {
-                ary.append(p.getOrigin());
+                ary.append(p.getDelegate().getOrigin());
             }
         }
 

--- a/spec/ruby/core/module/fixtures/classes.rb
+++ b/spec/ruby/core/module/fixtures/classes.rb
@@ -42,6 +42,14 @@ module ModuleSpecs
   class LookupChild < Lookup
   end
 
+  module ModuleWithPrepend 
+    prepend LookupMod
+  end
+
+  class WithPrependedModule
+    include ModuleWithPrepend
+  end
+
   class Parent
     # For private_class_method spec
     def self.private_method; end

--- a/spec/ruby/core/module/included_modules_spec.rb
+++ b/spec/ruby/core/module/included_modules_spec.rb
@@ -4,9 +4,11 @@ require_relative 'fixtures/classes'
 describe "Module#included_modules" do
   it "returns a list of modules included in self" do
     ModuleSpecs.included_modules.should == []
+	
     ModuleSpecs::Child.included_modules.should include(ModuleSpecs::Super, ModuleSpecs::Basic, Kernel)
     ModuleSpecs::Parent.included_modules.should include(Kernel)
     ModuleSpecs::Basic.included_modules.should == []
     ModuleSpecs::Super.included_modules.should include(ModuleSpecs::Basic)
+    ModuleSpecs::WithPrependedModule.included_modules.should include(ModuleSpecs::ModuleWithPrepend)
   end
 end


### PR DESCRIPTION
I discovered this issue while investigating https://github.com/jruby/jruby/issues/7256

The included_modules method would sometimes include a wrapped module. With this change, the prepended module now shows up in this list, and not the anonymous/wrapped module (which looks to be just a JRuby implementation detail). included_modules now matches what CRuby returns for this case