### PR TITLE
Use top self for evalScriptlet, since no frame yet

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -879,7 +879,7 @@ public final class Ruby implements Constantizable {
         context.preEvalScriptlet(scope);
 
         try {
-            return interpreter.execute(this, rootNode, context.getFrameSelf());
+            return interpreter.execute(this, rootNode, getTopSelf());
         } finally {
             context.postEvalScriptlet();
         }

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -1152,11 +1152,9 @@ public final class ThreadContext {
     }
 
     public void preEvalScriptlet(DynamicScope scope) {
-        pushScope(scope);
     }
 
     public void postEvalScriptlet() {
-        popScope();
     }
 
     public Frame preEvalWithBinding(Binding binding) {


### PR DESCRIPTION
No frame has been pushed yet for the script to run in, so we have no frame self to acquire. Use top self and let the script push a frame as needed.

Fixes #7820.

This may need to be backported to 9.3.