### PR TITLE
yield specific for interp should have same rest logic as other paths

### DIFF
--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -528,7 +528,9 @@ public class IRRuntimeHelpers {
                 return array.toJavaArray();
             case 0:
             case 1:
-                return new IRubyObject[] { array };
+                return signature.rest() == org.jruby.runtime.Signature.Rest.ANON ?
+                        IRBlockBody.toAry(context, array) :
+                        new IRubyObject[] { array };
         }
 
         return singleBlockArgToArray(Helpers.aryToAry(context, array.size() == 1 ? array.eltInternal(0) : array));

--- a/spec/regression/core/enumerable/reject_spec.rb
+++ b/spec/regression/core/enumerable/reject_spec.rb
@@ -1,0 +1,10 @@
+require 'rspec'
+
+describe 'Enumerable#reject' do
+  # https://github.com/jruby/jruby/issues/8252
+  it 'breaks up array with , form of proc' do
+    held = nil
+    [[1,2]].reject {|e,| held = e }
+    expect(held).to eq 1
+  end
+end


### PR DESCRIPTION
Should fix #8225.   This logic is the same as the overload of the same name so I think just a place I missed in previous PR which fixed arity for `|e,|`.