### PR TITLE
Fixes #7918.  Error with single splat method with keyword arguments

### DIFF
--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -790,7 +790,7 @@ public class IRRuntimeHelpers {
 
             args[args.length - 1] = hash;
             return UNDEFINED;
-        } else if (ruby2_keywords_hash && hash.isEmpty()) {
+        } else if ((callInfo & CALL_SPLATS) != 0 && ruby2_keywords_hash && hash.isEmpty()) {
             // case where we somehow (hash.clear) a marked ruby2_keyword.  We pass it as keyword even in non-keyword
             // accepting methods so it is subtracted from the arity count.  Normally empty keyword arguments are not
             // passed along but ruby2_keyword is a strange case since it is mutable by users.


### PR DESCRIPTION
Problem was that we were seeing an empty kwarg marked from ruby2_keyword_hash and omitting it because it was a kwarg.  The logic doing this was for a failing test in MRI test suite that was passing that empty kwarg using a splat.  The fix was to only pass this along if it is a non-splat caller.