### PR TITLE
Fix #7743. NPE during parsing the rspec documentation

### DIFF
--- a/core/src/main/java/org/jruby/ext/ripper/RubyLexer.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RubyLexer.java
@@ -48,6 +48,7 @@ import org.jruby.util.StringSupport;
 import org.jruby.util.cli.Options;
 
 import static org.jruby.ext.ripper.RipperParser.*;
+import static org.jruby.parser.RubyParser.tGVAR;
 import static org.jruby.util.StringSupport.CR_7BIT;
 import static org.jruby.util.StringSupport.codeRangeScan;
 
@@ -1499,9 +1500,7 @@ public class RubyLexer extends LexingCommon {
                 if (!tokadd_ident(c)) return EOF;
 
                 last_state = lex_state;
-                setState(EXPR_END);
-                identValue = createTokenString().intern();
-                return tGVAR;
+                return identifierToken(last_state, tGVAR, createTokenString().intern());
             }
             pushback(c);
             c = '_';

--- a/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
@@ -1418,9 +1418,7 @@ public class RubyLexer extends LexingCommon {
                 if (!tokadd_ident(c)) return EOF;
 
                 last_state = lex_state;
-                yaccValue = createTokenByteList();
-                return tGVAR;
-
+                return identifierToken(tGVAR, createTokenByteList());
             }
             pushback(c);
             c = '_';


### PR DESCRIPTION
base error is longer $_ddddddd variables was not doing set_yylval_name(). I aligned both lexers to have same code.

Fixes #7743.