### PR TITLE
END blocks had regressed and was calling same block >1

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -5813,7 +5813,7 @@ public final class Ruby implements Constantizable {
         }
 
         public boolean matches(Object o) {
-            return (o instanceof RubyProc) && ((RubyProc) o).getBlock() == proc.getBlock();
+            return (o instanceof RubyProc) && ((RubyProc) o).getBlock().getBody() == proc.getBlock().getBody();
         }
 
         @Override

--- a/spec/tags/ruby/language/END_tags.txt
+++ b/spec/tags/ruby/language/END_tags.txt
@@ -1,1 +1,0 @@
-fails:The END keyword runs only once for multiple calls


### PR DESCRIPTION
At some point we started making new block instances so they will never appear to be the same.  Change to blockbody and assume no one will be using the same body in multiple ways then register those are separate END blocks :)