### PR TITLE
Prepend internal marker to internal sources

### DIFF
--- a/core/src/main/java/org/jruby/AbstractRubyMethod.java
+++ b/core/src/main/java/org/jruby/AbstractRubyMethod.java
@@ -41,6 +41,7 @@ import org.jruby.internal.runtime.methods.UndefinedMethod;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.PositionAware;
 import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.backtrace.TraceType;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.callsite.CacheEntry;
 import org.jruby.runtime.marshal.DataType;
@@ -138,7 +139,7 @@ public abstract class AbstractRubyMethod extends RubyObject implements DataType 
         DynamicMethod realMethod = method.getRealMethod(); // Follow Aliases
         if (realMethod instanceof PositionAware) {
             PositionAware poser = (PositionAware) realMethod;
-            return poser.getFile();
+            return TraceType.maskInternalFiles(poser.getFile());
         }
         return null;
     }

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -2028,16 +2028,6 @@ public class RubyKernel {
         return fork(context, recv, block);
     }
 
-    @JRubyMethod(module = true)
-    public static IRubyObject tap(ThreadContext context, IRubyObject recv, Block block) {
-        if (block.getProcObject() != null) {
-            block.getProcObject().call(context, recv);
-        } else {
-            block.yield(context, recv);
-        }
-        return recv;
-    }
-
     @JRubyMethod(name = {"to_enum", "enum_for"}, rest = true, keywords = true)
     public static IRubyObject obj_to_enum(final ThreadContext context, IRubyObject self, IRubyObject[] args, final Block block) {
         // to_enum is a bit strange in that it will propagate the arguments it passes to each element it calls.  We are determining
@@ -2643,5 +2633,16 @@ public class RubyKernel {
     @Deprecated
     public static IRubyObject method19(IRubyObject self, IRubyObject symbol) {
         return method(self, symbol);
+    }
+
+    // defined in Ruby now but left here for backward compat
+    @Deprecated
+    public static IRubyObject tap(ThreadContext context, IRubyObject recv, Block block) {
+        if (block.getProcObject() != null) {
+            block.getProcObject().call(context, recv);
+        } else {
+            block.yield(context, recv);
+        }
+        return recv;
     }
 }

--- a/core/src/main/java/org/jruby/RubyMethod.java
+++ b/core/src/main/java/org/jruby/RubyMethod.java
@@ -49,6 +49,7 @@ import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.PositionAware;
 import org.jruby.runtime.Signature;
 import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.backtrace.TraceType;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.callsite.CacheEntry;
 
@@ -356,24 +357,6 @@ public class RubyMethod extends AbstractRubyMethod {
         }
 
         return context.nil;
-    }
-
-    public String getFilename() {
-        DynamicMethod realMethod = method.getRealMethod(); // Follow Aliases
-        if (realMethod instanceof PositionAware) {
-            PositionAware poser = (PositionAware) realMethod;
-            return poser.getFile();
-        }
-        return null;
-    }
-
-    public int getLine() {
-        DynamicMethod realMethod = method.getRealMethod(); // Follow Aliases
-        if (realMethod instanceof PositionAware) {
-            PositionAware poser = (PositionAware) realMethod;
-            return poser.getLine() + 1;
-        }
-        return -1;
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/runtime/backtrace/BacktraceData.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/BacktraceData.java
@@ -2,7 +2,6 @@ package org.jruby.runtime.backtrace;
 
 import com.headius.backport9.stack.StackWalker;
 import org.jruby.Ruby;
-import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.JavaNameMangler;
 
 import java.io.Serializable;
@@ -93,7 +92,7 @@ public class BacktraceData implements Serializable {
             // Only rewrite non-Java files when not in "raw" mode
             if (!(rawTrace || filename == null || filename.endsWith(".java"))) {
                 // skip internal sources if requested
-                if (excludeInternal && TraceType.isInternal(filename)) continue;
+                if (excludeInternal && TraceType.isExcludedInternal(filename)) continue;
 
                 List<String> mangledTuple = JavaNameMangler.decodeMethodTuple(methodName);
                 if (mangledTuple != null) {
@@ -173,7 +172,7 @@ public class BacktraceData implements Serializable {
 
                 // skip internal sources if requested
                 filename = rubyFrame.filename;
-                if (excludeInternal && TraceType.isInternal(filename)) continue;
+                if (excludeInternal && TraceType.isExcludedInternal(filename)) continue;
 
                 // mask internal file paths
                 filename = TraceType.maskInternalFiles(filename);

--- a/core/src/main/java/org/jruby/runtime/backtrace/BacktraceData.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/BacktraceData.java
@@ -24,19 +24,22 @@ public class BacktraceData implements Serializable {
     private final boolean rawTrace;
     private final boolean maskNative;
     private final boolean includeNonFiltered;
+    private final boolean excludeInternal;
 
-    public BacktraceData(Stream<StackWalker.StackFrame> stackStream, Stream<BacktraceElement> rubyTrace, boolean fullTrace, boolean rawTrace, boolean maskNative, boolean includeNonFiltered) {
+    public BacktraceData(Stream<StackWalker.StackFrame> stackStream, Stream<BacktraceElement> rubyTrace, boolean fullTrace, boolean rawTrace, boolean maskNative, boolean includeNonFiltered, boolean excludeInternal) {
         this.stackStream = stackStream;
         this.rubyTrace = rubyTrace;
         this.fullTrace = fullTrace;
         this.rawTrace = rawTrace;
         this.maskNative = maskNative;
         this.includeNonFiltered = includeNonFiltered;
+        this.excludeInternal = excludeInternal;
     }
 
     public static final BacktraceData EMPTY = new BacktraceData(
             Stream.empty(),
             Stream.empty(),
+            false,
             false,
             false,
             false,
@@ -89,6 +92,9 @@ public class BacktraceData implements Serializable {
 
             // Only rewrite non-Java files when not in "raw" mode
             if (!(rawTrace || filename == null || filename.endsWith(".java"))) {
+                // skip internal sources if requested
+                if (excludeInternal && TraceType.isInternal(filename)) continue;
+
                 List<String> mangledTuple = JavaNameMangler.decodeMethodTuple(methodName);
                 if (mangledTuple != null) {
                     FrameType type = JavaNameMangler.decodeFrameTypeFromMangledName(mangledTuple.get(1));
@@ -102,6 +108,9 @@ public class BacktraceData implements Serializable {
                             previousElement = null;
                             continue;
                         }
+
+                        // mask internal file paths
+                        filename = TraceType.maskInternalFiles(filename);
 
                         // construct Ruby trace element
                         RubyStackTraceElement rubyElement = new RubyStackTraceElement(className, decodedName, filename, line, false, type);
@@ -161,7 +170,15 @@ public class BacktraceData implements Serializable {
                         break;
                     default: newName = rubyFrame.method;
                 }
-                RubyStackTraceElement rubyElement = new RubyStackTraceElement("RUBY", newName, rubyFrame.filename, rubyFrame.line + 1, false, frameType);
+
+                // skip internal sources if requested
+                filename = rubyFrame.filename;
+                if (excludeInternal && TraceType.isInternal(filename)) continue;
+
+                // mask internal file paths
+                filename = TraceType.maskInternalFiles(filename);
+
+                RubyStackTraceElement rubyElement = new RubyStackTraceElement("RUBY", newName, filename, rubyFrame.line + 1, false, frameType);
 
                 // dup if masking native and previous frame was native
                 if (maskNative && dupFrame) {

--- a/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
@@ -603,16 +603,23 @@ public class TraceType {
     }
 
     public static String maskInternalFiles(String filename) {
-        if (isInternal(filename)) {
+        if (isInternalFile(filename)) {
             return "<internal:" + filename + ">";
         }
 
         return filename;
     }
 
-    public static boolean isInternal(String filename) {
-        return filename.startsWith("uri:classloader:/jruby/kernel/") ||
-                filename.startsWith("<internal:");
+    public static boolean isInternalFile(String filename) {
+        return filename.startsWith("uri:classloader:/jruby/kernel/");
+    }
+
+    public static boolean hasInternalMarker(String filename) {
+        return filename.startsWith("<internal:");
+    }
+
+    public static boolean isExcludedInternal(String filename) {
+        return TraceType.isInternalFile(filename) || TraceType.hasInternalMarker(filename);
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
@@ -172,6 +172,7 @@ public class TraceType {
                         true,
                         true,
                         false,
+                        false,
                         false);
             }
         },
@@ -185,6 +186,7 @@ public class TraceType {
                         stackStream,
                         context.getBacktrace(),
                         true,
+                        false,
                         false,
                         false,
                         false);
@@ -202,7 +204,8 @@ public class TraceType {
                         false,
                         false,
                         false,
-                        true);
+                        true,
+                        false);
             }
         },
 
@@ -217,6 +220,7 @@ public class TraceType {
                         false,
                         false,
                         context.runtime.getInstanceConfig().getBacktraceMask(),
+                        false,
                         false);
             }
         },
@@ -232,7 +236,24 @@ public class TraceType {
                         false,
                         false,
                         true,
+                        false,
                         false);
+            }
+        },
+
+        /**
+         * Warning traces, showing only Ruby and core class methods, excluding internal files.
+         */
+        WARN {
+            public BacktraceData getBacktraceData(ThreadContext context, Stream<StackWalker.StackFrame> stackStream) {
+                return new BacktraceData(
+                        stackStream,
+                        context.getBacktrace(),
+                        false,
+                        false,
+                        true,
+                        false,
+                        true);
             }
         };
 
@@ -579,6 +600,19 @@ public class TraceType {
         }
 
         return RubyArray.newArrayMayCopy(runtime, traceArray);
+    }
+
+    public static String maskInternalFiles(String filename) {
+        if (isInternal(filename)) {
+            return "<internal:" + filename + ">";
+        }
+
+        return filename;
+    }
+
+    public static boolean isInternal(String filename) {
+        return filename.startsWith("uri:classloader:/jruby/kernel/") ||
+                filename.startsWith("<internal:");
     }
 
     @Deprecated

--- a/core/src/main/ruby/jruby/kernel/kernel.rb
+++ b/core/src/main/ruby/jruby/kernel/kernel.rb
@@ -1,16 +1,22 @@
 module Kernel
-  module_function
-  def exec(*args)
+  module_function def exec(*args)
     _exec_internal(*JRuby::ProcessUtil.exec_args(args))
   end
 
   # Replaces Java version for better caching
-  def initialize_dup(original)
+  module_function def initialize_dup(original)
     initialize_copy(original)
   end
 
   # Replaces Java version for better caching
-  def initialize_clone(original, freeze: false)
+  module_function def initialize_clone(original, freeze: false)
     initialize_copy(original)
+  end
+
+  def tap(&b)
+    # workaround for yield to lambda not triggering arity error
+    # see https://bugs.ruby-lang.org/issues/12705
+    (b && b.lambda?) ? b.call(self) : yield(self)
+    self
   end
 end


### PR DESCRIPTION
This allows tools to omit any of our internal Ruby-based kernel sources when processing backtraces and source_locations. The filtering here is only done in source_location and backtrace generation currently, with some extra logic during backtrace mining to skip internal frames for e.g. Kernel#warn.

I only did this filtering at the highest levels, when the filename is actually about to be used and returned to a Ruby consumer, to avoid any internal usage of these filenames breaking due to the new prefix.

Fixes #6430