### PR TITLE
Fix last obvious syntax problem (involving nested pattern kwargs going off rails)

### DIFF
--- a/core/src/main/java/org/jruby/ext/ripper/RubyLexer.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RubyLexer.java
@@ -1162,7 +1162,7 @@ public class RubyLexer extends LexingCommon {
                     }
                 }
 
-                setState(isAfterOperator() ? EXPR_ARG : EXPR_BEG);
+                setState(IS_AFTER_OPERATOR() ? EXPR_ARG : EXPR_BEG);
 
                 c = nextc();
                 if (c == '=') {
@@ -1314,16 +1314,16 @@ public class RubyLexer extends LexingCommon {
         }
         pushback(c);
 
-        if (isSpaceArg(c, spaceSeen)) {
+        if (IS_SPCARG(c, spaceSeen)) {
             if (isVerbose()) warning("`&' interpreted as argument prefix");
             c = tAMPER;
-        } else if (isBEG()) {
+        } else if (IS_BEG()) {
             c = warn_balanced(c, spaceSeen, tAMPER, "&", "argument prefix");
         } else {
             c = '&';
         }
 
-        setState(isAfterOperator() ? EXPR_ARG : EXPR_BEG);
+        setState(IS_AFTER_OPERATOR() ? EXPR_ARG : EXPR_BEG);
 
         yaccValue = AMPERSAND;
         return c;
@@ -1387,7 +1387,7 @@ public class RubyLexer extends LexingCommon {
     private int bang() {
         int c = nextc();
 
-        if (isAfterOperator()) {
+        if (IS_AFTER_OPERATOR()) {
             setState(EXPR_ARG);
             if (c == '@') {
                 yaccValue = BANG;
@@ -1424,7 +1424,7 @@ public class RubyLexer extends LexingCommon {
             return tOP_ASGN;
         }
 
-        setState(isAfterOperator() ? EXPR_ARG : EXPR_BEG);
+        setState(IS_AFTER_OPERATOR() ? EXPR_ARG : EXPR_BEG);
         
         pushback(c);
         return '^';
@@ -1434,7 +1434,7 @@ public class RubyLexer extends LexingCommon {
         int c = nextc();
         
         if (c == ':') {
-            if (isBEG() || isLexState(lex_state, EXPR_CLASS) || (isARG() && spaceSeen)) {
+            if (IS_BEG() || isLexState(lex_state, EXPR_CLASS) || (IS_ARG() && spaceSeen)) {
                 setState(EXPR_BEG);
                 yaccValue = COLON_COLON;
                 return tCOLON3;
@@ -1445,7 +1445,7 @@ public class RubyLexer extends LexingCommon {
             return tCOLON2;
         }
 
-        if (isEND() || Character.isWhitespace(c) || c == '#') {
+        if (IS_END() || Character.isWhitespace(c) || c == '#') {
             pushback(c);
             setState(EXPR_BEG);
             yaccValue = COLON;
@@ -1602,7 +1602,7 @@ public class RubyLexer extends LexingCommon {
     private int dot() {
         int c;
 
-        boolean isBeg = isBEG();
+        boolean isBeg = IS_BEG();
         setState(EXPR_BEG);
         if ((c = nextc()) == '.') {
             if ((c = nextc()) == '.') {
@@ -1638,14 +1638,14 @@ public class RubyLexer extends LexingCommon {
     }
     
     private int doubleQuote(boolean commandState) {
-        int label = isLabelPossible(commandState) ? str_label : 0;
+        int label = IS_LABEL_POSSIBLE(commandState) ? str_label : 0;
         lex_strterm = new StringTerm(str_dquote|label, '\0', '"', ruby_sourceline);
         yaccValue = QQ;
         return tSTRING_BEG;
     }
     
     private int greaterThan() {
-        setState(isAfterOperator() ? EXPR_ARG : EXPR_BEG);
+        setState(IS_AFTER_OPERATOR() ? EXPR_ARG : EXPR_BEG);
 
         int c = nextc();
 
@@ -1736,8 +1736,8 @@ public class RubyLexer extends LexingCommon {
             }
         }
 
-        if (isLabelPossible(commandState)) {
-            if (isLabelSuffix()) {
+        if (IS_LABEL_POSSIBLE(commandState)) {
+            if (IS_LABEL_SUFFIX()) {
                 setState(EXPR_ARG|EXPR_LABELED);
                 yaccValue = tempVal;
                 identValue = tempVal.intern();
@@ -1788,7 +1788,7 @@ public class RubyLexer extends LexingCommon {
     private int leftBracket(boolean spaceSeen) {
         parenNest++;
         int c = '[';
-        if (isAfterOperator()) {
+        if (IS_AFTER_OPERATOR()) {
             if ((c = nextc()) == ']') {
                 setState(EXPR_ARG);
                 if (peek('=')) {
@@ -1803,7 +1803,7 @@ public class RubyLexer extends LexingCommon {
             setState(EXPR_ARG|EXPR_LABEL);
             yaccValue = LBRACKET;
             return '[';
-        } else if (isBEG() || (isARG() && (spaceSeen || isLexState(lex_state, EXPR_LABELED)))) {
+        } else if (IS_BEG() || (IS_ARG() && (spaceSeen || isLexState(lex_state, EXPR_LABELED)))) {
             c = tLBRACK;
         }
 
@@ -1847,11 +1847,11 @@ public class RubyLexer extends LexingCommon {
     private int leftParen(boolean spaceSeen) {
         int result;
 
-        if (isBEG()) {
+        if (IS_BEG()) {
             result = tLPAREN;
         } else if (!spaceSeen) {
             result = '(';
-        } else if (isARG() || isLexStateAll(lex_state, EXPR_END|EXPR_LABEL)) {
+        } else if (IS_ARG() || isLexStateAll(lex_state, EXPR_END|EXPR_LABEL)) {
             result = tLPAREN_ARG;
         } else if (isLexState(lex_state, EXPR_ENDFN) && !isLambdaBeginning()) {
             warn("parentheses after method name is interpreted as an argument list, not a decomposed argument");
@@ -1872,13 +1872,13 @@ public class RubyLexer extends LexingCommon {
         last_state = lex_state;
         int c = nextc();
         if (c == '<' && !isLexState(lex_state, EXPR_DOT|EXPR_CLASS) &&
-                !isEND() && (!isARG() || isLexState(lex_state, EXPR_LABELED) || spaceSeen)) {
+                !IS_END() && (!IS_ARG() || isLexState(lex_state, EXPR_LABELED) || spaceSeen)) {
             int tok = hereDocumentIdentifier();
             
             if (tok != 0) return tok;
         }
 
-        if (isAfterOperator()) {
+        if (IS_AFTER_OPERATOR()) {
             setState(EXPR_ARG);
         } else {
             if (isLexState(lex_state, EXPR_CLASS)) commandStart = true;
@@ -1913,7 +1913,7 @@ public class RubyLexer extends LexingCommon {
     private int minus(boolean spaceSeen) {
         int c = nextc();
         
-        if (isAfterOperator()) {
+        if (IS_AFTER_OPERATOR()) {
             setState(EXPR_ARG);
             if (c == '@') {
                 yaccValue = MINUS_AT;
@@ -1934,7 +1934,7 @@ public class RubyLexer extends LexingCommon {
             yaccValue = MINUS_GT;
             return tLAMBDA;
         }
-        if (isBEG() || (isSpaceArg(c, spaceSeen) && arg_ambiguous('-'))) {
+        if (IS_BEG() || (IS_SPCARG(c, spaceSeen) && arg_ambiguous('-'))) {
             setState(EXPR_BEG);
             pushback(c);
             yaccValue = MINUS_AT;
@@ -1951,7 +1951,7 @@ public class RubyLexer extends LexingCommon {
     }
 
     private int percent(boolean spaceSeen) {
-        if (isBEG()) return parseQuote(nextc());
+        if (IS_BEG()) return parseQuote(nextc());
 
         int c = nextc();
 
@@ -1962,9 +1962,9 @@ public class RubyLexer extends LexingCommon {
             return tOP_ASGN;
         }
 
-        if (isSpaceArg(c, spaceSeen) || (isLexState(lex_state, EXPR_FITEM) && c == 's')) return parseQuote(c);
+        if (IS_SPCARG(c, spaceSeen) || (isLexState(lex_state, EXPR_FITEM) && c == 's')) return parseQuote(c);
 
-        setState(isAfterOperator() ? EXPR_ARG : EXPR_BEG);
+        setState(IS_AFTER_OPERATOR() ? EXPR_ARG : EXPR_BEG);
 
         pushback(c);
         yaccValue = PERCENT;
@@ -1997,7 +1997,7 @@ public class RubyLexer extends LexingCommon {
             set_yylval_id(OR);
             return tOP_ASGN;
         default:
-            setState(isAfterOperator() ? EXPR_ARG : EXPR_BEG|EXPR_LABEL);
+            setState(IS_AFTER_OPERATOR() ? EXPR_ARG : EXPR_BEG|EXPR_LABEL);
 
             pushback(c);
             yaccValue = OR;
@@ -2007,7 +2007,7 @@ public class RubyLexer extends LexingCommon {
     
     private int plus(boolean spaceSeen) {
         int c = nextc();
-        if (isAfterOperator()) {
+        if (IS_AFTER_OPERATOR()) {
             setState(EXPR_ARG);
             if (c == '@') {
                 yaccValue = PLUS_AT;
@@ -2026,7 +2026,7 @@ public class RubyLexer extends LexingCommon {
             return tOP_ASGN;
         }
 
-        if (isBEG() || (isSpaceArg(c, spaceSeen) && arg_ambiguous('+'))) {
+        if (IS_BEG() || (IS_SPCARG(c, spaceSeen) && arg_ambiguous('+'))) {
             setState(EXPR_BEG);
             pushback(c);
             if (Character.isDigit(c)) {
@@ -2051,7 +2051,7 @@ public class RubyLexer extends LexingCommon {
     private int questionMark() throws IOException {
         int c;
         
-        if (isEND()) {
+        if (IS_END()) {
             setState(EXPR_VALUE);
             yaccValue = QUESTION;
             return '?';
@@ -2064,7 +2064,7 @@ public class RubyLexer extends LexingCommon {
         }
 
         if (Character.isWhitespace(c)){
-            if (!isARG()) {
+            if (!IS_ARG()) {
                 int c2 = 0;
                 switch (c) {
                 case ' ':
@@ -2164,7 +2164,7 @@ public class RubyLexer extends LexingCommon {
     }
     
     private int singleQuote(boolean commandState) {
-        int label = isLabelPossible(commandState) ? str_label : 0;
+        int label = IS_LABEL_POSSIBLE(commandState) ? str_label : 0;
         lex_strterm = new StringTerm(str_squote|label, '\0', '\'', ruby_sourceline);
         yaccValue = Q;
 
@@ -2172,7 +2172,7 @@ public class RubyLexer extends LexingCommon {
     }
     
     private int slash(boolean spaceSeen) {
-        if (isBEG()) {
+        if (IS_BEG()) {
             lex_strterm = new StringTerm(str_regexp, '\0', '/', ruby_sourceline);
             return tREGEXP_BEG;
         }
@@ -2185,13 +2185,13 @@ public class RubyLexer extends LexingCommon {
             return tOP_ASGN;
         }
         pushback(c);
-        if (isSpaceArg(c, spaceSeen)) {
+        if (IS_SPCARG(c, spaceSeen)) {
             arg_ambiguous('/');
             lex_strterm = new StringTerm(str_regexp, '\0', '/', ruby_sourceline);
             return tREGEXP_BEG;
         }
 
-        setState(isAfterOperator() ? EXPR_ARG : EXPR_BEG);
+        setState(IS_AFTER_OPERATOR() ? EXPR_ARG : EXPR_BEG);
 
         return warn_balanced(c, spaceSeen, '/', "/", "regexp literal");
     }
@@ -2211,10 +2211,10 @@ public class RubyLexer extends LexingCommon {
             pushback(c);
             yaccValue = STAR_STAR;
 
-            if (isSpaceArg(c, spaceSeen)) {
+            if (IS_SPCARG(c, spaceSeen)) {
                 if (isVerbose() && Options.PARSER_WARN_ARGUMENT_PREFIX.load()) warning("`**' interpreted as argument prefix");
                 c = tDSTAR;
-            } else if (isBEG()) {
+            } else if (IS_BEG()) {
                 c = tDSTAR;
             } else {
                 c = warn_balanced(c, spaceSeen, tPOW, "**", "argument prefix");
@@ -2227,10 +2227,10 @@ public class RubyLexer extends LexingCommon {
             return tOP_ASGN;
         default:
             pushback(c);
-            if (isSpaceArg(c, spaceSeen)) {
+            if (IS_SPCARG(c, spaceSeen)) {
                 if (isVerbose() && Options.PARSER_WARN_ARGUMENT_PREFIX.load()) warning("`*' interpreted as argument prefix");
                 c = tSTAR;
-            } else if (isBEG()) {
+            } else if (IS_BEG()) {
                 c = tSTAR;
             } else {
                 c = warn_balanced(c, spaceSeen, '*', "*", "argument prefix");
@@ -2238,14 +2238,14 @@ public class RubyLexer extends LexingCommon {
             yaccValue = STAR;
         }
 
-        setState(isAfterOperator() ? EXPR_ARG : EXPR_BEG);
+        setState(IS_AFTER_OPERATOR() ? EXPR_ARG : EXPR_BEG);
         return c;
     }
 
     private int tilde() {
         int c;
         
-        if (isAfterOperator()) {
+        if (IS_AFTER_OPERATOR()) {
             if ((c = nextc()) != '@') pushback(c);
             setState(EXPR_ARG);
         } else {

--- a/core/src/main/java/org/jruby/ext/ripper/RubyLexer.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RubyLexer.java
@@ -401,7 +401,7 @@ public class RubyLexer extends LexingCommon {
     public int tokenize_ident(int result) {
         String value = createTokenString();
 
-        if (!isLexState(last_state, EXPR_DOT|EXPR_FNAME) && parser.getCurrentScope().isDefined(value) >= 0) {
+        if (!IS_lex_state(last_state, EXPR_DOT|EXPR_FNAME) && parser.getCurrentScope().isDefined(value) >= 0) {
             setState(EXPR_END);
         }
 
@@ -1071,9 +1071,9 @@ public class RubyLexer extends LexingCommon {
             /* fall through */
             case '\n': {
                 this.tokenSeen = tokenSeen;
-                boolean normalArg = isLexState(lex_state, EXPR_BEG | EXPR_CLASS | EXPR_FNAME | EXPR_DOT) &&
-                        !isLexState(lex_state, EXPR_LABELED);
-                if (normalArg || isLexStateAll(lex_state, EXPR_ARG | EXPR_LABELED)) {
+                boolean normalArg = IS_lex_state(lex_state, EXPR_BEG | EXPR_CLASS | EXPR_FNAME | EXPR_DOT) &&
+                        !IS_lex_state(lex_state, EXPR_LABELED);
+                if (normalArg || IS_lex_state_all(lex_state, EXPR_ARG | EXPR_LABELED)) {
                     if (!fallthru) dispatchScanEvent(tIGNORED_NL);
                     fallthru = false;
                     if (!normalArg && getLexContext().in_kwarg) {
@@ -1276,7 +1276,7 @@ public class RubyLexer extends LexingCommon {
     }
 
     private int identifierToken(int last_state, int result, String value) {
-        if (result == tIDENTIFIER && !isLexState(last_state, EXPR_DOT|EXPR_FNAME) &&
+        if (result == tIDENTIFIER && !IS_lex_state(last_state, EXPR_DOT|EXPR_FNAME) &&
                 parser.getCurrentScope().isDefined(value) >= 0) {
             setState(EXPR_END|EXPR_LABEL);
         }
@@ -1339,7 +1339,7 @@ public class RubyLexer extends LexingCommon {
         } else {
             result = tIVAR;
         }
-        setState(isLexState(last_state, EXPR_FNAME) ? EXPR_ENDFN : EXPR_END);
+        setState(IS_lex_state(last_state, EXPR_FNAME) ? EXPR_ENDFN : EXPR_END);
 
         if (c == EOF || !isIdentifierChar(c)) {
             if (result == tIVAR) {
@@ -1370,11 +1370,11 @@ public class RubyLexer extends LexingCommon {
     private int backtick(boolean commandState) {
         yaccValue = BACKTICK;
 
-        if (isLexState(lex_state, EXPR_FNAME)) {
+        if (IS_lex_state(lex_state, EXPR_FNAME)) {
             setState(EXPR_ENDFN);
             return '`';
         }
-        if (isLexState(lex_state, EXPR_DOT)) {
+        if (IS_lex_state(lex_state, EXPR_DOT)) {
             setState(commandState ? EXPR_CMDARG : EXPR_ARG);
 
             return '`';
@@ -1434,7 +1434,7 @@ public class RubyLexer extends LexingCommon {
         int c = nextc();
         
         if (c == ':') {
-            if (IS_BEG() || isLexState(lex_state, EXPR_CLASS) || (IS_ARG() && spaceSeen)) {
+            if (IS_BEG() || IS_lex_state(lex_state, EXPR_CLASS) || (IS_ARG() && spaceSeen)) {
                 setState(EXPR_BEG);
                 yaccValue = COLON_COLON;
                 return tCOLON3;
@@ -1481,7 +1481,7 @@ public class RubyLexer extends LexingCommon {
 
         if (conditionState.set_p()) return keyword_do_cond;
 
-        if (cmdArgumentState.set_p() && !isLexState(state, EXPR_CMDARG)) {
+        if (cmdArgumentState.set_p() && !IS_lex_state(state, EXPR_CMDARG)) {
             return keyword_do_block;
         }
 
@@ -1544,7 +1544,7 @@ public class RubyLexer extends LexingCommon {
         case '\'':      /* $': string after last match */
         case '+':       /* $+: string matches last paren. */
             // Explicit reference to these vars as symbols...
-            if (isLexState(last_state, EXPR_FNAME)) {
+            if (IS_lex_state(last_state, EXPR_FNAME)) {
                 identValue = "$" + (char) c;
                 set_yylval_name(new ByteList(new byte[] {'$', (byte) c}));
                 return tGVAR;
@@ -1559,7 +1559,7 @@ public class RubyLexer extends LexingCommon {
                 c = nextc();
             } while (Character.isDigit(c));
             pushback(c);
-            if (isLexState(last_state, EXPR_FNAME)) {
+            if (IS_lex_state(last_state, EXPR_FNAME)) {
                 identValue = createTokenString().intern();
                 set_yylval_name(new ByteList(new byte[] {'$', (byte) c}));
                 return tGVAR;
@@ -1616,7 +1616,7 @@ public class RubyLexer extends LexingCommon {
                 if (parenNest == 0 && isLookingAtEOL()) {
                     warn("... at EOL, should be parenthesized?");
                 } else if (getLeftParenBegin() >= 0 && getLeftParenBegin() + 1 == parenNest) {
-                    if (isLexState(last_state, EXPR_LABEL)) {
+                    if (IS_lex_state(last_state, EXPR_LABEL)) {
                         return tDOT3;
                     }
                 }
@@ -1711,7 +1711,7 @@ public class RubyLexer extends LexingCommon {
             result = tFID;
             tempVal = createTokenString();
         } else {
-            if (isLexState(lex_state, EXPR_FNAME)) {
+            if (IS_lex_state(lex_state, EXPR_FNAME)) {
                 if ((c = nextc()) == '=') { 
                     int c2 = nextc();
 
@@ -1755,17 +1755,17 @@ public class RubyLexer extends LexingCommon {
                 setState(keyword.state);
                 set_yylval_name(createTokenByteList());
 
-                if (isLexState(state, EXPR_FNAME)) {
+                if (IS_lex_state(state, EXPR_FNAME)) {
                     setState(EXPR_ENDFN);
                     identValue = tempVal;
                     return keyword.id0;
                 }
 
-                if (isLexState(lex_state, EXPR_BEG)) commandStart = true;
+                if (IS_lex_state(lex_state, EXPR_BEG)) commandStart = true;
 
                 if (keyword.id0 == keyword_do) return doKeyword(state);
 
-                if (isLexState(state, EXPR_BEG|EXPR_LABELED)) {
+                if (IS_lex_state(state, EXPR_BEG|EXPR_LABELED)) {
                     return keyword.id0;
                 } else {
                     if (keyword.id0 != keyword.id1) setState(EXPR_BEG|EXPR_LABEL);
@@ -1774,7 +1774,7 @@ public class RubyLexer extends LexingCommon {
             }
         }
 
-        if (isLexState(lex_state, EXPR_BEG_ANY|EXPR_ARG_ANY|EXPR_DOT)) {
+        if (IS_lex_state(lex_state, EXPR_BEG_ANY|EXPR_ARG_ANY|EXPR_DOT)) {
             setState(commandState ? EXPR_CMDARG : EXPR_ARG);
         } else if (lex_state == EXPR_FNAME) {
             setState(EXPR_ENDFN);
@@ -1803,7 +1803,7 @@ public class RubyLexer extends LexingCommon {
             setState(EXPR_ARG|EXPR_LABEL);
             yaccValue = LBRACKET;
             return '[';
-        } else if (IS_BEG() || (IS_ARG() && (spaceSeen || isLexState(lex_state, EXPR_LABELED)))) {
+        } else if (IS_BEG() || (IS_ARG() && (spaceSeen || IS_lex_state(lex_state, EXPR_LABELED)))) {
             c = tLBRACK;
         }
 
@@ -1819,11 +1819,11 @@ public class RubyLexer extends LexingCommon {
         char c;
         if (isLambdaBeginning()) {
             c = tLAMBEG;
-        } else if (isLexState(lex_state, EXPR_LABELED)) {
+        } else if (IS_lex_state(lex_state, EXPR_LABELED)) {
             c = tLBRACE;
-        } else if (isLexState(lex_state, EXPR_ARG_ANY|EXPR_END|EXPR_ENDFN)) { // block (primary)
+        } else if (IS_lex_state(lex_state, EXPR_ARG_ANY|EXPR_END|EXPR_ENDFN)) { // block (primary)
             c = '{';
-        } else if (isLexState(lex_state, EXPR_ENDARG)) { // block (expr)
+        } else if (IS_lex_state(lex_state, EXPR_ENDARG)) { // block (expr)
             c = tLBRACE_ARG;
         } else { // hash
             c = tLBRACE;
@@ -1851,9 +1851,9 @@ public class RubyLexer extends LexingCommon {
             result = tLPAREN;
         } else if (!spaceSeen) {
             result = '(';
-        } else if (IS_ARG() || isLexStateAll(lex_state, EXPR_END|EXPR_LABEL)) {
+        } else if (IS_ARG() || IS_lex_state_all(lex_state, EXPR_END|EXPR_LABEL)) {
             result = tLPAREN_ARG;
-        } else if (isLexState(lex_state, EXPR_ENDFN) && !isLambdaBeginning()) {
+        } else if (IS_lex_state(lex_state, EXPR_ENDFN) && !isLambdaBeginning()) {
             warn("parentheses after method name is interpreted as an argument list, not a decomposed argument");
             result = '(';
         } else {
@@ -1871,8 +1871,8 @@ public class RubyLexer extends LexingCommon {
     private int lessThan(boolean spaceSeen) {
         last_state = lex_state;
         int c = nextc();
-        if (c == '<' && !isLexState(lex_state, EXPR_DOT|EXPR_CLASS) &&
-                !IS_END() && (!IS_ARG() || isLexState(lex_state, EXPR_LABELED) || spaceSeen)) {
+        if (c == '<' && !IS_lex_state(lex_state, EXPR_DOT|EXPR_CLASS) &&
+                !IS_END() && (!IS_ARG() || IS_lex_state(lex_state, EXPR_LABELED) || spaceSeen)) {
             int tok = hereDocumentIdentifier();
             
             if (tok != 0) return tok;
@@ -1881,7 +1881,7 @@ public class RubyLexer extends LexingCommon {
         if (IS_AFTER_OPERATOR()) {
             setState(EXPR_ARG);
         } else {
-            if (isLexState(lex_state, EXPR_CLASS)) commandStart = true;
+            if (IS_lex_state(lex_state, EXPR_CLASS)) commandStart = true;
             setState(EXPR_BEG);
         }
 
@@ -1962,7 +1962,7 @@ public class RubyLexer extends LexingCommon {
             return tOP_ASGN;
         }
 
-        if (IS_SPCARG(c, spaceSeen) || (isLexState(lex_state, EXPR_FITEM) && c == 's')) return parseQuote(c);
+        if (IS_SPCARG(c, spaceSeen) || (IS_lex_state(lex_state, EXPR_FITEM) && c == 's')) return parseQuote(c);
 
         setState(IS_AFTER_OPERATOR() ? EXPR_ARG : EXPR_BEG);
 
@@ -1984,7 +1984,7 @@ public class RubyLexer extends LexingCommon {
                 return tOP_ASGN;
             }
             pushback(c);
-            if (isLexStateAll(last_state, EXPR_BEG)) {
+            if (IS_lex_state_all(last_state, EXPR_BEG)) {
                 yaccValue = OR;
                 pushback('|');
                 return '|';

--- a/core/src/main/java/org/jruby/ext/ripper/StringTerm.java
+++ b/core/src/main/java/org/jruby/ext/ripper/StringTerm.java
@@ -97,7 +97,7 @@ public class StringTerm extends StrTerm {
             return RipperParser.tREGEXP_END;
         }
 
-        if ((flags & STR_FUNC_LABEL) != 0 && lexer.isLabelSuffix()) {
+        if ((flags & STR_FUNC_LABEL) != 0 && lexer.IS_LABEL_SUFFIX()) {
             lexer.nextc();
             lexer.setState(EXPR_BEG | EXPR_LABEL);
             return RipperParser.tLABEL_END;

--- a/core/src/main/java/org/jruby/lexer/LexingCommon.java
+++ b/core/src/main/java/org/jruby/lexer/LexingCommon.java
@@ -989,27 +989,35 @@ public abstract class LexingCommon {
         return (mask & state) == mask;
     }
 
-    protected boolean isARG() {
+    protected static boolean ISSPACE(int c) {
+        return Character.isWhitespace(c);
+    }
+
+    protected boolean IS_ARG() {
         return isLexState(lex_state, EXPR_ARG_ANY);
     }
 
-    protected boolean isBEG() {
-        return isLexState(lex_state, EXPR_BEG_ANY) || isLexStateAll(lex_state, EXPR_ARG|EXPR_LABELED);
-    }
-
-    protected boolean isEND() {
+    protected boolean IS_END() {
         return isLexState(lex_state, EXPR_END_ANY);
     }
 
-    protected boolean isLabelPossible(boolean commandState) {
-        return (isLexState(lex_state, EXPR_LABEL|EXPR_ENDFN) && !commandState) || isARG();
+    protected boolean IS_BEG() {
+        return isLexState(lex_state, EXPR_BEG_ANY) || isLexStateAll(lex_state, EXPR_ARG|EXPR_LABELED);
     }
 
-    public boolean isLabelSuffix() {
+    protected boolean IS_SPCARG(int c, boolean spaceSeen) {
+        return IS_ARG() && spaceSeen && !ISSPACE(c);
+    }
+
+    protected boolean IS_LABEL_POSSIBLE(boolean commandState) {
+        return (isLexState(lex_state, EXPR_LABEL|EXPR_ENDFN) && !commandState) || IS_ARG();
+    }
+
+    public boolean IS_LABEL_SUFFIX() {
         return peek(':') && !peek(':', 1);
     }
 
-    protected boolean isAfterOperator() {
+    protected boolean IS_AFTER_OPERATOR() {
         return isLexState(lex_state, EXPR_FNAME|EXPR_DOT);
     }
 
@@ -1030,10 +1038,6 @@ public abstract class LexingCommon {
 
     public static boolean isSpace(int c) {
         return c == ' ' || ('\t' <= c && c <= '\r');
-    }
-
-    protected boolean isSpaceArg(int c, boolean spaceSeen) {
-        return isARG() && spaceSeen && !Character.isWhitespace(c);
     }
 
     /* MRI: magic_comment_marker */

--- a/core/src/main/java/org/jruby/lexer/LexingCommon.java
+++ b/core/src/main/java/org/jruby/lexer/LexingCommon.java
@@ -892,7 +892,7 @@ public abstract class LexingCommon {
     }
 
     protected int warn_balanced(int c, boolean spaceSeen, int token, String op, String syn) {
-        if (!isLexState(last_state, EXPR_CLASS|EXPR_DOT|EXPR_FNAME|EXPR_ENDFN) && spaceSeen && !Character.isWhitespace(c)) {
+        if (!IS_lex_state(last_state, EXPR_CLASS|EXPR_DOT|EXPR_FNAME|EXPR_ENDFN) && spaceSeen && !Character.isWhitespace(c)) {
             ambiguousOperator(op, syn);
         }
 
@@ -981,11 +981,11 @@ public abstract class LexingCommon {
         return Character.isDigit(c) || ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F');
     }
 
-    public static boolean isLexState(int state, int mask) {
+    public static boolean IS_lex_state(int state, int mask) {
         return (mask & state) != 0;
     }
 
-    protected boolean isLexStateAll(int state, int mask) {
+    protected boolean IS_lex_state_all(int state, int mask) {
         return (mask & state) == mask;
     }
 
@@ -994,15 +994,15 @@ public abstract class LexingCommon {
     }
 
     protected boolean IS_ARG() {
-        return isLexState(lex_state, EXPR_ARG_ANY);
+        return IS_lex_state(lex_state, EXPR_ARG_ANY);
     }
 
     protected boolean IS_END() {
-        return isLexState(lex_state, EXPR_END_ANY);
+        return IS_lex_state(lex_state, EXPR_END_ANY);
     }
 
     protected boolean IS_BEG() {
-        return isLexState(lex_state, EXPR_BEG_ANY) || isLexStateAll(lex_state, EXPR_ARG|EXPR_LABELED);
+        return IS_lex_state(lex_state, EXPR_BEG_ANY) || IS_lex_state_all(lex_state, EXPR_ARG|EXPR_LABELED);
     }
 
     protected boolean IS_SPCARG(int c, boolean spaceSeen) {
@@ -1010,7 +1010,7 @@ public abstract class LexingCommon {
     }
 
     protected boolean IS_LABEL_POSSIBLE(boolean commandState) {
-        return (isLexState(lex_state, EXPR_LABEL|EXPR_ENDFN) && !commandState) || IS_ARG();
+        return (IS_lex_state(lex_state, EXPR_LABEL|EXPR_ENDFN) && !commandState) || IS_ARG();
     }
 
     public boolean IS_LABEL_SUFFIX() {
@@ -1018,7 +1018,7 @@ public abstract class LexingCommon {
     }
 
     protected boolean IS_AFTER_OPERATOR() {
-        return isLexState(lex_state, EXPR_FNAME|EXPR_DOT);
+        return IS_lex_state(lex_state, EXPR_FNAME|EXPR_DOT);
     }
 
     protected boolean isNext_identchar() throws IOException {

--- a/core/src/main/java/org/jruby/lexer/yacc/LexContext.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/LexContext.java
@@ -33,6 +33,7 @@ public class LexContext {
         LexContext context = new LexContext();
         context.in_class = in_class;
         context.in_def = in_def;
+        context.in_kwarg = in_kwarg;
         context.in_defined = in_defined;
         context.in_rescue = in_rescue;
         context.in_argdef = in_argdef;

--- a/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
@@ -1078,7 +1078,7 @@ public class RubyLexer extends LexingCommon {
                     }
                 }
 
-                setState(isAfterOperator() ? EXPR_ARG : EXPR_BEG);
+                setState(IS_AFTER_OPERATOR() ? EXPR_ARG : EXPR_BEG);
 
                 c = nextc();
                 if (c == '=') {
@@ -1234,17 +1234,17 @@ public class RubyLexer extends LexingCommon {
         //if the warning is generated, the getPosition() on line 954 (this line + 18) will create
         //a wrong position if the "inclusive" flag is not set.
         int tmpLine = ruby_sourceline;
-        if (isSpaceArg(c, spaceSeen)) {
+        if (IS_SPCARG(c, spaceSeen)) {
             if (warnings.isVerbose() && Options.PARSER_WARN_ARGUMENT_PREFIX.load())
                 warning(ID.ARGUMENT_AS_PREFIX, getFile(), tmpLine, "`&' interpreted as argument prefix");
             c = tAMPER;
-        } else if (isBEG()) {
+        } else if (IS_BEG()) {
             c = tAMPER;
         } else {
             c = warn_balanced(c, spaceSeen, '&', "&", "argument prefix");
         }
 
-        setState(isAfterOperator() ? EXPR_ARG : EXPR_BEG);
+        setState(IS_AFTER_OPERATOR() ? EXPR_ARG : EXPR_BEG);
         
         yaccValue = AMPERSAND;
         return c;
@@ -1306,7 +1306,7 @@ public class RubyLexer extends LexingCommon {
     private int bang() {
         int c = nextc();
 
-        if (isAfterOperator()) {
+        if (IS_AFTER_OPERATOR()) {
             setState(EXPR_ARG);
             if (c == '@') {
                 yaccValue = BANG;
@@ -1343,7 +1343,7 @@ public class RubyLexer extends LexingCommon {
             return tOP_ASGN;
         }
 
-        setState(isAfterOperator() ? EXPR_ARG : EXPR_BEG);
+        setState(IS_AFTER_OPERATOR() ? EXPR_ARG : EXPR_BEG);
 
         pushback(c);
         return '^';
@@ -1353,7 +1353,7 @@ public class RubyLexer extends LexingCommon {
         int c = nextc();
         
         if (c == ':') {
-            if (isBEG() || isLexState(lex_state, EXPR_CLASS) || (isARG() && spaceSeen)) {
+            if (IS_BEG() || isLexState(lex_state, EXPR_CLASS) || (IS_ARG() && spaceSeen)) {
                 setState(EXPR_BEG);
                 yaccValue = COLON_COLON;
                 return tCOLON3;
@@ -1364,7 +1364,7 @@ public class RubyLexer extends LexingCommon {
             return tCOLON2;
         }
 
-        if (isEND() || Character.isWhitespace(c) || c == '#') {
+        if (IS_END() || Character.isWhitespace(c) || c == '#') {
             pushback(c);
             setState(EXPR_BEG);
             yaccValue = COLON;
@@ -1523,7 +1523,7 @@ public class RubyLexer extends LexingCommon {
     private int dot() {
         int c;
 
-        boolean isBeg = isBEG();
+        boolean isBeg = IS_BEG();
         setState(EXPR_BEG);
         if ((c = nextc()) == '.') {
             if ((c = nextc()) == '.') {
@@ -1559,7 +1559,7 @@ public class RubyLexer extends LexingCommon {
     }
     
     private int doubleQuote(boolean commandState) {
-        int label = isLabelPossible(commandState) ? str_label : 0;
+        int label = IS_LABEL_POSSIBLE(commandState) ? str_label : 0;
         lex_strterm = new StringTerm(str_dquote|label, '\0', '"', ruby_sourceline);
         yaccValue = QQ;
 
@@ -1567,7 +1567,7 @@ public class RubyLexer extends LexingCommon {
     }
     
     private int greaterThan() {
-        setState(isAfterOperator() ? EXPR_ARG : EXPR_BEG);
+        setState(IS_AFTER_OPERATOR() ? EXPR_ARG : EXPR_BEG);
 
         int c = nextc();
 
@@ -1633,8 +1633,8 @@ public class RubyLexer extends LexingCommon {
             tempVal = createTokenByteList();
         }
 
-        if (isLabelPossible(commandState)) {
-            if (isLabelSuffix()) {
+        if (IS_LABEL_POSSIBLE(commandState)) {
+            if (IS_LABEL_SUFFIX()) {
                 setState(EXPR_ARG|EXPR_LABELED);
                 nextc();
                 yaccValue = tempVal;
@@ -1684,7 +1684,7 @@ public class RubyLexer extends LexingCommon {
     private int leftBracket(boolean spaceSeen) {
         parenNest++;
         int c = '[';
-        if (isAfterOperator()) {
+        if (IS_AFTER_OPERATOR()) {
             if ((c = nextc()) == ']') {
                 parenNest--;
                 setState(EXPR_ARG);
@@ -1700,7 +1700,7 @@ public class RubyLexer extends LexingCommon {
             setState(EXPR_ARG|EXPR_LABEL);
             yaccValue = LBRACKET;
             return '[';
-        } else if (isBEG() || (isARG() && (spaceSeen || isLexState(lex_state, EXPR_LABELED)))) {
+        } else if (IS_BEG() || (IS_ARG() && (spaceSeen || isLexState(lex_state, EXPR_LABELED)))) {
             c = tLBRACK;
         }
 
@@ -1744,11 +1744,11 @@ public class RubyLexer extends LexingCommon {
     private int leftParen(boolean spaceSeen) {
         int result;
 
-        if (isBEG()) {
+        if (IS_BEG()) {
             result = tLPAREN;
         } else if (!spaceSeen) {
             result = '(';
-        } else if (isARG() || isLexStateAll(lex_state, EXPR_END|EXPR_LABEL)) {
+        } else if (IS_ARG() || isLexStateAll(lex_state, EXPR_END|EXPR_LABEL)) {
             result = tLPAREN_ARG;
         } else if (isLexState(lex_state, EXPR_ENDFN) && !isLambdaBeginning()) {
             warnings.warn(ID.MISCELLANEOUS, "parentheses after method name is interpreted as an argument list, not a decomposed argument");
@@ -1770,13 +1770,13 @@ public class RubyLexer extends LexingCommon {
         last_state = lex_state;
         int c = nextc();
         if (c == '<' && !isLexState(lex_state, EXPR_DOT|EXPR_CLASS) &&
-                !isEND() && (!isARG() || isLexState(lex_state, EXPR_LABELED) || spaceSeen)) {
+                !IS_END() && (!IS_ARG() || isLexState(lex_state, EXPR_LABELED) || spaceSeen)) {
             int tok = hereDocumentIdentifier();
             
             if (tok != 0) return tok;
         }
 
-        if (isAfterOperator()) {
+        if (IS_AFTER_OPERATOR()) {
             setState(EXPR_ARG);
         } else {
             if (isLexState(lex_state, EXPR_CLASS)) commandStart = true;
@@ -1811,7 +1811,7 @@ public class RubyLexer extends LexingCommon {
     private int minus(boolean spaceSeen) {
         int c = nextc();
         
-        if (isAfterOperator()) {
+        if (IS_AFTER_OPERATOR()) {
             setState(EXPR_ARG);
             if (c == '@') {
                 yaccValue = MINUS_AT;
@@ -1832,7 +1832,7 @@ public class RubyLexer extends LexingCommon {
             yaccValue = MINUS_GT;
             return tLAMBDA;
         }
-        if (isBEG() || (isSpaceArg(c, spaceSeen) && arg_ambiguous('-'))) {
+        if (IS_BEG() || (IS_SPCARG(c, spaceSeen) && arg_ambiguous('-'))) {
             setState(EXPR_BEG);
             pushback(c);
             yaccValue = MINUS_AT;
@@ -1849,7 +1849,7 @@ public class RubyLexer extends LexingCommon {
     }
 
     private int percent(boolean spaceSeen) {
-        if (isBEG()) return parseQuote(nextc());
+        if (IS_BEG()) return parseQuote(nextc());
 
         int c = nextc();
 
@@ -1859,9 +1859,9 @@ public class RubyLexer extends LexingCommon {
             return tOP_ASGN;
         }
 
-        if (isSpaceArg(c, spaceSeen) || (isLexState(lex_state, EXPR_FITEM) && c == 's')) return parseQuote(c);
+        if (IS_SPCARG(c, spaceSeen) || (isLexState(lex_state, EXPR_FITEM) && c == 's')) return parseQuote(c);
 
-        setState(isAfterOperator() ? EXPR_ARG : EXPR_BEG);
+        setState(IS_AFTER_OPERATOR() ? EXPR_ARG : EXPR_BEG);
         
         pushback(c);
         yaccValue = PERCENT;
@@ -1895,7 +1895,7 @@ public class RubyLexer extends LexingCommon {
             set_yylval_id(OR);
             return tOP_ASGN;
         default:
-            setState(isAfterOperator() ? EXPR_ARG : EXPR_BEG|EXPR_LABEL);
+            setState(IS_AFTER_OPERATOR() ? EXPR_ARG : EXPR_BEG|EXPR_LABEL);
             
             pushback(c);
             yaccValue = OR;
@@ -1905,7 +1905,7 @@ public class RubyLexer extends LexingCommon {
     
     private int plus(boolean spaceSeen) {
         int c = nextc();
-        if (isAfterOperator()) {
+        if (IS_AFTER_OPERATOR()) {
             setState(EXPR_ARG);
             if (c == '@') {
                 yaccValue = PLUS_AT;
@@ -1923,7 +1923,7 @@ public class RubyLexer extends LexingCommon {
             return tOP_ASGN;
         }
         
-        if (isBEG() || (isSpaceArg(c, spaceSeen) && arg_ambiguous('+'))) {
+        if (IS_BEG() || (IS_SPCARG(c, spaceSeen) && arg_ambiguous('+'))) {
             setState(EXPR_BEG);
             pushback(c);
             if (Character.isDigit(c)) {
@@ -1944,7 +1944,7 @@ public class RubyLexer extends LexingCommon {
     private int questionMark() throws IOException {
         int c;
         
-        if (isEND()) {
+        if (IS_END()) {
             setState(EXPR_VALUE);
             yaccValue = QUESTION;
             return '?';
@@ -1954,7 +1954,7 @@ public class RubyLexer extends LexingCommon {
         if (c == EOF) compile_error("incomplete character syntax");
 
         if (Character.isWhitespace(c)){
-            if (!isARG()) {
+            if (!IS_ARG()) {
                 int c2 = 0;
                 switch (c) {
                 case ' ':
@@ -2060,7 +2060,7 @@ public class RubyLexer extends LexingCommon {
     }
     
     private int singleQuote(boolean commandState) {
-        int label = isLabelPossible(commandState) ? str_label : 0;
+        int label = IS_LABEL_POSSIBLE(commandState) ? str_label : 0;
         lex_strterm = new StringTerm(str_squote|label, '\0', '\'', ruby_sourceline);
         yaccValue = Q;
 
@@ -2070,7 +2070,7 @@ public class RubyLexer extends LexingCommon {
     private int slash(boolean spaceSeen) {
         yaccValue = SLASH;
 
-        if (isBEG()) {
+        if (IS_BEG()) {
             lex_strterm = new StringTerm(str_regexp, '\0', '/', ruby_sourceline);
             return tREGEXP_BEG;
         }
@@ -2083,13 +2083,13 @@ public class RubyLexer extends LexingCommon {
             return tOP_ASGN;
         }
         pushback(c);
-        if (isSpaceArg(c, spaceSeen)) {
+        if (IS_SPCARG(c, spaceSeen)) {
             arg_ambiguous('/');
             lex_strterm = new StringTerm(str_regexp, '\0', '/', ruby_sourceline);
             return tREGEXP_BEG;
         }
 
-        setState(isAfterOperator() ? EXPR_ARG : EXPR_BEG);
+        setState(IS_AFTER_OPERATOR() ? EXPR_ARG : EXPR_BEG);
 
         return warn_balanced(c, spaceSeen, '/', "/", "regexp literal");
     }
@@ -2109,11 +2109,11 @@ public class RubyLexer extends LexingCommon {
             pushback(c); // not a '=' put it back
             yaccValue = STAR_STAR;
 
-            if (isSpaceArg(c, spaceSeen)) {
+            if (IS_SPCARG(c, spaceSeen)) {
                 if (warnings.isVerbose() && Options.PARSER_WARN_ARGUMENT_PREFIX.load())
                     warning(ID.ARGUMENT_AS_PREFIX, "`**' interpreted as argument prefix");
                 c = tDSTAR;
-            } else if (isBEG()) {
+            } else if (IS_BEG()) {
                 c = tDSTAR;
             } else {
                 c = warn_balanced(c, spaceSeen, tPOW, "**", "argument prefix");
@@ -2126,11 +2126,11 @@ public class RubyLexer extends LexingCommon {
             return tOP_ASGN;
         default:
             pushback(c);
-            if (isSpaceArg(c, spaceSeen)) {
+            if (IS_SPCARG(c, spaceSeen)) {
                 if (warnings.isVerbose() && Options.PARSER_WARN_ARGUMENT_PREFIX.load())
                     warning(ID.ARGUMENT_AS_PREFIX, "`*' interpreted as argument prefix");
                 c = tSTAR;
-            } else if (isBEG()) {
+            } else if (IS_BEG()) {
                 c = tSTAR;
             } else {
                 c = warn_balanced(c, spaceSeen, '*', "*", "argument prefix");
@@ -2138,14 +2138,14 @@ public class RubyLexer extends LexingCommon {
             yaccValue = STAR;
         }
 
-        setState(isAfterOperator() ? EXPR_ARG : EXPR_BEG);
+        setState(IS_AFTER_OPERATOR() ? EXPR_ARG : EXPR_BEG);
         return c;
     }
 
     private int tilde() {
         int c;
         
-        if (isAfterOperator()) {
+        if (IS_AFTER_OPERATOR()) {
             if ((c = nextc()) != '@') pushback(c);
             setState(EXPR_ARG);
         } else {

--- a/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
@@ -294,7 +294,7 @@ public class RubyLexer extends LexingCommon {
         ByteList value = createTokenByteList();
         String id = getRuntime().newSymbol(value).idString();
 
-        if (isLexState(last_state, EXPR_DOT|EXPR_FNAME) && parser.getCurrentScope().isDefined(id) >= 0) {
+        if (IS_lex_state(last_state, EXPR_DOT|EXPR_FNAME) && parser.getCurrentScope().isDefined(id) >= 0) {
             setState(EXPR_END);
         }
 
@@ -1002,9 +1002,9 @@ public class RubyLexer extends LexingCommon {
             /* fall through */
             case '\n': {
                 this.tokenSeen = tokenSeen;
-                boolean normalArg = isLexState(lex_state, EXPR_BEG | EXPR_CLASS | EXPR_FNAME | EXPR_DOT) &&
-                        !isLexState(lex_state, EXPR_LABELED);
-                if (normalArg || isLexStateAll(lex_state, EXPR_ARG | EXPR_LABELED)) {
+                boolean normalArg = IS_lex_state(lex_state, EXPR_BEG | EXPR_CLASS | EXPR_FNAME | EXPR_DOT) &&
+                        !IS_lex_state(lex_state, EXPR_LABELED);
+                if (normalArg || IS_lex_state_all(lex_state, EXPR_ARG | EXPR_LABELED)) {
                     if (!normalArg && getLexContext().in_kwarg) {
                         commandStart = true;
                         setState(EXPR_BEG);
@@ -1192,7 +1192,7 @@ public class RubyLexer extends LexingCommon {
         String id = symbol.idString();
 
         if (result == tCONSTANT && !symbol.validConstantName()) result = tIDENTIFIER;
-        if (result == tIDENTIFIER && !isLexState(last_state, EXPR_DOT|EXPR_FNAME) &&
+        if (result == tIDENTIFIER && !IS_lex_state(last_state, EXPR_DOT|EXPR_FNAME) &&
                 parser.getCurrentScope().isDefined(id) >= 0) {
             setState(EXPR_END|EXPR_LABEL);
         }
@@ -1260,7 +1260,7 @@ public class RubyLexer extends LexingCommon {
         } else {
             result = tIVAR;
         }
-        setState(isLexState(last_state, EXPR_FNAME) ? EXPR_ENDFN : EXPR_END);
+        setState(IS_lex_state(last_state, EXPR_FNAME) ? EXPR_ENDFN : EXPR_END);
 
         if (c == EOF || !isIdentifierChar(c)) {
             if (result == tIVAR) {
@@ -1289,11 +1289,11 @@ public class RubyLexer extends LexingCommon {
     private int backtick(boolean commandState) {
         yaccValue = BACKTICK;
 
-        if (isLexState(lex_state, EXPR_FNAME)) {
+        if (IS_lex_state(lex_state, EXPR_FNAME)) {
             setState(EXPR_ENDFN);
             return '`';
         }
-        if (isLexState(lex_state, EXPR_DOT)) {
+        if (IS_lex_state(lex_state, EXPR_DOT)) {
             setState(commandState ? EXPR_CMDARG : EXPR_ARG);
 
             return '`';
@@ -1353,7 +1353,7 @@ public class RubyLexer extends LexingCommon {
         int c = nextc();
         
         if (c == ':') {
-            if (IS_BEG() || isLexState(lex_state, EXPR_CLASS) || (IS_ARG() && spaceSeen)) {
+            if (IS_BEG() || IS_lex_state(lex_state, EXPR_CLASS) || (IS_SPCARG(-1, spaceSeen))) {
                 setState(EXPR_BEG);
                 yaccValue = COLON_COLON;
                 return tCOLON3;
@@ -1364,7 +1364,7 @@ public class RubyLexer extends LexingCommon {
             return tCOLON2;
         }
 
-        if (IS_END() || Character.isWhitespace(c) || c == '#') {
+        if (IS_END() || ISSPACE(c) || c == '#') {
             pushback(c);
             setState(EXPR_BEG);
             yaccValue = COLON;
@@ -1403,7 +1403,7 @@ public class RubyLexer extends LexingCommon {
 
         if (conditionState.set_p()) return keyword_do_cond;
 
-        if (cmdArgumentState.set_p() && !isLexState(state, EXPR_CMDARG)) {
+        if (cmdArgumentState.set_p() && !IS_lex_state(state, EXPR_CMDARG)) {
             return keyword_do_block;
         }
 
@@ -1466,7 +1466,7 @@ public class RubyLexer extends LexingCommon {
         case '\'':      /* $': string after last match */
         case '+':       /* $+: string matches last paren. */
             // Explicit reference to these vars as symbols...
-            if (isLexState(last_state, EXPR_FNAME)) {
+            if (IS_lex_state(last_state, EXPR_FNAME)) {
                 yaccValue = new ByteList(new byte[] {'$', (byte) c}, USASCII_ENCODING);
                 set_yylval_name(new ByteList(new byte[] {'$', (byte) c}));
                 return tGVAR;
@@ -1481,7 +1481,7 @@ public class RubyLexer extends LexingCommon {
                 c = nextc();
             } while (Character.isDigit(c));
             pushback(c);
-            if (isLexState(last_state, EXPR_FNAME)) {
+            if (IS_lex_state(last_state, EXPR_FNAME)) {
                 yaccValue = createTokenByteList();
                 set_yylval_name(new ByteList(new byte[] {'$', (byte) c}));
                 return tGVAR;
@@ -1537,7 +1537,7 @@ public class RubyLexer extends LexingCommon {
                 if (parenNest == 0 && isLookingAtEOL()) {
                     warn(ID.MISCELLANEOUS, "... at EOL, should be parenthesized?");
                 } else if (getLeftParenBegin() >= 0 && getLeftParenBegin() + 1 == parenNest) {
-                    if (isLexState(last_state, EXPR_LABEL)) {
+                    if (IS_lex_state(last_state, EXPR_LABEL)) {
                         return tDOT3;
                     }
                 }
@@ -1616,7 +1616,7 @@ public class RubyLexer extends LexingCommon {
         if ((c == '!' || c == '?') && !peek('=')) {
             result = tFID;
             tempVal = createTokenByteList();
-        } else if (c == '=' && isLexState(lex_state, EXPR_FNAME)) {
+        } else if (c == '=' && IS_lex_state(lex_state, EXPR_FNAME)) {
             int c2 = nextc();
             if (c2 != '~' && c2 != '>' && (c2 != '=' || peek('>'))) {
                 result = tIDENTIFIER;
@@ -1651,17 +1651,17 @@ public class RubyLexer extends LexingCommon {
                 setState(keyword.state);
 
                 yaccValue = keyword.bytes;
-                if (isLexState(state, EXPR_FNAME)) {
+                if (IS_lex_state(state, EXPR_FNAME)) {
                     setState(EXPR_ENDFN);
                     set_yylval_name(createTokenByteList());
                     return keyword.id0;
                 }
 
-                if (isLexState(lex_state, EXPR_BEG)) commandStart = true;
+                if (IS_lex_state(lex_state, EXPR_BEG)) commandStart = true;
 
                 if (keyword.id0 == keyword_do) return doKeyword(state);
 
-                if (isLexState(state, EXPR_BEG|EXPR_LABELED)) {
+                if (IS_lex_state(state, EXPR_BEG|EXPR_LABELED)) {
                     return keyword.id0;
                 } else {
                     if (keyword.id0 != keyword.id1) setState(EXPR_BEG|EXPR_LABEL);
@@ -1670,7 +1670,7 @@ public class RubyLexer extends LexingCommon {
             }
         }
 
-        if (isLexState(lex_state, EXPR_BEG_ANY|EXPR_ARG_ANY|EXPR_DOT)) {
+        if (IS_lex_state(lex_state, EXPR_BEG_ANY|EXPR_ARG_ANY|EXPR_DOT)) {
             setState(commandState ? EXPR_CMDARG : EXPR_ARG);
         } else if (lex_state == EXPR_FNAME) {
             setState(EXPR_ENDFN);
@@ -1700,7 +1700,7 @@ public class RubyLexer extends LexingCommon {
             setState(EXPR_ARG|EXPR_LABEL);
             yaccValue = LBRACKET;
             return '[';
-        } else if (IS_BEG() || (IS_ARG() && (spaceSeen || isLexState(lex_state, EXPR_LABELED)))) {
+        } else if (IS_BEG() || (IS_ARG() && (spaceSeen || IS_lex_state(lex_state, EXPR_LABELED)))) {
             c = tLBRACK;
         }
 
@@ -1716,11 +1716,11 @@ public class RubyLexer extends LexingCommon {
         char c;
         if (isLambdaBeginning()) {
             c = tLAMBEG;
-        } else if (isLexState(lex_state, EXPR_LABELED)) {
+        } else if (IS_lex_state(lex_state, EXPR_LABELED)) {
             c = tLBRACE;
-        } else if (isLexState(lex_state, EXPR_ARG_ANY|EXPR_END|EXPR_ENDFN)) { // block (primary)
+        } else if (IS_lex_state(lex_state, EXPR_ARG_ANY|EXPR_END|EXPR_ENDFN)) { // block (primary)
             c = '{';
-        } else if (isLexState(lex_state, EXPR_ENDARG)) { // block (expr)
+        } else if (IS_lex_state(lex_state, EXPR_ENDARG)) { // block (expr)
             c = tLBRACE_ARG;
         } else { // hash
             c = tLBRACE;
@@ -1748,9 +1748,9 @@ public class RubyLexer extends LexingCommon {
             result = tLPAREN;
         } else if (!spaceSeen) {
             result = '(';
-        } else if (IS_ARG() || isLexStateAll(lex_state, EXPR_END|EXPR_LABEL)) {
+        } else if (IS_ARG() || IS_lex_state_all(lex_state, EXPR_END|EXPR_LABEL)) {
             result = tLPAREN_ARG;
-        } else if (isLexState(lex_state, EXPR_ENDFN) && !isLambdaBeginning()) {
+        } else if (IS_lex_state(lex_state, EXPR_ENDFN) && !isLambdaBeginning()) {
             warnings.warn(ID.MISCELLANEOUS, "parentheses after method name is interpreted as an argument list, not a decomposed argument");
             result = '(';
         } else {
@@ -1769,8 +1769,8 @@ public class RubyLexer extends LexingCommon {
     private int lessThan(boolean spaceSeen) {
         last_state = lex_state;
         int c = nextc();
-        if (c == '<' && !isLexState(lex_state, EXPR_DOT|EXPR_CLASS) &&
-                !IS_END() && (!IS_ARG() || isLexState(lex_state, EXPR_LABELED) || spaceSeen)) {
+        if (c == '<' && !IS_lex_state(lex_state, EXPR_DOT|EXPR_CLASS) &&
+                !IS_END() && (!IS_ARG() || IS_lex_state(lex_state, EXPR_LABELED) || spaceSeen)) {
             int tok = hereDocumentIdentifier();
             
             if (tok != 0) return tok;
@@ -1779,7 +1779,7 @@ public class RubyLexer extends LexingCommon {
         if (IS_AFTER_OPERATOR()) {
             setState(EXPR_ARG);
         } else {
-            if (isLexState(lex_state, EXPR_CLASS)) commandStart = true;
+            if (IS_lex_state(lex_state, EXPR_CLASS)) commandStart = true;
             setState(EXPR_BEG);
         }
 
@@ -1859,7 +1859,7 @@ public class RubyLexer extends LexingCommon {
             return tOP_ASGN;
         }
 
-        if (IS_SPCARG(c, spaceSeen) || (isLexState(lex_state, EXPR_FITEM) && c == 's')) return parseQuote(c);
+        if (IS_SPCARG(c, spaceSeen) || (IS_lex_state(lex_state, EXPR_FITEM) && c == 's')) return parseQuote(c);
 
         setState(IS_AFTER_OPERATOR() ? EXPR_ARG : EXPR_BEG);
         
@@ -1882,7 +1882,7 @@ public class RubyLexer extends LexingCommon {
                 return tOP_ASGN;
             }
             pushback(c);
-            if (isLexStateAll(last_state, EXPR_BEG)) {
+            if (IS_lex_state_all(last_state, EXPR_BEG)) {
                 yaccValue = OR;
                 pushback('|');
                 return '|';

--- a/core/src/main/java/org/jruby/lexer/yacc/StringTerm.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/StringTerm.java
@@ -85,7 +85,7 @@ public class StringTerm extends StrTerm {
             return RubyParser.tREGEXP_END;
         }
 
-        if ((flags & STR_FUNC_LABEL) != 0 && lexer.isLabelSuffix()) {
+        if ((flags & STR_FUNC_LABEL) != 0 && lexer.IS_LABEL_SUFFIX()) {
             lexer.nextc();
             lexer.setState(EXPR_BEG | EXPR_LABEL);
             return RubyParser.tLABEL_END;

--- a/core/src/main/java/org/jruby/parser/RubyParser.java
+++ b/core/src/main/java/org/jruby/parser/RubyParser.java
@@ -4430,12 +4430,12 @@ states[404] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
   return yyVal;
 };
 states[405] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
-                    yyVal = p.getLexContext();
+                    yyVal = p.getLexContext().clone();
                     p.getLexContext().in_rescue = LexContext.InRescue.AFTER_RESCUE;
   return yyVal;
 };
 states[406] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
-                    yyVal = p.getLexContext();
+                    yyVal = p.getLexContext().clone();
   return yyVal;
 };
 states[407] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
@@ -5020,7 +5020,7 @@ states[511] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
   return yyVal;
 };
 states[512] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
-                    yyVal = p.getLexContext();
+                    yyVal = p.getLexContext().clone();
                     p.setState(EXPR_BEG|EXPR_LABEL);
                     p.setCommandStart(false);
                     p.getLexContext().in_kwarg = true;
@@ -6211,7 +6211,7 @@ states[713] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
   return yyVal;
 };
 states[714] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
-                    yyVal = p.getLexContext();
+                    yyVal = p.getLexContext().clone();
                     p.getLexContext().in_kwarg = true;
                     p.getLexContext().in_argdef = true;
                     p.setState(p.getState() | EXPR_LABEL);

--- a/core/src/main/java/org/jruby/parser/RubyParser.java
+++ b/core/src/main/java/org/jruby/parser/RubyParser.java
@@ -2454,7 +2454,7 @@ states[70] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, i
                         $$ = new DefHolder(p.get_id(yyVals[yyTop - count + 1].id), currentArg, p.get_value($1), (LexContext) ctxt.clone());
                     %*/
                     ctxt.in_def = true;
-                    p.getLexContext().in_rescue = LexContext.InRescue.BEFORE_RESCUE;
+                    ctxt.in_rescue = LexContext.InRescue.BEFORE_RESCUE;
                     p.setCurrentArg(null);
   return yyVal;
 };
@@ -4239,12 +4239,7 @@ states[377] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
   return yyVal;
 };
 states[378] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
-                    LexContext ctxt = p.getLexContext();
-                    if (ctxt.in_def) {
-                        p.yyerror("class definition in method body");
-                    }
-                    ctxt.in_class = true;
-                    p.pushLocalScope();
+                    p.begin_definition("class");
   return yyVal;
 };
 states[379] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
@@ -4261,10 +4256,7 @@ states[379] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
   return yyVal;
 };
 states[380] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
-                    LexContext ctxt = p.getLexContext();
-                    ctxt.in_def = false;
-                    ctxt.in_class = false;
-                    p.pushLocalScope();
+                    p.begin_definition(null);
   return yyVal;
 };
 states[381] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
@@ -4282,12 +4274,7 @@ states[381] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
   return yyVal;
 };
 states[382] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
-                    LexContext ctxt = p.getLexContext();
-                    if (ctxt.in_def) { 
-                        p.yyerror("module definition in method body");
-                    }
-                    ctxt.in_class = true;
-                    p.pushLocalScope();
+                    p.begin_definition("module");
   return yyVal;
 };
 states[383] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
@@ -6806,7 +6793,7 @@ states[822] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
   return yyVal;
 };
 }
-					// line 4825 "parse.y"
+					// line 4812 "parse.y"
 
 }
-					// line 14938 "-"
+					// line 14925 "-"

--- a/core/src/main/java/org/jruby/parser/RubyParser.java
+++ b/core/src/main/java/org/jruby/parser/RubyParser.java
@@ -2415,7 +2415,7 @@ states[65] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, i
 };
 states[66] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
                     p.pop_pvtbl(((Set)yyVals[-2+yyTop].value));
-                    p.pop_pvtbl(((Set)yyVals[-1+yyTop].value));
+                    p.pop_pktbl(((Set)yyVals[-1+yyTop].value));
                     LexContext ctxt = p.getLexContext();
                     ctxt.in_kwarg = ((LexContext)yyVals[-3+yyTop].value).in_kwarg;
                     /*%%%*/
@@ -2430,7 +2430,7 @@ states[67] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, i
 };
 states[68] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
                     p.pop_pvtbl(((Set)yyVals[-2+yyTop].value));
-                    p.pop_pvtbl(((Set)yyVals[-1+yyTop].value));
+                    p.pop_pktbl(((Set)yyVals[-1+yyTop].value));
                     LexContext ctxt = p.getLexContext();
                     ctxt.in_kwarg = ((LexContext)yyVals[-3+yyTop].value).in_kwarg;
                     /*%%%*/
@@ -5033,15 +5033,15 @@ states[511] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
   return yyVal;
 };
 states[512] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
+                    yyVal = p.getLexContext();
                     p.setState(EXPR_BEG|EXPR_LABEL);
                     p.setCommandStart(false);
-                    yyVal = p.getLexContext();
                     p.getLexContext().in_kwarg = true;
   return yyVal;
 };
 states[513] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
-                    p.pop_pktbl(((Set)yyVals[-3+yyTop].value));
-                    p.pop_pvtbl(((Set)yyVals[-2+yyTop].value));
+                    p.pop_pvtbl(((Set)yyVals[-3+yyTop].value));
+                    p.pop_pktbl(((Set)yyVals[-2+yyTop].value));
                     p.getLexContext().in_kwarg = ((LexContext)yyVals[-4+yyTop].value).in_kwarg;
   return yyVal;
 };
@@ -6224,16 +6224,15 @@ states[713] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
   return yyVal;
 };
 states[714] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
-                    LexContext ctxt = p.getLexContext();
-                    yyVal = ctxt.in_kwarg;
-                    ctxt.in_kwarg = true;
-                    ctxt.in_argdef = true;
+                    yyVal = p.getLexContext();
+                    p.getLexContext().in_kwarg = true;
+                    p.getLexContext().in_argdef = true;
                     p.setState(p.getState() | EXPR_LABEL);
   return yyVal;
 };
 states[715] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, int count, int yychar) -> {
                     LexContext ctxt = p.getLexContext();
-                    ctxt.in_kwarg = ((Boolean)yyVals[-2+yyTop].value);
+                    ctxt.in_kwarg = ((LexContext)yyVals[-2+yyTop].value).in_kwarg;
                     ctxt.in_argdef = false;
                     yyVal = ((ArgsNode)yyVals[-1+yyTop].value);
                     p.setState(EXPR_BEG);
@@ -6807,7 +6806,7 @@ states[822] = (RubyParser p, Object yyVal, ProductionState[] yyVals, int yyTop, 
   return yyVal;
 };
 }
-					// line 4826 "parse.y"
+					// line 4825 "parse.y"
 
 }
-					// line 14939 "-"
+					// line 14938 "-"

--- a/core/src/main/java/org/jruby/parser/RubyParser.y
+++ b/core/src/main/java/org/jruby/parser/RubyParser.y
@@ -861,7 +861,7 @@ def_name        : fname {
                         $$ = new DefHolder(p.get_id(@1.id), currentArg, p.get_value($1), (LexContext) ctxt.clone());
                     %*/
                     ctxt.in_def = true;
-                    p.getLexContext().in_rescue = LexContext.InRescue.BEFORE_RESCUE;
+                    ctxt.in_rescue = LexContext.InRescue.BEFORE_RESCUE;
                     p.setCurrentArg(null);
                 };
 
@@ -2432,12 +2432,7 @@ primary         : literal
                     /*% ripper: for!($2, $4, $5) %*/
                 }
                 | k_class cpath superclass {
-                    LexContext ctxt = p.getLexContext();
-                    if (ctxt.in_def) {
-                        p.yyerror("class definition in method body");
-                    }
-                    ctxt.in_class = true;
-                    p.pushLocalScope();
+                    p.begin_definition("class");
                 } bodystmt k_end {
                     /*%%%*/
                     Node body = p.makeNullNil($5);
@@ -2451,10 +2446,7 @@ primary         : literal
                     ctxt.shareable_constant_value = $1.shareable_constant_value;
                 }
                 | k_class tLSHFT expr_value {
-                    LexContext ctxt = p.getLexContext();
-                    ctxt.in_def = false;
-                    ctxt.in_class = false;
-                    p.pushLocalScope();
+                    p.begin_definition(null);
                 } term bodystmt k_end {
                     /*%%%*/
                     Node body = p.makeNullNil($6);
@@ -2469,12 +2461,7 @@ primary         : literal
                     p.popCurrentScope();
                 }
                 | k_module cpath {
-                    LexContext ctxt = p.getLexContext();
-                    if (ctxt.in_def) { 
-                        p.yyerror("module definition in method body");
-                    }
-                    ctxt.in_class = true;
-                    p.pushLocalScope();
+                    p.begin_definition("module");
                 } bodystmt k_end {
                     /*%%%*/
                     Node body = p.makeNullNil($4);

--- a/core/src/main/java/org/jruby/parser/RubyParser.y
+++ b/core/src/main/java/org/jruby/parser/RubyParser.y
@@ -821,7 +821,7 @@ expr            : command_call
                     p.value_expr($1);
                 } p_in_kwarg p_pvtbl p_pktbl p_top_expr_body {
                     p.pop_pvtbl($<Set>5);
-                    p.pop_pvtbl($<Set>6);
+                    p.pop_pktbl($<Set>6);
                     LexContext ctxt = p.getLexContext();
                     ctxt.in_kwarg = $4.in_kwarg;
                     /*%%%*/
@@ -833,7 +833,7 @@ expr            : command_call
                     p.value_expr($1);
                 } p_in_kwarg p_pvtbl p_pktbl p_top_expr_body {
                     p.pop_pvtbl($<Set>5);
-                    p.pop_pvtbl($<Set>6);
+                    p.pop_pktbl($<Set>6);
                     LexContext ctxt = p.getLexContext();
                     ctxt.in_kwarg = $4.in_kwarg;
                     /*%%%*/
@@ -3177,16 +3177,16 @@ p_pktbl         : {
                 };
 
 p_in_kwarg      : {
+                    $$ = p.getLexContext();
                     p.setState(EXPR_BEG|EXPR_LABEL);
                     p.setCommandStart(false);
-                    $$ = p.getLexContext();
                     p.getLexContext().in_kwarg = true;
                 };
 
 // InNode - [!null]
 p_case_body     : keyword_in p_in_kwarg p_pvtbl p_pktbl p_top_expr then {
-                    p.pop_pktbl($<Set>3);
-                    p.pop_pvtbl($<Set>4);
+                    p.pop_pvtbl($<Set>3);
+                    p.pop_pktbl($<Set>4);
                     p.getLexContext().in_kwarg = $2.in_kwarg;
                 } compstmt p_cases {
                     /*%%%*/
@@ -4341,14 +4341,13 @@ f_arglist       : f_paren_args {
                    $$ = $1;
                 }
                 | {
-                    LexContext ctxt = p.getLexContext();
-                    $$ = ctxt.in_kwarg;
-                    ctxt.in_kwarg = true;
-                    ctxt.in_argdef = true;
+                    $$ = p.getLexContext();
+                    p.getLexContext().in_kwarg = true;
+                    p.getLexContext().in_argdef = true;
                     p.setState(p.getState() | EXPR_LABEL);
                 } f_args term {
                     LexContext ctxt = p.getLexContext();
-                    ctxt.in_kwarg = $<Boolean>1;
+                    ctxt.in_kwarg = $<LexContext>1.in_kwarg;
                     ctxt.in_argdef = false;
                     $$ = $2;
                     p.setState(EXPR_BEG);

--- a/core/src/main/java/org/jruby/parser/RubyParser.y
+++ b/core/src/main/java/org/jruby/parser/RubyParser.y
@@ -2606,12 +2606,12 @@ k_do_block      : keyword_do_block {
                 };
 
 k_rescue        : keyword_rescue {
-                    $$ = p.getLexContext();
+                    $$ = p.getLexContext().clone();
                     p.getLexContext().in_rescue = LexContext.InRescue.AFTER_RESCUE;
                 };
 
 k_ensure        : keyword_ensure {
-                    $$ = p.getLexContext();
+                    $$ = p.getLexContext().clone();
                 };
  
 k_when          : keyword_when {
@@ -3164,7 +3164,7 @@ p_pktbl         : {
                 };
 
 p_in_kwarg      : {
-                    $$ = p.getLexContext();
+                    $$ = p.getLexContext().clone();
                     p.setState(EXPR_BEG|EXPR_LABEL);
                     p.setCommandStart(false);
                     p.getLexContext().in_kwarg = true;
@@ -4328,7 +4328,7 @@ f_arglist       : f_paren_args {
                    $$ = $1;
                 }
                 | {
-                    $$ = p.getLexContext();
+                    $$ = p.getLexContext().clone();
                     p.getLexContext().in_kwarg = true;
                     p.getLexContext().in_argdef = true;
                     p.setState(p.getState() | EXPR_LABEL);

--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -1922,6 +1922,16 @@ public abstract class RubyParserBase {
         return INTERNAL_ID.toString();
     }
 
+    protected void begin_definition(String name) {
+        LexContext ctxt = getLexContext();
+        ctxt.in_class = name != null;
+        if (!ctxt.in_class) {
+            ctxt.in_def = false;
+        } else if (ctxt.in_def) {
+            yyerror((name != null ? (name + " ") : "") + "definition in method body");
+        }
+        pushLocalScope();
+    }
     public Set<ByteList> push_pvtbl() {
         Set<ByteList> currentTable = variableTable;
 


### PR DESCRIPTION
Just basic rekajiggering to get rid of last obvious syntax issue.

This branch did some renaming to make comparison with MRI parser simpler.