### PR TITLE
[deps] update joda-time to latest 2.12.5

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -65,7 +65,7 @@ project 'JRuby Base' do
   jar 'org.osgi:org.osgi.core:5.0.0', :scope => 'provided'
 
   # joda timezone must be before joda-time to be packed correctly
-  jar 'org.jruby:joda-timezones:${tzdata.version}', :scope => '${tzdata.scope}'
+  # jar 'org.jruby:joda-timezones:${tzdata.version}', :scope => '${tzdata.scope}'
   jar 'joda-time:joda-time:${joda.time.version}'
 
   # SLF4J only used within SLF4JLogger (JRuby logger impl) class

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -200,12 +200,6 @@ DO NOT MODIFY - GENERATED CODE
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.jruby</groupId>
-      <artifactId>joda-timezones</artifactId>
-      <version>${tzdata.version}</version>
-      <scope>${tzdata.scope}</scope>
-    </dependency>
-    <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
       <version>${joda.time.version}</version>

--- a/pom.rb
+++ b/pom.rb
@@ -73,7 +73,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
               'asm.version' => '9.2',
               'jar-dependencies.version' => '0.4.1',
               'jffi.version' => '1.3.10',
-              'joda.time.version' => '2.10.10' )
+              'joda.time.version' => '2.12.5' )
 
   plugin_management do
     jar( 'junit:junit:4.13.1',

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@ DO NOT MODIFY - GENERATED CODE
     <its.osgi>osgi*/pom.xml</its.osgi>
     <jar-dependencies.version>0.4.1</jar-dependencies.version>
     <jffi.version>1.3.10</jffi.version>
-    <joda.time.version>2.10.10</joda.time.version>
+    <joda.time.version>2.12.5</joda.time.version>
     <jruby-launcher.version>1.1.6</jruby-launcher.version>
     <jruby.basedir>${project.basedir}</jruby.basedir>
     <jruby.plugins.version>1.0.10</jruby.plugins.version>


### PR DESCRIPTION
believe we should also release and update `tzdata.version` from **2019c** to **2023cgtz** (used in joda-time 2.12.2).

I wonder if the `org.jruby:joda-timezones` matters thought given the current **2019c** version was not aligned with `joda-time` 2.10.10 which is meant to be using (packages inside the joda-time.jar) **2021a**