### PR TITLE
Fix IO#each_line specs

### DIFF
--- a/core/src/main/java/org/jruby/RubyArgsFile.java
+++ b/core/src/main/java/org/jruby/RubyArgsFile.java
@@ -43,6 +43,8 @@ import static org.jruby.RubyArgsFile.Next.NextFile;
 import static org.jruby.RubyArgsFile.Next.Stream;
 import static org.jruby.RubyEnumerator.enumeratorize;
 import static org.jruby.anno.FrameField.LASTLINE;
+import static org.jruby.runtime.ThreadContext.CALL_KEYWORD;
+import static org.jruby.runtime.ThreadContext.resetCallInfo;
 import static org.jruby.runtime.Visibility.PRIVATE;
 
 import org.jruby.anno.JRubyMethod;
@@ -362,6 +364,8 @@ public class RubyArgsFile extends RubyObject {
 
     // MRI: argf_getline
     private static IRubyObject argf_getline(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        boolean keywords = (resetCallInfo(context) & CALL_KEYWORD) != 0;
+
         Ruby runtime = context.runtime;
 
         IRubyObject line;
@@ -379,7 +383,7 @@ public class RubyArgsFile extends RubyObject {
                 if (args.length == 0 && runtime.getRecordSeparatorVar().get() == runtime.getGlobalVariables().getDefaultSeparator()) {
                     line = (currentFile).gets(context);
                 } else {
-                    line = Getline.getlineCall(context, GETLINE, currentFile, currentFile.getReadEncoding(), args);
+                    line = Getline.getlineCall(context, GETLINE, currentFile, currentFile.getReadEncoding(), keywords, args);
                 }
 
                 if (line.isNil() && data.next_p != Stream) {

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -3723,21 +3723,21 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), block);
     }
 
-    @JRubyMethod
+    @JRubyMethod(keywords = true)
     public IRubyObject each_line(final ThreadContext context, IRubyObject arg0, final Block block) {
         if (!block.isGiven()) return enumeratorize(context.runtime, this, "each_line");
 
         return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), arg0, block);
     }
 
-    @JRubyMethod
+    @JRubyMethod(keywords = true)
     public IRubyObject each_line(final ThreadContext context, IRubyObject arg0, IRubyObject arg1, final Block block) {
         if (!block.isGiven()) return enumeratorize(context.runtime, this, "each_line");
 
         return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), arg0, arg1, block);
     }
 
-    @JRubyMethod
+    @JRubyMethod(keywords = true)
     public IRubyObject each_line(final ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, final Block block) {
         if (!block.isGiven()) return enumeratorize(context.runtime, this, "each_line");
 

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -108,7 +108,7 @@ import static com.headius.backport9.buffer.Buffers.limitBuffer;
 import static org.jruby.RubyEnumerator.enumeratorize;
 import static org.jruby.anno.FrameField.LASTLINE;
 import static org.jruby.api.Error.typeError;
-import static org.jruby.runtime.ThreadContext.hasKeywords;
+import static org.jruby.runtime.ThreadContext.*;
 import static org.jruby.runtime.Visibility.*;
 import static org.jruby.util.RubyStringBuilder.str;
 import static org.jruby.util.RubyStringBuilder.types;
@@ -2543,21 +2543,24 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     }
 
     // rb_io_gets_m
-    @JRubyMethod(name = "gets", writes = LASTLINE)
+    @JRubyMethod(name = "gets", writes = LASTLINE, keywords = true)
     public IRubyObject gets(ThreadContext context, IRubyObject arg) {
-        return Getline.getlineCall(context, GETLINE, this, getReadEncoding(context), arg);
+        boolean keywords = (resetCallInfo(context) & CALL_KEYWORD) != 0;
+        return Getline.getlineCall(context, GETLINE, this, getReadEncoding(context), arg, keywords);
     }
 
     // rb_io_gets_m
