### PR TITLE
Fixes #7476. Zlib::GzipWriter cannot be properly sub-classed

### DIFF
--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
@@ -72,7 +72,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
     @JRubyClass(name = "Zlib::GzipReader::Error", parent = "Zlib::GzipReader")
     public static class Error {}
 
-    @JRubyMethod(name = "new", rest = true, meta = true)
+    @JRubyMethod(name = "new", rest = true, meta = true, keywords = true)
     public static IRubyObject newInstance(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         JZlibRubyGzipReader result = newInstance(recv, args);
 

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
@@ -61,7 +61,7 @@ import static org.jruby.runtime.Visibility.PRIVATE;
  */
 @JRubyClass(name = "Zlib::GzipWriter", parent = "Zlib::GzipFile")
 public class JZlibRubyGzipWriter extends RubyGzipFile {
-    @JRubyMethod(name = "new", rest = true, meta = true)
+    @JRubyMethod(name = "new", rest = true, meta = true, keywords = true)
     public static IRubyObject newInstance(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         JZlibRubyGzipWriter result = newInstance(recv, args);
 


### PR DESCRIPTION
Fixes #7476.  For any new to support subclasses we will have to annotate them until we make the newer keyword argument system. 