### PR TITLE
Optimize literal fixnum and float arrays

### DIFF
--- a/bench/bench_literal_array.rb
+++ b/bench/bench_literal_array.rb
@@ -1,0 +1,120 @@
+require 'benchmark/ips'
+
+def array0
+  []
+end
+
+def fixnum_array1
+  [1]
+end
+
+def fixnum_array2
+  [1,2]
+end
+
+def fixnum_array3
+  [1,2,3]
+end
+
+def fixnum_array10
+  [1,2,3,4,5,6,7,8,9,10]
+end
+
+def float_array1
+  [1.0]
+end
+
+def float_array2
+  [1.0,2.0]
+end
+
+def float_array3
+  [1.0,2.0,3.0]
+end
+
+def float_array10
+  [1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0]
+end
+
+Benchmark.ips do |bm|
+  bm.report("empty array") do |i|
+    n = 0
+    while i > 0
+      i-=1
+      n += array0.size
+    end
+    n
+  end
+
+  bm.report("fixnum array 1") do |i|
+    n = 0
+    while i > 0
+      i-=1
+      n += fixnum_array1.size
+    end
+    n
+  end
+
+  bm.report("fixnum array 2") do |i|
+    n = 0
+    while i > 0
+      i-=1
+      n += fixnum_array2.size
+    end
+    n
+  end
+
+  bm.report("fixnum array 3") do |i|
+    n = 0
+    while i > 0
+      i-=1
+      n += fixnum_array3.size
+    end
+    n
+  end
+
+  bm.report("fixnum array 10") do |i|
+    n = 0
+    while i > 0
+      i-=1
+      n += fixnum_array10.size
+    end
+    n
+  end
+
+  bm.report("float array 1") do |i|
+    n = 0
+    while i > 0
+      i-=1
+      n += float_array1.size
+    end
+    n
+  end
+
+  bm.report("float array 2") do |i|
+    n = 0
+    while i > 0
+      i-=1
+      n += float_array2.size
+    end
+    n
+  end
+
+  bm.report("float array 3") do |i|
+    n = 0
+    while i > 0
+      i-=1
+      n += float_array3.size
+    end
+    n
+  end
+
+  bm.report("float array 10") do |i|
+    n = 0
+    while i > 0
+      i-=1
+      n += float_array10.size
+    end
+    n
+  end
+end

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -218,8 +218,16 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return USE_PACKED_ARRAYS ? new RubyArrayOneObject(runtime, obj) : new RubyArray(runtime, arrayOf(obj));
     }
 
+    public static RubyArray newArrayLight(RubyClass arrayClass, IRubyObject obj) {
+        return USE_PACKED_ARRAYS ? new RubyArrayOneObject(arrayClass, obj) : new RubyArray(arrayClass, arrayOf(obj), false);
+    }
+
     public static RubyArray newArrayLight(Ruby runtime, IRubyObject car, IRubyObject cdr) {
         return USE_PACKED_ARRAYS ? new RubyArrayTwoObject(runtime, car, cdr) : new RubyArray(runtime, arrayOf(car, cdr));
+    }
+
+    public static RubyArray newArrayLight(RubyClass arrayClass, IRubyObject car, IRubyObject cdr) {
+        return USE_PACKED_ARRAYS ? new RubyArrayTwoObject(arrayClass, car, cdr) : new RubyArray(arrayClass, arrayOf(car, cdr), false);
     }
 
     public static RubyArray newArrayLight(Ruby runtime, IRubyObject... objs) {
@@ -273,6 +281,14 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
             return newEmptyArray(runtime);
         }
         return isPackedArray(list) ? packedArray(runtime, list) : new RubyArray(runtime, list.toArray(IRubyObject.NULL_ARRAY));
