### PR TITLE
Convert to lower, not upper, for casecmp

### DIFF
--- a/core/src/main/java/org/jruby/util/StringSupport.java
+++ b/core/src/main/java/org/jruby/util/StringSupport.java
@@ -2505,8 +2505,8 @@ public final class StringSupport {
 
             final int cl, ocl;
             if (Encoding.isAscii(c) && Encoding.isAscii(oc)) {
-                int dc = AsciiTables.ToUpperCaseTable[c];
-                int odc = AsciiTables.ToUpperCaseTable[oc];
+                int dc = AsciiTables.ToLowerCaseTable[c];
+                int odc = AsciiTables.ToLowerCaseTable[oc];
                 if (dc != odc) return dc < odc ? -1 : 1;
 
                 if (enc.isAsciiCompatible()) {


### PR DESCRIPTION
This matches the CRuby code at this point, but it's not clear to me how or why it was set up to use the upper case table many years ago.

Fixes #7946