### PR TITLE
rename all closures to more closely match a name you can read vs CLOSURE_2

### DIFF
--- a/core/src/main/java/org/jruby/ir/IRClosure.java
+++ b/core/src/main/java/org/jruby/ir/IRClosure.java
@@ -95,6 +95,9 @@ public class IRClosure extends IRScope {
         this(manager, lexicalParent, lineNumber, staticScope, signature, CLOSURE, false, coverageMode);
     }
 
+    public IRClosure(IRManager manager, IRScope lexicalParent, int lineNumber, StaticScope staticScope, Signature signature, ByteList prefix, int coverageMode) {
+        this(manager, lexicalParent, lineNumber, staticScope, signature, prefix, false, coverageMode);
+    }
 
     public IRClosure(IRManager manager, IRScope lexicalParent, int lineNumber, StaticScope staticScope, Signature signature, ByteList prefix) {
         this(manager, lexicalParent, lineNumber, staticScope, signature, prefix, false);

--- a/core/src/main/java/org/jruby/ir/IRClosure.java
+++ b/core/src/main/java/org/jruby/ir/IRClosure.java
@@ -359,16 +359,6 @@ public class IRClosure extends IRScope {
         return cloneForInlining(ii, clonedClosure);
     }
 
-    @Override
-    public void setByteName(ByteList name) {
-        ByteList newName = getLexicalParent().getByteName();
-
-        newName = newName == null ? new ByteList() : newName.dup();
-        newName.append(name);
-
-        super.setByteName(newName);
-    }
-
     public Signature getSignature() {
         return signature;
     }

--- a/core/src/main/java/org/jruby/ir/IRScope.java
+++ b/core/src/main/java/org/jruby/ir/IRScope.java
@@ -671,7 +671,7 @@ public abstract class IRScope implements ParseResult {
 
             if (spec.contains(":") && spec.equals(getFileName() + ":" + getLineNumber()) ||
                     spec.equals(getFileName())) {
-                return new IGVDumper(getFullyQualifiedName() + "; line " + getLineNumber(), RubyInstanceConfig.IR_DEBUG_IGV_STDOUT);
+                return new IGVDumper(getFullyQualifiedName() + "; line " + (getLineNumber() + 1), RubyInstanceConfig.IR_DEBUG_IGV_STDOUT);
             }
         }
 

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
@@ -1571,8 +1571,10 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
         return ic;
     }
 
+    private static final ByteList LAMBDA_PREFIX = new ByteList(new byte[] {'_', 'L', 'A', 'M', 'B', 'D', 'A', '_'});
+
     public Operand buildLambda(U args, U body, StaticScope staticScope, Signature signature, int line) {
-        IRClosure closure = new IRClosure(getManager(), scope, line, staticScope, signature, coverageMode);
+        IRClosure closure = new IRClosure(getManager(), scope, line, staticScope, signature, LAMBDA_PREFIX, coverageMode);
 
         // Create a new nested builder to ensure this gets its own IR builder state like the ensure block stack
         getManager().getBuilderFactory().newIRBuilder(getManager(), closure, this, encoding).buildLambdaInner(args, body);

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
@@ -64,6 +64,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.jruby.ir.instructions.RuntimeHelperCall.Methods.*;
 
@@ -2691,5 +2693,20 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
 
     public LocalVariable getLocalVariable(RubySymbol name, int scopeDepth) {
         return scope.getLocalVariable(name, scopeDepth);
+    }
+
+    protected void createPrefixFromArgs(ByteList prefix, Node args) {
+        if (args instanceof ArgsNode) {
+            ArgsNode argsNode = (ArgsNode) args;
+            prefix.append(Stream.of(argsNode.getArgs()).
+                    filter(n -> n instanceof INameNode).
+                    map(n -> {
+                        RubySymbol name = ((INameNode) n).getName();
+                        return name == null ? "(null)" : name.idString();
+                    }).
+                    collect(Collectors.joining(",")).getBytes());
+        } else { // for loops
+
+        }
     }
 }

