### PR TITLE
Fixes #7769. regexp with / before mbc should work.

### DIFF
--- a/spec/ruby/core/regexp/shared/new.rb
+++ b/spec/ruby/core/regexp/shared/new.rb
@@ -432,6 +432,10 @@ describe :regexp_new_string, shared: true do
       Regexp.send(@method, "\056\x42\u3042\x52\076").should == /#{"\x2e\x42\u3042\x52\x3e"}/
     end
 
+    it "accepts a multiple byte character which need not be escaped" do
+      Regexp.send(@method, "\§").should == /#{"§"}/
+    end
+
     it "raises a RegexpError if less than four digits are given for \\uHHHH" do
       -> { Regexp.send(@method, "\\" + "u304") }.should raise_error(RegexpError)
     end


### PR DESCRIPTION
Test case is: ```Regexp.new(%q{\§})``` (spec will be coming as separate commit).  Problem was we were missing mbc logic in backslash processing.  It would advance one too many times and then only see half of the mbc.

I should have put this against 9.3.x as well but I will cherry-pick it back.