### PR TITLE
Update jzlib and fix mtime

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -58,7 +58,7 @@ project 'JRuby Base' do
   jar 'com.headius:invokebinder:1.13'
   jar 'com.headius:options:1.6'
 
-  jar 'com.jcraft:jzlib:1.1.3'
+  jar 'org.jruby:jzlib:1.1.4'
   jar 'junit:junit', :scope => 'test'
   jar 'org.awaitility:awaitility', :scope => 'test'
   jar 'org.apache.ant:ant:${ant.version}', :scope => 'provided'

--- a/core/pom.rb
+++ b/core/pom.rb
@@ -58,7 +58,7 @@ project 'JRuby Base' do
   jar 'com.headius:invokebinder:1.13'
   jar 'com.headius:options:1.6'
 
-  jar 'org.jruby:jzlib:1.1.4'
+  jar 'org.jruby:jzlib:1.1.5'
   jar 'junit:junit', :scope => 'test'
   jar 'org.awaitility:awaitility', :scope => 'test'
   jar 'org.apache.ant:ant:${ant.version}', :scope => 'provided'

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -174,7 +174,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>org.jruby</groupId>
       <artifactId>jzlib</artifactId>
-      <version>1.1.4</version>
+      <version>1.1.5</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -172,9 +172,9 @@ DO NOT MODIFY - GENERATED CODE
       <version>1.6</version>
     </dependency>
     <dependency>
-      <groupId>com.jcraft</groupId>
+      <groupId>org.jruby</groupId>
       <artifactId>jzlib</artifactId>
-      <version>1.1.3</version>
+      <version>1.1.4</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
@@ -136,6 +136,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         position = 0;
         line = 0;
         bufferedStream = new PushbackInputStream(new BufferedInputStream(io), 512);
+        mtime = org.jruby.RubyTime.newTime(runtime, io.getModifiedTime() * 1000);
 
         return this;
     }

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
@@ -320,21 +320,22 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
 
     @JRubyMethod(name = "mtime=", required = 1)
     public IRubyObject set_mtime(IRubyObject arg) {
+        Ruby runtime = getRuntime();
+
         if (arg instanceof RubyTime) {
             this.mtime = ((RubyTime) arg);
         } else if (arg.isNil()) {
             // ...nothing
         } else {
-            this.mtime.setDateTime(new DateTime(RubyNumeric.fix2long(arg) * 1000));
+            this.mtime = RubyTime.newTime(runtime, RubyNumeric.fix2long(arg) * 1000);
         }
-        
         try {
             io.setModifiedTime(this.mtime.to_i().getLongValue());
         } catch (GZIPException e) {
-            throw RubyZlib.newGzipFileError(getRuntime(), "header is already written");
+            throw RubyZlib.newGzipFileError(runtime, "header is already written");
         }
         
-        return getRuntime().getNil();
+        return runtime.getNil();
     }
 
     @Override


### PR DESCRIPTION
This fixes the bogus mtime on gzip readers by switching to the JRuby version of jzlib and populating mtime after the header has parsed.

This fixes jruby/jruby#7746 and rack/rack#2027.