### PR TITLE
Restore default protection domain for OneShotCL

### DIFF
--- a/core/src/main/java/org/jruby/util/OneShotClassLoader.java
+++ b/core/src/main/java/org/jruby/util/OneShotClassLoader.java
@@ -17,7 +17,7 @@ public class OneShotClassLoader extends ClassLoader implements ClassDefiningClas
     }
 
     public Class<?> defineClass(String name, byte[] bytes) {
-        Class<?> cls = super.defineClass(name, bytes, 0, bytes.length);
+        Class<?> cls = super.defineClass(name, bytes, 0, bytes.length, ClassDefiningJRubyClassLoader.DEFAULT_DOMAIN);
         resolveClass(cls);
         return cls;
     }


### PR DESCRIPTION
This was lost while fixing class-resolution issues during JRuby 9.3 development. Without this, security checks that walk up the stack may hit jitted code that has an improper protection domain, different from JRuby or the system classloader, causing the check to fail.

See e352ba8265dd773fd341e8d6bbd0583540b119bd

Fixes #7216