### PR TITLE
Fix #7427. ripper blow up.

### DIFF
--- a/core/src/main/java/org/jruby/ext/ripper/RipperParser.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperParser.java
@@ -3213,7 +3213,7 @@ states[188] = (RipperParser p, Object yyVal, ProductionState[] yyVals, int yyTop
   return yyVal;
 };
 states[189] = (RipperParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
-                     yyVal = ((ByteList)yyVals[0+yyTop].value);
+                     yyVal = ((IRubyObject)yyVals[0+yyTop].value);
   return yyVal;
 };
 states[190] = (RipperParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {

--- a/core/src/main/java/org/jruby/parser/RubyParser.y
+++ b/core/src/main/java/org/jruby/parser/RubyParser.y
@@ -347,7 +347,7 @@ import static org.jruby.util.CommonByteLists.FWD_KWREST;
 %token <Integer> '\f'                   /* {{escaped form feed}} */
 %token <Integer> '\r'                   /* {{escaped carriage return}} */
 %token <Integer> '\v'                   /* {{escaped vertical tab}} */
-%token <ByteList> tUPLUS               /* {{unary+}} */
+%token <@@token_type@@> tUPLUS               /* {{unary+}} */
 %token <@@token_type@@> tUMINUS              /* {{unary-}} */
 %token <@@token_type@@> tPOW                 /* {{**}} */
 %token <@@token_type@@> tCMP                 /* {{<=>}} */


### PR DESCRIPTION
Fix #7274.  tUPLUS is an IRubyObject and not a ByteList.