-    @JRubyMethod(name = "gets", writes = LASTLINE)
+    @JRubyMethod(name = "gets", writes = LASTLINE, keywords = true)
     public IRubyObject gets(ThreadContext context, IRubyObject rs, IRubyObject limit_arg) {
-        return Getline.getlineCall(context, GETLINE, this, getReadEncoding(context), rs, limit_arg);
+        boolean keywords = (resetCallInfo(context) & CALL_KEYWORD) != 0;
+        return Getline.getlineCall(context, GETLINE, this, getReadEncoding(context), rs, limit_arg, keywords);
     }
 
     // rb_io_gets_m
-    @JRubyMethod(name = "gets", writes = LASTLINE)
+    @JRubyMethod(name = "gets", writes = LASTLINE, keywords = true)
     public IRubyObject gets(ThreadContext context, IRubyObject rs, IRubyObject limit_arg, IRubyObject opt) {
-        return Getline.getlineCall(context, GETLINE, this, getReadEncoding(context), rs, limit_arg, opt);
+        boolean keywords = (resetCallInfo(context) & CALL_KEYWORD) != 0;
+        return Getline.getlineCall(context, GETLINE, this, getReadEncoding(context), rs, limit_arg, opt, keywords);
     }
 
     private static final Getline.Callback<RubyIO, IRubyObject> GETLINE = new Getline.Callback<RubyIO, IRubyObject>() {
@@ -2917,7 +2920,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return line;
     }
 
-    @JRubyMethod(name = "readline", writes = LASTLINE)
+    @JRubyMethod(name = "readline", writes = LASTLINE, keywords = true)
     public IRubyObject readline(ThreadContext context, IRubyObject separator) {
         IRubyObject line = gets(context, separator);
 
@@ -3681,23 +3684,26 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     @JRubyMethod
     public IRubyObject each(final ThreadContext context, IRubyObject arg0, final Block block) {
+        boolean keywords = (resetCallInfo(context) & CALL_KEYWORD) != 0;
         if (!block.isGiven()) return enumeratorize(context.runtime, this, "each");
 
-        return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), arg0, block);
+        return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), arg0, block, keywords);
     }
 
     @JRubyMethod
     public IRubyObject each(final ThreadContext context, IRubyObject arg0, IRubyObject arg1, final Block block) {
+        boolean keywords = (resetCallInfo(context) & CALL_KEYWORD) != 0;
         if (!block.isGiven()) return enumeratorize(context.runtime, this, "each");
 
-        return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), arg0, arg1, block);
+        return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), arg0, arg1, block, keywords);
     }
 
     @JRubyMethod
     public IRubyObject each(final ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, final Block block) {
+        boolean keywords = (resetCallInfo(context) & CALL_KEYWORD) != 0;
         if (!block.isGiven()) return enumeratorize(context.runtime, this, "each");
 
-        return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), arg0, arg1, arg2, block);
+        return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), arg0, arg1, arg2, block, keywords);
     }
 
     public IRubyObject each(final ThreadContext context, IRubyObject[]args, final Block block) {
@@ -3725,23 +3731,29 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     @JRubyMethod(keywords = true)
     public IRubyObject each_line(final ThreadContext context, IRubyObject arg0, final Block block) {
+        boolean keywords = (resetCallInfo(context) & CALL_KEYWORD) != 0;
+
         if (!block.isGiven()) return enumeratorize(context.runtime, this, "each_line", arg0);
 
-        return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), arg0, block);
+        return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), arg0, block, keywords);
     }
 
     @JRubyMethod(keywords = true)
     public IRubyObject each_line(final ThreadContext context, IRubyObject arg0, IRubyObject arg1, final Block block) {
+        boolean keywords = (resetCallInfo(context) & CALL_KEYWORD) != 0;
+
         if (!block.isGiven()) return enumeratorize(context.runtime, this, "each_line", arg0, arg1);
 
-        return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), arg0, arg1, block);
+        return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), arg0, arg1, block, keywords);
     }
 
     @JRubyMethod(keywords = true)
     public IRubyObject each_line(final ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, final Block block) {
+        boolean keywords = (resetCallInfo(context) & CALL_KEYWORD) != 0;
+
         if (!block.isGiven()) return enumeratorize(context.runtime, this, "each_line", arg0, arg1, arg2);
 
-        return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), arg0, arg1, arg2, block);
+        return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), arg0, arg1, arg2, block, keywords);
     }
 
     public IRubyObject each_line(final ThreadContext context, IRubyObject[]args, final Block block) {
@@ -3771,19 +3783,22 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return Getline.getlineCall(context, GETLINE_ARY, this, getReadEncoding(context));
     }
 
