### PR TITLE
Move arity-checking into variable-arity method bodies

### DIFF
--- a/core/src/main/java/org/jruby/RubyArgsFile.java
+++ b/core/src/main/java/org/jruby/RubyArgsFile.java
@@ -48,6 +48,7 @@ import static org.jruby.runtime.Visibility.PRIVATE;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.internal.runtime.GlobalVariable;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.CallSite;
 import org.jruby.runtime.IAccessor;
@@ -406,6 +407,8 @@ public class RubyArgsFile extends RubyObject {
      */
     @JRubyMethod(name = "gets", optional = 1, writes = LASTLINE)
     public static IRubyObject gets(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 0, 1);
+
         return context.setLastLine(argf_getline(context, recv, args));
     }
 
@@ -423,6 +426,8 @@ public class RubyArgsFile extends RubyObject {
 
     @JRubyMethod(optional = 1)
     public static IRubyObject readlines(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 0, 1);
+
         Ruby runtime = context.runtime;
         ArgsFileData data = ArgsFileData.getArgsFileData(runtime);
 
@@ -440,6 +445,8 @@ public class RubyArgsFile extends RubyObject {
 
     @JRubyMethod(optional = 1)
     public static IRubyObject to_a(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 0, 1);
+
         Ruby runtime = context.runtime;
         ArgsFileData data = ArgsFileData.getArgsFileData(runtime);
 
@@ -473,6 +480,7 @@ public class RubyArgsFile extends RubyObject {
 
     @JRubyMethod(optional = 1)
     public static IRubyObject bytes(final ThreadContext context, IRubyObject recv, IRubyObject[] args, final Block block) {
+        Arity.checkArgumentCount(context, args, 0, 1);
         return block.isGiven() ? each_byte(context, recv, block) : enumeratorize(context.runtime, recv, "bytes");
     }
 
@@ -550,6 +558,8 @@ public class RubyArgsFile extends RubyObject {
     @JRubyMethod(name = "each_line", optional = 1)
     public static IRubyObject each_line(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         if (!block.isGiven()) return enumeratorize(context.runtime, recv, "each_line", args);
+
+        Arity.checkArgumentCount(context, args, 0, 1);
 
         ArgsFileData data = ArgsFileData.getArgsFileData(context.runtime);
 
@@ -729,6 +739,8 @@ public class RubyArgsFile extends RubyObject {
 
     @JRubyMethod(name = "seek", required = 1, optional = 1)
     public static IRubyObject seek(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 1, 2);
+
         return getCurrentDataFile(context, "no stream to seek").seek(context, args);
     }
 
@@ -764,11 +776,15 @@ public class RubyArgsFile extends RubyObject {
 
     @JRubyMethod(required = 1, optional = 2)
     public static IRubyObject read_nonblock(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 1, 3);
+
         return getPartial(context, recv, args, true);
     }
 
     @JRubyMethod(required = 1, optional = 1)
     public static IRubyObject readpartial(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 1, 2);
+
         return getPartial(context, recv, args, false);
     }
 
@@ -846,14 +862,16 @@ public class RubyArgsFile extends RubyObject {
 
     @JRubyMethod(name = "read", optional = 2)
     public static IRubyObject read(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 0, 2);
+
         Ruby runtime = context.runtime;
         ArgsFileData data = ArgsFileData.getArgsFileData(context.runtime);
         IRubyObject tmp, str, length;
             long len = 0;
 
-        if (args.length > 0) {
+        if (argc > 0) {
             length = args[0];
-            str = args.length > 1 ? args[1] : context.nil;
+            str = argc > 1 ? args[1] : context.nil;
         } else {
             str = length = context.nil;
         }
@@ -883,12 +901,12 @@ public class RubyArgsFile extends RubyObject {
             }
 
             if (tmp == context.nil || length == context.nil) {
-                if(data.next_p != Stream) {
+                if (data.next_p != Stream) {
                     argf_close(context, data.currentFile);
                     data.next_p = NextFile;
                     continue;
                 }
-            } else if(args.length >= 1) {
+            } else if (argc >= 1) {
                 final int strLen = ((RubyString) str).getByteList().length();
                 if (strLen < len) {
                     args[0] = runtime.newFixnum(len - strLen);

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -1180,9 +1180,13 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     @JRubyMethod(name = "insert", required = 1, rest = true)
     public IRubyObject insert(IRubyObject[] args) {
+        final Ruby runtime = metaClass.runtime;
+
+        int argc = Arity.checkArgumentCount(runtime, args, 1, -1);
+
         modifyCheck();
 
-        if (args.length == 1) return this;
+        if (argc == 1) return this;
 
         unpack();
 
@@ -1191,12 +1195,10 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         if (pos == -1) pos = realLength;
         if (pos < 0) pos++;
 
-        final Ruby runtime = metaClass.runtime;
-
         RubyArray inserted = new RubyArray(runtime, false);
         inserted.values = args;
         inserted.begin = 1;
-        inserted.realLength = args.length - 1;
+        inserted.realLength = argc - 1;
 
         splice(runtime, checkInt(runtime, pos), 0, inserted, inserted.realLength); // rb_ary_new4
 
@@ -2687,17 +2689,19 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      */
     @JRubyMethod(name = {"indexes", "indices"}, required = 1, rest = true)
     public IRubyObject indexes(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, -1);
+
         Ruby runtime = context.runtime;
         runtime.getWarnings().warn(ID.DEPRECATED_METHOD, "Array#indexes is deprecated; use Array#values_at");
 
-        if (args.length == 1) return newArray(runtime, args[0]);
+        if (argc == 1) return newArray(runtime, args[0]);
 
-        RubyArray ary = newBlankArrayInternal(runtime, args.length);
+        RubyArray ary = newBlankArrayInternal(runtime, argc);
 
-        for (int i = 0; i < args.length; i++) {
+        for (int i = 0; i < argc; i++) {
             ary.storeInternal(i, aref(context, args[i]));
         }
-        ary.realLength = args.length;
+        ary.realLength = argc;
 
         return ary;
     }
@@ -5485,8 +5489,10 @@ float_loop:
 
     @JRubyMethod(name = "dig", required = 1, rest = true)
     public IRubyObject dig(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, -1);
+
         final IRubyObject val = at( args[0] );
-        return args.length == 1 ? val : RubyObject.dig(context, val, args, 1);
+        return argc == 1 ? val : RubyObject.dig(context, val, args, 1);
     }
 
     private IRubyObject maxWithBlock(ThreadContext context, Block block) {

--- a/core/src/main/java/org/jruby/RubyBinding.java
+++ b/core/src/main/java/org/jruby/RubyBinding.java
@@ -37,6 +37,7 @@ package org.jruby;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.ext.ripper.RubyLexer;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Binding;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ClassIndex;
@@ -116,14 +117,16 @@ public class RubyBinding extends RubyObject {
     }
 
     // c: bind_eval
-    @JRubyMethod(name = "eval", required=1, optional=2)
+    @JRubyMethod(name = "eval", required = 1, optional = 2)
     public IRubyObject eval(ThreadContext context, IRubyObject[] args) {
-        IRubyObject[] newArgs = new IRubyObject[args.length+1];
+        int argc = Arity.checkArgumentCount(context, args, 1, 3);
+
+        IRubyObject[] newArgs = new IRubyObject[argc+1];
         newArgs[0] = args[0]; // eval string
         newArgs[1] = this; // binding
-        if(args.length>1) {
+        if (argc > 1) {
             newArgs[2] = args[1]; // file
-            if(args.length>2) {
+            if (argc > 2) {
                 newArgs[3] = args[2]; // line
             }
         }

--- a/core/src/main/java/org/jruby/RubyComplex.java
+++ b/core/src/main/java/org/jruby/RubyComplex.java
@@ -399,8 +399,10 @@ public class RubyComplex extends RubyNumeric {
      */
     @JRubyMethod(name = "polar", meta = true, required = 1, optional = 1)
     public static IRubyObject polar(ThreadContext context, IRubyObject clazz, IRubyObject... args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 2);
+
         IRubyObject abs = args[0];
-        IRubyObject arg = args.length < 2 ? RubyFixnum.zero(context.runtime) : args[1];
+        IRubyObject arg = argc < 2 ? RubyFixnum.zero(context.runtime) : args[1];
 
         realCheck(context, abs, true);
         realCheck(context, arg, true);

--- a/core/src/main/java/org/jruby/RubyConverter.java
+++ b/core/src/main/java/org/jruby/RubyConverter.java
@@ -44,6 +44,7 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyConstant;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.RaiseException;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.ClassIndex;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
@@ -136,6 +137,8 @@ public class RubyConverter extends RubyObject {
 
     @JRubyMethod(visibility = PRIVATE, required = 1, optional = 2)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 3);
+
         Ruby runtime = context.runtime;
         Encoding[] encs = {null, null};
         byte[][] encNames = {null, null};
@@ -148,7 +151,7 @@ public class RubyConverter extends RubyObject {
             throw runtime.newTypeError("already initialized");
         }
 
-        if (args.length == 1 && !(convpath = args[0].checkArrayType()).isNil()) {
+        if (argc == 1 && !(convpath = args[0].checkArrayType()).isNil()) {
             ec = EncodingUtils.econvInitByConvpath(context, convpath, encNames, encs);
             ecflags[0] = 0;
             ecopts[0] = context.nil;
@@ -220,6 +223,8 @@ public class RubyConverter extends RubyObject {
     // econv_primitive_convert
     @JRubyMethod(required = 2, optional = 4)
     public IRubyObject primitive_convert(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 2, 6);
+
         Ruby runtime = context.runtime;
         
         RubyString input = null;
@@ -231,9 +236,9 @@ public class RubyConverter extends RubyObject {
         int flags = 0;
         
         int hashArg = -1;
-        
-        if (args.length > 2 && !args[2].isNil()) {
-            if (args.length == 3 && args[2] instanceof RubyHash) {
+
+        if (argc > 2 && !args[2].isNil()) {
+            if (argc == 3 && args[2] instanceof RubyHash) {
                 hashArg = 2;
             } else {
                 outputByteOffsetObj = args[2];
@@ -241,8 +246,8 @@ public class RubyConverter extends RubyObject {
             }
         }
         
-        if (args.length > 3 && !args[3].isNil()) {
-            if (args.length == 4 && args[3] instanceof RubyHash) {
+        if (argc > 3 && !args[3].isNil()) {
+            if (argc == 4 && args[3] instanceof RubyHash) {
                 hashArg = 3;
             } else {
                 outputBytesizeObj = args[3];
@@ -250,9 +255,9 @@ public class RubyConverter extends RubyObject {
             }
         }
         
-        if (args.length > 4 && !args[4].isNil()) {
-            if (args.length > 5 && !args[5].isNil()) {
-                throw runtime.newArgumentError(args.length, 5);
+        if (argc > 4 && !args[4].isNil()) {
+            if (argc > 5 && !args[5].isNil()) {
+                throw runtime.newArgumentError(argc, 5);
             }
             
             if (args[4] instanceof RubyHash) {
@@ -591,15 +596,17 @@ public class RubyConverter extends RubyObject {
     }
 
     // econv_putback
-    @JRubyMethod(required = 0, optional = 1)
+    @JRubyMethod(optional = 1)
     public IRubyObject putback(ThreadContext context, IRubyObject[] argv)
     {
+        int argc = Arity.checkArgumentCount(context, argv, 0, 1);
+
         Ruby runtime = context.runtime;
         int n;
         int putbackable;
         IRubyObject str, max;
 
-        if (argv.length == 0) {
+        if (argc == 0) {
             max = context.nil;
         } else {
             max = argv[0];

--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -56,6 +56,7 @@ import org.jcodings.specific.USASCIIEncoding;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyClass;
 import org.jruby.exceptions.RaiseException;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ClassIndex;
 import org.jruby.runtime.ThreadContext;
@@ -320,6 +321,8 @@ public class RubyDir extends RubyObject implements Closeable {
      */
     @JRubyMethod(required = 1, optional = 2, meta = true)
     public static IRubyObject glob(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
+        Arity.checkArgumentCount(context, args, 1, 3);
+
         Ruby runtime = context.runtime;
         GlobOptions options = new GlobOptions();
         globOptions(context, args, BASE_FLAGS_KEYWORDS, options);
@@ -433,8 +436,9 @@ public class RubyDir extends RubyObject implements Closeable {
     /** Changes the current directory to <code>path</code> */
     @JRubyMethod(optional = 1, meta = true)
     public static IRubyObject chdir(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
+        int argc = Arity.checkArgumentCount(context, args, 0, 1);
         Ruby runtime = context.runtime;
-        RubyString path = args.length == 1 ?
+        RubyString path = argc == 1 ?
             StringSupport.checkEmbeddedNulls(runtime, RubyFile.get_path(context, args[0])) :
             getHomeDirectoryPath(context);
 
@@ -650,6 +654,7 @@ public class RubyDir extends RubyObject implements Closeable {
      */
     @JRubyMethod(name = "mkdir", required = 1, optional = 1, meta = true)
     public static IRubyObject mkdir(ThreadContext context, IRubyObject recv, IRubyObject... args) {
+        Arity.checkArgumentCount(context, args, 1, 2);
         Ruby runtime = context.runtime;
         RubyString path = StringSupport.checkEmbeddedNulls(runtime, RubyFile.get_path(context, args[0]));
         return mkdirCommon(runtime, path.asJavaString(), args);

--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -204,6 +204,8 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
     // and used internally to create enum from Enumerator::Lazy#eager
     @JRubyMethod(name = "__from", meta = true, required = 2, optional = 2, visibility = PRIVATE, keywords = true)
     public static IRubyObject __from(ThreadContext context, IRubyObject klass, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 2, 4);
+
         boolean keywords = (context.callInfo & CALL_KEYWORD) != 0 && (context.callInfo & ThreadContext.CALL_KEYWORD_EMPTY) == 0;
         context.resetCallInfo();
 
@@ -212,9 +214,9 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
         IRubyObject method = args[1];
         IRubyObject[] methodArgs;
         IRubyObject size = null; SizeFn sizeFn = null;
-        if (args.length > 2) {
+        if (argc > 2) {
             methodArgs = ((RubyArray) args[2]).toJavaArrayMaybeUnsafe();
-            if (args.length > 3) size = args[3];
+            if (argc > 3) size = args[3];
         } else {
             methodArgs = NULL_ARRAY;
         }
@@ -570,11 +572,13 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
      */
     @JRubyMethod(meta = true, optional = 1)
     public static IRubyObject produce(ThreadContext context, IRubyObject recv, IRubyObject[] args, final Block block) {
+        int argc = Arity.checkArgumentCount(context, args, 0, 1);
+
         IRubyObject init;
 
         if (!block.isGiven()) throw context.runtime.newArgumentError("no block given");
 
-        if (args.length == 0) {
+        if (argc == 0) {
             init = null;
         } else {
             init = args[0];

--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -343,16 +343,18 @@ public class RubyFile extends RubyIO implements EncodingCapable {
     // rb_file_initialize
     @JRubyMethod(name = "initialize", required = 1, optional = 3, visibility = PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args, Block block) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 4);
+
         if (openFile != null) {
             throw context.runtime.newRuntimeError("reinitializing File");
         }
 
-        if (args.length > 0 && args.length <= 3) {
+        if (argc > 0 && argc <= 3) {
             IRubyObject fd = TypeConverter.convertToTypeWithCheck(context, args[0], context.runtime.getFixnum(), sites(context).to_int_checked);
             if (!fd.isNil()) {
-                if (args.length == 1) {
+                if (argc == 1) {
                     return super.initialize(context, fd, block);
-                } else if (args.length == 2) {
+                } else if (argc == 2) {
                     return super.initialize(context, fd, args[1], block);
                 }
                 return super.initialize(context, fd, args[1], args[2], block);
@@ -625,11 +627,13 @@ public class RubyFile extends RubyIO implements EncodingCapable {
 
     @JRubyMethod(required = 2, rest = true, meta = true)
     public static IRubyObject chmod(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 2, -1);
+
         Ruby runtime = context.runtime;
 
         int count = 0;
         RubyInteger mode = args[0].convertToInteger();
-        for (int i = 1; i < args.length; i++) {
+        for (int i = 1; i < argc; i++) {
             JRubyFile filename = file(args[i]);
 
             if (!filename.exists()) {
@@ -648,6 +652,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
 
     @JRubyMethod(required = 2, rest = true, meta = true)
     public static IRubyObject chown(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 2, -1);
         Ruby runtime = context.runtime;
 
         int count = 0;
@@ -660,7 +665,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         if (!args[1].isNil()) {
             group = RubyNumeric.num2int(args[1]);
         }
-        for (int i = 2; i < args.length; i++) {
+        for (int i = 2; i < argc; i++) {
             JRubyFile filename = file(args[i]);
 
             if (!filename.exists()) {
@@ -679,10 +684,12 @@ public class RubyFile extends RubyIO implements EncodingCapable {
 
     @JRubyMethod(required = 1, optional = 1, meta = true)
     public static IRubyObject dirname(ThreadContext context, IRubyObject recv, IRubyObject [] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 2);
+
         Ruby runtime = context.runtime;
         RubyString filename = StringSupport.checkEmbeddedNulls(runtime, get_path(context, args[0]));
         int level = 1;
-        if (args.length == 2) {
+        if (argc == 2) {
             level = RubyNumeric.num2int(args[1]);
         }
 
@@ -892,6 +899,8 @@ public class RubyFile extends RubyIO implements EncodingCapable {
      */
     @JRubyMethod(name = "expand_path", required = 1, optional = 1, meta = true)
     public static IRubyObject expand_path(ThreadContext context, IRubyObject recv, IRubyObject... args) {
+        Arity.checkArgumentCount(context, args, 1, 2);
+
         return expandPathInternal(context, args, true, false);
     }
 
@@ -922,6 +931,8 @@ public class RubyFile extends RubyIO implements EncodingCapable {
      */
     @JRubyMethod(required = 1, optional = 1, meta = true)
     public static IRubyObject absolute_path(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 1, 2);
+
         return expandPathInternal(context, args, false, false);
     }
 
@@ -935,6 +946,8 @@ public class RubyFile extends RubyIO implements EncodingCapable {
 
     @JRubyMethod(required = 1, optional = 1, meta = true)
     public static IRubyObject realdirpath(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 1, 2);
+
         return expandPathInternal(context, args, false, true);
     }
 
@@ -982,8 +995,10 @@ public class RubyFile extends RubyIO implements EncodingCapable {
      */
     @JRubyMethod(name = {"fnmatch", "fnmatch?"}, required = 2, optional = 1, meta = true)
     public static IRubyObject fnmatch(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 2, 3);
+
         Ruby runtime = context.runtime;
-        int flags = args.length == 3 ? RubyNumeric.num2int(args[2]) : 0;
+        int flags = argc == 3 ? RubyNumeric.num2int(args[2]) : 0;
         boolean braces_match = false;
         boolean extglob = (flags & FNM_EXTGLOB) != 0;
 
@@ -1069,11 +1084,13 @@ public class RubyFile extends RubyIO implements EncodingCapable {
 
     @JRubyMethod(required = 1, rest = true, meta = true)
     public static IRubyObject lchmod(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, -1);
+
         Ruby runtime = context.runtime;
 
         int count = 0;
         RubyInteger mode = args[0].convertToInteger();
-        for (int i = 1; i < args.length; i++) {
+        for (int i = 1; i < argc; i++) {
             JRubyFile file = file(args[i]);
             if (0 != runtime.getPosix().lchmod(file.toString(), (int) mode.getLongValue())) {
                 throw runtime.newErrnoFromLastPOSIXErrno();
@@ -1087,12 +1104,14 @@ public class RubyFile extends RubyIO implements EncodingCapable {
 
     @JRubyMethod(required = 2, rest = true, meta = true)
     public static IRubyObject lchown(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 2, -1);
+
         Ruby runtime = context.runtime;
         int owner = !args[0].isNil() ? RubyNumeric.num2int(args[0]) : -1;
         int group = !args[1].isNil() ? RubyNumeric.num2int(args[1]) : -1;
         int count = 0;
 
-        for (int i = 2; i < args.length; i++) {
+        for (int i = 2; i < argc; i++) {
             JRubyFile file = file(args[i]);
 
             if (0 != runtime.getPosix().lchown(file.toString(), owner, group)) {
@@ -1244,11 +1263,13 @@ public class RubyFile extends RubyIO implements EncodingCapable {
 
     @JRubyMethod(meta = true, optional = 1)
     public static IRubyObject umask(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 0, 1);
+
         Ruby runtime = context.runtime;
         int oldMask;
-        if (args.length == 0) {
+        if (argc == 0) {
             oldMask = PosixShim.umask(runtime.getPosix());
-        } else if (args.length == 1) {
+        } else if (argc == 1) {
             int newMask = (int) args[0].convertToInteger().getLongValue();
             oldMask = PosixShim.umask(runtime.getPosix(), newMask);
         } else {
@@ -1260,6 +1281,8 @@ public class RubyFile extends RubyIO implements EncodingCapable {
 
     @JRubyMethod(required = 2, rest = true, meta = true)
     public static IRubyObject lutime(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 2, -1);
+
         Ruby runtime = context.runtime;
         long[] atimeval = null;
         long[] mtimeval = null;
@@ -1269,7 +1292,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
             mtimeval = extractTimespec(context, args[1]);
         }
 
-        for (int i = 2, j = args.length; i < j; i++) {
+        for (int i = 2, j = argc; i < j; i++) {
             RubyString filename = StringSupport.checkEmbeddedNulls(runtime, get_path(context, args[i]));
 
             JRubyFile fileToTouch = JRubyFile.create(runtime.getCurrentDirectory(), filename.toString());
@@ -1284,11 +1307,13 @@ public class RubyFile extends RubyIO implements EncodingCapable {
             }
         }
 
-        return runtime.newFixnum(args.length - 2);
+        return runtime.newFixnum(argc - 2);
     }
 
     @JRubyMethod(required = 2, rest = true, meta = true)
     public static IRubyObject utime(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 2, -1);
+
         Ruby runtime = context.runtime;
         long[] atimespec = null;
         long[] mtimespec = null;
@@ -1298,7 +1323,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
             mtimespec = extractTimespec(context, args[1]);
         }
 
-        for (int i = 2, j = args.length; i < j; i++) {
+        for (int i = 2, j = argc; i < j; i++) {
             RubyString filename = StringSupport.checkEmbeddedNulls(runtime, get_path(context, args[i]));
 
             JRubyFile fileToTouch = JRubyFile.create(runtime.getCurrentDirectory(),filename.toString());
@@ -1324,7 +1349,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
             }
         }
 
-        return runtime.newFixnum(args.length - 2);
+        return runtime.newFixnum(argc - 2);
     }
 
     @JRubyMethod(rest = true, meta = true)

--- a/core/src/main/java/org/jruby/RubyFloat.java
+++ b/core/src/main/java/org/jruby/RubyFloat.java
@@ -47,6 +47,7 @@ import org.jcodings.specific.USASCIIEncoding;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.ast.util.ArgsUtil;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.ClassIndex;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.JavaSites.FloatSites;
@@ -813,6 +814,8 @@ public class RubyFloat extends RubyNumeric {
      */
     @JRubyMethod(name = "rationalize", optional = 1)
     public IRubyObject rationalize(ThreadContext context, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 0, 1);
+
         if (f_negative_p(context, this)) {
             return f_negate(context, f_abs(context, this).rationalize(context, args));
         }

--- a/core/src/main/java/org/jruby/RubyGC.java
+++ b/core/src/main/java/org/jruby/RubyGC.java
@@ -36,6 +36,7 @@ import java.lang.management.ManagementFactory;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyModule;
 import org.jruby.common.IRubyWarnings.ID;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.ThreadContext;
 import static org.jruby.runtime.Visibility.*;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -68,11 +69,14 @@ public class RubyGC {
 
     @JRubyMethod(module = true, visibility = PRIVATE, optional = 1)
     public static IRubyObject start(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 0, 1);
+
         return context.nil;
     }
 
     @JRubyMethod(optional = 1)
     public static IRubyObject garbage_collect(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 0, 1);
         return context.nil;
     }
 

--- a/core/src/main/java/org/jruby/RubyGenerator.java
+++ b/core/src/main/java/org/jruby/RubyGenerator.java
@@ -31,6 +31,7 @@ package org.jruby;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.common.IRubyWarnings;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
@@ -55,11 +56,13 @@ public class RubyGenerator extends RubyObject {
     // generator_initialize
     @JRubyMethod(visibility = Visibility.PRIVATE, optional = 1)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args, Block block) {
+        int argc = Arity.checkArgumentCount(context, args, 0, 1);
+
         Ruby runtime = context.runtime;
 
         final RubyProc proc;
 
-        if (args.length == 0) {
+        if (argc == 0) {
             proc = RubyProc.newProc(runtime, block, Block.Type.PROC);
         } else {
             if (!(args[0] instanceof RubyProc)) {

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -2315,7 +2315,9 @@ public class RubyHash extends RubyObject implements Map {
 
     @JRubyMethod(name = "any?", optional = 1)
     public IRubyObject any_p(ThreadContext context, IRubyObject[] args, Block block) {
-        IRubyObject pattern = args.length > 0 ? args[0] : null;
+        int argc = Arity.checkArgumentCount(context, args, 0, 1);
+
+        IRubyObject pattern = argc > 0 ? args[0] : null;
         boolean patternGiven = pattern != null;
 
         if (isEmpty()) return context.fals;
@@ -2431,8 +2433,10 @@ public class RubyHash extends RubyObject implements Map {
 
     @JRubyMethod(name = "dig", required = 1, rest = true)
     public IRubyObject dig(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, -1);
+
         final IRubyObject val = op_aref(context, args[0] );
-        return args.length == 1 ? val : RubyObject.dig(context, val, args, 1);
+        return argc == 1 ? val : RubyObject.dig(context, val, args, 1);
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -3796,6 +3796,9 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
                 offset = argv[1];
             case 1:
                 advice = argv[0];
+                break;
+            default:
+                Arity.raiseArgumentError(runtime, argv, 1, 3);
         }
 
         PosixFadvise fadvise = adviceArgCheck(context, advice);

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -558,6 +558,8 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     // MRI: rb_io_reopen
     @JRubyMethod(name = "reopen", required = 1, optional = 1)
     public IRubyObject reopen(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 2);
+
         final Ruby runtime = context.runtime;
         final IRubyObject nil = context.nil;
         RubyIO file = this;
@@ -565,7 +567,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         int[] oflags_p = {0};
         OpenFile fptr;
 
-        switch (args.length) {
+        switch (argc) {
             case 3:
                 opt = TypeConverter.checkHashType(runtime, args[2]);
                 if (opt == nil) throw getRuntime().newArgumentError(3, 2);
@@ -582,7 +584,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
             case 1:
                 fname = args[0];
         }
-        if (args.length == 1) {
+        if (argc == 1) {
             IRubyObject tmp = TypeConverter.ioCheckIO(runtime, fname);
             if (tmp != nil) {
                 return file.reopenIO(context, (RubyIO) tmp);
@@ -1200,6 +1202,8 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     // rb_io_s_sysopen
     @JRubyMethod(name = "sysopen", required = 1, optional = 2, meta = true)
     public static IRubyObject sysopen(ThreadContext context, IRubyObject recv, IRubyObject[] argv, Block block) {
+        int argc = Arity.checkArgumentCount(context, argv, 1, 3);
+
         Ruby runtime = context.runtime;
         IRubyObject fname, vmode, vperm;
         fname = vmode = vperm = context.nil;
@@ -1207,7 +1211,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         int oflags;
         ChannelFD fd;
 
-        switch (argv.length) {
+        switch (argc) {
             case 3:
                 vperm = argv[2];
             case 2:
@@ -1377,6 +1381,8 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     // MRI: rb_io_write_nonblock
     @JRubyMethod(name = "write_nonblock", required = 1, optional = 1)
     public IRubyObject write_nonblock(ThreadContext context, IRubyObject[] argv) {
+        Arity.checkArgumentCount(context, argv, 1, 2);
+
         boolean exception = ArgsUtil.extractKeywordArg(context, "exception", argv) != context.fals;
 
         IRubyObject str = argv[0];
@@ -1875,13 +1881,15 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     // so I am parsing it for now.
     @JRubyMethod(required = 1, optional = 1)
     public RubyFixnum sysseek(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 2);
+
         final Ruby runtime = context.runtime;
         IRubyObject offset = context.nil;
         int whence = PosixShim.SEEK_SET;
         OpenFile fptr;
         long pos;
 
-        switch (args.length) {
+        switch (argc) {
             case 2:
                 IRubyObject ptrname = args[1];
                 whence = interpretSeekWhence(ptrname);
@@ -2560,10 +2568,12 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     @JRubyMethod(name = "ioctl", required = 1, optional = 1)
     public IRubyObject ioctl(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 2);
+
         IRubyObject cmd = args[0];
         IRubyObject arg;
 
-        if (args.length == 2) {
+        if (argc == 2) {
             arg = args[1];
         } else {
             arg = context.nil;
@@ -3026,6 +3036,8 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     @JRubyMethod(name = "read_nonblock", required = 1, optional = 2)
     public IRubyObject read_nonblock(ThreadContext context, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 1, 3);
+
         boolean exception = ArgsUtil.extractKeywordArg(context, "exception", args) != context.fals;
         return doReadNonblock(context, args, exception);
     }
@@ -3044,8 +3056,10 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     @JRubyMethod(name = "readpartial", required = 1, optional = 1)
     public IRubyObject readpartial(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 2);
+
         // ruby bug 11885
-        if (args.length == 2) {
+        if (argc == 2) {
             args[1] = args[1].convertToString();
         }
 
@@ -3146,10 +3160,12 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     // MRI: rb_io_sysread
     @JRubyMethod(name = "sysread", required = 1, optional = 1)
     public IRubyObject sysread(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 2);
+
         final Ruby runtime = context.runtime;
 
-        final int length = RubyNumeric.num2int(args.length >= 1 ? args[0] : context.nil);
-        RubyString str = EncodingUtils.setStrBuf(runtime, args.length >= 2 ? args[1] : context.nil, length);
+        final int length = RubyNumeric.num2int(argc >= 1 ? args[0] : context.nil);
+        RubyString str = EncodingUtils.setStrBuf(runtime, argc >= 2 ? args[1] : context.nil, length);
         if (length == 0) return str;
 
         final OpenFile fptr = getOpenFileChecked();
@@ -3746,10 +3762,12 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     @JRubyMethod(name = "select", required = 1, optional = 3, meta = true)
     public static IRubyObject select(ThreadContext context, IRubyObject recv, IRubyObject[] argv) {
+        int argc = Arity.checkArgumentCount(context, argv, 1, 4);
+
         IRubyObject read, write, except, _timeout;
         read = write = except = _timeout = context.nil;
 
-        switch (argv.length) {
+        switch (argc) {
             case 4:
                 _timeout = argv[3];
             case 3:
@@ -3948,6 +3966,8 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
      */
     @JRubyMethod(meta = true, required = 1, optional = 2)
     public static IRubyObject binread(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 3);
+
         Ruby runtime = context.runtime;
         IRubyObject path = StringSupport.checkEmbeddedNulls(runtime, RubyFile.get_path(context, args[0]));
         IRubyObject length, offset;
@@ -3958,10 +3978,10 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         OpenFlags oBinary = OpenFlags.O_BINARY;
         int oflags = OpenFlags.O_RDONLY.intValue() | (oBinary.defined() ? oBinary.intValue() : 0);
 
-        if (args.length > 2) {
+        if (argc > 2) {
             offset = args[2];
             length = args[1];
-        } else if (args.length > 1) {
+        } else if (argc > 1) {
             length = args[1];
         }
         convconfig.setEnc(ASCIIEncoding.INSTANCE);
@@ -3982,25 +4002,27 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     // Enebo: annotation processing forced me to do pangea method here...
     @JRubyMethod(name = "read", meta = true, required = 1, optional = 3)
     public static IRubyObject read(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block unusedBlock) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 4);
+
         Ruby runtime = context.runtime;
         IRubyObject path = args[0];
         IRubyObject length, offset, options;
         length = offset = options = context.nil;
 
         { // rb_scan_args logic, basically
-            if (args.length > 3) {
+            if (argc > 3) {
                 if (!(args[3] instanceof RubyHash)) throw runtime.newTypeError("Must be a hash");
                 options = (RubyHash) args[3];
                 offset = args[2];
                 length = args[1];
-            } else if (args.length > 2) {
+            } else if (argc > 2) {
                 if (args[2] instanceof RubyHash) {
                     options = (RubyHash) args[2];
                 } else {
                     offset = args[2];
                 }
                 length = args[1];
-            } else if (args.length > 1) {
+            } else if (argc > 1) {
                 if (args[1] instanceof RubyHash) {
                     options = (RubyHash) args[1];
                 } else {
@@ -4237,6 +4259,8 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     @JRubyMethod(name = "popen", required = 1, optional = 2, meta = true)
     public static IRubyObject popen(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 3);
+
         Ruby runtime = context.runtime;
 
         if (PopenExecutor.nativePopenAvailable(runtime)) {
@@ -4250,14 +4274,13 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         IRubyObject tmp;
 
         int firstArg = 0;
-        int argc = args.length;
 
         if (argc > 0 && !TypeConverter.checkHashType(runtime, args[0]).isNil()) {
             firstArg++;
             argc--;
         }
 
-        if (argc > 0 && !(tmp = TypeConverter.checkHashType(runtime, args[args.length - 1])).isNil()) {
+        if (argc > 0 && !(tmp = TypeConverter.checkHashType(runtime, args[argc - 1])).isNil()) {
             options = (RubyHash)tmp;
             argc--;
         }
@@ -4277,9 +4300,9 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
         // FIXME: Reprocessing logic twice for now...
         // for 1.9 mode, strip off the trailing options hash, if there
-        if (args.length > 1 && args[args.length - 1] instanceof RubyHash) {
-            options = (RubyHash) args[args.length - 1];
-            args = ArraySupport.newCopy(args, 0, args.length - 1);
+        if (argc > 1 && args[argc - 1] instanceof RubyHash) {
+            options = (RubyHash) args[argc - 1];
+            args = ArraySupport.newCopy(args, 0, argc - 1);
         }
 
         RubyPOpen pOpen = new RubyPOpen(runtime, args);
@@ -4338,6 +4361,8 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     @JRubyMethod(name = "pipe", optional = 3, meta = true)
     public static IRubyObject pipe(ThreadContext context, IRubyObject klass, IRubyObject[] argv, Block block) {
+        int argc = Arity.checkArgumentCount(context, argv, 0, 3);
+
         Ruby runtime = context.runtime;
         int state;
         RubyIO r, w;
@@ -4348,7 +4373,6 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         OpenFile fptr, fptr2;
         int[] fmode_p = {0};
         IRubyObject ret;
-        int argc = argv.length;
 
         switch (argc) {
             case 3:
@@ -4460,6 +4484,8 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     @JRubyMethod(name = "copy_stream", required = 2, optional = 2, meta = true)
     public static IRubyObject copy_stream(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 2, 4);
+
         Ruby runtime = context.runtime;
 
         IRubyObject arg1 = args[0];
@@ -4474,11 +4500,11 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         Channel channel1 = null;
         Channel channel2 = null;
 
-        if (args.length >= 3 && !args[2].isNil()) {
+        if (argc >= 3 && !args[2].isNil()) {
             length = args[2].convertToInteger();
         }
 
-        if (args.length == 4 && !args[3].isNil()) {
+        if (argc == 4 && !args[3].isNil()) {
             offset = args[3].convertToInteger();
         }
 

--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -42,6 +42,7 @@ import org.jcodings.specific.UTF8Encoding;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.ast.util.ArgsUtil;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.CallSite;
 import org.jruby.runtime.ClassIndex;
@@ -716,6 +717,8 @@ public abstract class RubyInteger extends RubyNumeric {
      */
     @JRubyMethod(name = "rationalize", optional = 1)
     public IRubyObject rationalize(ThreadContext context, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 0, 1);
+
         return to_r(context);
     }
 

--- a/core/src/main/java/org/jruby/RubyInterrupt.java
+++ b/core/src/main/java/org/jruby/RubyInterrupt.java
@@ -67,9 +67,9 @@ public class RubyInterrupt extends RubySignalException {
     @JRubyMethod(optional = 1, visibility = PRIVATE)
     @Override
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args, Block block) {
-        final Ruby runtime = context.runtime;
+        Arity.checkArgumentCount(context, args, 0, 1);
 
-        Arity.checkArgumentCount(runtime, args, 0, 1);
+        final Ruby runtime = context.runtime;
 
         IRubyObject signo = runtime.newFixnum(SIGINT);
 

--- a/core/src/main/java/org/jruby/RubyMarshal.java
+++ b/core/src/main/java/org/jruby/RubyMarshal.java
@@ -72,13 +72,15 @@ public class RubyMarshal {
 
     @JRubyMethod(required = 1, optional = 2, module = true, visibility = Visibility.PRIVATE)
     public static IRubyObject dump(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block unusedBlock) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 3);
+
         final Ruby runtime = context.runtime;
 
         IRubyObject objectToDump = args[0];
         IRubyObject io = null;
         int depthLimit = -1;
 
-        if (args.length >= 2) {
+        if (argc >= 2) {
             IRubyObject arg1 = args[1];
             if (sites(context).respond_to_write.respondsTo(context, arg1, arg1)) {
                 io = arg1;
@@ -87,7 +89,7 @@ public class RubyMarshal {
             } else {
                 throw runtime.newTypeError("Instance of IO needed");
             }
-            if (args.length == 3) {
+            if (argc == 3) {
                 depthLimit = (int) args[2].convertToInteger().getLongValue();
             }
         }
@@ -115,17 +117,19 @@ public class RubyMarshal {
 
     @JRubyMethod(name = {"load", "restore"}, required = 1, optional = 2, module = true, visibility = Visibility.PRIVATE)
     public static IRubyObject load(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block unusedBlock) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 3);
+
         Ruby runtime = context.runtime;
         IRubyObject in = args[0];
         boolean freeze = false;
         IRubyObject proc = null;
 
-        if (args.length > 1) {
-            RubyHash kwargs = ArgsUtil.extractKeywords(args[args.length - 1]);
+        if (argc > 1) {
+            RubyHash kwargs = ArgsUtil.extractKeywords(args[argc - 1]);
             if (kwargs != null) {
                 IRubyObject freezeOpt = ArgsUtil.getFreezeOpt(context, kwargs);
                 freeze = freezeOpt != null ? freezeOpt.isTrue() : false;
-                if (args.length > 2) proc = args[1];
+                if (argc > 2) proc = args[1];
             } else {
                 proc = args[1];
             }

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2957,6 +2957,8 @@ public class RubyModule extends RubyObject {
 
     @JRubyMethod(required = 1, rest = true, visibility = PRIVATE)
     public IRubyObject ruby2_keywords(ThreadContext context, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 1, -1);
+
         Ruby runtime = context.runtime;
 
         checkFrozen();
@@ -3173,6 +3175,8 @@ public class RubyModule extends RubyObject {
 
     @JRubyMethod(name = "instance_methods", optional = 1)
     public RubyArray instance_methods19(IRubyObject[] args) {
+        Arity.checkArgumentCount(getRuntime(), args, 0, 1);
+
         return instanceMethods(args, PRIVATE, false, true);
     }
 
@@ -3182,6 +3186,8 @@ public class RubyModule extends RubyObject {
 
     @JRubyMethod(name = "public_instance_methods", optional = 1)
     public RubyArray public_instance_methods19(IRubyObject[] args) {
+        Arity.checkArgumentCount(getRuntime(), args, 0, 1);
+
         return instanceMethods(args, PUBLIC, false, false);
     }
 
@@ -3204,6 +3210,8 @@ public class RubyModule extends RubyObject {
      */
     @JRubyMethod(name = "protected_instance_methods", optional = 1)
     public RubyArray protected_instance_methods(IRubyObject[] args) {
+        Arity.checkArgumentCount(getRuntime(), args, 0, 1);
+
         return instanceMethods(args, PROTECTED, false, false);
     }
 
@@ -3217,6 +3225,8 @@ public class RubyModule extends RubyObject {
      */
     @JRubyMethod(name = "private_instance_methods", optional = 1)
     public RubyArray private_instance_methods(IRubyObject[] args) {
+        Arity.checkArgumentCount(getRuntime(), args, 0, 1);
+
         return instanceMethods(args, PRIVATE, false, false);
     }
 
@@ -3282,17 +3292,21 @@ public class RubyModule extends RubyObject {
      */
     @JRubyMethod(name = "include", required = 1, rest = true)
     public RubyModule include(IRubyObject[] modules) {
+        Ruby runtime = getRuntime();
+
+        int argc = Arity.checkArgumentCount(runtime, modules, 1, -1);
+
         if (this.isRefinement()) {
-            getRuntime().getWarnings().warnDeprecated(ID.DEPRECATED_METHOD, "deprecated method to be removed: Refinement#include");
+            runtime.getWarnings().warnDeprecated(ID.DEPRECATED_METHOD, "deprecated method to be removed: Refinement#include");
         }
 
         for (IRubyObject module: modules) {
-            if (!module.isModule()) throw getRuntime().newTypeError(module, getRuntime().getModule());
+            if (!module.isModule()) throw runtime.newTypeError(module, runtime.getModule());
         }
 
-        ThreadContext context = getRuntime().getCurrentContext();
+        ThreadContext context = runtime.getCurrentContext();
 
-        for (int i = modules.length - 1; i >= 0; i--) {
+        for (int i = argc - 1; i >= 0; i--) {
             IRubyObject module = modules[i];
             module.callMethod(context, "append_features", this);
             module.callMethod(context, "included", this);
@@ -4154,8 +4168,10 @@ public class RubyModule extends RubyObject {
      */
     @JRubyMethod(name = "const_get", required = 1, optional = 1)
     public IRubyObject const_get(ThreadContext context, IRubyObject... args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 2);
+
         final Ruby runtime = context.runtime;
-        boolean inherit = args.length == 1 || ( ! args[1].isNil() && args[1].isTrue() );
+        boolean inherit = argc == 1 || ( ! args[1].isNil() && args[1].isTrue() );
 
         final IRubyObject symbol = args[0];
         RubySymbol fullName = TypeConverter.checkID(symbol);
@@ -4197,8 +4213,10 @@ public class RubyModule extends RubyObject {
 
     @JRubyMethod(required = 1, optional = 1)
     public IRubyObject const_source_location(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 2);
+
         final Ruby runtime = context.runtime;
-        boolean inherit = args.length == 1 || ( ! args[1].isNil() && args[1].isTrue() );
+        boolean inherit = argc == 1 || ( ! args[1].isNil() && args[1].isTrue() );
 
         final IRubyObject symbol = args[0];
         String name;
@@ -4424,6 +4442,8 @@ public class RubyModule extends RubyObject {
 
     @JRubyMethod(required = 1, rest = true)
     public IRubyObject private_constant(ThreadContext context, IRubyObject[] rubyNames) {
+        Arity.checkArgumentCount(context, rubyNames, 1, -1);
+
         for (IRubyObject rubyName : rubyNames) {
             private_constant(context, rubyName);
         }
@@ -4443,6 +4463,8 @@ public class RubyModule extends RubyObject {
 
     @JRubyMethod(required = 1, rest = true)
     public IRubyObject public_constant(ThreadContext context, IRubyObject[] rubyNames) {
+        Arity.checkArgumentCount(context, rubyNames, 1, -1);
+
         for (IRubyObject rubyName : rubyNames) {
             public_constant(context, rubyName);
         }
@@ -4451,18 +4473,20 @@ public class RubyModule extends RubyObject {
 
     @JRubyMethod(name = "prepend", required = 1, rest = true)
     public IRubyObject prepend(ThreadContext context, IRubyObject[] modules) {
+        int argc = Arity.checkArgumentCount(context, modules, 1, -1);
+
         if (this.isRefinement()) {
             context.runtime.getWarnings().warnDeprecated(ID.DEPRECATED_METHOD, "deprecated method to be removed: Refinement#prepend");
         }
 
         // MRI checks all types first:
-        for (int i = modules.length; --i >= 0; ) {
+        for (int i = argc; --i >= 0; ) {
             IRubyObject obj = modules[i];
             if (!obj.isModule()) {
                 throw context.runtime.newTypeError(obj, context.runtime.getModule());
             }
         }
-        for (int i = modules.length - 1; i >= 0; i--) {
+        for (int i = argc - 1; i >= 0; i--) {
             modules[i].callMethod(context, "prepend_features", this);
             modules[i].callMethod(context, "prepended", this);
         }
@@ -5941,6 +5965,8 @@ public class RubyModule extends RubyObject {
     public static class RefinementMethods {
         @JRubyMethod(required = 1, rest = true, visibility = PRIVATE)
         public static IRubyObject import_methods(ThreadContext context, IRubyObject self, IRubyObject[] modules) {
+            Arity.checkArgumentCount(context, modules, 1, -1);
+
             Ruby runtime = context.runtime;
 
             RubyModule selfModule = (RubyModule) self;

--- a/core/src/main/java/org/jruby/RubyNil.java
+++ b/core/src/main/java/org/jruby/RubyNil.java
@@ -37,6 +37,7 @@ import org.jcodings.specific.USASCIIEncoding;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyClass;
 import org.jruby.compiler.Constantizable;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.ClassIndex;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
@@ -246,6 +247,8 @@ public class RubyNil extends RubyObject implements Constantizable {
      */
     @JRubyMethod(optional = 1)
     public static IRubyObject rationalize(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 0, 1);
+
         return to_r(context, recv);
     }
 

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -41,6 +41,7 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.javasupport.JavaUtil;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.CallSite;
 import org.jruby.runtime.ClassIndex;
@@ -1013,6 +1014,8 @@ public class RubyNumeric extends RubyObject {
      */
     @JRubyMethod(optional = 2)
     public IRubyObject step(ThreadContext context, IRubyObject[] args, Block block) {
+        Arity.checkArgumentCount(context, args, 0, 2);
+
         if (!block.isGiven()) {
             IRubyObject[] newArgs = new IRubyObject[3];
             numExtractStepArgs(context, args, newArgs);

--- a/core/src/main/java/org/jruby/RubyObjectSpace.java
+++ b/core/src/main/java/org/jruby/RubyObjectSpace.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyModule;
 import org.jruby.javasupport.JavaPackage;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import static org.jruby.runtime.Visibility.*;
@@ -70,9 +71,12 @@ public class RubyObjectSpace {
     @JRubyMethod(required = 1, optional = 1, module = true, visibility = PRIVATE)
     public static IRubyObject define_finalizer(IRubyObject recv, IRubyObject[] args, Block block) {
         Ruby runtime = recv.getRuntime();
+
+        int argc = Arity.checkArgumentCount(runtime, args, 1, 2);
+
         IRubyObject finalizer;
         IRubyObject obj = args[0];
-        if (args.length == 2) {
+        if (argc == 2) {
             finalizer = args[1];
             if (!finalizer.respondsTo("call")) {
                 throw runtime.newArgumentError("wrong type argument " + finalizer.getType() + " (should be callable)");
@@ -204,6 +208,8 @@ public class RubyObjectSpace {
 
     @JRubyMethod(name = "each_object", optional = 1, module = true, visibility = PRIVATE)
     public static IRubyObject each_object(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
+        Arity.checkArgumentCount(context, args, 0, 1);
+
         return block.isGiven() ? each_objectInternal(context, recv, args, block) : enumeratorize(context.runtime, recv, "each_object", args);
     }
 

--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -47,6 +47,7 @@ import org.jruby.anno.JRubyModule;
 import org.jruby.javasupport.Java;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.platform.Platform;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.BlockCallback;
 import org.jruby.runtime.CallBlock;
@@ -218,8 +219,10 @@ public class RubyProcess {
 
         @JRubyMethod(module = true, optional = 2)
         public static IRubyObject wait(ThreadContext context, IRubyObject self, IRubyObject[] args) {
-            long pid = args.length > 0 ? args[0].convertToInteger().getLongValue() : -1;
-            int flags = args.length > 1 ? (int) args[1].convertToInteger().getLongValue() : 0;
+            int argc = Arity.checkArgumentCount(context, args, 0, 2);
+
+            long pid = argc > 0 ? args[0].convertToInteger().getLongValue() : -1;
+            int flags = argc > 1 ? (int) args[1].convertToInteger().getLongValue() : 0;
 
             return waitpidStatus(context, pid, flags);
             //checkErrno(runtime, pid, ECHILD);

--- a/core/src/main/java/org/jruby/RubyRandomBase.java
+++ b/core/src/main/java/org/jruby/RubyRandomBase.java
@@ -2,6 +2,7 @@ package org.jruby;
 
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -59,9 +60,11 @@ public class RubyRandomBase extends RubyObject {
 
     @JRubyMethod(visibility = PRIVATE, optional = 1)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 0, 1);
+
         checkFrozen();
 
-        random = new RubyRandom.RandomType((args.length == 0) ? RubyRandom.randomSeed(context.runtime) : args[0]);
+        random = new RubyRandom.RandomType((argc == 0) ? RubyRandom.randomSeed(context.runtime) : args[0]);
 
         return this;
     }

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -45,6 +45,7 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.api.API;
 import org.jruby.exceptions.JumpException;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.BlockCallback;
 import org.jruby.runtime.CallBlock;
@@ -287,6 +288,8 @@ public class RubyRange extends RubyObject {
 
     @JRubyMethod(required = 2, optional = 1, visibility = PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args, Block unusedBlock) {
+        Arity.checkArgumentCount(context, args, 2, 3);
+
         if (this.isInited) throw context.runtime.newFrozenError("`initialize' called twice", this);
         checkFrozen();
         init(context, args[0], args[1], args.length > 2 && args[2].isTrue());

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -1393,10 +1393,11 @@ public class RubyRational extends RubyNumeric {
      */
     @JRubyMethod(name = "rationalize", optional = 1)
     public IRubyObject rationalize(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 0, 1);
 
         IRubyObject a, b;
 
-        if (args.length == 0) return to_r(context);
+        if (argc == 0) return to_r(context);
 
         if (f_negative_p(context, this)) {
             return f_negate(context, ((RubyRational) f_abs(context, this)).rationalize(context, args));

--- a/core/src/main/java/org/jruby/RubySignalException.java
+++ b/core/src/main/java/org/jruby/RubySignalException.java
@@ -64,11 +64,12 @@ public class RubySignalException extends RubyException {
 
     @JRubyMethod(optional = 2, visibility = PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args, Block block) {
+        int argc = Arity.checkArgumentCount(context, args, 0, 2);
+
         final Ruby runtime = context.runtime;
         int argnum = 1;
         IRubyObject sig = context.nil;
         long _signo;
-        int argc = args.length;
 
         if (argc > 0) {
             sig = TypeConverter.checkToInteger(runtime, args[0], "to_int");

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1716,7 +1716,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     @JRubyMethod(name = "match", required = 1, rest = true)
     public IRubyObject match19(ThreadContext context, IRubyObject[] args, Block block) {
         if (args.length < 1) {
-            Arity.checkArgumentCount(context, args, 1, 2);
+            Arity.checkArgumentCount(context, args, 1, -1);
         }
         RubyRegexp pattern = getPattern(context.runtime, args[0]);
         args[0] = this;
@@ -5766,6 +5766,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     // MRI: rb_str_count for arity > 1, first half
     @JRubyMethod(name = "count", required = 1, rest = true)
     public IRubyObject count(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, -1);
+
         final Ruby runtime = context.runtime;
 
         if ( value.length() == 0 ) return RubyFixnum.zero(runtime);
@@ -5775,7 +5777,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
         final boolean[] table = new boolean[StringSupport.TRANS_SIZE + 1];
         StringSupport.TrTables tables = StringSupport.trSetupTable(countStr.value, runtime, table, null, true, enc);
-        for ( int i = 1; i < args.length; i++ ) {
+        for (int i = 1; i < argc; i++ ) {
             countStr = args[i].convertToString();
             enc = checkEncoding(countStr);
             tables = StringSupport.trSetupTable(countStr.value, runtime, table, tables, false, enc);
@@ -5831,6 +5833,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @JRubyMethod(name = "delete!", required = 1, rest = true)
     public IRubyObject delete_bang(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, -1);
+
         if (value.getRealSize() == 0) return context.nil;
 
         final Ruby runtime = context.runtime;
@@ -5839,7 +5843,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         boolean[] squeeze = new boolean[StringSupport.TRANS_SIZE + 1];
         StringSupport.TrTables tables = null;
 
-        for (int i=0; i<args.length; i++) {
+        for (int i = 0; i < argc; i++) {
             otherStr = args[i].convertToString();
             enc = checkEncoding(otherStr);
             tables = StringSupport.trSetupTable(otherStr.value, runtime, squeeze, tables, i == 0, enc);
@@ -5956,6 +5960,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @JRubyMethod(name = "squeeze!", required = 1, rest = true)
     public IRubyObject squeeze_bang(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, -1);
+
         if (value.getRealSize() == 0) {
             modifyCheck();
             return context.nil;
@@ -5968,7 +5974,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         StringSupport.TrTables tables = StringSupport.trSetupTable(otherStr.value, runtime, squeeze, null, true, enc);
 
         boolean singleByte = singleByteOptimizable() && otherStr.singleByteOptimizable();
-        for (int i=1; i<args.length; i++) {
+        for (int i = 1; i< argc; i++) {
             otherStr = args[i].convertToString();
             enc = checkEncoding(otherStr);
             singleByte = singleByte && otherStr.singleByteOptimizable();
@@ -6611,6 +6617,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @JRubyMethod(name = "encode!", optional = 3)
     public IRubyObject encode_bang(ThreadContext context, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 0, 3);
+
         IRubyObject[] newstr_p;
         Encoding encindex;
 

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -216,11 +216,14 @@ public class RubyStruct extends RubyObject {
      */
     @JRubyMethod(name = "new", required = 1, rest = true, meta = true, keywords = true)
     public static RubyClass newInstance(IRubyObject recv, IRubyObject[] args, Block block) {
-        String name = null;
-        boolean nilName = false;
         Ruby runtime = recv.getRuntime();
 
-        if (args.length > 0) {
+        int argc = Arity.checkArgumentCount(runtime, args, 1, -1);
+
+        String name = null;
+        boolean nilName = false;
+
+        if (argc > 0) {
             IRubyObject firstArgAsString = args[0].checkStringType();
             if (!firstArgAsString.isNil()) {
                 RubySymbol nameSym = ((RubyString)firstArgAsString).intern();
@@ -236,8 +239,7 @@ public class RubyStruct extends RubyObject {
         RubyArray member = runtime.newArray();
         IRubyObject keywordInitValue = runtime.getNil();
 
-        int argc = args.length;
-        final IRubyObject opts = args[args.length - 1];
+        final IRubyObject opts = args[argc - 1];
         if (opts instanceof RubyHash) {
             argc--;
             keywordInitValue = ArgsUtil.extractKeywordArg(runtime.getCurrentContext(), (RubyHash) opts, "keyword_init");
@@ -292,8 +294,8 @@ public class RubyStruct extends RubyObject {
         newStruct.getSingletonClass().defineAnnotatedMethods(StructMethods.class);
 
         // define access methods.
-        for (int i = (name == null && !nilName) ? 0 : 1; i < args.length; i++) {
-            if (i == args.length - 1 && args[i] instanceof RubyHash) break;
+        for (int i = (name == null && !nilName) ? 0 : 1; i < argc; i++) {
+            if (i == argc - 1 && args[i] instanceof RubyHash) break;
             final String memberName = args[i].asJavaString();
             // if we are storing a name as well, index is one too high for values
             final int index = (name == null && !nilName) ? i : i - 1;
@@ -883,8 +885,10 @@ public class RubyStruct extends RubyObject {
 
     @JRubyMethod(name = "dig", required = 1, rest = true)
     public IRubyObject dig(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, -1);
+
         final IRubyObject val = arefImpl( args[0], true );
-        return args.length == 1 ? val : RubyObject.dig(context, val, args, 1);
+        return argc == 1 ? val : RubyObject.dig(context, val, args, 1);
     }
 
     public static void marshalTo(RubyStruct struct, MarshalStream output) throws java.io.IOException {

--- a/core/src/main/java/org/jruby/RubySystemCallError.java
+++ b/core/src/main/java/org/jruby/RubySystemCallError.java
@@ -175,6 +175,9 @@ public class RubySystemCallError extends RubyStandardError {
     @Override
     public IRubyObject initialize(IRubyObject[] args, Block block) {
         Ruby runtime = getRuntime();
+
+        int argc = Arity.checkArgumentCount(runtime, args, 0, 2);
+
         RubyClass sCallErorrClass = runtime.getSystemCallError();
         RubyClass klass = getMetaClass().getRealClass();
 
@@ -187,17 +190,17 @@ public class RubySystemCallError extends RubyStandardError {
             // one optional, one required args
             Arity.checkArgumentCount(runtime, args, 1, 2);
             msg = args[0];
-            if (args.length == 2) {
+            if (argc == 2) {
                 err = args[1];
             }
-            if (args.length == 1 && (msg instanceof RubyFixnum)) {
+            if (argc == 1 && (msg instanceof RubyFixnum)) {
                 err = msg;
                 msg = runtime.getNil();
             }
         } else {
             // one optional and no required args
             Arity.checkArgumentCount(runtime, args, 0, 1);
-            if (args.length == 1) {
+            if (argc == 1) {
                 msg = args[0];
             }
             // try to get errno value out of the class

--- a/core/src/main/java/org/jruby/RubySystemExit.java
+++ b/core/src/main/java/org/jruby/RubySystemExit.java
@@ -30,6 +30,7 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyClass;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.SystemExit;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 
 import static org.jruby.runtime.Visibility.*;
@@ -74,24 +75,27 @@ public class RubySystemExit extends RubyException {
     @JRubyMethod(optional = 2, visibility = PRIVATE)
     @Override
     public IRubyObject initialize(IRubyObject[] args, Block block) {
-        if (args.length > 0) {
+        Ruby runtime = getRuntime();
+
+        int argc = Arity.checkArgumentCount(runtime, args, 0, 2);
+
+        if (argc > 0) {
             final IRubyObject arg = args[0];
             if (arg instanceof RubyFixnum) {
                 this.status = arg;
-                if (args.length > 1) this.message = args[1]; // (status, message)
+                if (argc > 1) this.message = args[1]; // (status, message)
             }
             else if (arg instanceof RubyBoolean) {
-                final Ruby runtime = getRuntime();
                 this.status = runtime.newFixnum( arg == runtime.getTrue() ? 0 : 1 );
-                if (args.length > 1) this.message = args[1]; // (status, message)
+                if (argc > 1) this.message = args[1]; // (status, message)
             }
             else {
                 this.message = arg;
-                this.status = RubyFixnum.zero(getRuntime());
+                this.status = RubyFixnum.zero(runtime);
             }
         }
         else {
-            this.status = RubyFixnum.zero(getRuntime());
+            this.status = RubyFixnum.zero(runtime);
         }
         super.initialize(NULL_ARRAY, block);
         return this;

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -872,10 +872,12 @@ public class RubyThread extends RubyObject implements ExecutionContext {
 
     @JRubyMethod(name = "pending_interrupt?", optional = 1)
     public IRubyObject pending_interrupt_p(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 0, 1);
+
         if (pendingInterruptQueue.isEmpty()) {
             return context.fals;
         }
-        if (args.length == 1) {
+        if (argc == 1) {
             IRubyObject err = args[0];
             if (!(err instanceof RubyModule)) {
                 throw context.runtime.newTypeError("class or module required for rescue clause");
@@ -1220,12 +1222,14 @@ public class RubyThread extends RubyObject implements ExecutionContext {
 
     @JRubyMethod(optional = 1)
     public IRubyObject join(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 0, 1);
+
         Ruby runtime = context.runtime;
         long timeoutMillis = Long.MAX_VALUE;
 
-        if (args.length > 0 && !args[0].isNil()) {
-            if (args.length > 1) {
-                throw runtime.newArgumentError(args.length, 1);
+        if (argc > 0 && !args[0].isNil()) {
+            if (argc > 1) {
+                throw runtime.newArgumentError(argc, 1);
             }
             // MRI behavior: value given in seconds; converted to Float; less
             // than or equal to zero returns immediately; returns nil
@@ -1481,6 +1485,8 @@ public class RubyThread extends RubyObject implements ExecutionContext {
 
     @JRubyMethod(optional = 3)
     public IRubyObject raise(ThreadContext context, IRubyObject[] args, Block block) {
+        Arity.checkArgumentCount(context, args, 0, 3);
+
         return genericRaise(context, context.getThread(), args);
     }
 
@@ -1512,7 +1518,6 @@ public class RubyThread extends RubyObject implements ExecutionContext {
 
     private IRubyObject genericRaise(ThreadContext context, RubyThread currentThread, IRubyObject... args) {
         if (!isAlive()) return context.nil;
-
 
         pendingInterruptEnqueue(prepareRaiseException(context, args));
         interrupt();

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -51,6 +51,7 @@ import org.jruby.ast.util.ArgsUtil;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.TypeError;
 import org.jruby.java.proxies.JavaProxy;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ClassIndex;
 import org.jruby.runtime.Helpers;
@@ -1334,6 +1335,8 @@ public class RubyTime extends RubyObject {
 
     @JRubyMethod(optional = 1)
     public RubyTime round(ThreadContext context, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 0, 1);
+
         int ndigits = getNdigits(context, args);
 
         int _nsec = this.dt.getMillisOfSecond() * 1000000 + (int) (this.nsec);
@@ -1345,6 +1348,8 @@ public class RubyTime extends RubyObject {
 
     @JRubyMethod(optional = 1)
     public RubyTime floor(ThreadContext context, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 0, 1);
+
         int ndigits = getNdigits(context, args);
 
         int _nsec = this.dt.getMillisOfSecond() * 1000000 + (int) (this.nsec);
@@ -1356,6 +1361,8 @@ public class RubyTime extends RubyObject {
 
     @JRubyMethod(optional = 1)
     public RubyTime ceil(ThreadContext context, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 0, 1);
+
         int ndigits = getNdigits(context, args);
 
         int _nsec = this.dt.getMillisOfSecond() * 1000000 + (int) (this.nsec);
@@ -1404,8 +1411,10 @@ public class RubyTime extends RubyObject {
 
     @JRubyMethod(name = "now", meta = true, optional = 1, keywords = true)
     public static RubyTime newInstance(ThreadContext context, IRubyObject recv, IRubyObject args[]) {
+        int argc = Arity.checkArgumentCount(context, args, 0, 1);
+
         RubyTime obj = allocateInstance((RubyClass) recv);
-        if (args.length == 1) {
+        if (argc == 1) {
             obj.getMetaClass().getBaseCallSite(RubyClass.CS_IDX_INITIALIZE).call(context, recv, obj, args);
         } else {
             obj.getMetaClass().getBaseCallSite(RubyClass.CS_IDX_INITIALIZE).call(context, recv, obj);
@@ -1611,6 +1620,8 @@ public class RubyTime extends RubyObject {
 
     @JRubyMethod(name = {"local", "mktime"}, required = 1, optional = 9, meta = true)
     public static RubyTime local(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 1, 10);
+
         RubyTime time = allocateInstance((RubyClass) recv);
 
         TimeArgs timeArgs = new TimeArgs(context, args);
@@ -1707,17 +1718,18 @@ public class RubyTime extends RubyObject {
         context.resetCallInfo();
         IRubyObject nil = context.nil;
 
+        int argc = args.length;
         if (keywords) {
-            IRubyObject in = ArgsUtil.extractKeywordArg(context, (RubyHash) args[args.length - 1], "in");
-            if (in != null && args.length > 7) {
+            IRubyObject in = ArgsUtil.extractKeywordArg(context, (RubyHash) args[argc - 1], "in");
+            if (in != null && argc > 7) {
                 throw context.runtime.newArgumentError("timezone argument given as positional and keyword arguments");
             }
             zone = in;
-        } else if (args.length > 6) {
+        } else if (argc > 6) {
             zone = args[6];
         }
 
-        switch (args.length) {
+        switch (argc) {
             case 0:
                 return initialize(context);
             case 1:
@@ -1747,7 +1759,7 @@ public class RubyTime extends RubyObject {
             case 7:
                 return initialize(context, args[0], args[1], args[2], args[3], args[4], args[5], zone);
             default:
-                throw context.runtime.newArgumentError(args.length, 0, 7);
+                throw context.runtime.newArgumentError(argc, 0, 7);
         }
     }
 
@@ -1830,6 +1842,8 @@ public class RubyTime extends RubyObject {
 
     @JRubyMethod(name = {"utc", "gm"}, required = 1, optional = 9, meta = true)
     public static RubyTime utc(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 1, 10);
+
         RubyTime time = allocateInstance((RubyClass) recv);
 
         TimeArgs timeArgs = new TimeArgs(context, args);

--- a/core/src/main/java/org/jruby/RubyUnboundMethod.java
+++ b/core/src/main/java/org/jruby/RubyUnboundMethod.java
@@ -34,6 +34,7 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.internal.runtime.methods.AliasMethod;
 import org.jruby.internal.runtime.methods.PartialDelegatingMethod;
 import org.jruby.internal.runtime.methods.ProcMethod;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ClassIndex;
 import org.jruby.runtime.ObjectAllocator;
@@ -153,9 +154,11 @@ public class RubyUnboundMethod extends AbstractRubyMethod {
 
     @JRubyMethod(required =  1, rest = true, keywords = true)
     public IRubyObject bind_call(ThreadContext context, IRubyObject[] args, Block block) {
+        int argc = Arity.checkArgumentCount(context, args, 1, -1);
+
         IRubyObject receiver = args[0];
-        IRubyObject[] newArgs = new IRubyObject[args.length - 1];
-        System.arraycopy(args, 1, newArgs, 0, args.length - 1);
+        IRubyObject[] newArgs = new IRubyObject[argc - 1];
+        System.arraycopy(args, 1, newArgs, 0, argc - 1);
 
         RubyClass receiverClass = receiver.getMetaClass();
 

--- a/core/src/main/java/org/jruby/RubyUncaughtThrowError.java
+++ b/core/src/main/java/org/jruby/RubyUncaughtThrowError.java
@@ -30,6 +30,7 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.UncaughtThrowError;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
@@ -74,8 +75,10 @@ public class RubyUncaughtThrowError extends RubyArgumentError {
     @Override
     @JRubyMethod(required = 2, optional = 1, visibility = Visibility.PRIVATE)
     public IRubyObject initialize(IRubyObject[] args, Block block) {
+        int argc = Arity.checkArgumentCount(getRuntime(), args, 2, 3);
+
         this.tag = args[0]; this.value = args[1];
-        if ( args.length > 2 ) this.message = args[2];
+        if ( argc > 2 ) this.message = args[2];
         // makes no-sense for us to have a cause or does it ?!
         // super.initialize(NULL_ARRAY, block); // already set message
         return this;

--- a/core/src/main/java/org/jruby/common/RubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/RubyWarnings.java
@@ -40,6 +40,7 @@ import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.ast.util.ArgsUtil;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.JavaSites;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.backtrace.RubyStackTraceElement;
@@ -277,7 +278,9 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
 
     @JRubyMethod(required = 1, optional = 1)
     public static IRubyObject warn(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
-        if (args.length > 1) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 2);
+
+        if (argc > 1) {
             IRubyObject opts = TypeConverter.checkHashType(context.runtime, args[1]);
             IRubyObject ret = ArgsUtil.extractKeywordArg(context, (RubyHash) opts, "category");
             if (ret.isNil()) {

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -1824,6 +1824,8 @@ public class RubyBigDecimal extends RubyNumeric {
 
     @JRubyMethod(name = "round", optional = 2)
     public IRubyObject round(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 0, 2);
+
         Ruby runtime = context.runtime;
 
         // Special treatment for BigDecimal::NAN and BigDecimal::INFINITY
@@ -1832,13 +1834,13 @@ public class RubyBigDecimal extends RubyNumeric {
         // FloatDomainError. Otherwise, we don't have to call round ;
         // we can simply return the number itself.
         if (isNaN()) {
-            if (args.length == 0) {
+            if (argc == 0) {
                 throw newNaNFloatDomainError(runtime);
             }
             return newNaN(runtime);
         }
         if (isInfinity()) {
-            if (args.length == 0) {
+            if (argc == 0) {
                 throw newInfinityFloatDomainError(runtime, infinitySign);
             }
             return newInfinity(runtime, infinitySign);
@@ -1847,7 +1849,6 @@ public class RubyBigDecimal extends RubyNumeric {
         RoundingMode mode = getRoundingMode(runtime);
         int scale = 0;
 
-        int argc = args.length;
         switch (argc) {
             case 2:
                 mode = javaRoundingModeFromRubyRoundingMode(context, args[1]);

--- a/core/src/main/java/org/jruby/ext/coverage/CoverageModule.java
+++ b/core/src/main/java/org/jruby/ext/coverage/CoverageModule.java
@@ -34,6 +34,7 @@ import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.ast.util.ArgsUtil;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.TypeConverter;
@@ -49,6 +50,8 @@ import static org.jruby.runtime.ThreadContext.hasKeywords;
 public class CoverageModule {
     @JRubyMethod(module = true, optional = 1, keywords = true)
     public static IRubyObject setup(ThreadContext context, IRubyObject self, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 0, 1);
+
         Ruby runtime = context.runtime;
         int mode = 0;
 
@@ -58,7 +61,7 @@ public class CoverageModule {
             throw runtime.newRuntimeError("coverage measurement is already setup");
         }
 
-        if (args.length != 0) {
+        if (argc != 0) {
             boolean keyword = hasKeywords(context.resetCallInfo());
 
             if (keyword) {
@@ -136,6 +139,8 @@ public class CoverageModule {
 
     @JRubyMethod(module = true, optional = 1, keywords = true)
     public static IRubyObject result(ThreadContext context, IRubyObject self, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 0, 1);
+
         Ruby runtime = context.runtime;
         CoverageData data = runtime.getCoverageData();
 
@@ -146,7 +151,7 @@ public class CoverageModule {
         boolean stop = true;
         boolean clear = true;
 
-        if (args.length > 0 && hasKeywords(context.resetCallInfo())) {
+        if (argc > 0 && hasKeywords(context.resetCallInfo())) {
             RubyHash keywords = (RubyHash) TypeConverter.convertToType(args[0], runtime.getHash(), "to_hash");
             stop = ArgsUtil.extractKeywordArg(context, "stop", keywords).isTrue();
             clear = ArgsUtil.extractKeywordArg(context, "clear", keywords).isTrue();

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -425,7 +425,9 @@ public class RubyDate extends RubyObject {
     @JRubyMethod(name = "civil", alias = "new", meta = true, optional = 4) // 4 args case
     public static RubyDate civil(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         // IRubyObject year, IRubyObject month, IRubyObject mday, IRubyObject start
-        switch (args.length) {
+        int argc = Arity.checkArgumentCount(context, args, 0, 4);
+
+        switch (argc) {
             // NOTE: slightly annoying but send might route its Date.send(:civil, *args) here
             case 0: return civil(context, self);
             case 1: return civil(context, self, args[0]);
@@ -474,7 +476,9 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod(name = "valid_civil?", alias = "valid_date?", meta = true, required = 3, optional = 1)
     public static IRubyObject valid_civil_p(ThreadContext context, IRubyObject self, IRubyObject[] args) {
-        final long sg = args.length > 3 ? val2sg(context, args[3]) : ITALY;
+        int argc = Arity.checkArgumentCount(context, args, 3, 4);
+
+        final long sg = argc > 3 ? val2sg(context, args[3]) : ITALY;
         final Long jd = validCivilImpl(args[0], args[1], args[2], sg);
         return jd == null ? context.fals : context.tru;
     }
@@ -622,12 +626,11 @@ public class RubyDate extends RubyObject {
     @JRubyMethod(name = "ordinal", meta = true, optional = 3)
     public static RubyDate ordinal(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         // ordinal(y=-4712, d=1, sg=ITALY)
+        int argc = Arity.checkArgumentCount(context, args, 0, 3);
 
-        final int len = args.length;
-
-        final long sg = len > 2 ? val2sg(context, args[2]) : ITALY;
-        IRubyObject year = (len > 0) ? args[0] : RubyFixnum.newFixnum(context.runtime, -4712);
-        IRubyObject day = (len > 1) ? args[1] : RubyFixnum.newFixnum(context.runtime, 1);
+        final long sg = argc > 2 ? val2sg(context, args[2]) : ITALY;
+        IRubyObject year = (argc > 0) ? args[0] : RubyFixnum.newFixnum(context.runtime, -4712);
+        IRubyObject day = (argc > 1) ? args[1] : RubyFixnum.newFixnum(context.runtime, 1);
 
         final long[] rest = new long[] { 0, 1 };
         final int d = (int) RubyDateTime.getDay(context, day, rest);
@@ -640,7 +643,9 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod(name = "valid_ordinal?", meta = true, required = 2, optional = 1)
     public static IRubyObject valid_ordinal_p(ThreadContext context, IRubyObject self, IRubyObject[] args) {
-        final long sg = args.length > 2 ? val2sg(context, args[2]) : ITALY;
+        int argc = Arity.checkArgumentCount(context, args, 2, 3);
+
+        final long sg = argc > 2 ? val2sg(context, args[2]) : ITALY;
         final Long jd = validOrdinalImpl(args[0], args[1], sg);
         return jd == null ? context.fals : context.tru;
     }
@@ -657,7 +662,9 @@ public class RubyDate extends RubyObject {
     @Deprecated // NOTE: should go away once no date.rb is using it
     @JRubyMethod(name = "_valid_ordinal?", meta = true, required = 2, optional = 1, visibility = Visibility.PRIVATE)
     public static IRubyObject _valid_ordinal_p(ThreadContext context, IRubyObject self, IRubyObject[] args) {
-        final long sg = args.length > 2 ? val2sg(context, args[2]) : GREGORIAN;
+        int argc = Arity.checkArgumentCount(context, args, 2, 3);
+
+        final long sg = argc > 2 ? val2sg(context, args[2]) : GREGORIAN;
         final Long jd = validOrdinalImpl(args[0], args[1], sg);
         return jd == null ? context.nil : RubyFixnum.newFixnum(context.runtime, jd);
     }
@@ -671,13 +678,12 @@ public class RubyDate extends RubyObject {
     @JRubyMethod(name = "commercial", meta = true, optional = 4)
     public static RubyDate commercial(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         // commercial(y=-4712, w=1, d=1, sg=ITALY)
+        int argc = Arity.checkArgumentCount(context, args, 0, 4);
 
-        final int len = args.length;
-
-        final long sg = len > 3 ? val2sg(context, args[3]) : ITALY;
-        IRubyObject year = (len > 0) ? args[0] : RubyFixnum.newFixnum(context.runtime, -4712);
-        IRubyObject week = (len > 1) ? args[1] : RubyFixnum.newFixnum(context.runtime, 1);
-        IRubyObject day = (len > 2) ? args[2] : RubyFixnum.newFixnum(context.runtime, 1);
+        final long sg = argc > 3 ? val2sg(context, args[3]) : ITALY;
+        IRubyObject year = (argc > 0) ? args[0] : RubyFixnum.newFixnum(context.runtime, -4712);
+        IRubyObject week = (argc > 1) ? args[1] : RubyFixnum.newFixnum(context.runtime, 1);
+        IRubyObject day = (argc > 2) ? args[2] : RubyFixnum.newFixnum(context.runtime, 1);
 
         Long jd = validCommercialImpl(year, week, day, sg);
         if (jd == null) throw newDateError(context, "invalid date");
@@ -687,7 +693,9 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod(name = "valid_commercial?", meta = true, required = 3, optional = 1)
     public static IRubyObject valid_commercial_p(ThreadContext context, IRubyObject self, IRubyObject[] args) {
-        final long sg = args.length > 3 ? val2sg(context, args[3]) : ITALY;
+        int argc = Arity.checkArgumentCount(context, args, 3, 4);
+
+        final long sg = argc > 3 ? val2sg(context, args[3]) : ITALY;
         final Long jd = validCommercialImpl(args[0], args[1], args[2], sg);
         return jd == null ? context.fals : context.tru;
     }
@@ -702,7 +710,9 @@ public class RubyDate extends RubyObject {
     @Deprecated // NOTE: should go away once no date.rb is using it
     @JRubyMethod(name = "_valid_commercial?", meta = true, required = 3, optional = 1, visibility = Visibility.PRIVATE)
     public static IRubyObject _valid_commercial_p(ThreadContext context, IRubyObject self, IRubyObject[] args) {
-        final long sg = args.length > 3 ? val2sg(context, args[3]) : GREGORIAN;
+        int argc = Arity.checkArgumentCount(context, args, 3, 4);
+
+        final long sg = argc > 3 ? val2sg(context, args[3]) : GREGORIAN;
         final Long jd = validCommercialImpl(args[0], args[1], args[2], sg);
         return jd == null ? context.nil : RubyFixnum.newFixnum(context.runtime, jd);
     }
@@ -710,7 +720,9 @@ public class RubyDate extends RubyObject {
     @Deprecated // NOTE: should go away once no date.rb is using it
     @JRubyMethod(name = "_valid_weeknum?", meta = true, required = 4, optional = 1, visibility = Visibility.PRIVATE)
     public static IRubyObject _valid_weeknum_p(ThreadContext context, IRubyObject self, IRubyObject[] args) {
-        final long sg = args.length > 4 ? val2sg(context, args[4]) : GREGORIAN;
+        int argc = Arity.checkArgumentCount(context, args, 4, 5);
+
+        final long sg = argc > 4 ? val2sg(context, args[4]) : GREGORIAN;
         final int y = args[0].convertToInteger().getIntValue();
         final int w = args[1].convertToInteger().getIntValue();
         final int d = args[2].convertToInteger().getIntValue();
@@ -744,7 +756,9 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod(name = "_valid_civil?", meta = true, required = 3, optional = 1)
     public static IRubyObject _valid_civil_p(ThreadContext context, IRubyObject self, IRubyObject[] args) {
-        final long sg = args.length > 3 ? val2sg(context, args[3]) : GREGORIAN;
+        int argc = Arity.checkArgumentCount(context, args, 3, 4);
+
+        final long sg = argc > 3 ? val2sg(context, args[3]) : GREGORIAN;
         final Long jd = validCivilImpl(args[0], args[1], args[2], sg);
         return jd == null ? context.nil : RubyFixnum.newFixnum(context.runtime, jd);
     }
@@ -1131,7 +1145,9 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod(optional = 1, visibility = Visibility.PRIVATE)
     public IRubyObject new_offset(ThreadContext context, IRubyObject[] args) {
-        IRubyObject of = args.length > 0 ? args[0] : RubyFixnum.zero(context.runtime);
+        int argc = Arity.checkArgumentCount(context, args, 0, 1);
+
+        IRubyObject of = argc > 0 ? args[0] : RubyFixnum.zero(context.runtime);
 
         final int off = val2off(context, of);
         DateTime dt = this.dt.withChronology(getChronology(context, start, off));
@@ -1498,10 +1514,12 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod(meta = true, required = 2, optional = 1, visibility = Visibility.PRIVATE)
     public static RubyNumeric jd_to_ajd(ThreadContext context, IRubyObject self, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 2, 3);
+
         RubyNumeric jd = (RubyNumeric) args[0];
         RubyNumeric fr = (RubyNumeric) args[1];
         int of_sec = 0;
-        if (args.length > 2 && ! ((RubyNumeric) args[2]).isZero()) {
+        if (argc > 2 && ! ((RubyNumeric) args[2]).isZero()) {
             RubyNumeric of = (RubyNumeric) f_mul(context, args[2], RubyFixnum.newFixnum(context.runtime, DAY_IN_SECONDS));
             of_sec = of.getIntValue();
         }
@@ -2350,13 +2368,15 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod(name = "s3e", meta = true, required = 4, optional = 1, visibility = Visibility.PRIVATE)
     public static IRubyObject _s3e(ThreadContext context, IRubyObject self, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 4, 5);
+
         final IRubyObject nil = context.nil;
 
         RubyString y = args[1] == nil ? null : (RubyString) args[1];
         RubyString m = args[2] == nil ? null : (RubyString) args[2];
         RubyString d = args[3] == nil ? null : (RubyString) args[3];
 
-        return s3e(context, (RubyHash) args[0], y, m, d, args.length > 4 ? args[4].isTrue() : false);
+        return s3e(context, (RubyHash) args[0], y, m, d, argc > 4 ? args[4].isTrue() : false);
     }
 
     private static IRubyObject s3e(ThreadContext context, final RubyHash hash,

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -48,6 +48,7 @@ import org.jruby.RubyString;
 import org.jruby.RubyTime;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
@@ -174,30 +175,29 @@ public class RubyDateTime extends RubyDate {
     public static RubyDateTime civil(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         // year=-4712, month=1, mday=1,
         //  hour=0, minute=0, second=0, offset=0, start=Date::ITALY
-
-        final int len = args.length;
+        int argc = Arity.checkArgumentCount(context, args, 0, 8);
 
         int hour = 0, minute = 0, second = 0; long millis = 0; long subMillisNum = 0, subMillisDen = 1;
         int off = 0; long sg = ITALY;
 
-        if (len == 8) sg = val2sg(context, args[7]);
-        if (len >= 7) off = val2off(context, args[6]);
+        if (argc == 8) sg = val2sg(context, args[7]);
+        if (argc >= 7) off = val2off(context, args[6]);
 
         final int year = (sg > 0) ? getYear(args[0]) : args[0].convertToInteger().getIntValue();
         final int month = getMonth(args[1]);
         final long[] rest = new long[] { 0, 1 };
         final int day = (int) getDay(context, args[2], rest);
 
-        if (len >= 4 || rest[0] != 0) {
-            hour = getHour(context, len >= 4 ? args[3] : RubyFixnum.zero(context.runtime), rest);
+        if (argc >= 4 || rest[0] != 0) {
+            hour = getHour(context, argc >= 4 ? args[3] : RubyFixnum.zero(context.runtime), rest);
         }
 
-        if (len >= 5 || rest[0] != 0) {
-            minute = getMinute(context, len >= 5 ? args[4] : RubyFixnum.zero(context.runtime), rest);
+        if (argc >= 5 || rest[0] != 0) {
+            minute = getMinute(context, argc >= 5 ? args[4] : RubyFixnum.zero(context.runtime), rest);
         }
 
-        if (len >= 6 || rest[0] != 0) {
-            IRubyObject sec = len >= 6 ? args[5] : RubyFixnum.zero(context.runtime);
+        if (argc >= 6 || rest[0] != 0) {
+            IRubyObject sec = argc >= 6 ? args[5] : RubyFixnum.zero(context.runtime);
             second = getSecond(context, sec, rest);
             final long r0 = rest[0], r1 = rest[1];
             if (r0 != 0) {
@@ -392,15 +392,16 @@ public class RubyDateTime extends RubyDate {
 
     @JRubyMethod(name = "jd", meta = true, optional = 6)
     public static RubyDateTime jd(ThreadContext context, IRubyObject self, IRubyObject[] args) {
-        final int len = args.length;
+        int argc = Arity.checkArgumentCount(context, args, 0, 6);
+
         final RubyFixnum zero = RubyFixnum.zero(context.runtime);
 
         final long[] rest = new long[] { 0, 1 };
         final long jd = getDay(context, args[0], rest);
 
-        final IRubyObject hour = (len > 1) ? args[1] : zero;
-        final IRubyObject min = (len > 2) ? args[2] : zero;
-        final IRubyObject sec = (len > 3) ? args[3] : zero;
+        final IRubyObject hour = (argc > 1) ? args[1] : zero;
+        final IRubyObject min = (argc > 2) ? args[2] : zero;
+        final IRubyObject sec = (argc > 3) ? args[3] : zero;
 
         final RubyNumeric fr;
         if (hour != zero || min != zero || sec != zero) {
@@ -413,8 +414,8 @@ public class RubyDateTime extends RubyDate {
         }
 
         int off = 0; long sg = ITALY;
-        if (len > 4) off = val2off(context, args[4]);
-        if (len > 5) sg = val2sg(context, args[5]);
+        if (argc > 4) off = val2off(context, args[4]);
+        if (argc > 5) sg = val2sg(context, args[5]);
 
         RubyNumeric ajd = jd_to_ajd(context, jd, fr, off);
         return new RubyDateTime(context, (RubyClass) self, ajd, rest, off, sg);

--- a/core/src/main/java/org/jruby/ext/digest/RubyDigest.java
+++ b/core/src/main/java/org/jruby/ext/digest/RubyDigest.java
@@ -50,6 +50,7 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyModule;
 import org.jruby.exceptions.RaiseException;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
@@ -274,7 +275,7 @@ public class RubyDigest {
 
         @JRubyMethod()
         public static IRubyObject digest_length(ThreadContext context, IRubyObject self) {
-            return digest(context, self, null).convertToString().bytesize();
+            return digest(context, self, IRubyObject.NULL_ARRAY).convertToString().bytesize();
         }
 
         @JRubyMethod()
@@ -290,8 +291,8 @@ public class RubyDigest {
             RubyString str1, str2;
             RubyModule instance = (RubyModule)context.runtime.getModule("Digest").getConstantAt("Instance");
             if (oth.getMetaClass().getRealClass().hasModuleInHierarchy(instance)) {
-                str1 = digest(context, self, null).convertToString();
-                str2 = digest(context, oth, null).convertToString();
+                str1 = digest(context, self, IRubyObject.NULL_ARRAY).convertToString();
+                str2 = digest(context, oth, IRubyObject.NULL_ARRAY).convertToString();
             } else {
                 str1 = to_s(context, self).convertToString();
                 str2 = oth.convertToString();
@@ -302,7 +303,7 @@ public class RubyDigest {
 
         @JRubyMethod()
         public static IRubyObject inspect(ThreadContext context, IRubyObject self) {
-            return RubyString.newStringNoCopy(self.getRuntime(), ByteList.plain("#<" + self.getMetaClass().getRealClass().getName() + ": " + hexdigest(context, self, null) + ">"));
+            return RubyString.newStringNoCopy(self.getRuntime(), ByteList.plain("#<" + self.getMetaClass().getRealClass().getName() + ": " + hexdigest(context, self, IRubyObject.NULL_ARRAY) + ">"));
         }
 
         /* instance methods that need not usually be overridden */
@@ -313,8 +314,10 @@ public class RubyDigest {
 
         @JRubyMethod(optional = 1)
         public static IRubyObject digest(ThreadContext context, IRubyObject self, IRubyObject[] args) {
+            int argc = Arity.checkArgumentCount(context, args, 0, 1);
+
             final IRubyObject value;
-            if (args != null && args.length > 0) {
+            if (args != null && argc > 0) {
                 self.callMethod(context, "reset");
                 self.callMethod(context, "update", args[0]);
                 value = self.callMethod(context, "finish");

--- a/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
+++ b/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
@@ -28,6 +28,7 @@ import org.jruby.RubyNumeric;
 import org.jruby.RubyString;
 import org.jruby.RubyStruct;
 import org.jruby.ext.rbconfig.RbConfigLibrary;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -214,6 +215,9 @@ public class RubyEtc {
     @JRubyMethod(optional=1, module = true)
     public static synchronized IRubyObject getpwuid(IRubyObject recv, IRubyObject[] args) {
         Ruby runtime = recv.getRuntime();
+
+        int argc = Arity.checkArgumentCount(runtime, args, 0, 1);
+
         POSIX posix = runtime.getPosix();
         IRubyObject oldExc = runtime.getGlobalVariables().get("$!"); // Save $!
         try {
@@ -395,10 +399,13 @@ public class RubyEtc {
     @JRubyMethod(optional=1, module = true)
     public static synchronized IRubyObject getgrgid(IRubyObject recv, IRubyObject[] args) {
         Ruby runtime = recv.getRuntime();
+
+        int argc = Arity.checkArgumentCount(runtime, args, 0, 1);
+
         POSIX posix = runtime.getPosix();
 
         try {
-            int gid = args.length == 0 ? posix.getgid() : RubyNumeric.fix2int(args[0]);
+            int gid = argc == 0 ? posix.getgid() : RubyNumeric.fix2int(args[0]);
             Group gr = posix.getgrgid(gid);
             if(gr == null) {
                 if (Platform.IS_WINDOWS) {  // MRI behavior

--- a/core/src/main/java/org/jruby/ext/ffi/AbstractMemory.java
+++ b/core/src/main/java/org/jruby/ext/ffi/AbstractMemory.java
@@ -44,6 +44,7 @@ import org.jruby.RubySymbol;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.internal.runtime.methods.DynamicMethod;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -166,11 +167,6 @@ abstract public class AbstractMemory extends MemoryObject {
     @JRubyMethod(name = "hash")
     public RubyFixnum hash(ThreadContext context) {
         return context.runtime.newFixnum(hashCode());
-    }
-
-    @JRubyMethod(name = "to_s", optional = 1)
-    public IRubyObject to_s(ThreadContext context, IRubyObject[] args) {
-        return RubyString.newString(context.runtime, ABSTRACT_MEMORY_RUBY_CLASS + "[size=" + size + "]");
     }
 
     @JRubyMethod(name = "[]")
@@ -1933,9 +1929,11 @@ abstract public class AbstractMemory extends MemoryObject {
 
     @JRubyMethod(name = "put_bytes", required = 2, optional = 2)
     public IRubyObject put_bytes(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 2, 4);
+
         ByteList bl = args[1].convertToString().getByteList();
-        int idx = args.length > 2 ? Util.int32Value(args[2]) : 0;
-        int len = args.length > 3 ? Util.int32Value(args[3]) : (bl.length() - idx);
+        int idx = argc > 2 ? Util.int32Value(args[2]) : 0;
+        int len = argc > 3 ? Util.int32Value(args[3]) : (bl.length() - idx);
 
         return putBytes(context, getOffset(args[0]), bl, idx, len);
     }
@@ -1947,9 +1945,11 @@ abstract public class AbstractMemory extends MemoryObject {
 
     @JRubyMethod(name = "write_bytes", required = 1, optional = 2)
     public IRubyObject write_bytes(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 3);
+
         ByteList bl = args[0].convertToString().getByteList();
-        int idx = args.length > 1 ? Util.int32Value(args[1]) : 0;
-        int len = args.length > 2 ? Util.int32Value(args[2]) : (bl.length() - idx);
+        int idx = argc > 1 ? Util.int32Value(args[1]) : 0;
+        int len = argc > 2 ? Util.int32Value(args[2]) : (bl.length() - idx);
         return putBytes(context, 0, bl, idx, len);
     }
 

--- a/core/src/main/java/org/jruby/ext/ffi/CallbackInfo.java
+++ b/core/src/main/java/org/jruby/ext/ffi/CallbackInfo.java
@@ -103,6 +103,8 @@ public class CallbackInfo extends Type {
     public static final IRubyObject newCallbackInfo(ThreadContext context, IRubyObject klass,
             IRubyObject[] args)
     {
+        int argc = Arity.checkArgumentCount(context, args, 2, 3);
+
         IRubyObject returnType = args[0], paramTypes = args[1];
 
         if (!(returnType instanceof Type)) {
@@ -110,13 +112,13 @@ public class CallbackInfo extends Type {
                     + returnType.getMetaClass().getName() + " (expected FFI::Type)");
         }
 
-        if (returnType instanceof MappedType) {
-            returnType = ((MappedType) returnType).getRealType();
-        }
-
         if (!(paramTypes instanceof RubyArray)) {
             throw context.runtime.newTypeError("wrong argument type "
                     + paramTypes.getMetaClass().getName() + " (expected Array)");
+        }
+
+        if (returnType instanceof MappedType) {
+            returnType = ((MappedType) returnType).getRealType();
         }
 
         Type[] nativeParamTypes = new Type[((RubyArray)paramTypes).size()];
@@ -130,7 +132,7 @@ public class CallbackInfo extends Type {
         }
 
         boolean stdcall = false;
-        if (args.length > 2) {
+        if (argc > 2) {
             if (!(args[2] instanceof RubyHash)) {
                 throw context.runtime.newTypeError("wrong argument type "
                         + args[2].getMetaClass().getName() + " (expected Enums or Hash)");

--- a/core/src/main/java/org/jruby/ext/ffi/Pointer.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Pointer.java
@@ -138,9 +138,8 @@ public class Pointer extends AbstractMemory {
     }
 
 
-    @Override
-    @JRubyMethod(name = { "to_s", "inspect" }, optional = 1)
-    public IRubyObject to_s(ThreadContext context, IRubyObject[] args) {
+    @JRubyMethod(name = { "to_s", "inspect" })
+    public IRubyObject to_s(ThreadContext context) {
         String s = size != Long.MAX_VALUE
                 ? String.format("#<%s address=0x%x size=%s>", getMetaClass().getName(), getAddress(), size)
                 : String.format("#<%s address=0x%x>", getMetaClass().getName(), getAddress());

--- a/core/src/main/java/org/jruby/ext/ffi/StructLayout.java
+++ b/core/src/main/java/org/jruby/ext/ffi/StructLayout.java
@@ -50,6 +50,7 @@ import org.jruby.RubySymbol;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.internal.runtime.methods.DynamicMethod;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
@@ -216,6 +217,7 @@ public final class StructLayout extends Type {
     @JRubyMethod(name = "new", meta = true, required = 3, optional = 1)
     public static final IRubyObject newStructLayout(ThreadContext context, IRubyObject klass, 
             IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 3, 4);
 
         IRubyObject rbFields = args[0], size = args[1], alignment = args[2];
 
@@ -649,6 +651,7 @@ public final class StructLayout extends Type {
 
         @JRubyMethod(name="initialize", visibility = PRIVATE, required = 3, optional = 1)
         public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
+            Arity.checkArgumentCount(context, args, 3, 4);
             
             init(args[0], args[2], args[1]);
 
@@ -830,6 +833,7 @@ public final class StructLayout extends Type {
         @Override
         @JRubyMethod(name="initialize", visibility = PRIVATE, required = 3, optional = 1)
         public final IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
+            Arity.checkArgumentCount(context, args, 3, 4);
             
             IRubyObject type = args[2];
 
@@ -852,6 +856,7 @@ public final class StructLayout extends Type {
         @Override
         @JRubyMethod(name="initialize", visibility = PRIVATE, required = 3, optional = 1)
         public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
+            Arity.checkArgumentCount(context, args, 3, 4);
 
             IRubyObject type = args[2];
 
@@ -875,6 +880,7 @@ public final class StructLayout extends Type {
         @Override
         @JRubyMethod(name="initialize", visibility = PRIVATE, required = 3, optional = 1)
         public final IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
+            Arity.checkArgumentCount(context, args, 3, 4);
 
             IRubyObject type = args[2];
             if (!(type instanceof Type.Array)) {

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/DynamicLibrary.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/DynamicLibrary.java
@@ -175,9 +175,8 @@ public class DynamicLibrary extends RubyObject {
                     getMetaClass().getName(), library.name, name, getAddress()));
         }
 
-        @Override
-        @JRubyMethod(name = "to_s", optional = 1)
-        public IRubyObject to_s(ThreadContext context, IRubyObject[] args) {
+        @JRubyMethod(name = "to_s")
+        public IRubyObject to_s(ThreadContext context) {
             return RubyString.newString(context.runtime, name);
         }
 

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/Function.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/Function.java
@@ -13,6 +13,7 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.ext.ffi.*;
 import org.jruby.internal.runtime.methods.DynamicMethod;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
@@ -70,6 +71,8 @@ public final class Function extends org.jruby.ext.ffi.AbstractInvoker {
     
     @JRubyMethod(name = { "new" }, meta = true, required = 2, optional = 2)
     public static IRubyObject newInstance(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
+        int argc = Arity.checkArgumentCount(context, args, 2, 4);
+
         MemoryIO fptr = null;
         RubyHash options = null;
         Object proc = null;
@@ -86,10 +89,10 @@ public final class Function extends org.jruby.ext.ffi.AbstractInvoker {
             parameterTypes[i] = org.jruby.ext.ffi.Util.findType(context, paramTypes.entry(i));
         }
 
-        if (args.length > 2 && args[2] instanceof Pointer) {
+        if (argc > 2 && args[2] instanceof Pointer) {
             fptr = new CodeMemoryIO(context.runtime, (Pointer) args[2]);
             optionsIndex = 3;
-        } else if (args.length > 2 && (args[2] instanceof RubyProc || args[2].respondsTo("call"))) {
+        } else if (argc > 2 && (args[2] instanceof RubyProc || args[2].respondsTo("call"))) {
             proc = args[2];
             optionsIndex = 3;
         } else if (block.isGiven()) {
@@ -106,7 +109,7 @@ public final class Function extends org.jruby.ext.ffi.AbstractInvoker {
         String convention = "default";
         IRubyObject enums = null;
         boolean saveError = true;
-        if (args.length > optionsIndex && args[optionsIndex] instanceof RubyHash) {
+        if (argc > optionsIndex && args[optionsIndex] instanceof RubyHash) {
             options = (RubyHash) args[optionsIndex];
 
             IRubyObject rbConvention = options.fastARef(context.runtime.newSymbol("convention"));

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyLibrary.java
@@ -263,11 +263,14 @@ public class JRubyLibrary implements Library {
     @JRubyMethod(module = true, name = "compile", required = 1, optional = 3)
     public static IRubyObject compile(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         // def compile(content = nil, filename = DEFAULT_FILENAME, extra_position_info = false, &block)
+
+        int argc = Arity.checkArgumentCount(context, args, 1, 4);
+
         final Ruby runtime = context.runtime;
 
         final RubyString content = args[0].convertToString();
         args[0] = content;
-        final RubyString filename = args.length > 1 ? args[1].convertToString() : RubyString.newEmptyString(runtime);
+        final RubyString filename = argc > 1 ? args[1].convertToString() : RubyString.newEmptyString(runtime);
 
         IRScriptBody scope = compileIR(context, args, block);
 

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
@@ -40,6 +40,7 @@ import org.jruby.ast.util.ArgsUtil;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.java.proxies.ConcreteJavaProxy;
 import org.jruby.javasupport.Java;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -121,6 +122,8 @@ public class JRubyUtilLibrary implements Library {
      */ // used from RGs' JRuby defaults (as well as jar_dependencies)
     @JRubyMethod(module = true, name = "class_loader_resources", alias = "classloader_resources", required = 1, optional = 1)
     public static IRubyObject class_loader_resources(ThreadContext context, IRubyObject recv, IRubyObject... args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 2);
+
         final Ruby runtime = context.runtime;
 
         final ClassLoader loader = runtime.getJRubyClassLoader();
@@ -128,7 +131,7 @@ public class JRubyUtilLibrary implements Library {
         final RubyArray resources = RubyArray.newArray(runtime);
 
         boolean raw = false, path = false;
-        if (args.length > 1 && args[1] instanceof RubyHash) {
+        if (argc > 1 && args[1] instanceof RubyHash) {
             IRubyObject[] values = ArgsUtil.extractKeywordArgs(context, (RubyHash) args[1], "raw", "path");
             raw  = values[0] != null && values[0].isTrue();
             path = values[1] != null && values[1].isTrue();

--- a/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
+++ b/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
@@ -273,6 +273,8 @@ public class RubyPathname extends RubyObject {
 
     @JRubyMethod(alias = "fnmatch?", required = 1, optional = 1)
     public IRubyObject fnmatch(ThreadContext context, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 1, 2);
+
         args = insertPath(args, 1);
         return context.runtime.getFile().callMethod(context, "fnmatch?", args);
     }
@@ -319,13 +321,15 @@ public class RubyPathname extends RubyObject {
 
     @JRubyMethod(required = 1, optional = 1)
     public IRubyObject glob(ThreadContext context, IRubyObject[] _args, Block block) {
+        int argc = Arity.checkArgumentCount(context, _args, 1, 2);
+
         Ruby runtime = context.runtime;
 
         IRubyObject[] args = new IRubyObject[3];
         boolean blockGiven = block.isGiven();
 
         args[0] = _args[0];
-        if (_args.length == 1) {
+        if (argc == 1) {
             args[1] = RubyFixnum.zero(runtime);
         } else {
             args[1] = _args[1];

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -311,6 +311,8 @@ public class RubySet extends RubyObject implements Set {
 
     @JRubyMethod(frame = true, keywords = true, required = 1, optional = 1)
     public IRubyObject initialize_clone(ThreadContext context, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 1, 2);
+
         sites(context).initialize_clone_super.call(context, this, this, args);
         IRubyObject orig = args[0];
         setHash((RubyHash) (((RubySet) orig).hash).rbClone(context));

--- a/core/src/main/java/org/jruby/ext/set/RubySortedSet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySortedSet.java
@@ -31,6 +31,7 @@ package org.jruby.ext.set;
 
 import org.jruby.*;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -159,6 +160,8 @@ public class RubySortedSet extends RubySet implements SortedSet {
 
     @JRubyMethod(frame = true, keywords = true, required = 1, optional = 1)
     public IRubyObject initialize_clone(ThreadContext context, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 1, 2);
+
         super.initialize_clone(context, args);
         IRubyObject orig = args[0];
         if (this != orig) order.addAll(((RubySortedSet) orig).order);

--- a/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
+++ b/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
@@ -16,6 +16,7 @@ import org.jruby.RubyInteger;
 import org.jruby.RubyObject;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -132,7 +133,7 @@ public class Addrinfo extends RubyObject {
         return context.nil;
     }
 
-    @JRubyMethod(required = 1, optional = 4, visibility = Visibility.PRIVATE)
+    @JRubyMethod(required = 1, optional = 3, visibility = Visibility.PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
         switch (args.length) {
             case 1:
@@ -141,6 +142,11 @@ public class Addrinfo extends RubyObject {
                 return initialize(context, args[0], args[1]);
             case 3:
                 return initialize(context, args[0], args[1], args[2]);
+            case 4:
+                // use logic below
+                break;
+            default:
+                Arity.raiseArgumentError(context, args.length, 1, 4);
         }
 
         IRubyObject _sockaddr = args[0];
@@ -733,10 +739,26 @@ public class Addrinfo extends RubyObject {
         }
     }
 
-    @JRubyMethod(optional = 1)
-    public IRubyObject getnameinfo(ThreadContext context, IRubyObject[] args) {
+    @JRubyMethod
+    public IRubyObject getnameinfo(ThreadContext context) {
+        return initializeCommon(context.runtime, null);
+    }
+
+    @JRubyMethod
+    public IRubyObject getnameinfo(ThreadContext context, IRubyObject _flags) {
         Ruby runtime = context.runtime;
 
+        RubyString rubyService = null;
+
+        int flags = _flags.convertToInteger().getIntValue();
+        if ((flags & NameInfo.NI_NUMERICSERV.intValue()) != 0) {
+            rubyService = runtime.newString(Integer.toString(getPort()));
+        }
+
+        return initializeCommon(runtime, rubyService);
+    }
+
+    private RubyArray initializeCommon(Ruby runtime, RubyString rubyService) {
         RubyString hostname;
 
         InetSocketAddress inet = getInetSocketAddress();
@@ -745,15 +767,6 @@ public class Addrinfo extends RubyObject {
         } else {
             UnixSocketAddress unix = getUnixSocketAddress();
             hostname = runtime.newString(unix.path());
-        }
-
-        RubyString rubyService = null;
-
-        if (args.length > 0) {
-            int flags = args[0].convertToInteger().getIntValue();
-            if ((flags & NameInfo.NI_NUMERICSERV.intValue()) != 0) {
-                rubyService = runtime.newString(Integer.toString(getPort()));
-            }
         }
 
         if (rubyService == null) {

--- a/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
@@ -55,6 +55,7 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.ext.fcntl.FcntlLibrary;
 import org.jruby.platform.Platform;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
@@ -207,8 +208,7 @@ public class RubyBasicSocket extends RubyIO {
                 str = null; flags = null;
                 break;
             default:
-                length = context.nil;
-                str = null; flags = null;
+                throw context.runtime.newArgumentError(args.length, 1, 3);
         }
 
         return recv(context, length, str, flags);
@@ -251,7 +251,8 @@ public class RubyBasicSocket extends RubyIO {
 
     @JRubyMethod(required = 1, optional = 3)
     public IRubyObject recv_nonblock(ThreadContext context, IRubyObject[] args) {
-        int argc = args.length;
+        int argc = Arity.checkArgumentCount(context, args, 1, 4);
+
         boolean exception = true;
         Ruby runtime = context.runtime;
         IRubyObject opts = ArgsUtil.getOptionsArg(runtime, args);
@@ -616,9 +617,11 @@ public class RubyBasicSocket extends RubyIO {
 
     @JRubyMethod(optional = 1)
     public IRubyObject shutdown(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 0, 1);
+
         int how = 2;
 
-        if (args.length > 0) {
+        if (argc > 0) {
             String howString = null;
             if (args[0] instanceof RubyString || args[0] instanceof RubySymbol) {
                 howString = args[0].asJavaString();

--- a/core/src/main/java/org/jruby/ext/socket/RubySocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubySocket.java
@@ -54,6 +54,7 @@ import org.jruby.RubyModule;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.RaiseException;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
@@ -243,6 +244,8 @@ public class RubySocket extends RubyBasicSocket {
 
     @JRubyMethod(required = 1, optional = 3)
     public IRubyObject recvfrom_nonblock(ThreadContext context, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 1, 4);
+
         if (getOpenFile() == null) {
             throw context.runtime.newErrnoENOTCONNError("socket is not connected");
         }
@@ -293,11 +296,15 @@ public class RubySocket extends RubyBasicSocket {
 
     @JRubyMethod(required = 1, rest = true, meta = true)
     public static IRubyObject gethostbyaddr(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 1, -1);
+
         return SocketUtils.gethostbyaddr(context, args);
     }
 
     @JRubyMethod(required = 1, optional = 1, meta = true)
     public static IRubyObject getservbyname(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 1, 2);
+
         return SocketUtils.getservbyname(context, args);
     }
 
@@ -329,11 +336,15 @@ public class RubySocket extends RubyBasicSocket {
 
     @JRubyMethod(required = 2, optional = 5, meta = true)
     public static IRubyObject getaddrinfo(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 2, 7);
+
         return SocketUtils.getaddrinfo(context, args);
     }
 
     @JRubyMethod(required = 1, optional = 1, meta = true)
     public static IRubyObject getnameinfo(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 1, 2);
+
         return SocketUtils.getnameinfo(context, args);
     }
 

--- a/core/src/main/java/org/jruby/ext/socket/RubyTCPSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyTCPSocket.java
@@ -36,6 +36,7 @@ import org.jruby.RubyClass;
 import org.jruby.RubyHash;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.ast.util.ArgsUtil;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
@@ -146,12 +147,14 @@ public class RubyTCPSocket extends RubyIPSocket {
 
     @JRubyMethod(required = 2, optional = 3, visibility = Visibility.PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 2, 5);
+
         String localHost = null;
         int localPort = 0;
         IRubyObject maybeOpts;
         RubyHash opts = null;
 
-        switch (args.length) {
+        switch (argc) {
             case 2:
                 return initialize(context, args[0], args[1]);
             case 3:
@@ -165,7 +168,7 @@ public class RubyTCPSocket extends RubyIPSocket {
         final String remoteHost = host.isNil() ? "localhost" : host.convertToString().toString();
         final int remotePort = SocketUtils.getPortFrom(context, port);
 
-        switch (args.length) {
+        switch (argc) {
             case 4:
                 if (!args[2].isNil()) localHost = args[2].convertToString().toString();
 
@@ -180,8 +183,6 @@ public class RubyTCPSocket extends RubyIPSocket {
             case 5:
                 if (!args[4].isNil()) opts = (RubyHash) ArgsUtil.getOptionsArg(context.runtime, args[4], true);
                 break;
-            default:
-                throw context.runtime.newArgumentError(args.length, 2, 4);
         }
 
         return initialize(context, remoteHost, remotePort, host, localHost, localPort, opts);

--- a/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
@@ -43,6 +43,7 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.exceptions.RaiseException;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
@@ -263,6 +264,8 @@ public class RubyUDPSocket extends RubyIPSocket {
 
     @JRubyMethod(required = 1, optional = 3)
     public IRubyObject recvfrom_nonblock(ThreadContext context, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 1, 4);
+
         return recvfrom_nonblock(this, context, args);
     }
 
@@ -360,6 +363,8 @@ public class RubyUDPSocket extends RubyIPSocket {
 
     @JRubyMethod(required = 2, optional = 2)
     public IRubyObject send(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 2, 4);
+
         // TODO: implement flags
         Ruby runtime = context.runtime;
         IRubyObject _mesg = args[0];
@@ -368,13 +373,13 @@ public class RubyUDPSocket extends RubyIPSocket {
         try {
             int written;
 
-            if (args.length == 2) {
+            if (argc == 2) {
                 return send(context, _mesg, _flags);
             }
 
             InetAddress[] addrs;
             int port;
-            if (args.length == 3) {
+            if (argc == 3) {
                 InetSocketAddress sockAddress;
                 IRubyObject sockaddr = args[2];
                 if (sockaddr instanceof Addrinfo) {

--- a/core/src/main/java/org/jruby/ext/socket/RubyUNIXSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUNIXSocket.java
@@ -48,6 +48,7 @@ import org.jruby.RubyNumeric;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
@@ -122,12 +123,14 @@ public class RubyUNIXSocket extends RubyBasicSocket {
 
     @JRubyMethod(name = "recvfrom", required = 1, optional = 1)
     public IRubyObject recvfrom(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 2);
+
         Ruby runtime = context.runtime;
 
         IRubyObject _length = args[0];
         IRubyObject _flags;
 
-        if(args.length == 2) {
+        if(argc == 2) {
             _flags = args[1];
         } else {
             _flags = runtime.getNil();
@@ -205,16 +208,18 @@ public class RubyUNIXSocket extends RubyBasicSocket {
 
     @JRubyMethod(optional = 2)
     public IRubyObject recv_io(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 0, 2);
+
         final Ruby runtime = context.runtime;
         final POSIX posix = runtime.getPosix();
         OpenFile fptr = getOpenFileChecked();
 
         IRubyObject klass = runtime.getIO();
         IRubyObject mode = runtime.getNil();
-        if (args.length > 0) {
+        if (argc > 0) {
             klass = args[0];
         }
-        if (args.length > 1) {
+        if (argc > 1) {
             mode = args[1];
         }
 
@@ -262,6 +267,8 @@ public class RubyUNIXSocket extends RubyBasicSocket {
 
     @JRubyMethod(name = {"socketpair", "pair"}, optional = 2, meta = true)
     public static IRubyObject socketpair(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 0, 2);
+
         final Ruby runtime = context.runtime;
 
         // TODO: type and protocol

--- a/core/src/main/java/org/jruby/ext/tempfile/Tempfile.java
+++ b/core/src/main/java/org/jruby/ext/tempfile/Tempfile.java
@@ -79,6 +79,8 @@ public class Tempfile extends RubyFile implements Finalizable {
     @JRubyMethod(optional = 4, visibility = Visibility.PRIVATE, keywords = true)
     @Override
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args, Block unused) {
+        Arity.checkArgumentCount(context, args, 0, 4);
+
         if (args.length == 0) {
             args = new IRubyObject[] { RubyString.newEmptyString(context.runtime) };
         }
@@ -162,7 +164,9 @@ public class Tempfile extends RubyFile implements Finalizable {
 
     @JRubyMethod(optional = 1)
     public IRubyObject close(ThreadContext context, IRubyObject[] args, Block block) {
-        boolean unlink = args.length == 1 ? args[0].isTrue() : false;
+        int argc = Arity.checkArgumentCount(context, args, 0, 1);
+
+        boolean unlink = argc == 1 ? args[0].isTrue() : false;
         return unlink ? close_bang(context) : _close(context);
     }
 

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibDeflate.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibDeflate.java
@@ -208,6 +208,8 @@ public class JZlibDeflate extends ZStream {
 
     @JRubyMethod(name = "flush", optional = 1)
     public IRubyObject flush(IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(getRuntime(), args, 0, 1);
+
         int flush = 2; // SYNC_FLUSH
         
         if (args.length == 1 && !args[0].isNil()) flush = RubyNumeric.fix2int(args[0]);

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibInflate.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibInflate.java
@@ -34,6 +34,7 @@ import org.jruby.RubyNumeric;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
@@ -71,6 +72,8 @@ public class JZlibInflate extends ZStream {
 
     @JRubyMethod(name = "initialize", optional = 1, visibility = PRIVATE)
     public IRubyObject _initialize(IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(getRuntime(), args, 0, 1);
+
         windowBits = JZlib.DEF_WBITS;
 
         if (args.length > 0 && !args[0].isNil()) {

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
@@ -42,6 +42,7 @@ import org.jruby.anno.FrameField;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.RaiseException;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ObjectAllocator;
@@ -90,7 +91,10 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
 
     @JRubyMethod(name = "open", required = 1, optional = 1, meta = true)
     public static IRubyObject open19(final ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
+        Arity.checkArgumentCount(context, args, 1, 2);
+
         Ruby runtime = recv.getRuntime();
+
         args[0] = Helpers.invoke(context, runtime.getFile(), "open", args[0], runtime.newString("rb"));
 
         JZlibRubyGzipReader gzio = newInstance(recv, args);
@@ -138,11 +142,13 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
 
     @JRubyMethod(name = "initialize", required = 1, optional = 1, visibility = PRIVATE)
     public IRubyObject initialize19(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 2);
+
         Ruby runtime = context.runtime;
         IRubyObject obj = initialize(context, args[0]);
         IRubyObject opt = context.nil;
         
-        if (args.length == 2) {
+        if (argc == 2) {
             opt = args[1];
             if (TypeConverter.checkHashType(runtime, opt).isNil()) {
                 throw runtime.newArgumentError(2, 1);
@@ -315,10 +321,12 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
 
     @JRubyMethod(name = "read", optional = 1)
     public IRubyObject read(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 0, 1);
+
         Ruby runtime = context.runtime;
 
         try {
-            if (args.length == 0 || args[0].isNil()) return readAll();
+            if (argc == 0 || args[0].isNil()) return readAll();
 
             int len = RubyNumeric.fix2int(args[0]);
             
@@ -353,16 +361,20 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
 
     @JRubyMethod(name = "readpartial", required = 1, optional = 1)
     public IRubyObject readpartial(IRubyObject[] args) {
+        Ruby runtime = getRuntime();
+
+        int argc = Arity.checkArgumentCount(runtime, args, 1, 2);
+
         try {
             int len = RubyNumeric.fix2int(args[0]);
 
             if (len < 0) {
-                throw getRuntime().newArgumentError("negative length " + len + " given");
+                throw runtime.newArgumentError("negative length " + len + " given");
             }
 
-            if (args.length > 1 && !args[1].isNil()) {
+            if (argc > 1 && !args[1].isNil()) {
                 if (!(args[1] instanceof RubyString)) {
-                    throw getRuntime().newTypeError(
+                    throw runtime.newTypeError(
                             "wrong argument type " + args[1].getMetaClass().getName()
                             + " (expected String)");
                 }
@@ -372,7 +384,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
 
             return readPartial(len, null);
         } catch (IOException ioe) {
-            throw getRuntime().newIOErrorFromException(ioe);
+            throw runtime.newIOErrorFromException(ioe);
         }
     }
 
@@ -630,11 +642,13 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
 
     @JRubyMethod(optional = 1)
     public IRubyObject each(ThreadContext context, IRubyObject[] args, Block block) {
+        int argc = Arity.checkArgumentCount(context, args, 0, 1);
+
         if (!block.isGiven()) return RubyEnumerator.enumeratorize(context.runtime, this, "each", args);
 
         ByteList sep = ((RubyString) context.runtime.getGlobalVariables().get("$/")).getByteList();
 
-        if (args.length > 0 && !args[0].isNil()) {
+        if (argc > 0 && !args[0].isNil()) {
             sep = args[0].convertToString().getByteList();
         }
 
@@ -692,15 +706,17 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
 
     @JRubyMethod(optional = 1)
     public IRubyObject readlines(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 0, 1);
+
         List<IRubyObject> array = new ArrayList<>();
 
-        if (args.length != 0 && args[0].isNil()) {
+        if (argc != 0 && args[0].isNil()) {
             array.add(read(context, IRubyObject.NULL_ARRAY));
 
         } else {
             ByteList sep = ((RubyString) context.runtime.getGlobalVariables().get("$/")).getByteList();
 
-            if (args.length > 0) sep = args[0].convertToString().getByteList();
+            if (argc > 0) sep = args[0].convertToString().getByteList();
 
             try {
                 for (IRubyObject result = internalSepGets(sep); !result.isNil(); result = internalSepGets(sep)) {
@@ -752,6 +768,8 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
      */
     @JRubyMethod(required = 1, optional = 1, meta = true)
     public static IRubyObject zcat(ThreadContext context, IRubyObject klass, IRubyObject[] args, Block block) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 2);
+
         Ruby runtime = context.runtime;
 
         IRubyObject io, unused;

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
@@ -43,6 +43,7 @@ import org.jruby.RubyString;
 import org.jruby.RubyTime;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
@@ -79,6 +80,8 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
 
     @JRubyMethod(name = "open", required = 1, optional = 3, meta = true)
     public static IRubyObject open19(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
+        int argc = Arity.checkArgumentCount(context, args, 1, 4);
+
         Ruby runtime = recv.getRuntime();
         
         args[0] = Helpers.invoke(context, runtime.getFile(), "open", args[0], runtime.newString("wb"));
@@ -290,9 +293,11 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
 
     @JRubyMethod(name = "flush", optional = 1)
     public IRubyObject flush(IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(getRuntime(), args, 0, 1);
+
         int flush = JZlib.Z_SYNC_FLUSH;
         
-        if (args.length > 0 && !args[0].isNil()) {
+        if (argc > 0 && !args[0].isNil()) {
             flush = RubyNumeric.fix2int(args[0]);
         }
         

--- a/core/src/main/java/org/jruby/internal/runtime/methods/InvocationMethodFactory.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InvocationMethodFactory.java
@@ -367,75 +367,6 @@ public class InvocationMethodFactory extends MethodFactory implements Opcodes {
         return ic;
     }
 
-    /**
-     * Emit code to check the arity of a call to a Java-based method.
-     *
-     * @param jrubyMethod The annotation of the called method
-     * @param method The code generator for the handle being created
-     */
-    private static void checkArity(JRubyMethod jrubyMethod, SkinnyMethodAdapter method, int specificArity) {
-        switch (specificArity) {
-        case 0:
-        case 1:
-        case 2:
-        case 3:
-            // for zero, one, two, three arities, JavaMethod.JavaMethod*.call(...IRubyObject[] args...) will check
-            return;
-        default:
-            final Label arityError = new Label();
-            final Label noArityError = new Label();
-            boolean checkArity = false;
-            if (jrubyMethod.rest()) {
-                if (jrubyMethod.required() > 0) {
-                    // just confirm minimum args provided
-                    method.aload(ARGS_INDEX);
-                    method.arraylength();
-                    method.ldc(jrubyMethod.required());
-                    method.if_icmplt(arityError);
-                    checkArity = true;
-                }
-            } else if (jrubyMethod.optional() > 0) {
-                if (jrubyMethod.required() > 0) {
-                    // confirm minimum args provided
-                    method.aload(ARGS_INDEX);
-                    method.arraylength();
-                    method.ldc(jrubyMethod.required());
-                    method.if_icmplt(arityError);
-                }
-
-                // confirm maximum not greater than optional
-                method.aload(ARGS_INDEX);
-                method.arraylength();
-                method.ldc(jrubyMethod.required() + jrubyMethod.optional());
-                method.if_icmpgt(arityError);
-                checkArity = true;
-            } else {
-                // just confirm args length == required
-                method.aload(ARGS_INDEX);
-                method.arraylength();
-                method.ldc(jrubyMethod.required());
-                method.if_icmpne(arityError);
-                checkArity = true;
-            }
-
-            if (checkArity) {
-                method.go_to(noArityError);
-
-                // Raise an error if arity does not match requirements
-                method.label(arityError);
-                method.aload(THREADCONTEXT_INDEX);
-                method.invokevirtual(p(ThreadContext.class), "getRuntime", sig(Ruby.class));
-                method.aload(ARGS_INDEX);
-                method.ldc(jrubyMethod.required());
-                method.ldc(jrubyMethod.required() + jrubyMethod.optional());
-                method.invokestatic(p(Arity.class), "checkArgumentCount", sig(int.class, Ruby.class, IRubyObject[].class, int.class, int.class));
-                method.pop();
-
-                method.label(noArityError);
-            }
-        }
-    }
-
     private static ClassWriter createJavaMethodCtor(String namePath, String sup, String parameterDesc) {
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
         String sourceFile = namePath.substring(namePath.lastIndexOf('/') + 1) + ".gen";
@@ -730,8 +661,6 @@ public class InvocationMethodFactory extends MethodFactory implements Opcodes {
             method.ldc(0);
             method.putfield("org/jruby/runtime/ThreadContext", "callInfo", "I");
         }
-
-        checkArity(desc.anno, method, specificArity);
 
         CallConfiguration callConfig = CallConfiguration.getCallConfigByAnno(desc.anno);
         if (!callConfig.isNoop()) {

--- a/core/src/main/java/org/jruby/java/addons/ClassJavaAddons.java
+++ b/core/src/main/java/org/jruby/java/addons/ClassJavaAddons.java
@@ -37,6 +37,7 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.java.proxies.JavaProxy;
 import org.jruby.javasupport.Java;
 import org.jruby.javasupport.proxy.JavaProxyClass;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -69,15 +70,17 @@ public abstract class ClassJavaAddons {
     public static IRubyObject become_java(ThreadContext context, final IRubyObject self, final IRubyObject[] args) {
         final RubyClass klass = (RubyClass) self;
 
+        int argc = Arity.checkArgumentCount(context, args, 1, 2);
+
         String dumpDir = null; boolean useChildLoader = true;
         if ( args[0] instanceof RubyString ) {
             dumpDir = args[0].asJavaString();
-            if ( args.length > 1 ) useChildLoader = args[1].isTrue();
+            if ( argc > 1 ) useChildLoader = args[1].isTrue();
         }
         else {
             useChildLoader = args[0].isTrue();
             // ~ compatibility with previous (.rb) args handling :
-            if ( args.length > 1 && args[1] instanceof RubyString ) {
+            if ( argc > 1 && args[1] instanceof RubyString ) {
                 dumpDir = args[1].asJavaString();
             }
         }

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -9,6 +9,7 @@ import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.java.util.ArrayUtils;
 import org.jruby.javasupport.Java;
 import org.jruby.javasupport.JavaUtil;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
@@ -105,7 +106,9 @@ public final class ArrayJavaProxy extends JavaProxy {
 
     @JRubyMethod(name = "[]", required = 1, rest = true)
     public final IRubyObject op_aref(ThreadContext context, IRubyObject[] args) {
-        if ( args.length == 1 ) return op_aref(context, args[0]);
+        int argc = Arity.checkArgumentCount(context, args, 1, -1);
+
+        if ( argc == 1 ) return op_aref(context, args[0]);
         return getRange(context, args);
     }
 
@@ -395,6 +398,8 @@ public final class ArrayJavaProxy extends JavaProxy {
 
     @JRubyMethod(name = "dig", required = 1, rest = true)
     public final IRubyObject dig(ThreadContext context, IRubyObject[] args) {
+        Arity.checkArgumentCount(context, args, 1, -1);
+
         return dig(context, args, 0);
     }
 

--- a/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
@@ -41,6 +41,7 @@ import org.jruby.javasupport.Java;
 import org.jruby.javasupport.JavaMethod;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.javasupport.binding.MethodGatherer;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
@@ -401,11 +402,13 @@ public class JavaProxy extends RubyObject {
 
     @JRubyMethod(required = 1, rest = true)
     public IRubyObject java_send(ThreadContext context, IRubyObject[] args) {
+        int argc = Arity.checkArgumentCount(context, args, 1, -1);
+
         Ruby runtime = context.runtime;
 
         String name = args[0].asJavaString();
         RubyArray argTypesAry = args[1].convertToArray();
-        final int argsLen = args.length - 2;
+        final int argsLen = argc - 2;
 
         checkArgSizeMismatch(runtime, argsLen, argTypesAry);
 
@@ -660,7 +663,9 @@ public class JavaProxy extends RubyObject {
 
         @JRubyMethod(required = 1, rest = true, meta = true)
         public static IRubyObject java_send(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
-            switch (args.length) {
+            int argc = Arity.checkArgumentCount(context, args, 1, -1);
+
+            switch (argc) {
                 case 1: return java_send(context, recv, args[0]);
                 case 2: return java_send(context, recv, args[0], args[1]);
                 case 3: return java_send(context, recv, args[0], args[1], args[2]);
@@ -670,7 +675,7 @@ public class JavaProxy extends RubyObject {
 
             String name = args[0].asJavaString();
             RubyArray argTypesAry = args[1].convertToArray();
-            final int argsLen = args.length - 2;
+            final int argsLen = argc - 2;
 
             checkArgSizeMismatch(runtime, argsLen, argTypesAry);
 

--- a/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
@@ -41,6 +41,7 @@ import org.jruby.RubyString;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.javasupport.JavaUtil;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
@@ -293,7 +294,9 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
 
         @Override // re-invent @JRubyMethod(name = "any?")
         public IRubyObject any_p(ThreadContext context, IRubyObject[] args, Block block) {
-            boolean patternGiven = args.length > 0;
+            int argc = Arity.checkArgumentCount(context, args, 0, 1);
+
+            boolean patternGiven = argc > 0;
 
             if (isEmpty()) return context.fals;
 

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -37,6 +37,7 @@ import org.jruby.internal.runtime.methods.JavaMethod;
 import org.jruby.java.proxies.ArrayJavaProxy;
 import org.jruby.java.util.ClassUtils;
 import org.jruby.javasupport.Java;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.JavaInternalBlockBody;
@@ -660,6 +661,8 @@ public abstract class JavaLang {
         @SuppressWarnings("deprecation")
         @JRubyMethod(required = 1, rest = true)
         public static IRubyObject java_method(ThreadContext context, IRubyObject self, final IRubyObject[] args) {
+            Arity.checkArgumentCount(context, args, 1, -1);
+
             final java.lang.Class klass = unwrapJavaObject(self);
 
             final java.lang.String methodName = args[0].asJavaString();
@@ -676,6 +679,8 @@ public abstract class JavaLang {
         @SuppressWarnings("deprecation")
         @JRubyMethod(required = 1, rest = true)
         public static IRubyObject declared_method(ThreadContext context, IRubyObject self, final IRubyObject[] args) {
+            Arity.checkArgumentCount(context, args, 1, -1);
+
             final java.lang.Class klass = unwrapJavaObject(self);
 
             final java.lang.String methodName = args[0].asJavaString();
@@ -691,6 +696,8 @@ public abstract class JavaLang {
 
         @JRubyMethod(required = 1, rest = true)
         public static IRubyObject declared_method_smart(ThreadContext context, IRubyObject self, final IRubyObject[] args) {
+            Arity.checkArgumentCount(context, args, 1, -1);
+
             final java.lang.Class klass = unwrapJavaObject(self);
 
             final java.lang.String methodName = args[0].asJavaString();

--- a/core/src/main/java/org/jruby/runtime/Arity.java
+++ b/core/src/main/java/org/jruby/runtime/Arity.java
@@ -261,6 +261,11 @@ public final class Arity implements Serializable {
     }
 
     // FIXME: JRuby 2/next should change this name since it only sometimes raises an error
+    public static void raiseArgumentError(ThreadContext context, IRubyObject[] args, int min, int max) {
+        raiseArgumentError(context.runtime, args.length, min, max);
+    }
+
+    // FIXME: JRuby 2/next should change this name since it only sometimes raises an error
     public static void raiseArgumentError(Ruby runtime, int length, int min, int max, boolean hasKwargs) {
         if (length < min) throw runtime.newArgumentError(length, min, max);
         if (max > UNLIMITED_ARGUMENTS && length > max) {

--- a/test/mri/excludes/TestStringIO.rb
+++ b/test/mri/excludes/TestStringIO.rb
@@ -1,2 +1,3 @@
 exclude :test_overflow, "unusual subprocess test trying to overflow some value"
+exclude :test_read_nonblock_no_exceptions, "temporary until StringIO ext does manual arity-checking (ruby/stringio#48)"
 exclude :test_write_integer_overflow, "JVM does not support > 32bit signed array offsets, so our StringIO cannot either"


### PR DESCRIPTION
During testing of indy-based compilation, it became obvious that we need to ensure variable-arity method bodies do their own arity-checking, so that direct calls from indy or Java do not cause array index errors. This PR adds such arity-checking to all such methods, following these rules:

Methods should do arity-checking manually if:

* they have a minimum argument count, or
* they have a maximum argument count
* and they access that argument list or pass it to normal Java methods that access that argument list

Methods do not need a manual check if they do not have minimums or maximums, or if they only pass their argument list to another variable-arity method that does a manual check.

This PR also removes arity-checking from the generated invokers, to avoid double-checking.

The main risk from this change lies in third-party extension code that has variable-arity methods but no manual checking. Passing incorrect numbers of arguments to these methods may trigger an array index error, as it would segfault in MRI (which also does not automatically check arity).