### PR TITLE
Implement ulong random logic with random bytes

### DIFF
--- a/core/src/main/java/org/jruby/RubyRandomBase.java
+++ b/core/src/main/java/org/jruby/RubyRandomBase.java
@@ -107,7 +107,7 @@ public class RubyRandomBase extends RubyObject {
                 if (restrictive) return context.nil;
                 max = -max;
             }
-            return randLimitedFixnum(context, random, max - 1);
+            return randomUlongLimited(context, self, random, max - 1);
         } else {
             BigInteger big = vmax.getBigIntegerValue();
             if (big.equals(BigInteger.ZERO)) {
@@ -175,6 +175,34 @@ public class RubyRandomBase extends RubyObject {
 
     public static RubyInteger randLimited(ThreadContext context, BigInteger limit) {
         return limitedBigRand(context, getDefaultRand(context), limit);
+    }
+
+    // c: random_ulong_limited
+    // Note this is a modified version of randomUlongLimitedBig due to lack of ulong in Java
+    private static IRubyObject randomUlongLimited(ThreadContext context, IRubyObject self, RubyRandom.RandomType random, long limit) {
+        if (limit == 0) {
+            return RubyFixnum.zero(context.runtime);
+        }
+        if (random == null) {
+            int octets = limit <= Integer.MAX_VALUE ? 4 : 8;
+
+            byte[] octetBytes = objRandomBytes(context, self, octets);
+            long randLong = 0L;
+            for (byte b : octetBytes) {
+                randLong = (randLong << 8) + Byte.toUnsignedLong(b);
+            }
+
+            if (randLong < 0) {
+                randLong = -randLong;
+            }
+
+            if (randLong > limit) {
+                randLong = randLong % limit;
+            }
+
+            return RubyFixnum.newFixnum(context.runtime, randLong);
+        }
+        return randLimitedFixnum(context, random, limit);
     }
 
     // c: random_ulong_limited_big


### PR DESCRIPTION
CRuby first attempts to call `bytes` on the given random object in order to allow random number implementations to override only that one method in order to change the random number source. We were skipping this logic and going straight back to our internal PRNG logic.

This had two effects:

* SecureRandom and similar classes would not always be the source for random numbers they appear to generate, since this callback to `bytes` was not happening for long-ranged random numbers.
* The test_ulong_limited_no_rand test from CRuby's test_rand.rb failed 50% of the time because we continued to generate actual random numbers (1..2) rather than using the non-random overridden `bytes` method.