-    @JRubyMethod(name = "readlines")
+    @JRubyMethod(name = "readlines", keywords = true)
     public RubyArray readlines(ThreadContext context, IRubyObject arg0) {
-        return Getline.getlineCall(context, GETLINE_ARY, this, getReadEncoding(context), arg0);
+        boolean keywords = (resetCallInfo(context) & CALL_KEYWORD) != 0;
+        return Getline.getlineCall(context, GETLINE_ARY, this, getReadEncoding(context), arg0, keywords);
     }
 
-    @JRubyMethod(name = "readlines")
+    @JRubyMethod(name = "readlines", keywords = true)
     public RubyArray readlines(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
-        return Getline.getlineCall(context, GETLINE_ARY, this, getReadEncoding(context), arg0, arg1);
+        boolean keywords = (resetCallInfo(context) & CALL_KEYWORD) != 0;
+        return Getline.getlineCall(context, GETLINE_ARY, this, getReadEncoding(context), arg0, arg1, keywords);
     }
 
-    @JRubyMethod(name = "readlines")
+    @JRubyMethod(name = "readlines", keywords = true)
     public RubyArray readlines(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
-        return Getline.getlineCall(context, GETLINE_ARY, this, getReadEncoding(context), arg0, arg1, arg2);
+        boolean keywords = (resetCallInfo(context) & CALL_KEYWORD) != 0;
+        return Getline.getlineCall(context, GETLINE_ARY, this, getReadEncoding(context), arg0, arg1, arg2, keywords);
     }
 
     private Encoding getReadEncoding(ThreadContext context) {
@@ -3820,6 +3835,8 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     // rb_io_s_foreach
     private static IRubyObject foreachInternal(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
+        boolean keywords = (resetCallInfo(context) & CALL_KEYWORD) != 0;
+
         IRubyObject opt = ArgsUtil.getOptionsArg(context.runtime, args);
         RubyIO io = openKeyArgs(context, recv, args, opt);
         IRubyObject nil = context.nil;
@@ -3836,10 +3853,10 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
                     Getline.getlineCall(context, GETLINE_YIELD, io, io.getReadEncoding(context), block);
                     break;
                 case 2:
-                    Getline.getlineCall(context, GETLINE_YIELD, io, io.getReadEncoding(context), args[1], block);
+                    Getline.getlineCall(context, GETLINE_YIELD, io, io.getReadEncoding(context), args[1], block, keywords);
                     break;
                 case 3:
-                    Getline.getlineCall(context, GETLINE_YIELD, io, io.getReadEncoding(context), args[1], args[2], block);
+                    Getline.getlineCall(context, GETLINE_YIELD, io, io.getReadEncoding(context), args[1], args[2], block, keywords);
                     break;
             }
         } finally {
@@ -3850,7 +3867,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return nil;
     }
 
-    @JRubyMethod(name = "foreach", required = 1, optional = 3, checkArity = false, meta = true, writes = LASTLINE)
+    @JRubyMethod(name = "foreach", required = 1, optional = 3, checkArity = false, meta = true, writes = LASTLINE, keywords = true)
     public static IRubyObject foreach(final ThreadContext context, IRubyObject recv, IRubyObject[] args, final Block block) {
         Arity.checkArgumentCount(context, args, 1, 4);
 
@@ -4342,10 +4359,15 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     }
 
     // rb_io_s_readlines
-    @JRubyMethod(name = "readlines", required = 1, optional = 3, checkArity = false, meta = true)
+    @JRubyMethod(name = "readlines", required = 1, optional = 3, checkArity = false, meta = true, keywords = true)
     public static IRubyObject readlines(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block unusedBlock) {
+        // FIXME: readlines and friends all look at kwargs deep in IO code but we also do it at beginning of methods
+        // as well.  Any internal dyndispatch will reset callInfo like in the next few lines.  I save callInfo here
+        // to be restored to save it for the deeper kwargs code.
+        int callInfo = context.callInfo;
         IRubyObject opt = ArgsUtil.getOptionsArg(context.runtime, args);
         final RubyIO io = openKeyArgs(context, recv, args, opt);
+        context.callInfo = callInfo;
         try {
             switch (args.length) {
                 case 1:

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -3682,7 +3682,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), block);
     }
 
