### PR TITLE
Only use NOSHARE_DELETE if accessible

### DIFF
--- a/core/src/main/java/org/jruby/util/io/ModeFlags.java
+++ b/core/src/main/java/org/jruby/util/io/ModeFlags.java
@@ -85,6 +85,17 @@ public class ModeFlags implements Cloneable {
     public static final int TEXT = 0x10000000;
     /** delete shared file flag for windows, otherwise zero */
     public static final int SHARE_DELETE = Platform.IS_WINDOWS ? 0x20000000 : 0;
+    /** try to access special mode flag, failover to default SHARE_DELETE otherwise */
+    public static final OpenOption NOSHARE_DELETE;
+    static {
+        OpenOption noshareDelete = null;
+        try {
+            noshareDelete = ExtendedOpenOption.NOSHARE_DELETE;
+        } catch (NoClassDefFoundError ncdfe) {
+            // leave null
+        }
+        NOSHARE_DELETE = noshareDelete;
+    }
     /** accmode flag, used to mask the read/write mode */
     public static final int ACCMODE = RDWR | WRONLY | RDONLY;
     
@@ -278,7 +289,7 @@ public class ModeFlags implements Cloneable {
         if (includeTruncate && isTruncate()) size++;
 
         // extended
-        if (isShareDelete()) {
+        if (isShareDelete() || NOSHARE_DELETE == null) {
             // do nothing, NIO defaults to share delete
         } else if (Platform.IS_WINDOWS) {
             size++;
@@ -296,10 +307,10 @@ public class ModeFlags implements Cloneable {
         if (includeTruncate && isTruncate()) options[index++] = StandardOpenOption.TRUNCATE_EXISTING;
 
         // extended
-        if (isShareDelete()) {
+        if (isShareDelete() || NOSHARE_DELETE == null) {
             // do nothing, NIO defaults to share delete
         } else if (Platform.IS_WINDOWS) {
-            options[index++] = ExtendedOpenOption.NOSHARE_DELETE;
+            options[index++] = NOSHARE_DELETE;
         }
 
         return options;


### PR DESCRIPTION
The NOSHARE_DELETE ExtendedOption is not always available on all
systems, since it is part of a com.sun package that's not a public
API on recent JDKs. This commit guards its use, falling back on
the default NIO behavior of SHARE_DELETE when we can't access the
sole option that would turn it off.

Fixes #7268