### PR TITLE
Fix Float#floor and Float#round for some edge cases

### DIFF
--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -1182,7 +1182,7 @@ public class RubyRational extends RubyNumeric {
     }
 
     // MRI: f_round_common
-    private IRubyObject roundCommon(ThreadContext context, final IRubyObject n, RoundingMode mode) {
+    public IRubyObject roundCommon(ThreadContext context, final IRubyObject n, RoundingMode mode) {
         if (n == context.nil) {
             return doRound(context, mode);
         }

--- a/test/mri/excludes_wip/TestNumeric.rb
+++ b/test/mri/excludes_wip/TestNumeric.rb
@@ -1,4 +1,2 @@
-exclude :"test_float_round_ndigits", "work in progress"
-exclude :"test_floor_ceil_ndigits", "work in progress"
 exclude :"test_remainder_infinity", "work in progress"
 exclude :"test_step", "work in progress"


### PR DESCRIPTION
This change is porting from mri(numeric.c and rational.c).

The following tests will pass.
 * test_floor_ceil_ndigits in test/mri/ruby/test_numeric.rb
 * test_float_round_ndigits in test/mri/ruby/test_numeric.rb