### PR TITLE
Use SmartBinder to set up struct calls

### DIFF
--- a/core/src/main/java/org/jruby/ir/targets/indy/InvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/InvokeSite.java
@@ -743,11 +743,11 @@ public abstract class InvokeSite extends MutableCallSite {
                 RubyStruct.Accessor accessor = (RubyStruct.Accessor) method;
                 int index = accessor.getIndex();
 
-                mh = Binder.from(type())
-                        .cast(type().changeParameterType(2, RubyStruct.class))
-                        .permute(2)
-                        .append(index)
-                        .invokeVirtual(LOOKUP, "get");
+                mh = SmartBinder.from(signature)
+                        .cast(signature.replaceArg("self", "self", RubyStruct.class))
+                        .permute("self")
+                        .append("index", index)
+                        .invokeVirtualQuiet(LOOKUP, "get").handle();
 
                 method.setHandle(mh);
 
@@ -764,11 +764,11 @@ public abstract class InvokeSite extends MutableCallSite {
                 RubyStruct.Mutator mutator = (RubyStruct.Mutator) method;
                 int index = mutator.getIndex();
 
-                mh = Binder.from(type())
-                        .cast(type().changeParameterType(2, RubyStruct.class))
-                        .permute(2, 3)
-                        .append(index)
-                        .invokeVirtual(LOOKUP, "set");
+                mh = SmartBinder.from(signature)
+                        .cast(signature.replaceArg("self", "self", RubyStruct.class))
+                        .permute("self", "arg0")
+                        .append("index", index)
+                        .invokeVirtualQuiet(LOOKUP, "set").handle();
 
                 method.setHandle(mh);
 

--- a/spec/compiler/general_spec.rb
+++ b/spec/compiler/general_spec.rb
@@ -1356,5 +1356,10 @@ modes.each do |mode|
     it "dispatches to Java using a block to implement an interface" do
       run('ary = []; 2.times { java.util.ArrayList.new([1]).forEach { |e| ary << e } }; ary') {|ary| ary.should == [1, 1]}
     end
+
+    it "calls struct field methods" do
+      run('StructTest1 = Struct.new(:foo); st1 = StructTest1.new; st1.foo = 1; st1.foo') {|x| expect(x).to eq(1)}
+      run('StructTest2 = Struct.new(:foo); class StructTest2; def do_foo; self.foo = 1; foo; end; end; StructTest2.new.do_foo') {|x| expect(x).to eq(1)}
+    end
   end
 end


### PR DESCRIPTION
Original logic used hardcoded argument offsets, which was broken by my work in #7589 that removed the "caller" argument from self- calls that don't need to check visibility.

The new logic uses SmartBinder and Signature to manipulate incoming arguments by name rather than by index.

Fixes #7642