### PR TITLE
Use a lookup() for field access in static constant

### DIFF
--- a/core/src/main/java/org/jruby/ir/targets/indy/Bootstrap.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/Bootstrap.java
@@ -620,9 +620,10 @@ public class Bootstrap {
                     .from(Ruby.class, ThreadContext.class, MutableCallSite.class)
                     .invokeStaticQuiet(LOOKUP, Bootstrap.class, "runtime");
 
+    // We use LOOKUP here to have a full-featured MethodHandles.Lookup, avoiding jruby/jruby#7911
     private static final MethodHandle RUNTIME_FROM_CONTEXT_HANDLE =
             Binder
-                    .from(Ruby.class, ThreadContext.class)
+                    .from(LOOKUP, Ruby.class, ThreadContext.class)
                     .getFieldQuiet("runtime");
 
     private static final MethodHandle NIL_HANDLE =


### PR DESCRIPTION
This field access appears to trigger a bug in Java 8 and 11 (at least) leading to linkage errors and classes leaking across classloaders when a method handle is resolved at static initialization time.

See https://github.com/jruby/jruby/issues/7911

The change here provides a local MethodHandles.Lookup object rather than using a publicLookup() to acquire the field handle. This may work around whatever the JDK bug was.

Fixes #7911