### PR TITLE
Excessive kwargs duplicate key warns

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -715,7 +715,7 @@ public class IRBuilder {
         Variable splatValue = copy(new Hash(new ArrayList<>()));
         for (KeyValuePair<Node, Node> pair: pairs) {
             Operand splat = buildWithOrder(pair.getValue(), keywordArgs.containsVariableAssignment());
-            addInstr(new RuntimeHelperCall(splatValue, MERGE_KWARGS, new Operand[] { splatValue, splat }));
+            addInstr(new RuntimeHelperCall(splatValue, MERGE_KWARGS, new Operand[] { splatValue, splat, fals() }));
         }
 
         return splatValue;
@@ -3660,11 +3660,11 @@ public class IRBuilder {
                     hash = copy(new Hash(args, hashNode.isLiteral()));
                     args = new ArrayList<>();           // Used args but we may find more after the splat so we reset
                 } else if (!args.isEmpty()) {
-                    addInstr(new RuntimeHelperCall(hash, MERGE_KWARGS, new Operand[] { hash, new Hash(args) }));
+                    addInstr(new RuntimeHelperCall(hash, MERGE_KWARGS, new Operand[] { hash, new Hash(args), tru()}));
                     args = new ArrayList<>();
                 }
                 Operand splat = buildWithOrder(pair.getValue(), hasAssignments);
-                addInstr(new RuntimeHelperCall(hash, MERGE_KWARGS, new Operand[] { hash, splat}));
+                addInstr(new RuntimeHelperCall(hash, MERGE_KWARGS, new Operand[] { hash, splat, tru()}));
                 continue;
             } else {
                 keyOperand = buildWithOrder(key, hasAssignments);
@@ -3676,7 +3676,7 @@ public class IRBuilder {
         if (hash == null) {           // non-**arg ordinary hash
             hash = copy(new Hash(args, hashNode.isLiteral()));
         } else if (!args.isEmpty()) { // ordinary hash values encountered after a **arg
-            addInstr(new RuntimeHelperCall(hash, MERGE_KWARGS, new Operand[] { hash, new Hash(args) }));
+            addInstr(new RuntimeHelperCall(hash, MERGE_KWARGS, new Operand[] { hash, new Hash(args), tru()}));
         }
 
         return hash;

--- a/core/src/main/java/org/jruby/ir/instructions/RuntimeHelperCall.java
+++ b/core/src/main/java/org/jruby/ir/instructions/RuntimeHelperCall.java
@@ -160,7 +160,8 @@ public class RuntimeHelperCall extends NOperandResultBaseInstr {
                         (IRubyObject) operands[3].retrieve(context, self, currScope, currDynScope, temp));
             case MERGE_KWARGS:
                 return IRRuntimeHelpers.mergeKeywordArguments(context, (IRubyObject) arg1,
-                        (IRubyObject) getArgs()[1].retrieve(context, self, currScope, currDynScope, temp));
+                        (IRubyObject) getArgs()[1].retrieve(context, self, currScope, currDynScope, temp),
+                        getArgs()[2] == context.runtime.getIRManager().getTrue());
             case IS_HASH_EMPTY:
                 return IRRuntimeHelpers.isHashEmpty(context, (IRubyObject) arg1);
             case HASH_CHECK:

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1017,7 +1017,8 @@ public class IRRuntimeHelpers {
     }
 
     @JIT @Interp
-    public static IRubyObject mergeKeywordArguments(ThreadContext context, IRubyObject restKwarg, IRubyObject explicitKwarg) {
+    public static IRubyObject mergeKeywordArguments(ThreadContext context, IRubyObject restKwarg,
+                                                    IRubyObject explicitKwarg, boolean checkForDuplicates) {
         // FIXME: JIT is generating a hash which is empty but seems to contain an %undefined within it.
         //   This was crashing because it would dup it and then try and dup the undefined within it.
         //   This replacement logic is correct even if that was figured out but this should just be
@@ -1041,7 +1042,12 @@ public class IRRuntimeHelpers {
             return hash;
         }
 
-        otherHash.visitAll(context, new KwargMergeVisitor(hash), Block.NULL_BLOCK);
+        if (checkForDuplicates) {
+            otherHash.visitAll(context, new KwargMergeVisitor(hash), Block.NULL_BLOCK);
+        } else {
+            hash.merge_bang(context, new IRubyObject[] { otherHash }, Block.NULL_BLOCK);
+        }
+
         context.callInfo = CALL_KEYWORD | CALL_KEYWORD_REST;
 
         return hash;

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -2270,7 +2270,8 @@ public class JVMVisitor extends IRVisitor {
                 jvmMethod().loadContext();
                 visit(runtimehelpercall.getArgs()[0]);
                 visit(runtimehelpercall.getArgs()[1]);
-                jvmAdapter().invokestatic(p(IRRuntimeHelpers.class), "mergeKeywordArguments", sig(IRubyObject.class, ThreadContext.class, IRubyObject.class, IRubyObject.class));
+                jvmAdapter().ldc(runtimehelpercall.getArgs()[2] == runtime.getIRManager().getTrue());
+                jvmAdapter().invokestatic(p(IRRuntimeHelpers.class), "mergeKeywordArguments", sig(IRubyObject.class, ThreadContext.class, IRubyObject.class, IRubyObject.class, boolean.class));
                 jvmStoreLocal(runtimehelpercall.getResult());
                 break;
             case HASH_CHECK:


### PR DESCRIPTION
The warns in place should happen for hash merging ** vs kwrest values combined with other kwrest or the kwreqs.

This fixes #7499