### PR TITLE
Remove redundant (and slightly broken) to_int and to_f aliases

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -355,10 +355,6 @@ public abstract class JavaLang {
 
         static RubyClass define(final Ruby runtime, final RubyClass proxy) {
             proxy.defineAnnotatedMethods(Number.class);
-
-            proxy.defineAlias("to_int", "longValue");
-            proxy.defineAlias("to_f", "doubleValue");
-
             return proxy;
         }
 


### PR DESCRIPTION
This fixes https://github.com/jruby/jruby/issues/8244