### PR TITLE
Last functional pattern match errors fixed.

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -1404,7 +1404,7 @@ public class IRBuilder {
                         Operand deconstructIndex = addResultInstr(new IntegerMathInstr(ADD, temp(), i, new Integer(j.value)));
                         Operand deconstructFixnum = as_fixnum(deconstructIndex);
                         Operand test = call(temp(), deconstructed, "[]", deconstructFixnum);
-                        buildPatternMatch(result, deconstructed, pat, test, false);
+                        buildPatternMatch(result, copy(buildNil()), pat, test, false);
                         cond_ne(bottom, result, tru());
                     });
 
@@ -1412,7 +1412,7 @@ public class IRBuilder {
                     if (pre != null && !(pre instanceof StarNode)) {
                         Operand iFixnum = as_fixnum(i);
                         Operand test = call(temp(), deconstructed, "[]", manager.newFixnum(0), iFixnum);
-                        buildPatternMatch(result, deconstructed, pre, test, false);
+                        buildPatternMatch(result, copy(buildNil()), pre, test, false);
                         cond_ne(bottom, result, tru());
                     }
 
@@ -1422,7 +1422,7 @@ public class IRBuilder {
                         Operand deconstructFixnum = as_fixnum(deconstructIndex);
                         Operand lengthFixnum = as_fixnum(length);
                         Operand test = call(temp(), deconstructed, "[]", deconstructFixnum, lengthFixnum);
-                        buildPatternMatch(result, deconstructed, post, test, false);
+                        buildPatternMatch(result, copy(buildNil()), post, test, false);
                         cond_ne(bottom, result, tru());
                     }
                     jump(after);
@@ -1468,8 +1468,7 @@ public class IRBuilder {
                 Variable elt = call(temp(), deconstructed, "[]", fix(i));
                 Node arg = preArgs.get(i);
 
-                Variable dd = addResultInstr(new CopyInstr(temp(), buildNil()));
-                buildPatternEach(testEnd, result, dd, elt, arg, inAlteration);
+                buildPatternEach(testEnd, result, copy(buildNil()), elt, arg, inAlteration);
                 cond_ne(testEnd, result, tru());
             }
         }
@@ -1481,8 +1480,8 @@ public class IRBuilder {
                 Variable min = copy(fix(preArgsSize));
                 Variable max = as_fixnum(restNum);
                 Variable elt = call(temp(), deconstructed, "[]", min, max);
-                Variable dd = copy(buildNil());
-                buildPatternMatch(result, dd, pattern.getRestArg(), elt, inAlteration);
+
+                buildPatternMatch(result, copy(buildNil()), pattern.getRestArg(), elt, inAlteration);
                 cond_ne(testEnd, result, tru());
             }
         }
@@ -1494,8 +1493,8 @@ public class IRBuilder {
                 Variable j = addResultInstr(new IntegerMathInstr(ADD, temp(), new Integer(i + preArgsSize), restNum));
                 Variable k = as_fixnum(j);
                 Variable elt = call(temp(), deconstructed, "[]", k);
-                Variable dd = addResultInstr(new CopyInstr(temp(), buildNil()));
-                buildPatternEach(testEnd, result, dd, elt, postArgs.get(i), inAlteration);
+
+                buildPatternEach(testEnd, result, copy(buildNil()), elt, postArgs.get(i), inAlteration);
                 addInstr(BNEInstr.create(matchElementCheck, result, buildFalse()));
                 addInstr(new JumpInstr(testEnd));
                 addInstr(new LabelInstr(matchElementCheck));
@@ -1554,8 +1553,7 @@ public class IRBuilder {
 
                 String method = pattern.hasRestArg() ? "delete" : "[]";
                 Operand value = call(temp(), d, method, key);
-                Variable deconstructedKey = copy(buildNil());
-                buildPatternEach(testEnd, result, deconstructedKey, value, pair.getValue(), inAlteration);
+                buildPatternEach(testEnd, result, copy(buildNil()), value, pair.getValue(), inAlteration);
                 cond_ne(testEnd, result, tru());
             }
         } else {
@@ -1568,8 +1566,7 @@ public class IRBuilder {
                 call(result, d, "empty?");
                 cond_ne(testEnd, result, tru());
             } else if (pattern.isNamedRestArg()) {
-                Variable deconstructedKey = copy(buildNil());
-                buildPatternEach(testEnd, result, deconstructedKey, d, pattern.getRestArg(), inAlteration);
+                buildPatternEach(testEnd, result, copy(buildNil()), d, pattern.getRestArg(), inAlteration);
                 cond_ne(testEnd, result, tru());
             }
         }

