### PR TITLE
Specific arity kwargs undefined

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -2125,8 +2125,7 @@ public class RubyHash extends RubyObject implements Map {
      */
     @JRubyMethod(rest = true)
     public RubyHash merge(ThreadContext context, IRubyObject[] others, Block block) {
-        RubyHash dup = (RubyHash) dup();
-        dup.setComparedByIdentity(isComparedByIdentity());
+        RubyHash dup = (RubyHash) dup(context);
         return dup.merge_bang(context, others, block);
     }
 

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -704,7 +704,7 @@ public class IRRuntimeHelpers {
             // This is just an ordinary hash as last argument
             return last;
         } else {
-            return hash.isEmpty() ? UNDEFINED : hash.dupFast(context);
+            return hash.dupFast(context);
         }
     }
 


### PR DESCRIPTION
This seems to fix an issue locally running railsbench under indy mode
that is superficially similar to #7434.

The issue occurs in our own Kernel#initialize_dup when running with JIT
and indy enabled. The originator is a Hash#merge that does a dup of an
empty hash, ultimately attempting to convert our UndefinedValue into a
hash object for the dup/replace logic. It seems like there's a rogue
keyword flag in the CallInfo at this point, such that it assumes the
incoming hash is supposed to be used as kwargs. Since it is empty, it
returns undefined which replaces the single hash argument passed in.
That value then goes on to be to_hash'ed and blows up.

It is unclear why this requires indy mode. There may be something
broken with CallInfo clearing alonst some indy path, or the non-indy
call path may not be using this single-argument kwarg-munging logic.

See #7434
