### PR TITLE
Fixes #7649. Infinite loop in StringScanner regex

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -2095,7 +2095,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
                 IRubyObject val = eltInternal(i);
                 if (!(val instanceof RubyString)) break;
                 if (i > 0 && sep != null) result.cat19(sep);
-                result.append19(val);
+                result.append(val);
             }
         } catch (ArrayIndexOutOfBoundsException e) {
             throw concurrentModification(getRuntime(), e);

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -2635,30 +2635,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      *
      */
     public RubyString append(IRubyObject other) {
-        modifyCheck();
-
-        if (other instanceof RubyFixnum) {
-            cat(ConvertBytes.longToByteList(((RubyFixnum) other).value));
-            return this;
-        }
-        if (other instanceof RubyFloat) {
-            return cat((RubyString) ((RubyFloat) other).to_s());
-        }
-        if (other instanceof RubySymbol) {
-            cat(((RubySymbol) other).getBytes());
-            return this;
-        }
-        RubyString otherStr = other.convertToString();
-        return cat(otherStr.value);
-    }
-
-    public RubyString append(RubyString other) {
-        modifyCheck();
-        return cat(other.value);
-    }
-
-    public RubyString append19(IRubyObject other) {
-        // fast path for fixnum straight into ascii-compatible bytelist
+        // fast path for fixnum straight into ascii-compatible bytelist (modify check happens inside here as well)
         if (other instanceof RubyFixnum && value.getEncoding().isAsciiCompatible()) {
             ConvertBytes.longIntoString(this, ((RubyFixnum) other).value);
             return this;
@@ -2669,11 +2646,21 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         if (other instanceof RubyFloat) {
             return cat19((RubyString) ((RubyFloat) other).to_s());
         } else if (other instanceof RubySymbol) {
-            cat19(((RubySymbol) other).getBytes(), 0);
+            cat19(((RubySymbol) other).getBytes(), CR_UNKNOWN);
             return this;
         }
 
         return cat19(other.convertToString());
+    }
+
+    public RubyString append(RubyString other) {
+        modifyCheck();
+        return cat19(other);
+    }
+
+    @Deprecated
+    public RubyString append19(IRubyObject other) {
+        return append(other);
     }
 
     public RubyString appendAsDynamicString(IRubyObject other) {


### PR DESCRIPTION
Crux of problem was strscan#concat was calling JRuby String append function in Java and that was a pre-m17n version of append which was not encoding aware OR coderange aware.  As a result, the string thought it was 7bit ASCII (narrator: it was not) and this made joni go off the rails.

The fix I used was to move append19 impl into append and deprecate append19.  This version does all the right things.  In looking at callers of append there were not many consumers.  ARGF#read was also broken in the same way since we would be appending what- ever file in its encoding onto the existing string.