### PR TITLE
one-time-execute can sometimes contain a closure.  guard it.

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRScope.java
+++ b/core/src/main/java/org/jruby/ir/IRScope.java
@@ -648,6 +648,9 @@ public abstract class IRScope implements ParseResult {
         if (optimizedInterpreterContext != null) return optimizedInterpreterContext.getLinearizedBBList();
         if (fullInterpreterContext != null) return fullInterpreterContext.getLinearizedBBList();
 
+        // IRB has some scenario where we mark ic = null then add a closure. If closure jits we boom.
+        if (interpreterContext == null) return null;
+
         for (IRScope scope: getClosures()) {
             scope.prepareForCompilation();
         }


### PR DESCRIPTION
in irb we get a scenarion where we delete parent scope of a closure because at the time we delete it we do not know a closure will exist. The fix is a trivial bullet-proof test line.  Our actual code calling prepareForCompilation already is aware that null fic is a failure case.