### PR TITLE
Launcher tweaks

### DIFF
--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -340,13 +340,22 @@ else
     fi
 fi
 
-# Detect modularized Java if modules file is present or a MODULES line appears in release
-if [ -f "$JAVA_HOME"/lib/modules ] \
-    || {
-        [ -f "$JAVA_HOME"/release ] \
-        && grep -q ^MODULES "$JAVA_HOME"/release
-    }
-then
+# Detect modularized Java
+java_is_modular() {
+    # check that modules file is present
+    if [ -f "$JAVA_HOME"/lib/modules ]; then
+        return 0
+    fi
+
+    # check if a MODULES line appears in release
+    if [ -f "$JAVA_HOME"/release ] && grep -q ^MODULES "$JAVA_HOME"/release; then
+        return 0
+    fi
+
+    return 1
+}
+
+if java_is_modular; then
     use_modules=true
 else
     use_modules=false

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=1007
 # -----------------------------------------------------------------------------
 # jruby.bash - Start Script for the JRuby interpreter
 # -----------------------------------------------------------------------------
@@ -442,7 +443,7 @@ readonly CP_DELIMITER
 # Scanning for args is aborted by '--'.
 # shellcheck disable=2086
 set -- $JRUBY_OPTS "$@"
-# shellcheck disable=354
+# shellcheck disable=3044
 [ "$BASH" ] && shopt -s expand_aliases
 # increment pointer, permute arguments
 while [ $# -gt 0 ]
@@ -606,6 +607,7 @@ fi
 JAVA_OPTS="$java_opts_from_files $JAVA_OPTS"
 
 # Don't quote JAVA_OPTS; we want it to expand
+# shellcheck disable=2086
 prepend java_args "$JAVACMD" $JAVA_OPTS "$JFFI_OPTS"
 
 if $NO_BOOTCLASSPATH || $VERIFY_JRUBY; then
@@ -628,7 +630,6 @@ append java_args -Djruby.home="$JRUBY_HOME" \
     "$java_class"
 extend java_args ruby_args
 
-# shellcheck disable=2086
 eval set -- "$java_args"
 
 add_log

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -83,23 +83,12 @@ prepend() {
     eval "$listname=\"\${result} \${$listname}\""
 }
 
-# map FUNCNAME LISTNAME1 LISTNAME2
-#
-# Run FUNCNAME on LISTNAME1 and the list named by LISTNAME2
-map() {
-    local funcname="$1"
-    local listname="$2"
-    # Load contents of array named by $3
-    eval eval set -- "\"\${$3}\""
-    "$funcname" "$listname" "$@"
-}
-
 # extend LISTNAME1 LISTNAME2
 #
 # Append the elements stored in the list named by LISTNAME2
 # to the list named by LISTNAME1.
 extend() {
-    map append "$@"
+    eval "$1=\"\${$1} \${$2}\""
 }
 
 # preextend LISTNAME1 LISTNAME2
@@ -107,7 +96,7 @@ extend() {
 # Prepend the elements stored in the list named by LISTNAME2
 # to the named by LISTNAME1, preserving order.
 preextend() {
-    map prepend "$@"
+    eval "$1=\"\${$2} \${$1}\""
 }
 
 # ----- Set variable defaults -------------------------------------------------

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -101,6 +101,13 @@ preextend() {
     eval "$1=\"\${$2} \${$1}\""
 }
 
+# echo [STRING...]
+#
+# Dumb echo, i.e. print arguments joined by spaces with no further processing
+echo() {
+    printf "%s\n" "$*"
+}
+
 # ----- Set variable defaults -------------------------------------------------
 
 readonly java_class=org.jruby.Main

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -20,13 +20,13 @@ fi
 # esceval [ARGUMENT...]
 #
 # Escape ARGUMENT for safe use with eval
-# Returns escaped arguments via $result
+# Returns escaped arguments via $REPLY
 # Thanks to @mentalisttraceur for original implementation:
 # https://github.com/mentalisttraceur/esceval
 esceval()
 {
     local escaped= unescaped= output=
-    result=
+    REPLY=
 
     [ $# -gt 0 ] || return 0
     while true; do
@@ -46,7 +46,7 @@ esceval()
         [ $# -gt 0 ] || break
         output="$output $escaped"
     done
-    result="$output $escaped"
+    REPLY="$output $escaped"
 }
 
 # assign LISTNAME ELEMENT [ELEMENT...]
@@ -54,11 +54,11 @@ esceval()
 # Assign ELEMENT to the list named by LISTNAME.
 assign() {
     local listname="$1"
-    local result=
+    local REPLY=
     shift
 
     esceval "$@"
-    eval "$listname=\"\${result}\""
+    eval "$listname=\"\${REPLY}\""
 }
 
 # append LISTNAME ELEMENT [ELEMENT...]
@@ -66,11 +66,11 @@ assign() {
 # Append ELEMENT to the list named by LISTNAME.
 append() {
     local listname="$1"
-    local result=
+    local REPLY=
     shift
 
     esceval "$@"
-    eval "$listname=\"\${$listname} \${result}\""
+    eval "$listname=\"\${$listname} \${REPLY}\""
 }
 
 # prepend LISTNAME ELEMENT [ELEMENT...]
@@ -78,11 +78,11 @@ append() {
 # Prepend ELEMENT to the list named by LISTNAME, preserving order.
 prepend() {
     local listname="$1"
-    local result=
+    local REPLY=
     shift
 
     esceval "$@"
-    eval "$listname=\"\${result} \${$listname}\""
+    eval "$listname=\"\${REPLY} \${$listname}\""
 }
 
 # extend LISTNAME1 LISTNAME2
@@ -196,14 +196,14 @@ dir_name() {
         */*[!/]*)
             trail=${filename##*[!/]}
             filename=${filename%%"$trail"}
-            result=${filename%/*}
+            REPLY=${filename%/*}
             ;;
         *[!/]*)
             trail=${filename##*[!/]}
-            result="."
+            REPLY="."
             ;;
         *)
-            result="/"
+            REPLY="/"
             ;;
     esac
 }
@@ -214,14 +214,14 @@ base_name() {
         */*[!/]*)
             trail=${filename##*[!/]}
             filename=${filename%%"$trail"}
-            result=${filename##*/}
+            REPLY=${filename##*/}
             ;;
         *[!/]*)
             trail=${filename##*[!/]}
-            result=${filename%%"$trail"}
+            REPLY=${filename%%"$trail"}
             ;;
         *)
-            result="/"
+            REPLY="/"
             ;;
     esac
 }
@@ -238,19 +238,19 @@ resolve_symlinks() {
         sym="$(readlink "$cur_path")"
 
         dir_name "$cur_path"
-        dirname="$result"
+        dirname="$REPLY"
 
         sym_base="$(cd -P -- "$dirname" >/dev/null && pwd -P)"
 
         dir_name "$sym"
-        dirname="$result"
+        dirname="$REPLY"
 
         base_name "$sym"
-        basename="$result"
+        basename="$REPLY"
 
         cur_path="$(cd "$sym_base" && cd "$dirname" && pwd -P)/$basename"
     done
-    result="$cur_path"
+    REPLY="$cur_path"
 }
 
 # ----- Determine JRUBY_HOME based on this executable's path ------------------
@@ -263,10 +263,10 @@ else
     script_src="$0"
 fi
 dir_name "$script_src"
-BASE_DIR="$(cd -P -- "$result" >/dev/null && pwd -P)"
+BASE_DIR="$(cd -P -- "$REPLY" >/dev/null && pwd -P)"
 base_name "$script_src"
-resolve_symlinks "$BASE_DIR/$result"
-SELF_PATH="$result"
+resolve_symlinks "$BASE_DIR/$REPLY"
+SELF_PATH="$REPLY"
 
 JRUBY_HOME="${SELF_PATH%/*/*}"
 
@@ -318,12 +318,12 @@ if [ -z "$JAVACMD" ]; then
         else
             # Linux and others have a chain of symlinks
             resolve_symlinks "$(command -v java)"
-            JAVACMD="$result"
+            JAVACMD="$REPLY"
 
             # export separately from command execution
             dir_name "$JAVACMD"
-            dir_name "$result"
-            JAVA_HOME="$result"
+            dir_name "$REPLY"
+            JAVA_HOME="$REPLY"
         fi
     elif $cygwin; then
         JAVACMD="$(cygpath -u "$JAVA_HOME")/bin/java"
@@ -332,11 +332,11 @@ if [ -z "$JAVACMD" ]; then
     fi
 else
     resolve_symlinks "$(command -v "$JAVACMD")"
-    expanded_javacmd="$result"
+    expanded_javacmd="$REPLY"
     if [ -z "$JAVA_HOME" ] && [ -x "$expanded_javacmd" ]; then
         dir_name "$expanded_javacmd"
-        dir_name "$result"
-        JAVA_HOME="$result"
+        dir_name "$REPLY"
+        JAVA_HOME="$REPLY"
     fi
 fi
 

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -174,13 +174,14 @@ add_log() {
 
 # Logic to process "arguments files" on both Java 8 and Java 9+
 process_java_opts() {
-    local java_opts_file="$1"
+    local java_opts_file="$1" java_opts=
     if [ -r "$java_opts_file" ]; then
         add_log
         add_log "Adding Java options from: $java_opts_file"
 
         while read -r line; do
             if [ "$line" ]; then
+                java_opts="${java_opts} ${line}"
                 add_log "  $line"
             fi
         done < "$java_opts_file"
@@ -190,7 +191,7 @@ process_java_opts() {
         if $use_modules; then
             java_opts_from_files="$java_opts_from_files @$java_opts_file"
         else
-            java_opts_from_files="$java_opts_from_files $(cat "$java_opts_file")"
+            java_opts_from_files="$java_opts_from_files $java_opts"
         fi
     fi
 }

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -8,8 +8,14 @@
 if command -v local >/dev/null; then
     :
 elif command -v typeset >/dev/null; then
-    # ksh93 has typeset but not local
+    # ksh93 and older have typeset but not local, and expand aliases at parse
+    # time so require re-sourcing the script
     alias local=typeset
+    if [ -z "$KSH_VERSION" ] || (eval : '"${.sh.version}"' >/dev/null 2>&1); then
+        # shellcheck source=/dev/null
+        . "$0"
+        exit
+    fi
 else
     echo >&2 "Error: Your shell does not support local variables. Re-run this script with one that does (e.g. bash, ksh)"
     exit 1

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -11,7 +11,7 @@ elif command -v typeset >/dev/null; then
     # ksh93 has typeset but not local
     alias local=typeset
 else
-    echo "Error: Your shell does not support local variables. Re-run with one that does (e.g. bash, ksh)"
+    echo >&2 "Error: Your shell does not support local variables. Re-run this script with one that does (e.g. bash, ksh)"
     exit 1
 fi
 
@@ -26,6 +26,7 @@ fi
 esceval()
 {
     local escaped= unescaped= output=
+    result=
 
     [ $# -gt 0 ] || return 0
     while true; do
@@ -151,11 +152,11 @@ if [ -r "/dev/urandom" ]; then
 fi
 
 # Gather environment information as we go
-cr='
+readonly cr='
 '
 environment_log="JRuby Environment$cr================="
 add_log() {
-    environment_log="${environment_log}${cr}${1}"
+    environment_log="${environment_log}${cr}${*}"
 }
 
 # Logic to process "arguments files" on both Java 8 and Java 9+
@@ -443,8 +444,6 @@ readonly CP_DELIMITER
 # Scanning for args is aborted by '--'.
 # shellcheck disable=2086
 set -- $JRUBY_OPTS "$@"
-# shellcheck disable=3044
-[ "$BASH" ] && shopt -s expand_aliases
 # increment pointer, permute arguments
 while [ $# -gt 0 ]
 do
@@ -479,7 +478,7 @@ do
         # Match -Xa.b.c=d to translate to -Da.b.c=d as a java option
         -X*.*) append java_args -Djruby."${1#-X}" ;;
         # Match switches that take an argument
-        -C|-e|-I|-S)
+        -[CeIS])
             append ruby_args "$1" "$2"
             shift
             ;;


### PR DESCRIPTION
Forgot to PR some improvements to the launcher! Should be pretty self-explanatory and I made some notes going back over them:

Finally got rid of the realpath function from Stackoverflow and replaced it with some more self-explanatory functions. Should be faster now too since it runs as few external commands as possible. Hopefully it doesn't break things, if you want to test the readlink logic you can comment out lines 290-292 or remove realpath from your PATH.

Also I added a couple lines for compatibility with ksh93! I think every Bourne shell that's installable on modern operating systems can launch jruby now.