### PR TITLE
Bundled and jarified native library loading for ffi

### DIFF
--- a/core/src/main/java/org/jruby/util/JRubyClassLoader.java
+++ b/core/src/main/java/org/jruby/util/JRubyClassLoader.java
@@ -113,7 +113,7 @@ public class JRubyClassLoader extends ClassDefiningJRubyClassLoader {
         super.addURL(url);
     }
 
-    private static synchronized File getTempDir() {
+    public static synchronized File getTempDir() {
         if (tempDir != null) return tempDir;
 
         tempDir = new File(tempDir(), tempDirName());

--- a/core/src/main/java/org/jruby/util/JRubyFile.java
+++ b/core/src/main/java/org/jruby/util/JRubyFile.java
@@ -123,6 +123,9 @@ public class JRubyFile extends JavaSecuredFile {
         // If any other special resource types fail, count it as a filesystem backed resource.
         return new RegularFileResource(runtime != null ? runtime.getPosix() : null, create(cwd, pathname), pathname);
     }
+    public static boolean isResourceRegularFile(FileResource res) {
+        return (res instanceof RegularFileResource);
+    }
 
     public static String normalizeSeps(String path) {
         return Platform.IS_WINDOWS ? path.replace(File.separatorChar, '/') : path;


### PR DESCRIPTION
After inspecting other options in the java ecosystem, like maven-lib-loader and others, I realized that all of them are for JNI and thus not applicable to JRuby. Further, doing this in JNR/JFFI would require duplicating code both there and in JRuby, so this seems to be the best spot for now.

so/dylib/dll files are now loadable from embedded resources by being extracted to the jruby temp dir before being sent to JFFI