### PR TITLE
Fix Process#euid and #egid when an argument is username/groupname

### DIFF
--- a/spec/tags/ruby/core/process/euid_tags.txt
+++ b/spec/tags/ruby/core/process/euid_tags.txt
@@ -1,1 +1,0 @@
-fails:Process.euid= raises Errno::ERPERM if run by a non superuser trying to set the superuser id from username


### PR DESCRIPTION
The following tests will pass.
 * spec/ruby/core/process/euid_spec.rb
 * spec/ruby/core/process/egid_spec.rb