### PR TITLE
Avoid accidentally killing the teardown thread

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
+++ b/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
@@ -148,6 +148,9 @@ public class ThreadService extends ThreadLocal<SoftReference<ThreadContext>> {
     public void teardown() {
         // kill and await all live Ruby threads
         for (RubyThread rth : getActiveRubyThreads()) {
+            // don't kill current thread that is doing teardown
+            if (rth == getCurrentContext().getThread()) continue;
+
             if (rth.isAdopted()) return;
 
             try {


### PR DESCRIPTION
If the main thread performing the teardown appears earlier in this map, we may skip the teardown of remaining threads. Instead, we avoid the kill+join dance for the current thread to ensure all other threads get a chance to terminate.