### PR TITLE
Fix BigDecimal#sub with Object and significant digits

### DIFF
--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -1380,7 +1380,7 @@ public class RubyBigDecimal extends RubyNumeric {
     }
 
     private IRubyObject subInternal(ThreadContext context, RubyBigDecimal val, IRubyObject b, int prec) {
-        if (val == null) return callCoerced(context, sites(context).op_minus, b, true);
+        if (val == null) return ((RubyBigDecimal)callCoerced(context, sites(context).op_minus, b, true)).setResult(prec);
         RubyBigDecimal res = subSpecialCases(context, val);
         return res != null ? res : new RubyBigDecimal(context.runtime, value.subtract(val.value)).setResult(prec);
     }

--- a/spec/tags/ruby/library/bigdecimal/sub_tags.txt
+++ b/spec/tags/ruby/library/bigdecimal/sub_tags.txt
@@ -1,1 +1,0 @@
-fails:BigDecimal#sub with Object tries to coerce the other operand to self


### PR DESCRIPTION
The following test will pass.
     * spec/ruby/library/bigdecimal/sub_spec.rb