### PR TITLE
[fix] avoid Class#subclasses deprecation with class.rb ext

### DIFF
--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -57,6 +57,7 @@ import java.util.stream.Collectors;
 
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.common.IRubyWarnings;
 import org.jruby.compiler.impl.SkinnyMethodAdapter;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.internal.runtime.methods.DynamicMethod;
@@ -1023,6 +1024,31 @@ public class RubyClass extends RubyModule {
         concreteSubclasses(subs);
 
         return subs;
+    }
+
+    /**
+     * JRuby had historically provided Class#subclasses as an opt-in extension, which got deprecated in JRuby 9.2.
+     *
+     * Once Ruby 3.1 compatibility was implemented (JRuby 9.4) the <code>require 'jruby/core_ext.class.rb'</code> used
+     * to still cause a redefinition of the <code>Class#subclasses</code> and print deprecation warnings even for the
+     * supported `subclasses()` (no-argument) version.
+     *
+     * @implNote This method was deprecated since it's inception and should be safe to remove in JRuby 9.5 or later
+     *
+     * @param context
+     * @param recursive { true/false } whether to recurse all sub-classes
+     * @return sub-classes of this class
+     */
+    @Deprecated
+    @JRubyMethod
+    public IRubyObject subclasses(ThreadContext context, IRubyObject recursive) {
+        context.runtime.getWarnings().warnDeprecated(IRubyWarnings.ID.DEPRECATED_METHOD,
+            "Class#subclasses(opts) is deprecated, please use the supported Class#subclasses() version");
+        IRubyObject opts = context.nil;
+        if (recursive != context.nil) {
+            opts = RubyHash.newKwargs(context.runtime, "all", recursive);
+        }
+        return org.jruby.ext.jruby.JRubyLibrary.subclasses(context, this, this, opts);
     }
 
     // introduced solely to provide some level of compatibility with previous

--- a/lib/ruby/stdlib/jruby/core_ext/class.rb
+++ b/lib/ruby/stdlib/jruby/core_ext/class.rb
@@ -27,13 +27,6 @@ class Class
   private_constant :JClass
 
   ##
-  # @deprecated since JRuby 9.2, use `JRuby.subclasses_of(klass)`
-  def subclasses(recursive = false)
-    warn("klass.subclasses is deprecated, use JRuby.subclasses(klass) instead", uplevel: 1)
-    JRuby.subclasses(self, all: recursive)
-  end
-
-  ##
   # java_signature will take the argument and annotate the method of the
   # same name with the Java type and annotation signatures.
   # 


### PR DESCRIPTION
When doing a `require 'jruby/core_ext/class.rb'` the `Class#subclasses` method gets re-defined and cause a deprecation warning. Rails 7.x relies on (the Ruby 3.1 feature) `Class#subclasses` causing a lot of warning under JRuby 9.4.

The javadoc should provide an explanation (history of `Class#subclasses`), here's the demonstration of the issue:

```
bin/jruby -v -rjruby/core_ext/class -e 'puts String.subclasses'
jruby 9.4.6.0-SNAPSHOT (3.1.4) 2024-01-25 98ca4a1a53 OpenJDK 64-Bit Server VM 11.0.14.1+1 on 11.0.14.1+1 +jit [x86_64-linux]
DidYouMean::ClassNameChecker::ClassName
```
:green_circle: no warning

```
bin/jruby -v -rjruby/core_ext/class -e 'puts String.subclasses'
jruby 9.4.6.0-SNAPSHOT (3.1.4) 2024-01-25 98ca4a1a53 OpenJDK 64-Bit Server VM 11.0.14.1+1 on 11.0.14.1+1 +jit [x86_64-linux]
-e:1: warning: klass.subclasses is deprecated, use JRuby.subclasses(klass) instead
DidYouMean::ClassNameChecker::ClassName
```
:red_circle: 

---

AFTER applying this patch:

```
bin/jruby -v -rjruby/core_ext/class -e 'puts String.subclasses'
jruby 9.4.6.0-SNAPSHOT (3.1.4) 2024-01-25 98ca4a1a53 OpenJDK 64-Bit Server VM 11.0.14.1+1 on 11.0.14.1+1 +jit [x86_64-linux]
DidYouMean::ClassNameChecker::ClassName
```

```
bin/jruby -v -rjruby/core_ext/class -e 'puts String.subclasses(all: false)'
jruby 9.4.6.0-SNAPSHOT (3.1.4) 2024-01-25 98ca4a1a53 OpenJDK 64-Bit Server VM 11.0.14.1+1 on 11.0.14.1+1 +jit [x86_64-linux]
-e:1: warning: Class#subclasses(opts) is deprecated, please use the supported Class#subclasses() version
DidYouMean::ClassNameChecker::ClassName
```

The only down-side is that `String.subclasses(one_arg)` will now be available even without doing a `require 'jruby/core_ext/class'` but than doing that "properly" seemed like a lot of extra work, lmkwyt.