### PR TITLE
Update CSV to 3.2.5

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -20,7 +20,7 @@ default_gems = [
     ['rubygems-update', '3.2.29', { bin: false }],
     ['bundler', '2.2.29'],
     ['cmath', '1.0.0'],
-    ['csv', '3.1.2'],
+    ['csv', '3.2.5'],
     ['e2mmap', '0.1.0'],
     ['ffi', '1.15.4'],
     ['fileutils', '1.4.1'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -73,7 +73,7 @@ DO NOT MODIFIY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>csv</artifactId>
-      <version>3.1.2</version>
+      <version>3.2.5</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -562,7 +562,7 @@ DO NOT MODIFIY - GENERATED CODE
           <include>specifications/rubygems-update-3.2.29*</include>
           <include>specifications/bundler-2.2.29*</include>
           <include>specifications/cmath-1.0.0*</include>
-          <include>specifications/csv-3.1.2*</include>
+          <include>specifications/csv-3.2.5*</include>
           <include>specifications/e2mmap-0.1.0*</include>
           <include>specifications/ffi-1.15.4*</include>
           <include>specifications/fileutils-1.4.1*</include>
@@ -601,7 +601,7 @@ DO NOT MODIFIY - GENERATED CODE
           <include>gems/rubygems-update-3.2.29*/**/*</include>
           <include>gems/bundler-2.2.29*/**/*</include>
           <include>gems/cmath-1.0.0*/**/*</include>
-          <include>gems/csv-3.1.2*/**/*</include>
+          <include>gems/csv-3.2.5*/**/*</include>
           <include>gems/e2mmap-0.1.0*/**/*</include>
           <include>gems/ffi-1.15.4*/**/*</include>
           <include>gems/fileutils-1.4.1*/**/*</include>
@@ -640,7 +640,7 @@ DO NOT MODIFIY - GENERATED CODE
           <include>cache/rubygems-update-3.2.29*</include>
           <include>cache/bundler-2.2.29*</include>
           <include>cache/cmath-1.0.0*</include>
-          <include>cache/csv-3.1.2*</include>
+          <include>cache/csv-3.2.5*</include>
           <include>cache/e2mmap-0.1.0*</include>
           <include>cache/ffi-1.15.4*</include>
           <include>cache/fileutils-1.4.1*</include>


### PR DESCRIPTION
This pulls in a couple years of fixes including ruby/csv#120 which fixes #7346 (dangling fiber threads after CSV.parse_line).