### PR TITLE
Add INT64_MAX, INT64_MIN, UINT64_MAX, LLONG_MAX, LLONG_MIN and ULLONG_MAX to RbConfig::LIMITS

### DIFF
--- a/lib/ruby/stdlib/rbconfig/sizeof.rb
+++ b/lib/ruby/stdlib/rbconfig/sizeof.rb
@@ -16,6 +16,12 @@ module RbConfig
   limits['INT_MAX'] = 0x7fffffff
   limits['INT_MIN'] = -0x80000000
   limits['INTPTR_MAX'] = 0x7FFFFFFFFFFFFFFF
+  limits['INT64_MAX'] = 0x7FFFFFFFFFFFFFFF
+  limits['INT64_MIN'] = -0x8000000000000000
+  limits['UINT64_MAX'] = 0xFFFFFFFFFFFFFFFF
+  limits['LLONG_MAX'] = limits['INT64_MAX']
+  limits['LLONG_MIN'] = limits['INT64_MIN']
+  limits['ULLONG_MAX'] = limits['UINT64_MAX']
   limits.freeze
   LIMITS = limits
 end

--- a/test/mri/excludes/TestBigDecimal.rb
+++ b/test/mri/excludes/TestBigDecimal.rb
@@ -4,8 +4,6 @@ exclude :test_limit, "needs investigation"
 
 exclude :test_round_up, "needs investigation"
 exclude :test_thread_local_mode, "needs investigation"
-exclude :"test_BigDecimal_with_integer", "work in progress"
-exclude :"test_llong_min_gh_200", "work in progress"
 exclude :"test_new_subclass", "work in progress"
 exclude :"test_s_allocate", "work in progress"
 exclude :"test_s_new", "work in progress"


### PR DESCRIPTION
This PR adds these values to run BigDecimal test.
    
The following tests will pass
 * test_BigDecimal_with_integer in test/mri/bigdecimal/test_bigdecimal.rb
 * test_llong_min_gh_200 in test/mri/bigdecimal/test_bigdecimal.rb