### PR TITLE
Pass keywords through call stack

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/methods/DynamicMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/DynamicMethod.java
@@ -41,6 +41,7 @@ import org.jruby.PrependedModule;
 import org.jruby.Ruby;
 import org.jruby.RubyModule;
 import org.jruby.RubySymbol;
+import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.CallType;
@@ -156,6 +157,45 @@ public abstract class DynamicMethod {
         } else {
             flags &= ~BUILTIN_FLAG;
         }
+    }
+
+    /**
+     * A call path specialized for passing keyword arguments. Keywords can be passed
+     * as a Hash or as a series of values, with the exact configuration being passed
+     * in callInfo. The default version sets callInfo using thread-local storage.
+     *
+     * @param context The thread context for the currently executing thread
+     * @param self The 'self' or 'receiver' object to use for this call
+     * @param clazz The Ruby class against which this method is binding
+     * @param name The incoming name used to invoke this method
+     * @param callInfo The call info flags for passing keyword configuration
+     * @param args The arguments and keywords for the method
+     * @return The result of the call
+     */
+    public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz,
+                                     String name, int callInfo, IRubyObject... args) {
+        IRRuntimeHelpers.setCallInfo(context, callInfo);
+        return call(context, self, clazz, name, args);
+    }
+
+    /**
+     * A call path specialized for passing keyword arguments. Keywords can be passed
+     * as a Hash or as a series of values, with the exact configuration being passed
+     * in callInfo. The default version sets callInfo using thread-local storage.
+     *
+     * @param context The thread context for the currently executing thread
+     * @param self The 'self' or 'receiver' object to use for this call
+     * @param clazz The Ruby class against which this method is binding
+     * @param name The incoming name used to invoke this method
+     * @param callInfo The call info flags for passing keyword configuration
+     * @param block The block passed to this invocation
+     * @param args The arguments and keywords for the method
+     * @return The result of the call
+     */
+    public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz,
+                            String name, int callInfo, Block block, IRubyObject... args) {
+        IRRuntimeHelpers.setCallInfo(context, callInfo);
+        return call(context, self, clazz, name, args, block);
     }
 
     /**

--- a/core/src/main/java/org/jruby/ir/instructions/CallBase.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CallBase.java
@@ -539,13 +539,13 @@ public abstract class CallBase extends NOperandInstr implements ClosureAccepting
         IRubyObject[] values = prepareArguments(context, self, currScope, dynamicScope, temp);
         Block preparedBlock = prepareBlock(context, self, currScope, dynamicScope, temp);
 
-        IRRuntimeHelpers.setCallInfo(context, getFlags());
+        int callInfo = getFlags();
 
         if (hasLiteralClosure()) {
-            return callSite.callIter(context, self, object, values, preparedBlock);
+            return callSite.callIter(context, self, object, callInfo, preparedBlock, values);
         }
 
-        return callSite.call(context, self, object, values, preparedBlock);
+        return callSite.call(context, self, object, callInfo, preparedBlock, values);
     }
 
     public IRubyObject[] prepareArguments(ThreadContext context, IRubyObject self, StaticScope currScope, DynamicScope dynamicScope, Object[] temp) {

--- a/core/src/main/java/org/jruby/ir/instructions/ClassSuperInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ClassSuperInstr.java
@@ -97,12 +97,12 @@ public class ClassSuperInstr extends CallInstr {
         IRubyObject[] args = prepareArguments(context, self, currScope, currDynScope, temp);
         Block block = prepareBlock(context, self, currScope, currDynScope, temp);
 
-        IRRuntimeHelpers.setCallInfo(context, getFlags());
+        int callInfo = getFlags();
 
         if (isLiteralBlock) {
-            return IRRuntimeHelpers.unresolvedSuperIter(context, self, args, block);
+            return IRRuntimeHelpers.unresolvedSuperIter(context, self, callInfo, args, block);
         } else {
-            return IRRuntimeHelpers.unresolvedSuper(context, self, args, block);
+            return IRRuntimeHelpers.unresolvedSuper(context, self, callInfo, args, block);
         }
     }
 

--- a/core/src/main/java/org/jruby/ir/instructions/InstanceSuperInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/InstanceSuperInstr.java
@@ -131,12 +131,12 @@ public class InstanceSuperInstr extends CallInstr {
         Block block = prepareBlock(context, self, currScope, currDynScope, temp);
         RubyModule definingModule = ((RubyModule) getDefiningModule().retrieve(context, self, currScope, currDynScope, temp));
 
-        IRRuntimeHelpers.setCallInfo(context, getFlags());
+        int callInfo = getFlags();
 
         if (isLiteralBlock) {
-            return IRRuntimeHelpers.instanceSuperIter(context, self, getId(), definingModule, args, block);
+            return IRRuntimeHelpers.instanceSuperIter(context, self, getId(), definingModule, callInfo, args, block);
         } else {
-            return IRRuntimeHelpers.instanceSuper(context, self, getId(), definingModule, args, block);
+            return IRRuntimeHelpers.instanceSuper(context, self, getId(), definingModule, callInfo, args, block);
         }
     }
 

--- a/core/src/main/java/org/jruby/ir/instructions/UnresolvedSuperInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/UnresolvedSuperInstr.java
@@ -115,12 +115,12 @@ public class UnresolvedSuperInstr extends CallInstr {
         IRubyObject[] args = prepareArguments(context, self, currScope, currDynScope, temp);
         Block block = prepareBlock(context, self, currScope, currDynScope, temp);
 
-        IRRuntimeHelpers.setCallInfo(context, getFlags());
+        int flags = getFlags();
 
         if (isLiteralBlock) {
-            return IRRuntimeHelpers.unresolvedSuperIter(context, self, args, block);
+            return IRRuntimeHelpers.unresolvedSuperIter(context, self, flags, args, block);
         } else {
-            return IRRuntimeHelpers.unresolvedSuper(context, self, args, block);
+            return IRRuntimeHelpers.unresolvedSuper(context, self, flags, args, block);
         }
     }
 

--- a/core/src/main/java/org/jruby/ir/instructions/ZSuperInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ZSuperInstr.java
@@ -81,9 +81,8 @@ public class ZSuperInstr extends UnresolvedSuperInstr {
         IRubyObject[] args = prepareArguments(context, self, currScope, currDynScope, temp);
         Block block = prepareBlock(context, self, currScope, currDynScope, temp);
 
-        IRRuntimeHelpers.setCallInfo(context, getFlags());
 
-        return IRRuntimeHelpers.zSuper(context, self, args, block);
+        return IRRuntimeHelpers.zSuper(context, self, getFlags(), args, block);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/targets/indy/ClassSuperInvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/ClassSuperInvokeSite.java
@@ -26,7 +26,6 @@ public class ClassSuperInvokeSite extends ResolvedSuperInvokeSite {
     public IRubyObject invoke(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass definingModule, IRubyObject[] args, Block block) throws Throwable {
         // TODO: get rid of caller
         // TODO: caching
-        IRRuntimeHelpers.setCallInfo(context, flags);
-        return IRRuntimeHelpers.classSuperSplatArgs(context, self, superName, definingModule, args, block, splatMap);
+        return IRRuntimeHelpers.classSuperSplatArgs(context, self, superName, definingModule, flags, args, block, splatMap);
     }
 }

--- a/core/src/main/java/org/jruby/ir/targets/indy/ClassSuperIterInvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/ClassSuperIterInvokeSite.java
@@ -26,7 +26,6 @@ public class ClassSuperIterInvokeSite extends ResolvedSuperInvokeSite {
     public IRubyObject invoke(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass definingModule, IRubyObject[] args, Block block) throws Throwable {
         // TODO: get rid of caller
         // TODO: caching
-        IRRuntimeHelpers.setCallInfo(context, flags);
-        return IRRuntimeHelpers.classSuperIterSplatArgs(context, self, superName, definingModule, args, block, splatMap);
+        return IRRuntimeHelpers.classSuperIterSplatArgs(context, self, superName, definingModule, flags, args, block, splatMap);
     }
 }

--- a/core/src/main/java/org/jruby/ir/targets/indy/InstanceSuperInvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/InstanceSuperInvokeSite.java
@@ -26,7 +26,6 @@ public class InstanceSuperInvokeSite extends ResolvedSuperInvokeSite {
     public IRubyObject invoke(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass definingModule, IRubyObject[] args, Block block) throws Throwable {
         // TODO: get rid of caller
         // TODO: caching
-        IRRuntimeHelpers.setCallInfo(context, flags);
-        return IRRuntimeHelpers.instanceSuperSplatArgs(context, self, superName, definingModule, args, block, splatMap);
+        return IRRuntimeHelpers.instanceSuperSplatArgs(context, self, superName, definingModule, flags, args, block, splatMap);
     }
 }

--- a/core/src/main/java/org/jruby/ir/targets/indy/InstanceSuperIterInvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/InstanceSuperIterInvokeSite.java
@@ -26,7 +26,6 @@ public class InstanceSuperIterInvokeSite extends ResolvedSuperInvokeSite {
     public IRubyObject invoke(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass definingModule, IRubyObject[] args, Block block) throws Throwable {
         // TODO: get rid of caller
         // TODO: caching
-        IRRuntimeHelpers.setCallInfo(context, flags);
-        return IRRuntimeHelpers.instanceSuperIterSplatArgs(context, self, superName, definingModule, args, block, splatMap);
+        return IRRuntimeHelpers.instanceSuperIterSplatArgs(context, self, superName, definingModule, flags, args, block, splatMap);
     }
 }

--- a/core/src/main/java/org/jruby/ir/targets/indy/UnresolvedSuperInvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/UnresolvedSuperInvokeSite.java
@@ -19,8 +19,7 @@ public class UnresolvedSuperInvokeSite extends SuperInvokeSite {
     public IRubyObject invoke(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass definingModule, IRubyObject[] args, Block block) throws Throwable {
         // TODO: get rid of caller
         // TODO: caching
-        IRRuntimeHelpers.setCallInfo(context, flags);
-        return IRRuntimeHelpers.unresolvedSuperSplatArgs(context, self, args, block, splatMap);
+        return IRRuntimeHelpers.unresolvedSuperSplatArgs(context, self, flags, args, block, splatMap);
     }
 
     public IRubyObject fail(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass definingModule, IRubyObject[] args, Block block) throws Throwable {

--- a/core/src/main/java/org/jruby/ir/targets/indy/UnresolvedSuperIterInvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/UnresolvedSuperIterInvokeSite.java
@@ -19,8 +19,7 @@ public class UnresolvedSuperIterInvokeSite extends SuperInvokeSite {
     public IRubyObject invoke(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass definingModule, IRubyObject[] args, Block block) throws Throwable {
         // TODO: get rid of caller
         // TODO: caching
-        IRRuntimeHelpers.setCallInfo(context, flags);
-        return IRRuntimeHelpers.unresolvedSuperIterSplatArgs(context, self, args, block, splatMap);
+        return IRRuntimeHelpers.unresolvedSuperIterSplatArgs(context, self, flags, args, block, splatMap);
     }
 
     public IRubyObject fail(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass definingModule, IRubyObject[] args, Block block) throws Throwable {

--- a/core/src/main/java/org/jruby/ir/targets/indy/ZSuperInvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/ZSuperInvokeSite.java
@@ -20,8 +20,7 @@ public class ZSuperInvokeSite extends SuperInvokeSite {
         // TODO: get rid of caller
         // TODO: caching
         if (block == null || !block.isGiven()) block = context.getFrameBlock();
-        IRRuntimeHelpers.setCallInfo(context, flags);
-        return IRRuntimeHelpers.zSuperSplatArgs(context, self, args, block, splatMap);
+        return IRRuntimeHelpers.zSuperSplatArgs(context, self, flags, args, block, splatMap);
     }
 
     public IRubyObject fail(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass definingModule, IRubyObject[] args, Block block) throws Throwable {

--- a/core/src/main/java/org/jruby/ir/targets/simple/NormalInvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/simple/NormalInvocationCompiler.java
@@ -74,6 +74,8 @@ public class NormalInvocationCompiler implements InvocationCompiler {
         MethodType incoming, outgoing;
         String incomingSig, outgoingSig;
 
+        boolean needsCallInfo = true;
+
         IRBytecodeAdapter.BlockPassType blockPassType = IRBytecodeAdapter.BlockPassType.fromIR(call);
         boolean blockGiven = blockPassType.given();
         boolean functional = call.getCallType() == CallType.FUNCTIONAL || call.getCallType() == CallType.VARIABLE;
@@ -81,8 +83,9 @@ public class NormalInvocationCompiler implements InvocationCompiler {
             if (blockGiven) {
                 switch (arity) {
                     case -1:
+                        needsCallInfo = false;
                         incoming = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT_ARRAY, Block.class));
-                        outgoing = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT_ARRAY, Block.class));
+                        outgoing = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, int.class, Block.class, JVM.OBJECT_ARRAY));
                         break;
                     case 0:
                     case 1:
@@ -92,15 +95,17 @@ public class NormalInvocationCompiler implements InvocationCompiler {
                         outgoing = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, arity, Block.class));
                         break;
                     default:
+                        needsCallInfo = false;
                         incoming = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, arity, Block.class));
-                        outgoing = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT_ARRAY, Block.class));
+                        outgoing = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, int.class, Block.class, JVM.OBJECT_ARRAY));
                         break;
                 }
             } else {
                 switch (arity) {
                     case -1:
+                        needsCallInfo = false;
                         incoming = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT_ARRAY));
-                        outgoing = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT_ARRAY));
+                        outgoing = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, int.class, JVM.OBJECT_ARRAY));
                         break;
                     case 0:
                     case 1:
@@ -110,8 +115,9 @@ public class NormalInvocationCompiler implements InvocationCompiler {
                         outgoing = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, arity));
                         break;
                     default:
+                        needsCallInfo = false;
                         incoming = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, arity));
-                        outgoing = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT_ARRAY));
+                        outgoing = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, int.class, JVM.OBJECT_ARRAY));
                         break;
                 }
             }
@@ -119,8 +125,9 @@ public class NormalInvocationCompiler implements InvocationCompiler {
             if (blockGiven) {
                 switch (arity) {
                     case -1:
+                        needsCallInfo = false;
                         incoming = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY, Block.class));
-                        outgoing = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY, Block.class));
+                        outgoing = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, int.class, Block.class, JVM.OBJECT_ARRAY));
                         break;
                     case 0:
                     case 1:
@@ -130,15 +137,17 @@ public class NormalInvocationCompiler implements InvocationCompiler {
                         outgoing = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT, arity, Block.class));
                         break;
                     default:
+                        needsCallInfo = false;
                         incoming = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT, arity, Block.class));
-                        outgoing = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY, Block.class));
+                        outgoing = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, int.class, Block.class, JVM.OBJECT_ARRAY));
                         break;
                 }
             } else {
                 switch (arity) {
                     case -1:
+                        needsCallInfo = false;
                         incoming = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY));
-                        outgoing = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY));
+                        outgoing = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, int.class, JVM.OBJECT_ARRAY));
                         break;
                     case 0:
                     case 1:
@@ -148,8 +157,9 @@ public class NormalInvocationCompiler implements InvocationCompiler {
                         outgoing = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT, arity));
                         break;
                     default:
+                        needsCallInfo = false;
                         incoming = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT, arity));
-                        outgoing = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, JVM.OBJECT_ARRAY));
+                        outgoing = MethodType.methodType(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, JVM.OBJECT, int.class, JVM.OBJECT_ARRAY));
                         break;
                 }
             }
@@ -179,6 +189,10 @@ public class NormalInvocationCompiler implements InvocationCompiler {
 
             switch (arity) {
                 case -1:
+                    compiler.adapter.pushInt(call.getFlags());
+                    if (blockGiven) compiler.adapter.aload(selfBase + 2);
+                    compiler.adapter.aload(selfBase + 1);
+                    break;
                 case 1:
                     compiler.adapter.aload(selfBase + 1);
                     if (blockGiven) compiler.adapter.aload(selfBase + 2);
@@ -198,8 +212,9 @@ public class NormalInvocationCompiler implements InvocationCompiler {
                     if (blockGiven) compiler.adapter.aload(selfBase + 4);
                     break;
                 default:
-                    IRBytecodeAdapter.buildArrayFromLocals(compiler.adapter, selfBase + 1, arity);
+                    compiler.adapter.pushInt(call.getFlags());
                     if (blockGiven) compiler.adapter.aload(selfBase + 1 + arity);
+                    IRBytecodeAdapter.buildArrayFromLocals(compiler.adapter, selfBase + 1, arity);
                     break;
             }
 
@@ -211,7 +226,7 @@ public class NormalInvocationCompiler implements InvocationCompiler {
         });
 
         // now set up callInfo and call the method
-        setCallInfo(call.getFlags());
+        if (needsCallInfo) setCallInfo(call.getFlags());
         compiler.adapter.invokestatic(clsName, methodName, incomingSig);
     }
 

--- a/core/src/main/java/org/jruby/runtime/CallSite.java
+++ b/core/src/main/java/org/jruby/runtime/CallSite.java
@@ -164,6 +164,31 @@ public abstract class CallSite {
 
     /**
      * Call the site's method against the target object passing arguments.
+     *
+     * @param context the ThreadContext for the current thread
+     * @param caller the caller, for visibility checks
+     * @param self the target object to call against
+     * @param callInfo the keyword call info
+     * @param args the arguments to pass
+     * @return the result of the call
+     */
+    public abstract IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, int callInfo, IRubyObject... args);
+
+    /**
+     * Call the site's method against the target object passing arguments.
+     *
+     * @param context the ThreadContext for the current thread
+     * @param caller the caller, for visibility checks
+     * @param self the target object to call against
+     * @param callInfo the keyword call info
+     * @param block the block for the call
+     * @param args the arguments to pass
+     * @return the result of the call
+     */
+    public abstract IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, int callInfo, Block block, IRubyObject... args);
+
+    /**
+     * Call the site's method against the target object passing arguments.
      * 
      * As a "varargs" method, this will use the length of the args array to
      * dispatch to the correct arity call, rather than dispatching unconditionally
@@ -334,6 +359,21 @@ public abstract class CallSite {
      * @return the result of the call
      */
     public abstract IRubyObject callIter(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject[] args, Block block);
