### PR TITLE
Fix 7317 it warns me about "warning: found = in conditional, should be =="

### DIFF
--- a/core/src/main/java/org/jruby/ast/BignumNode.java
+++ b/core/src/main/java/org/jruby/ast/BignumNode.java
@@ -36,7 +36,10 @@ package org.jruby.ast;
 import java.math.BigInteger;
 import java.util.List;
 
+import org.jruby.Ruby;
+import org.jruby.RubyBignum;
 import org.jruby.ast.visitor.NodeVisitor;
+import org.jruby.runtime.builtin.IRubyObject;
 
 /** 
  * Represents a big integer literal.
@@ -76,5 +79,10 @@ public class BignumNode extends NumericNode implements SideEffectFree {
 
     public void setValue(BigInteger value) {
         this.value = value;
+    }
+
+    @Override
+    public IRubyObject literalValue(Ruby runtime) {
+        return RubyBignum.newBignum(runtime, value);
     }
 }

--- a/core/src/main/java/org/jruby/ast/ComplexNode.java
+++ b/core/src/main/java/org/jruby/ast/ComplexNode.java
@@ -7,7 +7,11 @@
 package org.jruby.ast;
 
 import java.util.List;
+
+import org.jruby.Ruby;
 import org.jruby.ast.visitor.NodeVisitor;
+import org.jruby.ir.runtime.IRRuntimeHelpers;
+import org.jruby.runtime.builtin.IRubyObject;
 
 /**
  *
@@ -43,5 +47,10 @@ public class ComplexNode extends NumericNode implements SideEffectFree {
 
     public void setNumber(NumericNode y) {
         this.y = y;
+    }
+
+    @Override
+    public IRubyObject literalValue(Ruby runtime) {
+        return IRRuntimeHelpers.newComplexRaw(runtime.getCurrentContext(), y.literalValue(runtime));
     }
 }

--- a/core/src/main/java/org/jruby/ast/FixnumNode.java
+++ b/core/src/main/java/org/jruby/ast/FixnumNode.java
@@ -43,7 +43,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 /** 
  * Represents an integer literal.
  */
