### PR TITLE
[feat] make Ruby#setWarningsEnabled actually useful

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -2515,19 +2515,29 @@ public final class Ruby implements Constantizable {
         return charsetMap;
     }
 
-    /** Getter for property isVerbose.
-     * @return Value of property isVerbose.
+    /**
+     * @return $VERBOSE value
      */
     public IRubyObject getVerbose() {
         return verboseValue;
     }
 
+    /**
+     * @return $VERBOSE value as a Java primitive
+     */
     public boolean isVerbose() {
         return verbose;
     }
 
+    /**
+     * If the user explicitly disabled warnings using: {@link #setWarningsEnabled(boolean)} return false.
+     *
+     * Otherwise fallback to a $VERBOSE value check (which is the default behavior).
+     *
+     * @return whether warnings are enabled
+     */
     public boolean warningsEnabled() {
-        return warningsEnabled;
+        return warningsEnabled && verboseWarnings;
     }
 
     /**
@@ -2547,7 +2557,7 @@ public final class Ruby implements Constantizable {
     public void setVerbose(final IRubyObject verbose) {
         this.verbose = verbose.isTrue();
         this.verboseValue = verbose;
-        warningsEnabled = !verbose.isNil();
+        verboseWarnings = !verbose.isNil();
     }
 
     /**
@@ -2559,22 +2569,34 @@ public final class Ruby implements Constantizable {
         setVerbose(verbose == null ? nilObject : (verbose ? trueObject : falseObject));
     }
 
-    /** Getter for property isDebug.
-     * @return Value of property isDebug.
+    /**
+     * @return $DEBUG value
      */
     public IRubyObject getDebug() {
         return debug ? trueObject : falseObject;
     }
 
+    /**
+     * @return $DEBUG value as a boolean
+     */
     public boolean isDebug() {
         return debug;
     }
 
