### PR TITLE
Fix BigDecimal#div when an argument is object

### DIFF
--- a/spec/tags/ruby/library/bigdecimal/div_tags.txt
+++ b/spec/tags/ruby/library/bigdecimal/div_tags.txt
@@ -1,1 +1,0 @@
-fails:BigDecimal#div with precision set to 0 with Object tries to coerce the other operand to self


### PR DESCRIPTION
The following test will pass.
 * spec/ruby/library/bigdecimal/div_spec.rb
 