### PR TITLE
Fixes #7854. Pattern matching with an empty hash should not match

### DIFF
--- a/core/src/main/java/org/jruby/ast/HashPatternNode.java
+++ b/core/src/main/java/org/jruby/ast/HashPatternNode.java
@@ -60,7 +60,7 @@ public class HashPatternNode extends Node {
     }
 
     public boolean hasKeywordArgs() {
-        return keywordArgs != null;
+        return keywordArgs != null && !keywordArgs.isEmpty();
     }
 
     public HashNode getKeywordArgs() {


### PR DESCRIPTION
This had two problems first was IR build was not realizing the empty hash was actually empty.  {} is still put into the AST so we had to check that no elements are within that.

Second problem was missing logic to change the pattern error string to 'is not empty'.  This was a lesser issue since it still returns a proper error but we may as well match the strings.