### PR TITLE
Fix #7670. Coverage data goes off the rails.

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -434,7 +434,7 @@ public class IRBuilder {
     private void determineIfWeNeedLineNumber(Node node) {
         if (node.isNewline()) {
             int currLineNum = node.getLine();
-            if (currLineNum != lastProcessedLineNum) { // Do not emit multiple line number instrs for the same line
+            if (currLineNum != lastProcessedLineNum && !(node instanceof NilImplicitNode)) { // Do not emit multiple line number instrs for the same line
                 needsLineNumInfo = true;
                 lastProcessedLineNum = currLineNum;
             }


### PR DESCRIPTION
The Parser for JRuby 9.4 is very different from 9.3.  Somehow we are emitting an implicit nil node for empty returns AND that somehow is the node marked as newline (which then is used to emit a line number instr).  implicit nils have a line number of -1.