### PR TITLE
Add-Opens for complete -jar runs as expected in later Java's

### DIFF
--- a/maven/jruby-complete/pom.rb
+++ b/maven/jruby-complete/pom.rb
@@ -41,7 +41,8 @@ project 'JRuby Complete' do
               :mainClass => 'org.jruby.Main'
             },
             manifestEntries: {
-              'Automatic-Module-Name' => 'org.jruby.complete'
+              'Automatic-Module-Name' => 'org.jruby.complete',
+              'Add-Opens' => 'java.base/java.io java.base/java.nio.channels java.base/sun.nio.ch java.management/sun.management'
             }
           },
           :instructions => {


### PR DESCRIPTION
jruby-complete.jar needs some module opens to work in Java 11+

This is another fix for #8135.  This still may not fully solve the original issue as that executes through a gradle plugin but it definitely fixes calling complete via `java -jar jruby-complete.jar`.  So there is a chance it will address the gradle plugin problem as well.