### PR TITLE
Update to backport9 1.13 for module javadoc fix

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -74,7 +74,7 @@ project 'JRuby Base' do
 
   jar 'me.qmx.jitescript:jitescript:0.4.1', :exclusions => ['org.ow2.asm:asm-all']
 
-  jar 'com.headius:backport9:1.12'
+  jar 'com.headius:backport9:1.13'
 
   jar 'jakarta.annotation:jakarta.annotation-api:2.0.0', scope: 'provided'
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -236,7 +236,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>com.headius</groupId>
       <artifactId>backport9</artifactId>
-      <version>1.12</version>
+      <version>1.13</version>
     </dependency>
     <dependency>
       <groupId>jakarta.annotation</groupId>


### PR DESCRIPTION
We still use an internal class, StackWalker8, which I exposed in backport9 1.13. This allows javadoc under Java 11 to generate successfully.

There's still more work to fully modularize.

Fixes the last part of #6607.