### PR TITLE
Use platform bit width for J/j pack directive

### DIFF
--- a/core/src/main/java/org/jruby/platform/Platform.java
+++ b/core/src/main/java/org/jruby/platform/Platform.java
@@ -126,6 +126,7 @@ public abstract class Platform {
     public static final int BIG_ENDIAN = 4321;
     public static final int LITTLE_ENDIAN = 1234;
     public static final int BYTE_ORDER = ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN) ? BIG_ENDIAN : LITTLE_ENDIAN;
+    public static final int BIT_WIDTH = jnr.ffi.Platform.getNativePlatform().is32Bit() ? 32 : 64;
 
     public static final boolean IS_GCJ = JVM.equals(GCJ);
     public static final boolean IS_J9 = JVM.equals(OPENJ9) || JVM.equals(IBM);

--- a/core/src/main/java/org/jruby/util/Pack.java
+++ b/core/src/main/java/org/jruby/util/Pack.java
@@ -310,7 +310,8 @@ public class Pack {
         converters['V'] = tmp;
         converters['L' + LE] = tmp;
         converters['I' + LE] = tmp;
-        
+        if (Platform.BIT_WIDTH == 32) converters['J' + LE] = tmp;
+
         // unsigned long, big-endian
         tmp = new Converter(4, "Integer") {
             public IRubyObject decode(Ruby runtime, ByteBuffer enc) {
@@ -324,6 +325,7 @@ public class Pack {
         converters['N'] = tmp;
         converters['L' + BE] = tmp;
         converters['I' + BE] = tmp;
+        if (Platform.BIT_WIDTH == 32) converters['J' + BE] = tmp;
 
         // unsigned int, native
         tmp = new Converter(4, "Integer") {
@@ -341,6 +343,7 @@ public class Pack {
         };
         converters['I'] = tmp; // unsigned int, native
         converters['L'] = tmp; // unsigned long, native
+        if (Platform.BIT_WIDTH == 32) converters['J'] = tmp; // unsigned long, native
 
         // int, native
         tmp = new Converter(4, "Integer") {
@@ -355,7 +358,8 @@ public class Pack {
         };
         converters['i'] = tmp; // int, native
         converters['l'] = tmp; // long, native
-        
+        if (Platform.BIT_WIDTH == 32) converters['j'] = tmp; // long, native
+
         // int, little endian
         tmp = new Converter(4, "Integer") {
             public IRubyObject decode(Ruby runtime, ByteBuffer enc) {
@@ -368,7 +372,8 @@ public class Pack {
         };
         converters['i' + LE] = tmp; // int, native
         converters['l' + LE] = tmp; // long, native
-        
+        if (Platform.BIT_WIDTH == 32) converters['j' + LE] = tmp; // long, native
+
         // int, big endian
         tmp = new Converter(4, "Integer") {
             public IRubyObject decode(Ruby runtime, ByteBuffer enc) {
@@ -381,6 +386,7 @@ public class Pack {
         };
         converters['i' + BE] = tmp; // int, native
         converters['l' + BE] = tmp; // long, native
+        if (Platform.BIT_WIDTH == 32) converters['j' + BE] = tmp; // long, native
 
         // 64-bit number, native (as bignum)
         tmp = new QuadConverter(8, "Integer") {
@@ -396,7 +402,7 @@ public class Pack {
             }
         };
         converters['Q'] = tmp;
-        converters['J'] = tmp;
+        if (Platform.BIT_WIDTH == 64) converters['J'] = tmp;
 
         // 64-bit number, little endian (as bignum)
         tmp = new QuadConverter(8, "Integer") {
@@ -411,10 +417,9 @@ public class Pack {
             }
         };
         converters['Q' + LE] = tmp;
-        converters['J' + LE] = tmp;
+        if (Platform.BIT_WIDTH == 64) converters['J' + LE] = tmp;
 
         // 64-bit number, big endian (as bignum)
-
         tmp = new QuadConverter(8, "Integer") {
             public IRubyObject decode(Ruby runtime, ByteBuffer enc) {
                 long l = decodeLongBigEndian(enc);
@@ -427,7 +432,7 @@ public class Pack {
             }
         };
         converters['Q' + BE] = tmp;
-        converters['J' + BE] = tmp;
+        if (Platform.BIT_WIDTH == 64) converters['J' + BE] = tmp;
 
         // 64-bit number, native (as fixnum)
         tmp = new QuadConverter(8, "Integer") {
@@ -442,7 +447,7 @@ public class Pack {
             }
         };
         converters['q'] = tmp;
-        converters['j'] = tmp;
+        if (Platform.BIT_WIDTH == 64) converters['j'] = tmp;
 
         // 64-bit number, little-endian (as fixnum)
         tmp = new QuadConverter(8, "Integer") {
@@ -456,7 +461,7 @@ public class Pack {
             }
         };
         converters['q' + LE] = tmp;
-        converters['j' + LE] = tmp;
+        if (Platform.BIT_WIDTH == 64) converters['j' + LE] = tmp;
 
         // 64-bit number, big-endian (as fixnum)
         tmp = new QuadConverter(8, "Integer") {
@@ -470,7 +475,7 @@ public class Pack {
             }
         };
         converters['q' + BE] = tmp;
-        converters['j' + BE] = tmp;
+        if (Platform.BIT_WIDTH == 64) converters['j' + BE] = tmp;
     }
 
     public static int unpackInt_i(ByteBuffer enc) {


### PR DESCRIPTION
These pack directives are intended to produce an encoded signed or unsigned int of the width of a native pointer. Regardless of whether JRuby treats all platforms as 64-bit (due to JVM's 64-bit nature) we should probably encode these values according to the host platform's bit depth.

Fixes #7542

I do not have a 32-bit platform on which to test this, but hacking JRuby and mspec to pretend the system is 32-bit yields passing specs for the 32-bit logic:

```diff
diff --git a/core/src/main/java/org/jruby/platform/Platform.java b/core/src/main/java/org/jruby/platform/Platform.java
index 1b292498ce..2be4f03bf1 100644
--- a/core/src/main/java/org/jruby/platform/Platform.java
+++ b/core/src/main/java/org/jruby/platform/Platform.java
@@ -126,7 +126,7 @@ public abstract class Platform {
     public static final int BIG_ENDIAN = 4321;
     public static final int LITTLE_ENDIAN = 1234;
     public static final int BYTE_ORDER = ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN) ? BIG_ENDIAN : LITTLE_ENDIAN;
-    public static final int BIT_WIDTH = jnr.ffi.Platform.getNativePlatform().is32Bit() ? 32 : 64;
+    public static final int BIT_WIDTH = 32; //jnr.ffi.Platform.getNativePlatform().is32Bit() ? 32 : 64;
 
     public static final boolean IS_GCJ = JVM.equals(GCJ);
     public static final boolean IS_J9 = JVM.equals(OPENJ9) || JVM.equals(IBM);
diff --git a/spec/mspec/lib/mspec/guards/platform.rb b/spec/mspec/lib/mspec/guards/platform.rb
index 2d5c2de6b6..7076e8c62f 100644
--- a/spec/mspec/lib/mspec/guards/platform.rb
+++ b/spec/mspec/lib/mspec/guards/platform.rb
@@ -53,7 +53,7 @@ class PlatformGuard < SpecGuard
 
   POINTER_SIZE = begin
     require 'rbconfig/sizeof'
-    RbConfig::SIZEOF["void*"] * 8
+    RbConfig::SIZEOF["void*"] * 4
   rescue LoadError
     WORD_SIZE
   end
```