### PR TITLE
Fixes Time.at argument handling (#7265)

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -1391,6 +1391,10 @@ public class RubyTime extends RubyObject {
             return time;
         }
 
+        if (arg3.isNil()) {
+            arg3 = context.runtime.newSymbol("microsecond");
+        }
+
         return atMulti(context, (RubyClass) recv, arg1, arg2, arg3, zone);
     }
 

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -1346,7 +1346,7 @@ public class RubyTime extends RubyObject {
             return atOpts(context, recv, arg1, arg2, ms, context.nil);
         }
 
-        return atOpts(context, recv, arg1, context.nil, context.nil, maybeOpts);
+        return atOpts(context, recv, arg1, context.nil, null, maybeOpts);
     }
 
     @JRubyMethod(meta = true)
@@ -1357,7 +1357,7 @@ public class RubyTime extends RubyObject {
             return atOpts(context, recv, arg1, arg2, arg3, context.nil);
         }
 
-        return atOpts(context, recv, arg1, arg2, context.nil, arg3);
+        return atOpts(context, recv, arg1, arg2, null, arg3);
     }
 
     @JRubyMethod(required = 1, optional = 3, meta = true)
@@ -1379,7 +1379,7 @@ public class RubyTime extends RubyObject {
     private static IRubyObject atOpts(ThreadContext context, IRubyObject recv, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3, IRubyObject opts) {
         IRubyObject zone = ArgsUtil.extractKeywordArg(context, "in", opts);
 
-        if (arg2.isNil() && arg3.isNil()) {
+        if (arg2.isNil() && (arg3 == null || arg3.isNil())) {
             RubyTime time = at1(context, recv, arg1);
 
             time = time.gmtime();
@@ -1391,7 +1391,7 @@ public class RubyTime extends RubyObject {
             return time;
         }
 
-        if (arg3.isNil()) {
+        if (arg3 == null) {
             arg3 = context.runtime.newSymbol("microsecond");
         }
 


### PR DESCRIPTION
This version of the fix  for #7265 makes arg3 = :microseconds as a default value similar to Ruby (Time#at is now impld in Ruby and is this way).