### PR TITLE
Kwargs with JIT fix.  Arity errors when **{} happens to non-kwarg

### DIFF
--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -310,9 +310,7 @@ public class JVMVisitor extends IRVisitor {
         // set line number for backtrace
         jvmMethod().updateLineNumber(scope.getLine());
 
-        // check arity
         org.jruby.runtime.Signature scopeSig = scope.getStaticScope().getSignature();
-        checkArity(scopeSig.required(), scopeSig.opt(), scopeSig.hasRest(), scopeSig.keyRest());
 
         // push leading args
         m.loadContext();
@@ -1240,11 +1238,7 @@ public class JVMVisitor extends IRVisitor {
 
     @Override
     public void CheckArityInstr(CheckArityInstr checkarityinstr) {
-        if (jvm.methodData().specificArity >= 0) {
-            // no arity check in specific arity path
-        } else {
-            checkArity(checkarityinstr.getKeywords(), checkarityinstr.required, checkarityinstr.opt, checkarityinstr.rest, checkarityinstr.restKey);
-        }
+        checkArity(checkarityinstr.getKeywords(), checkarityinstr.required, checkarityinstr.opt, checkarityinstr.rest, checkarityinstr.restKey);
     }
 
     private void checkArity(int required, int opt, boolean rest, int restKey) {


### PR DESCRIPTION
There was a mandatory arity check but it was in Java code before the call.  The instruction for check_arity is aware of kwargs so it will do the right thing.

This is not emitting this call into the generated method vs being in prologue boilerplate.  In theory this will increase the size of the method being compiled but it also allows us to generate smaller versions of check_arity when we know more about what checks are needed?