### PR TITLE
Remove the CALL_KEYWORD_EMPTY masking

### DIFF
--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -827,8 +827,7 @@ public class IRRuntimeHelpers {
 
     @JIT @Interp
     public static void setCallInfo(ThreadContext context, int flags) {
-        // FIXME: This may propagate empty more than the current call?   empty might need to be stuff elsewhere to prevent this.
-        context.callInfo = (context.callInfo & CALL_KEYWORD_EMPTY) | flags;
+        context.callInfo = flags;
     }
 
     // specific args of arity 0 does not receive kwargs so we have to reset this.


### PR DESCRIPTION
This mask can cause empty keyword flags from a previous call to propagate into the next call. If that call passes keywords itself, it will impact arity checking as the empty flag triggers kwarg negotiation to not subtract one from the incoming arg count.

I am not sure why this flag gets propagated in this way, so I am pushing this as a test PR.