### PR TITLE
Store absolute path of main at load time

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -923,6 +923,9 @@ public final class Ruby implements Constantizable {
         getGlobalVariables().define("$PROGRAM_NAME", d, GLOBAL);
         getGlobalVariables().define("$0", d, GLOBAL);
 
+        // set main script and canonical path for require_relative use
+        loadService.setMainScript(filename, getCurrentDirectory());
+
         for (Map.Entry<String, String> entry : config.getOptionGlobals().entrySet()) {
             final IRubyObject varvalue;
             if (entry.getValue() != null) {

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1036,10 +1036,11 @@ public class RubyKernel {
             throw runtime.newLoadError("cannot infer basepath");
         }
 
+        file = runtime.getLoadService().getPathForLocation(file);
+
         RubyClass fileClass = runtime.getFile();
         IRubyObject realpath = RubyFile.realpath(context, fileClass, runtime.newString(file));
-        IRubyObject dirname = RubyFile.dirname(context, fileClass,
-                realpath);
+        IRubyObject dirname = RubyFile.dirname(context, fileClass, realpath);
         IRubyObject absoluteFeature = RubyFile.expand_path(context, fileClass, relativePath, dirname);
 
         return RubyKernel.require(context, runtime.getKernel(), absoluteFeature, Block.NULL_BLOCK);
@@ -1970,10 +1971,15 @@ public class RubyKernel {
 
     @JRubyMethod(name = "__dir__", module = true, visibility = PRIVATE, reads = FILENAME)
     public static IRubyObject __dir__(ThreadContext context, IRubyObject recv) {
+        Ruby runtime = context.runtime;
+
         // NOTE: not using __FILE__ = context.getFile() since it won't work with JIT
-        final String __FILE__ = context.getSingleBacktrace().getFileName();
-        RubyString path = RubyFile.expandPathInternal(context, RubyString.newString(context.runtime, __FILE__), null, false, true);
-        return RubyString.newString(context.runtime, RubyFile.dirname(context, path.asJavaString()));
+        String __FILE__ = context.getSingleBacktrace().getFileName();
+
+        __FILE__ = runtime.getLoadService().getPathForLocation(__FILE__);
+
+        RubyString path = RubyFile.expandPathInternal(context, RubyString.newString(runtime, __FILE__), null, false, true);
+        return RubyString.newString(runtime, RubyFile.dirname(context, path.asJavaString()));
     }
 
     @JRubyMethod(module = true)

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -81,6 +81,7 @@ import org.jruby.runtime.ExecutionContext;
 import org.jruby.runtime.backtrace.FrameType;
 import org.jruby.runtime.backtrace.RubyStackTraceElement;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.load.LoadService;
 import org.jruby.util.ByteList;
 import org.jruby.util.StringSupport;
 import org.jruby.util.io.BlockingIO;
@@ -482,7 +483,9 @@ public class RubyThread extends RubyObject implements ExecutionContext {
 
         @JRubyMethod
         public IRubyObject absolute_path(ThreadContext context) {
-            return context.runtime.newString(element.getFileName());
+            Ruby runtime = context.runtime;
+            return runtime.newString(
+                    runtime.getLoadService().getPathForLocation(element.getFileName()));
         }
 
         @JRubyMethod

--- a/core/src/main/java/org/jruby/runtime/load/LoadService.java
+++ b/core/src/main/java/org/jruby/runtime/load/LoadService.java
@@ -192,6 +192,9 @@ public class LoadService {
     protected final Ruby runtime;
     protected LibrarySearcher librarySearcher;
 
+    protected String mainScript;
+    protected String mainScriptPath;
+
     public LoadService(Ruby runtime) {
         this.runtime = runtime;
         if (RubyInstanceConfig.DEBUG_LOAD_TIMINGS) {
@@ -1026,6 +1029,37 @@ public class LoadService {
             }
         }
         return resolveLoadName(foundResource, previousPath);
+    }
+
+    public String getMainScript() {
+        return mainScript;
+    }
+
+    public String getMainScriptPath() {
+        return mainScriptPath;
+    }
+
+    public void setMainScript(String filename, String cwd) {
+        this.mainScript = filename;
+        File mainFile = new File(filename);
+
+        if (!mainFile.isAbsolute()) {
+            mainFile = new File(cwd, filename);
+        }
+
+        if (mainFile.exists()) {
+            this.mainScriptPath = mainFile.getAbsolutePath();
+        } else {
+            this.mainScriptPath = filename;
+        }
+    }
+
+    public String getPathForLocation(String filename) {
+        if (filename.equals(mainScript)) {
+            return mainScriptPath;
+        }
+
+        return filename;
     }
 
     //<editor-fold desc="Deprecated" defaultstate="collapsed">

--- a/spec/tags/ruby/core/thread/backtrace/location/absolute_path_tags.txt
+++ b/spec/tags/ruby/core/thread/backtrace/location/absolute_path_tags.txt
@@ -2,5 +2,4 @@ fails:Thread::Backtrace::Location#absolute_path returns a canonical path without
 fails:Thread::Backtrace::Location#absolute_path returns a canonical path without symlinks, even when __FILE__ is removed
 fails:Thread::Backtrace::Location#absolute_path canonicalization returns a canonical path without symlinks, even when __FILE__ does not
 fails:Thread::Backtrace::Location#absolute_path canonicalization returns a canonical path without symlinks, even when __FILE__ is removed
-fails:Thread::Backtrace::Location#absolute_path returns an absolute path when using a relative main script path
 fails:Thread::Backtrace::Location#absolute_path when used in a core method returns nil


### PR DESCRIPTION
This fix allows __dir__ and Thread::Backtrace::Location and require_relative to use the proper path for a main script specified without a full path.

It's a big hacky to store the path specifically for the main script this way, but it's the only such special case and works well enough to get these cases working.

Fixes #7394

Backported from master.