### PR TITLE
Simplify fixnum and string ranges

### DIFF
--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -128,11 +128,27 @@ public class RubyRange extends RubyObject {
         return range;
     }
 
+    public static RubyRange newRange(ThreadContext context, long begin, long end, boolean isExclusive) {
+        Ruby runtime = context.runtime;
+        RubyRange range = new RubyRange(runtime, runtime.getRange());
+        range.init(context, runtime.newFixnum(begin), runtime.newFixnum(end), isExclusive);
+        range.isInited = true;
+        return range;
+    }
+
     public static RubyRange newInclusiveRange(ThreadContext context, IRubyObject begin, IRubyObject end) {
         return newRange(context, begin, end, false);
     }
 
+    public static RubyRange newInclusiveRange(ThreadContext context, long begin, long end) {
+        return newRange(context, begin, end, false);
+    }
+
     public static RubyRange newExclusiveRange(ThreadContext context, IRubyObject begin, IRubyObject end) {
+        return newRange(context, begin, end, true);
+    }
+
+    public static RubyRange newExclusiveRange(ThreadContext context, long begin, long end) {
         return newRange(context, begin, end, true);
     }
 

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
@@ -7,6 +7,7 @@ import org.jruby.ParseResult;
 import org.jruby.RubyInstanceConfig;
 import org.jruby.RubySymbol;
 import org.jruby.ast.IterNode;
+import org.jruby.ast.StrNode;
 import org.jruby.common.IRubyWarnings;
 import org.jruby.ext.coverage.CoverageData;
 import org.jruby.ir.IRClassBody;
