### PR TITLE
Treat send of using or refine as refinement

### DIFF
--- a/core/src/main/java/org/jruby/util/CommonByteLists.java
+++ b/core/src/main/java/org/jruby/util/CommonByteLists.java
@@ -50,4 +50,5 @@ public class CommonByteLists {
     public static final ByteList USING_METHOD = new ByteList(new byte[] {'u', 's', 'i', 'n', 'g'});
     public static final ByteList REFINE_METHOD = new ByteList(new byte[] {'r', 'e', 'f', 'i', 'n', 'e'});
     public static final ByteList ZERO = new ByteList(new byte[] {'0'});
+    public static final ByteList SEND = new ByteList("send".getBytes());
 }


### PR DESCRIPTION
The tzinfo gem at some point started using `send(:using ...)` to get around a JRuby arity bug. Unfortunately this breaks our detection of refinements, which depends on seeing a direct call to `using` or `refine` and so the refinements were never honored.

This commit also treats `send` with a literal `:using` or `:refine` symbol as a call to the related method.

At some point we may simply have to accept that all scopes could be refined, but this is an ok fix for a very specific and unusual situation.

See https://github.com/tzinfo/tzinfo/issues/145 for the issue reported to tzinfo about all our untaint warnings, which should have been masked by refinement.