### PR TITLE
Always yield two-elt ary from Hash#each to lambda

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1568,7 +1568,9 @@ public class RubyHash extends RubyObject implements Map {
     private static final VisitorWithState<Block> YieldKeyValueArrayVisitor = new VisitorWithState<Block>() {
         @Override
         public void visit(ThreadContext context, RubyHash self, IRubyObject key, IRubyObject value, int index, Block block) {
-            if (block.getSignature().arityValue() > 1) {
+            if (block.type == Block.Type.LAMBDA) {
+                block.call(context, context.runtime.newArray(key, value));
+            } else if (block.getSignature().arityValue() > 1) {
                 block.yieldSpecific(context, key, value);
             } else {
                 block.yield(context, context.runtime.newArray(key, value));


### PR DESCRIPTION
This was never intended to dodge arity-checking and the original behavior was introduced with optimizations in Ruby 2.1. The new logic is to always yield a single two-element array when the target block is a lambda.

See https://bugs.ruby-lang.org/issues/12706