### PR TITLE
[deps] update jruby-openssl to 0.14.2

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -58,7 +58,7 @@ default_gems = [
     ['irb', '1.4.2'],
     ['jar-dependencies', '0.4.1'],
     ['jruby-readline', '1.3.7'],
-    ['jruby-openssl', '0.14.1'],
+    ['jruby-openssl', '0.14.2'],
     ['json', '2.6.1'],
     ['logger', '1.5.1'],
     ['mutex_m', '0.1.1'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -385,7 +385,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>jruby-openssl</artifactId>
-      <version>0.14.1</version>
+      <version>0.14.2</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1080,7 +1080,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/irb-1.4.2*</include>
           <include>specifications/jar-dependencies-0.4.1*</include>
           <include>specifications/jruby-readline-1.3.7*</include>
-          <include>specifications/jruby-openssl-0.14.1*</include>
+          <include>specifications/jruby-openssl-0.14.2*</include>
           <include>specifications/json-2.6.1*</include>
           <include>specifications/logger-1.5.1*</include>
           <include>specifications/mutex_m-0.1.1*</include>
@@ -1157,7 +1157,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/irb-1.4.2*/**/*</include>
           <include>gems/jar-dependencies-0.4.1*/**/*</include>
           <include>gems/jruby-readline-1.3.7*/**/*</include>
-          <include>gems/jruby-openssl-0.14.1*/**/*</include>
+          <include>gems/jruby-openssl-0.14.2*/**/*</include>
           <include>gems/json-2.6.1*/**/*</include>
           <include>gems/logger-1.5.1*/**/*</include>
           <include>gems/mutex_m-0.1.1*/**/*</include>
@@ -1234,7 +1234,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/irb-1.4.2*</include>
           <include>cache/jar-dependencies-0.4.1*</include>
           <include>cache/jruby-readline-1.3.7*</include>
-          <include>cache/jruby-openssl-0.14.1*</include>
+          <include>cache/jruby-openssl-0.14.2*</include>
           <include>cache/json-2.6.1*</include>
           <include>cache/logger-1.5.1*</include>
           <include>cache/mutex_m-0.1.1*</include>

--- a/test/check_versions.sh
+++ b/test/check_versions.sh
@@ -31,7 +31,7 @@ function check {
 
   if [[ $length -gt $max  ]]
   then
-    echo size of $archive expected smaller then $max but got $length
+    echo size of $archive expected smaller than $max but got $length
     failed[0]=1
   fi
 
@@ -61,11 +61,11 @@ function check {
 
 }
 
-check lib/target/jruby-stdlib-$jar_version.jar 15
+check lib/target/jruby-stdlib-$jar_version.jar 17
 check maven/jruby-jars/pkg/jruby-jars-$gem_version.gem 30
 check maven/jruby-jars/lib/jruby-core-$jar_version-complete.jar 16
-check maven/jruby-jars/lib/jruby-stdlib-$jar_version.jar 15
-check maven/jruby-complete/target/jruby-complete-$jar_version.jar 30
+check maven/jruby-jars/lib/jruby-stdlib-$jar_version.jar 17
+check maven/jruby-complete/target/jruby-complete-$jar_version.jar 32
 check maven/jruby/target/jruby-$jar_version.jar 9
 check maven/jruby-dist/target/jruby-dist-$jar_version-bin.tar.gz 45 jruby-$jar_version
 check maven/jruby-dist/target/jruby-dist-$jar_version-src.zip 20 jruby-$jar_version


### PR DESCRIPTION
See https://github.com/jruby/jruby-openssl/releases/tag/v0.14.2

Not sure from @kares if this is "ready", but there is some CVE noise (that doesn't affect JRuby) mentioned at https://github.com/jruby/jruby-openssl/pull/278 within the bundled bouncy castle version which would be nice to get rid of on the next JRuby `9.4.x` release.