### PR TITLE
Update mri.stdlib.index to execute 'rake test:mri:stdlib'.

### DIFF
--- a/test/mri.stdlib.index
+++ b/test/mri.stdlib.index
@@ -12,7 +12,19 @@ drb
 dtrace
 erb
 etc
-fiber
+#fiber #IO::Buffer is not implemented
+#fiber/test_address_resolve.rb
+fiber/test_backtrace.rb
+#fiber/test_enumerator.rb
+#fiber/test_io.rb
+#fiber/test_io_buffer.rb
+#fiber/test_mutex.rb
+#fiber/test_process.rb
+fiber/test_ractor.rb
+#fiber/test_scheduler.rb
+#fiber/test_sleep.rb
+#fiber/test_thread.rb
+#fiber/test_timeout.rb
 fileutils
 gdbm
 io


### PR DESCRIPTION
'uninitialized constant IO::Buffer (NameError)' occurs because of IO::Buffer is not implmented.