-public class FixnumNode extends NumericNode implements ILiteralNode, LiteralValue, SideEffectFree {
+public class FixnumNode extends NumericNode implements ILiteralNode, SideEffectFree {
     private long value;
 
     public FixnumNode(int line, long value) {

--- a/core/src/main/java/org/jruby/ast/NumericNode.java
+++ b/core/src/main/java/org/jruby/ast/NumericNode.java
@@ -5,7 +5,7 @@ import org.jruby.ast.types.ILiteralNode;
 /**
  * Any node representing a numeric value.
  */
-public abstract class NumericNode extends Node implements ILiteralNode {
+public abstract class NumericNode extends Node implements ILiteralNode, LiteralValue {
     public NumericNode(int line) {
         super(line, false);
     }

--- a/core/src/main/java/org/jruby/ast/RationalNode.java
+++ b/core/src/main/java/org/jruby/ast/RationalNode.java
@@ -7,13 +7,17 @@
 package org.jruby.ast;
 
 import java.util.List;
+
+import org.jruby.Ruby;
+import org.jruby.RubyRational;
 import org.jruby.ast.visitor.NodeVisitor;
+import org.jruby.runtime.builtin.IRubyObject;
 
 /**
  *
  * @author enebo
  */
-public class RationalNode extends NumericNode implements SideEffectFree {
+public class RationalNode extends NumericNode implements LiteralValue, SideEffectFree {
     private final NumericNode numerator;
     private final NumericNode denominator;
 
@@ -50,5 +54,11 @@ public class RationalNode extends NumericNode implements SideEffectFree {
 
     public NumericNode getDenominator() {
         return denominator;
+    }
+
+    @Override
+    public IRubyObject literalValue(Ruby runtime) {
+        return RubyRational.newRationalCanonicalize(runtime.getCurrentContext(),
+                numerator.literalValue(runtime), denominator.literalValue(runtime));
     }
 }

--- a/core/src/main/java/org/jruby/parser/ParserSupport.java
+++ b/core/src/main/java/org/jruby/parser/ParserSupport.java
@@ -617,7 +617,7 @@ public class ParserSupport {
             return true;
         }
 
-        return node instanceof ILiteralNode || node instanceof NilNode || node instanceof TrueNode || node instanceof FalseNode;
+        return node instanceof LiteralValue || node instanceof NilNode || node instanceof TrueNode || node instanceof FalseNode;
     }
     
     protected Node makeNullNil(Node node) {

--- a/core/src/main/java/org/jruby/parser/ParserSupport.java
+++ b/core/src/main/java/org/jruby/parser/ParserSupport.java
@@ -591,7 +591,7 @@ public class ParserSupport {
         if (node instanceof MultipleAsgnNode || node instanceof LocalAsgnNode || node instanceof DAsgnNode || node instanceof GlobalAsgnNode || node instanceof InstAsgnNode) {
             Node valueNode = ((AssignableNode) node).getValueNode();
             if (isStaticContent(valueNode)) {
-                warnings.warn(ID.ASSIGNMENT_IN_CONDITIONAL, lexer.getFile(), valueNode.getLine(), "found = in conditional, should be ==");
+                warnings.warn(ID.ASSIGNMENT_IN_CONDITIONAL, lexer.getFile(), valueNode.getLine(), "found `= literal' in conditional, should be ==");
             }
             return true;
         } 

--- a/core/src/main/java/org/jruby/parser/RubyParser.java
+++ b/core/src/main/java/org/jruby/parser/RubyParser.java
@@ -1860,12 +1860,12 @@ states[26] = (ParserSupport support, RubyLexer lexer, Object yyVal, ProductionSt
   return yyVal;
 };
 states[27] = (ParserSupport support, RubyLexer lexer, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
-                    yyVal = support.new_if(support.getPosition(((Node)yyVals[-2+yyTop].value)), support.cond(((Node)yyVals[0+yyTop].value)), ((Node)yyVals[-2+yyTop].value), null);
+                    yyVal = support.new_if(support.getPosition(((Node)yyVals[-2+yyTop].value)), ((Node)yyVals[0+yyTop].value), ((Node)yyVals[-2+yyTop].value), null);
                     support.fixpos(((Node)yyVal), ((Node)yyVals[0+yyTop].value));
   return yyVal;
 };
 states[28] = (ParserSupport support, RubyLexer lexer, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
-                    yyVal = support.new_if(support.getPosition(((Node)yyVals[-2+yyTop].value)), support.cond(((Node)yyVals[0+yyTop].value)), null, ((Node)yyVals[-2+yyTop].value));
+                    yyVal = support.new_if(support.getPosition(((Node)yyVals[-2+yyTop].value)), ((Node)yyVals[0+yyTop].value), null, ((Node)yyVals[-2+yyTop].value));
                     support.fixpos(((Node)yyVal), ((Node)yyVals[0+yyTop].value));
   return yyVal;
 };
@@ -2854,7 +2854,7 @@ states[261] = (ParserSupport support, RubyLexer lexer, Object yyVal, ProductionS
 };
 states[262] = (ParserSupport support, RubyLexer lexer, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
                     support.value_expr(lexer, ((Node)yyVals[-5+yyTop].value));
-                    yyVal = support.new_if(support.getPosition(((Node)yyVals[-5+yyTop].value)), support.cond(((Node)yyVals[-5+yyTop].value)), ((Node)yyVals[-3+yyTop].value), ((Node)yyVals[0+yyTop].value));
+                    yyVal = support.new_if(support.getPosition(((Node)yyVals[-5+yyTop].value)), ((Node)yyVals[-5+yyTop].value), ((Node)yyVals[-3+yyTop].value), ((Node)yyVals[0+yyTop].value));
   return yyVal;
 };
 states[263] = (ParserSupport support, RubyLexer lexer, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
@@ -3165,11 +3165,11 @@ states[336] = (ParserSupport support, RubyLexer lexer, Object yyVal, ProductionS
   return yyVal;
 };
 states[337] = (ParserSupport support, RubyLexer lexer, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
-                    yyVal = support.new_if(((Integer)yyVals[-5+yyTop].value), support.cond(((Node)yyVals[-4+yyTop].value)), ((Node)yyVals[-2+yyTop].value), ((Node)yyVals[-1+yyTop].value));
+                    yyVal = support.new_if(((Integer)yyVals[-5+yyTop].value), ((Node)yyVals[-4+yyTop].value), ((Node)yyVals[-2+yyTop].value), ((Node)yyVals[-1+yyTop].value));
   return yyVal;
 };
 states[338] = (ParserSupport support, RubyLexer lexer, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
-                    yyVal = support.new_if(((Integer)yyVals[-5+yyTop].value), support.cond(((Node)yyVals[-4+yyTop].value)), ((Node)yyVals[-1+yyTop].value), ((Node)yyVals[-2+yyTop].value));
+                    yyVal = support.new_if(((Integer)yyVals[-5+yyTop].value), ((Node)yyVals[-4+yyTop].value), ((Node)yyVals[-1+yyTop].value), ((Node)yyVals[-2+yyTop].value));
   return yyVal;
 };
 states[339] = (ParserSupport support, RubyLexer lexer, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
@@ -3364,7 +3364,7 @@ states[370] = (ParserSupport support, RubyLexer lexer, Object yyVal, ProductionS
   return yyVal;
 };
 states[377] = (ParserSupport support, RubyLexer lexer, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
-                    yyVal = support.new_if(((Integer)yyVals[-4+yyTop].value), support.cond(((Node)yyVals[-3+yyTop].value)), ((Node)yyVals[-1+yyTop].value), ((Node)yyVals[0+yyTop].value));
+                    yyVal = support.new_if(((Integer)yyVals[-4+yyTop].value), ((Node)yyVals[-3+yyTop].value), ((Node)yyVals[-1+yyTop].value), ((Node)yyVals[0+yyTop].value));
   return yyVal;
 };
 states[379] = (ParserSupport support, RubyLexer lexer, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {

--- a/core/src/main/java/org/jruby/parser/RubyParser.y
+++ b/core/src/main/java/org/jruby/parser/RubyParser.y
@@ -472,11 +472,11 @@ stmt            : keyword_alias fitem {
                     $$ = $2;
                 }
                 | stmt modifier_if expr_value {
-                    $$ = support.new_if(support.getPosition($1), support.cond($3), $1, null);
+                    $$ = support.new_if(support.getPosition($1), $3, $1, null);
                     support.fixpos($<Node>$, $3);
                 }
                 | stmt modifier_unless expr_value {
-                    $$ = support.new_if(support.getPosition($1), support.cond($3), null, $1);
+                    $$ = support.new_if(support.getPosition($1), $3, null, $1);
                     support.fixpos($<Node>$, $3);
                 }
                 | stmt modifier_while expr_value {
@@ -1293,7 +1293,7 @@ arg             : lhs '=' arg_rhs {
                 }
                 | arg '?' arg opt_nl ':' arg {
                     support.value_expr(lexer, $1);
-                    $$ = support.new_if(support.getPosition($1), support.cond($1), $3, $6);
+                    $$ = support.new_if(support.getPosition($1), $1, $3, $6);
                 }
                 | primary {
                     $$ = $1;
@@ -1575,10 +1575,10 @@ primary         : literal
                     $$ = $2;
                 }
                 | keyword_if expr_value then compstmt if_tail keyword_end {
-                    $$ = support.new_if($1, support.cond($2), $4, $5);
+                    $$ = support.new_if($1, $2, $4, $5);
                 }
                 | keyword_unless expr_value then compstmt opt_else keyword_end {
-                    $$ = support.new_if($1, support.cond($2), $5, $4);
+                    $$ = support.new_if($1, $2, $5, $4);
                 }
                 | keyword_while {
                     lexer.getConditionState().push1();
@@ -1741,7 +1741,7 @@ do              : term
 
 if_tail         : opt_else
                 | keyword_elsif expr_value then compstmt if_tail {
-                    $$ = support.new_if($1, support.cond($2), $4, $5);
+                    $$ = support.new_if($1, $2, $4, $5);
                 }
 
 opt_else        : none


### PR DESCRIPTION
The wrong interface was being checked which made too many things get hit with this warning.  Fixing to use proper one and also auditing and correcting some missing types from the proper type should make this all correct.

Two bonus fixes:
 1. Make warn text match 2.6.x from MRI
 2. Do not print the same warning twice for the same piece of code.