### PR TITLE
Handle prepend in subclasses

### DIFF
--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -1087,7 +1087,7 @@ public class RubyClass extends RubyModule {
             Set<RubyClass> keys = subclasses.keySet();
             for (RubyClass klass: keys) {
                 if (klass.isSingleton()) continue;
-                if (klass.isIncluded()) {
+                if (klass.isIncluded() || klass.isPrepended()) {
                     klass.concreteSubclasses(subs);
                     continue;
                 }

--- a/spec/ruby/core/class/subclasses_spec.rb
+++ b/spec/ruby/core/class/subclasses_spec.rb
@@ -7,11 +7,38 @@ ruby_version_is '3.1' do
       assert_subclasses(ModuleSpecs::Parent, [ModuleSpecs::Child, ModuleSpecs::Child2])
     end
 
-    it "does not return included modules" do
+    it "does not return included modules from the parent" do
       parent = Class.new
       child = Class.new(parent)
       mod = Module.new
       parent.include(mod)
+
+      assert_subclasses(parent, [child])
+    end
+
+    it "does not return included modules from the child" do
+      parent = Class.new
+      child = Class.new(parent)
+      mod = Module.new
+      parent.include(mod)
+
+      assert_subclasses(parent, [child])
+    end
+
+    it "does not return prepended modules from the parent" do
+      parent = Class.new
+      child = Class.new(parent)
+      mod = Module.new
+      parent.prepend(mod)
+
+      assert_subclasses(parent, [child])
+    end
+
+    it "does not return prepended modules from the child" do
+      parent = Class.new
+      child = Class.new(parent)
+      mod = Module.new
+      child.prepend(mod)
 
       assert_subclasses(parent, [child])
     end


### PR DESCRIPTION
Fixes #8121 by handling prepended subclasses the same way as included subclasses.