### PR TITLE
[build] update maven surefire plugin

### DIFF
--- a/pom.rb
+++ b/pom.rb
@@ -121,7 +121,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
 
     plugin :compiler, '3.8.1'
     plugin :shade, '3.2.4'
-    plugin :surefire, '3.0.0-M5'
+    plugin :surefire, '3.0.0'
     plugin :plugin, '3.6.0'
     plugin( :invoker, '3.2.1',
             'properties' => { 'jruby.version' => '${project.version}',

--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@ DO NOT MODIFY - GENERATED CODE
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>3.0.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-plugin-plugin</artifactId>


### PR DESCRIPTION
there were some failures due missing checksum from plugin:

```
Warning:  Could not validate integrity of download from
https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.0.0-M5/surefire-logger-api-3.0.0-M5.pom
org.eclipse.aether.transfer.ChecksumFailureException: Checksum
validation failed, no checksums available
```