-    @JRubyMethod
+    @JRubyMethod(keywords = true)
     public IRubyObject each(final ThreadContext context, IRubyObject arg0, final Block block) {
         boolean keywords = (resetCallInfo(context) & CALL_KEYWORD) != 0;
         if (!block.isGiven()) return enumeratorize(context.runtime, this, "each");
@@ -3690,7 +3690,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), arg0, block, keywords);
     }
 
-    @JRubyMethod
+    @JRubyMethod(keywords = true)
     public IRubyObject each(final ThreadContext context, IRubyObject arg0, IRubyObject arg1, final Block block) {
         boolean keywords = (resetCallInfo(context) & CALL_KEYWORD) != 0;
         if (!block.isGiven()) return enumeratorize(context.runtime, this, "each");
@@ -3698,7 +3698,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), arg0, arg1, block, keywords);
     }
 
-    @JRubyMethod
+    @JRubyMethod(keywords = true)
     public IRubyObject each(final ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, final Block block) {
         boolean keywords = (resetCallInfo(context) & CALL_KEYWORD) != 0;
         if (!block.isGiven()) return enumeratorize(context.runtime, this, "each");

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -3725,21 +3725,21 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     @JRubyMethod(keywords = true)
     public IRubyObject each_line(final ThreadContext context, IRubyObject arg0, final Block block) {
-        if (!block.isGiven()) return enumeratorize(context.runtime, this, "each_line");
+        if (!block.isGiven()) return enumeratorize(context.runtime, this, "each_line", arg0);
 
         return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), arg0, block);
     }
 
     @JRubyMethod(keywords = true)
     public IRubyObject each_line(final ThreadContext context, IRubyObject arg0, IRubyObject arg1, final Block block) {
-        if (!block.isGiven()) return enumeratorize(context.runtime, this, "each_line");
+        if (!block.isGiven()) return enumeratorize(context.runtime, this, "each_line", arg0, arg1);
 
         return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), arg0, arg1, block);
     }
 
     @JRubyMethod(keywords = true)
     public IRubyObject each_line(final ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, final Block block) {
-        if (!block.isGiven()) return enumeratorize(context.runtime, this, "each_line");
+        if (!block.isGiven()) return enumeratorize(context.runtime, this, "each_line", arg0, arg1, arg2);
 
         return Getline.getlineCall(context, GETLINE_YIELD, this, getReadEncoding(context), arg0, arg1, arg2, block);
     }

--- a/core/src/main/java/org/jruby/util/io/Getline.java
+++ b/core/src/main/java/org/jruby/util/io/Getline.java
@@ -26,20 +26,24 @@ public class Getline {
         return getlineCall(context, getline, self, enc_io, 0, null, null, null, Block.NULL_BLOCK, false);
     }
 
+    // Work around native extensions calling without marking keywords annotation AND not calling newer non-deprecated methods.
     @Deprecated
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
                                                                         Self self, Encoding enc_io, IRubyObject arg0) {
-        return getlineCall(context, getline, self, enc_io, 1, arg0, null, null, Block.NULL_BLOCK, false);
+        boolean keywords = arg0 instanceof RubyHash;
+        return getlineCall(context, getline, self, enc_io, 1, arg0, null, null, Block.NULL_BLOCK, keywords);
     }
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
                                                                         Self self, Encoding enc_io, IRubyObject arg0, boolean keywords) {
         return getlineCall(context, getline, self, enc_io, 1, arg0, null, null, Block.NULL_BLOCK, keywords);
     }
 
