### PR TITLE
Match `Exception#full_message` with MRI 3.2

### DIFF
--- a/core/src/main/java/org/jruby/Main.java
+++ b/core/src/main/java/org/jruby/Main.java
@@ -558,19 +558,6 @@ public class Main {
         boolean isatty = runtime.getPosix().isatty(FileDescriptor.err);
 
         System.err.print(traceType.printBacktrace(raisedException, isatty));
-
-        Set<Object> shownCauses = new HashSet<Object>();
-        shownCauses.add(raisedException);
-
-        for (
-                Object cause = raisedException.getCause();
-                cause != null && cause instanceof RubyException && !shownCauses.contains(cause);
-                cause = ((RubyException) cause).getCause()) {
-
-            System.err.print(traceType.printBacktrace((RubyException) cause, isatty));
-            shownCauses.add(cause);
-        }
-
         return 1;
     }
 

--- a/spec/java_integration/addons/throwable_spec.rb
+++ b/spec/java_integration/addons/throwable_spec.rb
@@ -36,8 +36,8 @@ describe "A Java Throwable" do
 
   it "implements full_message" do
     ex = java.lang.Exception.new('hello')
-    expect(ex.full_message).to match /hello \(Java::JavaLang::Exception\)/
-    expect(ex.full_message(:highlight => true, :order => :top)).to match /hello \(Java::JavaLang::Exception\)/
+    expect(ex.full_message(:highlight => false)).to match(/hello \(Java::JavaLang::Exception\)/)
+    expect(ex.full_message(:highlight => false, :order => :bottom)).to match(/hello \(Java::JavaLang::Exception\)/)
   end
 
   it "can be rescued by rescue Exception" do


### PR DESCRIPTION
In my very limited test, this should matches MRI 3.2's formatting at byte level as long as the backtrace is exactly the same. E.g. rescue then re-raise a different error creates an additional line in backtrace for MRI, but not in jruby - the output will be slightly different in such case.

Why match MRI 3.2 not 3.1? The only difference between 3.1 and 3.2 is how `order:` works. In 3.2, `order` default to `:top`, which is the same as the current jruby behavior. Therefore, matching 3.2 is actually a smaller change than matching 3.1.