### PR TITLE
Never store a null for closure operand

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -265,7 +265,7 @@ public class IRBuilder {
                 Instr clonedInstr = instr.clone(ii);
                 if (clonedInstr instanceof CallBase) {
                     CallBase call = (CallBase)clonedInstr;
-                    Operand block = call.getClosureArg(null);
+                    Operand block = call.getClosureArg(NullBlock.INSTANCE);
                     if (block instanceof WrappedIRClosure) builder.scope.addClosure(((WrappedIRClosure)block).getClosure());
                 }
                 builder.addInstr(clonedInstr);
@@ -1636,7 +1636,7 @@ public class IRBuilder {
     }
 
     private Variable _call(Variable result, CallType type, Operand object, RubySymbol name, Operand... args) {
-        addInstr(CallInstr.create(scope, type, result, name, object, args, null, 0));
+        addInstr(CallInstr.create(scope, type, result, name, object, args, NullBlock.INSTANCE, 0));
         return result;
     }
 
@@ -3571,7 +3571,7 @@ public class IRBuilder {
     }
 
     private Operand setupCallClosure(Node node) {
-        if (node == null) return null;
+        if (node == null) return NullBlock.INSTANCE;
 
         switch (node.getNodeType()) {
             case ITERNODE:
@@ -4697,7 +4697,7 @@ public class IRBuilder {
 
     public Operand buildSuper(SuperNode callNode) {
         Operand tempBlock = setupCallClosure(callNode.getIterNode());
-        if (tempBlock == null) tempBlock = getYieldClosureVariable();
+        if (tempBlock == NullBlock.INSTANCE) tempBlock = getYieldClosureVariable();
         Operand block = tempBlock;
 
         boolean inClassBody = scope instanceof IRMethod && scope.getLexicalParent() instanceof IRClassBody;
@@ -4941,7 +4941,7 @@ public class IRBuilder {
 
     public Operand buildZSuper(ZSuperNode zsuperNode) {
         Operand block = setupCallClosure(zsuperNode.getIterNode());
-        if (block == null) block = getYieldClosureVariable();
+        if (block == NullBlock.INSTANCE) block = getYieldClosureVariable();
 
         return scope instanceof IRMethod ? buildSuperInstr(block) : buildZSuperIfNest(block);
     }

--- a/core/src/main/java/org/jruby/ir/instructions/AttrAssignInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/AttrAssignInstr.java
@@ -6,6 +6,7 @@ import org.jruby.ir.IRScope;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
 import org.jruby.ir.instructions.specialized.OneArgOperandAttrAssignInstr;
+import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Self;
 import org.jruby.ir.persistence.IRReaderDecoder;
@@ -19,7 +20,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 // which is equivalent to: a.[]=(i,5)
 public class AttrAssignInstr extends NoResultCallInstr {
     public static AttrAssignInstr create(IRScope scope, Operand obj, RubySymbol attr, Operand[] args, Operand block, int flags, boolean isPotentiallyRefined) {
-        if (block == null && args.length == 1 && !containsArgSplat(args)) {
+        if (block == NullBlock.INSTANCE && args.length == 1 && !containsArgSplat(args)) {
             return new OneArgOperandAttrAssignInstr(scope, obj, attr, args, flags, isPotentiallyRefined);
         }
 
@@ -30,14 +31,14 @@ public class AttrAssignInstr extends NoResultCallInstr {
             return new OneArgOperandAttrAssignInstr(scope, obj, attr, args, flags, isPotentiallyRefined);
         }
 
-        return new AttrAssignInstr(scope, obj, attr, args, null, flags, isPotentiallyRefined);
+        return new AttrAssignInstr(scope, obj, attr, args, NullBlock.INSTANCE, flags, isPotentiallyRefined);
     }
 
     // clone constructor
     protected AttrAssignInstr(IRScope scope, CallType callType, RubySymbol name, Operand receiver,
                               Operand[] args, int flags, boolean potentiallyRefined, CallSite callSite,
                               long callSiteId) {
-        super(scope, Operation.ATTR_ASSIGN, callType, name, receiver, args, null, flags, potentiallyRefined, callSite, callSiteId);
+        super(scope, Operation.ATTR_ASSIGN, callType, name, receiver, args, NullBlock.INSTANCE, flags, potentiallyRefined, callSite, callSiteId);
     }
 
     // normal constructor

--- a/core/src/main/java/org/jruby/ir/instructions/CallBase.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CallBase.java
@@ -62,7 +62,7 @@ public abstract class CallBase extends NOperandInstr implements ClosureAccepting
         this.flags = flags;
         this.callSiteId = callSiteId;
         argsCount = args.length;
-        hasClosure = closure != null;
+        hasClosure = closure != NullBlock.INSTANCE;
         this.name = name;
         this.callType = callType;
         this.callSite = callSite == null ? getCallSiteFor(scope, callType, name.idString(), callSiteId, hasLiteralClosure(), potentiallyRefined) : callSite;
@@ -91,7 +91,7 @@ public abstract class CallBase extends NOperandInstr implements ClosureAccepting
             e.encode(arg);
         }
 
-        if (hasClosure) e.encode(getClosureArg(null));
+        if (hasClosure) e.encode(getClosureArg(NullBlock.INSTANCE));
 
         e.encode(flags);
     }
@@ -127,7 +127,7 @@ public abstract class CallBase extends NOperandInstr implements ClosureAccepting
 
     /** From interface ClosureAcceptingInstr */
     public Operand getClosureArg() {
-        return hasClosure ? operands[argsCount + 1] : null;
+        return hasClosure ? operands[argsCount + 1] : NullBlock.INSTANCE;
     }
 
     public Operand getClosureArg(Operand ifUnspecified) {
@@ -529,9 +529,10 @@ public abstract class CallBase extends NOperandInstr implements ClosureAccepting
 
     private final static int REQUIRED_OPERANDS = 1;
     private static Operand[] arrayifyOperands(Operand receiver, Operand[] callArgs, Operand closure) {
-        Operand[] allArgs = new Operand[callArgs.length + REQUIRED_OPERANDS + (closure != null ? 1 : 0)];
-
         assert receiver != null : "RECEIVER is null";
+        assert closure != null : "CLOSURE is null";
+
+        Operand[] allArgs = new Operand[callArgs.length + REQUIRED_OPERANDS + (closure != NullBlock.INSTANCE ? 1 : 0)];
 
         allArgs[0] = receiver;
         for (int i = 0; i < callArgs.length; i++) {
@@ -540,7 +541,7 @@ public abstract class CallBase extends NOperandInstr implements ClosureAccepting
             allArgs[i + REQUIRED_OPERANDS] = callArgs[i];
         }
 
-        if (closure != null) allArgs[callArgs.length + REQUIRED_OPERANDS] = closure;
+        if (closure != NullBlock.INSTANCE) allArgs[callArgs.length + REQUIRED_OPERANDS] = closure;
 
         return allArgs;
     }

--- a/core/src/main/java/org/jruby/ir/instructions/CallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CallInstr.java
@@ -12,6 +12,7 @@ import org.jruby.ir.instructions.specialized.OneOperandArgNoBlockCallInstr;
 import org.jruby.ir.instructions.specialized.TwoOperandArgNoBlockCallInstr;
 import org.jruby.ir.instructions.specialized.ZeroOperandArgNoBlockCallInstr;
 import org.jruby.ir.operands.Hash;
+import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.persistence.IRReaderDecoder;
@@ -34,7 +35,7 @@ public class CallInstr extends CallBase implements ResultInstr {
         boolean isPotentiallyRefined = scope.maybeUsingRefinements();
 
         if (!containsArgSplat(args)) {
-            boolean hasClosure = closure != null;
+            boolean hasClosure = closure != NullBlock.INSTANCE;
 
             if (args.length == 0 && !hasClosure) {
                 return new ZeroOperandArgNoBlockCallInstr(scope, callType, result, name, receiver, args, flags, isPotentiallyRefined);
@@ -113,7 +114,7 @@ public class CallInstr extends CallBase implements ResultInstr {
             args[i] = d.decodeOperand();
         }
 
-        Operand closure = hasClosureArg ? d.decodeOperand() : null;
+        Operand closure = hasClosureArg ? d.decodeOperand() : NullBlock.INSTANCE;
         if (RubyInstanceConfig.IR_READING_DEBUG) System.out.println("before result");
         int flags = d.decodeInt();
         Variable result = d.decodeVariable();
@@ -139,7 +140,7 @@ public class CallInstr extends CallBase implements ResultInstr {
     public Instr clone(CloneInfo ii) {
         return new CallInstr(ii.getScope(), getOperation(), getCallType(), ii.getRenamedVariable(result), getName(),
                 getReceiver().cloneForInlining(ii), cloneCallArgs(ii),
-                getClosureArg() == null ? null : getClosureArg().cloneForInlining(ii),
+                getClosureArg().cloneForInlining(ii),
                 getFlags(), isPotentiallyRefined(),
                 getCallSite(), getCallSiteId());
     }

--- a/core/src/main/java/org/jruby/ir/instructions/ClassSuperInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ClassSuperInstr.java
@@ -6,6 +6,7 @@ import org.jruby.ir.IRFlags;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
+import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.operands.WrappedIRClosure;
@@ -56,7 +57,7 @@ public class ClassSuperInstr extends CallInstr {
     @Override
     public Instr clone(CloneInfo ii) {
         return new ClassSuperInstr(ii.getScope(), ii.getRenamedVariable(getResult()), getDefiningModule().cloneForInlining(ii),
-                name, cloneCallArgs(ii), getClosureArg() == null ? null : getClosureArg().cloneForInlining(ii),
+                name, cloneCallArgs(ii), getClosureArg().cloneForInlining(ii),
                 getFlags(), isPotentiallyRefined(), getCallSite(), getCallSiteId());
     }
 
@@ -77,7 +78,7 @@ public class ClassSuperInstr extends CallInstr {
             args[i] = d.decodeOperand();
         }
 
-        Operand closure = hasClosureArg ? d.decodeOperand() : null;
+        Operand closure = hasClosureArg ? d.decodeOperand() : NullBlock.INSTANCE;
         int flags = d.decodeInt();
 
         return new ClassSuperInstr(d.getCurrentScope(), d.decodeVariable(), receiver, name, args, closure, flags, d.getCurrentScope().maybeUsingRefinements());

--- a/core/src/main/java/org/jruby/ir/instructions/EQQInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/EQQInstr.java
@@ -5,6 +5,7 @@ import org.jruby.RubySymbol;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
+import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.persistence.IRReaderDecoder;
@@ -28,7 +29,7 @@ public class EQQInstr extends CallInstr implements FixedArityInstr {
     protected EQQInstr(IRScope scope, Variable result, Operand v1, Operand v2, boolean splattedValue, boolean isPotentiallyRefined, CallSite callSite,
                        long callSiteID) {
         super(scope, Operation.EQQ, CallType.FUNCTIONAL, result, scope.getManager().getRuntime().newSymbol("==="),
-                v1, new Operand[] { v2 }, null, 0, isPotentiallyRefined, callSite, callSiteID);
+                v1, new Operand[] { v2 }, NullBlock.INSTANCE, 0, isPotentiallyRefined, callSite, callSiteID);
 
         this.splattedValue = splattedValue;
     }
@@ -36,7 +37,7 @@ public class EQQInstr extends CallInstr implements FixedArityInstr {
     // normal constructor
     public EQQInstr(IRScope scope, Variable result, Operand v1, Operand v2, boolean splattedValue, boolean isPotentiallyRefined) {
         super(scope, Operation.EQQ, CallType.FUNCTIONAL, result, scope.getManager().getRuntime().newSymbol("==="), v1,
-                new Operand[] { v2 }, null, 0, isPotentiallyRefined);
+                new Operand[] { v2 }, NullBlock.INSTANCE, 0, isPotentiallyRefined);
 
         assert result != null: "EQQInstr result is null";
 

--- a/core/src/main/java/org/jruby/ir/instructions/InstanceSuperInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/InstanceSuperInstr.java
@@ -34,6 +34,7 @@ import org.jruby.ir.IRFlags;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
+import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.operands.WrappedIRClosure;
@@ -88,7 +89,7 @@ public class InstanceSuperInstr extends CallInstr {
     public Instr clone(CloneInfo ii) {
         return new InstanceSuperInstr(ii.getScope(), ii.getRenamedVariable(getResult()),
                 getDefiningModule().cloneForInlining(ii), getName(), cloneCallArgs(ii),
-                getClosureArg() == null ? null : getClosureArg().cloneForInlining(ii), getFlags(),
+                getClosureArg().cloneForInlining(ii), getFlags(),
                 isPotentiallyRefined(), getCallSite(), getCallSiteId());
     }
 
@@ -109,7 +110,7 @@ public class InstanceSuperInstr extends CallInstr {
             args[i] = d.decodeOperand();
         }
 
-        Operand closure = hasClosureArg ? d.decodeOperand() : null;
+        Operand closure = hasClosureArg ? d.decodeOperand() : NullBlock.INSTANCE;
         int flags = d.decodeInt();
 
         return new InstanceSuperInstr(d.getCurrentScope(), d.decodeVariable(), receiver, name, args, closure, flags,

--- a/core/src/main/java/org/jruby/ir/instructions/MatchInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/MatchInstr.java
@@ -5,6 +5,7 @@ import org.jruby.ir.IRFlags;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
+import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.persistence.IRReaderDecoder;
@@ -24,13 +25,13 @@ public class MatchInstr extends CallInstr implements FixedArityInstr {
     // clone constructor
     protected MatchInstr(IRScope scope, Variable result, Operand receiver, Operand arg, CallSite callSite, long callSiteId) {
         super(scope, Operation.MATCH, CallType.NORMAL, result, scope.getManager().getRuntime().newSymbol(MATCH),
-                receiver, new Operand[]{arg}, null, 0, false, callSite, callSiteId);
+                receiver, new Operand[]{arg}, NullBlock.INSTANCE, 0, false, callSite, callSiteId);
     }
 
     // normal constructor
     public MatchInstr(IRScope scope, Variable result, Operand receiver, Operand arg) {
         super(scope, Operation.MATCH, CallType.NORMAL, result, scope.getManager().getRuntime().newSymbol(MATCH),
-                receiver, new Operand[]{arg}, null, 0, false);
+                receiver, new Operand[]{arg}, NullBlock.INSTANCE, 0, false);
 
         assert result != null : "Match2Instr result is null";
     }

--- a/core/src/main/java/org/jruby/ir/instructions/NoResultCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/NoResultCallInstr.java
@@ -6,6 +6,7 @@ import org.jruby.ir.IRScope;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
 import org.jruby.ir.instructions.specialized.OneOperandArgNoBlockNoResultCallInstr;
+import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.persistence.IRReaderDecoder;
@@ -18,7 +19,7 @@ public class NoResultCallInstr extends CallBase {
     public static NoResultCallInstr create(IRScope scope, CallType callType, RubySymbol name, Operand receiver,
                                            Operand[] args, Operand closure, int flags, boolean isPotentiallyRefined) {
         if (closure == null && !containsArgSplat(args) && args.length == 1) {
-            return new OneOperandArgNoBlockNoResultCallInstr(scope, callType, name, receiver, args, null, flags, isPotentiallyRefined);
+            return new OneOperandArgNoBlockNoResultCallInstr(scope, callType, name, receiver, args, NullBlock.INSTANCE, flags, isPotentiallyRefined);
         }
 
         return new NoResultCallInstr(scope, Operation.NORESULT_CALL, callType, name, receiver, args, closure, flags, isPotentiallyRefined);
@@ -50,7 +51,7 @@ public class NoResultCallInstr extends CallBase {
     public Instr clone(CloneInfo ii) {
         return new NoResultCallInstr(ii.getScope(), getOperation(), getCallType(), getName(),
                 getReceiver().cloneForInlining(ii), cloneCallArgs(ii),
-                getClosureArg() == null ? null : getClosureArg().cloneForInlining(ii), getFlags(),
+                getClosureArg().cloneForInlining(ii), getFlags(),
                 isPotentiallyRefined(), getCallSite(), getCallSiteId());
     }
 
@@ -70,7 +71,7 @@ public class NoResultCallInstr extends CallBase {
             args[i] = d.decodeOperand();
         }
 
-        Operand closure = hasClosureArg ? d.decodeOperand() : null;
+        Operand closure = hasClosureArg ? d.decodeOperand() : NullBlock.INSTANCE;
         int flags = d.decodeInt();
 
         return NoResultCallInstr.create(d.getCurrentScope(), CallType.fromOrdinal(callTypeOrdinal), name, receiver,

--- a/core/src/main/java/org/jruby/ir/instructions/UnresolvedSuperInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/UnresolvedSuperInstr.java
@@ -7,6 +7,7 @@ import org.jruby.ir.IRFlags;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
+import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.operands.WrappedIRClosure;
@@ -70,7 +71,7 @@ public class UnresolvedSuperInstr extends CallInstr {
     public Instr clone(CloneInfo ii) {
         return new UnresolvedSuperInstr(ii.getScope(), Operation.UNRESOLVED_SUPER, ii.getRenamedVariable(getResult()),
                 getReceiver().cloneForInlining(ii), cloneCallArgs(ii),
-                getClosureArg() == null ? null : getClosureArg().cloneForInlining(ii), getFlags(),
+                getClosureArg().cloneForInlining(ii), getFlags(),
                 isPotentiallyRefined(), getCallSite(), getCallSiteId());
     }
 
@@ -93,7 +94,7 @@ public class UnresolvedSuperInstr extends CallInstr {
             args[i] = d.decodeOperand();
         }
 
-        Operand closure = hasClosureArg ? d.decodeOperand() : null;
+        Operand closure = hasClosureArg ? d.decodeOperand() : NullBlock.INSTANCE;
         int flags = d.decodeInt();
         if (RubyInstanceConfig.IR_READING_DEBUG) System.out.println("before result");
 

--- a/core/src/main/java/org/jruby/ir/instructions/ZSuperInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ZSuperInstr.java
@@ -6,6 +6,7 @@ import org.jruby.ir.IRFlags;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
+import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.persistence.IRReaderDecoder;
@@ -43,7 +44,7 @@ public class ZSuperInstr extends UnresolvedSuperInstr {
     @Override
     public Instr clone(CloneInfo ii) {
         return new ZSuperInstr(ii.getScope(), ii.getRenamedVariable(getResult()), getReceiver().cloneForInlining(ii),
-                cloneCallArgs(ii), getClosureArg() == null ? null : getClosureArg().cloneForInlining(ii), getFlags(),
+                cloneCallArgs(ii), getClosureArg().cloneForInlining(ii), getFlags(),
                 isPotentiallyRefined(), getCallSite(), getCallSiteId());
     }
 
@@ -66,7 +67,7 @@ public class ZSuperInstr extends UnresolvedSuperInstr {
             args[i] = d.decodeOperand();
         }
 
-        Operand closure = hasClosureArg ? d.decodeOperand() : null;
+        Operand closure = hasClosureArg ? d.decodeOperand() : NullBlock.INSTANCE;
         int flags = d.decodeInt();
         if (RubyInstanceConfig.IR_READING_DEBUG) System.out.println("before result");
         Variable result = d.decodeVariable();

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneArgOperandAttrAssignInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneArgOperandAttrAssignInstr.java
@@ -5,6 +5,7 @@ import org.jruby.ir.IRScope;
 import org.jruby.ir.Operation;
 import org.jruby.ir.instructions.AttrAssignInstr;
 import org.jruby.ir.instructions.Instr;
+import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
@@ -22,7 +23,7 @@ public class OneArgOperandAttrAssignInstr extends AttrAssignInstr {
     // normal constructor
     public OneArgOperandAttrAssignInstr(IRScope scope, Operand obj, RubySymbol attr, Operand[] args, int flags,
                                         boolean isPotentiallyRefined) {
-        super(scope, obj, attr, args, null, flags, isPotentiallyRefined);
+        super(scope, obj, attr, args, NullBlock.INSTANCE, flags, isPotentiallyRefined);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneFixnumArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneFixnumArgNoBlockCallInstr.java
@@ -6,6 +6,7 @@ import org.jruby.ir.Operation;
 import org.jruby.ir.instructions.CallInstr;
 import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.operands.Fixnum;
+import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
@@ -24,7 +25,7 @@ public class OneFixnumArgNoBlockCallInstr extends CallInstr {
     protected OneFixnumArgNoBlockCallInstr(IRScope scope, CallType callType, Variable result, RubySymbol name,
                                            Operand receiver, Operand[] args, int flags, boolean potentiallyRefined,
                                            CallSite callSite, long callSiteId) {
-        super(scope, Operation.CALL_1F, callType, result, name, receiver, args, null, flags, potentiallyRefined,
+        super(scope, Operation.CALL_1F, callType, result, name, receiver, args, NullBlock.INSTANCE, flags, potentiallyRefined,
                 callSite, callSiteId);
 
         fixNum = ((Fixnum) args[0]).value;
@@ -33,7 +34,7 @@ public class OneFixnumArgNoBlockCallInstr extends CallInstr {
     // normal constructor
     public OneFixnumArgNoBlockCallInstr(IRScope scope, CallType callType, Variable result, RubySymbol name,
                                         Operand receiver, Operand[] args, int flags, boolean potentiallyRefined) {
-        super(scope, Operation.CALL_1F, callType, result, name, receiver, args, null, flags, potentiallyRefined);
+        super(scope, Operation.CALL_1F, callType, result, name, receiver, args, NullBlock.INSTANCE, flags, potentiallyRefined);
 
         assert args.length == 1;
 

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneFloatArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneFloatArgNoBlockCallInstr.java
@@ -6,6 +6,7 @@ import org.jruby.ir.Operation;
 import org.jruby.ir.instructions.CallInstr;
 import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.operands.Float;
+import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
@@ -24,7 +25,7 @@ public class OneFloatArgNoBlockCallInstr extends CallInstr {
     protected OneFloatArgNoBlockCallInstr(IRScope scope, CallType callType, Variable result, RubySymbol name,
                                           Operand receiver, Operand[] args, int flags, boolean potentiallyRefined,
                                           CallSite callSite, long callSiteId) {
-        super(scope, Operation.CALL_1D, callType, result, name, receiver, args, null, flags, potentiallyRefined,
+        super(scope, Operation.CALL_1D, callType, result, name, receiver, args, NullBlock.INSTANCE, flags, potentiallyRefined,
                 callSite, callSiteId);
 
         this.flote = ((Float) args[0]).value;
@@ -33,7 +34,7 @@ public class OneFloatArgNoBlockCallInstr extends CallInstr {
     // normal constructor
     public OneFloatArgNoBlockCallInstr(IRScope scope, CallType callType, Variable result, RubySymbol name,
                                        Operand receiver, Operand[] args, int flags, boolean potentiallyRefined) {
-        super(scope, Operation.CALL_1D, callType, result, name, receiver, args, null, flags, potentiallyRefined);
+        super(scope, Operation.CALL_1D, callType, result, name, receiver, args, NullBlock.INSTANCE, flags, potentiallyRefined);
 
         assert args.length == 1;
 

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgBlockCallInstr.java
@@ -37,7 +37,7 @@ public class OneOperandArgBlockCallInstr extends CallInstr {
     public Instr clone(CloneInfo ii) {
         return new OneOperandArgBlockCallInstr(ii.getScope(), getCallType(), ii.getRenamedVariable(result), getName(),
                 getReceiver().cloneForInlining(ii), cloneCallArgs(ii),
-                getClosureArg() == null ? null : getClosureArg().cloneForInlining(ii), getFlags(), isPotentiallyRefined(),
+                getClosureArg().cloneForInlining(ii), getFlags(), isPotentiallyRefined(),
                 getCallSite(), getCallSiteId());
     }
 

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgNoBlockCallInstr.java
@@ -5,6 +5,7 @@ import org.jruby.ir.IRScope;
 import org.jruby.ir.Operation;
 import org.jruby.ir.instructions.CallInstr;
 import org.jruby.ir.instructions.Instr;
+import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
@@ -27,14 +28,14 @@ public class OneOperandArgNoBlockCallInstr extends CallInstr {
     public OneOperandArgNoBlockCallInstr(IRScope scope, Operation op, CallType callType, Variable result,
                                          RubySymbol name, Operand receiver, Operand[] args, int flags,
                                          boolean isPotentiallyRefined, CallSite callSite, long callSiteId) {
-        super(scope, op, callType, result, name, receiver, args, null, flags, isPotentiallyRefined, callSite, callSiteId);
+        super(scope, op, callType, result, name, receiver, args, NullBlock.INSTANCE, flags, isPotentiallyRefined, callSite, callSiteId);
     }
 
     // normal constructor
     public OneOperandArgNoBlockCallInstr(IRScope scope, Operation op, CallType callType, Variable result,
                                          RubySymbol name, Operand receiver, Operand[] args, int flags,
                                          boolean isPotentiallyRefined) {
-        super(scope, op, callType, result, name, receiver, args, null, flags, isPotentiallyRefined);
+        super(scope, op, callType, result, name, receiver, args, NullBlock.INSTANCE, flags, isPotentiallyRefined);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgNoBlockNoResultCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/OneOperandArgNoBlockNoResultCallInstr.java
@@ -5,6 +5,7 @@ import org.jruby.ir.IRScope;
 import org.jruby.ir.Operation;
 import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.instructions.NoResultCallInstr;
+import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
@@ -32,7 +33,7 @@ public class OneOperandArgNoBlockNoResultCallInstr extends NoResultCallInstr {
     @Override
     public Instr clone(CloneInfo ii) {
         return new OneOperandArgNoBlockNoResultCallInstr(ii.getScope(), getCallType(), getName(), getReceiver().cloneForInlining(ii),
-                cloneCallArgs(ii), getClosureArg() == null ? null : getClosureArg().cloneForInlining(ii), getFlags(),
+                cloneCallArgs(ii), getClosureArg().cloneForInlining(ii), getFlags(),
                 isPotentiallyRefined(), getCallSite(), getCallSiteId());
     }
 

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/TwoOperandArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/TwoOperandArgNoBlockCallInstr.java
@@ -5,6 +5,7 @@ import org.jruby.ir.IRScope;
 import org.jruby.ir.Operation;
 import org.jruby.ir.instructions.CallInstr;
 import org.jruby.ir.instructions.Instr;
+import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
@@ -21,14 +22,14 @@ public class TwoOperandArgNoBlockCallInstr  extends CallInstr  {
     protected TwoOperandArgNoBlockCallInstr(IRScope scope, CallType callType, Variable result, RubySymbol name,
                                             Operand receiver, Operand[] args, int flags, boolean isPotentiallyRefined,
                                             CallSite callSite, long callSiteId) {
-        super(scope, Operation.CALL_2O, callType, result, name, receiver, args, null, flags, isPotentiallyRefined,
+        super(scope, Operation.CALL_2O, callType, result, name, receiver, args, NullBlock.INSTANCE, flags, isPotentiallyRefined,
                 callSite, callSiteId);
     }
 
     // normal constructor
     public TwoOperandArgNoBlockCallInstr(IRScope scope, CallType callType, Variable result, RubySymbol name,
                                          Operand receiver, Operand[] args, int flags, boolean isPotentiallyRefined) {
-        super(scope, Operation.CALL_2O, callType, result, name, receiver, args, null, flags, isPotentiallyRefined);
+        super(scope, Operation.CALL_2O, callType, result, name, receiver, args, NullBlock.INSTANCE, flags, isPotentiallyRefined);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/specialized/ZeroOperandArgNoBlockCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/specialized/ZeroOperandArgNoBlockCallInstr.java
@@ -5,6 +5,7 @@ import org.jruby.ir.IRScope;
 import org.jruby.ir.Operation;
 import org.jruby.ir.instructions.CallInstr;
 import org.jruby.ir.instructions.Instr;
+import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
@@ -21,20 +22,20 @@ public class ZeroOperandArgNoBlockCallInstr extends CallInstr {
     public ZeroOperandArgNoBlockCallInstr(IRScope scope, Operation op, CallType callType, Variable result,
                                           RubySymbol name, Operand receiver, Operand[] args, int flags,
                                           boolean isPotentiallyRefined, CallSite callSite, long callSiteId) {
-        super(scope, op, callType, result, name, receiver, args, null, flags, isPotentiallyRefined, callSite, callSiteId);
+        super(scope, op, callType, result, name, receiver, args, NullBlock.INSTANCE, flags, isPotentiallyRefined, callSite, callSiteId);
     }
 
     // normal constructor
     protected ZeroOperandArgNoBlockCallInstr(IRScope scope, Operation op, CallType callType, Variable result,
                                              RubySymbol name, Operand receiver, Operand[] args, int flags,
                                              boolean isPotentiallyRefined) {
-        super(scope, op, callType, result, name, receiver, args, null, flags, isPotentiallyRefined);
+        super(scope, op, callType, result, name, receiver, args, NullBlock.INSTANCE, flags, isPotentiallyRefined);
     }
 
     // normal constructor
     public ZeroOperandArgNoBlockCallInstr(IRScope scope, CallType callType, Variable result, RubySymbol name,
                                           Operand receiver, Operand[] args, int flags, boolean isPotentiallyRefined) {
-        super(scope, Operation.CALL_0O, callType, result, name, receiver, args, null, flags, isPotentiallyRefined);
+        super(scope, Operation.CALL_0O, callType, result, name, receiver, args, NullBlock.INSTANCE, flags, isPotentiallyRefined);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/interpreter/Profiler.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/Profiler.java
@@ -5,6 +5,7 @@ import org.jruby.internal.runtime.methods.MixedModeIRMethod;
 import org.jruby.ir.*;
 import org.jruby.ir.instructions.CallBase;
 import org.jruby.ir.instructions.Instr;
+import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.WrappedIRClosure;
 import org.jruby.runtime.CallSite;
@@ -176,7 +177,7 @@ public class Profiler {
             String n = tgtMethod.getId();
             boolean inlineCall = true;
             if (isHotClosure) {
-                Operand clArg = call.getClosureArg(null);
+                Operand clArg = call.getClosureArg(NullBlock.INSTANCE);
                 inlineCall = (clArg instanceof WrappedIRClosure) && (((WrappedIRClosure)clArg).getClosure() == hc);
             }
 /*

--- a/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter.java
+++ b/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter.java
@@ -8,6 +8,7 @@ import com.headius.invokebinder.Signature;
 import org.jruby.RubyModule;
 import org.jruby.compiler.impl.SkinnyMethodAdapter;
 import org.jruby.ir.instructions.ClosureAcceptingInstr;
+import org.jruby.ir.operands.NullBlock;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.targets.indy.IndyArgumentsCompiler;
@@ -434,8 +435,7 @@ public class IRBytecodeAdapter {
             return literal;
         }
         public static BlockPassType fromIR(ClosureAcceptingInstr callInstr) {
-            Operand closure = callInstr.getClosureArg();
-            return closure != null ? ( callInstr.hasLiteralClosure() ? BlockPassType.LITERAL : BlockPassType.GIVEN) : BlockPassType.NONE;
+            return callInstr.getClosureArg() != NullBlock.INSTANCE ? ( callInstr.hasLiteralClosure() ? BlockPassType.LITERAL : BlockPassType.GIVEN) : BlockPassType.NONE;
         }
     }
 

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -1290,7 +1290,7 @@ public class JVMVisitor extends IRVisitor {
         Operand[] args = classsuperinstr.getCallArgs();
         Operand definingModule = classsuperinstr.getDefiningModule();
         boolean[] splatMap = classsuperinstr.splatMap();
-        Operand closure = classsuperinstr.getClosureArg(null);
+        Operand closure = classsuperinstr.getClosureArg(NullBlock.INSTANCE);
 
         superCommon(name, classsuperinstr, args, definingModule, splatMap, closure);
     }
@@ -1596,7 +1596,7 @@ public class JVMVisitor extends IRVisitor {
         Operand[] args = instancesuperinstr.getCallArgs();
         Operand definingModule = instancesuperinstr.getDefiningModule();
         boolean[] splatMap = instancesuperinstr.splatMap();
-        Operand closure = instancesuperinstr.getClosureArg(null);
+        Operand closure = instancesuperinstr.getClosureArg(NullBlock.INSTANCE);
 
         superCommon(name, instancesuperinstr, args, definingModule, splatMap, closure);
     }
@@ -1624,7 +1624,7 @@ public class JVMVisitor extends IRVisitor {
             visit(operand);
         }
 
-        boolean hasClosure = closure != null;
+        boolean hasClosure = closure != NullBlock.INSTANCE;
         boolean literalClosure = closure instanceof WrappedIRClosure;
         if (hasClosure) {
             m.loadContext();
@@ -2447,7 +2447,7 @@ public class JVMVisitor extends IRVisitor {
         // this would be getDefiningModule but that is not used for unresolved super
         Operand definingModule = UndefinedValue.UNDEFINED;
         boolean[] splatMap = unresolvedsuperinstr.splatMap();
-        Operand closure = unresolvedsuperinstr.getClosureArg(null);
+        Operand closure = unresolvedsuperinstr.getClosureArg(NullBlock.INSTANCE);
 
         superCommon(name, unresolvedsuperinstr, args, definingModule, splatMap, closure);
     }
@@ -2491,7 +2491,7 @@ public class JVMVisitor extends IRVisitor {
         // this would be getDefiningModule but that is not used for unresolved super
         Operand definingModule = UndefinedValue.UNDEFINED;
         boolean[] splatMap = zsuperinstr.splatMap();
-        Operand closure = zsuperinstr.getClosureArg(null);
+        Operand closure = zsuperinstr.getClosureArg(NullBlock.INSTANCE);
 
         superCommon(name, zsuperinstr, args, definingModule, splatMap, closure);
     }

--- a/core/src/main/java/org/jruby/ir/transformations/inlining/CFGInliner.java
+++ b/core/src/main/java/org/jruby/ir/transformations/inlining/CFGInliner.java
@@ -293,7 +293,7 @@ public class CFGInliner {
         cfg.addEdge(failurePathBB, afterInlineBB, CFG.EdgeType.REGULAR);
 
         // Inline any closure argument passed into the call.
-        Operand closureArg = call.getClosureArg(null);
+        Operand closureArg = call.getClosureArg(NullBlock.INSTANCE);
         List<Tuple<BasicBlock, YieldInstr>> yieldSites = ii.getYieldSites();
         if (closureArg != null && !yieldSites.isEmpty()) {
             // FIXME: Do we care if we have too many yields?


### PR DESCRIPTION
Null object pattern is better here than constantly null-checking.

See f6ca739fbd4fc3fa101adb34ee319be6a78b232d for an example of confusion around whether this should be null or NullBlock.