### PR TITLE
ENV encoding fixes (windows)

### DIFF
--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -838,7 +838,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
      */
     @JRubyMethod(required = 1, meta = true)
     public static IRubyObject extname(ThreadContext context, IRubyObject recv, IRubyObject arg) {
-        String filename = basename(context, recv, arg).getUnicodeValue();
+        String filename = basename(context, recv, arg).toString();
 
         int dotIndex = filename.indexOf('.');
 
@@ -1024,7 +1024,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
     public static IRubyObject ftype(ThreadContext context, IRubyObject recv, IRubyObject filename) {
         Ruby runtime = context.runtime;
         RubyString path = StringSupport.checkEmbeddedNulls(runtime, get_path(context, filename));
-        return runtime.newFileStat(path.getUnicodeValue(), true).ftype();
+        return runtime.newFileStat(path.toString(), true).ftype();
     }
 
     @JRubyMethod(rest = true, meta = true)
@@ -1035,35 +1035,35 @@ public class RubyFile extends RubyIO implements EncodingCapable {
     @JRubyMethod(name = "lstat", required = 1, meta = true)
     public static IRubyObject lstat(ThreadContext context, IRubyObject recv, IRubyObject filename) {
         Ruby runtime = context.runtime;
-        String f = StringSupport.checkEmbeddedNulls(runtime, get_path(context, filename)).getUnicodeValue();
+        String f = StringSupport.checkEmbeddedNulls(runtime, get_path(context, filename)).toString();
         return runtime.newFileStat(f, true);
     }
 
     @JRubyMethod(name = "stat", required = 1, meta = true)
     public static IRubyObject stat(ThreadContext context, IRubyObject recv, IRubyObject filename) {
         Ruby runtime = context.runtime;
-        String f = StringSupport.checkEmbeddedNulls(runtime, get_path(context, filename)).getUnicodeValue();
+        String f = StringSupport.checkEmbeddedNulls(runtime, get_path(context, filename)).toString();
         return runtime.newFileStat(f, false);
     }
 
     @JRubyMethod(name = "atime", required = 1, meta = true)
     public static IRubyObject atime(ThreadContext context, IRubyObject recv, IRubyObject filename) {
         Ruby runtime = context.runtime;
-        String f = StringSupport.checkEmbeddedNulls(runtime, get_path(context, filename)).getUnicodeValue();
+        String f = StringSupport.checkEmbeddedNulls(runtime, get_path(context, filename)).toString();
         return runtime.newFileStat(f, false).atime();
     }
 
     @JRubyMethod(name = "ctime", required = 1, meta = true)
     public static IRubyObject ctime(ThreadContext context, IRubyObject recv, IRubyObject filename) {
         Ruby runtime = context.runtime;
-        String f = StringSupport.checkEmbeddedNulls(runtime, get_path(context, filename)).getUnicodeValue();
+        String f = StringSupport.checkEmbeddedNulls(runtime, get_path(context, filename)).toString();
         return runtime.newFileStat(f, false).ctime();
     }
 
     @JRubyMethod(name = "birthtime", required = 1, meta = true)
     public static IRubyObject birthtime(ThreadContext context, IRubyObject recv, IRubyObject filename) {
         Ruby runtime = context.runtime;
-        String f = StringSupport.checkEmbeddedNulls(runtime, get_path(context, filename)).getUnicodeValue();
+        String f = StringSupport.checkEmbeddedNulls(runtime, get_path(context, filename)).toString();
         return runtime.newFileStat(f, false).birthtime();
     }
 
@@ -1129,7 +1129,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
     @JRubyMethod(required = 1, meta = true)
     public static IRubyObject mtime(ThreadContext context, IRubyObject recv, IRubyObject filename) {
         Ruby runtime = context.runtime;
-        String f = StringSupport.checkEmbeddedNulls(runtime, get_path(context, filename)).getUnicodeValue();
+        String f = StringSupport.checkEmbeddedNulls(runtime, get_path(context, filename)).toString();
         return runtime.newFileStat(f, false).mtime();
     }
 
@@ -1139,8 +1139,8 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         RubyString oldNameString = StringSupport.checkEmbeddedNulls(runtime, get_path(context, oldName));
         RubyString newNameString = StringSupport.checkEmbeddedNulls(runtime, get_path(context, newName));
 
-        String newNameJavaString = newNameString.getUnicodeValue();
-        String oldNameJavaString = oldNameString.getUnicodeValue();
+        String newNameJavaString = newNameString.toString();
+        String oldNameJavaString = oldNameString.toString();
         JRubyFile oldFile = JRubyFile.create(runtime.getCurrentDirectory(), oldNameJavaString);
         JRubyFile newFile = JRubyFile.create(runtime.getCurrentDirectory(), newNameJavaString);
 
@@ -1189,10 +1189,10 @@ public class RubyFile extends RubyIO implements EncodingCapable {
 
         RubyString fromStr = StringSupport.checkEmbeddedNulls(runtime, get_path(context, from));
         RubyString toStr = StringSupport.checkEmbeddedNulls(runtime, get_path(context, to));
-        String tovalue = toStr.getUnicodeValue();
+        String tovalue = toStr.toString();
         tovalue = JRubyFile.create(runtime.getCurrentDirectory(), tovalue).getAbsolutePath();
         try {
-            if (runtime.getPosix().symlink(fromStr.getUnicodeValue(), tovalue) == -1) {
+            if (runtime.getPosix().symlink(fromStr.toString(), tovalue) == -1) {
                 if (runtime.getPosix().isNative()) {
                     throw runtime.newErrnoFromInt(runtime.getPosix().errno(), String.format("(%s, %s)", fromStr, toStr));
                 } else {
@@ -1272,7 +1272,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         for (int i = 2, j = args.length; i < j; i++) {
             RubyString filename = StringSupport.checkEmbeddedNulls(runtime, get_path(context, args[i]));
 
-            JRubyFile fileToTouch = JRubyFile.create(runtime.getCurrentDirectory(), filename.getUnicodeValue());
+            JRubyFile fileToTouch = JRubyFile.create(runtime.getCurrentDirectory(), filename.toString());
 
             if (!fileToTouch.exists()) {
                 throw runtime.newErrnoENOENTError(filename.toString());
@@ -1301,7 +1301,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         for (int i = 2, j = args.length; i < j; i++) {
             RubyString filename = StringSupport.checkEmbeddedNulls(runtime, get_path(context, args[i]));
 
-            JRubyFile fileToTouch = JRubyFile.create(runtime.getCurrentDirectory(),filename.getUnicodeValue());
+            JRubyFile fileToTouch = JRubyFile.create(runtime.getCurrentDirectory(),filename.toString());
 
             if (!fileToTouch.exists()) {
                 throw runtime.newErrnoENOENTError(filename.toString());
@@ -1333,20 +1333,20 @@ public class RubyFile extends RubyIO implements EncodingCapable {
 
         for (int i = 0; i < args.length; i++) {
             RubyString filename = StringSupport.checkEmbeddedNulls(runtime, get_path(context, args[i]));
-            JRubyFile file = JRubyFile.create(runtime.getCurrentDirectory(), filename.getUnicodeValue());
+            JRubyFile file = JRubyFile.create(runtime.getCurrentDirectory(), filename.toString());
 
             // Broken symlinks considered by exists() as non-existing,
             // so we need to check for symlinks explicitly.
             if (!file.exists() && !isSymlink(context, file)) {
-                throw runtime.newErrnoENOENTError(filename.getUnicodeValue());
+                throw runtime.newErrnoENOENTError(filename.toString());
             }
 
             if (file.isDirectory() && !isSymlink(context, file)) {
-                throw runtime.newErrnoEISDirError(filename.getUnicodeValue());
+                throw runtime.newErrnoEISDirError(filename.toString());
             }
 
             if (!file.delete()) {
-                throw runtime.newErrnoEACCESError(filename.getUnicodeValue());
+                throw runtime.newErrnoEACCESError(filename.toString());
             }
         }
 
@@ -1366,7 +1366,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
 
         for (int i = 0; i < args.length; i++) {
             RubyString filename = StringSupport.checkEmbeddedNulls(runtime, get_path(context, args[i]));
-            JRubyFile lToDelete = JRubyFile.create(runtime.getCurrentDirectory(), filename.getUnicodeValue());
+            JRubyFile lToDelete = JRubyFile.create(runtime.getCurrentDirectory(), filename.toString());
 
             if (posix.unlink(lToDelete.getAbsolutePath()) < 0) {
                 throw runtime.newErrnoFromInt(posix.errno());
@@ -2344,18 +2344,18 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         for (int i = 0; i < args.size(); i++) {
             final IRubyObject arg = args.eltInternal(i);
 
-            final CharSequence element;
+            final String element;
             if (arg instanceof RubyString) {
-                element = arg.convertToString().getUnicodeValue();
+                element = arg.convertToString().toString();
             } else if (arg instanceof RubyArray) {
                 if (context.runtime.isInspecting(arg)) {
                     throw context.runtime.newArgumentError("recursive array");
                 } else {
-                    element = joinImplInspecting(separator, context, recv, args, ((RubyArray) arg));
+                    element = joinImplInspecting(separator, context, recv, args, ((RubyArray) arg)).toString();
                 }
             } else {
                 RubyString path = StringSupport.checkEmbeddedNulls(context.runtime, get_path(context, arg));
-                element = path.getUnicodeValue();
+                element = path.toString();
             }
 
             int trailingDelimiterIndex = chomp(buffer);
@@ -2433,7 +2433,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         RubyInteger newLength = arg2.convertToInteger();
 
         File testFile ;
-        File childFile = new File(filename.getUnicodeValue());
+        File childFile = new File(filename.toString());
         String filenameString = Helpers.decodeByteList(runtime, filename.getByteList());
 
         if ( childFile.isAbsolute() ) {

--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -43,7 +43,6 @@ import jnr.posix.POSIX;
 
 import org.jcodings.Encoding;
 import org.jcodings.specific.USASCIIEncoding;
-import org.jcodings.specific.UTF8Encoding;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.common.IRubyWarnings.ID;
@@ -767,15 +766,12 @@ public class RubyGlobal {
             return actualKey;
         }
 
-        private static final ByteList PATH_BYTES = new ByteList(new byte[] {'P','A','T','H'}, USASCIIEncoding.INSTANCE, false);
-
         // MRI: env_name_new
         // TODO: mri 3.1 does not use env_name_new
         protected static IRubyObject newName(ThreadContext context, IRubyObject key, IRubyObject valueArg) {
             if (valueArg.isNil()) return context.nil;
 
             RubyString value = (RubyString) valueArg;
-            EncodingService encodingService = context.runtime.getEncodingService();
 
             return newString(context, value);
         }
@@ -790,20 +786,12 @@ public class RubyGlobal {
 
         // MRI: env_str_new
         protected static IRubyObject newString(ThreadContext context, RubyString value) {
-            // env_encoding(void)
-            Encoding encoding = Platform.IS_WINDOWS ? UTF8Encoding.INSTANCE : context.runtime.getEncodingService().getLocaleEncoding();
-            return newString(context, value, encoding);
+            return newString(context, value, context.runtime.getEncodingService().getEnvEncoding());
         }
 
         // MRI: env_str_new2
         protected static IRubyObject newString(ThreadContext context, IRubyObject obj) {
             return obj.isNil() ? context.nil : newString(context, (RubyString) obj);
-        }
-
-        private static boolean isPATH(ThreadContext context, RubyString name) {
-            return Platform.IS_WINDOWS ?
-                    equalIgnoreCase(context, name, RubyString.newString(context.runtime, PATH_BYTES)) :
-                    name.getByteList().equal(PATH_BYTES);
         }
 
         private static boolean equalIgnoreCase(ThreadContext context, final RubyString str1, final RubyString str2) {

--- a/core/src/main/java/org/jruby/runtime/encoding/EncodingService.java
+++ b/core/src/main/java/org/jruby/runtime/encoding/EncodingService.java
@@ -5,6 +5,7 @@ import org.jcodings.EncodingDB;
 import org.jcodings.EncodingDB.Entry;
 import org.jcodings.specific.ASCIIEncoding;
 import org.jcodings.specific.ISO8859_16Encoding;
+import org.jcodings.specific.UTF8Encoding;
 import org.jcodings.spi.ISO_8859_16;
 import org.jcodings.util.CaseInsensitiveBytesHash;
 import org.jcodings.util.Hash.HashEntryIterator;
@@ -459,6 +460,11 @@ public final class EncodingService {
         }
 
         return filesystemEncoding;
+    }
+
+    // MRI: env_encoding
+    public Encoding getEnvEncoding() {
+        return Platform.IS_WINDOWS ? UTF8Encoding.INSTANCE : getLocaleEncoding();
     }
 
     /**

--- a/core/src/main/java/org/jruby/util/OSEnvironment.java
+++ b/core/src/main/java/org/jruby/util/OSEnvironment.java
@@ -89,15 +89,15 @@ public class OSEnvironment {
     private static Map<RubyString, RubyString> asMapOfRubyStrings(final Ruby runtime, final Map<?, ?> map) {
         @SuppressWarnings("unchecked")
         final Map<RubyString, RubyString> rubyMap = new HashMap(map.size() + 2);
-        Encoding keyEncoding = runtime.getEncodingService().getLocaleEncoding();
+        Encoding encoding = runtime.getEncodingService().getEnvEncoding();
 
         // On Windows, map doesn't have corresponding keys for these
         if (Platform.IS_WINDOWS) {
             // these may be null when in a restricted environment (JRUBY-6514)
             String home = SafePropertyAccessor.getProperty("user.home");
             String user = SafePropertyAccessor.getProperty("user.name");
-            putRubyKeyValuePair(runtime, rubyMap, "HOME", keyEncoding, home == null ? "/" : home, keyEncoding);
-            putRubyKeyValuePair(runtime, rubyMap, "USER", keyEncoding, user == null ? "" : user, keyEncoding);
+            putRubyKeyValuePair(runtime, rubyMap, "HOME", encoding, home == null ? "/" : home, encoding);
+            putRubyKeyValuePair(runtime, rubyMap, "USER", encoding, user == null ? "" : user, encoding);
         }
 
         for (Map.Entry<?, ?> entry : map.entrySet()) {
@@ -111,15 +111,7 @@ public class OSEnvironment {
             val = entry.getValue();
             if ( ! (val instanceof String) ) continue; // Java devs can stuff non-string objects into env
 
-            // Ensure PATH is encoded like filesystem
-            Encoding valueEncoding = keyEncoding;
-            if ( org.jruby.platform.Platform.IS_WINDOWS ?
-                    key.equalsIgnoreCase("PATH") :
-                    key.equals("PATH") ) {
-                valueEncoding = runtime.getEncodingService().getFileSystemEncoding();
-            }
-
-            putRubyKeyValuePair(runtime, rubyMap, key, keyEncoding, (String) val, valueEncoding);
+            putRubyKeyValuePair(runtime, rubyMap, key, encoding, (String) val, encoding);
         }
 
         return rubyMap;


### PR DESCRIPTION
fixes a couple of broken encodings related to ENV variables like Dir.home and FileUtils.

CRuby 3.1 has switched from filesystem encodings to UTF-8, so let's try that... see https://github.com/ruby/ruby/pull/3818