### PR TITLE
override getDelegate in PrependedModule to return origin

### DIFF
--- a/core/src/main/java/org/jruby/PrependedModule.java
+++ b/core/src/main/java/org/jruby/PrependedModule.java
@@ -129,6 +129,11 @@ public class PrependedModule extends RubyClass implements DelegatedModule {
         return origin;
     }
 
+    @Override
+    public RubyModule getDelegate() {
+        return origin;
+    }
+
     @Deprecated
     @Override
     public RubyModule getNonIncludedClass() {

--- a/spec/ruby/core/module/prepend_spec.rb
+++ b/spec/ruby/core/module/prepend_spec.rb
@@ -726,6 +726,17 @@ describe "Module#prepend" do
     ary.should == [3, 2, 1]
   end
 
+  it "does not prepend a second copy if the module already indirectly exists in the hierarchy" do
+    mod = Module.new do; end
+    submod = Module.new do; end
+    klass = Class.new do; end
+    klass.include(mod)
+    mod.prepend(submod)
+    klass.include(mod)
+
+    klass.ancestors.take(4).should == [klass, submod, mod, Object]
+  end
+
   describe "called on a module" do
     describe "included into a class"
     it "does not obscure the module's methods from reflective access" do


### PR DESCRIPTION
issue #7845 "Including a module again after prepending another module to it isn't idempotent" 