### PR TITLE
Make bound method management threadsafe

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -2952,12 +2952,12 @@ public final class Ruby implements Constantizable {
     }
 
     public void addBoundMethod(String className, String methodName, String rubyName) {
-        Map<String, String> javaToRuby = boundMethods.computeIfAbsent(className, s -> new HashMap<>());
+        Map<String, String> javaToRuby = boundMethods.computeIfAbsent(className, s -> new ConcurrentHashMap<>(2, 0.9f, 2));
         javaToRuby.putIfAbsent(methodName, rubyName);
     }
 
     public void addBoundMethods(String className, String... tuples) {
-        Map<String, String> javaToRuby = boundMethods.computeIfAbsent(className, s -> new HashMap<>());
+        Map<String, String> javaToRuby = boundMethods.computeIfAbsent(className, s -> new ConcurrentHashMap<>(2, 0.9f, 2));
         for (int i = 0; i < tuples.length; i += 2) {
             javaToRuby.putIfAbsent(tuples[i], tuples[i+1]);
         }
@@ -2972,10 +2972,9 @@ public final class Ruby implements Constantizable {
 
         for (int i = 0; i < tuplesIndex; i++) {
             String className = classNamesAndTuples[i];
-            if (boundMethods.containsKey(className)) {
-                boundMethods.get(className).putAll(javaToRuby);
-            } else {
-                boundMethods.put(className, new HashMap<>(javaToRuby));
+            Map<String, String> javaToRubyForClass = boundMethods.computeIfAbsent(className, s -> new ConcurrentHashMap<>((int)(javaToRuby.size() / 0.9f) + 1, 0.9f, 2));
+            for (Map.Entry<String, String> entry : javaToRuby.entrySet()) {
+                javaToRubyForClass.putIfAbsent(entry.getKey(), entry.getValue());
             }
         }
     }
@@ -5597,7 +5596,7 @@ public final class Ruby implements Constantizable {
     private final AtomicInteger moduleGeneration = new AtomicInteger(1);
 
     // A list of Java class+method names to include in backtraces
-    private final Map<String, Map<String, String>> boundMethods = new HashMap();
+    private final Map<String, Map<String, String>> boundMethods = new ConcurrentHashMap<>();
 
     // A soft pool of selectors for blocking IO operations
     private final SelectorPool selectorPool = new SelectorPool();


### PR DESCRIPTION
- Hopefully fixes #7916 

I'm not quite sure the appropriate sizing of the Maps here, but tried to follow existing conventions elsewhere and be conscious of the additional overhead of `ConcurrentHashMap`s for the nested Maps. But this may also be premature optimization in some areas, so will take maintainer guidance.

- Kept the second level maps initial size small by default (maybe too small?)
- Used 0.9 load factors similar to those in `RubyModule`
- We shouldn't need high concurrency here, so set to 2. Even 1 might be fine?

I also can't find an appropriate place to write particular tests here, so any pointers useful.

Needs to be ported forward to 9.4/master if suitable.