### PR TITLE
Etc#sysconf errors when it shouldn't

### DIFF
--- a/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
+++ b/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
@@ -163,11 +163,15 @@ public class RubyEtc {
         Ruby runtime = context.runtime;
         Sysconf name = Sysconf.valueOf(RubyNumeric.num2long(arg));
         POSIX posix = runtime.getPosix();
+        posix.errno(0);
         long ret = posix.sysconf(name);
+
         if (ret == -1) {
-            if (posix.errno() == Errno.ENOENT.intValue()) {
-                return runtime.getNil();
-            } else if (posix.errno() == Errno.EOPNOTSUPP.intValue()) {
+            int errno = posix.errno();
+
+            if (errno == Errno.ENOENT.intValue() || errno == 0) {
+                return context.nil;
+            } else if (errno == Errno.EOPNOTSUPP.intValue()) {
                 throw runtime.newNotImplementedError("sysconf() function is unimplemented on this machine");
             } else {
                 throw runtime.newErrnoFromLastPOSIXErrno();


### PR DESCRIPTION
This is actually two fixes:
  1. errno() is not set to 0 by sysconf???  So while running spec:ruby:fast it would get set to something and a couple of sysconfs would return -1 but expect errno == 0.  Kaboom.
  2. we did not obey semantics that ret == -1 and errno == 0 should return nil.

(backported from 9.4)