### PR TITLE
[ji] support re-reifying class hierarchy

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -795,17 +795,17 @@ public class RubyModule extends RubyObject {
     }
 
     private String calculateAnonymousName() {
-        String cachedName = this.cachedName; // re-use cachedName field since it won't be set for anonymous class
+        String cachedName = this.cachedName;
         if (cachedName == null) {
             // anonymous classes get the #<Class:0xdeadbeef> format
-            StringBuilder anonBase = new StringBuilder(24);
-            anonBase.append("#<").append(metaClass.getRealClass().getName()).append(":0x");
-            anonBase.append(Integer.toHexString(System.identityHashCode(this))).append('>');
-            cachedName = this.cachedName = anonBase.toString();
+            cachedName = this.cachedName = "#<" + anonymousMetaNameWithIdentifier() + '>';
         }
         return cachedName;
     }
 
+    String anonymousMetaNameWithIdentifier() {
+        return metaClass.getRealClass().getName() + ":0x" + Integer.toHexString(System.identityHashCode(this));
+    }
 
     @JRubyMethod(name = "refine", reads = SCOPE)
     public IRubyObject refine(ThreadContext context, IRubyObject klass, Block block) {

--- a/core/src/main/java/org/jruby/util/ClassDefiningClassLoader.java
+++ b/core/src/main/java/org/jruby/util/ClassDefiningClassLoader.java
@@ -6,6 +6,8 @@ public interface ClassDefiningClassLoader {
 
     Class<?> loadClass(String name) throws ClassNotFoundException;
 
+    boolean hasDefinedClass(String name);
+
     default ClassLoader asClassLoader() { return (ClassLoader) this; }
 
 }

--- a/core/src/main/java/org/jruby/util/ClassDefiningJRubyClassLoader.java
+++ b/core/src/main/java/org/jruby/util/ClassDefiningJRubyClassLoader.java
@@ -73,6 +73,11 @@ public class ClassDefiningJRubyClassLoader extends URLClassLoader implements Cla
      * @return whether it's loadable
      */
     public boolean hasClass(String name) {
-        return definedClasses.contains(name) || super.findResource(name.replace('.', '/') + ".class") != null;
+        return hasDefinedClass(name) || super.findResource(name.replace('.', '/') + ".class") != null;
+    }
+
+    @Override
+    public boolean hasDefinedClass(String name) {
+        return definedClasses.contains(name);
     }
 }

--- a/core/src/main/java/org/jruby/util/NClassClassLoader.java
+++ b/core/src/main/java/org/jruby/util/NClassClassLoader.java
@@ -14,6 +14,11 @@ public class NClassClassLoader extends ClassLoader implements ClassDefiningClass
         return super.defineClass(name, bytes, 0, bytes.length, ClassDefiningJRubyClassLoader.DEFAULT_DOMAIN);
     }
 
+    @Override
+    public boolean hasDefinedClass(String name) {
+        return super.findLoadedClass(name) != null;
+    }
+
     public boolean isFull() {
         return i >= size;
     }

--- a/core/src/main/java/org/jruby/util/OneShotClassLoader.java
+++ b/core/src/main/java/org/jruby/util/OneShotClassLoader.java
@@ -21,4 +21,14 @@ public class OneShotClassLoader extends ClassLoader implements ClassDefiningClas
         resolveClass(cls);
         return cls;
     }
+
+    @Override
+    public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        return super.loadClass(name, resolve);
+    }
+
+    @Override
+    public boolean hasDefinedClass(String name) {
+        return super.findLoadedClass(name) != null;
+    }
 }

--- a/spec/java_integration/reify/become_java_spec.rb
+++ b/spec/java_integration/reify/become_java_spec.rb
@@ -33,8 +33,8 @@ describe "JRuby class reification" do
     jclass = java.lang.Class
 
     outer_java_class_name = ReifyInterfacesClass1.to_java(jclass).name
