### PR TITLE
Fixes #7774. ripper presents an extra on_var_field for opt params

### DIFF
--- a/core/src/main/java/org/jruby/ext/ripper/RipperParser.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RipperParser.java
@@ -6379,7 +6379,7 @@ states[759] = (RipperParser p, Object yyVal, ProductionState[] yyVals, int yyTop
   return yyVal;
 };
 states[760] = (RipperParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
-                      yyVal = p.new_assoc(p.assignable(yyVals[yyTop - count + 1].id, p.var_field(((IRubyObject)yyVals[-2+yyTop].value))), ((IRubyObject)yyVals[0+yyTop].value));
+                      yyVal = p.new_assoc(p.assignable(yyVals[yyTop - count + 1].id, ((IRubyObject)yyVals[-2+yyTop].value)), ((IRubyObject)yyVals[0+yyTop].value));
 
 
   return yyVal;
@@ -6387,7 +6387,7 @@ states[760] = (RipperParser p, Object yyVal, ProductionState[] yyVals, int yyTop
 states[761] = (RipperParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
                     p.getLexContext().in_argdef = true;
                     p.setCurrentArg(null);
-                      yyVal = p.new_assoc(p.assignable(yyVals[yyTop - count + 1].id, p.var_field(((IRubyObject)yyVals[-2+yyTop].value))), ((IRubyObject)yyVals[0+yyTop].value));
+                      yyVal = p.new_assoc(p.assignable(yyVals[yyTop - count + 1].id, ((IRubyObject)yyVals[-2+yyTop].value)), ((IRubyObject)yyVals[0+yyTop].value));
 
   return yyVal;
 };

--- a/core/src/main/java/org/jruby/parser/RubyParser.java
+++ b/core/src/main/java/org/jruby/parser/RubyParser.java
@@ -6492,7 +6492,7 @@ states[760] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
                     p.getLexContext().in_argdef = true;
                     yyVal = new OptArgNode(yyVals[yyTop - count + 3].start(), p.assignableLabelOrIdentifier(((ArgumentNode)yyVals[-2+yyTop].value).getName().getBytes(), ((Node)yyVals[0+yyTop].value)));
                     /*%
-                      $$ = p.new_assoc(p.assignable(yyVals[yyTop - count + 1].id, p.var_field($1)), $3);
+                      $$ = p.new_assoc(p.assignable(yyVals[yyTop - count + 1].id, $1), $3);
                     %*/
 
   return yyVal;
@@ -6503,7 +6503,7 @@ states[761] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
                     /*%%%*/
                     yyVal = new OptArgNode(yyVals[yyTop - count + 3].start(), p.assignableLabelOrIdentifier(((ArgumentNode)yyVals[-2+yyTop].value).getName().getBytes(), ((Node)yyVals[0+yyTop].value)));
                     /*%
-                      $$ = p.new_assoc(p.assignable(yyVals[yyTop - count + 1].id, p.var_field($1)), $3);
+                      $$ = p.new_assoc(p.assignable(yyVals[yyTop - count + 1].id, $1), $3);
                     %*/
   return yyVal;
 };

--- a/core/src/main/java/org/jruby/parser/RubyParser.y
+++ b/core/src/main/java/org/jruby/parser/RubyParser.y
@@ -4546,7 +4546,7 @@ f_opt           : f_arg_asgn f_eq arg_value {
                     p.getLexContext().in_argdef = true;
                     $$ = new OptArgNode(@3.start(), p.assignableLabelOrIdentifier($1.getName().getBytes(), $3));
                     /*%
-                      $$ = p.new_assoc(p.assignable(@1.id, p.var_field($1)), $3);
+                      $$ = p.new_assoc(p.assignable(@1.id, $1), $3);
                     %*/
 
                 }
@@ -4557,7 +4557,7 @@ f_block_opt     : f_arg_asgn f_eq primary_value {
                     /*%%%*/
                     $$ = new OptArgNode(@3.start(), p.assignableLabelOrIdentifier($1.getName().getBytes(), $3));
                     /*%
-                      $$ = p.new_assoc(p.assignable(@1.id, p.var_field($1)), $3);
+                      $$ = p.new_assoc(p.assignable(@1.id, $1), $3);
                     %*/
                 }
 


### PR DESCRIPTION
Fixes #7774.  We were calling var_field for opt params and opt block params when we shouldn't have been.  Simple fix.