### PR TITLE
Do not return early from ThreadService#terminate

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
+++ b/core/src/main/java/org/jruby/internal/runtime/ThreadService.java
@@ -151,7 +151,7 @@ public class ThreadService extends ThreadLocal<SoftReference<ThreadContext>> {
             // don't kill current thread that is doing teardown
             if (rth == getCurrentContext().getThread()) continue;
 
-            if (rth.isAdopted()) return;
+            if (rth.isAdopted()) continue;
 
             try {
                 rth.kill();


### PR DESCRIPTION
Previously, if we encounter an adopted thread when terminating the ThreadService we return early and fail to finish killing threads we spawned.

This changes the `return` to `continue` which I believe was always the intent.