### PR TITLE
Array#new size boundary error not tripping

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -680,7 +680,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
         long len = RubyNumeric.num2long(arg0);
         if (len < 0) throw runtime.newArgumentError("negative array size");
-        int ilen = validateBufferLength(runtime, (int) len);
+        int ilen = validateBufferLength(runtime, len);
 
         modify();
 

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -579,13 +579,13 @@ public class Helpers {
      * Check that the buffer length requested is within the valid range of 0 to MAX_ARRAY_SIZE, or raise an argument
      * error.
      */
-    public static int validateBufferLength(Ruby runtime, int length) {
+    public static int validateBufferLength(Ruby runtime, long length) {
         if (length < 0) {
             throw runtime.newArgumentError("negative argument");
         } else if (length > MAX_ARRAY_SIZE) {
             throw runtime.newArgumentError("argument too big");
         }
-        return length;
+        return (int) length;
     }
 
     public static class MethodMissingMethod extends DynamicMethod {

--- a/spec/tags/ruby/core/array/new_tags.txt
+++ b/spec/tags/ruby/core/array/new_tags.txt
@@ -1,1 +1,0 @@
-fails:Array.new with (size, object=nil) raises an ArgumentError if size is too large


### PR DESCRIPTION
When a common method was added to check for max size the call put an int cast on a long which truncated the value to 0 at max_int.  Making it a long restores the check.