### PR TITLE
More string interpolation optimizations

### DIFF
--- a/bench/bench_block_given.rb
+++ b/bench/bench_block_given.rb
@@ -9,10 +9,11 @@ def foo2
 end
 
 Benchmark.ips do |bm|
+  pr = proc { }
   bm.report("block") do |i|
     while i > 0
       i-=1
-      foo { }; foo { }; foo { }; foo { }; foo { }; foo { }; foo { }; foo { }; foo { }; foo { }
+      foo &pr; foo &pr; foo &pr; foo &pr; foo &pr; foo &pr; foo &pr; foo &pr; foo &pr; foo &pr
     end
   end
 
@@ -26,7 +27,7 @@ Benchmark.ips do |bm|
   bm.report("defined block") do |i|
     while i > 0
       i-=1
-      foo2 { }; foo2 { }; foo2 { }; foo2 { }; foo2 { }; foo2 { }; foo2 { }; foo2 { }; foo2 { }; foo2 { }
+      foo2 &pr; foo2 &pr; foo2 &pr; foo2 &pr; foo2 &pr; foo2 &pr; foo2 &pr; foo2 &pr; foo2 &pr; foo2 &pr
     end
   end
 

--- a/bench/bench_string_interpolation.rb
+++ b/bench/bench_string_interpolation.rb
@@ -2,7 +2,7 @@ require 'benchmark/ips'
 
 class Stringable
   def to_s
-    "quux"
+    "quux".freeze
   end
 end
 
@@ -96,12 +96,31 @@ Benchmark.ips {|bm|
     a
   }
 
+  bm.report('"foo#{n}bar#{n}baz#{n}" fixnum') {|n|
+    a = nil
+    while n > 0
+      n-=1
+      a = "foo#{n}bar#{n}baz"
+    end
+    a
+  }
+
   bm.report('"#{x}#{x}#{x}#{x}#{x}" to_s') {|n|
     a = nil
     x = Stringable.new
     while n > 0
       n-=1
       a = "#{x}#{x}#{x}#{x}#{x}"
+    end
+    a
+  }
+
+  bm.report('"#{x}#{x}#{x}#{x}#{x}#{x}#{x}#{x}#{x}#{x}" to_s') {|n|
+    a = nil
+    x = Stringable.new
+    while n > 0
+      n-=1
+      a = "#{x}#{x}#{x}#{x}#{x}#{x}#{x}#{x}#{x}#{x}"
     end
     a
   }


### PR DESCRIPTION
The string interpolation optimizations in #8180 left some improvements on the table. This PR implements those missing bits.

* The buffer created for the initial string when starting from a static segment was re-copying the buffer twice.
* Encoding was being re-set multiple times for no reason.

I also added more logging of dstring forms in the indy site and some additional cases in the benchmark. It's now consistently much faster than the old logic.