### PR TITLE
More frame name fixes

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRBodyMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRBodyMethod.java
@@ -41,9 +41,9 @@ public class InterpretedIRBodyMethod extends InterpretedIRMethod {
         ensureInstrsReady();
 
         switch (getIRScope().getScopeType()) {
-            case MODULE_BODY: return Interpreter.INTERPRET_MODULE(context, getIRScope(), clazz);
-            case CLASS_BODY: return Interpreter.INTERPRET_CLASS(context, getIRScope(), clazz);
-            case METACLASS_BODY: return Interpreter.INTERPRET_METACLASS(context, getIRScope(), clazz, getVisibility());
+            case MODULE_BODY: return Interpreter.INTERPRET_MODULE(context, getIRScope(), clazz, name);
+            case CLASS_BODY: return Interpreter.INTERPRET_CLASS(context, getIRScope(), clazz, name);
+            case METACLASS_BODY: return Interpreter.INTERPRET_METACLASS(context, getIRScope(), clazz, name, getVisibility());
             default: throw new RuntimeException("invalid body method type: " + getIRScope());
         }
     }

--- a/core/src/main/java/org/jruby/ir/instructions/DefineClassInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/DefineClassInstr.java
@@ -71,7 +71,7 @@ public class DefineClassInstr extends TwoOperandResultBaseInstr implements Fixed
         RubyModule clazz = IRRuntimeHelpers.newRubyClassFromIR(context, body.getId(), body.getStaticScope(),
                 superClass, container, body.maybeUsingRefinements());
 
-        return Interpreter.INTERPRET_CLASS(context, body, clazz);
+        return Interpreter.INTERPRET_CLASS(context, body, clazz, body.getId());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/DefineModuleInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/DefineModuleInstr.java
@@ -65,7 +65,7 @@ public class DefineModuleInstr extends OneOperandResultBaseInstr implements Fixe
         RubyModule clazz = IRRuntimeHelpers.newRubyModuleFromIR(context, body.getId(), body.getStaticScope(), container, body.maybeUsingRefinements());
 
 
-        return Interpreter.INTERPRET_MODULE(context, body, clazz);
+        return Interpreter.INTERPRET_MODULE(context, body, clazz, body.getId());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/instructions/FrameNameCallInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/FrameNameCallInstr.java
@@ -56,8 +56,6 @@ public class FrameNameCallInstr extends NoOperandResultBaseInstr implements Fixe
             return frameNameSite.call(context, self, self);
         }
 
-        if (compositeName == null) return context.nil;
-
         return callee ?
                 RubySymbol.newCalleeSymbolFromCompound(context.runtime, compositeName):
                 RubySymbol.newMethodSymbolFromCompound(context.runtime, compositeName);

--- a/core/src/main/java/org/jruby/ir/interpreter/ExitableInterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/ExitableInterpreterEngine.java
@@ -107,7 +107,7 @@ public class ExitableInterpreterEngine extends InterpreterEngine {
                         break;
                     case CALL_OP:
                         if (profile) Profiler.updateCallSite(instr, interpreterContext.getScope(), scopeVersion);
-                        processCall(context, instr, operation, currDynScope, currScope, temp, self, name, block);
+                        processCall(context, instr, operation, currDynScope, currScope, temp, self, name);
                         break;
                     case RET_OP:
                         processReturnOp(context, block, instr, operation, currDynScope, temp, self, currScope);

--- a/core/src/main/java/org/jruby/ir/interpreter/Interpreter.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/Interpreter.java
@@ -126,16 +126,16 @@ public class Interpreter extends IRTranslator<IRubyObject, IRubyObject> {
         }
     }
 
