### PR TITLE
Add support for a rescue trace event

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -4632,6 +4632,8 @@ public class IRBuilder {
         // Caught exception case -- build rescue body
         addInstr(new LabelInstr(caughtLabel));
         Node realBody = rescueBodyNode.getBodyNode();
+        int line = realBody instanceof NilImplicitNode ? rescueBodyNode.getLine() : realBody.getLine();
+        addInstr(new RuntimeHelperCall(createTemporaryVariable(), TRACE_RESCUE, new Operand[]{new FrozenString(getFileName()), new Integer(line + 1)}));
         Operand x = build(realBody);
         if (x != U_NIL) { // can be U_NIL if the rescue block has an explicit return
             // Set up node return value 'rv'

--- a/core/src/main/java/org/jruby/ir/instructions/RuntimeHelperCall.java
+++ b/core/src/main/java/org/jruby/ir/instructions/RuntimeHelperCall.java
@@ -7,7 +7,12 @@ import org.jruby.ir.IRScope;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
 import org.jruby.ir.operands.Boolean;
-import org.jruby.ir.operands.*;
+import org.jruby.ir.operands.Fixnum;
+import org.jruby.ir.operands.FrozenString;
+import org.jruby.ir.operands.Integer;
+import org.jruby.ir.operands.Operand;
+import org.jruby.ir.operands.Stringable;
+import org.jruby.ir.operands.Variable;
 import org.jruby.ir.persistence.IRReaderDecoder;
 import org.jruby.ir.persistence.IRWriterEncoder;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
@@ -27,7 +32,8 @@ public class RuntimeHelperCall extends NOperandResultBaseInstr {
         HANDLE_PROPAGATED_BREAK, HANDLE_NONLOCAL_RETURN, HANDLE_BREAK_AND_RETURNS_IN_LAMBDA,
         IS_DEFINED_BACKREF, IS_DEFINED_NTH_REF, IS_DEFINED_GLOBAL,
         IS_DEFINED_CLASS_VAR, IS_DEFINED_SUPER, IS_DEFINED_METHOD, IS_DEFINED_CALL,
-        IS_DEFINED_CONSTANT_OR_METHOD, MERGE_KWARGS, IS_HASH_EMPTY, HASH_CHECK, ARRAY_LENGTH;
+        IS_DEFINED_CONSTANT_OR_METHOD, MERGE_KWARGS, IS_HASH_EMPTY, HASH_CHECK, ARRAY_LENGTH,
+        TRACE_RESCUE;
 
         private static final Methods[] VALUES = values();
 
@@ -96,13 +102,12 @@ public class RuntimeHelperCall extends NOperandResultBaseInstr {
                              Object[] temp, Block block) {
         Operand[] operands = getOperands();
 
-        if (helperMethod == Methods.IS_DEFINED_BACKREF) {
-            return IRRuntimeHelpers.isDefinedBackref(
-                    context,
-                    (IRubyObject) operands[0].retrieve(context, self, currScope, currDynScope, temp));
-        }
-
+        // These have special operands[0] that we may not want to execute
         switch (helperMethod) {
+            case IS_DEFINED_BACKREF:
+                return IRRuntimeHelpers.isDefinedBackref(
+                        context,
+                        (IRubyObject) operands[0].retrieve(context, self, currScope, currDynScope, temp));
             case IS_DEFINED_NTH_REF:
                 return IRRuntimeHelpers.isDefinedNthRef(
                         context,
@@ -113,6 +118,9 @@ public class RuntimeHelperCall extends NOperandResultBaseInstr {
                         context,
                         ((Stringable) operands[0]).getString(),
                         (IRubyObject) operands[1].retrieve(context, self, currScope, currDynScope, temp));
+            case TRACE_RESCUE:
+                IRRuntimeHelpers.traceRescue(context, ((Stringable) operands[0]).getString(), (int) ((Integer) operands[1]).getValue());
+                return context.nil;
         }
 
         Object arg1 = operands[0].retrieve(context, self, currScope, currDynScope, temp);

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -2460,6 +2460,13 @@ public class IRRuntimeHelpers {
         }
     }
 
+    public static void traceRescue(ThreadContext context, String file, int line) {
+        TraceEventManager traceEvents = context.traceEvents;
+        if (traceEvents.hasEventHooks()) {
+            traceEvents.callEventHooks(context, RubyEvent.RESCUE, file, line, null, context.getErrorInfo());
+        }
+    }
+
     @JIT
     public static void callTrace(ThreadContext context, Block selfBlock, RubyEvent event, String name, String filename, int line) {
         TraceEventManager traceEvents = context.traceEvents;

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -2415,6 +2415,12 @@ public class JVMVisitor extends IRVisitor {
                 jvmMethod().invokeIRHelper("arrayLength", sig(int.class, RubyArray.class));
                 jvmStoreLocal(runtimehelpercall.getResult());
                 break;
+            case TRACE_RESCUE:
+                jvmMethod().loadContext();
+                jvmAdapter().ldc(((Stringable) runtimehelpercall.getOperands()[0]).getString());
+                visit(runtimehelpercall.getOperands()[1]);
+                jvmMethod().invokeIRHelper("traceRescue", sig(void.class, ThreadContext.class, String.class, int.class));
+                break;
             default:
                 throw new NotCompilableException("Unknown IR runtime helper method: " + runtimehelpercall.getHelperMethod() + "; INSTR: " + this);
         }

--- a/core/src/main/java/org/jruby/runtime/RubyEvent.java
+++ b/core/src/main/java/org/jruby/runtime/RubyEvent.java
@@ -29,7 +29,8 @@ public enum RubyEvent {
     // A_CALL is CALL + B_CALL + C_CALL
     A_CALL   ("a_call"),
     // A_RETURN is RETURN + B_RETURN + C_RETURN
-    A_RETURN ("a_return");
+    A_RETURN ("a_return"),
+    RESCUE ("rescue", false);
 
     public static final Set<RubyEvent> ALL_EVENTS = Collections.synchronizedSet(EnumSet.allOf(RubyEvent.class));
     public static final EnumSet ALL_EVENTS_ENUMSET = EnumSet.copyOf(RubyEvent.ALL_EVENTS);


### PR DESCRIPTION
Discussed in CRuby core developer meeting May 10, 2023 at RubyKaigi.

One test exists for this in the 3.3 ruby/test_settracefunc.rb and will be merged in once we update CRuby tests.

See https://bugs.ruby-lang.org/issues/19572