### PR TITLE
Fix dynscopes

### DIFF
--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -862,7 +862,6 @@ public class IRRuntimeHelpers {
             DynamicScope tlbScope = ((IRScriptBody) irScope).getScriptDynamicScope();
             if (tlbScope != null) {
                 context.preScopedBody(tlbScope);
-                tlbScope.growIfNeeded();
                 return tlbScope;
             }
         }

--- a/core/src/main/java/org/jruby/parser/Parser.java
+++ b/core/src/main/java/org/jruby/parser/Parser.java
@@ -144,15 +144,6 @@ public class Parser {
         } catch (SyntaxException e) {
             throw runtime.newSyntaxError(e.getFile() + ":" + (e.getLine() + 1) + ": " + e.getMessage());
         }
-        
-        // If variables were added then we may need to grow the dynamic scope to match the static
-        // one.
-        // FIXME: Make this so we only need to check this for blockScope != null.  We cannot
-        // currently since we create the DynamicScope for a LocalStaticScope before parse begins.
-        // Refactoring should make this fixable.
-        if (result.getScope() != null) {
-            result.getScope().growIfNeeded();
-        }
 
         Node ast = result.getAST();
         

--- a/core/src/main/java/org/jruby/parser/ParserConfiguration.java
+++ b/core/src/main/java/org/jruby/parser/ParserConfiguration.java
@@ -43,14 +43,14 @@ import org.jruby.util.KCode;
 import java.util.Arrays;
 
 public class ParserConfiguration {
-    // Scope passed in during an eval since we can see outside the root of this parse.
     private DynamicScope existingScope = null;
 
     // What linenumber will the source think it starts from?
     private int lineNumber = 0;
     // Is this inline source (aka -e "...source...")
     private boolean inlineSource = false;
-
+    // We parse evals more often in source so assume an eval parse.
+    private boolean isEvalParse = true;
     // Should we display extra debug information while parsing?
     private boolean isDebug = true;
     // whether we should save the end-of-file data as DATA
@@ -69,6 +69,7 @@ public class ParserConfiguration {
         this.runtime = runtime;
         this.inlineSource = inlineSource;
         this.lineNumber = lineNumber;
+        this.isEvalParse = !isFileParse;
         this.saveData = saveData;
     }
 
@@ -119,7 +120,7 @@ public class ParserConfiguration {
      * @return true if for eval
      */
     public boolean isEvalParse() {
-        return existingScope != null;
+        return isEvalParse;
     }
 
     public KCode getKCode() {
@@ -153,14 +154,14 @@ public class ParserConfiguration {
      * @return a static scope
      */
     public StaticScope getTopStaticScope(String file) {
-        return isEvalParse() ?
+        return existingScope != null ?
                 existingScope.getStaticScope() :
                 runtime.getStaticScopeFactory().newLocalScope(null, file);
     }
 
     public DynamicScope finalizeDynamicScope(StaticScope staticScope) {
         // Eval scooped up some new variables changing the size of the scope.
-        if (isEvalParse()) {
+        if (existingScope != null) {
             existingScope.growIfNeeded();
             return existingScope;
         }

--- a/core/src/main/java/org/jruby/parser/ParserConfiguration.java
+++ b/core/src/main/java/org/jruby/parser/ParserConfiguration.java
@@ -38,14 +38,13 @@ import org.jruby.RubyInstanceConfig;
 import org.jruby.ext.coverage.CoverageData;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.encoding.EncodingService;
-import org.jruby.runtime.scope.ManyVarsDynamicScope;
 import org.jruby.util.KCode;
 
 import java.util.Arrays;
 
 public class ParserConfiguration {
     private DynamicScope existingScope = null;
-    private boolean asBlock = false;
+
     // What linenumber will the source think it starts from?
     private int lineNumber = 0;
     // Is this inline source (aka -e "...source...")
@@ -139,7 +138,6 @@ public class ParserConfiguration {
      * @param existingScope is the scope that captures new vars, etc...
      */
     public void parseAsBlock(DynamicScope existingScope) {
-        this.asBlock = true;
         this.existingScope = existingScope;
     }
 
@@ -156,18 +154,19 @@ public class ParserConfiguration {
      * @return a static scope
      */
     public StaticScope getTopStaticScope(String file) {
-        return asBlock ?
+        return existingScope != null ?
                 existingScope.getStaticScope() :
                 runtime.getStaticScopeFactory().newLocalScope(null, file);
     }
 
     public DynamicScope finalizeDynamicScope(StaticScope staticScope) {
         // Eval scooped up some new variables changing the size of the scope.
-        if (existingScope != null) existingScope.growIfNeeded();
+        if (existingScope != null) {
+            existingScope.growIfNeeded();
+            return existingScope;
+        }
 
-        return asBlock ?
-                existingScope :
-                DynamicScope.newDynamicScope(staticScope, existingScope);
+        return DynamicScope.newDynamicScope(staticScope, existingScope);
     }
 
     public boolean isCoverageEnabled() {

--- a/core/src/main/java/org/jruby/parser/ParserConfiguration.java
+++ b/core/src/main/java/org/jruby/parser/ParserConfiguration.java
@@ -43,14 +43,14 @@ import org.jruby.util.KCode;
 import java.util.Arrays;
 
 public class ParserConfiguration {
+    // Scope passed in during an eval since we can see outside the root of this parse.
     private DynamicScope existingScope = null;
 
     // What linenumber will the source think it starts from?
     private int lineNumber = 0;
     // Is this inline source (aka -e "...source...")
     private boolean inlineSource = false;
-    // We parse evals more often in source so assume an eval parse.
-    private boolean isEvalParse = true;
+
     // Should we display extra debug information while parsing?
     private boolean isDebug = true;
     // whether we should save the end-of-file data as DATA
@@ -69,7 +69,6 @@ public class ParserConfiguration {
         this.runtime = runtime;
         this.inlineSource = inlineSource;
         this.lineNumber = lineNumber;
-        this.isEvalParse = !isFileParse;
         this.saveData = saveData;
     }
 
@@ -120,7 +119,7 @@ public class ParserConfiguration {
      * @return true if for eval
      */
     public boolean isEvalParse() {
-        return isEvalParse;
+        return existingScope != null;
     }
 
     public KCode getKCode() {
@@ -154,14 +153,14 @@ public class ParserConfiguration {
      * @return a static scope
      */
     public StaticScope getTopStaticScope(String file) {
-        return existingScope != null ?
+        return isEvalParse() ?
                 existingScope.getStaticScope() :
                 runtime.getStaticScopeFactory().newLocalScope(null, file);
     }
 
     public DynamicScope finalizeDynamicScope(StaticScope staticScope) {
         // Eval scooped up some new variables changing the size of the scope.
-        if (existingScope != null) {
+        if (isEvalParse()) {
             existingScope.growIfNeeded();
             return existingScope;
         }

--- a/core/src/main/java/org/jruby/parser/ParserConfiguration.java
+++ b/core/src/main/java/org/jruby/parser/ParserConfiguration.java
@@ -155,9 +155,7 @@ public class ParserConfiguration {
      * @param file to name top scope if we have a new scope
      * @return a static scope
      */
-    private int initialVariableCount = 0;
     public StaticScope getTopStaticScope(String file) {
-        if (existingScope != null) initialVariableCount = existingScope.getStaticScope().getNumberOfVariables();
         return asBlock ?
                 existingScope.getStaticScope() :
                 runtime.getStaticScopeFactory().newLocalScope(null, file);
@@ -165,9 +163,7 @@ public class ParserConfiguration {
 
     public DynamicScope finalizeDynamicScope(StaticScope staticScope) {
         // Eval scooped up some new variables changing the size of the scope.
-        if (existingScope != null && existingScope.getStaticScope().getNumberOfVariables() > initialVariableCount) {
-            existingScope.growIfNeeded();
-        }
+        if (existingScope != null) existingScope.growIfNeeded();
 
         return asBlock ?
                 existingScope :

--- a/core/src/main/java/org/jruby/parser/ParserConfiguration.java
+++ b/core/src/main/java/org/jruby/parser/ParserConfiguration.java
@@ -166,7 +166,7 @@ public class ParserConfiguration {
     public DynamicScope finalizeDynamicScope(StaticScope staticScope) {
         // Eval scooped up some new variables changing the size of the scope.
         if (existingScope != null && existingScope.getStaticScope().getNumberOfVariables() > initialVariableCount) {
-            existingScope = DynamicScope.newDynamicScope(existingScope.getStaticScope(), existingScope.getParentScope());
+            existingScope.growIfNeeded();
         }
 
         return asBlock ?

--- a/core/src/main/java/org/jruby/parser/RubyParser.java
+++ b/core/src/main/java/org/jruby/parser/RubyParser.java
@@ -1999,6 +1999,7 @@ states[2] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, in
                       expr = p.remove_begin(expr);
                       p.void_expr(expr);
                   }
+                  p.finalizeDynamicScope();
                   p.getResult().setAST(p.addRootNode(((Node)yyVals[0+yyTop].value)));
                   /*% %*/
                   /*% ripper[final]: program!($2) %*/
@@ -6798,7 +6799,7 @@ states[819] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
   return yyVal;
 };
 }
-					// line 4768 "parse.y"
+					// line 4769 "parse.y"
 
 }
-					// line 14584 "-"
+					// line 14585 "-"

--- a/core/src/main/java/org/jruby/parser/RubyParser.y
+++ b/core/src/main/java/org/jruby/parser/RubyParser.y
@@ -458,6 +458,7 @@ program       : {
                       expr = p.remove_begin(expr);
                       p.void_expr(expr);
                   }
+                  p.finalizeDynamicScope();
                   p.getResult().setAST(p.addRootNode($2));
                   /*% %*/
                   /*% ripper[final]: program!($2) %*/

--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -1275,12 +1275,13 @@ public abstract class RubyParserBase {
     *  Description of the RubyMethod
     */
     public void initTopLocalVariables() {
-        DynamicScope scope = configuration.getScope(lexer.getFile());
-        currentScope = scope.getStaticScope();
+        currentScope = configuration.getTopStaticScope(lexer.getFile());
         scopedParserState = new ScopedParserState(null);
         warnOnUnusedVariables = warnings.isVerbose() && !configuration.isEvalParse() && !configuration.isInlineSource();
-        
-        result.setScope(scope);
+    }
+
+    public void finalizeDynamicScope() {
+        getResult().setScope(configuration.finalizeDynamicScope(currentScope));
     }
     /**
      * Gets the result.


### PR DESCRIPTION
Top-level scopes for ordinary parses will no right-size dynscope vs always using manyvarsdynamicscope.  This work also made me realize first time simple non-binding evals can do this as well (first time binding also but it is more complicated).