-    expect(outer_java_class_name).to match /^rubyobj\.(\w)*?\.ReifyInterfacesClass1$/
-    expect(ReifyInterfacesClass1::Nested::InnerClass.to_java(jclass).name).to match /^rubyobj\.(\w)*?\.ReifyInterfacesClass1\.Nested\.InnerClass$/
+    expect(outer_java_class_name).to eql('rubyobj.ReifyInterfacesClass1')
+    expect(ReifyInterfacesClass1::Nested::InnerClass.to_java(jclass).name).to eql('rubyobj.ReifyInterfacesClass1.Nested.InnerClass')
 
     # checking that the packages are valid for Java's purposes
     expect do
@@ -468,7 +468,7 @@ describe "JRuby class reification" do
   it 'has a similar Java class name' do
     ReifiedSample.become_java!
     klass = ReifiedSample.java_class
-    expect( klass.getName ).to match /rubyobj\.(\w)*?\.ReifiedSample/
+    expect( klass.getName ).to eql('rubyobj.ReifiedSample')
     klass = Class.new(ReifiedSample)
     hexid = klass.inspect.match(/(0x[0-9a-f]+)/)[1]
     klass = klass.become_java!

--- a/spec/java_integration/reify/become_java_spec.rb
+++ b/spec/java_integration/reify/become_java_spec.rb
@@ -136,6 +136,8 @@ describe "JRuby class reification" do
     class ASubSubList < ASubList; end
     expect( ASubSubList.new(1, 2).args ).to eql [1, 2]
 
+    old_a_sub_list_reified_class = JRuby.reference(ASubList).reified_class
+
     Object.send(:remove_const, :ASubSubList)
     Object.send(:remove_const, :ASubList)
 
@@ -148,6 +150,8 @@ describe "JRuby class reification" do
     end
     class ASubSubList < ASubList; end
     expect( ASubSubList.new(1, 2).args ).to eql [2, 1]
+
+    expect(JRuby.reference(ASubList).reified_class).to_not equal(old_a_sub_list_reified_class) # new Java class generated
 
     Object.send(:remove_const, :ASubSubList)
     Object.send(:remove_const, :ASubList)

--- a/spec/regression/GH-1229_reified_parent_and_child_have_same_name_spec.rb
+++ b/spec/regression/GH-1229_reified_parent_and_child_have_same_name_spec.rb
@@ -1,7 +1,7 @@
 require 'jruby/core_ext'
 
 describe "A child class with the same fully-qualified name as a parent class" do
-  it "uses its reified parent class as its own reified class" do
+  it 'generates a new reified class' do
     module GH1229
       class Foo; end
     end
@@ -15,6 +15,8 @@ describe "A child class with the same fully-qualified name as a parent class" do
     foo_ref = JRuby.reference(foo)
     foo2_ref = JRuby.reference(GH1229::Foo)
 
-    expect(foo2_ref.reified_class).to equal(foo_ref.reified_class)
+    expect(foo_ref.reified_class).to_not be(nil)
+    expect(foo2_ref.reified_class).to_not be(nil)
+    expect(foo2_ref.reified_class).to_not equal(foo_ref.reified_class)
   end
 end

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -50,7 +50,7 @@ class TestHigherJavasupport < Test::Unit::TestCase
   def test_passing_a_java_class_auto_reifies
     assert_nil Klass2.to_java.getReifiedClass
     # previously TestHelper.getClassName(Klass2) returned 'org.jruby.RubyObject'
-    assert_equal 'rubyobj.TestHigherJavasupport.Klass2', org.jruby.test.TestHelper.getClassName(Klass2)
+    assert org.jruby.test.TestHelper.getClassName(Klass2).end_with?('.TestHigherJavasupport.Klass2')
     assert_not_nil Klass2.to_java.getReifiedClass
     assert_not_nil Klass1.to_java.getReifiedClass
   end


### PR DESCRIPTION
an attempt at fixing proper re-reification of Java (sub-)class hierarchy... (https://github.com/jruby/jruby/issues/8141)

this version behaves the same 99% of production uses (Java class name is kept); but when a Java class gets re-reified it will start using a versioned suffix  (`@v1`) for the Java class name.

2 previous attempts:
- https://github.com/jruby/jruby/pull/8140
- https://github.com/jruby/jruby/pull/8147