+    }
+
+    public static RubyArray newSharedArray(RubyClass arrayClass, IRubyObject[] shared) {
+        RubyArray sharedArray = new RubyArray(arrayClass, shared, true);
+
+        sharedArray.isShared = true;
+
+        return sharedArray;
     }
 
     private static RubyArray packedArray(final Ruby runtime, final IRubyObject[] args) {
@@ -448,6 +464,13 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         super(runtime, klass);
         values = vals;
         realLength = vals.length;
+    }
+
+    public RubyArray(RubyClass klass, IRubyObject[] vals, boolean shared) {
+        super(klass);
+        values = vals;
+        realLength = vals.length;
+        isShared = shared;
     }
 
     /**

--- a/core/src/main/java/org/jruby/ir/targets/ValueCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/ValueCompiler.java
@@ -234,6 +234,10 @@ public interface ValueCompiler {
 
     void pushChilledString(ByteList byteList, int codeRange);
 
+    void pushFixnumArray(List<Long> values);
+
+    void pushFloatArray(List<Double> values);
+
     enum DStringElementType { STRING, OTHER }
     record DStringElement<T>(DStringElementType type, T value) {}
 

--- a/core/src/main/java/org/jruby/ir/targets/indy/ArrayBootstrap.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/ArrayBootstrap.java
@@ -1,10 +1,16 @@
 package org.jruby.ir.targets.indy;
 
 import com.headius.invokebinder.Binder;
+import org.jruby.Ruby;
 import org.jruby.RubyArray;
+import org.jruby.RubyClass;
+import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.specialized.RubyArrayOneObject;
 import org.jruby.specialized.RubyArraySpecialized;
+import org.jruby.specialized.RubyArrayTwoObject;
+import org.jruby.util.func.ObjectObjectIntFunction;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Opcodes;
 
@@ -13,7 +19,10 @@ import java.lang.invoke.ConstantCallSite;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.lang.invoke.MutableCallSite;
+import java.util.stream.IntStream;
 
+import static org.jruby.runtime.Helpers.arrayOf;
 import static org.jruby.util.CodegenUtils.p;
 import static org.jruby.util.CodegenUtils.sig;
 
@@ -23,6 +32,12 @@ public class ArrayBootstrap {
             p(ArrayBootstrap.class),
             "array",
             sig(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class),
+            false);
+    public static final Handle NUMERIC_ARRAY = new Handle(
+            Opcodes.H_INVOKESTATIC,
+            p(ArrayBootstrap.class),
+            "literalArray",
+            sig(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class, String.class),
             false);
     private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
 
@@ -44,5 +59,73 @@ public class ArrayBootstrap {
         assert ary.length > RubyArraySpecialized.MAX_PACKED_SIZE;
         // array() only dispatches here if ^^ holds
         return RubyArray.newArrayNoCopy(context.runtime, ary);
+    }
+
+    public static CallSite literalArray(MethodHandles.Lookup lookup, String name, MethodType type, String stringValues) {
+        MutableCallSite site = new MutableCallSite(type);
+
+        Object values = switch (name) {
+            case "fixnumArray" -> Helpers.decodeLongString(stringValues);
+            case "floatArray" -> Helpers.decodeDoubleString(stringValues);
+            default -> throw new RuntimeException("invalid literal array type");
+        };
+
+        MethodHandle handle = Binder
+                .from(type)
+                .append(site, values)
+                .invokeStaticQuiet(ArrayBootstrap.class, name);
+
+        site.setTarget(handle);
+
+        return site;
+    }
+
+    public static RubyArray fixnumArray(ThreadContext context, MutableCallSite site, long[] values) {
+        return bindArray(context, site, values, values.length,
+                (runtime, vals, index) -> runtime.newFixnum(values[index]));
+    }
+
+    public static RubyArray floatArray(ThreadContext context, MutableCallSite site, double[] values) {
+        return bindArray(context, site, values, values.length,
+                (runtime, vals, index) -> runtime.newFloat(values[index]));
+    }
+
+    private static <ArrayType> RubyArray bindArray(ThreadContext context, MutableCallSite site, ArrayType values, int size, ObjectObjectIntFunction<Ruby, ArrayType, IRubyObject> mapper) {
+        Ruby runtime = context.runtime;
+        RubyClass arrayClass = runtime.getArray();
+
+        return switch (size) {
+            case 1 -> bindArray(site, arrayClass, mapper.apply(runtime, values, 0));
+            case 2 -> bindArray(site, arrayClass, mapper.apply(runtime, values, 0), mapper.apply(runtime, values, 1));
+            default -> bindArray(site, arrayClass,
+                    IntStream.range(0, size).mapToObj(i -> mapper.apply(runtime, values, i)).toArray(IRubyObject[]::new));
+        };
+    }
+
+    private static RubyArray bindArray(MutableCallSite site, RubyClass arrayClass, IRubyObject car) {
+        site.setTarget(Binder.from(site.type())
+                .drop(0)
+                .append(arrayOf(RubyClass.class, IRubyObject.class), arrayClass, car)
+                .invokeConstructorQuiet(RubyArrayOneObject.class));
+
+        return new RubyArrayOneObject(arrayClass, car);
+    }
+
+    private static RubyArray bindArray(MutableCallSite site, RubyClass arrayClass, IRubyObject car, IRubyObject cdr) {
+        site.setTarget(Binder.from(site.type())
+                .drop(0)
+                .append(arrayOf(RubyClass.class, IRubyObject.class, IRubyObject.class), arrayClass, car, cdr)
+                .invokeConstructorQuiet(RubyArrayTwoObject.class));
+
+        return new RubyArrayTwoObject(arrayClass, car, cdr);
+    }
+
+    private static RubyArray bindArray(MutableCallSite site, RubyClass arrayClass, IRubyObject[] values) {
+        site.setTarget(Binder.from(site.type())
+                .drop(0)
+                .append(arrayClass, values)
+                .invokeStaticQuiet(RubyArray.class, "newSharedArray"));
+
+        return RubyArray.newSharedArray(arrayClass, values);
     }
 }

--- a/core/src/main/java/org/jruby/ir/targets/indy/IndyValueCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/IndyValueCompiler.java
@@ -2,6 +2,7 @@ package org.jruby.ir.targets.indy;
 
 import org.jcodings.Encoding;
 import org.jruby.Ruby;
+import org.jruby.RubyArray;
 import org.jruby.RubyBignum;
 import org.jruby.RubyClass;
 import org.jruby.RubyEncoding;
@@ -18,6 +19,7 @@ import org.jruby.ir.targets.JVM;
 import org.jruby.ir.targets.ValueCompiler;
 import org.jruby.ir.targets.simple.NormalValueCompiler;
 import org.jruby.runtime.CallType;
+import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.callsite.CachingCallSite;
@@ -243,4 +245,19 @@ public class IndyValueCompiler implements ValueCompiler {
     public void pushConstantLookupSite(String className, String siteName, ByteList name) {
         normalValueCompiler.pushConstantLookupSite(className, siteName, name);
     }
+
+    @Override
+    public void pushFixnumArray(List<Long> values) {
+        String fixnumString = Helpers.encodeLongString(values);
+
+        compiler.adapter.invokedynamic("fixnumArray", sig(RubyArray.class, ThreadContext.class), ArrayBootstrap.NUMERIC_ARRAY, fixnumString);
+    }
+
+    @Override
+    public void pushFloatArray(List<Double> values) {
+        String doubleString = Helpers.encodeDoubleString(values);
+
+        compiler.adapter.invokedynamic("floatArray", sig(RubyArray.class, ThreadContext.class), ArrayBootstrap.NUMERIC_ARRAY, doubleString);
+    }
+
 }

--- a/core/src/main/java/org/jruby/ir/targets/simple/NormalValueCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/simple/NormalValueCompiler.java
@@ -507,4 +507,16 @@ public class NormalValueCompiler implements ValueCompiler {
     }
 
     private final Map<Object, String> cacheFieldNames = new HashMap<>();
+
+    public void pushFixnumArray(List<Long> values) {
+        values.forEach(obj -> pushFixnum(obj.longValue()));
+
+        compiler.getDynamicValueCompiler().array(values.size());
+    }
+
+    public void pushFloatArray(List<Double> values) {
+        values.forEach(obj -> pushFloat(obj.doubleValue()));
+
+        compiler.getDynamicValueCompiler().array(values.size());
+    }
 }

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -576,6 +576,63 @@ public class Helpers {
                 token);
     }
 
+    public static String encodeLongString(List<Long> values) {
+        char[] chars = new char[values.size() * 4];
+
+        for (int i = 0; i < values.size(); i++) {
+            encodeLongAsChars(chars, i * 4, values.get(i));
+        }
+
+        return new String(chars);
+    }
+
+    public static long[] decodeLongString(String fixnumString) {
+        char[] charValues = fixnumString.toCharArray();
+        long[] values = new long[charValues.length / 4];
+
+        for (int i = 0; i < values.length; i++) {
+            values[i] = decodeLongFromChars(charValues, i * 4);
+        }
+
+        return values;
+    }
+
+    public static String encodeDoubleString(List<Double> values) {
+        char[] chars = new char[values.size() * 4];
+
+        for (int i = 0; i < values.size(); i++) {
+            encodeLongAsChars(chars, i * 4, Double.doubleToRawLongBits(values.get(i)));
+        }
+
+        return new String(chars);
+    }
+
+    public static double[] decodeDoubleString(String fixnumString) {
+        char[] charValues = fixnumString.toCharArray();
+        double[] values = new double[charValues.length / 4];
+
+        for (int i = 0; i < values.length; i++) {
+            values[i] = decodeLongFromChars(charValues, i * 4);
+        }
+
+        return values;
+    }
+
+    private static void encodeLongAsChars(char[] chars, int index, long value) {
+        chars[index] = (char) value;
+        chars[index + 1] = (char) (value >>> 16);
+        chars[index + 2] = (char) (value >>> 32);
+        chars[index + 3] = (char) (value >>> 48);
+    }
+
+    private static long decodeLongFromChars(char[] charValues, int index) {
+        long l = charValues[index];
+        l |= (long) charValues[index + 1] << 16;
+        l |= (long) charValues[index + 2] << 32;
+        l |= (long) charValues[index + 3] << 48;
+        return l;
+    }
+
     /**
      * Wraps the target method_missing implementation, passing the called method name as a leading symbol argument.
      */

