### PR TITLE
fix zlib encoding

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -650,6 +650,10 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return newEmptyString(runtime, runtime.getString());
     }
 
+    public static RubyString newEmptyBinaryString(Ruby runtime) {
+        return newAllocatedString(runtime, runtime.getString());
+    }
+
     private static final ByteList EMPTY_ASCII8BIT_BYTELIST = new ByteList(ByteList.NULL_ARRAY, ASCIIEncoding.INSTANCE);
     private static final ByteList EMPTY_USASCII_BYTELIST = new ByteList(ByteList.NULL_ARRAY, USASCIIEncoding.INSTANCE);
 

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibDeflate.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibDeflate.java
@@ -281,7 +281,7 @@ public class JZlibDeflate extends ZStream {
     private IRubyObject flush(int flush) {
         int last_flush = this.flush;
         this.flush = flush;
-        if (flush == JZlib.Z_NO_FLUSH) return RubyString.newEmptyString(getRuntime());
+        if (flush == JZlib.Z_NO_FLUSH) return RubyString.newEmptyBinaryString(getRuntime());
 
         run();
         this.flush = last_flush;

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibInflate.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibInflate.java
@@ -108,7 +108,7 @@ public class JZlibInflate extends ZStream {
             }
             return res;
         }
-        return RubyString.newEmptyString(context.runtime);
+        return RubyString.newEmptyBinaryString(context.runtime);
     }
 
     @JRubyMethod(name = "<<", required = 1)

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
@@ -332,7 +332,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
                 return runtime.newString(buf);
             }
 
-            return RubyString.newEmptyString(runtime);
+            return RubyString.newEmptyBinaryString(runtime);
         } catch (IOException ioe) {
             String m = ioe.getMessage();
 

--- a/core/src/main/java/org/jruby/ext/zlib/ZStream.java
+++ b/core/src/main/java/org/jruby/ext/zlib/ZStream.java
@@ -77,7 +77,7 @@ public abstract class ZStream extends RubyObject {
 
     @JRubyMethod
     public IRubyObject flush_next_out(ThreadContext context, Block block) {
-        return RubyString.newEmptyString(context.getRuntime());
+        return RubyString.newEmptyBinaryString(context.getRuntime());
     }
 
     @JRubyMethod
@@ -145,7 +145,7 @@ public abstract class ZStream extends RubyObject {
 
     @JRubyMethod(name = "flush_next_in")
     public IRubyObject flush_next_in(ThreadContext context) {
-        return RubyString.newEmptyString(context.getRuntime());
+        return RubyString.newEmptyBinaryString(context.getRuntime());
     }
 
     @JRubyMethod(name = "total_in")


### PR DESCRIPTION
a slight incompatibility I've found while testing the hexapdf gem

spec https://github.com/ruby/spec/pull/941