### PR TITLE
Use method handles for binding ungenerated invokers

### DIFF
--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -83,7 +83,7 @@ public class Options {
     // ClassValue in OpenJDK appears to root data even after it goes away, so this is disabled again. See jruby/jruby#3228
     public static final Option<Boolean> INVOKEDYNAMIC_CLASS_VALUES = bool(INVOKEDYNAMIC, "invokedynamic.class.values", false, "Use ClassValue to store class-specific data.");
     public static final Option<Integer> INVOKEDYNAMIC_GLOBAL_MAXFAIL = integer(INVOKEDYNAMIC, "invokedynamic.global.maxfail", 100, "Maximum global cache failures after which to use slow path.");
-    public static final Option<Boolean> INVOKEDYNAMIC_HANDLES = bool(INVOKEDYNAMIC, "invokedynamic.handles", false, "Use MethodHandles rather than generated code to bind Ruby methods.");
+    public static final Option<Boolean> INVOKEDYNAMIC_HANDLES = bool(INVOKEDYNAMIC, "invokedynamic.handles", true, "Use MethodHandles rather than generated code to bind methods.");
     public static final Option<Boolean> INVOKEDYNAMIC_YIELD = bool(INVOKEDYNAMIC, "invokedynamic.yield", true, "Bind yields directly using invokedynamic.");
 
     // NOTE: -1 jit.threshold is way of having interpreter not promote full builds


### PR DESCRIPTION
JRuby extensions can be bound using bytecode-generated invokers, either pregenerated at build time or generated on the fly at runtime. In the latter case, the overhead of failing to find a pregenerated invoker, generating the new bytecode, and loading it appears to be more expensive than using invokedynamic method handles to do the binding. This PR enables using indy handles for all non-generated method bindings at runtime.