### PR TITLE
Make sure Ruby exception does not provide itself as cause.

### DIFF
--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -409,7 +409,7 @@ public class RubyException extends RubyObject {
 
     // NOTE: can not have IRubyObject as NativeException has getCause() returning Throwable
     public Object getCause() {
-        return cause;
+        return cause == this ? null : cause;
     }
 
     public RubyStackTraceElement[] getBacktraceElements() {


### PR DESCRIPTION
RubyException ends up getting called and it is used by RaiseException (which is a RuntimeException in Java).  It seems like Ruby itself much less Java should have cause of an exception be itself.  This should also prevent the Java exception from having the same condition?

This should fix #7861 but we shall see if anything complains or not in the expanded CI run.