+    // Work around native extensions calling without marking keywords annotation AND not calling newer non-deprecated methods.
     @Deprecated
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
                                                                         Self self, Encoding enc_io, IRubyObject arg0, IRubyObject arg1) {
-        return getlineCall(context, getline, self, enc_io, 2, arg0, arg1, null, Block.NULL_BLOCK, false);
+        boolean keywords = arg1 instanceof RubyHash;
+        return getlineCall(context, getline, self, enc_io, 2, arg0, arg1, null, Block.NULL_BLOCK, keywords);
     }
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
                                                                         Self self, Encoding enc_io, IRubyObject arg0,
@@ -47,11 +51,13 @@ public class Getline {
         return getlineCall(context, getline, self, enc_io, 2, arg0, arg1, null, Block.NULL_BLOCK, keywords);
     }
 
+    // Work around native extensions calling without marking keywords annotation AND not calling newer non-deprecated methods.
     @Deprecated
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
                                                                         Self self, Encoding enc_io, IRubyObject arg0,
                                                                         IRubyObject arg1, IRubyObject arg2) {
-        return getlineCall(context, getline, self, enc_io, 3, arg0, arg1, arg2, Block.NULL_BLOCK);
+        boolean keywords = arg2 instanceof RubyHash;
+        return getlineCall(context, getline, self, enc_io, 3, arg0, arg1, arg2, Block.NULL_BLOCK, keywords);
     }
 
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
@@ -65,10 +71,12 @@ public class Getline {
         return getlineCall(context, getline, self, enc_io, 0, null, null, null, block);
     }
 
+    // Work around native extensions calling without marking keywords annotation AND not calling newer non-deprecated methods.
     @Deprecated
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
                                                                         Self self, Encoding enc_io, IRubyObject arg0, Block block) {
-        return getlineCall(context, getline, self, enc_io, 1, arg0, null, null, block, false);
+        boolean keywords = arg0 instanceof RubyHash;
+        return getlineCall(context, getline, self, enc_io, 1, arg0, null, null, block, keywords);
     }
 
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
@@ -77,11 +85,13 @@ public class Getline {
         return getlineCall(context, getline, self, enc_io, 1, arg0, null, null, block, keywords);
     }
 
+    // Work around native extensions calling without marking keywords annotation AND not calling newer non-deprecated methods.
     @Deprecated
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
                                                                         Self self, Encoding enc_io, IRubyObject arg0,
                                                                         IRubyObject arg1, Block block) {
-        return getlineCall(context, getline, self, enc_io, 2, arg0, arg1, null, block, false);
+        boolean keywords = arg1 instanceof RubyHash;
+        return getlineCall(context, getline, self, enc_io, 2, arg0, arg1, null, block, keywords);
     }
 
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
@@ -90,11 +100,13 @@ public class Getline {
         return getlineCall(context, getline, self, enc_io, 2, arg0, arg1, null, block, keywords);
     }
 
+    // Work around native extensions calling without marking keywords annotation AND not calling newer non-deprecated methods.
     @Deprecated
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
                                                                         Self self, Encoding enc_io, IRubyObject arg0,
                                                                         IRubyObject arg1, IRubyObject arg2, Block block) {
-        return getlineCall(context, getline, self, enc_io, 3, arg0, arg1, arg2, block);
+        boolean keywords = arg2 instanceof RubyHash;
+        return getlineCall(context, getline, self, enc_io, 3, arg0, arg1, arg2, block, keywords);
     }
 
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
@@ -137,11 +149,17 @@ public class Getline {
         }
     }
 
+    // Work around native extensions calling without marking keywords annotation AND not calling newer non-deprecated methods.
+    // Note: some callers use this as the single entry point vs calling into the specific overload so we need to do extra null
+    //   checking to figure out actual last valid passed argument.
     @Deprecated
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
                                                                         Self self, Encoding enc_io, int argc, IRubyObject arg0,
                                                                         IRubyObject arg1, IRubyObject arg2, Block block) {
-        return getlineCall(context, getline, self, enc_io, argc, arg0, arg1, arg2, block, false);
+        IRubyObject lastArg = arg2 == null ? (arg1 == null ? (arg0 == null ? null : arg0) : arg1) : arg2;
+        boolean keywords = lastArg != null && lastArg instanceof RubyHash;
+
+        return getlineCall(context, getline, self, enc_io, argc, arg0, arg1, arg2, block, keywords);
     }
 
     public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,