-    public static IRubyObject INTERPRET_CLASS(ThreadContext context, IRScope body, RubyModule clazz) {
-        return interpretFrameScope(context, null, body, clazz, null, Visibility.PUBLIC, clazz, null, null, Block.NULL_BLOCK);
+    public static IRubyObject INTERPRET_CLASS(ThreadContext context, IRScope body, RubyModule clazz, String name) {
+        return interpretFrameScope(context, null, body, clazz, null, Visibility.PUBLIC, clazz, name, null, Block.NULL_BLOCK);
     }
 
-    public static IRubyObject INTERPRET_MODULE(ThreadContext context, IRScope body, RubyModule clazz) {
-        return interpretFrameScope(context, null, body, clazz, null, Visibility.PUBLIC, clazz, null, null, Block.NULL_BLOCK);
+    public static IRubyObject INTERPRET_MODULE(ThreadContext context, IRScope body, RubyModule clazz, String name) {
+        return interpretFrameScope(context, null, body, clazz, null, Visibility.PUBLIC, clazz, name, null, Block.NULL_BLOCK);
     }
 
-    public static IRubyObject INTERPRET_METACLASS(ThreadContext context, IRScope body, RubyModule clazz, Visibility visibility) {
-        return interpretFrameScope(context, null, body, clazz, context.getCurrentScope(), visibility, clazz, null, null, Block.NULL_BLOCK);
+    public static IRubyObject INTERPRET_METACLASS(ThreadContext context, IRScope body, RubyModule clazz, String name, Visibility visibility) {
+        return interpretFrameScope(context, null, body, clazz, context.getCurrentScope(), visibility, clazz, name, null, Block.NULL_BLOCK);
     }
 
     public static IRubyObject INTERPRET_METHOD(ThreadContext context, IRScope body, RubyModule implClass,

--- a/core/src/main/java/org/jruby/ir/interpreter/Interpreter.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/Interpreter.java
@@ -268,7 +268,7 @@ public class Interpreter extends IRTranslator<IRubyObject, IRubyObject> {
         Frame lastFrame = context.preEvalWithBinding(binding);
         try {
             return evalCommon(context, evalScope, self, src, binding.getFile(),
-                    binding.getLine(), binding.getFrame().getName(), binding.getFrame().getBlock(), EvalType.BINDING_EVAL, bindingGiven);
+                    binding.getLine(), binding.getMethod(), binding.getFrame().getBlock(), EvalType.BINDING_EVAL, bindingGiven);
         } finally {
             context.postEvalWithBinding(binding, lastFrame);
         }

--- a/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
@@ -151,7 +151,7 @@ public class InterpreterEngine {
                         break;
                     case CALL_OP:
                         if (profile) Profiler.updateCallSite(instr, interpreterContext.getScope(), scopeVersion);
-                        processCall(context, instr, operation, currDynScope, currScope, temp, self, name, block);
+                        processCall(context, instr, operation, currDynScope, currScope, temp, self, name);
                         break;
                     case RET_OP:
                         return processReturnOp(context, block, instr, operation, currDynScope, temp, self, currScope);
@@ -287,7 +287,7 @@ public class InterpreterEngine {
         }
     }
 
-    protected static void processCall(ThreadContext context, Instr instr, Operation operation, DynamicScope currDynScope, StaticScope currScope, Object[] temp, IRubyObject self, String frameName, Block selfBlock) {
+    protected static void processCall(ThreadContext context, Instr instr, Operation operation, DynamicScope currDynScope, StaticScope currScope, Object[] temp, IRubyObject self, String name) {
         Object result;
 
         switch(operation) {
@@ -360,9 +360,7 @@ public class InterpreterEngine {
                 instr.interpret(context, currScope, currDynScope, self, temp);
                 break;
             case FRAME_NAME_CALL:
-                setResult(temp, currDynScope, instr,
-                        ((FrameNameCallInstr) instr).getFrameName(
-                                context, self, selfBlock == null ? frameName : IRRuntimeHelpers.getFrameNameFromBlock(selfBlock)));
+                setResult(temp, currDynScope, instr, ((FrameNameCallInstr) instr).getFrameName(context, self, name));
                 break;
             case CALL:
             default:

--- a/core/src/main/java/org/jruby/ir/interpreter/StartupInterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/StartupInterpreterEngine.java
@@ -61,7 +61,7 @@ public class StartupInterpreterEngine extends InterpreterEngine {
                         break;
                     case CALL_OP:
                         if (profile) Profiler.updateCallSite(instr, interpreterContext.getScope(), scopeVersion);
-                        processCall(context, instr, operation, currDynScope, currScope, temp, self, name, block);
+                        processCall(context, instr, operation, currDynScope, currScope, temp, self, name);
                         break;
                     case RET_OP:
                         return processReturnOp(context, block, instr, operation, currDynScope, temp, self, currScope);

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1925,7 +1925,7 @@ public class IRRuntimeHelpers {
     public static IRubyObject invokeModuleBody(ThreadContext context, DynamicMethod method) {
         RubyModule implClass = method.getImplementationClass();
 
-        return method.call(context, implClass, implClass, null, Block.NULL_BLOCK);
+        return method.call(context, implClass, implClass, "", Block.NULL_BLOCK);
     }
 
     @JIT

--- a/core/src/main/java/org/jruby/ir/targets/indy/FrameNameSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/FrameNameSite.java
@@ -1,7 +1,6 @@
 package org.jruby.ir.targets.indy;
 
 import com.headius.invokebinder.Binder;
-import org.jruby.RubyNil;
 import org.jruby.RubySymbol;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
@@ -59,7 +58,7 @@ public class FrameNameSite extends MutableCallSite {
         if (entry.method.isBuiltin()) {
             target = Binder.from(type())
                     .permute(2)
-                    .append(context.runtime.getSymbolTable(), context.nil)
+                    .append(context.runtime.getSymbolTable())
                     .prepend(this)
                     .invokeVirtualQuiet(methodName);
         } else {
@@ -73,18 +72,14 @@ public class FrameNameSite extends MutableCallSite {
         return (IRubyObject) target.invokeExact(context, self, frameName);
     }
 
-    public IRubyObject __callee__(String frameName, RubySymbol.SymbolTable symbolTable, RubyNil nil) {
-        if (frameName == null) return nil;
-
+    public IRubyObject __callee__(String frameName, RubySymbol.SymbolTable symbolTable) {
         if (frameName.charAt(0) != '\0') {
             return getSimpleName(frameName, symbolTable);
         }
         return symbolTable.getCalleeSymbolFromCompound(frameName);
     }
 
-    public IRubyObject __method__(String frameName, RubySymbol.SymbolTable symbolTable, RubyNil nil) {
-        if (frameName == null) return nil;
-
+    public IRubyObject __method__(String frameName, RubySymbol.SymbolTable symbolTable) {
         if (frameName.charAt(0) != '\0') {
             return getSimpleName(frameName, symbolTable);
         }


### PR DESCRIPTION
Mostly reverting places where I tried to null out or dig up the proper frame method name for non-method scopes, many of which have no frame method name. We need to re-example all frame name and binding name (which frequently doesn't match) logic to ensure we're passing an appropriate method name through for both backtraces and `__method__`.