### PR TITLE
Raise EPIPE for all unseekable channels

### DIFF
--- a/core/src/main/java/org/jruby/util/io/PosixShim.java
+++ b/core/src/main/java/org/jruby/util/io/PosixShim.java
@@ -72,20 +72,8 @@ public class PosixShim {
             return ret;
         }
 
-        if (fd.chSelect != null) {
-            // For other channel types, we can't get at a native descriptor to lseek, and we can't use FileChannel
-            // .position, so we have to treat them as unseekable and raise EPIPE
-            //
-            // TODO: It's perhaps just a coincidence that all the channels for
-            // which we should raise are instanceof SelectableChannel, since
-            // stdio is not...so this bothers me slightly. -CON
-            //
-            // Original change made in 66b024fedbb2ee32316ccd9de8387931d07993ec
-            setErrno(Errno.EPIPE);
-            return -1;
-        }
-
-        return 0;
+        setErrno(Errno.EPIPE);
+        return -1;
     }
 
     public int write(ChannelFD fd, byte[] bytes, int offset, int length, boolean nonblock) {


### PR DESCRIPTION
This relates to the discussion in discourse/mini_mime#38 where the proposed patch must work around JRuby's silent seek failure for some types of resources (at least classloader resources).

The patch here will now raise EPIPE for all NIO channels that are not seekable through some means. It is rather aggressive given the old logic that only raised if a channel was not seekable AND not selectable (for reasons long lost).