--- a/core/src/main/java/org/jruby/ir/instructions/DebugOutputInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/DebugOutputInstr.java
@@ -1,0 +1,35 @@
+package org.jruby.ir.instructions;
+
+import org.jruby.ir.operands.Operand;
+import org.jruby.parser.StaticScope;
+import org.jruby.runtime.DynamicScope;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+/**
+ * This is only used for active debugging and should never end up showing up in real executed code.
+ * If it did happen to sneak in and it was persisted it would convert to a noop instr.
+ */
+public class DebugOutputInstr extends NopInstr {
+    private String message;
+    private Operand[] operands;
+
+    public DebugOutputInstr(String message, Operand[] operands) {
+        super();
+
+        this.message = message;
+        this.operands = operands;
+    }
+
+    @Override
+    public Object interpret(ThreadContext context, StaticScope currScope, DynamicScope currDynScope, IRubyObject self, Object[] temp) {
+        Object[] values = new Object[operands.length];
+
+        for (int i = 0; i < values.length; i++) {
+            values[i] = operands[i].retrieve(context, self, currScope, currDynScope, temp);
+        }
+
+        System.out.println(String.format(message, values));
+        return context.nil;
+    }
+}

--- a/core/src/main/java/org/jruby/ir/instructions/IntegerMathInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/IntegerMathInstr.java
@@ -12,6 +12,8 @@ import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import static org.jruby.util.StringSupport.EMPTY_STRING_ARRAY;
+
 public class IntegerMathInstr extends TwoOperandResultBaseInstr {
     public enum Op {
         ADD, SUBTRACT, MULTIPLY, DIVIDE;
@@ -48,6 +50,9 @@ public class IntegerMathInstr extends TwoOperandResultBaseInstr {
         e.encode(op.ordinal());
     }
 
+    public String[] toStringNonOperandArgs() {
+        return new String[] { "op:", op.name()};
+    }
 
     @Override
     public void visit(IRVisitor visitor) {

--- a/core/src/main/java/org/jruby/ir/instructions/NopInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/NopInstr.java
@@ -11,7 +11,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 public class NopInstr extends NoOperandInstr implements FixedArityInstr {
     public static final NopInstr NOP = new NopInstr();
 
-    private NopInstr() {
+    protected NopInstr() {
         super(Operation.NOP);
         this.markDead();
     }


### PR DESCRIPTION
This addresses all known pattern matching errors except enhanced error throw messages with single line matches.  The 10 failures of that still appropriately fail in === cases but does not print out the same amount of info ('{}' vs '{}: : Array === {} does not return true' .  I do not consider that important for 9.4.0.0 but I may still fix it by release time since it is 10E in MRI test suite.

This branch also changed labels in IR to be more friendly for debugging.  We are not sharing labels in IR so this should not really affect size.  It does help determine what a label is meant for.

This branch also added a new debug instr for printing out any operands live value to stdout.  This instr is never meant to be committed but is very useful: ```debug("Call receiver: %s", receiver")```.  Also note this just extends Noop so any analysis which removed dead instructions will also remove this.  I think this limited scope is all that is needed but if we wanted to see these statements without compiler passes eliminating them we will have to make it a full instr.