### PR TITLE
Protect cached threadlocal in recursive hash

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1356,11 +1356,18 @@ public class RubyHash extends RubyObject implements Map {
     @JRubyMethod(name = "hash")
     public RubyFixnum hash(ThreadContext context) {
         final int size = size();
-        long[] hval = { Helpers.hashStart(context.runtime, size) };
-        if (size > 0) {
+
+        long hash = Helpers.hashStart(context.runtime, size);
+
+        if (size != 0) {
+            long[] hval = {hash};
+
             iteratorVisitAll(context, CalculateHashVisitor, hval);
+
+            hash = hval[0];
         }
-        return context.runtime.newFixnum(hval[0]);
+
+        return context.runtime.newFixnum(hash);
     }
 
     private static final ThreadLocal<ByteBuffer> HASH_16_BYTE = ThreadLocal.withInitial(() -> ByteBuffer.allocate(16));


### PR DESCRIPTION
A change introduced in 60ae8bae9091ffdfe90ca9cb61ed0047d50653cd caused the once-transient buffer to be shared during recursive hash calculation, corrupting the results. This led to #7866.

The PR here fixes that by avoiding the shared buffer until all recursive hash calls have completed.

An additional small fix avoids allocating the long[] carrier object for hashes of size zero. Caching this in a thread-local would probably be worthwhile as well, but I was unsure how to do it safely.