-    /** Setter for property isDebug.
-     * @param debug New value of property isDebug.
+    /**
+     * Setter for property isDebug.
+     * @param debug the $DEBUG value
      */
     public void setDebug(IRubyObject debug) {
-        this.debug = debug.isTrue();
+        setDebug(debug.isTrue());
+    }
+
+    /**
+     * Sets the $DEBUG flag
+     * @param debug
+     */
+    public void setDebug(final boolean debug) {
+        this.debug = debug;
     }
 
     /**
@@ -5266,7 +5288,9 @@ public final class Ruby implements Constantizable {
     @Deprecated
     private IRubyObject rootFiber;
 
-    private boolean verbose, warningsEnabled, debug;
+    private boolean warningsEnabled = true; // global flag to be able to disable warnings regardless of $VERBOSE
+    private boolean verboseWarnings; // whether warnings are enabled based on $VERBOSE
+    private boolean verbose, debug;
     private IRubyObject verboseValue;
 
     // Set of categories we care about (set defined when creating warnings).

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -2548,7 +2548,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     @JRubyMethod(name = {"index", "find_index"})
     public IRubyObject index(ThreadContext context, IRubyObject obj, Block unused) {
-        if (unused.isGiven()) context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
+        if (unused.isGiven()) context.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
         return index(context, obj);
     }
 
@@ -2655,7 +2655,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     @JRubyMethod
     public IRubyObject rindex(ThreadContext context, IRubyObject obj, Block unused) {
-        if (unused.isGiven()) context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
+        if (unused.isGiven()) context.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
         return rindex(context, obj);
     }
 
@@ -3519,7 +3519,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     @JRubyMethod(name = "count")
     public IRubyObject count(ThreadContext context, IRubyObject obj, Block block) {
-        if (block.isGiven()) context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
+        if (block.isGiven()) context.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
 
         int n = 0;
         for (int i = 0; i < realLength; i++) {
@@ -4927,7 +4927,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         boolean patternGiven = arg != null;
 
         if (block.isGiven() && patternGiven) {
-            context.runtime.getWarnings().warn("given block not used");
+            context.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
         }
 
         if (!block.isGiven() || patternGiven) return all_pBlockless(context, arg);
@@ -4970,7 +4970,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         boolean patternGiven = arg != null;
 
         if (block.isGiven() && patternGiven) {
-            context.runtime.getWarnings().warn("given block not used");
+            context.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
         }
 
         if (!block.isGiven() || patternGiven) return any_pBlockless(context, arg);
@@ -5012,7 +5012,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         boolean patternGiven = arg != null;
 
         if (block.isGiven() && patternGiven) {
-            context.runtime.getWarnings().warn("given block not used");
+            context.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
         }
 
         if (!block.isGiven() || patternGiven) return none_pBlockless(context, arg);
@@ -5054,7 +5054,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         boolean patternGiven = arg != null;
 
         if (block.isGiven() && patternGiven) {
-            context.runtime.getWarnings().warn("given block not used");
+            context.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
         }
 
         if (!block.isGiven() || patternGiven) return one_pBlockless(context, arg);

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -162,7 +162,7 @@ public class RubyEnumerable {
         final Ruby runtime = context.runtime;
         final SingleInt result = new SingleInt();
 
-        if (block.isGiven()) runtime.getWarnings().warn(ID.BLOCK_UNUSED , "given block not used");
+        if (block.isGiven()) runtime.getWarnings().warning(ID.BLOCK_UNUSED , "given block not used");
 
         each(context, eachSite(context), self, new JavaInternalBlockBody(runtime, context, "Enumerable#count", Signature.ONE_REQUIRED) {
             public IRubyObject yield(ThreadContext context1, IRubyObject[] args) {
@@ -707,7 +707,7 @@ public class RubyEnumerable {
     public static IRubyObject find_index(ThreadContext context, IRubyObject self, final IRubyObject cond, final Block block) {
         final Ruby runtime = context.runtime;
 
-        if (block.isGiven()) runtime.getWarnings().warn(ID.BLOCK_UNUSED , "given block not used");
+        if (block.isGiven()) runtime.getWarnings().warning(ID.BLOCK_UNUSED , "given block not used");
         if (self instanceof RubyArray) return ((RubyArray) self).find_index(context, cond);
 
         return find_indexCommon(context, eachSite(context), self, cond);
@@ -1103,7 +1103,7 @@ public class RubyEnumerable {
     public static IRubyObject inject(ThreadContext context, IRubyObject self, IRubyObject init, IRubyObject method, final Block block) {
         final Ruby runtime = context.runtime;
 
-        if (block.isGiven()) runtime.getWarnings().warn(ID.BLOCK_UNUSED , "given block not used");
+        if (block.isGiven()) runtime.getWarnings().warning(ID.BLOCK_UNUSED , "given block not used");
 
         final String methodId = method.asJavaString();
         final SingleObject<IRubyObject> result = new SingleObject<>(init);
@@ -1608,7 +1608,7 @@ public class RubyEnumerable {
         final boolean patternGiven = pattern != null;
 
         if (block.isGiven() && patternGiven) {
-            context.runtime.getWarnings().warn("given block not used");
+            context.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
         }
 
         try {
@@ -1663,7 +1663,7 @@ public class RubyEnumerable {
         final boolean patternGiven = pattern != null;
 
         if (block.isGiven() && patternGiven) {
-            context.runtime.getWarnings().warn("given block not used");
+            context.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
         }
 
         try {
@@ -1746,7 +1746,7 @@ public class RubyEnumerable {
         final boolean patternGiven = pattern != null;
 
         if (block.isGiven() && patternGiven) {
-            localContext.runtime.getWarnings().warn("given block not used");
+            localContext.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
         }
 
         try {
@@ -1836,7 +1836,7 @@ public class RubyEnumerable {
         final boolean patternGiven = pattern != null;
 
         if (block.isGiven() && patternGiven) {
-            localContext.runtime.getWarnings().warn("given block not used");
+            localContext.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
         }
 
         try {

--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -198,13 +198,14 @@ public class RubyGlobal {
         } else {
             verboseValue = runtime.getFalse();
         }
-        runtime.defineVariable(new VerboseGlobalVariable(runtime, "$VERBOSE", verboseValue), GLOBAL);
-        runtime.defineVariable(new VerboseGlobalVariable(runtime, "$-v", verboseValue), GLOBAL);
-        runtime.defineVariable(new VerboseGlobalVariable(runtime, "$-w", verboseValue), GLOBAL);
+        runtime.setVerbose(verboseValue);
+        runtime.defineVariable(new VerboseGlobalVariable(runtime, "$VERBOSE"), GLOBAL);
+        runtime.defineVariable(new VerboseGlobalVariable(runtime, "$-v"), GLOBAL);
+        runtime.defineVariable(new VerboseGlobalVariable(runtime, "$-w"), GLOBAL);
 
-        IRubyObject debug = runtime.newBoolean(runtime.getInstanceConfig().isDebug());
-        runtime.defineVariable(new DebugGlobalVariable(runtime, "$DEBUG", debug), GLOBAL);
-        runtime.defineVariable(new DebugGlobalVariable(runtime, "$-d", debug), GLOBAL);
+        runtime.setDebug(runtime.newBoolean(runtime.getInstanceConfig().isDebug()));
+        runtime.defineVariable(new DebugGlobalVariable(runtime, "$DEBUG"), GLOBAL);
+        runtime.defineVariable(new DebugGlobalVariable(runtime, "$-d"), GLOBAL);
 
         runtime.defineVariable(new BacktraceGlobalVariable(runtime, "$@"), THREAD);
 
@@ -1061,9 +1062,8 @@ public class RubyGlobal {
     }
 
     private static class VerboseGlobalVariable extends GlobalVariable {
-        public VerboseGlobalVariable(Ruby runtime, String name, IRubyObject initialValue) {
-            super(runtime, name, initialValue);
-            set(initialValue);
+        public VerboseGlobalVariable(Ruby runtime, String name) {
+            super(runtime, name, null); // this.value not used
         }
 
         @Override
@@ -1073,11 +1073,7 @@ public class RubyGlobal {
 
         @Override
         public IRubyObject set(IRubyObject newValue) {
-            if (newValue.isNil()) {
-                runtime.setVerbose(newValue);
-            } else {
-                runtime.setVerbose(runtime.newBoolean(newValue.isTrue()));
-            }
+            runtime.setVerbose(newValue.isNil() ? null : newValue.isTrue());
 
             return newValue;
         }
@@ -1095,9 +1091,8 @@ public class RubyGlobal {
     }
 
     private static class DebugGlobalVariable extends GlobalVariable {
-        public DebugGlobalVariable(Ruby runtime, String name, IRubyObject initialValue) {
-            super(runtime, name, initialValue);
-            set(initialValue);
+        public DebugGlobalVariable(Ruby runtime, String name) {
+            super(runtime, name, null); // this.value not used
         }
 
         @Override
@@ -1107,11 +1102,7 @@ public class RubyGlobal {
 
         @Override
         public IRubyObject set(IRubyObject newValue) {
-            if (newValue.isNil()) {
-                runtime.setDebug(newValue);
-            } else {
-                runtime.setDebug(runtime.newBoolean(newValue.isTrue()));
-            }
+            runtime.setDebug(newValue.isTrue());
 
             return newValue;
         }

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1375,7 +1375,7 @@ public class RubyKernel {
         }
 
         if (recv == runtime.getWarning()) {
-            RubyWarnings.warn(context, recv, message);
+            RubyWarnings.warn(context, message);
             return;
         }
 

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -68,7 +68,6 @@ import org.jruby.anno.JRubyConstant;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JavaMethodDescriptor;
 import org.jruby.anno.TypePopulator;
-import org.jruby.common.IRubyWarnings;
 import org.jruby.common.IRubyWarnings.ID;
 import org.jruby.embed.Extension;
 import org.jruby.exceptions.LoadError;
@@ -2983,13 +2982,13 @@ public class RubyModule extends RubyObject {
                     if (signature.hasRest() && !signature.hasKwargs()) {
                         method.setRuby2Keywords();
                     } else {
-                        context.runtime.getWarnings().warn(IRubyWarnings.ID.MISCELLANEOUS, str(context.runtime, "Skipping set of ruby2_keywords flag for ", name, " (method accepts keywords or method does not accept argument splat)"));
+                        context.runtime.getWarnings().warn(ID.MISCELLANEOUS, str(context.runtime, "Skipping set of ruby2_keywords flag for ", name, " (method accepts keywords or method does not accept argument splat)"));
                     }
                 } else {
-                    context.runtime.getWarnings().warn(IRubyWarnings.ID.MISCELLANEOUS, str(context.runtime, "Skipping set of ruby2_keywords flag for ", name, " (method not defined in Ruby)"));
+                    context.runtime.getWarnings().warn(ID.MISCELLANEOUS, str(context.runtime, "Skipping set of ruby2_keywords flag for ", name, " (method not defined in Ruby)"));
                 }
             } else {
-                context.runtime.getWarnings().warn(IRubyWarnings.ID.MISCELLANEOUS, str(context.runtime, "Skipping set of ruby2_keywords flag for ", name, " (can only set in method defining module)"));
+                context.runtime.getWarnings().warn(ID.MISCELLANEOUS, str(context.runtime, "Skipping set of ruby2_keywords flag for ", name, " (can only set in method defining module)"));
             }
         }
         return context.nil;
@@ -4903,9 +4902,9 @@ public class RubyModule extends RubyObject {
             if (notAutoload || !setAutoloadConstant(name, value, file, line)) {
                 if (warn && notAutoload) {
                     if (this.equals(getRuntime().getObject())) {
-                        getRuntime().getWarnings().warn(ID.CONSTANT_ALREADY_INITIALIZED, "already initialized constant " + name);
+                        getRuntime().getWarnings().warning(ID.CONSTANT_ALREADY_INITIALIZED, "already initialized constant " + name);
                     } else {
-                        getRuntime().getWarnings().warn(ID.CONSTANT_ALREADY_INITIALIZED, "already initialized constant " + this + "::" + name);
+                        getRuntime().getWarnings().warning(ID.CONSTANT_ALREADY_INITIALIZED, "already initialized constant " + this + "::" + name);
                     }
                 }
 

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2064,11 +2064,11 @@ public class RubyModule extends RubyObject {
         DynamicMethod method = getMethods().get(name);
         if (method != null && entry.method.getRealMethod() != method.getRealMethod() && !method.isUndefined()) {
             // warn if overwriting an existing method on this module
-            if (method.getRealMethod().getAliasCount() == 0) runtime.getWarnings().warning("method redefined; discarding old " + name);
+            if (method.getRealMethod().getAliasCount() == 0) runtime.getWarnings().warning(ID.REDEFINING_METHOD, "method redefined; discarding old " + name);
 
             if (method instanceof PositionAware) {
                 PositionAware posAware = (PositionAware) method;
-                runtime.getWarnings().warning(posAware.getFile(), posAware.getLine(), "previous definition of bar " + name);
+                runtime.getWarnings().warning(ID.REDEFINING_METHOD, posAware.getFile(), posAware.getLine() + 1, "previous definition of " + name + " was here");
             }
         }
 

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -60,7 +60,7 @@ import org.joni.Region;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.ast.util.ArgsUtil;
-import org.jruby.common.IRubyWarnings;
+import org.jruby.common.IRubyWarnings.ID;
 import org.jruby.exceptions.JumpException;
 import org.jruby.platform.Platform;
 import org.jruby.runtime.Arity;
@@ -4534,7 +4534,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
             if (splitPattern.isNil()) return context.nil;
 
-            context.runtime.getWarnings().warnDeprecated(IRubyWarnings.ID.MISCELLANEOUS, "$; is set to non-nil value");
+            context.runtime.getWarnings().warnDeprecated(ID.MISCELLANEOUS, "$; is set to non-nil value");
 
             pattern = splitPattern;
         }
@@ -6240,7 +6240,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
         if (block.isGiven()) {
             if (wantarray) {
-                runtime.getWarnings().warning("passing a block to String#" + name + " is deprecated");
+                runtime.getWarnings().warning(ID.BLOCK_DEPRECATED, "passing a block to String#" + name + " is deprecated");
                 wantarray = false;
             }
         }
@@ -6293,7 +6293,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
         if (block.isGiven()) {
             if (wantarray) {
-                runtime.getWarnings().warning("passing a block to String#" + name + " is deprecated");
+                runtime.getWarnings().warning(ID.BLOCK_DEPRECATED, "passing a block to String#" + name + " is deprecated");
                 wantarray = false;
             }
         }
@@ -6326,7 +6326,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
         if (block.isGiven()) {
             if (wantarray) {
-                runtime.getWarnings().warning("passing a block to String#" + name + " is deprecated");
+                runtime.getWarnings().warning(ID.BLOCK_DEPRECATED, "passing a block to String#" + name + " is deprecated");
                 wantarray = false;
             }
         }
@@ -6392,7 +6392,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
         if (block.isGiven()) {
             if (wantarray) {
-                runtime.getWarnings().warning("passing a block to String#" + name + " is deprecated");
+                runtime.getWarnings().warning(ID.BLOCK_DEPRECATED, "passing a block to String#" + name + " is deprecated");
                 wantarray = false;
             }
         }

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -60,6 +60,7 @@ import org.joni.Region;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.ast.util.ArgsUtil;
+import org.jruby.common.IRubyWarnings;
 import org.jruby.exceptions.JumpException;
 import org.jruby.platform.Platform;
 import org.jruby.runtime.Arity;
@@ -4533,7 +4534,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
             if (splitPattern.isNil()) return context.nil;
 
-            context.runtime.getWarnings().warnDeprecated("$; is set to non-nil value");
+            context.runtime.getWarnings().warnDeprecated(IRubyWarnings.ID.MISCELLANEOUS, "$; is set to non-nil value");
 
             pattern = splitPattern;
         }

--- a/core/src/main/java/org/jruby/common/IRubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/IRubyWarnings.java
@@ -99,7 +99,8 @@ public interface IRubyWarnings {
         GC_STRESS_UNIMPLEMENTED,
         GC_ENABLE_UNIMPLEMENTED,
         GC_DISABLE_UNIMPLEMENTED,
-        RATIONAL_OUT_OF_RANGE,;
+        RATIONAL_OUT_OF_RANGE,
+        REDEFINING_METHOD;
 
         public String getID() {
             return name();

--- a/core/src/main/java/org/jruby/common/IRubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/IRubyWarnings.java
@@ -38,6 +38,11 @@ import org.jruby.Ruby;
  */
 public interface IRubyWarnings {
     enum ID {
+        /**
+         * Generic identifier often used when there isn't an extra ID type.
+         * @implNote Some of the "MISCELLANEOUS" warnings might end up being re-categorized.
+         */
+        MISCELLANEOUS,
         AMBIGUOUS_ARGUMENT,
         ACCESSOR_NOT_INITIALIZED,
         ACCESSOR_MODULE_FUNCTION,
@@ -48,6 +53,7 @@ public interface IRubyWarnings {
         BLOCK_BEATS_DEFAULT_VALUE,
         BLOCK_NOT_ACCEPTED,
         BLOCK_UNUSED,
+        BLOCK_DEPRECATED,
         CONSTANT_ALREADY_INITIALIZED,
         CONSTANT_DEPRECATED,
         CONSTANT_BAD_REFERENCE,
@@ -67,7 +73,6 @@ public interface IRubyWarnings {
         INVALID_CHAR_SEQUENCE,
         IVAR_NOT_INITIALIZED,
         MAY_BE_TOO_BIG,
-        MISCELLANEOUS,
         MULTIPLE_VALUES_FOR_BLOCK,
         NEGATIVE_NUMBER_FOR_U,
         NO_SUPER_CLASS,

--- a/core/src/main/java/org/jruby/common/RubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/RubyWarnings.java
@@ -191,7 +191,7 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
     }
 
     public void warnDeprecatedAlternate(String name, String alternate) {
-        if (runtime.getWarningCategories().contains(Category.DEPRECATED)) warn(ID.MISCELLANEOUS, name + " is deprecated; use " + alternate + " instead");
+        if (runtime.getWarningCategories().contains(Category.DEPRECATED)) warn(ID.DEPRECATED_METHOD, name + " is deprecated; use " + alternate + " instead");
     }
 
     public void warnDeprecatedForRemoval(String name, String version) {

--- a/core/src/main/java/org/jruby/common/RubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/RubyWarnings.java
@@ -126,7 +126,7 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
 
         String fullMessage;
         if (lineNumber != LINE_NUMBER_NON_WARNING) {
-            fullMessage = fileName + ':' + (lineNumber + 1) + ": warning: " + message + '\n';
+            fullMessage = fileName + ':' + lineNumber + ": warning: " + message + '\n';
         } else {
             fullMessage = fileName + ": " + message + '\n'; // warn(fileName, message) behave as in MRI
         }

--- a/core/src/main/java/org/jruby/common/RubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/RubyWarnings.java
@@ -95,8 +95,7 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
             line = trace.getLineNumber();
         }
 
-        // 1 is subtracted here because getRubyStackTrace is 1-indexed.
-        warn(ID.MISCELLANEOUS, file, line - 1, message);
+        warn(ID.MISCELLANEOUS, file, line, message);
     }
 
     @Override
@@ -176,8 +175,7 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
             line = stack.getLineNumber();
         }
 
-        // 1 is subtracted here because getRubyStackTrace is 1-indexed.
-        doWarn(id, file, line - 1, message);
+        doWarn(id, file, line, message);
     }
 
     public void warn(String filename, String message) {
@@ -217,25 +215,7 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
 
     @Override
     public void warning(ID id, String message) {
-        if (!runtime.warningsEnabled()) return;
-
-        writeWarning(runtime, id, message);
-    }
-
-    private static void writeWarning(Ruby runtime, ID id, String message) {
-        RubyStackTraceElement stack = runtime.getCurrentContext().getSingleBacktrace();
-        String file;
-        int line;
-
-        if (stack == null) {
-            file = "(unknown)";
-            line = -1;
-        } else {
-            file = stack.getFileName();
-            line = stack.getLineNumber();
-        }
-
-        runtime.getWarnings().warning(id, file, line, message);
+        warn(id, message);
     }
 
     /**
@@ -322,9 +302,7 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
     public void warn(ID id, String fileName, String message) {
         if (!runtime.warningsEnabled()) return;
 
-        IRubyObject errorStream = runtime.getGlobalVariables().get("$stderr");
-        String buffer = fileName + " warning: " + message + '\n';
-        errorStream.callMethod(runtime.getCurrentContext(), "write", runtime.newString(buffer));
+        warn(runtime.getCurrentContext(), runtime.newString(fileName + " warning: " + message + '\n'));
     }
 
     public enum Category {

--- a/core/src/main/java/org/jruby/common/RubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/RubyWarnings.java
@@ -207,11 +207,9 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
     }
 
     /**
-     * Verbose mode warning methods, their contract is that consumer must explicitly check for runtime.isVerbose()
-     * before calling them
+     * Verbose mode warning methods, their contract is that consumer must explicitly check for runtime.isVerbose() before calling them
      */
     public void warning(String message) {
-        if (!isVerbose()) return;
         if (!runtime.warningsEnabled()) return;
 
         warning(ID.MISCELLANEOUS, message);
@@ -219,7 +217,7 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
 
     @Override
     public void warning(ID id, String message) {
-        if (!runtime.warningsEnabled() || !runtime.isVerbose()) return;
+        if (!runtime.warningsEnabled()) return;
 
         writeWarning(runtime, id, message);
     }
@@ -249,7 +247,7 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
     }
 
     public void warning(String fileName, int lineNumber, String message) {
-        if (!runtime.warningsEnabled() || !runtime.isVerbose()) return;
+        if (!runtime.warningsEnabled()) return;
 
         warn(fileName, lineNumber, message);
     }
@@ -289,12 +287,13 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
 
     // This used to be jrubymethod but leave recv behind for backwards compat
     public static IRubyObject warn(ThreadContext context, IRubyObject recv, IRubyObject arg) {
-        Ruby runtime = context.runtime;
+        TypeConverter.checkType(context, arg, context.runtime.getString());
+        return warn(context, (RubyString) arg);
+    }
 
-        TypeConverter.checkType(context, arg, runtime.getString());
-        RubyString str = (RubyString) arg;
+    public static IRubyObject warn(ThreadContext context, RubyString str) {
         str.verifyAsciiCompatible();
-        writeWarningToError(runtime.getCurrentContext(), str);
+        writeWarningToError(context, str);
         return context.nil;
     }
 

--- a/core/src/main/java/org/jruby/common/RubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/RubyWarnings.java
@@ -192,10 +192,6 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
         if (runtime.getWarningCategories().contains(Category.DEPRECATED)) warn(id, message);
     }
 
