### PR TITLE
DNodes are ListNodes and get compiled wrong in presence of a splat.

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -788,7 +788,7 @@ public class IRBuilder {
 
                 flags[0] |= CALL_SPLATS;
                 Operand valueToSplat;
-                if (secondNode instanceof ListNode) {
+                if (secondNode instanceof ListNode && !(secondNode instanceof DNode)) {
                     valueToSplat = buildCallArgsArrayForSplat((ListNode) secondNode, flags);
                 } else if (secondNode instanceof HashNode && !((HashNode) secondNode).isLiteral()) {
                     valueToSplat = buildCallKeywordArguments((HashNode) secondNode, flags);


### PR DESCRIPTION
Fixes #7500.  The check in splats assumes any instanceof ListNode is arguments to be merged with the splat but all dynamic nodes like interpolated strings happen to be ListNodes as well (damn you OO).