### PR TITLE
Ruby 3.3 support: add symbolize_names kwarg to MatchData#named_captures

### DIFF
--- a/core/src/main/java/org/jruby/RubyMatchData.java
+++ b/core/src/main/java/org/jruby/RubyMatchData.java
@@ -857,19 +857,18 @@ public class RubyMatchData extends RubyObject {
         RubyHash hash = RubyHash.newHash(runtime);
         if (regexp == context.nil) return hash;
 
-        IRubyObject symbolizeNamesValue = runtime.getNil();
-
+        boolean symbolizeNames = false;
         if ( argc == 1 ) {
             final IRubyObject opts = args[0];
             if (opts instanceof RubyHash) {
-                symbolizeNamesValue = ArgsUtil.extractKeywordArg(runtime.getCurrentContext(), (RubyHash) opts, "symbolize_names");
+                symbolizeNames = ArgsUtil.extractKeywordArg(runtime.getCurrentContext(), (RubyHash) opts, "symbolize_names").isTrue();
             }
         }
 
         for (Iterator<NameEntry> i = getPattern().namedBackrefIterator(); i.hasNext();) {
             NameEntry entry = i.next();
             IRubyObject key;
-            if (symbolizeNamesValue.isTrue()) {
+            if (symbolizeNames) {
                 key = runtime.newSymbol(new ByteList(entry.name, entry.nameP, entry.nameEnd - entry.nameP, regexp.getEncoding(), false));
             } else {
                 key = RubyString.newStringShared(runtime, new ByteList(entry.name, entry.nameP, entry.nameEnd - entry.nameP, regexp.getEncoding(), false));

--- a/core/src/main/java/org/jruby/RubyMatchData.java
+++ b/core/src/main/java/org/jruby/RubyMatchData.java
@@ -881,21 +881,13 @@ public class RubyMatchData extends RubyObject {
                 IRubyObject value = RubyRegexp.nth_match(b, this);
                 if (value.isTrue()) {
 
-                    if (symbolizeNamesValue.isTrue()) {
-                        hash.op_aset(context, key, value);
-                    } else {
-                        hash.op_asetForString(runtime, (RubyString)key, value);
-                    }
+                    hash.op_aset(context, key, value);
                     found = true;
                 }
             }
 
             if (!found) {
-                if (symbolizeNamesValue.isTrue()) {
-                    hash.op_aset(context, key, context.nil);
-                } else {
-                    hash.op_asetForString(runtime, (RubyString)key, context.nil);
-                }
+                hash.op_aset(context, key, context.nil);
             }
         }
 

--- a/core/src/main/java/org/jruby/RubyMatchData.java
+++ b/core/src/main/java/org/jruby/RubyMatchData.java
@@ -862,6 +862,8 @@ public class RubyMatchData extends RubyObject {
             final IRubyObject opts = args[0];
             if (opts instanceof RubyHash) {
                 symbolizeNames = ArgsUtil.extractKeywordArg(runtime.getCurrentContext(), (RubyHash) opts, "symbolize_names").isTrue();
+            } else {
+              throw runtime.newArgumentError(1, 0);
             }
         }
 

--- a/core/src/main/java/org/jruby/RubyMatchData.java
+++ b/core/src/main/java/org/jruby/RubyMatchData.java
@@ -45,6 +45,8 @@ import org.joni.Region;
 import org.joni.exception.JOniException;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyClass;
+import org.jruby.ast.util.ArgsUtil;
+import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ClassIndex;
 import org.jruby.runtime.ThreadContext;
@@ -846,27 +848,60 @@ public class RubyMatchData extends RubyObject {
         return metaClass.runtime.newFixnum( hashCode() );
     }
 
-    @JRubyMethod
-    public RubyHash named_captures(ThreadContext context) {
+    @JRubyMethod(keywords = true, checkArity = false, optional = 1)
+    public RubyHash named_captures(ThreadContext context, IRubyObject[] args) {
         check();
+
         Ruby runtime = context.runtime;
+        int argc = Arity.checkArgumentCount(runtime, args.length, 0, 0, true);
         RubyHash hash = RubyHash.newHash(runtime);
         if (regexp == context.nil) return hash;
 
-        for (Iterator<NameEntry> i = getPattern().namedBackrefIterator(); i.hasNext();) {
-            NameEntry entry = i.next();
-            RubyString key = RubyString.newStringShared(runtime, new ByteList(entry.name, entry.nameP, entry.nameEnd - entry.nameP, regexp.getEncoding(), false));
-            boolean found = false;
+        IRubyObject symbolizeNamesValue = runtime.getNil();
 
-            for (int b : entry.getBackRefs()) {
-                IRubyObject value = RubyRegexp.nth_match(b, this);
-                if (value.isTrue()) {
-                    hash.op_asetForString(runtime, key, value);
-                    found = true;
+        if ( argc == 1 ) {
+            final IRubyObject opts = args[0];
+            if (opts instanceof RubyHash) {
+                symbolizeNamesValue = ArgsUtil.extractKeywordArg(runtime.getCurrentContext(), (RubyHash) opts, "symbolize_names");
+            }
+        }
+
+        if (symbolizeNamesValue.isTrue()) {
+            for (Iterator<NameEntry> i = getPattern().namedBackrefIterator(); i.hasNext();) {
+                NameEntry entry = i.next();
+                RubySymbol key = runtime.newSymbol(new ByteList(entry.name, entry.nameP, entry.nameEnd - entry.nameP, regexp.getEncoding(), false));
+                boolean found = false;
+
+                for (int b : entry.getBackRefs()) {
+                    IRubyObject value = RubyRegexp.nth_match(b, this);
+                    if (value.isTrue()) {
+                        hash.op_aset(context, key, value);
+                        found = true;
+                    }
+                }
+
+                if (!found) {
+                    hash.op_aset(context, key, context.nil);
                 }
             }
+        } else {
+            for (Iterator<NameEntry> i = getPattern().namedBackrefIterator(); i.hasNext();) {
+                NameEntry entry = i.next();
+                RubyString key = RubyString.newStringShared(runtime, new ByteList(entry.name, entry.nameP, entry.nameEnd - entry.nameP, regexp.getEncoding(), false));
+                boolean found = false;
 
-            if (!found) hash.op_asetForString(runtime, key, context.nil);
+                for (int b : entry.getBackRefs()) {
+                    IRubyObject value = RubyRegexp.nth_match(b, this);
+                    if (value.isTrue()) {
+                        hash.op_asetForString(runtime, key, value);
+                        found = true;
+                    }
+                }
+
+                if (!found) {
+                    hash.op_asetForString(runtime, key, context.nil);
+                }
+            }
         }
 
         return hash;

--- a/core/src/main/java/org/jruby/RubyMatchData.java
+++ b/core/src/main/java/org/jruby/RubyMatchData.java
@@ -863,7 +863,7 @@ public class RubyMatchData extends RubyObject {
             if (opts instanceof RubyHash) {
                 symbolizeNames = ArgsUtil.extractKeywordArg(runtime.getCurrentContext(), (RubyHash) opts, "symbolize_names").isTrue();
             } else {
-              throw runtime.newArgumentError(1, 0);
+                throw runtime.newArgumentError(1, 0);
             }
         }
 


### PR DESCRIPTION
issue #8029 

I am unsure if my usage of keywords/checkArity/optional/checkArgumentCount is correct. I couldn't find another example exactly like this in the codebase. It seems I can still call `named_captures(:bogus)` without any complaints so perhaps someone can point me in the right direction.