-    public void warnDeprecated(String name) {
-        if (runtime.getWarningCategories().contains(Category.DEPRECATED)) warn(ID.MISCELLANEOUS, "" + name + " is deprecated");
-    }
-
     public void warnDeprecatedAlternate(String name, String alternate) {
         if (runtime.getWarningCategories().contains(Category.DEPRECATED)) warn(ID.DEPRECATED_METHOD, name + " is deprecated; use " + alternate + " instead");
     }

--- a/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
@@ -150,9 +150,16 @@ public class RubyLexer extends LexingCommon {
     }
     
     protected void ambiguousOperator(String op, String syn) {
-        warnings.warn(ID.AMBIGUOUS_ARGUMENT, getFile(), ruby_sourceline,
-                "`" + op + "' after local variable or literal is interpreted as binary operator");
-        warnings.warn(ID.AMBIGUOUS_ARGUMENT, getFile(), ruby_sourceline, "even though it seems like " + syn);
+        warning(ID.AMBIGUOUS_ARGUMENT, "`" + op + "' after local variable or literal is interpreted as binary operator");
+        warning(ID.AMBIGUOUS_ARGUMENT, "even though it seems like " + syn);
+    }
+
+    private void warning(ID id, String message) {
+        warning(id, getFile(), getRubySourceline(), message);
+    }
+
+    private void warning(ID id, String file, int line, String message) {
+        warnings.warning(id, file, line + 1, message); // rubysource-line is 0 based
     }
 
     public enum Keyword {
@@ -347,7 +354,7 @@ public class RubyLexer extends LexingCommon {
                 c = '\n';
             } else if (ruby_sourceline > last_cr_line) {
                 last_cr_line = ruby_sourceline;
-                warnings.warn(ID.VOID_VALUE_EXPRESSION, getFile(), ruby_sourceline, "encountered \\r in middle of line, treated as a mere space");
+                warning(ID.VOID_VALUE_EXPRESSION, "encountered \\r in middle of line, treated as a mere space");
             }
         }
 
