### PR TITLE
Update actions/checkout version to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: cache dependencies
         uses: actions/cache@v2
         with:
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: cache dependencies
         uses: actions/cache@v2
         with:
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: cache dependencies
         uses: actions/cache@v2
         with:
@@ -119,7 +119,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: cache dependencies
         uses: actions/cache@v2
         with:
@@ -152,7 +152,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: cache dependencies
         uses: actions/cache@v2
         with:
@@ -184,7 +184,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: cache dependencies
         uses: actions/cache@v2
         with:
@@ -214,7 +214,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: cache dependencies
         uses: actions/cache@v2
         with:
@@ -244,7 +244,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: cache dependencies
         uses: actions/cache@v2
         with:
@@ -277,7 +277,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: set up java 11
         uses: actions/setup-java@v3
         with:
@@ -309,7 +309,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: cache dependencies
         uses: actions/cache@v2
         with:
@@ -335,7 +335,7 @@ jobs:
     name: Verify build artifacts
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: cache dependencies
         uses: actions/cache@v2
         with:
@@ -373,7 +373,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: cache dependencies
         uses: actions/cache@v2
         with:
@@ -398,7 +398,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: cache dependencies
         uses: actions/cache@v2
         with:
@@ -429,7 +429,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: set up java ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
@@ -456,7 +456,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: set up java ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
@@ -478,7 +478,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: cache dependencies
         uses: actions/cache@v2
         with:
@@ -508,7 +508,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: cache dependencies
         uses: actions/cache@v2
         with:

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: set up Java
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
The version 3.x appears to be due to the following:
- https://github.com/actions/checkout/pull/689

There have been no breaking changes, and we seem to have no problem keeping up with the latest version.