### PR TITLE
Frozen string debugging off by one.

### DIFF
--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -2368,7 +2368,7 @@ public class IRRuntimeHelpers {
 
         if (runtime.getInstanceConfig().isDebuggingFrozenStringLiteral()) {
             // stuff location info into the string and then freeze it
-            RubyArray info = (RubyArray) runtime.newArray(runtime.newString(file).freeze(context), runtime.newFixnum(line)).freeze(context);
+            RubyArray info = (RubyArray) runtime.newArray(runtime.newString(file).freeze(context), runtime.newFixnum(line + 1)).freeze(context);
             string.setInstanceVariable(RubyString.DEBUG_INFO_FIELD, info);
             string.setFrozen(true);
         } else {
@@ -2391,7 +2391,7 @@ public class IRRuntimeHelpers {
 
         if (runtime.getInstanceConfig().isDebuggingFrozenStringLiteral()) {
             // stuff location info into the string and then freeze it
-            RubyArray info = (RubyArray) runtime.newArray(runtime.newString(file).freeze(context), runtime.newFixnum(line)).freeze(context);
+            RubyArray info = (RubyArray) runtime.newArray(runtime.newString(file).freeze(context), runtime.newFixnum(line + 1)).freeze(context);
             string.setInstanceVariable(RubyString.DEBUG_INFO_FIELD, info);
         }
 

--- a/spec/tags/ruby/command_line/frozen_strings_tags.txt
+++ b/spec/tags/ruby/command_line/frozen_strings_tags.txt
@@ -1,1 +1,0 @@
-fails:The --debug flag produces debugging info on attempted frozen string modification


### PR DESCRIPTION
AST/IR stores lines as zero-offset.  We report as one-offset.