### PR TITLE
begin node coverage line should not get added if it has been removed

### DIFF
--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -438,7 +438,9 @@ public abstract class RubyParserBase {
     public Node newline_node(Node node, int line) {
         if (node == null) return null;
 
-        node = remove_begin(node);
+        Node newNode = remove_begin(node);
+        // Conservative fix...try and use line unless we see remove has been removed then use the newNode.
+        if (newNode != node) line = newNode.getLine();
         coverLine(line);
         node.setNewline();
 


### PR DESCRIPTION
This was adding begin line to coverage list whether it had been removed or not.  It should use the line of the node
it contained as the line to add for coverage.  This fixes #8173 