### PR TITLE
Fix File#expantd_path to prevent many errors when stdlib tests run

### DIFF
--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -1755,7 +1755,11 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         RubyString path = StringSupport.checkEmbeddedNulls(context.runtime, get_path(context, args[0]));
         RubyString wd = null;
         if (args.length == 2 && args[1] != context.nil) {
-            wd = StringSupport.checkEmbeddedNulls(context.runtime, get_path(context, args[1]));
+            if (args[1] instanceof RubyHash) {
+                // FIXME : do nothing when args[1] is Hash(e.g. {:mode=>0}, {:encoding=>"ascii-8bit"})
+            } else {
+                wd = StringSupport.checkEmbeddedNulls(context.runtime, get_path(context, args[1]));
+            }
         }
         return expandPathInternal(context, path, wd, expandUser, canonicalize);
     }


### PR DESCRIPTION
This patch prevents TypeError.
```
TypeError: no implicit conversion of Hash into String
    org/jruby/RubyFile.java:868:in `expand_path'
```

JRuby head
```
ruby test/mri/runner.rb  --excludes=test/mri/excludes -q -- csv test_tempfile.rb ruby/test_file.rb

results
930 tests, 9007 assertions, 0 failures, 151 errors, 0 skips
```

JRuby head + patched
```
jruby test/mri/runner.rb  --excludes=test/mri/excludes -q -- csv test_tempfile.rb ruby/test_file.rb

results
930 tests, 9091 assertions, 1 failures, 1 errors, 0 skips
```



