### PR TITLE
Fix #7672. warning about duplicated keys

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -493,7 +493,7 @@ public class IRBuilder {
             case FORNODE: return buildFor((ForNode) node);
             case GLOBALASGNNODE: return buildGlobalAsgn((GlobalAsgnNode) node);
             case GLOBALVARNODE: return buildGlobalVar(result, (GlobalVarNode) node);
-            case HASHNODE: return buildHash((HashNode) node);
+            case HASHNODE: return buildHash((HashNode) node, false);
             case IFNODE: return buildIf(result, (IfNode) node);
             case INSTASGNNODE: return buildInstAsgn((InstAsgnNode) node);
             case INSTVARNODE: return buildInstVar((InstVarNode) node);
@@ -736,7 +736,7 @@ public class IRBuilder {
 
         if (keywords.hasOnlyRestKwargs()) return buildRestKeywordArgs(keywords, flags);
 
-        return buildWithOrder(keywords, keywords.containsVariableAssignment());
+        return buildHash(keywords, true);
     }
 
     // This is very similar to buildArray but when building generic arrays we do not want to mark callinfo
@@ -3691,7 +3691,7 @@ public class IRBuilder {
         return addResultInstr(new GetGlobalVariableInstr(result, node.getName()));
     }
 
-    public Operand buildHash(HashNode hashNode) {
+    public Operand buildHash(HashNode hashNode, boolean keywordArgsCall) {
         List<KeyValuePair<Operand, Operand>> args = new ArrayList<>();
         boolean hasAssignments = hashNode.containsVariableAssignment();
         Variable hash = null;
@@ -3709,7 +3709,7 @@ public class IRBuilder {
                     args = new ArrayList<>();
                 }
                 Operand splat = buildWithOrder(pair.getValue(), hasAssignments);
-                addInstr(new RuntimeHelperCall(hash, MERGE_KWARGS, new Operand[] { hash, splat, tru()}));
+                addInstr(new RuntimeHelperCall(hash, MERGE_KWARGS, new Operand[] { hash, splat, keywordArgsCall ? fals() : tru()}));
                 continue;
             } else {
                 keyOperand = buildWithOrder(key, hasAssignments);

--- a/spec/ruby/language/hash_spec.rb
+++ b/spec/ruby/language/hash_spec.rb
@@ -134,6 +134,13 @@ describe "Hash literal" do
     @h.should == {a: 2, b: 3, c: 3}
   end
 
+  it "expands an '**{}' and warns when finding an additional duplicate key afterwards" do
+    -> {
+      @h = eval "{d: 1, **{a: 2, b: 3, c: 1}, c: 3}"
+    }.should complain(/key :c is duplicated|duplicated key/)
+    @h.should == {a: 2, b: 3, c: 3, d: 1}
+  end
+
   it "merges multiple nested '**obj' in Hash literals" do
     -> {
       @h = eval "{a: 1, **{a: 2, **{b: 3, **{c: 4}}, **{d: 5}, }, **{d: 6}}"


### PR DESCRIPTION
Issue is in ordinary hash building this sort of duplication should be warned but in explicit kwargs they should not be.  When we built hashes we did not differentiate between the two types.

This is still missing testing.