### PR TITLE
Delegating methods must be able to set ruby2_keywords on delegate.

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -81,7 +81,6 @@ import org.jruby.internal.runtime.methods.AttrWriterMethod;
 import org.jruby.internal.runtime.methods.DefineMethodMethod;
 import org.jruby.internal.runtime.methods.DelegatingDynamicMethod;
 import org.jruby.internal.runtime.methods.DynamicMethod;
-import org.jruby.internal.runtime.methods.IRMethodArgs;
 import org.jruby.internal.runtime.methods.JavaMethod;
 import org.jruby.internal.runtime.methods.NativeCallMethod;
 import org.jruby.internal.runtime.methods.PartialDelegatingMethod;
@@ -2981,7 +2980,7 @@ public class RubyModule extends RubyObject {
                 if (!method.isNative()) {
                     Signature signature = method.getSignature();
                     if (signature.hasRest() && !signature.hasKwargs()) {
-                        ((IRMethodArgs) method).setRuby2Keywords();
+                        method.setRuby2Keywords();
                     } else {
                         context.runtime.getWarnings().warn(IRubyWarnings.ID.MISCELLANEOUS, str(context.runtime, "Skipping set of ruby2_keywords flag for ", name, " (method accepts keywords or method does not accept argument splat)"));
                     }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/AliasMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/AliasMethod.java
@@ -176,4 +176,9 @@ public class AliasMethod extends DynamicMethod {
     public boolean isNative() {
         return entry.method.isNative();
     }
+
+    @Override
+    public void setRuby2Keywords() {
+        entry.method.setRuby2Keywords();
+    }
 }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/DynamicMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/DynamicMethod.java
@@ -633,4 +633,21 @@ public abstract class DynamicMethod {
     public int getAliasCount() {
         return this.aliasCount;
     }
+
+    /**
+     * Indicates the method will behave like a ruby2 keywords accepting method.
+     * This must be a Ruby implementation to work.  See Module#ruby2_keywords
+     * for information on the semantics of a method which is marked this way.
+     */
+    public void setRuby2Keywords() {
+        // non-native (Ruby) methods implement this.  We have an empty impl here vs
+        // abstract because we are unsure if any external native extensions happen
+        // to implement their own methods.  If it were abstract that extension would
+        // no longer compile.
+        //
+        // If an external does have their own special method impl AND it is not
+        // a native (Java) method then it must override this method and handle state.
+        // Our IR subsystem will know by how it is marked to process arguments
+        // in an appropriate way.
+    }
 }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/SynchronizedDynamicMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/SynchronizedDynamicMethod.java
@@ -118,4 +118,13 @@ public class SynchronizedDynamicMethod extends DelegatingDynamicMethod {
         return new SynchronizedDynamicMethod(delegate.dup());
     }
 
+    @Override
+    public boolean isNative() {
+        return delegate.isNative();
+    }
+
+    @Override
+    public void setRuby2Keywords() {
+        delegate.setRuby2Keywords();
+    }
 }


### PR DESCRIPTION
alias and synchronized methods are only wrappers so they should mark their source methods as being ruby2_keywords.  This also put setRuby2Keywords onto DynamicMethod to make it more clear this is a Ruby thing and not an IR-specific thing (IRMethodArgs as a cast is confusing).