--- a/core/src/main/java/org/jruby/util/io/Getline.java
+++ b/core/src/main/java/org/jruby/util/io/Getline.java
@@ -100,7 +100,7 @@ public class Getline {
             }
         } else {
             IRubyObject chompKwarg = ArgsUtil.extractKeywordArg(context, "chomp", (RubyHash) opt);
-            if (chompKwarg != null) {
+            if (chompKwarg != null && (sepArg == null || !sepArg.isNil())) {
                 chomp = chompKwarg.isTrue();
             }
         }

--- a/core/src/main/java/org/jruby/util/io/Getline.java
+++ b/core/src/main/java/org/jruby/util/io/Getline.java
@@ -21,55 +21,132 @@ public class Getline {
         Return getline(ThreadContext context, Self self, IRubyObject rs, int limit, boolean chomp, Block block);
     }
 
-    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline, Self self, Encoding enc_io) {
-        return getlineCall(context, getline, self, enc_io, 0, null, null, null, Block.NULL_BLOCK);
+    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
+                                                                        Self self, Encoding enc_io) {
+        return getlineCall(context, getline, self, enc_io, 0, null, null, null, Block.NULL_BLOCK, false);
     }
 
-    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline, Self self, Encoding enc_io, IRubyObject arg0) {
-        return getlineCall(context, getline, self, enc_io, 1, arg0, null, null, Block.NULL_BLOCK);
+    @Deprecated
+    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
+                                                                        Self self, Encoding enc_io, IRubyObject arg0) {
+        return getlineCall(context, getline, self, enc_io, 1, arg0, null, null, Block.NULL_BLOCK, false);
+    }
+    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
+                                                                        Self self, Encoding enc_io, IRubyObject arg0, boolean keywords) {
+        return getlineCall(context, getline, self, enc_io, 1, arg0, null, null, Block.NULL_BLOCK, keywords);
     }
 
-    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline, Self self, Encoding enc_io, IRubyObject arg0, IRubyObject arg1) {
-        return getlineCall(context, getline, self, enc_io, 2, arg0, arg1, null, Block.NULL_BLOCK);
+    @Deprecated
+    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
+                                                                        Self self, Encoding enc_io, IRubyObject arg0, IRubyObject arg1) {
+        return getlineCall(context, getline, self, enc_io, 2, arg0, arg1, null, Block.NULL_BLOCK, false);
+    }
+    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
+                                                                        Self self, Encoding enc_io, IRubyObject arg0,
+                                                                        IRubyObject arg1, boolean keywords) {
+        return getlineCall(context, getline, self, enc_io, 2, arg0, arg1, null, Block.NULL_BLOCK, keywords);
     }
 
-    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline, Self self, Encoding enc_io, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
+    @Deprecated
+    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
+                                                                        Self self, Encoding enc_io, IRubyObject arg0,
+                                                                        IRubyObject arg1, IRubyObject arg2) {
         return getlineCall(context, getline, self, enc_io, 3, arg0, arg1, arg2, Block.NULL_BLOCK);
     }
 
-    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline, Self self, Encoding enc_io, Block block) {
+    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
+                                                                        Self self, Encoding enc_io, IRubyObject arg0,
+                                                                        IRubyObject arg1, IRubyObject arg2, boolean keywords) {
+        return getlineCall(context, getline, self, enc_io, 3, arg0, arg1, arg2, Block.NULL_BLOCK, keywords);
+    }
+
+    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
+                                                                        Self self, Encoding enc_io, Block block) {
         return getlineCall(context, getline, self, enc_io, 0, null, null, null, block);
     }
 
-    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline, Self self, Encoding enc_io, IRubyObject arg0, Block block) {
-        return getlineCall(context, getline, self, enc_io, 1, arg0, null, null, block);
+    @Deprecated
+    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
+                                                                        Self self, Encoding enc_io, IRubyObject arg0, Block block) {
+        return getlineCall(context, getline, self, enc_io, 1, arg0, null, null, block, false);
     }
 
