### PR TITLE
Add infra to support Ruby 3.1 pattern error messages.

### DIFF
--- a/core/src/main/java/org/jruby/ast/InNode.java
+++ b/core/src/main/java/org/jruby/ast/InNode.java
@@ -29,6 +29,10 @@ public class InNode extends Node {
         return nextCase;
     }
 
+    public boolean isSinglePattern() {
+        return getNextCase() == null;
+    }
+
     @Override
     public <T> T accept(NodeVisitor<T> visitor) {
         return visitor.visitInNode(this);


### PR DESCRIPTION
Ruby 3.1 added more descriptive error strings.  This requires fishing some variables around.  Thus far only error for array pattern is supported.  More will be added in the future.