### PR TITLE
Move frozen string debug fields into subclass

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -1598,7 +1598,7 @@ public class IRBuilder {
         label("empty", (empty) ->
                 cond(empty, result, tru(), ()->
                         addInstr(new BuildCompoundStringInstr(errorString, new Operand[] {value, new FrozenString(" is not empty")},
-                                UTF8Encoding.INSTANCE, 13, true, false, getFileName(), lastProcessedLineNum))));
+                                UTF8Encoding.INSTANCE, 13, true, getFileName(), lastProcessedLineNum))));
     }
 
     public interface RunIt {
@@ -3418,8 +3418,7 @@ public class IRBuilder {
 
         if (result == null) result = createTemporaryVariable();
 
-        boolean debuggingFrozenStringLiteral = manager.getInstanceConfig().isDebuggingFrozenStringLiteral();
-        addInstr(new BuildCompoundStringInstr(result, pieces, node.getEncoding(), estimatedSize, node.isFrozen(), debuggingFrozenStringLiteral, getFileName(), node.getLine()));
+        addInstr(new BuildCompoundStringInstr(result, pieces, node.getEncoding(), estimatedSize, node.isFrozen(), getFileName(), node.getLine()));
 
         return result;
     }
@@ -3436,7 +3435,7 @@ public class IRBuilder {
         if (result == null) result = createTemporaryVariable();
 
         boolean debuggingFrozenStringLiteral = manager.getInstanceConfig().isDebuggingFrozenStringLiteral();
-        addInstr(new BuildCompoundStringInstr(result, pieces, node.getEncoding(), estimatedSize, false, debuggingFrozenStringLiteral, getFileName(), node.getLine()));
+        addInstr(new BuildCompoundStringInstr(result, pieces, node.getEncoding(), estimatedSize, false, getFileName(), node.getLine()));
 
         return copy(new DynamicSymbol(result));
     }
@@ -3458,7 +3457,7 @@ public class IRBuilder {
         if (result == null) result = createTemporaryVariable();
 
         boolean debuggingFrozenStringLiteral = manager.getInstanceConfig().isDebuggingFrozenStringLiteral();
-        addInstr(new BuildCompoundStringInstr(stringResult, pieces, node.getEncoding(), estimatedSize, false, debuggingFrozenStringLiteral, getFileName(), node.getLine()));
+        addInstr(new BuildCompoundStringInstr(stringResult, pieces, node.getEncoding(), estimatedSize, false, getFileName(), node.getLine()));
 
         return fcall(result, Self.SELF, "`", stringResult);
     }

--- a/core/src/main/java/org/jruby/ir/instructions/BuildCompoundStringInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/BuildCompoundStringInstr.java
@@ -23,17 +23,15 @@ import org.jruby.util.ByteList;
 public class BuildCompoundStringInstr extends NOperandResultBaseInstr {
     final private Encoding encoding;
     final private boolean frozen;
-    final private boolean debug;
     final private String file;
     final private int line;
     private final int estimatedSize;
 
-    public BuildCompoundStringInstr(Variable result, Operand[] pieces, Encoding encoding, int estimatedSize, boolean frozen, boolean debug, String file, int line) {
+    public BuildCompoundStringInstr(Variable result, Operand[] pieces, Encoding encoding, int estimatedSize, boolean frozen, String file, int line) {
         super(Operation.BUILD_COMPOUND_STRING, result, pieces);
 
         this.encoding = encoding;
         this.frozen = frozen;
-        this.debug = debug;
         this.file = file;
         this.line = line;
         this.estimatedSize = estimatedSize;
@@ -53,7 +51,7 @@ public class BuildCompoundStringInstr extends NOperandResultBaseInstr {
 
     @Override
     public Instr clone(CloneInfo ii) {
-        return new BuildCompoundStringInstr(ii.getRenamedVariable(result), cloneOperands(ii), encoding, estimatedSize, frozen, debug, file, line);
+        return new BuildCompoundStringInstr(ii.getRenamedVariable(result), cloneOperands(ii), encoding, estimatedSize, frozen, file, line);
     }
 
     @Override
@@ -69,7 +67,7 @@ public class BuildCompoundStringInstr extends NOperandResultBaseInstr {
 
     public static BuildCompoundStringInstr decode(IRReaderDecoder d) {
         boolean debuggingFrozenStringLiteral = d.getCurrentScope().getManager().getInstanceConfig().isDebuggingFrozenStringLiteral();
-        return new BuildCompoundStringInstr(d.decodeVariable(), d.decodeOperandArray(), d.decodeEncoding(), d.decodeInt(), d.decodeBoolean(), debuggingFrozenStringLiteral, d.decodeString(), d.decodeInt());
+        return new BuildCompoundStringInstr(d.decodeVariable(), d.decodeOperandArray(), d.decodeEncoding(), d.decodeInt(), d.decodeBoolean(), d.decodeString(), d.decodeInt());
     }
 
     @Override
@@ -90,9 +88,6 @@ public class BuildCompoundStringInstr extends NOperandResultBaseInstr {
         }
 
         if (frozen) {
-            if (debug) {
-                return IRRuntimeHelpers.freezeLiteralString(str, context, file, line);
-            }
             return IRRuntimeHelpers.freezeLiteralString(str);
         }
         return str;

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -2370,18 +2370,11 @@ public class IRRuntimeHelpers {
     public static RubyString newFrozenString(ThreadContext context, ByteList bytelist, int coderange, String file, int line) {
         Ruby runtime = context.runtime;
 
-        RubyString string = RubyString.newString(runtime, bytelist, coderange);
-
         if (runtime.getInstanceConfig().isDebuggingFrozenStringLiteral()) {
-            // stuff location info into the string and then freeze it
-            RubyArray info = (RubyArray) runtime.newArray(runtime.newString(file).freeze(context), runtime.newFixnum(line + 1)).freeze(context);
-            string.setInstanceVariable(RubyString.DEBUG_INFO_FIELD, info);
-            string.setFrozen(true);
-        } else {
-            string = runtime.freezeAndDedupString(string);
+            return RubyString.newDebugFrozenString(runtime, runtime.getString(), bytelist, coderange, file, line + 1);
         }
 
-        return string;
+        return runtime.freezeAndDedupString(RubyString.newString(runtime, bytelist, coderange));
     }
 
     @JIT @Interp
@@ -2389,19 +2382,6 @@ public class IRRuntimeHelpers {
         string.setFrozen(true);
 
         return string;
-    }
-
-    @JIT @Interp
-    public static RubyString freezeLiteralString(RubyString string, ThreadContext context, String file, int line) {
-        Ruby runtime = context.runtime;
-
-        if (runtime.getInstanceConfig().isDebuggingFrozenStringLiteral()) {
-            // stuff location info into the string and then freeze it
-            RubyArray info = (RubyArray) runtime.newArray(runtime.newString(file).freeze(context), runtime.newFixnum(line + 1)).freeze(context);
-            string.setInstanceVariable(RubyString.DEBUG_INFO_FIELD, info);
-        }
-
-        return freezeLiteralString(string);
     }
 
     @JIT


### PR DESCRIPTION
This avoids adding anything to the ivar table and short-circuits the frozen check. We may want to consider doing this for non-debug frozen literal strings as well.