### PR TITLE
[fix] avoid walking constructor instructions on every call

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1562,7 +1562,7 @@ public class RubyModule extends RubyObject {
     }
 
     // MRI: method_entry_resolve_refinement
-    private final CacheEntry searchWithCacheAndRefinements(String id, boolean cacheUndef, StaticScope refinedScope) {
+    private CacheEntry searchWithCacheAndRefinements(String id, boolean cacheUndef, StaticScope refinedScope) {
         CacheEntry entry = searchWithCache(id, cacheUndef);
 
         if (entry.method.isRefined()) {
@@ -1835,18 +1835,11 @@ public class RubyModule extends RubyObject {
     }
 
     /**
-     * Searches for a method up until the superclass, but include modules. This is
-     * for Concrete java ctor initialization
-     * TODO: add a cache?
+     * Searches for a method up until the superclass, but include modules.
      */
+    @Deprecated
     public DynamicMethod searchMethodLateral(String id) {
-       // int token = generation;
-        // This flattens some of the recursion that would be otherwise be necessary.
-        // Used to recurse up the class hierarchy which got messy with prepend.
-        for (RubyModule module = this; module != null && (module == this || (module instanceof IncludedModuleWrapper)); module = module.getSuperClass()) {
-            // Only recurs if module is an IncludedModuleWrapper.
-            // This way only the recursion needs to be handled differently on
-            // IncludedModuleWrapper.
+        for (RubyModule module = this; (module == this || (module instanceof IncludedModuleWrapper)); module = module.getSuperClass()) {
             DynamicMethod method = module.searchMethodCommon(id);
             if (method != null) return method.isNull() ? null : method;
         }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
@@ -265,10 +265,10 @@ public class CompiledIRMethod extends AbstractIRMethod implements Compilable<Dyn
     public SplitSuperState<MethodSplitState> startSplitSuperCall(ThreadContext context, IRubyObject self,
             RubyModule clazz, String name, IRubyObject[] args, Block block) {
         // TODO: check if IR method, or is it guaranteed?
-        InterpreterContext ic = ((IRMethod) getIRScope()).builtInterperterContextForJavaConstructor();
-        if (!(ic instanceof ExitableInterpreterContext)) return null; // no super call/can't split this
+        ExitableInterpreterContext ic = ((IRMethod) getIRScope()).builtInterperterContextForJavaConstructor();
+        if (ic == null) return null; // no super call/can't split this
 
-        MethodSplitState state = new MethodSplitState(context, (ExitableInterpreterContext) ic, clazz, self, name);
+        MethodSplitState state = new MethodSplitState(context, ic, clazz, self, name);
 
         // TODO: JIT?
 

--- a/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRMethod.java
@@ -265,7 +265,7 @@ public class CompiledIRMethod extends AbstractIRMethod implements Compilable<Dyn
     public SplitSuperState<MethodSplitState> startSplitSuperCall(ThreadContext context, IRubyObject self,
             RubyModule clazz, String name, IRubyObject[] args, Block block) {
         // TODO: check if IR method, or is it guaranteed?
-        ExitableInterpreterContext ic = ((IRMethod) getIRScope()).builtInterperterContextForJavaConstructor();
+        ExitableInterpreterContext ic = ((IRMethod) getIRScope()).builtInterpreterContextForJavaConstructor();
         if (ic == null) return null; // no super call/can't split this
 
         MethodSplitState state = new MethodSplitState(context, ic, clazz, self, name);

--- a/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRNoProtocolMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRNoProtocolMethod.java
@@ -129,10 +129,10 @@ public class CompiledIRNoProtocolMethod extends AbstractIRMethod {
     public SplitSuperState<MethodSplitState> startSplitSuperCall(ThreadContext context, IRubyObject self,
             RubyModule clazz, String name, IRubyObject[] args, Block block) {
         // TODO: check if IR method, or is it guaranteed?
-        InterpreterContext ic = ((IRMethod) getIRScope()).builtInterperterContextForJavaConstructor();
-        if (!(ic instanceof ExitableInterpreterContext)) return null; // no super call/can't split this
+        ExitableInterpreterContext ic = ((IRMethod) getIRScope()).builtInterperterContextForJavaConstructor();
+        if (ic == null) return null; // no super call/can't split this
 
-        MethodSplitState state = new MethodSplitState(context, (ExitableInterpreterContext) ic, clazz, self, name);
+        MethodSplitState state = new MethodSplitState(context, ic, clazz, self, name);
 
         // TODO: JIT?
 

--- a/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRNoProtocolMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/CompiledIRNoProtocolMethod.java
@@ -129,7 +129,7 @@ public class CompiledIRNoProtocolMethod extends AbstractIRMethod {
     public SplitSuperState<MethodSplitState> startSplitSuperCall(ThreadContext context, IRubyObject self,
             RubyModule clazz, String name, IRubyObject[] args, Block block) {
         // TODO: check if IR method, or is it guaranteed?
-        ExitableInterpreterContext ic = ((IRMethod) getIRScope()).builtInterperterContextForJavaConstructor();
+        ExitableInterpreterContext ic = ((IRMethod) getIRScope()).builtInterpreterContextForJavaConstructor();
         if (ic == null) return null; // no super call/can't split this
 
         MethodSplitState state = new MethodSplitState(context, ic, clazz, self, name);

--- a/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
@@ -292,12 +292,10 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
     public SplitSuperState<MethodSplitState> startSplitSuperCall(ThreadContext context, IRubyObject self,
             RubyModule clazz, String name, IRubyObject[] args, Block block) {
         // TODO: check if IR method, or is it guaranteed?
-        InterpreterContext ic = ((IRMethod) getIRScope()).builtInterperterContextForJavaConstructor();
-        if (!(ic instanceof ExitableInterpreterContext)) return null; // no super call/can't split this
+        ExitableInterpreterContext ic = ((IRMethod) getIRScope()).builtInterperterContextForJavaConstructor();
+        if (ic == null) return null; // no super call/can't split this
 
-        MethodSplitState state = new MethodSplitState(context, (ExitableInterpreterContext) ic, clazz, self, name);
-
-        if (IRRuntimeHelpers.isDebug()) doDebug(); // TODO?
+        MethodSplitState state = new MethodSplitState(context, ic, clazz, self, name);
 
         ExitableReturn result = INTERPRET_METHOD(state, args, block);
 

--- a/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
@@ -292,7 +292,7 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
     public SplitSuperState<MethodSplitState> startSplitSuperCall(ThreadContext context, IRubyObject self,
             RubyModule clazz, String name, IRubyObject[] args, Block block) {
         // TODO: check if IR method, or is it guaranteed?
-        ExitableInterpreterContext ic = ((IRMethod) getIRScope()).builtInterperterContextForJavaConstructor();
+        ExitableInterpreterContext ic = ((IRMethod) getIRScope()).builtInterpreterContextForJavaConstructor();
         if (ic == null) return null; // no super call/can't split this
 
         MethodSplitState state = new MethodSplitState(context, ic, clazz, self, name);

--- a/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
@@ -287,12 +287,11 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
     public SplitSuperState<MethodSplitState> startSplitSuperCall(ThreadContext context, IRubyObject self,
             RubyModule clazz, String name, IRubyObject[] args, Block block) {
         // TODO: check if IR method, or is it guaranteed?
-        InterpreterContext ic = ((IRMethod) getIRScope()).builtInterperterContextForJavaConstructor();
-        if (!(ic instanceof ExitableInterpreterContext)) return null; // no super call/can't split this
+        // 2 -> IRMethod
+        ExitableInterpreterContext ic = ((IRMethod) getIRScope()).builtInterperterContextForJavaConstructor();
+        if (ic == null) return null; // no super call/can't split this
 
-        MethodSplitState state = new MethodSplitState(context, (ExitableInterpreterContext) ic, clazz, self, name);
-
-        if (IRRuntimeHelpers.isDebug()) doDebug(); // TODO?
+        MethodSplitState state = new MethodSplitState(context, ic, clazz, self, name);
 
         // TODO: JIT?
 

--- a/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
@@ -288,7 +288,7 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
             RubyModule clazz, String name, IRubyObject[] args, Block block) {
         // TODO: check if IR method, or is it guaranteed?
         // 2 -> IRMethod
-        ExitableInterpreterContext ic = ((IRMethod) getIRScope()).builtInterperterContextForJavaConstructor();
+        ExitableInterpreterContext ic = ((IRMethod) getIRScope()).builtInterpreterContextForJavaConstructor();
         if (ic == null) return null; // no super call/can't split this
 
         MethodSplitState state = new MethodSplitState(context, ic, clazz, self, name);

--- a/core/src/main/java/org/jruby/ir/IRMethod.java
+++ b/core/src/main/java/org/jruby/ir/IRMethod.java
@@ -126,7 +126,6 @@ public class IRMethod extends IRScope {
         return lazilyAcquireInterpreterContext();
     }
 
-    // 3 -> piling up here synchronized on the same method :
     /**
      * initialize methods in reified Java types will try and dispatch to the Java base classes
      * constructor when the Ruby in the initialize:
@@ -139,13 +138,13 @@ public class IRMethod extends IRScope {
      *
      * @return appropriate interpretercontext
      */
-    public ExitableInterpreterContext builtInterperterContextForJavaConstructor() {
+    public ExitableInterpreterContext builtInterpreterContextForJavaConstructor() {
         ExitableInterpreterContext interpreterContextForJavaConstructor = this.interpreterContextForJavaConstructor;
         if (interpreterContextForJavaConstructor == null) {
             synchronized (this) {
                 interpreterContextForJavaConstructor = this.interpreterContextForJavaConstructor;
                 if (interpreterContextForJavaConstructor == null) {
-                    interpreterContextForJavaConstructor = doBuiltInterperterContextForJavaConstructor();
+                    interpreterContextForJavaConstructor = builtInterpreterContextForJavaConstructorImpl();
                     this.interpreterContextForJavaConstructor = interpreterContextForJavaConstructor;
                 }
             }
@@ -155,7 +154,7 @@ public class IRMethod extends IRScope {
 
     private volatile ExitableInterpreterContext interpreterContextForJavaConstructor;
 
-    private synchronized ExitableInterpreterContext doBuiltInterperterContextForJavaConstructor() {
+    private synchronized ExitableInterpreterContext builtInterpreterContextForJavaConstructorImpl() {
         final InterpreterContext interpreterContext = builtInterpreterContext();
         if (usesSuper()) {
             // We know at least one super is in here somewhere
@@ -204,6 +203,15 @@ public class IRMethod extends IRScope {
         }
 
         return ExitableInterpreterContext.NULL;
+    }
+
+    /**
+     * This method was renamed (due a typo).
+     * @see #builtInterpreterContextForJavaConstructor()
+     */
+    @Deprecated
+    public ExitableInterpreterContext builtInterperterContextForJavaConstructor() {
+        return builtInterpreterContextForJavaConstructor();
     }
 
     final InterpreterContext lazilyAcquireInterpreterContext() {

--- a/core/src/main/java/org/jruby/ir/interpreter/ExitableInterpreterContext.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/ExitableInterpreterContext.java
@@ -27,8 +27,13 @@
 package org.jruby.ir.interpreter;
 
 import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
 
+import org.jruby.ir.IRFlags;
+import org.jruby.ir.IRScope;
 import org.jruby.ir.instructions.CallBase;
+import org.jruby.ir.instructions.Instr;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
@@ -36,14 +41,19 @@ import org.jruby.runtime.builtin.IRubyObject;
 
 public class ExitableInterpreterContext extends InterpreterContext {
 
+    public static final ExitableInterpreterContext NULL = new ExitableInterpreterContext(null, null, 0, null, null, 0);
+
     private final static ExitableInterpreterEngine EXITABLE_INTERPRETER = new ExitableInterpreterEngine();
 	
-    private CallBase superCall;
-    private int exitIPC;
+    private final CallBase superCall;
+    private final int exitIPC;
 
     public ExitableInterpreterContext(InterpreterContext originalIC, CallBase superCall, int exitIPC) {
-        super(originalIC.getScope(), Arrays.asList(originalIC.getInstructions()),
-                originalIC.getTemporaryVariableCount(), originalIC.getFlags());
+        this(originalIC.getScope(), Arrays.asList(originalIC.getInstructions()), originalIC.getTemporaryVariableCount(), originalIC.getFlags(), superCall, exitIPC);
+    }
+
+    private ExitableInterpreterContext(IRScope scope, List<Instr> instructions, int temporaryVariableCount, EnumSet<IRFlags> flags, CallBase superCall, int exitIPC) {
+        super(scope, instructions, temporaryVariableCount, flags);
 
         this.superCall = superCall;
         this.exitIPC = exitIPC;
@@ -58,8 +68,7 @@ public class ExitableInterpreterContext extends InterpreterContext {
     }
     
     @Override
-    public ExitableInterpreterEngine getEngine()
-    {
+    public ExitableInterpreterEngine getEngine() {
     	return EXITABLE_INTERPRETER;
     }
 

--- a/core/src/main/java/org/jruby/ir/interpreter/InterpreterContext.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/InterpreterContext.java
@@ -41,11 +41,11 @@ public class InterpreterContext {
     protected boolean hasExplicitCallProtocol; // Only can be true in Full+
     protected boolean dynamicScopeEliminated; // Only can be true in Full+
     private boolean reuseParentDynScope; // Only can be true in Full+
-    private boolean metaClassBodyScope;
+    private final boolean metaClassBodyScope;
 
     private InterpreterEngine engine;
     public final Supplier<List<Instr>> instructionsCallback;
-    private EnumSet<IRFlags> flags;
+    private final EnumSet<IRFlags> flags;
 
     private final IRScope scope;
 


### PR DESCRIPTION
Since JRuby 9.3 Ruby sub-classes of Java classes are backed with a generated Java class,
the interpreter context for the constructor was always rebuild from scratch on every IR method call -> effectively looping through method's instructions.

---

**NOTE**: while this improves numbers by 5x it's still 4x slower than JRuby 9.2 (should probably implement a way of JIT-ing and avoid method lookup), the script from: https://github.com/jruby/jruby/issues/7763 ends up with the following numbers:

>```
> $ jruby slow_java_super.rb 
> jruby 9.2.20.0 (2.5.8) 2021-11-02 1a3255440b OpenJDK 64-Bit Server VM 11.0.14.1+1 on 11.0.14.1+1 +jit [linux-x86_64]
> 
> 1 RubyList.new(...) elapsed real-time: 3.4137503600068158
> 2 RubyList.new elapsed real-time: 2.6153695250031888
> ```

> ```
> $ jruby slow_java_super.rb 
> jruby 9.3.10.0 (2.6.8) 2023-02-01 107b2e6697 OpenJDK 64-Bit Server VM 11.0.14.1+1 on 11.0.14.1+1 +jit [x86_64-linux]
> 
> 1 RubyList.new(...) elapsed real-time: 54.96447179099778
> 2 RubyList.new elapsed real-time: 54.98580553600186
> ```

```
bin/jruby slow_java_super.rb 
jruby 9.3.11.0-SNAPSHOT (2.6.8) 2023-04-20 0a07e21a3b OpenJDK 64-Bit Server VM 25.322-b06 on 1.8.0_322-b06 +jit [x86_64-linux]

1 RubyList.new(...) elapsed real-time: 9.032593938994978
2 RubyList.new elapsed real-time: 7.724980847997358

```