### PR TITLE
Update joni to 2.2.1 to fix regex match regression for 9.3

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -51,7 +51,7 @@ project 'JRuby Base' do
   jar 'com.github.jnr:jffi:${jffi.version}'
   jar 'com.github.jnr:jffi:${jffi.version}:native'
 
-  jar 'org.jruby.joni:joni:2.1.48'
+  jar 'org.jruby.joni:joni:2.2.1'
   jar 'org.jruby.jcodings:jcodings:1.0.58'
   jar 'org.jruby:dirgra:0.3'
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -150,7 +150,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>org.jruby.joni</groupId>
       <artifactId>joni</artifactId>
-      <version>2.1.48</version>
+      <version>2.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.jruby.jcodings</groupId>


### PR DESCRIPTION
9.3.10.0 is currently broken with https://github.com/jruby/jruby/issues/7830. 9.3.9.0 is healthy. And `joni` should be updated in order to have a healthy `9.3.11.0` release in the future.