### PR TITLE
Fix Float#to_d of bigdecimal/util

### DIFF
--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -545,7 +545,7 @@ public class RubyBigDecimal extends RubyNumeric {
         RubyBigDecimal res = newFloatSpecialCases(runtime, arg);
         if (res != null) return res;
 
-        return new RubyBigDecimal(runtime, (RubyClass) recv, new BigDecimal(arg.getDoubleValue(), mathContext));
+        return new RubyBigDecimal(runtime, (RubyClass) recv, new BigDecimal(arg.inspect().asJavaString(), mathContext));
     }
 
     private static RubyBigDecimal newFloatSpecialCases(Ruby runtime, RubyFloat val) {

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -545,7 +545,7 @@ public class RubyBigDecimal extends RubyNumeric {
         RubyBigDecimal res = newFloatSpecialCases(runtime, arg);
         if (res != null) return res;
 
-        return new RubyBigDecimal(runtime, (RubyClass) recv, new BigDecimal(arg.inspect().asJavaString(), mathContext));
+        return new RubyBigDecimal(runtime, (RubyClass) recv, new BigDecimal(arg.toString(), mathContext));
     }
 
     private static RubyBigDecimal newFloatSpecialCases(Ruby runtime, RubyFloat val) {

--- a/test/mri/excludes/TestBigDecimalUtil.rb
+++ b/test/mri/excludes/TestBigDecimalUtil.rb
@@ -1,5 +1,3 @@
 exclude :"test_Complex_to_d", "work in progress"
 exclude :"test_Float_to_d_bug13331", "work in progress"
-exclude :"test_Float_to_d_issue_192", "work in progress"
-exclude :"test_Float_to_d_without_precision", "work in progress"
 exclude :"test_String_to_d", "work in progress"


### PR DESCRIPTION
This change uses BigDecimal(string) instead of BigDecimal(double) to generate correct BigDecimal value and to avoid precision error.

Fixes #7650