### PR TITLE
inherit encoding for interned symbols

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -6311,6 +6311,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         }
 
         RubySymbol symbol = runtime.getSymbolTable().getSymbol(value);
+        symbol.associateEncoding(getEncoding());
         if (symbol.getBytes() == value) shareLevel = SHARE_LEVEL_BYTELIST;
         return symbol;
     }

--- a/spec/tags/ruby/core/string/intern_tags.txt
+++ b/spec/tags/ruby/core/string/intern_tags.txt
@@ -1,2 +1,0 @@
-fails:String#intern ignores exising symbols with different encoding
-fails:String#intern ignores existing symbols with different encoding

--- a/spec/tags/ruby/core/string/to_sym_tags.txt
+++ b/spec/tags/ruby/core/string/to_sym_tags.txt
@@ -1,2 +1,0 @@
-fails:String#to_sym ignores exising symbols with different encoding
-fails:String#to_sym ignores existing symbols with different encoding


### PR DESCRIPTION
fixes a rare case with incorrect encoding sharing
```ruby
source = "fée"
iso_symbol = source.force_encoding(Encoding::ISO_8859_1).to_sym
iso_symbol.encoding # Encoding::ISO_8859_1
binary_symbol = source.force_encoding(Encoding::BINARY).to_sym
binary_symbol.encoding # Encoding::ISO_8859_1 (Encoding::BINARY is expected)
```

it applies to 9.3 as well. Is it worth backporting?