### PR TITLE
Fixes #8010. Kernel#send + empty kwargs hash error

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -1690,9 +1690,14 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
             if ((callInfo & CALL_SPLATS) != 0) {
                 IRubyObject last = args[argc - 1];
                 if (last instanceof RubyHash && ((RubyHash) last).isRuby2KeywordHash()) {
-                    args[argc - 1] = ((RubyHash) last).dupFast(context);
-                    ((RubyHash) args[argc - 1]).setRuby2KeywordHash(false);
-                    context.callInfo |= (CALL_KEYWORD | CALL_KEYWORD_REST);
+                    if (((RubyHash) last).isEmpty()) { // empty kwargs hashes should never get passed on.
+                        argc--;
+                        args = ArraySupport.newCopy(args, argc);
+                    } else {
+                        args[argc - 1] = ((RubyHash) last).dupFast(context);
+                        ((RubyHash) args[argc - 1]).setRuby2KeywordHash(false);
+                        context.callInfo |= (CALL_KEYWORD | CALL_KEYWORD_REST);
+                    }
                 }
             } else if (argc > 1) {
               args[argc - 1] = dupIfKeywordRestAtCallsite(context, args[argc - 1]);


### PR DESCRIPTION
The fix added is very simple.  If we have an empty hash marked as a ruby2 keyword we just remove it.  This is basically how all ruby to ruby interactions work.