### PR TITLE
Support for LoongArch64

### DIFF
--- a/core/src/main/java/org/jruby/ext/ffi/Platform.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Platform.java
@@ -92,6 +92,7 @@ public class Platform {
         S390X,
         ARM,
         AARCH64,
+        LOONGARCH64,
         UNKNOWN;
         @Override
         public String toString() { return name().toLowerCase(LOCALE); }
@@ -155,7 +156,9 @@ public class Platform {
             return CPU.ARM;
         } else if ("aarch64".equals(archString)) {
             return CPU.AARCH64;
-        } else if ("universal".equals(archString)) {
+        } else if ("loongarch64".equals(archString)) {
+            return CPU.LOONGARCH64;
+	} else if ("universal".equals(archString)) {
             // OS X OpenJDK7 builds report "universal" right now
             String bits = SafePropertyAccessor.getProperty("sun.arch.data.model");
             if ("32".equals(bits)) {
@@ -214,6 +217,7 @@ public class Platform {
                 case SPARCV9:
                 case S390X:
                 case AARCH64:
+                case LOONGARCH64:
                     dataModel = 64;
                     break;
                 default:

--- a/core/src/main/java/org/jruby/ext/rbconfig/RbConfigLibrary.java
+++ b/core/src/main/java/org/jruby/ext/rbconfig/RbConfigLibrary.java
@@ -104,6 +104,7 @@ public class RbConfigLibrary implements Library {
         if (architecture == null) architecture = "unknown";
         if ("amd64".equals(architecture)) architecture = "x86_64";
         if ("aarch64".equals(architecture) && Platform.IS_MAC) architecture = "arm64";
+        if ("loongarch64".equals(architecture)) architecture = "loongarch64";
 
         return architecture;
     }

--- a/install/jruby.install4j
+++ b/install/jruby.install4j
@@ -82,6 +82,7 @@
           <entry location="lib/jni/i386-SunOS" />
           <entry location="lib/jni/i386-FreeBSD" />
           <entry location="lib/jni/i386-OpenBSD" />
+          <entry location="lib/jni/loongarch64-Linux" />
           <entry location="lib/jni/ppc-AIX" />
           <entry location="lib/jni/ppc64-Linux" />
           <entry location="lib/jni/ppc64le-Linux" />
@@ -106,6 +107,7 @@
           <entry location="lib/jni/i386-OpenBSD" />
           <entry location="lib/jni/i386-SunOS" />
           <entry location="lib/jni/i386-Windows" />
+          <entry location="lib/jni/loongarch64-Linux" />
           <entry location="lib/jni/ppc64-Linux" />
           <entry location="lib/jni/ppc64le-Linux" />
           <entry location="lib/jni/ppc-AIX" />

--- a/spec/ffi/fixtures/compile.rb
+++ b/spec/ffi/fixtures/compile.rb
@@ -18,6 +18,8 @@ module TestLibrary
       end
     when /amd64|x86_64|x64/
       "x86_64"
+    when /loongarch64/
+      "loongarch64"
     when /ppc64|powerpc64/
       "powerpc64"
     when /ppc|powerpc/


### PR DESCRIPTION
This is cherry-picked from https://github.com/jruby/jruby/pull/7518 to align LoongArch64 support in both JRuby 9.3 and 9.4. Will resolve #7260.