### PR TITLE
Allow extended DateTime to still be constructed using DateTime

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -303,7 +303,7 @@ public class RubyModule extends RubyObject {
             // Not sure how but this happens in test_objects_are_released_by_cache_map
             if (cl == null) return false;
 
-            return cl.searchAncestor(type.getDelegate().getOrigin()) != null;
+            return cl.hasAncestor(type);
         }
     }
 
@@ -322,6 +322,10 @@ public class RubyModule extends RubyObject {
 
     public boolean isInstance(IRubyObject object) {
         return kindOf.isKindOf(object, this);
+    }
+
+    public boolean hasAncestor(RubyModule type) {
+        return searchAncestor(type.getDelegate().getOrigin()) != null;
     }
 
     public Map<String, ConstantEntry> getConstantMap() {

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -130,6 +130,10 @@ public class RubyDate extends RubyObject {
         return (RubyClass) runtime.getObject().getConstantAt("DateTime");
     }
 
+    static boolean isDateTime(final Ruby runtime, final IRubyObject type) {
+        return ((RubyModule) type).hasAncestor(getDateTime(runtime));
+    }
+
     protected RubyDate(Ruby runtime, RubyClass klass) {
         this(runtime, klass, defaultDateTime);
     }
@@ -292,7 +296,7 @@ public class RubyDate extends RubyObject {
      */
     @JRubyMethod(name = "new!", meta = true, visibility = Visibility.PRIVATE)
     public static RubyDate new_(ThreadContext context, IRubyObject self) {
-        if (self == getDateTime(context.runtime)) {
+        if (isDateTime(context.runtime, self)) {
             return new RubyDateTime(context.runtime, 0, CHRONO_ITALY_UTC);
         }
         return new RubyDate(context.runtime, 0, CHRONO_ITALY_UTC);
@@ -304,12 +308,12 @@ public class RubyDate extends RubyObject {
     @JRubyMethod(name = "new!", meta = true, visibility = Visibility.PRIVATE)
     public static RubyDate new_(ThreadContext context, IRubyObject self, IRubyObject ajd) {
         if (ajd instanceof JavaProxy) { // backwards - compatibility with JRuby's date.rb
-            if (self == getDateTime(context.runtime)) {
-                return new RubyDateTime(context.runtime, (RubyClass) self, (DateTime) JavaUtil.unwrapJavaValue(ajd));
+            if (isDateTime(context.runtime, self)) {
+                return new RubyDateTime(context.runtime, (RubyClass) self, JavaUtil.unwrapJavaValue(ajd));
             }
-            return new RubyDate(context.runtime, (RubyClass) self, (DateTime) JavaUtil.unwrapJavaValue(ajd));
+            return new RubyDate(context.runtime, (RubyClass) self, JavaUtil.unwrapJavaValue(ajd));
         }
-        if (self == getDateTime(context.runtime)) {
+        if (isDateTime(context.runtime, self)) {
             return new RubyDateTime(context, (RubyClass) self, ajd, CHRONO_ITALY_UTC, 0);
         }
         return new RubyDate(context, (RubyClass) self, ajd, CHRONO_ITALY_UTC, 0);
@@ -320,7 +324,7 @@ public class RubyDate extends RubyObject {
      */
     @JRubyMethod(name = "new!", meta = true, visibility = Visibility.PRIVATE)
     public static RubyDate new_(ThreadContext context, IRubyObject self, IRubyObject ajd, IRubyObject of) {
-        if (self == getDateTime(context.runtime)) {
+        if (isDateTime(context.runtime, self)) {
             return new RubyDateTime(context.runtime, (RubyClass) self).initialize(context, ajd, of);
         }
         return new RubyDate(context.runtime, (RubyClass) self).initialize(context, ajd, of);
@@ -331,7 +335,7 @@ public class RubyDate extends RubyObject {
      */
     @JRubyMethod(name = "new!", meta = true, visibility = Visibility.PRIVATE)
     public static RubyDate new_(ThreadContext context, IRubyObject self, IRubyObject ajd, IRubyObject of, IRubyObject sg) {
-        if (self == getDateTime(context.runtime)) {
+        if (isDateTime(context.runtime, self)) {
             return new RubyDateTime(context.runtime, (RubyClass) self).initialize(context, ajd, of, sg);
         }
         return new RubyDate(context.runtime, (RubyClass) self).initialize(context, ajd, of, sg);


### PR DESCRIPTION
Allow extended DateTime to still be constructed using DateTime.  Fixes #8139.