### PR TITLE
Fix String#unpack from using capacity() and causing wrong error

### DIFF
--- a/core/src/main/java/org/jruby/util/Pack.java
+++ b/core/src/main/java/org/jruby/util/Pack.java
@@ -1598,24 +1598,11 @@ public class Pack {
     }
 
     private static void unpack_at(Ruby runtime, ByteList encodedString, ByteBuffer encode, int occurrences) {
-        try {
-            int limit;
-            if (occurrences == IS_STAR) {
-                limit = checkLimit(runtime, encode, encodedString.begin() + encode.remaining());
-            } else {
-                limit = checkLimit(runtime, encode, encodedString.begin() + occurrences);
-            }
-            positionBuffer(encode, limit);
-        } catch (IllegalArgumentException iae) {
-            throw runtime.newArgumentError("@ outside of string");
-        }
-    }
+        int limit = encodedString.begin() + (occurrences == IS_STAR ? encode.remaining() : occurrences);
 
-    private static int checkLimit(Ruby runtime, ByteBuffer encode, int limit) {
-        if (limit >= encode.capacity() || limit < 0) {
-            throw runtime.newRangeError("pack length too big");
-        }
-        return limit;
+        if (limit > encode.limit() || limit < 0) throw runtime.newArgumentError("@ outside of string");
+
+        positionBuffer(encode, limit);
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/util/Pack.java
+++ b/core/src/main/java/org/jruby/util/Pack.java
@@ -44,6 +44,7 @@ import org.jcodings.specific.ASCIIEncoding;
 import org.jcodings.specific.USASCIIEncoding;
 import org.jcodings.specific.UTF8Encoding;
 import org.jruby.*;
+import org.jruby.exceptions.RangeError;
 import org.jruby.platform.Platform;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
@@ -1035,6 +1036,7 @@ public class Pack {
                     do {
                         occurrences = occurrences * 10 + Character.digit((char)(next & 0xFF), 10);
                         next = safeGet(format);
+                        if (occurrences < 0) throw runtime.newRangeError("pack length too big");
                     } while (next != 0 && ASCII.isDigit(next));
                 } else {
                     occurrences = type == '@' ? 0 : 1;


### PR DESCRIPTION
JIT and new Prism parser were right-sizing Strings whereas the current parser will create larger than actual string length mostly. This lead to a problem where checkLimit in original unpack code would examine capacity and pass the test even though capacity is not valid data.

The solution is to raise the proper error and use actual encoding limit.  the original checkLimit error message is for STRTOUL in MRI in processing the number after the '@' and that was not what we were doing.  I am unable to get that RangeError to occur in MRI so I am not sure when it is possible?