### PR TITLE
Better match CRuby zone negotiation

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -1385,7 +1385,7 @@ public class RubyTime extends RubyObject {
             time = time.gmtime();
 
             if (!zone.isNil()) {
-                timeZoneLocal(context, zone, time);
+                time = timeZoneLocal(context, zone, time);
             }
 
             return time;
@@ -1461,8 +1461,6 @@ public class RubyTime extends RubyObject {
 
     private static RubyTime atMulti(ThreadContext context, RubyClass recv, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3, IRubyObject zone) {
         Ruby runtime = context.runtime;
-
-        RubyTime time = new RubyTime(runtime, recv, new DateTime(0L, getLocalTimeZone(runtime)));
         long millisecs;
         long nanosecs = 0;
 
@@ -1519,11 +1517,11 @@ public class RubyTime extends RubyObject {
 
         long nanosecOverflow = (nanosecs / 1000000);
 
+        RubyTime time = new RubyTime(runtime, recv, new DateTime(millisecs + nanosecOverflow, getLocalTimeZone(runtime)));
         time.setNSec(nanosecs % 1000000);
-        time.dt = time.dt.withMillis(millisecs + nanosecOverflow);
 
         if (!zone.isNil()) {
-            timeZoneLocal(context, zone, time);
+            time = timeZoneLocal(context, zone, time.gmtime());
         }
 
         return time;


### PR DESCRIPTION
* Don't normalize to UTC before setting time zone in the single- arg Time.at with a zone kwarg. timeZoneLocal does that before setting the passed-in zone, and if no zone is provided we should leave it local.
* When normalizing to UTC in zoneLocalTime, allow DateTime to also adjust the time, so we get the real equivalent time in UTC. This pairs with the above fix to only apply the zone offset once, and only apply it in the timeZoneLocal call tree.

Fixes #7406