### PR TITLE
Avoid ANSI formatting when not on a TTY

### DIFF
--- a/core/src/main/java/org/jruby/Main.java
+++ b/core/src/main/java/org/jruby/Main.java
@@ -463,9 +463,13 @@ public class Main {
         if (config.getShouldPrintUsage() || force) {
             String rubyPager = getRubyPagerEnv();
 
+            // Do not want to boot native subsystem here, so we do best guess based on System.console. It will be
+            // non-null only if both STDIN and STDOUT are tty.
+            boolean tty = System.console() != null;
+
             if (rubyPager == null) {
-                config.getOutput().print(OutputStrings.getBasicUsageHelp());
-                config.getOutput().print(OutputStrings.getFeaturesHelp());
+                config.getOutput().print(OutputStrings.getBasicUsageHelp(tty));
+                config.getOutput().print(OutputStrings.getFeaturesHelp(tty));
             } else {
                 try {
                     ProcessBuilder builder = new ProcessBuilder(rubyPager);
@@ -477,7 +481,7 @@ public class Main {
                     Process process = builder.start();
                     OutputStream in = process.getOutputStream();
 
-                    String fullHelp = OutputStrings.getBasicUsageHelp() + OutputStrings.getFeaturesHelp();
+                    String fullHelp = OutputStrings.getBasicUsageHelp(tty) + OutputStrings.getFeaturesHelp(tty);
                     in.write(fullHelp.getBytes(StandardCharsets.UTF_8));
 
                     in.flush();

--- a/core/src/main/java/org/jruby/util/cli/OutputStrings.java
+++ b/core/src/main/java/org/jruby/util/cli/OutputStrings.java
@@ -7,6 +7,7 @@ import org.jruby.runtime.Constants;
 import org.jruby.util.SafePropertyAccessor;
 
 import java.time.LocalDate;
+import java.util.Arrays;
 
 /**
  * Utility methods to generate the command-line output strings for help,
@@ -167,13 +168,23 @@ public class OutputStrings {
         return "\033[1m" + str + "\033[0m";
     }
 
+    private static final int SPACES_MAX = 256;
+    private static final char[] SPACES = new char[SPACES_MAX];
+    static {
+        Arrays.fill(SPACES, ' ');
+    }
+
     private static String generateSpaces(int total) {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < total; i++) {
-            sb.append(" ");
+        char[] spaces;
+
+        if (total > SPACES_MAX) {
+            spaces = new char[total];
+            Arrays.fill(spaces, ' ');
+        } else {
+            spaces = SPACES;
         }
 
-        return sb.toString();
+        return new String(spaces, 0, total);
     }
 
     private static String breakLine(String str, int index, int spaces) {

--- a/core/src/main/java/org/jruby/util/cli/OutputStrings.java
+++ b/core/src/main/java/org/jruby/util/cli/OutputStrings.java
@@ -14,6 +14,10 @@ import java.time.LocalDate;
  */
 public class OutputStrings {
     public static String getBasicUsageHelp() {
+        return getBasicUsageHelp(false);
+    }
+
+    public static String getBasicUsageHelp(boolean tty) {
         String[][] basicUsageOptions = {
                 {"-0[octal]", "specify record separator (\\0, if no argument)"},
                 {"-a", "autosplit mode with -n or -p (splits $_ into $F)"},
@@ -65,13 +69,13 @@ public class OutputStrings {
                 {"--enable=feature[,...], --disable=feature[,...]", "enable or disable features"}
         };
 
-        String header = strBold("Usage:") + " jruby [switches] [--] [programfile] [arguments]";
-        return buildOutputOptions(basicUsageOptions, header);
+        String header = strBold("Usage:", tty) + " jruby [switches] [--] [programfile] [arguments]";
+        return buildOutputOptions(basicUsageOptions, header, tty);
     }
 
-    private static String buildOutputOptions(String[][] options, String header) {
+    private static String buildOutputOptions(String[][] options, String header, boolean tty) {
         StringBuilder sb = new StringBuilder();
-        sb.append(strBold(header)).append("\n");
+        sb.append(strBold(header, tty)).append("\n");
 
         int max = Integer.MIN_VALUE;
         for (String[] strings : options) {
@@ -86,12 +90,16 @@ public class OutputStrings {
             String value = option[1];
 
             String text = breakLine(value, 60, max + 8);
-            sb.append("   ").append(strBold(key)).append(generateSpaces(max + 5 - key.length())).append(text).append("\n");
+            sb.append("   ").append(strBold(key, tty)).append(generateSpaces(max + 5 - key.length())).append(text).append("\n");
         }
         return sb.toString();
     }
 
     public static String getFeaturesHelp() {
+        return getFeaturesHelp(false);
+    }
+
+    public static String getFeaturesHelp(boolean tty) {
         String header = "Features:";
 
         String[][] options = {
@@ -100,7 +108,7 @@ public class OutputStrings {
                 {"rubyopt", "RUBYOPT environment variable (default: " + (Options.CLI_RUBYOPT_ENABLE.defaultValue() ? "enabled" : "disabled") + ")"},
                 {"frozen-string-literal", "freeze all string literals (default: disabled)"}};
 
-        return buildOutputOptions(options, header);
+        return buildOutputOptions(options, header, tty);
     }
 
     public static String getExtendedHelp() { return
@@ -152,8 +160,8 @@ public class OutputStrings {
         return String.format("JRuby - Copyright (C) 2001-%s The JRuby Community (and contribs)", LocalDate.now().getYear());
     }
 
-    private static String strBold(String str) {
-        if(Platform.IS_WINDOWS)
+    private static String strBold(String str, boolean tty) {
+        if (!tty || Platform.IS_WINDOWS)
             return str;
 
         return "\033[1m" + str + "\033[0m";


### PR DESCRIPTION
Fixes #7864.

Output before (`jruby --help | less`):

```
ESC[1mESC[1mUsage:ESC[0m jruby [switches] [--] [programfile] [arguments]ESC[0m
   ESC[1m-0[octal]ESC[0m                                           specify record separator (\0, if no argument) 
   ESC[1m-aESC[0m                                                  autosplit mode with -n or -p (splits $_ into $F) 
   ESC[1m-cESC[0m                                                  check syntax only 
   ESC[1m-CdirectoryESC[0m                                         cd to directory, before executing your script 
...
```

After:

```
Usage: jruby [switches] [--] [programfile] [arguments]
   -0[octal]                                           specify record separator (\0, if no argument) 
   -a                                                  autosplit mode with -n or -p (splits $_ into $F) 
   -c                                                  check syntax only 
   -Cdirectory                                         cd to directory, before executing your script 
```