### PR TITLE
disabling RUBYOPT processing was not hooked up.

### DIFF
--- a/core/src/main/java/org/jruby/RubyInstanceConfig.java
+++ b/core/src/main/java/org/jruby/RubyInstanceConfig.java
@@ -167,6 +167,8 @@ public class RubyInstanceConfig {
     }
 
     public void processArgumentsWithRubyopts() {
+        if (disableRUBYOPT) return;
+        
         // environment defaults to System.getenv normally
         Object rubyoptObj = environment.get("RUBYOPT");
 

--- a/spec/tags/ruby/command_line/feature_tags.txt
+++ b/spec/tags/ruby/command_line/feature_tags.txt
@@ -1,3 +1,0 @@
-fails:The --enable and --disable flags can be used with rubyopt
-fails:The --enable and --disable flags can be used with all
-fails:The --enable and --disable flags can be used with all for disable


### PR DESCRIPTION
RUBYOPT was still processed whether it was disabled or not.