### PR TITLE
Implement RuntimeError for overtaken cvars

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -4602,12 +4602,18 @@ public class RubyModule extends RubyObject {
         assert IdUtil.isClassVariable(name);
         RubyModule module = this;
         RubyModule highest = null;
+        RubyModule lowest = null;
 
         do {
             if (module.hasClassVariable(name)) {
                 highest = module;
+                if (lowest == null) lowest = module;
             }
         } while ((module = module.getSuperClass()) != null);
+
+        if (lowest != highest) {
+            throw getRuntime().newRuntimeError(str(getRuntime(), "class variable " + name + " of ", lowest, " is overtaken by ", highest));
+        }
 
         if (highest != null) return highest.fetchClassVariable(name);
 

--- a/spec/tags/ruby/language/class_variable_tags.txt
+++ b/spec/tags/ruby/language/class_variable_tags.txt
@@ -1,1 +1,0 @@
-fails:Accessing a class variable raises a RuntimeError when a class variable is overtaken in an ancestor class


### PR DESCRIPTION
Implement RuntimeError for overtaken cvars:

```ruby
class C
end

class CC<C
  @@a=:CC
end

class C
  @@a=:C
end

class CC
  p @@a
end
```

Error:

```text
RuntimeError: class variable @@a of CC is overtaken by C
```