### PR TITLE
Optimize @a ||= x and defined?(@a)

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -4939,6 +4939,17 @@ public final class Ruby implements Constantizable {
         return this.nullToNil = nullToNil;
     }
 
+    public MethodHandle getNullToUndefinedHandle() {
+        MethodHandle filter = this.nullToUndefined;
+
+        if (filter != null) return filter;
+
+        filter = InvokeDynamicSupport.findStatic(Helpers.class, "nullToUndefined", methodType(IRubyObject.class, IRubyObject.class));
+        filter = explicitCastArguments(filter, methodType(IRubyObject.class, Object.class));
+
+        return this.nullToUndefined = filter;
+    }
+
     // Parser stats methods
     private void addLoadParseToStats() {
         if (parserStats != null) parserStats.addLoadParse();
@@ -5745,6 +5756,7 @@ public final class Ruby implements Constantizable {
      * The nullToNil filter for this runtime.
      */
     private MethodHandle nullToNil;
+    private MethodHandle nullToUndefined;
 
     public final ClassValue<TypePopulator> POPULATORS = new ClassValue<TypePopulator>() {
         @Override

--- a/core/src/main/java/org/jruby/ir/instructions/GetFieldInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/GetFieldInstr.java
@@ -6,8 +6,10 @@ import org.jruby.RubySymbol;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
 import org.jruby.ir.operands.Operand;
+import org.jruby.ir.operands.UndefinedValue;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.persistence.IRReaderDecoder;
+import org.jruby.ir.persistence.IRWriterEncoder;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.DynamicScope;
@@ -22,18 +24,29 @@ import static org.jruby.util.RubyStringBuilder.str;
 public class GetFieldInstr extends GetInstr implements FixedArityInstr {
     private transient VariableAccessor accessor = VariableAccessor.DUMMY_ACCESSOR;
 
-    public GetFieldInstr(Variable dest, Operand obj, RubySymbol fieldName) {
+    // do not return as nil if it doesn't exist but as undefined.
+    public final boolean rawValue;
+
+    public GetFieldInstr(Variable dest, Operand obj, RubySymbol fieldName, boolean rawValue) {
         super(Operation.GET_FIELD, dest, obj, fieldName);
+
+        this.rawValue = rawValue;
     }
 
     @Override
     public Instr clone(CloneInfo ii) {
         return new GetFieldInstr(ii.getRenamedVariable(getResult()),
-                getSource().cloneForInlining(ii), getName());
+                getSource().cloneForInlining(ii), getName(), rawValue);
     }
 
     public static GetFieldInstr decode(IRReaderDecoder d) {
-        return new GetFieldInstr(d.decodeVariable(), d.decodeOperand(), d.decodeSymbol());
+        return new GetFieldInstr(d.decodeVariable(), d.decodeOperand(), d.decodeSymbol(), d.decodeBoolean());
+    }
+
+    @Override
+    public void encode(IRWriterEncoder e) {
+        super.encode(e);
+        e.encode(rawValue);
     }
 
     public VariableAccessor getAccessor(IRubyObject o) {
@@ -51,15 +64,19 @@ public class GetFieldInstr extends GetInstr implements FixedArityInstr {
     public Object interpret(ThreadContext context, StaticScope currScope, DynamicScope currDynScope, IRubyObject self, Object[] temp) {
         IRubyObject object = (IRubyObject) getSource().retrieve(context, self, currScope, currDynScope, temp);
         VariableAccessor a = getAccessor(object);
-        Object result = a == null ? null : (IRubyObject)a.get(object);
-        if (result == null) {
-            result = context.nil;
-        }
-        return result;
+        Object result = a == null ? null : (IRubyObject) a.get(object);
+
+        if (result == null && rawValue) return UndefinedValue.UNDEFINED;
+        return result == null && !rawValue ? context.nil : result;
     }
 
     @Override
     public void visit(IRVisitor visitor) {
         visitor.GetFieldInstr(this);
+    }
+
+    @Override
+    public String[] toStringNonOperandArgs() {
+        return new String[] {"name: " + getName(), "raw: " + rawValue};
     }
 }

--- a/core/src/main/java/org/jruby/ir/instructions/RuntimeHelperCall.java
+++ b/core/src/main/java/org/jruby/ir/instructions/RuntimeHelperCall.java
@@ -25,7 +25,7 @@ import static org.jruby.ir.IRFlags.REQUIRES_CLASS;
 public class RuntimeHelperCall extends NOperandResultBaseInstr {
     public enum Methods {
         HANDLE_PROPAGATED_BREAK, HANDLE_NONLOCAL_RETURN, HANDLE_BREAK_AND_RETURNS_IN_LAMBDA,
-        IS_DEFINED_BACKREF, IS_DEFINED_NTH_REF, IS_DEFINED_GLOBAL, IS_DEFINED_INSTANCE_VAR,
+        IS_DEFINED_BACKREF, IS_DEFINED_NTH_REF, IS_DEFINED_GLOBAL,
         IS_DEFINED_CLASS_VAR, IS_DEFINED_SUPER, IS_DEFINED_METHOD, IS_DEFINED_CALL,
         IS_DEFINED_CONSTANT_OR_METHOD, MERGE_KWARGS, IS_HASH_EMPTY, HASH_CHECK, ARRAY_LENGTH;
 
@@ -138,12 +138,6 @@ public class RuntimeHelperCall extends NOperandResultBaseInstr {
                         ((FrozenString) operands[1]).retrieve(context, self, currScope, currDynScope, temp),
                         (IRubyObject) operands[2].retrieve(context, self, currScope, currDynScope, temp),
                         (IRubyObject) operands[3].retrieve(context, self, currScope, currDynScope, temp));
-            case IS_DEFINED_INSTANCE_VAR:
-                return IRRuntimeHelpers.isDefinedInstanceVar(
-                        context,
-                        (IRubyObject) arg1,
-                        ((Stringable) operands[1]).getString(),
-                        (IRubyObject) operands[2].retrieve(context, self, currScope, currDynScope, temp));
             case IS_DEFINED_CLASS_VAR:
                 return IRRuntimeHelpers.isDefinedClassVar(
                         context,

--- a/core/src/main/java/org/jruby/ir/interpreter/ExitableInterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/ExitableInterpreterEngine.java
@@ -178,17 +178,6 @@ public class ExitableInterpreterEngine extends InterpreterEngine {
                 setResult(temp, currDynScope, c.getResult(), retrieveOp(c.getSource(), context, self, currDynScope, currScope, temp));
                 break;
             }
-            case GET_FIELD: {
-                GetFieldInstr gfi = (GetFieldInstr)instr;
-                IRubyObject object = (IRubyObject)gfi.getSource().retrieve(context, self, currScope, currDynScope, temp);
-                VariableAccessor a = gfi.getAccessor(object);
-                Object result = a == null ? null : (IRubyObject)a.get(object);
-                if (result == null) {
-                    result = context.nil;
-                }
-                setResult(temp, currDynScope, gfi.getResult(), result);
-                break;
-            }
             case RUNTIME_HELPER: {
                 RuntimeHelperCall rhc = (RuntimeHelperCall)instr;
                 setResult(temp, currDynScope, rhc.getResult(),

--- a/core/src/main/java/org/jruby/ir/interpreter/StartupInterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/StartupInterpreterEngine.java
@@ -132,17 +132,6 @@ public class StartupInterpreterEngine extends InterpreterEngine {
                 setResult(temp, currDynScope, c.getResult(), retrieveOp(c.getSource(), context, self, currDynScope, currScope, temp));
                 break;
             }
-            case GET_FIELD: {
-                GetFieldInstr gfi = (GetFieldInstr)instr;
-                IRubyObject object = (IRubyObject)gfi.getSource().retrieve(context, self, currScope, currDynScope, temp);
-                VariableAccessor a = gfi.getAccessor(object);
-                Object result = a == null ? null : (IRubyObject)a.get(object);
-                if (result == null) {
-                    result = context.nil;
-                }
-                setResult(temp, currDynScope, gfi.getResult(), result);
-                break;
-            }
             case RUNTIME_HELPER: {
                 RuntimeHelperCall rhc = (RuntimeHelperCall)instr;
                 setResult(temp, currDynScope, rhc.getResult(),

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -959,12 +959,6 @@ public class IRRuntimeHelpers {
     }
 
     @JIT @Interp
-    public static IRubyObject isDefinedInstanceVar(ThreadContext context, IRubyObject receiver, String name, IRubyObject definedMessage) {
-        return receiver.getInstanceVariables().hasInstanceVariable(name) ?
-                definedMessage : context.nil;
-    }
-
-    @JIT @Interp
     public static IRubyObject isDefinedCall(ThreadContext context, IRubyObject self, IRubyObject receiver, String name, IRubyObject definedMessage) {
         IRubyObject boundValue = Helpers.getDefinedCall(context, self, receiver, name, definedMessage);
 

--- a/core/src/main/java/org/jruby/ir/targets/InstanceVariableCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/InstanceVariableCompiler.java
@@ -21,6 +21,7 @@ public interface InstanceVariableCompiler {
      *
      * @param source runnable to push source object, may be called twice
      * @param name name of variable to load
+     * @param rawValue should the result be null instead of nil on non-existent field
      */
-    public abstract void getField(Runnable source, String name);
+    public abstract void getField(Runnable source, String name, boolean rawValue);
 }

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -1614,7 +1614,7 @@ public class JVMVisitor extends IRVisitor {
             throw new NotCompilableException("non-propagatable target for PutField: " + source);
         }
 
-        jvmMethod().getInstanceVariableCompiler().getField(() -> visit(source), getfieldinstr.getId());
+        jvmMethod().getInstanceVariableCompiler().getField(() -> visit(source), getfieldinstr.getId(), getfieldinstr.rawValue);
         jvmStoreLocal(getfieldinstr.getResult());
     }
 

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -2295,14 +2295,6 @@ public class JVMVisitor extends IRVisitor {
                 jvmAdapter().invokestatic(p(IRRuntimeHelpers.class), "isDefinedGlobal", sig(IRubyObject.class, ThreadContext.class, String.class, IRubyObject.class));
                 jvmStoreLocal(runtimehelpercall.getResult());
                 break;
-            case IS_DEFINED_INSTANCE_VAR:
-                jvmMethod().loadContext();
-                visit(runtimehelpercall.getArgs()[0]);
-                jvmAdapter().ldc(((Stringable)runtimehelpercall.getArgs()[1]).getString());
-                visit(runtimehelpercall.getArgs()[2]);
-                jvmAdapter().invokestatic(p(IRRuntimeHelpers.class), "isDefinedInstanceVar", sig(IRubyObject.class, ThreadContext.class, IRubyObject.class, String.class, IRubyObject.class));
-                jvmStoreLocal(runtimehelpercall.getResult());
-                break;
             case IS_DEFINED_CLASS_VAR:
                 jvmMethod().loadContext();
                 visit(runtimehelpercall.getArgs()[0]);

--- a/core/src/main/java/org/jruby/ir/targets/indy/IndyInstanceVariableCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/IndyInstanceVariableCompiler.java
@@ -23,8 +23,8 @@ public class IndyInstanceVariableCompiler implements InstanceVariableCompiler {
         compiler.adapter.invokedynamic("ivarSet:" + JavaNameMangler.mangleMethodName(name), sig(void.class, IRubyObject.class, IRubyObject.class), VariableSite.IVAR_ASM_HANDLE);
     }
 
-    public void getField(Runnable source, String name) {
+    public void getField(Runnable source, String name, boolean rawValue) {
         source.run();
-        compiler.adapter.invokedynamic("ivarGet:" + JavaNameMangler.mangleMethodName(name), CodegenUtils.sig(JVM.OBJECT, IRubyObject.class), VariableSite.IVAR_ASM_HANDLE);
+        compiler.adapter.invokedynamic("ivarGet:" + JavaNameMangler.mangleMethodName(name) + (rawValue ? ":true" : ""), CodegenUtils.sig(JVM.OBJECT, IRubyObject.class), VariableSite.IVAR_ASM_HANDLE);
     }
 }

--- a/core/src/main/java/org/jruby/ir/targets/simple/NormalInstanceVariableCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/simple/NormalInstanceVariableCompiler.java
@@ -33,12 +33,16 @@ public class NormalInstanceVariableCompiler implements InstanceVariableCompiler 
         compiler.adapter.invokevirtual(p(VariableAccessor.class), "set", sig(void.class, Object.class, Object.class));
     }
 
-    public void getField(Runnable source, String name) {
+    public void getField(Runnable source, String name, boolean rawValue) {
         source.run();
         cacheVariableAccessor(name, false);
         source.run();
-        compiler.loadContext();
-        compiler.adapter.invokevirtual(p(VariableAccessor.class), "getOrNil", sig(IRubyObject.class, Object.class, ThreadContext.class));
+        if (rawValue) {
+            compiler.adapter.invokevirtual(p(VariableAccessor.class), "getOrUndefined", sig(Object.class, Object.class));
+        } else {
+            compiler.loadContext();
+            compiler.adapter.invokevirtual(p(VariableAccessor.class), "getOrNil", sig(IRubyObject.class, Object.class, ThreadContext.class));
+        }
     }
 
     /**

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -920,6 +920,10 @@ public class Helpers {
         return value != null ? value : nil;
     }
 
+    public static IRubyObject nullToUndefined(IRubyObject value) {
+        return value != null ? value : UndefinedValue.UNDEFINED;
+    }
+
     public static void handleArgumentSizes(ThreadContext context, Ruby runtime, int given, int required, int opt, int rest) {
         if (opt == 0) {
             if (rest < 0) {

--- a/core/src/main/java/org/jruby/runtime/invokedynamic/VariableSite.java
+++ b/core/src/main/java/org/jruby/runtime/invokedynamic/VariableSite.java
@@ -101,7 +101,9 @@ public class VariableSite extends MutableCallSite {
         VariableAccessor accessor = realClass.getVariableAccessorForRead(name());
 
         // produce nil if the variable has not been initialize
-        MethodHandle nullToNil = self.getRuntime().getNullToNilHandle();
+        MethodHandle nullToNil = rawValue ?
+                self.getRuntime().getNullToUndefinedHandle() :
+                self.getRuntime().getNullToNilHandle();
 
         // get variable value and filter with nullToNil
         MethodHandle getValue;

--- a/core/src/main/java/org/jruby/runtime/ivars/FieldVariableAccessor.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/FieldVariableAccessor.java
@@ -30,6 +30,7 @@ package org.jruby.runtime.ivars;
 import com.headius.invokebinder.Binder;
 import org.jruby.RubyBasicObject;
 import org.jruby.RubyClass;
+import org.jruby.ir.operands.UndefinedValue;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -91,6 +92,21 @@ public class FieldVariableAccessor extends VariableAccessor {
         }
     }
 
+    /**
+     * Retrieve the variable's value from the given object.
+     *
+     * @param object the object from which to retrieve this variable
+     * @return the variable's value or %undefined
+     */
+    public Object getOrUndefined(Object object) {
+        try {
+            Object value =  getter.invoke(object);
+            return value == null ? UndefinedValue.UNDEFINED : (IRubyObject) value;
+        } catch (Throwable t) {
+            Helpers.throwException(t);
+            return null;
+        }
+    }
     /**
      * Retrieve the variable's value from the given object.
      *

--- a/core/src/main/java/org/jruby/runtime/ivars/FieldVariableAccessor.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/FieldVariableAccessor.java
@@ -96,21 +96,6 @@ public class FieldVariableAccessor extends VariableAccessor {
      * Retrieve the variable's value from the given object.
      *
      * @param object the object from which to retrieve this variable
-     * @return the variable's value or %undefined
-     */
-    public Object getOrUndefined(Object object) {
-        try {
-            Object value =  getter.invoke(object);
-            return value == null ? UndefinedValue.UNDEFINED : (IRubyObject) value;
-        } catch (Throwable t) {
-            Helpers.throwException(t);
-            return null;
-        }
-    }
-    /**
-     * Retrieve the variable's value from the given object.
-     *
-     * @param object the object from which to retrieve this variable
      * @return the variable's value
      */
     public IRubyObject getOrNil(Object object, ThreadContext context) {

--- a/core/src/main/java/org/jruby/runtime/ivars/VariableAccessor.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/VariableAccessor.java
@@ -106,8 +106,7 @@ public abstract class VariableAccessor {
      * Retrieve object or IR %undefined
      */
     public Object getOrUndefined(Object object) {
-        Object value = getVariable((RubyBasicObject) object, index);
-
+        Object value = get(object);
         return value == null ? UndefinedValue.UNDEFINED : value;
     }
 

--- a/core/src/main/java/org/jruby/runtime/ivars/VariableAccessor.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/VariableAccessor.java
@@ -27,8 +27,10 @@
 
 package org.jruby.runtime.ivars;
 
+import org.jruby.Ruby;
 import org.jruby.RubyBasicObject;
 import org.jruby.RubyClass;
+import org.jruby.ir.operands.UndefinedValue;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -98,6 +100,15 @@ public abstract class VariableAccessor {
      */
     public Object get(Object object) {
         return getVariable((RubyBasicObject)object, index);
+    }
+
+    /**
+     * Retrieve object or IR %undefined
+     */
+    public Object getOrUndefined(Object object) {
+        Object value = getVariable((RubyBasicObject) object, index);
+
+        return value == null ? UndefinedValue.UNDEFINED : value;
     }
 
     /**


### PR DESCRIPTION
 Optimize both @A ||= 1 and defined?(@A).

Changes:
 1. @A ||= 1 will not use defined? at all but use get_field.  get_field
    uses a cached VariableAccessor so repeated calls will get the value
    much faster.

    Secondly by not using defined? it is able to go from 2 branches to
    1 branch.  This reduces resulting codesize a lot.

 2. defined?(@A) is now written in terms of get_field.  get_field itself
    added an option rawValue which will return %undefined instead of nil
    when @A is not present.  This allows us to rewrite defined?(@) in terms
    of an if/else branch (in IR) instead of the baked in ruby runtime helper
    instr.

The general notion behind both is to use instrs which has a variable
accessor cache.

An interesting wrinkle is that indy on failed defined? is only a tiny
bit faster than it was.  I think this because the cache only fails and
the new version of defined?(@A) uses IR for branching.  On the other
hand if @A does exist we get an amazing perf boost.

This is a bad microbench but it gives the general idea:
https://gist.github.com/enebo/589df91808387e16f56ed032632a4fbb