### PR TITLE
[fix] infinite loop calling Java super from Ruby

### DIFF
--- a/core/src/main/java/org/jruby/java/proxies/ConcreteJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ConcreteJavaProxy.java
@@ -397,6 +397,7 @@ public class ConcreteJavaProxy extends JavaProxy {
         RubyClass candidate = klass.getSuperClass();
         while (candidate != null && (candidate.isIncluded() || candidate.isPrepended())) { // up till 'real' superclass
             if (candidate == klass) return true;
+            candidate = candidate.getSuperClass();
         }
 
         return false;

--- a/core/src/test/java/org/jruby/javasupport/TestJava.java
+++ b/core/src/test/java/org/jruby/javasupport/TestJava.java
@@ -1,6 +1,7 @@
 package org.jruby.javasupport;
 
 import java.lang.reflect.Method;
+import java.text.SimpleDateFormat;
 
 import org.jruby.*;
 import org.jruby.exceptions.RaiseException;
@@ -117,4 +118,23 @@ public class TestJava extends junit.framework.TestCase {
         }
     }
 
+    @Test
+    public void testOverrideNewOnConcreteJavaProxySubClassRegression() {
+        String script =
+            "class FormatImpl < java.text.SimpleDateFormat\n" +
+            "  include Enumerable\n" +
+            "  public_class_method :new\n" +
+            "  class << self\n" +
+            "    def new(thread_provider: true)\n" +
+            "      super()\n" +
+            "    end\n" +
+            "  end\n" +
+            "end\n";
+
+        final Ruby runtime = Ruby.newInstance();
+        runtime.evalScriptlet(script);
+
+        assertNotNull(runtime.evalScriptlet("FormatImpl.new")); // used to cause an infinite loop
+        assertTrue(runtime.evalScriptlet("FormatImpl.new").toJava(Object.class) instanceof SimpleDateFormat);
+    }
 }


### PR DESCRIPTION
introduced in 9.4.4.0 while doing a variant of: https://github.com/jruby/jruby/commit/bd9d40c02a1a693b46aa14e5feac7d64b5442246#diff-d269af154b613900dfe27e6c544a8c6748bf52af91e74395df49c70764db1478R1841

managed to miss copy-ing the loop last step (and I was pretty confident that is a tested code path)