### PR TITLE
[fix] duplicate hash key literal removal

### DIFF
--- a/core/src/main/java/org/jruby/ast/HashNode.java
+++ b/core/src/main/java/org/jruby/ast/HashNode.java
@@ -33,6 +33,7 @@
 package org.jruby.ast;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.jruby.ast.types.ILiteralNode;
@@ -44,7 +45,7 @@ import org.jruby.util.KeyValuePair;
  * of default values or kwarg in a method call.
  */
 public class HashNode extends Node implements ILiteralNode {
-    private final List<KeyValuePair<Node,Node>> pairs;
+    private final List<KeyValuePair<Node,Node>> pairs = new ArrayList<>();
     // contains at least one **k {a: 1, **k}, {**{}, **{}}
     private boolean hasRestKwarg = false;
 
@@ -56,8 +57,6 @@ public class HashNode extends Node implements ILiteralNode {
 
     public HashNode(int line) {
         super(line, false);
-
-        pairs = new ArrayList<>();
     }
     
     public HashNode(int line, KeyValuePair<Node,Node> pair) {
@@ -122,6 +121,25 @@ public class HashNode extends Node implements ILiteralNode {
         pairs.add(pair);
 
         return this;
+    }
+
+    public boolean removeAll(final Collection<KeyValuePair<Node, Node>> pairsToRemove) {
+        boolean changed = this.pairs.removeAll(pairsToRemove);
+
+        if (changed) {
+            // reset as we're to re-built internal state
+            hasRestKwarg = false;
+            isLiteral = false;
+            hasOnlySymbolKeys = true;
+            // clear pairs and add what is meant to be kept:
+            Object[] pairsCopy = this.pairs.toArray();
+            this.pairs.clear();
+            for (int i = 0; i < pairsCopy.length; i++) {
+                add((KeyValuePair<Node, Node>) pairsCopy[i]);
+            }
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -1515,7 +1515,6 @@ public abstract class RubyParserBase {
 
     public Node remove_duplicate_keys(final HashNode hash) {
         final Map<Node, KeyValuePair<Node, Node>> encounteredKeys = new HashMap<>();
-        List<KeyValuePair<Node, Node>> pairsToRemove = null;
 
         for (KeyValuePair<Node,Node> pair: hash.getPairs()) {
             final Node key = pair.getKey();
@@ -1525,9 +1524,6 @@ public abstract class RubyParserBase {
                 IRubyObject value = ((LiteralValue) key).literalValue(runtime);
                 warning(ID.AMBIGUOUS_ARGUMENT, lexer.getFile(), hash.getLine(), str(runtime, "key ", value.inspect(),
                         " is duplicated and overwritten on line " + (key.getLine() + 1)));
-
-                if (pairsToRemove == null) pairsToRemove = new ArrayList<>(4);
-                pairsToRemove.add(encounteredKeys.get(key));
             }
             // even if the key was previously seen, we replace the value to properly remove multiple duplicates
             encounteredKeys.put(key, pair);
@@ -1536,7 +1532,6 @@ public abstract class RubyParserBase {
         // NOTE: we do not really remove the value part (RHS) as in that case we should evaluate the code - despite
         // the value being dropped the side effects are desired and something MRI evaluates explicitly during removal
         // with JRuby the modification of the hash should be done in the IR and not here (during the parsing phase)...
-        // if (pairsToRemove != null) hash.removeAll(pairsToRemove);
 
         return hash;
     }

--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -1533,7 +1533,10 @@ public abstract class RubyParserBase {
             encounteredKeys.put(key, pair);
         }
 
-        if (pairsToRemove != null) hash.removeAll(pairsToRemove);
+        // NOTE: we do not really remove the value part (RHS) as in that case we should evaluate the code - despite
+        // the value being dropped the side effects are desired and something MRI evaluates explicitly during removal
+        // with JRuby the modification of the hash should be done in the IR and not here (during the parsing phase)...
+        // if (pairsToRemove != null) hash.removeAll(pairsToRemove);
 
         return hash;
     }


### PR DESCRIPTION
This PR is a follow-up on https://github.com/jruby/jruby/pull/7623, namely the detected collection usage issue: https://github.com/jruby/jruby/commit/0224d5d2991abf6fd2492ae9e1bbf52a30bb181c

While fixing the collection removal (type) issue I discovered that the actual AST node removal on duplicate hash keys is problematic (there's a need to evaluate the RHS even despite it's end result being thrown away), so the actual removal is still NOT happening.

**The PR still fixes the duplicate line reporting - will now point to the correct (duplicate) location as does MRI! **