### PR TITLE
Migrate to new mavengem

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>io.takari.polyglot</groupId>
     <artifactId>polyglot-ruby</artifactId>
-    <version>0.4.7</version>
+    <version>0.4.11</version>
   </extension>
 </extensions>

--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -154,7 +154,7 @@ project 'JRuby Lib Setup' do
 
   properties( 'polyglot.dump.pom' => 'pom.xml',
               'polyglot.dump.readonly' => true,
-              'jruby.plugins.version' => '1.1.2',
+              'jruby.plugins.version' => '3.0.1',
               'gem.home' => '${basedir}/ruby/gems/shared',
               # we copy everything into the target/classes/META-INF
               # so the jar plugin just packs it - see build/resources below
@@ -164,7 +164,7 @@ project 'JRuby Lib Setup' do
   # just depends on jruby-core so we are sure the jruby.jar is in place
   jar "org.jruby:jruby-core:#{version}", :scope => 'test'
 
-  extension 'org.torquebox.mojo:mavengem-wagon:1.0.3'
+  extension 'org.jruby.maven:mavengem-wagon:2.0.1'
 
   repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
@@ -259,7 +259,7 @@ project 'JRuby Lib Setup' do
       ghome = default_gemnames.member?( a.artifact_id ) ? gem_home : jruby_gems
       if Dir[ File.join( ghome, 'cache', File.basename( a.file.to_pathname ).sub( /.gem/, '*.gem' ) ) ].empty?
         log a.file.to_pathname
-        installer = Gem::Installer.new( a.file.to_pathname,
+        installer = Gem::Installer.new( Gem::Package.new(a.file.to_pathname),
                                         wrappers: true,
                                         ignore_dependencies: true,
                                         install_dir: ghome,

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -20,7 +20,7 @@ DO NOT MODIFY - GENERATED CODE
     <gem.home>${basedir}/ruby/gems/shared</gem.home>
     <jruby.complete.gems>${jruby.complete.home}/lib/ruby/gems/shared</jruby.complete.gems>
     <jruby.complete.home>${project.build.outputDirectory}/META-INF/jruby.home</jruby.complete.home>
-    <jruby.plugins.version>1.1.2</jruby.plugins.version>
+    <jruby.plugins.version>3.0.1</jruby.plugins.version>
     <polyglot.dump.pom>pom.xml</polyglot.dump.pom>
     <polyglot.dump.readonly>true</polyglot.dump.readonly>
   </properties>
@@ -1042,9 +1042,9 @@ DO NOT MODIFY - GENERATED CODE
   <build>
     <extensions>
       <extension>
-        <groupId>org.torquebox.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>1.0.3</version>
+        <version>2.0.1</version>
       </extension>
     </extensions>
     <resources>
@@ -1365,7 +1365,7 @@ DO NOT MODIFY - GENERATED CODE
       <plugin>
         <groupId>io.takari.polyglot</groupId>
         <artifactId>polyglot-maven-plugin</artifactId>
-        <version>0.4.7</version>
+        <version>0.4.11</version>
         <executions>
           <execution>
             <id>install_gems</id>
@@ -1416,7 +1416,7 @@ DO NOT MODIFY - GENERATED CODE
           <dependency>
             <groupId>io.takari.polyglot</groupId>
             <artifactId>polyglot-ruby</artifactId>
-            <version>0.4.7</version>
+            <version>0.4.11</version>
           </dependency>
         </dependencies>
         <inherited>false</inherited>

--- a/lifecycle-mapping-metadata.xml
+++ b/lifecycle-mapping-metadata.xml
@@ -29,9 +29,9 @@
     </pluginExecution>
     <pluginExecution>
       <pluginExecutionFilter>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
-        <versionRange>1.0.0-rc</versionRange>
+        <versionRange>3.0.1</versionRange>
         <goals>
           <goal>initialize</goal>
         </goals>
@@ -42,9 +42,9 @@
     </pluginExecution>
     <pluginExecution>
       <pluginExecutionFilter>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
-        <versionRange>1.0.0-rc2</versionRange>
+        <versionRange>3.0.1</versionRange>
         <goals>
           <goal>initialize</goal>
         </goals>

--- a/maven/jruby-complete/pom.rb
+++ b/maven/jruby-complete/pom.rb
@@ -11,7 +11,7 @@ project 'JRuby Complete' do
   packaging 'bundle'
 
 
-  extension 'org.torquebox.mojo:mavengem-wagon:1.0.3'
+  extension 'org.jruby.maven:mavengem-wagon:2.0.1'
 
   plugin_repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 

--- a/maven/jruby-complete/src/it/GH-3095-gem-install-with-forked-jruby/pom.xml
+++ b/maven/jruby-complete/src/it/GH-3095-gem-install-with-forked-jruby/pom.xml
@@ -29,9 +29,9 @@
   <build>
     <extensions>
       <extension>
-        <groupId>org.torquebox.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>1.0.3</version>
+        <version>2.0.1</version>
       </extension>
     </extensions>
     <plugins>

--- a/maven/jruby-complete/src/it/extended/Mavenfile
+++ b/maven/jruby-complete/src/it/extended/Mavenfile
@@ -1,7 +1,7 @@
 #-*- mode: ruby -*-
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '1.0.10',
+properties( 'jruby.plugins.version' => '3.0.1',
             'project.build.sourceEncoding' => 'utf-8',
             'jruby.home' => '${basedir}/../../../../..' )
 

--- a/maven/jruby-complete/src/it/runnable/Mavenfile
+++ b/maven/jruby-complete/src/it/runnable/Mavenfile
@@ -1,9 +1,9 @@
 #-*- mode: ruby -*-
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '1.0.10',
-            'mavengem.wagon.version' => '1.0.3',
-            'jruby.version' => '9.0.5.0' )
+properties( 'jruby.plugins.version' => '3.0.1',
+            'mavengem.wagon.version' => '2.0.1',
+            'jruby.version' => '9.4.3.0' )
 
 gemfile
 

--- a/maven/jruby-complete/src/templates/osgi_many_bundles_with_embedded_gems/gems-bundle/pom.rb
+++ b/maven/jruby-complete/src/templates/osgi_many_bundles_with_embedded_gems/gems-bundle/pom.rb
@@ -4,7 +4,7 @@ gemfile
 
 model.repositories.clear
 
-extension 'org.torquebox.mojo:mavengem-wagon:1.0.3'
+extension 'org.jruby.maven:mavengem-wagon:2.0.1'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 id 'org.jruby.osgi:gems-bundle', '1.0'
@@ -12,7 +12,7 @@ id 'org.jruby.osgi:gems-bundle', '1.0'
 packaging 'bundle'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '1.0.10',
+properties( 'jruby.plugins.version' => '3.0.1',
             # needed bundle plugin
             'polyglot.dump.pom' => 'pom.xml' )
 

--- a/maven/jruby-complete/src/templates/osgi_many_bundles_with_embedded_gems/pom.rb
+++ b/maven/jruby-complete/src/templates/osgi_many_bundles_with_embedded_gems/pom.rb
@@ -5,7 +5,7 @@ id 'org.jruby.test:osgi-complete:1'
 packaging :pom
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '1.0.10',
+properties( 'jruby.plugins.version' => '3.0.1',
             'project.build.sourceEncoding' => 'utf-8' )
 
 modules [ 'gems-bundle', 'scripts-bundle', 'test' ]

--- a/maven/jruby-jars/Mavenfile
+++ b/maven/jruby-jars/Mavenfile
@@ -28,7 +28,7 @@ end
 
 properties( 'tesla.dump.pom' => 'pom.xml',
             'tesla.dump.readonly' => true,
-            'jruby.plugins.version' => '1.1.8',
+            'jruby.plugins.version' => '3.0.1',
             # we share the already installed gems
             'gem.home' => '${jruby_home}/lib/ruby/gems/shared',
             # need jruby_home but not jruby.home as name otherwise

--- a/maven/jruby-jars/src/it/integrity/pom.xml
+++ b/maven/jruby-jars/src/it/integrity/pom.xml
@@ -16,17 +16,14 @@
   <build>
     <plugins>
       <plugin>
-	<groupId>de.saumya.mojo</groupId>
+	<groupId>org.jruby.maven</groupId>
 	<artifactId>gem-maven-plugin</artifactId>
-	<version>1.0.5</version>
+	<version>3.0.1</version>
 	<executions>
 	  <execution>
 	    <goals><goal>initialize</goal></goals>
 	  </execution>
 	</executions>
-        <configuration>
-          <jrubyVersion>1.7.22</jrubyVersion>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/maven/jruby/src/it/j2ee_jetty/pom.rb
+++ b/maven/jruby/src/it/j2ee_jetty/pom.rb
@@ -2,7 +2,7 @@
 packaging 'war'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '1.0.10',
+properties( 'jruby.plugins.version' => '3.0.1',
             'project.build.sourceEncoding' => 'utf-8' )
 
 pom( 'org.jruby:jruby', '${jruby.version}' )
@@ -10,7 +10,7 @@ pom( 'org.jruby:jruby', '${jruby.version}' )
 # a gem to be used
 gem 'flickraw', '0.9.7'
 
-extension 'org.torquebox.mojo:mavengem-wagon:1.0.3'
+extension 'org.jruby.maven:mavengem-wagon:2.0.1'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 jruby_plugin :gem, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0' do

--- a/maven/jruby/src/it/j2ee_jetty_rack/Mavenfile
+++ b/maven/jruby/src/it/j2ee_jetty_rack/Mavenfile
@@ -4,7 +4,7 @@
 packaging 'war'
 
 # get jruby dependencies
-properties( 'jruby.plugins.version' => '1.0.10',
+properties( 'jruby.plugins.version' => '3.0.1',
             'project.build.sourceEncoding' => 'utf-8',
             'public.dir' => '${basedir}/public' )
 
@@ -16,7 +16,7 @@ jar( 'org.jruby.rack:jruby-rack', '1.1.18',
 # a gem to be used
 gem 'flickraw', '0.9.7'
 
-extension 'org.torquebox.mojo:mavengem-wagon:1.0.3'
+extension 'org.jruby.maven:mavengem-wagon:2.0.1'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 jruby_plugin :gem, :includeRubygemsInResources => true, :includeLibDirectoryInResources => true, :jrubyVersion => '9.0.0.0' do

--- a/maven/jruby/src/it/j2ee_tomcat/pom.rb
+++ b/maven/jruby/src/it/j2ee_tomcat/pom.rb
@@ -2,7 +2,7 @@
 packaging 'war'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '1.0.10',
+properties( 'jruby.plugins.version' => '3.0.1',
             'project.build.sourceEncoding' => 'utf-8' )
 
 pom( 'org.jruby:jruby', '${jruby.version}' )
@@ -10,7 +10,7 @@ pom( 'org.jruby:jruby', '${jruby.version}' )
 # a gem to be used
 gem 'flickraw', '0.9.7'
 
-extension 'org.torquebox.mojo:mavengem-wagon:1.0.3'
+extension 'org.jruby.maven:mavengem-wagon:2.0.1'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 jruby_plugin :gem, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0' do

--- a/maven/jruby/src/it/j2ee_tomcat_rack/Mavenfile
+++ b/maven/jruby/src/it/j2ee_tomcat_rack/Mavenfile
@@ -4,7 +4,7 @@
 packaging 'war'
 
 # get jruby dependencies
-properties( 'jruby.plugins.version' => '1.0.10',
+properties( 'jruby.plugins.version' => '3.0.1',
             'project.build.sourceEncoding' => 'utf-8',
             'public.dir' => '${basedir}/public' )
 
@@ -16,7 +16,7 @@ jar( 'org.jruby.rack:jruby-rack', '1.1.18',
 # a gem to be used
 gem 'flickraw', '0.9.7'
 
-extension 'org.torquebox.mojo:mavengem-wagon:1.0.3'
+extension 'org.jruby.maven:mavengem-wagon:2.0.1'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 jruby_plugin :gem, :includeRubygemsInResources => true, :includeLibDirectoryInResources => true, :jrubyVersion => '9.0.0.0' do

--- a/maven/jruby/src/it/j2ee_wildfly/pom.rb
+++ b/maven/jruby/src/it/j2ee_wildfly/pom.rb
@@ -2,7 +2,7 @@
 packaging 'war'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '1.0.10',
+properties( 'jruby.plugins.version' => '3.0.1',
             'wildfly.version' => '9.0.2.Final',
             'project.build.sourceEncoding' => 'utf-8' )
 
@@ -11,7 +11,7 @@ pom( 'org.jruby:jruby', '${jruby.version}' )
 # a gem to be used
 gem 'virtus', '0.5.5'
 
-extension 'org.torquebox.mojo:mavengem-wagon:1.0.3'
+extension 'org.jruby.maven:mavengem-wagon:2.0.1'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 jruby_plugin :gem, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0' do

--- a/maven/jruby/src/it/jetty/Mavenfile
+++ b/maven/jruby/src/it/jetty/Mavenfile
@@ -4,7 +4,7 @@
 packaging 'war'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '1.0.10',
+properties( 'jruby.plugins.version' => '3.0.1',
             'project.build.sourceEncoding' => 'utf-8',
             'public.dir' => '${basedir}/public' )
 
@@ -16,7 +16,7 @@ jar( 'org.jruby.rack:jruby-rack', '1.1.14',
 # a gem to be used
 gem 'flickraw', '0.9.7'
 
-extension 'org.torquebox.mojo:mavengem-wagon:1.0.3'
+extension 'org.jruby.maven:mavengem-wagon:2.0.1'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 jruby_plugin :gem, :includeRubygemsInTestResources => false, :includeRubygemsInResources => true, :includeLibDirectoryInResources => true, :jrubyVersion => '9.0.0.0' do

--- a/maven/jruby/src/it/many_jars_with_embedded_gems/app/pom.rb
+++ b/maven/jruby/src/it/many_jars_with_embedded_gems/app/pom.rb
@@ -1,5 +1,5 @@
 # two jars with embedded gems
-jar 'de.saumya.mojo:maven-tools', '1.0.0.rc1'
+jar 'org.jruby.maven:maven-tools', '3.0.1'
 jar 'org.rubygems:zip', '2.0.2'
 
 # jruby scripting container

--- a/maven/jruby/src/it/many_jars_with_embedded_gems/pom.rb
+++ b/maven/jruby/src/it/many_jars_with_embedded_gems/pom.rb
@@ -1,7 +1,7 @@
 #-*- mode: ruby -*-
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '1.0.10' )
+properties( 'jruby.plugins.version' => '3.0.1' )
 
 packaging :pom
 

--- a/maven/jruby/src/it/many_jars_with_embedded_gems/zip_gem/pom.rb
+++ b/maven/jruby/src/it/many_jars_with_embedded_gems/zip_gem/pom.rb
@@ -4,7 +4,7 @@ gemfile
 
 model.repositories.clear
 
-extension 'org.torquebox.mojo:mavengem-wagon:1.0.3'
+extension 'org.jruby.maven:mavengem-wagon:2.0.1'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 id 'org.rubygems:zip', VERSION

--- a/maven/jruby/src/it/many_jars_with_embedded_gems_ng/gem1/pom.rb
+++ b/maven/jruby/src/it/many_jars_with_embedded_gems_ng/gem1/pom.rb
@@ -4,7 +4,7 @@ gemfile
 
 model.repositories.clear
 
-extension 'org.torquebox.mojo:mavengem-wagon:1.0.3'
+extension 'org.jruby.maven:mavengem-wagon:2.0.1'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 id 'org.rubygems:gem1', '1'

--- a/maven/jruby/src/it/many_jars_with_embedded_gems_ng/gem2/Gemfile
+++ b/maven/jruby/src/it/many_jars_with_embedded_gems_ng/gem2/Gemfile
@@ -1,4 +1,4 @@
 #-*- mode: ruby -*-
 source 'https://rubygems.org'
 
-gem 'maven-tools', '0.34.5'
+gem 'maven-tools', '1.2.1'

--- a/maven/jruby/src/it/many_jars_with_embedded_gems_ng/gem2/pom.rb
+++ b/maven/jruby/src/it/many_jars_with_embedded_gems_ng/gem2/pom.rb
@@ -4,7 +4,7 @@ gemfile
 
 model.repositories.clear
 
-extension 'org.torquebox.mojo:mavengem-wagon:1.0.3'
+extension 'org.jruby.maven:mavengem-wagon:2.0.1'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 id 'org.rubygems:gem2', '2'

--- a/maven/jruby/src/it/many_jars_with_embedded_gems_ng/pom.rb
+++ b/maven/jruby/src/it/many_jars_with_embedded_gems_ng/pom.rb
@@ -1,7 +1,7 @@
 #-*- mode: ruby -*-
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '1.0.10' )
+properties( 'jruby.plugins.version' => '3.0.1' )
 
 packaging :pom
 

--- a/maven/jruby/src/it/terminate-container-and-extensions-GH-3300/pom.xml
+++ b/maven/jruby/src/it/terminate-container-and-extensions-GH-3300/pom.xml
@@ -33,21 +33,21 @@
   </repositories>
 
   <properties>
-    <jruby.plugins.version>1.0.10</jruby.plugins.version>
+    <jruby.plugins.version>3.0.1</jruby.plugins.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <build>
     <extensions>
       <extension>
-        <groupId>org.torquebox.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>1.0.3</version>
+        <version>2.0.1</version>
       </extension>
     </extensions>
     <plugins>
       <plugin>
-        <groupId>de.saumya.mojo</groupId>
+        <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>${jruby.plugins.version}</version>
         <executions>
@@ -55,9 +55,6 @@
             <goals><goal>initialize</goal></goals>
           </execution>
         </executions>
-        <configuration>
-          <jrubyVersion>1.7.22</jrubyVersion>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/maven/jruby/src/it/tomcat/pom.rb
+++ b/maven/jruby/src/it/tomcat/pom.rb
@@ -4,7 +4,7 @@ id 'dummy:tomcat:1.0-SNAPSHOT'
 packaging 'war'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '1.0.10',
+properties( 'jruby.plugins.version' => '3.0.1',
             'project.build.sourceEncoding' => 'utf-8' )
 
 pom( 'org.jruby:jruby', '${jruby.version}' )
@@ -12,7 +12,7 @@ pom( 'org.jruby:jruby', '${jruby.version}' )
 # a gem to be used
 gem 'flickraw', '0.9.7'
 
-extension 'org.torquebox.mojo:mavengem-wagon:1.0.3'
+extension 'org.jruby.maven:mavengem-wagon:2.0.1'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 jruby_plugin :gem, :includeRubygemsInTestResources => false, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0' do

--- a/maven/jruby/src/templates/hellowarld/Mavenfile
+++ b/maven/jruby/src/templates/hellowarld/Mavenfile
@@ -10,9 +10,9 @@ name '${cmd} ${framework} from ${package}'
 packaging 'pom' 
 
 # TODO add extension to .mvn/extensions.xml
-extension 'de.saumya.mojo', 'jruby9-extensions', '${jruby9.plugins.version}'
+extension 'org.jruby.maven', 'jruby9-extensions', '${jruby9.plugins.version}'
 
-properties( 'jruby.plugins.version' => '1.1.0',
+properties( 'jruby.plugins.version' => '3.0.1',
             'jruby9.plugins.version' => '0.2.0' )
 
 # integration tests

--- a/maven/jruby/src/templates/j2ee_wlp/pom.rb
+++ b/maven/jruby/src/templates/j2ee_wlp/pom.rb
@@ -2,7 +2,7 @@
 packaging 'war'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '1.0.10',
+properties( 'jruby.plugins.version' => '3.0.1',
             'project.build.sourceEncoding' => 'utf-8' )
 
 pom( 'org.jruby:jruby', '${jruby.version}' )
@@ -10,7 +10,7 @@ pom( 'org.jruby:jruby', '${jruby.version}' )
 # a gem to be used
 gem 'virtus', '0.5.5'
 
-extension 'org.torquebox.mojo:mavengem-wagon:1.0.3'
+extension 'org.jruby.maven:mavengem-wagon:2.0.1'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 jruby_plugin :gem, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0' do

--- a/maven/jruby/src/templates/osgi_all_inclusive/pom.rb
+++ b/maven/jruby/src/templates/osgi_all_inclusive/pom.rb
@@ -3,7 +3,7 @@ gemfile
 packaging 'bundle'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '1.0.10',
+properties( 'jruby.plugins.version' => '3.0.1',
             'exam.version' => '3.0.3',
             'url.version' => '1.5.2',
             'logback.version' => '1.0.13',
@@ -14,7 +14,7 @@ pom 'org.jruby:jruby', '${jruby.version}'
 
 model.repositories.clear
 
-extension 'org.torquebox.mojo:mavengem-wagon:1.0.3'
+extension 'org.jruby.maven:mavengem-wagon:2.0.1'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 jruby_plugin! :gem, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0'

--- a/pom.rb
+++ b/pom.rb
@@ -63,7 +63,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
               'github.global.server' => 'github',
               'polyglot.dump.pom' => 'pom.xml',
               'polyglot.dump.readonly' => 'true',
-              'jruby.plugins.version' => '1.0.10',
+              'jruby.plugins.version' => '3.0.1',
 
               # versions for default gems with bin executables
               # used in ./lib/pom.rb and ./maven/jruby-stdlib/pom.rb

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ DO NOT MODIFY - GENERATED CODE
     <joda.time.version>2.12.5</joda.time.version>
     <jruby-launcher.version>1.1.6</jruby-launcher.version>
     <jruby.basedir>${project.basedir}</jruby.basedir>
-    <jruby.plugins.version>1.0.10</jruby.plugins.version>
+    <jruby.plugins.version>3.0.1</jruby.plugins.version>
     <main.basedir>${project.basedir}</main.basedir>
     <polyglot.dump.pom>pom.xml</polyglot.dump.pom>
     <polyglot.dump.readonly>true</polyglot.dump.readonly>

--- a/test/pom.rb
+++ b/test/pom.rb
@@ -8,7 +8,7 @@ project 'JRuby Integration Tests' do
   inherit 'org.jruby:jruby-parent', version
   id 'org.jruby:jruby-tests'
 
-  extension 'org.torquebox.mojo:mavengem-wagon:1.0.3'
+  extension 'org.jruby.maven:mavengem-wagon:2.0.1'
 
   repository :id => :mavengems, :url => 'mavengem:http://rubygems.org'
   plugin_repository :id => :mavengems, :url => 'mavengem:http://rubygems.org'
@@ -41,7 +41,7 @@ project 'JRuby Integration Tests' do
     plugin( 'org.eclipse.m2e:lifecycle-mapping:1.0.0',
             'lifecycleMappingMetadata' => {
               'pluginExecutions' => [ { 'pluginExecutionFilter' => {
-                                          'groupId' =>  'de.saumya.mojo',
+                                          'groupId' =>  'org.jruby.maven',
                                           'artifactId' =>  'gem-maven-plugin',
                                           'versionRange' =>  '[1.0.0-rc3,)',
                                           'goals' => [ 'initialize' ]
@@ -58,7 +58,6 @@ project 'JRuby Integration Tests' do
       'gemHome' => '${gem.home}',
       'binDirectory' => '${jruby.home}/bin',
       'includeRubygemsInTestResources' => 'false',
-      'jrubyVersion' => '9.2.9.0'
     }
 
     execute_goals( 'initialize', options )


### PR DESCRIPTION
Mavengem has used the v1/dependencies API on rubygems.org to get gem information, but that API has now gone away (whitelisted for us until August 8). This change migrates to a newer version of mavengem that uses newer APIs to make up the same functionality.

See jruby/mavengem#9