### PR TITLE
[ji] support re-reifying class hierarchy

### DIFF
--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -1403,25 +1403,10 @@ public class RubyClass extends RubyModule {
         if (!isReifiable(java_box)) return;
         final boolean concreteExt = java_box[0];
 
-        final String javaName = getReifiedJavaClassName();
-        final String javaPath = javaName.replace('.', '/');
-
         final Class<?> parentReified = superClass.getRealClass().getReifiedClass();
         if (parentReified == null) {
             throw getClassRuntime().newTypeError(getName() + "'s parent class is not yet reified");
         }
-
-        Class<?> reifiedParent = superClass.reifiedClass;
-        if (reifiedParent == null) reifiedParent = RubyObject.class;
-
-        Reificator reifier;
-        if (concreteExt) {
-            reifier = new ConcreteJavaReifier(parentReified, javaName, javaPath);
-        } else {
-            reifier = new MethodReificator(reifiedParent, javaName, javaPath, null, javaPath);
-        }
-
-        final byte[] classBytes = reifier.reify();
 
         ClassDefiningClassLoader classLoader; // usually parent's class-loader
         if (parentReified.getClassLoader() instanceof OneShotClassLoader) {
@@ -1437,6 +1422,32 @@ public class RubyClass extends RubyModule {
                 classLoader = runtime.getJRubyClassLoader();
             }
         }
+
+        String javaName = getReifiedJavaClassName();
+        // *might* need to include a Class identifier in the Java class name, since a Ruby class might be dropped
+        // (using remove_const) and re-created in which case using the same name would cause a conflict...
+        if (classLoader.hasDefinedClass(javaName)) { // as Ruby class dropping is "unusual" - assume v0 to be the raw name
+            int v = 1;
+            // NOTE: '$' is not supported in Ruby class names thus it's safe to use as a "separator"
+            String versionedName = javaName + "$v" + v; // rubyobj.SomeModule.FooKlass$v1
+            while (classLoader.hasDefinedClass(versionedName)) {
+                versionedName = javaName + "$v" + (++v);
+            }
+            javaName = versionedName;
+        }
+        final String javaPath = javaName.replace('.', '/');
+
+        Reificator reifier;
+        if (concreteExt) {
+            reifier = new ConcreteJavaReifier(parentReified, javaName, javaPath);
+        } else {
+            Class<?> reifiedParent = superClass.reifiedClass;
+            if (reifiedParent == null) reifiedParent = RubyObject.class;
+            reifier = new MethodReificator(reifiedParent, javaName, javaPath, null, javaPath);
+        }
+
+        final byte[] classBytes = reifier.reify();
+
         boolean nearEnd = false;
         // Attempt to load the name we plan to use; skip reification if it exists already (see #1229).
         try {
@@ -1497,11 +1508,8 @@ public class RubyClass extends RubyModule {
         if (getBaseName() == null) { // anonymous Class instance: rubyobj.Class$0x1234abcd
             return basePackagePrefix + anonymousMetaNameWithIdentifier().replace(':', '$');
         }
-        final String identityHash = Integer.toHexString(System.identityHashCode(this));
         final CharSequence name = StringSupport.replaceAll(getName(), "::", ".");
-        // we need to include a Class identifier in the Java class name, since a Ruby class might be dropped
-        // (using remove_const) and re-created in which case using the same name would cause a conflict...
-        return basePackagePrefix + identityHash + '.' + name; // TheFoo::Bar -> rubyobj.320efdf5.TheFoo.Bar
+        return basePackagePrefix + name; // TheFoo::Bar -> rubyobj.TheFoo.Bar
     }
 
     interface Reificator {

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -795,17 +795,17 @@ public class RubyModule extends RubyObject {
     }
 
     private String calculateAnonymousName() {
-        String cachedName = this.cachedName; // re-use cachedName field since it won't be set for anonymous class
+        String cachedName = this.cachedName;
         if (cachedName == null) {
             // anonymous classes get the #<Class:0xdeadbeef> format
-            StringBuilder anonBase = new StringBuilder(24);
-            anonBase.append("#<").append(metaClass.getRealClass().getName()).append(":0x");
-            anonBase.append(Integer.toHexString(System.identityHashCode(this))).append('>');
-            cachedName = this.cachedName = anonBase.toString();
+            cachedName = this.cachedName = "#<" + anonymousMetaNameWithIdentifier() + '>';
         }
         return cachedName;
     }
 
+    String anonymousMetaNameWithIdentifier() {
+        return metaClass.getRealClass().getName() + ":0x" + Integer.toHexString(System.identityHashCode(this));
+    }
 
     @JRubyMethod(name = "refine", reads = SCOPE)
     public IRubyObject refine(ThreadContext context, IRubyObject klass, Block block) {

--- a/core/src/main/java/org/jruby/util/ClassDefiningClassLoader.java
+++ b/core/src/main/java/org/jruby/util/ClassDefiningClassLoader.java
@@ -6,6 +6,8 @@ public interface ClassDefiningClassLoader {
 
     Class<?> loadClass(String name) throws ClassNotFoundException;
 
+    boolean hasDefinedClass(String name);
+
     default ClassLoader asClassLoader() { return (ClassLoader) this; }
 
 }

--- a/core/src/main/java/org/jruby/util/ClassDefiningJRubyClassLoader.java
+++ b/core/src/main/java/org/jruby/util/ClassDefiningJRubyClassLoader.java
@@ -73,6 +73,11 @@ public class ClassDefiningJRubyClassLoader extends URLClassLoader implements Cla
      * @return whether it's loadable
      */
     public boolean hasClass(String name) {
-        return definedClasses.contains(name) || super.findResource(name.replace('.', '/') + ".class") != null;
+        return hasDefinedClass(name) || super.findResource(name.replace('.', '/') + ".class") != null;
+    }
+
+    @Override
+    public boolean hasDefinedClass(String name) {
+        return definedClasses.contains(name);
     }
 }

--- a/core/src/main/java/org/jruby/util/NClassClassLoader.java
+++ b/core/src/main/java/org/jruby/util/NClassClassLoader.java
@@ -14,6 +14,11 @@ public class NClassClassLoader extends ClassLoader implements ClassDefiningClass
         return super.defineClass(name, bytes, 0, bytes.length, ClassDefiningJRubyClassLoader.DEFAULT_DOMAIN);
     }
 
+    @Override
+    public boolean hasDefinedClass(String name) {
+        return super.findLoadedClass(name) != null;
+    }
+
     public boolean isFull() {
         return i >= size;
     }

--- a/core/src/main/java/org/jruby/util/OneShotClassLoader.java
+++ b/core/src/main/java/org/jruby/util/OneShotClassLoader.java
@@ -21,4 +21,14 @@ public class OneShotClassLoader extends ClassLoader implements ClassDefiningClas
         resolveClass(cls);
         return cls;
     }
+
+    @Override
+    public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        return super.loadClass(name, resolve);
+    }
+
+    @Override
+    public boolean hasDefinedClass(String name) {
+        return super.findLoadedClass(name) != null;
+    }
 }

