### PR TITLE
Fix Date#strftime and DateTime#strftime with %v

### DIFF
--- a/core/src/main/java/org/jruby/util/RubyDateFormatter.java
+++ b/core/src/main/java/org/jruby/util/RubyDateFormatter.java
@@ -365,7 +365,7 @@ public class RubyDateFormatter {
                         addToPattern("e-");
                         if (!dateLibrary)
                             addToken(Token.formatter(new RubyTimeOutputFormatter(CARET, 0)));
-                        addToPattern("b-Y");
+                        addToPattern("^b-Y");
                         break;
                     case 'Z':
                         if (dateLibrary) {
@@ -430,6 +430,8 @@ public class RubyDateFormatter {
         final ByteList output = new ByteList(27, patternEncoding); // Typical length produced by logger by default
         final ByteList tmp = new ByteList(48);
 
+        boolean toUpper = false;
+
         for (int ti = 0; ti < compiledPatternLength; ti++) {
             Token token = compiledPattern[ti];
             CharSequence data = null;
@@ -443,6 +445,10 @@ public class RubyDateFormatter {
                     continue; // go to next token
                 case FORMAT_STRING:
                     data = (ByteList) token.getData();
+                    if ("^".equals(data.toString())) {
+                        toUpper = true;
+                        continue;
+                    }
                     break;
                 case FORMAT_WEEK_LONG:
                     // This is GROSS, but Java API's aren't ISO 8601 compliant at all
@@ -603,7 +609,12 @@ public class RubyDateFormatter {
                 if (data == null) {
                     formatter.format(output, value, type);
                 } else {
-                    formatter.format(output, data);
+                    if (toUpper) {
+                        formatter.format(output, data.toString().toUpperCase());
+                        toUpper = false;
+                    } else {
+                        formatter.format(output, data);
+                    }
                 }
             } catch (IndexOutOfBoundsException ioobe) {
                 throw runtime.newErrnoFromErrno(Errno.ERANGE, "strftime");

--- a/spec/tags/ruby/library/date/strftime_tags.txt
+++ b/spec/tags/ruby/library/date/strftime_tags.txt
@@ -1,1 +1,0 @@
-wip:Date#strftime should be able to show the commercial week

--- a/spec/tags/ruby/library/datetime/strftime_tags.txt
+++ b/spec/tags/ruby/library/datetime/strftime_tags.txt
@@ -1,1 +1,0 @@
-wip:DateTime#strftime should be able to show the commercial week


### PR DESCRIPTION
When %v is given, the month should be uppercase.
See https://bugs.ruby-lang.org/issues/13810