### PR TITLE
Fix syntax error in all cases where & is a param.

### DIFF
--- a/core/src/main/java/org/jruby/ast/ForwardingBlockArgNode.java
+++ b/core/src/main/java/org/jruby/ast/ForwardingBlockArgNode.java
@@ -1,0 +1,7 @@
+package org.jruby.ast;
+
+public class ForwardingBlockArgNode extends BlockArgNode {
+    public ForwardingBlockArgNode(ArgumentNode argNode) {
+        super(argNode);
+    }
+}

--- a/core/src/main/java/org/jruby/ext/ripper/RipperParser.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperParser.java
@@ -88,6 +88,7 @@ import static org.jruby.lexer.LexingCommon.EXPR_ENDFN;
 import static org.jruby.lexer.LexingCommon.EXPR_ENDARG;
 import static org.jruby.lexer.LexingCommon.EXPR_END;
 import static org.jruby.lexer.LexingCommon.EXPR_LABEL;
+import static org.jruby.util.CommonByteLists.ANON_BLOCK;
 import static org.jruby.util.CommonByteLists.FWD_BLOCK;
 import static org.jruby.util.CommonByteLists.FWD_KWREST;
  
@@ -95,7 +96,7 @@ import static org.jruby.util.CommonByteLists.FWD_KWREST;
     public RipperParser(ThreadContext context, IRubyObject ripper, LexerSource source) {
         super(context, ripper, source);
     }
-					// line 99 "-"
+					// line 100 "-"
   // %token constants
   public static final int keyword_class = 257;
   public static final int keyword_module = 258;
@@ -6437,7 +6438,7 @@ states[770] = (RipperParser p, Object yyVal, ProductionState[] yyVals, int yyTop
   return yyVal;
 };
 states[771] = (RipperParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
-                    yyVal = p.arg_var(p.shadowing_lvar(FWD_BLOCK));
+                    yyVal = p.arg_var(p.shadowing_lvar(ANON_BLOCK));
                         yyVal = p.dispatch("on_blockarg", p.nil());
 
   return yyVal;
@@ -6606,7 +6607,7 @@ states[817] = (RipperParser p, Object yyVal, ProductionState[] yyVals, int yyTop
   return yyVal;
 };
 }
-					// line 4585 "ripper_RubyParser.out"
+					// line 4586 "ripper_RubyParser.out"
 
 }
-					// line 14362 "-"
+					// line 14363 "-"

--- a/core/src/main/java/org/jruby/parser/RubyParser.java
+++ b/core/src/main/java/org/jruby/parser/RubyParser.java
@@ -88,6 +88,7 @@ import static org.jruby.lexer.LexingCommon.EXPR_ENDFN;
 import static org.jruby.lexer.LexingCommon.EXPR_ENDARG;
 import static org.jruby.lexer.LexingCommon.EXPR_END;
 import static org.jruby.lexer.LexingCommon.EXPR_LABEL;
+import static org.jruby.util.CommonByteLists.ANON_BLOCK;
 import static org.jruby.util.CommonByteLists.FWD_BLOCK;
 import static org.jruby.util.CommonByteLists.FWD_KWREST;
  
@@ -95,7 +96,7 @@ import static org.jruby.util.CommonByteLists.FWD_KWREST;
     public RubyParser(LexerSource source, IRubyWarnings warnings) {
         super(warnings); setLexer(new RubyLexer(this, source, warnings));
     }
-					// line 99 "-"
+					// line 100 "-"
   // %token constants
   public static final int keyword_class = 257;
   public static final int keyword_module = 258;
@@ -3869,8 +3870,8 @@ states[315] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
 };
 states[316] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
                     /*%%%*/
-                    if (!p.local_id(FWD_BLOCK)) p.compile_error("no anonymous block parameter");
-                    yyVal = new BlockPassNode(yyVals[yyTop - count + 1].start(), p.arg_var(FWD_BLOCK));
+                    if (!p.local_id(ANON_BLOCK)) p.compile_error("no anonymous block parameter");
+                    yyVal = new BlockPassNode(yyVals[yyTop - count + 1].start(), p.arg_var(ANON_BLOCK));
                     /* Changed from MRI*/
                     /*%
                     $$ = p.nil();
@@ -6565,7 +6566,7 @@ states[770] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
   return yyVal;
 };
 states[771] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
-                    yyVal = p.arg_var(p.shadowing_lvar(FWD_BLOCK));
+                    yyVal = p.arg_var(p.shadowing_lvar(ANON_BLOCK));
                     /*%%%*/
                     yyVal = new BlockArgNode(((ArgumentNode)yyVal));
                     /* Changed from MRI*/
