### PR TITLE
Update joni and strscan for recent fixes

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -51,7 +51,7 @@ project 'JRuby Base' do
   jar 'com.github.jnr:jffi:${jffi.version}'
   jar 'com.github.jnr:jffi:${jffi.version}:native'
 
-  jar 'org.jruby.joni:joni:2.1.48'
+  jar 'org.jruby.joni:joni:2.2.1'
   jar 'org.jruby.jcodings:jcodings:1.0.58'
   jar 'org.jruby:dirgra:0.3'
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -150,7 +150,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>org.jruby.joni</groupId>
       <artifactId>joni</artifactId>
-      <version>2.1.48</version>
+      <version>2.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.jruby.jcodings</groupId>


### PR DESCRIPTION
* joni updated to 2.2.1 with the new Region factory and shapes.
* strscan updated to a modified version of the gem 3.0.6 that can compile against joni 2.2 (which hides Region fields).

Note that these changes mean any users depending on access to joni Region fields, or its constructor, will see some breakage, but these changes have been in the wild in 9.4.x for sevreal months without issues.

Relates to #7884