### PR TITLE
Remove unused variable assignment from Fiddle::Pointer.to_ptr

### DIFF
--- a/lib/ruby/stdlib/fiddle/jruby.rb
+++ b/lib/ruby/stdlib/fiddle/jruby.rb
@@ -155,7 +155,6 @@ module Fiddle
     def self.to_ptr(value)
       if value.is_a?(String)
         cptr = Pointer.malloc(value.bytesize)
-        size = value.bytesize
         cptr.ffi_ptr.put_string(0, value)
         cptr
 
@@ -350,7 +349,7 @@ module Fiddle
     def ptr
       Pointer.new(ffi_ptr.get_pointer(0))
     end
-    
+
     def +@
       ptr
     end


### PR DESCRIPTION
It seems that the `size` variable defined in `Fiddle::Pointer.to_ptr` is never used:

https://github.com/jruby/jruby/blob/2ff07a3c2b6823fc541fc08d924f5bb53d50a371/lib/ruby/stdlib/fiddle/jruby.rb#L158

This triggers an "assigned but unused variable" warning if this code is loaded in verbose mode.
