### PR TITLE
[build] make generated .class files deterministic

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1210,9 +1210,12 @@ public class RubyModule extends RubyObject {
         public Map<Set<FrameField>, List<String>> readGroups = Collections.EMPTY_MAP;
         public Map<Set<FrameField>, List<String>> writeGroups = Collections.EMPTY_MAP;
 
-        @SuppressWarnings("deprecation")
         public void clump(final Class klass) {
-            Method[] declaredMethods = MethodGatherer.DECLARED_METHODS.get(klass);
+            clump(MethodGatherer.DECLARED_METHODS.get(klass));
+        }
+
+        @SuppressWarnings("deprecation")
+        public void clump(final Method[] declaredMethods) {
             for (Method method: declaredMethods) {
                 JRubyMethod anno = method.getAnnotation(JRubyMethod.class);
 

--- a/core/src/main/java/org/jruby/anno/AnnotationBinder.java
+++ b/core/src/main/java/org/jruby/anno/AnnotationBinder.java
@@ -165,14 +165,18 @@ public class AnnotationBinder extends AbstractProcessor {
             out.println("        Ruby runtime = cls.getRuntime();");
             out.println("        boolean core = runtime.isBootingCore();");
 
-            Map<CharSequence, List<ExecutableElement>> annotatedMethods = new HashMap<>();
-            Map<CharSequence, List<ExecutableElement>> staticAnnotatedMethods = new HashMap<>();
+            Map<CharSequence, List<ExecutableElement>> annotatedMethods = new LinkedHashMap<>();
+            Map<CharSequence, List<ExecutableElement>> staticAnnotatedMethods = new LinkedHashMap<>();
 
             Map<Set<FrameField>, List<String>> readGroups = new HashMap<>();
             Map<Set<FrameField>, List<String>> writeGroups = new HashMap<>();
 
+            List<ExecutableElement> methods = ElementFilter.methodsIn(cd.getEnclosedElements());
+            methods.sort((m1, m2) -> m1.toString().compareTo(m2.toString())); // e.g.
+            // "methodName(org.jruby.runtime.ThreadContext,org.jruby.runtime.builtin.IRubyObject)"
+
             int methodCount = 0;
-            for (ExecutableElement method : ElementFilter.methodsIn(cd.getEnclosedElements())) {
+            for (ExecutableElement method : methods) {
                 JRubyMethod anno = method.getAnnotation(JRubyMethod.class);
 
                 if (anno == null) continue;
@@ -221,6 +225,8 @@ public class AnnotationBinder extends AbstractProcessor {
 
             processMethodDeclarations(staticAnnotatedMethods);
             gatherMappings(staticAnnotatedMethods, mappings);
+
+            out.println("");
 
             processMethodDeclarations(annotatedMethods);
             gatherMappings(annotatedMethods, mappings);


### PR DESCRIPTION
This PR contains 2 commits which should make the generated .class files more deterministic.

Essentially the problem is `Class#getDeclaredMethods` returns an undefined order, so even when a simple patch is applied to a stable version one ends up with a ton of .class files (mostly the "INVOKER" ones) *modified* in the resulting artifact (jruby-base.jar).

---
sample diff after re-compiling and decompiling `org/jruby/RubyArray\$INVOKER\$i\$all_p.class` using `javap` (nothing was changed against stable 9.3.10.0 the difference is likely just a different Java or OS version):
```diff
16,17c16,17
<   public org.jruby.runtime.builtin.IRubyObject call(org.jruby.runtime.ThreadContext, org.jruby.runtime.builtin.IRubyObject, org.jruby.RubyModule, java.lang.String, org.jruby.runtime.builtin.IRubyObject, org.jruby.runtime.Block);
<     descriptor: (Lorg/jruby/runtime/ThreadContext;Lorg/jruby/runtime/builtin/IRubyObject;Lorg/jruby/RubyModule;Ljava/lang/String;Lorg/jruby/runtime/builtin/IRubyObject;Lorg/jruby/runtime/Block;)Lorg/jruby/runtime/builtin/IRubyObject;
---
>   public org.jruby.runtime.builtin.IRubyObject call(org.jruby.runtime.ThreadContext, org.jruby.runtime.builtin.IRubyObject, org.jruby.RubyModule, java.lang.String, org.jruby.runtime.Block);
>     descriptor: (Lorg/jruby/runtime/ThreadContext;Lorg/jruby/runtime/builtin/IRubyObject;Lorg/jruby/RubyModule;Ljava/lang/String;Lorg/jruby/runtime/Block;)Lorg/jruby/runtime/builtin/IRubyObject;
23,25c23,24
<        7: aload         6
<        9: invokevirtual #28                 // Method org/jruby/RubyArray.all_p:(Lorg/jruby/runtime/ThreadContext;Lorg/jruby/runtime/builtin/IRubyObject;Lorg/jruby/runtime/Block;)Lorg/jruby/runtime/builtin/IRubyObject;
<       12: areturn
---
>        7: invokevirtual #28                 // Method org/jruby/RubyArray.all_p:(Lorg/jruby/runtime/ThreadContext;Lorg/jruby/runtime/Block;)Lorg/jruby/runtime/builtin/IRubyObject;
>       10: areturn
27,28c26,27
<   public org.jruby.runtime.builtin.IRubyObject call(org.jruby.runtime.ThreadContext, org.jruby.runtime.builtin.IRubyObject, org.jruby.RubyModule, java.lang.String, org.jruby.runtime.Block);
<     descriptor: (Lorg/jruby/runtime/ThreadContext;Lorg/jruby/runtime/builtin/IRubyObject;Lorg/jruby/RubyModule;Ljava/lang/String;Lorg/jruby/runtime/Block;)Lorg/jruby/runtime/builtin/IRubyObject;
---
>   public org.jruby.runtime.builtin.IRubyObject call(org.jruby.runtime.ThreadContext, org.jruby.runtime.builtin.IRubyObject, org.jruby.RubyModule, java.lang.String, org.jruby.runtime.builtin.IRubyObject, org.jruby.runtime.Block);
>     descriptor: (Lorg/jruby/runtime/ThreadContext;Lorg/jruby/runtime/builtin/IRubyObject;Lorg/jruby/RubyModule;Ljava/lang/String;Lorg/jruby/runtime/builtin/IRubyObject;Lorg/jruby/runtime/Block;)Lorg/jruby/runtime/builtin/IRubyObject;
34,35c33,35
<        7: invokevirtual #32                 // Method org/jruby/RubyArray.all_p:(Lorg/jruby/runtime/ThreadContext;Lorg/jruby/runtime/Block;)Lorg/jruby/runtime/builtin/IRubyObject;
<       10: areturn
---
>        7: aload         6
>        9: invokevirtual #32                 // Method org/jruby/RubyArray.all_p:(Lorg/jruby/runtime/ThreadContext;Lorg/jruby/runtime/builtin/IRubyObject;Lorg/jruby/runtime/Block;)Lorg/jruby/runtime/builtin/IRubyObject;
>       12: areturn

```
---

NOTE: all of the code touched here should only be used during compilation - thus "if compiles" should be fairly low risk.