### PR TITLE
Fixes #7804.  Incorrect ArgumentError: wrong number of arguments

### DIFF
--- a/core/src/main/java/org/jruby/ir/Operation.java
+++ b/core/src/main/java/org/jruby/ir/Operation.java
@@ -46,7 +46,7 @@ public enum Operation {
     RECV_SELF(0),
     RECV_PRE_REQD_ARG(OpFlags.f_is_arg_receive),
     RECV_POST_REQD_ARG(OpFlags.f_is_arg_receive),
-    RECV_KW(OpFlags.f_is_arg_receive),
+    RECV_KW(OpFlags.f_is_arg_receive | OpFlags.f_has_side_effect),
     RECV_KW_ARG(OpFlags.f_is_arg_receive),
     RECV_KW_REST_ARG(OpFlags.f_is_arg_receive),
     RECV_REST_ARG(OpFlags.f_is_arg_receive),


### PR DESCRIPTION
Problem was receive_keywords has a side-effect of resetting callInfo but dead code elimination thought it could be removed. Once removed it allowed CALL_KEYWORDS_EMPTY to persist from parent method to next call.