### PR TITLE
Remove skipped tests from TestAssignment

### DIFF
--- a/test/mri/excludes/TestAssignment.rb
+++ b/test/mri/excludes/TestAssignment.rb
@@ -1,2 +1,0 @@
-exclude :test_assign_private_self, "disagreement about visibility of attrs (MRI #9907)"
-exclude :test_yield, "needs investigation"

--- a/test/mri/excludes/TestAssignmentGen.rb
+++ b/test/mri/excludes/TestAssignmentGen.rb
@@ -1,2 +1,0 @@
-exclude :test_assignment, "needs investigation"
-exclude :test_chainged_assign_command, "needs investigation"


### PR DESCRIPTION
All tests from `test_assigment.rb `are passing, so I think we can remove the excluded ones:

`bin/jruby test/mri/runner.rb  test/mri/ruby/test_assignment.rb```