### PR TITLE
Update Integer#fdiv to match mri behavior

### DIFF
--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -62,6 +62,7 @@ import static org.jruby.RubyEnumerator.SizeFn;
 import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
 import static org.jruby.util.Numeric.f_gcd;
 import static org.jruby.util.Numeric.f_lcm;
+import static org.jruby.util.Numeric.f_zero_p;
 
 /** Implementation of the Integer class.
  *
@@ -732,7 +733,15 @@ public abstract class RubyInteger extends RubyNumeric {
     @Override
     @JRubyMethod(name = "fdiv")
     public IRubyObject fdiv(ThreadContext context, IRubyObject y) {
-        return fdivDouble(context, y);
+        RubyInteger x = this;
+        if (y instanceof RubyInteger && !f_zero_p(context, y)) {
+            IRubyObject gcd = gcd(context, y);
+            if (!f_zero_p(context, gcd)) {
+                x = (RubyInteger)x.idiv(context, gcd);
+                y = ((RubyInteger)y).idiv(context, gcd);
+            }
+        }
+        return x.fdivDouble(context, y);
     }
 
     public abstract IRubyObject fdivDouble(ThreadContext context, IRubyObject y);

--- a/test/mri/excludes_wip/Rational_Test.rb
+++ b/test/mri/excludes_wip/Rational_Test.rb
@@ -2,5 +2,4 @@ exclude :"test_Rational_without_exception", "work in progress"
 exclude :"test_conv", "work in progress"
 exclude :"test_gcd_no_memory_leak", "work in progress"
 exclude :"test_ratsub", "work in progress"
-exclude :"test_supp", "work in progress"
-exclude :"test_supp", "work in progress"
+


### PR DESCRIPTION
When operands are Integer type, operands should be divided by gcd.
After applying this patch, the following test will pass.
 * test_supp in test/mri/ruby/test_rational.rb