### PR TITLE
Fix Dir#read when external encoding changed

### DIFF
--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -883,7 +883,7 @@ public class RubyDir extends RubyObject implements Closeable {
         final String[] snapshot = this.snapshot;
         if (pos >= snapshot.length) return getRuntime().getNil();
 
-        RubyString result = RubyString.newString(getRuntime(), snapshot[pos], encoding);
+        RubyString result = newExternalStringWithEncoding(getRuntime(), snapshot[pos], encoding);
         pos++;
         return result;
     }

--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -43,6 +43,7 @@ import jnr.posix.POSIX;
 
 import org.jcodings.Encoding;
 import org.jcodings.specific.USASCIIEncoding;
+import org.jcodings.specific.UTF8Encoding;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.common.IRubyWarnings.ID;
 import org.jruby.common.RubyWarnings;
@@ -735,16 +736,14 @@ public class RubyGlobal {
         private static final ByteList PATH_BYTES = new ByteList(new byte[] {'P','A','T','H'}, USASCIIEncoding.INSTANCE, false);
 
         // MRI: env_name_new
+        // TODO: mri 3.1 does not use env_name_new
         protected static IRubyObject newName(ThreadContext context, IRubyObject key, IRubyObject valueArg) {
             if (valueArg.isNil()) return context.nil;
 
             RubyString value = (RubyString) valueArg;
             EncodingService encodingService = context.runtime.getEncodingService();
-            Encoding encoding = isPATH(context, (RubyString) key) ?
-                    encodingService.getFileSystemEncoding() :
-                    encodingService.getLocaleEncoding();
 
-            return newString(context, value, encoding);
+            return newString(context, value);
         }
 
         protected static IRubyObject newString(ThreadContext context, RubyString value, Encoding encoding) {
@@ -757,7 +756,9 @@ public class RubyGlobal {
 
         // MRI: env_str_new
         protected static IRubyObject newString(ThreadContext context, RubyString value) {
-            return newString(context, value, context.runtime.getEncodingService().getLocaleEncoding());
+            // env_encoding(void)
+            Encoding encoding = Platform.IS_WINDOWS ? UTF8Encoding.INSTANCE : context.runtime.getEncodingService().getLocaleEncoding();
+            return newString(context, value, encoding);
         }
 
         // MRI: env_str_new2

--- a/core/src/main/java/org/jruby/util/io/EncodingUtils.java
+++ b/core/src/main/java/org/jruby/util/io/EncodingUtils.java
@@ -1777,7 +1777,7 @@ public class EncodingUtils {
         }
 
         if (name.equals("external")) {
-            // TODO: set filesystem encoding
+            context.runtime.setDefaultFilesystemEncoding(rbToEncoding(context, encoding));
         }
 
         return overridden;

--- a/spec/tags/ruby/core/dir/read_tags.txt
+++ b/spec/tags/ruby/core/dir/read_tags.txt
@@ -1,1 +1,0 @@
-wip:Dir#read returns all directory entries even when encoding conversion will fail

--- a/spec/tags/ruby/core/encoding/default_external_tags.txt
+++ b/spec/tags/ruby/core/encoding/default_external_tags.txt
@@ -1,2 +1,0 @@
-fails:Encoding.default_external with command line options is not changed by the -U option
-

--- a/spec/tags/ruby/core/encoding/default_external_tags.txt
+++ b/spec/tags/ruby/core/encoding/default_external_tags.txt
@@ -1,2 +1,2 @@
 fails:Encoding.default_external with command line options is not changed by the -U option
-fails:Encoding.default_external= also sets the filesystem encoding
+

--- a/spec/tags/ruby/core/encoding/list_tags.txt
+++ b/spec/tags/ruby/core/encoding/list_tags.txt
@@ -1,1 +1,0 @@
-wip:Encoding.list includes CESU-8 encoding


### PR DESCRIPTION
This commit also fixes 'Encoding.default_external=' behavior.

The following test will pass when this two updates are complete.
 * spec/ruby/core/dir/read_spec.rb