### PR TITLE
Fix Enumerable#zip when an argument does not have each method

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -1883,6 +1883,9 @@ public class RubyEnumerable {
         if (hasUncoercible) {
             final RubySymbol each = runtime.newSymbol("each");
             for (int i = 0; i < args.length; i++) {
+                if (!args[i].respondsTo("each")) {
+                    throw context.runtime.newTypeError("wrong argument type " + args[i].getMetaClass() + " (must respond to :each)");
+                }
                 newArgs[i] = sites(context).to_enum.call(context, args[i], args[i], each); // args[i].to_enum(:each)
             }
 

--- a/test/mri/excludes/TestEnumerable.rb
+++ b/test/mri/excludes/TestEnumerable.rb
@@ -1,3 +1,2 @@
 exclude :test_callcc, "Continuations are not supported"
-exclude :test_zip, "needs investigation"
 exclude :test_first, "works - but output is not exactly 'unexpected break' as in MRI"


### PR DESCRIPTION
The following test will pass.
 * test_zip in test/mri/ruby/test_enum.rb