### PR TITLE
Fix BigDecimal#eql? when an argument is Rational

### DIFF
--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -511,7 +511,7 @@ public class RubyBigDecimal extends RubyNumeric {
             return new RubyBigDecimal(context.runtime, new BigDecimal(value.toString(), mathContext));
         }
         if (value instanceof RubyRational) {
-            return div2Impl(context, ((RubyRational) value).getNumerator(), ((RubyRational) value).getDenominator(), this.value.precision() * BASE_FIG);
+            return div2Impl(context, ((RubyRational) value).getNumerator(), ((RubyRational) value).getDenominator(), this.getPrec() * BASE_FIG);
         }
 
         return getVpValue(context, value, must);
@@ -1660,7 +1660,12 @@ public class RubyBigDecimal extends RubyNumeric {
 
     private IRubyObject cmp(ThreadContext context, final IRubyObject arg, final char op) {
         final int e;
-        RubyBigDecimal rb = getVpValue(context, arg, false);
+        RubyBigDecimal rb;
+        if (arg instanceof RubyRational) {
+            rb = getVpValueWithPrec(context, arg, false);
+        } else {
+            rb = getVpValue(context, arg, false);
+        }
         if (rb == null) {
             String id = "!=";
             switch (op) {

--- a/test/mri/excludes/TestBigDecimal.rb
+++ b/test/mri/excludes/TestBigDecimal.rb
@@ -2,8 +2,6 @@ exclude :test_exception_overflow, "runs forever"
 
 exclude :test_limit, "needs investigation"
 
-exclude :test_power_of_three, "pow's precision isn't calculated the same as in MRI (for 1/81)"
-
 exclude :test_round_up, "needs investigation"
 exclude :test_thread_local_mode, "needs investigation"
 exclude :"test_BigDecimal_with_integer", "work in progress"


### PR DESCRIPTION
The following test will pass.
 * test_power_of_three in test/mri/bigdecimal/test_bigdecimal.rb