### PR TITLE
Re-enable J9 test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,7 +349,7 @@ jobs:
   maven-test-openj9-8:
     runs-on: ubuntu-latest
 
-    name: mvn -Ptest (OpenJ9 Java 8; disabled)
+    name: mvn -Ptest (OpenJ9 Java 17)
 
     steps:
       - name: Bootstrap build
@@ -358,11 +358,10 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt-openj9'
-          java-version: '8'
+          java-version: '17'
           cache: 'maven'
       - name: test profile
-#        run: "tool/maven-ci-script.sh"
-        run: "true"
+        run: "tool/maven-ci-script.sh"
         env:
           PHASE: 'package -Ptest'
 


### PR DESCRIPTION
Was disabled due to an unusual failure (see jruby/jruby#7470) but appears to pass with more recent J9 JDKs