### PR TITLE
Introduce a DEFAULT visibility to indicate unspecified

### DIFF
--- a/core/src/main/java/org/jruby/anno/AnnotationBinder.java
+++ b/core/src/main/java/org/jruby/anno/AnnotationBinder.java
@@ -330,7 +330,7 @@ public class AnnotationBinder extends AbstractProcessor {
             String implClass = anno.meta() ? "singletonClass" : "cls";
 
             String baseName = getBaseName(anno.name(), method);
-            out.println("        javaMethod = new " + annotatedBindingName + "(" + implClass + ", Visibility." + anno.visibility() + ", \"" + baseName + "\");");
+            out.println("        javaMethod = new " + annotatedBindingName + "(" + implClass + ", Visibility." + anno.visibility().getDefaultVisibilityFor(baseName) + ", \"" + baseName + "\");");
             out.println("        populateMethod(javaMethod, " +
                     join(AnnotationHelper.getArityValue(anno, actualRequired),
                             quote(method.getSimpleName()),
@@ -367,7 +367,7 @@ public class AnnotationBinder extends AbstractProcessor {
             String implClass = anno.meta() ? "singletonClass" : "cls";
 
             String baseName = getBaseName(anno.name(), method);
-            out.println("        javaMethod = new " + annotatedBindingName + "(" + implClass + ", Visibility." + anno.visibility() + ", \"" + baseName + "\");");
+            out.println("        javaMethod = new " + annotatedBindingName + "(" + implClass + ", Visibility." + anno.visibility().getDefaultVisibilityFor(baseName) + ", \"" + baseName + "\");");
             out.println("        populateMethod(javaMethod, " +
                         join(-1,
                                 quote(method.getSimpleName()),

--- a/core/src/main/java/org/jruby/anno/IndyBinder.java
+++ b/core/src/main/java/org/jruby/anno/IndyBinder.java
@@ -392,8 +392,9 @@ public class IndyBinder extends AbstractProcessor {
         mv.dup();
 
         mv.aload(implClass);
-        mv.getstatic(p(Visibility.class), anno.visibility().name(), ci(Visibility.class));
-        mv.ldc(AnnotationBinder.getBaseName(anno.name(), methods.get(0)));
+        String baseName = AnnotationBinder.getBaseName(anno.name(), methods.get(0));
+        mv.getstatic(p(Visibility.class), anno.visibility().getDefaultVisibilityFor(baseName).name(), ci(Visibility.class));
+        mv.ldc(baseName);
         mv.ldc(encodeSignature(0, 0, 0, 0, 0, true, false));
         mv.ldc(true);
         mv.ldc(anno.notImplemented());

--- a/core/src/main/java/org/jruby/anno/JRubyMethod.java
+++ b/core/src/main/java/org/jruby/anno/JRubyMethod.java
@@ -81,7 +81,7 @@ public @interface JRubyMethod {
     /**
      * The visibility of this method.
      */
-    Visibility visibility() default Visibility.PUBLIC;
+    Visibility visibility() default Visibility.DEFAULT;
 
     /**
      * What, if anything, method reads from caller's frame

--- a/core/src/main/java/org/jruby/internal/runtime/methods/InvocationMethodFactory.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InvocationMethodFactory.java
@@ -357,13 +357,13 @@ public class InvocationMethodFactory extends MethodFactory implements Opcodes {
             // Old constructor with no name, use thread-local to pass it.
             JavaMethod.NAME_PASSER.set(name);
             try {
-                ic = (JavaMethod) c.getConstructor(RubyModule_and_Visibility).newInstance(implementationClass, desc.anno.visibility());
+                ic = (JavaMethod) c.getConstructor(RubyModule_and_Visibility).newInstance(implementationClass, desc.anno.visibility().getDefaultVisibilityFor(name));
             } finally {
                 JavaMethod.NAME_PASSER.remove();
             }
         } else {
             // New constructor with name.
-            ic = (JavaMethod) c.getConstructor(RubyModule_and_Visibility_and_Name).newInstance(implementationClass, desc.anno.visibility(), name);
+            ic = (JavaMethod) c.getConstructor(RubyModule_and_Visibility_and_Name).newInstance(implementationClass, desc.anno.visibility().getDefaultVisibilityFor(name), name);
         }
         return ic;
     }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/InvokeDynamicMethodFactory.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InvokeDynamicMethodFactory.java
@@ -120,7 +120,7 @@ public class InvokeDynamicMethodFactory extends InvocationMethodFactory {
 
         return new HandleMethod(
                 implementationClass,
-                desc1.anno.visibility(),
+                desc1.anno.visibility().getDefaultVisibilityFor(desc1.name),
                 desc1.name,
                 (min == max) ?
                         org.jruby.runtime.Signature.from(min, 0, 0, 0, 0, org.jruby.runtime.Signature.Rest.NONE, -1).encode() :

--- a/core/src/main/java/org/jruby/runtime/Visibility.java
+++ b/core/src/main/java/org/jruby/runtime/Visibility.java
@@ -27,7 +27,7 @@
 package org.jruby.runtime;
 
 public enum Visibility {
-    PUBLIC, PROTECTED, PRIVATE, MODULE_FUNCTION, UNDEFINED;
+    PUBLIC, PROTECTED, PRIVATE, MODULE_FUNCTION, UNDEFINED, DEFAULT;
     private static final Visibility[] VALUES = values();
 
     public boolean isPublic() {
@@ -48,5 +48,19 @@ public enum Visibility {
 
     public static Visibility[] getValues() {
         return VALUES;
+    }
+
+    public Visibility getDefaultVisibilityFor(String name) {
+        switch (this) {
+            case DEFAULT:
+                switch (name) {
+                    case "initialize":
+                    case "initialize_copy":
+                       return PRIVATE;
+                }
+                return PUBLIC;
+            default:
+                return this;
+        }
     }
 }

--- a/core/src/test/java/org/jruby/test/TestMethodFactories.java
+++ b/core/src/test/java/org/jruby/test/TestMethodFactories.java
@@ -30,12 +30,15 @@ package org.jruby.test;
 
 import org.jruby.CompatVersion;
 import org.jruby.Ruby;
+import org.jruby.RubyClass;
 import org.jruby.RubyMethod;
 import org.jruby.RubyModule;
+import org.jruby.RubyObject;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.ArgumentError;
 import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 
 
@@ -164,6 +167,39 @@ public class TestMethodFactories extends Base {
         mod.defineAnnotatedMethods(VersionedMethods.class);
 
         assertNotNull(mod.searchMethod("method"));
+    }
+
+    public void testDefaultVisibility() {
+        RubyClass cls = runtime.defineClass("NoVisibilityInitialize", runtime.getObject(), NoVisibilityInitialize::new);
+
+        cls.defineAnnotatedMethods(NoVisibilityInitialize.class);
+
+        assertEquals(Visibility.PRIVATE, cls.searchMethod("initialize").getVisibility());
+        assertEquals(Visibility.PRIVATE, cls.searchMethod("initialize_copy").getVisibility());
+        assertEquals(Visibility.PUBLIC, cls.searchMethod("some_other_method").getVisibility());
+    }
+
+    public static class NoVisibilityInitialize extends RubyObject {
+        public NoVisibilityInitialize(Ruby runtime, RubyClass metaClass) {
+            super(metaClass);
+        }
+
+        // intentionally no visibility
+        @JRubyMethod
+        public IRubyObject initialize(ThreadContext context) {
+            return context.nil;
+        }
+
+        // intentionally no visibility
+        @JRubyMethod
+        public IRubyObject initialize_copy(ThreadContext context, IRubyObject copy) {
+            return context.nil;
+        }
+
+        @JRubyMethod
+        public IRubyObject some_other_method(ThreadContext context) {
+            return context.nil;
+        }
     }
 
 }


### PR DESCRIPTION
In jruby/jruby#8146 we saw that DelegateClass can be broken by JRuby extensions that do not explicitly set their initialize methods to Visibility.PRIVATE. This is an error-prone requirement as detailed in jruby/jruby#8210, since there's no indication that initialize is special and should always be private.

This patch introduces a "DEFAULT" visibility to be the default for the annotation. When binding methods using annotation processing, the DEFAULT visibility will translate itself to PRIVATE for the initialize method and PUBLIC for other cases. This ensures that initialize is always set to PRIVATE if no other visibility is specified, avoiding the bug. If initialize is set to some other visibility, it will keep that visibility.

Fixes jruby/jruby#8210