### PR TITLE
More testing with Java 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         target: ['test:jruby:int', 'spec:ruby:fast', 'spec:ji', 'spec:ffi']
-        java-version: ['8', '17']
+        java-version: ['8', '17', '21']
       fail-fast: false
 
     name: rake ${{ matrix.target }} (Java ${{ matrix.java-version }})
@@ -76,13 +76,13 @@ jobs:
       - name: rake test:jruby
         run: bin/jruby --dev -S rake test:jruby
 
-  rake-test-17-indy:
+  rake-test-21-indy:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         target: ['test:mri:core:jit', 'test:jruby:jit', 'spec:compiler', 'spec:ruby:fast:jit', 'spec:ji']
-        java-version: ['21-ea']
+        java-version: 21
       fail-fast: false
 
     name: rake ${{ matrix.target }} (Java ${{ matrix.java-version }} +indy)
@@ -146,7 +146,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '8'
+          java-version: 8
           cache: 'maven'
       - name: mvn package ${{ matrix.package-flags }}
         run: tool/maven-ci-script.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         target: ['test:jruby:int', 'spec:ruby:fast', 'spec:ji', 'spec:ffi']
-        java-version: ['8', '17', '21']
+        java-version: ['8', '11', '17', '21']
       fail-fast: false
 
     name: rake ${{ matrix.target }} (Java ${{ matrix.java-version }})
@@ -70,19 +70,19 @@ jobs:
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: 8
           cache: 'maven'
       - name: rake test:jruby
         run: bin/jruby --dev -S rake test:jruby
 
-  rake-test-21-indy:
+  rake-test-17-indy:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         target: ['test:mri:core:jit', 'test:jruby:jit', 'spec:compiler', 'spec:ruby:fast:jit', 'spec:ji']
-        java-version: 21
+        java-version: ['17', '21']
       fail-fast: false
 
     name: rake ${{ matrix.target }} (Java ${{ matrix.java-version }} +indy)
@@ -266,10 +266,10 @@ jobs:
     steps:
       - name: Bootstrap build
         uses: jruby/jruby-ci-build@v1
-      - name: set up java 8
+      - name: set up java
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: 11
           cache: 'maven'
       - name: sequel
@@ -287,7 +287,7 @@ jobs:
       - name: set up java 8
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: 8
           cache: 'maven'
       - name: concurrent-ruby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,10 +136,6 @@ jobs:
         java-version: [11, 17]
       fail-fast: false
 
-    env:
-      # some tests from jruby_complete_jar_extended (test/jruby/test_kernel.rb, test/jruby/test_socket.rb) need sub-process control
-      MAVEN_OPTS: '--add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED'
-
 
     name: mvn ${{ matrix.package-flags }} (Java ${{ matrix.java-version }})
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,11 @@ jobs:
         java-version: [11, 17]
       fail-fast: false
 
+    env:
+      # some tests from jruby_complete_jar_extended (test/jruby/test_kernel.rb, test/jruby/test_socket.rb) need sub-process control
+      MAVEN_OPTS: '--add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED'
+
+
     name: mvn ${{ matrix.package-flags }} (Java ${{ matrix.java-version }})
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,7 @@ jobs:
     strategy:
       matrix:
         package-flags: ['-Pmain', '-Pdist', '-Pcomplete', '-Posgi', '-Ptest', '-Pmain,test -Dinvoker.test=extended']
-        # dist, complete, and osgi do not pass on 17 yet
-        java-version: ['11']
+        java-version: [8, 11, 21]
       fail-fast: false
 
     name: mvn ${{ matrix.package-flags }} (Java ${{ matrix.java-version }})
@@ -128,25 +127,25 @@ jobs:
         env:
           PHASE: 'package ${{ matrix.package-flags }}'
 
-  mvn-test-8:
+  mvn-test-extended:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        # jruby-jars phase only passes on 8
         package-flags: ['-Pjruby-jars', '-Pjruby-jars,test -Dinvoker.test=extended', '-Pjruby_complete_jar_extended -Dinvoker.skip=true']
