### PR TITLE
Make attrs position-aware

### DIFF
--- a/bench/bench_attr_reader.rb
+++ b/bench/bench_attr_reader.rb
@@ -1,0 +1,12 @@
+require 'benchmark/ips'
+
+Benchmark.ips do |bm|
+  bm.report("attr_reader") do |i|
+    Class.new do
+      while i > 0
+        i-=1
+        attr_reader :foo
+      end
+    end
+  end
+end

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2303,13 +2303,14 @@ public class RubyModule extends RubyObject {
         }
 
         final String variableName = identifier.asInstanceVariable().idString();
+        RubyStackTraceElement trace = context.getSingleBacktrace(1);
         if (readable) {
-            addMethod(internedIdentifier, new AttrReaderMethod(methodLocation, visibility, variableName));
+            addMethod(internedIdentifier, new AttrReaderMethod(methodLocation, visibility, variableName, trace));
             methodAdded(context, identifier);
         }
         if (writeable) {
             identifier = identifier.asWriter();
-            addMethod(identifier.idString(), new AttrWriterMethod(methodLocation, visibility, variableName));
+            addMethod(identifier.idString(), new AttrWriterMethod(methodLocation, visibility, variableName, trace));
             methodAdded(context, identifier);
         }
     }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/AttrReaderMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/AttrReaderMethod.java
@@ -34,6 +34,8 @@ import java.util.Collections;
 
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
+import org.jruby.runtime.PositionAware;
+import org.jruby.runtime.backtrace.RubyStackTraceElement;
 import org.jruby.runtime.ivars.VariableAccessor;
 import org.jruby.internal.runtime.methods.JavaMethod.JavaMethodZero;
 import org.jruby.runtime.ThreadContext;
@@ -44,12 +46,17 @@ import org.jruby.runtime.ivars.MethodData;
 /**
  * A method type for attribute writers (as created by attr_writer or attr_accessor).
  */
-public class AttrReaderMethod extends JavaMethodZero {
+public class AttrReaderMethod extends JavaMethodZero implements PositionAware {
     private MethodData methodData;
     private VariableAccessor accessor = VariableAccessor.DUMMY_ACCESSOR;
+    private final String file;
+    private final int line;
 
-    public AttrReaderMethod(RubyModule implementationClass, Visibility visibility, String variableName) {
+    public AttrReaderMethod(RubyModule implementationClass, Visibility visibility, String variableName, RubyStackTraceElement trace) {
         super(implementationClass, visibility, variableName);
+
+        this.file = trace == null ? null : trace.getFileName();
+        this.line = trace == null ? -1 : trace.getLineNumber();
     }
 
     public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name) {
@@ -87,6 +94,16 @@ public class AttrReaderMethod extends JavaMethodZero {
     // Used by racc extension, needed for backward-compat with 1.7.
     @Deprecated
     public AttrReaderMethod(RubyModule implementationClass, Visibility visibility, CallConfiguration callConfiguration, String variableName) {
-        this(implementationClass, visibility, variableName);
+        this(implementationClass, visibility, variableName, null);
+    }
+
+    @Override
+    public String getFile() {
+        return file;
+    }
+
+    @Override
+    public int getLine() {
+        return line;
     }
 }


### PR DESCRIPTION
This is a proof-of-concept for adding the definition location (from source where `attr`, `attr_reader`, `attr_accessor` or `attr_writer` was called) into all `attr`-style methods, to address the missing information reported in #8079.

A benchmark is included, and shows how severely this impacts the creation of attrs, due to the stack walking involved:

```
[] jruby $ jruby bench/bench_attr_reader.rb 
jruby 10.0.0.0-SNAPSHOT (3.4.0) 2024-04-25 feb5f4c851 OpenJDK 64-Bit Server VM 17.0.5+8 on 17.0.5+8 +jit [arm64-darwin]
Warming up --------------------------------------
         attr_reader    11.853k i/100ms
Calculating -------------------------------------
         attr_reader    128.672k (± 0.5%) i/s -    651.915k in   5.066593s
[] jruby $ (chruby jruby-9.4.6.0 ; jruby bench/bench_attr_reader.rb)
Warming up --------------------------------------
         attr_reader   960.880k i/100ms
Calculating -------------------------------------
         attr_reader      9.701M (± 0.4%) i/s -     49.005M in   5.051463s
```

Using a specialized call site would make this largely free, similar to how #8170 avoids frame access for `block_given?` but this example demonstrates one (slow) way to solve the bug.