### PR TITLE
Update time and uri for recent ReDoS issues

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -106,7 +106,7 @@ default_gems = [
     # ['tempfile', '0.1.2'],
     # Depends on date gem
     # ['time', '0.2.0'],
-    ['time', '0.1.0'],
+    ['time', '0.1.1'],
     ['timeout', '0.3.0'],
     # https://github.com/ruby/tmpdir/issues/13
     # ['tmpdir', '0.1.2'],

--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -112,7 +112,7 @@ default_gems = [
     # ['tmpdir', '0.1.2'],
     ['tsort', '0.1.0'],
     ['un', '0.2.0'],
-    ['uri', '0.11.0'],
+    ['uri', '0.11.1'],
     ['weakref', '0.1.1'],
     # https://github.com/ruby/win32ole/issues/12
     # ['win32ole', '1.8.8'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -827,7 +827,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>uri</artifactId>
-      <version>0.11.0</version>
+      <version>0.11.1</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1101,7 +1101,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/timeout-0.3.0*</include>
           <include>specifications/tsort-0.1.0*</include>
           <include>specifications/un-0.2.0*</include>
-          <include>specifications/uri-0.11.0*</include>
+          <include>specifications/uri-0.11.1*</include>
           <include>specifications/weakref-0.1.1*</include>
           <include>specifications/yaml-0.2.0*</include>
           <include>specifications/matrix-0.4.2*</include>
@@ -1177,7 +1177,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/timeout-0.3.0*/**/*</include>
           <include>gems/tsort-0.1.0*/**/*</include>
           <include>gems/un-0.2.0*/**/*</include>
-          <include>gems/uri-0.11.0*/**/*</include>
+          <include>gems/uri-0.11.1*/**/*</include>
           <include>gems/weakref-0.1.1*/**/*</include>
           <include>gems/yaml-0.2.0*/**/*</include>
           <include>gems/matrix-0.4.2*/**/*</include>
@@ -1253,7 +1253,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/timeout-0.3.0*</include>
           <include>cache/tsort-0.1.0*</include>
           <include>cache/un-0.2.0*</include>
-          <include>cache/uri-0.11.0*</include>
+          <include>cache/uri-0.11.1*</include>
           <include>cache/weakref-0.1.1*</include>
           <include>cache/yaml-0.2.0*</include>
           <include>cache/matrix-0.4.2*</include>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -775,7 +775,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>time</artifactId>
-      <version>0.1.0</version>
+      <version>0.1.1</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1097,7 +1097,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/subspawn-posix-0.1.1*</include>
           <include>specifications/ffi-binary-libfixposix-0.5.1.0*</include>
           <include>specifications/ffi-bindings-libfixposix-0.5.1.0*</include>
-          <include>specifications/time-0.1.0*</include>
+          <include>specifications/time-0.1.1*</include>
           <include>specifications/timeout-0.3.0*</include>
           <include>specifications/tsort-0.1.0*</include>
           <include>specifications/un-0.2.0*</include>
@@ -1173,7 +1173,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/subspawn-posix-0.1.1*/**/*</include>
           <include>gems/ffi-binary-libfixposix-0.5.1.0*/**/*</include>
           <include>gems/ffi-bindings-libfixposix-0.5.1.0*/**/*</include>
-          <include>gems/time-0.1.0*/**/*</include>
+          <include>gems/time-0.1.1*/**/*</include>
           <include>gems/timeout-0.3.0*/**/*</include>
           <include>gems/tsort-0.1.0*/**/*</include>
           <include>gems/un-0.2.0*/**/*</include>
@@ -1249,7 +1249,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/subspawn-posix-0.1.1*</include>
           <include>cache/ffi-binary-libfixposix-0.5.1.0*</include>
           <include>cache/ffi-bindings-libfixposix-0.5.1.0*</include>
-          <include>cache/time-0.1.0*</include>
+          <include>cache/time-0.1.1*</include>
           <include>cache/timeout-0.3.0*</include>
           <include>cache/tsort-0.1.0*</include>
           <include>cache/un-0.2.0*</include>


### PR DESCRIPTION
time: https://www.ruby-lang.org/en/news/2023/03/30/redos-in-time-cve-2023-28756/

uri: https://www.ruby-lang.org/en/news/2023/03/28/redos-in-uri-cve-2023-28755/