### PR TITLE
Revert "Fixes #7859. Coverage returns incorrect info for hash literal constants"

### DIFF
--- a/core/src/main/java/org/jruby/ast/CallNode.java
+++ b/core/src/main/java/org/jruby/ast/CallNode.java
@@ -42,7 +42,7 @@ import org.jruby.ast.visitor.NodeVisitor;
 /**
  * A method or operator call.
  */
-public class CallNode extends Node implements INameNode, IArgumentNode, BlockAcceptingNode, CanRaise {
+public class CallNode extends Node implements INameNode, IArgumentNode, BlockAcceptingNode {
     private final Node receiverNode;
     private Node argsNode;
     protected Node iterNode;
@@ -60,6 +60,7 @@ public class CallNode extends Node implements INameNode, IArgumentNode, BlockAcc
         this.argsNode = argsNode;
         this.iterNode = iterNode;
         this.isLazy = isLazy;
+        setNewline();
     }
 
     public NodeType getNodeType() {

--- a/core/src/main/java/org/jruby/ast/CanRaise.java
+++ b/core/src/main/java/org/jruby/ast/CanRaise.java
@@ -1,4 +1,0 @@
-package org.jruby.ast;
-
-public interface CanRaise {
-}

--- a/core/src/main/java/org/jruby/ast/FCallNode.java
+++ b/core/src/main/java/org/jruby/ast/FCallNode.java
@@ -42,7 +42,7 @@ import org.jruby.ast.visitor.NodeVisitor;
 /** 
  * Represents a method call with self as an implicit receiver.
  */
-public class FCallNode extends Node implements INameNode, IArgumentNode, BlockAcceptingNode, CanRaise {
+public class FCallNode extends Node implements INameNode, IArgumentNode, BlockAcceptingNode {
     private final RubySymbol name;
     protected Node argsNode;
     protected Node iterNode;
@@ -56,6 +56,7 @@ public class FCallNode extends Node implements INameNode, IArgumentNode, BlockAc
         this.name = name;
         this.argsNode = argsNode;
         this.iterNode = iterNode;
+        setNewline();
     }
 
 

--- a/core/src/main/java/org/jruby/ast/VCallNode.java
+++ b/core/src/main/java/org/jruby/ast/VCallNode.java
@@ -43,13 +43,14 @@ import org.jruby.ast.visitor.NodeVisitor;
  * RubyMethod call without any arguments
  *
  */
-public class VCallNode extends Node implements INameNode, CanRaise {
+public class VCallNode extends Node implements INameNode {
     private final RubySymbol name;
 
     public VCallNode(int line, RubySymbol name) {
         super(line, false);
 
         this.name = name;
+        setNewline();
     }
 
     public NodeType getNodeType() {


### PR DESCRIPTION
Reverts jruby/jruby#7863