--- a/core/src/main/java/org/jruby/specialized/RubyArrayOneObject.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArrayOneObject.java
@@ -28,7 +28,7 @@ public class RubyArrayOneObject extends RubyArraySpecialized {
 
     public RubyArrayOneObject(RubyClass otherClass, IRubyObject value) {
         // packed arrays are omitted from ObjectSpace
-        super(otherClass, false);
+        super(otherClass);
         this.value = value;
         this.realLength = 1;
     }

--- a/core/src/main/java/org/jruby/specialized/RubyArraySpecialized.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArraySpecialized.java
@@ -53,6 +53,10 @@ public abstract class RubyArraySpecialized extends RubyArray {
         super(otherClass.getClassRuntime(), otherClass, light);
     }
 
+    public RubyArraySpecialized(RubyClass otherClass) {
+        super(otherClass.getClassRuntime(), otherClass);
+    }
+
     protected final void unpack() {
         if (!packed()) return;
 

--- a/core/src/main/java/org/jruby/specialized/RubyArrayTwoObject.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArrayTwoObject.java
@@ -36,7 +36,7 @@ public class RubyArrayTwoObject extends RubyArraySpecialized {
 
     public RubyArrayTwoObject(RubyClass otherClass, IRubyObject car, IRubyObject cdr) {
         // packed arrays are omitted from ObjectSpace
-        super(otherClass, false);
+        super(otherClass);
         this.car = car;
         this.cdr = cdr;
         this.realLength = 2;


### PR DESCRIPTION
This change detects when a literal array contains only fixnums or floats and uses indy to embed those values in a call site, greatly reducing the bytecode size for constructing the array. Arrays that are too large will not fit into the encoded String and prevent compilation, but they would not likely have fit into bytecode limits with the old logic anyway.

A benchmark is included.