### PR TITLE
Reuse prebuild workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,6 @@ jobs:
           distribution: 'zulu'
           java-version: '8'
           cache: 'maven'
-      - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.6.0
-        with:
-          java-version: '8'
-          maven-version: '3.8.7'
       - name: rake ${{ matrix.target }}
         run: bin/jruby -S rake ${{ matrix.target }}
 
@@ -78,11 +73,6 @@ jobs:
           distribution: 'zulu'
           java-version: 8
           cache: 'maven'
-      - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.6.0
-        with:
-          java-version: 8
-          maven-version: '3.8.7'
       - name: rake test:jruby
         run: bin/jruby --dev -S rake test:jruby
 
@@ -158,11 +148,6 @@ jobs:
           distribution: 'zulu'
           java-version: '8'
           cache: 'maven'
-      - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.6.0
-        with:
-          java-version: '8'
-          maven-version: '3.8.7'
       - name: mvn package ${{ matrix.package-flags }}
         run: tool/maven-ci-script.sh
         env:
@@ -186,11 +171,6 @@ jobs:
           distribution: 'zulu'
           java-version: 8
           cache: 'maven'
-      - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.6.0
-        with:
-          java-version: 8
-          maven-version: '3.8.7'
       - name: rake spec:ji
         run: bin/jruby -S rake spec:ji
 
@@ -212,11 +192,6 @@ jobs:
           distribution: 'zulu'
           java-version: 8
           cache: 'maven'
-      - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.6.0
-        with:
-          java-version: 8
-          maven-version: '3.8.7'
       - name: rake spec:regression
         run: bin/jruby -S rake spec:regression
 
@@ -241,11 +216,6 @@ jobs:
           distribution: 'zulu'
           java-version: 11
           cache: 'maven'
-      - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.6.0
-        with:
-          java-version: 11
-          maven-version: '3.8.7'
       - name: bootstrap
         run: ./mvnw -Pbootstrap clean package
       - name: install bundler
@@ -273,11 +243,6 @@ jobs:
           distribution: 'zulu'
           java-version: '8'
           cache: 'maven'
-      - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.6.0
-        with:
-          java-version: '8'
-          maven-version: '3.8.7'
       - name: dependency convergence
         run: tool/maven-ci-script.sh
         env:
@@ -299,11 +264,6 @@ jobs:
           distribution: 'zulu'
           java-version: 8
           cache: 'maven'
-      - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.6.0
-        with:
-          java-version: 8
-          maven-version: '3.8.7'
       - name: maven-ci-script.sh
         run: tool/maven-ci-script.sh
         env:
@@ -339,11 +299,6 @@ jobs:
           distribution: 'zulu'
           java-version: 11
           cache: 'maven'
-      - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.6.0
-        with:
-          java-version: 11
-          maven-version: '3.8.7'
       - name: sequel
         run: tool/sequel-github-actions.sh
 
@@ -362,11 +317,6 @@ jobs:
           distribution: 'zulu'
           java-version: 8
           cache: 'maven'
-      - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.6.0
-        with:
-          java-version: 8
-          maven-version: '3.8.7'
       - name: concurrent-ruby
         run: tool/concurrent-ruby-github-actions.sh
 
@@ -437,11 +387,6 @@ jobs:
           distribution: 'adopt-openj9'
           java-version: '8'
           cache: 'maven'
-      - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.6.0
-        with:
-          java-version: '8'
-          maven-version: '3.8.7'
       - name: Bootstrap build
         uses: headius/jruby-ci-build@v1
       - name: test profile
@@ -469,11 +414,6 @@ jobs:
           distribution: 'zulu'
           java-version: '8'
           cache: 'maven'
-      - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.6.0
-        with:
-          java-version: '8'
-          maven-version: '3.8.7'
       - name: rake ${{ matrix.target }}
         continue-on-error: true
         run: "bin/jruby -S rake ${{ matrix.target }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,41 +10,6 @@ permissions:
 
 jobs:
 
-  bootstrap-build:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        java-version: ['8']
-      fail-fast: true
-
-    name: bootstrap JRuby build
-
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-      - name: set up java ${{ matrix.java-version }}
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: ${{ matrix.java-version }}
-          cache: 'maven'
-      - name: bootstrap
-        run: ./mvnw -Pbootstrap clean package
-      - name: bundle install
-        run: bin/jruby --dev -S bundle install
-      - name: Save bootstrap build
-        id: cache-bootstrap-save
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            bin
-            core
-            lib
-            shaded
-            test
-          key: ${{ github.sha }}-bootstrap
-
   rake-test:
     runs-on: ubuntu-latest
 
