### PR TITLE
We were quoting symbols in inspect we shouldnt have

### DIFF
--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -447,7 +447,8 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
 
         RubyString str = RubyString.newString(runtime, getBytes());
 
-        if (!(isPrintable(runtime) && (resenc.equals(getBytes().getEncoding()) || str.isAsciiOnly()) && isSymbolName(symbol))) {
+        if (!(isPrintable(runtime) && (resenc.equals(getBytes().getEncoding()) || str.isAsciiOnly()) &&
+                isSymbolName(symbol))) {
             str = str.inspect(runtime);
         }
 
@@ -890,7 +891,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
     private static boolean isSymbolLocal(final String str, final char first, final int length) {
         if (!isIdentStart(first)) return false;
 
-        boolean localID = (first >= 'a' && first <= 'z');
+        boolean localID = isIdentStart(first);
         int last = 1;
 
         for (; last < length; last++) {

--- a/spec/ruby/core/symbol/inspect_spec.rb
+++ b/spec/ruby/core/symbol/inspect_spec.rb
@@ -5,6 +5,8 @@ describe "Symbol#inspect" do
     fred:         ":fred",
     :fred?     => ":fred?",
     :fred!     => ":fred!",
+    :BAD!      => ":BAD!",
+    :_BAD!      => ":_BAD!",
     :$ruby     => ":$ruby",
     :@ruby     => ":@ruby",
     :@@ruby    => ":@@ruby",


### PR DESCRIPTION
We only checked if first char was lower case if not a special character and if so we would always quote the symbol in Symbol#inspect! (e.g. :BAD.inspect -> ":\"BAD\"").