### PR TITLE
Update JRuby/Maven stack

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>io.takari.polyglot</groupId>
     <artifactId>polyglot-ruby</artifactId>
-    <version>0.4.11</version>
+    <version>0.5.0</version>
   </extension>
 </extensions>

--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -154,7 +154,7 @@ project 'JRuby Lib Setup' do
 
   properties( 'polyglot.dump.pom' => 'pom.xml',
               'polyglot.dump.readonly' => true,
-              'jruby.plugins.version' => '3.0.1',
+              'jruby.plugins.version' => '3.0.2',
               'gem.home' => '${basedir}/ruby/gems/shared',
               # we copy everything into the target/classes/META-INF
               # so the jar plugin just packs it - see build/resources below
@@ -164,7 +164,7 @@ project 'JRuby Lib Setup' do
   # just depends on jruby-core so we are sure the jruby.jar is in place
   jar "org.jruby:jruby-core:#{version}", :scope => 'test'
 
-  extension 'org.jruby.maven:mavengem-wagon:2.0.1'
+  extension 'org.jruby.maven:mavengem-wagon:2.0.2'
 
   repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -20,7 +20,7 @@ DO NOT MODIFY - GENERATED CODE
     <gem.home>${basedir}/ruby/gems/shared</gem.home>
     <jruby.complete.gems>${jruby.complete.home}/lib/ruby/gems/shared</jruby.complete.gems>
     <jruby.complete.home>${project.build.outputDirectory}/META-INF/jruby.home</jruby.complete.home>
-    <jruby.plugins.version>3.0.1</jruby.plugins.version>
+    <jruby.plugins.version>3.0.2</jruby.plugins.version>
     <polyglot.dump.pom>pom.xml</polyglot.dump.pom>
     <polyglot.dump.readonly>true</polyglot.dump.readonly>
   </properties>
@@ -1057,7 +1057,7 @@ DO NOT MODIFY - GENERATED CODE
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2</version>
       </extension>
     </extensions>
     <resources>
@@ -1381,7 +1381,7 @@ DO NOT MODIFY - GENERATED CODE
       <plugin>
         <groupId>io.takari.polyglot</groupId>
         <artifactId>polyglot-maven-plugin</artifactId>
-        <version>0.4.11</version>
+        <version>0.5.0</version>
         <executions>
           <execution>
             <id>install_gems</id>
@@ -1432,7 +1432,7 @@ DO NOT MODIFY - GENERATED CODE
           <dependency>
             <groupId>io.takari.polyglot</groupId>
             <artifactId>polyglot-ruby</artifactId>
-            <version>0.4.11</version>
+            <version>0.5.0</version>
           </dependency>
         </dependencies>
         <inherited>false</inherited>

--- a/lifecycle-mapping-metadata.xml
+++ b/lifecycle-mapping-metadata.xml
@@ -31,7 +31,7 @@
       <pluginExecutionFilter>
         <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
-        <versionRange>3.0.1</versionRange>
+        <versionRange>3.0.2</versionRange>
         <goals>
           <goal>initialize</goal>
         </goals>
@@ -44,7 +44,7 @@
       <pluginExecutionFilter>
         <groupId>org.jruby.maven</groupId>
         <artifactId>gem-maven-plugin</artifactId>
-        <versionRange>3.0.1</versionRange>
+        <versionRange>3.0.2</versionRange>
         <goals>
           <goal>initialize</goal>
         </goals>

--- a/maven/jruby-complete/pom.rb
+++ b/maven/jruby-complete/pom.rb
@@ -11,7 +11,7 @@ project 'JRuby Complete' do
   packaging 'bundle'
 
 
-  extension 'org.jruby.maven:mavengem-wagon:2.0.1'
+  extension 'org.jruby.maven:mavengem-wagon:2.0.2'
 
   plugin_repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 

--- a/maven/jruby-complete/src/it/GH-3095-gem-install-with-forked-jruby/pom.xml
+++ b/maven/jruby-complete/src/it/GH-3095-gem-install-with-forked-jruby/pom.xml
@@ -31,7 +31,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2</version>
       </extension>
     </extensions>
     <plugins>

--- a/maven/jruby-complete/src/it/extended/Mavenfile
+++ b/maven/jruby-complete/src/it/extended/Mavenfile
@@ -1,7 +1,7 @@
 #-*- mode: ruby -*-
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.1',
+properties( 'jruby.plugins.version' => '3.0.2',
             'project.build.sourceEncoding' => 'utf-8',
             'jruby.home' => '${basedir}/../../../../..' )
 

--- a/maven/jruby-complete/src/it/runnable/Mavenfile
+++ b/maven/jruby-complete/src/it/runnable/Mavenfile
@@ -1,7 +1,7 @@
 #-*- mode: ruby -*-
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.1',
+properties( 'jruby.plugins.version' => '3.0.2',
             'mavengem.wagon.version' => '2.0.1',
             'jruby.version' => '9.4.3.0' )
 

--- a/maven/jruby-complete/src/templates/osgi_many_bundles_with_embedded_gems/gems-bundle/pom.rb
+++ b/maven/jruby-complete/src/templates/osgi_many_bundles_with_embedded_gems/gems-bundle/pom.rb
@@ -4,7 +4,7 @@ gemfile
 
 model.repositories.clear
 
-extension 'org.jruby.maven:mavengem-wagon:2.0.1'
+extension 'org.jruby.maven:mavengem-wagon:2.0.2'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 id 'org.jruby.osgi:gems-bundle', '1.0'
@@ -12,7 +12,7 @@ id 'org.jruby.osgi:gems-bundle', '1.0'
 packaging 'bundle'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.1',
+properties( 'jruby.plugins.version' => '3.0.2',
             # needed bundle plugin
             'polyglot.dump.pom' => 'pom.xml' )
 

--- a/maven/jruby-complete/src/templates/osgi_many_bundles_with_embedded_gems/pom.rb
+++ b/maven/jruby-complete/src/templates/osgi_many_bundles_with_embedded_gems/pom.rb
@@ -5,7 +5,7 @@ id 'org.jruby.test:osgi-complete:1'
 packaging :pom
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.1',
+properties( 'jruby.plugins.version' => '3.0.2',
             'project.build.sourceEncoding' => 'utf-8' )
 
 modules [ 'gems-bundle', 'scripts-bundle', 'test' ]

--- a/maven/jruby-jars/Mavenfile
+++ b/maven/jruby-jars/Mavenfile
@@ -28,7 +28,7 @@ end
 
 properties( 'tesla.dump.pom' => 'pom.xml',
             'tesla.dump.readonly' => true,
-            'jruby.plugins.version' => '3.0.1',
+            'jruby.plugins.version' => '3.0.2',
             # we share the already installed gems
             'gem.home' => '${jruby_home}/lib/ruby/gems/shared',
             # need jruby_home but not jruby.home as name otherwise

--- a/maven/jruby-jars/src/it/integrity/pom.xml
+++ b/maven/jruby-jars/src/it/integrity/pom.xml
@@ -18,7 +18,7 @@
       <plugin>
 	<groupId>org.jruby.maven</groupId>
 	<artifactId>gem-maven-plugin</artifactId>
-	<version>3.0.1</version>
+	<version>3.0.2</version>
 	<executions>
 	  <execution>
 	    <goals><goal>initialize</goal></goals>

--- a/maven/jruby/src/it/j2ee_jetty/pom.rb
+++ b/maven/jruby/src/it/j2ee_jetty/pom.rb
@@ -2,7 +2,7 @@
 packaging 'war'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.1',
+properties( 'jruby.plugins.version' => '3.0.2',
             'project.build.sourceEncoding' => 'utf-8' )
 
 pom( 'org.jruby:jruby', '${jruby.version}' )
@@ -10,7 +10,7 @@ pom( 'org.jruby:jruby', '${jruby.version}' )
 # a gem to be used
 gem 'flickraw', '0.9.7'
 
-extension 'org.jruby.maven:mavengem-wagon:2.0.1'
+extension 'org.jruby.maven:mavengem-wagon:2.0.2'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 jruby_plugin :gem, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0' do

--- a/maven/jruby/src/it/j2ee_jetty_rack/Mavenfile
+++ b/maven/jruby/src/it/j2ee_jetty_rack/Mavenfile
@@ -4,7 +4,7 @@
 packaging 'war'
 
 # get jruby dependencies
-properties( 'jruby.plugins.version' => '3.0.1',
+properties( 'jruby.plugins.version' => '3.0.2',
             'project.build.sourceEncoding' => 'utf-8',
             'public.dir' => '${basedir}/public' )
 
@@ -16,7 +16,7 @@ jar( 'org.jruby.rack:jruby-rack', '1.1.18',
 # a gem to be used
 gem 'flickraw', '0.9.7'
 
-extension 'org.jruby.maven:mavengem-wagon:2.0.1'
+extension 'org.jruby.maven:mavengem-wagon:2.0.2'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 jruby_plugin :gem, :includeRubygemsInResources => true, :includeLibDirectoryInResources => true, :jrubyVersion => '9.0.0.0' do

--- a/maven/jruby/src/it/j2ee_tomcat/pom.rb
+++ b/maven/jruby/src/it/j2ee_tomcat/pom.rb
@@ -2,7 +2,7 @@
 packaging 'war'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.1',
+properties( 'jruby.plugins.version' => '3.0.2',
             'project.build.sourceEncoding' => 'utf-8' )
 
 pom( 'org.jruby:jruby', '${jruby.version}' )
@@ -10,7 +10,7 @@ pom( 'org.jruby:jruby', '${jruby.version}' )
 # a gem to be used
 gem 'flickraw', '0.9.7'
 
-extension 'org.jruby.maven:mavengem-wagon:2.0.1'
+extension 'org.jruby.maven:mavengem-wagon:2.0.2'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 jruby_plugin :gem, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0' do

--- a/maven/jruby/src/it/j2ee_tomcat_rack/Mavenfile
+++ b/maven/jruby/src/it/j2ee_tomcat_rack/Mavenfile
@@ -4,7 +4,7 @@
 packaging 'war'
 
 # get jruby dependencies
-properties( 'jruby.plugins.version' => '3.0.1',
+properties( 'jruby.plugins.version' => '3.0.2',
             'project.build.sourceEncoding' => 'utf-8',
             'public.dir' => '${basedir}/public' )
 
@@ -16,7 +16,7 @@ jar( 'org.jruby.rack:jruby-rack', '1.1.18',
 # a gem to be used
 gem 'flickraw', '0.9.7'
 
-extension 'org.jruby.maven:mavengem-wagon:2.0.1'
+extension 'org.jruby.maven:mavengem-wagon:2.0.2'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 jruby_plugin :gem, :includeRubygemsInResources => true, :includeLibDirectoryInResources => true, :jrubyVersion => '9.0.0.0' do

--- a/maven/jruby/src/it/j2ee_wildfly/pom.rb
+++ b/maven/jruby/src/it/j2ee_wildfly/pom.rb
@@ -2,7 +2,7 @@
 packaging 'war'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.1',
+properties( 'jruby.plugins.version' => '3.0.2',
             'wildfly.version' => '9.0.2.Final',
             'project.build.sourceEncoding' => 'utf-8' )
 
@@ -11,7 +11,7 @@ pom( 'org.jruby:jruby', '${jruby.version}' )
 # a gem to be used
 gem 'virtus', '0.5.5'
 
-extension 'org.jruby.maven:mavengem-wagon:2.0.1'
+extension 'org.jruby.maven:mavengem-wagon:2.0.2'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 jruby_plugin :gem, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0' do

--- a/maven/jruby/src/it/jetty/Mavenfile
+++ b/maven/jruby/src/it/jetty/Mavenfile
@@ -4,7 +4,7 @@
 packaging 'war'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.1',
+properties( 'jruby.plugins.version' => '3.0.2',
             'project.build.sourceEncoding' => 'utf-8',
             'public.dir' => '${basedir}/public' )
 
@@ -16,7 +16,7 @@ jar( 'org.jruby.rack:jruby-rack', '1.1.14',
 # a gem to be used
 gem 'flickraw', '0.9.7'
 
-extension 'org.jruby.maven:mavengem-wagon:2.0.1'
+extension 'org.jruby.maven:mavengem-wagon:2.0.2'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 jruby_plugin :gem, :includeRubygemsInTestResources => false, :includeRubygemsInResources => true, :includeLibDirectoryInResources => true, :jrubyVersion => '9.0.0.0' do

--- a/maven/jruby/src/it/many_jars_with_embedded_gems/app/pom.rb
+++ b/maven/jruby/src/it/many_jars_with_embedded_gems/app/pom.rb
@@ -1,5 +1,5 @@
 # two jars with embedded gems
-jar 'org.jruby.maven:maven-tools', '3.0.1'
+jar 'org.jruby.maven:maven-tools', '3.0.2'
 jar 'org.rubygems:zip', '2.0.2'
 
 # jruby scripting container

--- a/maven/jruby/src/it/many_jars_with_embedded_gems/pom.rb
+++ b/maven/jruby/src/it/many_jars_with_embedded_gems/pom.rb
@@ -1,7 +1,7 @@
 #-*- mode: ruby -*-
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.1' )
+properties( 'jruby.plugins.version' => '3.0.2' )
 
 packaging :pom
 

--- a/maven/jruby/src/it/many_jars_with_embedded_gems/zip_gem/pom.rb
+++ b/maven/jruby/src/it/many_jars_with_embedded_gems/zip_gem/pom.rb
@@ -4,7 +4,7 @@ gemfile
 
 model.repositories.clear
 
-extension 'org.jruby.maven:mavengem-wagon:2.0.1'
+extension 'org.jruby.maven:mavengem-wagon:2.0.2'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 id 'org.rubygems:zip', VERSION

--- a/maven/jruby/src/it/many_jars_with_embedded_gems_ng/gem1/pom.rb
+++ b/maven/jruby/src/it/many_jars_with_embedded_gems_ng/gem1/pom.rb
@@ -4,7 +4,7 @@ gemfile
 
 model.repositories.clear
 
-extension 'org.jruby.maven:mavengem-wagon:2.0.1'
+extension 'org.jruby.maven:mavengem-wagon:2.0.2'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 id 'org.rubygems:gem1', '1'

--- a/maven/jruby/src/it/many_jars_with_embedded_gems_ng/gem2/pom.rb
+++ b/maven/jruby/src/it/many_jars_with_embedded_gems_ng/gem2/pom.rb
@@ -4,7 +4,7 @@ gemfile
 
 model.repositories.clear
 
-extension 'org.jruby.maven:mavengem-wagon:2.0.1'
+extension 'org.jruby.maven:mavengem-wagon:2.0.2'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 id 'org.rubygems:gem2', '2'

--- a/maven/jruby/src/it/many_jars_with_embedded_gems_ng/pom.rb
+++ b/maven/jruby/src/it/many_jars_with_embedded_gems_ng/pom.rb
@@ -1,7 +1,7 @@
 #-*- mode: ruby -*-
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.1' )
+properties( 'jruby.plugins.version' => '3.0.2' )
 
 packaging :pom
 

--- a/maven/jruby/src/it/terminate-container-and-extensions-GH-3300/pom.xml
+++ b/maven/jruby/src/it/terminate-container-and-extensions-GH-3300/pom.xml
@@ -33,7 +33,7 @@
   </repositories>
 
   <properties>
-    <jruby.plugins.version>3.0.1</jruby.plugins.version>
+    <jruby.plugins.version>3.0.2</jruby.plugins.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -42,7 +42,7 @@
       <extension>
         <groupId>org.jruby.maven</groupId>
         <artifactId>mavengem-wagon</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2</version>
       </extension>
     </extensions>
     <plugins>

--- a/maven/jruby/src/it/tomcat/pom.rb
+++ b/maven/jruby/src/it/tomcat/pom.rb
@@ -4,7 +4,7 @@ id 'dummy:tomcat:1.0-SNAPSHOT'
 packaging 'war'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.1',
+properties( 'jruby.plugins.version' => '3.0.2',
             'project.build.sourceEncoding' => 'utf-8' )
 
 pom( 'org.jruby:jruby', '${jruby.version}' )
@@ -12,7 +12,7 @@ pom( 'org.jruby:jruby', '${jruby.version}' )
 # a gem to be used
 gem 'flickraw', '0.9.7'
 
-extension 'org.jruby.maven:mavengem-wagon:2.0.1'
+extension 'org.jruby.maven:mavengem-wagon:2.0.2'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 jruby_plugin :gem, :includeRubygemsInTestResources => false, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0' do

--- a/maven/jruby/src/templates/hellowarld/Mavenfile
+++ b/maven/jruby/src/templates/hellowarld/Mavenfile
@@ -12,7 +12,7 @@ packaging 'pom'
 # TODO add extension to .mvn/extensions.xml
 extension 'org.jruby.maven', 'jruby9-extensions', '${jruby9.plugins.version}'
 
-properties( 'jruby.plugins.version' => '3.0.1',
+properties( 'jruby.plugins.version' => '3.0.2',
             'jruby9.plugins.version' => '0.2.0' )
 
 # integration tests

--- a/maven/jruby/src/templates/j2ee_wlp/pom.rb
+++ b/maven/jruby/src/templates/j2ee_wlp/pom.rb
@@ -2,7 +2,7 @@
 packaging 'war'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.1',
+properties( 'jruby.plugins.version' => '3.0.2',
             'project.build.sourceEncoding' => 'utf-8' )
 
 pom( 'org.jruby:jruby', '${jruby.version}' )
@@ -10,7 +10,7 @@ pom( 'org.jruby:jruby', '${jruby.version}' )
 # a gem to be used
 gem 'virtus', '0.5.5'
 
-extension 'org.jruby.maven:mavengem-wagon:2.0.1'
+extension 'org.jruby.maven:mavengem-wagon:2.0.2'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 jruby_plugin :gem, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0' do

--- a/maven/jruby/src/templates/osgi_all_inclusive/pom.rb
+++ b/maven/jruby/src/templates/osgi_all_inclusive/pom.rb
@@ -3,7 +3,7 @@ gemfile
 packaging 'bundle'
 
 # default versions will be overwritten by pom.rb from root directory
-properties( 'jruby.plugins.version' => '3.0.1',
+properties( 'jruby.plugins.version' => '3.0.2',
             'exam.version' => '3.0.3',
             'url.version' => '1.5.2',
             'logback.version' => '1.0.13',
@@ -14,7 +14,7 @@ pom 'org.jruby:jruby', '${jruby.version}'
 
 model.repositories.clear
 
-extension 'org.jruby.maven:mavengem-wagon:2.0.1'
+extension 'org.jruby.maven:mavengem-wagon:2.0.2'
 repository :id => :mavengems, :url => 'mavengem:https://rubygems.org'
 
 jruby_plugin! :gem, :includeRubygemsInResources => true, :jrubyVersion => '9.0.0.0'

--- a/pom.rb
+++ b/pom.rb
@@ -63,7 +63,7 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
               'github.global.server' => 'github',
               'polyglot.dump.pom' => 'pom.xml',
               'polyglot.dump.readonly' => 'true',
-              'jruby.plugins.version' => '3.0.1',
+              'jruby.plugins.version' => '3.0.2',
 
               # versions for default gems with bin executables
               # used in ./lib/pom.rb and ./maven/jruby-stdlib/pom.rb

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ DO NOT MODIFY - GENERATED CODE
     <joda.time.version>2.12.5</joda.time.version>
     <jruby-launcher.version>1.1.6</jruby-launcher.version>
     <jruby.basedir>${project.basedir}</jruby.basedir>
-    <jruby.plugins.version>3.0.1</jruby.plugins.version>
+    <jruby.plugins.version>3.0.2</jruby.plugins.version>
     <main.basedir>${project.basedir}</main.basedir>
     <polyglot.dump.pom>pom.xml</polyglot.dump.pom>
     <polyglot.dump.readonly>true</polyglot.dump.readonly>

--- a/test/pom.rb
+++ b/test/pom.rb
@@ -8,7 +8,7 @@ project 'JRuby Integration Tests' do
   inherit 'org.jruby:jruby-parent', version
   id 'org.jruby:jruby-tests'
 
-  extension 'org.jruby.maven:mavengem-wagon:2.0.1'
+  extension 'org.jruby.maven:mavengem-wagon:2.0.2'
 
   repository :id => :mavengems, :url => 'mavengem:http://rubygems.org'
   plugin_repository :id => :mavengems, :url => 'mavengem:http://rubygems.org'


### PR DESCRIPTION
This eliminates the fileno warning when running on a JPMS-enabled JVM.

Fixes #7987