### PR TITLE
Update JNR dependencies for loongarch64 support

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -43,11 +43,11 @@ project 'JRuby Base' do
 
   # exclude jnr-ffi to avoid problems with shading and relocation of the asm packages
   jar 'com.github.jnr:jnr-netdb:1.2.0', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-enxio:0.32.13', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-unixsocket:0.38.17', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-posix:3.1.15', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-constants:0.10.3', :exclusions => ['com.github.jnr:jnr-ffi']
-  jar 'com.github.jnr:jnr-ffi:2.2.11'
+  jar 'com.github.jnr:jnr-enxio:0.32.14', :exclusions => ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-unixsocket:0.38.19', :exclusions => ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-posix:3.1.16', :exclusions => ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-constants:0.10.4', :exclusions => ['com.github.jnr:jnr-ffi']
+  jar 'com.github.jnr:jnr-ffi:2.2.13'
   jar 'com.github.jnr:jffi:${jffi.version}'
   jar 'com.github.jnr:jffi:${jffi.version}:native'
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -89,7 +89,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-enxio</artifactId>
-      <version>0.32.13</version>
+      <version>0.32.14</version>
       <exclusions>
         <exclusion>
           <artifactId>jnr-ffi</artifactId>
@@ -100,7 +100,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-unixsocket</artifactId>
-      <version>0.38.17</version>
+      <version>0.38.19</version>
       <exclusions>
         <exclusion>
           <artifactId>jnr-ffi</artifactId>
@@ -111,7 +111,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
-      <version>3.1.15</version>
+      <version>3.1.16</version>
       <exclusions>
         <exclusion>
           <artifactId>jnr-ffi</artifactId>
@@ -122,7 +122,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-constants</artifactId>
-      <version>0.10.3</version>
+      <version>0.10.4</version>
       <exclusions>
         <exclusion>
           <artifactId>jnr-ffi</artifactId>
@@ -133,7 +133,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-ffi</artifactId>
-      <version>2.2.11</version>
+      <version>2.2.13</version>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>

--- a/pom.rb
+++ b/pom.rb
@@ -72,7 +72,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
               'ant.version' => '1.9.8',
               'asm.version' => '9.2',
               'jar-dependencies.version' => '0.4.1',
-              'jffi.version' => '1.3.9',
+              'jffi.version' => '1.3.10',
               'joda.time.version' => '2.10.10' )
 
   plugin_management do

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ DO NOT MODIFY - GENERATED CODE
     <its.j2ee>j2ee*/pom.xml</its.j2ee>
     <its.osgi>osgi*/pom.xml</its.osgi>
     <jar-dependencies.version>0.4.1</jar-dependencies.version>
-    <jffi.version>1.3.9</jffi.version>
+    <jffi.version>1.3.10</jffi.version>
     <joda.time.version>2.10.10</joda.time.version>
     <jruby-launcher.version>1.1.6</jruby-launcher.version>
     <jruby.basedir>${project.basedir}</jruby.basedir>


### PR DESCRIPTION
This brings in updates to jffi and jnr-ffi for LoongArch64 support plus miscellaneous fixes.