### PR TITLE
Fixes #7848.  Wrong interpretation of multi-expr when clause

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -1991,11 +1991,18 @@ public class IRBuilder {
         }
     }
 
+    // AST could be more expressive here (e.g. WhenValuesNode < ListNode)
+    private boolean isListOfWhenValues(Node expr) {
+        return expr instanceof ListNode &&
+                !(expr instanceof BlockNode || expr instanceof DNode ||
+                        expr instanceof ArrayNode || expr instanceof ZArrayNode);
+    }
+
     private void buildWhenArgs(WhenNode whenNode, Operand testValue, Label bodyLabel, Set<IRubyObject> seenLiterals) {
         Variable eqqResult = createTemporaryVariable();
         Node exprNodes = whenNode.getExpressionNodes();
 
-        if (exprNodes instanceof ListNode && !(exprNodes instanceof DNode) && !(exprNodes instanceof ArrayNode) && !(exprNodes instanceof ZArrayNode)) {
+        if (isListOfWhenValues(exprNodes)) {
             buildWhenValues(eqqResult, (ListNode) exprNodes, testValue, bodyLabel, seenLiterals);
         } else if (exprNodes instanceof ArgsPushNode || exprNodes instanceof SplatNode || exprNodes instanceof ArgsCatNode) {
             buildWhenSplatValues(eqqResult, exprNodes, testValue, bodyLabel, seenLiterals);

--- a/spec/ruby/language/case_spec.rb
+++ b/spec/ruby/language/case_spec.rb
@@ -434,6 +434,15 @@ describe "The 'case'-construct with no target expression" do
     end.should == :called
   end
 
+  it "only matches last value in complex expressions within ()" do
+    case 'a'
+    when ('a'; 'b')
+      :wrong_called
+    when ('b'; 'a')
+      :called
+    end.should == :called
+  end
+
   # Homogeneous cases are often optimized to avoid === using a jump table, and should be tested separately.
   # See https://github.com/jruby/jruby/issues/6440
   it "handles homogeneous cases" do


### PR DESCRIPTION
The when logic was seeing a BlockNode but thinking it was a ListNode of when conditions.  Minimizing fix because I will cherry-pick this back to 9.3 and onto YARP branch which has a large number of IR builder changes stacked up.