### PR TITLE
Optimized __method__ and __callee__

### DIFF
--- a/bench/bench_frame_name_methods.rb
+++ b/bench/bench_frame_name_methods.rb
@@ -1,0 +1,43 @@
+require 'benchmark/ips'
+
+def foo_method
+  __method__
+end
+
+def foo_callee
+  __callee__
+end
+
+alias bar_method foo_method
+alias bar_callee foo_callee
+
+Benchmark.ips do |bm|
+  bm.report("__method__ same") do |i|
+    while i > 0
+      i-=1
+      foo_method;foo_method;foo_method;foo_method;foo_method;foo_method;foo_method;foo_method;foo_method;foo_method
+    end
+  end
+
+  bm.report("__method__ different") do |i|
+    while i > 0
+      i-=1
+      bar_method;bar_method;bar_method;bar_method;bar_method;bar_method;bar_method;bar_method;bar_method;bar_method
+    end
+  end
+
+
+  bm.report("__callee__ same") do |i|
+    while i > 0
+      i-=1
+      foo_callee;foo_callee;foo_callee;foo_callee;foo_callee;foo_callee;foo_callee;foo_callee;foo_callee;foo_callee
+    end
+  end
+
+  bm.report("__callee__ different") do |i|
+    while i > 0
+      i-=1
+      bar_callee;bar_callee;bar_callee;bar_callee;bar_callee;bar_callee;bar_callee;bar_callee;bar_callee;bar_callee
+    end
+  end
+end

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -350,11 +350,11 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
     }
 
     public static RubySymbol newMethodSymbolFromCompound(Ruby runtime, String compoundName) {
-        return runtime.getSymbolTable().getCompoundSymbol(compoundName).getKey();
+        return runtime.getSymbolTable().getMethodSymbolFromCompound(compoundName);
     }
 
     public static RubySymbol newCalleeSymbolFromCompound(Ruby runtime, String compoundName) {
-        return runtime.getSymbolTable().getCompoundSymbol(compoundName).getValue();
+        return runtime.getSymbolTable().getCalleeSymbolFromCompound(compoundName);
     }
 
     /**
@@ -990,7 +990,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
 
         private final ReentrantLock tableLock = new ReentrantLock();
         private volatile SymbolEntry[] symbolTable;
-        private Map<String, AbstractMap.SimpleImmutableEntry<RubySymbol, RubySymbol>> compoundSymbolTable = new ConcurrentHashMap<>();
+        private Map<String, CompoundSymbol> compoundSymbolTable = new ConcurrentHashMap<>();
         private int size;
         private int threshold;
         private final float loadFactor;
@@ -1106,6 +1106,29 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
         }
 
         /**
+         * Get the method name symbol from a compound name.
+         *
+         * @see #getCompoundSymbol(String)
+         * @param compoundName the compound name
+         * @return the method component of the compound name, as a symbol
+         */
+        public RubySymbol getMethodSymbolFromCompound(String compoundName) {
+            return getCompoundSymbol(compoundName).method;
+        }
+
+
+        /**
+         * Get the callee name symbol from a compound name.
+         *
+         * @see #getCompoundSymbol(String)
+         * @param compoundName the compound name
+         * @return the callee component of the compound name, as a symbol
+         */
+        public RubySymbol getCalleeSymbolFromCompound(String compoundName) {
+            return getCompoundSymbol(compoundName).callee;
+        }
+
+        /**
          * Get a pair of symbols associated with the given compound method name, used by aliases to pass both the callee
          * name and the original method name on the stack. This avoids re-parsing the compoundName and constructing new
          * strings every time __method__ or __callee__ are used in an aliased call.
@@ -1113,12 +1136,14 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
          * @param compoundName the compound name used for a combination of alias and method
          * @return a Map.Entry representing the __method__ and __callee__ symbols for that compound name as key and value
          */
