### PR TITLE
Update stdlib gems and compat to 3.1.4

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -55,9 +55,9 @@ DO NOT MODIFY - GENERATED CODE
     <test.results.dir>${build.dir}/test-results</test.results.dir>
     <tzdata.scope>provided</tzdata.scope>
     <tzdata.version>2019c</tzdata.version>
-    <version.ruby>3.1.0</version.ruby>
+    <version.ruby>3.1.4</version.ruby>
     <version.ruby.major>3.1</version.ruby.major>
-    <version.ruby.minor>0</version.ruby.minor>
+    <version.ruby.minor>4</version.ruby.minor>
   </properties>
   <dependencies>
     <dependency>

--- a/default.build.properties
+++ b/default.build.properties
@@ -28,7 +28,7 @@ rake.args=
 install4j.executable=/Applications/install4j9/bin/install4jc
 
 # Ruby versions
-version.ruby=3.1.0
+version.ruby=3.1.4
 version.ruby.major=3.1
-version.ruby.minor=0
+version.ruby.minor=4
 

--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -17,18 +17,20 @@ end
 default_gems = [
     # treat RGs update special:
     # - we do not want bin/update_rubygems or bin/gem overrides
-    ['rubygems-update', '3.3.25', { bin: false, require_paths: ['lib'] }],
+    ['rubygems-update', '3.3.26', { bin: false, require_paths: ['lib'] }],
     ['abbrev', '0.1.0'],
     ['base64', '0.1.1'],
     ['benchmark', '0.2.0'],
     # https://github.com/ruby/bigdecimal/issues/169
     # ['bigdecimal', '3.1.1'],
-    ['bundler', '2.3.25'],
-    ['cgi', '0.3.5'],
+    ['bundler', '2.3.26'],
+    ['cgi', '0.3.6'],
     ['csv', '3.2.5'],
     # Currently using a stub gem for JRuby until we can incorporate our code.
     # https://github.com/ruby/date/issues/48
     ['date', '3.3.3'],
+    # Newer versions require deep control over CRuby, needs work to support JRuby.
+    # See bundled gems below.
     ['debug', '0.2.1'],
     ['delegate', '0.2.0'],
     ['did_you_mean', '1.6.1'],
@@ -41,7 +43,7 @@ default_gems = [
     # ['etc', '1.3.0'],
     # https://github.com/ruby/fcntl/issues/9
     # ['fcntl', '1.0.1'],
-    ['ffi', '1.15.4'],
+    ['ffi', '1.15.5'],
     # ['fiddle', '1.1.0'],
     ['fileutils', '1.6.0'],
     ['find', '0.1.1'],
@@ -53,15 +55,15 @@ default_gems = [
     # ['io-nonblock', '0.1.0'],
     ['io-wait', '0.3.0'],
     ['ipaddr', '1.2.4'],
-    ['irb', '1.4.2'],
+    ['irb', '1.7.0'],
     ['jar-dependencies', '0.4.1'],
     ['jruby-readline', '1.3.7'],
     ['jruby-openssl', '0.14.1'],
     ['json', '2.6.1'],
     ['logger', '1.5.1'],
     ['mutex_m', '0.1.1'],
-    ['net-http', '0.2.2'],
-    ['net-protocol', '0.1.1'],
+    ['net-http', '0.3.0'],
+    ['net-protocol', '0.1.2'],
     # Partial implementation in JRuby, unsure whether this is important
     # ['nkf', '0.1.1'],
     ['observer', '0.1.1'],
@@ -84,7 +86,7 @@ default_gems = [
     # ['readline', '0.0.3'],
     # Will be solved with readline
     # ['readline-ext', '0.1.4'],
-    ['reline', '0.3.0'],
+    ['reline', '0.3.5'],
     # https://github.com/ruby/resolv/issues/19
     # ['resolv', '0.2.1'],
     ['resolv-replace', '0.1.0'],
@@ -106,12 +108,12 @@ default_gems = [
     # https://github.com/ruby/tempfile/issues/7
     # ['tempfile', '0.1.2'],
     ['time', '0.2.2'],
-    ['timeout', '0.3.0'],
+    ['timeout', '0.3.2'],
     # https://github.com/ruby/tmpdir/issues/13
     # ['tmpdir', '0.1.2'],
     ['tsort', '0.1.0'],
     ['un', '0.2.0'],
-    ['uri', '0.11.1'],
+    ['uri', '0.12.1'],
     ['weakref', '0.1.1'],
     # https://github.com/ruby/win32ole/issues/12
     # ['win32ole', '1.8.8'],
@@ -126,7 +128,7 @@ bundled_gems = [
     ['matrix', '0.4.2'],
     ['minitest', '5.15.0'],
     ['net-ftp', '0.1.3'],
-    ['net-imap', '0.2.2'],
+    ['net-imap', '0.2.3'],
     ['net-pop', '0.1.1'],
     ['net-smtp', '0.3.1'],
     ['prime', '0.1.2'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -34,7 +34,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>rubygems-update</artifactId>
-      <version>3.3.25</version>
+      <version>3.3.26</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -86,7 +86,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>bundler</artifactId>
-      <version>2.3.25</version>
+      <version>2.3.26</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -99,7 +99,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>cgi</artifactId>
-      <version>0.3.5</version>
+      <version>0.3.6</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -242,7 +242,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>ffi</artifactId>
-      <version>1.15.4</version>
+      <version>1.15.5</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -346,7 +346,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>irb</artifactId>
-      <version>1.4.2</version>
+      <version>1.7.0</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -437,7 +437,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>net-http</artifactId>
-      <version>0.2.2</version>
+      <version>0.3.0</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -450,7 +450,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>net-protocol</artifactId>
-      <version>0.1.1</version>
+      <version>0.1.2</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -619,7 +619,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>reline</artifactId>
-      <version>0.3.0</version>
+      <version>0.3.5</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -801,7 +801,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>timeout</artifactId>
-      <version>0.3.0</version>
+      <version>0.3.2</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -840,7 +840,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>uri</artifactId>
-      <version>0.11.1</version>
+      <version>0.12.1</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -918,7 +918,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>net-imap</artifactId>
-      <version>0.2.2</version>
+      <version>0.2.3</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1053,12 +1053,12 @@ DO NOT MODIFY - GENERATED CODE
         <directory>${gem.home}</directory>
         <includes>
           <include>specifications/default/*</include>
-          <include>specifications/rubygems-update-3.3.25*</include>
+          <include>specifications/rubygems-update-3.3.26*</include>
           <include>specifications/abbrev-0.1.0*</include>
           <include>specifications/base64-0.1.1*</include>
           <include>specifications/benchmark-0.2.0*</include>
-          <include>specifications/bundler-2.3.25*</include>
-          <include>specifications/cgi-0.3.5*</include>
+          <include>specifications/bundler-2.3.26*</include>
+          <include>specifications/cgi-0.3.6*</include>
           <include>specifications/csv-3.2.5*</include>
           <include>specifications/date-3.3.3*</include>
           <include>specifications/debug-0.2.1*</include>
@@ -1069,7 +1069,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/english-0.7.1*</include>
           <include>specifications/erb-2.2.3*</include>
           <include>specifications/error_highlight-0.3.0*</include>
-          <include>specifications/ffi-1.15.4*</include>
+          <include>specifications/ffi-1.15.5*</include>
           <include>specifications/fileutils-1.6.0*</include>
           <include>specifications/find-0.1.1*</include>
           <include>specifications/forwardable-1.3.2*</include>
@@ -1077,15 +1077,15 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/io-console-0.5.11*</include>
           <include>specifications/io-wait-0.3.0*</include>
           <include>specifications/ipaddr-1.2.4*</include>
-          <include>specifications/irb-1.4.2*</include>
+          <include>specifications/irb-1.7.0*</include>
           <include>specifications/jar-dependencies-0.4.1*</include>
           <include>specifications/jruby-readline-1.3.7*</include>
           <include>specifications/jruby-openssl-0.14.1*</include>
           <include>specifications/json-2.6.1*</include>
           <include>specifications/logger-1.5.1*</include>
           <include>specifications/mutex_m-0.1.1*</include>
-          <include>specifications/net-http-0.2.2*</include>
-          <include>specifications/net-protocol-0.1.1*</include>
+          <include>specifications/net-http-0.3.0*</include>
+          <include>specifications/net-protocol-0.1.2*</include>
           <include>specifications/observer-0.1.1*</include>
           <include>specifications/open3-0.1.2*</include>
           <include>specifications/open-uri-0.3.0*</include>
@@ -1098,7 +1098,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/racc-1.6.0*</include>
           <include>specifications/rake-ant-1.0.6*</include>
           <include>specifications/rdoc-6.4.0*</include>
-          <include>specifications/reline-0.3.0*</include>
+          <include>specifications/reline-0.3.5*</include>
           <include>specifications/resolv-replace-0.1.0*</include>
           <include>specifications/rinda-0.1.1*</include>
           <include>specifications/ruby2_keywords-0.0.5*</include>
@@ -1112,16 +1112,16 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/ffi-binary-libfixposix-0.5.1.1*</include>
           <include>specifications/ffi-bindings-libfixposix-0.5.1.0*</include>
           <include>specifications/time-0.2.2*</include>
-          <include>specifications/timeout-0.3.0*</include>
+          <include>specifications/timeout-0.3.2*</include>
           <include>specifications/tsort-0.1.0*</include>
           <include>specifications/un-0.2.0*</include>
-          <include>specifications/uri-0.11.1*</include>
+          <include>specifications/uri-0.12.1*</include>
           <include>specifications/weakref-0.1.1*</include>
           <include>specifications/yaml-0.2.0*</include>
           <include>specifications/matrix-0.4.2*</include>
           <include>specifications/minitest-5.15.0*</include>
           <include>specifications/net-ftp-0.1.3*</include>
-          <include>specifications/net-imap-0.2.2*</include>
+          <include>specifications/net-imap-0.2.3*</include>
           <include>specifications/net-pop-0.1.1*</include>
           <include>specifications/net-smtp-0.3.1*</include>
           <include>specifications/prime-0.1.2*</include>
@@ -1130,12 +1130,12 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/rexml-3.2.5*</include>
           <include>specifications/rss-0.2.9*</include>
           <include>specifications/test-unit-3.5.3*</include>
-          <include>gems/rubygems-update-3.3.25*/**/*</include>
+          <include>gems/rubygems-update-3.3.26*/**/*</include>
           <include>gems/abbrev-0.1.0*/**/*</include>
           <include>gems/base64-0.1.1*/**/*</include>
           <include>gems/benchmark-0.2.0*/**/*</include>
-          <include>gems/bundler-2.3.25*/**/*</include>
-          <include>gems/cgi-0.3.5*/**/*</include>
+          <include>gems/bundler-2.3.26*/**/*</include>
+          <include>gems/cgi-0.3.6*/**/*</include>
           <include>gems/csv-3.2.5*/**/*</include>
           <include>gems/date-3.3.3*/**/*</include>
           <include>gems/debug-0.2.1*/**/*</include>
@@ -1146,7 +1146,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/english-0.7.1*/**/*</include>
           <include>gems/erb-2.2.3*/**/*</include>
           <include>gems/error_highlight-0.3.0*/**/*</include>
-          <include>gems/ffi-1.15.4*/**/*</include>
+          <include>gems/ffi-1.15.5*/**/*</include>
           <include>gems/fileutils-1.6.0*/**/*</include>
           <include>gems/find-0.1.1*/**/*</include>
           <include>gems/forwardable-1.3.2*/**/*</include>
@@ -1154,15 +1154,15 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/io-console-0.5.11*/**/*</include>
           <include>gems/io-wait-0.3.0*/**/*</include>
           <include>gems/ipaddr-1.2.4*/**/*</include>
-          <include>gems/irb-1.4.2*/**/*</include>
+          <include>gems/irb-1.7.0*/**/*</include>
           <include>gems/jar-dependencies-0.4.1*/**/*</include>
           <include>gems/jruby-readline-1.3.7*/**/*</include>
           <include>gems/jruby-openssl-0.14.1*/**/*</include>
           <include>gems/json-2.6.1*/**/*</include>
           <include>gems/logger-1.5.1*/**/*</include>
           <include>gems/mutex_m-0.1.1*/**/*</include>
-          <include>gems/net-http-0.2.2*/**/*</include>
-          <include>gems/net-protocol-0.1.1*/**/*</include>
+          <include>gems/net-http-0.3.0*/**/*</include>
+          <include>gems/net-protocol-0.1.2*/**/*</include>
           <include>gems/observer-0.1.1*/**/*</include>
           <include>gems/open3-0.1.2*/**/*</include>
           <include>gems/open-uri-0.3.0*/**/*</include>
@@ -1175,7 +1175,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/racc-1.6.0*/**/*</include>
           <include>gems/rake-ant-1.0.6*/**/*</include>
           <include>gems/rdoc-6.4.0*/**/*</include>
-          <include>gems/reline-0.3.0*/**/*</include>
+          <include>gems/reline-0.3.5*/**/*</include>
           <include>gems/resolv-replace-0.1.0*/**/*</include>
           <include>gems/rinda-0.1.1*/**/*</include>
           <include>gems/ruby2_keywords-0.0.5*/**/*</include>
@@ -1189,16 +1189,16 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/ffi-binary-libfixposix-0.5.1.1*/**/*</include>
           <include>gems/ffi-bindings-libfixposix-0.5.1.0*/**/*</include>
           <include>gems/time-0.2.2*/**/*</include>
-          <include>gems/timeout-0.3.0*/**/*</include>
+          <include>gems/timeout-0.3.2*/**/*</include>
           <include>gems/tsort-0.1.0*/**/*</include>
           <include>gems/un-0.2.0*/**/*</include>
-          <include>gems/uri-0.11.1*/**/*</include>
+          <include>gems/uri-0.12.1*/**/*</include>
           <include>gems/weakref-0.1.1*/**/*</include>
           <include>gems/yaml-0.2.0*/**/*</include>
           <include>gems/matrix-0.4.2*/**/*</include>
           <include>gems/minitest-5.15.0*/**/*</include>
           <include>gems/net-ftp-0.1.3*/**/*</include>
-          <include>gems/net-imap-0.2.2*/**/*</include>
+          <include>gems/net-imap-0.2.3*/**/*</include>
           <include>gems/net-pop-0.1.1*/**/*</include>
           <include>gems/net-smtp-0.3.1*/**/*</include>
           <include>gems/prime-0.1.2*/**/*</include>
@@ -1207,12 +1207,12 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/rexml-3.2.5*/**/*</include>
           <include>gems/rss-0.2.9*/**/*</include>
           <include>gems/test-unit-3.5.3*/**/*</include>
-          <include>cache/rubygems-update-3.3.25*</include>
+          <include>cache/rubygems-update-3.3.26*</include>
           <include>cache/abbrev-0.1.0*</include>
           <include>cache/base64-0.1.1*</include>
           <include>cache/benchmark-0.2.0*</include>
-          <include>cache/bundler-2.3.25*</include>
-          <include>cache/cgi-0.3.5*</include>
+          <include>cache/bundler-2.3.26*</include>
+          <include>cache/cgi-0.3.6*</include>
           <include>cache/csv-3.2.5*</include>
           <include>cache/date-3.3.3*</include>
           <include>cache/debug-0.2.1*</include>
@@ -1223,7 +1223,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/english-0.7.1*</include>
           <include>cache/erb-2.2.3*</include>
           <include>cache/error_highlight-0.3.0*</include>
-          <include>cache/ffi-1.15.4*</include>
+          <include>cache/ffi-1.15.5*</include>
           <include>cache/fileutils-1.6.0*</include>
           <include>cache/find-0.1.1*</include>
           <include>cache/forwardable-1.3.2*</include>
@@ -1231,15 +1231,15 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/io-console-0.5.11*</include>
           <include>cache/io-wait-0.3.0*</include>
           <include>cache/ipaddr-1.2.4*</include>
-          <include>cache/irb-1.4.2*</include>
+          <include>cache/irb-1.7.0*</include>
           <include>cache/jar-dependencies-0.4.1*</include>
           <include>cache/jruby-readline-1.3.7*</include>
           <include>cache/jruby-openssl-0.14.1*</include>
           <include>cache/json-2.6.1*</include>
           <include>cache/logger-1.5.1*</include>
           <include>cache/mutex_m-0.1.1*</include>
-          <include>cache/net-http-0.2.2*</include>
-          <include>cache/net-protocol-0.1.1*</include>
+          <include>cache/net-http-0.3.0*</include>
+          <include>cache/net-protocol-0.1.2*</include>
           <include>cache/observer-0.1.1*</include>
           <include>cache/open3-0.1.2*</include>
           <include>cache/open-uri-0.3.0*</include>
@@ -1252,7 +1252,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/racc-1.6.0*</include>
           <include>cache/rake-ant-1.0.6*</include>
           <include>cache/rdoc-6.4.0*</include>
-          <include>cache/reline-0.3.0*</include>
+          <include>cache/reline-0.3.5*</include>
           <include>cache/resolv-replace-0.1.0*</include>
           <include>cache/rinda-0.1.1*</include>
           <include>cache/ruby2_keywords-0.0.5*</include>
@@ -1266,16 +1266,16 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/ffi-binary-libfixposix-0.5.1.1*</include>
           <include>cache/ffi-bindings-libfixposix-0.5.1.0*</include>
           <include>cache/time-0.2.2*</include>
-          <include>cache/timeout-0.3.0*</include>
+          <include>cache/timeout-0.3.2*</include>
           <include>cache/tsort-0.1.0*</include>
           <include>cache/un-0.2.0*</include>
-          <include>cache/uri-0.11.1*</include>
+          <include>cache/uri-0.12.1*</include>
           <include>cache/weakref-0.1.1*</include>
           <include>cache/yaml-0.2.0*</include>
           <include>cache/matrix-0.4.2*</include>
           <include>cache/minitest-5.15.0*</include>
           <include>cache/net-ftp-0.1.3*</include>
-          <include>cache/net-imap-0.2.2*</include>
+          <include>cache/net-imap-0.2.3*</include>
           <include>cache/net-pop-0.1.1*</include>
           <include>cache/net-smtp-0.3.1*</include>
           <include>cache/prime-0.1.2*</include>


### PR DESCRIPTION
Updating all default and bundled gems to meet or exceed CRuby 3.1.4 and bumping the reported compat version.