### PR TITLE
Fix String#to_i with leading zero and underscores

### DIFF
--- a/core/src/main/java/org/jruby/util/ConvertBytes.java
+++ b/core/src/main/java/org/jruby/util/ConvertBytes.java
@@ -558,7 +558,7 @@ public class ConvertBytes {
                         break;
                     }
                 } else {
-                    us += 0;
+                    us = 0;
                 }
                 beg++;
             }

--- a/spec/ruby/core/string/to_i_spec.rb
+++ b/spec/ruby/core/string/to_i_spec.rb
@@ -10,6 +10,18 @@ describe "String#to_i" do
     "1_2_3asdf".to_i.should == 123
   end
 
+  it "ignores multiple non-consecutive underscoes when the first digit is 0" do
+    (2..16).each do |base|
+      "0_0_010".to_i(base).should == base;
+    end
+  end
+
+  it "bails out at the first double underscore if the first digit is 0" do
+    (2..16).each do |base|
+      "010__1".to_i(base).should == base;
+    end
+  end
+
   it "ignores leading whitespaces" do
     [ " 123", "     123", "\r\n\r\n123", "\t\t123",
       "\r\n\t\n123", " \t\n\r\t 123"].each do |str|


### PR DESCRIPTION
Logic here is intended to bail out when the leading digit is `0` and there are two or more consecutive underscores, but it appears it was ported incorrectly (`us += 0` 🤨) resulting in it bailing out after ANY second underscore.

Fixes #7749.