### PR TITLE
Implement Thread.ignore_deadlock as no-op

### DIFF
--- a/core/src/main/ruby/jruby/kernel.rb
+++ b/core/src/main/ruby/jruby/kernel.rb
@@ -26,4 +26,5 @@ load 'jruby/kernel/gc.rb'
 load 'jruby/kernel/range.rb'
 load 'jruby/kernel/file.rb'
 load 'jruby/kernel/method.rb'
+load 'jruby/kernel/thread.rb'
 

--- a/core/src/main/ruby/jruby/kernel/thread.rb
+++ b/core/src/main/ruby/jruby/kernel/thread.rb
@@ -1,0 +1,7 @@
+class Thread
+  @ignore_deadlock = false
+
+  class << self
+    attr_accessor :ignore_deadlock
+  end
+end

--- a/spec/tags/ruby/core/thread/ignore_deadlock_tags.txt
+++ b/spec/tags/ruby/core/thread/ignore_deadlock_tags.txt
@@ -1,2 +1,0 @@
-wip:Thread.ignore_deadlock returns false by default
-wip:Thread.ignore_deadlock= changes the value of Thread.ignore_deadlock


### PR DESCRIPTION
We do not have deadlock detection at lock edges, so there's no way to implement this. This patch adds it as a simple attr_accessor that does nothing else.