### PR TITLE
Prototype of fast block_given? logic using indy

### DIFF
--- a/core/src/main/java/org/jruby/ir/instructions/CallBase.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CallBase.java
@@ -242,6 +242,11 @@ public abstract class CallBase extends NOperandInstr implements ClosureAccepting
         modifiedScope |= setIRFlagsFromFrameFields(flags, frameReads);
         modifiedScope |= setIRFlagsFromFrameFields(flags, frameWrites);
 
+        if (getId().equals("block_given?") && argsCount == 0) {
+            // remove frame read from flags for optimizable methods
+            flags.remove(REQUIRES_BLOCK);
+        }
+
         // literal closures can be used to capture surrounding binding
         if (hasLiteralClosure()) {
             modifiedScope = true;

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1191,7 +1191,11 @@ public class IRRuntimeHelpers {
     public static RubyBoolean isBlockGiven(ThreadContext context, Object blk) {
         if (blk instanceof RubyProc) blk = ((RubyProc) blk).getBlock();
         if (blk instanceof RubyNil) blk = Block.NULL_BLOCK;
-        return RubyBoolean.newBoolean(context,  ((Block) blk).isGiven() );
+        return isBlockGiven(context, (Block) blk);
+    }
+
+    public static RubyBoolean isBlockGiven(ThreadContext context, Block blk) {
+        return RubyBoolean.newBoolean(context,  blk != null && blk.isGiven() );
     }
 
     @JIT @Interp

--- a/core/src/main/java/org/jruby/ir/targets/indy/IndyInvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/IndyInvocationCompiler.java
@@ -126,6 +126,13 @@ public class IndyInvocationCompiler implements InvocationCompiler {
 
         int flags = call.getFlags();
 
+        if (id.equals("block_given?") && arity == 0) {
+            // specialized call site for block_given? that passes given block through
+            compiler.loadBlock();
+            compiler.adapter.invokedynamic("callFunctional:" + JavaNameMangler.mangleMethodName(id), sig(JVM.OBJECT, params(ThreadContext.class, JVM.OBJECT, Block.class)), SelfInvokeSite.BOOTSTRAP, false, flags, file, compiler.getLastLine());
+            return;
+        }
+
         String action = call.getCallType() == CallType.FUNCTIONAL ? "callFunctional" : "callVariable";
         IRBytecodeAdapter.BlockPassType blockPassType = IRBytecodeAdapter.BlockPassType.fromIR(call);
         if (blockPassType != IRBytecodeAdapter.BlockPassType.NONE) {


### PR DESCRIPTION
The basic idea here is to avoid pushing a frame for block_given? when it is known to be our core implementation. Instead, we use indy to test the block the current method was called with and return a result directly. When the block_given? is not our core impl, it falls back on a normal indy invocation. This allows us to remove the frame requirement from block_given? callers, and the cost of the block_given? call largely disappears.

Caveats:

* This is very much hacked in place, with duplicated code in multiple places.
* In order to pass through the block we were given, we add a Block parameter to the call site. If someone defines a block_given? in Ruby, it would receive our given block.