### PR TITLE
Reduce deopt from print use of $_

### DIFF
--- a/bench/bench_print.rb
+++ b/bench/bench_print.rb
@@ -1,0 +1,60 @@
+require 'benchmark/ips'
+
+def do_print0(io)
+  io.print
+end
+
+def do_print1(io)
+  io.print ?x
+end
+
+def do_print2(io)
+  io.print ?x, ?x
+end
+
+def do_print3(io)
+  io.print ?x, ?x, ?x
+end
+
+def do_print4(io)
+  io.print ?x, ?x, ?x, ?x
+end
+
+Benchmark.ips do |bm|
+  io = File.open(IO::NULL, 'w')
+
+  bm.report("print no arg") do |i|
+    while i > 0
+      i-=1
+      do_print0(io);do_print0(io);do_print0(io);do_print0(io);do_print0(io);do_print0(io);do_print0(io);do_print0(io);do_print0(io);do_print0(io)
+    end
+  end
+
+  bm.report("print one arg") do |i|
+    while i > 0
+      i-=1
+      do_print1(io);do_print1(io);do_print1(io);do_print1(io);do_print1(io);do_print1(io);do_print1(io);do_print1(io);do_print1(io);do_print1(io)
+    end
+  end
+
+  bm.report("print two arg") do |i|
+    while i > 0
+      i-=1
+      do_print2(io);do_print2(io);do_print2(io);do_print2(io);do_print2(io);do_print2(io);do_print2(io);do_print2(io);do_print2(io);do_print2(io)
+    end
+  end
+
+  bm.report("print three arg") do |i|
+    while i > 0
+      i-=1
+      do_print3(io);do_print3(io);do_print3(io);do_print3(io);do_print3(io);do_print3(io);do_print3(io);do_print3(io);do_print3(io);do_print3(io)
+    end
+  end
+
+  bm.report("print four arg") do |i|
+    while i > 0
+      i-=1
+      do_print4(io);do_print4(io);do_print4(io);do_print4(io);do_print4(io);do_print4(io);do_print4(io);do_print4(io);do_print4(io);do_print4(io)
+    end
+  end
+end

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1828,17 +1828,17 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return print0(context, this);
     }
 
-    @JRubyMethod(reads = LASTLINE)
+    @JRubyMethod
     public IRubyObject print(ThreadContext context, IRubyObject arg0) {
         return print1(context, this, arg0);
     }
 
-    @JRubyMethod(reads = LASTLINE)
+    @JRubyMethod
     public IRubyObject print(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
         return print2(context, this, arg0, arg1);
     }
 
-    @JRubyMethod(reads = LASTLINE)
+    @JRubyMethod
     public IRubyObject print(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
         return print3(context, this, arg0, arg1, arg2);
     }

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1823,37 +1823,113 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return print(context, this, args);
     }
 
