### PR TITLE
Use new GHA M1 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
         run: tool/concurrent-ruby-github-actions.sh
 
   mvn-test-m1:
-    runs-on: [self-hosted, macos, aarch64]
+    runs-on: macos-latest-xlarge
 
     strategy:
       matrix:
@@ -322,7 +322,7 @@ jobs:
           PHASE: 'package ${{ matrix.package-flags }}'
 
   spec-m1:
-    runs-on: [self-hosted, macos, aarch64]
+    runs-on: macos-latest-xlarge
 
     strategy:
       matrix:


### PR DESCRIPTION
We would not need our self-hosted runner if this works out.