### PR TITLE
Fixed launch jruby in MSYS2 environment

### DIFF
--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -120,8 +120,14 @@ cygwin=false
 case "$(uname)" in
     CYGWIN*) cygwin=true ;;
     MINGW*)
-        jruby.exe "$@"
-        exit $?
+        release_id=$(awk -F= '$1=="ID" { print $2; }' /etc/os-release 2> /dev/null)
+        case $release_id in
+            "msys2") ;;
+            *)
+                jruby.exe "$@"
+                exit $?
+                ;;
+        esac
         ;;
 esac
 readonly cygwin


### PR DESCRIPTION
I'm using MSYS2 environment.
jruby.exe is launched not from current directory but globally in system. Even if you run it from current directory, there will be no effect because jruby.exe does nothing but returns code 0.
In PR #37 was added launch jruby.exe of MSYS, but this is the first version of MSYS not MSYS2.
