### PR TITLE
Preserve insertion order for ivars

### DIFF
--- a/core/src/main/java/org/jruby/runtime/ivars/VariableTableManager.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/VariableTableManager.java
@@ -33,7 +33,7 @@ import java.io.ObjectOutputStream;
 import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -258,7 +258,7 @@ public class VariableTableManager {
                 if (ivarAccessor == null) {
                     // allocate a new accessor and populate a new table
                     ivarAccessor = allocateVariableAccessors(name, defaultAccessorBuilder);
-                    Map<String, VariableAccessor> newVariableAccessors = new HashMap<String, VariableAccessor>(myVariableAccessors.size() + 1);
+                    Map<String, VariableAccessor> newVariableAccessors = new LinkedHashMap<>(myVariableAccessors.size() + 1);
 
                     newVariableAccessors.putAll(myVariableAccessors);
                     newVariableAccessors.put(name, ivarAccessor);
@@ -390,7 +390,7 @@ public class VariableTableManager {
      * @return a map of names to accessors for all variables
      */
     public Map<String, VariableAccessor> getVariableTableCopy() {
-        return new HashMap<String, VariableAccessor>(getVariableAccessorsForRead());
+        return new LinkedHashMap<String, VariableAccessor>(getVariableAccessorsForRead());
     }
 
     /**

--- a/spec/tags/ruby/core/kernel/instance_variables_tags.txt
+++ b/spec/tags/ruby/core/kernel/instance_variables_tags.txt
@@ -1,1 +1,0 @@
-fails:Kernel#instance_variables regular objects returns the instances variables in the order declared


### PR DESCRIPTION
I could not find anywhere this is specified, except for:

* A very recent test in CRuby's test/ruby/test_shape.rb that confirms a degraded "complex" shape using CRuby's "st table" hashtable will continue to be returned in insertion order. This implies that insertion order is expected.
* A rubyspec added in 2021 in instance_variable_spec.rb that confirms instance variables are returned in insertion order. No links to issues or discussions is provided.

Since this is a simple enough change, we'll go ahead with it, but I don't know that it has ever been formally specified (and indeed I looked through other tests of other types of variables and see that there are commits to .sort them before inspection in tests.)

Fixes #7988
