### PR TITLE
Use real stack trace for autoload const location

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -109,6 +109,7 @@ import org.jruby.runtime.PositionAware;
 import org.jruby.runtime.Signature;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
+import org.jruby.runtime.backtrace.RubyStackTraceElement;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.builtin.Variable;
 import org.jruby.runtime.callsite.CacheEntry;
@@ -5530,7 +5531,8 @@ public class RubyModule extends RubyObject {
         if (existingAutoload == null || existingAutoload.getValue() == null) {
             storeConstant(symbol, RubyObject.UNDEF);
             ThreadContext context = path.getRuntime().getCurrentContext();
-            getAutoloadMapForWrite().put(symbol, new Autoload(symbol, path, context.getFile(), context.getLine() + 1));
+            RubyStackTraceElement caller = context.getSingleBacktrace();
+            getAutoloadMapForWrite().put(symbol, new Autoload(symbol, path, caller.getFileName(), caller.getLineNumber()));
         }
     }
 


### PR DESCRIPTION
Autoload constants should show their assigned location as the point at which autoload was called. This was broken in the JIT because it depended on artificial Backtrace frames that JIT- compiled code does not populate.

This patch switches the logic to use a real generated backtrace frame, making it accurate in all cases.

This has the side effect of using our fully-canonicalized path from the backtrace as the file location of the constant, which may not match CRuby's uncanonicalized paths. This breaks the same CRuby test that was getting incorrect line numbers before:

  1) Failure:
TestAutoload#test_source_location [/Users/headius/work/jruby/test/mri/ruby/test_autoload.rb:440]: <"/var/folders/h_/tmq357111c18sxbwlyq34mh80000gn/T/autoload20230302-39483-kwznu0/test-Bug16764.rb"> expected but was <"/private/var/folders/h_/tmq357111c18sxbwlyq34mh80000gn/T/autoload20230302-39483-kwznu0/test-Bug16764.rb">.

Fixes #7711 but introduces a new (minor?) incompatibility