### PR TITLE
Return to IRB 1.4.2 for now

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -55,7 +55,7 @@ default_gems = [
     # ['io-nonblock', '0.1.0'],
     ['io-wait', '0.3.0'],
     ['ipaddr', '1.2.4'],
-    ['irb', '1.7.0'],
+    ['irb', '1.4.2'],
     ['jar-dependencies', '0.4.1'],
     ['jruby-readline', '1.3.7'],
     ['jruby-openssl', '0.14.1'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -346,7 +346,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>irb</artifactId>
-      <version>1.7.0</version>
+      <version>1.4.2</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1077,7 +1077,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/io-console-0.5.11*</include>
           <include>specifications/io-wait-0.3.0*</include>
           <include>specifications/ipaddr-1.2.4*</include>
-          <include>specifications/irb-1.7.0*</include>
+          <include>specifications/irb-1.4.2*</include>
           <include>specifications/jar-dependencies-0.4.1*</include>
           <include>specifications/jruby-readline-1.3.7*</include>
           <include>specifications/jruby-openssl-0.14.1*</include>
@@ -1154,7 +1154,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/io-console-0.5.11*/**/*</include>
           <include>gems/io-wait-0.3.0*/**/*</include>
           <include>gems/ipaddr-1.2.4*/**/*</include>
-          <include>gems/irb-1.7.0*/**/*</include>
+          <include>gems/irb-1.4.2*/**/*</include>
           <include>gems/jar-dependencies-0.4.1*/**/*</include>
           <include>gems/jruby-readline-1.3.7*/**/*</include>
           <include>gems/jruby-openssl-0.14.1*/**/*</include>
@@ -1231,7 +1231,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/io-console-0.5.11*</include>
           <include>cache/io-wait-0.3.0*</include>
           <include>cache/ipaddr-1.2.4*</include>
-          <include>cache/irb-1.7.0*</include>
+          <include>cache/irb-1.4.2*</include>
           <include>cache/jar-dependencies-0.4.1*</include>
           <include>cache/jruby-readline-1.3.7*</include>
           <include>cache/jruby-openssl-0.14.1*</include>


### PR DESCRIPTION
IRB 1.7.0 brought in a bunch of new tests, some of which seem to cause our MRI stdlib suite to terminate early. Rather than wrestle with this right before release, we are going back to 1.4.2 for now and will do a proper upgrade for 9.4.4.