@@ -6759,7 +6760,7 @@ states[817] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
   return yyVal;
 };
 }
-					// line 4738 "parse.y"
+					// line 4739 "parse.y"
 
 }
-					// line 14515 "-"
+					// line 14516 "-"

--- a/core/src/main/java/org/jruby/parser/RubyParser.y
+++ b/core/src/main/java/org/jruby/parser/RubyParser.y
@@ -162,6 +162,7 @@ import static org.jruby.lexer.LexingCommon.EXPR_ENDFN;
 import static org.jruby.lexer.LexingCommon.EXPR_ENDARG;
 import static org.jruby.lexer.LexingCommon.EXPR_END;
 import static org.jruby.lexer.LexingCommon.EXPR_LABEL;
+import static org.jruby.util.CommonByteLists.ANON_BLOCK;
 import static org.jruby.util.CommonByteLists.FWD_BLOCK;
 import static org.jruby.util.CommonByteLists.FWD_KWREST;
  
@@ -2110,8 +2111,8 @@ block_arg       : tAMPER arg_value {
                 }
                 | tAMPER {
                     /*%%%*/
-                    if (!p.local_id(FWD_BLOCK)) p.compile_error("no anonymous block parameter");
-                    $$ = new BlockPassNode(@1.start(), p.arg_var(FWD_BLOCK));
+                    if (!p.local_id(ANON_BLOCK)) p.compile_error("no anonymous block parameter");
+                    $$ = new BlockPassNode(@1.start(), p.arg_var(ANON_BLOCK));
                     // Changed from MRI
                     /*%
                     $$ = p.nil();
@@ -4625,7 +4626,7 @@ f_block_arg     : blkarg_mark tIDENTIFIER {
                     /*% ripper: blockarg!($2) %*/
                 }
                 | blkarg_mark {
-                    $$ = p.arg_var(p.shadowing_lvar(FWD_BLOCK));
+                    $$ = p.arg_var(p.shadowing_lvar(ANON_BLOCK));
                     /*%%%*/
                     $$ = new BlockArgNode($<ArgumentNode>$);
                     // Changed from MRI

--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -1460,7 +1460,7 @@ public abstract class RubyParserBase {
         if (tail == null) {
             argsNode = new ArgsNode(line, pre, optional, rest, post, null);
         } else {
-            if (tail.getBlockArg() != null && FWD_BLOCK.equals(tail.getBlockArg().getName().getBytes())) {
+            if (tail.getBlockArg() instanceof ForwardingBlockArgNode) {
                 if (rest != null) {
                     yyerror("... after rest argument");
                     argsNode = new ArgsNode(line, null, null, null, null,
@@ -1503,7 +1503,8 @@ public abstract class RubyParserBase {
         BlockArgNode blockArg = null;
         if (block != null) {
             ArgumentNode var = arg_var(block);
-            blockArg = new BlockArgNode(var);
+
+            blockArg = block == FWD_BLOCK ? new ForwardingBlockArgNode(var) : new BlockArgNode(var);
         }
 
         return new_args_tail(line, keywordArg, keywordRestArgName, blockArg);

--- a/core/src/main/java/org/jruby/util/CommonByteLists.java
+++ b/core/src/main/java/org/jruby/util/CommonByteLists.java
@@ -1,5 +1,7 @@
 package org.jruby.util;
 
+import org.jcodings.specific.USASCIIEncoding;
+
 /**
  * Values which are referenced in multiple places.  A ByteList warehouse!
  */
@@ -40,6 +42,9 @@ public class CommonByteLists {
     public static final ByteList FWD_REST = STAR;
     public static final ByteList FWD_KWREST = STAR_STAR;
     public static final ByteList FWD_BLOCK = AMPERSAND;
+    // Needs to be different than FWD_BLOCK for object identity comparisons.
+    public static final ByteList ANON_BLOCK = new ByteList(new byte[] {'&'}, USASCIIEncoding.INSTANCE);
+
     public static final ByteList TAB = new ByteList(new byte[] {'\t'});
     public static final ByteList UNDERSCORE = new ByteList(new byte[] {'_'});
     public static final ByteList USING_METHOD = new ByteList(new byte[] {'u', 's', 'i', 'n', 'g'});


### PR DESCRIPTION
The primary fix here is to make a new subtype to tell whether we are using FWD_BLOCK or not (ForwaringBlockArgNode).  Secondary clarifier is to make ANON_BLOCK to complement FWD_BLOCK (both are '&').

The irony of the check is this is for a warning of something like: def foo(*r, ...); end

Notice '&' is not even in this signature.  They use existence of '&' as a proxy for '...'.

Fixes #7506