### PR TITLE
Update ffi to 1.16.2

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -43,7 +43,7 @@ default_gems = [
     # ['etc', '1.3.0'],
     # https://github.com/ruby/fcntl/issues/9
     # ['fcntl', '1.0.1'],
-    ['ffi', '1.16.1'],
+    ['ffi', '1.16.2'],
     # ['fiddle', '1.1.0'],
     ['fileutils', '1.6.0'],
     ['find', '0.1.1'],


### PR DESCRIPTION
Follow-up to #7941, looks like there's a minor regression in 1.16.1 (https://github.com/ffi/ffi/issues/1050)