### PR TITLE
Fix comparator of Bignum and Infinity 

### DIFF
--- a/core/src/main/java/org/jruby/RubyBignum.java
+++ b/core/src/main/java/org/jruby/RubyBignum.java
@@ -1118,9 +1118,9 @@ public class RubyBignum extends RubyInteger {
 
         if (Double.isInfinite(yd)) {
             if (yd > 0.0) {
-                return RubyFixnum.one(runtime);
-            } else {
                 return RubyFixnum.minus_one(runtime);
+            } else {
+                return RubyFixnum.one(runtime);
             }
         }
 

--- a/spec/tags/ruby/core/float/gt_tags.txt
+++ b/spec/tags/ruby/core/float/gt_tags.txt
@@ -1,2 +1,0 @@
-fails:Float#> handles positive infinity
-fails:Float#> handles negative infinity

--- a/spec/tags/ruby/core/float/gte_tags.txt
+++ b/spec/tags/ruby/core/float/gte_tags.txt
@@ -1,2 +1,0 @@
-fails:Float#>= handles positive infinity
-fails:Float#>= handles negative infinity

--- a/spec/tags/ruby/core/float/lt_tags.txt
+++ b/spec/tags/ruby/core/float/lt_tags.txt
@@ -1,2 +1,0 @@
-fails:Float#< handles positive infinity
-fails:Float#< handles negative infinity

--- a/spec/tags/ruby/core/float/lte_tags.txt
+++ b/spec/tags/ruby/core/float/lte_tags.txt
@@ -1,2 +1,0 @@
-fails:Float#<= handles positive infinity
-fails:Float#<= handles negative infinity


### PR DESCRIPTION
This fixes float_cmp function to return correct value when float argument is infinity.

The following tests will pass.
 * spec/ruby/core/float/gt_spec.rb
 * spec/ruby/core/float/gte_spec.rb
 * spec/ruby/core/float/lt_spec.rb
 * spec/ruby/core/float/lte_spec.rb