### PR TITLE
arity for {|a,| } was -2 and should have been 1

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1624,7 +1624,7 @@ public class RubyHash extends RubyObject implements Map {
         public void visit(ThreadContext context, RubyHash self, IRubyObject key, IRubyObject value, int index, Block block) {
             if (block.type == Block.Type.LAMBDA) {
                 block.call(context, context.runtime.newArray(key, value));
-            } else if (block.getSignature().arityValue() > 1 || block.getSignature().isSpreadable()) {
+            } else if (block.getSignature().isSpreadable()) {
                 block.yieldSpecific(context, key, value);
             } else {
                 block.yield(context, context.runtime.newArray(key, value));

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1624,7 +1624,7 @@ public class RubyHash extends RubyObject implements Map {
         public void visit(ThreadContext context, RubyHash self, IRubyObject key, IRubyObject value, int index, Block block) {
             if (block.type == Block.Type.LAMBDA) {
                 block.call(context, context.runtime.newArray(key, value));
-            } else if (block.getSignature().arityValue() > 1) {
+            } else if (block.getSignature().arityValue() > 1 || block.getSignature().isSpreadable()) {
                 block.yieldSpecific(context, key, value);
             } else {
                 block.yield(context, context.runtime.newArray(key, value));

--- a/core/src/main/java/org/jruby/ir/passes/AddCallProtocolInstructions.java
+++ b/core/src/main/java/org/jruby/ir/passes/AddCallProtocolInstructions.java
@@ -121,7 +121,7 @@ public class AddCallProtocolInstructions extends CompilerPass {
                 Signature sig = ((IRClosure)fic.getScope()).getSignature();
                 if (sig.isNoArguments()) {
                     prologueBB.addInstr(PrepareNoBlockArgsInstr.INSTANCE);
-                } else if (sig.isOneArgument() && !sig.isSpreadable() && !sig.hasKwargs()) { // no kwargs and just a single required argument
+                } else if (sig.isOneArgument() && !sig.hasKwargs()) { // no kwargs and just a single required argument
                     prologueBB.addInstr(PrepareSingleBlockArgInstr.INSTANCE);
                 } else {
                     prologueBB.addInstr(PrepareBlockArgsInstr.INSTANCE);

--- a/core/src/main/java/org/jruby/ir/passes/AddCallProtocolInstructions.java
+++ b/core/src/main/java/org/jruby/ir/passes/AddCallProtocolInstructions.java
@@ -121,7 +121,7 @@ public class AddCallProtocolInstructions extends CompilerPass {
                 Signature sig = ((IRClosure)fic.getScope()).getSignature();
                 if (sig.isNoArguments()) {
                     prologueBB.addInstr(PrepareNoBlockArgsInstr.INSTANCE);
-                } else if (sig.isOneArgument() && !sig.hasKwargs()) { // no kwargs and just a single required argument
+                } else if (sig.isOneArgument() && !sig.isSpreadable() && !sig.hasKwargs()) { // no kwargs and just a single required argument
                     prologueBB.addInstr(PrepareSingleBlockArgInstr.INSTANCE);
                 } else {
                     prologueBB.addInstr(PrepareBlockArgsInstr.INSTANCE);

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -513,7 +513,7 @@ public class IRRuntimeHelpers {
                         new IRubyObject[] { value };
             case  0:
             case  1:
-                return signature.isSpreadable() ?
+                return signature.rest() == org.jruby.runtime.Signature.Rest.ANON ?
                         IRBlockBody.toAry(context, value) :
                         new IRubyObject[] { value };
         }

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -513,7 +513,9 @@ public class IRRuntimeHelpers {
                         new IRubyObject[] { value };
             case  0:
             case  1:
-                return new IRubyObject[] { value };
+                return signature.isSpreadable() ?
+                        IRBlockBody.toAry(context, value) :
+                        new IRubyObject[] { value };
         }
 
         return IRBlockBody.toAry(context, value);

--- a/core/src/main/java/org/jruby/runtime/IRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/IRBlockBody.java
@@ -103,7 +103,7 @@ public abstract class IRBlockBody extends ContextAwareBlockBody {
 
     private IRubyObject yieldSpecificMultiArgsCommon(ThreadContext context, Block block, IRubyObject... args) {
         int blockArity = signature.arityValue();
-        if (blockArity == 1) {
+        if (blockArity == 1 && !signature.isSpreadable()) {
             args = new IRubyObject[] { RubyArray.newArrayMayCopy(context.runtime, args) };
         }
 

--- a/core/src/main/java/org/jruby/runtime/IRBlockBody.java
+++ b/core/src/main/java/org/jruby/runtime/IRBlockBody.java
@@ -102,14 +102,13 @@ public abstract class IRBlockBody extends ContextAwareBlockBody {
     }
 
     private IRubyObject yieldSpecificMultiArgsCommon(ThreadContext context, Block block, IRubyObject... args) {
-        int blockArity = signature.arityValue();
-        if (blockArity == 1 && !signature.isSpreadable()) {
+        if (signature.isOneArgument()) {
             args = new IRubyObject[] { RubyArray.newArrayMayCopy(context.runtime, args) };
         }
 
         if (canCallDirect()) return yieldDirect(context, block, args, null);
 
-        if (blockArity == 0) {
+        if (signature.arityValue() == 0) {
             args = IRubyObject.NULL_ARRAY; // discard args
         }
         if (block.type == Block.Type.LAMBDA) signature.checkArity(context.runtime, args);

--- a/core/src/main/java/org/jruby/runtime/Signature.java
+++ b/core/src/main/java/org/jruby/runtime/Signature.java
@@ -135,8 +135,9 @@ public class Signature {
         int oneForKeywords = requiredKwargs > 0 ? 1 : 0;
         int fixedValue = pre() + post() + oneForKeywords;
         boolean hasOptionalKeywords = kwargs - requiredKwargs > 0;
+        boolean optionalFromRest = rest() != Rest.NONE && rest != Rest.ANON;
 
-        if (opt() > 0 || rest() != Rest.NONE || (hasOptionalKeywords || restKwargs()) && oneForKeywords == 0) {
+        if (opt() > 0 || optionalFromRest || (hasOptionalKeywords || restKwargs()) && oneForKeywords == 0) {
             return -1 * (fixedValue + 1);
         }
 

--- a/core/src/main/java/org/jruby/runtime/Signature.java
+++ b/core/src/main/java/org/jruby/runtime/Signature.java
@@ -85,7 +85,7 @@ public class Signature {
      * Are there an exact (fixed) number of parameters to this signature?
      */
     public boolean isFixed() {
-        return arityValue() >= 0;
+        return arityValue() >= 0 && rest != Rest.ANON;
     }
 
     /**

--- a/core/src/main/java/org/jruby/runtime/Signature.java
+++ b/core/src/main/java/org/jruby/runtime/Signature.java
@@ -154,7 +154,7 @@ public class Signature {
      * @return true if the signature expects multiple args
      */
     public boolean isSpreadable() {
-        return arityValue < -1 || arityValue > 1 || (opt > 0 && !restKwargs());
+        return arityValue < -1 || arityValue > 1 || (opt > 0 && !restKwargs()) || rest == Rest.ANON;
     }
 
 

--- a/spec/tags/ruby/core/proc/arity_tags.txt
+++ b/spec/tags/ruby/core/proc/arity_tags.txt
@@ -1,2 +1,0 @@
-fails:Proc#arity for instances created with lambda { || } returns positive values for definition '@a = lambda { |a, | }'
-fails:Proc#arity for instances created with proc { || } returns positive values for definition '@a = proc { |a, | }'


### PR DESCRIPTION
arity for {|a,| } was -2 and should have been 1

We still use arity value for dispatch which led to four changes:

 1.  anonrest which is after the `a` variable in first sentence means it is not really a rest so -2 (1+arity)*-1{rest} becomes 1
 2. generic yield must always check on positive arity whether it should be spreadable or not
 3. specific yields must also check spreadable
 4. ACP should not specify single value it is spreadable (since it will have more than one value).

We need to transition to something instead of arityValue in signature.  I think an enum would likely simplify code and be more readable as well.
