### PR TITLE
setup and fix issues reported by error-prone compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: ${{ matrix.java-version }}
           cache: 'maven'
       - name: bootstrap
-        run: mvn -Pbootstrap clean package
+        run: ./mvnw -Pbootstrap clean package
       - name: bundle install
         run: bin/jruby --dev -S bundle install
       - name: Save bootstrap build
@@ -78,7 +78,7 @@ jobs:
           key: ${{ github.sha }}-bootstrap
       - name: conditional-bootstrap
         if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "mvn -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
+        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: rake ${{ matrix.target }}
         run: bin/jruby -S rake ${{ matrix.target }}
 
@@ -119,7 +119,7 @@ jobs:
           key: ${{ github.sha }}-bootstrap
       - name: conditional-bootstrap
         if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "mvn -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
+        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: rake ${{ matrix.target }}
         run: bin/jruby -S rake ${{ matrix.target }}
 
@@ -159,7 +159,7 @@ jobs:
           key: ${{ github.sha }}-bootstrap
       - name: conditional-bootstrap
         if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "mvn -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
+        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: rake test:jruby
         run: bin/jruby --dev -S rake test:jruby
 
@@ -199,7 +199,7 @@ jobs:
           key: ${{ github.sha }}-bootstrap
       - name: conditional-bootstrap
         if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "mvn -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
+        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: rake ${{ matrix.target }}
         run: bin/jruby -S rake ${{ matrix.target }}
 
@@ -237,7 +237,7 @@ jobs:
           key: ${{ github.sha }}-bootstrap
       - name: conditional-bootstrap
         if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "mvn -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
+        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: mvn package ${{ matrix.package-flags }}
         run: tool/maven-ci-script.sh
         env:
@@ -281,7 +281,7 @@ jobs:
           key: ${{ github.sha }}-bootstrap
       - name: conditional-bootstrap
         if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "mvn -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
+        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: mvn package ${{ matrix.package-flags }}
         run: tool/maven-ci-script.sh
         env:
@@ -323,7 +323,7 @@ jobs:
           key: ${{ github.sha }}-bootstrap
       - name: conditional-bootstrap
         if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "mvn -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
+        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: rake spec:ji
         run: bin/jruby -S rake spec:ji
 
@@ -363,7 +363,7 @@ jobs:
           key: ${{ github.sha }}-bootstrap
       - name: conditional-bootstrap
         if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "mvn -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
+        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: rake spec:regression
         run: bin/jruby -S rake spec:regression
 
@@ -394,7 +394,7 @@ jobs:
           java-version: 11
           maven-version: '3.8.7'
       - name: bootstrap
-        run: mvn -Pbootstrap clean package
+        run: ./mvnw -Pbootstrap clean package
       - name: install bundler
         run: bin/jruby --dev -S gem install bundler
       - name: bundle install
@@ -504,7 +504,7 @@ jobs:
           key: ${{ github.sha }}-bootstrap
       - name: conditional-bootstrap
         if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "mvn -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
+        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: sequel
         run: tool/sequel-github-actions.sh
 
@@ -541,7 +541,7 @@ jobs:
           key: ${{ github.sha }}-bootstrap
       - name: conditional-bootstrap
         if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "mvn -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
+        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: concurrent-ruby
         run: tool/concurrent-ruby-github-actions.sh
 
@@ -567,7 +567,7 @@ jobs:
           java-version: ${{ matrix.java-version }}
           architecture: arm
       - name: bootstrap
-        run: mvn -Pbootstrap clean package
+        run: ./mvnw -Pbootstrap clean package
       - name: mvn package ${{ matrix.package-flags }}
         run: tool/maven-ci-script.sh
         env:
@@ -642,7 +642,7 @@ jobs:
           key: ${{ github.sha }}-bootstrap
       - name: conditional-bootstrap
         if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "mvn -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
+        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: test profile
 #        run: "tool/maven-ci-script.sh"
         run: "true"
@@ -686,7 +686,7 @@ jobs:
           key: ${{ github.sha }}-bootstrap
       - name: conditional-bootstrap
         if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "mvn -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
+        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: rake ${{ matrix.target }}
         continue-on-error: true
         run: "bin/jruby -S rake ${{ matrix.target }}"

--- a/core/pom.rb
+++ b/core/pom.rb
@@ -198,7 +198,16 @@ project 'JRuby Base' do
                    'compilerArgs' => [ '-XDignore.symbol.file=true',
                                        '-J-Duser.language=en',
                                        '-J-Dfile.encoding=UTF-8',
-                                       '-J-Xmx${jruby.compile.memory}' ] )
+                                       '-J-Xmx${jruby.compile.memory}',
+                                       '-XDcompilePolicy=simple', '-Xplugin:ErrorProne' ],
+                   'annotationProcessorPaths' => { 'path' => [ {
+                                                                'groupId' => 'com.google.errorprone',
+                                                                'artifactId' => 'error_prone_core',
+                                                                'version' => '2.10.0' }, # last version that works on Java 8
+                                                               {
+                                                                 'groupId' => 'org.jruby',
+                                                                 'artifactId' => 'jruby-base',
+                                                                 'version' => version } ] })
     execute_goals( 'compile',
                    :id => 'populators',
                    :phase => 'process-classes',

--- a/core/pom.rb
+++ b/core/pom.rb
@@ -167,12 +167,21 @@ project 'JRuby Base' do
     end
   end
 
+  fork_compiler_args = [ '-XDignore.symbol.file=true',
+                         '-J-Duser.language=en',
+                         '-J-Dfile.encoding=UTF-8',
+                         '-J-Xmx${jruby.compile.memory}' ]
+
+  default_compile_configuration = {
+    'fork' => 'true',
+    'annotationProcessors' => [ 'org.jruby.anno.AnnotationBinder' ],
+    'generatedSourcesDirectory' =>  'target/generated-sources',
+    'compilerArgs' => fork_compiler_args
+  }
+
   plugin( :compiler,
           'encoding' => 'utf-8',
-          'debug' => 'true',
           'verbose' => 'false',
-          'fork' => 'true',
-          'compilerArgs' => { 'arg' => '-J-Xmx1G' },
           'showWarnings' => 'true',
           'showDeprecation' => 'true',
           'source' => [ '${base.java.version}', '1.8' ],
@@ -190,33 +199,19 @@ project 'JRuby Base' do
                                    'org/jruby/util/CodegenUtils.java',
                                    'org/jruby/util/SafePropertyAccessor.java' ] )
     execute_goals( 'compile',
-                   :id => 'default-compile',
-                   :phase => 'compile',
-                   'debug' => 'true',
-                   'annotationProcessors' => [ 'org.jruby.anno.AnnotationBinder' ],
-                   'generatedSourcesDirectory' =>  'target/generated-sources',
-                   'compilerArgs' => [ '-XDignore.symbol.file=true',
-                                       '-J-Duser.language=en',
-                                       '-J-Dfile.encoding=UTF-8',
-                                       '-J-Xmx${jruby.compile.memory}',
-                                       '-XDcompilePolicy=simple', '-Xplugin:ErrorProne' ],
-                   'annotationProcessorPaths' => { 'path' => [ {
-                                                                'groupId' => 'com.google.errorprone',
-                                                                'artifactId' => 'error_prone_core',
-                                                                'version' => '2.10.0' }, # last version that works on Java 8
-                                                               {
-                                                                 'groupId' => 'org.jruby',
-                                                                 'artifactId' => 'jruby-base',
-                                                                 'version' => version } ] })
+                   default_compile_configuration.merge(
+                     :id => 'default-compile',
+                     :phase => 'compile'
+                   ))
+
     execute_goals( 'compile',
                    :id => 'populators',
                    :phase => 'process-classes',
-                   'debug' => 'true',
-                   'compilerArgs' => [ '-XDignore.symbol.file=true',
-                                       '-J-Duser.language=en',
-                                       '-J-Dfile.encoding=UTF-8',
-                                       '-J-Xmx${jruby.compile.memory}' ],
+                   'debug' => 'false',
+                   'fork' => 'true',
+                   'compilerArgs' => fork_compiler_args,
                    'includes' => [ 'org/jruby/gen/**/*.java' ] )
