### PR TITLE
Hide FilenoUtil warning behind native.verbose property

### DIFF
--- a/core/src/main/java/org/jruby/util/io/FilenoUtil.java
+++ b/core/src/main/java/org/jruby/util/io/FilenoUtil.java
@@ -16,6 +16,7 @@ import jnr.unixsocket.UnixSocketChannel;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.platform.Platform;
 import org.jruby.runtime.Helpers;
+import org.jruby.util.cli.Options;
 import org.jruby.util.collections.NonBlockingHashMapLong;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
@@ -269,14 +270,16 @@ public class FilenoUtil {
             FILE_DESCRIPTOR_SET_FILENO_HANDLE = fdSetFileno;
 
             if (selChImplGetFD == null || fileChannelGetFD == null || fdGetFileno == null) {
-                // Warn users since we don't currently handle half-native process control.
-                Module module = Modules.getModule(ReflectiveAccess.class);
-                String moduleName = module.getName();
-                if (moduleName == null) {
-                    moduleName = "ALL-UNNAMED";
+                if (Options.NATIVE_VERBOSE.load()) {
+                    // Warn users since we don't currently handle half-native process control.
+                    Module module = Modules.getModule(ReflectiveAccess.class);
+                    String moduleName = module.getName();
+                    if (moduleName == null) {
+                        moduleName = "ALL-UNNAMED";
+                    }
+                    LOG.warn("Native IO integration requires open access to the JDK IO subsystem\n" +
+                            "Pass '--add-opens java.base/sun.nio.ch=" + moduleName + " --add-opens java.base/java.io=" + moduleName + "' to enable.");
                 }
-                LOG.warn("Native subprocess control requires open access to the JDK IO subsystem\n" +
-                        "Pass '--add-opens java.base/sun.nio.ch=" + moduleName + " --add-opens java.base/java.io=" + moduleName + "' to enable.");
             }
         }
 


### PR DESCRIPTION
My goal with this warning was to avoid bug reports about native
process functionality not working well when running without the
module flags we need to dig up native file descriptors from Java
channels. Since I added this, however, many things have changed:

* Native process IO does not go through Java channels anymore; it
  instead uses real native IO all the way through.
* File IO now also usually goes through JNR using a native file
  descriptor.
* The fileno extraction is now primarily used to provide a fileno
  for RubyIO objects, but most Ruby code will not need the real
  fileno.
* Module flags are frequently difficult to inject into a jar-based
  usage of JRuby, so these flags may not be helpful anyway.

I believe a warning about degraded functionality is important, but
it should be at point-of-use rather than globally just in case the
native fileno functionality might become necessary in the future.
As such, I am hiding this global warning behind the native.verbose
property, and we can consider adding other more targeted warnings
going forward.