-    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline, Self self, Encoding enc_io, IRubyObject arg0, IRubyObject arg1, Block block) {
-        return getlineCall(context, getline, self, enc_io, 2, arg0, arg1, null, block);
+    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
+                                                                        Self self, Encoding enc_io, IRubyObject arg0,
+                                                                        Block block, boolean keywords) {
+        return getlineCall(context, getline, self, enc_io, 1, arg0, null, null, block, keywords);
     }
 
-    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline, Self self, Encoding enc_io, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
+    @Deprecated
+    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
+                                                                        Self self, Encoding enc_io, IRubyObject arg0,
+                                                                        IRubyObject arg1, Block block) {
+        return getlineCall(context, getline, self, enc_io, 2, arg0, arg1, null, block, false);
+    }
+
+    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
+                                                                        Self self, Encoding enc_io, IRubyObject arg0,
+                                                                        IRubyObject arg1, Block block, boolean keywords) {
+        return getlineCall(context, getline, self, enc_io, 2, arg0, arg1, null, block, keywords);
+    }
+
+    @Deprecated
+    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
+                                                                        Self self, Encoding enc_io, IRubyObject arg0,
+                                                                        IRubyObject arg1, IRubyObject arg2, Block block) {
         return getlineCall(context, getline, self, enc_io, 3, arg0, arg1, arg2, block);
     }
 
-    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline, Self self, Encoding enc_io, IRubyObject... args) {
+    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
+                                                                        Self self, Encoding enc_io, IRubyObject arg0,
+                                                                        IRubyObject arg1, IRubyObject arg2, Block block,
+                                                                        boolean keywords) {
+        return getlineCall(context, getline, self, enc_io, 3, arg0, arg1, arg2, block, keywords);
+    }
+
+    @Deprecated
+    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
+                                                                        Self self, Encoding enc_io, IRubyObject... args) {
         switch (args.length) {
             case 0:
-                return getlineCall(context, getline, self, enc_io);
+                return getlineCall(context, getline, self, enc_io, false);
             case 1:
-                return getlineCall(context, getline, self, enc_io, args[0]);
+                return getlineCall(context, getline, self, enc_io, false, args[0]);
             case 2:
-                return getlineCall(context, getline, self, enc_io, args[0], args[1]);
+                return getlineCall(context, getline, self, enc_io, false, args[0], args[1]);
             case 3:
-                return getlineCall(context, getline, self, enc_io, args[0], args[1], args[2]);
+                return getlineCall(context, getline, self, enc_io, false, args[0], args[1], args[2]);
             default:
                 throw context.runtime.newArgumentError(args.length, 0, 3);
         }
     }
 
-    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline, Self self, Encoding enc_io, int argc, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
-        boolean keywords = (resetCallInfo(context) & ThreadContext.CALL_KEYWORD) != 0;
+    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
+                                                                        Self self, Encoding enc_io, boolean keywords, IRubyObject... args) {
+        switch (args.length) {
+            case 0:
+                return getlineCall(context, getline, self, enc_io, keywords);
+            case 1:
+                return getlineCall(context, getline, self, enc_io, args[0], keywords);
+            case 2:
+                return getlineCall(context, getline, self, enc_io, args[0], args[1], keywords);
+            case 3:
+                return getlineCall(context, getline, self, enc_io, args[0], args[1], args[2], keywords);
+            default:
+                throw context.runtime.newArgumentError(args.length, 0, 3);
+        }
+    }
+
+    @Deprecated
+    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
+                                                                        Self self, Encoding enc_io, int argc, IRubyObject arg0,
+                                                                        IRubyObject arg1, IRubyObject arg2, Block block) {
+        return getlineCall(context, getline, self, enc_io, argc, arg0, arg1, arg2, block, false);
+    }
+
+    public static <Self, Return extends IRubyObject> Return getlineCall(ThreadContext context, Callback<Self, Return> getline,
+                                                                        Self self, Encoding enc_io, int argc, IRubyObject arg0,
+                                                                        IRubyObject arg1, IRubyObject arg2, Block block, boolean keywords) {
         final IRubyObject nil = context.nil;
 
         boolean chomp = false;


### PR DESCRIPTION
Fix IO#each_line specs

This will also fix a few other incidental methods which share the same code in IO.