### PR TITLE
Update strscan to fix improper sharing

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -98,7 +98,7 @@ default_gems = [
     ['shellwords', '0.1.0'],
     ['singleton', '0.1.1'],
     ['stringio', '3.0.8'],
-    ['strscan', '3.0.7'],
+    ['strscan', '3.0.9'],
     ['subspawn', '0.1.1'], # has 3 transitive deps:
       ['subspawn-posix', '0.1.1'],
       ['ffi-binary-libfixposix', '0.5.1.1'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -736,7 +736,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>strscan</artifactId>
-      <version>3.0.7</version>
+      <version>3.0.9</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1120,7 +1120,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/shellwords-0.1.0*</include>
           <include>specifications/singleton-0.1.1*</include>
           <include>specifications/stringio-3.0.8*</include>
-          <include>specifications/strscan-3.0.7*</include>
+          <include>specifications/strscan-3.0.9*</include>
           <include>specifications/subspawn-0.1.1*</include>
           <include>specifications/subspawn-posix-0.1.1*</include>
           <include>specifications/ffi-binary-libfixposix-0.5.1.1*</include>
@@ -1198,7 +1198,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/shellwords-0.1.0*/**/*</include>
           <include>gems/singleton-0.1.1*/**/*</include>
           <include>gems/stringio-3.0.8*/**/*</include>
-          <include>gems/strscan-3.0.7*/**/*</include>
+          <include>gems/strscan-3.0.9*/**/*</include>
           <include>gems/subspawn-0.1.1*/**/*</include>
           <include>gems/subspawn-posix-0.1.1*/**/*</include>
           <include>gems/ffi-binary-libfixposix-0.5.1.1*/**/*</include>
@@ -1276,7 +1276,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/shellwords-0.1.0*</include>
           <include>cache/singleton-0.1.1*</include>
           <include>cache/stringio-3.0.8*</include>
-          <include>cache/strscan-3.0.7*</include>
+          <include>cache/strscan-3.0.9*</include>
           <include>cache/subspawn-0.1.1*</include>
           <include>cache/subspawn-posix-0.1.1*</include>
           <include>cache/ffi-binary-libfixposix-0.5.1.1*</include>


### PR DESCRIPTION
The issue arises when the `StringScanner` string is being modified while being scanned. In such a case, that string's buffers will be improperly shared, forcing a new buffer to be created each time it is modified. Meanwhile the ever-growing buffers are held in memory by the improperly shared return values.

This was fixed by https://github.com/ruby/strscan/issues/84 and strscan is updated in this PR.