+        java-version: [11, 17]
       fail-fast: false
 
-    name: mvn ${{ matrix.package-flags }} (Java 8)
+    name: mvn ${{ matrix.package-flags }} (Java ${{ matrix.java-version }})
 
     steps:
       - name: Bootstrap build
         uses: jruby/jruby-ci-build@v1
-      - name: set up java 8
+      - name: set up java ${{ matrix.java-version }}
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
-          java-version: 8
+          distribution: temurin
+          java-version: ${{ matrix.java-version }}
           cache: 'maven'
       - name: mvn package ${{ matrix.package-flags }}
         run: tool/maven-ci-script.sh
@@ -394,7 +393,7 @@ jobs:
     permissions:
       contents: none
     if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/jruby-9.3' }}
-    needs: [mvn-test, mvn-test-8, mvn-test-windows, dependency-check, rake-test, rake-test-17-indy, rake-test-8, test-versions, sequel, concurrent-ruby, jruby-tests-dev, regression-specs-jit, mvn-test-m1]
+    needs: [mvn-test, mvn-test-extended, mvn-test-windows, dependency-check, rake-test, rake-test-17-indy, rake-test-8, test-versions, sequel, concurrent-ruby, jruby-tests-dev, regression-specs-jit, mvn-test-m1]
     uses: jruby/jruby/.github/workflows/snapshot-publish.yml@6cd0d4d96d9406635183d81cf91acc82cd78245f
     secrets:
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1348,7 +1348,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @SuppressWarnings("NonOverridingEquals")
     final boolean equals(RubyString other) {
-        return ((RubyString) other).value.equal(value);
+        return other.value.equal(value);
     }
 
     /** rb_obj_as_string

--- a/core/src/main/java/org/jruby/javasupport/JavaPackage.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaPackage.java
@@ -272,7 +272,13 @@ public class JavaPackage extends RubyModule {
 
     public final boolean isAvailable() {
         // may be null if no package information is available from the archive or codebase
-        return Package.getPackage(packageName) != null;
+        return getPackage() != null;
+    }
+
+    @SuppressWarnings("deprecation")
+    private Package getPackage() {
+        // NOTE: can not switch to getRuntime().getJRubyClassLoader().getDefinedPackage(packageName) as it's Java 9+
+        return Package.getPackage(packageName);
     }
 
     @JRubyMethod(name = "available?")
@@ -282,7 +288,7 @@ public class JavaPackage extends RubyModule {
 
     @JRubyMethod(name = "sealed?")
     public IRubyObject sealed_p(ThreadContext context) {
-        final Package pkg = Package.getPackage(packageName);
+        final Package pkg = getPackage();
         if ( pkg == null ) return context.nil;
         return RubyBoolean.newBoolean(context, pkg.isSealed());
     }
@@ -291,7 +297,7 @@ public class JavaPackage extends RubyModule {
     @SuppressWarnings("unchecked")
     public <T> T toJava(Class<T> target) {
         if ( target.isAssignableFrom( Package.class ) ) {
-            return target.cast(Package.getPackage(packageName));
+            return target.cast(getPackage());
         }
         return super.toJava(target);
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtil.java
@@ -1538,7 +1538,7 @@ public class JavaUtil {
             }
             break;
         case FLOAT:
-            javaObject = new Double(((RubyFloat) object).getValue());
+            javaObject = Double.valueOf(((RubyFloat) object).getValue());
             break;
         case STRING:
             ByteList bytes = ((RubyString) object).getByteList();

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyClass.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyClass.java
@@ -281,8 +281,8 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
             if (returnType == Short.TYPE) return Short.valueOf((short) 0);
             if (returnType == Integer.TYPE) return Integer.valueOf(0);
             if (returnType == Long.TYPE) return Long.valueOf(0L);
-            if (returnType == Float.TYPE) return new Float(0.0f);
-            if (returnType == Double.TYPE) return new Double(0.0);
+            if (returnType == Float.TYPE) return Float.valueOf(0.0f);
+            if (returnType == Double.TYPE) return Double.valueOf(0.0);
 
             return null;
         }

--- a/test/jruby/test_tempfile_cleanup.rb
+++ b/test/jruby/test_tempfile_cleanup.rb
@@ -4,7 +4,7 @@ class TestTempfileCleanup < Test::Unit::TestCase
 
   def setup
     require 'jruby' if defined?(JRUBY_VERSION)
-    require 'tempfile'; require 'fileutils'
+    %w{ tmpdir tempfile fileutils}.each { |feat| require(feat) }
 
     @tmpdir = Dir.mktmpdir(File.basename(__FILE__) + $$.to_s)
     FileUtils.rm_f @tmpdir rescue nil
@@ -33,7 +33,8 @@ class TestTempfileCleanup < Test::Unit::TestCase
       sleep(0.1)
     end
 
+    tmp_files = Dir["#{@tmpdir}/*"]
     # test that the files are gone
-    assert_equal 0, Dir["#{@tmpdir}/*"].size, 'Files were not cleaned up'
+    assert_equal 0, tmp_files.size, "Files were not cleaned up: (#{tmp_files.size}) #{tmp_files}"
   end
 end

--- a/test/pom.rb
+++ b/test/pom.rb
@@ -127,7 +127,7 @@ project 'JRuby Integration Tests' do
 
     plugin :antrun do
       [ 'jruby', 'objectspace', 'slow' ].each do |index|
-        files = []
+        filenames = []
         File.open(File.join(basedir, index + '.index')) do |file|
           file.each_line do |line|
             next if line =~ /^#/ || line.strip.empty?
@@ -137,15 +137,29 @@ project 'JRuby Integration Tests' do
             next if filename =~ /mri\/psych\//
             next if filename =~ /mri\/net\/http\//
             next unless File.exist? File.join(basedir, filename)
-            files << "<arg value='test/#{filename}'/>"
+            filenames << filename
           end
         end
-        files = files.join('')
 
         execute_goals( 'run',
                        :id => "jruby_complete_jar_#{index}",
                        :phase => 'test',
-                       :configuration => [ xml( "<target><exec dir='${jruby.home}' executable='java' failonerror='true'><arg value='-cp'/><arg value='core/target/test-classes:test/target/test-classes:maven/jruby-complete/target/jruby-complete-${project.version}.jar'/><arg value='-Djruby.home=${jruby.home}'/><arg value='-Djruby.aot.loadClasses=true'/><arg value='org.jruby.Main'/><arg value='-I.'/><arg value='-Itest'/><arg value='lib/ruby/gems/shared/gems/rake-${rake.version}/lib/rake/rake_test_loader.rb'/>#{files}<arg value='-v'/></exec></target>" ) ] )
+                       :configuration => [
+                         xml( "<target>" +
+                                "<exec dir='${jruby.home}' executable='java' failonerror='true'>" +
+                                  "<arg value='-cp'/>" +
+                                  "<arg value='core/target/test-classes:test/target/test-classes:maven/jruby-complete/target/jruby-complete-${project.version}.jar'/>" +
+                                  "<arg value='-Djruby.home=${jruby.home}'/>" +
+                                  "<arg value='-Djruby.aot.loadClasses=true'/>" +
+                                  "<arg value='org.jruby.Main'/>" +
+                                  "<arg value='-I.'/>" +
+                                  "<arg value='-Itest'/>" +
+                                  "<arg value='lib/ruby/gems/shared/gems/rake-${rake.version}/lib/rake/rake_test_loader.rb'/>" +
+                                  filenames.map { |filename| "<arg value='test/#{filename}'/>" }.join('') +
+                                  "<arg value='-v'/>
+                                </exec>
+                              </target>" )
+                       ] )
       end
     end
 


### PR DESCRIPTION
The PR adds CI testing with Java 21 (release), also added some variations on the Java flavor used (with temurin).

The embedded (jruby-complete) test targets now also work on Java > 8 and are actively tested against later versions.

A few minor (Java) deprecations are addressed, most of the remaining ones are around SecurityManager and the related access exception being used... which are likely going to be tricky to get rid of.