### PR TITLE
Remove parallel testing from mri stdlib

### DIFF
--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -98,9 +98,11 @@ namespace :test do
         aot: "-X+C -Xjit.background=false #{get_meta_size.call()}"
     }
 
-    mri_suites = [:core, :extra, :stdlib]
+    j_flag = "-j#{AVAILABLE_PROCESSORS}"
 
-    mri_suites.each do |suite|
+    mri_suites = [[:core, j_flag], [:extra, j_flag], [:stdlib, ""]]
+
+    mri_suites.each do |(suite, extra_flags)|
       files = File.readlines("test/mri.#{suite}.index").grep(/^[^#]\w+/).map(&:chomp).join(' ')
 
       namespace suite do
@@ -109,7 +111,7 @@ namespace :test do
 
           task task do
             ENV['JRUBY_OPTS'] = "#{ENV['JRUBY_OPTS']} --disable-gems -Xbacktrace.style=mri -Xdebug.fullTrace #{opts}"
-            ruby "test/mri/runner.rb -j#{AVAILABLE_PROCESSORS} #{ADDITIONAL_TEST_OPTIONS} --excludes=test/mri/excludes -q -- #{files}"
+            ruby "test/mri/runner.rb #{extra_flags} #{ADDITIONAL_TEST_OPTIONS} --excludes=test/mri/excludes -q -- #{files}"
           end
         end
       end


### PR DESCRIPTION
A symlink-related test shown below fails intermittently, with no obvious cause. I suspect it may be related to parallel tests that are late to clean up resources, stepping on the subsequent single-threaded run. This is an attempt to eliminate the failure by removing the parallel test run for this suite.

The error, or at least one form of it:

  1) Failure:
TestFileUtils#test_cp_r_symlink_preserve [/home/runner/work/jruby/jruby/test/mri/fileutils/test_fileutils.rb:428]: Exception raised:
<#<Errno::EOPNOTSUPP: Operation not supported - No message available>>.