### PR TITLE
Fixes #7492.  define_method should use definition scope.

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2568,7 +2568,6 @@ public class RubyModule extends RubyObject {
 
         block.getBinding().getFrame().setKlazz(this);
         block.getBinding().getFrame().setName(name);
-        block.getBinding().setMethod(name);
 
         // a normal block passed to define_method changes to do arity checking; make it a lambda
         RubyProc proc = runtime.newProc(Block.Type.LAMBDA, block);


### PR DESCRIPTION
So the basic problem is that (only in the interpreter) we would emit the name of the method/define_method in backtraces instead of the name where the block was originally conceived (lexical location).

This issue has been strange for 3 reasons:
  1. JIT/FORCE works.  It generates backtraces differently.
  2. mocha tests run in 9.3 in spite of this issue (something else happens)
  3. As far as I can tell we have always been incompatible (9.2 at least)