### PR TITLE
NameError and NoMethodError should be dup'ing receiver

### DIFF
--- a/core/src/main/java/org/jruby/RubyNameError.java
+++ b/core/src/main/java/org/jruby/RubyNameError.java
@@ -287,6 +287,7 @@ public class RubyNameError extends RubyStandardError {
     public void copySpecialInstanceVariables(IRubyObject clone) {
         super.copySpecialInstanceVariables(clone);
         RubyNameError exception = (RubyNameError)clone;
+        exception.receiver = receiver;
         exception.name = name;
     }
 

--- a/spec/tags/ruby/core/exception/name_error_tags.txt
+++ b/spec/tags/ruby/core/exception/name_error_tags.txt
@@ -1,1 +1,0 @@
-fails:NameError#dup copies the name and receiver

--- a/spec/tags/ruby/core/exception/no_method_error_tags.txt
+++ b/spec/tags/ruby/core/exception/no_method_error_tags.txt
@@ -1,1 +1,0 @@
-fails:NoMethodError#dup copies the name, arguments and receiver


### PR DESCRIPTION
NameError and NoMethodError should be dup'ing receiver