### PR TITLE
Attribute definition on singleton should call singleton_method_added

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1444,11 +1444,9 @@ public class RubyModule extends RubyObject {
         }
         methodLocation.addMethod(name, UndefinedMethod.getInstance());
 
-        if (isSingleton()) {
-            ((MetaClass) this).getAttached().callMethod(context, "singleton_method_undefined", runtime.newSymbol(name));
-        } else {
-            callMethod(context, "method_undefined", runtime.newSymbol(name));
-        }
+        RubySymbol nameSymbol = runtime.newSymbol(name);
+
+        methodUndefined(context, nameSymbol);
     }
 
     @JRubyMethod(name = "include?")
@@ -1567,11 +1565,7 @@ public class RubyModule extends RubyObject {
             invalidateCacheDescendants();
         }
 
-        if (isSingleton()) {
-            ((MetaClass) this).getAttached().callMethod(context, "singleton_method_removed", name);
-        } else {
-            callMethod(context, "method_removed", name);
-        }
+        methodRemoved(context, name);
     }
 
     private static void warnMethodRemoval(final ThreadContext context, final String id) {
@@ -2303,6 +2297,22 @@ public class RubyModule extends RubyObject {
             ((MetaClass) this).getAttached().callMethod(context, "singleton_method_added", identifier);
         } else {
             callMethod(context, "method_added", identifier);
+        }
+    }
+
+    private void methodUndefined(ThreadContext context, RubySymbol nameSymbol) {
+        if (isSingleton()) {
+            ((MetaClass) this).getAttached().callMethod(context, "singleton_method_undefined", nameSymbol);
+        } else {
+            callMethod(context, "method_undefined", nameSymbol);
+        }
+    }
+
+    private void methodRemoved(ThreadContext context, RubySymbol name) {
+        if (isSingleton()) {
+            ((MetaClass) this).getAttached().callMethod(context, "singleton_method_removed", name);
+        } else {
+            callMethod(context, "method_removed", name);
         }
     }
 

--- a/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/MethodGatherer.java
@@ -72,6 +72,8 @@ public class MethodGatherer {
     static {
         STATIC_RESERVED_NAMES = newReservedNamesMap(1);
         STATIC_RESERVED_NAMES.put("new", new AssignedName("new", Priority.RESERVED));
+        // "singleton_method_added" gets called on the metaclass for metaclass method definitions
+        STATIC_RESERVED_NAMES.put("singleton_method_added", new AssignedName("singleton_method_added", Priority.RESERVED));
     }
 
     static {
@@ -82,6 +84,8 @@ public class MethodGatherer {
         INSTANCE_RESERVED_NAMES.put("initialize", new AssignedName("initialize", Priority.RESERVED));
         // "equal?" should not be overridden (GH-5990)
         INSTANCE_RESERVED_NAMES.put("equal?", new AssignedName("equal?", Priority.RESERVED));
+        // "singleton_method_added" gets called on the object for singleton method definitions
+        INSTANCE_RESERVED_NAMES.put("singleton_method_added", new AssignedName("singleton_method_added", Priority.RESERVED));
     }
 
     // TODO: other reserved names?

--- a/spec/ruby/core/module/attr_accessor_spec.rb
+++ b/spec/ruby/core/module/attr_accessor_spec.rb
@@ -1,5 +1,6 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative 'shared/attr_added'
 
 describe "Module#attr_accessor" do
   it "creates a getter and setter for each given attribute name" do
@@ -106,4 +107,6 @@ describe "Module#attr_accessor" do
       1.foobar.should be_nil
     end
   end
+
+  it_behaves_like :module_attr_added, :attr_accessor
 end

--- a/spec/ruby/core/module/attr_reader_spec.rb
+++ b/spec/ruby/core/module/attr_reader_spec.rb
@@ -1,5 +1,6 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative 'shared/attr_added'
 
 describe "Module#attr_reader" do
   it "creates a getter for each given attribute name" do
@@ -67,4 +68,6 @@ describe "Module#attr_reader" do
       (attr_reader :foo, 'bar').should == [:foo, :bar]
     end
   end
+
+  it_behaves_like :module_attr_added, :attr_reader
 end

--- a/spec/ruby/core/module/attr_spec.rb
+++ b/spec/ruby/core/module/attr_spec.rb
@@ -1,5 +1,6 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative 'shared/attr_added'
 
 describe "Module#attr" do
   before :each do
@@ -153,4 +154,6 @@ describe "Module#attr" do
       (attr :qux, true).should == [:qux, :qux=]
     end
   end
+
+  it_behaves_like :module_attr_added, :attr
 end

--- a/spec/ruby/core/module/attr_writer_spec.rb
+++ b/spec/ruby/core/module/attr_writer_spec.rb
@@ -1,5 +1,6 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative 'shared/attr_added'
 
 describe "Module#attr_writer" do
   it "creates a setter for each given attribute name" do
@@ -77,4 +78,6 @@ describe "Module#attr_writer" do
       (attr_writer :foo, 'bar').should == [:foo=, :bar=]
     end
   end
+
+  it_behaves_like :module_attr_added, :attr_writer
 end

--- a/spec/ruby/core/module/shared/attr_added.rb
+++ b/spec/ruby/core/module/shared/attr_added.rb
@@ -1,0 +1,34 @@
+describe :module_attr_added, shared: true do
+  it "calls method_added for normal classes" do
+    ScratchPad.record []
+
+    cls = Class.new do
+      class << self
+        def method_added(name)
+          ScratchPad.recorded << name
+        end
+      end
+    end
+
+    cls.send(@method, :foo)
+
+    ScratchPad.recorded.each {|name| name.to_s.should =~ /foo[=]?/}
+  end
+
+  it "calls singleton_method_added for singleton classes" do
+    ScratchPad.record []
+    cls = Class.new do
+      class << self
+        def singleton_method_added(name)
+          # called for this def so ignore it
+          return if name == :singleton_method_added
+          ScratchPad.recorded << name
+        end
+      end
+    end
+
+    cls.singleton_class.send(@method, :foo)
+
+    ScratchPad.recorded.each {|name| name.to_s.should =~ /foo[=]?/}
+  end
+end


### PR DESCRIPTION
See Shopify/ruby-lsp#1263 for background on this.

When defining an attribute (`attr`, `attr_reader`, `attr_writer`, `attr_accessor`) on a metaclass or singleton object, we should be calling `singleton_method_added`. Instead, we were calling `method_added`.

The caused Shopify/ruby-lsp#1263 when an `attr_reader` in a metaclass body did not consume a Sorbet `sig` set up for it.

I've also factored out two other method hook cases in case they are needed other places in the future: `method_undefined` and `method_removed`.