### PR TITLE
Rework visibility checks for Java integration

### DIFF
--- a/core/src/main/java/org/jruby/ext/ffi/Platform.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Platform.java
@@ -63,7 +63,6 @@ public class Platform {
     protected final int addressSize, longSize;
     private final long addressMask;
     protected final Pattern libPattern;
-    private int javaVersionMajor = -1;
 
     public enum OS_TYPE {
         DARWIN,
@@ -276,34 +275,9 @@ public class Platform {
         return CPU;
     }
 
-    /**
-     * Gets the version of the Java Virtual Machine (JVM) jffi is running on.
-     *
-     * @return A number representing the java version.  e.g. 8 for java 1.8, 9 for java 9
-     */
+    @Deprecated
     public final int getJavaMajorVersion() {
-        if (javaVersionMajor != -1) return javaVersionMajor;
-
-        int version = 5;
-        try {
-            String versionString = SafePropertyAccessor.getProperty("java.version");
-            if (versionString != null) {
-                // remove additional version identifiers, e.g. -ea
-                versionString = versionString.split("-|\\+")[0];
-                String[] v = versionString.split("\\.");
-                if (v[0].equals("1")) {
-                    // Pre Java 9, 1.x style
-                    version = Integer.valueOf(v[1]);
-                } else {
-                    // Java 9+, x.y.z style
-                    version = Integer.valueOf(v[0]);
-                }
-            }
-        } catch (Exception ex) {
-            version = 0;
-        }
-
-        return javaVersionMajor = version;
+        return org.jruby.platform.Platform.JAVA_VERSION;
     }
     public final boolean isBSD() {
         return OS == OS.FREEBSD || OS == OS.OPENBSD || OS == OS.NETBSD || OS == OS.DARWIN || OS == OS.DRAGONFLYBSD;

--- a/core/src/main/java/org/jruby/platform/Platform.java
+++ b/core/src/main/java/org/jruby/platform/Platform.java
@@ -94,10 +94,41 @@ public abstract class Platform {
         return arch;
     }
 
+
+    /**
+     * Gets the version of the Java platform that JRuby is running on.
+     */
+    private static int initJavaVersion() {
+        int version = 5;
+        try {
+            String versionString = SafePropertyAccessor.getProperty("java.version");
+            if (versionString != null) {
+                // remove additional version identifiers, e.g. -ea
+                versionString = versionString.split("-|\\+")[0];
+                String[] v = versionString.split("\\.");
+                if (v[0].equals("1")) {
+                    // Pre Java 9, 1.x style
+                    version = Integer.valueOf(v[1]);
+                } else {
+                    // Java 9+, x.y.z style
+                    version = Integer.valueOf(v[0]);
+                }
+            }
+        } catch (Exception ex) {
+            version = 0;
+        }
+
+        return version;
+    }
+
     public static final String ARCH = initArchitecture();
     public static final String OS = initOperatingSystem();
     public static final String JVM = getProperty("java.vm.name", "unknown");
     public static final String OS_VERSION = getProperty("os.version", "unknown");
+    /**
+     * An integer value representing the major Java/JDK release, e.g. 8 for java 1.8, 9 for java 9.
+     */
+    public static final int JAVA_VERSION = initJavaVersion();
 
     public static final boolean IS_WINDOWS = OS.equals(WINDOWS);
 


### PR DESCRIPTION
In #8061 we found that Gradle is opening several core JDK packages to support the needs of Groovy. Unfortunately this causes some normally-inaccessible methods to be accessible to JRuby's Java integration layer. In the case of HashSet, a package-private `map` method gets bound that conflicts with the Ruby version, leading to the bug reported in #8061.

Gradle's behavior is unsanitary, but ultimately the fix we have settled on here is to never try to set package-private methods accessible since they are truly not intended for consumption outside the package. That fixes this issue without addressing the larger problem of Gradle opening up core JDK packages.

Fixes #8061