@@ -79,8 +44,8 @@ jobs:
     name: rake ${{ matrix.target }} (Java 8)
 
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
+      - name: Bootstrap build
+        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -92,20 +57,6 @@ jobs:
         with:
           java-version: '8'
           maven-version: '3.8.7'
-      - name: Restore bootstrap build
-        id: cache-bootstrap-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            bin
-            core
-            lib
-            shaded
-            test
-          key: ${{ github.sha }}-bootstrap
-      - name: conditional-bootstrap
-        if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: rake ${{ matrix.target }}
         run: bin/jruby -S rake ${{ matrix.target }}
 
@@ -119,8 +70,8 @@ jobs:
       JRUBY_OPTS: '--dev'
 
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
+      - name: Bootstrap build
+        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -132,20 +83,6 @@ jobs:
         with:
           java-version: 8
           maven-version: '3.8.7'
-      - name: Restore bootstrap build
-        id: cache-bootstrap-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            bin
-            core
-            lib
-            shaded
-            test
-          key: ${{ github.sha }}-bootstrap
-      - name: conditional-bootstrap
-        if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: rake test:jruby
         run: bin/jruby --dev -S rake test:jruby
 
@@ -164,28 +101,14 @@ jobs:
       JRUBY_OPTS: '-Xcompile.invokedynamic'
 
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
+      - name: Bootstrap build
+        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
       - name: set up java ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java-version }}
           cache: 'maven'
-      - name: Restore bootstrap build
-        id: cache-bootstrap-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            bin
-            core
-            lib
-            shaded
-            test
-          key: ${{ github.sha }}-bootstrap
-      - name: conditional-bootstrap
-        if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: rake ${{ matrix.target }}
         run: bin/jruby -S rake ${{ matrix.target }}
 
@@ -202,28 +125,14 @@ jobs:
     name: mvn ${{ matrix.package-flags }} (Java ${{ matrix.java-version }})
 
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
+      - name: Bootstrap build
+        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
       - name: set up java ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java-version }}
-          cache: 'maven'
-      - name: Restore bootstrap build
-        id: cache-bootstrap-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            bin
-            core
-            lib
-            shaded
-            test
-          key: ${{ github.sha }}-bootstrap
-      - name: conditional-bootstrap
-        if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
+          cache: 'maven' 
       - name: mvn package ${{ matrix.package-flags }}
         run: tool/maven-ci-script.sh
         env:
@@ -241,8 +150,8 @@ jobs:
     name: mvn ${{ matrix.package-flags }} (Java 8)
 
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
+      - name: Bootstrap build
+        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -254,20 +163,6 @@ jobs:
         with:
           java-version: '8'
           maven-version: '3.8.7'
-      - name: Restore bootstrap build
-        id: cache-bootstrap-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            bin
-            core
-            lib
-            shaded
-            test
-          key: ${{ github.sha }}-bootstrap
-      - name: conditional-bootstrap
-        if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: mvn package ${{ matrix.package-flags }}
         run: tool/maven-ci-script.sh
         env:
@@ -283,8 +178,8 @@ jobs:
       JRUBY_OPTS: '-Xcompile.invokedynamic'
 
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
+      - name: Bootstrap build
+        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -296,20 +191,6 @@ jobs:
         with:
           java-version: 8
           maven-version: '3.8.7'
-      - name: Restore bootstrap build
-        id: cache-bootstrap-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            bin
-            core
-            lib
-            shaded
-            test
-          key: ${{ github.sha }}-bootstrap
-      - name: conditional-bootstrap
-        if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: rake spec:ji
         run: bin/jruby -S rake spec:ji
 
@@ -323,8 +204,8 @@ jobs:
       JRUBY_OPTS: '-Xjit.threshold=0'
 
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
+      - name: Bootstrap build
+        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -336,20 +217,6 @@ jobs:
         with:
           java-version: 8
           maven-version: '3.8.7'
-      - name: Restore bootstrap build
-        id: cache-bootstrap-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            bin
-            core
-            lib
-            shaded
-            test
-          key: ${{ github.sha }}-bootstrap
-      - name: conditional-bootstrap
-        if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: rake spec:regression
         run: bin/jruby -S rake spec:regression
 
