### PR TITLE
Fix issues in global variable thread-safety

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/GlobalVariable.java
+++ b/core/src/main/java/org/jruby/internal/runtime/GlobalVariable.java
@@ -97,6 +97,7 @@ public final class GlobalVariable {
 
     public void setAccessor(IAccessor accessor) {
         this.accessor = accessor;
+        this.invalidator.invalidate();
     }
     public boolean isTracing() {
         return tracing;

--- a/core/src/main/java/org/jruby/internal/runtime/GlobalVariables.java
+++ b/core/src/main/java/org/jruby/internal/runtime/GlobalVariables.java
@@ -97,6 +97,8 @@ public class GlobalVariables {
             throw RaiseException.from(runtime, runtime.getRuntimeError(), "can't alias in tracer");
         }
 
+        if (variable != null) variable.invalidate();
+
         globalVariables.put(name, oldVariable);
     }
 

--- a/core/src/main/java/org/jruby/internal/runtime/GlobalVariables.java
+++ b/core/src/main/java/org/jruby/internal/runtime/GlobalVariables.java
@@ -117,9 +117,6 @@ public class GlobalVariables {
         assert name != null;
         assert name.startsWith("$");
 
-        GlobalVariable variable = globalVariables.get(name);
-        if (variable != null) return variable;
-
         return createIfNotDefined(name);
     }
 
@@ -139,11 +136,7 @@ public class GlobalVariables {
     }
 
     public void setTraceVar(String name, RubyProc proc) {
-        assert name != null;
-        assert name.startsWith("$");
-
-        GlobalVariable variable = createIfNotDefined(name);
-        variable.addTrace(proc);
+        getVariable(name).addTrace(proc);
     }
 
     public boolean untraceVar(String name, IRubyObject command) {
@@ -172,12 +165,7 @@ public class GlobalVariables {
     }
 
     private GlobalVariable createIfNotDefined(String name) {
-        GlobalVariable variable = globalVariables.get(name);
-        if (variable == null) {
-            variable = GlobalVariable.newUndefined(runtime, name);
-            globalVariables.put(name, variable);
-        }
-        return variable;
+        return globalVariables.computeIfAbsent(name, (n) -> GlobalVariable.newUndefined(runtime, n));
     }
 
     private IRubyObject defaultSeparator;

--- a/core/src/main/java/org/jruby/internal/runtime/GlobalVariables.java
+++ b/core/src/main/java/org/jruby/internal/runtime/GlobalVariables.java
@@ -101,23 +101,23 @@ public class GlobalVariables {
     }
 
     public IRubyObject get(String name) {
-	    assert name != null;
-	    assert name.startsWith("$");
+        assert name != null;
+        assert name.startsWith("$");
 
-	    GlobalVariable variable = globalVariables.get(name);
-	    if (variable != null) return variable.getAccessor().getValue();
+        GlobalVariable variable = globalVariables.get(name);
+        if (variable != null) return variable.getAccessor().getValue();
 
-	    if (runtime.isVerbose()) {
-	        runtime.getWarnings().warning(ID.GLOBAL_NOT_INITIALIZED, "global variable `" + name + "' not initialized");
-	    }
-		return runtime.getNil();
-	}
+        if (runtime.isVerbose()) {
+            runtime.getWarnings().warning(ID.GLOBAL_NOT_INITIALIZED, "global variable `" + name + "' not initialized");
+        }
+        return runtime.getNil();
+    }
 
     public GlobalVariable getVariable(String name) {
-	    assert name != null;
-	    assert name.startsWith("$");
+        assert name != null;
+        assert name.startsWith("$");
 
-	    GlobalVariable variable = globalVariables.get(name);
+        GlobalVariable variable = globalVariables.get(name);
         if (variable != null) return variable;
 
         return createIfNotDefined(name);

--- a/core/src/main/java/org/jruby/internal/runtime/GlobalVariables.java
+++ b/core/src/main/java/org/jruby/internal/runtime/GlobalVariables.java
@@ -123,10 +123,7 @@ public class GlobalVariables {
     }
 
     public IRubyObject set(String name, IRubyObject value) {
-        assert name != null;
-        assert name.startsWith("$");
-
-        GlobalVariable variable = createIfNotDefined(name);
+        GlobalVariable variable = getVariable(name);
         IRubyObject result = variable.getAccessor().setValue(value);
         variable.trace(value);
         variable.invalidate();

--- a/core/src/main/java/org/jruby/runtime/invokedynamic/GlobalSite.java
+++ b/core/src/main/java/org/jruby/runtime/invokedynamic/GlobalSite.java
@@ -105,7 +105,7 @@ public class GlobalSite extends MutableCallSite {
             return (IRubyObject)uncached.invokeWithArguments(context);
         }
 
-        Invalidator invalidator = variable.getInvalidator();
+        SwitchPoint invalidator = (SwitchPoint) variable.getInvalidator().getData();
         IRubyObject value = variable.getAccessor().getValue();
 
         MethodHandle target = constant(IRubyObject.class, value);
@@ -113,7 +113,7 @@ public class GlobalSite extends MutableCallSite {
         MethodHandle fallback = lookup().findVirtual(GlobalSite.class, "getGlobalFallback", methodType(IRubyObject.class, ThreadContext.class));
         fallback = fallback.bindTo(this);
 
-        target = ((SwitchPoint)invalidator.getData()).guardWithTest(target, fallback);
+        target = invalidator.guardWithTest(target, fallback);
 
         setTarget(target);
 

--- a/core/src/main/java/org/jruby/runtime/invokedynamic/GlobalSite.java
+++ b/core/src/main/java/org/jruby/runtime/invokedynamic/GlobalSite.java
@@ -105,7 +105,8 @@ public class GlobalSite extends MutableCallSite {
             return (IRubyObject)uncached.invokeWithArguments(context);
         }
 
-        SwitchPoint invalidator = (SwitchPoint) variable.getInvalidator().getData();
+        // get switchpoint before value
+        SwitchPoint switchPoint = (SwitchPoint) variable.getInvalidator().getData();
         IRubyObject value = variable.getAccessor().getValue();
 
         MethodHandle target = constant(IRubyObject.class, value);
@@ -113,11 +114,11 @@ public class GlobalSite extends MutableCallSite {
         MethodHandle fallback = lookup().findVirtual(GlobalSite.class, "getGlobalFallback", methodType(IRubyObject.class, ThreadContext.class));
         fallback = fallback.bindTo(this);
 
-        target = invalidator.guardWithTest(target, fallback);
+        target = switchPoint.guardWithTest(target, fallback);
 
         setTarget(target);
 
-//        if (Options.INVOKEDYNAMIC_LOG_GLOBALS.load()) LOG.info("global " + name() + " (" + file() + ":" + line() + ") cached");
+        if (Options.INVOKEDYNAMIC_LOG_GLOBALS.load()) LOG.info("global " + name() + " (" + file() + ":" + line() + ") cached");
 
         return value;
     }

--- a/core/src/main/java/org/jruby/runtime/invokedynamic/MathLinker.java
+++ b/core/src/main/java/org/jruby/runtime/invokedynamic/MathLinker.java
@@ -132,6 +132,9 @@ public class MathLinker {
         MethodType fallbackType = site.type().appendParameterTypes(IRubyObject.class);
         CallSite normalSite = NormalInvokeSite.newSite(LOOKUP, site.name, fallbackType, false, 0, site.file(), site.line());
 
+        RubyClass classFixnum = runtime.getFixnum();
+        SwitchPoint switchPoint = (SwitchPoint) classFixnum.getInvalidator().getData();
+
         MethodHandle fallback = Binder.from(site.type())
                 .append(IRubyObject.class, runtime.newFixnum(value))
                 .invoke(normalSite.dynamicInvoker());
@@ -159,11 +162,9 @@ public class MathLinker {
 
             if (target == null) target = findTargetImpl(name, IRubyObject.class, value);
 
-            RubyClass classFixnum = runtime.getFixnum();
-
             // confirm it's still a Fixnum
             target = guardWithTest(FIXNUM_TEST_ARG_2_TO_0, target, fallback);
-            target = ((SwitchPoint) classFixnum.getInvalidator().getData()).guardWithTest(target, fallback);
+            target = switchPoint.guardWithTest(target, fallback);
             site.setTarget(target);
 
             if (LOG_BINDING) LOG.debug(name + "\tFixnum operation at site #" + site.siteID + " (" + site.file() + ":" + site.line() + ") bound directly");
@@ -278,6 +279,9 @@ public class MathLinker {
                 .append(IRubyObject.class, runtime.newFloat(value))
                 .invoke(normalSite.dynamicInvoker());
 
+        RubyClass classFloat = runtime.getFloat();
+        SwitchPoint switchPoint = (SwitchPoint) classFloat.getInvalidator().getData();
+
         CacheEntry entry = searchWithCache(operator, caller, self.getMetaClass(), site);
 
         if (!(self instanceof RubyFloat) || entry == null || !entry.method.isBuiltin()) {
@@ -290,11 +294,9 @@ public class MathLinker {
 
             target = findTargetImpl(name, IRubyObject.class, value);
 
-            RubyClass classFloat = runtime.getFloat();
-
             // confirm it's still a Float
             target = guardWithTest(FLOAT_TEST_ARG_2_TO_0, target, fallback);
-            target = ((SwitchPoint) classFloat.getInvalidator().getData()).guardWithTest(target, fallback);
+            target = switchPoint.guardWithTest(target, fallback);
             site.setTarget(target);
 
             if (LOG_BINDING) LOG.debug(name + "\tFloat operation at site #" + site.siteID + " (" + site.file() + ":" + site.line() + ") bound directly");

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -82,7 +82,7 @@ public class Options {
     public static final Option<Boolean> INVOKEDYNAMIC_LOG_GLOBALS = bool(INVOKEDYNAMIC, "invokedynamic.log.globals", false, "Log invokedynamic-based global lookups.");
     // ClassValue in OpenJDK appears to root data even after it goes away, so this is disabled again. See jruby/jruby#3228
     public static final Option<Boolean> INVOKEDYNAMIC_CLASS_VALUES = bool(INVOKEDYNAMIC, "invokedynamic.class.values", false, "Use ClassValue to store class-specific data.");
-    public static final Option<Integer> INVOKEDYNAMIC_GLOBAL_MAXFAIL = integer(INVOKEDYNAMIC, "invokedynamic.global.maxfail", 0, "Maximum global cache failures after which to use slow path.");
+    public static final Option<Integer> INVOKEDYNAMIC_GLOBAL_MAXFAIL = integer(INVOKEDYNAMIC, "invokedynamic.global.maxfail", 100, "Maximum global cache failures after which to use slow path.");
     public static final Option<Boolean> INVOKEDYNAMIC_HANDLES = bool(INVOKEDYNAMIC, "invokedynamic.handles", false, "Use MethodHandles rather than generated code to bind Ruby methods.");
     public static final Option<Boolean> INVOKEDYNAMIC_YIELD = bool(INVOKEDYNAMIC, "invokedynamic.yield", true, "Bind yields directly using invokedynamic.");
 


### PR DESCRIPTION
A few places where we access and cache global variables were found to have races while investigating some `Process.kill` specs hanging only in JIT mode. I found the following issues:

* GlobalVariables.getVariable can race with a parallel global variable set, ending up with two different GlobalVariable accessor objects getting created. Caching the wrong one will result in a stale value cached permanently.
* The indy logic for caching global variable values had a race in acquiring the value and the SwitchPoint that guards it. Because they were acquired in the wrong order (value first) there's a chance that an old value might be guarded by a newer SwitchPoint and never get invalidated.

With these fixes made the `Process#kill` specs in question always run to completion, and I have re-enabled indy-based global variable caching (up to 100 invalidations, and then it falls back on a slow path).

Based on these changes I also audited other uses of `SwitchPoint.guardWithTest` and found a few more cases where the SwitchPoint was acquired after the value. All the cases I found are fixed in this PR.