### PR TITLE
Update to Psych 4.0.6

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -77,7 +77,7 @@ default_gems = [
     ['pp', '0.3.0'],
     ['prettyprint', '0.1.1'],
     ['pstore', '0.1.1'],
-    ['psych', '4.0.5'],
+    ['psych', '4.0.6'],
     ['racc', '1.6.0'],
     ['rake-ant', '1.0.5'],
     ['rdoc', '6.4.0'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -541,7 +541,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>psych</artifactId>
-      <version>4.0.5</version>
+      <version>4.0.6</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1014,7 +1014,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/pp-0.3.0*</include>
           <include>specifications/prettyprint-0.1.1*</include>
           <include>specifications/pstore-0.1.1*</include>
-          <include>specifications/psych-4.0.5*</include>
+          <include>specifications/psych-4.0.6*</include>
           <include>specifications/racc-1.6.0*</include>
           <include>specifications/rake-ant-1.0.5*</include>
           <include>specifications/rdoc-6.4.0*</include>
@@ -1085,7 +1085,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/pp-0.3.0*/**/*</include>
           <include>gems/prettyprint-0.1.1*/**/*</include>
           <include>gems/pstore-0.1.1*/**/*</include>
-          <include>gems/psych-4.0.5*/**/*</include>
+          <include>gems/psych-4.0.6*/**/*</include>
           <include>gems/racc-1.6.0*/**/*</include>
           <include>gems/rake-ant-1.0.5*/**/*</include>
           <include>gems/rdoc-6.4.0*/**/*</include>
@@ -1156,7 +1156,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/pp-0.3.0*</include>
           <include>cache/prettyprint-0.1.1*</include>
           <include>cache/pstore-0.1.1*</include>
-          <include>cache/psych-4.0.5*</include>
+          <include>cache/psych-4.0.6*</include>
           <include>cache/racc-1.6.0*</include>
           <include>cache/rake-ant-1.0.5*</include>
           <include>cache/rdoc-6.4.0*</include>


### PR DESCRIPTION
Updates SnakeYAML to 1.33 to address CVE-2022-38752 per #7386