### PR TITLE
Remove some alias warnings

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2064,7 +2064,7 @@ public class RubyModule extends RubyObject {
         DynamicMethod method = getMethods().get(name);
         if (method != null && entry.method.getRealMethod() != method.getRealMethod()) {
             // warn if overwriting an existing method on this module
-            runtime.getWarnings().warning("method redefined; discarding old " + name);
+            if (entry.method.getRealMethod().getAliasCount() != 0) runtime.getWarnings().warning("method redefined; discarding old " + name);
 
             if (method instanceof PositionAware) {
                 PositionAware posAware = (PositionAware) method;

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2064,7 +2064,7 @@ public class RubyModule extends RubyObject {
         DynamicMethod method = getMethods().get(name);
         if (method != null && entry.method.getRealMethod() != method.getRealMethod()) {
             // warn if overwriting an existing method on this module
-            if (entry.method.getRealMethod().getAliasCount() != 0) runtime.getWarnings().warning("method redefined; discarding old " + name);
+            if (method.getRealMethod().getAliasCount() == 0) runtime.getWarnings().warning("method redefined; discarding old " + name);
 
             if (method instanceof PositionAware) {
                 PositionAware posAware = (PositionAware) method;

--- a/core/src/main/java/org/jruby/internal/runtime/methods/AliasMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/AliasMethod.java
@@ -60,6 +60,7 @@ public class AliasMethod extends DynamicMethod {
      */ 
     public AliasMethod(RubyModule implementationClass, CacheEntry entry, String oldName) {
         super(implementationClass, entry.method.getVisibility(), oldName);
+        entry.method.getRealMethod().adjustAliasCount(1);
 
         this.entry = entry;
 

--- a/core/src/main/java/org/jruby/internal/runtime/methods/DynamicMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/DynamicMethod.java
@@ -75,6 +75,8 @@ public abstract class DynamicMethod {
     protected final String name;
     /** An arbitrarily-typed "method handle" for use by compilers and call sites */
     protected Object handle;
+    /** How many times has this method been aliased. */
+    protected int aliasCount;
 
     private static final int BUILTIN_FLAG = 0b1;
     private static final int NOTIMPL_FLAG = 0b10;
@@ -622,5 +624,13 @@ public abstract class DynamicMethod {
     @Deprecated
     protected DynamicMethod(RubyModule implementationClass, Visibility visibility) {
         this(implementationClass, visibility, "(anonymous)");
+    }
+
+    public void adjustAliasCount(int delta) {
+        this.aliasCount += delta;
+    }
+
+    public int getAliasCount() {
+        return this.aliasCount;
     }
 }


### PR DESCRIPTION
MRI has more logic than this so I think something is missing but we are also already missing logic associated with potentially redefined refinements.  This will definitely get rid of some warnings but perhaps too many.