### PR TITLE
Make coderange set on strings created from some IO ops

### DIFF
--- a/core/src/main/java/org/jruby/util/io/OpenFile.java
+++ b/core/src/main/java/org/jruby/util/io/OpenFile.java
@@ -1626,10 +1626,12 @@ public class OpenFile implements Finalizable {
                         rbuf.len -= chomplen;
                     }
                     len += pending - chomplen;
-                    //if (cr != StringSupport.CR_BROKEN) {
+                    if (cr != StringSupport.CR_BROKEN) {
                         final int beg = strByteList.begin();
-                        pos += codeRangeScanRestartable(enc, strByteList.unsafeBytes(), beg + pos, beg + len, cr);
-                    //}
+                        long v = codeRangeScanRestartable(enc, strByteList.unsafeBytes(), beg + pos, beg + len, cr);
+                        cr = unpackArg(v);
+                        pos += unpackResult(v);
+                    }
                     if (e != -1) break;
                 }
                 READ_CHECK(context);
@@ -1722,10 +1724,12 @@ public class OpenFile implements Finalizable {
                 }
                 bytes += n;
                 strByteList.setRealSize(bytes);
-                //if (cr != StringSupport.CR_BROKEN) {
+                if (cr != StringSupport.CR_BROKEN) {
                     final int beg = strByteList.begin();
-                    pos += codeRangeScanRestartable(enc, strByteList.unsafeBytes(), beg + pos, beg + bytes, cr);
-                //}
+                    long v = codeRangeScanRestartable(enc, strByteList.unsafeBytes(), beg + pos, beg + bytes, cr);
+                    cr = unpackArg(v);
+                    pos += unpackResult(v);
+                }
                 if (bytes < siz) break;
                 siz += BUFSIZ;
                 ((RubyString) str).modify(BUFSIZ);


### PR DESCRIPTION
read all and read line were calculating CR but not setting it on the resulting string.  This prevents resulting string from having single byte optimizable code paths work.  I only did one benchmark using aref and it appears to be a little faster consistently but not a lot.  I imagine using really long lines and a complicated backtracking regexp will make this pop.