--- a/core/src/main/java/org/jruby/ir/persistence/IRDumper.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRDumper.java
@@ -93,7 +93,7 @@ public class IRDumper extends IRVisitor {
     }
 
     public void visit(IRScope scope, boolean full, boolean recurse) {
-        println("begin " + scope.getScopeType().name() + "<" + scope.getId() + ">");
+        println("begin " + scope.getFullyQualifiedName());
 
         InterpreterContext ic = full ? scope.getFullInterpreterContext() : scope.getInterpreterContext();
 

--- a/core/src/main/java/org/jruby/ir/representations/IGVCFGVisitor.java
+++ b/core/src/main/java/org/jruby/ir/representations/IGVCFGVisitor.java
@@ -12,6 +12,7 @@ import org.jruby.ir.instructions.JumpInstr;
 import org.jruby.ir.instructions.JumpTargetInstr;
 import org.jruby.ir.util.IGVInstrListener;
 
+import static org.jruby.ir.util.IGVDumper.sanitize;
 import static org.jruby.ir.util.IGVHelper.emptyTag;
 import static org.jruby.ir.util.IGVHelper.endTag;
 import static org.jruby.ir.util.IGVHelper.property;
@@ -112,7 +113,7 @@ public class IGVCFGVisitor {
     public void CFG(CFG cfg, String name) {
         startTag(writer, "graph");
         startTag(writer, "properties");
-        property(writer, "name", name);
+        property(writer, "name", sanitize(name));
         endTag(writer, "properties");
 
         startTag(writer, "nodes");

--- a/core/src/main/java/org/jruby/ir/util/IGVDumper.java
+++ b/core/src/main/java/org/jruby/ir/util/IGVDumper.java
@@ -21,7 +21,7 @@ public class IGVDumper {
     final String baseLabel;
 
     public IGVDumper(String baseLabel, boolean saveToFile) {
-        this.baseLabel = baseLabel;
+        this.baseLabel = sanitize(baseLabel);
 
         try {
             if (saveToFile) {
@@ -38,6 +38,14 @@ public class IGVDumper {
 
         } catch (IOException e) {
         }
+    }
+
+    public static String sanitize(String string) {
+        return string.replaceAll("&", "&amp;").
+                replaceAll("\"", "&quot;").
+                replaceAll("<", "&lt;").
+                replaceAll(">", "&gt;").
+                replaceAll("'", "&apos;");
     }
 
     public void dump(CFG cfg, String name) {

--- a/core/src/main/java/org/jruby/ir/util/IGVHelper.java
+++ b/core/src/main/java/org/jruby/ir/util/IGVHelper.java
@@ -2,22 +2,24 @@ package org.jruby.ir.util;
 
 import java.io.PrintStream;
 
+import static org.jruby.ir.util.IGVDumper.sanitize;
+
 /**
  * Created by enebo on 1/28/17.
  */
 public class IGVHelper {
     public static void property(PrintStream writer, String name, Object content) {
         startTag(writer, "p", "name", name);
-        writer.print(content.toString().replace("<", "&lt;"));
+        writer.print(sanitize(content.toString()));
         endTag(writer, "p");
     }
 
     public static void emptyTag(PrintStream writer, String name, Object... attributes) {
         writer.print("<" + name + " ");
         for (int i = 0; i < attributes.length; i += 2) {
-            writer.print(attributes[i]);
+            writer.print(sanitize(attributes[i].toString()));
             writer.print("=\"");
-            writer.print(attributes[i+1]);
+            writer.print(sanitize(attributes[i+1].toString()));
             writer.print("\" ");
         }
         writer.println("/>");
@@ -35,9 +37,9 @@ public class IGVHelper {
     public static void startTag(PrintStream writer, String name, Object... attributes) {
         writer.print("<" + name + " ");
         for (int i = 0; i < attributes.length; i += 2) {
-            writer.print(attributes[i]);
+            writer.print(sanitize(attributes[i].toString()));
             writer.print("=\"");
-            writer.print(attributes[i+1]);
+            writer.print(sanitize(attributes[i+1].toString()));
             writer.print("\" ");
         }
         writer.println(">");


### PR DESCRIPTION
Allow closures names of scopes to be more readable:

```retriable::CLOSURE_1::CLOSURE2```  now looks like ```retriable::times &|index|2::any? &|e|4```

Literal lambdas also print out with `->(a)1`.