### PR TITLE
Add ordering to ivars

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -1534,14 +1534,13 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      */
     @Override
     public List<String> getInstanceVariableNameList() {
-        Map<String, VariableAccessor> ivarAccessors = metaClass.getVariableAccessorsForRead();
-        ArrayList<String> list = new ArrayList<>(ivarAccessors.size());
-        for (Map.Entry<String, VariableAccessor> entry : ivarAccessors.entrySet()) {
-            final String key = entry.getKey();
-            final Object value = entry.getValue().get(this);
-            if (!(value instanceof IRubyObject) || !IdUtil.isInstanceVariable(key)) continue;
-            list.add(key);
+        String[] names = metaClass.getVariableTableManager().getVariableNames();
+        List<String> list = new ArrayList<>(names.length);
+
+        for (String name: names) {
+            list.add(name);
         }
+
         return list;
     }
 

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -52,6 +52,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -5872,17 +5873,18 @@ public class RubyModule extends RubyObject {
         return super.toJava(target);
     }
 
-    public Set<String> discoverInstanceVariables() {
-        HashSet<String> set = new HashSet();
-        RubyModule cls = this;
-        while (cls != null) {
-            Map<String, DynamicMethod> methods = cls.getOrigin().getMethodLocation().getMethods();
+    private Set<String> discoverInstanceVariablesInner(RubyModule cls, Set<String> set) {
+        if (cls == null) return set;
 
-            methods.forEach((name, method) -> set.addAll(method.getInstanceVariableNames()));
+        discoverInstanceVariablesInner(cls.getSuperClass(), set);
+        Map<String, DynamicMethod> methods = cls.getOrigin().getMethodLocation().getMethods();
+        methods.forEach((name, method) -> set.addAll(method.getInstanceVariableNames()));
 
-            cls = cls.getSuperClass();
-        }
         return set;
+    }
+
+    public Set<String> discoverInstanceVariables() {
+        return discoverInstanceVariablesInner(this, new LinkedHashSet());
     }
 
     public boolean isRefinement() {


### PR DESCRIPTION
This is broken and it actually isn't a true solution but I am confused on why this is so broken.

The premise of this solution is to build up the ivar list from descent first traversal of the inheritance hierarchy with a flawed assumption that all ivars will be initialized in the order they are first encountered.  This is a 70% solution since not all classes/modules will initialize in this way but for simple types the order will match first encountered order.

The larger problem is I seem to be including more variables than actually are living and this is break tests yuugely.  I am not saying I want to land this or not if i fix this issue but I find it an interesting compromise between what we do now and what we could do.  This would fix a few Rails unit tests where it does seem to access ivars in a pattern which matches this.