### PR TITLE
Fix BigDecimal#power with negative integer

### DIFF
--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -1217,10 +1217,10 @@ public class RubyBigDecimal extends RubyNumeric {
 
         final int times;
         final double rem; // exp's decimal part
-        final int nx = prec.isNil() ? getPrec(context) * BASE_FIG : num2int(prec);
+        final int nx = prec.isNil() ? getPrec() * BASE_FIG : num2int(prec);
         if (exp instanceof RubyBigDecimal) {
             RubyBigDecimal bdExp = (RubyBigDecimal)exp;
-            int ny = bdExp.getPrec(context) * BASE_FIG;
+            int ny = bdExp.getPrec() * BASE_FIG;
             return bigdecimal_power_by_bigdecimal(context, exp, prec.isNil() ? nx + ny : nx);
         } else if ( exp instanceof RubyFloat ) {
             int ny = VP_DOUBLE_FIG;
@@ -1292,9 +1292,21 @@ public class RubyBigDecimal extends RubyNumeric {
 
     private BigDecimal powNegative(final int times) {
         // Note: MRI has a very non-trivial way of calculating the precision,
-        // so we use very simple approximation here:
-        int precision = (-times + 4) * (getAllDigits().length() + 4);
-        return value.pow(times, new MathContext(precision, RoundingMode.HALF_UP));
+        // so we use approximation here :
+        int mp = getPrec() * (BASE_FIG + 1) * (-times + 1);
+        int precision = (mp + 8) / BASE_FIG * BASE_FIG;
+        BigDecimal pow = value.pow(times, new MathContext(precision * 2, RoundingMode.DOWN));
+        // calculates exponent of pow
+        BigDecimal tmp = pow.abs().stripTrailingZeros();
+        int exponent = tmp.precision() - tmp.scale();
+        // adjusts precision using exponent. it seems like to match MRI behavior.
+        if (exponent < 0) {
+            precision += Math.abs(exponent) / BASE_FIG * BASE_FIG;
+        } else {
+            precision -= (exponent + 8) / BASE_FIG * BASE_FIG;
+        }
+        pow = pow.setScale(precision, RoundingMode.DOWN);
+        return pow;
     }
 
     @JRubyMethod(name = "+")
@@ -1933,12 +1945,11 @@ public class RubyBigDecimal extends RubyNumeric {
     @JRubyMethod
     public RubyArray precision_scale(ThreadContext context) {
         Ruby runtime = context.runtime;
-        int [] ary = getPrecisionScale(context);
+        int [] ary = getPrecisionScale();
         return runtime.newArray(runtime.newFixnum(ary[0]), runtime.newFixnum(ary[1]));
     }
 
-    private int [] getPrecisionScale(ThreadContext context) {
-        Ruby runtime = context.runtime;
+    private int [] getPrecisionScale() {
         int precision = 0;
         int scale = 0;
         String plainString = value.toPlainString();
@@ -1965,8 +1976,18 @@ public class RubyBigDecimal extends RubyNumeric {
     }
 
     // mri x->Prec
-    private int getPrec(ThreadContext context) {
-        return getPrecisionScale(context)[0] / 8 + 1;
+    private int getPrec() {
+        // precision > scale (exponent > 0)
+        // e.g. "123.456789" is represented as "0. 000000123 456789 * 1000000000 ^ 1" in MRI BigDecimal internal..
+        // so, in this case Prec becomes 2.
+        int [] precisionScale = getPrecisionScale();
+        if (precisionScale[0] > precisionScale[1]) {
+            return (precisionScale[0] + (BASE_FIG - (precisionScale[0] - precisionScale[1])) + 8) / BASE_FIG;
+        }
+        // precision = scale
+        // e.g. "0.0000000000123456789" is represented as "0 .012345678 9 * 1000000000 ^ -1" in MRI BigDecimal internal.
+        // so, in this case Prec becomes 1.
+        return (value.toBigInteger().toString().length() + 8) / BASE_FIG;
     }
 
     @Deprecated

--- a/test/mri/excludes/TestBigDecimal.rb
+++ b/test/mri/excludes/TestBigDecimal.rb
@@ -3,7 +3,6 @@ exclude :test_exception_overflow, "runs forever"
 exclude :test_limit, "needs investigation"
 
 exclude :test_power_of_three, "pow's precision isn't calculated the same as in MRI (for 1/81)"
-exclude :test_power_without_prec, "needs investigation"
 
 exclude :test_round_up, "needs investigation"
 exclude :test_thread_local_mode, "needs investigation"


### PR DESCRIPTION
This commits improves precision of power algorithm.
This commits also updates getPrec() of private method to match MRI behavior.

The following test will pass.
 * test_power_without_prec in test/mri/bigdecimal/test_bigdecimal.rb
