### PR TITLE
[ji] support java_alias with constructor

### DIFF
--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -144,23 +144,32 @@ public class RubyClass extends RubyModule {
      * Set a reflective allocator that calls a no-arg constructor on the given
      * class.
      *
-     * @param cls The class on which to call the default constructor to allocate
+     * @param clazz The class on which to call the default constructor to allocate
      */
     @SuppressWarnings("unchecked")
-    public void setClassAllocator(final Class<?> cls) {
+    public void setClassAllocator(final Class<?> clazz) {
+        final Constructor<?> constructor;
+        try {
+            constructor = clazz.getConstructor();
+        } catch (NoSuchMethodException nsme) {
+            throw new RuntimeException(nsme);
+        }
+
         this.allocator = (runtime, klazz) -> {
             try {
-                RubyBasicObject object = (RubyBasicObject)cls.getConstructor().newInstance();
+                RubyBasicObject object = (RubyBasicObject) constructor.newInstance();
                 object.setMetaClass(klazz);
                 return object;
-            } catch (InstantiationException | InvocationTargetException ie) {
-                throw runtime.newTypeError("could not allocate " + cls + " with default constructor:\n" + ie);
-            } catch (IllegalAccessException | NoSuchMethodException iae) {
-                throw runtime.newSecurityError("could not allocate " + cls + " due to inaccessible default constructor:\n" + iae);
+            } catch (InvocationTargetException e) {
+                throw newTypeError(runtime, "could not allocate " + clazz + " with default constructor:\n" + e.getTargetException(), e);
+            } catch (InstantiationException e) {
+                throw newTypeError(runtime, "could not allocate " + clazz + " with default constructor:\n" + e, e);
+            } catch (IllegalAccessException e) {
+                throw runtime.newSecurityError("could not allocate " + clazz + " due to inaccessible default constructor:\n" + e);
             }
         };
 
-        this.reifiedClass = (Class<? extends Reified>) cls;
+        this.reifiedClass = (Class<? extends Reified>) clazz;
     }
 
     /**
@@ -171,25 +180,26 @@ public class RubyClass extends RubyModule {
      */
     @SuppressWarnings("unchecked")
     public void setRubyClassAllocator(final Class<? extends IRubyObject> clazz) {
+        final Constructor<? extends IRubyObject> constructor;
         try {
-            final Constructor<? extends IRubyObject> constructor = clazz.getConstructor(Ruby.class, RubyClass.class);
-
-            this.allocator = (runtime, klazz) -> {
-                try {
-                    return constructor.newInstance(runtime, klazz);
-                } catch (InvocationTargetException ite) {
-                    throw runtime.newTypeError("could not allocate " + clazz + " with (Ruby, RubyClass) constructor:\n" + ite);
-                } catch (InstantiationException ie) {
-                    throw runtime.newTypeError("could not allocate " + clazz + " with (Ruby, RubyClass) constructor:\n" + ie);
-                } catch (IllegalAccessException iae) {
-                    throw runtime.newSecurityError("could not allocate " + clazz + " due to inaccessible (Ruby, RubyClass) constructor:\n" + iae);
-                }
-            };
-
-            this.reifiedClass = (Class<? extends Reified>) clazz;
+            constructor = clazz.getConstructor(Ruby.class, RubyClass.class);
         } catch (NoSuchMethodException nsme) {
             throw new RuntimeException(nsme);
         }
+
+        this.allocator = (runtime, klazz) -> {
+            try {
+                return constructor.newInstance(runtime, klazz);
+            } catch (InvocationTargetException e) {
+                throw newTypeError(runtime, "could not allocate " + clazz + " with (Ruby, RubyClass) constructor:\n" + e.getTargetException(), e);
+            } catch (InstantiationException e) {
+                throw newTypeError(runtime, "could not allocate " + clazz + " with (Ruby, RubyClass) constructor:\n" + e, e);
+            } catch (IllegalAccessException e) {
+                throw runtime.newSecurityError("could not allocate " + clazz + " due to inaccessible (Ruby, RubyClass) constructor:\n" + e);
+            }
+        };
+
+        this.reifiedClass = (Class<? extends Reified>) clazz;
     }
 
     /**
@@ -203,23 +213,30 @@ public class RubyClass extends RubyModule {
      * <p>Note: Used with new concrete extension.</p>
      */
     public void setRubyStaticAllocator(final Class<?> clazz) {
+        final Method method;
         try {
-            final Method method = clazz.getDeclaredMethod("__allocate__", Ruby.class, RubyClass.class);
-
-            this.allocator = (runtime, klazz) -> {
-                try {
-                    return (IRubyObject) method.invoke(null, runtime, klazz);
-                } catch (InvocationTargetException ite) {
-                    throw runtime.newTypeError("could not allocate " + clazz + " with (Ruby, RubyClass) constructor:\n" + ite);
-                } catch (IllegalAccessException iae) {
-                    throw runtime.newSecurityError("could not allocate " + clazz + " due to inaccessible (Ruby, RubyClass) constructor:\n" + iae);
-                }
-            };
-
-            this.reifiedClass = (Class<? extends Reified>) clazz;
+            method = clazz.getDeclaredMethod("__allocate__", Ruby.class, RubyClass.class);
         } catch (NoSuchMethodException nsme) {
             throw new RuntimeException(nsme);
         }
+
+        this.allocator = (runtime, klazz) -> {
+            try {
+                return (IRubyObject) method.invoke(null, runtime, klazz);
+            } catch (InvocationTargetException e) {
+                throw newTypeError(runtime, "could not allocate " + clazz + " with (Ruby, RubyClass) method:\n" + e.getTargetException(), e);
+            } catch (IllegalAccessException e) {
+                throw runtime.newSecurityError("could not allocate " + clazz + " due to inaccessible (Ruby, RubyClass) method:\n" + e);
+            }
+        };
+
+        this.reifiedClass = (Class<? extends Reified>) clazz;
+    }
+
+    private static RaiseException newTypeError(final Ruby runtime, final String msg, final Exception e) {
+        RaiseException error = runtime.newTypeError(msg);
+        error.initCause(e);
+        return error;
     }
 
     @JRubyMethod(name = "allocate")

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -936,22 +936,14 @@ public class RubyClass extends RubyModule {
      *
      */
     @Override
-    public IRubyObject initialize(ThreadContext context, Block block) {
-        return initialize19(context, block);
-    }
-
-    public IRubyObject initialize(ThreadContext context, IRubyObject superObject, Block block) {
-        return initialize19(context, superObject, block);
-    }
-
     @JRubyMethod(name = "initialize", visibility = PRIVATE)
-    public IRubyObject initialize19(ThreadContext context, Block block) {
+    public IRubyObject initialize(ThreadContext context, Block block) {
         checkNotInitialized();
         return initializeCommon(context, runtime.getObject(), block);
     }
 
     @JRubyMethod(name = "initialize", visibility = PRIVATE)
-    public IRubyObject initialize19(ThreadContext context, IRubyObject superObject, Block block) {
+    public IRubyObject initialize(ThreadContext context, IRubyObject superObject, Block block) {
         checkNotInitialized();
         checkInheritable(superObject);
         return initializeCommon(context, (RubyClass) superObject, block);
@@ -2897,6 +2889,16 @@ public class RubyClass extends RubyModule {
     @Deprecated
     public VariableAccessorField getObjectGroupAccessorField() {
         return variableTableManager.getObjectGroupAccessorField();
+    }
+
+    @Deprecated
+    public IRubyObject initialize19(ThreadContext context, Block block) {
+        return initialize(context, block);
+    }
+
+    @Deprecated
+    public IRubyObject initialize19(ThreadContext context, IRubyObject superObject, Block block) {
+        return initialize(context, superObject, block);
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -85,8 +85,6 @@ public class RubyDir extends RubyObject implements Closeable {
     private boolean isOpen = true;
     private Encoding encoding;
 
-    private static final Pattern PROTOCOL_PATTERN = Pattern.compile("^(uri|jar|file|classpath):([^:]*:)?//?.*");
-
     public RubyDir(Ruby runtime, RubyClass type) {
         super(runtime, type);
     }
@@ -103,13 +101,13 @@ public class RubyDir extends RubyObject implements Closeable {
         return dirClass;
     }
 
-    private final void checkDir() {
+    private void checkDir() {
         checkDirIgnoreClosed();
 
         if (!isOpen) throw getRuntime().newIOError("closed directory");
     }
 
-    private final void checkDirIgnoreClosed() {
+    private void checkDirIgnoreClosed() {
         testFrozen("Dir");
         // update snapshot (if changed) :
         if (snapshot == null || dir.exists() && dir.lastModified() > lastModified) {

--- a/core/src/main/java/org/jruby/java/invokers/ConstructorInvoker.java
+++ b/core/src/main/java/org/jruby/java/invokers/ConstructorInvoker.java
@@ -213,7 +213,7 @@ public final class ConstructorInvoker extends RubyToJavaInvoker {
         return call(context, self, clazz, name, arg0, arg1, arg2);
     }
 
-    private void setAndCacheProxyObject(ThreadContext context, RubyModule clazz, JavaProxy proxy, Object object) {
+    private static void setAndCacheProxyObject(ThreadContext context, RubyModule clazz, JavaProxy proxy, Object object) {
         proxy.setObject(object);
 
         if (Java.OBJECT_PROXY_CACHE || clazz.getCacheProxy()) {

--- a/core/src/main/java/org/jruby/java/invokers/RubyToJavaInvoker.java
+++ b/core/src/main/java/org/jruby/java/invokers/RubyToJavaInvoker.java
@@ -161,7 +161,7 @@ public abstract class RubyToJavaInvoker<T extends JavaCallable> extends JavaMeth
                 }
 
                 if (varArgs != null /* && varargsMethods.size() > 0 */) {
-                    varargsCallables = (T[]) varArgs.toArray(createCallableArray(varArgs.size()));
+                    varargsCallables = varArgs.toArray(createCallableArray(varArgs.size()));
                 }
                 // NOTE: tested (4, false); with opt_for_space: false but does not
                 // seem to give  the promised ~10% improvement in map's speed ...
@@ -341,7 +341,7 @@ public abstract class RubyToJavaInvoker<T extends JavaCallable> extends JavaMeth
     }
 
     static JavaProxy castJavaProxy(final IRubyObject self) {
-        assert self instanceof JavaProxy : "Java methods can only be invoked on Java objects";
+        assert self instanceof JavaProxy : "Java methods can only be invoked on Java objects; got: " + self;
         return (JavaProxy) self;
     }
 

--- a/spec/java_integration/fixtures/AnArrayList.java
+++ b/spec/java_integration/fixtures/AnArrayList.java
@@ -1,0 +1,17 @@
+package java_integration.fixtures;
+
+public class AnArrayList extends java.util.ArrayList {
+    public static final java.util.Vector CREATED_INSTANCES = new java.util.Vector();
+
+    public AnArrayList() {
+        super();
+        CREATED_INSTANCES.add(this);
+    }
+
+    public AnArrayList(int c) {
+        super(c);
+        for (int i=0; i<c; i++) this.add(null);
+        CREATED_INSTANCES.add(this);
+    }
+
+}

--- a/spec/java_integration/methods/java_alias_spec.rb
+++ b/spec/java_integration/methods/java_alias_spec.rb
@@ -1,6 +1,6 @@
 require 'java'
 
-describe "A Java object's java_send method" do
+describe "A Java object's java_alias method" do
   before :all do
     class java::util::ArrayList
       java_alias :add_int_object, :add, [Java::int, java.lang.Object]
@@ -44,6 +44,49 @@ describe "A Java object's java_send method" do
     expect do
       @list.add_int_object 0, 'foo', 'bar'
     end.to raise_error(ArgumentError)
+  end
+
+  context 'constructor' do
+
+    before(:all) do
+      Java::java_integration.fixtures::AnArrayList.class_eval do
+        java_alias :init, :'<init>', [Java::int] # AnArrayList(int)
+
+        def initialize(num)
+          init(num) if num
+          @@last_instance = self
+        end
+
+        @@last_instance = nil
+        def self.last_instance; @@last_instance end
+      end
+    end
+
+    before(:each) { klass::CREATED_INSTANCES.clear }
+
+    let(:klass) { Java::java_integration.fixtures::AnArrayList }
+
+    it 'is supported' do
+      a_list = klass.new(3)
+      expect( a_list ).to be klass::last_instance
+      expect( klass::CREATED_INSTANCES.size ).to be 1
+      expect( klass::CREATED_INSTANCES[0].size ).to eql(3)
+
+      a_list = klass.allocate
+      a_list.init(10) # useful to bypass :initialize
+      expect( klass::CREATED_INSTANCES.size ).to be 2
+      expect( a_list ).to_not be klass::last_instance
+    end
+
+    it 'raises on invalid arguments' do
+      expect { klass.new(:foo) }.to raise_error(TypeError)
+    end
+
+    it 'raises on unexpected arguments' do
+      a_list = klass.new(nil)
+      expect { a_list.init(1, 2) }.to raise_error(ArgumentError)
+    end
+
   end
 
   context 'interface' do


### PR DESCRIPTION
the use-case, as demonstrated in the spec, is to be able to bypass constructor lookup with:

`java_alias :_java_ctor_alias, :'<init>'` the reasoning is similar to using [`java_alias` with overloads](https://github.com/jruby/jruby/wiki/ImprovingJavaIntegrationPerformance)

---

also, there's a bunch of refactoring/cleanup commits:  
- avoid constructor lookup when using `setClassAllocator(Class)`
- set-up Java causes for (Java) allocator failing exceptions