### PR TITLE
Reduce contention in heavy IO operations

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -1067,7 +1067,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      * @see org.jruby.runtime.builtin.IRubyObject#dataWrapStruct(Object)
      */
     @Override
-    public synchronized void dataWrapStruct(Object obj) {
+    public void dataWrapStruct(Object obj) {
         if (obj == null) {
             removeInternalVariable("__wrap_struct__");
         } else {
@@ -1086,7 +1086,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      * @see org.jruby.runtime.builtin.IRubyObject#dataGetStruct()
      */
     @Override
-    public synchronized Object dataGetStruct() {
+    public Object dataGetStruct() {
         return getInternalVariable("__wrap_struct__");
     }
 

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1418,9 +1418,39 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
      * @param context the current context
      * @param str the string to write
      */
-    @JRubyMethod(name = "write", required = 1)
+    @JRubyMethod(name = "write")
     public IRubyObject write(ThreadContext context, IRubyObject str) {
         return write(context, str, false);
+    }
+
+    /**
+     * Ruby method IO#write(str, ...), equivalent to io_write_m.
+     *
+     * @param context the current context
+     * @param arg0 the first string to write
+     * @param arg1 the second string to write
+     */
+    @JRubyMethod(name = "write")
+    public IRubyObject write2(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
+        long acc = RubyNumeric.num2long(write(context, arg0, false));
+        acc += RubyNumeric.num2long(write(context, arg1, false));
+        return RubyFixnum.newFixnum(context.runtime, acc);
+    }
+
+    /**
+     * Ruby method IO#write(str, ...), equivalent to io_write_m.
+     *
+     * @param context the current context
+     * @param arg0 the first string to write
+     * @param arg1 the second string to write
+     * @param arg2 the third string to write
+     */
+    @JRubyMethod(name = "write")
+    public IRubyObject write3(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
+        long acc = RubyNumeric.num2long(write(context, arg0, false));
+        acc += RubyNumeric.num2long(write(context, arg1, false));
+        acc += RubyNumeric.num2long(write(context, arg2, false));
+        return RubyFixnum.newFixnum(context.runtime, acc);
     }
 
     /**

--- a/core/src/main/java/org/jruby/util/io/SelectorPool.java
+++ b/core/src/main/java/org/jruby/util/io/SelectorPool.java
@@ -63,7 +63,7 @@ public class SelectorPool {
      * @return a java.nio.channels.Selector
      * @throws IOException if there's a problem opening a new selector
      */
-    public synchronized Selector get() throws IOException{
+    public Selector get() throws IOException{
         return retrieveFromPool(SelectorProvider.provider());
     }
 
@@ -74,7 +74,7 @@ public class SelectorPool {
      * @return a java.nio.channels.Selector
      * @throws IOException if there's a problem opening a new selector
      */
-    public synchronized Selector get(SelectorProvider provider) throws IOException{
+    public Selector get(SelectorProvider provider) throws IOException{
         return retrieveFromPool(provider);
     }
 
@@ -125,11 +125,14 @@ public class SelectorPool {
     }
 
     private Selector retrieveFromPool(SelectorProvider provider) throws IOException {
-        List<Selector> providerPool = pool.get(provider);
-        if (providerPool != null && !providerPool.isEmpty()) {
-            return providerPool.remove(providerPool.size() - 1);
+        synchronized (this) {
+            List<Selector> providerPool = pool.get(provider);
+            if (providerPool != null && !providerPool.isEmpty()) {
+                return providerPool.remove(providerPool.size() - 1);
+            }
         }
 
+        // otherwise just return a new one
         return SelectorFactory.openWithRetryFrom(null, provider);
     }
 

--- a/core/src/main/java/org/jruby/util/io/SelectorPool.java
+++ b/core/src/main/java/org/jruby/util/io/SelectorPool.java
@@ -33,13 +33,13 @@ import java.io.IOException;
 import java.nio.channels.ClosedSelectorException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
-import java.util.List;
 
 import java.nio.channels.spi.SelectorProvider;
-import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.Map;
-import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * This is a simple implementation of a hard-referenced java.nio.channels.Selector
@@ -54,7 +54,7 @@ import java.util.Iterator;
  * @author headius
  */
 public class SelectorPool {
-    private final Map<SelectorProvider, List<Selector>> pool = new HashMap<SelectorProvider, List<Selector>>();
+    private final Map<SelectorProvider, Queue<Selector>> pool = new ConcurrentHashMap<>();
 
     /**
      * Get a selector from the pool (or create a new one). Selectors come from
@@ -109,26 +109,36 @@ public class SelectorPool {
      * All selectors in a pool are closed and the pool gets empty.
      * 
      */
-    public synchronized void cleanup() {
-        for (Map.Entry<SelectorProvider, List<Selector>> entry : pool.entrySet()) {
-            List<Selector> providerPool = entry.getValue();
-            while (!providerPool.isEmpty()) {
-                Selector selector = providerPool.remove(providerPool.size() - 1);
-                try {
-                    selector.close();
-                } catch (IOException ioe) {
-                    // ignore IOException at termination.
-                }
-            }
-        }
+    public void cleanup() {
+        pool.forEach(SelectorPool::clearProviderPool);
         pool.clear();
     }
 
+    private static void clearProviderPool(SelectorProvider provider, Queue<Selector> providerPool) {
+        while (!providerPool.isEmpty()) {
+            Selector selector;
+            try {
+                selector = providerPool.remove();
+            } catch (NoSuchElementException nsme) {
+                // empty, done
+                break;
+            }
+
+            try {
+                selector.close();
+            } catch (IOException ioe) {
+                // ignore IOException at termination.
+            }
+        }
+    }
+
     private Selector retrieveFromPool(SelectorProvider provider) throws IOException {
-        synchronized (this) {
-            List<Selector> providerPool = pool.get(provider);
-            if (providerPool != null && !providerPool.isEmpty()) {
-                return providerPool.remove(providerPool.size() - 1);
+        Queue<Selector> providerPool = pool.get(provider);
+        if (providerPool != null && !providerPool.isEmpty()) {
+            try {
+                return providerPool.remove();
+            } catch (NoSuchElementException nsme) {
+                // someone drained it before us, just fall back on creating a new one below
             }
         }
 
@@ -136,14 +146,10 @@ public class SelectorPool {
         return SelectorFactory.openWithRetryFrom(null, provider);
     }
 
-    private synchronized void returnToPool(Selector selector) {
+    private void returnToPool(Selector selector) {
         if (selector.isOpen()) {
             SelectorProvider provider = selector.provider();
-            List<Selector> providerPool = pool.get(provider);
-            if (providerPool == null) {
-                providerPool = new LinkedList<Selector>();
-                pool.put(provider, providerPool);
-            }
+            Queue<Selector> providerPool = pool.computeIfAbsent(provider, p -> new ConcurrentLinkedQueue<>());
             providerPool.add(selector);
         }
     }

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -203,7 +203,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>jruby-openssl</artifactId>
-      <version>0.14.0</version>
+      <version>0.14.1</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>


### PR DESCRIPTION
This moves the creation of a new selector outside of the sync section, to avoid blocking threads that are just trying to put a selector back when we are waiting to open a new one.

This whole class could use some improvement using nonblocking collections, but this should help reduce contention for now.

Edit: This has expanded to remove additional areas of contention.

See jruby/jruby#7805.