### PR TITLE
Fix File::Stat#inspect

### DIFF
--- a/core/src/main/java/org/jruby/RubyFileStat.java
+++ b/core/src/main/java/org/jruby/RubyFileStat.java
@@ -346,9 +346,9 @@ public class RubyFileStat extends RubyObject {
                 buf.append("blksize=").append(blockSize(context).inspect().toString()); } catch (Exception e) {} finally { buf.append(", "); }
             try { buf.append("blocks=").append(blocks().inspect().toString()); } catch (Exception e) {} finally { buf.append(", "); }
 
-            buf.append("atime=").append(atime()).append(", ");
-            buf.append("mtime=").append(mtime()).append(", ");
-            buf.append("ctime=").append(ctime());
+            buf.append("atime=").append(atime().inspect()).append(", ");
+            buf.append("mtime=").append(mtime().inspect()).append(", ");
+            buf.append("ctime=").append(ctime().inspect());
             if (Platform.IS_BSD || Platform.IS_MAC) {
                 buf.append(", ").append("birthtime=").append(birthtime());
             }

--- a/spec/tags/ruby/core/file/stat/inspect_tags.txt
+++ b/spec/tags/ruby/core/file/stat/inspect_tags.txt
@@ -1,1 +1,0 @@
-wip:File::Stat#inspect produces a nicely formatted description of a File::Stat object


### PR DESCRIPTION
This commit fixes Files::Stat#inspect by using atime#inspect, mtime#inspect and ctime#inspect.
The following test will pass.
 * spec/ruby/core/file/stat/inspect_spec.rb