### PR TITLE
Refactor external API to ease extension porting

### DIFF
--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -44,6 +44,7 @@ import org.jcodings.specific.ASCIIEncoding;
 import org.jcodings.specific.UTF8Encoding;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.api.API;
 import org.jruby.exceptions.NotImplementedError;
 import org.jruby.runtime.*;
 import org.jruby.runtime.JavaSites.FileSites;
@@ -1487,7 +1488,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
     protected IRubyObject openFile(ThreadContext context, IRubyObject args[]) {
         Ruby runtime = context.runtime;
 
-        Object pm = EncodingUtils.vmodeVperm(null, null);
+        API.ModeAndPermission pm = EncodingUtils.vmodeVperm(null, null);
         IRubyObject options = context.nil;
 
         switch(args.length) {

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -2435,11 +2435,11 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         if (this != write_io) {
             fptr = write_io.getOpenFileChecked();
             if (fptr != null && 0 <= (fd = fptr.fd().realFileno)) {
-                if ((ret = posix.fcntl(fd, Fcntl.F_GETFD)) == -1) return API.rb_sys_fail_path(runtime, fptr.getPath());
+                if ((ret = posix.fcntl(fd, Fcntl.F_GETFD)) == -1) return API.sysFailWithPath(context, fptr.getPath());
                 if ((ret & FD_CLOEXEC) != flag) {
                     ret = (ret & ~FD_CLOEXEC) | flag;
                     ret = posix.fcntlInt(fd, Fcntl.F_SETFD, ret);
-                    if (ret == -1) API.rb_sys_fail_path(runtime, fptr.getPath());
+                    if (ret == -1) API.sysFailWithPath(context, fptr.getPath());
                 }
             }
 
@@ -2447,11 +2447,11 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
         fptr = getOpenFileChecked();
         if (fptr != null && 0 <= (fd = fptr.fd().realFileno)) {
-            if ((ret = posix.fcntl(fd, Fcntl.F_GETFD)) == -1) API.rb_sys_fail_path(runtime, fptr.getPath());
+            if ((ret = posix.fcntl(fd, Fcntl.F_GETFD)) == -1) API.sysFailWithPath(context, fptr.getPath());
             if ((ret & FD_CLOEXEC) != flag) {
                 ret = (ret & ~FD_CLOEXEC) | flag;
                 ret = posix.fcntlInt(fd, Fcntl.F_SETFD, ret);
-                if (ret == -1) API.rb_sys_fail_path(runtime, fptr.getPath());
+                if (ret == -1) API.sysFailWithPath(context, fptr.getPath());
             }
         }
 
@@ -2477,14 +2477,14 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         if (this != write_io) {
             fptr = write_io.getOpenFileChecked();
             if (fptr != null && 0 <= (fd = fptr.fd().realFileno)) {
-                if ((ret = posix.fcntl(fd, Fcntl.F_GETFD)) == -1) API.rb_sys_fail_path(runtime, fptr.getPath());
+                if ((ret = posix.fcntl(fd, Fcntl.F_GETFD)) == -1) API.sysFailWithPath(context, fptr.getPath());
                 if ((ret & FD_CLOEXEC) == 0) return context.fals;
             }
         }
 
         fptr = getOpenFileChecked();
         if (fptr != null && 0 <= (fd = fptr.fd().realFileno)) {
-            if ((ret = posix.fcntl(fd, Fcntl.F_GETFD)) == -1) API.rb_sys_fail_path(runtime, fptr.getPath());
+            if ((ret = posix.fcntl(fd, Fcntl.F_GETFD)) == -1) API.sysFailWithPath(context, fptr.getPath());
             if ((ret & FD_CLOEXEC) == 0) return context.fals;
         }
         return context.tru;

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -622,7 +622,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         try {
             if (nmode != nil || opt != nil) {
                 ConvConfig convconfig = new ConvConfig();
-                Object vmode_vperm = vmodeVperm(nmode, null);
+                API.ModeAndPermission vmode_vperm = vmodeVperm(nmode, null);
                 int[] fmode_p = {0};
 
                 EncodingUtils.extractModeEncoding(context, convconfig, vmode_vperm, opt, oflags_p, fmode_p);
@@ -955,7 +955,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
             throw runtime.newErrnoEBADFError();
         }
 
-        Object pm = EncodingUtils.vmodeVperm(vmodeArg, runtime.newFixnum(0));
+        API.ModeAndPermission pm = EncodingUtils.vmodeVperm(vmodeArg, runtime.newFixnum(0));
         int[] fmode_p = {0};
         ConvConfig convconfig = new ConvConfig();
         EncodingUtils.extractModeEncoding(context, convconfig, pm, opt, oflags_p, fmode_p);
@@ -4154,7 +4154,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         int[] oflags_p = {0}, fmode_p = {0};
         ConvConfig convConfig = new ConvConfig();
 
-        Object pm = EncodingUtils.vmodeVperm(vmode, vperm);
+        API.ModeAndPermission pm = EncodingUtils.vmodeVperm(vmode, vperm);
         EncodingUtils.extractModeEncoding(context, convConfig, pm, opt, oflags_p, fmode_p);
         vperm = vperm(pm);
         int perm = (vperm == null || vperm == context.nil) ? 0666 : RubyNumeric.num2int(vperm);
@@ -4520,7 +4520,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
         io.MakeOpenFile();
 
-        Object pm = vmodeVperm(pmode, runtime.newFixnum(0));
+        API.ModeAndPermission pm = vmodeVperm(pmode, runtime.newFixnum(0));
         int[] oflags_p = {0}, fmode_p = {0};
         EncodingUtils.extractModeEncoding(context, io, pm, options, oflags_p, fmode_p);
         ModeFlags modes = ModeFlags.createModeFlags(oflags_p[0]);

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -557,7 +557,7 @@ public class RubyRange extends RubyObject {
 
         IRubyObject nil = context.nil;
 
-        IRubyObject valMax = API.rb_rescue_typeerror(context, nil, () -> sites(context).max.call(context, this, val));
+        IRubyObject valMax = API.rescueTypeError(context, nil, () -> sites(context).max.call(context, this, val));
 
         if (valMax == nil) return false;
 

--- a/core/src/main/java/org/jruby/api/API.java
+++ b/core/src/main/java/org/jruby/api/API.java
@@ -84,4 +84,14 @@ public class API {
             context.setExceptionRequiresBacktrace(exceptionRequiresBacktrace);
         }
     }
+
+    public static class ModeAndPermission {
+        public IRubyObject mode;
+        public IRubyObject permission;
+
+        public ModeAndPermission(IRubyObject mode, IRubyObject permission) {
+            this.mode = mode;
+            this.permission = permission;
+        }
+    }
 }

--- a/core/src/main/java/org/jruby/api/MRI.java
+++ b/core/src/main/java/org/jruby/api/MRI.java
@@ -1,9 +1,26 @@
 package org.jruby.api;
 
+import org.jcodings.Encoding;
+import org.jcodings.transcode.EConv;
+import org.jruby.Ruby;
+import org.jruby.RubyArray;
+import org.jruby.RubyEncoding;
+import org.jruby.RubyHash;
+import org.jruby.RubyString;
+import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.ByteList;
+import org.jruby.util.io.EncodingUtils;
+import org.jruby.util.io.IOEncodable;
+import org.jruby.util.io.OpenFile;
 
 import java.util.function.Supplier;
+
+import static org.jruby.RubyString.newBinaryString;
+import static org.jruby.RubyString.newEmptyString;
+import static org.jruby.RubyString.newString;
+import static org.jruby.util.StringSupport.searchNonAscii;
 
 public class MRI {
     public static IRubyObject rb_sys_fail_path(ThreadContext context, String path) {
@@ -24,5 +41,195 @@ public class MRI {
 
     public static <T> T rb_rescue_typeerror(ThreadContext context, T dflt, Supplier<T> func) {
         return API.rescueTypeError(context, dflt, func);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Encoding-related functions
+    ///////////////////////////////////////////////////////////////////////////
+
+    public static Encoding rb_to_encoding(ThreadContext context, IRubyObject enc) {
+        return EncodingUtils.rbToEncoding(context, enc);
+    }
+
+    public static Encoding rb_ascii8bit_encoding(Ruby runtime) {
+        return EncodingUtils.ascii8bitEncoding(runtime);
+    }
+
+    public static void rb_io_extract_modeenc(ThreadContext context,
+                                             IOEncodable ioEncodable, API.ModeAndPermission vmodeAndVperm_p, IRubyObject options, int[] oflags_p, int[] fmode_p) {
+        EncodingUtils.extractModeEncoding(context, ioEncodable, vmodeAndVperm_p, options, oflags_p, fmode_p);
+    }
+
+    public static boolean rb_io_extract_encoding_option(ThreadContext context, IOEncodable ioEncodable, IRubyObject options, int[] fmode_p) {
+        return EncodingUtils.ioExtractEncodingOption(context, ioEncodable, options, fmode_p);
+    }
+
+    public static RubyString rb_external_str_new_with_enc(Ruby runtime, String string, Encoding encoding) {
+        return EncodingUtils.newExternalStringWithEncoding(runtime, string, encoding);
+    }
+
+    public static RubyString rb_external_str_new_with_enc(Ruby runtime, ByteList bytelist, Encoding encoding) {
+        return EncodingUtils.newExternalStringWithEncoding(runtime, bytelist, encoding);
+    }
+
+    public static ByteList rb_econv_str_convert(ThreadContext context, EConv ec, ByteList src, int flags) {
+        return EncodingUtils.econvStrConvert(context, ec, src, flags);
+    }
+
+    public static ByteList rb_econv_str_convert(ThreadContext context, EConv ec, byte[] bytes, int start, int length, int flags) {
+        return EncodingUtils.econvByteConvert(context, ec, bytes, start, length, flags);
+    }
+
+    public static ByteList rb_econv_substr_append(ThreadContext context, EConv ec, ByteList src, ByteList dst, int flags) {
+        return EncodingUtils.econvSubstrAppend(context, ec, src, dst, flags);
+    }
+
+    public static ByteList rb_econv_append(ThreadContext context, EConv ec, ByteList sByteList, ByteList dst, int flags) {
+        return EncodingUtils.econvAppend(context, ec, sByteList, dst, flags);
+    }
+
+    public static ByteList rb_econv_append(ThreadContext context, EConv ec, byte[] bytes, int start, int length, ByteList dst, int flags) {
+        return EncodingUtils.econvAppend(context, ec, bytes, start, length, dst, flags);
+    }
+
+    public static void rb_econv_check_error(ThreadContext context, EConv ec) {
+        EncodingUtils.econvCheckError(context, ec);
+    }
+
+    public static int rb_econv_prepare_opts(ThreadContext context, IRubyObject opthash, IRubyObject[] opts) {
+        return EncodingUtils.econvPrepareOpts(context, opthash, opts);
+    }
+
+    public static int rb_econv_prepare_options(ThreadContext context, IRubyObject opthash, IRubyObject[] opts, int ecflags) {
+        return EncodingUtils.econvPrepareOptions(context, opthash, opts, ecflags);
+    }
+
+    public static EConv rb_econv_open_opts(ThreadContext context, byte[] sourceEncoding, byte[] destinationEncoding, int ecflags, IRubyObject opthash) {
+        return EncodingUtils.econvOpenOpts(context, sourceEncoding, destinationEncoding, ecflags, opthash);
+    }
+
+    public static RaiseException rb_econv_open_exc(ThreadContext context, byte[] sourceEncoding, byte[] destinationEncoding, int ecflags) {
+        return EncodingUtils.econvOpenExc(context, sourceEncoding, destinationEncoding, ecflags);
+    }
+
+    public static Encoding rb_econv_asciicompat_encoding(Encoding enc) {
+        return EncodingUtils.econvAsciicompatEncoding(enc);
+    }
+
+    public static boolean rb_enc_asciicompat(Encoding enc) {
+        return EncodingUtils.encAsciicompat(enc);
+    }
+
+    public static int rb_enc_ascget(byte[] pBytes, int p, int e, int[] len, Encoding enc) {
+        return EncodingUtils.encAscget(pBytes, p, e, len, enc);
+    }
+
+    public static int rb_enc_mbminlen(Encoding encoding) {
+        return EncodingUtils.encMbminlen(encoding);
+    }
+
+    public static boolean rb_enc_dummy_p(Encoding enc) {
+        return EncodingUtils.encDummy(enc);
+    }
+
+    public static Encoding rb_enc_get(ThreadContext context, IRubyObject obj) {
+        return EncodingUtils.encGet(context, obj);
+    }
+
+    public static Encoding rb_to_encoding_index(ThreadContext context, IRubyObject enc) {
+        return EncodingUtils.toEncodingIndex(context, enc);
+    }
+
+    public static IRubyObject rb_enc_associate_index(IRubyObject obj, Encoding encidx) {
+        return EncodingUtils.encAssociateIndex(obj, encidx);
+    }
+
+    public static IRubyObject rb_str_encode(ThreadContext context, IRubyObject str, IRubyObject to, int ecflags, IRubyObject ecopt) {
+        return EncodingUtils.rbStrEncode(context, str, to, ecflags, ecopt);
+    }
+
+    public static ByteList rb_str_encode(ThreadContext context, byte[] bytes, int start, int length, Encoding encoding, int cr, Encoding to, int ecflags, IRubyObject ecopt) {
+        return EncodingUtils.rbByteEncode(context, bytes, start, length, encoding, cr, to, ecflags, ecopt);
+    }
+
+    public static IRubyObject rb_obj_encoding(ThreadContext context, IRubyObject obj) {
+        return EncodingUtils.objEncoding(context, obj);
+    }
+
+    public static Encoding rb_define_dummy_encoding(ThreadContext context, byte[] name) {
+        return EncodingUtils.defineDummyEncoding(context, name);
+    }
+
+    public static RubyString rb_str_conv_enc_opts(ThreadContext context, RubyString str, Encoding fromEncoding,
+                                            Encoding toEncoding, int ecflags, IRubyObject ecopts) {
+        return EncodingUtils.strConvEncOpts(context, str, fromEncoding, toEncoding, ecflags, ecopts);
+    }
+
+    public static RubyString rb_str_conv_enc(ThreadContext context, RubyString value, Encoding fromEncoding, Encoding toEncoding) {
+        return EncodingUtils.strConvEnc(context, value, fromEncoding, toEncoding);
+    }
+
+    public static ByteList rb_str_conv_enc(ThreadContext context, ByteList value, Encoding fromEncoding, Encoding toEncoding) {
+        return EncodingUtils.strConvEnc(context, value, fromEncoding, toEncoding);
+    }
+
+    public static void rb_enc_set_default_external(ThreadContext context, IRubyObject encoding) {
+        EncodingUtils.rbEncSetDefaultExternal(context, encoding);
+    }
+
+    public static void rb_enc_set_default_internal(ThreadContext context, IRubyObject encoding) {
+        EncodingUtils.rbEncSetDefaultInternal(context, encoding);
+    }
+
+    public static Encoding rb_default_external_encoding(ThreadContext context) {
+        return EncodingUtils.defaultExternalEncoding(context.runtime);
+    }
+
+    public static void rb_enc_str_buf_cat(ThreadContext context, RubyString str, ByteList ptr, Encoding enc) {
+        EncodingUtils.encStrBufCat(context.runtime, str, ptr, enc);
+    }
+
+    public static void rb_enc_str_buf_cat(ThreadContext context, RubyString str, ByteList ptr) {
+        EncodingUtils.encStrBufCat(context.runtime, str, ptr);
+    }
+
+    public static void rb_enc_str_buf_cat(ThreadContext context, RubyString str, byte[] ptrBytes) {
+        EncodingUtils.encStrBufCat(context.runtime, str, ptrBytes);
+    }
+
+    public static void rb_enc_str_buf_cat(ThreadContext context, RubyString str, byte[] ptrBytes, Encoding enc) {
+        EncodingUtils.encStrBufCat(context.runtime, str, ptrBytes, enc);
+    }
+
+    public static void rb_enc_str_buf_cat(ThreadContext context, RubyString str, byte[] ptrBytes, int ptr, int len, Encoding enc) {
+        EncodingUtils.encStrBufCat(context.runtime, str, ptrBytes, ptr, len, enc);
+    }
+
+    public static void rb_enc_str_buf_cat(ThreadContext context, RubyString str, CharSequence cseq) {
+        EncodingUtils.encStrBufCat(context.runtime, str, cseq);
+    }
+
+    public static RubyString rb_enc_uint_chr(ThreadContext context, int code, Encoding enc) {
+        return EncodingUtils.encUintChr(context, code, enc);
+    }
+
+    public static int rb_enc_mbcput(ThreadContext context, int c, byte[] buf, int p, Encoding enc) {
+        return EncodingUtils.encMbcput(context, c, buf, p, enc);
+    }
+
+    public static int rb_enc_codepoint_len(ThreadContext context, byte[] pBytes, int p, int e, int[] len_p, Encoding enc) {
+        return EncodingUtils.encCodepointLength(context.runtime, pBytes, p, e, len_p, enc);
+    }
+
+    public static RubyString rb_str_escape(ThreadContext context, RubyString str) {
+        return EncodingUtils.rbStrEscape(context, str);
+    }
+
+    public static int rb_str_buf_cat_escaped_char(RubyString result, long c, boolean unicode_p) {
+        return EncodingUtils.rbStrBufCatEscapedChar(result, c, unicode_p);
+    }
+
+    public static int rb_enc_codelen(ThreadContext context, int c, Encoding enc) {
+        return EncodingUtils.encCodelen(context, c, enc);
     }
 }

--- a/core/src/main/java/org/jruby/api/MRI.java
+++ b/core/src/main/java/org/jruby/api/MRI.java
@@ -11,6 +11,7 @@ import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
+import org.jruby.util.ByteListHolder;
 import org.jruby.util.io.EncodingUtils;
 import org.jruby.util.io.IOEncodable;
 import org.jruby.util.io.OpenFile;
@@ -171,6 +172,18 @@ public class MRI {
 
     public static Encoding rb_default_external_encoding(ThreadContext context) {
         return EncodingUtils.defaultExternalEncoding(context.runtime);
+    }
+
+    public static void  rb_str_buf_cat(Ruby runtime, RubyString str, ByteList ptr) {
+        EncodingUtils.rbStrBufCat(runtime, str, ptr);
+    }
+
+    public static void  rb_str_buf_cat(Ruby runtime, ByteListHolder str, byte[] ptrBytes, int ptr, int len) {
+        EncodingUtils.rbStrBufCat(runtime, str, ptrBytes, ptr, len);
+    }
+
+    public static void  rb_str_buf_cat(Ruby runtime, ByteList str, byte[] ptrBytes, int ptr, int len) {
+        EncodingUtils.rbStrBufCat(runtime, str, ptrBytes, ptr, len);
     }
 
     public static void rb_enc_str_buf_cat(ThreadContext context, RubyString str, ByteList ptr, Encoding enc) {

--- a/core/src/main/java/org/jruby/api/MRI.java
+++ b/core/src/main/java/org/jruby/api/MRI.java
@@ -23,24 +23,12 @@ import static org.jruby.RubyString.newString;
 import static org.jruby.util.StringSupport.searchNonAscii;
 
 public class MRI {
-    public static IRubyObject rb_sys_fail_path(ThreadContext context, String path) {
-        return API.sysFailWithPath(context, path);
-    }
-
     public static int rb_pipe(ThreadContext context, int[] pipes) {
         return API.newPipe(context, pipes);
     }
 
     public static int rb_cloexec_pipe(ThreadContext context, int[] pipes) {
         return API.cloexecPipe(context, pipes);
-    }
-
-    public static void rb_maygvl_fd_fix_cloexec(ThreadContext context, int fd) {
-        API.fdFixCloexec(context, fd);
-    }
-
-    public static <T> T rb_rescue_typeerror(ThreadContext context, T dflt, Supplier<T> func) {
-        return API.rescueTypeError(context, dflt, func);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/org/jruby/api/MRI.java
+++ b/core/src/main/java/org/jruby/api/MRI.java
@@ -1,0 +1,28 @@
+package org.jruby.api;
+
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import java.util.function.Supplier;
+
+public class MRI {
+    public static IRubyObject rb_sys_fail_path(ThreadContext context, String path) {
+        return API.sysFailWithPath(context, path);
+    }
+
+    public static int rb_pipe(ThreadContext context, int[] pipes) {
+        return API.newPipe(context, pipes);
+    }
+
+    public static int rb_cloexec_pipe(ThreadContext context, int[] pipes) {
+        return API.cloexecPipe(context, pipes);
+    }
+
+    public static void rb_maygvl_fd_fix_cloexec(ThreadContext context, int fd) {
+        API.fdFixCloexec(context, fd);
+    }
+
+    public static <T> T rb_rescue_typeerror(ThreadContext context, T dflt, Supplier<T> func) {
+        return API.rescueTypeError(context, dflt, func);
+    }
+}

--- a/core/src/main/java/org/jruby/util/io/EncodingUtils.java
+++ b/core/src/main/java/org/jruby/util/io/EncodingUtils.java
@@ -137,6 +137,7 @@ public class EncodingUtils {
         return value == null ? runtime.getNil() : value;
     }
 
+    // MRI: rb_ascii8bit_encoding
     public static Encoding ascii8bitEncoding(Ruby runtime) {
         return runtime.getEncodingService().getAscii8bitEncoding();
     }
@@ -2308,8 +2309,8 @@ public class EncodingUtils {
         return getEncoding(str.getByteList());
     }
 
-    public static RubyString rbStrEscape(Ruby runtime, RubyString str) {
-        return (RubyString) RubyString.rbStrEscape(runtime.getCurrentContext(), str);
+    public static RubyString rbStrEscape(ThreadContext context, RubyString str) {
+        return (RubyString) RubyString.rbStrEscape(context, str);
     }
 
     // MRI: ISPRINT

--- a/core/src/main/java/org/jruby/util/io/EncodingUtils.java
+++ b/core/src/main/java/org/jruby/util/io/EncodingUtils.java
@@ -34,6 +34,7 @@ import org.jruby.RubyNumeric;
 import org.jruby.RubyProc;
 import org.jruby.RubyString;
 import org.jruby.RubySymbol;
+import org.jruby.api.API;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.platform.Platform;
 import org.jruby.runtime.Block;
@@ -140,27 +141,24 @@ public class EncodingUtils {
         return runtime.getEncodingService().getAscii8bitEncoding();
     }
 
-    static final int VMODE = 0;
-    static final int PERM = 1;
-
-    public static Object vmodeVperm(IRubyObject vmode, IRubyObject vperm) {
-        return new IRubyObject[] {vmode, vperm};
+    public static API.ModeAndPermission vmodeVperm(IRubyObject vmode, IRubyObject vperm) {
+        return new API.ModeAndPermission(vmode, vperm);
     }
 
-    public static IRubyObject vmode(Object vmodeVperm) {
-        return ((IRubyObject[])vmodeVperm)[VMODE];
+    public static IRubyObject vmode(API.ModeAndPermission vmodeVperm) {
+        return vmodeVperm.mode;
     }
 
-    public static void vmode(Object vmodeVperm, IRubyObject vmode) {
-        ((IRubyObject[])vmodeVperm)[VMODE] = vmode;
+    public static void vmode(API.ModeAndPermission vmodeVperm, IRubyObject vmode) {
+        vmodeVperm.mode = vmode;
     }
 
-    public static IRubyObject vperm(Object vmodeVperm) {
-        return ((IRubyObject[])vmodeVperm)[PERM];
+    public static IRubyObject vperm(API.ModeAndPermission vmodeVperm) {
+        return vmodeVperm.permission;
     }
 
-    public static void vperm(Object vmodeVperm, IRubyObject vperm) {
-        ((IRubyObject[])vmodeVperm)[PERM] = vperm;
+    public static void vperm(API.ModeAndPermission vmodeVperm, IRubyObject vperm) {
+        vmodeVperm.permission = vperm;
     }
 
     public static final int MODE_BTMODE(int fmode, int a, int b, int c) {
@@ -188,7 +186,7 @@ public class EncodingUtils {
      */
     // mri: rb_io_extract_modeenc
     public static void extractModeEncoding(ThreadContext context,
-            IOEncodable ioEncodable, Object vmodeAndVperm_p, IRubyObject options, int[] oflags_p, int[] fmode_p) {
+                                           IOEncodable ioEncodable, API.ModeAndPermission vmodeAndVperm_p, IRubyObject options, int[] oflags_p, int[] fmode_p) {
         Ruby runtime = context.runtime;
         int ecflags;
         IRubyObject[] ecopts_p = {context.nil};

--- a/core/src/main/java/org/jruby/util/io/PopenExecutor.java
+++ b/core/src/main/java/org/jruby/util/io/PopenExecutor.java
@@ -306,7 +306,7 @@ public class PopenExecutor {
         Ruby runtime = context.runtime;
         String modestr;
         IRubyObject pname, port, tmp, opt = context.nil, env = context.nil;
-        Object pmode = EncodingUtils.vmodeVperm(null, null);
+        API.ModeAndPermission pmode = EncodingUtils.vmodeVperm(null, null);
         ExecArg eargp;
         int[] oflags_p = {0}, fmode_p = {0};
         IOEncodable.ConvConfig convconfig = new IOEncodable.ConvConfig();

--- a/core/src/main/java/org/jruby/util/io/PopenExecutor.java
+++ b/core/src/main/java/org/jruby/util/io/PopenExecutor.java
@@ -601,9 +601,9 @@ public class PopenExecutor {
         int[] pair = {-1,-1}, writePair = {-1, -1};
         switch (fmode & (OpenFile.READABLE|OpenFile.WRITABLE)) {
             case OpenFile.READABLE | OpenFile.WRITABLE:
-                if (API.rb_pipe(runtime, writePair) == -1)
+                if (API.newPipe(context, writePair) == -1)
                     throw runtime.newErrnoFromErrno(posix.getErrno(), prog.toString());
-                if (API.rb_pipe(runtime, pair) == -1) {
+                if (API.newPipe(context, pair) == -1) {
                     e = posix.getErrno();
                     runtime.getPosix().close(writePair[1]);
                     runtime.getPosix().close(writePair[0]);
@@ -615,14 +615,14 @@ public class PopenExecutor {
 
                 break;
             case OpenFile.READABLE:
-                if (API.rb_pipe(runtime, pair) == -1)
+                if (API.newPipe(context, pair) == -1)
                     throw runtime.newErrnoFromErrno(posix.getErrno(), prog.toString());
 
                 if (eargp != null) prepareStdioRedirects(runtime, pair, null, eargp);
 
                 break;
             case OpenFile.WRITABLE:
-                if (API.rb_pipe(runtime, pair) == -1)
+                if (API.newPipe(context, pair) == -1)
                     throw runtime.newErrnoFromErrno(posix.getErrno(), prog.toString());
 
                 if (eargp != null) prepareStdioRedirects(runtime, null, pair, eargp);


### PR DESCRIPTION
This is a proof-of-concept of a new external API that meets the following needs:

* Simple static methods easily imported and used from extension code, similar to C functions.
* JRuby and MRI-friendly names for 1:1 matching with extension code when that makes porting easier.
* Update to modern JRuby standards with ThreadContext and call site cache support.