### PR TITLE
Fix #7323 by excluding java packages from ObjectSpace Module iteration

### DIFF
--- a/core/src/main/java/org/jruby/RubyObjectSpace.java
+++ b/core/src/main/java/org/jruby/RubyObjectSpace.java
@@ -40,6 +40,7 @@ import java.util.Map;
 
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyModule;
+import org.jruby.javasupport.JavaPackage;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import static org.jruby.runtime.Visibility.*;
@@ -145,7 +146,7 @@ public class RubyObjectSpace {
             final ArrayList<IRubyObject> modules = new ArrayList<>(96);
             runtime.eachModule((module) -> {
                     if (rubyClass.isInstance(module)) {
-                        if (!(module instanceof IncludedModule || module instanceof PrependedModule)) {
+                        if (!(module instanceof IncludedModule || module instanceof PrependedModule || module == runtime.getJavaSupport().getJavaPackageClass() || module instanceof JavaPackage)) {
                             // do nothing for included wrappers or singleton classes
                             modules.add(module); // store the module to avoid concurrent modification exceptions
                         }

--- a/core/src/main/java/org/jruby/javasupport/JavaPackage.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaPackage.java
@@ -90,7 +90,7 @@ public class JavaPackage extends RubyModule {
     final String packageName;
 
     private JavaPackage(final Ruby runtime, final CharSequence packageName) {
-        super(runtime, runtime.getJavaSupport().getJavaPackageClass());
+        super(runtime, runtime.getJavaSupport().getJavaPackageClass(), false); // java packages are phantom objects, and should never be added to objectspace
         this.packageName = packageName.toString();
     }
 

--- a/core/src/main/java/org/jruby/runtime/ObjectSpace.java
+++ b/core/src/main/java/org/jruby/runtime/ObjectSpace.java
@@ -44,6 +44,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import org.jruby.RubyModule;
 import org.jruby.java.proxies.JavaProxy;
+import org.jruby.javasupport.JavaPackage;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.WeakIdentityHashMap;
 
@@ -131,6 +132,8 @@ public class ObjectSpace {
     }
 
     public void add(IRubyObject object) {
+        if (object instanceof JavaPackage)
+            return;
         if (true && object.getMetaClass() != null && !(object instanceof JavaProxy)) {
             // If the object is already frozen when we encounter it, it's pre-frozen.
             // Since this only (currently) applies to objects created outside the


### PR DESCRIPTION
IRB and Pry find modules via ObjectSpace, and arguably packages aren't  modules.
This change removes java packages from iteration. 

Fixes #7323 

While this change and the IRB change have overlap, I think both should be implemented for completeness