### PR TITLE
Propagate read errors in IO backend

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -2222,7 +2222,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
                         if (result == 1) {
                             Set<SelectionKey> keySet = currentSelector.selectedKeys();
 
-                            if (keySet.iterator().next() == key) {
+                            if (keySet.contains(key) && key.isValid()) {
                                 return true;
                             }
                         }

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Array;
 
 import java.net.BindException;
 import java.net.PortUnreachableException;
+import java.net.SocketException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.NonReadableChannelException;
 import java.nio.channels.NonWritableChannelException;
@@ -240,7 +241,7 @@ public class Helpers {
         // Try specific exception types by rethrowing and catching.
         try {
             throw t;
-        } catch (FileNotFoundException fnfe) {
+        } catch (FileNotFoundException | NoSuchFileException fnfe) {
             return Errno.ENOENT;
         } catch (EOFException eofe) {
             return Errno.EPIPE;
@@ -254,15 +255,11 @@ public class Helpers {
             return Errno.EEXIST;
         } catch (FileSystemLoopException fsle) {
             return Errno.ELOOP;
-        } catch (NoSuchFileException nsfe) {
-            return Errno.ENOENT;
         } catch (NotDirectoryException nde) {
             return Errno.ENOTDIR;
         } catch (AccessDeniedException ade) {
             return Errno.EACCES;
-        } catch (DirectoryNotEmptyException dnee) {
-            return errnoFromMessage(dnee);
-        } catch (BindException be) {
+        } catch (IOException be) {
             return errnoFromMessage(be);
         } catch (NotYetConnectedException nyce) {
             return Errno.ENOTCONN;
@@ -271,12 +268,6 @@ public class Helpers {
             return Errno.EINVAL;
         } catch (IllegalArgumentException nrce) {
             return Errno.EINVAL;
-        } catch (IOException ioe) {
-            String message = ioe.getMessage();
-            // Raised on Windows for process launch with missing file
-            if (message.endsWith("The system cannot find the file specified")) {
-                return Errno.ENOENT;
-            }
         } catch (Throwable t2) {
             // fall through
         }
@@ -302,6 +293,7 @@ public class Helpers {
                     return Errno.ECONNABORTED;
                 case "Broken pipe":
                     return Errno.EPIPE;
+                case "Connection reset":
                 case "Connection reset by peer":
                 case "An existing connection was forcibly closed by the remote host":
                     return Errno.ECONNRESET;
@@ -335,7 +327,13 @@ public class Helpers {
                 case "Protocol family not supported":
                     return Errno.EPFNOSUPPORT;
             }
+
+            // Raised on Windows for process launch with missing file
+            if (errorMessage.endsWith("The system cannot find the file specified")) {
+                return Errno.ENOENT;
+            }
         }
+
         return null;
     }
 

--- a/core/src/main/java/org/jruby/util/io/OpenFile.java
+++ b/core/src/main/java/org/jruby/util/io/OpenFile.java
@@ -1298,10 +1298,12 @@ public class OpenFile implements Finalizable {
                     r = readInternal(context, this, fd, rbuf.ptr, 0, rbuf.capa);
 
                     if (r < 0) {
-                        if (waitReadable(context, fd)) {
+                        Errno errno = posix.getErrno();
+                        if (errno == Errno.EAGAIN || errno == Errno.EWOULDBLOCK
+                                && waitReadable(context, fd)) {
                             continue retry;
                         }
-                        throw context.runtime.newErrnoFromErrno(posix.getErrno(), "channel: " + fd + (pathv != null ? " " + pathv : ""));
+                        throw context.runtime.newErrnoFromErrno(errno, "channel: " + fd + (pathv != null ? " " + pathv : ""));
                     }
                     break;
                 }


### PR DESCRIPTION
The JRuby IO subsystem simulates a POSIX environment by capturing Java exceptions and translating them to their equivalent errno values. When a read produces an error, we return -1 and set the local shim's errno. This can then be used by POSIX-like consumers of the API to process the error without exception-handling.

However in the case of IO read operations, we were not appropriately checking the errno result for a failed (i.e. -1) read. Instead we assumed it was always an EAGAIN-like result and proceeded to select for read on the socket. Under normal circumstances, like the socket being fully closed on both ends, that select would raise an error anyway so no errors were lost.

In the example from #7961 (and likely the case in #6346), only one side of the socket was closed using SO_LINGER=0, causing an RST packet to be returned to future reads, manifested by the `read` operation as a SocketException("Connection reset"). The logic described above then proceeded directly to a `select` operation, which did not in this case raise any error. Instead, `select` reported that the socket was still readable, so we loop back to the `read` ad infinatum.

The changes here make three changes:

* Properly handle IOExceptions with a message of "Connection reset" by producing an ECONNRESET errno. The translation logic from Java exceptions to errnos was also cleaned up a bit.
* When `read` returns -1, only proceed to selection if the errno result was `EAGAIN`/`EWOULDBLOCK`, otherwise raising the appropriate error.
* An unrelated change to avoid using an iterator to check `select` results.

Fixes #7961 and #6346.