### PR TITLE
Reduce overhead of kwargs for no-arg methods and blocks

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -3129,6 +3129,13 @@ public class IRBuilder {
      */
     public void receiveArgs(final ArgsNode argsNode) {
         Signature signature = scope.getStaticScope().getSignature();
+
+        if (signature.equals(Signature.NO_ARGUMENTS)) {
+            addInstr(new CheckArityInstr(0, 0, false, -1, UndefinedValue.UNDEFINED));
+            receiveBlockArg(argsNode);
+            return;
+        }
+
         Variable keywords = addResultInstr(new ReceiveKeywordsInstr(temp(), signature.hasRest(), argsNode.hasKwargs()));
 
         KeywordRestArgNode keyRest = argsNode.getKeyRest();

--- a/core/src/main/java/org/jruby/ir/instructions/CheckArityInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CheckArityInstr.java
@@ -69,7 +69,7 @@ public class CheckArityInstr extends OneOperandInstr implements FixedArityInstr 
     }
 
     public static CheckArityInstr decode(IRReaderDecoder d) {
-        return new CheckArityInstr(d.decodeInt(), d.decodeInt(), d.decodeBoolean(), d.decodeInt(), d.decodeVariable());
+        return new CheckArityInstr(d.decodeInt(), d.decodeInt(), d.decodeBoolean(), d.decodeInt(), d.decodeOperand());
     }
 
     public void checkArity(ThreadContext context, IRubyObject self, StaticScope scope, DynamicScope dynamicScope, IRubyObject[] args, Block block, Object[] temp) {

--- a/core/src/main/java/org/jruby/ir/instructions/CheckArityInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CheckArityInstr.java
@@ -2,6 +2,7 @@ package org.jruby.ir.instructions;
 
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
+import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.persistence.IRReaderDecoder;
 import org.jruby.ir.persistence.IRWriterEncoder;
@@ -21,7 +22,7 @@ public class CheckArityInstr extends OneOperandInstr implements FixedArityInstr 
     public final boolean rest;
     public final int restKey;
 
-    public CheckArityInstr(int required, int opt, boolean rest, int restKey, Variable keywords) {
+    public CheckArityInstr(int required, int opt, boolean rest, int restKey, Operand keywords) {
         super(Operation.CHECK_ARITY, keywords);
 
         this.required = required;
@@ -30,8 +31,8 @@ public class CheckArityInstr extends OneOperandInstr implements FixedArityInstr 
         this.restKey = restKey;
     }
 
-    public Variable getKeywords() {
-        return (Variable) getOperand1();
+    public Operand getKeywords() {
+        return getOperand1();
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/CheckArityInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CheckArityInstr.java
@@ -42,7 +42,7 @@ public class CheckArityInstr extends OneOperandInstr implements FixedArityInstr 
 
     @Override
     public Instr clone(CloneInfo info) {
-        if (info instanceof SimpleCloneInfo) return new CheckArityInstr(required, opt, rest, restKey, (Variable) getOperand1());
+        if (info instanceof SimpleCloneInfo) return new CheckArityInstr(required, opt, rest, restKey, getOperand1());
 
         InlineCloneInfo ii = (InlineCloneInfo) info;
         if (ii.canMapArgsStatically()) { // we can error on bad arity or remove check_arity


### PR DESCRIPTION
There is some improvement with JIT and indy but my larger goal is to speed up startup time and removing recv_keywords and short-circuiting to a simple check_arity instr has a big effect on tiny no-arg methods/blocks.

BEFORE:
```text
jruby --dev ../snippets/bench1.rb
Warming up --------------------------------------
                foo2   425.349k i/100ms
                 foo   439.825k i/100ms
Calculating -------------------------------------
                foo2      4.697M (± 1.1%) i/s -     94.002M in  20.015869s
                 foo      4.887M (± 0.9%) i/s -     98.081M in  20.071418s

Comparison:
                 foo:  4887008.2 i/s
                foo2:  4697008.2 i/s - 1.04x  slower
```

AFTER:
```text
jruby --dev ../snippets/bench1.rb
Warming up --------------------------------------
                foo2   427.370k i/100ms
                 foo   599.189k i/100ms
Calculating -------------------------------------
                foo2      4.771M (± 0.9%) i/s -     95.731M in  20.065909s
                 foo      7.012M (± 1.3%) i/s -    140.210M in  19.999977s

Comparison:
                 foo:  7011664.4 i/s
                 foo2:  4771233.1 i/s - 1.47x  slower
```

```ruby
require 'benchmark/ips'

def foo
  1
end

def foo2(a)
  1
end

Benchmark.ips do |x|
  x.config(:time => 20, :warmup => 20)


  x.report("foo2", "foo2(1)")
  x.report("foo", "foo")

  x.compare!
end
```