+    @JRubyMethod(reads = LASTLINE)
+    public IRubyObject print(ThreadContext context) {
+        return print0(context, this);
+    }
+
+    @JRubyMethod(reads = LASTLINE)
+    public IRubyObject print(ThreadContext context, IRubyObject arg0) {
+        return print1(context, this, arg0);
+    }
+
+    @JRubyMethod(reads = LASTLINE)
+    public IRubyObject print(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
+        return print2(context, this, arg0, arg1);
+    }
+
+    @JRubyMethod(reads = LASTLINE)
+    public IRubyObject print(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
+        return print3(context, this, arg0, arg1, arg2);
+    }
+
     /**
      * Print some objects to the stream.
      *
      * MRI: rb_io_print
      */
     public static IRubyObject print(ThreadContext context, IRubyObject out, IRubyObject[] args) {
+        switch (args.length) {
+            case 0:
+                return print0(context, out);
+            case 1:
+                return print1(context, out, args[0]);
+            case 2:
+                return print2(context, out, args[0], args[1]);
+            case 3:
+                return print3(context, out, args[0], args[1], args[2]);
+        }
+
         Ruby runtime = context.runtime;
         int i;
-        IRubyObject line;
         int argc = args.length;
         IRubyObject outputFS = runtime.getGlobalVariables().get("$,");
 
-        /* if no argument given, print `$_' */
-        if (argc == 0) {
-            argc = 1;
-            line = context.getLastLine();
-            args = new IRubyObject[]{line};
-        }
-        if (argc > 1 && !outputFS.isNil()) {
+        boolean fieldSeparatorNotNil = !outputFS.isNil();
+        if (fieldSeparatorNotNil) {
             runtime.getWarnings().warnDeprecated("$, is set to non-nil value");
         }
         for (i=0; i<argc; i++) {
-            if (!outputFS.isNil() && i>0) {
+            if (fieldSeparatorNotNil && i>0) {
                 write(context, out, outputFS);
             }
             write(context, out, args[i]);
         }
-        IRubyObject outputRS = runtime.getGlobalVariables().get("$\\");
-        if (argc > 0 && !outputRS.isNil()) {
+
+        writeRecordSeparator(context, out);
+
+        return context.nil;
+    }
+
+    public static IRubyObject print0(ThreadContext context, IRubyObject out) {
+        return print1(context, out, context.getLastLine());
+    }
+
+    public static IRubyObject print1(ThreadContext context, IRubyObject out, IRubyObject arg1) {
+        write(context, out, arg1);
+
+        writeRecordSeparator(context, out);
+
+        return context.nil;
+    }
+
+    private static void writeRecordSeparator(ThreadContext context, IRubyObject out) {
+        IRubyObject outputRS = context.runtime.getGlobalVariables().get("$\\");
+        if (!outputRS.isNil()) {
             write(context, out, outputRS);
         }
+    }
+
+    public static IRubyObject print2(ThreadContext context, IRubyObject out, IRubyObject arg0, IRubyObject arg1) {
+        Ruby runtime = context.runtime;
+
+        IRubyObject outputFS = runtime.getGlobalVariables().get("$,");
+        boolean fieldSeparatorNotNil = !outputFS.isNil();
+        if (fieldSeparatorNotNil) runtime.getWarnings().warnDeprecated("$, is set to non-nil value");
+
+        write(context, out, arg0);
+        if (fieldSeparatorNotNil) write(context, out, outputFS);
+        write(context, out, arg1);
+
+        writeRecordSeparator(context, out);
+
+        return context.nil;
+    }
+
+    public static IRubyObject print3(ThreadContext context, IRubyObject out, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
+        Ruby runtime = context.runtime;
+
+        IRubyObject outputFS = runtime.getGlobalVariables().get("$,");
+        boolean fieldSeparatorNotNil = !outputFS.isNil();
+        if (fieldSeparatorNotNil) runtime.getWarnings().warnDeprecated("$, is set to non-nil value");
+
+        write(context, out, arg0);
+        if (fieldSeparatorNotNil) write(context, out, outputFS);
+        write(context, out, arg1);
+        if (fieldSeparatorNotNil) write(context, out, outputFS);
+        write(context, out, arg2);
+
+        writeRecordSeparator(context, out);
 
         return context.nil;
     }

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -743,10 +743,29 @@ public class RubyKernel {
     }
 
     // rb_f_print
+    @JRubyMethod(module = true, visibility = PRIVATE, reads = LASTLINE)
+    public static IRubyObject print(ThreadContext context, IRubyObject recv) {
+        return RubyIO.print0(context, context.runtime.getGlobalVariables().get("$>"));
+    }
+
+    @JRubyMethod(module = true, visibility = PRIVATE, reads = LASTLINE)
+    public static IRubyObject print(ThreadContext context, IRubyObject recv, IRubyObject arg0) {
+        return RubyIO.print1(context, context.runtime.getGlobalVariables().get("$>"), arg0);
+    }
+
+    @JRubyMethod(module = true, visibility = PRIVATE, reads = LASTLINE)
+    public static IRubyObject print(ThreadContext context, IRubyObject recv, IRubyObject arg0, IRubyObject arg1) {
+        return RubyIO.print2(context, context.runtime.getGlobalVariables().get("$>"), arg0, arg1);
+    }
+
+    @JRubyMethod(module = true, visibility = PRIVATE, reads = LASTLINE)
+    public static IRubyObject print(ThreadContext context, IRubyObject recv, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
+        return RubyIO.print3(context, context.runtime.getGlobalVariables().get("$>"), arg0, arg1, arg2);
+    }
+
     @JRubyMethod(rest = true, module = true, visibility = PRIVATE, reads = LASTLINE)
     public static IRubyObject print(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
-        RubyIO.print(context, context.runtime.getGlobalVariables().get("$>"), args);
-        return context.nil;
+        return RubyIO.print(context, context.runtime.getGlobalVariables().get("$>"), args);
     }
 
     // rb_f_printf

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -748,17 +748,17 @@ public class RubyKernel {
         return RubyIO.print0(context, context.runtime.getGlobalVariables().get("$>"));
     }
 
-    @JRubyMethod(module = true, visibility = PRIVATE, reads = LASTLINE)
+    @JRubyMethod(module = true, visibility = PRIVATE)
     public static IRubyObject print(ThreadContext context, IRubyObject recv, IRubyObject arg0) {
         return RubyIO.print1(context, context.runtime.getGlobalVariables().get("$>"), arg0);
     }
 
-    @JRubyMethod(module = true, visibility = PRIVATE, reads = LASTLINE)
+    @JRubyMethod(module = true, visibility = PRIVATE)
     public static IRubyObject print(ThreadContext context, IRubyObject recv, IRubyObject arg0, IRubyObject arg1) {
         return RubyIO.print2(context, context.runtime.getGlobalVariables().get("$>"), arg0, arg1);
     }
 
-    @JRubyMethod(module = true, visibility = PRIVATE, reads = LASTLINE)
+    @JRubyMethod(module = true, visibility = PRIVATE)
     public static IRubyObject print(ThreadContext context, IRubyObject recv, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
         return RubyIO.print3(context, context.runtime.getGlobalVariables().get("$>"), arg0, arg1, arg2);
     }

--- a/core/src/main/java/org/jruby/ir/instructions/CallBase.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CallBase.java
@@ -470,6 +470,14 @@ public abstract class CallBase extends NOperandInstr implements ClosureAccepting
                 frameWrites = ALL;
             }
         } else {
+            // special cases
+            if (getId().equals("print") && argsCount != 0) {
+                // only arity 0 print requirest access to LASTLINE
+                frameReads = Collections.EMPTY_SET;
+                frameWrites = Collections.EMPTY_SET;
+                return;
+            }
+
             frameReads = MethodIndex.METHOD_FRAME_READS.getOrDefault(getId(), Collections.EMPTY_SET);
             frameWrites = MethodIndex.METHOD_FRAME_WRITES.getOrDefault(getId(), Collections.EMPTY_SET);
         }


### PR DESCRIPTION
This started out as a call site optimization to pass `$_` directly yo `Kernel#print` or `IO#print` rather than provide it through a heap frame, but the simpler change is to reduce the deoptimization to only zero-arity. There are unlikely to be many non-core case for calling `print` without any arguments other than for the core version.

If there is such a case in the wild, we can revisit the call site optimization.

The patch as written here eliminates the frame requirement for all non-zero arity calls to `print`.