### PR TITLE
Fix Range#dup and Range#last

### DIFF
--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -299,7 +299,11 @@ public class RubyRange extends RubyObject {
         if (this.isInited) throw context.runtime.newFrozenError("`initialize' called twice", this);
 
         RubyRange other = (RubyRange) original;
-        init(context, other.begin, other.end, other.isExclusive);
+        this.begin = other.begin;
+        this.end = other.end;
+        this.isExclusive = other.isExclusive;
+        this.isEndless = other.end.isNil();
+        this.isBeginless = other.begin.isNil();
         this.isInited = true;
         return context.nil;
     }

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -1083,15 +1083,15 @@ public class RubyRange extends RubyObject {
 
         len1 = ((RubyInteger)end).op_minus(context, begin);
 
-        if (((RubyInteger)len1).isZero() || Numeric.f_negative_p(context, (RubyInteger)len1)) {
-            return RubyArray.newEmptyArray(context.runtime);
-        }
-
         if (isExclusive) {
             end = ((RubyInteger)end).op_minus(context, one);
             len = len1;
         } else {
             len = ((RubyInteger)len1).op_plus(context, one);
+        }
+
+        if (((RubyInteger)len).isZero() || Numeric.f_negative_p(context, (RubyInteger)len)) {
+            return RubyArray.newEmptyArray(context.runtime);
         }
 
         long n = RubyNumeric.num2long(arg);

--- a/spec/tags/ruby/core/range/dup_tags.txt
+++ b/spec/tags/ruby/core/range/dup_tags.txt
@@ -1,1 +1,0 @@
-wip:Range#dup creates an unfrozen range

--- a/spec/tags/ruby/core/range/last_tags.txt
+++ b/spec/tags/ruby/core/range/last_tags.txt
@@ -1,1 +1,0 @@
-fails:Range#last returns the specified number if elements for single element inclusive range

--- a/spec/tags/ruby/core/range/minmax_tags.txt
+++ b/spec/tags/ruby/core/range/minmax_tags.txt
@@ -1,2 +1,0 @@
-fails:Range#minmax on an inclusive range should try to iterate endlessly on an endless range
-fails:Range#minmax on an exclusive range should try to iterate endlessly on an endless range


### PR DESCRIPTION
- Fix Range#dup to create an unfrozen range
- Fix Range#last (See https://bugs.ruby-lang.org/issues/18994)