### PR TITLE
Update StringIO and reenable specs

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -97,7 +97,7 @@ default_gems = [
     # ['set', '1.0.2'],
     ['shellwords', '0.1.0'],
     ['singleton', '0.1.1'],
-    ['stringio', '3.0.5'],
+    ['stringio', '3.0.8'],
     ['strscan', '3.0.6'],
     ['subspawn', '0.1.1'], # has 3 transitive deps:
       ['subspawn-posix', '0.1.1'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -710,7 +710,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>stringio</artifactId>
-      <version>3.0.5</version>
+      <version>3.0.8</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1105,7 +1105,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/securerandom-0.2.0*</include>
           <include>specifications/shellwords-0.1.0*</include>
           <include>specifications/singleton-0.1.1*</include>
-          <include>specifications/stringio-3.0.5*</include>
+          <include>specifications/stringio-3.0.8*</include>
           <include>specifications/strscan-3.0.6*</include>
           <include>specifications/subspawn-0.1.1*</include>
           <include>specifications/subspawn-posix-0.1.1*</include>
@@ -1182,7 +1182,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/securerandom-0.2.0*/**/*</include>
           <include>gems/shellwords-0.1.0*/**/*</include>
           <include>gems/singleton-0.1.1*/**/*</include>
-          <include>gems/stringio-3.0.5*/**/*</include>
+          <include>gems/stringio-3.0.8*/**/*</include>
           <include>gems/strscan-3.0.6*/**/*</include>
           <include>gems/subspawn-0.1.1*/**/*</include>
           <include>gems/subspawn-posix-0.1.1*/**/*</include>
@@ -1259,7 +1259,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/securerandom-0.2.0*</include>
           <include>cache/shellwords-0.1.0*</include>
           <include>cache/singleton-0.1.1*</include>
-          <include>cache/stringio-3.0.5*</include>
+          <include>cache/stringio-3.0.8*</include>
           <include>cache/strscan-3.0.6*</include>
           <include>cache/subspawn-0.1.1*</include>
           <include>cache/subspawn-posix-0.1.1*</include>

--- a/spec/jruby.mspec
+++ b/spec/jruby.mspec
@@ -34,9 +34,6 @@ class MSpecScript
   jruby = File.expand_path("../../bin/#{jruby}", __FILE__)
   set :target, jruby
 
-  # exclude stringio specs until we can address ruby/stringio#57
-  get(:library) << '^' + SPEC_DIR + '/library/stringio'
-
   slow_specs = [
       SPEC_DIR + '/core/process',
       SPEC_DIR + '/core/io/popen',

--- a/spec/tags/ruby/library/stringio/each_line_tags.txt
+++ b/spec/tags/ruby/library/stringio/each_line_tags.txt
@@ -1,1 +1,2 @@
 fails:An exception occurred during: stringio_each_separator
+fails(https://github.com/ruby/stringio/pull/61):StringIO#each_line when passed a separator yields each paragraph with all separation characters when passed an empty String as separator

--- a/spec/tags/ruby/library/stringio/each_tags.txt
+++ b/spec/tags/ruby/library/stringio/each_tags.txt
@@ -1,0 +1,1 @@
+fails(https://github.com/ruby/stringio/pull/61):StringIO#each when passed a separator yields each paragraph with all separation characters when passed an empty String as separator


### PR DESCRIPTION
This fixes the missing `StringIO::VERSION` and tags two new failures due to updated behavior (to be fixed by https://github.com/ruby/stringio/pull/61).