### PR TITLE
Fixes #7370: yield in class body produces two SyntaxError outputs

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1084,6 +1084,8 @@ public final class Ruby implements Constantizable {
                 if (Options.JIT_LOGGING.load()) {
                     LOG.info("successfully compiled: {}", scriptNode.getFile());
                 }
+            } catch (RaiseException e) {
+                throw e;
             } catch (Throwable e) {
                 if (Options.JIT_LOGGING.load()) {
                     if (Options.JIT_LOGGING_VERBOSE.load()) {
@@ -1205,6 +1207,8 @@ public final class Ruby implements Constantizable {
             if (scriptAndCode != null && Options.JIT_LOGGING.load()) {
                 LOG.info("done compiling target script: {}", scriptNode.getFile());
             }
+        } catch (RaiseException e) {
+            throw e;
         } catch (Exception e) {
             if (Options.JIT_LOGGING.load()) {
                 if (Options.JIT_LOGGING_VERBOSE.load()) {


### PR DESCRIPTION
Fixes #7370.  We print out twice because main script will try and precompile and we will raise a syntaxerror (RaiseError) but our code will blanket catch Exception/Throwable and end up trying to run the same code through the interpreter.