### PR TITLE
Fixes #7572.  Blocks with only keywords losing keyword status.

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -4825,11 +4825,15 @@ public class IRBuilder {
 
         boolean unwrap = true;
         Node argNode = node.getArgsNode();
-        // FIXME: This is likely wrong. single argnode array may only be the kwarg
         // Get rid of one level of array wrapping
         if (argNode != null && (argNode instanceof ArrayNode) && ((ArrayNode)argNode).size() == 1) {
-            argNode = ((ArrayNode)argNode).getLast();
-            unwrap = false;
+            Node onlyArg = ((ArrayNode)argNode).getLast();
+
+            // We should not unwrap if it is a keyword argument.
+            if (!(onlyArg instanceof HashNode) || ((HashNode) onlyArg).isLiteral()) {
+                argNode = onlyArg;
+                unwrap = false;
+            }
         }
 
         Variable ret = result == null ? createTemporaryVariable() : result;


### PR DESCRIPTION
This was very narrow in scope.  If you only passed in a single argument we "unwrap" it from the original ```[arg]``` and just pass arg.  This in turn *spreads* whatever is there (if an array).

In this case arg is the keywords arg.  So the fix was to not unwrap in this case.