### PR TITLE
Fixes #7859. Coverage returns incorrect info for hash literal constants

### DIFF
--- a/core/src/main/java/org/jruby/ast/CallNode.java
+++ b/core/src/main/java/org/jruby/ast/CallNode.java
@@ -42,7 +42,7 @@ import org.jruby.ast.visitor.NodeVisitor;
 /**
  * A method or operator call.
  */
-public class CallNode extends Node implements INameNode, IArgumentNode, BlockAcceptingNode {
+public class CallNode extends Node implements INameNode, IArgumentNode, BlockAcceptingNode, CanRaise {
     private final Node receiverNode;
     private Node argsNode;
     protected Node iterNode;
@@ -60,7 +60,6 @@ public class CallNode extends Node implements INameNode, IArgumentNode, BlockAcc
         this.argsNode = argsNode;
         this.iterNode = iterNode;
         this.isLazy = isLazy;
-        setNewline();
     }
 
     public NodeType getNodeType() {

--- a/core/src/main/java/org/jruby/ast/CanRaise.java
+++ b/core/src/main/java/org/jruby/ast/CanRaise.java
@@ -1,0 +1,4 @@
+package org.jruby.ast;
+
+public interface CanRaise {
+}

--- a/core/src/main/java/org/jruby/ast/FCallNode.java
+++ b/core/src/main/java/org/jruby/ast/FCallNode.java
@@ -42,7 +42,7 @@ import org.jruby.ast.visitor.NodeVisitor;
 /** 
  * Represents a method call with self as an implicit receiver.
  */
-public class FCallNode extends Node implements INameNode, IArgumentNode, BlockAcceptingNode {
+public class FCallNode extends Node implements INameNode, IArgumentNode, BlockAcceptingNode, CanRaise {
     private final RubySymbol name;
     protected Node argsNode;
     protected Node iterNode;
@@ -56,7 +56,6 @@ public class FCallNode extends Node implements INameNode, IArgumentNode, BlockAc
         this.name = name;
         this.argsNode = argsNode;
         this.iterNode = iterNode;
-        setNewline();
     }
 
 

--- a/core/src/main/java/org/jruby/ast/VCallNode.java
+++ b/core/src/main/java/org/jruby/ast/VCallNode.java
@@ -43,14 +43,13 @@ import org.jruby.ast.visitor.NodeVisitor;
  * RubyMethod call without any arguments
  *
  */
-public class VCallNode extends Node implements INameNode {
+public class VCallNode extends Node implements INameNode, CanRaise {
     private final RubySymbol name;
 
     public VCallNode(int line, RubySymbol name) {
         super(line, false);
 
         this.name = name;
-        setNewline();
     }
 
     public NodeType getNodeType() {

--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -304,6 +304,13 @@ public class IRBuilder {
 
     private int lastProcessedLineNum = -1;
 
+    // anything which can raise needs a line instr before it so we can emit proper line
+    // number in the backtrace.  In most cases this will be handled by ordinary line
+    // code by seeing newline nodes.  Nested calls within things like hash or array
+    // literals are not newlines leading to this secondary field to emit extra
+    // line instrs when it calls for it.
+    private int raiseLineNum = -1;
+
     // We do not need n consecutive line num instrs but only the last one in the sequence.
     // We set this flag to indicate that we need to emit a line number but have not yet.
     // addInstr will then appropriately add line info when it is called (which will never be
@@ -378,8 +385,11 @@ public class IRBuilder {
         if (needsLineNumInfo) {
             needsLineNumInfo = false;
 
-            if (needsCodeCoverage()) {
+            if (needsCodeCoverage() || lastProcessedLineNum != -1 && lastProcessedLineNum == raiseLineNum) {
                 addInstr(new LineNumberInstr(lastProcessedLineNum, coverageMode));
+            } else if (raiseLineNum != -1 && lastProcessedLineNum != raiseLineNum) {
+                addInstr(manager.newLineNumber(raiseLineNum));
+                raiseLineNum = -1;
             } else {
                 addInstr(manager.newLineNumber(lastProcessedLineNum));
             }
@@ -440,6 +450,8 @@ public class IRBuilder {
                 needsLineNumInfo = true;
                 lastProcessedLineNum = currLineNum;
             }
+        } else if (node instanceof CanRaise) { // calls in things like hashes can raise and we need a linenum instr for backtraces.
+            raiseLineNum = node.getLine();
         }
     }
 


### PR DESCRIPTION
This does not fix where the constant is highlighted for hash (see: https://bugs.ruby-lang.org/issues/16819 for more info) but it does fix the odd string of 0s in the reported case.

An older fix was marking all calls as newline nodes.  newline nodes up to this point was the only reason emit a line instruction.  I reverted this fix and instead marked call* nodes as CanRaise.  Then in IRBuilder I have a secondary field to track whether we have encountered something which can raise but is not a newline.  If so it will emit a linenum instr but will not mark it as needing line coverage.