### PR TITLE
Fix Enumerator.new without a block

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -258,30 +258,18 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
         IRubyObject method = runtime.newSymbol("each");
         IRubyObject size = null;
 
-        if (block.isGiven()) {
-            Arity.checkArgumentCount(runtime, args, 0, 1);
-            if (args.length > 0) {
-                size = args[0];
-                args = ArraySupport.newCopy(args, 1, args.length - 1);
-
-                if ( ! (size.isNil() || size.respondsTo("call")) &&
-                     ! (size instanceof RubyFloat && ((RubyFloat) size).value == Float.POSITIVE_INFINITY) &&
-                     ! (size instanceof RubyInteger) ) {
-                    throw runtime.newTypeError(size, runtime.getInteger());
-                }
-            }
-            object = runtime.getGenerator().newInstance(context, IRubyObject.NULL_ARRAY, block);
-
-        } else {
-            Arity.checkArgumentCount(runtime, args, 1, -1);
-            runtime.getWarnings().warn("Enumerator.new without a block is deprecated; use Object#to_enum");
-            object = args[0];
+        Arity.checkArgumentCount(runtime, args, 0, 1);
+        if (args.length > 0) {
+            size = args[0];
             args = ArraySupport.newCopy(args, 1, args.length - 1);
-            if (args.length > 0) {
-                method = args[0];
-                args = ArraySupport.newCopy(args, 1, args.length - 1);
+
+            if ( ! (size.isNil() || size.respondsTo("call")) &&
+                 ! (size instanceof RubyFloat && ((RubyFloat) size).value == Float.POSITIVE_INFINITY) &&
+                 ! (size instanceof RubyInteger) ) {
+                throw runtime.newTypeError(size, runtime.getInteger());
             }
         }
+        object = runtime.getGenerator().newInstance(context, IRubyObject.NULL_ARRAY, block);
 
         return initialize(runtime, object, method, args, size, null, keywords);
     }

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -21,6 +21,7 @@ import org.jruby.util.ConvertBytes;
 import org.jruby.util.RubyStringBuilder;
 
 import static org.jruby.javasupport.ext.JavaLang.Character.inspectCharValue;
+import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
 import static org.jruby.util.Inspector.*;
 
 public final class ArrayJavaProxy extends JavaProxy {
@@ -447,7 +448,7 @@ public final class ArrayJavaProxy extends JavaProxy {
     public IRubyObject each(ThreadContext context, Block block) {
         final Ruby runtime = context.runtime;
         if ( ! block.isGiven() ) { // ... Enumerator.new(self, :each)
-            return runtime.getEnumerator().callMethod("new", this, runtime.newSymbol("each"));
+            return enumeratorizeWithSize(context, this, "each", ArrayJavaProxy::size);
         }
 
         final Object array = getObject();
@@ -463,8 +464,8 @@ public final class ArrayJavaProxy extends JavaProxy {
     @JRubyMethod
     public IRubyObject each_with_index(final ThreadContext context, final Block block) {
         final Ruby runtime = context.runtime;
-        if ( ! block.isGiven() ) { // ... Enumerator.new(self, :each)
-            return runtime.getEnumerator().callMethod("new", this, runtime.newSymbol("each_with_index"));
+        if ( ! block.isGiven() ) { // ... Enumerator.new(self, :each_with_index)
+            return enumeratorizeWithSize(context, this, "each_with_index", ArrayJavaProxy::size);
         }
 
         final boolean twoArguments = block.getSignature().isTwoArguments();
@@ -909,5 +910,14 @@ public final class ArrayJavaProxy extends JavaProxy {
             return proxy;
         }
 
+    }
+
+    /**
+     * A size method suitable for lambda method reference implementation of {@link RubyEnumerator.SizeFn#size(ThreadContext, IRubyObject, IRubyObject[])}
+     *
+     * @see RubyEnumerator.SizeFn#size(ThreadContext, IRubyObject, IRubyObject[])
+     */
+    protected static IRubyObject size(ThreadContext context, ArrayJavaProxy self, IRubyObject[] args) {
+        return self.length(context);
     }
 }

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -52,6 +52,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
+import static org.jruby.RubyEnumerator.enumeratorize;
 import static org.jruby.RubyModule.undefinedMethodMessage;
 import static org.jruby.javasupport.JavaUtil.convertJavaToUsableRubyObject;
 import static org.jruby.javasupport.JavaUtil.isJavaObject;
@@ -102,7 +103,7 @@ public abstract class JavaLang {
         public static IRubyObject each(final ThreadContext context, final IRubyObject self, final Block block) {
             final Ruby runtime = context.runtime;
             if ( ! block.isGiven() ) { // ... Enumerator.new(self, :each)
-                return runtime.getEnumerator().callMethod("new", self, runtime.newSymbol("each"));
+                return enumeratorize(context.runtime, self, "each");
             }
             java.lang.Iterable iterable = unwrapIfJavaObject(self);
             java.util.Iterator iterator = iterable.iterator();
@@ -116,8 +117,8 @@ public abstract class JavaLang {
         @JRubyMethod
         public static IRubyObject each_with_index(final ThreadContext context, final IRubyObject self, final Block block) {
             final Ruby runtime = context.runtime;
-            if ( ! block.isGiven() ) { // ... Enumerator.new(self, :each)
-                return runtime.getEnumerator().callMethod("new", self, runtime.newSymbol("each_with_index"));
+            if ( ! block.isGiven() ) { // ... Enumerator.new(self, :each_with_index)
+                return enumeratorize(context.runtime, self, "each_with_index");
             }
             java.lang.Iterable iterable = unwrapIfJavaObject(self);
             java.util.Iterator iterator = iterable.iterator();

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
@@ -44,6 +44,7 @@ import org.jruby.util.RubyStringBuilder;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
+import static org.jruby.RubyEnumerator.enumeratorize;
 import static org.jruby.javasupport.JavaUtil.convertJavaArrayToRuby;
 import static org.jruby.javasupport.JavaUtil.convertJavaToUsableRubyObject;
 import static org.jruby.javasupport.JavaUtil.inspectObject;
@@ -419,7 +420,7 @@ public abstract class JavaUtil {
         public static IRubyObject index(final ThreadContext context, final IRubyObject self, final Block block) {
             final Ruby runtime = context.runtime;
             if ( ! block.isGiven() ) { // list.index ... Enumerator.new(self, :index)
-                return runtime.getEnumerator().callMethod("new", self, runtime.newSymbol("index"));
+                return enumeratorize(context.runtime, self, "index");
             }
 
             final java.util.List list = unwrapIfJavaObject(self);
@@ -472,7 +473,7 @@ public abstract class JavaUtil {
         public static IRubyObject rindex(final ThreadContext context, final IRubyObject self, final Block block) {
             final Ruby runtime = context.runtime;
             if ( ! block.isGiven() ) { // list.rindex ... Enumerator.new(self, :rindex)
-                return runtime.getEnumerator().callMethod("new", self, runtime.newSymbol("rindex"));
+                return enumeratorize(context.runtime, self, "rindex");
             }
 
             final java.util.List list = unwrapIfJavaObject(self);

--- a/spec/compiler/general_spec.rb
+++ b/spec/compiler/general_spec.rb
@@ -899,9 +899,10 @@ modes.each do |mode|
       end
       "){}}.to_not raise_error
 
+      # Enumerator.new without a block
       expect {
         JRuby5871A.new("foo", :each_byte)
-      }.to_not raise_error
+      }.to raise_error(ArgumentError)
 
       expect{run("
       class JRuby5871B < #{enumerable}
@@ -911,9 +912,10 @@ modes.each do |mode|
       end
       "){}}.to_not raise_error
 
+      # Enumerator.new without a block
       expect {
         JRuby5871B.new("foo", :each_byte)
-      }.to_not raise_error
+      }.to raise_error(ArgumentError)
     end
 
     it "allows colon2 const assignment on LHS of masgn" do

--- a/spec/tags/ruby/core/enumerator/new_tags.txt
+++ b/spec/tags/ruby/core/enumerator/new_tags.txt
@@ -1,1 +1,0 @@
-wip:Enumerator.new no block given raises


### PR DESCRIPTION
Enumerator.new without a block should raise ArgumentError. 

The following tests will pass.
 * spec/ruby/core/enumerator/new_spec.rb
 * test_initialize in test/mri/ruby/test_enumerator.rb

This PR also update `spec/compiler/general_spec.rb` to adapt Enuemurator.new behavior.
And this PR uses enumeratorize or enumeratorizeWithSize instead of `runtime.getEnumerator().callMethod("new", ...)` in som Java classes to prevent spec:compiler and spec:ji failures(https://github.com/jruby/jruby/actions/runs/3290468184).