### PR TITLE
Remove unnecessary cast of kwargs

### DIFF
--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -1715,16 +1715,21 @@ public class RubyTime extends RubyObject {
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args) {
         boolean keywords = hasKeywords(context.resetCallInfo());
         IRubyObject zone = null;
-        context.resetCallInfo();
         IRubyObject nil = context.nil;
 
         int argc = args.length;
         if (keywords) {
-            IRubyObject in = ArgsUtil.extractKeywordArg(context, (RubyHash) args[argc - 1], "in");
-            if (in != null && argc > 7) {
-                throw context.runtime.newArgumentError("timezone argument given as positional and keyword arguments");
+            IRubyObject in = ArgsUtil.extractKeywordArg(context, args[argc - 1], "in");
+            if (in != null) {
+                if (argc > 7) {
+                    throw context.runtime.newArgumentError("timezone argument given as positional and keyword arguments");
+                }
+                zone = in;
+            } else {
+                if (argc > 6) {
+                    zone = args[6];
+                }
             }
-            zone = in;
         } else if (argc > 6) {
             zone = args[6];
         }


### PR DESCRIPTION
The intent here was to pass in what might be kwargs if the keyword flag was set, indicating that kwargs were being passed in. This assumption seems ok so I'm not sure why it doesn't hold. In any case, the cast here is unnecessary and the IRubyObject form will return null for non-RubyHashes.

The code that triggered this does deal directly with kwargs, but as a kwrest, forwarding it through a block:

https://github.com/rails/rails/blob/v7.1.1/activesupport/lib/active_support/testing/time_helpers.rb#L176-L183

This could indicate JRuby failing to pass along a keyword flag when forwarding kwrest.

The additional changes here are:

* Fall back on non-kwargs behavior if last arg turns out not to be a hash.
* Remove a redundant reset of the `callInfo` that governs keyword- passing.

Fixes #7982