### PR TITLE
Fix errant ... warning

### DIFF
--- a/core/src/main/java/org/jruby/lexer/LexingCommon.java
+++ b/core/src/main/java/org/jruby/lexer/LexingCommon.java
@@ -333,7 +333,7 @@ public abstract class LexingCommon {
     }
 
     public boolean isLookingAtEOL() {
-        for (int i = lex_p + 1; i < lex_pend; i++) {
+        for (int i = lex_p; i < lex_pend; i++) {
             int c = lexb.get(i);
             boolean eol = c == '\n' || c == '#';
             if (eol || !isSpace(c)) {


### PR DESCRIPTION
Fixes #7602.  The method checking the next char was actually checking the next char after the next char.  So ranges with an end of one char would see the newline/eof.