### PR TITLE
Fix #7815. NullPointerException for compiled code with for loop

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRScope.java
+++ b/core/src/main/java/org/jruby/ir/IRScope.java
@@ -385,14 +385,20 @@ public abstract class IRScope implements ParseResult {
         return lineNumber;
     }
 
-    public int countForLoops() {
-        int count = 0;
+    public int correctVariableDepthForForLoopsForEncoding(int depth) {
+        int forCount = 0;
+        int currentDepth = 0;
         
         for (IRScope current = this; current != null && !current.isTopLocalVariableScope(); current = current.getLexicalParent()) {
-            if (current instanceof IRFor) count++;
+            if (currentDepth == depth) break;
+            if (current instanceof IRFor) {
+                forCount++;
+            } else {
+                currentDepth++;
+            }
         }
 
-        return count;
+        return depth - forCount;
     }
 
     /**

--- a/core/src/main/java/org/jruby/ir/operands/LocalVariable.java
+++ b/core/src/main/java/org/jruby/ir/operands/LocalVariable.java
@@ -113,9 +113,7 @@ public class LocalVariable extends Variable implements DepthCloneable {
     public void encode(IRWriterEncoder e) {
         super.encode(e);
         e.encode(getName());
-
-        int forCount = e.getCurrentScope().countForLoops();
-        e.encode(getScopeDepth() - forCount);
+        e.encode(e.getCurrentScope().correctVariableDepthForForLoopsForEncoding(getScopeDepth()));
         // We do not encode location because we rebuild lvars from IRScope when being rebuilt
     }
 

--- a/test/jruby/compiler/test_jrubyc.rb
+++ b/test/jruby/compiler/test_jrubyc.rb
@@ -127,6 +127,38 @@ class TestJRubyc < Test::Unit::TestCase
       File.delete("C.class") rescue nil
     end
 
+    # encode/decode ends up correcting depth for real static scopes.  Some mixture of nesting
+    # here to sample various counting scenarios.
+    def test_for
+       File.open("test_for1.rb", "w") { |file| file.write(<<-RUBY
+      def npe_when_compiled(arr)
+        x = []
+        for j in 0..1
+          o = "o"
+          1.times do |g|
+            for i in 0..1
+              arr.collect { |e| x << e << o}
+            end
+          end
+        end
+        x.join('')
+      end
+
+      puts npe_when_compiled(["x"])
+      RUBY
+      )}
+
+      JRuby::Compiler::compile_argv(["--verbose", "--javac", "test_for1.rb"])
+      output = File.read(@tempfile_stderr.path)
+
+      assert_equal("xoxoxoxo", output)
+    rescue
+
+    ensure
+      File.delete("test_for1.rb") rescue nil
+      File.delete("test_for1.class") rescue nil
+    end
+
   end
 
   private


### PR DESCRIPTION
AOT code encodes IR into the .class file and it was not correctly adjusting local variable operands to account for `for` loops.  The code before the fix would count all possible `for` loops and not just the `for` loops between the current accessing scope and the destination scope.

Added a single test which has a complicated set of variable accesses which should exercise the depth adjustment which was fixed in this commit.