### PR TITLE
Remove implicit prologue state to methods/blocks if that state is unused

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -350,6 +350,7 @@ public class IRBuilder {
     private EnumSet<IRFlags> flags;
 
     private boolean selfUsed = false;
+    private boolean currentModuleUsed = false;
 
     public IRBuilder(IRManager manager, IRScope scope, IRBuilder parent, IRBuilder variableBuilder) {
         this.manager = manager;
@@ -594,10 +595,6 @@ public class IRBuilder {
     }
 
     private InterpreterContext buildLambdaInner(LambdaNode node) {
-        prepareClosureImplicitState();
-
-        addCurrentModule();                                        // %current_module
-
         receiveBlockArgs(node);
 
         Operand closureRetVal = node.getBody() == null ? manager.getNil() : build(node.getBody());
@@ -605,20 +602,12 @@ public class IRBuilder {
         // can be U_NIL if the node is an if node with returns in both branches.
         if (closureRetVal != U_NIL) addInstr(new ReturnInstr(closureRetVal));
 
-        preloadBlockImplicitClosure();
+        prependUsedClosureImplicitState(false);
 
         handleBreakAndReturnsInLambdas();
 
-        if (selfUsed) addInstrAtBeginning(manager.getReceiveSelfInstr());
-
         computeScopeFlagsFrom(instructions);
         return scope.allocateInterpreterContext(instructions, temporaryVariableIndex + 1, flags);
-    }
-
-    private void preloadBlockImplicitClosure() {
-        if (needsYieldBlock) {
-            addInstrAtBeginning(new LoadBlockImplicitClosureInstr(getYieldClosureVariable()));
-        }
     }
 
     public Operand buildLambda(LambdaNode node) {
@@ -2871,15 +2860,6 @@ public class IRBuilder {
             addInstr(new TraceInstr(RubyEvent.CALL, getCurrentModuleVariable(), getName(), getFileName(), scope.getLine() + 1));
         }
 
-
-        prepareImplicitState();                                    // recv_self, add frame block, etc)
-
-        // These instructions need to be toward the top of the method because they may both be needed for processing
-        // optional arguments as in def foo(a = Object).
-        // Set %current_module = isInstanceMethod ? %self.metaclass : %self
-        int nearestScopeDepth = parent.getNearestModuleReferencingScopeDepth();
-        addInstr(new CopyInstr(getCurrentModuleVariable(), ScopeModule.ModuleFor(nearestScopeDepth == -1 ? 1 : nearestScopeDepth)));
-
         // Build IR for arguments (including the block arg)
         receiveMethodArgs(defNode.getArgsNode());
 
@@ -2914,11 +2894,61 @@ public class IRBuilder {
 
         ((IRMethod) scope).setArgumentDescriptors(argDesc);
 
-        if (selfUsed) addInstrAtBeginning(manager.getReceiveSelfInstr());
+        prependUsedImplicitState(parent);
 
         computeScopeFlagsFrom(instructions);
 
         return scope.allocateInterpreterContext(instructions, temporaryVariableIndex + 1, flags);
+    }
+
+    private void prependUsedImplicitState(IRScope parent) {
+        int numberOfInstrs = 0;
+        if (needsYieldBlock) {
+            if (scope instanceof IRMethod) {
+                numberOfInstrs++;
+                addInstrAtBeginning(new LoadImplicitClosureInstr(getYieldClosureVariable()));
+            } else if (!(scope instanceof IRModuleBody) && !(scope instanceof IRClassBody) && !(scope instanceof IRMetaClassBody)) {
+                numberOfInstrs++;
+                addInstrAtBeginning(new LoadFrameClosureInstr(getYieldClosureVariable()));
+            }
+        }
+        if (currentModuleUsed) {
+            // These instructions need to be toward the top of the method because they may both be needed for processing
+            // optional arguments as in def foo(a = Object).
+            // Set %current_module = isInstanceMethod ? %self.metaclass : %self
+            if (scope instanceof IRMethod && parent != null) {
+                numberOfInstrs++;
+                int nearestScopeDepth = parent.getNearestModuleReferencingScopeDepth();
+                addInstrAtBeginning(new CopyInstr(getCurrentModuleVariable(), ScopeModule.ModuleFor(nearestScopeDepth == -1 ? 1 : nearestScopeDepth)));
+            } else {
+                numberOfInstrs++;
+                addInstrAtBeginning(new CopyInstr(getCurrentModuleVariable(), SCOPE_MODULE[0])); // %current_module
+            }
+        }
+        if (selfUsed) {
+            numberOfInstrs++;
+            addInstrAtBeginning(manager.getReceiveSelfInstr());
+        }
+
+        if (numberOfInstrs > 0) afterPrologueIndex += numberOfInstrs;
+    }
+
+    private void prependUsedClosureImplicitState(boolean forLoop) {
+        int numberOfInstrs = 0;
+        if (needsYieldBlock) {
+            numberOfInstrs++;
+            addInstrAtBeginning(new LoadBlockImplicitClosureInstr(getYieldClosureVariable()));
+        }
+        if (!forLoop && currentModuleUsed) {
+            numberOfInstrs++;
+            addInstrAtBeginning(new CopyInstr(getCurrentModuleVariable(), SCOPE_MODULE[0]));
+        }
+        if (selfUsed) {
+            numberOfInstrs++;
+            addInstrAtBeginning(manager.getReceiveSelfInstr());
+        }
+
+        if (numberOfInstrs > 0) afterPrologueIndex += numberOfInstrs;
     }
 
     private IRMethod defineNewMethod(MethodDefNode defNode, boolean isInstanceMethod) {
@@ -3099,30 +3129,6 @@ public class IRBuilder {
             addInstr(new LoadImplicitClosureInstr(tmp));
             addInstr(new ReifyClosureInstr(blockVar, tmp));
         }
-    }
-
-    /**
-     * Prepare implicit runtime state needed for typical methods to execute. This includes such things
-     * as the implicit self variable and any yieldable block available to this scope.
-     */
-    private void prepareImplicitState() {
-        // Receive self
-        //addInstr(manager.getReceiveSelfInstr());
-
-        if (scope instanceof IRMethod) {
-            addInstr(new LoadImplicitClosureInstr(getYieldClosureVariable()));
-        } else if (!(scope instanceof IRModuleBody) && !(scope instanceof IRClassBody) && !(scope instanceof IRMetaClassBody)) {
-            addInstr(new LoadFrameClosureInstr(getYieldClosureVariable()));
-        }
-    }
-
-    /**
-     * Prepare closure runtime state. This includes the implicit self variable and setting up a variable to hold any
-     * frame closure if it is needed later.
-     */
-    private void prepareClosureImplicitState() {
-        // Receive self
-        addInstr(manager.getReceiveSelfInstr());
     }
 
     /**
@@ -3875,13 +3881,11 @@ public class IRBuilder {
         this.methodName = methodName;
 
         boolean forNode = iterNode instanceof ForNode;
-        prepareClosureImplicitState();                                    // recv_self, add frame block, etc)
 
         if (RubyInstanceConfig.FULL_TRACE_ENABLED) {
             addInstr(new TraceInstr(RubyEvent.B_CALL, getCurrentModuleVariable(), getName(), getFileName(), scope.getLine() + 1));
         }
 
-        if (!forNode) addCurrentModule();                                // %current_module
         receiveBlockArgs(iterNode);
         // for adds these after processing binding block args because and operations at that point happen relative
         // to the previous scope.
@@ -3900,13 +3904,11 @@ public class IRBuilder {
         // can be U_NIL if the node is an if node with returns in both branches.
         if (closureRetVal != U_NIL) addInstr(new ReturnInstr(closureRetVal));
 
-        preloadBlockImplicitClosure();
+        prependUsedClosureImplicitState(forNode);
 
         // Add break/return handling in case it is a lambda (we cannot know at parse time what it is).
         // SSS FIXME: At a later time, see if we can optimize this and do this on demand.
         if (!forNode) handleBreakAndReturnsInLambdas();
-
-        if (selfUsed) addInstrAtBeginning(manager.getReceiveSelfInstr());
 
         computeScopeFlagsFrom(instructions);
         return scope.allocateInterpreterContext(instructions, temporaryVariableIndex + 1, flags);
@@ -4370,12 +4372,12 @@ public class IRBuilder {
     }
 
     private InterpreterContext buildPrePostExeInner(Node body) {
-        // Set up %current_module
-        addInstr(new CopyInstr(getCurrentModuleVariable(), SCOPE_MODULE[0]));
         build(body);
 
         // END does not have either explicit or implicit return, so we add one
         addInstr(new ReturnInstr(new Nil()));
+
+        prependUsedImplicitState(null);
 
         computeScopeFlagsFrom(instructions);
         return scope.allocateInterpreterContext(instructions, temporaryVariableIndex + 1, flags);
@@ -4727,15 +4729,12 @@ public class IRBuilder {
         coverageMode = CoverageData.NONE;  // Assuming there is no path into build eval root without actually being an eval.
         addInstr(manager.newLineNumber(scope.getLine()));
 
-        prepareImplicitState();                                    // recv_self, add frame block, etc)
-        addCurrentModule();                                        // %current_module
-
         afterPrologueIndex = instructions.size() - 1;                      // added BEGINs start after scope prologue stuff
 
         Operand returnValue = rootNode.getBodyNode() == null ? manager.getNil() : build(rootNode.getBodyNode());
         addInstr(new ReturnInstr(returnValue));
 
-        if (selfUsed) addInstrAtBeginning(manager.getReceiveSelfInstr());
+        prependUsedImplicitState(null);
 
         computeScopeFlagsFrom(instructions);
         return scope.allocateInterpreterContext(instructions, temporaryVariableIndex + 2, flags);
@@ -4754,10 +4753,6 @@ public class IRBuilder {
 
     private InterpreterContext buildRootInner(RootNode rootNode) {
         coverageMode = rootNode.coverageMode();
-        prepareImplicitState();                                    // recv_self, add frame block, etc)
-        addCurrentModule();                                        // %current_module
-
-        afterPrologueIndex = instructions.size() - 1;                      // added BEGINs start after scope prologue stuff
 
         // Build IR for the tree and return the result of the expression tree
         addInstr(new ReturnInstr(build(rootNode.getBodyNode())));
@@ -4766,7 +4761,7 @@ public class IRBuilder {
         // Root scope can receive returns now, so we add non-local return logic if necessary (2.5+)
         if (scope.canReceiveNonlocalReturns()) handleNonlocalReturnInMethod();
 
-        if (selfUsed) addInstrAtBeginning(manager.getReceiveSelfInstr());
+        prependUsedImplicitState(null);
 
         return scope.allocateInterpreterContext(instructions, temporaryVariableIndex + 1, flags);
     }
@@ -5111,9 +5106,6 @@ public class IRBuilder {
     private InterpreterContext buildModuleOrClassBody(Node bodyNode, int startLine, int endLine) {
         addInstr(new TraceInstr(RubyEvent.CLASS, getCurrentModuleVariable(), null, getFileName(), startLine + 1));
 
-        prepareImplicitState();                                    // recv_self, add frame block, etc)
-        addCurrentModule();                                        // %current_module
-
         Operand bodyReturnValue = build(bodyNode);
 
         // This is only added when tracing is enabled because an 'end' will normally have no other instrs which can
@@ -5123,7 +5115,7 @@ public class IRBuilder {
 
         addInstr(new ReturnInstr(bodyReturnValue));
 
-        if (selfUsed) addInstrAtBeginning(manager.getReceiveSelfInstr());
+        prependUsedImplicitState(null);
 
         computeScopeFlagsFrom(instructions);
         return scope.allocateInterpreterContext(instructions, temporaryVariableIndex + 1, flags);
@@ -5267,6 +5259,8 @@ public class IRBuilder {
     }
 
     public Variable getCurrentModuleVariable() {
+        currentModuleUsed = true;
+
         if (currentModuleVariable == null) currentModuleVariable = createCurrentModuleVariable();
 
         return currentModuleVariable;


### PR DESCRIPTION
Remove implicit prologue state to methods/blocks if that state is unused

This is for work to speed up the startup of JRuby by reducing instrs visited in the startup interpreter.  The implicit state
at the front of methods/blocks generally gets remove as dead instrs since their variables are not used.  The startup
interpreter does not run the compiler passes which do this due to the significant time they take to analyze the code.

This PR is doing cheap existence checks which will remove a lot of these instrs during build time.