### PR TITLE
Fix Numeric#remainder when divisor is infinity 

### DIFF
--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -875,6 +875,9 @@ public class RubyNumeric extends RubyObject {
                         RubyNumeric.positiveInt(context, y)) ||
                         (x.isPositive() &&
                                 RubyNumeric.negativeInt(context, y)))) {
+            if (y instanceof RubyFloat && Double.isInfinite(((RubyFloat)y).value)) {
+                return x;
+            }
             return sites.op_minus.call(context, z, z, y);
         }
         return z;

--- a/test/mri/excludes_wip/TestNumeric.rb
+++ b/test/mri/excludes_wip/TestNumeric.rb
@@ -1,4 +1,3 @@
 exclude :"test_float_round_ndigits", "work in progress"
 exclude :"test_floor_ceil_ndigits", "work in progress"
-exclude :"test_remainder_infinity", "work in progress"
 exclude :"test_step", "work in progress"


### PR DESCRIPTION
The following test will pass.
 * test_remainder_infinity in test/mri/ruby/test_numeric.rb