+
     execute_goals( 'compile',
                    :id => 'eclipse-hack',
                    :phase => 'process-classes',
@@ -305,6 +300,40 @@ project 'JRuby Base' do
       plugin 'org.codehaus.mojo:exec-maven-plugin' do
         execute_goals( *copy_goal )
       end
+    end
+  end
+
+  profile 'error-prone' do
+    activation do
+      jdk('11') # even an older (2.10.0) version of error-prone would need an adjusted setup on Java 8
+      property(name: 'env.CI') # for keeping fast development cycle, by default only run on CI
+    end
+
+    plugin :compiler do
+      execute_goals( 'compile',
+                     :id => 'default-compile',
+                     :phase => 'none' ) # do not execute default-compile, we have a replacement bellow
+
+      execute_goals( 'compile',
+                     default_compile_configuration.merge(
+                       :id => 'default-compile_with_error_prone',
+                       :phase => 'compile',
+                       'fork' => 'true',
+                       'compilerArgs' => default_compile_configuration['compilerArgs'] + [
+                         '-XDcompilePolicy=simple', '-Xplugin:ErrorProne'
+                       ],
+                        'annotationProcessorPaths' => { 'path' => [ {
+                                                                      'groupId' => 'com.google.errorprone',
+                                                                      'artifactId' => 'error_prone_core',
+                                                                      'version' => '2.10.0'
+                                                                    },
+                                                                    {
+                                                                      'groupId' => 'org.jruby',
+                                                                      'artifactId' => 'jruby-base',
+                                                                      'version' => version
+                                                                    } ]
+                        }
+                    ) )
     end
   end
 

--- a/core/pom.rb
+++ b/core/pom.rb
@@ -325,7 +325,7 @@ project 'JRuby Base' do
                         'annotationProcessorPaths' => { 'path' => [ {
                                                                       'groupId' => 'com.google.errorprone',
                                                                       'artifactId' => 'error_prone_core',
-                                                                      'version' => '2.10.0'
+                                                                      'version' => '2.18.0'
                                                                     },
                                                                     {
                                                                       'groupId' => 'org.jruby',

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -453,7 +453,21 @@ DO NOT MODIFY - GENERATED CODE
                 <compilerArg>-J-Duser.language=en</compilerArg>
                 <compilerArg>-J-Dfile.encoding=UTF-8</compilerArg>
                 <compilerArg>-J-Xmx${jruby.compile.memory}</compilerArg>
+                <compilerArg>-XDcompilePolicy=simple</compilerArg>
+                <compilerArg>-Xplugin:ErrorProne</compilerArg>
               </compilerArgs>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>2.10.0</version>
+                </path>
+                <path>
+                  <groupId>org.jruby</groupId>
+                  <artifactId>jruby-base</artifactId>
+                  <version>9.4.4.0-SNAPSHOT</version>
+                </path>
+              </annotationProcessorPaths>
             </configuration>
           </execution>
           <execution>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -706,7 +706,7 @@ DO NOT MODIFY - GENERATED CODE
                     <path>
                       <groupId>com.google.errorprone</groupId>
                       <artifactId>error_prone_core</artifactId>
-                      <version>2.10.0</version>
+                      <version>2.18.0</version>
                     </path>
                     <path>
                       <groupId>org.jruby</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -443,7 +443,7 @@ DO NOT MODIFY - GENERATED CODE
               <goal>compile</goal>
             </goals>
             <configuration>
-              <debug>true</debug>
+              <fork>true</fork>
               <annotationProcessors>
                 <annotationProcessor>org.jruby.anno.AnnotationBinder</annotationProcessor>
               </annotationProcessors>
@@ -453,21 +453,7 @@ DO NOT MODIFY - GENERATED CODE
                 <compilerArg>-J-Duser.language=en</compilerArg>
                 <compilerArg>-J-Dfile.encoding=UTF-8</compilerArg>
                 <compilerArg>-J-Xmx${jruby.compile.memory}</compilerArg>
-                <compilerArg>-XDcompilePolicy=simple</compilerArg>
-                <compilerArg>-Xplugin:ErrorProne</compilerArg>
               </compilerArgs>
-              <annotationProcessorPaths>
-                <path>
-                  <groupId>com.google.errorprone</groupId>
-                  <artifactId>error_prone_core</artifactId>
-                  <version>2.10.0</version>
-                </path>
-                <path>
-                  <groupId>org.jruby</groupId>
-                  <artifactId>jruby-base</artifactId>
-                  <version>9.4.4.0-SNAPSHOT</version>
-                </path>
-              </annotationProcessorPaths>
             </configuration>
           </execution>
           <execution>
@@ -477,7 +463,8 @@ DO NOT MODIFY - GENERATED CODE
               <goal>compile</goal>
             </goals>
             <configuration>
-              <debug>true</debug>
+              <debug>false</debug>
+              <fork>true</fork>
               <compilerArgs>
                 <compilerArg>-XDignore.symbol.file=true</compilerArg>
                 <compilerArg>-J-Duser.language=en</compilerArg>
@@ -505,12 +492,7 @@ DO NOT MODIFY - GENERATED CODE
         </executions>
         <configuration>
           <encoding>utf-8</encoding>
-          <debug>true</debug>
           <verbose>false</verbose>
-          <fork>true</fork>
-          <compilerArgs>
-            <arg>-J-Xmx1G</arg>
-          </compilerArgs>
           <showWarnings>true</showWarnings>
           <showDeprecation>true</showDeprecation>
           <source>${base.java.version}</source>
@@ -673,6 +655,65 @@ DO NOT MODIFY - GENERATED CODE
                     <argument>-c</argument>
                     <argument>cp ${jruby.basedir}/bin/jruby.sh ${jruby.basedir}/bin/jruby</argument>
                   </arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>error-prone</id>
+      <activation>
+        <jdk>11</jdk>
+        <property>
+          <name>env.CI</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-compile</id>
+                <phase>none</phase>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>default-compile_with_error_prone</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+                <configuration>
+                  <fork>true</fork>
+                  <annotationProcessors>
+                    <annotationProcessor>org.jruby.anno.AnnotationBinder</annotationProcessor>
+                  </annotationProcessors>
+                  <generatedSourcesDirectory>target/generated-sources</generatedSourcesDirectory>
+                  <compilerArgs>
+                    <compilerArg>-XDignore.symbol.file=true</compilerArg>
+                    <compilerArg>-J-Duser.language=en</compilerArg>
+                    <compilerArg>-J-Dfile.encoding=UTF-8</compilerArg>
+                    <compilerArg>-J-Xmx${jruby.compile.memory}</compilerArg>
+                    <compilerArg>-XDcompilePolicy=simple</compilerArg>
+                    <compilerArg>-Xplugin:ErrorProne</compilerArg>
+                  </compilerArgs>
+                  <annotationProcessorPaths>
+                    <path>
+                      <groupId>com.google.errorprone</groupId>
+                      <artifactId>error_prone_core</artifactId>
+                      <version>2.10.0</version>
+                    </path>
+                    <path>
+                      <groupId>org.jruby</groupId>
+                      <artifactId>jruby-base</artifactId>
+                      <version>9.4.4.0-SNAPSHOT</version>
+                    </path>
+                  </annotationProcessorPaths>
                 </configuration>
               </execution>
             </executions>

--- a/core/src/main/java/org/jruby/EvalType.java
+++ b/core/src/main/java/org/jruby/EvalType.java
@@ -1,5 +1,8 @@
 package org.jruby;
 
+/**
+ * Code evaluation type
+ */
 public enum EvalType {
     NONE, BINDING_EVAL, INSTANCE_EVAL, MODULE_EVAL
-};
+}

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1616,6 +1616,7 @@ public final class Ruby implements Constantizable {
         loadService.loadFromClassLoader(getClassLoader(), "jruby/bundler/startup.rb", false);
     }
 
+    @SuppressWarnings("ReturnValueIgnored")
     private boolean doesReflectionWork() {
         try {
             ClassLoader.class.getDeclaredMethod("getResourceAsStream", String.class);
@@ -3266,11 +3267,12 @@ public final class Ruby implements Constantizable {
         }
     }
 
-    private void systemTeardown(ThreadContext context) {
+    @SuppressWarnings("ReturnValueIgnored")
+    private void systemTeardown(final ThreadContext context) {
         // Run post-user exit hooks, such as for shutting down internal JRuby services
         while (!postExitBlocks.isEmpty()) {
             ExitFunction fun = postExitBlocks.remove(0);
-            fun.applyAsInt(context);
+            fun.applyAsInt(context); // return value ignored
         }
 
         synchronized (internalFinalizersMutex) {

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -2890,7 +2890,6 @@ public final class Ruby implements Constantizable {
             throw newRaiseException(getTypeError(), str(this, "can't retrieve anonymous class ", ids(this, path)));
         }
 
-        ThreadContext context = getCurrentContext();
         RubyModule c = getObject();
         int pbeg = 0, p = 0;
         for (int l = path.length(); p < l; ) {
@@ -2906,8 +2905,7 @@ public final class Ruby implements Constantizable {
             }
 
             // FIXME: JI depends on const_missing getting called from Marshal.load (ruby objests do not).  We should marshal JI objects differently so we do not differentiate here.
-            boolean isJava = c instanceof JavaPackage || ClassUtils.isJavaClassProxyType(context, c);
-            IRubyObject cc = flexibleSearch || isJava ? c.getConstant(str) : c.getConstantAt(str);
+            IRubyObject cc = flexibleSearch || isJavaPackageOrJavaClassProxyType(c) ? c.getConstant(str) : c.getConstantAt(str);
 
             if (!flexibleSearch && cc == null) return null;
 
@@ -2918,6 +2916,10 @@ public final class Ruby implements Constantizable {
         }
 
         return c;
+    }
+
+    private static boolean isJavaPackageOrJavaClassProxyType(final RubyModule type) {
+        return type instanceof JavaPackage || ClassUtils.isJavaClassProxyType(type);
     }
 
     /** Prints an error with backtrace to the error stream.

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -120,6 +120,7 @@ import org.jruby.runtime.ivars.VariableTableManager;
  * with care; reification of Ruby classes into Java classes can produce
  * conflicting method names in rare cases. See JRUBY-5906 for an example.
  */
+@SuppressWarnings("ComparableType")
 public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Comparable<IRubyObject>, CoreObjectType, InstanceVariables, InternalVariables {
 
     //private static final Logger LOG = LoggerFactory.getLogger(RubyBasicObject.class);

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -2429,7 +2429,6 @@ public class RubyClass extends RubyModule {
         if (target == Class.class) {
             if (reifiedClass == null) reifyWithAncestors(); // possibly auto-reify
             // Class requested; try java_class or else return nearest reified class
-            final ThreadContext context = runtime.getCurrentContext();
             Class<?> javaClass = JavaUtil.getJavaClass(this, null);
             if (javaClass != null) return (T) javaClass;
 

--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -511,10 +511,6 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
         }
     }
 
-    private IRubyObject getGenerator() {
-        return getInstanceVariable(GENERATOR);
-    }
-
     private IRubyObject getMethod() {
         return getInstanceVariable(METHOD);
     }

--- a/core/src/main/java/org/jruby/RubyInstanceConfig.java
+++ b/core/src/main/java/org/jruby/RubyInstanceConfig.java
@@ -1555,7 +1555,6 @@ public class RubyInstanceConfig {
     private boolean shouldRunInterpreter = true;
     private boolean shouldPrintUsage = Options.CLI_HELP.load();
     private boolean shouldPrintProperties=Options.CLI_PROPERTIES.load();
-    private boolean dumpConfig=false;
     private KCode kcode = Options.CLI_KCODE.load();
     private String recordSeparator = Options.CLI_RECORD_SEPARATOR.load();
     private boolean shouldCheckSyntax = Options.CLI_CHECK_SYNTAX.load();

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -207,7 +207,6 @@ public class RubyModule extends RubyObject {
      *
      * @param classIndex the ClassIndex for this type
      */
-    @SuppressWarnings("deprecated")
     void setClassIndex(ClassIndex classIndex) {
         this.classIndex = classIndex;
         this.index = classIndex.ordinal();

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -5895,7 +5895,6 @@ public class RubyModule extends RubyObject {
     @Override
     public <T> T toJava(Class<T> target) {
         if (target == Class.class) { // try java_class for proxy modules
-            final ThreadContext context = metaClass.runtime.getCurrentContext();
             Class<?> javaClass = JavaUtil.getJavaClass(this, null);
             if (javaClass != null) return (T) javaClass;
         }

--- a/core/src/main/java/org/jruby/RubyRegexp.java
+++ b/core/src/main/java/org/jruby/RubyRegexp.java
@@ -1229,7 +1229,10 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
     private RubyBoolean matchP(ThreadContext context, IRubyObject arg, int pos) {
         if (arg == context.nil) return context.fals;
         RubyString str = arg instanceof RubySymbol ? ((RubySymbol) arg).to_s(context.runtime) : arg.convertToString();
+        return matchP(context, str, pos);
+    }
 
+    final RubyBoolean matchP(ThreadContext context, RubyString str, int pos) {
         if (pos != 0) {
             if (pos < 0) {
                 pos += str.strLength();

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -444,23 +444,12 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     }
 
     // Deprecated String construction routines
-    /** Create a new String which uses the same Ruby runtime and the same
-     *  class like this String.
-     *
-     *  This method should be used to satisfy RCR #38.
-     *  @deprecated
-     */
+
     @Deprecated
     public RubyString newString(CharSequence s) {
         return new RubyString(getRuntime(), getType(), s);
     }
 
-    /** Create a new String which uses the same Ruby runtime and the same
-     *  class like this String.
-     *
-     *  This method should be used to satisfy RCR #38.
-     *  @deprecated
-     */
     @Deprecated
     public RubyString newString(ByteList s) {
         return new RubyString(getRuntime(), getMetaClass(), s);
@@ -968,10 +957,6 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     }
 
     private void frozenCheck() {
-        frozenCheck(false);
-    }
-
-    private void frozenCheck(boolean runtimeError) {
         if (isFrozen()) {
             if (getRuntime().getInstanceConfig().isDebuggingFrozenStringLiteral()) {
                 IRubyObject obj = getInstanceVariable(DEBUG_INFO_FIELD);
@@ -1301,8 +1286,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     /**
      * Generate a hash for the String, using its associated Ruby instance's hash seed.
      *
-     * @param runtime
-     * @return
+     * @param runtime the runtime
+     * @return calculated hash
      */
     public int strHashCode(Ruby runtime) {
         final ByteList value = this.value;
@@ -1318,8 +1303,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     /**
      * Generate a hash for the String, without a seed.
      *
-     * @param runtime
-     * @return
+     * @param runtime the runtime
+     * @return calculated hash
      */
     public int unseededStrHashCode(Ruby runtime) {
         final ByteList value = this.value;
@@ -2315,7 +2300,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         long retval = 0;
         int tmp;
 
-        while ((len--) > 0 && s < bytes.length && (tmp = memchr(hexdigit, 0, bytes[s], hexdigit.length)) != -1) {
+        while (len-- > 0 && s < bytes.length && (tmp = memchr(hexdigit, 0, bytes[s], hexdigit.length)) != -1) {
             retval <<= 4;
             retval |= tmp & 15;
             s++;
@@ -2359,15 +2344,6 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         if (index < 0) index++;
         replaceInternal19(index, 0, str);
         return this;
-    }
-
-    private int checkIndex(int beg, int len) {
-        if (beg > len) raiseIndexOutOfString(beg);
-        if (beg < 0) {
-            if (-beg > len) raiseIndexOutOfString(beg);
-            beg += len;
-        }
-        return beg;
     }
 
     private int checkIndexForRef(int beg, int len) {
@@ -2426,8 +2402,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
                 if (p > prev) result.cat(pBytes, prev, p - prev);
                 n = enc.minLength();
                 if (pend < p + n)
-                    n = (int)(pend - p);
-                while ((n--) > 0) {
+                    n = (pend - p);
+                while (n-- > 0) {
                     result.modify();
                     Sprintf.sprintf(runtime, result.getByteList(), "\\x%02X", pBytes[p] & 0377);
                     prev = ++p;
@@ -2955,11 +2931,6 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return subBangIter(context, arg0, (RubyHash) hash, block);
     }
 
-    private static RubyRegexp asRegexpArg(final Ruby runtime, final IRubyObject arg0) {
-        return arg0 instanceof RubyRegexp ? (RubyRegexp) arg0 :
-            RubyRegexp.newRegexp(runtime, RubyRegexp.quote(getStringForPattern(runtime, arg0).getByteList(), false), new RegexpOptions());
-    }
-
     private IRubyObject subBangIter(ThreadContext context, IRubyObject arg0, RubyHash hash, Block block) {
         if (arg0 instanceof RubyRegexp ) {
             return subBangIter(context, (RubyRegexp) arg0, hash, block);
@@ -3086,10 +3057,10 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     /**
      * sub! but without any frame globals ...
-     * <p>Note: Internal API, subject to change!</p>
-     * @param context
-     * @param regexp
-     * @param repl
+     * @note Internal API, subject to change!
+     * @param context current context
+     * @param regexp the regular expression
+     * @param repl replacement string value
      * @return sub result
      */
     public final IRubyObject subBangFast(ThreadContext context, RubyRegexp regexp, RubyString repl) {

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1723,12 +1723,12 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @JRubyMethod(name = "match?")
     public IRubyObject match_p(ThreadContext context, IRubyObject pattern) {
-        return getPattern(context.runtime, pattern).match_p(context, this);
+        return getPattern(context.runtime, pattern).matchP(context, this, 0);
     }
 
     @JRubyMethod(name = "match?")
     public IRubyObject match_p(ThreadContext context, IRubyObject pattern, IRubyObject pos) {
-        return getPattern(context.runtime, pattern).match_p(context, this, pos);
+        return getPattern(context.runtime, pattern).matchP(context, this, RubyNumeric.num2int(pos));
     }
 
     public IRubyObject op_ge(ThreadContext context, IRubyObject other) {

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -165,6 +165,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     }
 
     @Override
+    @SuppressWarnings("ReferenceEquality")
     public void setEncoding(Encoding encoding) {
         if (encoding != value.getEncoding()) {
             if (shareLevel == SHARE_LEVEL_BYTELIST) modify();
@@ -174,6 +175,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     }
 
     @Override
+    @SuppressWarnings("ReferenceEquality")
     public boolean shouldMarshalEncoding() {
         return getEncoding() != ASCIIEncoding.INSTANCE;
     }
@@ -282,6 +284,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return StringSupport.isSingleByteOptimizable(this, enc);
     }
 
+    @SuppressWarnings("ReferenceEquality")
     final Encoding isCompatibleWith(EncodingCapable other) {
         if (other instanceof RubyString) return checkEncoding((RubyString)other);
         Encoding enc1 = value.getEncoding();
@@ -350,6 +353,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      *
      */
     @Override
+    @SuppressWarnings("ReferenceEquality")
     public final boolean eql(IRubyObject other) {
         RubyClass meta = this.metaClass;
         if (meta != meta.runtime.getString() || meta != other.getMetaClass()) return super.eql(other);
@@ -538,6 +542,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return new RubyString(runtime, runtime.getString(), RubyInteger.singleCharByteList(b));
     }
 
+    @SuppressWarnings("ReferenceEquality")
     public static RubyString newUnicodeString(Ruby runtime, String str) {
         Encoding defaultInternal = runtime.getDefaultInternalEncoding();
         if (defaultInternal == UTF16BEEncoding.INSTANCE) {
@@ -555,6 +560,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return new RubyString(runtime, runtime.getString(), RubyEncoding.doEncodeUTF16(str));
     }
 
+    @SuppressWarnings("ReferenceEquality")
     public static RubyString newUnicodeString(Ruby runtime, CharSequence str) {
         Encoding defaultInternal = runtime.getDefaultInternalEncoding();
         if (defaultInternal == UTF16BEEncoding.INSTANCE) {
@@ -629,6 +635,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return str;
     }
 
+    @SuppressWarnings("ReferenceEquality")
     public static RubyString newStringShared(Ruby runtime, RubyClass clazz, ByteList bytes, Encoding encoding) {
         if (bytes.getEncoding() == encoding) return newStringShared(runtime, clazz, bytes);
         RubyString str = new RubyString(runtime, clazz, bytes.makeShared(bytes.getBegin(), bytes.getRealSize()), encoding);
@@ -955,6 +962,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         if (value.getUnsafeBytes() != b || value.getRealSize() != len) throw getRuntime().newRuntimeError("string modified");
     }
 
+    @SuppressWarnings("ReferenceEquality")
     private void modifyCheck(byte[] b, int len, Encoding enc) {
         if (value.getUnsafeBytes() != b || value.getRealSize() != len || value.getEncoding() != enc) throw getRuntime().newRuntimeError("string modified");
     }
@@ -984,6 +992,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     /** rb_str_modify
      *
      */
+    @Override
     public final void modify() {
         modifyCheck();
 
@@ -1013,6 +1022,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     /** rb_str_modify (with length bytes ensured)
      *
      */
+    @Override
     public final void modify(int length) {
         modifyCheck();
 
@@ -1138,6 +1148,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return str.checkStringType();
     }
 
+    @SuppressWarnings("ReferenceEquality")
     @JRubyMethod(name = {"to_s", "to_str"})
     @Override
     public IRubyObject to_s() {
@@ -1327,6 +1338,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return (other instanceof RubyString) && equals((RubyString) other);
     }
 
+    @SuppressWarnings("NonOverridingEquals")
     final boolean equals(RubyString other) {
         return ((RubyString) other).value.equal(value);
     }
@@ -2190,6 +2202,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         throw runtime.newRuntimeError("invalid dumped string; not wrapped with '\"' nor '\"...\".force_encoding(\"...\")' form");
     }
 
+    @SuppressWarnings("ReferenceEquality")
     private void undumpAfterBackslash(Ruby runtime, byte[] ssBytes, int[] ss, int s_end, Encoding[] penc, boolean[] utf8, boolean[] binary) {
         int s = ss[0];
         long c;
@@ -2365,7 +2378,6 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         }
         return beg;
     }
-
     private int checkLength(int len) {
         if (len < 0) throw getRuntime().newIndexError("negative length " + len);
         return len;
@@ -2462,6 +2474,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return inspect(runtime, byteList);
     }
 
+    @SuppressWarnings("ReferenceEquality")
     public static RubyString inspect(final Ruby runtime, ByteList byteList) {
         Encoding enc = byteList.getEncoding();
         byte bytes[] = byteList.getUnsafeBytes();
@@ -2773,6 +2786,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return concat(context, other);
     }
 
+    @SuppressWarnings("ReferenceEquality")
     private RubyString concatNumeric(Ruby runtime, int c) {
         Encoding enc = value.getEncoding();
         int cl;

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -1637,7 +1637,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     }
 
     @Deprecated
-    public static interface BlockingTask {
+    public interface BlockingTask {
         public void run() throws InterruptedException;
         public void wakeup();
     }
@@ -2227,7 +2227,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         }
     }
 
-    @SuppressWarnings("deprecated")
+    @SuppressWarnings("deprecation")
     public synchronized void interrupt() {
         setInterrupt();
 

--- a/core/src/main/java/org/jruby/ast/SymbolNode.java
+++ b/core/src/main/java/org/jruby/ast/SymbolNode.java
@@ -56,10 +56,16 @@ public class SymbolNode extends Node implements ILiteralNode, INameNode, Literal
         this.name = value;
     }
 
+    @Override
     public boolean equals(Object other) {
         return other instanceof SymbolNode &&
                 name.equals(((SymbolNode) other).name) &&
                 name.getEncoding() == ((SymbolNode) other).name.getEncoding();
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * name.hashCode();
     }
 
     public NodeType getNodeType() {

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -1479,7 +1479,7 @@ public class RubyDate extends RubyObject {
             ajd = newRationalConvert(context, df, DAY_IN_SECONDS).op_plus(context, ajd);
         }
         if ( ! ( (RubyNumeric) sf ).isZero() ) {
-            ajd = newRationalConvert(context, sf, DAY_IN_SECONDS * 1_000_000_000).op_plus(context, ajd);
+            ajd = newRationalConvert(context, sf, DAY_IN_SECONDS * 1_000_000_000L).op_plus(context, ajd);
         }
         return ajd;
     }

--- a/core/src/main/java/org/jruby/ext/digest/RubyDigest.java
+++ b/core/src/main/java/org/jruby/ext/digest/RubyDigest.java
@@ -70,15 +70,23 @@ public class RubyDigest {
     static {
         // standard digests from JCA specification; if we can retrieve and clone, save them
         for (String name : new String[] {"MD2", "MD5", "SHA-1", "SHA-256", "SHA-384", "SHA-512"}) {
-            try {
-                MessageDigest digest = MessageDigest.getInstance(name);
-                digest.clone();
-                CLONEABLE_DIGESTS.put(name, digest);
-            }
-            catch (Exception e) {
-                logger().debug(name + " not clonable", e);
-            }
+            MessageDigest digest = getCloneableMessageDigestInstance(name);
+            if (digest != null) CLONEABLE_DIGESTS.put(name, digest);
         }
+    }
+
+    @SuppressWarnings("ReturnValueIgnored")
+    private static MessageDigest getCloneableMessageDigestInstance(final String name) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance(name);
+            digest.clone(); // ignored return value - we're checking clone-ability
+            return digest;
+        } catch (NoSuchAlgorithmException e) {
+            logger().warn("digest '" + name + "' not supported", e);
+        } catch (Exception e) {
+            logger().debug("digest '" + name + "' not cloneable", e);
+        }
+        return null;
     }
 
     private static Logger logger() { return LoggerFactory.getLogger(RubyDigest.class); }

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/FastIntMethodGenerator.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/FastIntMethodGenerator.java
@@ -68,6 +68,7 @@ final class FastIntMethodGenerator extends AbstractNumericMethodGenerator {
     }
 
 
+    @SuppressWarnings("ReturnValueIgnored")
     final static int getMaximumFastIntParameters() {
         try {
             com.kenai.jffi.Invoker.class.getDeclaredMethod("invokeI6", CallContext.class, long.class,

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/FastLongMethodGenerator.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/FastLongMethodGenerator.java
@@ -69,6 +69,7 @@ final class FastLongMethodGenerator extends AbstractNumericMethodGenerator {
     }
 
 
+    @SuppressWarnings("ReturnValueIgnored")
     final static int getMaximumFastLongParameters() {
         try {
             com.kenai.jffi.Invoker.class.getDeclaredMethod("invokeL6", CallContext.class, long.class,

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/FastNumericMethodGenerator.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/FastNumericMethodGenerator.java
@@ -68,7 +68,7 @@ final class FastNumericMethodGenerator extends AbstractNumericMethodGenerator {
         return isFastNumericResult(platform, signature.getResultType());
     }
 
-
+    @SuppressWarnings("ReturnValueIgnored")
     final static int getMaximumFastNumericParameters() {
         try {
             com.kenai.jffi.Invoker.class.getDeclaredMethod("invokeN6", CallContext.class, long.class,

--- a/core/src/main/java/org/jruby/ext/ripper/RubyRipper.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RubyRipper.java
@@ -43,7 +43,6 @@ import org.jruby.lexer.ByteListLexerSource;
 import org.jruby.lexer.GetsLexerSource;
 import org.jruby.lexer.LexerSource;
 import org.jruby.lexer.LexingCommon;
-import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -54,8 +53,8 @@ public class RubyRipper extends RubyObject {
     public static void initRipper(Ruby runtime) {
         RubyClass ripper = runtime.defineClass("Ripper", runtime.getObject(), RubyRipper::new);
         
-        ripper.defineConstant("SCANNER_EVENT_TABLE", createScannerEventTable(runtime, ripper));
-        ripper.defineConstant("PARSER_EVENT_TABLE", createParserEventTable(runtime, ripper));
+        ripper.defineConstant("SCANNER_EVENT_TABLE", createScannerEventTable(runtime));
+        ripper.defineConstant("PARSER_EVENT_TABLE", createParserEventTable(runtime));
         defineLexStateConstants(runtime, ripper);
 
         ripper.defineAnnotatedMethods(RubyRipper.class);
@@ -68,7 +67,7 @@ public class RubyRipper extends RubyObject {
     }
     
     // Creates mapping table of token to arity for on_* method calls for the scanner support
-    private static IRubyObject createScannerEventTable(Ruby runtime, RubyClass ripper) {
+    private static RubyHash createScannerEventTable(Ruby runtime) {
         RubyHash hash = new RubyHash(runtime);
 
         hash.fastASet(runtime.newSymbol("CHAR"), runtime.newFixnum(1));
@@ -127,7 +126,7 @@ public class RubyRipper extends RubyObject {
     }
     
     // Creates mapping table of token to arity for on_* method calls for the parser support    
-    private static IRubyObject createParserEventTable(Ruby runtime, RubyClass ripper) {
+    private static RubyHash createParserEventTable(Ruby runtime) {
         RubyHash hash = new RubyHash(runtime);
 
         hash.fastASet(runtime.newSymbol("BEGIN"), runtime.newFixnum(1));

--- a/core/src/main/java/org/jruby/internal/runtime/methods/DelegatingDynamicMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/DelegatingDynamicMethod.java
@@ -227,4 +227,9 @@ public abstract class DelegatingDynamicMethod extends DynamicMethod {
 
         return delegate.equals(other);
     }
+
+    @Override
+    public int hashCode() {
+        return 11 * delegate.hashCode();
+    }
 }

--- a/core/src/main/java/org/jruby/ir/operands/ClosureLocalVariable.java
+++ b/core/src/main/java/org/jruby/ir/operands/ClosureLocalVariable.java
@@ -20,18 +20,10 @@ public class ClosureLocalVariable extends LocalVariable {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null || !(obj instanceof ClosureLocalVariable)) return false;
-
-        return hashCode() == obj.hashCode();
-    }
-
-    public int compareTo(Object arg0) {
-        // ENEBO: what should compareTo when it is not comparable?
-        if (!(arg0 instanceof ClosureLocalVariable)) return 0;
-
-        int a = hashCode();
-        int b = arg0.hashCode();
-        return a < b ? -1 : (a == b ? 0 : 1);
+        if (obj instanceof ClosureLocalVariable) {
+            return hcode == ((ClosureLocalVariable) obj).hcode;
+        }
+        return false;
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/operands/Integer.java
+++ b/core/src/main/java/org/jruby/ir/operands/Integer.java
@@ -28,7 +28,7 @@ public class Integer extends ImmutableLiteral {
 
     @Override
     public int hashCode() {
-        return 47 * 7 + (int) (this.value ^ (this.value >>> 32));
+        return 47 * this.value;
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/operands/LocalVariable.java
+++ b/core/src/main/java/org/jruby/ir/operands/LocalVariable.java
@@ -83,18 +83,10 @@ public class LocalVariable extends Variable implements DepthCloneable {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null || !(obj instanceof LocalVariable)) return false;
-
-        return hashCode() == obj.hashCode();
-    }
-
-    public int compareTo(Object arg0) {
-        // ENEBO: what should compareTo when it is not comparable?
-        if (!(arg0 instanceof LocalVariable)) return 0;
-
-        int a = hashCode();
-        int b = arg0.hashCode();
-        return a < b ? -1 : (a == b ? 0 : 1);
+        if (obj instanceof LocalVariable) {
+            return hcode == ((LocalVariable) obj).hcode;
+        }
+        return false;
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/operands/Self.java
+++ b/core/src/main/java/org/jruby/ir/operands/Self.java
@@ -37,6 +37,11 @@ public class Self extends Variable {
     }
 
     @Override
+    public int hashCode() {
+        return System.identityHashCode(this);
+    }
+
+    @Override
     public Object retrieve(ThreadContext context, IRubyObject self, StaticScope currScope, DynamicScope currDynScope, Object[] temp) {
         return self;
     }

--- a/core/src/main/java/org/jruby/ir/operands/Self.java
+++ b/core/src/main/java/org/jruby/ir/operands/Self.java
@@ -73,11 +73,6 @@ public class Self extends Variable {
     }
 
     @Override
-    public int compareTo(Object o) {
-        return this == o ? 0 : -1;
-    }
-
-    @Override
     public String toString() {
         return NAME;
     }

--- a/core/src/main/java/org/jruby/ir/operands/Symbol.java
+++ b/core/src/main/java/org/jruby/ir/operands/Symbol.java
@@ -19,9 +19,15 @@ public class Symbol extends ImmutableLiteral implements Stringable {
         this.symbol = symbol;
     }
 
+    @Override
     public boolean equals(Object other) {
         return other instanceof Symbol &&
                 (this == KW_REST_ARG_DUMMY && other == KW_REST_ARG_DUMMY || symbol.equals(((Symbol) other).symbol));
+    }
+
+    @Override
+    public int hashCode() {
+        return 43 * symbol.hashCode();
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/operands/TemporaryVariable.java
+++ b/core/src/main/java/org/jruby/ir/operands/TemporaryVariable.java
@@ -30,13 +30,6 @@ public abstract class TemporaryVariable extends Variable {
     }
 
     @Override
-    public int compareTo(Object other) {
-        if (!(other instanceof TemporaryVariable)) return 0;
-
-        return getId().compareTo(((TemporaryVariable) other).getId());
-    }
-
-    @Override
     public void visit(IRVisitor visitor) {
         visitor.TemporaryVariable(this);
     }

--- a/core/src/main/java/org/jruby/ir/operands/UndefinedValue.java
+++ b/core/src/main/java/org/jruby/ir/operands/UndefinedValue.java
@@ -58,12 +58,17 @@ public class UndefinedValue extends Operand implements IRubyObject {
         return new RuntimeException("IR compiler/interpreter bug: org.jruby.ir.operands.UndefinedValue should not be used as a valid value during execution.");
     }
 
+    @Override
     @Deprecated
     public IRubyObject callSuper(ThreadContext context, IRubyObject[] args, Block block) { throw undefinedOperation(); }
 
+    @Override
     public IRubyObject callMethod(ThreadContext context, String name) { throw undefinedOperation(); }
+    @Override
     public IRubyObject callMethod(ThreadContext context, String name, IRubyObject arg) { throw undefinedOperation(); }
+    @Override
     public IRubyObject callMethod(ThreadContext context, String name, IRubyObject[] args) { throw undefinedOperation(); }
+    @Override
     public IRubyObject callMethod(ThreadContext context, String name, IRubyObject[] args, Block block) { throw undefinedOperation(); }
 
     @Deprecated
@@ -71,155 +76,93 @@ public class UndefinedValue extends Operand implements IRubyObject {
     @Deprecated
     public IRubyObject callMethod(ThreadContext context, int methodIndex, String name, IRubyObject arg) { throw undefinedOperation(); }
 
+    @Override
     public IRubyObject checkCallMethod(ThreadContext context, String name) { throw undefinedOperation(); }
 
+    @Override
     public IRubyObject checkCallMethod(ThreadContext context, JavaSites.CheckedSites sites) { throw undefinedOperation(); }
 
+    @Override
     public boolean isNil() { throw undefinedOperation(); }
 
-    /**
-     *
-     * @return
-     */
+    @Override
     public boolean isTrue() { throw undefinedOperation(); }
 
     /**
      * RubyMethod isFrozen.
      * @return boolean
      */
+    @Override
     public boolean isFrozen() { throw undefinedOperation(); }
 
     /**
      * RubyMethod setFrozen.
      * @param b
      */
+    @Override
     public void setFrozen(boolean b) { throw undefinedOperation(); }
 
-    /**
-     *
-     * @return
-     */
+    @Override
     public boolean isImmediate() { throw undefinedOperation(); }
 
     @Override
     public boolean isSpecialConst() { throw undefinedOperation(); }
 
-    /**
-     * RubyMethod getRubyClass.
-     * @return
-     */
+    @Override
     public RubyClass getMetaClass() { throw undefinedOperation(); }
 
-    /**
-     * RubyMethod getSingletonClass.
-     * @return RubyClass
-     */
+    @Override
     public RubyClass getSingletonClass() { throw undefinedOperation(); }
 
-    /**
-     * RubyMethod getType.
-     * @return RubyClass
-     */
+    @Override
     public RubyClass getType() { throw undefinedOperation(); }
 
-    /**
-     * RubyMethod respondsTo.
-     * @param string
-     * @return boolean
-     */
+    @Override
     public boolean respondsTo(String string) { throw undefinedOperation(); }
 
-    /**
-     * RubyMethod respondsTo.
-     * @param string
-     * @return boolean
-     */
+    @Override
     public boolean respondsToMissing(String string) { throw undefinedOperation(); }
 
-    /**
-     * RubyMethod respondsTo.
-     * @param string
-     * @return boolean
-     */
+    @Override
     public boolean respondsToMissing(String string, boolean priv) { throw undefinedOperation(); }
 
-    /**
-     * RubyMethod getRuntime.
-     * @return
-     */
+    @Override
     public Ruby getRuntime() { throw undefinedOperation(); }
 
-    /**
-     * RubyMethod getJavaClass.
-     * @return Class
-     */
+    @Override
     public Class getJavaClass() { throw undefinedOperation(); }
 
-    /**
-     * Convert the object into a symbol name if possible.
-     *
-     * @return String the symbol name
-     */
+    @Override
     public String asJavaString() { throw undefinedOperation(); }
 
-    /** rb_obj_as_string
-     * @return
-     */
+    @Override
     public RubyString asString() { throw undefinedOperation(); }
 
-    /**
-     * Methods which perform to_xxx if the object has such a method
-     * @return
-     */
+    @Override
     public RubyArray convertToArray() { throw undefinedOperation(); }
-    /**
-     *
-     * @return
-     */
+
+    @Override
     public RubyHash convertToHash() { throw undefinedOperation(); }
-    /**
-    *
-    * @return
-    */
+
+    @Override
     public RubyFloat convertToFloat() { throw undefinedOperation(); }
-    /**
-     *
-     * @return
-     */
+
+    @Override
     public RubyInteger convertToInteger() { throw undefinedOperation(); }
-    /**
-     *
-     * @return
-     */
-    @Deprecated
-    public RubyInteger convertToInteger(int convertMethodIndex, String convertMethod) { throw undefinedOperation(); }
-    /**
-     *
-     * @return
-     */
+
+    @Override
     public RubyInteger convertToInteger(String convertMethod) { throw undefinedOperation(); }
-    /**
-     *
-     * @return
-     */
+
+    @Override
     public RubyString convertToString() { throw undefinedOperation(); }
 
-    /**
-     *
-     * @return
-     */
+    @Override
     public IRubyObject anyToString() { throw undefinedOperation(); }
 
-    /**
-     *
-     * @return
-     */
+    @Override
     public IRubyObject checkStringType() { throw undefinedOperation(); }
 
-    /**
-     *
-     * @return
-     */
+    @Override
     public IRubyObject checkArrayType() { throw undefinedOperation(); }
 
     /**
@@ -227,36 +170,34 @@ public class UndefinedValue extends Operand implements IRubyObject {
      *
      * @param cls The target type to which the object should be converted.
      */
+    @Override
     public Object toJava(Class cls) { throw undefinedOperation(); }
 
-    /**
-     * RubyMethod dup.
-     * @return
-     */
+    @Override
     public IRubyObject dup() { throw undefinedOperation(); }
 
-    /**
-     * RubyMethod inspect.
-     * @return String
-     */
+    @Override
     public IRubyObject inspect() { throw undefinedOperation(); }
 
     /**
      * RubyMethod rbClone.
      * @return IRubyObject
      */
+    @Override
     public IRubyObject rbClone() { throw undefinedOperation(); }
 
     /**
      * @return true if an object is Ruby Module instance (note that it will return false for Ruby Classes).
      * If is_a? semantics is required, use <code>(someObject instanceof RubyModule)</code> instead.
      */
+    @Override
     public boolean isModule() { throw undefinedOperation(); }
 
     /**
      * @return true if an object is Ruby Class instance (note that it will return false for Ruby singleton classes).
      * If is_a? semantics is required, use <code>(someObject instanceof RubyClass/MetaClass)</code> instead.
      */
+    @Override
     public boolean isClass() { throw undefinedOperation(); }
 
     /**
@@ -267,6 +208,7 @@ public class UndefinedValue extends Operand implements IRubyObject {
      *
      * @param obj the object to wrap
      */
+    @Override
     public void dataWrapStruct(Object obj) { throw undefinedOperation(); }
 
     /**
@@ -276,88 +218,68 @@ public class UndefinedValue extends Operand implements IRubyObject {
      *
      * @return the object wrapped.
      */
+    @Override
     public Object dataGetStruct() { throw undefinedOperation(); }
 
-    /**
-     *
-     * @return
-     */
+    @Override
     public IRubyObject id() { throw undefinedOperation(); }
 
-
+    @Override
     public IRubyObject op_equal(ThreadContext context, IRubyObject other) { throw undefinedOperation(); }
+    @Override
     public IRubyObject op_eqq(ThreadContext context, IRubyObject other) { throw undefinedOperation(); }
+    @Override
     public boolean eql(IRubyObject other) { throw undefinedOperation(); }
 
+    @Override
     public void addFinalizer(IRubyObject finalizer) { throw undefinedOperation(); }
 
+    @Override
     public void removeFinalizers() { throw undefinedOperation(); }
 
     //
     // COMMON VARIABLE METHODS
     //
 
-    /**
-     * Returns true if object has any variables, defined as:
-     * <ul>
-     * <li> instance variables
-     * <li> class variables
-     * <li> constants
-     * <li> internal variables, such as those used when marshalling Ranges and Exceptions
-     * </ul>
-     * @return true if object has any variables, else false
-     */
+    @Override
     public boolean hasVariables() { throw undefinedOperation(); }
 
-    /**
-     * @return the count of all variables (ivar/cvar/constant/internal)
-     */
+    @Override
     public int getVariableCount() { throw undefinedOperation(); }
 
-    /**
-     * Sets object's variables to those in the supplied list,
-     * removing/replacing any previously defined variables.  Applies
-     * to all variable types (ivar/cvar/constant/internal).
-     *
-     * @param variables the variables to be set for object
-     */
+    @Override
     @Deprecated
     public void syncVariables(List<Variable<Object>> variables) { throw undefinedOperation(); }
 
-    /**
-     * Sets object's variables to those in the supplied object,
-     * removing/replacing any previously defined variables of the same name.
-     * Applies to all variable types (ivar/cvar/constant/internal).
-     *
-     * @param source the source object containing the variables to sync
-     */
+    @Override
     public void syncVariables(IRubyObject source) { throw undefinedOperation(); }
 
-    /**
-     * @return a list of all variables (ivar/cvar/constant/internal)
-     */
+    @Override
     public List<Variable<Object>> getVariableList() { throw undefinedOperation(); }
 
     //
     // INSTANCE VARIABLE METHODS
     //
 
+    @Override
     public InstanceVariables getInstanceVariables() { throw undefinedOperation(); }
 
     //
     // INTERNAL VARIABLE METHODS
     //
 
+    @Override
     public InternalVariables getInternalVariables() { throw undefinedOperation(); }
 
-    /**
-     * @return a list of all variable names (ivar/cvar/constant/internal)
-     */
+    @Override
     public List<String> getVariableNameList() { throw undefinedOperation(); }
 
+    @Override
     public void copySpecialInstanceVariables(IRubyObject clone) { throw undefinedOperation(); }
 
+    @Override
     public Object getVariable(int index) { throw undefinedOperation(); }
+    @Override
     public void setVariable(int index, Object value) { throw undefinedOperation(); }
 
     @Override
@@ -370,21 +292,27 @@ public class UndefinedValue extends Operand implements IRubyObject {
         visitor.UndefinedValue(this);
     }
 
+    @Override
     @Deprecated
     public Object dataGetStructChecked() { throw undefinedOperation(); }
 
+    @Override
     @Deprecated
     public boolean isTaint() { throw undefinedOperation(); }
 
+    @Override
     @Deprecated
     public void setTaint(boolean b) { throw undefinedOperation(); }
 
+    @Override
     @Deprecated
     public IRubyObject infectBy(IRubyObject obj) { throw undefinedOperation(); }
 
+    @Override
     @Deprecated
     public boolean isUntrusted() { throw undefinedOperation(); }
 
+    @Override
     @Deprecated
     public void setUntrusted(boolean b) { throw undefinedOperation(); }
 }

--- a/core/src/main/java/org/jruby/ir/operands/Variable.java
+++ b/core/src/main/java/org/jruby/ir/operands/Variable.java
@@ -1,6 +1,5 @@
 package org.jruby.ir.operands;
 
-import org.jruby.RubySymbol;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.ir.transformations.inlining.SimpleCloneInfo;
 

--- a/core/src/main/java/org/jruby/ir/operands/Variable.java
+++ b/core/src/main/java/org/jruby/ir/operands/Variable.java
@@ -6,7 +6,7 @@ import org.jruby.ir.transformations.inlining.SimpleCloneInfo;
 import java.util.List;
 import java.util.Map;
 
-public abstract class Variable extends Operand implements Comparable {
+public abstract class Variable extends Operand {
     public Variable() {
         super();
     }

--- a/core/src/main/java/org/jruby/ir/representations/BasicBlock.java
+++ b/core/src/main/java/org/jruby/ir/representations/BasicBlock.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-public class BasicBlock implements ExplicitVertexID, Comparable {
+public class BasicBlock implements ExplicitVertexID, Comparable<BasicBlock> {
     private final int         id;             // Basic Block id
     private final CFG         cfg;            // CFG that this basic block belongs to
     private Label       label;          // All basic blocks have a starting label
@@ -247,9 +247,7 @@ public class BasicBlock implements ExplicitVertexID, Comparable {
     }
 
     @Override
-    public int compareTo(Object o) {
-        BasicBlock other = (BasicBlock) o;
-
+    public int compareTo(final BasicBlock other) {
         if (id == other.id) return 0;
         if (id < other.id) return -1;
 

--- a/core/src/main/java/org/jruby/java/util/ClassUtils.java
+++ b/core/src/main/java/org/jruby/java/util/ClassUtils.java
@@ -192,7 +192,7 @@ public class ClassUtils {
         catch (SecurityException e) { return new Constructor[0]; }
     }
 
-    public static boolean isJavaClassProxyType(ThreadContext context, RubyModule c) {
-        return JavaUtil.getJavaClass(c, null) != null;
+    public static boolean isJavaClassProxyType(final RubyModule clazz) {
+        return JavaUtil.getJavaClass(clazz, null) != null;
     }
 }

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -345,7 +345,7 @@ public class Java implements Library {
             klass = resolveShortClassName(className);
             if (klass == null) klass = getJavaClass(runtime, className);
         } else {
-            klass = resolveClassType(runtime, type);
+            klass = resolveClassType(type);
             if (klass == null) {
                 throw runtime.newTypeError("expected a Java class, got: " + type);
             }
@@ -354,7 +354,7 @@ public class Java implements Library {
     }
 
     // this should handle the type returned from Class#java_class
-    static Class<?> resolveClassType(final Ruby runtime, final IRubyObject type) {
+    static Class<?> resolveClassType(final IRubyObject type) {
         if (type instanceof JavaProxy) { // due Class#java_class wrapping
             final Object wrapped = ((JavaProxy) type).getObject();
             if (wrapped instanceof Class) return (Class) wrapped;
@@ -362,7 +362,6 @@ public class Java implements Library {
         }
 
         if (type instanceof RubyModule) { // assuming a proxy module/class e.g. to_java(java.lang.String)
-            runtime.getCurrentContext();
             return JavaUtil.getJavaClass((RubyModule) type, null);
         }
         return null;

--- a/core/src/main/java/org/jruby/lexer/LexingCommon.java
+++ b/core/src/main/java/org/jruby/lexer/LexingCommon.java
@@ -1241,6 +1241,7 @@ public abstract class LexingCommon {
 
     protected abstract void mismatchedRegexpEncodingError(Encoding optionEncoding, Encoding encoding);
 
+    @SuppressWarnings("ReferenceEquality")
     // MRI: reg_fragment_setenc_gen
     public void setRegexpEncoding(Ruby runtime, ByteList value, RegexpOptions options) {
         Encoding optionsEncoding = options.setup(runtime);
@@ -1266,10 +1267,11 @@ public abstract class LexingCommon {
         }
     }
 
-    private boolean is7BitASCII(ByteList value) {
-      return StringSupport.codeRangeScan(value.getEncoding(), value) == StringSupport.CR_7BIT;
+    private static boolean is7BitASCII(ByteList value) {
+        return StringSupport.codeRangeScan(value.getEncoding(), value) == StringSupport.CR_7BIT;
     }
 
+    @SuppressWarnings("ReferenceEquality")
     // TODO: Put somewhere more consolidated (similiar
     protected char optionsEncodingChar(Encoding optionEncoding) {
         if (optionEncoding == USASCIIEncoding.INSTANCE) return 'n';
@@ -1418,6 +1420,7 @@ public abstract class LexingCommon {
         return scanHex(count, false, errorMessage);
     }
 
+    @SuppressWarnings("ReferenceEquality")
     protected void readUTF8EscapeIntoBuffer(int codepoint, ByteList buffer, boolean stringLiteral, boolean[] encodingDetermined) throws IOException {
         if (codepoint >= 0x80) {
             if (encodingDetermined[0] && buffer.getEncoding() != UTF8Encoding.INSTANCE) {

--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -1512,6 +1512,7 @@ public abstract class RubyParserBase {
     }
 
 
+    @SuppressWarnings("CollectionIncompatibleType") // TODO: this should get reviewed/fixed, the error-prone warning is legit!
     public Node remove_duplicate_keys(HashNode hash) {
         List<Node> encounteredKeys = new ArrayList<>();
 

--- a/core/src/main/java/org/jruby/runtime/Binding.java
+++ b/core/src/main/java/org/jruby/runtime/Binding.java
@@ -260,6 +260,11 @@ public class Binding {
             this.dynamicScope == bOther.dynamicScope;
     }
 
+    @Override
+    public int hashCode() {
+        return (self == null ? 1 : self.hashCode()) * dynamicScope.hashCode();
+    }
+
     // FIXME: This is because we clone the same explicit binding whenever we execute because both the captured Frame
     // and the binding gets mutated during execution.  This means that we cannot share the same instance across
     // concurrent evals of the same binding.  The mutated Frames I think can become new frames during execution and

--- a/core/src/main/java/org/jruby/runtime/Binding.java
+++ b/core/src/main/java/org/jruby/runtime/Binding.java
@@ -240,12 +240,13 @@ public class Binding {
         this.method = method;
     }
 
+    @Override
     public boolean equals(Object other) {
-        if(this == other) {
+        if (this == other) {
             return true;
         }
 
-        if(!(other instanceof Binding)) {
+        if (!(other instanceof Binding)) {
             return false;
         }
 

--- a/core/src/main/java/org/jruby/runtime/Binding.java
+++ b/core/src/main/java/org/jruby/runtime/Binding.java
@@ -82,8 +82,7 @@ public class Binding {
 
     public Binding(IRubyObject self, Frame frame,
                    Visibility visibility, DynamicScope dynamicScope, String method, String filename, int line) {
-        frame.getClass(); // null check
-
+        assert frame != null;
         this.self = self;
         this.frame = frame;
         this.visibility = visibility;
@@ -95,8 +94,7 @@ public class Binding {
 
     private Binding(IRubyObject self, Frame frame,
                     Visibility visibility, DynamicScope dynamicScope, String method, String filename, int line, DynamicScope dummyScope) {
-        frame.getClass(); // null check
-
+        assert frame != null;
         this.self = self;
         this.frame = frame;
         this.visibility = visibility;
@@ -108,8 +106,7 @@ public class Binding {
     }
     
     public Binding(Frame frame, DynamicScope dynamicScope, String method, String filename, int line) {
-        frame.getClass(); // null check
-
+        assert frame != null;
         this.self = frame.getSelf();
         this.frame = frame;
         this.visibility = frame.getVisibility();
@@ -127,8 +124,7 @@ public class Binding {
 
     public Binding(IRubyObject self, Frame frame,
                    Visibility visibility) {
-        frame.getClass(); // null check
-
+        assert frame != null;
         this.self = self;
         this.frame = frame;
         this.visibility = visibility;
@@ -143,8 +139,7 @@ public class Binding {
 
     public Binding(IRubyObject self, Frame frame,
                    Visibility visibility, DynamicScope dynamicScope) {
-        frame.getClass(); // null check
-
+        assert frame != null;
         this.self = self;
         this.frame = frame;
         this.visibility = visibility;

--- a/core/src/main/java/org/jruby/runtime/Block.java
+++ b/core/src/main/java/org/jruby/runtime/Block.java
@@ -330,6 +330,7 @@ public class Block implements FunctionOneOrTwoOrThree<ThreadContext, IRubyObject
      *
      * @return true if this is a valid block or false otherwise
      */
+    @SuppressWarnings("ReferenceEquality")
     public final boolean isGiven() {
         return this != NULL_BLOCK;
     }

--- a/core/src/main/java/org/jruby/runtime/Block.java
+++ b/core/src/main/java/org/jruby/runtime/Block.java
@@ -192,6 +192,7 @@ public class Block implements FunctionOneOrTwoOrThree<ThreadContext, IRubyObject
     /**
      * @see Function#apply(Object)
      */
+    @Override
     public IRubyObject apply(ThreadContext context) {
         return call(context);
     }
@@ -199,6 +200,7 @@ public class Block implements FunctionOneOrTwoOrThree<ThreadContext, IRubyObject
     /**
      * @see BiFunction#apply(Object, Object)
      */
+    @Override
     public IRubyObject apply(ThreadContext context, IRubyObject arg0) {
         return call(context, arg0);
     }
@@ -206,6 +208,7 @@ public class Block implements FunctionOneOrTwoOrThree<ThreadContext, IRubyObject
     /**
      * @see TriFunction#apply(Object, Object, Object)
      */
+    @Override
     public IRubyObject apply(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
         return call(context, arg0, arg1);
     }
@@ -316,7 +319,7 @@ public class Block implements FunctionOneOrTwoOrThree<ThreadContext, IRubyObject
     /**
      * Set the proc object associated with this block
      *
-     * @param procObject
+     * @param procObject the proc tu associate
      */
     public void setProcObject(RubyProc procObject) {
     	this.proc = procObject;

--- a/core/src/main/java/org/jruby/runtime/Frame.java
+++ b/core/src/main/java/org/jruby/runtime/Frame.java
@@ -146,8 +146,7 @@ public final class Frame {
      */
     public void updateFrame(Frame frame) {
         Block block = frame.block;
-
-        block.getClass(); // null check
+        assert block != null;
 
         this.self = frame.self;
         this.name = frame.name;
@@ -165,8 +164,7 @@ public final class Frame {
      * @param block The block passed to the method
      */
     public void updateFrame(RubyModule klazz, IRubyObject self, String name, Block block) {
-        block.getClass(); // null check
-
+        assert block != null;
         this.self = self;
         this.name = name;
         this.klazz = klazz;
@@ -183,8 +181,7 @@ public final class Frame {
      * @param block The block passed to the method
      */
     public void updateFrame(RubyModule klazz, IRubyObject self, String name, Visibility visibility, Block block) {
-        block.getClass(); // null check
-
+        assert block != null;
         this.self = self;
         this.name = name;
         this.klazz = klazz;

--- a/core/src/main/java/org/jruby/runtime/Signature.java
+++ b/core/src/main/java/org/jruby/runtime/Signature.java
@@ -360,6 +360,7 @@ public class Signature {
         }
     }
 
+    @Override
     public boolean equals(Object other) {
         if (!(other instanceof Signature)) return false;
 
@@ -372,5 +373,10 @@ public class Signature {
                 kwargs == otherSig.kwargs &&
                 requiredKwargs == otherSig.requiredKwargs &&
                 keyRest == otherSig.keyRest;
+    }
+
+    @Override
+    public int hashCode() {
+        return rest.hashCode() + pre * 3 + opt * 5 + post * 7 + kwargs * 11 + requiredKwargs * 13 + arityValue * 17 + keyRest * 19;
     }
 }

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -177,8 +177,7 @@ public final class ThreadContext {
 
     /**
      * This fields is no longer initialized, is null by default!
-     * Use {@link #getSecureRandom()} instead.
-     * @deprecated
+     * @deprecated Use {@link #getSecureRandom()} instead.
      */
     @Deprecated
     public transient SecureRandom secureRandom;
@@ -813,6 +812,7 @@ public final class ThreadContext {
         return callNumber;
     }
 
+    @SuppressWarnings("AmbiguousMethodReference")
     public void callThreadPoll() {
         if ((callNumber++ & CALL_POLL_COUNT) == 0) pollThreadEvents();
     }
@@ -1340,7 +1340,7 @@ public final class ThreadContext {
         setExceptionRequiresBacktrace(false);
     }
 
-    private Map<String, Map<IRubyObject, IRubyObject>> symToGuards;
+    private Map<String, IdentityHashMap<IRubyObject, IRubyObject>> symToGuards;
 
     // Thread#set_trace_func of nil will not only remove the one via set_trace_func but also any which
     // were added via add_trace_func.
@@ -1440,15 +1440,14 @@ public final class ThreadContext {
     }
 
     private Map<IRubyObject, IRubyObject> safeRecurseGetGuards(String name) {
-        Map<String, Map<IRubyObject, IRubyObject>> symToGuards = this.symToGuards;
+        Map<String, IdentityHashMap<IRubyObject, IRubyObject>> symToGuards = this.symToGuards;
         if (symToGuards == null) {
             this.symToGuards = symToGuards = new HashMap<>();
         }
 
-        Map<IRubyObject, IRubyObject> guards = symToGuards.get(name);
-        if (guards == null) {
-            guards = new IdentityHashMap<>();
-            symToGuards.put(name, guards);
+        IdentityHashMap<IRubyObject, IRubyObject> guards = symToGuards.get(name);
+        if (guards == null) {;
+            symToGuards.put(name, guards = new IdentityHashMap<>());
         }
 
         return guards;

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -461,6 +461,7 @@ public final class ThreadContext {
      * @param tag The interned string to search for
      * @return The continuation associated with this tag
      */
+    @SuppressWarnings("ReferenceEquality")
     public CatchThrow getActiveCatch(Object tag) {
         for (int i = catchIndex; i >= 0; i--) {
             CatchThrow c = catchStack[i];

--- a/core/src/main/java/org/jruby/runtime/TraceEventManager.java
+++ b/core/src/main/java/org/jruby/runtime/TraceEventManager.java
@@ -257,6 +257,11 @@ public class TraceEventManager {
         }
 
         @Override
+        public int hashCode() {
+            return 13 * traceFunc.hashCode() + 5 * (thread == null ? 0 : thread.hashCode());
+        }
+
+        @Override
         public boolean isInterestedInEvent(RubyEvent event) {
             return interest.contains(event);
         }

--- a/core/src/main/java/org/jruby/util/ByteList.java
+++ b/core/src/main/java/org/jruby/util/ByteList.java
@@ -52,7 +52,7 @@ import org.jruby.runtime.Helpers;
  * of characters. However, its API resembles StringBuffer/StringBuilder more than String
  * because it is a mutable object.
  */
-@SuppressWarnings("deprecation")
+@SuppressWarnings("ComparableType")
 public class ByteList implements Comparable, CharSequence, Serializable {
     private static final long serialVersionUID = -1286166947275543731L;
 

--- a/core/src/main/java/org/jruby/util/IdUtil.java
+++ b/core/src/main/java/org/jruby/util/IdUtil.java
@@ -185,7 +185,7 @@ public final class IdUtil {
 
     @Deprecated
     public static boolean isNameCharacter19(char c) {
-        return isNameCharacter19(c);
+        return isNameCharacter(c);
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/util/Sprintf.java
+++ b/core/src/main/java/org/jruby/util/Sprintf.java
@@ -939,7 +939,7 @@ public class Sprintf {
                     arg = args.getArg();
 
                     double fval = RubyKernel.new_float(runtime, arg).getDoubleValue();
-                    boolean isnan = fval != fval;
+                    boolean isnan = Double.isNaN(fval);
                     boolean isinf = fval == Double.POSITIVE_INFINITY || fval == Double.NEGATIVE_INFINITY;
                     boolean negative = fval < 0.0d || (fval == 0.0d && Double.doubleToLongBits(fval) == Double.doubleToLongBits(-0.0));
 

--- a/core/src/main/java/org/jruby/util/io/EncodingUtils.java
+++ b/core/src/main/java/org/jruby/util/io/EncodingUtils.java
@@ -49,6 +49,7 @@ import org.jruby.util.StringSupport;
 import org.jruby.util.TypeConverter;
 
 import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -2310,7 +2311,7 @@ public class EncodingUtils {
      * @param enc the encoding for which to get a matching charset
      * @return the matching charset
      */
-    public static Charset charsetForEncoding(Encoding enc) {
+    public static Charset charsetForEncoding(Encoding enc) throws UnsupportedCharsetException {
         Charset charset = enc.getCharset();
 
         if (charset == null) {

--- a/core/src/main/java/org/jruby/util/io/PosixShim.java
+++ b/core/src/main/java/org/jruby/util/io/PosixShim.java
@@ -462,7 +462,7 @@ public class PosixShim {
 
     // no longer used
     public Channel open(String cwd, String path, ModeFlags flags, int perm) {
-        return open(cwd, path, flags, perm);
+        return open(cwd, path, flags.getFlags(), perm);
     }
 
     @Deprecated // special case is already handled with JRubyFile.createResource

--- a/core/src/main/java/org/jruby/util/io/SelectExecutor.java
+++ b/core/src/main/java/org/jruby/util/io/SelectExecutor.java
@@ -211,11 +211,11 @@ public class SelectExecutor {
                 RubyIO io = TypeConverter.ioGetIO(runtime, obj);
                 RubyIO write_io = io.GetWriteIO();
                 fptr = io.getOpenFileChecked();
-                if (errorKeyList.contains(fptr.fd())) {
+                if (fdIsSet(errorKeyList, fptr.fd(), READ_ACCEPT_OPS | WRITE_CONNECT_OPS)) {
                     list.push(obj);
                 } else if (io != write_io) {
                     fptr = write_io.getOpenFileChecked();
-                    if (errorKeyList.contains(fptr.fd())) {
+                    if (fdIsSet(errorKeyList, fptr.fd(), READ_ACCEPT_OPS | WRITE_CONNECT_OPS)) {
                         list.push(obj);
                     }
                 }
@@ -265,7 +265,7 @@ public class SelectExecutor {
         writeKeyList.add(key);
     }
 
-    private boolean fdIsSet(List<SelectionKey> fds, ChannelFD fd, int operations) {
+    private boolean fdIsSet(List<SelectionKey> fds, ChannelFD fd, final int operations) {
         if (fds == null) return false;
 
         for (SelectionKey key : fds) {
@@ -349,7 +349,7 @@ public class SelectExecutor {
     }
 
     // MRI: rb_thread_fd_select
-    private int threadFdSelect(ThreadContext context) throws IOException {
+    private int threadFdSelect(ThreadContext context) {
         if (readKeyList == null && writeKeyList == null && errorKeyList == null) {
             if (timeout == null) { // sleep forever
                 try {


### PR DESCRIPTION
set up https://errorprone.info/ which provides additional checks and indeed discovered a bug or two in the code base.

the compiler plugin is currently hidden behind `-Perror-prone` as it slows down Java compilation considerably...
the profile is meant to activate on CI (with `ENV['CI']`).
also, error-prone plugin needs Java 11 (getting a Java 8 compatible version hooked up turned out to be quite difficult).

there are still warnings emitted but the blocking and most relevant stuff should be cleaned up here ... 