### PR TITLE
Restore arity-checking with an opt-out flag

### DIFF
--- a/core/src/main/java/org/jruby/RubyArgsFile.java
+++ b/core/src/main/java/org/jruby/RubyArgsFile.java
@@ -405,7 +405,7 @@ public class RubyArgsFile extends RubyObject {
     /** Read a line.
      *
      */
-    @JRubyMethod(name = "gets", optional = 1, writes = LASTLINE)
+    @JRubyMethod(name = "gets", optional = 1, checkArity = false, writes = LASTLINE)
     public static IRubyObject gets(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -415,7 +415,7 @@ public class RubyArgsFile extends RubyObject {
     /** Read a line.
      *
      */
-    @JRubyMethod(name = "readline", optional = 1, writes = LASTLINE)
+    @JRubyMethod(name = "readline", optional = 1, checkArity = false, writes = LASTLINE)
     public static IRubyObject readline(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         IRubyObject line = gets(context, recv, args);
 
@@ -424,7 +424,7 @@ public class RubyArgsFile extends RubyObject {
         return line;
     }
 
-    @JRubyMethod(optional = 1)
+    @JRubyMethod(optional = 1, checkArity = false)
     public static IRubyObject readlines(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -443,7 +443,7 @@ public class RubyArgsFile extends RubyObject {
         return ary;
     }
 
-    @JRubyMethod(optional = 1)
+    @JRubyMethod(optional = 1, checkArity = false)
     public static IRubyObject to_a(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -478,7 +478,7 @@ public class RubyArgsFile extends RubyObject {
         return block.isGiven() ? each_byte(context, recv, block) : enumeratorize(context.runtime, recv, "each_byte");
     }
 
-    @JRubyMethod(optional = 1)
+    @JRubyMethod(optional = 1, checkArity = false)
     public static IRubyObject bytes(final ThreadContext context, IRubyObject recv, IRubyObject[] args, final Block block) {
         Arity.checkArgumentCount(context, args, 0, 1);
         return block.isGiven() ? each_byte(context, recv, block) : enumeratorize(context.runtime, recv, "bytes");
@@ -555,7 +555,7 @@ public class RubyArgsFile extends RubyObject {
     /** Invoke a block for each line.
      *
      */
-    @JRubyMethod(name = "each_line", optional = 1)
+    @JRubyMethod(name = "each_line", optional = 1, checkArity = false)
     public static IRubyObject each_line(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         if (!block.isGiven()) return enumeratorize(context.runtime, recv, "each_line", args);
 
@@ -581,7 +581,7 @@ public class RubyArgsFile extends RubyObject {
     }
 
     @Deprecated // TODO "warning: ARGF#lines is deprecated; use #each_line instead"
-    @JRubyMethod(optional = 1)
+    @JRubyMethod(optional = 1, checkArity = false)
     public static IRubyObject lines(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         if (!block.isGiven()) return RubyEnumerator.enumeratorize(context.runtime, recv, "each_line");
         return each_line(context, recv, args, block);
@@ -592,7 +592,7 @@ public class RubyArgsFile extends RubyObject {
         return each_line(context, recv, args, block);
     }
 
-    @JRubyMethod(name = "each", optional = 1)
+    @JRubyMethod(name = "each", optional = 1, checkArity = false)
     public static IRubyObject each(final ThreadContext context, IRubyObject recv, IRubyObject[] args, final Block block) {
         return block.isGiven() ? each_line(context, recv, args, block) : enumeratorize(context.runtime, recv, "each", args);
     }
@@ -737,7 +737,7 @@ public class RubyArgsFile extends RubyObject {
         return getCurrentDataFile(context, "no stream to set position").pos_set(context, offset);
     }
 
-    @JRubyMethod(name = "seek", required = 1, optional = 1)
+    @JRubyMethod(name = "seek", required = 1, optional = 1, checkArity = false)
     public static IRubyObject seek(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -774,14 +774,14 @@ public class RubyArgsFile extends RubyObject {
         }
     }
 
-    @JRubyMethod(required = 1, optional = 2)
+    @JRubyMethod(required = 1, optional = 2, checkArity = false)
     public static IRubyObject read_nonblock(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 1, 3);
 
         return getPartial(context, recv, args, true);
     }
 
-    @JRubyMethod(required = 1, optional = 1)
+    @JRubyMethod(required = 1, optional = 1, checkArity = false)
     public static IRubyObject readpartial(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -860,7 +860,7 @@ public class RubyArgsFile extends RubyObject {
         }
     }
 
-    @JRubyMethod(name = "read", optional = 2)
+    @JRubyMethod(name = "read", optional = 2, checkArity = false)
     public static IRubyObject read(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 0, 2);
 

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -1178,7 +1178,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return insert(arg1, arg2);
     }
 
-    @JRubyMethod(name = "insert", required = 1, rest = true)
+    @JRubyMethod(name = "insert", required = 1, rest = true, checkArity = false)
     public IRubyObject insert(IRubyObject[] args) {
         final Ruby runtime = metaClass.runtime;
 
@@ -2687,7 +2687,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     /** rb_ary_indexes
      *
      */
-    @JRubyMethod(name = {"indexes", "indices"}, required = 1, rest = true)
+    @JRubyMethod(name = {"indexes", "indices"}, required = 1, rest = true, checkArity = false)
     public IRubyObject indexes(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, -1);
 
@@ -3126,7 +3126,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     /** rb_ary_zip
      *
      */
-    @JRubyMethod(optional = 1, rest = true)
+    @JRubyMethod(optional = 1, rest = true, checkArity = false)
     public IRubyObject zip(ThreadContext context, IRubyObject[] args, Block block) {
         final Ruby runtime = context.runtime;
         RubyClass array = runtime.getArray();
@@ -5487,7 +5487,7 @@ float_loop:
         return RubyObject.dig2(context, val, arg1, arg2);
     }
 
-    @JRubyMethod(name = "dig", required = 1, rest = true)
+    @JRubyMethod(name = "dig", required = 1, rest = true, checkArity = false)
     public IRubyObject dig(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, -1);
 

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -1678,7 +1678,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
 
         return getMetaClass().finvokeWithRefinements(context, this, staticScope, name, arg1, arg2, block);
     }
-    @JRubyMethod(name = "__send__", required = 1, rest = true, omit = true, keywords = true)
+    @JRubyMethod(name = "__send__", required = 1, rest = true, checkArity = false, omit = true, keywords = true)
     public IRubyObject send(ThreadContext context, IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(context, args, 1, -1);
         int callInfo = context.callInfo;
@@ -2594,7 +2594,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      *     k = Klass.new
      *     k.instance_exec(5) {|x| {@literal @}secret+x }   #=&gt; 104
      */
-    @JRubyMethod(name = "instance_exec", optional = 3, rest = true, keywords = true,
+    @JRubyMethod(name = "instance_exec", rest = true, keywords = true,
             reads = {LASTLINE, BACKREF, VISIBILITY, BLOCK, SELF, METHODNAME, LINE, CLASS, FILENAME, SCOPE},
             writes = {LASTLINE, BACKREF, VISIBILITY, BLOCK, SELF, METHODNAME, LINE, CLASS, FILENAME, SCOPE})
     public IRubyObject instance_exec(ThreadContext context, IRubyObject[] args, Block block) {

--- a/core/src/main/java/org/jruby/RubyBinding.java
+++ b/core/src/main/java/org/jruby/RubyBinding.java
@@ -117,7 +117,7 @@ public class RubyBinding extends RubyObject {
     }
 
     // c: bind_eval
-    @JRubyMethod(name = "eval", required = 1, optional = 2)
+    @JRubyMethod(name = "eval", required = 1, optional = 2, checkArity = false)
     public IRubyObject eval(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 3);
 

--- a/core/src/main/java/org/jruby/RubyComplex.java
+++ b/core/src/main/java/org/jruby/RubyComplex.java
@@ -397,7 +397,7 @@ public class RubyComplex extends RubyNumeric {
     /** nucomp_s_polar
      *
      */
-    @JRubyMethod(name = "polar", meta = true, required = 1, optional = 1)
+    @JRubyMethod(name = "polar", meta = true, required = 1, optional = 1, checkArity = false)
     public static IRubyObject polar(ThreadContext context, IRubyObject clazz, IRubyObject... args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -1177,7 +1177,7 @@ public class RubyComplex extends RubyNumeric {
     /** nucomp_rationalize
      *
      */
-    @JRubyMethod(name = "rationalize", optional = 1)
+    @JRubyMethod(name = "rationalize", optional = 1, checkArity = false)
     public IRubyObject rationalize(ThreadContext context, IRubyObject[] args) {
         if (k_inexact_p(image) || !f_zero_p(context, image)) {
             throw context.runtime.newRangeError("can't convert " + f_to_s(context, this).convertToString() + " into Rational");

--- a/core/src/main/java/org/jruby/RubyConverter.java
+++ b/core/src/main/java/org/jruby/RubyConverter.java
@@ -135,7 +135,7 @@ public class RubyConverter extends RubyObject {
         super(runtime, runtime.getConverter());
     }
 
-    @JRubyMethod(visibility = PRIVATE, required = 1, optional = 2)
+    @JRubyMethod(visibility = PRIVATE, required = 1, optional = 2, checkArity = false)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 3);
 
@@ -221,7 +221,7 @@ public class RubyConverter extends RubyObject {
     }
 
     // econv_primitive_convert
-    @JRubyMethod(required = 2, optional = 4)
+    @JRubyMethod(required = 2, optional = 4, checkArity = false)
     public IRubyObject primitive_convert(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 2, 6);
 
@@ -524,7 +524,7 @@ public class RubyConverter extends RubyObject {
         return ary;
     }
 
-    @JRubyMethod(meta = true, required = 2, optional = 1)
+    @JRubyMethod(meta = true, required = 2, optional = 1, checkArity = false)
     public static IRubyObject search_convpath(ThreadContext context, IRubyObject self, IRubyObject[] argv) {
         final Ruby runtime = context.runtime;
         final IRubyObject nil = context.nil;
@@ -596,7 +596,7 @@ public class RubyConverter extends RubyObject {
     }
 
     // econv_putback
-    @JRubyMethod(optional = 1)
+    @JRubyMethod(optional = 1, checkArity = false)
     public IRubyObject putback(ThreadContext context, IRubyObject[] argv)
     {
         int argc = Arity.checkArgumentCount(context, argv, 0, 1);

--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -319,7 +319,7 @@ public class RubyDir extends RubyObject implements Closeable {
      * with each filename is passed to the block in turn. In this case, Nil is
      * returned.
      */
-    @JRubyMethod(required = 1, optional = 2, meta = true)
+    @JRubyMethod(required = 1, optional = 2, checkArity = false, meta = true)
     public static IRubyObject glob(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         Arity.checkArgumentCount(context, args, 1, 3);
 
@@ -434,7 +434,7 @@ public class RubyDir extends RubyObject implements Closeable {
     }
 
     /** Changes the current directory to <code>path</code> */
-    @JRubyMethod(optional = 1, meta = true)
+    @JRubyMethod(optional = 1, checkArity = false, meta = true)
     public static IRubyObject chdir(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
         Ruby runtime = context.runtime;
@@ -652,7 +652,7 @@ public class RubyDir extends RubyObject implements Closeable {
      * <code>mode</code> parameter is provided only to support existing Ruby
      * code, and is ignored.
      */
-    @JRubyMethod(name = "mkdir", required = 1, optional = 1, meta = true)
+    @JRubyMethod(name = "mkdir", required = 1, optional = 1, checkArity = false, meta = true)
     public static IRubyObject mkdir(ThreadContext context, IRubyObject recv, IRubyObject... args) {
         Arity.checkArgumentCount(context, args, 1, 2);
         Ruby runtime = context.runtime;

--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -202,7 +202,7 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
 
     // used internally to create lazy without block (from Enumerator/Enumerable)
     // and used internally to create enum from Enumerator::Lazy#eager
-    @JRubyMethod(name = "__from", meta = true, required = 2, optional = 2, visibility = PRIVATE, keywords = true)
+    @JRubyMethod(name = "__from", meta = true, required = 2, optional = 2, checkArity = false, visibility = PRIVATE, keywords = true)
     public static IRubyObject __from(ThreadContext context, IRubyObject klass, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 2, 4);
 
@@ -570,7 +570,7 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
     /** MRI: enumerator_s_produce
      *
      */
-    @JRubyMethod(meta = true, optional = 1)
+    @JRubyMethod(meta = true, optional = 1, checkArity = false)
     public static IRubyObject produce(ThreadContext context, IRubyObject recv, IRubyObject[] args, final Block block) {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
 

--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -124,7 +124,7 @@ public class RubyException extends RubyObject {
         this.setMessage(message == null ? runtime.getNil() : runtime.newString(message));
     }
 
-    @JRubyMethod(name = "exception", optional = 1, rest = true, meta = true)
+    @JRubyMethod(name = "exception", rest = true, meta = true)
     public static IRubyObject exception(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         return ((RubyClass) recv).newInstance(context, args, block);
     }
@@ -291,7 +291,7 @@ public class RubyException extends RubyObject {
         return backtrace.backtraceLocations = backtrace.generateBacktraceLocations(context);
     }
 
-    @JRubyMethod(optional = 1)
+    @JRubyMethod(optional = 1, checkArity = false)
     public RubyException exception(IRubyObject[] args) {
         switch (args.length) {
             case 0 :

--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -341,7 +341,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
     }
 
     // rb_file_initialize
-    @JRubyMethod(name = "initialize", required = 1, optional = 3, visibility = PRIVATE)
+    @JRubyMethod(name = "initialize", required = 1, optional = 3, checkArity = false, visibility = PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(context, args, 1, 4);
 
@@ -625,7 +625,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         return NULL_CHAR;
     }
 
-    @JRubyMethod(required = 2, rest = true, meta = true)
+    @JRubyMethod(required = 2, rest = true, checkArity = false, meta = true)
     public static IRubyObject chmod(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 2, -1);
 
@@ -650,7 +650,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         return runtime.newFixnum(count);
     }
 
-    @JRubyMethod(required = 2, rest = true, meta = true)
+    @JRubyMethod(required = 2, rest = true, checkArity = false, meta = true)
     public static IRubyObject chown(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 2, -1);
         Ruby runtime = context.runtime;
@@ -682,7 +682,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         return runtime.newFixnum(count);
     }
 
-    @JRubyMethod(required = 1, optional = 1, meta = true)
+    @JRubyMethod(required = 1, optional = 1, checkArity = false, meta = true)
     public static IRubyObject dirname(ThreadContext context, IRubyObject recv, IRubyObject [] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -897,7 +897,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
      * @param args
      * @return Resulting absolute path as a String
      */
-    @JRubyMethod(name = "expand_path", required = 1, optional = 1, meta = true)
+    @JRubyMethod(name = "expand_path", required = 1, optional = 1, checkArity = false, meta = true)
     public static IRubyObject expand_path(ThreadContext context, IRubyObject recv, IRubyObject... args) {
         Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -929,7 +929,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
      * @param args
      * @return
      */
-    @JRubyMethod(required = 1, optional = 1, meta = true)
+    @JRubyMethod(required = 1, optional = 1, checkArity = false, meta = true)
     public static IRubyObject absolute_path(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -944,7 +944,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         return context.runtime.newBoolean(isJRubyAbsolutePath(file.asJavaString()));
     }
 
-    @JRubyMethod(required = 1, optional = 1, meta = true)
+    @JRubyMethod(required = 1, optional = 1, checkArity = false, meta = true)
     public static IRubyObject realdirpath(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -993,7 +993,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
      *   [set]:  Matches a single char in a set (re: [...]).
      *
      */
-    @JRubyMethod(name = {"fnmatch", "fnmatch?"}, required = 2, optional = 1, meta = true)
+    @JRubyMethod(name = {"fnmatch", "fnmatch?"}, required = 2, optional = 1, checkArity = false, meta = true)
     public static IRubyObject fnmatch(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 2, 3);
 
@@ -1082,7 +1082,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         return runtime.newFileStat(f, false).birthtime();
     }
 
-    @JRubyMethod(required = 1, rest = true, meta = true)
+    @JRubyMethod(required = 1, rest = true, checkArity = false, meta = true)
     public static IRubyObject lchmod(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, -1);
 
@@ -1102,7 +1102,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         return runtime.newFixnum(count);
     }
 
-    @JRubyMethod(required = 2, rest = true, meta = true)
+    @JRubyMethod(required = 2, rest = true, checkArity = false, meta = true)
     public static IRubyObject lchown(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 2, -1);
 
@@ -1261,7 +1261,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         return truncateCommon(context, recv, path, arg2);
     }
 
-    @JRubyMethod(meta = true, optional = 1)
+    @JRubyMethod(meta = true, optional = 1, checkArity = false)
     public static IRubyObject umask(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -1279,7 +1279,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         return runtime.newFixnum(oldMask);
     }
 
-    @JRubyMethod(required = 2, rest = true, meta = true)
+    @JRubyMethod(required = 2, rest = true, checkArity = false, meta = true)
     public static IRubyObject lutime(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 2, -1);
 
@@ -1310,7 +1310,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         return runtime.newFixnum(argc - 2);
     }
 
-    @JRubyMethod(required = 2, rest = true, meta = true)
+    @JRubyMethod(required = 2, rest = true, checkArity = false, meta = true)
     public static IRubyObject utime(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 2, -1);
 

--- a/core/src/main/java/org/jruby/RubyFloat.java
+++ b/core/src/main/java/org/jruby/RubyFloat.java
@@ -812,7 +812,7 @@ public class RubyFloat extends RubyNumeric {
     /** float_rationalize
      *
      */
-    @JRubyMethod(name = "rationalize", optional = 1)
+    @JRubyMethod(name = "rationalize", optional = 1, checkArity = false)
     public IRubyObject rationalize(ThreadContext context, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 1);
 

--- a/core/src/main/java/org/jruby/RubyGC.java
+++ b/core/src/main/java/org/jruby/RubyGC.java
@@ -67,14 +67,14 @@ public class RubyGC {
         return result;        
     }
 
-    @JRubyMethod(module = true, visibility = PRIVATE, optional = 1)
+    @JRubyMethod(module = true, visibility = PRIVATE, optional = 1, checkArity = false)
     public static IRubyObject start(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 1);
 
         return context.nil;
     }
 
-    @JRubyMethod(optional = 1)
+    @JRubyMethod(optional = 1, checkArity = false)
     public static IRubyObject garbage_collect(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 1);
         return context.nil;

--- a/core/src/main/java/org/jruby/RubyGenerator.java
+++ b/core/src/main/java/org/jruby/RubyGenerator.java
@@ -54,7 +54,7 @@ public class RubyGenerator extends RubyObject {
     }
 
     // generator_initialize
-    @JRubyMethod(visibility = Visibility.PRIVATE, optional = 1)
+    @JRubyMethod(visibility = Visibility.PRIVATE, optional = 1, checkArity = false)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
 

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -796,7 +796,7 @@ public class RubyHash extends RubyObject implements Map {
     /** rb_hash_initialize
      *
      */
-    @JRubyMethod(optional = 1, visibility = PRIVATE)
+    @JRubyMethod(optional = 1, checkArity = false, visibility = PRIVATE)
     public IRubyObject initialize(IRubyObject[] args, final Block block) {
         modify();
 
@@ -1651,7 +1651,7 @@ public class RubyHash extends RubyObject implements Map {
         return block.isGiven() ? each_keyCommon(context, block) : enumeratorizeWithSize(context, this, "each_key", RubyHash::size);
     }
 
-    @JRubyMethod(name = "transform_keys", optional =  1, rest = true)
+    @JRubyMethod(name = "transform_keys", rest = true)
     public IRubyObject transform_keys(final ThreadContext context, IRubyObject[] args, final Block block) {
         if (args.length == 0 && !block.isGiven()) {
             return enumeratorizeWithSize(context, this, "transform_keys", RubyHash::size);
@@ -1692,7 +1692,7 @@ public class RubyHash extends RubyObject implements Map {
         return hashCopyWithIdentity(context).transform_values_bang(context, block);
     }
 
-    @JRubyMethod(name = "transform_keys!", optional =  1, rest = true)
+    @JRubyMethod(name = "transform_keys!", rest = true)
     public IRubyObject transform_keys_bang(final ThreadContext context, IRubyObject[] args, final Block block) {
         if (args.length == 0 && !block.isGiven()) {
             return enumeratorizeWithSize(context, this, "transform_keys!", RubyHash::size);
@@ -2316,7 +2316,7 @@ public class RubyHash extends RubyObject implements Map {
         return rbClone(context, context.nil);
     }
 
-    @JRubyMethod(name = "any?", optional = 1)
+    @JRubyMethod(name = "any?", optional = 1, checkArity = false)
     public IRubyObject any_p(ThreadContext context, IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -2434,7 +2434,7 @@ public class RubyHash extends RubyObject implements Map {
         return RubyObject.dig2(context, val, arg1, arg2);
     }
 
-    @JRubyMethod(name = "dig", required = 1, rest = true)
+    @JRubyMethod(name = "dig", required = 1, rest = true, checkArity = false)
     public IRubyObject dig(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, -1);
 

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -556,7 +556,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     }
 
     // MRI: rb_io_reopen
-    @JRubyMethod(name = "reopen", required = 1, optional = 1)
+    @JRubyMethod(name = "reopen", required = 1, optional = 1, checkArity = false)
     public IRubyObject reopen(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -1171,7 +1171,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     }
 
     // rb_io_s_open, 2014/5/16
-    @JRubyMethod(required = 1, rest = true, meta = true, keywords = true)
+    @JRubyMethod(required = 1, rest = true, checkArity = false, meta = true, keywords = true)
     public static IRubyObject open(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         IRubyObject io = ((RubyClass)recv).newInstance(context, args, Block.NULL_BLOCK);
 
@@ -1200,7 +1200,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     }
 
     // rb_io_s_sysopen
-    @JRubyMethod(name = "sysopen", required = 1, optional = 2, meta = true)
+    @JRubyMethod(name = "sysopen", required = 1, optional = 2, checkArity = false, meta = true)
     public static IRubyObject sysopen(ThreadContext context, IRubyObject recv, IRubyObject[] argv, Block block) {
         int argc = Arity.checkArgumentCount(context, argv, 1, 3);
 
@@ -1379,7 +1379,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     }
 
     // MRI: rb_io_write_nonblock
-    @JRubyMethod(name = "write_nonblock", required = 1, optional = 1)
+    @JRubyMethod(name = "write_nonblock", required = 1, optional = 1, checkArity = false)
     public IRubyObject write_nonblock(ThreadContext context, IRubyObject[] argv) {
         Arity.checkArgumentCount(context, argv, 1, 2);
 
@@ -1837,7 +1837,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return context.nil;
     }
 
-    @JRubyMethod(required = 1, rest = true)
+    @JRubyMethod(required = 1, rest = true, checkArity = false)
     public IRubyObject printf(ThreadContext context, IRubyObject[] args) {
         write(context, this, RubyKernel.sprintf(context, this, args));
         return context.nil;
@@ -1909,7 +1909,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     // This was a getOpt with one mandatory arg, but it did not work
     // so I am parsing it for now.
-    @JRubyMethod(required = 1, optional = 1)
+    @JRubyMethod(required = 1, optional = 1, checkArity = false)
     public RubyFixnum sysseek(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -2596,7 +2596,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return ctl(context, cmd, arg);
     }
 
-    @JRubyMethod(name = "ioctl", required = 1, optional = 1)
+    @JRubyMethod(name = "ioctl", required = 1, optional = 1, checkArity = false)
     public IRubyObject ioctl(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -3064,7 +3064,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return context.nil;
     }
 
-    @JRubyMethod(name = "read_nonblock", required = 1, optional = 2)
+    @JRubyMethod(name = "read_nonblock", required = 1, optional = 2, checkArity = false)
     public IRubyObject read_nonblock(ThreadContext context, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 1, 3);
 
@@ -3084,7 +3084,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         throw runtime.newEOFError();
     }
 
-    @JRubyMethod(name = "readpartial", required = 1, optional = 1)
+    @JRubyMethod(name = "readpartial", required = 1, optional = 1, checkArity = false)
     public IRubyObject readpartial(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -3188,7 +3188,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     }
 
     // MRI: rb_io_sysread
-    @JRubyMethod(name = "sysread", required = 1, optional = 1)
+    @JRubyMethod(name = "sysread", required = 1, optional = 1, checkArity = false)
     public IRubyObject sysread(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -3779,7 +3779,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return nil;
     }
 
-    @JRubyMethod(name = "foreach", required = 1, optional = 3, meta = true, writes = LASTLINE)
+    @JRubyMethod(name = "foreach", required = 1, optional = 3, checkArity = false, meta = true, writes = LASTLINE)
     public static IRubyObject foreach(final ThreadContext context, IRubyObject recv, IRubyObject[] args, final Block block) {
         Arity.checkArgumentCount(context, args, 1, 4);
 
@@ -3792,7 +3792,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return TypeConverter.ioGetIO(context.runtime, obj);
     }
 
-    @JRubyMethod(name = "select", required = 1, optional = 3, meta = true)
+    @JRubyMethod(name = "select", required = 1, optional = 3, checkArity = false, meta = true)
     public static IRubyObject select(ThreadContext context, IRubyObject recv, IRubyObject[] argv) {
         int argc = Arity.checkArgumentCount(context, argv, 1, 4);
 
@@ -3832,7 +3832,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     }
 
     // MRI: rb_io_advise
-    @JRubyMethod(required = 1, optional = 2)
+    @JRubyMethod(required = 1, optional = 2, checkArity = false)
     public IRubyObject advise(ThreadContext context, IRubyObject[] argv) {
         Ruby runtime = context.runtime;
         IRubyObject advice, offset, len;
@@ -3996,7 +3996,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
      * @param args arguments; path [, length [, offset]]
      * @return the binary contents of the given file, at specified length and offset
      */
-    @JRubyMethod(meta = true, required = 1, optional = 2)
+    @JRubyMethod(meta = true, required = 1, optional = 2, checkArity = false)
     public static IRubyObject binread(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 3);
 
@@ -4032,7 +4032,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     }
 
     // Enebo: annotation processing forced me to do pangea method here...
-    @JRubyMethod(name = "read", meta = true, required = 1, optional = 3)
+    @JRubyMethod(name = "read", meta = true, required = 1, optional = 3, checkArity = false)
     public static IRubyObject read(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block unusedBlock) {
         int argc = Arity.checkArgumentCount(context, args, 1, 4);
 
@@ -4084,13 +4084,13 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     }
 
     // rb_io_s_binwrite
-    @JRubyMethod(meta = true, required = 2, optional = 2)
+    @JRubyMethod(meta = true, required = 2, optional = 2, checkArity = false)
     public static IRubyObject binwrite(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         return ioStaticWrite(context, recv, args, true);
     }
 
     // MRI: rb_io_s_write
-    @JRubyMethod(name = "write", meta = true, required = 2, optional = 2)
+    @JRubyMethod(name = "write", meta = true, required = 2, optional = 2, checkArity = false)
     public static IRubyObject write(ThreadContext context, IRubyObject recv, IRubyObject[] argv) {
         return (ioStaticWrite(context, recv, argv, false));
     }
@@ -4161,7 +4161,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     }
 
     // rb_io_s_readlines
-    @JRubyMethod(name = "readlines", required = 1, optional = 3, meta = true)
+    @JRubyMethod(name = "readlines", required = 1, optional = 3, checkArity = false, meta = true)
     public static IRubyObject readlines(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block unusedBlock) {
         IRubyObject opt = ArgsUtil.getOptionsArg(context.runtime, args);
         final RubyIO io = openKeyArgs(context, recv, args, opt);
@@ -4289,7 +4289,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         }
     }
 
-    @JRubyMethod(name = "popen", required = 1, optional = 2, meta = true)
+    @JRubyMethod(name = "popen", required = 1, optional = 2, checkArity = false, meta = true)
     public static IRubyObject popen(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(context, args, 1, 3);
 
@@ -4391,7 +4391,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return pipe(context, recv, IRubyObject.NULL_ARRAY, Block.NULL_BLOCK);
     }
 
-    @JRubyMethod(name = "pipe", optional = 3, meta = true)
+    @JRubyMethod(name = "pipe", optional = 3, checkArity = false, meta = true)
     public static IRubyObject pipe(ThreadContext context, IRubyObject klass, IRubyObject[] argv, Block block) {
         int argc = Arity.checkArgumentCount(context, argv, 0, 3);
 
@@ -4514,7 +4514,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         }
     }
 
-    @JRubyMethod(name = "copy_stream", required = 2, optional = 2, meta = true)
+    @JRubyMethod(name = "copy_stream", required = 2, optional = 2, checkArity = false, meta = true)
     public static IRubyObject copy_stream(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 2, 4);
 

--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -715,7 +715,7 @@ public abstract class RubyInteger extends RubyNumeric {
     /** integer_rationalize
      *
      */
-    @JRubyMethod(name = "rationalize", optional = 1)
+    @JRubyMethod(name = "rationalize", optional = 1, checkArity = false)
     public IRubyObject rationalize(ThreadContext context, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 1);
 

--- a/core/src/main/java/org/jruby/RubyInterrupt.java
+++ b/core/src/main/java/org/jruby/RubyInterrupt.java
@@ -64,7 +64,7 @@ public class RubyInterrupt extends RubySignalException {
         return new Interrupt(message, this);
     }
 
-    @JRubyMethod(optional = 1, visibility = PRIVATE)
+    @JRubyMethod(optional = 1, checkArity = false, visibility = PRIVATE)
     @Override
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args, Block block) {
         Arity.checkArgumentCount(context, args, 0, 1);

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -253,7 +253,7 @@ public class RubyKernel {
         return open(context, recv, args, block);
     }
 
-    @JRubyMethod(name = "open", required = 1, optional = 3, module = true, visibility = PRIVATE, keywords = true)
+    @JRubyMethod(name = "open", required = 1, optional = 3, checkArity = false, module = true, visibility = PRIVATE, keywords = true)
     public static IRubyObject open(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(context, args, 1, 4);
 
@@ -302,7 +302,7 @@ public class RubyKernel {
     }
 
     // MRI: rb_f_gets
-    @JRubyMethod(optional = 1, module = true, visibility = PRIVATE)
+    @JRubyMethod(optional = 1, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject gets(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Ruby runtime = context.runtime;
         IRubyObject argsFile = runtime.getArgsFile();
@@ -313,7 +313,7 @@ public class RubyKernel {
         return sites(context).gets.call(context, argsFile, argsFile, args);
     }
 
-    @JRubyMethod(optional = 1, module = true, visibility = PRIVATE)
+    @JRubyMethod(optional = 1, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject abort(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -668,7 +668,7 @@ public class RubyKernel {
         return context.nil;
     }
 
-    @JRubyMethod(optional = 1, module = true, visibility = PRIVATE)
+    @JRubyMethod(optional = 1, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject readline(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         IRubyObject line = gets(context, recv, args);
 
@@ -679,7 +679,7 @@ public class RubyKernel {
         return line;
     }
 
-    @JRubyMethod(optional = 1, module = true, visibility = PRIVATE)
+    @JRubyMethod(optional = 1, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject readlines(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         return RubyArgsFile.readlines(context, context.runtime.getArgsFile(), args);
     }
@@ -711,12 +711,12 @@ public class RubyKernel {
         }
     }
 
-    @JRubyMethod(required = 1, optional = 3, module = true, visibility = PRIVATE)
+    @JRubyMethod(required = 1, optional = 3, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject select(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         return RubyIO.select(context, recv, args);
     }
 
-    @JRubyMethod(optional = 1, module = true, visibility = PRIVATE)
+    @JRubyMethod(optional = 1, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject sleep(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -768,7 +768,7 @@ public class RubyKernel {
         return runtime.getNil(); // not reached
     }
 
-    @JRubyMethod(name = "exit!", optional = 1, module = true, visibility = PRIVATE)
+    @JRubyMethod(name = "exit!", optional = 1, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject exit_bang(IRubyObject recv, IRubyObject[] args) {
         Ruby runtime = recv.getRuntime();
 
@@ -867,7 +867,7 @@ public class RubyKernel {
         return RubyBoolean.newBoolean(context, context.getCurrentFrame().getBlock().isGiven());
     }
 
-    @JRubyMethod(name = {"sprintf", "format"}, required = 1, rest = true, module = true, visibility = PRIVATE)
+    @JRubyMethod(name = {"sprintf", "format"}, required = 1, rest = true, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject sprintf(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         if (args.length == 0) {
             throw context.runtime.newArgumentError("sprintf must have at least one argument");
@@ -926,7 +926,7 @@ public class RubyKernel {
         throw raise;
     }
 
-    @JRubyMethod(name = {"raise", "fail"}, optional = 3, module = true, visibility = PRIVATE, omit = true)
+    @JRubyMethod(name = {"raise", "fail"}, optional = 3, checkArity = false, module = true, visibility = PRIVATE, omit = true)
     public static IRubyObject raise(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(context, args, 0, 3);
 
@@ -1150,7 +1150,7 @@ public class RubyKernel {
         return runtime.getTrue();
     }
 
-    @JRubyMethod(name = "eval", required = 1, optional = 3, module = true, visibility = PRIVATE,
+    @JRubyMethod(name = "eval", required = 1, optional = 3, checkArity = false, module = true, visibility = PRIVATE,
             reads = {LASTLINE, BACKREF, VISIBILITY, BLOCK, SELF, METHODNAME, LINE, CLASS, FILENAME, SCOPE},
             writes = {LASTLINE, BACKREF, VISIBILITY, BLOCK, SELF, METHODNAME, LINE, CLASS, FILENAME, SCOPE})
     public static IRubyObject eval(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
@@ -1496,7 +1496,7 @@ public class RubyKernel {
         return trace_func;
     }
 
-    @JRubyMethod(required = 1, optional = 1, module = true, visibility = PRIVATE)
+    @JRubyMethod(required = 1, optional = 1, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject trace_var(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -1517,7 +1517,7 @@ public class RubyKernel {
         return context.nil;
     }
 
-    @JRubyMethod(required = 1, optional = 1, module = true, visibility = PRIVATE)
+    @JRubyMethod(required = 1, optional = 1, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject untrace_var(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -1543,7 +1543,7 @@ public class RubyKernel {
         return context.nil;
     }
 
-    @JRubyMethod(required = 1, optional = 1)
+    @JRubyMethod(required = 1, optional = 1, checkArity = false)
     public static IRubyObject define_singleton_method(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -1624,7 +1624,7 @@ public class RubyKernel {
         return RubyFloat.newFloat(context.runtime, RubyFloat.INFINITY);
     }
 
-    @JRubyMethod(required = 2, optional = 1, module = true, visibility = PRIVATE)
+    @JRubyMethod(required = 2, optional = 1, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject test(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 2, 3);
 
@@ -1815,12 +1815,12 @@ public class RubyKernel {
         return RubyProcess.spawn(context, recv, args);
     }
 
-    @JRubyMethod(required = 1, optional = 9, module = true, visibility = PRIVATE)
+    @JRubyMethod(required = 1, optional = 9, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject syscall(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         throw context.runtime.newNotImplementedError("Kernel#syscall is not implemented in JRuby");
     }
 
-    @JRubyMethod(name = "system", required = 1, rest = true, module = true, visibility = PRIVATE)
+    @JRubyMethod(name = "system", required = 1, rest = true, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject    system(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 1, -1);
 
@@ -2036,7 +2036,7 @@ public class RubyKernel {
         return recv;
     }
 
-    @JRubyMethod(name = {"to_enum", "enum_for"}, optional = 1, rest = true, keywords = true)
+    @JRubyMethod(name = {"to_enum", "enum_for"}, rest = true, keywords = true)
     public static IRubyObject obj_to_enum(final ThreadContext context, IRubyObject self, IRubyObject[] args, final Block block) {
         // to_enum is a bit strange in that it will propagate the arguments it passes to each element it calls.  We are determining
         // whether we have received keywords so we can propagate this info.
@@ -2212,7 +2212,7 @@ public class RubyKernel {
         return ((RubyBasicObject)self).dup();
     }
 
-    @JRubyMethod(optional = 1)
+    @JRubyMethod(optional = 1, checkArity = false)
     public static IRubyObject display(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -2249,7 +2249,7 @@ public class RubyKernel {
         return ((RubyBasicObject)self).kind_of_p(context, type);
     }
 
-    @JRubyMethod(name = "methods", optional = 1)
+    @JRubyMethod(name = "methods", optional = 1, checkArity = false)
     public static IRubyObject methods(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -2266,7 +2266,7 @@ public class RubyKernel {
         return self.id();
     }
 
-    @JRubyMethod(name = "public_methods", optional = 1)
+    @JRubyMethod(name = "public_methods", optional = 1, checkArity = false)
     public static IRubyObject public_methods(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -2278,7 +2278,7 @@ public class RubyKernel {
         return ((RubyBasicObject)self).public_methods(context, args);
     }
 
-    @JRubyMethod(name = "protected_methods", optional = 1)
+    @JRubyMethod(name = "protected_methods", optional = 1, checkArity = false)
     public static IRubyObject protected_methods(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -2290,7 +2290,7 @@ public class RubyKernel {
         return ((RubyBasicObject)self).protected_methods(context, args);
     }
 
-    @JRubyMethod(name = "private_methods", optional = 1)
+    @JRubyMethod(name = "private_methods", optional = 1, checkArity = false)
     public static IRubyObject private_methods(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -2302,7 +2302,7 @@ public class RubyKernel {
         return ((RubyBasicObject)self).private_methods(context, args);
     }
 
-    @JRubyMethod(name = "singleton_methods", optional = 1)
+    @JRubyMethod(name = "singleton_methods", optional = 1, checkArity = false)
     public static RubyArray singleton_methods(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -2329,7 +2329,7 @@ public class RubyKernel {
         return ((RubyBasicObject)self).to_s();
     }
 
-    @JRubyMethod(name = "extend", required = 1, rest = true)
+    @JRubyMethod(name = "extend", required = 1, rest = true, checkArity = false)
     public static IRubyObject extend(IRubyObject self, IRubyObject[] args) {
         Arity.checkArgumentCount(self.getRuntime(), args, 1, -1);
 
@@ -2348,7 +2348,7 @@ public class RubyKernel {
     public static IRubyObject send(ThreadContext context, IRubyObject self, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
         return ((RubyBasicObject)self).send(context, arg0, arg1, arg2, block);
     }
-    @JRubyMethod(name = "send", required = 1, rest = true, omit = true, keywords = true)
+    @JRubyMethod(name = "send", required = 1, rest = true, checkArity = false, omit = true, keywords = true)
     public static IRubyObject send(ThreadContext context, IRubyObject self, IRubyObject[] args, Block block) {
         Arity.checkArgumentCount(context, args, 1, -1);
 

--- a/core/src/main/java/org/jruby/RubyMarshal.java
+++ b/core/src/main/java/org/jruby/RubyMarshal.java
@@ -70,7 +70,7 @@ public class RubyMarshal {
         return module;
     }
 
-    @JRubyMethod(required = 1, optional = 2, module = true, visibility = Visibility.PRIVATE)
+    @JRubyMethod(required = 1, optional = 2, checkArity = false, module = true, visibility = Visibility.PRIVATE)
     public static IRubyObject dump(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block unusedBlock) {
         int argc = Arity.checkArgumentCount(context, args, 1, 3);
 
@@ -115,7 +115,7 @@ public class RubyMarshal {
         return dump(recv.getRuntime().getCurrentContext(), recv, args, unusedBlock);
     }
 
-    @JRubyMethod(name = {"load", "restore"}, required = 1, optional = 2, module = true, visibility = Visibility.PRIVATE)
+    @JRubyMethod(name = {"load", "restore"}, required = 1, optional = 2, checkArity = false, module = true, visibility = Visibility.PRIVATE)
     public static IRubyObject load(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block unusedBlock) {
         int argc = Arity.checkArgumentCount(context, args, 1, 3);
 

--- a/core/src/main/java/org/jruby/RubyMethod.java
+++ b/core/src/main/java/org/jruby/RubyMethod.java
@@ -381,7 +381,7 @@ public class RubyMethod extends AbstractRubyMethod {
         return Helpers.methodToParameters(context.runtime, this);
     }
 
-    @JRubyMethod(optional = 1)
+    @JRubyMethod(optional = 1, checkArity = false)
     public IRubyObject curry(ThreadContext context, IRubyObject[] args) {
         return to_proc(context).callMethod(context, "curry", args);
     }

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2958,7 +2958,7 @@ public class RubyModule extends RubyObject {
         addAccessor(context, TypeConverter.checkID(context.runtime, name), PUBLIC, false, true);
     }
 
-    @JRubyMethod(required = 1, rest = true, visibility = PRIVATE)
+    @JRubyMethod(required = 1, rest = true, checkArity = false, visibility = PRIVATE)
     public IRubyObject ruby2_keywords(ThreadContext context, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 1, -1);
 
@@ -3178,7 +3178,7 @@ public class RubyModule extends RubyObject {
         return instance_methods19(args);
     }
 
-    @JRubyMethod(name = "instance_methods", optional = 1)
+    @JRubyMethod(name = "instance_methods", optional = 1, checkArity = false)
     public RubyArray instance_methods19(IRubyObject[] args) {
         Arity.checkArgumentCount(getRuntime(), args, 0, 1);
 
@@ -3189,7 +3189,7 @@ public class RubyModule extends RubyObject {
         return public_instance_methods19(args);
     }
 
-    @JRubyMethod(name = "public_instance_methods", optional = 1)
+    @JRubyMethod(name = "public_instance_methods", optional = 1, checkArity = false)
     public RubyArray public_instance_methods19(IRubyObject[] args) {
         Arity.checkArgumentCount(getRuntime(), args, 0, 1);
 
@@ -3213,7 +3213,7 @@ public class RubyModule extends RubyObject {
     /** rb_class_protected_instance_methods
      *
      */
-    @JRubyMethod(name = "protected_instance_methods", optional = 1)
+    @JRubyMethod(name = "protected_instance_methods", optional = 1, checkArity = false)
     public RubyArray protected_instance_methods(IRubyObject[] args) {
         Arity.checkArgumentCount(getRuntime(), args, 0, 1);
 
@@ -3228,7 +3228,7 @@ public class RubyModule extends RubyObject {
     /** rb_class_private_instance_methods
      *
      */
-    @JRubyMethod(name = "private_instance_methods", optional = 1)
+    @JRubyMethod(name = "private_instance_methods", optional = 1, checkArity = false)
     public RubyArray private_instance_methods(IRubyObject[] args) {
         Arity.checkArgumentCount(getRuntime(), args, 0, 1);
 
@@ -3295,7 +3295,7 @@ public class RubyModule extends RubyObject {
     /** rb_mod_include
      *
      */
-    @JRubyMethod(name = "include", required = 1, rest = true)
+    @JRubyMethod(name = "include", required = 1, rest = true, checkArity = false)
     public RubyModule include(IRubyObject[] modules) {
         Ruby runtime = getRuntime();
 
@@ -4171,7 +4171,7 @@ public class RubyModule extends RubyObject {
     /** rb_mod_const_get
      *
      */
-    @JRubyMethod(name = "const_get", required = 1, optional = 1)
+    @JRubyMethod(name = "const_get", required = 1, optional = 1, checkArity = false)
     public IRubyObject const_get(ThreadContext context, IRubyObject... args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -4216,7 +4216,7 @@ public class RubyModule extends RubyObject {
         return mod.getConstant(validateConstant(name, symbol), firstConstant && inherit, firstConstant && inherit);
     }
 
-    @JRubyMethod(required = 1, optional = 1)
+    @JRubyMethod(required = 1, optional = 1, checkArity = false)
     public IRubyObject const_source_location(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -4445,7 +4445,7 @@ public class RubyModule extends RubyObject {
         return this;
     }
 
-    @JRubyMethod(required = 1, rest = true)
+    @JRubyMethod(required = 1, rest = true, checkArity = false)
     public IRubyObject private_constant(ThreadContext context, IRubyObject[] rubyNames) {
         Arity.checkArgumentCount(context, rubyNames, 1, -1);
 
@@ -4466,7 +4466,7 @@ public class RubyModule extends RubyObject {
         return this;
     }
 
-    @JRubyMethod(required = 1, rest = true)
+    @JRubyMethod(required = 1, rest = true, checkArity = false)
     public IRubyObject public_constant(ThreadContext context, IRubyObject[] rubyNames) {
         Arity.checkArgumentCount(context, rubyNames, 1, -1);
 
@@ -4476,7 +4476,7 @@ public class RubyModule extends RubyObject {
         return this;
     }
 
-    @JRubyMethod(name = "prepend", required = 1, rest = true)
+    @JRubyMethod(name = "prepend", required = 1, rest = true, checkArity = false)
     public IRubyObject prepend(ThreadContext context, IRubyObject[] modules) {
         int argc = Arity.checkArgumentCount(context, modules, 1, -1);
 
@@ -5968,7 +5968,7 @@ public class RubyModule extends RubyObject {
     }
 
     public static class RefinementMethods {
-        @JRubyMethod(required = 1, rest = true, visibility = PRIVATE)
+        @JRubyMethod(required = 1, rest = true, checkArity = false, visibility = PRIVATE)
         public static IRubyObject import_methods(ThreadContext context, IRubyObject self, IRubyObject[] modules) {
             Arity.checkArgumentCount(context, modules, 1, -1);
 

--- a/core/src/main/java/org/jruby/RubyNil.java
+++ b/core/src/main/java/org/jruby/RubyNil.java
@@ -245,7 +245,7 @@ public class RubyNil extends RubyObject implements Constantizable {
     /** nilclass_rationalize
      *
      */
-    @JRubyMethod(optional = 1)
+    @JRubyMethod(optional = 1, checkArity = false)
     public static IRubyObject rationalize(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 1);
 

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -1012,7 +1012,7 @@ public class RubyNumeric extends RubyObject {
     /**
      * num_step
      */
-    @JRubyMethod(optional = 2)
+    @JRubyMethod(optional = 2, checkArity = false)
     public IRubyObject step(ThreadContext context, IRubyObject[] args, Block block) {
         Arity.checkArgumentCount(context, args, 0, 2);
 

--- a/core/src/main/java/org/jruby/RubyObjectSpace.java
+++ b/core/src/main/java/org/jruby/RubyObjectSpace.java
@@ -68,7 +68,7 @@ public class RubyObjectSpace {
         return objectSpaceModule;
     }
 
-    @JRubyMethod(required = 1, optional = 1, module = true, visibility = PRIVATE)
+    @JRubyMethod(required = 1, optional = 1, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject define_finalizer(IRubyObject recv, IRubyObject[] args, Block block) {
         Ruby runtime = recv.getRuntime();
 
@@ -206,14 +206,14 @@ public class RubyObjectSpace {
         return runtime.newFixnum(count);
     }
 
-    @JRubyMethod(name = "each_object", optional = 1, module = true, visibility = PRIVATE)
+    @JRubyMethod(name = "each_object", optional = 1, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject each_object(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         Arity.checkArgumentCount(context, args, 0, 1);
 
         return block.isGiven() ? each_objectInternal(context, recv, args, block) : enumeratorize(context.runtime, recv, "each_object", args);
     }
 
-    @JRubyMethod(name = "garbage_collect", module = true, visibility = PRIVATE, optional = 1)
+    @JRubyMethod(name = "garbage_collect", module = true, visibility = PRIVATE, optional = 1, checkArity = false)
     public static IRubyObject garbage_collect(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         return RubyGC.start(context, recv, args);
     }

--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -217,7 +217,7 @@ public class RubyProcess {
             return new RubyStatus(runtime, runtime.getProcStatus(), status, pid);
         }
 
-        @JRubyMethod(module = true, optional = 2)
+        @JRubyMethod(module = true, optional = 2, checkArity = false)
         public static IRubyObject wait(ThreadContext context, IRubyObject self, IRubyObject[] args) {
             int argc = Arity.checkArgumentCount(context, args, 0, 2);
 
@@ -667,12 +667,12 @@ public class RubyProcess {
         }
     }
 
-    @JRubyMethod(name = "abort", optional = 1, module = true, visibility = PRIVATE)
+    @JRubyMethod(name = "abort", optional = 1, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject abort(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         return RubyKernel.abort(context, recv, args);
     }
 
-    @JRubyMethod(name = "exit!", optional = 1, module = true, visibility = PRIVATE)
+    @JRubyMethod(name = "exit!", optional = 1, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject exit_bang(IRubyObject recv, IRubyObject[] args) {
         return RubyKernel.exit_bang(recv, args);
     }
@@ -1782,7 +1782,7 @@ public class RubyProcess {
         return RubyFixnum.newFixnum(runtime, ShellLauncher.runExternalWithoutWait(runtime, args));
     }
 
-    @JRubyMethod(name = "exit", optional = 1, module = true, visibility = PRIVATE)
+    @JRubyMethod(name = "exit", optional = 1, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject exit(IRubyObject recv, IRubyObject[] args) {
         return RubyKernel.exit(recv, args);
     }

--- a/core/src/main/java/org/jruby/RubyRandomBase.java
+++ b/core/src/main/java/org/jruby/RubyRandomBase.java
@@ -58,7 +58,7 @@ public class RubyRandomBase extends RubyObject {
 
     protected RubyRandom.RandomType random = null;
 
-    @JRubyMethod(visibility = PRIVATE, optional = 1)
+    @JRubyMethod(visibility = PRIVATE, optional = 1, checkArity = false)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
 

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -286,7 +286,7 @@ public class RubyRange extends RubyObject {
         }
     }
 
-    @JRubyMethod(required = 2, optional = 1, visibility = PRIVATE)
+    @JRubyMethod(required = 2, optional = 1, checkArity = false, visibility = PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args, Block unusedBlock) {
         Arity.checkArgumentCount(context, args, 2, 3);
 

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -1392,7 +1392,7 @@ public class RubyRational extends RubyNumeric {
     /** nurat_rationalize
      *
      */
-    @JRubyMethod(name = "rationalize", optional = 1)
+    @JRubyMethod(name = "rationalize", optional = 1, checkArity = false)
     public IRubyObject rationalize(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
 

--- a/core/src/main/java/org/jruby/RubySignalException.java
+++ b/core/src/main/java/org/jruby/RubySignalException.java
@@ -62,7 +62,7 @@ public class RubySignalException extends RubyException {
         return signalExceptionClass;
     }
 
-    @JRubyMethod(optional = 2, visibility = PRIVATE)
+    @JRubyMethod(optional = 2, checkArity = false, visibility = PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(context, args, 0, 2);
 

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1713,7 +1713,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return block.isGiven() && result != context.nil ? block.yield(context, result) : result;
     }
 
-    @JRubyMethod(name = "match", required = 1, rest = true)
+    @JRubyMethod(name = "match", required = 1, rest = true, checkArity = false)
     public IRubyObject match19(ThreadContext context, IRubyObject[] args, Block block) {
         if (args.length < 1) {
             Arity.checkArgumentCount(context, args, 1, -1);
@@ -5764,7 +5764,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     }
 
     // MRI: rb_str_count for arity > 1, first half
-    @JRubyMethod(name = "count", required = 1, rest = true)
+    @JRubyMethod(name = "count", required = 1, rest = true, checkArity = false)
     public IRubyObject count(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, -1);
 
@@ -5802,7 +5802,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return str;
     }
 
-    @JRubyMethod(name = "delete", required = 1, rest = true)
+    @JRubyMethod(name = "delete", required = 1, rest = true, checkArity = false)
     public IRubyObject delete(ThreadContext context, IRubyObject[] args) {
         RubyString str = strDup(context.runtime, context.runtime.getString());
         str.delete_bang(context, args);
@@ -5831,7 +5831,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return this;
     }
 
-    @JRubyMethod(name = "delete!", required = 1, rest = true)
+    @JRubyMethod(name = "delete!", required = 1, rest = true, checkArity = false)
     public IRubyObject delete_bang(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, -1);
 
@@ -5904,7 +5904,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return str;
     }
 
-    @JRubyMethod(name = "squeeze", required = 1, rest = true)
+    @JRubyMethod(name = "squeeze", required = 1, rest = true, checkArity = false)
     public IRubyObject squeeze(ThreadContext context, IRubyObject[] args) {
         RubyString str = strDup(context.runtime, context.runtime.getString());
         str.squeeze_bang(context, args);
@@ -5958,7 +5958,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return this;
     }
 
-    @JRubyMethod(name = "squeeze!", required = 1, rest = true)
+    @JRubyMethod(name = "squeeze!", required = 1, rest = true, checkArity = false)
     public IRubyObject squeeze_bang(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, -1);
 
@@ -6615,7 +6615,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return encode_bang(context, new IRubyObject[]{arg0,arg1,arg2});
     }
 
-    @JRubyMethod(name = "encode!", optional = 3)
+    @JRubyMethod(name = "encode!", optional = 3, checkArity = false)
     public IRubyObject encode_bang(ThreadContext context, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 3);
 

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -214,7 +214,7 @@ public class RubyStruct extends RubyObject {
      * MRI: rb_struct_s_def / make_struct
      *
      */
-    @JRubyMethod(name = "new", required = 1, rest = true, meta = true, keywords = true)
+    @JRubyMethod(name = "new", required = 1, rest = true, checkArity = false, meta = true, keywords = true)
     public static RubyClass newInstance(IRubyObject recv, IRubyObject[] args, Block block) {
         Ruby runtime = recv.getRuntime();
 
@@ -883,7 +883,7 @@ public class RubyStruct extends RubyObject {
         return RubyObject.dig2(context, val, arg1, arg2);
     }
 
-    @JRubyMethod(name = "dig", required = 1, rest = true)
+    @JRubyMethod(name = "dig", required = 1, rest = true, checkArity = false)
     public IRubyObject dig(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, -1);
 

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -610,7 +610,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
         return newShared(context.runtime).match19(context, other, pos, block);
     }
 
-    @JRubyMethod(name = "match", required = 1, rest = true)
+    @JRubyMethod(name = "match", required = 1, rest = true, checkArity = false)
     public IRubyObject match_m(ThreadContext context, IRubyObject[] args, Block block) {
         return newShared(context.runtime).match19(context, args, block);
     }

--- a/core/src/main/java/org/jruby/RubySystemCallError.java
+++ b/core/src/main/java/org/jruby/RubySystemCallError.java
@@ -171,7 +171,7 @@ public class RubySystemCallError extends RubyStandardError {
         return exceptionClass;
     }
     
-    @JRubyMethod(optional = 2, visibility = PRIVATE)
+    @JRubyMethod(optional = 2, checkArity = false, visibility = PRIVATE)
     @Override
     public IRubyObject initialize(IRubyObject[] args, Block block) {
         Ruby runtime = getRuntime();

--- a/core/src/main/java/org/jruby/RubySystemExit.java
+++ b/core/src/main/java/org/jruby/RubySystemExit.java
@@ -72,7 +72,7 @@ public class RubySystemExit extends RubyException {
         return new SystemExit(message, this);
     }
 
-    @JRubyMethod(optional = 2, visibility = PRIVATE)
+    @JRubyMethod(optional = 2, checkArity = false, visibility = PRIVATE)
     @Override
     public IRubyObject initialize(IRubyObject[] args, Block block) {
         Ruby runtime = getRuntime();

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -865,12 +865,12 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         throw context.runtime.newArgumentError("unknown mask signature");
     }
 
-    @JRubyMethod(name = "pending_interrupt?", meta = true, optional = 1)
+    @JRubyMethod(name = "pending_interrupt?", meta = true, optional = 1, checkArity = false)
     public static IRubyObject pending_interrupt_p(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         return context.getThread().pending_interrupt_p(context, args);
     }
 
-    @JRubyMethod(name = "pending_interrupt?", optional = 1)
+    @JRubyMethod(name = "pending_interrupt?", optional = 1, checkArity = false)
     public IRubyObject pending_interrupt_p(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -1220,7 +1220,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         return join(getRuntime().getCurrentContext(), args);
     }
 
-    @JRubyMethod(optional = 1)
+    @JRubyMethod(optional = 1, checkArity = false)
     public IRubyObject join(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -1483,7 +1483,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         return genericRaise(context, context.getThread(), exception, message);
     }
 
-    @JRubyMethod(optional = 3)
+    @JRubyMethod(optional = 3, checkArity = false)
     public IRubyObject raise(ThreadContext context, IRubyObject[] args, Block block) {
         Arity.checkArgumentCount(context, args, 0, 3);
 

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -1333,7 +1333,7 @@ public class RubyTime extends RubyObject {
         return string;
     }
 
-    @JRubyMethod(optional = 1)
+    @JRubyMethod(optional = 1, checkArity = false)
     public RubyTime round(ThreadContext context, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -1346,7 +1346,7 @@ public class RubyTime extends RubyObject {
         return newTime(context.runtime, _dt, rounded % 1000000);
     }
 
-    @JRubyMethod(optional = 1)
+    @JRubyMethod(optional = 1, checkArity = false)
     public RubyTime floor(ThreadContext context, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -1359,7 +1359,7 @@ public class RubyTime extends RubyObject {
         return newTime(context.runtime, _dt, floored % 1000000);
     }
 
-    @JRubyMethod(optional = 1)
+    @JRubyMethod(optional = 1, checkArity = false)
     public RubyTime ceil(ThreadContext context, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -1409,7 +1409,7 @@ public class RubyTime extends RubyObject {
         return newInstance(context, recv, args);
     }
 
-    @JRubyMethod(name = "now", meta = true, optional = 1, keywords = true)
+    @JRubyMethod(name = "now", meta = true, optional = 1, checkArity = false, keywords = true)
     public static RubyTime newInstance(ThreadContext context, IRubyObject recv, IRubyObject args[]) {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -1451,7 +1451,7 @@ public class RubyTime extends RubyObject {
         return atOpts(context, recv, arg1, arg2, null, arg3);
     }
 
-    @JRubyMethod(required = 1, optional = 3, meta = true)
+    @JRubyMethod(required = 1, optional = 3, checkArity = false, meta = true)
     public static IRubyObject at(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         switch (args.length) {
             case 1:
@@ -1618,7 +1618,7 @@ public class RubyTime extends RubyObject {
         return time;
     }
 
-    @JRubyMethod(name = {"local", "mktime"}, required = 1, optional = 9, meta = true)
+    @JRubyMethod(name = {"local", "mktime"}, required = 1, optional = 9, checkArity = false, meta = true)
     public static RubyTime local(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 1, 10);
 
@@ -1711,7 +1711,7 @@ public class RubyTime extends RubyObject {
         return context.nil;
     }
 
-    @JRubyMethod(name = "initialize", optional = 7, visibility = PRIVATE, keywords = true)
+    @JRubyMethod(name = "initialize", optional = 7, checkArity = false, visibility = PRIVATE, keywords = true)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
         boolean keywords = hasKeywords(context.resetCallInfo());
         IRubyObject zone = null;
@@ -1840,7 +1840,7 @@ public class RubyTime extends RubyObject {
         return Helpers.invokeChecked(context, metaClass, "find_timezone", zone);
     }
 
-    @JRubyMethod(name = {"utc", "gm"}, required = 1, optional = 9, meta = true)
+    @JRubyMethod(name = {"utc", "gm"}, required = 1, optional = 9, checkArity = false, meta = true)
     public static RubyTime utc(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 1, 10);
 

--- a/core/src/main/java/org/jruby/RubyUnboundMethod.java
+++ b/core/src/main/java/org/jruby/RubyUnboundMethod.java
@@ -152,7 +152,7 @@ public class RubyUnboundMethod extends AbstractRubyMethod {
         return newUnboundMethod(implementationModule, methodName, originModule, originName, entry);
     }
 
-    @JRubyMethod(required =  1, rest = true, keywords = true)
+    @JRubyMethod(required =  1, rest = true, checkArity = false, keywords = true)
     public IRubyObject bind_call(ThreadContext context, IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(context, args, 1, -1);
 

--- a/core/src/main/java/org/jruby/RubyUncaughtThrowError.java
+++ b/core/src/main/java/org/jruby/RubyUncaughtThrowError.java
@@ -73,7 +73,7 @@ public class RubyUncaughtThrowError extends RubyArgumentError {
     }
 
     @Override
-    @JRubyMethod(required = 2, optional = 1, visibility = Visibility.PRIVATE)
+    @JRubyMethod(required = 2, optional = 1, checkArity = false, visibility = Visibility.PRIVATE)
     public IRubyObject initialize(IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(getRuntime(), args, 2, 3);
 

--- a/core/src/main/java/org/jruby/anno/JRubyMethod.java
+++ b/core/src/main/java/org/jruby/anno/JRubyMethod.java
@@ -109,6 +109,12 @@ public @interface JRubyMethod {
     boolean notImplemented() default false;
 
     /**
+     * Whether automatic arity-checking should be added to the Ruby binding for this
+     * method. Users can opt-out and do their own arity-checking in the method body.
+     */
+    boolean checkArity() default true;
+
+    /**
      * A list of classes that implement an abstract JRubyMethod, for backtrace purposes.
      */
     Class[] implementers() default {};

--- a/core/src/main/java/org/jruby/common/RubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/RubyWarnings.java
@@ -276,7 +276,7 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
         return context.nil;
     }
 
-    @JRubyMethod(required = 1, optional = 1)
+    @JRubyMethod(required = 1, optional = 1, checkArity = false)
     public static IRubyObject warn(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -367,7 +367,7 @@ public class RubyBigDecimal extends RubyNumeric {
         }
     }
 
-    @JRubyMethod(required = 1, optional = 1, meta = true)
+    @JRubyMethod(required = 1, optional = 1, checkArity = false, meta = true)
     public static IRubyObject mode(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Ruby runtime = context.runtime;
 
@@ -1978,7 +1978,7 @@ public class RubyBigDecimal extends RubyNumeric {
                 context.runtime.newFixnum(((getAllDigits().length() / 4) + 1) * 4));
     }
 
-    @JRubyMethod(name = "round", optional = 2)
+    @JRubyMethod(name = "round", optional = 2, checkArity = false)
     public IRubyObject round(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 0, 2);
 

--- a/core/src/main/java/org/jruby/ext/coverage/CoverageModule.java
+++ b/core/src/main/java/org/jruby/ext/coverage/CoverageModule.java
@@ -48,7 +48,7 @@ import static org.jruby.runtime.ThreadContext.hasKeywords;
  * Implementation of Ruby 1.9.2's "Coverage" module
  */
 public class CoverageModule {
-    @JRubyMethod(module = true, optional = 1, keywords = true)
+    @JRubyMethod(module = true, optional = 1, keywords = true, checkArity = false)
     public static IRubyObject setup(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -130,14 +130,14 @@ public class CoverageModule {
         return context.nil;
     }
 
-    @JRubyMethod(module = true, optional = 1, keywords = true)
+    @JRubyMethod(module = true, optional = 1, keywords = true, checkArity = false)
     public static IRubyObject start(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         setup(context, self, args);
         resume(context, self);
         return context.nil;
     }
 
-    @JRubyMethod(module = true, optional = 1, keywords = true)
+    @JRubyMethod(module = true, optional = 1, keywords = true, checkArity = false)
     public static IRubyObject result(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
 

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -422,7 +422,7 @@ public class RubyDate extends RubyObject {
         return date;
     }
 
-    @JRubyMethod(name = "civil", alias = "new", meta = true, optional = 4) // 4 args case
+    @JRubyMethod(name = "civil", alias = "new", meta = true, optional = 4, checkArity = false) // 4 args case
     public static RubyDate civil(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         // IRubyObject year, IRubyObject month, IRubyObject mday, IRubyObject start
         int argc = Arity.checkArgumentCount(context, args, 0, 4);
@@ -474,7 +474,7 @@ public class RubyDate extends RubyObject {
         return (m < 0) ? m + 13 : m;
     }
 
-    @JRubyMethod(name = "valid_civil?", alias = "valid_date?", meta = true, required = 3, optional = 1)
+    @JRubyMethod(name = "valid_civil?", alias = "valid_date?", meta = true, required = 3, optional = 1, checkArity = false)
     public static IRubyObject valid_civil_p(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 3, 4);
 
@@ -623,7 +623,7 @@ public class RubyDate extends RubyObject {
         return jd;
     }
 
-    @JRubyMethod(name = "ordinal", meta = true, optional = 3)
+    @JRubyMethod(name = "ordinal", meta = true, optional = 3, checkArity = false)
     public static RubyDate ordinal(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         // ordinal(y=-4712, d=1, sg=ITALY)
         int argc = Arity.checkArgumentCount(context, args, 0, 3);
@@ -641,7 +641,7 @@ public class RubyDate extends RubyObject {
         return new RubyDate(context, (RubyClass) self, jd_to_ajd(context, jd), rest, 0, sg);
     }
 
-    @JRubyMethod(name = "valid_ordinal?", meta = true, required = 2, optional = 1)
+    @JRubyMethod(name = "valid_ordinal?", meta = true, required = 2, optional = 1, checkArity = false)
     public static IRubyObject valid_ordinal_p(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 2, 3);
 
@@ -660,7 +660,7 @@ public class RubyDate extends RubyObject {
     }
 
     @Deprecated // NOTE: should go away once no date.rb is using it
-    @JRubyMethod(name = "_valid_ordinal?", meta = true, required = 2, optional = 1, visibility = Visibility.PRIVATE)
+    @JRubyMethod(name = "_valid_ordinal?", meta = true, required = 2, optional = 1, checkArity = false, visibility = Visibility.PRIVATE)
     public static IRubyObject _valid_ordinal_p(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 2, 3);
 
@@ -670,12 +670,12 @@ public class RubyDate extends RubyObject {
     }
 
     @Deprecated // NOTE: should go away once no date.rb is using it
-    @JRubyMethod(name = "_valid_ordinal?", required = 2, optional = 1, visibility = Visibility.PRIVATE)
+    @JRubyMethod(name = "_valid_ordinal?", required = 2, optional = 1, checkArity = false, visibility = Visibility.PRIVATE)
     public IRubyObject _valid_ordinal_p(ThreadContext context, IRubyObject[] args) {
         return RubyDate._valid_ordinal_p(context, null, args);
     }
 
-    @JRubyMethod(name = "commercial", meta = true, optional = 4)
+    @JRubyMethod(name = "commercial", meta = true, optional = 4, checkArity = false)
     public static RubyDate commercial(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         // commercial(y=-4712, w=1, d=1, sg=ITALY)
         int argc = Arity.checkArgumentCount(context, args, 0, 4);
@@ -691,7 +691,7 @@ public class RubyDate extends RubyObject {
         return new RubyDate(context, (RubyClass) self, jd_to_ajd(context, jd), 0, sg);
     }
 
-    @JRubyMethod(name = "valid_commercial?", meta = true, required = 3, optional = 1)
+    @JRubyMethod(name = "valid_commercial?", meta = true, required = 3, optional = 1, checkArity = false)
     public static IRubyObject valid_commercial_p(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 3, 4);
 
@@ -708,7 +708,7 @@ public class RubyDate extends RubyObject {
     }
 
     @Deprecated // NOTE: should go away once no date.rb is using it
-    @JRubyMethod(name = "_valid_commercial?", meta = true, required = 3, optional = 1, visibility = Visibility.PRIVATE)
+    @JRubyMethod(name = "_valid_commercial?", meta = true, required = 3, optional = 1, checkArity = false, visibility = Visibility.PRIVATE)
     public static IRubyObject _valid_commercial_p(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 3, 4);
 
@@ -718,7 +718,7 @@ public class RubyDate extends RubyObject {
     }
 
     @Deprecated // NOTE: should go away once no date.rb is using it
-    @JRubyMethod(name = "_valid_weeknum?", meta = true, required = 4, optional = 1, visibility = Visibility.PRIVATE)
+    @JRubyMethod(name = "_valid_weeknum?", meta = true, required = 4, optional = 1, checkArity = false, visibility = Visibility.PRIVATE)
     public static IRubyObject _valid_weeknum_p(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 4, 5);
 
@@ -754,7 +754,7 @@ public class RubyDate extends RubyObject {
         return new DateTime(today.getYear(), today.getMonthOfYear(), today.getDayOfMonth(), 0, 0, chrono);
     }
 
-    @JRubyMethod(name = "_valid_civil?", meta = true, required = 3, optional = 1)
+    @JRubyMethod(name = "_valid_civil?", meta = true, required = 3, optional = 1, checkArity = false)
     public static IRubyObject _valid_civil_p(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 3, 4);
 
@@ -764,7 +764,7 @@ public class RubyDate extends RubyObject {
     }
 
     @Deprecated // NOTE: should go away once no date.rb is using it
-    @JRubyMethod(name = "_valid_civil?", required = 3, optional = 1, visibility = Visibility.PRIVATE)
+    @JRubyMethod(name = "_valid_civil?", required = 3, optional = 1, checkArity = false, visibility = Visibility.PRIVATE)
     public IRubyObject _valid_civil_p(ThreadContext context, IRubyObject[] args) {
         return RubyDate._valid_civil_p(context, null, args);
     }
@@ -1143,7 +1143,7 @@ public class RubyDate extends RubyObject {
         return RubyRational.newRationalCanonicalize(context, offset, DAY_MS);
     }
 
-    @JRubyMethod(optional = 1, visibility = Visibility.PRIVATE)
+    @JRubyMethod(optional = 1, checkArity = false, visibility = Visibility.PRIVATE)
     public IRubyObject new_offset(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -1512,7 +1512,7 @@ public class RubyDate extends RubyObject {
         return (RubyNumeric) ((RubyNumeric) tmp.op_plus(context, fr)).op_plus(context, MINUS_HALF);
     }
 
-    @JRubyMethod(meta = true, required = 2, optional = 1, visibility = Visibility.PRIVATE)
+    @JRubyMethod(meta = true, required = 2, optional = 1, checkArity = false, visibility = Visibility.PRIVATE)
     public static RubyNumeric jd_to_ajd(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 2, 3);
 
@@ -2366,7 +2366,7 @@ public class RubyDate extends RubyObject {
         return ((RubyRegexp) reg).match_m(context, str, false);
     }
 
-    @JRubyMethod(name = "s3e", meta = true, required = 4, optional = 1, visibility = Visibility.PRIVATE)
+    @JRubyMethod(name = "s3e", meta = true, required = 4, optional = 1, checkArity = false, visibility = Visibility.PRIVATE)
     public static IRubyObject _s3e(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 4, 5);
 

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -171,7 +171,7 @@ public class RubyDateTime extends RubyDate {
         return new RubyDateTime(context.runtime, (RubyClass) self, civilImpl(context, year, month), 0);
     }
 
-    @JRubyMethod(name = "civil", alias = "new", meta = true, optional = 8)
+    @JRubyMethod(name = "civil", alias = "new", meta = true, optional = 8, checkArity = false)
     public static RubyDateTime civil(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         // year=-4712, month=1, mday=1,
         //  hour=0, minute=0, second=0, offset=0, start=Date::ITALY
@@ -390,7 +390,7 @@ public class RubyDateTime extends RubyDate {
         return new RubyDateTime(context.runtime, (RubyClass) self, defaultDateTime, 0);
     }
 
-    @JRubyMethod(name = "jd", meta = true, optional = 6)
+    @JRubyMethod(name = "jd", meta = true, optional = 6, checkArity = false)
     public static RubyDateTime jd(ThreadContext context, IRubyObject self, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 0, 6);
 

--- a/core/src/main/java/org/jruby/ext/digest/RubyDigest.java
+++ b/core/src/main/java/org/jruby/ext/digest/RubyDigest.java
@@ -312,7 +312,7 @@ public class RubyDigest {
             return self.rbClone().callMethod(context, "reset");
         }
 
-        @JRubyMethod(optional = 1)
+        @JRubyMethod(optional = 1, checkArity = false)
         public static IRubyObject digest(ThreadContext context, IRubyObject self, IRubyObject[] args) {
             int argc = Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -337,7 +337,7 @@ public class RubyDigest {
             return value;
         }
 
-        @JRubyMethod(optional = 1)
+        @JRubyMethod(optional = 1, checkArity = false)
         public static IRubyObject hexdigest(ThreadContext context, IRubyObject self, IRubyObject[] args) {
             return toHexString(context.runtime, digest(context, self, args).convertToString().getBytes());
         }
@@ -347,7 +347,7 @@ public class RubyDigest {
             return toHexString(context.runtime, digest_bang(context, self).convertToString().getBytes());
         }
 
-        @JRubyMethod(name = "bubblebabble", required = 1, optional = 1, meta = true)
+        @JRubyMethod(name = "bubblebabble", required = 1, optional = 1, checkArity = false, meta = true)
         public static IRubyObject bubblebabble(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block unusedBlock) {
             byte[] digest = recv.callMethod(context, "digest", args, Block.NULL_BLOCK).convertToString().getBytes();
             return RubyString.newString(recv.getRuntime(), BubbleBabble.bubblebabble(digest, 0, digest.length));
@@ -371,7 +371,7 @@ public class RubyDigest {
             super(runtime, type);
         }
 
-        @JRubyMethod(name = "digest", required = 1, rest = true, meta = true)
+        @JRubyMethod(name = "digest", required = 1, rest = true, checkArity = false, meta = true)
         public static IRubyObject s_digest(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block unusedBlock) {
             final Ruby runtime = context.runtime;
             if (args.length < 1) {
@@ -383,7 +383,7 @@ public class RubyDigest {
             return obj.callMethod(context, "digest", str);
         }
 
-        @JRubyMethod(name = "hexdigest", required = 1, optional = 1, meta = true)
+        @JRubyMethod(name = "hexdigest", required = 1, optional = 1, checkArity = false, meta = true)
         public static IRubyObject s_hexdigest(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block unusedBlock) {
             Ruby runtime = recv.getRuntime();
             byte[] digest = recv.callMethod(context, "digest", args, Block.NULL_BLOCK).convertToString().getBytes();

--- a/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
+++ b/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
@@ -212,7 +212,7 @@ public class RubyEtc {
         return RubyString.newString(context.runtime, bytes);
     }
 
-    @JRubyMethod(optional=1, module = true)
+    @JRubyMethod(optional = 1, checkArity = false, module = true)
     public static synchronized IRubyObject getpwuid(IRubyObject recv, IRubyObject[] args) {
         Ruby runtime = recv.getRuntime();
 
@@ -396,7 +396,7 @@ public class RubyEtc {
         }
     }
 
-    @JRubyMethod(optional=1, module = true)
+    @JRubyMethod(optional = 1, checkArity = false, module = true)
     public static synchronized IRubyObject getgrgid(IRubyObject recv, IRubyObject[] args) {
         Ruby runtime = recv.getRuntime();
 

--- a/core/src/main/java/org/jruby/ext/ffi/AbstractMemory.java
+++ b/core/src/main/java/org/jruby/ext/ffi/AbstractMemory.java
@@ -1973,7 +1973,7 @@ abstract public class AbstractMemory extends MemoryObject {
         return this;
     }
 
-    @JRubyMethod(name = "put_bytes", required = 2, optional = 2)
+    @JRubyMethod(name = "put_bytes", required = 2, optional = 2, checkArity = false)
     public IRubyObject put_bytes(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 2, 4);
 
@@ -1989,7 +1989,7 @@ abstract public class AbstractMemory extends MemoryObject {
         return MemoryUtil.getTaintedByteString(context.runtime, getMemoryIO(), 0, Util.int32Value(lenArg));
     }
 
-    @JRubyMethod(name = "write_bytes", required = 1, optional = 2)
+    @JRubyMethod(name = "write_bytes", required = 1, optional = 2, checkArity = false)
     public IRubyObject write_bytes(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 3);
 

--- a/core/src/main/java/org/jruby/ext/ffi/CallbackInfo.java
+++ b/core/src/main/java/org/jruby/ext/ffi/CallbackInfo.java
@@ -98,7 +98,7 @@ public class CallbackInfo extends Type {
      *
      * @return A new CallbackInfo instance
      */
-    @JRubyMethod(name = "new", meta = true, required = 2, optional = 1)
+    @JRubyMethod(name = "new", meta = true, required = 2, optional = 1, checkArity = false)
     public static final IRubyObject newCallbackInfo(ThreadContext context, IRubyObject klass,
             IRubyObject[] args)
     {

--- a/core/src/main/java/org/jruby/ext/ffi/StructLayout.java
+++ b/core/src/main/java/org/jruby/ext/ffi/StructLayout.java
@@ -214,7 +214,7 @@ public final class StructLayout extends Type {
         this.isUnion = offset == 0 && memberList.size() > 1;
     }
     
-    @JRubyMethod(name = "new", meta = true, required = 3, optional = 1)
+    @JRubyMethod(name = "new", meta = true, required = 3, optional = 1, checkArity = false)
     public static final IRubyObject newStructLayout(ThreadContext context, IRubyObject klass, 
             IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 3, 4);
@@ -649,7 +649,7 @@ public final class StructLayout extends Type {
             init(args[0], args[2], args[1], io);
         }
 
-        @JRubyMethod(name="initialize", visibility = PRIVATE, required = 3, optional = 1)
+        @JRubyMethod(name="initialize", visibility = PRIVATE, required = 3, optional = 1, checkArity = false)
         public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
             Arity.checkArgumentCount(context, args, 3, 4);
             
@@ -831,7 +831,7 @@ public final class StructLayout extends Type {
         }
 
         @Override
-        @JRubyMethod(name="initialize", visibility = PRIVATE, required = 3, optional = 1)
+        @JRubyMethod(name="initialize", visibility = PRIVATE, required = 3, optional = 1, checkArity = false)
         public final IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
             Arity.checkArgumentCount(context, args, 3, 4);
             
@@ -854,7 +854,7 @@ public final class StructLayout extends Type {
         }
         
         @Override
-        @JRubyMethod(name="initialize", visibility = PRIVATE, required = 3, optional = 1)
+        @JRubyMethod(name="initialize", visibility = PRIVATE, required = 3, optional = 1, checkArity = false)
         public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
             Arity.checkArgumentCount(context, args, 3, 4);
 
@@ -878,7 +878,7 @@ public final class StructLayout extends Type {
         }
 
         @Override
-        @JRubyMethod(name="initialize", visibility = PRIVATE, required = 3, optional = 1)
+        @JRubyMethod(name="initialize", visibility = PRIVATE, required = 3, optional = 1, checkArity = false)
         public final IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
             Arity.checkArgumentCount(context, args, 3, 4);
 

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/Function.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/Function.java
@@ -69,7 +69,7 @@ public final class Function extends org.jruby.ext.ffi.AbstractInvoker {
         getSingletonClass().addMethod("call", createDynamicMethod(getSingletonClass()));
     }
     
-    @JRubyMethod(name = { "new" }, meta = true, required = 2, optional = 2)
+    @JRubyMethod(name = { "new" }, meta = true, required = 2, optional = 2, checkArity = false)
     public static IRubyObject newInstance(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(context, args, 2, 4);
 

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyExecutionContextLocal.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyExecutionContextLocal.java
@@ -49,7 +49,7 @@ public abstract class JRubyExecutionContextLocal extends RubyObject {
         default_proc = null;
     }
 
-    @JRubyMethod(name = "initialize", optional = 1, visibility = Visibility.PRIVATE)
+    @JRubyMethod(name = "initialize", optional = 1, checkArity = false, visibility = Visibility.PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args, Block block) {
         if (block.isGiven()) {
             if (args.length != 0) {

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyLibrary.java
@@ -156,7 +156,7 @@ public class JRubyLibrary implements Library {
         }
     }
 
-    @JRubyMethod(module = true, rest = true, optional = 1) // (loader = JRuby.runtime.jruby_class_loader)
+    @JRubyMethod(module = true, rest = true) // (loader = JRuby.runtime.jruby_class_loader)
     public static IRubyObject set_context_class_loader(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         final ClassLoader loader;
         if (args.length == 0 || args[0] == context.nil) {
@@ -194,7 +194,7 @@ public class JRubyLibrary implements Library {
         return context.runtime.newFixnum(System.identityHashCode(obj));
     }
 
-    @JRubyMethod(module = true, name = "parse", alias = "ast_for", required = 1, optional = 3)
+    @JRubyMethod(module = true, name = "parse", alias = "ast_for", required = 1, optional = 3, checkArity = false)
     public static IRubyObject parse(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         // def parse(content = nil, filename = DEFAULT_FILENAME, extra_position_info = false, lineno = 0, &block)
         return Java.wrapJavaObject(context.runtime, parseImpl(context, args, block));
@@ -245,7 +245,7 @@ public class JRubyLibrary implements Library {
         return parseResult;
     }
 
-    @JRubyMethod(module = true, name = "compile_ir", required = 1, optional = 3)
+    @JRubyMethod(module = true, name = "compile_ir", required = 1, optional = 3, checkArity = false)
     public static IRubyObject compile_ir(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         // def compile_ir(content = nil, filename = DEFAULT_FILENAME, extra_position_info = false, &block)
         return Java.wrapJavaObject(context.runtime, compileIR(context, args, block));
@@ -260,7 +260,7 @@ public class JRubyLibrary implements Library {
         return scope;
     }
 
-    @JRubyMethod(module = true, name = "compile", required = 1, optional = 3)
+    @JRubyMethod(module = true, name = "compile", required = 1, optional = 3, checkArity = false)
     public static IRubyObject compile(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         // def compile(content = nil, filename = DEFAULT_FILENAME, extra_position_info = false, &block)
 

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
@@ -120,7 +120,7 @@ public class JRubyUtilLibrary implements Library {
      * @param args (name, raw: false, path: false)
      * @return an enumerable of class-loader resources
      */ // used from RGs' JRuby defaults (as well as jar_dependencies)
-    @JRubyMethod(module = true, name = "class_loader_resources", alias = "classloader_resources", required = 1, optional = 1)
+    @JRubyMethod(module = true, name = "class_loader_resources", alias = "classloader_resources", required = 1, optional = 1, checkArity = false)
     public static IRubyObject class_loader_resources(ThreadContext context, IRubyObject recv, IRubyObject... args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 

--- a/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
+++ b/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
@@ -256,7 +256,7 @@ public class RubyPathname extends RubyObject {
         return context.runtime.newString("#<Pathname:" + getPath() + ">");
     }
 
-    @JRubyMethod(required = 1, optional = 1, writes = BACKREF)
+    @JRubyMethod(required = 1, optional = 1, checkArity = false, writes = BACKREF)
     public IRubyObject sub(ThreadContext context, IRubyObject[] args, Block block) {
         IRubyObject result = sites(context).sub.call(context, this, getPath(), args, block);
         return newInstance(context, result);
@@ -271,7 +271,7 @@ public class RubyPathname extends RubyObject {
 
     /* Facade for File */
 
-    @JRubyMethod(alias = "fnmatch?", required = 1, optional = 1)
+    @JRubyMethod(alias = "fnmatch?", required = 1, optional = 1, checkArity = false)
     public IRubyObject fnmatch(ThreadContext context, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -293,7 +293,7 @@ public class RubyPathname extends RubyObject {
 
     /* Facade for IO */
 
-    @JRubyMethod(optional = 3)
+    @JRubyMethod(optional = 3, checkArity = false)
     public IRubyObject each_line(ThreadContext context, IRubyObject[] args, Block block) {
         return context.runtime.getIO().callMethod(context, "foreach", unshiftPath(args), block);
     }
@@ -305,7 +305,7 @@ public class RubyPathname extends RubyObject {
         return newInstance(context, context.runtime.getDir().callMethod("getwd"));
     }
 
-    @JRubyMethod(required = 1, optional = 2, meta = true)
+    @JRubyMethod(required = 1, optional = 2, checkArity = false, meta = true)
     public static IRubyObject glob(ThreadContext context, IRubyObject recv, IRubyObject[] args,
             Block block) {
         // TODO: yield block while iterating
@@ -319,7 +319,7 @@ public class RubyPathname extends RubyObject {
         }
     }
 
-    @JRubyMethod(required = 1, optional = 1)
+    @JRubyMethod(required = 1, optional = 1, checkArity = false)
     public IRubyObject glob(ThreadContext context, IRubyObject[] _args, Block block) {
         int argc = Arity.checkArgumentCount(context, _args, 1, 2);
 

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -309,7 +309,7 @@ public class RubySet extends RubyObject implements Set {
         return this;
     }
 
-    @JRubyMethod(frame = true, keywords = true, required = 1, optional = 1)
+    @JRubyMethod(frame = true, keywords = true, required = 1, optional = 1, checkArity = false)
     public IRubyObject initialize_clone(ThreadContext context, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 1, 2);
 

--- a/core/src/main/java/org/jruby/ext/set/RubySortedSet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySortedSet.java
@@ -158,7 +158,7 @@ public class RubySortedSet extends RubySet implements SortedSet {
         return this;
     }
 
-    @JRubyMethod(frame = true, keywords = true, required = 1, optional = 1)
+    @JRubyMethod(frame = true, keywords = true, required = 1, optional = 1, checkArity = false)
     public IRubyObject initialize_clone(ThreadContext context, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 1, 2);
 

--- a/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
+++ b/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
@@ -133,7 +133,7 @@ public class Addrinfo extends RubyObject {
         return context.nil;
     }
 
-    @JRubyMethod(required = 1, optional = 3, visibility = Visibility.PRIVATE)
+    @JRubyMethod(required = 1, optional = 3, checkArity = false, visibility = Visibility.PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
         switch (args.length) {
             case 1:

--- a/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
@@ -189,7 +189,7 @@ public class RubyBasicSocket extends RubyIO {
         return recv(context, length, null, null);
     }
 
-    @JRubyMethod(required = 1, optional = 2) // (length) required = 1 handled above
+    @JRubyMethod(required = 1, optional = 2, checkArity = false) // (length) required = 1 handled above
     public IRubyObject recv(ThreadContext context, IRubyObject[] args) {
         IRubyObject length; RubyString str; IRubyObject flags;
 
@@ -250,7 +250,7 @@ public class RubyBasicSocket extends RubyIO {
         return RubyString.newString(runtime, bytes);
     }
 
-    @JRubyMethod(required = 1, optional = 3)
+    @JRubyMethod(required = 1, optional = 3, checkArity = false)
     public IRubyObject recv_nonblock(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 4);
 
@@ -320,7 +320,7 @@ public class RubyBasicSocket extends RubyIO {
     }
 
     @Override
-    @JRubyMethod(required = 1, optional = 2)
+    @JRubyMethod(required = 1, optional = 2, checkArity = false)
     public IRubyObject read_nonblock(ThreadContext context, IRubyObject[] args) {
         Ruby runtime = context.runtime;
         Channel channel = getChannel();
@@ -616,7 +616,7 @@ public class RubyBasicSocket extends RubyIO {
          throw runtime.newErrnoENOTCONNError();
     }
 
-    @JRubyMethod(optional = 1)
+    @JRubyMethod(optional = 1, checkArity = false)
     public IRubyObject shutdown(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
 

--- a/core/src/main/java/org/jruby/ext/socket/RubySocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubySocket.java
@@ -242,7 +242,7 @@ public class RubySocket extends RubyBasicSocket {
         return recvfrom(context, _length);
     }
 
-    @JRubyMethod(required = 1, optional = 3)
+    @JRubyMethod(required = 1, optional = 3, checkArity = false)
     public IRubyObject recvfrom_nonblock(ThreadContext context, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 1, 4);
 
@@ -262,7 +262,7 @@ public class RubySocket extends RubyBasicSocket {
         throw SocketUtils.sockerr(context.runtime, JRUBY_SERVER_SOCKET_ERROR);
     }
 
-    @JRubyMethod(notImplemented = true, optional = 1)
+    @JRubyMethod(notImplemented = true, optional = 1, checkArity = false)
     public IRubyObject accept_nonblock(ThreadContext context, IRubyObject[] args) {
         throw SocketUtils.sockerr(context.runtime, JRUBY_SERVER_SOCKET_ERROR);
     }
@@ -294,14 +294,14 @@ public class RubySocket extends RubyBasicSocket {
         return list;
     }
 
-    @JRubyMethod(required = 1, rest = true, meta = true)
+    @JRubyMethod(required = 1, rest = true, checkArity = false, meta = true)
     public static IRubyObject gethostbyaddr(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 1, -1);
 
         return SocketUtils.gethostbyaddr(context, args);
     }
 
-    @JRubyMethod(required = 1, optional = 1, meta = true)
+    @JRubyMethod(required = 1, optional = 1, checkArity = false, meta = true)
     public static IRubyObject getservbyname(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -334,14 +334,14 @@ public class RubySocket extends RubyBasicSocket {
         return SocketUtils.gethostbyname(context, hostname);
     }
 
-    @JRubyMethod(required = 2, optional = 5, meta = true)
+    @JRubyMethod(required = 2, optional = 5, checkArity = false, meta = true)
     public static IRubyObject getaddrinfo(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 2, 7);
 
         return SocketUtils.getaddrinfo(context, args);
     }
 
-    @JRubyMethod(required = 1, optional = 1, meta = true)
+    @JRubyMethod(required = 1, optional = 1, checkArity = false, meta = true)
     public static IRubyObject getnameinfo(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 1, 2);
 

--- a/core/src/main/java/org/jruby/ext/socket/RubyTCPServer.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyTCPServer.java
@@ -72,7 +72,7 @@ public class RubyTCPServer extends RubyTCPSocket {
         super(runtime, type);
     }
 
-    @JRubyMethod(name = "initialize", required = 1, optional = 1, visibility = Visibility.PRIVATE)
+    @JRubyMethod(name = "initialize", required = 1, optional = 1, checkArity = false, visibility = Visibility.PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
         Ruby runtime = context.runtime;
         IRubyObject _host;

--- a/core/src/main/java/org/jruby/ext/socket/RubyTCPSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyTCPSocket.java
@@ -145,7 +145,7 @@ public class RubyTCPSocket extends RubyIPSocket {
 
     }
 
-    @JRubyMethod(required = 2, optional = 3, visibility = Visibility.PRIVATE)
+    @JRubyMethod(required = 2, optional = 3, checkArity = false, visibility = Visibility.PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 2, 5);
 

--- a/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
@@ -262,7 +262,7 @@ public class RubyUDPSocket extends RubyIPSocket {
         return (DatagramChannel) getChannel();
     }
 
-    @JRubyMethod(required = 1, optional = 3)
+    @JRubyMethod(required = 1, optional = 3, checkArity = false)
     public IRubyObject recvfrom_nonblock(ThreadContext context, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 1, 4);
 
@@ -361,7 +361,7 @@ public class RubyUDPSocket extends RubyIPSocket {
         }
     }
 
-    @JRubyMethod(required = 2, optional = 2)
+    @JRubyMethod(required = 2, optional = 2, checkArity = false)
     public IRubyObject send(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 2, 4);
 

--- a/core/src/main/java/org/jruby/ext/socket/RubyUNIXSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUNIXSocket.java
@@ -121,7 +121,7 @@ public class RubyUNIXSocket extends RubyBasicSocket {
         return runtime.newArray( runtime.newString("AF_UNIX"), path );
     }
 
-    @JRubyMethod(name = "recvfrom", required = 1, optional = 1)
+    @JRubyMethod(name = "recvfrom", required = 1, optional = 1, checkArity = false)
     public IRubyObject recvfrom(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -206,7 +206,7 @@ public class RubyUNIXSocket extends RubyBasicSocket {
         return runtime.getNil();
     }
 
-    @JRubyMethod(optional = 2)
+    @JRubyMethod(optional = 2, checkArity = false)
     public IRubyObject recv_io(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 0, 2);
 
@@ -265,7 +265,7 @@ public class RubyUNIXSocket extends RubyBasicSocket {
         }
     }
 
-    @JRubyMethod(name = {"socketpair", "pair"}, optional = 2, meta = true)
+    @JRubyMethod(name = {"socketpair", "pair"}, optional = 2, checkArity = false, meta = true)
     public static IRubyObject socketpair(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 0, 2);
 

--- a/core/src/main/java/org/jruby/ext/tempfile/Tempfile.java
+++ b/core/src/main/java/org/jruby/ext/tempfile/Tempfile.java
@@ -76,7 +76,7 @@ public class Tempfile extends RubyFile implements Finalizable {
         super(runtime, type);
     }
 
-    @JRubyMethod(optional = 4, visibility = Visibility.PRIVATE, keywords = true)
+    @JRubyMethod(optional = 4, checkArity = false, visibility = Visibility.PRIVATE, keywords = true)
     @Override
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args, Block unused) {
         Arity.checkArgumentCount(context, args, 0, 4);
@@ -162,7 +162,7 @@ public class Tempfile extends RubyFile implements Finalizable {
         return !isClosed() ? super.close(context) : context.nil;
     }
 
-    @JRubyMethod(optional = 1)
+    @JRubyMethod(optional = 1, checkArity = false)
     public IRubyObject close(ThreadContext context, IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -236,7 +236,7 @@ public class Tempfile extends RubyFile implements Finalizable {
         return open(context, recv, args, block);
     }
 
-    @JRubyMethod(optional = 4, meta = true, keywords = true)
+    @JRubyMethod(optional = 4, checkArity = false, meta = true, keywords = true)
     public static IRubyObject open(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         RubyClass klass = (RubyClass) recv;
         Tempfile tempfile = (Tempfile) klass.newInstance(context, args, block);

--- a/core/src/main/java/org/jruby/ext/thread/SizedQueue.java
+++ b/core/src/main/java/org/jruby/ext/thread/SizedQueue.java
@@ -130,7 +130,7 @@ public class SizedQueue extends Queue {
         }
     }
 
-    @JRubyMethod(name = {"push", "<<", "enq"}, required = 1, optional = 1)
+    @JRubyMethod(name = {"push", "<<", "enq"}, required = 1, optional = 1, checkArity = false)
     public IRubyObject push(ThreadContext context, final IRubyObject[] argv) {
         initializedCheck();
 

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibDeflate.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibDeflate.java
@@ -57,7 +57,7 @@ public class JZlibDeflate extends ZStream {
     private com.jcraft.jzlib.Deflater flater = null;
     private int flush = JZlib.Z_NO_FLUSH;
 
-    @JRubyMethod(name = "deflate", required = 1, optional = 1, meta = true)
+    @JRubyMethod(name = "deflate", required = 1, optional = 1, checkArity = false, meta = true)
     public static IRubyObject s_deflate(IRubyObject recv, IRubyObject[] args) {
         Ruby runtime = recv.getRuntime();
         args = Arity.scanArgs(runtime, args, 1, 1);
@@ -84,7 +84,7 @@ public class JZlibDeflate extends ZStream {
         super(runtime, type);
     }
 
-    @JRubyMethod(name = "initialize", optional = 4, visibility = PRIVATE)
+    @JRubyMethod(name = "initialize", optional = 4, checkArity = false, visibility = PRIVATE)
     public IRubyObject _initialize(IRubyObject[] args) {
         args = Arity.scanArgs(getRuntime(), args, 0, 4);
         level = -1;
@@ -206,7 +206,7 @@ public class JZlibDeflate extends ZStream {
         }
     }
 
-    @JRubyMethod(name = "flush", optional = 1)
+    @JRubyMethod(name = "flush", optional = 1, checkArity = false)
     public IRubyObject flush(IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(getRuntime(), args, 0, 1);
 
@@ -217,7 +217,7 @@ public class JZlibDeflate extends ZStream {
         return flush(flush);
     }
 
-    @JRubyMethod(name = "deflate", required = 1, optional = 1)
+    @JRubyMethod(name = "deflate", required = 1, optional = 1, checkArity = false)
     public IRubyObject deflate(IRubyObject[] args) {
         args = Arity.scanArgs(getRuntime(), args, 1, 1);
         if (internalFinished()) throw RubyZlib.newStreamError(getRuntime(), "stream error");

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibInflate.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibInflate.java
@@ -70,7 +70,7 @@ public class JZlibInflate extends ZStream {
         }
     }
 
-    @JRubyMethod(name = "initialize", optional = 1, visibility = PRIVATE)
+    @JRubyMethod(name = "initialize", optional = 1, checkArity = false, visibility = PRIVATE)
     public IRubyObject _initialize(IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(getRuntime(), args, 0, 1);
 

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
@@ -90,7 +90,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         return result;
     }
 
-    @JRubyMethod(name = "open", required = 1, optional = 1, meta = true)
+    @JRubyMethod(name = "open", required = 1, optional = 1, checkArity = false, meta = true)
     public static IRubyObject open19(final ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -142,7 +142,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         return this;
     }
 
-    @JRubyMethod(name = "initialize", required = 1, optional = 1, visibility = PRIVATE)
+    @JRubyMethod(name = "initialize", required = 1, optional = 1, checkArity = false, visibility = PRIVATE)
     public IRubyObject initialize19(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 
@@ -307,7 +307,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         return gets(context, args);
     }
 
-    @JRubyMethod(name = "gets", optional = 2, writes = FrameField.LASTLINE)
+    @JRubyMethod(name = "gets", optional = 2, checkArity = false, writes = FrameField.LASTLINE)
     public IRubyObject gets(ThreadContext context, IRubyObject[] args) {
         try {
             IRubyObject result = internalGets(args);
@@ -321,7 +321,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
     }
     private final static int BUFF_SIZE = 4096;
 
-    @JRubyMethod(name = "read", optional = 1)
+    @JRubyMethod(name = "read", optional = 1, checkArity = false)
     public IRubyObject read(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -361,7 +361,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         }
     }
 
-    @JRubyMethod(name = "readpartial", required = 1, optional = 1)
+    @JRubyMethod(name = "readpartial", required = 1, optional = 1, checkArity = false)
     public IRubyObject readpartial(IRubyObject[] args) {
         Ruby runtime = getRuntime();
 
@@ -642,7 +642,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         return super.comment();
     }
 
-    @JRubyMethod(optional = 1)
+    @JRubyMethod(optional = 1, checkArity = false)
     public IRubyObject each(ThreadContext context, IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -665,7 +665,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         return context.nil;
     }
 
-    @JRubyMethod(optional = 1)
+    @JRubyMethod(optional = 1, checkArity = false)
     public IRubyObject each_line(ThreadContext context, IRubyObject[] args, Block block) {
         if (!block.isGiven()) return RubyEnumerator.enumeratorize(context.runtime, this, "each_line", args);
 
@@ -706,7 +706,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         return getRuntime().getNil();
     }
 
-    @JRubyMethod(optional = 1)
+    @JRubyMethod(optional = 1, checkArity = false)
     public IRubyObject readlines(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
 
@@ -768,7 +768,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
      * If a block is not given, the method returns the concatenation of
      * all uncompressed data in all gzip streams.
      */
-    @JRubyMethod(required = 1, optional = 1, meta = true)
+    @JRubyMethod(required = 1, optional = 1, checkArity = false, meta = true)
     public static IRubyObject zcat(ThreadContext context, IRubyObject klass, IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
@@ -78,7 +78,7 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
         return result;
     }
 
-    @JRubyMethod(name = "open", required = 1, optional = 3, meta = true)
+    @JRubyMethod(name = "open", required = 1, optional = 3, checkArity = false, meta = true)
     public static IRubyObject open19(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(context, args, 1, 4);
 
@@ -197,7 +197,7 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
         return this;
     }
 
-    @JRubyMethod(name = "printf", required = 1, rest = true)
+    @JRubyMethod(name = "printf", required = 1, rest = true, checkArity = false)
     public IRubyObject printf(ThreadContext context, IRubyObject[] args) {
         write(RubyKernel.sprintf(context, this, args));
         
@@ -291,7 +291,7 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
         return realIo;
     }
 
-    @JRubyMethod(name = "flush", optional = 1)
+    @JRubyMethod(name = "flush", optional = 1, checkArity = false)
     public IRubyObject flush(IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(getRuntime(), args, 0, 1);
 

--- a/core/src/main/java/org/jruby/ext/zlib/RubyGzipFile.java
+++ b/core/src/main/java/org/jruby/ext/zlib/RubyGzipFile.java
@@ -82,7 +82,7 @@ public class RubyGzipFile extends RubyObject implements IOEncodable {
         return wrap19(context, recv, new IRubyObject[]{io}, block);
     }
     
-    @JRubyMethod(meta = true, name = "wrap", required = 1, optional = 1)
+    @JRubyMethod(meta = true, name = "wrap", required = 1, optional = 1, checkArity = false)
     public static IRubyObject wrap19(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         Ruby runtime = recv.getRuntime();
         RubyGzipFile instance;

--- a/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
+++ b/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
@@ -183,7 +183,7 @@ public class RubyZlib {
         return ((RubyModule)recv).getConstant("ZLIB_VERSION");
     }
 
-    @JRubyMethod(name = "crc32", optional = 2, module = true, visibility = PRIVATE)
+    @JRubyMethod(name = "crc32", optional = 2, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject crc32(IRubyObject recv, IRubyObject[] args) {
         args = Arity.scanArgs(recv.getRuntime(),args,0,2);
         long start = 0;
@@ -206,7 +206,7 @@ public class RubyZlib {
         return recv.getRuntime().newFixnum(result);
     }
 
-    @JRubyMethod(name = "adler32", optional = 2, module = true, visibility = PRIVATE)
+    @JRubyMethod(name = "adler32", optional = 2, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject adler32(IRubyObject recv, IRubyObject[] args) {
         args = Arity.scanArgs(recv.getRuntime(),args,0,2);
         int start = 1;
@@ -230,7 +230,7 @@ public class RubyZlib {
         return JZlibInflate.s_inflate(context, recv, string);
     }
 
-    @JRubyMethod(required = 1, optional = 1, module = true)
+    @JRubyMethod(required = 1, optional = 1, checkArity = false, module = true)
     public static IRubyObject deflate(IRubyObject recv, IRubyObject[] args) {
         return JZlibDeflate.s_deflate(recv, args);
     }

--- a/core/src/main/java/org/jruby/java/addons/ClassJavaAddons.java
+++ b/core/src/main/java/org/jruby/java/addons/ClassJavaAddons.java
@@ -66,7 +66,7 @@ public abstract class ClassJavaAddons {
         return becomeJava(context, (RubyClass) self, null, true);
     }
 
-    @JRubyMethod(name = "become_java!", required = 1, optional = 1)
+    @JRubyMethod(name = "become_java!", required = 1, optional = 1, checkArity = false)
     public static IRubyObject become_java(ThreadContext context, final IRubyObject self, final IRubyObject[] args) {
         final RubyClass klass = (RubyClass) self;
 

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -104,7 +104,7 @@ public final class ArrayJavaProxy extends JavaProxy {
         return ArrayUtils.arefDirect(context.runtime, getObject(), converter, i);
     }
 
-    @JRubyMethod(name = "[]", required = 1, rest = true)
+    @JRubyMethod(name = "[]", required = 1, rest = true, checkArity = false)
     public final IRubyObject op_aref(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, -1);
 
@@ -396,7 +396,7 @@ public final class ArrayJavaProxy extends JavaProxy {
         return RubyFixnum.newFixnum(runtime, count);
     }
 
-    @JRubyMethod(name = "dig", required = 1, rest = true)
+    @JRubyMethod(name = "dig", required = 1, rest = true, checkArity = false)
     public final IRubyObject dig(ThreadContext context, IRubyObject[] args) {
         Arity.checkArgumentCount(context, args, 1, -1);
 

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxyCreator.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxyCreator.java
@@ -47,7 +47,7 @@ public class ArrayJavaProxyCreator extends RubyObject {
         this.elementType = elementType;
     }
 
-    @JRubyMethod(name = "[]", required = 1, rest = true)
+    @JRubyMethod(name = "[]", required = 1, rest = true, checkArity = false)
     public final IRubyObject op_aref(ThreadContext context, IRubyObject[] sizes) {
         Arity.checkArgumentCount(context.runtime, sizes, 1, -1);
         aggregateDimensions(sizes);

--- a/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
@@ -400,7 +400,7 @@ public class JavaProxy extends RubyObject {
         return method.invokeDirect(context, getObject(), arg0.toJava(argTypeClass));
     }
 
-    @JRubyMethod(required = 1, rest = true)
+    @JRubyMethod(required = 1, rest = true, checkArity = false)
     public IRubyObject java_send(ThreadContext context, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 1, -1);
 
@@ -661,7 +661,7 @@ public class JavaProxy extends RubyObject {
             return method.invokeStaticDirect(context, arg0.toJava(argTypeClass));
         }
 
-        @JRubyMethod(required = 1, rest = true, meta = true)
+        @JRubyMethod(required = 1, rest = true, checkArity = false, meta = true)
         public static IRubyObject java_send(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
             int argc = Arity.checkArgumentCount(context, args, 1, -1);
 

--- a/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
@@ -813,12 +813,12 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         return dupImpl("clone");
     }
 
-    @JRubyMethod(name = "any?", optional = 1)
+    @JRubyMethod(name = "any?", optional = 1, checkArity = false)
     public IRubyObject any_p(ThreadContext context, IRubyObject[] args, Block block) {
         return getOrCreateRubyHashMap(context.runtime).any_p(context, args, block);
     }
 
-    @JRubyMethod(name = "dig", required = 1, rest = true)
+    @JRubyMethod(name = "dig", required = 1, rest = true, checkArity = false)
     public IRubyObject dig(ThreadContext context, IRubyObject[] args) {
         return getOrCreateRubyHashMap(context.runtime).dig(context, args);
     }

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -659,7 +659,7 @@ public abstract class JavaLang {
         //}
 
         @SuppressWarnings("deprecation")
-        @JRubyMethod(required = 1, rest = true)
+        @JRubyMethod(required = 1, rest = true, checkArity = false)
         public static IRubyObject java_method(ThreadContext context, IRubyObject self, final IRubyObject[] args) {
             Arity.checkArgumentCount(context, args, 1, -1);
 
@@ -677,7 +677,7 @@ public abstract class JavaLang {
         }
 
         @SuppressWarnings("deprecation")
-        @JRubyMethod(required = 1, rest = true)
+        @JRubyMethod(required = 1, rest = true, checkArity = false)
         public static IRubyObject declared_method(ThreadContext context, IRubyObject self, final IRubyObject[] args) {
             Arity.checkArgumentCount(context, args, 1, -1);
 
@@ -694,7 +694,7 @@ public abstract class JavaLang {
             }
         }
 
-        @JRubyMethod(required = 1, rest = true)
+        @JRubyMethod(required = 1, rest = true, checkArity = false)
         public static IRubyObject declared_method_smart(ThreadContext context, IRubyObject self, final IRubyObject[] args) {
             Arity.checkArgumentCount(context, args, 1, -1);
 

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyConstructor.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyConstructor.java
@@ -243,7 +243,7 @@ public class JavaProxyConstructor extends JavaProxyReflectionObject implements P
         return new RuntimeException("Dead code... If you see this, file a bug: JPCtIEC fail"); // greppable
     }
 
-    @JRubyMethod(required = 1, optional = 1)
+    @JRubyMethod(required = 1, optional = 1, checkArity = false)
     public IRubyObject new_instance(IRubyObject[] args, Block block) {
         final Ruby runtime = getRuntime();
 


### PR DESCRIPTION
Removing automatic arity-checking for Java-based Ruby methods broke some users' test suites that expected ArgumentError to be thrown; without a manual arity-check, the target methods now tried to access the incoming vararg array blindly and raised Java index errors. This was reported as #7851.

This fixes the issue by restoring arity-checking by default and providing an opt-out flag that we and users can use to indicate that the Java code will check arity manually.