@@ -464,8 +331,8 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
+      - name: Bootstrap build
+        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -477,20 +344,6 @@ jobs:
         with:
           java-version: 11
           maven-version: '3.8.7'
-      - name: Restore bootstrap build
-        id: cache-bootstrap-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            bin
-            core
-            lib
-            shaded
-            test
-          key: ${{ github.sha }}-bootstrap
-      - name: conditional-bootstrap
-        if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: sequel
         run: tool/sequel-github-actions.sh
 
@@ -501,8 +354,8 @@ jobs:
       fail-fast: false
 
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
+      - name: Bootstrap build
+        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -514,20 +367,6 @@ jobs:
         with:
           java-version: 8
           maven-version: '3.8.7'
-      - name: Restore bootstrap build
-        id: cache-bootstrap-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            bin
-            core
-            lib
-            shaded
-            test
-          key: ${{ github.sha }}-bootstrap
-      - name: conditional-bootstrap
-        if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: concurrent-ruby
         run: tool/concurrent-ruby-github-actions.sh
 
@@ -569,11 +408,10 @@ jobs:
       fail-fast: false
 
     name: rake ${{ matrix.target }} (Java ${{ matrix.java-version }} Apple aarch64)
-    needs: bootstrap-build
 
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
+      - name: Bootstrap build
+        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
       - name: set up java ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
@@ -581,17 +419,6 @@ jobs:
           java-version: ${{ matrix.java-version }}
           architecture: arm
           cache: 'maven'
-      - name: Restore bootstrap build
-        id: cache-bootstrap-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            bin
-            core
-            lib
-            shaded
-            test
-          key: ${{ github.sha }}-bootstrap
       - name: rake ${{ matrix.target }}
 #        run: "bin/jruby -S rake ${{ matrix.target }}"
         run: "true"
@@ -602,8 +429,8 @@ jobs:
     name: mvn -Ptest (OpenJ9 Java 8; disabled)
 
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
+      - name: Bootstrap build
+        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
       - name: set up java ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
@@ -615,20 +442,8 @@ jobs:
         with:
           java-version: '8'
           maven-version: '3.8.7'
-      - name: Restore bootstrap build
-        id: cache-bootstrap-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            bin
-            core
-            lib
-            shaded
-            test
-          key: ${{ github.sha }}-bootstrap
-      - name: conditional-bootstrap
-        if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
+      - name: Bootstrap build
+        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
       - name: test profile
 #        run: "tool/maven-ci-script.sh"
         run: "true"
@@ -646,8 +461,8 @@ jobs:
     name: rake ${{ matrix.target }} (Java 8)
 
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
+      - name: Bootstrap build
+        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -659,20 +474,6 @@ jobs:
         with:
           java-version: '8'
           maven-version: '3.8.7'
-      - name: Restore bootstrap build
-        id: cache-bootstrap-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            bin
-            core
-            lib
-            shaded
-            test
-          key: ${{ github.sha }}-bootstrap
-      - name: conditional-bootstrap
-        if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: rake ${{ matrix.target }}
         continue-on-error: true
         run: "bin/jruby -S rake ${{ matrix.target }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,20 +208,14 @@ jobs:
       JDK_JAVA_OPTS: "-Djdk.io.File.enableADS=true"
 
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
+      - name: Bootstrap build
+        uses: headius/jruby-ci-build@v1
       - name: set up java 11
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 11
           cache: 'maven'
-      - name: bootstrap
-        run: ./mvnw -Pbootstrap clean package
-      - name: install bundler
-        run: bin/jruby --dev -S gem install bundler
-      - name: bundle install
-        run: bin/jruby --dev -S bundle install
       - name: rake test:jruby
         run: bin/jruby -S rake test:jruby TESTOPTS="--no-show-detail-immediately"
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,8 +387,6 @@ jobs:
           distribution: 'adopt-openj9'
           java-version: '8'
           cache: 'maven'
-      - name: Bootstrap build
-        uses: headius/jruby-ci-build@v1
       - name: test profile
 #        run: "tool/maven-ci-script.sh"
         run: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
+        uses: headius/jruby-ci-build@v1
       - name: set up java ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
+        uses: headius/jruby-ci-build@v1
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
+        uses: headius/jruby-ci-build@v1
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -102,7 +102,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
+        uses: headius/jruby-ci-build@v1
       - name: set up java ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
