### PR TITLE
Add a warn form that takes a callback

### DIFF
--- a/core/src/main/java/org/jruby/common/RubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/RubyWarnings.java
@@ -31,6 +31,8 @@ package org.jruby.common;
 
 import java.util.EnumSet;
 import java.util.Set;
+import java.util.function.Function;
+
 import org.joni.WarnCallback;
 import org.jruby.Ruby;
 import org.jruby.RubyHash;
@@ -71,6 +73,10 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
     @Override
     public void warn(String message) {
         warn(ID.MISCELLANEOUS, message);
+    }
+
+    public void warn(Function<RubyStackTraceElement, String> callback) {
+        warn(ID.MISCELLANEOUS, callback);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/common/RubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/RubyWarnings.java
@@ -31,7 +31,6 @@ package org.jruby.common;
 
 import java.util.EnumSet;
 import java.util.Set;
-import java.util.function.Function;
 
 import org.joni.WarnCallback;
 import org.jruby.Ruby;
@@ -46,6 +45,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.backtrace.RubyStackTraceElement;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.TypeConverter;
+import org.jruby.util.func.TriFunction;
 
 import static org.jruby.util.RubyStringBuilder.cat;
 import static org.jruby.util.RubyStringBuilder.str;
@@ -75,8 +75,25 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
         warn(ID.MISCELLANEOUS, message);
     }
 
-    public void warn(Function<RubyStackTraceElement, String> callback) {
-        warn(ID.MISCELLANEOUS, callback);
+    public <Context, State> void warn(Context context, State state, TriFunction<Context, State, RubyStackTraceElement, String> callback) {
+        if (!runtime.warningsEnabled()) return;
+
+        RubyStackTraceElement trace = runtime.getCurrentContext().getSingleBacktrace();
+
+        String message = callback.apply(context, state, trace);
+        String file;
+        int line;
+
+        if (trace == null) {
+            file = "(unknown)";
+            line = 0;
+        } else {
+            file = trace.getFileName();
+            line = trace.getLineNumber();
+        }
+
+        // 1 is subtracted here because getRubyStackTrace is 1-indexed.
+        warn(file, line - 1, message);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1099,7 +1099,8 @@ public class IRRuntimeHelpers {
         @Override
         public void visit(ThreadContext context, RubyHash self, IRubyObject key, IRubyObject value, int index, Block block) {
             if (target.fastARef(key) != null) {
-                context.runtime.getWarnings().warn(str(context.runtime, "key ", key.inspect(), " is duplicated and overwritten on line " + (context.getLine() + 1)));
+                context.runtime.getWarnings().warn(
+                        (trace) -> str(context.runtime, "key ", key.inspect(), " is duplicated and overwritten on line " + (trace.getLineNumber())));
             }
             target.op_aset(context, key, value);
         }

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -69,6 +69,7 @@ import org.jruby.runtime.JavaSites.IRRuntimeHelpersSites;
 import org.jruby.runtime.RubyEvent;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
+import org.jruby.runtime.backtrace.RubyStackTraceElement;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.callsite.CacheEntry;
 import org.jruby.runtime.callsite.CachingCallSite;
@@ -1099,10 +1100,13 @@ public class IRRuntimeHelpers {
         @Override
         public void visit(ThreadContext context, RubyHash self, IRubyObject key, IRubyObject value, int index, Block block) {
             if (target.fastARef(key) != null) {
-                context.runtime.getWarnings().warn(
-                        (trace) -> str(context.runtime, "key ", key.inspect(), " is duplicated and overwritten on line " + (trace.getLineNumber())));
+                context.runtime.getWarnings().warn(context, key, KwargMergeVisitor::duplicationWarning);
             }
             target.op_aset(context, key, value);
+        }
+
+        private static String duplicationWarning(ThreadContext c, IRubyObject k, RubyStackTraceElement trace) {
+            return str(c.runtime, "key ", k.inspect(), " is duplicated and overwritten on line " + (trace.getLineNumber()));
         }
     }
 


### PR DESCRIPTION
Callback receives the warning's stack trace element and must return a formatted message. This allows reusing the same single trace element rather than generating it twice to build the message elsewhere.