### PR TITLE
Proc#inspect with &:foo should print that out in str

### DIFF
--- a/core/src/main/java/org/jruby/RubyProc.java
+++ b/core/src/main/java/org/jruby/RubyProc.java
@@ -232,16 +232,11 @@ public class RubyProc extends RubyObject implements DataType {
         string.append(types(runtime, type()));
         string.catString(":0x" + Integer.toString(System.identityHashCode(block), 16));
 
-        String file = block.getBody().getFile();
-
-        if (file != null) {
-            boolean isSymbolProc = block.getBody() instanceof RubySymbol.SymbolProcBody;
-
-            if (isSymbolProc) {
-                string.catString("(&:" + file + ")");
-            } else {
-                string.catString(" " + file + ":" + (block.getBody().getLine() + 1));
-            }
+        boolean isSymbolProc = block.getBody() instanceof RubySymbol.SymbolProcBody;
+        if (isSymbolProc) {
+            string.catString("(&:" + ((RubySymbol.SymbolProcBody) block.getBody()).getId() + ")");
+        } else if ((file = block.getBody().getFile()) != null) {
+            string.catString(" " + file + ":" + (block.getBody().getLine() + 1));
         }
 
         if (isLambda()) string.catString(" (lambda)");

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -1484,15 +1484,18 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
 
     public static final class SymbolProcBody extends ContextAwareBlockBody {
         private final CallSite site;
+        private final String id;
 
-        public SymbolProcBody(Ruby runtime, String symbol) {
+        public SymbolProcBody(Ruby runtime, String id) {
             super(runtime.getStaticScopeFactory().getDummyScope(), Signature.OPTIONAL);
-            this.site = MethodIndex.getFunctionalCallSite(symbol);
+            this.site = MethodIndex.getFunctionalCallSite(id);
+            this.id = id;
         }
 
-        public SymbolProcBody(Ruby runtime, String symbol, StaticScope scope) {
+        public SymbolProcBody(Ruby runtime, String id, StaticScope scope) {
             super(scope, Signature.OPTIONAL);
-            this.site = new RefinedCachingCallSite(symbol, scope, CallType.FUNCTIONAL);
+            this.site = new RefinedCachingCallSite(id, scope, CallType.FUNCTIONAL);
+            this.id = id;
         }
 
         private IRubyObject yieldInner(ThreadContext context, RubyArray array, Block blockArg) {
@@ -1544,12 +1547,16 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
 
         @Override
         public String getFile() {
-            return null;
+            return site.methodName;
         }
 
         @Override
         public int getLine() {
             return -1;
+        }
+
+        public String getId() {
+            return id;
         }
 
         @Override

--- a/spec/tags/ruby/core/proc/inspect_tags.txt
+++ b/spec/tags/ruby/core/proc/inspect_tags.txt
@@ -1,1 +1,0 @@
-fails:Proc#inspect for a proc created with Symbol#to_proc returns a description including '(&:symbol)'

--- a/spec/tags/ruby/core/proc/to_s_tags.txt
+++ b/spec/tags/ruby/core/proc/to_s_tags.txt
@@ -1,1 +1,0 @@
-fails:Proc#to_s for a proc created with Symbol#to_proc returns a description including '(&:symbol)'


### PR DESCRIPTION
Logic was there but weird relying on a side-effect which was never made.  This logic is less clever but also less likely to cause weird behavior (who knows what will happen if you reuse file in blockbody for other stuff?).