### PR TITLE
Fix defined?(super) on BasicObject from causing NullPointerException

### DIFF
--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1004,6 +1004,7 @@ public class IRRuntimeHelpers {
     @JIT
     public static IRubyObject isDefinedSuper(ThreadContext context, IRubyObject receiver, String frameName, RubyModule frameClass, IRubyObject definedMessage) {
         boolean defined = frameName != null && frameClass != null &&
+                frameClass.getSuperClass() != null &&
                 frameClass.getSuperClass().isMethodBound(frameName, false);
 
         return defined ? definedMessage : context.nil;


### PR DESCRIPTION
Related to https://github.com/ruby/ruby/pull/7758

Stops `defined?(super)` on `BasicObject` from causing a NullPointerException and instead makes it return `nil` like expected

```rb
class BasicObject
  def nullPtr
    defined?(super)
  end
end

nullPtr
```