### PR TITLE
Fix Array#fill for edge case

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -2350,8 +2350,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         unpack();
         modify();
 
-        // See [ruby-core:17483]
-        if (len <= 0) return this;
+        if (len < 0) return this;
 
         if (len > Integer.MAX_VALUE - beg) throw context.runtime.newArgumentError("argument too big");
 
@@ -2377,8 +2376,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         unpack();
         modify();
 
-        // See [ruby-core:17483]
-        if (len <= 0) return this;
+        if (len < 0) return this;
 
         if (len > Integer.MAX_VALUE - beg) throw context.runtime.newArgumentError("argument too big");
 

--- a/test/jruby/test_array.rb
+++ b/test/jruby/test_array.rb
@@ -102,6 +102,14 @@ class TestArray < Test::Unit::TestCase
     assert_equal [[1, 3, 5], [2, 4, 6]], res
   end
 
+  # GH-7684
+  def test_fill
+    assert_equal [:foo, nil], [:foo].fill(:a, 2, 0)
+    assert_equal [:foo, nil, :a, :a, :a], [:foo].fill(:a, 2, 3)
+    assert_equal [:foo, nil], [:foo].fill(2,0) {|i| i}
+    assert_equal [:foo, nil, 2, 3, 4], [:foo].fill(2,3) {|i| i}
+  end
+
   class MyArray < Array; end
 
   def test_array_instance_methods_on_subclass


### PR DESCRIPTION
If start >= array.size and length = 0, array#fill should extends self with nil.

Fixes #7648