### PR TITLE
Enumerator inspect tests

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -450,7 +450,7 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
         } else {
             result.cat19(RubyObject.inspect(context, object));
             result.cat(':');
-            result.catString(method);
+            result.cat19(getMethod().asString());
             if (methodArgs.length > 0) {
                 result.cat('(');
                 for (int i= 0; i < methodArgs.length; i++) {
@@ -617,6 +617,10 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
 
     private IRubyObject getGenerator() {
         return getInstanceVariable(GENERATOR);
+    }
+
+    private IRubyObject getMethod() {
+        return getInstanceVariable(METHOD);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -437,7 +437,7 @@ public class RubyKernel {
             if (!exception) return object;
             throw runtime.newTypeError("can't convert nil into Float");
         }
-        
+
         try {
             IRubyObject flote = TypeConverter.convertToType(context, object, runtime.getFloat(), sites(context).to_f_checked, false);
             if (flote instanceof RubyFloat) return flote;
@@ -2024,13 +2024,13 @@ public class RubyKernel {
     @JRubyMethod(name = {"to_enum", "enum_for"}, optional = 1, rest = true, keywords = true)
     public static IRubyObject obj_to_enum(final ThreadContext context, IRubyObject self, IRubyObject[] args, final Block block) {
         // to_enum is a bit strange in that it will propagate the arguments it passes to each element it calls.  We are determining
-        // whether we have recieved keywords so we can propagate this info.
+        // whether we have received keywords so we can propagate this info.
         int callInfo = context.callInfo;
         String method = "each";
         SizeFn sizeFn = null;
 
         if (args.length > 0) {
-            method = args[0].asJavaString();
+            method = RubySymbol.retrieveIDSymbol(args[0]).asJavaString();
             args = Arrays.copyOfRange(args, 1, args.length);
         }
 

--- a/spec/regression/GH-7529_enumerator_inspect_has_ascii_encoding_spec.rb
+++ b/spec/regression/GH-7529_enumerator_inspect_has_ascii_encoding_spec.rb
@@ -1,0 +1,17 @@
+# -*- encoding: utf-8 -*-
+
+# https://github.com/jruby/jruby/issues/7529
+if RUBY_VERSION > '1.9'
+  describe 'Enumerator#inspect' do
+    it 'returns UTF_8 String value when needed' do
+      e = ["ΆἅἇἈ"].each
+      expect(e.inspect).to eq("#<Enumerator: [\"ΆἅἇἈ\"]:each>")
+      expect(e.inspect.encoding).to eq(Encoding::UTF_8)
+    end
+    it 'returns ASCII_8BIT String value when possible' do
+      e = ["abc"].each
+      expect(e.inspect).to eq("#<Enumerator: [\"abc\"]:each>")
+      expect(e.inspect.encoding).to eq(Encoding::ASCII_8BIT)
+    end
+  end
+end

--- a/spec/regression/GH-7529_enumerator_inspect_has_ascii_encoding_spec.rb
+++ b/spec/regression/GH-7529_enumerator_inspect_has_ascii_encoding_spec.rb
@@ -13,5 +13,13 @@ if RUBY_VERSION > '1.9'
       expect(e.inspect).to eq("#<Enumerator: [\"abc\"]:each>")
       expect(e.inspect.encoding).to eq(Encoding::ASCII_8BIT)
     end
+    it 'returns UTF_8 String value when the method is UTF_8' do
+      # example derived from TestEnumerator#test_inspect_encoding
+      # in test/mri/ruby/test_enumerator.rb
+      c = Class.new{define_method(:"\u{3042}"){}}
+      e = c.new.enum_for(:"\u{3042}")
+      expect(e.inspect).to match(/\A#<Enumerator: .*:\u{3042}>\z/)
+      expect(e.inspect.encoding).to eq(Encoding::UTF_8)
+    end
   end
 end

--- a/spec/regression/GH-7529_enumerator_inspect_has_ascii_encoding_spec.rb
+++ b/spec/regression/GH-7529_enumerator_inspect_has_ascii_encoding_spec.rb
@@ -13,13 +13,24 @@ if RUBY_VERSION > '1.9'
       expect(e.inspect).to eq("#<Enumerator: [\"abc\"]:each>")
       expect(e.inspect.encoding).to eq(Encoding::ASCII_8BIT)
     end
-    it 'returns UTF_8 String value when the method is UTF_8' do
-      # example derived from TestEnumerator#test_inspect_encoding
-      # in test/mri/ruby/test_enumerator.rb
+    it 'returns UTF_8 String value when the method is UTF_8 Symbol' do
+      # example derived from TestEnumerator#test_inspect_encoding in
+      # test/mri/ruby/test_enumerator.rb, but with :"\u{3042}" instead
+      # of "\u{3042}"
       c = Class.new{define_method(:"\u{3042}"){}}
       e = c.new.enum_for(:"\u{3042}")
       expect(e.inspect).to match(/\A#<Enumerator: .*:\u{3042}>\z/)
       expect(e.inspect.encoding).to eq(Encoding::UTF_8)
+    end
+    it 'returns UTF_8 String value when the method is UTF_8 String' do
+      # same example as TestEnumerator#test_inspect_encoding
+      # in test/mri/ruby/test_enumerator.rb
+      c = Class.new{define_method("\u{3042}"){}}
+      e = c.new.enum_for("\u{3042}")
+      expect(e.inspect).to match(/\A#<Enumerator: .*:\u{3042}>\z/)
+      expect(e.inspect.encoding).to eq(Encoding::UTF_8)
+      # not to the least, the enumerator also enumerates correctly
+      expect { e.next }.to raise_error(StopIteration)
     end
   end
 end


### PR DESCRIPTION
I wanted to contribute a regression test for issue #7529, as a follow-up to its fix by @enebo in #7531, but I noticed that there was *already* a corresponding test case in the MRI test suite.

Before the fix, with master 278aaac1cf29da19e245a3903aedbac6d6e34334:

```
$ jruby test/mri/runner.rb  test/mri/ruby/test_enumerator.rb
...
[48/63] TestEnumerator#test_inspect_encoding = 0.02 s
  7) Failure:
TestEnumerator#test_inspect_encoding [/home/cboos/workspace/jruby/test/mri/ruby/test_enumerator.rb:440]:
<#<Encoding:UTF-8>> expected but was
<#<Encoding:ASCII-8BIT>>.

Finished tests in 2.532488s, 24.8767 tests/s, 171.7678 assertions/s.
63 tests, 435 assertions, 6 failures, 1 errors, 0 skips

```

However, after the fix, with 1d9723771bb93d53acc4c6480e0097d65ba5154b, that test still failed!

With JRuby we got: `"#<Enumerator: #<#<Class:0x43312512>:0x1b868ef0>:?>"` instead of the expected `"#<Enumerator: #<#<Class:0x000002c3ad457ec8>:0x000002c3ad5dacc8>:あ>"` as with CRuby 3.0, for example. 

Reproducing with irb what the `TestEnumerator#test_inspect_encoding` test does gives the following:

```ruby
irb(main):001:0> c = Class.new{define_method("\u{3042}"){}}
=> #<Class:0x79cfc008>
irb(main):002:0> c.new.enum_for("\u{3042}")
=> #<Enumerator: #<#<Class:0x79cfc008>:0x54ebd3b4>:?>
c.new.enum_for("\u{3042}").instance_eval("@__method__")
=> :B
```

Even worse, trying to use that enumerator leads to:

```
irb(main):003:0> e.next
uri:classloader:/jruby/kernel/enumerator.rb:72:in `block in initialize': undefined method `B' for #<#<Class:0x4834e816>:0x3389c69d> (NoMethodError)
```

This pull request adds some follow-up tests and fixes for the above.