### PR TITLE
Implement block_given? call as optimized instruction

### DIFF
--- a/bench/bench_block_given.rb
+++ b/bench/bench_block_given.rb
@@ -1,0 +1,39 @@
+require 'benchmark/ips'
+
+def foo
+  block_given?
+end
+
+def foo2
+  defined?(yield)
+end
+
+Benchmark.ips do |bm|
+  bm.report("block") do |i|
+    while i > 0
+      i-=1
+      foo { }; foo { }; foo { }; foo { }; foo { }; foo { }; foo { }; foo { }; foo { }; foo { }
+    end
+  end
+
+  bm.report("no block") do |i|
+    while i > 0
+      i-=1
+      foo; foo; foo; foo; foo; foo; foo; foo; foo; foo
+    end
+  end
+
+  bm.report("defined block") do |i|
+    while i > 0
+      i-=1
+      foo2 { }; foo2 { }; foo2 { }; foo2 { }; foo2 { }; foo2 { }; foo2 { }; foo2 { }; foo2 { }; foo2 { }
+    end
+  end
+
+  bm.report("defined no block") do |i|
+    while i > 0
+      i-=1
+      foo2; foo2; foo2; foo2; foo2; foo2; foo2; foo2; foo2; foo2
+    end
+  end
+end

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -957,6 +957,10 @@ public class RubyKernel {
         return RubyBoolean.newBoolean(context, context.getCurrentFrame().getBlock().isGiven());
     }
 
