### PR TITLE
Ambiguous arg warning

### DIFF
--- a/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
@@ -858,9 +858,13 @@ public class RubyLexer extends LexingCommon {
         return token;
     }
     
-    private boolean arg_ambiguous() {
+    private boolean arg_ambiguous(int c) {
         if (warnings.isVerbose() && Options.PARSER_WARN_AMBIGUOUS_ARGUMENTS.load()) {
-            warnings.warning(ID.AMBIGUOUS_ARGUMENT, getFile(), ruby_sourceline, "Ambiguous first argument; make sure.");
+            if (c == '/') {
+                warnings.warning(ID.AMBIGUOUS_ARGUMENT, getFile(), ruby_sourceline, "ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator");
+            } else {
+                warnings.warning(ID.AMBIGUOUS_ARGUMENT, getFile(), ruby_sourceline, "ambiguous first argument; put parentheses or a space even after `" + (char) c + "' operator");
+            }
         }
         return true;
     }
@@ -1822,7 +1826,7 @@ public class RubyLexer extends LexingCommon {
             yaccValue = MINUS_GT;
             return RubyParser.tLAMBDA;
         }
-        if (isBEG() || (isSpaceArg(c, spaceSeen) && arg_ambiguous())) {
+        if (isBEG() || (isSpaceArg(c, spaceSeen) && arg_ambiguous('-'))) {
             setState(EXPR_BEG);
             pushback(c);
             yaccValue = MINUS_AT;
@@ -1910,7 +1914,7 @@ public class RubyLexer extends LexingCommon {
             return RubyParser.tOP_ASGN;
         }
         
-        if (isBEG() || (isSpaceArg(c, spaceSeen) && arg_ambiguous())) {
+        if (isBEG() || (isSpaceArg(c, spaceSeen) && arg_ambiguous('+'))) {
             setState(EXPR_BEG);
             pushback(c);
             if (Character.isDigit(c)) {
@@ -2072,7 +2076,7 @@ public class RubyLexer extends LexingCommon {
         }
         pushback(c);
         if (isSpaceArg(c, spaceSeen)) {
-            arg_ambiguous();
+            arg_ambiguous('/');
             lex_strterm = new StringTerm(str_regexp, '\0', '/', ruby_sourceline);
             yaccValue = SLASH;
             return RubyParser.tREGEXP_BEG;

--- a/lib/ruby/stdlib/rubygems/defaults/jruby.rb
+++ b/lib/ruby/stdlib/rubygems/defaults/jruby.rb
@@ -18,7 +18,7 @@ module Gem
     end
   end
 
-  unless RbConfig::CONFIG['host_os'].match? /linux/
+  unless RbConfig::CONFIG['host_os'].match?(/linux/)
     def self.platform_defaults
       return {
           'install' => '--env-shebang',


### PR DESCRIPTION
The warning did not match CRuby, and we had one warning during a normal boot in our RubyGems defaults jruby.rb.