### PR TITLE
EncodingError should be SyntaxError for bad symbols?

### DIFF
--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -1228,7 +1228,7 @@ public abstract class RubyParserBase {
         // FIXME: We walk this during identifier construction so we should calculate CR without having to walk twice.
         if (RubyString.scanForCodeRange(identifierValue) == StringSupport.CR_BROKEN) {
             Ruby runtime = getRuntime();
-            throw runtime.newEncodingError(str(runtime, "invalid symbol in encoding " + lexer.getEncoding() + " :\"", inspectIdentifierByteList(runtime, identifierValue), "\""));
+            throw runtime.newSyntaxError(str(runtime, "invalid symbol in encoding " + lexer.getEncoding() + " :\"", inspectIdentifierByteList(runtime, identifierValue), "\""));
         }
 
         return RubySymbol.newIDSymbol(getRuntime(), identifierValue);

--- a/spec/tags/ruby/language/hash_tags.txt
+++ b/spec/tags/ruby/language/hash_tags.txt
@@ -1,3 +1,1 @@
 fails:The ** operator makes a copy when calling a method taking a positional Hash
-fails:Hash literal raises a SyntaxError at parse time when Symbol key with invalid bytes
-fails:Hash literal raises a SyntaxError at parse time when Symbol key with invalid bytes and 'key: value' syntax used

--- a/spec/tags/ruby/language/symbol_tags.txt
+++ b/spec/tags/ruby/language/symbol_tags.txt
@@ -1,1 +1,0 @@
-fails:A Symbol literal raises an SyntaxError at parse time when Symbol with invalid bytes


### PR DESCRIPTION
EncodingError should be SyntaxError for bad symbols?