@@ -126,13 +126,13 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
+        uses: headius/jruby-ci-build@v1
       - name: set up java ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java-version }}
-          cache: 'maven' 
+          cache: 'maven'
       - name: mvn package ${{ matrix.package-flags }}
         run: tool/maven-ci-script.sh
         env:
@@ -151,7 +151,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
+        uses: headius/jruby-ci-build@v1
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -179,7 +179,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
+        uses: headius/jruby-ci-build@v1
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -205,7 +205,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
+        uses: headius/jruby-ci-build@v1
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -332,7 +332,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
+        uses: headius/jruby-ci-build@v1
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -355,7 +355,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
+        uses: headius/jruby-ci-build@v1
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -411,7 +411,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
+        uses: headius/jruby-ci-build@v1
       - name: set up java ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
@@ -430,7 +430,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
+        uses: headius/jruby-ci-build@v1
       - name: set up java ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
@@ -443,7 +443,7 @@ jobs:
           java-version: '8'
           maven-version: '3.8.7'
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
+        uses: headius/jruby-ci-build@v1
       - name: test profile
 #        run: "tool/maven-ci-script.sh"
         run: "true"
@@ -462,7 +462,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
+        uses: headius/jruby-ci-build@v1
       - name: set up java 8
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@v1
+        uses: jruby/jruby-ci-build@v1
       - name: set up java ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@v1
+        uses: jruby/jruby-ci-build@v1
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@v1
+        uses: jruby/jruby-ci-build@v1
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -92,7 +92,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@v1
+        uses: jruby/jruby-ci-build@v1
       - name: set up java ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@v1
+        uses: jruby/jruby-ci-build@v1
       - name: set up java ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
@@ -141,7 +141,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@v1
+        uses: jruby/jruby-ci-build@v1
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -164,7 +164,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@v1
+        uses: jruby/jruby-ci-build@v1
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -185,7 +185,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@v1
+        uses: jruby/jruby-ci-build@v1
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -209,7 +209,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@v1
+        uses: jruby/jruby-ci-build@v1
       - name: set up java 11
         uses: actions/setup-java@v3
         with:
@@ -286,7 +286,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@v1
+        uses: jruby/jruby-ci-build@v1
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -304,7 +304,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@v1
+        uses: jruby/jruby-ci-build@v1
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
@@ -355,7 +355,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@v1
+        uses: jruby/jruby-ci-build@v1
       - name: set up java ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
@@ -374,7 +374,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@v1
+        uses: jruby/jruby-ci-build@v1
       - name: set up java ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
@@ -399,7 +399,7 @@ jobs:
 
     steps:
       - name: Bootstrap build
-        uses: headius/jruby-ci-build@v1
+        uses: jruby/jruby-ci-build@v1
       - name: set up java 8
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,28 +57,14 @@ jobs:
     name: rake ${{ matrix.target }} (Java ${{ matrix.java-version }})
 
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
+      - name: Bootstrap build
+        uses: headius/jruby-ci-build@1f3b75ee85067fd6e8a91c19d662149601644a68
       - name: set up java ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java-version }}
           cache: 'maven'
-      - name: Restore bootstrap build
-        id: cache-bootstrap-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            bin
-            core
-            lib
-            shaded
-            test
-          key: ${{ github.sha }}-bootstrap
-      - name: conditional-bootstrap
-        if: ${{ steps.cache-bootstrap-restore.outputs.cache-hit == false }}
-        run: "./mvnw -Pbootstrap clean package && bin/jruby --dev -S gem install bundler && bin/jruby --dev -S bundle install"
       - name: rake ${{ matrix.target }}
         run: bin/jruby -S rake ${{ matrix.target }}
 


### PR DESCRIPTION
This moves the logic of building JRuby and caching the build artifacts out to a reusable action.

The action lives at https://github.com/jruby/jruby-ci-build and performs the following actions in sequence:

* Checks out JRuby on the current branch
* Sets up Zulu Java 8
* Attempts to download a cached build of JRuby
* If the cache was unavailable, build and upload JRuby

All of the major jobs use this action to prep the JRuby build they test against. While the first several jobs (up to whatever concurrency we get) will all end up building JRuby themselves, once a cache has been uploaded no future jobs will need to build and bootstrap JRuby.

The primary goal here is to reduce duplication in the main build, but this also enhances the build by moving the bootstrap cache step into each job, so whichever job builds fastest will upload first.