### PR TITLE
Always on traces

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -252,11 +252,11 @@ public final class Ruby implements Constantizable {
     private static final Logger LOG = LoggerFactory.getLogger(Ruby.class);
     private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
     public static final MethodHandle TRACE_OFF = Binder
-            .from(void.class, ThreadContext.class, RubyModule.class, RubyEvent.class, String.class, String.class, int.class)
+            .from(void.class, ThreadContext.class, IRubyObject.class, RubyEvent.class, String.class, String.class, int.class)
             .drop(1, 5)
             .identity();
     public static final MethodHandle TRACE_ON = Binder
-            .from(void.class, ThreadContext.class, RubyModule.class, RubyEvent.class, String.class, String.class, int.class)
+            .from(void.class, ThreadContext.class, IRubyObject.class, RubyEvent.class, String.class, String.class, int.class)
             .invokeStaticQuiet(LOOKUP, IRRuntimeHelpers.class, "callTrace");
     public static final MethodHandle B_TRACE_OFF = Binder
             .from(void.class, ThreadContext.class, Block.class, RubyEvent.class, String.class, String.class, int.class)

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1471,11 +1471,11 @@ public class RubyKernel {
     @JRubyMethod(module = true, visibility = PRIVATE)
     public static IRubyObject set_trace_func(ThreadContext context, IRubyObject recv, IRubyObject trace_func, Block block) {
         if (trace_func.isNil()) {
-            context.runtime.setTraceFunction(null);
+            context.traceEvents.setTraceFunction(null);
         } else if (!(trace_func instanceof RubyProc)) {
             throw context.runtime.newTypeError("trace_func needs to be Proc.");
         } else {
-            context.runtime.setTraceFunction((RubyProc) trace_func);
+            context.traceEvents.setTraceFunction((RubyProc) trace_func);
         }
         return trace_func;
     }

--- a/core/src/main/java/org/jruby/exceptions/RaiseException.java
+++ b/core/src/main/java/org/jruby/exceptions/RaiseException.java
@@ -45,9 +45,9 @@ import org.jruby.RubyException;
 import org.jruby.RubyInstanceConfig;
 import org.jruby.RubyStandardError;
 import org.jruby.RubyString;
+import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.JavaSites;
-import org.jruby.runtime.RubyEvent;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.backtrace.RubyStackTraceElement;
 import org.jruby.runtime.backtrace.TraceType;
@@ -201,7 +201,6 @@ public class RaiseException extends JumpException {
         if (RubyInstanceConfig.LOG_EXCEPTIONS) TraceType.logException(exception);
 
         doSetLastError(context);
-        doCallEventHook(context);
 
         if (backtrace == null) {
             if (capture) { // only false to support legacy RaiseException construction (not setting trace)
@@ -215,6 +214,8 @@ public class RaiseException extends JumpException {
             }
             setStackTraceFromException();
         }
+
+        IRRuntimeHelpers.traceRaise(context, getException());
     }
 
     private void setStackTraceFromException() {
@@ -257,12 +258,6 @@ public class RaiseException extends JumpException {
         StackTraceElement[] curTrace = getStackTrace();
         StackTraceElement[] newTrace = skipFillInStackTracePart(curTrace);
         if (newTrace != curTrace) setStackTrace(newTrace);
-    }
-
-    private static void doCallEventHook(final ThreadContext context) {
-        if (context.runtime.hasEventHooks()) {
-            context.runtime.callEventHooks(context, RubyEvent.RAISE, context.getFile(), context.getLine(), context.getFrameName(), context.getFrameKlazz());
-        }
     }
 
     private void doSetLastError(final ThreadContext context) {

--- a/core/src/main/java/org/jruby/exceptions/RaiseException.java
+++ b/core/src/main/java/org/jruby/exceptions/RaiseException.java
@@ -215,7 +215,7 @@ public class RaiseException extends JumpException {
             setStackTraceFromException();
         }
 
-        IRRuntimeHelpers.traceRaise(context, getException());
+        IRRuntimeHelpers.traceRaise(context);
     }
 
     private void setStackTraceFromException() {

--- a/core/src/main/java/org/jruby/ext/tracepoint/TracePoint.java
+++ b/core/src/main/java/org/jruby/ext/tracepoint/TracePoint.java
@@ -271,9 +271,9 @@ public class TracePoint extends RubyObject {
         enabled = toggle;
         
         if (toggle) {
-            context.runtime.addEventHook(hook);
+            context.traceEvents.addEventHook(hook);
         } else {
-            context.runtime.removeEventHook(hook);
+            context.traceEvents.removeEventHook(hook);
         }
     }
 

--- a/core/src/main/java/org/jruby/internal/runtime/RubyRunnable.java
+++ b/core/src/main/java/org/jruby/internal/runtime/RubyRunnable.java
@@ -36,6 +36,7 @@ import org.jruby.exceptions.JumpException;
 import org.jruby.exceptions.MainExitException;
 import org.jruby.exceptions.ThreadKill;
 import org.jruby.ir.runtime.IRBreakJump;
+import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.RubyEvent;
@@ -106,9 +107,9 @@ public class RubyRunnable implements ThreadedRunnable {
             String file = threadBlock.getBinding().getFile();
             int line = threadBlock.getBinding().getLine();
             try {
-                if (runtime.hasEventHooks()) context.trace(RubyEvent.THREAD_BEGIN, null, frameClass, file, line);
+                IRRuntimeHelpers.callTrace(context, frameClass, RubyEvent.THREAD_BEGIN, null, file, line);
                 IRubyObject result = proc.call(context, arguments);
-                if (runtime.hasEventHooks()) context.trace(RubyEvent.THREAD_END, null, frameClass, file, line);
+                IRRuntimeHelpers.callTrace(context, frameClass, RubyEvent.THREAD_END, null, file, line);
                 rubyThread.cleanTerminate(result);
             } catch (MainExitException mee) {
                 // Someone called exit!, so we need to kill the main thread

--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -2789,9 +2789,9 @@ public class IRBuilder {
         if (RubyInstanceConfig.FULL_TRACE_ENABLED) {
             // Explicit line number here because we need a line number for trace before we process any nodes
             addInstr(manager.newLineNumber(scope.getLine() + 1));
+            addInstr(new TraceInstr(RubyEvent.CALL, getCurrentModuleVariable(), getName(), getFileName(), scope.getLine() + 1));
         }
 
-        addInstr(new TraceInstr(RubyEvent.CALL, getCurrentModuleVariable(), getName(), getFileName(), scope.getLine() + 1));
 
         prepareImplicitState();                                    // recv_self, add frame block, etc)
 
@@ -2809,9 +2809,9 @@ public class IRBuilder {
 
         if (RubyInstanceConfig.FULL_TRACE_ENABLED) {
             addInstr(new LineNumberInstr(defNode.getEndLine() + 1));
+            addInstr(new TraceInstr(RubyEvent.RETURN, getCurrentModuleVariable(), getName(), getFileName(), defNode.getEndLine() + 1));
         }
 
-        addInstr(new TraceInstr(RubyEvent.RETURN, getCurrentModuleVariable(), getName(), getFileName(), defNode.getEndLine() + 1));
 
         if (rv != null) addInstr(new ReturnInstr(rv));
 
@@ -3786,7 +3786,9 @@ public class IRBuilder {
         boolean forNode = iterNode instanceof ForNode;
         prepareClosureImplicitState();                                    // recv_self, add frame block, etc)
 
-        addInstr(new TraceInstr(RubyEvent.B_CALL, getCurrentModuleVariable(), getName(), getFileName(), scope.getLine() + 1));
+        if (RubyInstanceConfig.FULL_TRACE_ENABLED) {
+            addInstr(new TraceInstr(RubyEvent.B_CALL, getCurrentModuleVariable(), getName(), getFileName(), scope.getLine() + 1));
+        }
 
         if (!forNode) addCurrentModule();                                // %current_module
         receiveBlockArgs(iterNode);
@@ -3800,7 +3802,9 @@ public class IRBuilder {
         // Build closure body and return the result of the closure
         Operand closureRetVal = iterNode.getBodyNode() == null ? manager.getNil() : build(iterNode.getBodyNode());
 
-        addInstr(new TraceInstr(RubyEvent.B_RETURN, getCurrentModuleVariable(), getName(), getFileName(), iterNode.getEndLine() + 1));
+        if (RubyInstanceConfig.FULL_TRACE_ENABLED) {
+            addInstr(new TraceInstr(RubyEvent.B_RETURN, getCurrentModuleVariable(), getName(), getFileName(), iterNode.getEndLine() + 1));
+        }
 
         // can be U_NIL if the node is an if node with returns in both branches.
         if (closureRetVal != U_NIL) addInstr(new ReturnInstr(closureRetVal));
@@ -4580,7 +4584,9 @@ public class IRBuilder {
         } else {
             retVal = processEnsureRescueBlocks(retVal);
 
-            addInstr(new TraceInstr(RubyEvent.RETURN, getCurrentModuleVariable(), getName(), getFileName(), returnNode.getLine() + 1));
+            if (RubyInstanceConfig.FULL_TRACE_ENABLED) {
+                addInstr(new TraceInstr(RubyEvent.RETURN, getCurrentModuleVariable(), getName(), getFileName(), returnNode.getLine() + 1));
+            }
             addInstr(new ReturnInstr(retVal));
         }
 

--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -377,7 +377,7 @@ public class IRBuilder {
             }
 
             if (RubyInstanceConfig.FULL_TRACE_ENABLED) {
-                addInstr(new TraceInstr(RubyEvent.LINE, methodNameFor(), getFileName(), lastProcessedLineNum + 1));
+                addInstr(new TraceInstr(RubyEvent.LINE, getCurrentModuleVariable(), methodNameFor(), getFileName(), lastProcessedLineNum + 1));
             }
         }
 
@@ -2791,7 +2791,7 @@ public class IRBuilder {
             addInstr(manager.newLineNumber(scope.getLine() + 1));
         }
 
-        addInstr(new TraceInstr(RubyEvent.CALL, getName(), getFileName(), scope.getLine() + 1));
+        addInstr(new TraceInstr(RubyEvent.CALL, getCurrentModuleVariable(), getName(), getFileName(), scope.getLine() + 1));
 
         prepareImplicitState();                                    // recv_self, add frame block, etc)
 
@@ -2811,7 +2811,7 @@ public class IRBuilder {
             addInstr(new LineNumberInstr(defNode.getEndLine() + 1));
         }
 
-        addInstr(new TraceInstr(RubyEvent.RETURN, getName(), getFileName(), defNode.getEndLine() + 1));
+        addInstr(new TraceInstr(RubyEvent.RETURN, getCurrentModuleVariable(), getName(), getFileName(), defNode.getEndLine() + 1));
 
         if (rv != null) addInstr(new ReturnInstr(rv));
 
@@ -3786,7 +3786,7 @@ public class IRBuilder {
         boolean forNode = iterNode instanceof ForNode;
         prepareClosureImplicitState();                                    // recv_self, add frame block, etc)
 
-        addInstr(new TraceInstr(RubyEvent.B_CALL, getName(), getFileName(), scope.getLine() + 1));
+        addInstr(new TraceInstr(RubyEvent.B_CALL, getCurrentModuleVariable(), getName(), getFileName(), scope.getLine() + 1));
 
         if (!forNode) addCurrentModule();                                // %current_module
         receiveBlockArgs(iterNode);
@@ -3800,7 +3800,7 @@ public class IRBuilder {
         // Build closure body and return the result of the closure
         Operand closureRetVal = iterNode.getBodyNode() == null ? manager.getNil() : build(iterNode.getBodyNode());
 
-        addInstr(new TraceInstr(RubyEvent.B_RETURN, getName(), getFileName(), iterNode.getEndLine() + 1));
+        addInstr(new TraceInstr(RubyEvent.B_RETURN, getCurrentModuleVariable(), getName(), getFileName(), iterNode.getEndLine() + 1));
 
         // can be U_NIL if the node is an if node with returns in both branches.
         if (closureRetVal != U_NIL) addInstr(new ReturnInstr(closureRetVal));
@@ -4580,7 +4580,7 @@ public class IRBuilder {
         } else {
             retVal = processEnsureRescueBlocks(retVal);
 
-            addInstr(new TraceInstr(RubyEvent.RETURN, getName(), getFileName(), returnNode.getLine() + 1));
+            addInstr(new TraceInstr(RubyEvent.RETURN, getCurrentModuleVariable(), getName(), getFileName(), returnNode.getLine() + 1));
             addInstr(new ReturnInstr(retVal));
         }
 
@@ -4971,7 +4971,7 @@ public class IRBuilder {
     }
 
     private InterpreterContext buildModuleOrClassBody(Node bodyNode, int startLine, int endLine) {
-        addInstr(new TraceInstr(RubyEvent.CLASS, null, getFileName(), startLine + 1));
+        addInstr(new TraceInstr(RubyEvent.CLASS, getCurrentModuleVariable(), null, getFileName(), startLine + 1));
 
         prepareImplicitState();                                    // recv_self, add frame block, etc)
         addCurrentModule();                                        // %current_module
@@ -4981,7 +4981,7 @@ public class IRBuilder {
         // This is only added when tracing is enabled because an 'end' will normally have no other instrs which can
         // raise after this point.  When we add trace we need to add one so backtrace generated shows the 'end' line.
         addInstr(manager.newLineNumber(endLine));
-        addInstr(new TraceInstr(RubyEvent.END, null, getFileName(), endLine + 1));
+        addInstr(new TraceInstr(RubyEvent.END, getCurrentModuleVariable(), null, getFileName(), endLine + 1));
 
         addInstr(new ReturnInstr(bodyReturnValue));
 

--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -2789,8 +2789,9 @@ public class IRBuilder {
         if (RubyInstanceConfig.FULL_TRACE_ENABLED) {
             // Explicit line number here because we need a line number for trace before we process any nodes
             addInstr(manager.newLineNumber(scope.getLine() + 1));
-            addInstr(new TraceInstr(RubyEvent.CALL, getName(), getFileName(), scope.getLine() + 1));
         }
+
+        addInstr(new TraceInstr(RubyEvent.CALL, getName(), getFileName(), scope.getLine() + 1));
 
         prepareImplicitState();                                    // recv_self, add frame block, etc)
 
@@ -2808,8 +2809,9 @@ public class IRBuilder {
 
         if (RubyInstanceConfig.FULL_TRACE_ENABLED) {
             addInstr(new LineNumberInstr(defNode.getEndLine() + 1));
-            addInstr(new TraceInstr(RubyEvent.RETURN, getName(), getFileName(), defNode.getEndLine() + 1));
         }
+
+        addInstr(new TraceInstr(RubyEvent.RETURN, getName(), getFileName(), defNode.getEndLine() + 1));
 
         if (rv != null) addInstr(new ReturnInstr(rv));
 
@@ -3784,9 +3786,7 @@ public class IRBuilder {
         boolean forNode = iterNode instanceof ForNode;
         prepareClosureImplicitState();                                    // recv_self, add frame block, etc)
 
-        if (RubyInstanceConfig.FULL_TRACE_ENABLED) {
-            addInstr(new TraceInstr(RubyEvent.B_CALL, getName(), getFileName(), scope.getLine() + 1));
-        }
+        addInstr(new TraceInstr(RubyEvent.B_CALL, getName(), getFileName(), scope.getLine() + 1));
 
         if (!forNode) addCurrentModule();                                // %current_module
         receiveBlockArgs(iterNode);
@@ -3800,9 +3800,7 @@ public class IRBuilder {
         // Build closure body and return the result of the closure
         Operand closureRetVal = iterNode.getBodyNode() == null ? manager.getNil() : build(iterNode.getBodyNode());
 
-        if (RubyInstanceConfig.FULL_TRACE_ENABLED) {
-            addInstr(new TraceInstr(RubyEvent.B_RETURN, getName(), getFileName(), iterNode.getEndLine() + 1));
-        }
+        addInstr(new TraceInstr(RubyEvent.B_RETURN, getName(), getFileName(), iterNode.getEndLine() + 1));
 
         // can be U_NIL if the node is an if node with returns in both branches.
         if (closureRetVal != U_NIL) addInstr(new ReturnInstr(closureRetVal));
@@ -4582,10 +4580,7 @@ public class IRBuilder {
         } else {
             retVal = processEnsureRescueBlocks(retVal);
 
-            if (RubyInstanceConfig.FULL_TRACE_ENABLED) {
-                addInstr(new TraceInstr(RubyEvent.RETURN, getName(), getFileName(), returnNode.getLine() + 1));
-            }
-
+            addInstr(new TraceInstr(RubyEvent.RETURN, getName(), getFileName(), returnNode.getLine() + 1));
             addInstr(new ReturnInstr(retVal));
         }
 

--- a/core/src/main/java/org/jruby/ir/instructions/TraceInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/TraceInstr.java
@@ -78,7 +78,7 @@ public class TraceInstr extends NoOperandInstr {
 
     @Override
     public Object interpret(ThreadContext context, StaticScope currScope, DynamicScope currDynScope, IRubyObject self, Object[] temp) {
-        IRRuntimeHelpers.callTrace(context, getEvent(), getName(), getFilename(), getLinenumber());
+        IRRuntimeHelpers.callTrace(context, context.getFrameKlazz(), getEvent(), getName(), getFilename(), getLinenumber());
 
         return null;
     }
@@ -90,6 +90,13 @@ public class TraceInstr extends NoOperandInstr {
 
     @Override
     public boolean computeScopeFlags(IRScope scope, EnumSet<IRFlags> flags) {
+        if (event == RubyEvent.CALL || event == RubyEvent.RETURN
+                || event == RubyEvent.B_CALL || event == RubyEvent.B_RETURN) {
+            // no need for frame for these currently
+            return false;
+        }
+
+        // other instrs need frame
         flags.addAll(IRFlags.REQUIRE_ALL_FRAME_FIELDS);
         return true;
     }

--- a/core/src/main/java/org/jruby/ir/instructions/TraceInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/TraceInstr.java
@@ -1,15 +1,18 @@
 package org.jruby.ir.instructions;
 
+import org.jruby.RubyModule;
 import org.jruby.RubySymbol;
 import org.jruby.ir.IRFlags;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
+import org.jruby.ir.operands.Operand;
 import org.jruby.ir.persistence.IRReaderDecoder;
 import org.jruby.ir.persistence.IRWriterEncoder;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
+import org.jruby.runtime.Block;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.RubyEvent;
 import org.jruby.runtime.ThreadContext;
@@ -22,16 +25,18 @@ import java.util.EnumSet;
 /**
  * Instrumented trace.
  */
-public class TraceInstr extends NoOperandInstr {
+public class TraceInstr extends OneOperandInstr {
     private final RubyEvent event;
+    private final Operand module;
     private final RubySymbol name;
     private final String filename;
     private final int linenumber;
 
-    public TraceInstr(RubyEvent event, RubySymbol name, String filename, int linenumber) {
-        super(Operation.TRACE);
+    public TraceInstr(RubyEvent event, Operand module, RubySymbol name, String filename, int linenumber) {
+        super(Operation.TRACE, module);
 
         this.event = event;
+        this.module = module;
         this.name = name;
         this.filename = filename;
         this.linenumber = linenumber;
@@ -39,7 +44,7 @@ public class TraceInstr extends NoOperandInstr {
 
     @Override
     public Instr clone(CloneInfo ii) {
-        return new TraceInstr(event, name, filename, linenumber);
+        return new TraceInstr(event, module, name, filename, linenumber);
     }
 
     public RubyEvent getEvent() {
@@ -67,18 +72,26 @@ public class TraceInstr extends NoOperandInstr {
     public void encode(IRWriterEncoder e) {
         super.encode(e);
         e.encode(getEvent());
+        e.encode(module);
         e.encode(name);
         e.encode(getFilename());
         e.encode(getLinenumber());
     }
 
     public static TraceInstr decode(IRReaderDecoder d) {
-        return new TraceInstr(d.decodeRubyEvent(), d.decodeSymbol(), d.decodeString(), d.decodeInt());
+        return new TraceInstr(d.decodeRubyEvent(), d.decodeOperand(), d.decodeSymbol(), d.decodeString(), d.decodeInt());
     }
 
     @Override
     public Object interpret(ThreadContext context, StaticScope currScope, DynamicScope currDynScope, IRubyObject self, Object[] temp) {
-        IRRuntimeHelpers.callTrace(context, context.getFrameKlazz(), getEvent(), getName(), getFilename(), getLinenumber());
+        Object moduleValue = module.retrieve(context, self, currScope, currDynScope, temp);
+        if (moduleValue instanceof Block) {
+            Block block = (Block) moduleValue;
+            IRRuntimeHelpers.callTrace(context, block, getEvent(), getName(), getFilename(), getLinenumber());
+        } else {
+            IRubyObject selfClass = (IRubyObject) moduleValue;
+            IRRuntimeHelpers.callTrace(context, selfClass, getEvent(), getName(), getFilename(), getLinenumber());
+        }
 
         return null;
     }

--- a/core/src/main/java/org/jruby/ir/instructions/TraceInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/TraceInstr.java
@@ -103,13 +103,6 @@ public class TraceInstr extends OneOperandInstr {
 
     @Override
     public boolean computeScopeFlags(IRScope scope, EnumSet<IRFlags> flags) {
-        if (event == RubyEvent.CALL || event == RubyEvent.RETURN
-                || event == RubyEvent.B_CALL || event == RubyEvent.B_RETURN) {
-            // no need for frame for these currently
-            return false;
-        }
-
-        // other instrs need frame
         flags.addAll(IRFlags.REQUIRE_ALL_FRAME_FIELDS);
         return true;
     }

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -2474,6 +2474,25 @@ public class IRRuntimeHelpers {
         }
     }
 
+    @JIT
+    public static void callTrace(ThreadContext context, Block selfBlock, RubyEvent event, String name, String filename, int line) {
+        Ruby runtime = context.runtime;
+        if (runtime.hasEventHooks()) {
+            // FIXME: Try and statically generate END linenumber instead of hacking it.
+            int linenumber = line == -1 ? context.getLine() : line;
+
+            runtime.callEventHooks(context, event, filename, linenumber, name, selfBlock.getFrameClass());
+        }
+    }
+
+    @JIT
+    public static void callTraceHooks(ThreadContext context, Block selfBlock, RubyEvent event, String name, String filename, int line) {
+        // FIXME: Try and statically generate END linenumber instead of hacking it.
+        int linenumber = line == -1 ? context.getLine() : line;
+
+        context.runtime.callEventHooks(context, event, filename, linenumber, name, selfBlock.getFrameClass());
+    }
+
     public static void warnSetConstInRefinement(ThreadContext context, IRubyObject self) {
         if (self instanceof RubyModule && ((RubyModule) self).isRefinement()) {
             context.runtime.getWarnings().warn("not defined at the refinement, but at the outer class/module");

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -69,6 +69,7 @@ import org.jruby.runtime.IRBlockBody;
 import org.jruby.runtime.JavaSites.IRRuntimeHelpersSites;
 import org.jruby.runtime.RubyEvent;
 import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.TraceEventManager;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.backtrace.RubyStackTraceElement;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -2451,18 +2452,18 @@ public class IRRuntimeHelpers {
 
     @JIT
     public static void callTrace(ThreadContext context, IRubyObject selfClass, RubyEvent event, String name, String filename, int line) {
-        Ruby runtime = context.runtime;
-        if (runtime.hasEventHooks()) {
+        TraceEventManager traceEvents = context.traceEvents;
+        if (traceEvents.hasEventHooks()) {
             // FIXME: Try and statically generate END linenumber instead of hacking it.
             int linenumber = line == -1 ? context.getLine() : line;
 
-            runtime.callEventHooks(context, event, filename, linenumber, name, selfClass);
+            traceEvents.callEventHooks(context, event, filename, linenumber, name, selfClass);
         }
     }
 
-    public static void traceRaise(ThreadContext context, RubyException exception) {
-        Ruby runtime = context.runtime;
-        if (runtime.hasEventHooks()) {
+    public static void traceRaise(ThreadContext context) {
+        TraceEventManager traceEvents = context.traceEvents;
+        if (traceEvents.hasEventHooks()) {
             RubyStackTraceElement backtraceElement = context.getSingleBacktrace();
             String file = backtraceElement.getFileName();
             int line = backtraceElement.getLineNumber();
@@ -2470,18 +2471,18 @@ public class IRRuntimeHelpers {
             // FIXME: Try and statically generate END linenumber instead of hacking it.
             int linenumber = line == -1 ? context.getLine() : line;
 
-            runtime.callEventHooks(context, RubyEvent.RAISE, file, linenumber, null, context.nil);
+            traceEvents.callEventHooks(context, RubyEvent.RAISE, file, linenumber, null, context.nil);
         }
     }
 
     @JIT
     public static void callTrace(ThreadContext context, Block selfBlock, RubyEvent event, String name, String filename, int line) {
-        Ruby runtime = context.runtime;
-        if (runtime.hasEventHooks()) {
+        TraceEventManager traceEvents = context.traceEvents;
+        if (traceEvents.hasEventHooks()) {
             // FIXME: Try and statically generate END linenumber instead of hacking it.
             int linenumber = line == -1 ? context.getLine() : line;
 
-            runtime.callEventHooks(context, event, filename, linenumber, name, selfBlock.getFrameClass());
+            traceEvents.callEventHooks(context, event, filename, linenumber, name, selfBlock.getFrameClass());
         }
     }
 
@@ -2490,7 +2491,7 @@ public class IRRuntimeHelpers {
         // FIXME: Try and statically generate END linenumber instead of hacking it.
         int linenumber = line == -1 ? context.getLine() : line;
 
-        context.runtime.callEventHooks(context, event, filename, linenumber, name, selfBlock.getFrameClass());
+        context.traceEvents.callEventHooks(context, event, filename, linenumber, name, selfBlock.getFrameClass());
     }
 
     public static void warnSetConstInRefinement(ThreadContext context, IRubyObject self) {

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -15,6 +15,7 @@ import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyComplex;
 import org.jruby.RubyEncoding;
+import org.jruby.RubyException;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
 import org.jruby.RubyHash;
@@ -69,6 +70,7 @@ import org.jruby.runtime.JavaSites.IRRuntimeHelpersSites;
 import org.jruby.runtime.RubyEvent;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
+import org.jruby.runtime.backtrace.RubyStackTraceElement;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.callsite.CacheEntry;
 import org.jruby.runtime.callsite.CachingCallSite;
@@ -2454,6 +2456,20 @@ public class IRRuntimeHelpers {
             int linenumber = line == -1 ? context.getLine() : line;
 
             context.trace(event, name, context.getFrameKlazz(), filename, linenumber);
+        }
+    }
+
+    public static void traceRaise(ThreadContext context, RubyException exception) {
+        Ruby runtime = context.runtime;
+        if (runtime.hasEventHooks()) {
+            RubyStackTraceElement backtraceElement = context.getSingleBacktrace();
+            String file = backtraceElement.getFileName();
+            int line = backtraceElement.getLineNumber();
+
+            // FIXME: Try and statically generate END linenumber instead of hacking it.
+            int linenumber = line == -1 ? context.getLine() : line;
+
+            runtime.callEventHooks(context, RubyEvent.RAISE, file, linenumber, null, context.nil);
         }
     }
 

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -2450,12 +2450,13 @@ public class IRRuntimeHelpers {
     }
 
     @JIT
-    public static void callTrace(ThreadContext context, RubyEvent event, String name, String filename, int line) {
-        if (context.runtime.hasEventHooks()) {
+    public static void callTrace(ThreadContext context, RubyModule selfClass, RubyEvent event, String name, String filename, int line) {
+        Ruby runtime = context.runtime;
+        if (runtime.hasEventHooks()) {
             // FIXME: Try and statically generate END linenumber instead of hacking it.
             int linenumber = line == -1 ? context.getLine() : line;
 
-            context.trace(event, name, context.getFrameKlazz(), filename, linenumber);
+            runtime.callEventHooks(context, event, filename, linenumber, name, selfClass);
         }
     }
 

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -2450,7 +2450,7 @@ public class IRRuntimeHelpers {
     }
 
     @JIT
-    public static void callTrace(ThreadContext context, RubyModule selfClass, RubyEvent event, String name, String filename, int line) {
+    public static void callTrace(ThreadContext context, IRubyObject selfClass, RubyEvent event, String name, String filename, int line) {
         Ruby runtime = context.runtime;
         if (runtime.hasEventHooks()) {
             // FIXME: Try and statically generate END linenumber instead of hacking it.

--- a/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter.java
+++ b/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter.java
@@ -305,9 +305,7 @@ public class IRBytecodeAdapter {
         if (superNameOffset == -1) {
             // load from self block
             loadSelfBlock();
-            adapter.invokevirtual(p(Block.class), "getBinding", sig(Binding.class));
-            adapter.invokevirtual(p(Binding.class), "getFrame", sig(Frame.class));
-            adapter.invokevirtual(p(Frame.class), "getKlazz", sig(RubyModule.class));
+            adapter.invokevirtual(p(Block.class), "getFrameClass", sig(RubyModule.class));
         } else {
             // when present, should be second-to-last element in signature
             adapter.aload(signature.argCount() - 2);

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -2491,7 +2491,7 @@ public class JVMVisitor extends IRVisitor {
 
                 jvmAdapter().invokedynamic(
                         name,
-                        sig(void.class, ThreadContext.class, RubyModule.class),
+                        sig(void.class, ThreadContext.class, IRubyObject.class),
                         CallTraceSite.BOOTSTRAP,
                         traceInstr.getEvent().getName(),
                         traceInstr.getFilename(),

--- a/core/src/main/java/org/jruby/ir/targets/indy/CallTraceSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/CallTraceSite.java
@@ -1,13 +1,17 @@
 package org.jruby.ir.targets.indy;
 
 import com.headius.invokebinder.Binder;
+import org.jruby.RubyModule;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
+import org.jruby.runtime.Block;
+import org.jruby.runtime.Helpers;
 import org.jruby.runtime.RubyEvent;
 import org.jruby.runtime.ThreadContext;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Opcodes;
 
 import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.MutableCallSite;
@@ -33,23 +37,32 @@ public class CallTraceSite extends MutableCallSite {
     public static final Handle BOOTSTRAP = new Handle(
             Opcodes.H_INVOKESTATIC,
             p(CallTraceSite.class),
-            "bootstrap", sig(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class, String.class, String.class, String.class, int.class),
+            "bootstrap", sig(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class, String.class, String.class, int.class),
             false);
 
-    public static CallSite bootstrap(MethodHandles.Lookup lookup, String unused, MethodType type, String event, String name, String file, int line) {
-        MutableCallSite site = new CallTraceSite(type, event, name, file, line);
+    public static CallSite bootstrap(MethodHandles.Lookup lookup, String name, MethodType type, String event, String file, int line) {
+        CallTraceSite site = new CallTraceSite(type, event, name, file, line);
+        MethodHandle traceSetup = Binder
+                        .from(type)
+                        .prepend(site)
+                        .invokeVirtualQuiet(lookup, "traceBootstrap");
 
-        site.setTarget(
-                Binder
-                        .from(void.class, ThreadContext.class)
-                        .insert(0, site)
-                        .invokeVirtualQuiet(lookup, "trace")
-        );
+        site.setTarget(traceSetup);
 
         return site;
     }
 
-    public void trace(ThreadContext context) {
-        IRRuntimeHelpers.callTrace(context, event, name, file, line);
+    public void traceBootstrap(ThreadContext context, RubyModule clazz) {
+        // bind to dynamic invoker from runtime
+        setTarget(Binder.from(type()).append(Helpers.arrayOf(RubyEvent.class, String.class, String.class, int.class), event, name, file, line).invoke(context.getRuntime().getCallTrace().dynamicInvoker()));
+
+        IRRuntimeHelpers.callTrace(context, clazz, event, name, file, line);
+    }
+
+    public void traceBootstrap(ThreadContext context, Block selfBlock) {
+        // bind to dynamic invoker from runtime
+        setTarget(Binder.from(type()).append(Helpers.arrayOf(RubyEvent.class, String.class, String.class, int.class), event, name, file, line).invoke(context.getRuntime().getBcallTrace().dynamicInvoker()));
+
+        IRRuntimeHelpers.callTrace(context, selfBlock.getFrameClass(), event, name, file, line);
     }
 }

--- a/core/src/main/java/org/jruby/ir/targets/indy/CallTraceSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/CallTraceSite.java
@@ -7,6 +7,7 @@ import org.jruby.runtime.Block;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.RubyEvent;
 import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Opcodes;
 
@@ -16,6 +17,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.MutableCallSite;
 
+import static org.jruby.runtime.Helpers.arrayOf;
 import static org.jruby.util.CodegenUtils.p;
 import static org.jruby.util.CodegenUtils.sig;
 
@@ -52,16 +54,16 @@ public class CallTraceSite extends MutableCallSite {
         return site;
     }
 
-    public void traceBootstrap(ThreadContext context, RubyModule clazz) {
+    public void traceBootstrap(ThreadContext context, IRubyObject clazz) {
         // bind to dynamic invoker from runtime
-        setTarget(Binder.from(type()).append(Helpers.arrayOf(RubyEvent.class, String.class, String.class, int.class), event, name, file, line).invoke(context.getRuntime().getCallTrace().dynamicInvoker()));
+        setTarget(Binder.from(type()).append(arrayOf(RubyEvent.class, String.class, String.class, int.class), event, name, file, line).invoke(context.traceEvents.getCallReturnSite().dynamicInvoker()));
 
         IRRuntimeHelpers.callTrace(context, clazz, event, name, file, line);
     }
 
     public void traceBootstrap(ThreadContext context, Block selfBlock) {
         // bind to dynamic invoker from runtime
-        setTarget(Binder.from(type()).append(Helpers.arrayOf(RubyEvent.class, String.class, String.class, int.class), event, name, file, line).invoke(context.getRuntime().getBcallTrace().dynamicInvoker()));
+        setTarget(Binder.from(type()).append(arrayOf(RubyEvent.class, String.class, String.class, int.class), event, name, file, line).invoke(context.traceEvents.getBCallBReturnSite().dynamicInvoker()));
 
         IRRuntimeHelpers.callTrace(context, selfBlock.getFrameClass(), event, name, file, line);
     }

--- a/core/src/main/java/org/jruby/runtime/Block.java
+++ b/core/src/main/java/org/jruby/runtime/Block.java
@@ -45,6 +45,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.jruby.EvalType;
+import org.jruby.RubyModule;
 import org.jruby.RubyProc;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -345,6 +346,15 @@ public class Block implements FunctionOneOrTwoOrThree<ThreadContext, IRubyObject
      */
     public Frame getFrame() {
         return binding.getFrame();
+    }
+
+    /**
+     * Gets the frame class.
+     *
+     * @return the binding's frame's self class
+     */
+    public RubyModule getFrameClass() {
+        return binding.getFrame().getKlazz();
     }
 
     public boolean isEscaped() {

--- a/core/src/main/java/org/jruby/runtime/RubyEvent.java
+++ b/core/src/main/java/org/jruby/runtime/RubyEvent.java
@@ -24,7 +24,7 @@ public enum RubyEvent {
     B_RETURN ("b_return"),
     THREAD_BEGIN   ("thread_begin"),
     THREAD_END ("thread_end"),
-    RAISE    ("raise"),
+    RAISE    ("raise", false),
     COVERAGE ("coverage"),
     // A_CALL is CALL + B_CALL + C_CALL
     A_CALL   ("a_call"),

--- a/core/src/main/java/org/jruby/runtime/RubyEvent.java
+++ b/core/src/main/java/org/jruby/runtime/RubyEvent.java
@@ -22,8 +22,8 @@ public enum RubyEvent {
     C_RETURN ("c_return"),
     B_CALL   ("b_call"),
     B_RETURN ("b_return"),
-    THREAD_BEGIN   ("thread_begin"),
-    THREAD_END ("thread_end"),
+    THREAD_BEGIN   ("thread_begin", false),
+    THREAD_END ("thread_end", false),
     RAISE    ("raise", false),
     COVERAGE ("coverage"),
     // A_CALL is CALL + B_CALL + C_CALL

--- a/core/src/main/java/org/jruby/runtime/TraceEventManager.java
+++ b/core/src/main/java/org/jruby/runtime/TraceEventManager.java
@@ -1,0 +1,273 @@
+package org.jruby.runtime;
+
+import com.headius.invokebinder.Binder;
+import org.jruby.MetaClass;
+import org.jruby.Ruby;
+import org.jruby.RubyBinding;
+import org.jruby.RubyInstanceConfig;
+import org.jruby.RubyModule;
+import org.jruby.RubyProc;
+import org.jruby.ir.runtime.IRRuntimeHelpers;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MutableCallSite;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class TraceEventManager {
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+    public static final MethodHandle TRACE_ON = Binder
+            .from(void.class, ThreadContext.class, IRubyObject.class, RubyEvent.class, String.class, String.class, int.class)
+            .invokeStaticQuiet(LOOKUP, IRRuntimeHelpers.class, "callTrace");
+    public static final MethodHandle TRACE_OFF = Binder
+            .from(void.class, ThreadContext.class, IRubyObject.class, RubyEvent.class, String.class, String.class, int.class)
+            .drop(1, 5)
+            .identity();
+    public static final MethodHandle B_TRACE_ON = Binder
+            .from(void.class, ThreadContext.class, Block.class, RubyEvent.class, String.class, String.class, int.class)
+            .invokeStaticQuiet(LOOKUP, IRRuntimeHelpers.class, "callTrace");
+    public static final MethodHandle B_TRACE_OFF = Binder
+            .from(void.class, ThreadContext.class, Block.class, RubyEvent.class, String.class, String.class, int.class)
+            .drop(1, 5)
+            .identity();
+
+    private static final EventHook[] EMPTY_HOOKS = new EventHook[0];
+
+    private final Ruby runtime;
+    private volatile EventHook[] eventHooks = EMPTY_HOOKS;
+    private boolean hasEventHooks;
+    private final CallTraceFuncHook callTraceFuncHook = new CallTraceFuncHook(null);
+
+    private final MutableCallSite callTrace = new MutableCallSite(TRACE_OFF);
+    private final MutableCallSite bcallTrace = new MutableCallSite(B_TRACE_OFF);
+
+    public TraceEventManager(Ruby runtime) {
+        this.runtime = runtime;
+    }
+
+    private static final EnumSet<RubyEvent> interest =
+            EnumSet.of(
+                    RubyEvent.C_CALL,
+                    RubyEvent.C_RETURN,
+                    RubyEvent.CALL,
+                    RubyEvent.CLASS,
+                    RubyEvent.END,
+                    RubyEvent.LINE,
+                    RubyEvent.RAISE,
+                    RubyEvent.RETURN
+            );
+
+    public synchronized void addEventHook(EventHook hook) {
+        if (!RubyInstanceConfig.FULL_TRACE_ENABLED && hook.needsDebug()) {
+            // without full tracing, many events will not fire
+            runtime.getWarnings().warn("tracing (e.g. set_trace_func) will not capture all events without --debug flag");
+        }
+
+        EventHook[] hooks = eventHooks;
+        EventHook[] newHooks = Arrays.copyOf(hooks, hooks.length + 1);
+        newHooks[hooks.length] = hook;
+        eventHooks = newHooks;
+
+        hasEventHooks = true;
+
+        enableTraceSites(hook);
+    }
+
+    public synchronized void removeEventHook(EventHook hook) {
+        EventHook[] hooks = eventHooks;
+
+        if (hooks.length == 0) return;
+
+        int pivot = -1;
+        for (int i = 0; i < hooks.length; i++) {
+            if (hooks[i].equals(hook)) {
+                pivot = i;
+                break;
+            }
+        }
+
+        if (pivot == -1) return; // No such hook found.
+
+        EventHook[] newHooks = new EventHook[hooks.length - 1];
+        // copy before and after pivot into the new array but don't bother
+        // to arraycopy if pivot is first/last element of the old list.
+        if (pivot != 0) System.arraycopy(hooks, 0, newHooks, 0, pivot);
+        if (pivot != hooks.length - 1) System.arraycopy(hooks, pivot + 1, newHooks, pivot, hooks.length - (pivot + 1));
+
+        eventHooks = newHooks;
+        if (newHooks.length == 0) {
+            hasEventHooks = false;
+
+            disableTraceSites(hook);
+        }
+    }
+
+    private void enableTraceSites(EventHook hook) {
+        if (hook.isInterestedInEvent(RubyEvent.CALL) || hook.isInterestedInEvent(RubyEvent.RETURN)) {
+            callTrace.setTarget(TRACE_ON);
+        }
+
+        if (hook.isInterestedInEvent(RubyEvent.B_CALL) || hook.isInterestedInEvent(RubyEvent.B_RETURN)) {
+            bcallTrace.setTarget(B_TRACE_ON);
+        }
+    }
+
+    private void disableTraceSites(EventHook hook) {
+        if (hook.isInterestedInEvent(RubyEvent.CALL) || hook.isInterestedInEvent(RubyEvent.RETURN)) {
+            callTrace.setTarget(TRACE_OFF);
+        }
+
+        if (hook.isInterestedInEvent(RubyEvent.B_CALL) || hook.isInterestedInEvent(RubyEvent.B_RETURN)) {
+            bcallTrace.setTarget(B_TRACE_OFF);
+        }
+    }
+
+    private void disableTraceSites() {
+        callTrace.setTarget(TRACE_OFF);
+
+        bcallTrace.setTarget(B_TRACE_OFF);
+    }
+
+    public void setTraceFunction(RubyProc traceFunction) {
+        setTraceFunction(callTraceFuncHook, traceFunction);
+    }
+
+    public void setTraceFunction(CallTraceFuncHook hook, RubyProc traceFunction) {
+        removeEventHook(hook);
+
+        if (traceFunction == null) return;
+
+        hook.setTraceFunc(traceFunction);
+        addEventHook(hook);
+    }
+
+    /**
+     * Remove all event hooks which are associated with a particular thread.
+     *
+     * @param context the context of the ruby thread we are interested in.
+     */
+    public void removeAllCallEventHooksFor(ThreadContext context) {
+        if (eventHooks.length == 0) return;
+
+        List<EventHook> hooks = new ArrayList<>(Arrays.asList(eventHooks));
+
+        hooks = hooks.stream().filter(hook ->
+                !(hook instanceof CallTraceFuncHook) || !((CallTraceFuncHook) hook).getThread().equals(context)
+        ).collect(Collectors.toList());
+
+        EventHook[] newHooks = new EventHook[hooks.size()];
+        eventHooks = hooks.toArray(newHooks);
+        if (hooks.size() == 0) {
+            hasEventHooks = false;
+
+            disableTraceSites();
+        }
+    }
+
+    public void callEventHooks(ThreadContext context, RubyEvent event, String file, int line, String name, IRubyObject type) {
+        if (context.isEventHooksEnabled()) {
+            EventHook hooks[] = eventHooks;
+
+            for (EventHook eventHook : hooks) {
+                if (eventHook.isInterestedInEvent(event)) {
+                    IRubyObject klass = context.nil;
+                    if (type instanceof RubyModule) {
+                        if (((RubyModule) type).isIncluded()) {
+                            klass = ((RubyModule) type).getOrigin();
+                        } else if (((RubyModule) type).isSingleton()) {
+                            klass = ((MetaClass) type).getAttached();
+                        }
+                    }
+                    eventHook.event(context, event, file, line, name, klass);
+                }
+            }
+        }
+    }
+
+    public MutableCallSite getCallReturnSite() {
+        return callTrace;
+    }
+
+    public MutableCallSite getBCallBReturnSite() {
+        return bcallTrace;
+    }
+
+    public boolean hasEventHooks() {
+        return hasEventHooks;
+    }
+
+    public static class CallTraceFuncHook extends EventHook {
+        private RubyProc traceFunc;
+        private final ThreadContext thread; // if non-null only call traceFunc if it is from this thread.
+
+        public CallTraceFuncHook(ThreadContext context) {
+            this.thread = context;
+        }
+
+        public void setTraceFunc(RubyProc traceFunc) {
+            this.traceFunc = traceFunc;
+        }
+
+        public void eventHandler(ThreadContext context, String eventName, String file, int line, String name, IRubyObject type) {
+            if (context.isWithinTrace()) return;
+            if (thread != null && thread != context) return;
+
+            if (file == null) file = "(ruby)";
+            if (type == null) type = context.nil;
+
+            Ruby runtime = context.runtime;
+            RubyBinding binding = RubyBinding.newBinding(runtime, context.currentBinding());
+
+            // FIXME: Ultimately we should be getting proper string for this event type
+            switch (eventName) {
+                case "c_return":
+                    eventName = "c-return";
+                    break;
+                case "c_call":
+                    eventName = "c-call";
+                    break;
+            }
+            ;
+
+            context.preTrace();
+            try {
+                traceFunc.call(context, new IRubyObject[]{
+                        runtime.newString(eventName), // event name
+                        runtime.newString(file), // filename
+                        runtime.newFixnum(line), // line numbers should be 1-based
+                        name != null ? runtime.newSymbol(name) : runtime.getNil(),
+                        binding,
+                        type
+                });
+            } finally {
+                context.postTrace();
+            }
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (!(other instanceof CallTraceFuncHook)) return false;
+
+            return super.equals(other) && thread == ((CallTraceFuncHook) other).thread;
+        }
+
+        @Override
+        public boolean isInterestedInEvent(RubyEvent event) {
+            return interest.contains(event);
+        }
+
+        public ThreadContext getThread() {
+            return thread;
+        }
+
+        @Override
+        public EnumSet<RubyEvent> eventSet() {
+            return interest;
+        }
+    }
+}

--- a/core/src/main/java/org/jruby/runtime/TraceEventManager.java
+++ b/core/src/main/java/org/jruby/runtime/TraceEventManager.java
@@ -253,7 +253,7 @@ public class TraceEventManager {
         public boolean equals(Object other) {
             if (!(other instanceof CallTraceFuncHook)) return false;
 
-            return super.equals(other) && thread == ((CallTraceFuncHook) other).thread;
+            return traceFunc == ((CallTraceFuncHook) other).traceFunc && thread == ((CallTraceFuncHook) other).thread;
         }
 
         @Override

--- a/core/src/test/java/org/jruby/runtime/EventHookTest.java
+++ b/core/src/test/java/org/jruby/runtime/EventHookTest.java
@@ -22,7 +22,7 @@ public final class EventHookTest extends TestCase {
         config.processArguments(new String[]{"--debug"});
         Ruby rt = JavaEmbedUtils.initialize(Collections.<String>emptyList(), config);
         NativeTracer tracer = new NativeTracer();
-        rt.addEventHook(tracer);
+        rt.getTraceEvents().addEventHook(tracer);
         RubyRuntimeAdapter evaler = JavaEmbedUtils.newRuntimeAdapter();
         evaler.eval(rt, "sleep 0.01\nsleep 0.01\nsleep 0.01");
         assertEquals("expected tracing", Arrays.asList(1,1,1,2,2,2,3,3,3), tracer.lines);


### PR DESCRIPTION
This PR is an attempt to make more of the trace events (for TracePoint and set_trace_func) always-on, without introducing significant overhead if they are not active (i.e. no enabled tracepoint or trace func).