### PR TITLE
Fix full_message formatting and Throwable impl

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1508,8 +1508,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     }
 
     public final RubyString catString(String str) {
-        ByteList other = encodeBytelist(str, getEncoding());
-        catWithCodeRange(other, CR_UNKNOWN);
+        ByteList other = encodeBytelist(str, UTF8);
+        catWithCodeRange(other, CR_VALID);
         return this;
     }
 

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -259,7 +259,29 @@ public abstract class JavaLang {
 
         @JRubyMethod
         public static IRubyObject full_message(final ThreadContext context, final IRubyObject self, final IRubyObject opts) {
-            return RubyString.newString(context.runtime, TraceType.printFullMessage(context, self, opts));
+            return TraceType.printFullMessage(context, self, opts);
+        }
+
+        @JRubyMethod
+        public static IRubyObject detailed_message(final ThreadContext context, final IRubyObject self) {
+            return detailed_message(context, self, (IRubyObject) null);
+        }
+
+        @JRubyMethod
+        public static IRubyObject detailed_message(final ThreadContext context, final IRubyObject self, final IRubyObject opts) {
+            return TraceType.printDetailedMessage(context, self, opts);
+        }
+
+        @JRubyMethod(optional = 1)
+        public static IRubyObject detailed_message(final ThreadContext context, final IRubyObject self, final IRubyObject[] args) {
+            switch (args.length) {
+                case 0:
+                    return detailed_message(context, self);
+                case 1:
+                    return detailed_message(context, self, args[0]);
+                default:
+                    throw context.runtime.newArgumentError(args.length, 0, 1);
+            }
         }
 
         @JRubyMethod // Ruby exception to_s is the same as message

--- a/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
@@ -569,7 +569,7 @@ public class TraceType {
                     if (highlight) errorStream.catString(RESET);
                 }
 
-                if (tail != null) {
+                if (tail != null && tail.length() > 0) {
                     errorStream.cat('\n');
                     if (!highlight) {
                         errorStream.catString(tail);
@@ -767,11 +767,11 @@ public class TraceType {
                 }
                 if (stackTraceLine instanceof RubyString) {
                     errorStream.catString("from " + stackTraceLine);
+                    errorStream.cat('\n');
                 }
                 else {
                     errorStream.append(stackTraceLine);
                 }
-                errorStream.cat('\n');
             }
 
             if ((elements.length > i)) {

--- a/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
@@ -753,6 +753,7 @@ public class TraceType {
                 else {
                     errorStream.append(stackTraceLine);
                 }
+                errorStream.cat('\n');
             }
 
             if ((elements.length > i)) {


### PR DESCRIPTION
* java.lang.Throwable#full_message uses the same logic as Exception#full_message but without #detailed_message it did not include the exception message in output.
* Shared full_message logic did not insert newlines between backtrace lines.