@@ -2371,8 +2372,21 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
     }
 
     protected Operand buildRange(U beginNode, U endNode, boolean isExclusive) {
-        Operand begin = build(beginNode);
-        Operand end = build(endNode);
+        Operand begin;
+        Operand end;
+
+        // string ranges should have frozen begin and end
+        if (beginNode instanceof StrNode beginString) {
+            begin = new FrozenString(beginString.getValue(), beginString.getCodeRange(), beginString.getFile(), beginString.getLine());
+        } else {
+            begin = build(beginNode);
+        }
+
+        if (endNode instanceof StrNode endString) {
+            end = new FrozenString(endString.getValue(), endString.getCodeRange(), endString.getFile(), endString.getLine());
+        } else {
+            end = build(endNode);
+        }
 
         if (begin instanceof ImmutableLiteral && end instanceof ImmutableLiteral) {
             // endpoints are free of side effects, cache the range after creation

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1638,6 +1638,11 @@ public class IRRuntimeHelpers {
     }
 
     @JIT
+    public static RubyString newFrozenStringFromRaw(ThreadContext context, String str, String encoding, int cr) {
+        return newFrozenString(context, newByteListFromRaw(context.runtime, str, encoding), cr);
+    }
+
+    @JIT
     public static final ByteList newByteListFromRaw(Ruby runtime, String str, String encoding) {
         return new ByteList(RubyEncoding.encodeISO(str), runtime.getEncodingService().getEncodingFromString(encoding), false);
     }
@@ -2457,6 +2462,12 @@ public class IRRuntimeHelpers {
         if (runtime.getInstanceConfig().isDebuggingFrozenStringLiteral()) {
             return RubyString.newDebugFrozenString(runtime, runtime.getString(), bytelist, coderange, file, line + 1);
         }
+
+        return runtime.freezeAndDedupString(RubyString.newString(runtime, bytelist, coderange));
+    }
+
+    public static RubyString newFrozenString(ThreadContext context, ByteList bytelist, int coderange) {
+        Ruby runtime = context.runtime;
 
         return runtime.freezeAndDedupString(RubyString.newString(runtime, bytelist, coderange));
     }

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -2914,10 +2914,18 @@ public class JVMVisitor extends IRVisitor {
 
     @Override
     public void Range(Range range) {
-        jvmMethod().getValueCompiler().pushRange(
-                () -> visit(range.getBegin()),
-                () -> visit(range.getEnd()),
-                range.isExclusive());
+        if (range.getBegin() instanceof Fixnum && range.getEnd() instanceof Fixnum) {
+            jvmMethod().getValueCompiler().pushRange(
+                    ((Fixnum) range.getBegin()).getValue(), ((Fixnum) range.getEnd()).getValue(), range.isExclusive());
+        } else if (range.getBegin() instanceof StringLiteral begin && range.getEnd() instanceof StringLiteral end) {
+            jvmMethod().getValueCompiler().pushRange(
+                    begin.getByteList(), begin.getCodeRange(), end.getByteList(), end.getCodeRange(), range.isExclusive());
+        } else {
+            jvmMethod().getValueCompiler().pushRange(
+                    () -> visit(range.getBegin()),
+                    () -> visit(range.getEnd()),
+                    range.isExclusive());
+        }
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/targets/ValueCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/ValueCompiler.java
@@ -89,6 +89,28 @@ public interface ValueCompiler {
     void pushRange(Runnable begin, Runnable end, boolean exclusive);
 
     /**
+     * Build and save a literal fixnum..fixnum range.
+     * <p>
+     * Stack required: context
+     *
+     * @param begin begin value
+     * @param end end value
+     * @param exclusive whether this is an exclusive range
+     */
+    void pushRange(long begin, long end, boolean exclusive);
+
+    /**
+     * Build and save a literal string..string range.
+     * <p>
+     * Stack required: context
+     *
+     * @param begin begin value
+     * @param end end value
+     * @param exclusive whether this is an exclusive range
+     */
+    void pushRange(ByteList begin, int beginCR, ByteList end, int endCR, boolean exclusive);
+
+    /**
      * Build and save a literal regular expression.
      * <p>
      * Stack required: none

--- a/core/src/main/java/org/jruby/ir/targets/indy/IndyValueCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/IndyValueCompiler.java
@@ -106,6 +106,16 @@ public class IndyValueCompiler implements ValueCompiler {
         compiler.adapter.invokedynamic("range", sig(RubyRange.class, ThreadContext.class, IRubyObject.class, IRubyObject.class), RangeObjectSite.BOOTSTRAP, exclusive ? 1 : 0);
     }
 
+    public void pushRange(long begin, long end, boolean exclusive) {
+        compiler.loadContext();
+        compiler.adapter.invokedynamic("range", sig(RubyRange.class, ThreadContext.class), RangeObjectSite.BOOTSTRAP_LONG_LONG, begin, end, exclusive ? 1 : 0);
+    }
+
+    public void pushRange(ByteList begin, int beginCR, ByteList end, int endCR, boolean exclusive) {
+        compiler.loadContext();
+        compiler.adapter.invokedynamic("range", sig(RubyRange.class, ThreadContext.class), RangeObjectSite.BOOTSTRAP_STRING_STRING, RubyEncoding.decodeRaw(begin), begin.getEncoding().toString(), beginCR, RubyEncoding.decodeRaw(end), end.getEncoding().toString(), endCR, exclusive ? 1 : 0);
+    }
+
     public void pushRegexp(ByteList source, int options) {
         compiler.loadContext();
         compiler.adapter.invokedynamic("regexp", sig(RubyRegexp.class, ThreadContext.class), RegexpObjectSite.BOOTSTRAP, RubyEncoding.decodeRaw(source), source.getEncoding().toString(), options);

--- a/core/src/main/java/org/jruby/ir/targets/indy/RangeObjectSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/RangeObjectSite.java
@@ -1,8 +1,11 @@
 package org.jruby.ir.targets.indy;
 
 import org.jruby.RubyRange;
+import org.jruby.RubyString;
+import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.ByteList;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Opcodes;
 
@@ -35,5 +38,67 @@ public class RangeObjectSite extends LazyObjectSite {
 
     public IRubyObject construct(ThreadContext context, IRubyObject begin, IRubyObject end) throws Throwable {
         return RubyRange.newRange(context, begin, end, exclusive);
+    }
+
+    public static final Handle BOOTSTRAP_LONG_LONG = new Handle(
+            Opcodes.H_INVOKESTATIC,
+            p(RangeObjectSite.class),
+            "bootstrapFixnums",
+            sig(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class, long.class, long.class, int.class),
+            false);
+
+    public static CallSite bootstrapFixnums(MethodHandles.Lookup lookup, String name, MethodType type, long begin, long end, int exclusive) {
+        return new FixnumRangeObjectSite(type, begin, end, exclusive != 0).bootstrap(lookup);
+    }
+
+    public static class FixnumRangeObjectSite extends RangeObjectSite {
+        protected final long begin;
+        protected final long end;
+
+        public FixnumRangeObjectSite(MethodType type, long begin, long end, boolean exclusive) {
+            super(type, exclusive);
+
+            this.begin = begin;
+            this.end = end;
+        }
+
+        public IRubyObject construct(ThreadContext context) throws Throwable {
+            return RubyRange.newRange(context, begin, end, exclusive);
+        }
+    }
+
+    public static final Handle BOOTSTRAP_STRING_STRING = new Handle(
+            Opcodes.H_INVOKESTATIC,
+            p(RangeObjectSite.class),
+            "bootstrapStrings",
+            sig(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class, String.class, String.class, int.class, String.class, String.class, int.class, int.class),
+            false);
+
+    public static CallSite bootstrapStrings(MethodHandles.Lookup lookup, String name, MethodType type, String begin, String beginEnc, int beginCR, String end, String endEnc, int endCR, int exclusive) {
+        return new StringRangeObjectSite(type, StringBootstrap.bytelist(begin, beginEnc), beginCR, StringBootstrap.bytelist(end, endEnc), endCR, exclusive != 0).bootstrap(lookup);
+    }
+
+    public static class StringRangeObjectSite extends RangeObjectSite {
+        protected final ByteList begin;
+        protected final int beginCR;
+        protected final ByteList end;
+        protected final int endCR;
+
+        public StringRangeObjectSite(MethodType type, ByteList begin, int beginCR, ByteList end, int endCR, boolean exclusive) {
+            super(type, exclusive);
+
+            this.begin = begin;
+            this.beginCR = beginCR;
+            this.end = end;
+            this.endCR = endCR;
+        }
+
+        public IRubyObject construct(ThreadContext context) throws Throwable {
+            return RubyRange.newRange(
+                    context,
+                    IRRuntimeHelpers.newFrozenString(context, begin, beginCR),
+                    IRRuntimeHelpers.newFrozenString(context, end, endCR),
+                    exclusive);
+        }
     }
 }


### PR DESCRIPTION
Fixnum and String ranges can be reduced in complexity by doing all of the construction in one go rather than each piece individually. A Range of fixnum..fixnum now uses indy to pass the long values to the bootstrap, avoiding bytecode to construct the fixnum objects. A Range of string..string embeds the bytelist and CR into the bootstrap parameters, for the same result. Both also have simplified forms in the non-indy JIT mode.

From ideas list in #7588.