### PR TITLE
opted case needs to use updated ints when loaded into new runtime.

### DIFF
--- a/core/src/main/java/org/jruby/ir/instructions/BSwitchInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/BSwitchInstr.java
@@ -5,8 +5,11 @@ import org.jruby.RubyFixnum;
 import org.jruby.RubySymbol;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
+import org.jruby.ir.operands.Fixnum;
+import org.jruby.ir.operands.FrozenString;
 import org.jruby.ir.operands.Label;
 import org.jruby.ir.operands.Operand;
+import org.jruby.ir.operands.Symbol;
 import org.jruby.ir.persistence.IRReaderDecoder;
 import org.jruby.ir.persistence.IRWriterEncoder;
 import org.jruby.ir.transformations.inlining.CloneInfo;
@@ -22,6 +25,7 @@ import java.util.Arrays;
  * Represents a multiple-target jump instruction based on a switch-like table
  */
 public class BSwitchInstr extends MultiBranchInstr {
+    private final Operand[] jumpOperands;
     private final int[] jumps;
     private Operand operand;
     private final Label rubyCase;
@@ -29,7 +33,8 @@ public class BSwitchInstr extends MultiBranchInstr {
     private final Label elseTarget;
     private final Class expectedClass;
 
-    public BSwitchInstr(int[] jumps, Operand operand, Label rubyCase, Label[] targets, Label elseTarget, Class expectedClass) {
+    public BSwitchInstr(int[] jumps, Operand[] jumpOperands, Operand operand, Label rubyCase, Label[] targets,
+                        Label elseTarget, Class expectedClass) {
         super(Operation.B_SWITCH);
 
         // We depend on the jump table being sorted, so ensure that's the case here
@@ -38,6 +43,7 @@ public class BSwitchInstr extends MultiBranchInstr {
         // Switch cases must not have an empty "case" value (GH-6440)
         assert operand != null : "Switch cases must not have an empty \"case\" value";
 
+        this.jumpOperands = jumpOperands;
         this.jumps = jumps;
         this.operand = operand;
         this.rubyCase = rubyCase;
@@ -87,13 +93,13 @@ public class BSwitchInstr extends MultiBranchInstr {
         Label[] targets = new Label[this.targets.length];
         for (int i = 0; i < targets.length; i++) targets[i] = info.getRenamedLabel(this.targets[i]);
         Label elseTarget = info.getRenamedLabel(this.elseTarget);
-        return new BSwitchInstr(jumps, operand, rubyCase, targets, elseTarget, expectedClass);
+        return new BSwitchInstr(jumps, jumpOperands, operand, rubyCase, targets, elseTarget, expectedClass);
     }
 
     @Override
     public void encode(IRWriterEncoder e) {
         super.encode(e);
-        e.encode(jumps);
+        e.encode(jumpOperands);
         e.encode(operand);
         e.encode(rubyCase);
         e.encode(targets); // FXXXX
@@ -103,7 +109,18 @@ public class BSwitchInstr extends MultiBranchInstr {
 
     public static BSwitchInstr decode(IRReaderDecoder d) {
         try {
-            return new BSwitchInstr(d.decodeIntArray(), d.decodeOperand(), d.decodeLabel(), d.decodeLabelArray(), d.decodeLabel(), Class.forName(d.decodeString()));
+            Operand[] jumpOperands = d.decodeOperandArray();
+            int[] jumps = new int[jumpOperands.length];
+            for (int i = 0; i < jumps.length; i++) {
+                Operand operand = jumpOperands[i];
+                if (operand instanceof Symbol) {
+                    jumps[i] = ((Symbol) operand).getSymbol().getId();
+                } else if (operand instanceof FrozenString) {
+                    jumps[i] = (int) ((Fixnum) operand).getValue();
+                }
+            }
+
+            return new BSwitchInstr(jumps, jumpOperands, d.decodeOperand(), d.decodeLabel(), d.decodeLabelArray(), d.decodeLabel(), Class.forName(d.decodeString()));
         } catch (Exception e) {
             // should never happen unless encode was corrupted
             Helpers.throwException(e);

--- a/core/src/main/java/org/jruby/ir/instructions/BSwitchInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/BSwitchInstr.java
@@ -1,12 +1,10 @@
 package org.jruby.ir.instructions;
 
-import org.jruby.RubyClass;
 import org.jruby.RubyFixnum;
 import org.jruby.RubySymbol;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.Operation;
 import org.jruby.ir.operands.Fixnum;
-import org.jruby.ir.operands.FrozenString;
 import org.jruby.ir.operands.Label;
 import org.jruby.ir.operands.Operand;
 import org.jruby.ir.operands.Symbol;
@@ -115,7 +113,7 @@ public class BSwitchInstr extends MultiBranchInstr {
                 Operand operand = jumpOperands[i];
                 if (operand instanceof Symbol) {
                     jumps[i] = ((Symbol) operand).getSymbol().getId();
-                } else if (operand instanceof FrozenString) {
+                } else if (operand instanceof Fixnum) {
                     jumps[i] = (int) ((Fixnum) operand).getValue();
                 }
             }

--- a/spec/compiler/general_spec.rb
+++ b/spec/compiler/general_spec.rb
@@ -589,6 +589,47 @@ modes.each do |mode|
       end
     end
 
+    it "handles optimized homogeneous case/when" do
+      run('
+        case "a"
+        when "b"
+          fail
+        when "a"
+          1
+        else
+          fail
+        end
+      ') do |result|
+        expect(result).to eq 1
+      end
+
+      run('
+        case :a
+        when :b
+          fail
+        when :a
+          1
+        else
+          fail
+        end
+      ') do |result|
+        expect(result).to eq 1
+      end
+
+      run('
+        case 1
+        when 2
+          fail
+        when 1
+          1
+        else
+          fail
+        end
+      ') do |result|
+        expect(result).to eq 1
+      end
+    end     
+
     it "handles 0-4 arg and splatted whens in a caseless case/when" do
       run('
         case


### PR DESCRIPTION
fixes #8157.  the int values we calculate are only valid for the runtime they are created in.  When loading AOT code we have to generate new int values.  This fix just saves the operands we are making the jump table for so we can regenerate new ints from them.