### PR TITLE
If no seed given, use current millis

### DIFF
--- a/core/src/main/java/org/jruby/RubyRandomBase.java
+++ b/core/src/main/java/org/jruby/RubyRandomBase.java
@@ -142,7 +142,7 @@ public class RubyRandomBase extends RubyObject {
         if (limit == 0) return RubyFixnum.zero(runtime);
         Random impl;
         if (random == null) {
-            impl = new Random();
+            impl = new Random(runtime.getDefaultRandom().random.genrandInt32());
         } else {
             impl = random.impl;
         }

--- a/core/src/main/java/org/jruby/util/Random.java
+++ b/core/src/main/java/org/jruby/util/Random.java
@@ -48,6 +48,7 @@ public class Random {
     private int left = 1;
 
     public Random() {
+        this((int) System.currentTimeMillis());
     }
 
     public Random(int s) {


### PR DESCRIPTION
Without initializing the seed array, this will return zero for all PRNG calls.

Fixes #7586