### PR TITLE
passing specs

### DIFF
--- a/spec/tags/ruby/library/etc/getgrgid_tags.txt
+++ b/spec/tags/ruby/library/etc/getgrgid_tags.txt
@@ -1,2 +1,0 @@
-windows:Etc.getgrgid returns nil
-critical:Etc.getgrgid can be called safely by multiple threads

--- a/spec/tags/ruby/library/etc/getgrnam_tags.txt
+++ b/spec/tags/ruby/library/etc/getgrnam_tags.txt
@@ -1,1 +1,0 @@
-windows:Etc.getgrnam returns nil

--- a/spec/tags/ruby/library/etc/getlogin_tags.txt
+++ b/spec/tags/ruby/library/etc/getlogin_tags.txt
@@ -1,1 +1,0 @@
-tty:Etc.getlogin returns the name associated with the current login activity

--- a/spec/tags/ruby/library/etc/getlogin_tags.txt
+++ b/spec/tags/ruby/library/etc/getlogin_tags.txt
@@ -1,0 +1,1 @@
+fails(on GHA):Etc.getlogin returns the name associated with the current login activity

--- a/spec/tags/ruby/library/etc/getpwuid_tags.txt
+++ b/spec/tags/ruby/library/etc/getpwuid_tags.txt
@@ -1,1 +1,0 @@
-windows:Etc.getpwuid returns nil

--- a/spec/tags/ruby/library/etc/group_tags.txt
+++ b/spec/tags/ruby/library/etc/group_tags.txt
@@ -1,1 +1,0 @@
-windows:Etc.group raises a RuntimeError for parallel iteration


### PR DESCRIPTION
These all work now and one for windows was removed at some point (still a spec for non-windows though).