### PR TITLE
[ji] fix java_import when constant exists in Object

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/ext/Module.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/Module.java
@@ -139,9 +139,8 @@ public class Module {
         proxyClass = Java.getProxyClass(runtime, javaClass);
 
         try {
-            if (!target.const_defined_p(context, runtime.newSymbol(constant)).isTrue() ||
-                    !target.getConstant(constant).equals(proxyClass)) {
-                target.setConstant(constant, proxyClass);
+            if (!target.constDefinedAt(constant) || !target.getConstant(constant, false).equals(proxyClass)) {
+                target.const_set(runtime.newSymbol(constant), proxyClass); // setConstant would not validate const-name
             }
         } catch (NameError e) {
             String message = "cannot import Java class " + javaClass.getName() + " as `" + constant + "' : " + e.getException().getMessage();

--- a/spec/java_integration/module/java_import_spec.rb
+++ b/spec/java_integration/module/java_import_spec.rb
@@ -46,5 +46,35 @@ describe "java_import" do
     expect(mod::CapsInnerClass).to eq(InnerClasses::CapsInnerClass)
   end
 
+  class Object
+    java_import 'javax.lang.model.element.Element'
+  end
+
+  module JavaImportSpec
+    java_import 'javax.lang.model.element.Element'
+    module Nested
+      java_import org.w3c.dom.Element
+      module Nested2
+        java_import 'org.w3c.dom.Element'
+      end
+    end if Element
+    module NestedAgain
+      java_import 'javax.lang.model.element.Element'
+    end
+  end
+
+  it "sets constant into proper scope (when parent has same name)" do
+    Object.send(:remove_const, :Element)
+    expect(JavaImportSpec::Element).to be(javax.lang.model.element.Element) # used to fail in JRuby <= 9.4.5
+
+    expect(JavaImportSpec::Nested::Element).to be(org.w3c.dom.Element)
+
+    expect(JavaImportSpec::Nested::Nested2.constants).to eql [:Element]
+    expect(JavaImportSpec::NestedAgain.constants).to eql [:Element]
+
+    expect(JavaImportSpec::Nested::Nested2::Element).to be(org.w3c.dom.Element)
+    expect(JavaImportSpec::NestedAgain::Element).to be(javax.lang.model.element.Element)
+  end
+
 end
 


### PR DESCRIPTION
there's a bug with `java_import` in the sense that it does not set the imported class constant on the target module/class if the Java type has been imported on Object already e.g.

```ruby
java_import 'java.util.ArrayList'
module Foo
  java_import 'java.util.ArrayList' # :ArrayList constant not set
end
Object.send(:remove_const, :ArrayList)
Foo::ArrayList # should still work but does raise...
```