### PR TITLE
Fix Thread#inspect and #to_s behaviors to match mri

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -1309,7 +1309,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         return inspect(metaClass.runtime.getCurrentContext());
     }
 
-    @JRubyMethod
+    @JRubyMethod(name = { "inspect", "to_s"})
     public RubyString inspect(ThreadContext context) {
         final Ruby runtime = context.runtime;
         RubyString result = runtime.newString("#<");
@@ -1320,11 +1320,11 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         synchronized (this) {
             String id = threadImpl.getRubyName(); // thread.name
             if (notEmpty(id)) {
-                result.cat('@');
+                result.cat(' ');
                 result.cat(runtime.newSymbol(id).getBytes());
             }
             if (notEmpty(file) && line >= 0) {
-                result.cat('@');
+                result.cat(' ');
                 result.catString(file);
                 result.cat(':');
                 result.catString(Integer.toString(line + 1));

--- a/spec/tags/ruby/core/thread/inspect_tags.txt
+++ b/spec/tags/ruby/core/thread/inspect_tags.txt
@@ -1,2 +1,1 @@
 fails:Thread#inspect has a binary encoding
-wip:Thread#inspect returns a description including file and line number

--- a/spec/tags/ruby/core/thread/to_s_tags.txt
+++ b/spec/tags/ruby/core/thread/to_s_tags.txt
@@ -1,12 +1,1 @@
-fails:Thread#to_s returns a description including file and line number
 fails:Thread#to_s has a binary encoding
-fails:Thread#to_s can check it's own status
-fails:Thread#to_s describes a running thread
-fails:Thread#to_s describes a sleeping thread
-fails:Thread#to_s describes a blocked thread
-fails:Thread#to_s describes a completed thread
-fails:Thread#to_s describes a killed thread
-fails:Thread#to_s describes a thread with an uncaught exception
-fails:Thread#to_s describes a dying sleeping thread
-fails:Thread#to_s reports aborting on a killed thread
-fails:Thread#to_s reports aborting on a killed thread after sleep


### PR DESCRIPTION
The following tests will pass except encoding test.
 * spec/ruby/core/thread/inspect_spec.rb
 * spec/ruby/core/thread/to_s_spec.rb