### PR TITLE
Fix Enumerator::Lazy#filter_map

### DIFF
--- a/core/src/main/ruby/jruby/kernel/enumerator.rb
+++ b/core/src/main/ruby/jruby/kernel/enumerator.rb
@@ -246,6 +246,14 @@ class Enumerator
       end.__set_inspect :filter
     end
 
+    def filter_map
+      _block_error(:filter_map) unless block_given?
+      Lazy.new(self) do |yielder, *values|
+        v = yield(*values)
+        yielder << v if v
+      end.__set_inspect :filter_map
+    end
+
     def reject
       _block_error(:reject) unless block_given?
       Lazy.new(self) do |yielder, *values|

--- a/spec/tags/ruby/core/enumerator/lazy/filter_map_tags.txt
+++ b/spec/tags/ruby/core/enumerator/lazy/filter_map_tags.txt
@@ -1,2 +1,0 @@
-hangs(excessive memory use):Enumerator::Lazy#filter_map maps only truthy results
-hangs(excessive memory use):Enumerator::Lazy#filter_map does not map false results


### PR DESCRIPTION
This commit implements filter_map method in ruby code. 
The following tests will pass.
 * test_filter_map in test/mri/ruby/test_lazy_enumerator.rb
 * spec/ruby/core/enumerator/lazy/filter_map_spec.rb