### PR TITLE
Partially undo kwarg optz from #8095

### DIFF
--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -670,14 +670,18 @@ public class IRRuntimeHelpers {
     // specific arity methods in JIT will only be fixed arity meaning no kwargs and no rest args.
     // this logic is the same as recieveKeywords but we know it will never be a keyword argument (jit
     // will save %undefined as the keyword value).
-    @JIT // Only used for specificArity JITted methods with at least one parameter
-    public static IRubyObject receiveSpecificArityKeywords(ThreadContext context, IRubyObject last) {
+    // Due to jruby/jruby#8119 and the potential for ruby2_keywords flags to change after JIT, jitted code will always
+    // call on this path and pass in the live value of ruby2_keywords from the scope.
+    @JIT
+    public static IRubyObject receiveSpecificArityKeywords(ThreadContext context, IRubyObject last, boolean ruby2Keywords) {
         if (!(last instanceof RubyHash)) {
             ThreadContext.clearCallInfo(context);
             return last;
         }
 
-        return receiveSpecificArityHashKeywords(context, last);
+        return ruby2Keywords ?
+                receiveSpecificArityRuby2HashKeywords(context, last) :
+                receiveSpecificArityHashKeywords(context, last);
     }
 
     private static IRubyObject receiveSpecificArityHashKeywords(ThreadContext context, IRubyObject last) {
@@ -685,17 +689,6 @@ public class IRRuntimeHelpers {
         boolean isKwarg = (callInfo & CALL_KEYWORD) != 0;
 
         return receiverSpecificArityKwargsCommon(context, last, callInfo, isKwarg);
-    }
-
-    // same as receiveSpecificArityKeywords but only used when the scope demands ruby2 keywords.
-    @JIT // Only used for specificArity JITted methods with at least one parameter
-    public static IRubyObject receiveSpecificArityRuby2Keywords(ThreadContext context, IRubyObject last) {
-        if (!(last instanceof RubyHash)) {
-            ThreadContext.clearCallInfo(context);
-            return last;
-        }
-
-        return receiveSpecificArityRuby2HashKeywords(context, last);
     }
 
     private static IRubyObject receiveSpecificArityRuby2HashKeywords(ThreadContext context, IRubyObject last) {
@@ -757,34 +750,6 @@ public class IRRuntimeHelpers {
         }
 
         return UNDEFINED;
-    }
-
-    /**
-     * Simplified receiveKeywords when receiver IS NOT a ruby2_keywords method.
-     *
-     * @param context
-     * @param args
-     * @param hasRestArgs
-     * @param acceptKeywords
-     * @return the prepared kwargs hash, or UNDEFINED as a sigil for no kwargs
-     */
-    @JIT
-    public static IRubyObject receiveNormalKeywords(ThreadContext context, IRubyObject[] args, boolean hasRestArgs, boolean acceptKeywords) {
-        return receiveKeywords(context, args, hasRestArgs, acceptKeywords, false);
-    }
-
-    /**
-     * Simplified receiveKeywords when receiver IS a ruby2_keywords method.
-     *
-     * @param context
-     * @param args
-     * @param hasRestArgs
-     * @param acceptKeywords
-     * @return the prepared kwargs hash, or UNDEFINED as a sigil for no kwargs
-     */
-    @JIT
-    public static IRubyObject receiveRuby2Keywords(ThreadContext context, IRubyObject[] args, boolean hasRestArgs, boolean acceptKeywords) {
-        return receiveKeywords(context, args, hasRestArgs, acceptKeywords, true);
     }
 
     /**

--- a/core/src/main/java/org/jruby/parser/StaticScope.java
+++ b/core/src/main/java/org/jruby/parser/StaticScope.java
@@ -731,4 +731,8 @@ public class StaticScope implements Serializable {
     public void setInstanceVariableNames(Collection<String> ivarWrites) {
         this.ivarNames = ivarWrites;
     }
+
+    public boolean isRuby2Keywords() {
+        return irScope.isRuby2Keywords();
+    }
 }


### PR DESCRIPTION
In jruby/jruby#8095 (jruby/jruby@121c60fb) I optimized the JIT to statically compile in the logic for ruby2_keywords at the time of JIT. Unfortunately there turned out to be too many cases where this flag can change at runtime, leading to bugs like jruby/jruby#8119 where a previously-jitted scope gets flipped to ruby2_keywords later on.

This patch partially reverts that optimization and resumes passing in the live ruby2_keywords value from the scope. We can revisit this in the future when it is possible to throw out and re-compile scopes that get this flag set later on.

Fixes jruby/jruby#8119