### PR TITLE
Investigating slow and hanging MRI tests

### DIFF
--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -104,7 +104,7 @@ namespace :test do
 
           task task do
             ENV['JRUBY_OPTS'] = "#{ENV['JRUBY_OPTS']} #{extra_jruby_opts} #{opts}"
-            ruby "test/mri/runner.rb #{ADDITIONAL_TEST_OPTIONS} --excludes=test/mri/excludes -q -- #{files}"
+            ruby "test/mri/runner.rb #{ADDITIONAL_TEST_OPTIONS} --excludes=test/mri/excludes -v -- #{files}"
           end
         end
       end


### PR DESCRIPTION
Some tests seem much slower lately and some are outright hanging. This PR is to investigate them, and possibly move more slow tests to a slow run.