### PR TITLE
Add support for -W:category flag

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -201,6 +201,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
@@ -487,6 +488,7 @@ public final class Ruby implements Constantizable {
 
         TracePoint.createTracePointClass(this);
 
+        warningCategories = config.getWarningCategories();
         warningModule = RubyWarnings.createWarningModule(this);
 
         // Initialize exceptions
@@ -2538,6 +2540,15 @@ public final class Ruby implements Constantizable {
      */
     public void setDebug(IRubyObject debug) {
         this.debug = debug.isTrue();
+    }
+
+    /**
+     * Get the current enabled warning categories.
+     *
+     * @return a set of the currently-enabled warning categories
+     */
+    public Set<RubyWarnings.Category> getWarningCategories() {
+        return warningCategories;
     }
 
     public JavaSupport getJavaSupport() {
@@ -5391,6 +5402,9 @@ public final class Ruby implements Constantizable {
 
     private boolean verbose, warningsEnabled, debug;
     private IRubyObject verboseValue;
+
+    // Set of categories we care about (set defined when creating warnings).
+    private final Set<RubyWarnings.Category> warningCategories;
 
     private RubyThreadGroup defaultThreadGroup;
 

--- a/core/src/main/java/org/jruby/RubyInstanceConfig.java
+++ b/core/src/main/java/org/jruby/RubyInstanceConfig.java
@@ -31,6 +31,7 @@ package org.jruby;
 
 import jnr.posix.util.Platform;
 
+import org.jruby.common.RubyWarnings;
 import org.jruby.exceptions.MainExitException;
 import org.jruby.runtime.Constants;
 import org.jruby.runtime.backtrace.TraceType;
@@ -57,6 +58,8 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -931,6 +934,15 @@ public class RubyInstanceConfig {
     }
 
     /**
+     * Get the set of enabled warning categories.
+     *
+     * @return the set of enabled warning categories
+     */
+    public Set<RubyWarnings.Category> getWarningCategories() {
+        return warningCategories;
+    }
+
+    /**
      * @see Options#CLI_PARSER_DEBUG
      */
     public boolean isParserDebug() {
@@ -1586,6 +1598,8 @@ public class RubyInstanceConfig {
     private boolean allowUppercasePackageNames = Options.JI_UPPER_CASE_PACKAGE_NAME_ALLOWED.load();
 
     private boolean forceStdin = false;
+
+    private final Set<RubyWarnings.Category> warningCategories = Collections.synchronizedSet(EnumSet.of(RubyWarnings.Category.EXPERIMENTAL));
 
     ////////////////////////////////////////////////////////////////////////////
     // Support classes, etc.

--- a/core/src/main/java/org/jruby/runtime/load/LoadService.java
+++ b/core/src/main/java/org/jruby/runtime/load/LoadService.java
@@ -772,7 +772,7 @@ public class LoadService {
     /**
      * Replaces findLibraryBySearchState but split off for require. Needed for OSGiLoadService to override.
      */
-    protected char searchForRequire(String file, LibrarySearcher.FoundLibrary[] path) {
+    public char searchForRequire(String file, LibrarySearcher.FoundLibrary[] path) {
         return librarySearcher.findLibraryForRequire(file, path);
     }
 


### PR DESCRIPTION
* Move active set of categories into Ruby state.
* Handle -W with :deprecated, :no-deprecated, :experimental, and :no-experimental.

A behavioral difference remains, in that if -W is not followed by a digit or a colon, the next character is interpreted as the next single-character command-line flag.