### PR TITLE
Fixes #7537.  Kwargs arg regression.

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -4668,7 +4668,7 @@ public class IRBuilder {
                     () -> receiveBreakException(block,
                             determineSuperInstr(zsuperResult, addArg(args, keywordRest), block, flags[0], inClassBody, isInstanceMethod)));
         } else {
-            Operand[] args = getCallOperands(scope, callArgs, keywordArgs, flags);
+            Operand[] args = getZSuperCallOperands(scope, callArgs, keywordArgs, flags);
             receiveBreakException(block,
                     determineSuperInstr(zsuperResult, args, block, flags[0], inClassBody, isInstanceMethod));
         }
@@ -4892,7 +4892,7 @@ public class IRBuilder {
                         () -> addInstr(new ZSuperInstr(scope, zsuperResult, buildSelf(), args, block, flags[0], scope.maybeUsingRefinements())),
                         () -> addInstr(new ZSuperInstr(scope, zsuperResult, buildSelf(), addArg(args, keywordRest), block, flags[0], scope.maybeUsingRefinements())));
             } else {
-                Operand[] args = adjustVariableDepth(getCallOperands(scope, callArgs, keywordArgs, flags), depthFromSuper);
+                Operand[] args = adjustVariableDepth(getZSuperCallOperands(scope, callArgs, keywordArgs, flags), depthFromSuper);
                 addInstr(new ZSuperInstr(scope, zsuperResult, buildSelf(), args, block, flags[0], scope.maybeUsingRefinements()));
             }
         } else {
@@ -5058,8 +5058,8 @@ public class IRBuilder {
         }
     }
 
-    private static Operand[] getCallOperands(IRScope scope, List<Operand> callArgs, List<KeyValuePair<Operand, Operand>> keywordArgs, int[] flags) {
-        if (scope.receivesKeywordArgs()) {
+    private static Operand[] getZSuperCallOperands(IRScope scope, List<Operand> callArgs, List<KeyValuePair<Operand, Operand>> keywordArgs, int[] flags) {
+        if (scope.getNearestTopLocalVariableScope().receivesKeywordArgs()) {
             flags[0] |= CALL_KEYWORD;
             int i = 0;
             Operand[] args = new Operand[callArgs.size() + 1];

--- a/spec/ruby/language/fixtures/super.rb
+++ b/spec/ruby/language/fixtures/super.rb
@@ -556,6 +556,20 @@ module SuperSpecs
     end
   end
 
+  module ZSuperInBlock
+    class A
+      def m(arg:)
+        arg
+      end
+    end
+
+    class B < A
+      def m(arg:)
+        proc { super }.call
+      end
+    end
+  end
+
   module Keywords
     class Arguments
       def foo(**args)

--- a/spec/ruby/language/super_spec.rb
+++ b/spec/ruby/language/super_spec.rb
@@ -322,6 +322,10 @@ describe "The super keyword" do
     SuperSpecs::ZSuperWithUnderscores::B.new.m_modified(1, 2).should == [14, 2]
   end
 
+  it "should pass method arguments when called within a closure" do
+    SuperSpecs::ZSuperInBlock::B.new.m(arg: 1).should == 1
+  end
+  
   describe 'when using keyword arguments' do
     before :each do
       @req  = SuperSpecs::Keywords::RequiredArguments.new


### PR DESCRIPTION
Fixes #7537.

zsuper within closure was not detecting keywords from the surrounding method.  This was pretty simple.  We were asking current scope (closure) if it received keywords.  We should be asking method scope for this.