### PR TITLE
update jruby-openssl to 0.14.3

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -58,7 +58,7 @@ default_gems = [
     ['irb', '1.4.2'],
     ['jar-dependencies', '0.4.1'],
     ['jruby-readline', '1.3.7'],
-    ['jruby-openssl', '0.14.2'],
+    ['jruby-openssl', '0.14.3'],
     ['json', '2.7.1'],
     ['logger', '1.5.1'],
     ['mutex_m', '0.1.1'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -398,7 +398,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>jruby-openssl</artifactId>
-      <version>0.14.2</version>
+      <version>0.14.3</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1107,7 +1107,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/irb-1.4.2*</include>
           <include>specifications/jar-dependencies-0.4.1*</include>
           <include>specifications/jruby-readline-1.3.7*</include>
-          <include>specifications/jruby-openssl-0.14.2*</include>
+          <include>specifications/jruby-openssl-0.14.3*</include>
           <include>specifications/json-2.7.1*</include>
           <include>specifications/logger-1.5.1*</include>
           <include>specifications/mutex_m-0.1.1*</include>
@@ -1186,7 +1186,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/irb-1.4.2*/**/*</include>
           <include>gems/jar-dependencies-0.4.1*/**/*</include>
           <include>gems/jruby-readline-1.3.7*/**/*</include>
-          <include>gems/jruby-openssl-0.14.2*/**/*</include>
+          <include>gems/jruby-openssl-0.14.3*/**/*</include>
           <include>gems/json-2.7.1*/**/*</include>
           <include>gems/logger-1.5.1*/**/*</include>
           <include>gems/mutex_m-0.1.1*/**/*</include>
@@ -1265,7 +1265,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/irb-1.4.2*</include>
           <include>cache/jar-dependencies-0.4.1*</include>
           <include>cache/jruby-readline-1.3.7*</include>
-          <include>cache/jruby-openssl-0.14.2*</include>
+          <include>cache/jruby-openssl-0.14.3*</include>
           <include>cache/json-2.7.1*</include>
           <include>cache/logger-1.5.1*</include>
           <include>cache/mutex_m-0.1.1*</include>


### PR DESCRIPTION
details at: https://github.com/jruby/jruby-openssl/releases/tag/v0.14.3

but namely Rails 7.1 (default configuration) compatibility - authenticated cipher
also `OpenSSL:PKey::EC` compatibility improvement such as `dsa_verify_asn1`