### PR TITLE
The -p command line should use print and not puts.

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1158,7 +1158,7 @@ public final class Ruby implements Constantizable {
             whileBody.add(oldRoot.getBodyNode());
         }
 
-        if (printing) whileBody.add(new FCallNode(line, newSymbol("puts"), new ArrayNode(line, dollarUnderscore), null));
+        if (printing) whileBody.add(new FCallNode(line, newSymbol("print"), new ArrayNode(line, dollarUnderscore), null));
 
         return new RootNode(line, oldRoot.getScope(), newBody, oldRoot.getFile());
     }

--- a/spec/tags/ruby/command_line/dash_p_tags.txt
+++ b/spec/tags/ruby/command_line/dash_p_tags.txt
@@ -1,1 +1,0 @@
-fails:The -p command line option sets $-p


### PR DESCRIPTION
The -p command line should use print and not puts.