### PR TITLE
Fix missing require in mri-core tests

### DIFF
--- a/test/mri/ruby/test_enum.rb
+++ b/test/mri/ruby/test_enum.rb
@@ -2,6 +2,7 @@
 require 'test/unit'
 EnvUtil.suppress_warning {require 'continuation'}
 require 'stringio'
+require 'delegate'
 
 class TestEnumerable < Test::Unit::TestCase
   def setup


### PR DESCRIPTION
Its absence causes an intermittent failure, likely caused by load ordering randomness.

```
TestEnumerable#test_sum:
NameError: uninitialized constant TestEnumerable::SimpleDelegator
    org/jruby/RubyModule.java:3947:in `const_missing'
        /tmp/autopkgtest-lxc.wadx2atf/downtmp/autopkgtest_tmp/test/mri/ruby/test_enum.rb:1051:in `test_sum'
```