### PR TITLE
Mark frame-aware method names with bang suffix for ostruct

### DIFF
--- a/core/src/main/java/org/jruby/anno/AnnotationHelper.java
+++ b/core/src/main/java/org/jruby/anno/AnnotationHelper.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
@@ -103,15 +104,20 @@ public class AnnotationHelper {
 
     public static void populateMethodIndex(Map<Set<FrameField>, List<String>> accessGroups, BiConsumer<Integer, String> action) {
         if (!accessGroups.isEmpty()) {
-            for (Map.Entry<Set<FrameField>, List<String>> accessEntry : accessGroups.entrySet()) {
-                Set<FrameField> reads = accessEntry.getKey();
-                List<String> names = accessEntry.getValue();
-
+            accessGroups.forEach((reads, names) -> {
                 int bits = FrameField.pack(reads.stream().toArray(n -> new FrameField[n]));
-                String namesJoined = names.stream().distinct().collect(Collectors.joining(";"));
+
+                StringJoiner joiner = new StringJoiner(";");
+                Set<String> uniqueValues = new HashSet<>();
+                for (String name : names) {
+                    if (uniqueValues.add(name)) {
+                        joiner.add(name);
+                    }
+                }
+                String namesJoined = joiner.toString();
 
                 action.accept(bits, namesJoined);
-            }
+            });
         }
     }
 

--- a/core/src/main/java/org/jruby/anno/AnnotationHelper.java
+++ b/core/src/main/java/org/jruby/anno/AnnotationHelper.java
@@ -112,6 +112,11 @@ public class AnnotationHelper {
                 for (String name : names) {
                     if (uniqueValues.add(name)) {
                         joiner.add(name);
+
+                        // in order to support these names aliased with "!" we eagerly add those names as well (jruby/jruby#8200)
+                        if (name.matches("^[a-z_]+$")) {
+                            joiner.add(name + '!');
+                        }
                     }
                 }
                 String namesJoined = joiner.toString();


### PR DESCRIPTION
Also flag frame names with "!" for ostruct

The ostruct library aliases all methods from Object/Kernel with a bang suffix ("!") to allow them to be callable even though the OpenStruct should support them as field names. Because we use record these names in a table of known frame-aware methods, we have typically warned when aliasing them. This rarely comes up, since aliasing usually is accompanied by wrapping, which breaks their behavior on all implementations, but this aliasing in ostruct is unusual and pervasive, leading to issues like #8200.

This patch assumes we're going to have issues with ostruct forever and eagerly adds the "!" names alongside the regular names for all method names that match /[a-z_]/, so taht existing methods and future methods will behavior properly and not warn when aliased.

It adds a small amount to startup, since these method names must be added twice, but there are not many such names in the system.

Fixes #8200

Replaces #7524
