### PR TITLE
Update test.rake option

### DIFF
--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -100,7 +100,7 @@ namespace :test do
 
     mri_suites = [:core, :extra, :stdlib]
     mri_suites = {
-      core: "--disable-gems -Xbacktrace.style=mri -Xdebug.fullTrace",
+      core: "-Xbacktrace.style=mri -Xdebug.fullTrace",
       extra: "--disable-gems -Xbacktrace.style=mri -Xdebug.fullTrace",
       stdlib: "-Xbacktrace.style=mri -Xdebug.fullTrace",
     }


### PR DESCRIPTION
When test:mri:core:int or test:mri:core:jit run, many NoMethodError occurs.
```
NoMethodError: undefined method `formatter' for DidYouMean:Module
```
This commit removes --disable-gem option from test.rake file because test/mir/ruby/test_pattern_match.rb requires DidYouMean module.