### PR TITLE
Fixes language specs involving blocks/yield

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -2223,7 +2223,7 @@ public class IRBuilder {
     private boolean isTopScope() {
         IRScope topScope = scope.getNearestNonClosurelikeScope();
 
-        boolean isTopScope = topScope instanceof IRScriptBody ||
+        boolean isTopScope = topScope instanceof IRScriptBody && evalType == null ||
                 (evalType != null && evalType != EvalType.MODULE_EVAL && evalType != EvalType.BINDING_EVAL);
 
         // we think it could be a top scope but it could still be called from within a module/class which
@@ -4936,7 +4936,8 @@ public class IRBuilder {
     }
 
     public Operand buildYield(YieldNode node, Variable result) {
-        if (scope instanceof IRScriptBody || scope instanceof IRModuleBody) throwSyntaxError(node, "Invalid yield");
+        IRScope hardScope = scope.getNearestNonClosurelikeScope();
+        if (hardScope instanceof IRScriptBody || hardScope instanceof IRModuleBody) throwSyntaxError(node, "Invalid yield");
 
         boolean unwrap = true;
         Node argNode = node.getArgsNode();

--- a/core/src/main/java/org/jruby/ir/IRScope.java
+++ b/core/src/main/java/org/jruby/ir/IRScope.java
@@ -280,7 +280,7 @@ public abstract class IRScope implements ParseResult {
     public IRScope getNearestNonClosurelikeScope() {
         IRScope current = this;
 
-        while (current != null && !(current instanceof IRClosure)) {
+        while (current != null && current instanceof IRClosure) {
             current = current.getLexicalParent();
         }
 

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -2155,10 +2155,7 @@ public class IRRuntimeHelpers {
 
         // FIXME: For NORMAL/THREAD but it is unclear if we really need any keyword logic in here anymore.
         org.jruby.runtime.Signature sig = block.getBody().getSignature();
-        int arityValue = sig.arityValue();
-        if (!sig.hasKwargs() && arityValue >= -1 && arityValue <= 1) {
-            return args;
-        }
+        if (!sig.isSpreadable()) return args;
 
         // We get here only when we need both required and optional/rest args
         // (keyword or non-keyword in either case).

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -8,9 +8,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Array;
 
-import java.net.BindException;
 import java.net.PortUnreachableException;
-import java.net.SocketException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.NonReadableChannelException;
 import java.nio.channels.NonWritableChannelException;
@@ -18,7 +16,6 @@ import java.nio.channels.NotYetConnectedException;
 import java.nio.charset.Charset;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.AtomicMoveNotSupportedException;
-import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystemLoopException;
 import java.nio.file.NoSuchFileException;
@@ -50,6 +47,7 @@ import org.jruby.ast.RequiredKeywordArgumentValueNode;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.common.IRubyWarnings.ID;
 import org.jruby.exceptions.ArgumentError;
+import org.jruby.exceptions.NoMethodError;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.Unrescuable;
 import org.jruby.internal.runtime.methods.*;
@@ -1914,21 +1912,27 @@ public class Helpers {
     public static IRubyObject aryToAry(ThreadContext context, IRubyObject value) {
         if (value instanceof RubyArray) return value;
 
-        if (value.respondsTo("to_ary")) {
-            return TypeConverter.convertToType(context, value, context.runtime.getArray(), "to_ary", false);
-        }
+        return respondsTo_to_ary(value) ?
+                TypeConverter.convertToType(context, value, context.runtime.getArray(), "to_ary", false) :
+                context.runtime.newArray(value);
+    }
 
-        return context.runtime.newArray(value);
+    private static boolean respondsTo_to_ary(IRubyObject value) {
+        try {
+            return value.respondsTo("to_ary");
+        } catch (NoMethodError e) {
+            // A non-existent respond_to? should still end up calling method_missing but if m_m does not
+            // handle it then we should not raise.
+            return false;
+        }
     }
 
     public static IRubyObject aryOrToAry(ThreadContext context, IRubyObject value) {
         if (value instanceof RubyArray) return value;
 
-        if (value.respondsTo("to_ary")) {
-            return TypeConverter.convertToType(context, value, context.runtime.getArray(), "to_ary", false);
-        }
-
-        return context.nil;
+        return respondsTo_to_ary(value) ?
+                TypeConverter.convertToType(context, value, context.runtime.getArray(), "to_ary", false) :
+                context.nil;
     }
 
     @Deprecated // not used

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -1913,7 +1913,7 @@ public class Helpers {
         if (value instanceof RubyArray) return value;
 
         return respondsTo_to_ary(value) ?
-                TypeConverter.convertToType(context, value, context.runtime.getArray(), "to_ary", false) :
+                TypeConverter.convertToTypeUnchecked(context, value, context.runtime.getArray(), "to_ary", false) :
                 context.runtime.newArray(value);
     }
 
@@ -1931,7 +1931,7 @@ public class Helpers {
         if (value instanceof RubyArray) return value;
 
         return respondsTo_to_ary(value) ?
-                TypeConverter.convertToType(context, value, context.runtime.getArray(), "to_ary", false) :
+                TypeConverter.convertToTypeUnchecked(context, value, context.runtime.getArray(), "to_ary", false) :
                 context.nil;
     }
 

--- a/core/src/main/java/org/jruby/runtime/Signature.java
+++ b/core/src/main/java/org/jruby/runtime/Signature.java
@@ -153,7 +153,7 @@ public class Signature {
      * @return true if the signature expects multiple args
      */
     public boolean isSpreadable() {
-        return arityValue < -1 || arityValue > 1;
+        return arityValue < -1 || arityValue > 1 || (opt > 0 && !restKwargs());
     }
 
 

--- a/core/src/main/java/org/jruby/util/TypeConverter.java
+++ b/core/src/main/java/org/jruby/util/TypeConverter.java
@@ -76,6 +76,14 @@ public class TypeConverter {
         return r == null ? handleUncoercibleObject(context.runtime, obj, target, raise) : r;
     }
 
+    // This is essentially convertToType but it is used when we already know the method we are going to call will exist
+    // (as much as we can due to possible race conditions all convert methods have).  This is used in places where we
+    // need to explicitly check for the method (e.g. to_ary) before we actually try and convert the value.
+    public static IRubyObject convertToTypeUnchecked(ThreadContext context, IRubyObject obj, RubyClass target, String convertMethod, boolean raise) {
+        IRubyObject r = obj.callMethod(context, convertMethod);
+        return r == null ? handleUncoercibleObject(context.runtime, obj, target, raise) : r;
+    }
+
     /**
      * Converts this object to type 'targetType' using 'convertMethod' method (MRI: convert_type 1.9).
      *

--- a/spec/java_integration/methods/java_alias_spec.rb
+++ b/spec/java_integration/methods/java_alias_spec.rb
@@ -57,7 +57,6 @@ describe "A Java object's java_alias method" do
           @@last_instance = self
         end
 
-        @@last_instance = nil
         def self.last_instance; @@last_instance end
       end
     end

--- a/spec/tags/ruby/language/block_tags.txt
+++ b/spec/tags/ruby/language/block_tags.txt
@@ -1,2 +1,0 @@
-fails:A block yielded a single Array assigns elements to optional arguments
-

--- a/spec/tags/ruby/language/block_tags.txt
+++ b/spec/tags/ruby/language/block_tags.txt
@@ -1,3 +1,3 @@
 fails:A block yielded a single Array assigns elements to optional arguments
 fails:A block yielded a single Object calls #respond_to? to check if object has method #to_ary
-fails:A block yielded a single Object receives the object if it does not respond to #respond_to?
+

--- a/spec/tags/ruby/language/block_tags.txt
+++ b/spec/tags/ruby/language/block_tags.txt
@@ -1,3 +1,2 @@
 fails:A block yielded a single Array assigns elements to optional arguments
-fails:A block yielded a single Object calls #respond_to? to check if object has method #to_ary
 

--- a/spec/tags/ruby/language/yield_tags.txt
+++ b/spec/tags/ruby/language/yield_tags.txt
@@ -1,2 +1,2 @@
 fails:The yield call taking a single argument yielding to a lambda should not destructure an Array into multiple arguments
-fails:Using yield in non-lambda block raises a SyntaxError
+


### PR DESCRIPTION
The issue is if we try to call to_ary during block dispatch and respond_to? does not exist on the object it should return the original object.  We were failing because we rightly called method_missing but because m_m did not handle to_ary we just raised NoMethodError and not the original object.

This also fixes improper spreading of a single value array into a proc which only has optargs.

Some very minor error handling for uncommon syntax.