### PR TITLE
Fix UNIXServer.open, UNIXSocket.open and some Dir class methods when argument contains NUL byte

### DIFF
--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -187,7 +187,7 @@ public class RubyDir extends RubyObject implements Closeable {
         ArrayList<ByteList> dirs = new ArrayList<>();
 
         for ( int i = 0; i < args.length; i++ ) {
-            dirs.addAll(Dir.push_glob(context.runtime, cwd, globArgumentAsByteList(context, args[i]), flags));
+            dirs.addAll(Dir.push_glob(context.runtime, cwd, globArgumentAsByteList(context, RubyFile.get_path(context, args[i])), flags));
         }
 
         return dirs;
@@ -301,16 +301,19 @@ public class RubyDir extends RubyObject implements Closeable {
     }
 
     private static ByteList globArgumentAsByteList(ThreadContext context, IRubyObject arg) {
-        if (!(arg instanceof RubyString) && arg.respondsTo("to_path")) arg = arg.callMethod(context, "to_path");
-
-        RubyString checked = StringSupport.checkEmbeddedNulls(context.runtime, arg, "nul-separated glob pattern is unsupported");
-
-        // FIXME: It is possible this can just be EncodingUtils.strCompatAndValid() but the spec says specifically it must be ascii compat which is more constrained than that method.
-        if (!checked.getEncoding().isAsciiCompatible()) {
-            throw context.runtime.newEncodingCompatibilityError("incompatible character encodings: " + checked.getEncoding() + " and " + USASCIIEncoding.INSTANCE);
+        RubyString str;
+        if (!(arg instanceof RubyString)) {
+            str = RubyFile.get_path(context, arg);
+        } else if (StringSupport.strNullCheck(arg)[0] == null) {
+            throw context.runtime.newArgumentError("nul-separated glob pattern is deprecated");
+        } else {
+            str = (RubyString) arg;
+            // FIXME: It is possible this can just be EncodingUtils.strCompatAndValid() but the spec says specifically it must be ascii compat which is more constrained than that method.
+            if (!str.getEncoding().isAsciiCompatible()) {
+                throw context.runtime.newEncodingCompatibilityError("incompatible character encodings: " + str.getEncoding() + " and " + USASCIIEncoding.INSTANCE);
+            }
         }
-
-        return filePathConvert(context, checked).getByteList();
+        return filePathConvert(context, str).getByteList();
     }
 
     /**

--- a/spec/tags/ruby/core/dir/element_reference_tags.txt
+++ b/spec/tags/ruby/core/dir/element_reference_tags.txt
@@ -1,4 +1,2 @@
-fails:Dir.[] raises an Encoding::CompatibilityError if the argument encoding is not compatible with US-ASCII
-fails:Dir.[] matches files with backslashes in their name
 wip:Dir.[] respects the order of {} expressions, expanding left most first
 wip:Dir.[] respects the optional nested {} expressions

--- a/spec/tags/ruby/core/dir/glob_tags.txt
+++ b/spec/tags/ruby/core/dir/glob_tags.txt
@@ -1,6 +1,3 @@
-fails:Dir.glob raises an Encoding::CompatibilityError if the argument encoding is not compatible with US-ASCII
-fails:Dir.glob recursively matches files and directories in nested dot subdirectory with 'nested/**/*' from the current directory and option File::FNM_DOTMATCH
-fails:Dir.glob matches files with backslashes in their name
 wip:Dir.glob respects the order of {} expressions, expanding left most first
 wip:Dir.glob respects the optional nested {} expressions
 fails:Dir.glob will follow symlinks when processing a `*/` pattern.


### PR DESCRIPTION
This PR make the following test will all pass.
  * spec/ruby/security/cve_2018_8779_spec.rb
  * spec/ruby/security/cve_2018_8780_spec.rb


Results without this PR.
```
ruby spec/mspec/bin/mspec ci spec/ruby/security/cve_2018_8779_spec.rb
$ /Users/kiichi/IdeaProjects/jruby/bin/jruby -Xbacktrace.style=mri /Users/kiichi/IdeaProjects/jruby/spec/mspec/bin/mspec-ci spec/ruby/security/cve_2018_8779_spec.rb
uri:classloader:/jruby/kernel/kernel.rb:4: warning: unsupported exec option: close_others
jruby 9.4.0.0-SNAPSHOT (3.1.0) 2022-08-20 ddd1ed1ec1 OpenJDK 64-Bit Server VM 11.0.15+0 on 11.0.15+0 +jit [arm64-darwin]
                                                                                             
1)
CVE-2018-8779 is resisted by UNIXServer.open by raising an exception when there is a NUL byte ERROR
Expected ArgumentError ((?-mix:(path name|string) contains null byte))
but got: ArgumentError (string contains null char)
org/jruby/ext/socket/RubyUNIXServer.java:65:in `initialize'
org/jruby/RubyClass.java:923:in `new'
org/jruby/RubyIO.java:1174:in `open'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8779_spec.rb:20:in `block in <main>'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8779_spec.rb:21:in `block in <main>'
org/jruby/RubyBasicObject.java:2567:in `instance_exec'
org/jruby/RubyArray.java:4913:in `all?'
org/jruby/RubyArray.java:1988:in `each'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8779_spec.rb:7:in `block in <main>'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8779_spec.rb:6:in `<main>'
org/jruby/RubyKernel.java:1052:in `load'
org/jruby/RubyBasicObject.java:2567:in `instance_exec'
org/jruby/RubyArray.java:1988:in `each'
                                                                                             
2)
CVE-2018-8779 is resisted by UNIXSocket.open by raising an exception when there is a NUL byte ERROR
Expected ArgumentError ((?-mix:(path name|string) contains null byte))
but got: ArgumentError (string contains null char)
org/jruby/ext/socket/RubyUNIXSocket.java:98:in `initialize'
org/jruby/RubyClass.java:923:in `new'
org/jruby/RubyIO.java:1174:in `open'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8779_spec.rb:26:in `block in <main>'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8779_spec.rb:27:in `block in <main>'
org/jruby/RubyBasicObject.java:2567:in `instance_exec'
org/jruby/RubyArray.java:4913:in `all?'
org/jruby/RubyArray.java:1988:in `each'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8779_spec.rb:7:in `block in <main>'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8779_spec.rb:6:in `<main>'
org/jruby/RubyKernel.java:1052:in `load'
org/jruby/RubyBasicObject.java:2567:in `instance_exec'
org/jruby/RubyArray.java:1988:in `each'
[- | ==================100%================== | 00:00:00]      0F      2E 

Finished in 0.095935 seconds

1 file, 2 examples, 2 expectations, 0 failures, 2 errors, 0 tagged


ruby spec/mspec/bin/mspec ci spec/ruby/security/cve_2018_8780_spec.rb 
$ /Users/kiichi/IdeaProjects/jruby/bin/jruby -Xbacktrace.style=mri /Users/kiichi/IdeaProjects/jruby/spec/mspec/bin/mspec-ci spec/ruby/security/cve_2018_8780_spec.rb
uri:classloader:/jruby/kernel/kernel.rb:4: warning: unsupported exec option: close_others
jruby 9.4.0.0-SNAPSHOT (3.1.0) 2022-08-20 ddd1ed1ec1 OpenJDK 64-Bit Server VM 11.0.15+0 on 11.0.15+0 +jit [arm64-darwin]
                                                                                             
1)
CVE-2018-8780 is resisted by Dir.glob by raising an exception when there is a NUL byte ERROR
Expected ArgumentError ((?-mix:(path name|string) contains null byte))
but got: ArgumentError (nul-separated glob pattern is unsupported)
org/jruby/RubyDir.java:339:in `glob'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8780_spec.rb:10:in `block in <main>'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8780_spec.rb:11:in `block in <main>'
org/jruby/RubyBasicObject.java:2567:in `instance_exec'
org/jruby/RubyArray.java:4913:in `all?'
org/jruby/RubyArray.java:1988:in `each'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8780_spec.rb:3:in `<main>'
org/jruby/RubyKernel.java:1052:in `load'
org/jruby/RubyBasicObject.java:2567:in `instance_exec'
org/jruby/RubyArray.java:1988:in `each'
                                                                                             
2)
CVE-2018-8780 is resisted by Dir.entries by raising an exception when there is a NUL byte ERROR
Expected ArgumentError ((?-mix:(path name|string) contains null byte))
but got: ArgumentError (string contains null char)
org/jruby/RubyDir.java:371:in `entries'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8780_spec.rb:16:in `block in <main>'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8780_spec.rb:17:in `block in <main>'
org/jruby/RubyBasicObject.java:2567:in `instance_exec'
org/jruby/RubyArray.java:4913:in `all?'
org/jruby/RubyArray.java:1988:in `each'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8780_spec.rb:3:in `<main>'
org/jruby/RubyKernel.java:1052:in `load'
org/jruby/RubyBasicObject.java:2567:in `instance_exec'
org/jruby/RubyArray.java:1988:in `each'
                                                                                             
3)
CVE-2018-8780 is resisted by Dir.foreach by raising an exception when there is a NUL byte ERROR
Expected ArgumentError ((?-mix:(path name|string) contains null byte))
but got: ArgumentError (string contains null char)
org/jruby/RubyDir.java:549:in `foreach'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8780_spec.rb:22:in `block in <main>'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8780_spec.rb:23:in `block in <main>'
org/jruby/RubyBasicObject.java:2567:in `instance_exec'
org/jruby/RubyArray.java:4913:in `all?'
org/jruby/RubyArray.java:1988:in `each'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8780_spec.rb:3:in `<main>'
org/jruby/RubyKernel.java:1052:in `load'
org/jruby/RubyBasicObject.java:2567:in `instance_exec'
org/jruby/RubyArray.java:1988:in `each'
                                                                                             
4)
CVE-2018-8780 is resisted by Dir.empty? by raising an exception when there is a NUL byte ERROR
Expected ArgumentError ((?-mix:(path name|string) contains null byte))
but got: ArgumentError (string contains null char)
org/jruby/RubyDir.java:904:in `empty?'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8780_spec.rb:28:in `block in <main>'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8780_spec.rb:29:in `block in <main>'
org/jruby/RubyBasicObject.java:2567:in `instance_exec'
org/jruby/RubyArray.java:4913:in `all?'
org/jruby/RubyArray.java:1988:in `each'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8780_spec.rb:3:in `<main>'
org/jruby/RubyKernel.java:1052:in `load'
org/jruby/RubyBasicObject.java:2567:in `instance_exec'
org/jruby/RubyArray.java:1988:in `each'
                                                                                             
5)
CVE-2018-8780 is resisted by Dir.children by raising an exception when there is a NUL byte ERROR
Expected ArgumentError ((?-mix:(path name|string) contains null byte))
but got: ArgumentError (string contains null char)
org/jruby/RubyDir.java:146:in `initialize'
org/jruby/RubyClass.java:909:in `new'
org/jruby/RubyDir.java:491:in `children'
org/jruby/RubyDir.java:486:in `children'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8780_spec.rb:34:in `block in <main>'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8780_spec.rb:35:in `block in <main>'
org/jruby/RubyBasicObject.java:2567:in `instance_exec'
org/jruby/RubyArray.java:4913:in `all?'
org/jruby/RubyArray.java:1988:in `each'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8780_spec.rb:3:in `<main>'
org/jruby/RubyKernel.java:1052:in `load'
org/jruby/RubyBasicObject.java:2567:in `instance_exec'
org/jruby/RubyArray.java:1988:in `each'
                                                                                             
6)
CVE-2018-8780 is resisted by Dir.each_child by raising an exception when there is a NUL byte ERROR
Expected ArgumentError ((?-mix:(path name|string) contains null byte))
but got: ArgumentError (string contains null char)
org/jruby/RubyDir.java:528:in `each_child'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8780_spec.rb:40:in `block in <main>'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8780_spec.rb:41:in `block in <main>'
org/jruby/RubyBasicObject.java:2567:in `instance_exec'
org/jruby/RubyArray.java:4913:in `all?'
org/jruby/RubyArray.java:1988:in `each'
/Users/kiichi/IdeaProjects/jruby/spec/ruby/security/cve_2018_8780_spec.rb:3:in `<main>'
org/jruby/RubyKernel.java:1052:in `load'
org/jruby/RubyBasicObject.java:2567:in `instance_exec'
org/jruby/RubyArray.java:1988:in `each'
[- | ==================100%================== | 00:00:00]      0F      6E 

Finished in 0.027536 seconds

1 file, 6 examples, 6 expectations, 0 failures, 6 errors, 0 tagged
```