--- a/spec/java_integration/reify/become_java_spec.rb
+++ b/spec/java_integration/reify/become_java_spec.rb
@@ -33,8 +33,8 @@ describe "JRuby class reification" do
     jclass = java.lang.Class
 
     outer_java_class_name = ReifyInterfacesClass1.to_java(jclass).name
-    expect(outer_java_class_name).to match /^rubyobj\.(\w)*?\.ReifyInterfacesClass1$/
-    expect(ReifyInterfacesClass1::Nested::InnerClass.to_java(jclass).name).to match /^rubyobj\.(\w)*?\.ReifyInterfacesClass1\.Nested\.InnerClass$/
+    expect(outer_java_class_name).to eql('rubyobj.ReifyInterfacesClass1')
+    expect(ReifyInterfacesClass1::Nested::InnerClass.to_java(jclass).name).to eql('rubyobj.ReifyInterfacesClass1.Nested.InnerClass')
 
     # checking that the packages are valid for Java's purposes
     expect do
@@ -468,7 +468,7 @@ describe "JRuby class reification" do
   it 'has a similar Java class name' do
     ReifiedSample.become_java!
     klass = ReifiedSample.java_class
-    expect( klass.getName ).to match /rubyobj\.(\w)*?\.ReifiedSample/
+    expect( klass.getName ).to eql('rubyobj.ReifiedSample')
     klass = Class.new(ReifiedSample)
     hexid = klass.inspect.match(/(0x[0-9a-f]+)/)[1]
     klass = klass.become_java!

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -50,7 +50,7 @@ class TestHigherJavasupport < Test::Unit::TestCase
   def test_passing_a_java_class_auto_reifies
     assert_nil Klass2.to_java.getReifiedClass
     # previously TestHelper.getClassName(Klass2) returned 'org.jruby.RubyObject'
-    assert_equal 'rubyobj.TestHigherJavasupport.Klass2', org.jruby.test.TestHelper.getClassName(Klass2)
+    assert org.jruby.test.TestHelper.getClassName(Klass2).end_with?('.TestHigherJavasupport.Klass2')
     assert_not_nil Klass2.to_java.getReifiedClass
     assert_not_nil Klass1.to_java.getReifiedClass
   end


### PR DESCRIPTION
this is an alternative to https://github.com/jruby/jruby/pull/8140

the difference is no class-loader magic on re-created reified classes but it changes the Java class naming:

```ruby
module Bar
  class Foo < java.lang.Object
  end
end
```
when reified this class would be named:

- current `rubyobj.Bar.Foo`
- after the change in this MR: `rubyobj.23e5fef5.Bar.Foo`

to support the case of potential dropping and re-creating a named Ruby class

---

:warning: the fix would need to revert https://github.com/jruby/jruby/issues/1229 which I do not think has a good test [assuming 2 classes with the same name](https://github.com/jruby/jruby/blob/c50fb9b/spec/regression/GH-1229_reified_parent_and_child_have_same_name_spec.rb#L11) would share the same Java class