### PR TITLE
Fix String#to_r and Marshal#load for Rational Class

### DIFF
--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -1529,7 +1529,7 @@ public class RubyRational extends RubyNumeric {
             }
 
             if (de != nil) {
-                v = f_div(context, v, f_to_i(context, de));
+                v = f_div(context, v, f_to_r(context, de));
             }
             return new IRubyObject[] { v, re };
         }

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -184,7 +184,7 @@ public class RubyRational extends RubyNumeric {
     private static RubyInteger intCheck(ThreadContext context, IRubyObject num) {
         if (num instanceof RubyInteger) return (RubyInteger) num;
         if (!(num instanceof RubyNumeric) || !integer_p(context).call(context, num, num).isTrue()) { // num.integer?
-            throw context.runtime.newTypeError("not a integer");
+            throw context.runtime.newTypeError("not an integer");
         }
         return num.convertToInteger();
     }

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -184,7 +184,7 @@ public class RubyRational extends RubyNumeric {
     private static RubyInteger intCheck(ThreadContext context, IRubyObject num) {
         if (num instanceof RubyInteger) return (RubyInteger) num;
         if (!(num instanceof RubyNumeric) || !integer_p(context).call(context, num, num).isTrue()) { // num.integer?
-            throw context.runtime.newTypeError("can't convert " + num.getMetaClass().getName() + " into Rational");
+            throw context.runtime.newTypeError("not a integer");
         }
         return num.convertToInteger();
     }
@@ -1425,6 +1425,7 @@ public class RubyRational extends RubyNumeric {
      */
     @JRubyMethod(name = "marshal_load")
     public IRubyObject marshal_load(ThreadContext context, IRubyObject arg) {
+        checkFrozen();
         RubyArray load = arg.convertToArray();
         IRubyObject num = load.size() > 0 ? load.eltInternal(0) : context.nil;
         IRubyObject den = load.size() > 1 ? load.eltInternal(1) : context.nil;
@@ -1434,6 +1435,8 @@ public class RubyRational extends RubyNumeric {
             num = f_negate(context, num);
             den = f_negate(context, den);
         }
+        intCheck(context, num);
+        intCheck(context, den);
 
         this.num = (RubyInteger) num;
         this.den = (RubyInteger) den;

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -6387,10 +6387,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     public IRubyObject to_r(ThreadContext context) {
         Ruby runtime = context.runtime;
 
-        RubyRegexp underscore_pattern = RubyRegexp.newDummyRegexp(runtime, Numeric.ComplexPatterns.underscores_pat);
-        RubyString s = gsubFast(context, underscore_pattern, runtime.newString(UNDERSCORE), Block.NULL_BLOCK);
-
-        IRubyObject[] ary = RubyRational.str_to_r_internal(context, s);
+        IRubyObject[] ary = RubyRational.str_to_r_internal(context, this);
 
         IRubyObject first = ary[0];
         if ( first != context.nil ) return first;

--- a/core/src/main/java/org/jruby/util/Numeric.java
+++ b/core/src/main/java/org/jruby/util/Numeric.java
@@ -822,7 +822,7 @@ public class Numeric {
             String WS = "\\s*";
             String DIGITS = "(?:\\d(?:_\\d|\\d)*)";
             String NUMERATOR = "(?:" + DIGITS + "?\\.)?" + DIGITS + "(?:[eE][-+]?" + DIGITS + ")?";
-            String DENOMINATOR = DIGITS;
+            String DENOMINATOR = "(?:" + DIGITS + "?\\.)?" + DIGITS + "(?:[eE][-+]?" + DIGITS + ")?";
             String PATTERN = "\\A" + WS + "([-+])?(" + NUMERATOR + ")(?:\\/(" + DENOMINATOR + "))?" + WS;
             rat_pat = new Regex(PATTERN.getBytes(), 0, PATTERN.length(), 0, ASCIIEncoding.INSTANCE, WarnCallback.NONE);
             an_e_pat = new Regex("[Ee]".getBytes(), 0, 4, 0, ASCIIEncoding.INSTANCE, WarnCallback.NONE);

--- a/test/mri/excludes_wip/Rational_Test.rb
+++ b/test/mri/excludes_wip/Rational_Test.rb
@@ -1,8 +1,6 @@
 exclude :"test_Rational_without_exception", "work in progress"
 exclude :"test_conv", "work in progress"
 exclude :"test_gcd_no_memory_leak", "work in progress"
-exclude :"test_marshal", "work in progress"
-exclude :"test_parse", "work in progress"
 exclude :"test_ratsub", "work in progress"
 exclude :"test_supp", "work in progress"
 exclude :"test_supp", "work in progress"


### PR DESCRIPTION
This PR fixes String#to_r for edges case
 e.g. '5__5/33'.to_r => 5/1, '5/3.3_'.to_r => 50/33
This PR also fixes Marshal#load for Rational Class

The following tests will pass.
 * test_parse in test/mri/ruby/test_rational.rb
 * test_marshal in test/mri/ruby/test_rational.rb
