### PR TITLE
Update some warnings to deprecated

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -5608,7 +5608,7 @@ public final class Ruby implements Constantizable {
     private final WarnCallback regexpWarnings = new WarnCallback() {
         @Override
         public void warn(String message) {
-            getWarnings().warning(message);
+            getWarnings().warn(message);
         }
     };
 

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -2210,7 +2210,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         IRubyObject sep;
         sep = runtime.getGlobalVariables().get("$,");
         if (!sep.isNil()) {
-            runtime.getWarnings().warn("$, is set to non-nil value");
+            runtime.getWarnings().warningDeprecated("$, is set to non-nil value");
         }
         return sep;
     }

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -645,7 +645,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         unpack();
         realLength = 0;
         if (block.isGiven() && context.runtime.isVerbose()) {
-            context.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
+            context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
         }
         return this;
     }
@@ -2210,7 +2210,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         IRubyObject sep;
         sep = runtime.getGlobalVariables().get("$,");
         if (!sep.isNil()) {
-            runtime.getWarnings().warningDeprecated("$, is set to non-nil value");
+            runtime.getWarnings().warnDeprecated("$, is set to non-nil value");
         }
         return sep;
     }
@@ -2549,7 +2549,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     @JRubyMethod(name = {"index", "find_index"})
     public IRubyObject index(ThreadContext context, IRubyObject obj, Block unused) {
-        if (unused.isGiven()) context.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
+        if (unused.isGiven()) context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
         return index(context, obj);
     }
 
@@ -2656,7 +2656,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     @JRubyMethod
     public IRubyObject rindex(ThreadContext context, IRubyObject obj, Block unused) {
-        if (unused.isGiven()) context.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
+        if (unused.isGiven()) context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
         return rindex(context, obj);
     }
 