+
+    /**
+     * Call the site's method against the target object passing arguments and
+     * a literal block. This version handles break jumps by returning their
+     * value if this is the appropriate place in the call stack to do so.
+     *
+     * @param context the ThreadContext for the current thread
+     * @param caller the caller, for visibility checks
+     * @param self the target object to call against
+     * @param callInfo the keyword call info
+     * @param block the literal block to pass
+     * @param args the arguments to pass
+     * @return the result of the call
+     */
+    public abstract IRubyObject callIter(ThreadContext context, IRubyObject caller, IRubyObject self, int callInfo, Block block, IRubyObject... args);
 
     /**
      * Call the site's method against the target object passing arguments and

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -118,9 +118,18 @@ public class Helpers {
         return selectMethodMissing(context, klass, visibility, name, callType).call(context, self, klass, name, args, block);
     }
 
+    public static IRubyObject callMethodMissing(ThreadContext context, IRubyObject self, RubyClass klass, Visibility visibility, String name, CallType callType, int callInfo, IRubyObject[] args, Block block) {
+        return selectMethodMissing(context, klass, visibility, name, callType).call(context, self, klass, name, callInfo, block, args);
+    }
+
     public static IRubyObject callMethodMissing(ThreadContext context, IRubyObject receiver, Visibility visibility, String name, CallType callType, IRubyObject[] args, Block block) {
         final RubyClass klass = getMetaClass(receiver);
         return selectMethodMissing(context, klass, visibility, name, callType).call(context, receiver, klass, name, args, block);
+    }
+
+    public static IRubyObject callMethodMissing(ThreadContext context, IRubyObject receiver, Visibility visibility, String name, CallType callType, int callInfo, IRubyObject[] args, Block block) {
+        final RubyClass klass = getMetaClass(receiver);
+        return selectMethodMissing(context, klass, visibility, name, callType).call(context, receiver, klass, name, callInfo, block, args);
     }
 
     public static IRubyObject callMethodMissing(ThreadContext context, IRubyObject self, RubyClass klass, Visibility visibility, String name, CallType callType, IRubyObject arg0, Block block) {

--- a/core/src/main/java/org/jruby/runtime/callsite/RefinedCachingCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/RefinedCachingCallSite.java
@@ -36,6 +36,20 @@ public class RefinedCachingCallSite extends CachingCallSite {
         return method.call(context, self, entry.sourceModule, methodName, args);
     }
 
+    @Override
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, int callInfo, IRubyObject... args) {
+        RubyClass selfType = getClass(self);
+        CacheEntry entry = selfType.searchWithRefinements(methodName, scope);
+        DynamicMethod method = entry.method;
+
+        if (methodMissing(method, caller)) {
+            method = Helpers.selectMethodMissing(context, selfType, method.getVisibility(), methodName, callType);
+        }
+
+        return method.call(context, self, entry.sourceModule, methodName, callInfo, args);
+    }
+
+    @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject[] args, Block block) {
         RubyClass selfType = getClass(self);
         CacheEntry entry = selfType.searchWithRefinements(methodName, scope);
@@ -48,6 +62,20 @@ public class RefinedCachingCallSite extends CachingCallSite {
         return method.call(context, self, entry.sourceModule, methodName, args, block);
     }
 
+    @Override
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, int callInfo, Block block, IRubyObject[] args) {
+        RubyClass selfType = getClass(self);
+        CacheEntry entry = selfType.searchWithRefinements(methodName, scope);
+        DynamicMethod method = entry.method;
+
+        if (methodMissing(method, caller)) {
+            method = Helpers.selectMethodMissing(context, selfType, method.getVisibility(), methodName, callType);
+        }
+
+        return method.call(context, self, entry.sourceModule, methodName, callInfo, block, args);
+    }
+
+    @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self) {
         RubyClass selfType = getClass(self);
         CacheEntry entry = selfType.searchWithRefinements(methodName, scope);
@@ -60,6 +88,7 @@ public class RefinedCachingCallSite extends CachingCallSite {
         return method.call(context, self, entry.sourceModule, methodName);
     }
 
+    @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, Block block) {
         RubyClass selfType = getClass(self);
         CacheEntry entry = selfType.searchWithRefinements(methodName, scope);
@@ -72,6 +101,7 @@ public class RefinedCachingCallSite extends CachingCallSite {
         return method.call(context, self, entry.sourceModule, methodName, block);
     }
 
+    @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg0) {
         RubyClass selfType = getClass(self);
         CacheEntry entry = selfType.searchWithRefinements(methodName, scope);
@@ -84,6 +114,7 @@ public class RefinedCachingCallSite extends CachingCallSite {
         return method.call(context, self, entry.sourceModule, methodName, arg0);
     }
 
+    @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg0, Block block) {
         RubyClass selfType = getClass(self);
         CacheEntry entry = selfType.searchWithRefinements(methodName, scope);
@@ -96,6 +127,7 @@ public class RefinedCachingCallSite extends CachingCallSite {
         return method.call(context, self, entry.sourceModule, methodName, arg0, block);
     }
 
+    @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg0, IRubyObject arg1) {
         RubyClass selfType = getClass(self);
         CacheEntry entry = selfType.searchWithRefinements(methodName, scope);
@@ -108,6 +140,7 @@ public class RefinedCachingCallSite extends CachingCallSite {
         return method.call(context, self, entry.sourceModule, methodName, arg0, arg1);
     }
 
+    @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg0, IRubyObject arg1, Block block) {
         RubyClass selfType = getClass(self);
         CacheEntry entry = selfType.searchWithRefinements(methodName, scope);
@@ -120,6 +153,7 @@ public class RefinedCachingCallSite extends CachingCallSite {
         return method.call(context, self, entry.sourceModule, methodName, arg0, arg1, block);
     }
 
+    @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
         RubyClass selfType = getClass(self);
         CacheEntry entry = selfType.searchWithRefinements(methodName, scope);
@@ -132,6 +166,7 @@ public class RefinedCachingCallSite extends CachingCallSite {
         return method.call(context, self, entry.sourceModule, methodName, arg0, arg1, arg2);
     }
 
+    @Override
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
         RubyClass selfType = getClass(self);
         CacheEntry entry = selfType.searchWithRefinements(methodName, scope);
@@ -144,6 +179,7 @@ public class RefinedCachingCallSite extends CachingCallSite {
         return method.call(context, self, entry.sourceModule, methodName, arg0, arg1, arg2, block);
     }
 
+    @Override
     protected boolean methodMissing(DynamicMethod method, IRubyObject caller) {
         // doing full "normal" MM check rather than multiple refined sites by call types
         return method.isUndefined() || (!methodName.equals("method_missing") && !method.isCallableFrom(caller, callType));

--- a/core/src/main/java/org/jruby/runtime/callsite/SuperCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/SuperCallSite.java
@@ -50,6 +50,13 @@ public class SuperCallSite extends CallSite {
         return call(context, caller, self, klazz, name, args);
     }
 
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, int callInfo, IRubyObject... args) {
+        RubyModule klazz = context.getFrameKlazz();
+        String name = context.getFrameName();
+
+        return call(context, caller, self, klazz, name, callInfo, args);
+    }
+
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, RubyModule klazz, String name, IRubyObject... args) {
         RubyClass selfType = pollAndGetClass(context, self, klazz, name);
 
@@ -57,7 +64,17 @@ public class SuperCallSite extends CallSite {
         if (selfType != null && myCache.cacheOk(name, selfType)) {
             return myCache.cache.method.call(context, self, cache.cache.sourceModule, name, args);
         }
-        return cacheAndCall(caller, selfType, args, context, self, name);
+        return cacheAndCall(context, caller, self, selfType, name, args);
+    }
+
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, RubyModule klazz, String name, int callInfo, IRubyObject... args) {
+        RubyClass selfType = pollAndGetClass(context, self, klazz, name);
+
+        SuperTuple myCache = cache;
+        if (selfType != null && myCache.cacheOk(name, selfType)) {
+            return myCache.cache.method.call(context, self, cache.cache.sourceModule, name, callInfo, args);
+        }
+        return cacheAndCall(context, caller, self, selfType, name, callInfo, args);
     }
 
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject[] args, Block block) {
@@ -67,6 +84,13 @@ public class SuperCallSite extends CallSite {
         return call(context, caller, self, klazz, name, args, block);
     }
 
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, int callInfo, Block block, IRubyObject... args) {
+        RubyModule klazz = context.getFrameKlazz();
+        String name = context.getFrameName();
+
+        return call(context, caller, self, klazz, name, callInfo, block, args);
+    }
+
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, RubyModule klazz, String name, IRubyObject[] args, Block block) {
         RubyClass selfType = pollAndGetClass(context, self, klazz, name);
 
@@ -74,12 +98,30 @@ public class SuperCallSite extends CallSite {
         if (selfType != null && myCache.cacheOk(name, selfType)) {
             return myCache.cache.method.call(context, self, cache.cache.sourceModule, name, args, block);
         }
-        return cacheAndCall(caller, selfType, block, args, context, self, name);
+        return cacheAndCall(context, caller, self, selfType, name, args, block);
+    }
+
+    public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, RubyModule klazz, String name, int callInfo, Block block, IRubyObject... args) {
+        RubyClass selfType = pollAndGetClass(context, self, klazz, name);
+
+        SuperTuple myCache = cache;
+        if (selfType != null && myCache.cacheOk(name, selfType)) {
+            return myCache.cache.method.call(context, self, cache.cache.sourceModule, name, callInfo, block, args);
+        }
+        return cacheAndCall(context, caller, self, selfType, name, callInfo, args, block);
     }
 
     public IRubyObject callIter(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject[] args, Block block) {
         try {
             return call(context, caller, self, args, block);
+        } finally {
+            block.escape();
+        }
+    }
+
+    public IRubyObject callIter(ThreadContext context, IRubyObject caller, IRubyObject self, int callInfo, Block block, IRubyObject... args) {
+        try {
+            return call(context, caller, self, callInfo, block, args);
         } finally {
             block.escape();
         }
@@ -184,7 +226,7 @@ public class SuperCallSite extends CallSite {
         if (selfType != null && myCache.cacheOk(name, selfType)) {
             return myCache.cache.method.call(context, self, cache.cache.sourceModule, name, block);
         }
-        return cacheAndCall(caller, selfType, block, context, self, name);
+        return cacheAndCall(context, caller, self, selfType, name, block);
     }
 
     public IRubyObject callIter(ThreadContext context, IRubyObject caller, IRubyObject self, Block block) {
@@ -217,7 +259,7 @@ public class SuperCallSite extends CallSite {
         if (selfType != null && myCache.cacheOk(name, selfType)) {
             return myCache.cache.method.call(context, self, cache.cache.sourceModule, name, arg1);
         }
-        return cacheAndCall(caller, selfType, context, self, name, arg1);
+        return cacheAndCall(context, caller, self, selfType, name, arg1);
     }
 
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1, Block block) {
@@ -234,7 +276,7 @@ public class SuperCallSite extends CallSite {
         if (selfType != null && myCache.cacheOk(name, selfType)) {
             return myCache.cache.method.call(context, self, cache.cache.sourceModule, name, arg1, block);
         }
-        return cacheAndCall(caller, selfType, block, context, self, name, arg1);
+        return cacheAndCall(context, caller, self, selfType, name, arg1, block);
     }
 
     public IRubyObject callIter(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1, Block block) {
@@ -267,7 +309,7 @@ public class SuperCallSite extends CallSite {
         if (selfType != null && myCache.cacheOk(name, selfType)) {
             return myCache.cache.method.call(context, self, cache.cache.sourceModule, name, arg1, arg2);
         }
-        return cacheAndCall(caller, selfType, context, self, name, arg1, arg2);
+        return cacheAndCall(context, caller, self, selfType, name, arg1, arg2);
     }
 
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1, IRubyObject arg2, Block block) {
@@ -284,7 +326,7 @@ public class SuperCallSite extends CallSite {
         if (selfType != null && myCache.cacheOk(name, selfType)) {
             return myCache.cache.method.call(context, self, cache.cache.sourceModule, name, arg1, arg2, block);
         }
-        return cacheAndCall(caller, selfType, block, context, self, name, arg1, arg2);
+        return cacheAndCall(context, caller, self, selfType, name, arg1, block, arg2);
     }
 
     public IRubyObject callIter(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1, IRubyObject arg2, Block block) {
@@ -317,7 +359,7 @@ public class SuperCallSite extends CallSite {
         if (selfType != null && myCache.cacheOk(name, selfType)) {
             return myCache.cache.method.call(context, self, cache.cache.sourceModule, name, arg1, arg2, arg3);
         }
-        return cacheAndCall(caller, selfType, context, self, name, arg1, arg2, arg3);
+        return cacheAndCall(context, caller, self, selfType, name, arg1, arg2, arg3);
     }
 
     public IRubyObject call(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3, Block block) {
@@ -334,7 +376,7 @@ public class SuperCallSite extends CallSite {
         if (selfType != null && myCache.cacheOk(name, selfType)) {
             return myCache.cache.method.call(context, self, cache.cache.sourceModule, name, arg1, arg2, arg3, block);
         }
-        return cacheAndCall(caller, selfType, block, context, self, name, arg1, arg2, arg3);
+        return cacheAndCall(context, caller, self, selfType, name, arg1, arg2, arg3, block);
     }
 
     public IRubyObject callIter(ThreadContext context, IRubyObject caller, IRubyObject self, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3, Block block) {
@@ -353,7 +395,7 @@ public class SuperCallSite extends CallSite {
         }
     }
     
-    protected IRubyObject cacheAndCall(IRubyObject caller, RubyClass selfType, Block block, IRubyObject[] args, ThreadContext context, IRubyObject self, String name) {
+    protected IRubyObject cacheAndCall(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass selfType, String name, IRubyObject[] args, Block block) {
         CacheEntry entry = selfType != null ? selfType.searchWithCache(name) : CacheEntry.NULL_CACHE;
         DynamicMethod method = entry.method;
         if (methodMissing(method, caller)) {
@@ -363,7 +405,17 @@ public class SuperCallSite extends CallSite {
         return method.call(context, self, entry.sourceModule, name, args, block);
     }
 
-    protected IRubyObject cacheAndCall(IRubyObject caller, RubyClass selfType, IRubyObject[] args, ThreadContext context, IRubyObject self, String name) {
+    protected IRubyObject cacheAndCall(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass selfType, String name, int callInfo, IRubyObject[] args, Block block) {
+        CacheEntry entry = selfType != null ? selfType.searchWithCache(name) : CacheEntry.NULL_CACHE;
+        DynamicMethod method = entry.method;
+        if (methodMissing(method, caller)) {
+            return callMethodMissing(context, self, selfType, name, method, callInfo, args, block);
+        }
+        cache = new SuperTuple(name, entry);
+        return method.call(context, self, entry.sourceModule, name, callInfo, block, args);
+    }
+
+    protected IRubyObject cacheAndCall(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass selfType, String name, IRubyObject[] args) {
         CacheEntry entry = selfType != null ? selfType.searchWithCache(name) : CacheEntry.NULL_CACHE;
         DynamicMethod method = entry.method;
         if (methodMissing(method, caller)) {
@@ -371,6 +423,16 @@ public class SuperCallSite extends CallSite {
         }
         cache = new SuperTuple(name, entry);
         return method.call(context, self, entry.sourceModule, name, args);
+    }
+
+    protected IRubyObject cacheAndCall(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass selfType, String name, int callInfo, IRubyObject[] args) {
+        CacheEntry entry = selfType != null ? selfType.searchWithCache(name) : CacheEntry.NULL_CACHE;
+        DynamicMethod method = entry.method;
+        if (methodMissing(method, caller)) {
+            return callMethodMissing(context, self, selfType, name, method, callInfo, args);
+        }
+        cache = new SuperTuple(name, entry);
+        return method.call(context, self, entry.sourceModule, name, callInfo, args);
     }
 
     protected IRubyObject cacheAndCall(IRubyObject caller, RubyClass selfType, ThreadContext context, IRubyObject self, String name) {
@@ -383,7 +445,7 @@ public class SuperCallSite extends CallSite {
         return method.call(context, self, entry.sourceModule, name);
     }
 
-    protected IRubyObject cacheAndCall(IRubyObject caller, RubyClass selfType, Block block, ThreadContext context, IRubyObject self, String name) {
+    protected IRubyObject cacheAndCall(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass selfType, String name, Block block) {
         CacheEntry entry = selfType != null ? selfType.searchWithCache(name) : CacheEntry.NULL_CACHE;
         DynamicMethod method = entry.method;
         if (methodMissing(method, caller)) {
@@ -393,7 +455,7 @@ public class SuperCallSite extends CallSite {
         return method.call(context, self, entry.sourceModule, name, block);
     }
 
-    protected IRubyObject cacheAndCall(IRubyObject caller, RubyClass selfType, ThreadContext context, IRubyObject self, String name, IRubyObject arg) {
+    protected IRubyObject cacheAndCall(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass selfType, String name, IRubyObject arg) {
         CacheEntry entry = selfType != null ? selfType.searchWithCache(name) : CacheEntry.NULL_CACHE;
         DynamicMethod method = entry.method;
         if (methodMissing(method, caller)) {
@@ -403,7 +465,7 @@ public class SuperCallSite extends CallSite {
         return method.call(context, self, entry.sourceModule, name, arg);
     }
 
-    protected IRubyObject cacheAndCall(IRubyObject caller, RubyClass selfType, Block block, ThreadContext context, IRubyObject self, String name, IRubyObject arg) {
+    protected IRubyObject cacheAndCall(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass selfType, String name, IRubyObject arg, Block block) {
         CacheEntry entry = selfType != null ? selfType.searchWithCache(name) : CacheEntry.NULL_CACHE;
         DynamicMethod method = entry.method;
         if (methodMissing(method, caller)) {
@@ -413,7 +475,7 @@ public class SuperCallSite extends CallSite {
         return method.call(context, self, entry.sourceModule, name, arg, block);
     }
 
-    protected IRubyObject cacheAndCall(IRubyObject caller, RubyClass selfType, ThreadContext context, IRubyObject self, String name, IRubyObject arg1, IRubyObject arg2) {
+    protected IRubyObject cacheAndCall(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass selfType, String name, IRubyObject arg1, IRubyObject arg2) {
         CacheEntry entry = selfType != null ? selfType.searchWithCache(name) : CacheEntry.NULL_CACHE;
         DynamicMethod method = entry.method;
         if (methodMissing(method, caller)) {
@@ -423,7 +485,7 @@ public class SuperCallSite extends CallSite {
         return method.call(context, self, entry.sourceModule, name, arg1, arg2);
     }
 
-    protected IRubyObject cacheAndCall(IRubyObject caller, RubyClass selfType, Block block, ThreadContext context, IRubyObject self, String name, IRubyObject arg1, IRubyObject arg2) {
+    protected IRubyObject cacheAndCall(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass selfType, String name, IRubyObject arg1, Block block, IRubyObject arg2) {
         CacheEntry entry = selfType != null ? selfType.searchWithCache(name) : CacheEntry.NULL_CACHE;
         DynamicMethod method = entry.method;
         if (methodMissing(method, caller)) {
@@ -433,7 +495,7 @@ public class SuperCallSite extends CallSite {
         return method.call(context, self, entry.sourceModule, name, arg1, arg2, block);
     }
 
-    protected IRubyObject cacheAndCall(IRubyObject caller, RubyClass selfType, ThreadContext context, IRubyObject self, String name, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3) {
+    protected IRubyObject cacheAndCall(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass selfType, String name, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3) {
         CacheEntry entry = selfType != null ? selfType.searchWithCache(name) : CacheEntry.NULL_CACHE;
         DynamicMethod method = entry.method;
         if (methodMissing(method, caller)) {
@@ -443,7 +505,7 @@ public class SuperCallSite extends CallSite {
         return method.call(context, self, entry.sourceModule, name, arg1, arg2, arg3);
     }
 
-    protected IRubyObject cacheAndCall(IRubyObject caller, RubyClass selfType, Block block, ThreadContext context, IRubyObject self, String name, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3) {
+    protected IRubyObject cacheAndCall(ThreadContext context, IRubyObject caller, IRubyObject self, RubyClass selfType, String name, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3, Block block) {
         CacheEntry entry = selfType != null ? selfType.searchWithCache(name) : CacheEntry.NULL_CACHE;
         DynamicMethod method = entry.method;
         if (methodMissing(method, caller)) {
@@ -455,6 +517,10 @@ public class SuperCallSite extends CallSite {
 
     protected IRubyObject callMethodMissing(ThreadContext context, IRubyObject self, RubyClass selfType, String name, DynamicMethod method, IRubyObject[] args) {
         return Helpers.callMethodMissing(context, self, selfType, method.getVisibility(), name, callType, args, Block.NULL_BLOCK);
+    }
+
+    protected IRubyObject callMethodMissing(ThreadContext context, IRubyObject self, RubyClass selfType, String name, DynamicMethod method, int callInfo, IRubyObject[] args) {
+        return Helpers.callMethodMissing(context, self, selfType, method.getVisibility(), name, callType, callInfo, args, Block.NULL_BLOCK);
     }
 
     protected IRubyObject callMethodMissing(ThreadContext context, IRubyObject self, RubyClass selfType, String name, DynamicMethod method) {
@@ -471,6 +537,10 @@ public class SuperCallSite extends CallSite {
 
     protected IRubyObject callMethodMissing(ThreadContext context, IRubyObject self, RubyClass selfType, String name, DynamicMethod method, IRubyObject[] args, Block block) {
         return Helpers.callMethodMissing(context, self, selfType, method.getVisibility(), name, callType, args, block);
+    }
+
+    protected IRubyObject callMethodMissing(ThreadContext context, IRubyObject self, RubyClass selfType, String name, DynamicMethod method, int callInfo, IRubyObject[] args, Block block) {
+        return Helpers.callMethodMissing(context, self, selfType, method.getVisibility(), name, callType, callInfo, args, block);
     }
 
     protected IRubyObject callMethodMissing(ThreadContext context, IRubyObject self, RubyClass selfType, String name, DynamicMethod method, IRubyObject arg0, Block block) {


### PR DESCRIPTION
This PR will attempt to pass enough information on the call stack that we can eliminate the thread-local `callInfo` state, which must be set before each call and cleared immediately upon entering the target body.