### PR TITLE
Fixes #7855. pattern assoc assigns should scope

### DIFF
--- a/core/src/main/java/org/jruby/parser/RubyParser.java
+++ b/core/src/main/java/org/jruby/parser/RubyParser.java
@@ -5060,7 +5060,7 @@ states[520] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
 };
 states[522] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
                     /*%%%*/
-                    yyVal = p.logop(((Node)yyVals[-2+yyTop].value), OR_OR, ((Node)yyVals[0+yyTop].value));
+                    yyVal = p.logop(((Node)yyVals[-2+yyTop].value), OR, ((Node)yyVals[0+yyTop].value));
                     /*% %*/
                     /*% ripper: binary!($1, STATIC_ID2SYM(idOr), $3) %*/
   return yyVal;
@@ -5484,7 +5484,7 @@ states[602] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
 states[603] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
                     /*%%%*/
                     p.error_duplicate_pattern_variable(((ByteList)yyVals[0+yyTop].value));
-                    yyVal = p.assignableInCurr(((ByteList)yyVals[0+yyTop].value), null);
+                    yyVal = p.assignableLabelOrIdentifier(((ByteList)yyVals[0+yyTop].value), null);
                     /*%
                       $$ = p.assignable(yyVals[yyTop - count + 1].id, p.var_field($1));
                     %*/

--- a/core/src/main/java/org/jruby/parser/RubyParser.y
+++ b/core/src/main/java/org/jruby/parser/RubyParser.y
@@ -3591,7 +3591,7 @@ p_primitive     : literal
 p_variable      : tIDENTIFIER {
                     /*%%%*/
                     p.error_duplicate_pattern_variable($1);
-                    $$ = p.assignableInCurr($1, null);
+                    $$ = p.assignableLabelOrIdentifier($1, null);
                     /*%
                       $$ = p.assignable(@1.id, p.var_field($1));
                     %*/

--- a/spec/ruby/language/pattern_matching_spec.rb
+++ b/spec/ruby/language/pattern_matching_spec.rb
@@ -8,12 +8,26 @@ describe "Pattern matching" do
     ScratchPad.record []
   end
 
-  it "can be standalone assoc operator that deconstructs value" do
-    suppress_warning do
-      eval(<<-RUBY).should == [0, 1]
-        [0, 1] => [a, b]
-        [a, b]
-      RUBY
+  describe "can be standalone assoc operator that" do
+    it "deconstructs value" do
+      suppress_warning do
+        eval(<<-RUBY).should == [0, 1]
+          [0, 1] => [a, b]
+          [a, b]
+        RUBY
+      end
+    end
+
+    it "deconstructs value and properly scopes variables" do
+      suppress_warning do
+        eval(<<-RUBY).should == [0, nil]
+          a = nil
+          eval(<<-PATTERN)
+            [0, 1] => [a, b]
+          PATTERN
+          [a, defined?(b)]
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
assoc assigns in pattern matching was erroneously always creating
a new local variable in the current lexical scope vs looking for
it already existing in a higher scope.