### PR TITLE
[refactor] warnings which assumed a message is being passed

### DIFF
--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -408,6 +408,10 @@ public class RubyGlobal {
         runtime.defineGlobalConstant("ENV_JAVA", envJava);
     }
 
+    private static void warnDeprecatedGlobal(final Ruby runtime, final String name) {
+        runtime.getWarnings().warnDeprecated(ID.MISCELLANEOUS, "`" + name + "' is deprecated");
+    }
+
     /**
      * Obligate string-keyed and string-valued hash, used for ENV.
      * On Windows, the keys are case-insensitive for ENV
@@ -1003,7 +1007,7 @@ public class RubyGlobal {
         public IRubyObject set(IRubyObject value) {
             IRubyObject result = super.set(value);
 
-            if (!value.isNil()) runtime.getWarnings().warnDeprecated("`" + name + "'");
+            if (!value.isNil()) warnDeprecatedGlobal(runtime, name);
 
             return result;
         }
@@ -1018,7 +1022,7 @@ public class RubyGlobal {
         public IRubyObject set(IRubyObject value) {
             IRubyObject result = super.set(value);
 
-            if (!result.isNil()) runtime.getWarnings().warnDeprecated("`" + name + "'");
+            if (!result.isNil()) warnDeprecatedGlobal(runtime, name);
 
             return result;
         }

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1561,7 +1561,7 @@ public class RubyKernel {
         Block.Type type = block.type;
 
         if (type == Block.Type.PROC) {
-            context.runtime.getWarnings().warnDeprecated("lambda without a literal block is deprecated; use the proc without lambda instead");
+            context.runtime.getWarnings().warnDeprecated(ID.MISCELLANEOUS, "lambda without a literal block is deprecated; use the proc without lambda instead");
         } else {
             type = Block.Type.LAMBDA;
         }

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -3283,7 +3283,7 @@ public class RubyModule extends RubyObject {
     @JRubyMethod(name = "include", required = 1, rest = true)
     public RubyModule include(IRubyObject[] modules) {
         if (this.isRefinement()) {
-            getRuntime().getWarnings().warnDeprecated("deprecated method to be removed: Refinement#include");
+            getRuntime().getWarnings().warnDeprecated(ID.DEPRECATED_METHOD, "deprecated method to be removed: Refinement#include");
         }
 
         for (IRubyObject module: modules) {
@@ -4451,7 +4451,7 @@ public class RubyModule extends RubyObject {
     @JRubyMethod(name = "prepend", required = 1, rest = true)
     public IRubyObject prepend(ThreadContext context, IRubyObject[] modules) {
         if (this.isRefinement()) {
-            context.runtime.getWarnings().warnDeprecated("deprecated method to be removed: Refinement#prepend");
+            context.runtime.getWarnings().warnDeprecated(ID.DEPRECATED_METHOD, "deprecated method to be removed: Refinement#prepend");
         }
 
         // MRI checks all types first:
@@ -5324,7 +5324,7 @@ public class RubyModule extends RubyObject {
         if (entry.deprecated) {
             final Ruby runtime = getRuntime();
             String parent = "Object".equals(getName()) ? "" : getName();
-            runtime.getWarnings().warnDeprecated("constant " + parent + "::" + name);
+            runtime.getWarnings().warnDeprecated(ID.CONSTANT_DEPRECATED, "constant " + parent + "::" + name + " is deprecated");
         }
 
         return entry;

--- a/core/src/main/java/org/jruby/common/RubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/RubyWarnings.java
@@ -159,6 +159,10 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
         if (runtime.getWarningCategories().contains(Category.EXPERIMENTAL)) warn(ID.MISCELLANEOUS, filename, line, message);
     }
 
+    public void warnDeprecated(ID id, String message) {
+        if (runtime.getWarningCategories().contains(Category.DEPRECATED)) warn(id, message);
+    }
+
     public void warnDeprecated(String name) {
         if (runtime.getWarningCategories().contains(Category.DEPRECATED)) warn(ID.MISCELLANEOUS, "" + name + " is deprecated");
     }


### PR DESCRIPTION
the `runtime.getWarnings().warnDeprecated(name)` call was sometimes used as if it was passed a `"message"`
... which leads to deprecated warnings such as `jruby -v -e 'puts lambda(&proc {})'` : 
```
jruby 9.4.0.0 (3.1.0) 2022-11-23 95c0ec159f OpenJDK 64-Bit Server VM 11.0.14.1+1 on 11.0.14.1+1 +jit [x86_64-linux]
-e:1: warning: lambda without a literal block is deprecated; use the proc without lambda instead is deprecated
#<Proc:0x68d6f48e -e:1>
```
(not the `" is deprecated"` at the end - added by the `warnDeprecated(String)` invocation)


reviewed all places using `warnDeprecated(String)` and started using an `warnDeprecated(ID, String)` overload which passes the message - this means some places also have a better ID tag (although it isn't used that much).