-        public Map.Entry<RubySymbol, RubySymbol> getCompoundSymbol(String compoundName) {
+        private CompoundSymbol getCompoundSymbol(String compoundName) {
             return compoundSymbolTable.computeIfAbsent(compoundName, (cname) ->
-                    new AbstractMap.SimpleImmutableEntry(
+                    new CompoundSymbol(
                             getSymbol(Helpers.getSuperNameFromCompositeName(cname), true),
                             getSymbol(Helpers.getCalleeNameFromCompositeName(cname), true)));
         }
+
+        private record CompoundSymbol(RubySymbol method, RubySymbol callee){}
 
         private RubySymbol findSymbol(ByteList bytes, int hash, boolean hard) {
             RubySymbol symbol = null;

--- a/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRBodyMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRBodyMethod.java
@@ -71,7 +71,7 @@ public class InterpretedIRBodyMethod extends InterpretedIRMethod {
     private IRubyObject interpretWithBacktrace(InterpreterContext ic, ThreadContext context, IRubyObject self, String name, Block block) {
         try {
             ThreadContext.pushBacktrace(context, name, ic.getFileName(), ic.getLine());
-            return ic.getEngine().interpret(context, null, self, ic, getImplementationClass().getMethodLocation(), name, block);
+            return ic.getEngine().interpret(context, null, self, ic, getImplementationClass().getMethodLocation(), null, block);
         } finally {
             ThreadContext.popBacktrace(context);
         }

--- a/core/src/main/java/org/jruby/ir/IRVisitor.java
+++ b/core/src/main/java/org/jruby/ir/IRVisitor.java
@@ -65,6 +65,7 @@ public abstract class IRVisitor {
     public void EQQInstr(EQQInstr eqqinstr) { error(eqqinstr); }
     public void ExceptionRegionEndMarkerInstr(ExceptionRegionEndMarkerInstr exceptionregionendmarkerinstr) { error(exceptionregionendmarkerinstr); }
     public void ExceptionRegionStartMarkerInstr(ExceptionRegionStartMarkerInstr exceptionregionstartmarkerinstr) { error(exceptionregionstartmarkerinstr); }
+    public void FrameNameCallInstr(FrameNameCallInstr framenamecallinstr) { error(framenamecallinstr); }
     public void GetClassVarContainerModuleInstr(GetClassVarContainerModuleInstr getclassvarcontainermoduleinstr) { error(getclassvarcontainermoduleinstr); }
     public void GetClassVariableInstr(GetClassVariableInstr getclassvariableinstr) { error(getclassvariableinstr); }
     public void GetFieldInstr(GetFieldInstr getfieldinstr) { error(getfieldinstr); }

--- a/core/src/main/java/org/jruby/ir/Operation.java
+++ b/core/src/main/java/org/jruby/ir/Operation.java
@@ -84,6 +84,7 @@ public enum Operation {
     CALL_0O(OpFlags.f_has_side_effect | OpFlags.f_is_call | OpFlags.f_can_raise_exception),
     NORESULT_CALL_1O(OpFlags.f_has_side_effect | OpFlags.f_is_call | OpFlags.f_can_raise_exception),
     BLOCK_GIVEN_CALL(OpFlags.f_has_side_effect | OpFlags.f_is_call | OpFlags.f_can_raise_exception),
+    FRAME_NAME_CALL(OpFlags.f_has_side_effect | OpFlags.f_is_call | OpFlags.f_can_raise_exception),
 
     /** Ruby operators: should all these be calls? Implementing instrs don't inherit from CallBase.java */
     EQQ(OpFlags.f_has_side_effect | OpFlags.f_can_raise_exception), // a === call used in when

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
@@ -2486,6 +2486,19 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
     }
 
     public Operand buildVCall(Variable result, VCallNode node) {
+        if (result == null) result = temp();
+
+        RubySymbol name = methodName = node.getName();
+
+        // special case methods with frame handling
+        String callName = name.idString();
+        switch (callName) {
+            case "__method__":
+            case "__callee__":
+                addInstr(new FrameNameCallInstr(result, callName));
+                return result;
+        }
+
         return _call(result, VARIABLE, buildSelf(), node.getName());
     }
 

--- a/core/src/main/java/org/jruby/ir/instructions/DefineClassInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/DefineClassInstr.java
@@ -86,7 +86,7 @@ public class DefineClassInstr extends TwoOperandResultBaseInstr implements Fixed
 
         try {
             ThreadContext.pushBacktrace(context, id, ic.getFileName(), ic.getLine());
-            return ic.getEngine().interpret(context, null, clazz, ic, clazz.getMethodLocation(), id, Block.NULL_BLOCK);
+            return ic.getEngine().interpret(context, null, clazz, ic, clazz.getMethodLocation(), null, Block.NULL_BLOCK);
         } finally {
             body.cleanupAfterExecution();
             if (!hasExplicitCallProtocol) post(ic, context);

--- a/core/src/main/java/org/jruby/ir/instructions/DefineModuleInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/DefineModuleInstr.java
@@ -77,7 +77,7 @@ public class DefineModuleInstr extends OneOperandResultBaseInstr implements Fixe
 
         try {
             ThreadContext.pushBacktrace(context, id, ic.getFileName(), ic.getLine());
-            return ic.getEngine().interpret(context, null, clazz, ic, clazz.getMethodLocation(), id, Block.NULL_BLOCK);
+            return ic.getEngine().interpret(context, null, clazz, ic, clazz.getMethodLocation(), null, Block.NULL_BLOCK);
         } finally {
             body.cleanupAfterExecution();
             if (!hasExplicitCallProtocol) post(ic, context);

--- a/core/src/main/java/org/jruby/ir/instructions/FrameNameCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/FrameNameCallInstr.java
@@ -1,12 +1,12 @@
 package org.jruby.ir.instructions;
 
+import org.jruby.RubySymbol;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
 import org.jruby.ir.operands.Variable;
 import org.jruby.ir.persistence.IRReaderDecoder;
 import org.jruby.ir.persistence.IRWriterEncoder;
 import org.jruby.ir.transformations.inlining.CloneInfo;
-import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.callsite.CacheEntry;
@@ -56,10 +56,9 @@ public class FrameNameCallInstr extends NoOperandResultBaseInstr implements Fixe
             return frameNameSite.call(context, self, self);
         }
 
-        return context.runtime.newSymbol(
-                callee ?
-                        Helpers.getSuperNameFromCompositeName(compositeName) :
-                        Helpers.getCalleeNameFromCompositeName(compositeName));
+        return callee ?
+                RubySymbol.newCalleeSymbolFromCompound(context.runtime, compositeName):
+                RubySymbol.newMethodSymbolFromCompound(context.runtime, compositeName);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/FrameNameCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/FrameNameCallInstr.java
@@ -1,0 +1,69 @@
+package org.jruby.ir.instructions;
+
+import org.jruby.ir.IRVisitor;
+import org.jruby.ir.Operation;
+import org.jruby.ir.operands.Variable;
+import org.jruby.ir.persistence.IRReaderDecoder;
+import org.jruby.ir.persistence.IRWriterEncoder;
+import org.jruby.ir.transformations.inlining.CloneInfo;
+import org.jruby.runtime.Helpers;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.callsite.CacheEntry;
+import org.jruby.runtime.callsite.VariableCachingCallSite;
+
+import java.util.Objects;
+
+/**
+ * A call to __method__ or __callee__ which can be optimized to use the frame method name directly.
+ */
+public class FrameNameCallInstr extends NoOperandResultBaseInstr implements FixedArityInstr {
+    private final VariableCachingCallSite frameNameSite;
+    private final boolean callee;
+
+    public FrameNameCallInstr(Variable result, String methodName) {
+        super(Operation.FRAME_NAME_CALL, Objects.requireNonNull(result, "FrameNameCallInstr result is null"));
+
+        this.frameNameSite =
+                new VariableCachingCallSite(Objects.requireNonNull(methodName, "FrameNameCallInstr methodName is null"));
+
+        this.callee = methodName.equals("__callee__");
+    }
+
+    public String getMethodName() {
+        return frameNameSite.getMethodName();
+    }
+
+    @Override
+    public Instr clone(CloneInfo ii) {
+        return new FrameNameCallInstr(ii.getRenamedVariable(result), frameNameSite.getMethodName());
+    }
+
+    public static FrameNameCallInstr decode(IRReaderDecoder d) {
+        return new FrameNameCallInstr(d.decodeVariable(), d.decodeString());
+    }
+
+    @Override
+    public void encode(IRWriterEncoder e) {
+        super.encode(e);
+        e.encode(frameNameSite.getMethodName());
+    }
+
+    public IRubyObject getFrameName(ThreadContext context, IRubyObject self, String compositeName) {
+        CacheEntry frameNameEntry = frameNameSite.retrieveCache(self);
+
+        if (!frameNameEntry.method.getRealMethod().isBuiltin()) {
+            return frameNameSite.call(context, self, self);
+        }
+
+        return context.runtime.newSymbol(
+                callee ?
+                        Helpers.getSuperNameFromCompositeName(compositeName) :
+                        Helpers.getCalleeNameFromCompositeName(compositeName));
+    }
+
+    @Override
+    public void visit(IRVisitor visitor) {
+        visitor.FrameNameCallInstr(this);
+    }
+}

--- a/core/src/main/java/org/jruby/ir/instructions/FrameNameCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/FrameNameCallInstr.java
@@ -56,6 +56,8 @@ public class FrameNameCallInstr extends NoOperandResultBaseInstr implements Fixe
             return frameNameSite.call(context, self, self);
         }
 
+        if (compositeName == null) return context.nil;
+
         return callee ?
                 RubySymbol.newCalleeSymbolFromCompound(context.runtime, compositeName):
                 RubySymbol.newMethodSymbolFromCompound(context.runtime, compositeName);

--- a/core/src/main/java/org/jruby/ir/interpreter/ExitableInterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/ExitableInterpreterEngine.java
@@ -108,7 +108,7 @@ public class ExitableInterpreterEngine extends InterpreterEngine {
                         break;
                     case CALL_OP:
                         if (profile) Profiler.updateCallSite(instr, interpreterContext.getScope(), scopeVersion);
-                        processCall(context, instr, operation, currDynScope, currScope, temp, self, name);
+                        processCall(context, instr, operation, currDynScope, currScope, temp, self, name, block);
                         break;
                     case RET_OP:
                         processReturnOp(context, block, instr, operation, currDynScope, temp, self, currScope);

--- a/core/src/main/java/org/jruby/ir/interpreter/ExitableInterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/ExitableInterpreterEngine.java
@@ -108,7 +108,7 @@ public class ExitableInterpreterEngine extends InterpreterEngine {
                         break;
                     case CALL_OP:
                         if (profile) Profiler.updateCallSite(instr, interpreterContext.getScope(), scopeVersion);
-                        processCall(context, instr, operation, currDynScope, currScope, temp, self);
+                        processCall(context, instr, operation, currDynScope, currScope, temp, self, name);
                         break;
                     case RET_OP:
                         processReturnOp(context, block, instr, operation, currDynScope, temp, self, currScope);

--- a/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
@@ -151,7 +151,7 @@ public class InterpreterEngine {
                         break;
                     case CALL_OP:
                         if (profile) Profiler.updateCallSite(instr, interpreterContext.getScope(), scopeVersion);
-                        processCall(context, instr, operation, currDynScope, currScope, temp, self, name);
+                        processCall(context, instr, operation, currDynScope, currScope, temp, self, name, block);
                         break;
                     case RET_OP:
                         return processReturnOp(context, block, instr, operation, currDynScope, temp, self, currScope);
@@ -287,7 +287,7 @@ public class InterpreterEngine {
         }
     }
 
-    protected static void processCall(ThreadContext context, Instr instr, Operation operation, DynamicScope currDynScope, StaticScope currScope, Object[] temp, IRubyObject self, String name) {
+    protected static void processCall(ThreadContext context, Instr instr, Operation operation, DynamicScope currDynScope, StaticScope currScope, Object[] temp, IRubyObject self, String frameName, Block selfBlock) {
         Object result;
 
         switch(operation) {
@@ -360,7 +360,7 @@ public class InterpreterEngine {
                 instr.interpret(context, currScope, currDynScope, self, temp);
                 break;
             case FRAME_NAME_CALL:
-                setResult(temp, currDynScope, instr, ((FrameNameCallInstr) instr).getFrameName(context, self, name));
+                setResult(temp, currDynScope, instr, ((FrameNameCallInstr) instr).getFrameName(context, self, selfBlock == null ? frameName : selfBlock.getBinding().getFrame().getName()));
                 break;
             case CALL:
             default:

--- a/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
@@ -11,6 +11,7 @@ import org.jruby.ir.instructions.BreakInstr;
 import org.jruby.ir.instructions.CheckArityInstr;
 import org.jruby.ir.instructions.CheckForLJEInstr;
 import org.jruby.ir.instructions.CopyInstr;
+import org.jruby.ir.instructions.FrameNameCallInstr;
 import org.jruby.ir.instructions.Instr;
 import org.jruby.ir.instructions.JumpInstr;
 import org.jruby.ir.instructions.LineNumberInstr;
@@ -150,7 +151,7 @@ public class InterpreterEngine {
                         break;
                     case CALL_OP:
                         if (profile) Profiler.updateCallSite(instr, interpreterContext.getScope(), scopeVersion);
-                        processCall(context, instr, operation, currDynScope, currScope, temp, self);
+                        processCall(context, instr, operation, currDynScope, currScope, temp, self, name);
                         break;
                     case RET_OP:
                         return processReturnOp(context, block, instr, operation, currDynScope, temp, self, currScope);
@@ -286,7 +287,7 @@ public class InterpreterEngine {
         }
     }
 
-    protected static void processCall(ThreadContext context, Instr instr, Operation operation, DynamicScope currDynScope, StaticScope currScope, Object[] temp, IRubyObject self) {
+    protected static void processCall(ThreadContext context, Instr instr, Operation operation, DynamicScope currDynScope, StaticScope currScope, Object[] temp, IRubyObject self, String name) {
         Object result;
 
         switch(operation) {
@@ -357,6 +358,9 @@ public class InterpreterEngine {
             }
             case NORESULT_CALL:
                 instr.interpret(context, currScope, currDynScope, self, temp);
+                break;
+            case FRAME_NAME_CALL:
+                setResult(temp, currDynScope, instr, ((FrameNameCallInstr) instr).getFrameName(context, self, name));
                 break;
             case CALL:
             default:

--- a/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
@@ -360,7 +360,9 @@ public class InterpreterEngine {
                 instr.interpret(context, currScope, currDynScope, self, temp);
                 break;
             case FRAME_NAME_CALL:
-                setResult(temp, currDynScope, instr, ((FrameNameCallInstr) instr).getFrameName(context, self, selfBlock == null ? frameName : selfBlock.getBinding().getFrame().getName()));
+                setResult(temp, currDynScope, instr,
+                        ((FrameNameCallInstr) instr).getFrameName(
+                                context, self, selfBlock == null ? frameName : IRRuntimeHelpers.getFrameNameFromBlock(selfBlock)));
                 break;
             case CALL:
             default:

--- a/core/src/main/java/org/jruby/ir/interpreter/StartupInterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/StartupInterpreterEngine.java
@@ -63,7 +63,7 @@ public class StartupInterpreterEngine extends InterpreterEngine {
                         break;
                     case CALL_OP:
                         if (profile) Profiler.updateCallSite(instr, interpreterContext.getScope(), scopeVersion);
-                        processCall(context, instr, operation, currDynScope, currScope, temp, self, name);
+                        processCall(context, instr, operation, currDynScope, currScope, temp, self, name, block);
                         break;
                     case RET_OP:
                         return processReturnOp(context, block, instr, operation, currDynScope, temp, self, currScope);

--- a/core/src/main/java/org/jruby/ir/interpreter/StartupInterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/StartupInterpreterEngine.java
@@ -63,7 +63,7 @@ public class StartupInterpreterEngine extends InterpreterEngine {
                         break;
                     case CALL_OP:
                         if (profile) Profiler.updateCallSite(instr, interpreterContext.getScope(), scopeVersion);
-                        processCall(context, instr, operation, currDynScope, currScope, temp, self);
+                        processCall(context, instr, operation, currDynScope, currScope, temp, self, name);
                         break;
                     case RET_OP:
                         return processReturnOp(context, block, instr, operation, currDynScope, temp, self, currScope);

--- a/core/src/main/java/org/jruby/ir/persistence/IRReaderStream.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRReaderStream.java
@@ -295,6 +295,7 @@ public class IRReaderStream implements IRReaderDecoder, IRPersistenceValues {
             case EQQ: return EQQInstr.decode(this);
             case EXC_REGION_END: return new ExceptionRegionEndMarkerInstr();
             case EXC_REGION_START: return ExceptionRegionStartMarkerInstr.decode(this);
+            case FRAME_NAME_CALL: return FrameNameCallInstr.decode(this);
             case GET_CVAR: return GetClassVariableInstr.decode(this);
             case GET_ENCODING: return GetEncodingInstr.decode(this);
             case GET_ERROR_INFO: return GetErrorInfoInstr.decode(this);

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1964,7 +1964,7 @@ public class IRRuntimeHelpers {
     public static IRubyObject invokeModuleBody(ThreadContext context, DynamicMethod method) {
         RubyModule implClass = method.getImplementationClass();
 
-        return method.call(context, implClass, implClass, "", Block.NULL_BLOCK);
+        return method.call(context, implClass, implClass, null, Block.NULL_BLOCK);
     }
 
     @JIT

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -2662,4 +2662,10 @@ public class IRRuntimeHelpers {
     public static int arrayLength(RubyArray array) {
         return array.getLength();
     }
+
+    @Interp @JIT
+    public static String getFrameNameFromBlock(Block block) {
+        // FIXME: binding.getMethod does not appear to be the right name in defined_method bodies... WHY?
+        return block.getBinding().getFrame().getName();
+    }
 }

--- a/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter.java
+++ b/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter.java
@@ -318,8 +318,7 @@ public class IRBytecodeAdapter {
         if (superNameOffset == -1) {
             // load from self block
             loadSelfBlock();
-            adapter.invokevirtual(p(Block.class), "getBinding", sig(Binding.class));
-            adapter.invokevirtual(p(Binding.class), "getMethod", sig(String.class));
+            adapter.invokestatic(p(IRRuntimeHelpers.class), "getFrameNameFromBlock", sig(String.class, Block.class));
         } else {
             adapter.aload(superNameOffset);
         }

--- a/core/src/main/java/org/jruby/ir/targets/InvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/InvocationCompiler.java
@@ -133,4 +133,9 @@ public interface InvocationCompiler {
      * Invoke block_given? or iterator? with awareness of any built-in methods.
      */
     void invokeBlockGiven(String methodName, String file);
+
+    /**
+     * Invoke __method__ or __callee__ with awareness of any built-in methods.
+     */
+    void invokeFrameName(String methodName, String file);
 }

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -1651,6 +1651,12 @@ public class JVMVisitor extends IRVisitor {
     }
 
     @Override
+    public void FrameNameCallInstr(FrameNameCallInstr framenamecallinstr) {
+        jvmMethod().getInvocationCompiler().invokeFrameName(framenamecallinstr.getMethodName(), file);
+        handleCallResult(jvmMethod(), framenamecallinstr.getResult());
+    }
+
+    @Override
     public void GetClassVarContainerModuleInstr(GetClassVarContainerModuleInstr getclassvarcontainermoduleinstr) {
         jvmMethod().loadContext();
         visit(getclassvarcontainermoduleinstr.getStartingScope());

--- a/core/src/main/java/org/jruby/ir/targets/indy/FrameNameSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/FrameNameSite.java
@@ -1,6 +1,7 @@
 package org.jruby.ir.targets.indy;
 
 import com.headius.invokebinder.Binder;
+import org.jruby.RubyNil;
 import org.jruby.RubySymbol;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
@@ -58,7 +59,7 @@ public class FrameNameSite extends MutableCallSite {
         if (entry.method.isBuiltin()) {
             target = Binder.from(type())
                     .permute(2)
-                    .append(context.runtime.getSymbolTable())
+                    .append(context.runtime.getSymbolTable(), context.nil)
                     .prepend(this)
                     .invokeVirtualQuiet(methodName);
         } else {
@@ -72,14 +73,18 @@ public class FrameNameSite extends MutableCallSite {
         return (IRubyObject) target.invokeExact(context, self, frameName);
     }
 
-    public IRubyObject __callee__(String frameName, RubySymbol.SymbolTable symbolTable) {
+    public IRubyObject __callee__(String frameName, RubySymbol.SymbolTable symbolTable, RubyNil nil) {
+        if (frameName == null) return nil;
+
         if (frameName.charAt(0) != '\0') {
             return getSimpleName(frameName, symbolTable);
         }
         return symbolTable.getCalleeSymbolFromCompound(frameName);
     }
 
-    public IRubyObject __method__(String frameName, RubySymbol.SymbolTable symbolTable) {
+    public IRubyObject __method__(String frameName, RubySymbol.SymbolTable symbolTable, RubyNil nil) {
+        if (frameName == null) return nil;
+
         if (frameName.charAt(0) != '\0') {
             return getSimpleName(frameName, symbolTable);
         }

--- a/core/src/main/java/org/jruby/ir/targets/indy/FrameNameSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/FrameNameSite.java
@@ -1,0 +1,78 @@
+package org.jruby.ir.targets.indy;
+
+import com.headius.invokebinder.Binder;
+import org.jruby.runtime.Helpers;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.callsite.CacheEntry;
+import org.objectweb.asm.Handle;
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.MutableCallSite;
+
+import static java.lang.invoke.MethodHandles.lookup;
+import static java.lang.invoke.MethodType.methodType;
+import static org.jruby.util.CodegenUtils.sig;
+
+/**
+ * Perform an optimized __method__ or __callee__ invocation without accessing a caller's frame.
+ *
+ * This logic checks if the target method is our built-in version and uses fast logic in that case. All other calls
+ * fall back on normal indy call logic.
+ *
+ * Note that if the target method is initially not built-in, or becomes a not built-in version later, we permanently
+ * fall back on the invocation logic. No further checking is done and the site is optimized as a normal call from there.
+ */
+public class FrameNameSite extends MutableCallSite {
+    private final String file;
+    private final int line;
+
+    public FrameNameSite(MethodType type, String file, int line) {
+        super(type);
+
+        this.file = file;
+        this.line = line;
+    }
+
+    public static final Handle FRAME_NAME_BOOTSTRAP = Bootstrap.getBootstrapHandle("frameNameBootstrap", FrameNameSite.class, sig(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class, String.class, int.class));
+
+    public static CallSite frameNameBootstrap(MethodHandles.Lookup lookup, String name, MethodType methodType, String file, int line) {
+        FrameNameSite frameNameSite = new FrameNameSite(methodType, file, line);
+
+        frameNameSite.setTarget(Binder.from(methodType).prepend(frameNameSite, name).invokeVirtualQuiet("frameNameFallback"));
+
+        return frameNameSite;
+    }
+
+    public IRubyObject frameNameFallback(String name, ThreadContext context, IRubyObject self, String frameName) throws Throwable {
+        String methodName = name.split(":")[1];
+
+        CacheEntry entry = self.getMetaClass().searchWithCache(methodName);
+        MethodHandle target;
+
+        if (entry.method.isBuiltin()) {
+            target = Binder.from(type())
+                    .permute(0, 2)
+                    .invokeStaticQuiet(FrameNameSite.class, methodName);
+        } else {
+            target = Binder.from(type())
+                    .permute(0, 1)
+                    .invoke(SelfInvokeSite.bootstrap(lookup(), name, methodType(IRubyObject.class, ThreadContext.class, IRubyObject.class), 0, 0, file, line).dynamicInvoker());
+        }
+
+        setTarget(target);
+
+        return (IRubyObject) target.invokeExact(context, self, frameName);
+    }
+
+    public static IRubyObject __callee__(ThreadContext context, String frameName) {
+        return context.runtime.newSymbol(Helpers.getCalleeNameFromCompositeName(frameName));
+    }
+
+    public static IRubyObject __method__(ThreadContext context, String frameName) {
+        return context.runtime.newSymbol(Helpers.getSuperNameFromCompositeName(frameName));
+    }
+}

--- a/core/src/main/java/org/jruby/ir/targets/indy/FrameNameSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/FrameNameSite.java
@@ -1,6 +1,7 @@
 package org.jruby.ir.targets.indy;
 
 import com.headius.invokebinder.Binder;
+import org.jruby.RubySymbol;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -69,10 +70,10 @@ public class FrameNameSite extends MutableCallSite {
     }
 
     public static IRubyObject __callee__(ThreadContext context, String frameName) {
-        return context.runtime.newSymbol(Helpers.getCalleeNameFromCompositeName(frameName));
+        return RubySymbol.newCalleeSymbolFromCompound(context.runtime, frameName);
     }
 
     public static IRubyObject __method__(ThreadContext context, String frameName) {
-        return context.runtime.newSymbol(Helpers.getSuperNameFromCompositeName(frameName));
+        return RubySymbol.newMethodSymbolFromCompound(context.runtime, frameName);
     }
 }

--- a/core/src/main/java/org/jruby/ir/targets/indy/IndyInvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/IndyInvocationCompiler.java
@@ -233,4 +233,17 @@ public class IndyInvocationCompiler implements InvocationCompiler {
         compiler.loadBlock();
         compiler.adapter.invokedynamic(IndyInvocationCompiler.constructIndyCallName("callFunctional", methodName), sig(IRubyObject.class, ThreadContext.class, IRubyObject.class, Block.class), BlockGivenSite.BLOCK_GIVEN_BOOTSTRAP, file, compiler.getLastLine());
     }
+
+    @Override
+    public void invokeFrameName(String methodName, String file) {
+        invokeFrameName(compiler, methodName, file);
+    }
+
+    // shared with normal for now
+    public static void invokeFrameName(IRBytecodeAdapter compiler, String methodName, String file) {
+        compiler.loadContext();
+        compiler.loadSelf();
+        compiler.loadFrameName();
+        compiler.adapter.invokedynamic(IndyInvocationCompiler.constructIndyCallName("callVariable", methodName), sig(IRubyObject.class, ThreadContext.class, IRubyObject.class, String.class), FrameNameSite.FRAME_NAME_BOOTSTRAP, file, compiler.getLastLine());
+    }
 }

--- a/core/src/main/java/org/jruby/ir/targets/simple/NormalInvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/simple/NormalInvocationCompiler.java
@@ -495,7 +495,13 @@ public class NormalInvocationCompiler implements InvocationCompiler {
 
     @Override
     public void invokeBlockGiven(String methodName, String file) {
-        // direct block_given? calls always use indy
+        // direct block_given? and iterator? calls always use indy
         IndyInvocationCompiler.invokeBlockGiven(compiler, methodName, file);
+    }
+
+    @Override
+    public void invokeFrameName(String methodName, String file) {
+        // direct __method__ and __callee__ calls always use indy
+        IndyInvocationCompiler.invokeFrameName(compiler, methodName, file);
     }
 }


### PR DESCRIPTION
This PR optimizes the `__method__` and `__callee__` methods by doing the following:

* Introduce the FrameNameInstr instruction that performs a lightweight, frameless operation when the target `__method__` or `__callee__` is the built-in version (similar to `block_given?` in #8170).
* Introduce a new mapping from AliasMethod compound names to the pair of symbols they would produce for `__method__` and `__callee__`, avoiding extra allocation of strings while parsing that compound string.

As with #8170, if either of the target methods have been replaced by a user, we fall back to a normal invocation. If either method is called via metaprogramming paths, they will force a frame and use it as before.

A benchmark is included, and shows that both forms are now much faster (due to them no longer needing the caller's frame), and neither slow down when being used inside an aliased call:

```
[] jruby $ (chruby jruby-9.4.5.0 ; jruby bench/bench_frame_name_methods.rb)
Warming up --------------------------------------
     __method__ same   522.657k i/100ms
__method__ different   252.464k i/100ms
     __callee__ same   523.748k i/100ms
__callee__ different   264.330k i/100ms
Calculating -------------------------------------
     __method__ same      5.213M (± 1.8%) i/s -     26.133M in   5.014736s
__method__ different      2.565M (± 4.0%) i/s -     12.876M in   5.027256s
     __callee__ same      5.475M (± 1.8%) i/s -     27.759M in   5.071986s
__callee__ different      2.793M (± 1.9%) i/s -     14.009M in   5.017930s
[] jruby $ jruby bench/bench_frame_name_methods.rb                        
Warming up --------------------------------------
     __method__ same   885.744k i/100ms
__method__ different   936.830k i/100ms
     __callee__ same   926.174k i/100ms
__callee__ different   938.103k i/100ms
Calculating -------------------------------------
     __method__ same      9.313M (± 0.4%) i/s -     46.944M in   5.040932s
__method__ different      9.119M (± 0.5%) i/s -     45.905M in   5.034226s
     __callee__ same      9.187M (± 1.1%) i/s -     46.309M in   5.041351s
__callee__ different      9.056M (± 0.5%) i/s -     45.967M in   5.075968s
```