### PR TITLE
[ji] support converting RubyThread to a java.lang.Thread

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -2464,6 +2464,21 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     }
 
     /**
+     * Customized for retrieving a Java thread from a Ruby one.
+     *
+     * @param target The target type to which the object should be converted (e.g. <code></>java.lang.Thread.class</code>).
+     * @since 9.4
+     */
+    @Override
+    public <T> T toJava(final Class<T> target) {
+        // since 9.4 the default toJava(java.lang.Object.class) is formalized to return a Java thread
+        if (target.isAssignableFrom(Thread.class)) { // Thread | Runnable | Object
+            return target.cast(getNativeThread());
+        }
+        return super.toJava(target);
+    }
+
+    /**
      * Run the provided {@link BiFunction} without allowing for any cross-thread interrupts (equivalent to calling
      * {@link #handle_interrupt(ThreadContext, IRubyObject, IRubyObject, Block)} with Object => :never.
      *

--- a/spec/java_integration/extensions/thread_spec.rb
+++ b/spec/java_integration/extensions/thread_spec.rb
@@ -1,0 +1,24 @@
+require File.dirname(__FILE__) + "/../spec_helper"
+
+describe "Thread" do
+
+  context 'RubyThread' do
+
+    it 'is (default) convertible to a java thread' do
+      expect( Thread.current.to_java ).to be_a java.lang.Thread
+      expect( Thread.current.to_java ).to be java.lang.Thread.currentThread
+    end
+
+    it 'is explicitly convertible to a java thread' do
+      thread = Thread.start { sleep 1.0 }
+      expect( thread.to_java(java.lang.Thread) ).to be_a java.lang.Thread
+      expect( thread.to_java('java.lang.Object') ).to be_a java.lang.Thread
+    end
+
+    it 'can be converted to internal JRuby class' do
+      expect( Thread.current.to_java('org.jruby.RubyThread') ).to be_a org.jruby.RubyThread
+    end
+
+  end
+
+end


### PR DESCRIPTION
stumbled upon `thread.to_java('org.jruby.RubyThread').native_thread` at least in 2 separate code-bases

believe 9.4 is a good opportunity to formalize `RubyThread#to_java` support to return a Java thread by default