### PR TITLE
Narrow frame name optimization to method scopes

### DIFF
--- a/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
@@ -2655,8 +2655,11 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
         switch (callName) {
             case "__method__":
             case "__callee__":
-                addInstr(new FrameNameCallInstr(result, callName));
-                return result;
+                // narrow to methods until we can fix other scopes' frame names
+                if (scope instanceof IRMethod) {
+                    addInstr(new FrameNameCallInstr(result, callName));
+                    return result;
+                }
         }
 
         return _call(result, VARIABLE, buildSelf(), node.getName());


### PR DESCRIPTION
Non-method scopes like classes and modules have issues with the frame name not properly propagating into the executing body, and blocks may be used for define_method which introduces similar complexities in getting the frame name. This patch temporarily narrows the frame name optimization to method bodies only.