### PR TITLE
Match MRI inspect values for PTY.open

### DIFF
--- a/lib/ruby/stdlib/pty.rb
+++ b/lib/ruby/stdlib/pty.rb
@@ -50,6 +50,14 @@ module PTY
         true
       end
 
+      slave.define_singleton_method(:inspect) do
+        "#<File:#{slave_name}>"
+      end
+
+      master.define_singleton_method(:inspect) do
+        "#<IO:masterpty:#{slave_name}>"
+      end
+
       fds = [master, slave]
       fds.each do |fd|
         fd.sync = true


### PR DESCRIPTION
Also now looks less error-y

Before:

```
jruby-9.3.4.0 :016 > PTY.open
 => [#<IO:fd 18>, #<File:nil>] 
```

After/MRI:

```
2.6.2 :035 > PTY.open
 => [#<IO:masterpty:/dev/pts/42>, #<File:/dev/pts/42>] 

9.4.0.0 :002> PTY.open
=> [#<IO:masterpty:/dev/pts/49>, #<File:/dev/pts/49>]

```