### PR TITLE
Re-arrange indexerror string when matching group name cannot be found

### DIFF
--- a/core/src/main/java/org/jruby/RubyMatchData.java
+++ b/core/src/main/java/org/jruby/RubyMatchData.java
@@ -43,6 +43,7 @@ import org.joni.NameEntry;
 import org.joni.Regex;
 import org.joni.Region;
 import org.joni.exception.JOniException;
+import org.joni.exception.ValueException;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyClass;
 import org.jruby.runtime.Block;
@@ -53,6 +54,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 import org.jruby.util.ByteListHolder;
 import org.jruby.util.RegexpOptions;
+import org.jruby.util.RubyStringBuilder;
 import org.jruby.util.StringSupport;
 
 /**
@@ -467,6 +469,10 @@ public class RubyMatchData extends RubyObject {
         try {
             return pattern.nameToBackrefNumber(value.getUnsafeBytes(), value.getBegin(), value.getBegin() + value.getRealSize(), regs);
         } catch (JOniException je) {
+            if (je instanceof ValueException) {
+                throw runtime.newIndexError(RubyStringBuilder.str(runtime, "undefined group name reference: ", runtime.newString(value)));
+            }
+            // FIXME: I think we could only catch ValueException here, but someone needs to audit that.
             throw runtime.newIndexError(je.getMessage());
         }
     }

--- a/spec/tags/ruby/core/matchdata/begin_tags.txt
+++ b/spec/tags/ruby/core/matchdata/begin_tags.txt
@@ -1,2 +1,0 @@
-fails:MatchData#begin when passed a String argument raises IndexError if there is no group with the provided name
-fails:MatchData#begin when passed a Symbol argument raises IndexError if there is no group with the provided name

--- a/spec/tags/ruby/core/matchdata/values_at_tags.txt
+++ b/spec/tags/ruby/core/matchdata/values_at_tags.txt
@@ -1,1 +1,0 @@
-fails:Struct#values_at when passed an integer Range supports endless Range


### PR DESCRIPTION
Re-arrange indexerror string when matching group name cannot be found