### PR TITLE
Fixed windowsJ encoding and do not set on invalid K values

### DIFF
--- a/core/src/main/java/org/jruby/util/KCode.java
+++ b/core/src/main/java/org/jruby/util/KCode.java
@@ -33,12 +33,13 @@ import org.jcodings.specific.ASCIIEncoding;
 import org.jcodings.specific.EUCJPEncoding;
 import org.jcodings.specific.SJISEncoding;
 import org.jcodings.specific.UTF8Encoding;
+import org.jcodings.specific.Windows_31JEncoding;
 
 public enum KCode {
     NIL(null, ASCIIEncoding.INSTANCE, 0),
     NONE("NONE", ASCIIEncoding.INSTANCE, 0),
     UTF8("UTF8", UTF8Encoding.INSTANCE, 64),
-    SJIS("SJIS", SJISEncoding.INSTANCE, 48),
+    SJIS("SJIS", Windows_31JEncoding.INSTANCE, 48),
     EUC("EUC", EUCJPEncoding.INSTANCE, 32);
 
     private final String kcode;

--- a/core/src/main/java/org/jruby/util/cli/ArgumentProcessor.java
+++ b/core/src/main/java/org/jruby/util/cli/ArgumentProcessor.java
@@ -287,14 +287,18 @@ public class ArgumentProcessor {
                 case 'K': // @Deprecated TODO no longer relevant in Ruby 2.x
                     String eArg = grabValue(getArgumentError("provide a value for -K"));
 
-                    config.setKCode(KCode.create(eArg));
+                    KCode kcode = KCode.create(eArg);
 
-                    // source encoding
-                    config.setSourceEncoding(config.getKCode().getEncoding().toString());
+                    if (kcode != KCode.NIL) {
+                        config.setKCode(kcode);
 
-                    // set external encoding if not already specified
-                    if (config.getExternalEncoding() == null) {
-                        config.setExternalEncoding(config.getKCode().getEncoding().toString());
+                        // source encoding
+                        config.setSourceEncoding(config.getKCode().getEncoding().toString());
+
+                        // set external encoding if not already specified
+                        if (config.getExternalEncoding() == null) {
+                            config.setExternalEncoding(config.getKCode().getEncoding().toString());
+                        }
                     }
 
                     break;

--- a/spec/tags/ruby/command_line/dash_upper_k_tags.txt
+++ b/spec/tags/ruby/command_line/dash_upper_k_tags.txt
@@ -1,5 +1,0 @@
-fails:The -K command line option sets __ENCODING__ to Encoding::Windows_31J with -Ks
-fails:The -K command line option sets __ENCODING__ to Encoding::Windows_31J with -KS
-fails:The -K command line option ignores unknown codes
-fails:The -K command line option sets __ENCODING__ and Encoding.default_external to Encoding::Windows_31J with -Ks
-fails:The -K command line option sets __ENCODING__ and Encoding.default_external to Encoding::Windows_31J with -KS


### PR DESCRIPTION
Fixed windowsJ encoding and do not set on invalid K values