### PR TITLE
Fix Hash#hash to return a correct value when key and value are same

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1332,11 +1332,13 @@ public class RubyHash extends RubyObject implements Map {
         return context.runtime.newFixnum(hval[0]);
     }
 
+    private static final ThreadLocal<byte []> hash16byte = ThreadLocal.withInitial(() -> {return new byte[16];});
+
     private static final VisitorWithState<long[]> CalculateHashVisitor = new VisitorWithState<long[]>() {
         @Override
         public void visit(ThreadContext context, RubyHash self, IRubyObject key, IRubyObject value, int index, long[] hval) {
-            byte [] bytes = ByteBuffer.allocate(16).putLong(Helpers.safeHash(context, key).value).putLong(Helpers.safeHash(context, value).value).array();
-            hval[0] ^= Helpers.multAndMix(context.runtime.getHashSeedK0(), Arrays.hashCode(bytes));
+            ByteBuffer.wrap(hash16byte.get()).putLong(Helpers.safeHash(context, key).value).putLong(Helpers.safeHash(context, value).value);
+            hval[0] ^= Helpers.multAndMix(context.runtime.getHashSeedK0(), Arrays.hashCode(hash16byte.get()));
         }
     };
 

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -63,9 +63,10 @@ import org.jruby.util.RecursiveComparator;
 import org.jruby.util.TypeConverter;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.AbstractCollection;
 import java.util.AbstractSet;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
@@ -1334,7 +1335,8 @@ public class RubyHash extends RubyObject implements Map {
     private static final VisitorWithState<long[]> CalculateHashVisitor = new VisitorWithState<long[]>() {
         @Override
         public void visit(ThreadContext context, RubyHash self, IRubyObject key, IRubyObject value, int index, long[] hval) {
-            hval[0] += Helpers.safeHash(context, key).value ^ Helpers.safeHash(context, value).value;
+            byte [] bytes = ByteBuffer.allocate(16).putLong(Helpers.safeHash(context, key).value).putLong(Helpers.safeHash(context, value).value).array();
+            hval[0] ^= Helpers.multAndMix(context.runtime.getHashSeedK0(), Arrays.hashCode(bytes));
         }
     };
 

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1332,13 +1332,13 @@ public class RubyHash extends RubyObject implements Map {
         return context.runtime.newFixnum(hval[0]);
     }
 
-    private static final ThreadLocal<byte []> hash16byte = ThreadLocal.withInitial(() -> {return new byte[16];});
+    private static final ThreadLocal<byte[]> HASH_16_BYTE = ThreadLocal.withInitial(() -> {return new byte[16];});
 
     private static final VisitorWithState<long[]> CalculateHashVisitor = new VisitorWithState<long[]>() {
         @Override
         public void visit(ThreadContext context, RubyHash self, IRubyObject key, IRubyObject value, int index, long[] hval) {
-            ByteBuffer.wrap(hash16byte.get()).putLong(Helpers.safeHash(context, key).value).putLong(Helpers.safeHash(context, value).value);
-            hval[0] ^= Helpers.multAndMix(context.runtime.getHashSeedK0(), Arrays.hashCode(hash16byte.get()));
+            ByteBuffer.wrap(HASH_16_BYTE.get()).putLong(Helpers.safeHash(context, key).value).putLong(Helpers.safeHash(context, value).value);
+            hval[0] ^= Helpers.multAndMix(context.runtime.getHashSeedK0(), Arrays.hashCode(HASH_16_BYTE.get()));
         }
     };
 

--- a/spec/tags/ruby/core/hash/hash_tags.txt
+++ b/spec/tags/ruby/core/hash/hash_tags.txt
@@ -1,1 +1,0 @@
-fails:Hash#hash returns a value in which element keys and values do not cancel each other out


### PR DESCRIPTION
If using xor of key's hash and value's hash, a hash value always become to be 0. Therefore, to avoid generating 0 value, this commit uses hash of 16 bytes array which contains key's hash and values's hash.

The following test will pass.
 * spec/ruby/core/hash/hash_spec.rb