### PR TITLE
Fix #7839. `clone': wrong number of arguments

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -452,7 +452,10 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
 
     // MRI: special_object_p
     public boolean isSpecialObject() {
-        return isImmediate() || this instanceof RubyBignum || this instanceof RubyFloat || this instanceof RubyRational || this instanceof RubyComplex;
+        // This is broader than MRI but immediates and numeric overlap so I don't think it will hurt.
+        // RubyNumeric vs limited list to also include Numeric/Integer so we need not duplicate clone
+        // (and potentially others).
+        return isImmediate() || this instanceof RubyNumeric;
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -2306,11 +2306,14 @@ public class RubyHash extends RubyObject implements Map {
         return dup;
     }
 
-    @JRubyMethod(name = "clone")
-    public IRubyObject rbClone(ThreadContext context) {
-        RubyHash clone = (RubyHash) super.rbClone();
+    public IRubyObject rbClone(ThreadContext context, IRubyObject opts) {
+        RubyHash clone = (RubyHash) super.rbClone(context, opts);
         clone.setComparedByIdentity(isComparedByIdentity());
         return clone;
+    }
+
+    public IRubyObject rbClone(ThreadContext context) {
+        return rbClone(context, context.nil);
     }
 
     @JRubyMethod(name = "any?", optional = 1)

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -1632,14 +1632,9 @@ public class RubyNumeric extends RubyObject {
     @Override
     @JRubyMethod(name = "clone")
     public final IRubyObject rbClone(ThreadContext context, IRubyObject arg) {
-        if (!(arg instanceof RubyHash)) {
-            throw context.runtime.newArgumentError("wrong number of arguments (given 1, expected 0)");
-        }
-
-        IRubyObject ret = ArgsUtil.getFreezeOpt(context, arg);
-        if (ret == context.fals) throw context.runtime.newArgumentError("can't unfreeze " + getType());
-
-        return this;
+        // BasicObject handles "special" objects like all numerics but we leave this because Ruby
+        // has an explicit Numeric#clone binding.
+        return super.rbClone(context, arg);
     }
 
     @Override


### PR DESCRIPTION
RubyHash had no signature for options but it was bound and it is not a bound method in MRI so I removed the annotation and added a java override for options variant of clone.

RubyNumeric had its own impl but RubyBasicObject implements that logic already for multiple immutable types so I just changed it to call that impl with a comment why the binding is there.