### PR TITLE
[fix] java_alias-ing for interface methods

### DIFF
--- a/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
@@ -669,10 +669,10 @@ public class JavaProxy extends RubyObject {
         @JRubyMethod(meta = true, visibility = Visibility.PRIVATE)
         public static IRubyObject java_alias(ThreadContext context, IRubyObject clazz, IRubyObject newName, IRubyObject rubyName, IRubyObject argTypes) {
             final Ruby runtime = context.runtime;
-            if ( ! ( clazz instanceof RubyClass ) ) {
+            if ( ! ( clazz instanceof RubyModule ) ) {
                 throw runtime.newTypeError(clazz, runtime.getModule());
             }
-            final RubyClass proxyClass = (RubyClass) clazz;
+            final RubyModule proxyClass = (RubyModule) clazz;
 
             String name = rubyName.asJavaString();
             String newNameStr = newName.asJavaString();

--- a/spec/java_integration/methods/java_alias_spec.rb
+++ b/spec/java_integration/methods/java_alias_spec.rb
@@ -45,4 +45,25 @@ describe "A Java object's java_send method" do
       @list.add_int_object 0, 'foo', 'bar'
     end.to raise_error(ArgumentError)
   end
+
+  context 'interface' do
+
+    before(:all) do
+      java.lang.Iterable.module_eval do
+        java_alias :__do_for_each, :forEach, [java.util.function.Consumer]
+      end
+    end
+
+    let(:iterable) do
+      java.util.concurrent.ConcurrentLinkedQueue.new.tap { |coll| coll.add(111) }
+    end
+
+
+    it "allows calling alias" do
+      last_element = nil
+      iterable.__do_for_each { |elem| last_element = elem }
+      expect(last_element).to eql 111
+    end
+
+  end
 end


### PR DESCRIPTION
previously doing a MyInterface.java_alias just errored:

`ClassCastException: class org.jruby.RubyModule cannot be cast to class org.jruby.RubyClass`

---

*extracted from https://github.com/jruby/jruby/pull/7503 after I bumped into this twice in 9.3.9.0*