### PR TITLE
Update EPL version in jruby-jars Gemspec

### DIFF
--- a/maven/jruby-jars/jruby-jars.gemspec
+++ b/maven/jruby-jars/jruby-jars.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.summary = 'The core JRuby code and the JRuby stdlib as jar files.'
   s.homepage = 'https://github.com/jruby/jruby/tree/master/maven/jruby-jars'
   s.description = File.read('README.txt', encoding: 'UTF-8').split(/\n{2,}/)[3]
-  s.licenses = %w(EPL-1.0 GPL-2.0 LGPL-2.1)
+  s.licenses = %w(EPL-2.0 GPL-2.0 LGPL-2.1)
   s.files = Dir['[A-Z]*'] +
       Dir['lib/**/*.rb'] +
       Dir[ 'test/**/*'] +


### PR DESCRIPTION
JRuby was updated from EPL-1.0 to EPL-2.0 in https://github.com/jruby/jruby/commit/6fe0e5a1a93b006ee41764e2b7c1d7fc72514a90, but this metadata was missed.

If I've misunderstood, and the licensing of jruby-jars differs from jruby itself, I'm sorry. The [jruby-jars README](https://github.com/jruby/jruby/commit/6fe0e5a1a93b006ee41764e2b7c1d7fc72514a90#diff-7dce96ed26a75ec1de92a0f8111704c57e1ca510fc6ee8451428286b7a673186L835) was updated at the same time to use EPL-2.0