### PR TITLE
FIXED #7710

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -127,7 +127,22 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
             this.value = context.nil;
             return value;
         }
+    }
 
+    private RubyEnumerator(Ruby runtime, RubyClass type) {
+        super(runtime, type);
+        initialize(runtime, runtime.getNil(), RubyString.newEmptyString(runtime), NULL_ARRAY);
+    }
+
+    private RubyEnumerator(Ruby runtime, RubyClass type, IRubyObject object, RubySymbol method, IRubyObject[] args,
+                           IRubyObject size, SizeFn sizeFn, boolean keywords) {
+        super(runtime, type);
+        initialize(runtime, object, method, args, size, sizeFn, keywords);
+    }
+
+    private RubyEnumerator(Ruby runtime, RubyClass type, IRubyObject object, IRubyObject method, IRubyObject[] args) {
+        super(runtime, type);
+        initialize(runtime, object, method, args);
     }
 
     /**
@@ -210,6 +225,8 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
         if (size == null) {
             sizeFn = RubyEnumerable::size;
         }
+
+        instance.initialize(context.runtime, object, method, methodArgs, size, sizeFn, keywords);
         // set: @receiver = obj.object, @method = obj.method || :each, *@args = obj.args || []
         // (for Lazy#inspect)
         instance.setInstanceVariable("@receiver", object);
@@ -222,16 +239,6 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
     @Override
     public IRubyObject initialize(ThreadContext context) {
         return initialize(context, Block.NULL_BLOCK);
-    }
-
-    @JRubyMethod(name = "initialize", visibility = PRIVATE)
-    public IRubyObject initialize(ThreadContext context, Block block) {
-        return initializeWithSize(context, null, block);
-    }
-
-    @JRubyMethod(name = "initialize", visibility = PRIVATE)
-    public IRubyObject initialize(ThreadContext context, IRubyObject size, Block block) {
-        return initializeWithSize(context, size, block);
     }
 
     private static void checkSize(IRubyObject size, Ruby runtime) {
@@ -569,6 +576,7 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
         RubyProducer producer = RubyProducer.newProducer(context, init, block);
         return enumeratorizeWithSize(context, producer, "each", RubyProducer::size);
     }
+
 
     @Deprecated
     public IRubyObject inspect19(ThreadContext context) {

--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -131,7 +131,7 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
 
     private RubyEnumerator(Ruby runtime, RubyClass type) {
         super(runtime, type);
-        initialize(runtime, runtime.getNil(), RubyString.newEmptyString(runtime), NULL_ARRAY);
+        initialize(runtime, runtime.getNil(), RubyString.newEmptyString(runtime), NULL_ARRAY, null, null, false);
     }
 
     private RubyEnumerator(Ruby runtime, RubyClass type, IRubyObject object, RubySymbol method, IRubyObject[] args,
@@ -142,7 +142,7 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
 
     private RubyEnumerator(Ruby runtime, RubyClass type, IRubyObject object, IRubyObject method, IRubyObject[] args) {
         super(runtime, type);
-        initialize(runtime, object, method, args);
+        initialize(runtime, object, method, args, null, null, false);
     }
 
     /**
@@ -236,11 +236,6 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
         return instance;
     }
 
-    @Override
-    public IRubyObject initialize(ThreadContext context) {
-        return initialize(context, Block.NULL_BLOCK);
-    }
-
     private static void checkSize(IRubyObject size, Ruby runtime) {
         if (size != null &&
                 !(size.isNil() || size.respondsTo("call")) &&
@@ -259,10 +254,6 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
         IRubyObject method = runtime.newSymbol("each");
 
         return initialize(runtime, object, method, NULL_ARRAY, size, null, false);
-    }
-
-    private IRubyObject initialize(Ruby runtime, IRubyObject object, IRubyObject method, IRubyObject[] methodArgs) {
-        return initialize(runtime, object, method, methodArgs, null, null, false);
     }
 
     private IRubyObject initialize(Ruby runtime, IRubyObject object, IRubyObject method, IRubyObject[] methodArgs,

--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -130,22 +130,6 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
 
     }
 
-    private RubyEnumerator(Ruby runtime, RubyClass type) {
-        super(runtime, type);
-        initialize(runtime, runtime.getNil(), RubyString.newEmptyString(runtime), NULL_ARRAY);
-    }
-
-    private RubyEnumerator(Ruby runtime, RubyClass type, IRubyObject object, RubySymbol method, IRubyObject[] args,
-                           IRubyObject size, SizeFn sizeFn, boolean keywords) {
-        super(runtime, type);
-        initialize(runtime, object, method, args, size, sizeFn, keywords);
-    }
-
-    private RubyEnumerator(Ruby runtime, RubyClass type, IRubyObject object, IRubyObject method, IRubyObject[] args) {
-        super(runtime, type);
-        initialize(runtime, object, method, args);
-    }
-
     /**
      * Transform object into an Enumerator with the given size
      */
@@ -226,8 +210,6 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
         if (size == null) {
             sizeFn = RubyEnumerable::size;
         }
-
-        instance.initialize(context.runtime, object, method, methodArgs, size, sizeFn, keywords);
         // set: @receiver = obj.object, @method = obj.method || :each, *@args = obj.args || []
         // (for Lazy#inspect)
         instance.setInstanceVariable("@receiver", object);
@@ -586,20 +568,6 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
 
         RubyProducer producer = RubyProducer.newProducer(context, init, block);
         return enumeratorizeWithSize(context, producer, "each", RubyProducer::size);
-    }
-
-    @Deprecated
-    public IRubyObject initialize(ThreadContext context, IRubyObject[] args, Block block) {
-        Ruby runtime = context.runtime;
-
-        IRubyObject size = Arity.checkArgumentCount(runtime, args, 0, 1) == 1 ? args[0] : null;
-
-        return initializeWithSize(context, size, block);
-    }
-
-    @Deprecated
-    public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
-        return initialize(context, args, Block.NULL_BLOCK);
     }
 
     @Deprecated


### PR DESCRIPTION
Some Ruby methods being removed in MRI. There are some dead codes in RubyEnumerator, so I removed it. It used to create Ruby for lazy evaluation and to create infinite sequences, but some of the code required modification. That modification brought dead code in Enumerator java code.