### PR TITLE
Less Load{Frame,Implicit}ClosureInstr

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -2212,7 +2212,7 @@ public class IRBuilder {
         Variable sClassVar = addResultInstr(new DefineMetaClassInstr(createTemporaryVariable(), receiver, body));
 
         // sclass bodies inherit the block of their containing method
-        Variable processBodyResult = addResultInstr(new ProcessModuleBodyInstr(createTemporaryVariable(), sClassVar, getYieldClosureVariable()));
+        Variable processBodyResult = addResultInstr(new ProcessModuleBodyInstr(createTemporaryVariable(), sClassVar));
         newIRBuilder(manager, body).buildModuleOrClassBody(sclassNode.getBodyNode(), sclassNode.getLine(), sclassNode.getEndLine());
         return processBodyResult;
     }
@@ -3103,10 +3103,9 @@ public class IRBuilder {
         // Receive self
         addInstr(manager.getReceiveSelfInstr());
 
-        // used for yields; metaclass body (sclass) inherits yield var from surrounding, and accesses it as implicit
-        if (scope instanceof IRMethod || scope instanceof IRMetaClassBody) {
+        if (scope instanceof IRMethod) {
             addInstr(new LoadImplicitClosureInstr(getYieldClosureVariable()));
-        } else {
+        } else if (!(scope instanceof IRModuleBody) && !(scope instanceof IRClassBody) && !(scope instanceof IRMetaClassBody)) {
             addInstr(new LoadFrameClosureInstr(getYieldClosureVariable()));
         }
     }

--- a/core/src/main/java/org/jruby/ir/instructions/ProcessModuleBodyInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ProcessModuleBodyInstr.java
@@ -15,9 +15,9 @@ import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
-public class ProcessModuleBodyInstr extends TwoOperandResultBaseInstr implements FixedArityInstr {
-    public ProcessModuleBodyInstr(Variable result, Operand moduleBody, Operand block) {
-        super(Operation.PROCESS_MODULE_BODY, result, moduleBody, block);
+public class ProcessModuleBodyInstr extends OneOperandResultBaseInstr implements FixedArityInstr {
+    public ProcessModuleBodyInstr(Variable result, Operand moduleBody) {
+        super(Operation.PROCESS_MODULE_BODY, result, moduleBody);
 
         assert result != null: "ProcessModuleBodyInstr result is null";
     }
@@ -26,34 +26,27 @@ public class ProcessModuleBodyInstr extends TwoOperandResultBaseInstr implements
         return getOperand1();
     }
 
-    public Operand getBlock() {
-        return getOperand2();
-    }
-
     @Override
     public Instr clone(CloneInfo ii) {
-        return new ProcessModuleBodyInstr(ii.getRenamedVariable(result), getModuleBody().cloneForInlining(ii),
-                getBlock().cloneForInlining(ii));
+        return new ProcessModuleBodyInstr(ii.getRenamedVariable(result), getModuleBody().cloneForInlining(ii));
     }
 
     @Override
     public void encode(IRWriterEncoder e) {
         super.encode(e);
         e.encode(getModuleBody());
-        e.encode(getBlock());
     }
 
     public static ProcessModuleBodyInstr decode(IRReaderDecoder d) {
-        return new ProcessModuleBodyInstr(d.decodeVariable(), d.decodeOperand(), d.decodeOperand());
+        return new ProcessModuleBodyInstr(d.decodeVariable(), d.decodeOperand());
     }
 
     @Override
     public Object interpret(ThreadContext context, StaticScope currScope, DynamicScope currDynScope, IRubyObject self, Object[] temp) {
         InterpretedIRBodyMethod bodyMethod = (InterpretedIRBodyMethod) getModuleBody().retrieve(context, self, currScope, currDynScope, temp);
-        Block b = (Block) getBlock().retrieve(context, self, currScope, currDynScope, temp);
 		RubyModule implClass = bodyMethod.getImplementationClass();
 
-        return bodyMethod.call(context, implClass, implClass, null, b);
+        return bodyMethod.call(context, implClass, implClass, null, Block.NULL_BLOCK);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/ProcessModuleBodyInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/ProcessModuleBodyInstr.java
@@ -31,12 +31,6 @@ public class ProcessModuleBodyInstr extends OneOperandResultBaseInstr implements
         return new ProcessModuleBodyInstr(ii.getRenamedVariable(result), getModuleBody().cloneForInlining(ii));
     }
 
-    @Override
-    public void encode(IRWriterEncoder e) {
-        super.encode(e);
-        e.encode(getModuleBody());
-    }
-
     public static ProcessModuleBodyInstr decode(IRReaderDecoder d) {
         return new ProcessModuleBodyInstr(d.decodeVariable(), d.decodeOperand());
     }

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1864,15 +1864,7 @@ public class IRRuntimeHelpers {
         // FIXME: needs checkID and proper encoding to force hard symbol
         Helpers.addInstanceMethod(clazz, methodName, newMethod, currVisibility, context, runtime);
     }
-
-    @JIT
-    public static IRubyObject invokeModuleBody(ThreadContext context, DynamicMethod method, Block block) {
-        RubyModule implClass = method.getImplementationClass();
-
-        return method.call(context, implClass, implClass, "", block);
-    }
-
-    // FIXME: Temporary until CompiledIRMethod part of this is removed.
+    
     @JIT
     public static IRubyObject invokeModuleBody(ThreadContext context, DynamicMethod method) {
         RubyModule implClass = method.getImplementationClass();

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -1918,7 +1918,6 @@ public class JVMVisitor extends IRVisitor {
     public void ProcessModuleBodyInstr(ProcessModuleBodyInstr processmodulebodyinstr) {
         jvmMethod().loadContext();
         visit(processmodulebodyinstr.getModuleBody());
-        visit(processmodulebodyinstr.getBlock());
         jvmMethod().invokeIRHelper("invokeModuleBody", sig(IRubyObject.class, ThreadContext.class, DynamicMethod.class, Block.class));
         jvmStoreLocal(processmodulebodyinstr.getResult());
     }

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -1918,7 +1918,7 @@ public class JVMVisitor extends IRVisitor {
     public void ProcessModuleBodyInstr(ProcessModuleBodyInstr processmodulebodyinstr) {
         jvmMethod().loadContext();
         visit(processmodulebodyinstr.getModuleBody());
-        jvmMethod().invokeIRHelper("invokeModuleBody", sig(IRubyObject.class, ThreadContext.class, DynamicMethod.class, Block.class));
+        jvmMethod().invokeIRHelper("invokeModuleBody", sig(IRubyObject.class, ThreadContext.class, DynamicMethod.class));
         jvmStoreLocal(processmodulebodyinstr.getResult());
     }
 


### PR DESCRIPTION
I think since Ruby 3 esoteric forms where an SClass can get a block body to yield is no longer possible.  This I think has always been try for Class and Module bodies (syntactically) so I am removing emitting Load{Frame,Implicit}ClosureInstr for those scope types.