### PR TITLE
Fix Hash#rehash when a hash is large and contains duplicate keys

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -67,6 +67,7 @@ import java.util.AbstractCollection;
 import java.util.AbstractSet;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -1019,6 +1020,7 @@ public class RubyHash extends RubyObject implements Map {
         modify();
         final RubyHashEntry[] oldTable = table;
         final RubyHashEntry[] newTable = new RubyHashEntry[oldTable.length];
+        Set<Integer> rehashedIndexes = new HashSet<>();
         for (int j = 0; j < oldTable.length; j++) {
             RubyHashEntry entry = oldTable[j];
             oldTable[j] = null;
@@ -1041,6 +1043,8 @@ public class RubyHash extends RubyObject implements Map {
                     // replace entry if hash changed
                     if (oldHash != newHash) {
                         entry = new RubyHashEntry(entry, newHash);
+                        // memorize hash value
+                        rehashedIndexes.add(newHash);
                     }
 
                     entry.next = newEntry;
@@ -1050,6 +1054,28 @@ public class RubyHash extends RubyObject implements Map {
             }
         }
         table = newTable;
+
+        // When a hash is large and contains duplicate keys, sometimes the above logic can not remove duplicate key.
+        // searches duplicate keys and removes it.
+        for (int hash : rehashedIndexes) {
+            RubyHashEntry entry = table[bucketIndex(hash, newTable.length)];
+            while (entry != null) {
+                if (entry.hash == hash) {
+                    RubyHashEntry nextEntry = entry.next;
+                    while (nextEntry != null) {
+                        if (internalKeyExist(entry.hash, entry.key, nextEntry.hash, nextEntry.key)) {
+                            RubyHashEntry tmpNext = entry.nextAdded;
+                            RubyHashEntry tmpPrev = entry.prevAdded;
+                            tmpPrev.nextAdded = tmpNext;
+                            tmpPrev.prevAdded = tmpPrev;
+                            size--;
+                        }
+                        nextEntry = nextEntry.next;
+                    }
+                }
+            entry = entry.next;
+            }
+        }
         return this;
     }
 

--- a/spec/tags/ruby/core/hash/each_pair_tags.txt
+++ b/spec/tags/ruby/core/hash/each_pair_tags.txt
@@ -1,1 +1,0 @@
-wip:Hash#each_pair always yields an Array of 2 elements, even when given a callable of arity 2

--- a/spec/tags/ruby/core/hash/each_tags.txt
+++ b/spec/tags/ruby/core/hash/each_tags.txt
@@ -1,1 +1,0 @@
-wip:Hash#each always yields an Array of 2 elements, even when given a callable of arity 2

--- a/spec/tags/ruby/core/hash/rehash_tags.txt
+++ b/spec/tags/ruby/core/hash/rehash_tags.txt
@@ -1,1 +1,0 @@
-fails:Hash#rehash removes duplicate keys for large hashes

--- a/spec/tags/ruby/core/hash/ruby2_keywords_hash_tags.txt
+++ b/spec/tags/ruby/core/hash/ruby2_keywords_hash_tags.txt
@@ -1,1 +1,0 @@
-fails:Hash.ruby2_keywords_hash? returns true if the Hash is a keywords Hash marked by Module#ruby2_keywords


### PR DESCRIPTION
 This commit adds additional logic to remove duplicate key.  
 The following test will pass.
   * spec/ruby/core/hash/rehash_spec.rb

Before applies this patch, the rehash spec sometimes fails.
```
  it "removes duplicate keys for large hashes" do
    a = [1,2]
    b = [1]

    h = {}
    h[a] = true
    h[b] = true
    100.times { |n| h[n] = true }
    b << 2
    h.size.should == 102
    h.keys.should.include? a
    h.keys.should.include? b
    h.rehash
    h.size.should == 101
    h.keys.should.include? a
    h.keys.should_not.include? [1]
  end
```