### PR TITLE
Prevent regression #7219 on master

### DIFF
--- a/core/src/main/java/org/jruby/java/proxies/ConcreteJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ConcreteJavaProxy.java
@@ -260,8 +260,14 @@ public class ConcreteJavaProxy extends JavaProxy {
 
             Constructor<? extends ReifiedJavaProxy> withBlock;
             try {
-                withBlock = reified.getConstructor(
-                        ConcreteJavaProxy.class, IRubyObject[].class, Block.class, Ruby.class, RubyClass.class);
+                Class _clazz;
+                if (Map.class.isAssignableFrom(reified)) {
+                    _clazz = MapJavaProxy.class;
+                } else {
+                    _clazz = ConcreteJavaProxy.class;
+                }
+                withBlock = reified.getConstructor(new Class[] { _clazz, IRubyObject[].class,
+                        Block.class, Ruby.class, RubyClass.class });
             } catch (SecurityException | NoSuchMethodException e) {
                 // ignore, don't install
                 withBlock = null;


### PR DESCRIPTION
Cherry-pick 6bf31f7c6462c798ebecaad7e5f96623951ae7a3 to prevent regression #7219 .

When this PR and #7312 are merged, `bin/jruby --dev -S rake spec:regression` becomes green.

