### PR TITLE
Add method! and public_send! for OpenStruct warnings

### DIFF
--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -46,6 +46,7 @@ package org.jruby;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.Map;
 
 import jnr.constants.platform.Errno;
@@ -73,6 +74,7 @@ import org.jruby.runtime.Block;
 import org.jruby.runtime.CallType;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.JavaSites.KernelSites;
+import org.jruby.runtime.MethodIndex;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.backtrace.RubyStackTraceElement;
@@ -152,6 +154,9 @@ public class RubyKernel {
         if (runtime.getInstanceConfig().isAssumeLoop()) {
             module.defineAnnotatedMethods(LoopMethods.class);
         }
+
+        MethodIndex.METHOD_FRAME_READS.put("method!", EnumSet.of(SCOPE));
+        MethodIndex.METHOD_FRAME_READS.put("public_send!", EnumSet.of(SCOPE));
 
         recacheBuiltinMethods(runtime, module);
 


### PR DESCRIPTION
Due to these methods now accessing the caller's scope (for refinements) they now warn when being aliased to another name. We suppress the warning when the target name has a superset of client frame reads, so this patch adds `method!` and `public_send!` with SCOPE read.

This is not ideal, since any future method gaining frame fields will need to have the same treatment, and other similar methods are being skipped by OpenStruct (by our request). However this suppresses the warning for now and we can work on a long-term option.