### PR TITLE
Fix intermittent fails in CI

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -4209,6 +4209,16 @@ public final class Ruby implements Constantizable {
         return RubySystemExit.newInstance(this, status, message).toThrowable();
     }
 
+    /**
+     * Prepare a throwable IOError with the given message.
+     *
+     * This constructor should not be used to create a RubyException object to be raised on a different thread.
+     *
+     * @see RaiseException#from(Ruby, RubyClass, String)
+     *
+     * @param message the message for the new IOError
+     * @return a fully-prepared IOError throwable
+     */
     public RaiseException newIOError(String message) {
         return newRaiseException(getIOError(), message);
     }
@@ -4312,10 +4322,13 @@ public final class Ruby implements Constantizable {
      *
      * There are additional forms of this construction logic in {@link RaiseException#from}.
      *
+     * This constructor should not be used to create a RubyException object to be raised on a different thread.
+     *
+     * @see RaiseException#from(Ruby, RubyClass, String)
+     *
      * @param exceptionClass the exception class from which to construct the exception object
      * @param message a simple message for the exception
      * @return a new RaiseException wrapping a new Ruby exception
-     * @see RaiseException#from(Ruby, RubyClass, String)
      */
     public RaiseException newRaiseException(RubyClass exceptionClass, String message) {
         IRubyObject cause = getCurrentContext().getErrorInfo();

--- a/core/src/main/java/org/jruby/RubyIOError.java
+++ b/core/src/main/java/org/jruby/RubyIOError.java
@@ -50,4 +50,8 @@ public class RubyIOError extends RubyStandardError {
     protected RaiseException constructThrowable(String message) {
         return new IOError(message, this);
     }
+
+    public static RubyIOError newIOError(Ruby runtime, String message) {
+        return ((RubyIOError) runtime.getIOError().newInstance(runtime.getCurrentContext(), RubyString.newString(runtime, message)));
+    }
 }

--- a/core/src/main/java/org/jruby/exceptions/RaiseException.java
+++ b/core/src/main/java/org/jruby/exceptions/RaiseException.java
@@ -75,6 +75,16 @@ public class RaiseException extends JumpException {
     /**
      * Construct a new throwable RaiseException appropriate for the target Ruby exception class.
      *
+     * Note that this will produce a RaiseException that has fully prepared for being thrown, including:
+     *
+     * <ul>
+     *     <li>Populating the stack trace based on the current thread</li>
+     *     <li>Setting the cause to any currently in-flight exception</li>
+     *     <li>Setting the thread-local $! "error info" to this exception</li>
+     * </ul>
+     *
+     * This constructor should not be used to create a RubyException object to be raised on a different thread.
+     *
      * @param runtime the current JRuby runtime
      * @param exceptionClass the class of the exception to construct and raise
      * @param msg a simple message for the exception

--- a/core/src/main/java/org/jruby/util/SunSignalFacade.java
+++ b/core/src/main/java/org/jruby/util/SunSignalFacade.java
@@ -89,6 +89,9 @@ public class SunSignalFacade implements SignalFacade {
         }
 
         public void handle(Signal signal) {
+            // reinstall handler for platforms that clear it (HP-UX)
+            Signal.handle(new Signal(this.signal), this);
+
             ThreadContext context = runtime.getCurrentContext();
             IRubyObject oldExc = runtime.getGlobalVariables().get("$!"); // Save $!
             try {
@@ -106,8 +109,6 @@ public class SunSignalFacade implements SignalFacade {
                 runtime.getGlobalVariables().set("$!", oldExc); // Restore $!
             } catch (MainExitException mee) {
                 runtime.getThreadService().getMainThread().kill();
-            } finally {
-                Signal.handle(new Signal(this.signal), this);
             }
         }
     }

--- a/core/src/main/java/org/jruby/util/io/OpenFile.java
+++ b/core/src/main/java/org/jruby/util/io/OpenFile.java
@@ -1354,7 +1354,7 @@ public class OpenFile implements Finalizable {
 
             // We should not get here without previously checking, so this must have been closed by another thread
             if (fd == null) {
-                throw newInterruptedException(context.runtime).toThrowable();
+                throw streamClosedInParallelError(context.runtime).toThrowable();
             }
 
             assert fptr.lockedByMe();
@@ -1563,7 +1563,7 @@ public class OpenFile implements Finalizable {
     private static void selectForRead(ThreadContext context, OpenFile fptr, ChannelFD fd) {
         // We should not get here without previously checking, so this must have been closed by another thread
         if (fd == null) {
-            throw newInterruptedException(context.runtime).toThrowable();
+            throw streamClosedInParallelError(context.runtime).toThrowable();
         }
 
         fptr.unlock();
@@ -2905,13 +2905,13 @@ public class OpenFile implements Finalizable {
                 if (thread == context.getThread()) continue;
 
                 // raise will also wake the thread from selection
-                RubyException exception = newInterruptedException(runtime);
+                RubyException exception = streamClosedInParallelError(runtime);
                 thread.raise(exception);
             }
         }
     }
 
-    static RubyIOError newInterruptedException(Ruby runtime) {
+    static RubyIOError streamClosedInParallelError(Ruby runtime) {
         return RubyIOError.newIOError(runtime, "stream closed in another thread");
     }
 

--- a/core/src/main/java/org/jruby/util/io/OpenFile.java
+++ b/core/src/main/java/org/jruby/util/io/OpenFile.java
@@ -33,6 +33,7 @@ import org.jruby.RubyEncoding;
 import org.jruby.RubyException;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyIO;
+import org.jruby.RubyIOError;
 import org.jruby.RubyNumeric;
 import org.jruby.FiberScheduler;
 import org.jruby.RubyString;
@@ -1353,7 +1354,7 @@ public class OpenFile implements Finalizable {
 
             // We should not get here without previously checking, so this must have been closed by another thread
             if (fd == null) {
-                throw newInterruptedException(context.runtime);
+                throw newInterruptedException(context.runtime).toThrowable();
             }
 
             assert fptr.lockedByMe();
@@ -2904,14 +2905,14 @@ public class OpenFile implements Finalizable {
                 if (thread == context.getThread()) continue;
 
                 // raise will also wake the thread from selection
-                RubyException exception = newInterruptedException(runtime).getException();
+                RubyException exception = newInterruptedException(runtime);
                 thread.raise(exception);
             }
         }
     }
 
-    static RaiseException newInterruptedException(Ruby runtime) {
-        return runtime.newIOError("stream closed in another thread");
+    static RubyIOError newInterruptedException(Ruby runtime) {
+        return RubyIOError.newIOError(runtime, "stream closed in another thread");
     }
 
     /**

--- a/core/src/main/java/org/jruby/util/io/OpenFile.java
+++ b/core/src/main/java/org/jruby/util/io/OpenFile.java
@@ -1571,7 +1571,11 @@ public class OpenFile implements Finalizable {
             if (fd.chSelect != null
                     && fd.chNative == null // MRI does not select for rb_read_internal on native descriptors
                     && !fptr.nonblock) {
-                context.getThread().select(fd.chSelect, fptr, SelectionKey.OP_READ);
+
+                // keep selecting for read until ready, polling each time we wake up
+                while (!context.getThread().select(fd.chSelect, fptr, SelectionKey.OP_READ)) {
+                    context.pollThreadEvents();
+                }
             }
         } finally {
             fptr.lock();

--- a/core/src/main/java/org/jruby/util/io/OpenFile.java
+++ b/core/src/main/java/org/jruby/util/io/OpenFile.java
@@ -1561,9 +1561,9 @@ public class OpenFile implements Finalizable {
     }
 
     private static void selectForRead(ThreadContext context, OpenFile fptr, ChannelFD fd) {
+        // We should not get here without previously checking, so this must have been closed by another thread
         if (fd == null) {
-            // stream was closed on its way in, raise appropriate error
-            throw context.runtime.newErrnoEBADFError();
+            throw newInterruptedException(context.runtime).toThrowable();
         }
 
         fptr.unlock();

--- a/rakelib/rubyspec.rake
+++ b/rakelib/rubyspec.rake
@@ -14,7 +14,8 @@ namespace :spec do
   task :'ruby:aot' => :ci_precompiled
 
   if ENV['CI']
-    MSPEC_FORMAT = "f"
+    # can't easily see file output on CI so we use specdoc
+    MSPEC_FORMAT = "s"
   else
     MSPEC_FORMAT = "d"
   end

--- a/test/jruby/test_io.rb
+++ b/test/jruby/test_io.rb
@@ -518,16 +518,30 @@ class TestIO < Test::Unit::TestCase
   # JRUBY-6137
   def test_rubyio_fileno_mapping_leak
     fileno_util = JRuby.runtime.fileno_util
-    starting_count = fileno_util.number_of_wrappers
 
-    # use a non-channel stream to ensure we use our mapping
-    io = org.jruby.RubyIO.new(JRuby.runtime, java.io.ByteArrayOutputStream.new)
+    # other test threads may still be cleaning up filenos, so we give a few rounds for this to settle
+    count = 0
+    while count < 10
+      starting_count = fileno_util.number_of_wrappers
 
-    open_io_count = fileno_util.number_of_wrappers
+      # use a non-channel stream to ensure we use our mapping
+      io = org.jruby.RubyIO.new(JRuby.runtime, java.io.ByteArrayOutputStream.new)
+
+      open_io_count = fileno_util.number_of_wrappers
+
+      io.close
+      closed_io_count = fileno_util.number_of_wrappers
+
+      if starting_count == closed_io_count
+        break
+      end
+
+      # either leaking or other threads are opening and closing; pause and try again
+      Thread.pass
+    end
+
+    # proceed to assertions
     assert_equal(starting_count + 1, open_io_count)
-
-    io.close
-    closed_io_count = fileno_util.number_of_wrappers
     assert_equal(starting_count, closed_io_count)
   end if RUBY_ENGINE == 'jruby'
 

--- a/test/jruby/test_io.rb
+++ b/test/jruby/test_io.rb
@@ -3,6 +3,7 @@ require 'test/unit'
 require 'test/jruby/test_helper'
 require 'rbconfig'
 require 'stringio'
+require 'tempfile'
 
 class TestIO < Test::Unit::TestCase
   include TestHelper

--- a/test/jruby/test_tempfile_cleanup.rb
+++ b/test/jruby/test_tempfile_cleanup.rb
@@ -19,7 +19,7 @@ class TestTempfileCleanup < Test::Unit::TestCase
     10.times { Tempfile.open('blah', @tmpdir) }
 
     # check that files were created
-    assert Dir["#{@tmpdir}/*"].size > 0
+    assert Dir["#{@tmpdir}/*blah*"].size > 0
 
     # spin for up to 10 seconds, attempting to get finalization to trigger
     t = Time.now
@@ -29,11 +29,11 @@ class TestTempfileCleanup < Test::Unit::TestCase
       else
         GC.start
       end
-      break if Time.now - t > 20 || Dir["#{@tmpdir}/*"].size == 0
+      break if Time.now - t > 20 || Dir["#{@tmpdir}/*blah*"].size == 0
       sleep(0.1)
     end
 
-    tmp_files = Dir["#{@tmpdir}/*"]
+    tmp_files = Dir["#{@tmpdir}/*blah*"]
     # test that the files are gone
     assert_equal 0, tmp_files.size, "Files were not cleaned up: (#{tmp_files.size}) #{tmp_files}"
   end

--- a/test/jruby/test_tempfile_cleanup.rb
+++ b/test/jruby/test_tempfile_cleanup.rb
@@ -16,6 +16,7 @@ class TestTempfileCleanup < Test::Unit::TestCase
   end
 
   def test_cleanup
+    skip if RbConfig::CONFIG['host_os'] =~ /win32|win64|mswin|windows/
     10.times { Tempfile.open('blah', @tmpdir) }
 
     # check that files were created

--- a/test/tool/lib/webrick/server.rb
+++ b/test/tool/lib/webrick/server.rb
@@ -350,7 +350,7 @@ module WEBrick
         if !pipe.closed?
           begin
             yield pipe
-          rescue IOError # closed by another thread.
+          rescue IOError, Errno::EBADF, Errno::EPIPE # closed by another thread.
           end
         end
       end


### PR DESCRIPTION
This will contain small fixes to get our CI more reliable, by fixing the causes of intermittent failures.

* `IO#read raises IOError when stream is closed by another thread` intermittent due to different ways of handling a nulled-out "fd". All cases where "fd" is null when it was previously confirmed to be non-null should indicate parallel close occurred. (Better state management here would be helpful, to ensure we **know** it only could have been closed in parallel.