+    public static RubyBoolean blockGiven(ThreadContext context, IRubyObject recv, Block frameBlock) {
+        return RubyBoolean.newBoolean(context, frameBlock.isGiven());
+    }
+
     @JRubyMethod(name = {"sprintf", "format"}, required = 1, rest = true, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject sprintf(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         if (args.length == 0) {

--- a/core/src/main/java/org/jruby/ir/IRVisitor.java
+++ b/core/src/main/java/org/jruby/ir/IRVisitor.java
@@ -37,6 +37,7 @@ public abstract class IRVisitor {
     public void AttrAssignInstr(AttrAssignInstr attrassigninstr) { error(attrassigninstr); }
     public void BFalseInstr(BFalseInstr bfalseinstr) { error(bfalseinstr); }
     public void BlockGivenInstr(BlockGivenInstr blockgiveninstr) { error(blockgiveninstr); }
+    public void BlockGivenCallInstr(BlockGivenCallInstr blockgivencallinstr) { error(blockgivencallinstr); }
     public void BIntInstr(BIntInstr bIntInstr) { error(bIntInstr); }
     public void BNEInstr(BNEInstr bneinstr) { error(bneinstr); }
     public void BNilInstr(BNilInstr bnilinstr) { error(bnilinstr); }

--- a/core/src/main/java/org/jruby/ir/Operation.java
+++ b/core/src/main/java/org/jruby/ir/Operation.java
@@ -83,6 +83,7 @@ public enum Operation {
     CALL_1OB(OpFlags.f_has_side_effect | OpFlags.f_is_call | OpFlags.f_can_raise_exception),
     CALL_0O(OpFlags.f_has_side_effect | OpFlags.f_is_call | OpFlags.f_can_raise_exception),
     NORESULT_CALL_1O(OpFlags.f_has_side_effect | OpFlags.f_is_call | OpFlags.f_can_raise_exception),
+    BLOCK_GIVEN_CALL(OpFlags.f_has_side_effect | OpFlags.f_is_call | OpFlags.f_can_raise_exception),
 
     /** Ruby operators: should all these be calls? Implementing instrs don't inherit from CallBase.java */
     EQQ(OpFlags.f_has_side_effect | OpFlags.f_can_raise_exception), // a === call used in when

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
@@ -2042,7 +2042,7 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
             case "iterator?":
                 if (node.getArgsNode() == null
                         && node.getIterNode() == null) {
-                    addInstr(new BlockGivenInstr(result, getYieldClosureVariable(), callName));
+                    addInstr(new BlockGivenCallInstr(result, getYieldClosureVariable(), callName));
                     return result;
                 }
         }

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
@@ -1301,7 +1301,7 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
                     )
             );
         case YIELDNODE:
-            return buildDefinitionCheck(new BlockGivenInstr(temp(), getYieldClosureVariable(), true), DefinedMessage.YIELD.getText());
+            return buildDefinitionCheck(new BlockGivenInstr(temp(), getYieldClosureVariable()), DefinedMessage.YIELD.getText());
         case ZSUPERNODE:
             return addResultInstr(
                     new RuntimeHelperCall(
@@ -2036,11 +2036,15 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
         RubySymbol name = methodName = node.getName();
 
         // special case methods with frame handling
-        if (name.idString().equals("block_given?")
-                && node.getArgsNode() == null
-                && node.getIterNode() == null) {
-            addInstr(new BlockGivenInstr(result, getYieldClosureVariable(), false));
-            return result;
+        String callName = name.idString();
+        switch (callName) {
+            case "block_given?":
+            case "iterator?":
+                if (node.getArgsNode() == null
+                        && node.getIterNode() == null) {
+                    addInstr(new BlockGivenInstr(result, getYieldClosureVariable(), callName));
+                    return result;
+                }
         }
 
         return createCall(result, buildSelf(), FUNCTIONAL, name, node.getArgsNode(), node.getIterNode(),

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
@@ -1301,7 +1301,7 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
                     )
             );
         case YIELDNODE:
-            return buildDefinitionCheck(new BlockGivenInstr(temp(), getYieldClosureVariable()), DefinedMessage.YIELD.getText());
+            return buildDefinitionCheck(new BlockGivenInstr(temp(), getYieldClosureVariable(), true), DefinedMessage.YIELD.getText());
         case ZSUPERNODE:
             return addResultInstr(
                     new RuntimeHelperCall(
@@ -2034,6 +2034,14 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
     public Operand buildFCall(Variable result, FCallNode node) {
         if (result == null) result = temp();
         RubySymbol name = methodName = node.getName();
+
+        // special case methods with frame handling
+        if (name.idString().equals("block_given?")
+                && node.getArgsNode() == null
+                && node.getIterNode() == null) {
+            addInstr(new BlockGivenInstr(result, getYieldClosureVariable(), false));
+            return result;
+        }
 
         return createCall(result, buildSelf(), FUNCTIONAL, name, node.getArgsNode(), node.getIterNode(),
                 node.getLine(), node.isNewline());

--- a/core/src/main/java/org/jruby/ir/instructions/BlockGivenCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/BlockGivenCallInstr.java
@@ -20,27 +20,26 @@ import java.util.Objects;
  * A call to block_given? which can be optimized like defined?(yield) or a regular call.
  */
 public class BlockGivenCallInstr extends OneOperandResultBaseInstr implements FixedArityInstr {
-    private final String callName;
     private final FunctionalCachingCallSite blockGivenSite;
 
-    public BlockGivenCallInstr(Variable result, Operand block, String callName) {
+    public BlockGivenCallInstr(Variable result, Operand block, String methodName) {
         super(Operation.BLOCK_GIVEN_CALL, Objects.requireNonNull(result, "BlockGivenCallInstr result is null"), block);
 
-        this.callName = Objects.requireNonNull(callName, "BlockGivenCallInstr callName is null");
-        this.blockGivenSite = new FunctionalCachingCallSite(callName);
+        this.blockGivenSite =
+                new FunctionalCachingCallSite(Objects.requireNonNull(methodName, "BlockGivenCallInstr methodName is null"));
     }
 
     public Operand getBlockArg() {
         return getOperand1();
     }
 
-    public String getCallName() {
-        return callName;
+    public String getMethodName() {
+        return blockGivenSite.getMethodName();
     }
 
     @Override
     public Instr clone(CloneInfo ii) {
-        return new BlockGivenCallInstr(ii.getRenamedVariable(result), getBlockArg().cloneForInlining(ii), callName);
+        return new BlockGivenCallInstr(ii.getRenamedVariable(result), getBlockArg().cloneForInlining(ii), blockGivenSite.getMethodName());
     }
 
     public static BlockGivenCallInstr decode(IRReaderDecoder d) {
@@ -50,7 +49,7 @@ public class BlockGivenCallInstr extends OneOperandResultBaseInstr implements Fi
     @Override
     public void encode(IRWriterEncoder e) {
         super.encode(e);
-        e.encode(callName);
+        e.encode(blockGivenSite.getMethodName());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/BlockGivenCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/BlockGivenCallInstr.java
@@ -1,0 +1,67 @@
+package org.jruby.ir.instructions;
+
+import org.jruby.ir.IRVisitor;
+import org.jruby.ir.Operation;
+import org.jruby.ir.operands.Operand;
+import org.jruby.ir.operands.Variable;
+import org.jruby.ir.persistence.IRReaderDecoder;
+import org.jruby.ir.persistence.IRWriterEncoder;
+import org.jruby.ir.runtime.IRRuntimeHelpers;
+import org.jruby.ir.transformations.inlining.CloneInfo;
+import org.jruby.parser.StaticScope;
+import org.jruby.runtime.DynamicScope;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.callsite.FunctionalCachingCallSite;
+
+import java.util.Objects;
+
+/**
+ * A call to block_given? which can be optimized like defined?(yield) or a regular call.
+ */
+public class BlockGivenCallInstr extends OneOperandResultBaseInstr implements FixedArityInstr {
+    private final String callName;
+    private final FunctionalCachingCallSite blockGivenSite;
+
+    public BlockGivenCallInstr(Variable result, Operand block, String callName) {
+        super(Operation.BLOCK_GIVEN_CALL, Objects.requireNonNull(result, "BlockGivenCallInstr result is null"), block);
+
+        this.callName = Objects.requireNonNull(callName, "BlockGivenCallInstr callName is null");
+        this.blockGivenSite = new FunctionalCachingCallSite(callName);
+    }
+
+    public Operand getBlockArg() {
+        return getOperand1();
+    }
+
+    public String getCallName() {
+        return callName;
+    }
+
+    @Override
+    public Instr clone(CloneInfo ii) {
+        return new BlockGivenCallInstr(ii.getRenamedVariable(result), getBlockArg().cloneForInlining(ii), callName);
+    }
+
+    public static BlockGivenCallInstr decode(IRReaderDecoder d) {
+        return new BlockGivenCallInstr(d.decodeVariable(), d.decodeOperand(), d.decodeString());
+    }
+
+    @Override
+    public void encode(IRWriterEncoder e) {
+        super.encode(e);
+        e.encode(callName);
+    }
+
+    @Override
+    public Object interpret(ThreadContext context, StaticScope currScope, DynamicScope currDynScope, IRubyObject self, Object[] temp) {
+        Object blk = getBlockArg().retrieve(context, self, currScope, currDynScope, temp);
+
+        return IRRuntimeHelpers.blockGivenOrCall(context, self, blockGivenSite, blk);
+    }
+
+    @Override
+    public void visit(IRVisitor visitor) {
+        visitor.BlockGivenCallInstr(this);
+    }
+}

--- a/core/src/main/java/org/jruby/ir/instructions/BlockGivenInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/BlockGivenInstr.java
@@ -5,71 +5,40 @@ import org.jruby.ir.Operation;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.persistence.IRReaderDecoder;
-import org.jruby.ir.persistence.IRWriterEncoder;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.transformations.inlining.CloneInfo;
 import org.jruby.parser.StaticScope;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.runtime.callsite.FunctionalCachingCallSite;
+
+import java.util.Objects;
 
 /**
  * Represents a defined?(yield) check, which works like a call to block_given? without
  * requiring special access to the caller's frame.
  */
 public class BlockGivenInstr extends OneOperandResultBaseInstr implements FixedArityInstr {
-    private final String callName;
-    private final FunctionalCachingCallSite blockGivenSite;
-
     public BlockGivenInstr(Variable result, Operand block) {
-        this(result, block, null);
-    }
-
-    public BlockGivenInstr(Variable result, Operand block, String callName) {
-        super(Operation.BLOCK_GIVEN, result, block);
-
-        assert result != null: "BlockGivenInstr result is null";
-
-        this.callName = callName;
-
-        if (callName == null) {
-            blockGivenSite = null;
-        } else {
-            blockGivenSite = new FunctionalCachingCallSite(callName);
-        }
+        super(Operation.BLOCK_GIVEN, Objects.requireNonNull(result, "BlockGivenCallInstr result is null"), block);
     }
 
     public Operand getBlockArg() {
         return getOperand1();
     }
 
-    public String getCallName() {
-        return callName;
-    }
-
     @Override
     public Instr clone(CloneInfo ii) {
-        return new BlockGivenInstr(ii.getRenamedVariable(result), getBlockArg().cloneForInlining(ii), callName);
+        return new BlockGivenInstr(ii.getRenamedVariable(result), getBlockArg().cloneForInlining(ii));
     }
 
     public static BlockGivenInstr decode(IRReaderDecoder d) {
-        return new BlockGivenInstr(d.decodeVariable(), d.decodeOperand(), d.decodeString());
-    }
-
-    @Override
-    public void encode(IRWriterEncoder e) {
-        super.encode(e);
-        e.encode(callName);
+        return new BlockGivenInstr(d.decodeVariable(), d.decodeOperand());
     }
 
     @Override
     public Object interpret(ThreadContext context, StaticScope currScope, DynamicScope currDynScope, IRubyObject self, Object[] temp) {
         Object blk = getBlockArg().retrieve(context, self, currScope, currDynScope, temp);
-
-        if (callName != null) {
-            return IRRuntimeHelpers.blockGivenOrCall(context, self, blockGivenSite, blk);
-        }
 
         return IRRuntimeHelpers.isBlockGiven(context, blk);
     }

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -944,6 +944,16 @@ public class IRRuntimeHelpers {
         return dynScope;
     }
 
+    public static IRubyObject blockGivenOrCall(ThreadContext context, IRubyObject self, FunctionalCachingCallSite blockGivenSite, Object blk) {
+        CacheEntry blockGivenEntry = blockGivenSite.retrieveCache(self);
+
+        if (!blockGivenEntry.method.getRealMethod().isBuiltin()) {
+            return blockGivenSite.call(context, self, self);
+        }
+
+        return isBlockGiven(context, blk);
+    }
+
     private static class InvalidKeyException extends RuntimeException {}
     private static final InvalidKeyException INVALID_KEY_EXCEPTION = new InvalidKeyException();
     private static final RubyHash.VisitorWithState<StaticScope> CheckUnwantedKeywordsVisitor = new RubyHash.VisitorWithState<StaticScope>() {

--- a/core/src/main/java/org/jruby/ir/targets/InvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/InvocationCompiler.java
@@ -132,5 +132,5 @@ public interface InvocationCompiler {
     /**
      * Invoke block_given? or iterator? with awareness of any built-in methods.
      */
-    void invokeBlockGiven(String callName, String file);
+    void invokeBlockGiven(String methodName, String file);
 }

--- a/core/src/main/java/org/jruby/ir/targets/InvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/InvocationCompiler.java
@@ -128,4 +128,11 @@ public interface InvocationCompiler {
      * Stack required: none
      */
     void setCallInfo(int flags);
+
+    /**
+     * Invoke block_given? with awareness of any built-in methods.
+     *
+     * @param call a CallBase representing the call to block_given?
+     */
+    void invokeBlockGiven(String file, String scopeFieldName, CallBase call);
 }

--- a/core/src/main/java/org/jruby/ir/targets/InvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/InvocationCompiler.java
@@ -130,7 +130,7 @@ public interface InvocationCompiler {
     void setCallInfo(int flags);
 
     /**
-     * Invoke block_given? with awareness of any built-in methods.
+     * Invoke block_given? or iterator? with awareness of any built-in methods.
      */
-    void invokeBlockGiven(String file, String scopeFieldName);
+    void invokeBlockGiven(String callName, String file);
 }

--- a/core/src/main/java/org/jruby/ir/targets/InvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/InvocationCompiler.java
@@ -131,8 +131,6 @@ public interface InvocationCompiler {
 
     /**
      * Invoke block_given? with awareness of any built-in methods.
-     *
-     * @param call a CallBase representing the call to block_given?
      */
-    void invokeBlockGiven(String file, String scopeFieldName, CallBase call);
+    void invokeBlockGiven(String file, String scopeFieldName);
 }

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -816,9 +816,11 @@ public class JVMVisitor extends IRVisitor {
 
     @Override
     public void BlockGivenInstr(BlockGivenInstr blockGivenInstr) {
-        if (!blockGivenInstr.isDefined()) {
+        String callName = blockGivenInstr.getCallName();
+
+        if (callName != null) {
             IRBytecodeAdapter m = jvmMethod();
-            m.getInvocationCompiler().invokeBlockGiven(file, jvm.methodData().scopeField);
+            m.getInvocationCompiler().invokeBlockGiven(callName, file);
             handleCallResult(m, blockGivenInstr.getResult());
             return;
         }

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -816,19 +816,18 @@ public class JVMVisitor extends IRVisitor {
 
     @Override
     public void BlockGivenInstr(BlockGivenInstr blockGivenInstr) {
-        String callName = blockGivenInstr.getCallName();
-
-        if (callName != null) {
-            IRBytecodeAdapter m = jvmMethod();
-            m.getInvocationCompiler().invokeBlockGiven(callName, file);
-            handleCallResult(m, blockGivenInstr.getResult());
-            return;
-        }
-
         jvmMethod().loadContext();
         visit(blockGivenInstr.getBlockArg());
         jvmMethod().invokeIRHelper("isBlockGiven", sig(RubyBoolean.class, ThreadContext.class, Object.class));
         jvmStoreLocal(blockGivenInstr.getResult());
+    }
+
+    @Override
+    public void BlockGivenCallInstr(BlockGivenCallInstr blockGivenCallInstr) {
+        String callName = blockGivenCallInstr.getCallName();
+        IRBytecodeAdapter m = jvmMethod();
+        m.getInvocationCompiler().invokeBlockGiven(callName, file);
+        handleCallResult(m, blockGivenCallInstr.getResult());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -824,9 +824,9 @@ public class JVMVisitor extends IRVisitor {
 
     @Override
     public void BlockGivenCallInstr(BlockGivenCallInstr blockGivenCallInstr) {
-        String callName = blockGivenCallInstr.getCallName();
+        String methodName = blockGivenCallInstr.getMethodName();
         IRBytecodeAdapter m = jvmMethod();
-        m.getInvocationCompiler().invokeBlockGiven(callName, file);
+        m.getInvocationCompiler().invokeBlockGiven(methodName, file);
         handleCallResult(m, blockGivenCallInstr.getResult());
     }
 

--- a/core/src/main/java/org/jruby/ir/targets/indy/BlockGivenSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/BlockGivenSite.java
@@ -1,0 +1,74 @@
+package org.jruby.ir.targets.indy;
+
+import com.headius.invokebinder.Binder;
+import org.jruby.runtime.Block;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.callsite.CacheEntry;
+import org.objectweb.asm.Handle;
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.MutableCallSite;
+
+import static java.lang.invoke.MethodHandles.lookup;
+import static java.lang.invoke.MethodType.methodType;
+import static org.jruby.util.CodegenUtils.sig;
+
+/**
+ * Perform an optimized block_given? check without accessing a caller's frame.
+ *
+ * This logic checks if the target method is our built-in block_given? and uses fast logic in that case. All other calls
+ * fall back on normal indy call logic.
+ *
+ * Note that if the target method is initially not built-in, or becomes a not built-in version later, we permanently
+ * fall back on the invocation logic. No further checking is done and the site is optimized as a normal call from there.
+ */
+public class BlockGivenSite extends MutableCallSite {
+    private final String file;
+    private final int line;
+
+    public BlockGivenSite(MethodType type, String file, int line) {
+        super(type);
+
+        this.file = file;
+        this.line = line;
+    }
+
+    public static final Handle BLOCK_GIVEN_BOOTSTRAP = Bootstrap.getBootstrapHandle("blockGivenBootstrap", BlockGivenSite.class, sig(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class, String.class, int.class));
+
+    public static CallSite blockGivenBootstrap(MethodHandles.Lookup lookup, String name, MethodType methodType, String file, int line) {
+        BlockGivenSite blockGivenSite = new BlockGivenSite(methodType, file, line);
+
+        blockGivenSite.setTarget(Binder.from(methodType).prepend(blockGivenSite, name).invokeVirtualQuiet("blockGivenFallback"));
+
+        return blockGivenSite;
+    }
+
+    public IRubyObject blockGivenFallback(String name, ThreadContext context, IRubyObject self, Block block) throws Throwable {
+        String callName = name.split(":")[1];
+
+        CacheEntry entry = self.getMetaClass().searchWithCache(callName);
+        MethodHandle target;
+
+        if (entry.method.isBuiltin()) {
+            target = Binder.from(type())
+                    .permute(0, 2)
+                    .invokeStaticQuiet(BlockGivenSite.class, "blockGiven");
+        } else {
+            target = Binder.from(type())
+                    .permute(0, 1)
+                    .invoke(SelfInvokeSite.bootstrap(lookup(), name, methodType(IRubyObject.class, ThreadContext.class, IRubyObject.class), 0, 0, file, line).dynamicInvoker());
+        }
+
+        setTarget(target);
+
+        return (IRubyObject) target.invokeExact(context, self, block);
+    }
+
+    public static IRubyObject blockGiven(ThreadContext context, Block block) {
+        return block.isGiven() ? context.tru : context.fals;
+    }
+}

--- a/core/src/main/java/org/jruby/ir/targets/indy/BlockGivenSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/BlockGivenSite.java
@@ -48,9 +48,9 @@ public class BlockGivenSite extends MutableCallSite {
     }
 
     public IRubyObject blockGivenFallback(String name, ThreadContext context, IRubyObject self, Block block) throws Throwable {
-        String callName = name.split(":")[1];
+        String methodName = name.split(":")[1];
 
-        CacheEntry entry = self.getMetaClass().searchWithCache(callName);
+        CacheEntry entry = self.getMetaClass().searchWithCache(methodName);
         MethodHandle target;
 
         if (entry.method.isBuiltin()) {

--- a/core/src/main/java/org/jruby/ir/targets/indy/Bootstrap.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/Bootstrap.java
@@ -26,19 +26,26 @@
 
 package org.jruby.ir.targets.indy;
 
+import com.headius.invokebinder.Binder;
 import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.runtime.Block;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.callsite.CacheEntry;
 import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Opcodes;
 
 import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.lang.invoke.MutableCallSite;
 
 import static java.lang.invoke.MethodHandles.Lookup;
 import static java.lang.invoke.MethodHandles.dropArguments;
+import static java.lang.invoke.MethodHandles.lookup;
 import static java.lang.invoke.MethodType.methodType;
 import static org.jruby.runtime.Helpers.arrayOf;
 import static org.jruby.util.CodegenUtils.p;
@@ -72,5 +79,38 @@ public class Bootstrap {
                 name,
                 sig,
                 false);
+    }
+
+    public static final Handle BLOCK_GIVEN_BOOTSTRAP = getBootstrapHandle("blockGivenBootstrap", Bootstrap.class, sig(CallSite.class, Lookup.class, String.class, MethodType.class));
+
+    public static CallSite blockGivenBootstrap(Lookup lookup, String name, MethodType methodType) {
+        MutableCallSite blockGivenSite = new MutableCallSite(methodType);
+
+        blockGivenSite.setTarget(Binder.from(methodType).prepend(blockGivenSite, name).invokeStaticQuiet(Bootstrap.class, "blockGivenFallback"));
+
+        return blockGivenSite;
+    }
+
+    public static IRubyObject blockGivenFallback(MutableCallSite blockGivenSite, String name, ThreadContext context, IRubyObject self, Block block) throws Throwable {
+        CacheEntry entry = self.getMetaClass().searchWithCache("block_given?");
+        MethodHandle target;
+
+        if (entry.method.isBuiltin()) {
+            target = Binder.from(blockGivenSite.type())
+                    .permute(0, 2)
+                    .invokeStaticQuiet(Bootstrap.class, "blockGiven");
+        } else {
+            target = Binder.from(blockGivenSite.type())
+                    .permute(0, 1)
+                    .invoke(SelfInvokeSite.bootstrap(lookup(), name, methodType(IRubyObject.class, ThreadContext.class, IRubyObject.class), 0, 0, "", 0).dynamicInvoker());
+        }
+
+        blockGivenSite.setTarget(target);
+
+        return (IRubyObject) target.invokeExact(context, self, block);
+    }
+
+    public static IRubyObject blockGiven(ThreadContext context, Block block) {
+        return block.isGiven() ? context.tru : context.fals;
     }
 }

--- a/core/src/main/java/org/jruby/ir/targets/indy/IndyInvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/IndyInvocationCompiler.java
@@ -222,8 +222,15 @@ public class IndyInvocationCompiler implements InvocationCompiler {
     }
 
     @Override
-    public void invokeBlockGiven(String file, String scopeFieldName) {
-        // block_given? explicit calls always use indy
-        normalCompiler.invokeBlockGiven(file, scopeFieldName);
+    public void invokeBlockGiven(String callName, String file) {
+        invokeBlockGiven(compiler, callName, file);
+    }
+
+    // shared with normal for now
+    public static void invokeBlockGiven(IRBytecodeAdapter compiler, String callName, String file) {
+        compiler.loadContext();
+        compiler.loadSelf();
+        compiler.loadBlock();
+        compiler.adapter.invokedynamic(IndyInvocationCompiler.constructIndyCallName("callFunctional", callName), sig(IRubyObject.class, ThreadContext.class, IRubyObject.class, Block.class), BlockGivenSite.BLOCK_GIVEN_BOOTSTRAP, file, compiler.getLastLine());
     }
 }

--- a/core/src/main/java/org/jruby/ir/targets/indy/IndyInvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/IndyInvocationCompiler.java
@@ -222,15 +222,15 @@ public class IndyInvocationCompiler implements InvocationCompiler {
     }
 
     @Override
-    public void invokeBlockGiven(String callName, String file) {
-        invokeBlockGiven(compiler, callName, file);
+    public void invokeBlockGiven(String methodName, String file) {
+        invokeBlockGiven(compiler, methodName, file);
     }
 
     // shared with normal for now
-    public static void invokeBlockGiven(IRBytecodeAdapter compiler, String callName, String file) {
+    public static void invokeBlockGiven(IRBytecodeAdapter compiler, String methodName, String file) {
         compiler.loadContext();
         compiler.loadSelf();
         compiler.loadBlock();
-        compiler.adapter.invokedynamic(IndyInvocationCompiler.constructIndyCallName("callFunctional", callName), sig(IRubyObject.class, ThreadContext.class, IRubyObject.class, Block.class), BlockGivenSite.BLOCK_GIVEN_BOOTSTRAP, file, compiler.getLastLine());
+        compiler.adapter.invokedynamic(IndyInvocationCompiler.constructIndyCallName("callFunctional", methodName), sig(IRubyObject.class, ThreadContext.class, IRubyObject.class, Block.class), BlockGivenSite.BLOCK_GIVEN_BOOTSTRAP, file, compiler.getLastLine());
     }
 }

--- a/core/src/main/java/org/jruby/ir/targets/indy/IndyInvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/IndyInvocationCompiler.java
@@ -145,7 +145,7 @@ public class IndyInvocationCompiler implements InvocationCompiler {
         }
     }
 
-    private static String constructIndyCallName(String action, String id) {
+    public static String constructIndyCallName(String action, String id) {
         return action + ':' + JavaNameMangler.mangleMethodName(id);
     }
 
@@ -222,10 +222,8 @@ public class IndyInvocationCompiler implements InvocationCompiler {
     }
 
     @Override
-    public void invokeBlockGiven(String file, String scopeFieldName, CallBase call) {
-        compiler.loadContext();
-        compiler.loadSelf();
-        compiler.loadBlock();
-        compiler.adapter.invokedynamic(constructIndyCallName("callFunctional", "block_given?"), sig(IRubyObject.class, ThreadContext.class, IRubyObject.class, Block.class), Bootstrap.BLOCK_GIVEN_BOOTSTRAP);
+    public void invokeBlockGiven(String file, String scopeFieldName) {
+        // block_given? explicit calls always use indy
+        normalCompiler.invokeBlockGiven(file, scopeFieldName);
     }
 }

--- a/core/src/main/java/org/jruby/ir/targets/simple/NormalInvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/simple/NormalInvocationCompiler.java
@@ -8,12 +8,10 @@ import org.jruby.compiler.impl.SkinnyMethodAdapter;
 import org.jruby.ir.instructions.AsStringInstr;
 import org.jruby.ir.instructions.CallBase;
 import org.jruby.ir.instructions.EQQInstr;
-import org.jruby.ir.instructions.specialized.ZeroOperandArgNoBlockCallInstr;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.targets.IRBytecodeAdapter;
 import org.jruby.ir.targets.InvocationCompiler;
 import org.jruby.ir.targets.JVM;
-import org.jruby.ir.targets.indy.Bootstrap;
 import org.jruby.ir.targets.indy.IndyInvocationCompiler;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.CallSite;
@@ -496,10 +494,8 @@ public class NormalInvocationCompiler implements InvocationCompiler {
     }
 
     @Override
-    public void invokeBlockGiven(String file, String scopeFieldName) {
-        compiler.loadContext();
-        compiler.loadSelf();
-        compiler.loadBlock();
-        compiler.adapter.invokedynamic(IndyInvocationCompiler.constructIndyCallName("callFunctional", "block_given?"), sig(IRubyObject.class, ThreadContext.class, IRubyObject.class, Block.class), Bootstrap.BLOCK_GIVEN_BOOTSTRAP);
+    public void invokeBlockGiven(String callName, String file) {
+        // direct block_given? calls always use indy
+        IndyInvocationCompiler.invokeBlockGiven(compiler, callName, file);
     }
 }

--- a/core/src/main/java/org/jruby/ir/targets/simple/NormalInvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/simple/NormalInvocationCompiler.java
@@ -494,8 +494,8 @@ public class NormalInvocationCompiler implements InvocationCompiler {
     }
 
     @Override
-    public void invokeBlockGiven(String callName, String file) {
+    public void invokeBlockGiven(String methodName, String file) {
         // direct block_given? calls always use indy
-        IndyInvocationCompiler.invokeBlockGiven(compiler, callName, file);
+        IndyInvocationCompiler.invokeBlockGiven(compiler, methodName, file);
     }
 }

--- a/core/src/main/java/org/jruby/ir/targets/simple/NormalInvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/simple/NormalInvocationCompiler.java
@@ -8,10 +8,13 @@ import org.jruby.compiler.impl.SkinnyMethodAdapter;
 import org.jruby.ir.instructions.AsStringInstr;
 import org.jruby.ir.instructions.CallBase;
 import org.jruby.ir.instructions.EQQInstr;
+import org.jruby.ir.instructions.specialized.ZeroOperandArgNoBlockCallInstr;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.ir.targets.IRBytecodeAdapter;
 import org.jruby.ir.targets.InvocationCompiler;
 import org.jruby.ir.targets.JVM;
+import org.jruby.ir.targets.indy.Bootstrap;
+import org.jruby.ir.targets.indy.IndyInvocationCompiler;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.CallSite;
 import org.jruby.runtime.CallType;
@@ -493,10 +496,10 @@ public class NormalInvocationCompiler implements InvocationCompiler {
     }
 
     @Override
-    public void invokeBlockGiven(String file, String scopeFieldName, CallBase call) {
-        // just invoke normally; no magic without indy
+    public void invokeBlockGiven(String file, String scopeFieldName) {
         compiler.loadContext();
         compiler.loadSelf();
-        invokeSelf(file, scopeFieldName, call, 0);
+        compiler.loadBlock();
+        compiler.adapter.invokedynamic(IndyInvocationCompiler.constructIndyCallName("callFunctional", "block_given?"), sig(IRubyObject.class, ThreadContext.class, IRubyObject.class, Block.class), Bootstrap.BLOCK_GIVEN_BOOTSTRAP);
     }
 }

--- a/core/src/main/java/org/jruby/ir/targets/simple/NormalInvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/simple/NormalInvocationCompiler.java
@@ -491,4 +491,12 @@ public class NormalInvocationCompiler implements InvocationCompiler {
             compiler.invokeIRHelper("setCallInfo", sig(void.class, ThreadContext.class, int.class));
         }
     }
+
+    @Override
+    public void invokeBlockGiven(String file, String scopeFieldName, CallBase call) {
+        // just invoke normally; no magic without indy
+        compiler.loadContext();
+        compiler.loadSelf();
+        invokeSelf(file, scopeFieldName, call, 0);
+    }
 }


### PR DESCRIPTION
This PR reworks fcalls to `block_given?` as a custom instruction based on `BlockGivenInstr` used by the lighter-weight `defined?(yield)` form.

Instead of forcing a caller frame (so that the caller's received block can be accessed downstack), the new logic checks if the target method is the core version and uses `defined?(yield)` logic in that case. When the method is not from JRuby core, then we dispatch normally... but without the caller frame requirement, since only the core `block_given?` is allowed to have that access. All other call paths leading to `block_given?` continue to use the deoptimized logic, so we are not introducing any new incompatibility.

This makes the performance of `block_given?`-calling methods equivalent to those that use `defined?(yield)` and avoids the framing cost in all situations that fcall `block_given?`.

Performance is shown through the added benchmark:

```
[] jruby $ (chruby jruby-9.4.5.0 ; jruby bench/bench_block_given.rb)
Warming up --------------------------------------
               block   417.419k i/100ms
            no block   609.148k i/100ms
       defined block   714.207k i/100ms
    defined no block     1.711M i/100ms
Calculating -------------------------------------
               block      4.199M (± 0.5%) i/s -     21.288M in   5.069484s
            no block      6.514M (± 0.3%) i/s -     32.894M in   5.049702s
       defined block      7.291M (± 0.5%) i/s -     37.139M in   5.093778s
    defined no block     17.039M (± 0.4%) i/s -     85.566M in   5.021866s
[] jruby $ jruby bench/bench_block_given.rb                         
Warming up --------------------------------------
               block   713.008k i/100ms
            no block     1.818M i/100ms
       defined block   752.260k i/100ms
    defined no block     1.709M i/100ms
Calculating -------------------------------------
               block      7.670M (± 0.4%) i/s -     38.502M in   5.020222s
            no block     18.201M (± 0.4%) i/s -     92.738M in   5.095348s
       defined block      7.569M (± 0.6%) i/s -     38.365M in   5.068610s
    defined no block     17.051M (± 1.3%) i/s -     85.467M in   5.013348s
```