### PR TITLE
Fix Time.at with unit

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -1554,10 +1554,7 @@ public class RubyTime extends RubyObject {
             millisecs = RubyNumeric.num2long(arg1) * 1000;
         }
 
-        if (arg3 instanceof RubyNil) {
-            // Default value according the Ruby time.c
-            arg3 = runtime.newSymbol("microsecond");
-        } else if (!(arg3 instanceof RubySymbol)) {
+        if (!(arg3 instanceof RubySymbol)) {
             throw context.runtime.newArgumentError("unexpected unit " + arg3);
         }
 


### PR DESCRIPTION
The following test will pass.
 * test_at_with_uni in test/mri/ruby/test_time.rb
 * spec/ruby/core/time/at_spec.rb

I think `bin/jruby --dev -S rake spec:ruby:fast` and `bin/jruby --dev -S rake spec:ruby:fast:jit` become green.