@@ -3521,7 +3521,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     @JRubyMethod(name = "count")
     public IRubyObject count(ThreadContext context, IRubyObject obj, Block block) {
-        if (block.isGiven()) context.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
+        if (block.isGiven()) context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
 
         int n = 0;
         for (int i = 0; i < realLength; i++) {
@@ -4929,7 +4929,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         boolean patternGiven = arg != null;
 
         if (block.isGiven() && patternGiven) {
-            context.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
+            context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
         }
 
         if (!block.isGiven() || patternGiven) return all_pBlockless(context, arg);
@@ -4972,7 +4972,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         boolean patternGiven = arg != null;
 
         if (block.isGiven() && patternGiven) {
-            context.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
+            context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
         }
 
         if (!block.isGiven() || patternGiven) return any_pBlockless(context, arg);
@@ -5014,7 +5014,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         boolean patternGiven = arg != null;
 
         if (block.isGiven() && patternGiven) {
-            context.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
+            context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
         }
 
         if (!block.isGiven() || patternGiven) return none_pBlockless(context, arg);
@@ -5056,7 +5056,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         boolean patternGiven = arg != null;
 
         if (block.isGiven() && patternGiven) {
-            context.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
+            context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
         }
 
         if (!block.isGiven() || patternGiven) return one_pBlockless(context, arg);

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -163,7 +163,7 @@ public class RubyEnumerable {
         final Ruby runtime = context.runtime;
         final SingleInt result = new SingleInt();
 
-        if (block.isGiven()) runtime.getWarnings().warning(ID.BLOCK_UNUSED , "given block not used");
+        if (block.isGiven()) runtime.getWarnings().warn(ID.BLOCK_UNUSED , "given block not used");
 
         each(context, eachSite(context), self, new JavaInternalBlockBody(runtime, context, "Enumerable#count", Signature.ONE_REQUIRED) {
             public IRubyObject yield(ThreadContext context1, IRubyObject[] args) {
@@ -690,7 +690,7 @@ public class RubyEnumerable {
     public static IRubyObject find_index(ThreadContext context, IRubyObject self, final IRubyObject cond, final Block block) {
         final Ruby runtime = context.runtime;
 
-        if (block.isGiven()) runtime.getWarnings().warning(ID.BLOCK_UNUSED , "given block not used");
+        if (block.isGiven()) runtime.getWarnings().warn(ID.BLOCK_UNUSED , "given block not used");
         if (self instanceof RubyArray) return ((RubyArray) self).find_index(context, cond);
 
         return find_indexCommon(context, eachSite(context), self, cond);
@@ -1086,7 +1086,7 @@ public class RubyEnumerable {
     public static IRubyObject inject(ThreadContext context, IRubyObject self, IRubyObject init, IRubyObject method, final Block block) {
         final Ruby runtime = context.runtime;
 
-        if (block.isGiven()) runtime.getWarnings().warning(ID.BLOCK_UNUSED , "given block not used");
+        if (block.isGiven()) runtime.getWarnings().warn(ID.BLOCK_UNUSED , "given block not used");
 
         final String methodId = method.asJavaString();
         final SingleObject<IRubyObject> result = new SingleObject<>(init);
@@ -1591,7 +1591,7 @@ public class RubyEnumerable {
         final boolean patternGiven = pattern != null;
 
         if (block.isGiven() && patternGiven) {
-            context.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
+            context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
         }
 
         try {
@@ -1646,7 +1646,7 @@ public class RubyEnumerable {
         final boolean patternGiven = pattern != null;
 
         if (block.isGiven() && patternGiven) {
-            context.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
+            context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
         }
 
         try {
@@ -1729,7 +1729,7 @@ public class RubyEnumerable {
         final boolean patternGiven = pattern != null;
 
         if (block.isGiven() && patternGiven) {
-            localContext.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
+            localContext.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
         }
 
         try {
@@ -1819,7 +1819,7 @@ public class RubyEnumerable {
         final boolean patternGiven = pattern != null;
 
         if (block.isGiven() && patternGiven) {
-            localContext.runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
+            localContext.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
         }
 
         try {

--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -829,13 +829,13 @@ public class RubyGlobal {
 
         @Override
         public IRubyObject set(IRubyObject value) {
-            runtime.getWarnings().warn(ID.INEFFECTIVE_GLOBAL, "warning: variable " + name + " is no longer effective; ignored");
+            runtime.getWarnings().warnDeprecated(ID.INEFFECTIVE_GLOBAL, "warning: variable " + name + " is no longer effective; ignored");
             return value;
         }
 
         @Override
         public IRubyObject get() {
-            runtime.getWarnings().warn(ID.INEFFECTIVE_GLOBAL, "warning: variable " + name + " is no longer effective");
+            runtime.getWarnings().warnDeprecated(ID.INEFFECTIVE_GLOBAL, "warning: variable " + name + " is no longer effective");
             return value;
         }
     }

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1819,6 +1819,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         int i;
         IRubyObject line;
         int argc = args.length;
+        IRubyObject outputFS = runtime.getGlobalVariables().get("$,");
 
         /* if no argument given, print `$_' */
         if (argc == 0) {
@@ -1826,8 +1827,10 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
             line = context.getLastLine();
             args = new IRubyObject[]{line};
         }
+        if (argc > 1 && !outputFS.isNil()) {
+            runtime.getWarnings().warnDeprecated("$, is set to non-nil value");
+        }
         for (i=0; i<argc; i++) {
-            IRubyObject outputFS = runtime.getGlobalVariables().get("$,");
             if (!outputFS.isNil() && i>0) {
                 write(context, out, outputFS);
             }
@@ -2403,7 +2406,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
         if (fptr == null || (fd = fptr.fd().realFileno) == -1
                 || !posix.isNative() || Platform.IS_WINDOWS ) {
-            runtime.getWarnings().warning("close_on_exec is not implemented on this platform for this stream type: " + fptr.fd().ch.getClass().getSimpleName());
+            runtime.getWarnings().warningDeprecated("close_on_exec is not implemented on this platform for this stream type: " + fptr.fd().ch.getClass().getSimpleName());
             return context.nil;
         }
 
@@ -2858,7 +2861,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         } else {
             sep = '#';
         }
-        runtime.getWarnings().warning(klass.toString() + sep + "write is outdated interface which accepts just one argument");
+        runtime.getWarnings().warningDeprecated(klass.toString() + sep + "write is outdated interface which accepts just one argument");
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1933,7 +1933,7 @@ public class RubyKernel {
         return RubyProcess.spawn(context, recv, args);
     }
 
-    @JRubyMethod(required = 1, optional = 9, checkArity = false, module = true, visibility = PRIVATE)
+    @JRubyMethod(required = 1, optional = 9, checkArity = false, module = true, notImplemented = true, visibility = PRIVATE)
     public static IRubyObject syscall(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         throw context.runtime.newNotImplementedError("Kernel#syscall is not implemented in JRuby");
     }
@@ -2493,7 +2493,7 @@ public class RubyKernel {
     // Writes backref due to decendant calls ending up in Regexp#=~
     @JRubyMethod(name = "=~", writes = FrameField.BACKREF)
     public static IRubyObject op_match(ThreadContext context, IRubyObject self, IRubyObject arg) {
-        context.runtime.getWarnings().warn(ID.DEPRECATED_METHOD,
+        context.runtime.getWarnings().warnDeprecated(ID.DEPRECATED_METHOD,
             "deprecated Object#=~ is called on " + ((RubyBasicObject) self).type() +
                 "; it always returns nil");
         return ((RubyBasicObject) self).op_match(context, arg);

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -4912,9 +4912,9 @@ public class RubyModule extends RubyObject {
             if (notAutoload || !setAutoloadConstant(name, value, file, line)) {
                 if (warn && notAutoload) {
                     if (this.equals(getRuntime().getObject())) {
-                        getRuntime().getWarnings().warning(ID.CONSTANT_ALREADY_INITIALIZED, "already initialized constant " + name);
+                        getRuntime().getWarnings().warn(ID.CONSTANT_ALREADY_INITIALIZED, "already initialized constant " + name);
                     } else {
-                        getRuntime().getWarnings().warning(ID.CONSTANT_ALREADY_INITIALIZED, "already initialized constant " + this + "::" + name);
+                        getRuntime().getWarnings().warn(ID.CONSTANT_ALREADY_INITIALIZED, "already initialized constant " + this + "::" + name);
                     }
                 }
 

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -3000,7 +3000,7 @@ public class RubyModule extends RubyObject {
         Ruby runtime = context.runtime;
 
         if (args.length == 2 && (args[1] == runtime.getTrue() || args[1] == runtime.getFalse())) {
-            runtime.getWarnings().warning(ID.OBSOLETE_ARGUMENT, "optional boolean argument is obsoleted");
+            runtime.getWarnings().warnDeprecated(ID.OBSOLETE_ARGUMENT, "optional boolean argument is obsoleted");
             boolean writeable = args[1].isTrue();
             RubySymbol sym = TypeConverter.checkID(args[0]);
             addAccessor(context, sym, getCurrentVisibilityForDefineMethod(context), args[0].isTrue(), writeable);

--- a/core/src/main/java/org/jruby/RubyRegexp.java
+++ b/core/src/main/java/org/jruby/RubyRegexp.java
@@ -934,7 +934,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
                 newOptions.setEncodingNone(true);
                 return regexpInitialize(arg0.convertToString().getByteList(), ASCIIEncoding.INSTANCE, newOptions);
             } else {
-                metaClass.runtime.getWarnings().warn("encoding option is ignored - " + kcodeBytes);
+                metaClass.runtime.getWarnings().warnDeprecated("encoding option is ignored - " + kcodeBytes);
             }
         }
         return regexpInitializeString(arg0.convertToString(), newOptions);

--- a/core/src/main/java/org/jruby/common/RubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/RubyWarnings.java
@@ -191,6 +191,10 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
         if (runtime.getWarningCategories().contains(Category.DEPRECATED)) warn(id, message);
     }
 
+    public void warnDeprecated(String message) {
+        if (runtime.getWarningCategories().contains(Category.DEPRECATED)) warn(message);
+    }
+
     public void warnDeprecatedAlternate(String name, String alternate) {
         if (runtime.getWarningCategories().contains(Category.DEPRECATED)) warn(ID.DEPRECATED_METHOD, name + " is deprecated; use " + alternate + " instead");
     }
@@ -208,15 +212,27 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
     }
 
     /**
-     * Verbose mode warning methods, their contract is that consumer must explicitly check for runtime.isVerbose() before calling them
+     * Verbose mode warning methods, only warn in verbose mode
      */
     public void warning(String message) {
         warning(ID.MISCELLANEOUS, message);
     }
 
+    public void warningDeprecated(String message) {
+        warningDeprecated(ID.MISCELLANEOUS, message);
+    }
+
     @Override
     public void warning(ID id, String message) {
+        if (!isVerbose()) return;
+
         warn(id, message);
+    }
+
+    public void warningDeprecated(ID id, String message) {
+        if (!isVerbose()) return;
+
+        warnDeprecated(id, message);
     }
 
     /**
@@ -224,10 +240,14 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
      */
     @Override
     public void warning(ID id, String fileName, int lineNumber, String message) {
+        if (!isVerbose()) return;
+
         warn(id, fileName, lineNumber, message);
     }
 
     public void warning(String fileName, int lineNumber, String message) {
+        if (!isVerbose()) return;
+
         warn(fileName, lineNumber, message);
     }
 

--- a/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
@@ -162,6 +162,10 @@ public class RubyLexer extends LexingCommon {
         warnings.warning(id, file, line + 1, message); // rubysource-line is 0 based
     }
 
+    private void warn(ID id, String message) {
+        warnings.warn(id, getFile(), getRubySourceline(), message);
+    }
+
     public enum Keyword {
         END ("end", new ByteList(new byte[] {'e', 'n', 'd'}, USASCII_ENCODING), keyword_end, keyword_end, EXPR_END),
         ELSE ("else", new ByteList(new byte[] {'e', 'l', 's', 'e'}, USASCII_ENCODING), keyword_else, keyword_else, EXPR_BEG),
@@ -354,7 +358,7 @@ public class RubyLexer extends LexingCommon {
                 c = '\n';
             } else if (ruby_sourceline > last_cr_line) {
                 last_cr_line = ruby_sourceline;
-                warning(ID.VOID_VALUE_EXPRESSION, "encountered \\r in middle of line, treated as a mere space");
+                warn(ID.VOID_VALUE_EXPRESSION, "encountered \\r in middle of line, treated as a mere space");
             }
         }
 
@@ -1489,7 +1493,7 @@ public class RubyLexer extends LexingCommon {
             try {
                 ref = Integer.parseInt(refAsString.substring(1));
             } catch (NumberFormatException e) {
-                warning(ID.AMBIGUOUS_ARGUMENT, "`" + refAsString + "' is too big for a number variable, always nil");
+                warn(ID.AMBIGUOUS_ARGUMENT, "`" + refAsString + "' is too big for a number variable, always nil");
                 ref = 0;
             }
 
@@ -1531,7 +1535,7 @@ public class RubyLexer extends LexingCommon {
                 }
 
                 if (parenNest == 0 && isLookingAtEOL()) {
-                    warning(ID.MISCELLANEOUS, "... at EOL, should be parenthesized?");
+                    warn(ID.MISCELLANEOUS, "... at EOL, should be parenthesized?");
                 } else if (getLeftParenBegin() >= 0 && getLeftParenBegin() + 1 == parenNest) {
                     if (isLexState(last_state, EXPR_LABEL)) {
                         return tDOT3;

--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -1597,11 +1597,11 @@ public abstract class RubyParserBase {
 
     // FIXME: Replace this with file/line version and stop using ISourcePosition
     public void warning(int line, String message) {
-        if (warnings.isVerbose()) warning(ID.USELESS_EXPRESSION, lexer.getFile(), line, message);
+        warning(ID.USELESS_EXPRESSION, lexer.getFile(), line, message);
     }
 
     public void warning(ID id, String file, int line, String message) {
-        warnings.warning(id, file, line + 1, message); // node/lexer lines are 0 based
+        warnings.warn(id, file, line + 1, message); // node/lexer lines are 0 based
     }
 
     // ENEBO: Totally weird naming (in MRI is not allocated and is a local var name) [1.9]

--- a/core/src/main/java/org/jruby/util/StringSupport.java
+++ b/core/src/main/java/org/jruby/util/StringSupport.java
@@ -2071,7 +2071,7 @@ public final class StringSupport {
             if (wantarray) {
                 // this code should be live in 3.0
                 if (false) { // #if STRING_ENUMERATORS_WANTARRAY
-                    runtime.getWarnings().warning(ID.BLOCK_UNUSED, "given block not used");
+                    runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
                 } else {
                     runtime.getWarnings().warning(ID.BLOCK_DEPRECATED, "passing a block to String#lines is deprecated");
                     wantarray = false;


### PR DESCRIPTION
This also marks syscall as not implemented (warns of pending deletion in CRuby) and modifies all RubyWarnings.warning* forms to no-op on verbose, as they used to (unsure when this changed).