### PR TITLE
bump rdoc dependency to 6.4.1.1

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -80,7 +80,7 @@ default_gems = [
     ['psych', '5.1.1.1'],
     ['racc', '1.6.0'],
     ['rake-ant', '1.0.6'],
-    ['rdoc', '6.4.0'],
+    ['rdoc', '6.4.1.1'],
     # https://github.com/ruby/readline/issues/5
     # ['readline', '0.0.3'],
     # Will be solved with readline

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -632,7 +632,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>rdoc</artifactId>
-      <version>6.4.0</version>
+      <version>6.4.1.1</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1125,7 +1125,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/psych-5.1.1.1*</include>
           <include>specifications/racc-1.6.0*</include>
           <include>specifications/rake-ant-1.0.6*</include>
-          <include>specifications/rdoc-6.4.0*</include>
+          <include>specifications/rdoc-6.4.1.1*</include>
           <include>specifications/reline-0.4.2*</include>
           <include>specifications/resolv-replace-0.1.0*</include>
           <include>specifications/rinda-0.1.1*</include>
@@ -1204,7 +1204,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/psych-5.1.1.1*/**/*</include>
           <include>gems/racc-1.6.0*/**/*</include>
           <include>gems/rake-ant-1.0.6*/**/*</include>
-          <include>gems/rdoc-6.4.0*/**/*</include>
+          <include>gems/rdoc-6.4.1.1*/**/*</include>
           <include>gems/reline-0.4.2*/**/*</include>
           <include>gems/resolv-replace-0.1.0*/**/*</include>
           <include>gems/rinda-0.1.1*/**/*</include>
@@ -1283,7 +1283,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/psych-5.1.1.1*</include>
           <include>cache/racc-1.6.0*</include>
           <include>cache/rake-ant-1.0.6*</include>
-          <include>cache/rdoc-6.4.0*</include>
+          <include>cache/rdoc-6.4.1.1*</include>
           <include>cache/reline-0.4.2*</include>
           <include>cache/resolv-replace-0.1.0*</include>
           <include>cache/rinda-0.1.1*</include>


### PR DESCRIPTION
The current recommendation for Ruby 3.1 users is to update to rdoc 6.4.1.1 due to known issues.
