### PR TITLE
Synchronize state in AbstractVariable and Argv

### DIFF
--- a/core/src/main/java/org/jruby/embed/variable/AbstractVariable.java
+++ b/core/src/main/java/org/jruby/embed/variable/AbstractVariable.java
@@ -49,10 +49,10 @@ abstract class AbstractVariable implements BiVariable {
      */
     protected final IRubyObject receiver;
     protected final String name;
-    protected Object javaObject = null;
-    protected Class javaType = null;
-    protected IRubyObject rubyObject = null;
-    protected boolean fromRuby;
+    protected volatile Object javaObject;
+    protected volatile Class javaType;
+    protected volatile IRubyObject rubyObject;
+    protected volatile boolean fromRuby;
 
     /**
      * Constructor used when this variable is originaed from Java.
@@ -94,7 +94,7 @@ abstract class AbstractVariable implements BiVariable {
         return (RubyObject) receiver.getRuntime().getTopSelf();
     }
 
-    protected void updateByJavaObject(final Ruby runtime, Object... values) {
+    protected synchronized void updateByJavaObject(final Ruby runtime, Object... values) {
         assert values != null;
         javaObject = values[0];
         if (javaObject == null) {
@@ -108,7 +108,7 @@ abstract class AbstractVariable implements BiVariable {
         fromRuby = false;
     }
 
-    protected void updateRubyObject(final IRubyObject rubyObject) {
+    protected synchronized void updateRubyObject(final IRubyObject rubyObject) {
         if ( rubyObject == null ) return;
         this.rubyObject = rubyObject;
         this.javaType = null;
@@ -134,7 +134,7 @@ abstract class AbstractVariable implements BiVariable {
         return name;
     }
 
-    public Object getJavaObject() {
+    public synchronized Object getJavaObject() {
         if (rubyObject == null) return javaObject;
 
         if (javaType != null) { // Java originated variables

--- a/core/src/main/java/org/jruby/embed/variable/Argv.java
+++ b/core/src/main/java/org/jruby/embed/variable/Argv.java
@@ -114,7 +114,7 @@ public class Argv extends AbstractVariable {
      * invoked during EvalUnit#run() is executed.
      */
     @Override
-    public void inject() {
+    public synchronized void inject() {
         final Ruby runtime = getRuntime();
 
         final RubyArray argv = RubyArray.newArray(runtime);
@@ -141,7 +141,7 @@ public class Argv extends AbstractVariable {
      * this variable in top self.
      */
     @Override
-    public void remove() {
+    public synchronized void remove() {
         this.javaObject = new ArrayList();
         inject();
     }
@@ -173,7 +173,7 @@ public class Argv extends AbstractVariable {
     }
 
     // ARGV appears to require special treatment, leaving javaType intact
-    protected void updateRubyObject(final IRubyObject rubyObject) {
+    protected synchronized void updateRubyObject(final IRubyObject rubyObject) {
         if ( rubyObject == null ) return;
         this.rubyObject = rubyObject;
     }
@@ -193,7 +193,7 @@ public class Argv extends AbstractVariable {
 
     @Override
     @SuppressWarnings("unchecked")
-    public Object getJavaObject() {
+    public synchronized Object getJavaObject() {
         if ( rubyObject == null || ! fromRuby ) return javaObject;
 
         final RubyArray ary = (RubyArray) rubyObject;


### PR DESCRIPTION
These fields are changed together but without any synchronization or atomicity. Simplest fix for now is to synchronize the methods and mark them as volatile.

Fixes #8178

I looked over other descendants of AbstractVariable but none of them had state changes like Argv.

I also tried to figure out a way to encapsulate those fields better but I will look at that a different time after learning why these variables work this way.