### PR TITLE
UnboundMethod#bind should introduce include class

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -3515,6 +3515,21 @@ public class RubyModule extends RubyObject {
         }
     }
 
+    IncludedModuleWrapper findModuleInAncestors(RubyModule arg) {
+        for (RubyClass nextClass = getSuperClass(); nextClass != null; nextClass = nextClass.getSuperClass()) {
+            if (nextClass.isIncluded()) {
+                // does the class equal the module
+                if (nextClass.getDelegate() == arg.getDelegate()) {
+                    // next in hierarchy is an included version of the module we're attempting,
+                    // so we skip including it
+                    return (IncludedModuleWrapper) nextClass;
+                }
+            }
+        }
+
+        return null;
+    }
+
     /**
      * Prepend the given module and all related modules into the hierarchy above
      * this module/class. Inspects the hierarchy to ensure the same module isn't

--- a/core/src/main/java/org/jruby/RubyUnboundMethod.java
+++ b/core/src/main/java/org/jruby/RubyUnboundMethod.java
@@ -120,8 +120,27 @@ public class RubyUnboundMethod extends AbstractRubyMethod {
         RubyClass receiverClass = aReceiver.getMetaClass();
         
         receiverClass.checkValidBindTargetFrom(context, (RubyModule) owner(context), true);
-        
-        return RubyMethod.newMethod(implementationModule, methodName, receiverClass, originName, entry, aReceiver);
+
+        CacheEntry methodEntry = convertUnboundMethodToCallableEntry(context, receiverClass);
+
+        return RubyMethod.newMethod(implementationModule, methodName, receiverClass, originName, methodEntry, aReceiver);
+    }
+
+    private CacheEntry convertUnboundMethodToCallableEntry(ThreadContext context, RubyClass receiverClass) {
+        CacheEntry methodEntry = entry;
+
+        if (implementationModule.isModule()) {
+            IncludedModuleWrapper alreadyIncluded = receiverClass.findModuleInAncestors(implementationModule);
+
+            if (alreadyIncluded != null) {
+                methodEntry = new CacheEntry(method, alreadyIncluded, entry.token);
+            } else {
+                RubyModule boundModule = new IncludedModuleWrapper(context.runtime, receiverClass, implementationModule);
+                methodEntry = new CacheEntry(method, boundModule, entry.token);
+            }
+        }
+
+        return methodEntry;
     }
 
     @JRubyMethod(name = "clone")

--- a/test/mri/excludes/TestSuper.rb
+++ b/test/mri/excludes/TestSuper.rb
@@ -1,5 +1,4 @@
 exclude :test_super_in_instance_eval, "needs investigation"
 exclude :test_super_in_instance_eval_with_define_method, "needs investigation"
-exclude :test_super_in_module_unbound_method, "needs investigation"
 exclude :test_super_in_orphan_block_with_instance_eval, "needs investigation"
 


### PR DESCRIPTION
When the incoming UnboundMethod is from a Module not already
included in the target receiver's class hierarchy, the newly bound
Method should treat that method as living in a virtual module
included below the receiver's class. This allows the rebound
method to use `super` to call a method of the same name in the
receiver's hierarchy.

For the original change in CRuby (2.2) see:

https://github.com/ruby/ruby/commit/46f578d806df70c4cae43b614e56558977a4cc44

For the additional change to avoid the extra include class when
the owner module is already in the target hierarchy, see:

https://github.com/ruby/ruby/commit/160b67df68655322d09f566914c89e2d3e7cfc05

Fixes #7548.