### PR TITLE
Fixes #7717. sass-embedded gem extension install fails with jruby-com…

### DIFF
--- a/core/src/main/java/org/jruby/util/cli/ArgumentProcessor.java
+++ b/core/src/main/java/org/jruby/util/cli/ArgumentProcessor.java
@@ -51,6 +51,8 @@ import java.util.Set;
 import java.util.HashSet;
 import java.util.function.BiFunction;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Encapsulated logic for processing JRuby's command-line arguments.
@@ -274,23 +276,10 @@ public class ArgumentProcessor {
                     break FOR;
                 case 'I':
                     String s = grabValue(getArgumentError("-I must be followed by a directory name to add to lib path"));
-                    String separator = java.io.File.pathSeparator;
-                    if (":".equals(separator)) {
-                        separator = SEPARATOR;
-                    }
-                    String[] ls = s.split(separator);
+                    String separator = ":".equals(File.pathSeparator) ? SEPARATOR : File.pathSeparator;
+                    Stream<String> paths = Arrays.stream(s.split(separator)).map(path -> new JRubyFile(path).getAbsolutePath());
 
-                    for (int i = 0; i < ls.length; i++) {
-                        File file = new File(ls[i]);
-                        if (!file.isAbsolute()) {
-                            try {
-                                ls[i] = file.getCanonicalPath();
-                            } catch (IOException e) {
-                                ls[i] = file.getAbsolutePath();
-                            }
-                        }
-                    }
-                    config.getLoadPaths().addAll(Arrays.asList(ls));
+                    config.getLoadPaths().addAll(paths.collect(Collectors.toList()));
                     break FOR;
                 case 'J':
                     String js = grabOptionalValue();

--- a/test/jruby/test_command_line_switches.rb
+++ b/test/jruby/test_command_line_switches.rb
@@ -114,8 +114,9 @@ class TestCommandLineSwitches < Test::Unit::TestCase
   end
 
   def test_dash_little_v_version_verbose_d_debug_K_kcode_r_require_b_benchmarks_a_splitsinput_I_loadpath_C_cwd_F_delimeter_J_javaprop_19
-    e_line = 'puts $VERBOSE, $DEBUG, Encoding.default_external, $F.join(59.chr), Dir.pwd, Java::java::lang::System.getProperty(:foo.to_s)'
-    args = "-v -d -a -n -C .. -F, -e #{q + e_line + q}"
+    e_line = 'puts $VERBOSE, $DEBUG, Encoding.default_external, $F.join(59.chr), Dir.pwd, Java::java::lang::System.getProperty(:foo.to_s), $LOAD_PATH.join("|")'
+    path = 'uri:classpath://foo'
+    args = "-v -d -a -n -C .. -F, -I #{path}  -e #{q + e_line + q}"
     # the options at the end will add -J-Dfoo=bar to the args
     lines = jruby_with_pipe("echo 1,2,3", args, :foo => 'bar').split("\n")
     assert_equal 0, $?.exitstatus, "failed execution with output:\n#{lines}"
@@ -129,6 +130,7 @@ class TestCommandLineSwitches < Test::Unit::TestCase
     # The gsub is for windows
     assert_equal "#{parent_dir}", lines[5].gsub('\\', '/')
     assert_equal "bar", lines[6]
+    assert lines[7].split("|").include?(path)
 
     e_line = 'puts Gem'
     args = " -rrubygems -e #{q + e_line + q}"


### PR DESCRIPTION
…plete.

I need to still run this on windows itself but
https://github.com/jruby/jruby/pull/7683 only use File and not JRubyFile so it had no knowledge of uri:classpath files.  It also was trying to canonicalize by default.

Solution is to just get absolute path (still need to softlink test to show that -I will not canonicalize paths) and to not bother even testing if it is absolute since it is really doing same amount of work.