### PR TITLE
Thread#pending_interupt? crashes

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -905,8 +905,8 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     private boolean pendingInterruptInclude(RubyModule err) {
         Iterator<IRubyObject> iterator = pendingInterruptQueue.iterator();
         while (iterator.hasNext()) {
-            RubyModule e = (RubyModule) iterator.next();
-            if (e.isKindOfModule(err)) return true;
+            IRubyObject e = iterator.next();
+            if (e.getMetaClass().isKindOfModule(err)) return true;
         }
         return false;
     }


### PR DESCRIPTION
Amazingly this also crashes in Ruby 3.1.  Later MRI tests exercise this method but it would appear no one ever used it or they would see it crash.

I am fixing it for 9.4 just because I don't want us to ever crash.