@@ -620,7 +627,7 @@ public class RubyLexer extends LexingCommon {
         try {
             d = SafeDoubleParser.parseDouble(number);
         } catch (NumberFormatException e) {
-            warnings.warn(ID.FLOAT_OUT_OF_RANGE, getFile(), ruby_sourceline, "Float " + number + " out of range.");
+            warning(ID.FLOAT_OUT_OF_RANGE, "Float " + number + " out of range.");
 
             d = number.startsWith("-") ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
         }
@@ -847,9 +854,9 @@ public class RubyLexer extends LexingCommon {
     private boolean arg_ambiguous(int c) {
         if (warnings.isVerbose() && Options.PARSER_WARN_AMBIGUOUS_ARGUMENTS.load()) {
             if (c == '/') {
-                warnings.warning(ID.AMBIGUOUS_ARGUMENT, getFile(), ruby_sourceline, "ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator");
+                warning(ID.AMBIGUOUS_ARGUMENT, "ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator");
             } else {
-                warnings.warning(ID.AMBIGUOUS_ARGUMENT, getFile(), ruby_sourceline, "ambiguous first argument; put parentheses or a space even after `" + (char) c + "' operator");
+                warning(ID.AMBIGUOUS_ARGUMENT, "ambiguous first argument; put parentheses or a space even after `" + (char) c + "' operator");
             }
         }
         return true;
@@ -1225,7 +1232,7 @@ public class RubyLexer extends LexingCommon {
         int tmpLine = ruby_sourceline;
         if (isSpaceArg(c, spaceSeen)) {
             if (warnings.isVerbose() && Options.PARSER_WARN_ARGUMENT_PREFIX.load())
-                warnings.warning(ID.ARGUMENT_AS_PREFIX, getFile(), tmpLine, "`&' interpreted as argument prefix");
+                warning(ID.ARGUMENT_AS_PREFIX, getFile(), tmpLine, "`&' interpreted as argument prefix");
             c = tAMPER;
         } else if (isBEG()) {
             c = tAMPER;
@@ -1484,7 +1491,7 @@ public class RubyLexer extends LexingCommon {
             try {
                 ref = Integer.parseInt(refAsString.substring(1));
             } catch (NumberFormatException e) {
-                warnings.warn(ID.AMBIGUOUS_ARGUMENT, "`" + refAsString + "' is too big for a number variable, always nil");
+                warning(ID.AMBIGUOUS_ARGUMENT, "`" + refAsString + "' is too big for a number variable, always nil");
                 ref = 0;
             }
 
@@ -1526,7 +1533,7 @@ public class RubyLexer extends LexingCommon {
                 }
 
                 if (parenNest == 0 && isLookingAtEOL()) {
-                    warnings.warn(ID.MISCELLANEOUS, "... at EOL, should be parenthesized?");
+                    warning(ID.MISCELLANEOUS, "... at EOL, should be parenthesized?");
                 } else if (getLeftParenBegin() >= 0 && getLeftParenBegin() + 1 == parenNest) {
                     if (isLexState(last_state, EXPR_LABEL)) {
                         return tDOT3;
@@ -1970,7 +1977,7 @@ public class RubyLexer extends LexingCommon {
                     break;
                 }
                 if (c2 != 0) {
-                    warnings.warn(ID.INVALID_CHAR_SEQUENCE, getFile(), ruby_sourceline, "invalid character syntax; use ?\\" + c2);
+                    warning(ID.INVALID_CHAR_SEQUENCE, "invalid character syntax; use ?\\" + c2);
                 }
             }
             pushback(c);
@@ -2102,7 +2109,7 @@ public class RubyLexer extends LexingCommon {
 
             if (isSpaceArg(c, spaceSeen)) {
                 if (warnings.isVerbose() && Options.PARSER_WARN_ARGUMENT_PREFIX.load())
-                    warnings.warning(ID.ARGUMENT_AS_PREFIX, getFile(), ruby_sourceline, "`**' interpreted as argument prefix");
+                    warning(ID.ARGUMENT_AS_PREFIX, "`**' interpreted as argument prefix");
                 c = tDSTAR;
             } else if (isBEG()) {
                 c = tDSTAR;
@@ -2119,7 +2126,7 @@ public class RubyLexer extends LexingCommon {
             pushback(c);
             if (isSpaceArg(c, spaceSeen)) {
                 if (warnings.isVerbose() && Options.PARSER_WARN_ARGUMENT_PREFIX.load())
-                    warnings.warning(ID.ARGUMENT_AS_PREFIX, getFile(), ruby_sourceline, "`*' interpreted as argument prefix");
+                    warning(ID.ARGUMENT_AS_PREFIX, "`*' interpreted as argument prefix");
                 c = tSTAR;
             } else if (isBEG()) {
                 c = tSTAR;

--- a/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
@@ -807,7 +807,7 @@ public class RubyLexer extends LexingCommon {
 
             switch (newline) {
                 case 1:
-                    parser.warn(ruby_sourceline, "here document identifier ends with a newline");
+                    parser.warn("here document identifier ends with a newline");
                     markerValue.setRealSize(markerValue.realSize() - 1);
                     if (markerValue.get(markerValue.realSize() - 1) == '\r') markerValue.setRealSize(markerValue.realSize() - 1);
                     break;

--- a/core/src/main/java/org/jruby/parser/ScopedParserState.java
+++ b/core/src/main/java/org/jruby/parser/ScopedParserState.java
@@ -95,13 +95,15 @@ public class ScopedParserState {
         usedVariables.add(name);
     }
 
-    public void warnUnusedVariables(Ruby runtime, IRubyWarnings warnings, String file) {
+    public void warnUnusedVariables(RubyParserBase parser, String file) {
         if (definedVariables == null) return;
 
-        for(RubySymbol name: definedVariables.keySet()) {
+        final Ruby runtime = parser.getRuntime();
+        for (RubySymbol name: definedVariables.keySet()) {
             if (RubyParserBase.is_private_local_id(name.getBytes())) continue; // Hidden variable cannot be used.
             if (usedVariables == null || !usedVariables.contains(name)) {
-                warnings.warn(IRubyWarnings.ID.AMBIGUOUS_ARGUMENT, file, definedVariables.get(name), str(runtime, "assigned but unused variable - ", name));
+                parser.warning(IRubyWarnings.ID.AMBIGUOUS_ARGUMENT, file, definedVariables.get(name),
+                    str(runtime, "assigned but unused variable - ", name));
             }
         }
 

--- a/core/src/main/java/org/jruby/util/StringSupport.java
+++ b/core/src/main/java/org/jruby/util/StringSupport.java
@@ -48,6 +48,7 @@ import org.jruby.RubyEncoding;
 import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.jruby.ast.util.ArgsUtil;
+import org.jruby.common.IRubyWarnings.ID;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
@@ -2070,9 +2071,9 @@ public final class StringSupport {
             if (wantarray) {
                 // this code should be live in 3.0
                 if (false) { // #if STRING_ENUMERATORS_WANTARRAY
-                    runtime.getWarnings().warn("given block not used");
+                    runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
                 } else {
-                    runtime.getWarnings().warning("passing a block to String#lines is deprecated");
+                    runtime.getWarnings().warning(ID.BLOCK_DEPRECATED, "passing a block to String#lines is deprecated");
                     wantarray = false;
                 }
             }


### PR DESCRIPTION
`runtime.setWarningsEnabled()` in it's current form is actually useless given typical Ruby apps usage of `Kernel.silence_warnings` and `$VERBOSE = ...`. so I tried to re-invent the idea to actually make it useful: 

setting `runtime.setWarningsEnabled(false)` would act as a kill switch (typically in a production env) to avoid nasty surprises esp. with embedded JRuby scenarios - regardless of gems fiddling with `$VERBOSE` warnings end up disabled.


second I reviewed warning calls to use `warning` method, have an ID and report proper line number (some were of due the +1/-1 going on) by moving the line adjustment logic to the "source". also,  `RubyWarnings` got refactored so that the warning/warn calls delegate to pretty much one method as I was thinking of adding a `getWarningFilter` on the runtime (it's just a few lines to add and works good but I am not yet sure whether it would be worth maintaining given the introduction of the *warning* gem :thinking:).
