### PR TITLE
Default to nonblocking whenever possible

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -905,6 +905,15 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
                     }
                 }
             }
+
+            // set to nonblocking if possible (Ruby 3.0 change for IO/fiber scheduling)
+            if (fd.chSelect != null) {
+                try {
+                    fd.chSelect.configureBlocking(false);
+                } catch (IOException ioe) {
+                    // ignore, can't set nonblocking
+                }
+            }
         } else {
             fd = runtime.getFilenoUtil().getWrapperFromFileno(fileno);
 
@@ -4173,6 +4182,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
             ChannelFD main = new ChannelFD(inChannel, runtime.getPosix(), runtime.getFilenoUtil());
 
             openFile.setFD(main);
+            openFile.setBlocking(runtime, false);
         }
 
         if (openFile.isWritable() && process.hasOutput()) {
@@ -4195,6 +4205,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
                 setInstanceVariable("@tied_io_for_writing", writeIO);
             } else {
                 openFile.setFD(pipe);
+                openFile.setBlocking(runtime, false);
             }
         }
     }

--- a/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
@@ -892,6 +892,7 @@ public class RubyBasicSocket extends RubyIO {
         MakeOpenFile();
 
         openFile.setFD(fd);
+        openFile.setBlocking(getRuntime(), false);
         openFile.setMode(OpenFile.READWRITE | OpenFile.SYNC);
 
         // see rsock_init_sock in MRI; sockets are initialized to binary

--- a/core/src/main/java/org/jruby/ext/socket/RubyUNIXSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUNIXSocket.java
@@ -391,6 +391,7 @@ public class RubyUNIXSocket extends RubyBasicSocket {
         ModeFlags modes = newModeFlags(runtime, ModeFlags.RDWR);
 
         openFile.setFD(newChannelFD(runtime, channel));
+        openFile.setBlocking(runtime, false);
         openFile.setMode(modes.getOpenFileFlags());
         openFile.setSync(true);
         openFile.setPath(path);

--- a/core/src/main/java/org/jruby/util/io/OpenFile.java
+++ b/core/src/main/java/org/jruby/util/io/OpenFile.java
@@ -192,10 +192,18 @@ public class OpenFile implements Finalizable {
 
     public void setFD(ChannelFD fd) {
         this.fd = fd;
+        updateBlockingFromFD(fd);
     }
 
     public void setChannel(Channel fd) {
         this.fd = new ChannelFD(fd, runtime.getPosix(), runtime.getFilenoUtil());
+        updateBlockingFromFD(this.fd);
+    }
+
+    private void updateBlockingFromFD(ChannelFD fd) {
+        if (fd.chSelect != null ) {
+            this.nonblock = !fd.chSelect.isBlocking();
+        }
     }
 
     public int getMode() {


### PR DESCRIPTION
Ruby 3.0 began to set O_NONBLOCK by default for all IO, to allow more IO types to enlist in the new IO/fiber scheduling. JRuby has not previously defaulted to nonblock, but all IO operations against nonblock-compatible channels does use nonblocking semantics, so all we really need to align with CRuby is to just set them non-blocking at the NIO level on creation.

We can only do this when the underlying channel supports nonblocking semantics, but this commit attempts to set such channels up properly.

Part of scheduler work in #7459 and related issues.