### PR TITLE
Various fixes for Thread#to_s

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -72,6 +72,7 @@ import org.jruby.java.proxies.ConcreteJavaProxy;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
+import org.jruby.runtime.BlockBody;
 import org.jruby.runtime.ClassIndex;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ObjectAllocator;
@@ -237,7 +238,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     public RubyThread(Ruby runtime, RubyClass klass, Runnable runnable) {
         this(runtime, klass, true);
 
-        startThread(runtime.getCurrentContext(), runnable);
+        startThread(runtime.getCurrentContext(), runnable, "<internal>", -1);
     }
 
     private void executeInterrupts(ThreadContext context, boolean blockingTiming) {
@@ -613,19 +614,20 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         if (!block.isGiven()) throw context.runtime.newThreadError("must be called with a block");
         if (threadImpl != ThreadLike.DUMMY) throw context.runtime.newThreadError("already initialized thread");
 
-        startThread(context, new RubyRunnable(this, args, block, callInfo));
+        BlockBody body = block.getBody();
+        startThread(context, new RubyRunnable(this, args, block, callInfo), body.getFile(), body.getLine());
 
         return context.nil;
     }
 
-    private Thread startThread(ThreadContext context, Runnable runnable) throws RaiseException, OutOfMemoryError {
+    private Thread startThread(ThreadContext context, Runnable runnable, String file, int line) throws RaiseException, OutOfMemoryError {
         final Ruby runtime = context.runtime;
         try {
             Thread thread = new Thread(runnable);
             thread.setDaemon(true);
 
-            this.file = context.getFile();
-            this.line = context.getLine();
+            this.file = file;
+            this.line = line;
 
             initThreadName(runtime, thread, file, line);
             

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -1322,7 +1322,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         synchronized (this) {
             String id = threadImpl.getRubyName(); // thread.name
             if (notEmpty(id)) {
-                result.cat(' ');
+                result.cat('@');
                 result.cat(runtime.newSymbol(id).getBytes());
             }
             if (notEmpty(file) && line >= 0) {

--- a/test/jruby/test_thread.rb
+++ b/test/jruby/test_thread.rb
@@ -353,8 +353,8 @@ class TestThread < Test::Unit::TestCase
 
   def test_inspect_and_to_s
     t = Thread.new {}.join
-    assert_match(/#<Thread:0x[0-9a-z]+ test\/jruby\/test_thread\.rb\:355 \w+>/, t.to_s)
-    assert_match(/#<Thread:0x[0-9a-z]+ test\/jruby\/test_thread\.rb\:355 \w+>/, t.inspect)
+    assert_match(/#<Thread:0x[0-9a-z]+ #{__FILE__}\:#{__LINE__ - 1} \w+>/, t.to_s)
+    assert_match(/#<Thread:0x[0-9a-z]+ #{__FILE__}\:#{__LINE__ - 2} \w+>/, t.inspect)
 
     assert_nil t.name
 

--- a/test/jruby/test_thread.rb
+++ b/test/jruby/test_thread.rb
@@ -353,18 +353,15 @@ class TestThread < Test::Unit::TestCase
 
   def test_inspect_and_to_s
     t = Thread.new {}.join
-    assert_match(/#<Thread:0x[0-9a-z]+>/, t.to_s)
-    # TODO we do not have file/line right :
-    # MRI: #<Thread:0x000000014b0e28@test/jruby/test_thread.rb:346 dead>
-    #assert_match(/#<Thread:0x[0-9a-z]+@test\/jruby\/test_thread\.rb\:346 \w+>/, t.inspect)
-    assert_match(/#<Thread:0x[0-9a-z]+(@.*\.rb\:\d+)? \w+>/, t.inspect)
+    assert_match(/#<Thread:0x[0-9a-z]+ test\/jruby\/test_thread\.rb\:355 \w+>/, t.to_s)
+    assert_match(/#<Thread:0x[0-9a-z]+ test\/jruby\/test_thread\.rb\:355 \w+>/, t.inspect)
 
     assert_nil t.name
 
     t = Thread.new {}.join
     t.name = 'universal'
-    assert_match(/#<Thread:0x[0-9a-z]+>/, t.to_s)
-    assert_match(/#<Thread:0x[0-9a-z]+@universal(@.*\.rb\:\d+)? \w+>/, t.inspect)
+    assert_match(/#<Thread:0x[0-9a-z]+@universal( .*\.rb\:\d+)? \w+>/, t.to_s)
+    assert_match(/#<Thread:0x[0-9a-z]+@universal( .*\.rb\:\d+)? \w+>/, t.inspect)
   end
 
   def test_thread_name

--- a/test/jruby/test_thread.rb
+++ b/test/jruby/test_thread.rb
@@ -366,24 +366,24 @@ class TestThread < Test::Unit::TestCase
 
   def test_thread_name
     Thread.new do
-      assert_match(/\#\<Thread\:0x\h+(@([A-Z]:)?[\w\/\.\-_]+\:\d+)?\srun\>/, Thread.current.inspect)
+      assert_match(/\#\<Thread\:0x\h+( ([A-Z]:)?[\w\/\.\-_]+\:\d+)?\srun\>/, Thread.current.inspect)
       # Thread.current on Windows: "#<Thread:0x11aa8f4@D:/a/jruby/jruby/test/jruby/test_thread.rb:371 run>"
       # TODO? currently in JIT file comes as "" and line as 0
-      assert_match(/Ruby\-\d+\-Thread\-\d+\:\s(.*\.rb)?\:\d+/, native_thread_name(Thread.current)) if defined? JRUBY_VERSION
+      assert_match(/Ruby\-\d+\-Thread\-\d+\:\s(.*\.rb)?\:\d+/, native_thread_name(Thread.current))
     end.join
 
     Thread.new do
       Thread.current.name = 'foo'
-      assert_match(/\#\<Thread\:0x\h+@foo(@([A-Z]:)?[\w\/\.\-_]+\:\d+)?\srun\>/, Thread.current.inspect)
-      assert_match(/Ruby\-\d+\-Thread\-\d+\@foo:\s(.*\.rb)?\:\d+/, native_thread_name(Thread.current)) if defined? JRUBY_VERSION
+      assert_match(/\#\<Thread\:0x\h+@foo( ([A-Z]:)?[\w\/\.\-_]+\:\d+)?\srun\>/, Thread.current.inspect)
+      assert_match(/Ruby\-\d+\-Thread\-\d+\@foo:\s(.*\.rb)?\:\d+/, native_thread_name(Thread.current))
 
       Thread.current.name = 'bar'
-      assert_match(/\#\<Thread\:0x\h+@bar(@([A-Z]:)?[\w\/\.\-_]+\:\d+)?\srun\>/, Thread.current.inspect)
-      assert_match(/Ruby\-\d+\-Thread\-\d+\@bar:\s(.*\.rb)?\:\d+/, native_thread_name(Thread.current)) if defined? JRUBY_VERSION
+      assert_match(/\#\<Thread\:0x\h+@bar( ([A-Z]:)?[\w\/\.\-_]+\:\d+)?\srun\>/, Thread.current.inspect)
+      assert_match(/Ruby\-\d+\-Thread\-\d+\@bar:\s(.*\.rb)?\:\d+/, native_thread_name(Thread.current))
 
       Thread.current.name = nil
-      assert_match(/\#\<Thread\:0x\h+(@([A-Z]:)?[\w\/\.\-_]+\:\d+)?\srun\>/, Thread.current.inspect)
-      assert_match(/Ruby\-\d+\-Thread\-\d+\:\s(.*\.rb)?\:\d+/, native_thread_name(Thread.current)) if defined? JRUBY_VERSION
+      assert_match(/\#\<Thread\:0x\h+( ([A-Z]:)?[\w\/\.\-_]+\:\d+)?\srun\>/, Thread.current.inspect)
+      assert_match(/Ruby\-\d+\-Thread\-\d+\:\s(.*\.rb)?\:\d+/, native_thread_name(Thread.current))
     end.join
 
 


### PR DESCRIPTION
Some of this was already fixed by @k77ch7 in #7376 but those changes were made to match our own `test_inspect_and_to_s`, which had several lines modified to pass on JRuby and not run on CRuby. I have unmasked those lines, modified them to pass on CRuby, and adjusted JRuby behavior accordingly.