### PR TITLE
backport: fnmatch not matching glob syntax

### DIFF
--- a/core/src/main/java/org/jruby/util/Dir.java
+++ b/core/src/main/java/org/jruby/util/Dir.java
@@ -122,7 +122,18 @@ public class Dir {
                 while (true) {
                     // in place of expected C null char check that falls into default in switch below
                     if (p >= pend) {
-                        return isEnd(sbytes, s, send) ? 0 : FNM_NOMATCH;
+                        if (isEnd(sbytes, s, send)) {
+                          return 0;
+                        }
+
+                        // failed: duplicated below due to inability to goto
+                        if (ptmp != -1 && stmp != -1) {
+                          p = ptmp;
+                          stmp++; /* !ISEND(*stmp) */
+                          s = stmp;
+                          continue;
+                        }
+                        return FNM_NOMATCH;
                     }
 
                     switch (pbytes[p]) {
@@ -195,14 +206,17 @@ public class Dir {
                             continue;
                     }
 
-                    failed: // reached by breaking from above switch rather than continuing
-                    if (ptmp != -1 && stmp != -1) {
-                        p = ptmp;
-                        stmp++; /* !ISEND(*stmp) */
-                        s = stmp;
-                        continue;
+                    // failed: duplicated above due to inability to goto
+                    // reached by breaking from above switch rather than continuing
+                    {
+                        if (ptmp != -1 && stmp != -1) {
+                            p = ptmp;
+                            stmp++; /* !ISEND(*stmp) */
+                            s = stmp;
+                            continue;
+                        }
+                        return FNM_NOMATCH;
                     }
-                    return FNM_NOMATCH;
                 }
             } finally {
                 // RETURN macro in MRI


### PR DESCRIPTION
backport https://github.com/jruby/jruby/issues/7942 to 9.3.x