### PR TITLE
Use thread-local for load wrapper

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -2905,17 +2905,7 @@ public final class Ruby implements Constantizable {
     static final String ROOT_FRAME_NAME = "(root)";
 
     public void loadFile(String scriptName, InputStream in, boolean wrap) {
-        IRubyObject self;
-
-        if (wrap) {
-            self = loadService.getWrapperSelf();
-
-            if (self == null || self.isNil()) {
-                self = getTopSelf().rbClone();
-            }
-        } else {
-            self = getTopSelf();
-        }
+        IRubyObject self = wrap ? getTopSelf().rbClone() : getTopSelf();
 
         if (!wrap && Options.COMPILE_CACHE_CLASSES.load()) {
             Script script = tryScriptFromClass(scriptName);
@@ -2977,8 +2967,13 @@ public final class Ruby implements Constantizable {
     }
 
     public StaticScope setupWrappedToplevel(IRubyObject self, StaticScope top) {
+        RubyModule wrapper = loadService.getWrapperSelf();
+
+        if (wrapper == null || wrapper.isNil()) {
+            wrapper = RubyModule.newModule(this);
+        }
+
         // toss an anonymous module into the search path
-        RubyModule wrapper = RubyModule.newModule(this);
         ((RubyBasicObject) self).extend(new IRubyObject[] {wrapper});
         StaticScope newTop = staticScopeFactory.newLocalScope(null);
         top.setPreviousCRefScope(newTop);

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -2905,7 +2905,17 @@ public final class Ruby implements Constantizable {
     static final String ROOT_FRAME_NAME = "(root)";
 
     public void loadFile(String scriptName, InputStream in, boolean wrap) {
-        IRubyObject self = wrap ? getTopSelf().rbClone() : getTopSelf();
+        IRubyObject self;
+
+        if (wrap) {
+            self = loadService.getWrapperSelf();
+
+            if (self == null || self.isNil()) {
+                self = getTopSelf().rbClone();
+            }
+        } else {
+            self = getTopSelf();
+        }
 
         if (!wrap && Options.COMPILE_CACHE_CLASSES.load()) {
             Script script = tryScriptFromClass(scriptName);

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1133,8 +1133,10 @@ public class IRRuntimeHelpers {
                                 return self instanceof RubyModule ? (RubyModule) self : self.getMetaClass();
 
                             case INSTANCE_METHOD:
-                            case SCRIPT_BODY:
                                 return self.getMetaClass();
+
+                            case SCRIPT_BODY:
+                                return currDynScope.getStaticScope().getModule();
 
                             default:
                                 throw new RuntimeException("Should not get here! scopeType is " + scopeType);

--- a/core/src/main/java/org/jruby/runtime/load/LoadService.java
+++ b/core/src/main/java/org/jruby/runtime/load/LoadService.java
@@ -342,23 +342,27 @@ public class LoadService {
         }
     }
 
-    private final ThreadLocal<IRubyObject> wrapperSelf = new ThreadLocal<>();
+    private final ThreadLocal<RubyModule> wrapperSelf = new ThreadLocal<>();
 
-    public IRubyObject getWrapperSelf() {
+    public RubyModule getWrapperSelf() {
         return wrapperSelf.get();
     }
 
     public void load(String file, IRubyObject wrapWith) {
-        if (wrapWith == null || wrapWith.isNil()) {
+        if (wrapWith == null || !wrapWith.isTrue()) {
             load(file, false);
             return;
         }
 
-        wrapperSelf.set(wrapWith);
-        try {
+        if (wrapWith instanceof RubyModule) {
+            wrapperSelf.set((RubyModule) wrapWith);
+            try {
+                load(file, true);
+            } finally {
+                wrapperSelf.remove();
+            }
+        } else {
             load(file, true);
-        } finally {
-            wrapperSelf.remove();
         }
     }
 

--- a/core/src/main/java/org/jruby/runtime/load/LoadService.java
+++ b/core/src/main/java/org/jruby/runtime/load/LoadService.java
@@ -63,6 +63,7 @@ import org.jruby.RubyDir;
 import org.jruby.RubyFile;
 import org.jruby.RubyHash;
 import org.jruby.RubyInstanceConfig;
+import org.jruby.RubyModule;
 import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.jruby.RubyThread;
@@ -338,6 +339,26 @@ public class LoadService {
             }
 
             return runtime.newArray(ext, name);
+        }
+    }
+
+    private final ThreadLocal<IRubyObject> wrapperSelf = new ThreadLocal<>();
+
+    public IRubyObject getWrapperSelf() {
+        return wrapperSelf.get();
+    }
+
+    public void load(String file, IRubyObject wrapWith) {
+        if (wrapWith == null || wrapWith.isNil()) {
+            load(file, false);
+            return;
+        }
+
+        wrapperSelf.set(wrapWith);
+        try {
+            load(file, true);
+        } finally {
+            wrapperSelf.remove();
         }
     }
 

--- a/test/mri/excludes_wip/TestRequire.rb
+++ b/test/mri/excludes_wip/TestRequire.rb
@@ -1,4 +1,3 @@
-exclude :"test_load_into_module", "work in progress"
 exclude :"test_provide_in_required_file", "work in progress"
 exclude :"test_require_nonascii_path", "work in progress"
 exclude :"test_resolve_feature_path", "work in progress"


### PR DESCRIPTION
Plumbing the wrapper all the way through the interfaces involved is more of a change than we are comfortable with at this stage, so use a thread-local to set up the fea cases that currently honor the wrapper.

Ruby feature https://bugs.ruby-lang.org/issues/6210

Part of Ruby 3.1 features (#7015).

Fixes #7439