### PR TITLE
Reuse thread-local jump exceptions to avoid construction

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1302,8 +1302,8 @@ public final class Ruby implements Constantizable {
              * This will capture any return which says it should return to a script scope as the reasonable
              * exit point.  We still raise when jump off point is anything else since that is a bug.
              */
-            if (!ex.methodToReturnFrom.getStaticScope().getIRScope().isScriptScope()) {
-                System.err.println("Unexpected 'return' escaped the runtime from " + ex.returnScope.getIRScope() + " to " + ex.methodToReturnFrom.getStaticScope().getIRScope());
+            if (!ex.isReturningToScriptScope()) {
+                System.err.println("Unexpected 'return' escaped the runtime: " + ex.toString());
                 System.err.println(ThreadContext.createRawBacktraceStringFromThrowable(ex, false));
                 Throwable t = ex;
                 while ((t = t.getCause()) != null) {

--- a/core/src/main/java/org/jruby/ir/runtime/IRReturnJump.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRReturnJump.java
@@ -1,7 +1,6 @@
 package org.jruby.ir.runtime;
 
 import org.jruby.exceptions.Unrescuable;
-import org.jruby.ir.IRScope;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.DynamicScope;
 
@@ -11,19 +10,16 @@ public class IRReturnJump extends IRJump implements Unrescuable {
     private Object returnValue;
     private boolean inUse = false;
 
-    private static final ThreadLocal<IRReturnJump> RETURN_JUMP = new ThreadLocal<>();
-
-    private IRReturnJump(StaticScope returnScope, DynamicScope scopeToReturnFrom, Object rv) {
-        update(returnScope, scopeToReturnFrom, rv);
+    private IRReturnJump() {
     }
 
     public static IRReturnJump create(StaticScope returnScope, DynamicScope scopeToReturnFrom, Object rv) {
-        IRReturnJump jump = RETURN_JUMP.get();
+        IRReturnJump jump = returnScope.getReturnJump();
         if (jump == null || jump.inUse) {
-            RETURN_JUMP.set(jump = new IRReturnJump(returnScope, scopeToReturnFrom, rv));
-        } else {
-            jump.update(returnScope, scopeToReturnFrom, rv);
+            returnScope.setReturnJump(jump = new IRReturnJump());
         }
+
+        jump.update(returnScope, scopeToReturnFrom, rv);
 
         return jump;
     }

--- a/core/src/main/java/org/jruby/ir/runtime/IRReturnJump.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRReturnJump.java
@@ -6,39 +6,58 @@ import org.jruby.parser.StaticScope;
 import org.jruby.runtime.DynamicScope;
 
 public class IRReturnJump extends IRJump implements Unrescuable {
-    public StaticScope returnScope;
-    public DynamicScope methodToReturnFrom;
-    public Object returnValue;
+    private StaticScope returnScope;
+    private DynamicScope methodToReturnFrom;
+    private Object returnValue;
+    private boolean inUse = false;
 
     private static final ThreadLocal<IRReturnJump> RETURN_JUMP = new ThreadLocal<>();
 
     private IRReturnJump(StaticScope returnScope, DynamicScope scopeToReturnFrom, Object rv) {
-        reset(returnScope, scopeToReturnFrom, rv);
+        update(returnScope, scopeToReturnFrom, rv);
     }
 
     public static IRReturnJump create(StaticScope returnScope, DynamicScope scopeToReturnFrom, Object rv) {
         IRReturnJump jump = RETURN_JUMP.get();
-        if (jump == null) {
+        if (jump == null || jump.inUse) {
             RETURN_JUMP.set(jump = new IRReturnJump(returnScope, scopeToReturnFrom, rv));
         } else {
-            jump.reset(returnScope, scopeToReturnFrom, rv);
+            jump.update(returnScope, scopeToReturnFrom, rv);
         }
 
         return jump;
     }
 
-    private void reset(StaticScope returnScope, DynamicScope scopeToReturnFrom, Object rv) {
+    private void update(StaticScope returnScope, DynamicScope scopeToReturnFrom, Object rv) {
         this.methodToReturnFrom = scopeToReturnFrom;
         this.returnScope = returnScope;
         this.returnValue = rv;
+        this.inUse = true;
+    }
+
+    public void reset() {
+        methodToReturnFrom = null;
+        returnScope = null;
+        returnValue = null;
+        inUse = false;
     }
 
     public boolean isReturnToScope(DynamicScope scope) {
         return methodToReturnFrom == scope;
     }
 
+    public Object returnAndReset() {
+        Object returnValue = this.returnValue;
+        reset();
+        return returnValue;
+    }
+
     @Override
     public String toString() {
-        return "IRReturnJump:<" + methodToReturnFrom + ":" + returnValue + ">";
+        return "IRReturnJump:<" + returnScope.getIRScope() + ":" + methodToReturnFrom.getStaticScope().getIRScope() + ">";
+    }
+
+    public boolean isReturningToScriptScope() {
+        return methodToReturnFrom.getStaticScope().getIRScope().isScriptScope();
     }
 }

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -193,7 +193,7 @@ public class IRRuntimeHelpers {
             // If we are in the method scope we are supposed to return from, stop p<ropagating.
             if (rj.isReturnToScope(currentScope)) {
                 if (isDebug()) System.out.println("---> Non-local Return reached target in scope: " + currentScope);
-                return (IRubyObject) rj.returnValue;
+                return (IRubyObject) rj.returnAndReset();
             }
 
             // If not, Just pass it along!
@@ -243,7 +243,7 @@ public class IRRuntimeHelpers {
             return ((IRWrappedLambdaReturnValue) exc).returnValue;
         } else if (exc instanceof IRReturnJump && dynScope != null && inReturnToScope(block.type, (IRReturnJump) exc, dynScope)) {
             if (isDebug()) System.out.println("---> Non-local Return reached target in scope: " + dynScope);
-            return (IRubyObject) ((IRReturnJump) exc).returnValue;
+            return (IRubyObject) ((IRReturnJump) exc).returnAndReset();
         } else {
             // Propagate the exception
             context.setSavedExceptionInLambda((Throwable) exc);

--- a/core/src/main/java/org/jruby/parser/StaticScope.java
+++ b/core/src/main/java/org/jruby/parser/StaticScope.java
@@ -56,6 +56,7 @@ import org.jruby.ast.VCallNode;
 import org.jruby.ir.IRMethod;
 import org.jruby.ir.IRScope;
 import org.jruby.ir.IRScopeType;
+import org.jruby.ir.runtime.IRReturnJump;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.Signature;
@@ -122,6 +123,8 @@ public class StaticScope implements Serializable {
     private volatile MethodHandle constructor;
 
     private volatile Collection<String> ivarNames;
+
+    private ThreadLocal<IRReturnJump> returnJump;
 
     public enum Type {
         LOCAL, BLOCK, EVAL;
@@ -740,5 +743,21 @@ public class StaticScope implements Serializable {
         }
 
         return scope != null && scope.enclosingScope == null;
+    }
+
+    public IRReturnJump getReturnJump() {
+        return getReturnJumpThreadLocal().get();
+    }
+
+    public void setReturnJump(IRReturnJump rj) {
+        getReturnJumpThreadLocal().set(rj);
+    }
+
+    private ThreadLocal<IRReturnJump> getReturnJumpThreadLocal() {
+        ThreadLocal<IRReturnJump> returnJump = this.returnJump;
+        if (returnJump == null) {
+            returnJump = this.returnJump = new ThreadLocal<>();
+        }
+        return returnJump;
     }
 }


### PR DESCRIPTION
Thread-local branching requires us to raise an exception to unroll the stack past multiple frames. These exceptions should never escape a given thread, and yet we always construct a new object for them. We could improve performance of non-local flow control by using a thread-local exception object (for cases that have state) or a global singleton exception object (for cases that do not).

This PR will attempt to do that.

Relates to performance challenges like #5933