### PR TITLE
Fixes #7676. ruby2_keywords should not warn when using ...

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2981,12 +2981,12 @@ public class RubyModule extends RubyObject {
             if (method.getDefinedClass() == this) {
                 if (!method.isNative()) {
                     Signature signature = method.getSignature();
-                    if (signature.hasRest()) {
-                        if (!signature.hasKwargs()) {
-                            method.setRuby2Keywords();
-                        } else if (method instanceof AbstractIRMethod && ((AbstractIRMethod) method).getStaticScope().exists("...") == -1) {
-                            context.runtime.getWarnings().warn(ID.MISCELLANEOUS, str(context.runtime, "Skipping set of ruby2_keywords flag for ", name, " (method accepts keywords or method does not accept argument splat)"));
-                        }
+                    if (!signature.hasRest()) {
+                        context.runtime.getWarnings().warn(ID.MISCELLANEOUS, str(context.runtime, "Skipping set of ruby2_keywords flag for ", name, " (method accepts keywords or method does not accept argument splat)"));
+                    } else if (!signature.hasKwargs()) {
+                        method.setRuby2Keywords();
+                    } else if (method instanceof AbstractIRMethod && ((AbstractIRMethod) method).getStaticScope().exists("...") == -1) {
+                        context.runtime.getWarnings().warn(ID.MISCELLANEOUS, str(context.runtime, "Skipping set of ruby2_keywords flag for ", name, " (method accepts keywords or method does not accept argument splat)"));
                     }
                 } else {
                     context.runtime.getWarnings().warn(ID.MISCELLANEOUS, str(context.runtime, "Skipping set of ruby2_keywords flag for ", name, " (method not defined in Ruby)"));

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2981,10 +2981,12 @@ public class RubyModule extends RubyObject {
             if (method.getDefinedClass() == this) {
                 if (!method.isNative()) {
                     Signature signature = method.getSignature();
-                    if (signature.hasRest() && !signature.hasKwargs()) {
-                        method.setRuby2Keywords();
-                    } else {
-                        context.runtime.getWarnings().warn(ID.MISCELLANEOUS, str(context.runtime, "Skipping set of ruby2_keywords flag for ", name, " (method accepts keywords or method does not accept argument splat)"));
+                    if (signature.hasRest()) {
+                        if (!signature.hasKwargs()) {
+                            method.setRuby2Keywords();
+                        } else if (method instanceof AbstractIRMethod && ((AbstractIRMethod) method).getStaticScope().exists("...") == -1) {
+                            context.runtime.getWarnings().warn(ID.MISCELLANEOUS, str(context.runtime, "Skipping set of ruby2_keywords flag for ", name, " (method accepts keywords or method does not accept argument splat)"));
+                        }
                     }
                 } else {
                     context.runtime.getWarnings().warn(ID.MISCELLANEOUS, str(context.runtime, "Skipping set of ruby2_keywords flag for ", name, " (method not defined in Ruby)"));

--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -2006,10 +2006,7 @@ public abstract class RubyParserBase {
     }
 
     public boolean check_forwarding_args() {
-        if (local_id(FWD_REST) &&
-                local_id(FWD_KWREST) &&
-                local_id(FWD_BLOCK)) return true;
-
+        if (local_id(FWD_ALL)) return true;
         compile_error("unexpected ...");
         return false;
     }
@@ -2018,6 +2015,7 @@ public abstract class RubyParserBase {
         arg_var(FWD_REST);
         arg_var(FWD_KWREST);
         arg_var(FWD_BLOCK);
+        arg_var(FWD_ALL);  // Add dummy value to make it easy to see later that is ...
     }
 
     public Node new_args_forward_call(int line, Node leadingArgs) {

--- a/core/src/main/java/org/jruby/util/CommonByteLists.java
+++ b/core/src/main/java/org/jruby/util/CommonByteLists.java
@@ -42,6 +42,7 @@ public class CommonByteLists {
     public static final ByteList FWD_REST = STAR;
     public static final ByteList FWD_KWREST = STAR_STAR;
     public static final ByteList FWD_BLOCK = AMPERSAND;
+    public static final ByteList FWD_ALL = new ByteList(new byte[] {'.', '.', '.'});
     // Needs to be different than FWD_BLOCK for object identity comparisons.
     public static final ByteList ANON_BLOCK = new ByteList(new byte[] {'&'}, USASCIIEncoding.INSTANCE);
 


### PR DESCRIPTION
Decided to preemptively use ... as a special local variable in staticscope. This is used more for newer warnings in Ruby 3.2 so we might as well leverage it now.