### PR TITLE
Extra splat instr which did nothing

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/IRBuilder.java
@@ -818,7 +818,7 @@ public class IRBuilder {
                 return buildCallArgsArray((ListNode) args, flags);
             case SPLATNODE:
                 flags[0] |= CALL_SPLATS;
-                return new Operand[] { new Splat(addResultInstr(new BuildSplatInstr(createTemporaryVariable(), build(args), false))) };
+                return new Operand[] { new Splat(addResultInstr(new BuildSplatInstr(createTemporaryVariable(), build(((SplatNode) args).getValue()), true))) };
 
         }
 


### PR DESCRIPTION
Extra splat instr which did nothing

Ultimately this was an extra static helper method which would end up just doing an instanceof and a call to .nil() but a waste nonetheless.

Also it makes it so much more obvious this can be optimized more for pass through calls where there is no use of the variable being splatted.  For that work we would have to determine if putting more logic into builder even makes sense.