### PR TITLE
Fix ENOENT with TestProcessSpawn on Debian

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -240,7 +240,7 @@ project 'JRuby Base' do
           },
           'argLine' =>  '-Xmx${jruby.test.memory} -Dfile.encoding=UTF-8 -Djava.awt.headless=true',
           'environmentVariables' => {
-              'JDK_JAVA_OPTIONS' => '--add-modules java.scripting'
+              'JDK_JAVA_OPTIONS' => '--add-modules java.scripting --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED'
           },
           includes: [
             'org/jruby/test/**/*Test*.java',

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -547,7 +547,7 @@ DO NOT MODIFY - GENERATED CODE
           </systemProperties>
           <argLine>-Xmx${jruby.test.memory} -Dfile.encoding=UTF-8 -Djava.awt.headless=true</argLine>
           <environmentVariables>
-            <JDK_JAVA_OPTIONS>--add-modules java.scripting</JDK_JAVA_OPTIONS>
+            <JDK_JAVA_OPTIONS>--add-modules java.scripting --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED</JDK_JAVA_OPTIONS>
           </environmentVariables>
           <includes>
             <include>org/jruby/test/**/*Test*.java</include>


### PR DESCRIPTION
On Debian, possibly because of some OpenJDK hardening, TestProcessSpawn consistently fails:

```
[INFO] Running org.jruby.test.TestProcessSpawn
2023-10-24T00:19:47.130Z [main] WARN FilenoUtil : Native subprocess control requires open access to the JDK IO subsystem
Pass '--add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED' to enable.
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 1.889 s <<< FAILURE! - in org.jruby.test.TestProcessSpawn
[ERROR] testSpawnAndDetach(org.jruby.test.TestProcessSpawn)  Time elapsed: 1.867 s  <<< ERROR!
org.jruby.exceptions.SystemCallError: (ENOENT) No such file or directory - echo
```

Adding --add-opens to the java options envvar fixes the problem.