### PR TITLE
Improved representation of JRuby for JVM tools

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -43,7 +43,6 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -1364,12 +1363,14 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      * @see IRubyObject#getMarshalVariableList()
      */
     public List<Variable<Object>> getMarshalVariableList() {
-        return metaClass.getVariableAccessorsForRead()
-                .entrySet()
-                .stream()
-                .map(entry -> (Variable<Object>) new VariableEntry<>(entry.getKey(), entry.getValue().get(this)))
-                .filter(var -> var.getValue() != null && var.getValue() instanceof Serializable)
-                .toList();
+        Map<String, VariableAccessor> ivarAccessors = metaClass.getVariableAccessorsForRead();
+        ArrayList<Variable<Object>> list = new ArrayList<>(ivarAccessors.size());
+        for (Map.Entry<String, VariableAccessor> entry : ivarAccessors.entrySet()) {
+            Object value = entry.getValue().get(this);
+            if (value == null || !(value instanceof Serializable)) continue;
+            list.add(new VariableEntry<>(entry.getKey(), value));
+        }
+        return list;
     }
 
     /**
@@ -1377,12 +1378,14 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      */
     @Override
     public List<String> getVariableNameList() {
-        return metaClass.getVariableAccessorsForRead()
-                .entrySet()
-                .stream()
-                .filter(entry -> entry.getValue().get(this) != null)
-                .map(entry -> entry.getKey())
-                .toList();
+        Map<String, VariableAccessor> ivarAccessors = metaClass.getVariableAccessorsForRead();
+        ArrayList<String> list = new ArrayList<>(ivarAccessors.size());
+        for (Map.Entry<String, VariableAccessor> entry : ivarAccessors.entrySet()) {
+            Object value = entry.getValue().get(this);
+            if (value == null) continue;
+            list.add(entry.getKey());
+        }
+        return list;
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -1363,14 +1364,12 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      * @see IRubyObject#getMarshalVariableList()
      */
     public List<Variable<Object>> getMarshalVariableList() {
-        Map<String, VariableAccessor> ivarAccessors = metaClass.getVariableAccessorsForRead();
-        ArrayList<Variable<Object>> list = new ArrayList<>(ivarAccessors.size());
-        for (Map.Entry<String, VariableAccessor> entry : ivarAccessors.entrySet()) {
-            Object value = entry.getValue().get(this);
-            if (value == null || !(value instanceof Serializable)) continue;
-            list.add(new VariableEntry<>(entry.getKey(), value));
-        }
-        return list;
+        return metaClass.getVariableAccessorsForRead()
+                .entrySet()
+                .stream()
+                .map(entry -> (Variable<Object>) new VariableEntry<>(entry.getKey(), entry.getValue().get(this)))
+                .filter(var -> var.getValue() != null && var.getValue() instanceof Serializable)
+                .toList();
     }
 
     /**
@@ -1378,14 +1377,12 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      */
     @Override
     public List<String> getVariableNameList() {
-        Map<String, VariableAccessor> ivarAccessors = metaClass.getVariableAccessorsForRead();
-        ArrayList<String> list = new ArrayList<>(ivarAccessors.size());
-        for (Map.Entry<String, VariableAccessor> entry : ivarAccessors.entrySet()) {
-            Object value = entry.getValue().get(this);
-            if (value == null) continue;
-            list.add(entry.getKey());
-        }
-        return list;
+        return metaClass.getVariableAccessorsForRead()
+                .entrySet()
+                .stream()
+                .filter(entry -> entry.getValue().get(this) != null)
+                .map(entry -> entry.getKey())
+                .toList();
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -1349,10 +1349,10 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      */
     @Override
     public List<Variable<Object>> getVariableList() {
-        Map<String, VariableAccessor> ivarAccessors = metaClass.getVariableAccessorsForRead();
-        ArrayList<Variable<Object>> list = new ArrayList<>(ivarAccessors.size());
-        for (Map.Entry<String, VariableAccessor> entry : ivarAccessors.entrySet()) {
-            Object value = entry.getValue().get(this);
+        var ivarAccessors = metaClass.getVariableAccessorsForRead();
+        var list = new ArrayList<Variable<Object>>(ivarAccessors.size());
+        for (var entry : ivarAccessors.entrySet()) {
+            var value = entry.getValue().get(this);
             if (value == null) continue;
             list.add(new VariableEntry<>(entry.getKey(), value));
         }
@@ -1363,10 +1363,10 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      * @see IRubyObject#getMarshalVariableList()
      */
     public List<Variable<Object>> getMarshalVariableList() {
-        Map<String, VariableAccessor> ivarAccessors = metaClass.getVariableAccessorsForRead();
-        ArrayList<Variable<Object>> list = new ArrayList<>(ivarAccessors.size());
+        var ivarAccessors = metaClass.getVariableAccessorsForRead();
+        var list = new ArrayList<Variable<Object>>(ivarAccessors.size());
         for (Map.Entry<String, VariableAccessor> entry : ivarAccessors.entrySet()) {
-            Object value = entry.getValue().get(this);
+            var value = entry.getValue().get(this);
             if (value == null || !(value instanceof Serializable)) continue;
             list.add(new VariableEntry<>(entry.getKey(), value));
         }
@@ -1378,10 +1378,10 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      */
     @Override
     public List<String> getVariableNameList() {
-        Map<String, VariableAccessor> ivarAccessors = metaClass.getVariableAccessorsForRead();
-        ArrayList<String> list = new ArrayList<>(ivarAccessors.size());
-        for (Map.Entry<String, VariableAccessor> entry : ivarAccessors.entrySet()) {
-            Object value = entry.getValue().get(this);
+        var ivarAccessors = metaClass.getVariableAccessorsForRead();
+        var list = new ArrayList<String>(ivarAccessors.size());
+        for (var entry : ivarAccessors.entrySet()) {
+            var value = entry.getValue().get(this);
             if (value == null) continue;
             list.add(entry.getKey());
         }

--- a/core/src/main/java/org/jruby/compiler/impl/SkinnyMethodAdapter.java
+++ b/core/src/main/java/org/jruby/compiler/impl/SkinnyMethodAdapter.java
@@ -642,6 +642,10 @@ public final class SkinnyMethodAdapter extends MethodVisitor {
         getMethodVisitor().visitLocalVariable(name, type.getDescriptor(), null, start, end, index);
     }
 
+    public void local(int index, String name, Type type, Label start) {
+        getMethodVisitor().visitLocalVariable(name, type.getDescriptor(), null, start, end, index);
+    }
+
     public void line(int line) {
         Label label = new Label();
         label(label);

--- a/core/src/main/java/org/jruby/ir/operands/TemporaryLocalReplacementVariable.java
+++ b/core/src/main/java/org/jruby/ir/operands/TemporaryLocalReplacementVariable.java
@@ -25,7 +25,12 @@ public class TemporaryLocalReplacementVariable extends TemporaryLocalVariable im
 
     @Override
     public String getPrefix() {
-        return PREFIX + oldName + "_";
+        return oldName;
+    }
+
+    @Override
+    public String getId() {
+        return oldName;
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter.java
+++ b/core/src/main/java/org/jruby/ir/targets/IRBytecodeAdapter.java
@@ -42,6 +42,7 @@ import org.jruby.runtime.Frame;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.JavaNameMangler;
+import org.jruby.util.cli.Options;
 import org.jruby.util.collections.IntHashMap;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Label;
@@ -260,7 +261,9 @@ public class IRBytecodeAdapter {
                 for (IntHashMap.Entry<Type> entry : variableTypes.entrySet()) {
                     final int i = entry.getKey();
                     String name = variableNames.get(i);
-                    adapter.local(i, name, entry.getValue());
+                    if (!name.startsWith("$") || Options.JIT_DEBUG.load()) {
+                        adapter.local(i, name, entry.getValue());
+                    }
                 }
             }
         });

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -100,6 +100,7 @@ public class JVMVisitor extends IRVisitor {
     public static final String DYNAMIC_SCOPE = "variableStore";
     private static final boolean DEBUG = false;
     public static final String BLOCK_ARG_NAME = "blockArg";
+    public static final String BLOCK_ARG_LOCAL_NAME = "&";
     public static final String SELF_BLOCK_NAME = "selfBlock";
     public static final String SUPER_NAME_NAME = "superName";
 
@@ -2131,7 +2132,7 @@ public class JVMVisitor extends IRVisitor {
     @Override
     public void ReifyClosureInstr(ReifyClosureInstr reifyclosureinstr) {
         jvmMethod().loadContext();
-        jvmLoadLocal("$blockArg");
+        jvmLoadLocal(BLOCK_ARG_LOCAL_NAME);
         jvmMethod().invokeIRHelper("newProc", sig(IRubyObject.class, ThreadContext.class, Block.class));
         jvmStoreLocal(reifyclosureinstr.getResult());
     }

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -508,14 +508,14 @@ public class JVMVisitor extends IRVisitor {
     }
 
     protected void emitMethod(IRMethod method, JVMVisitorMethodContext context) {
-        String name = JavaNameMangler.encodeScopeForBacktrace(method) + '$' + methodIndex++;
+        String name = JavaNameMangler.encodeNumberedScopeForBacktrace(method, methodIndex++);
 
         emitWithSignatures(method, context, name);
     }
 
     protected void emitMethodJIT(IRMethod method, JVMVisitorMethodContext context) {
         String clsName = jvm.scriptToClass(method.getFile());
-        String name = JavaNameMangler.encodeScopeForBacktrace(method) + '$' + methodIndex++;
+        String name = JavaNameMangler.encodeNumberedScopeForBacktrace(method, methodIndex++);
         jvm.pushscript(this, clsName, method.getFile());
 
         emitWithSignatures(method, context, name);
@@ -526,7 +526,7 @@ public class JVMVisitor extends IRVisitor {
 
     protected void emitBlockJIT(IRClosure closure, JVMVisitorMethodContext context) {
         String clsName = jvm.scriptToClass(closure.getFile());
-        String name = JavaNameMangler.encodeScopeForBacktrace(closure) + '$' + methodIndex++;
+        String name = JavaNameMangler.encodeNumberedScopeForBacktrace(closure, methodIndex++);
         jvm.pushscript(this, clsName, closure.getFile());
 
         emitScope(closure, name, CLOSURE_SIGNATURE, false, true);
@@ -568,7 +568,7 @@ public class JVMVisitor extends IRVisitor {
     }
 
     protected Handle emitModuleBodyJIT(IRModuleBody method) {
-        String name = JavaNameMangler.encodeScopeForBacktrace(method) + '$' + methodIndex++;
+        String name = JavaNameMangler.encodeNumberedScopeForBacktrace(method, methodIndex++);
 
         String clsName = jvm.scriptToClass(method.getFile());
         jvm.pushscript(this, clsName, method.getFile());
@@ -598,7 +598,7 @@ public class JVMVisitor extends IRVisitor {
 
     protected Handle emitClosure(IRClosure closure, boolean print) {
         /* Compile the closure like a method */
-        String name = JavaNameMangler.encodeScopeForBacktrace(closure) + '$' + methodIndex++;
+        String name = JavaNameMangler.encodeNumberedScopeForBacktrace(closure, methodIndex++);
 
         emitScope(closure, name, CLOSURE_SIGNATURE, false, print);
 
@@ -615,7 +615,7 @@ public class JVMVisitor extends IRVisitor {
     }
 
     protected Handle emitModuleBody(IRModuleBody method) {
-        String name = JavaNameMangler.encodeScopeForBacktrace(method) + '$' + methodIndex++;
+        String name = JavaNameMangler.encodeNumberedScopeForBacktrace(method, methodIndex++);
 
         Signature signature = signatureFor(method, false);
         emitScope(method, name, signature, false, true);

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -97,7 +97,7 @@ import static org.jruby.util.CodegenUtils.sig;
 public class JVMVisitor extends IRVisitor {
 
     private static final Logger LOG = LoggerFactory.getLogger(JVMVisitor.class);
-    public static final String DYNAMIC_SCOPE = "$dynamicScope";
+    public static final String DYNAMIC_SCOPE = "variableStore";
     private static final boolean DEBUG = false;
     public static final String BLOCK_ARG_NAME = "blockArg";
     public static final String SELF_BLOCK_NAME = "selfBlock";

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -218,7 +218,7 @@ public class JVMVisitor extends IRVisitor {
 
         if (fullIC.needsBinding() || !fullIC.hasExplicitCallProtocol()) {
             // declare dynamic scope local only if we'll need it
-            jvm.methodData().local("$dynamicScope", Type.getType(DynamicScope.class));
+            jvm.methodData().local(DYNAMIC_SCOPE, Type.getType(DynamicScope.class));
         }
 
         if (!fullIC.hasExplicitCallProtocol()) {

--- a/core/src/main/java/org/jruby/ir/targets/MethodData.java
+++ b/core/src/main/java/org/jruby/ir/targets/MethodData.java
@@ -30,7 +30,13 @@ public class MethodData {
 
         // incoming arguments
         for (int i = 0; i < signature.argCount(); i++) {
-            local("$" + signature.argName(i), Type.getType(signature.argType(i)));
+            String argName = signature.argName(i);
+            argName = switch (argName) {
+                case "self" -> "self";
+                case "blockArg" -> "&";
+                default -> "$" + argName;
+            };
+            local(argName, Type.getType(signature.argType(i)));
         }
     }
 

--- a/core/src/main/java/org/jruby/ir/targets/MethodData.java
+++ b/core/src/main/java/org/jruby/ir/targets/MethodData.java
@@ -33,7 +33,7 @@ public class MethodData {
             String argName = signature.argName(i);
             argName = switch (argName) {
                 case "self" -> "self";
-                case "blockArg" -> "&";
+                case "blockArg" -> JVMVisitor.BLOCK_ARG_LOCAL_NAME;
                 default -> "$" + argName;
             };
             local(argName, Type.getType(signature.argType(i)));

--- a/core/src/main/java/org/jruby/runtime/builtin/IRubyObject.java
+++ b/core/src/main/java/org/jruby/runtime/builtin/IRubyObject.java
@@ -365,12 +365,12 @@ public interface IRubyObject {
     void syncVariables(IRubyObject source);
     
     /**
-     * @return a list of all variables (ivar/cvar/constant/internal)
+     * @return a list of all variables (ivar/internal)
      */
     List<Variable<Object>> getVariableList();
 
     /**
-     * @return a list of all marshalable variables (ivar/cvar/constant/internal)
+     * @return a mutable list of all marshalable variables (ivar/internal)
      */
     default List<Variable<Object>> getMarshalVariableList() {
         return getVariableList();

--- a/core/src/main/java/org/jruby/util/JavaNameMangler.java
+++ b/core/src/main/java/org/jruby/util/JavaNameMangler.java
@@ -290,6 +290,8 @@ public class JavaNameMangler {
     private static final String SCRIPT_MARKER = "script";
     private static final char DELIMITER = '\u00A0';
 
+    public static final String SCRIPT_METHOD_NAME = RUBY_MARKER + DELIMITER + SCRIPT_MARKER;
+
     public static String encodeNumberedScopeForBacktrace(IRScope scope, int number) {
         return encodeScopeForBacktrace(scope) + DELIMITER + '#' + number;
     }
@@ -316,7 +318,7 @@ public class JavaNameMangler {
         } else if (scope instanceof IRModuleBody) {
             base = RUBY_MARKER + DELIMITER + MODULE_MARKER + DELIMITER + mangleMethodNameInternal(scope.getId());
         } else if (scope instanceof IRScriptBody) {
-            base = RUBY_MARKER + DELIMITER + SCRIPT_MARKER;
+            base = SCRIPT_METHOD_NAME;
         } else {
             throw new IllegalStateException("unknown scope type for backtrace encoding: " + scope.getClass());
         }

--- a/core/src/main/java/org/jruby/util/JavaNameMangler.java
+++ b/core/src/main/java/org/jruby/util/JavaNameMangler.java
@@ -281,12 +281,26 @@ public class JavaNameMangler {
         return DANGEROUS_CHARS.charAt(REPLACEMENT_CHARS.indexOf(character));
     }
 
+    private static final String RUBY_MARKER = "️❤";
+    private static final String METHOD_MARKER = "def";
+    private static final String BLOCK_MARKER = "{}";
+    private static final String METACLASS_MARKER = "metaclass";
+    private static final String CLASS_MARKER = "class";
+    private static final String MODULE_MARKER = "module";
+    private static final String SCRIPT_MARKER = "script";
+    private static final char DELIMITER = '\u00A0';
+
+    public static String encodeNumberedScopeForBacktrace(IRScope scope, int number) {
+        return encodeScopeForBacktrace(scope) + DELIMITER + '#' + number;
+    }
+
     // FIXME: bytelist_love - if we want these mangled names to display properly we should be building this up with encoded data.
     public static String encodeScopeForBacktrace(IRScope scope) {
+        String base;
+
         if (scope instanceof IRMethod) {
-            return "RUBY$method$" + mangleMethodNameInternal(scope.getId());
-        }
-        if (scope instanceof IRClosure) {
+            base = RUBY_MARKER + DELIMITER + METHOD_MARKER + DELIMITER + mangleMethodNameInternal(scope.getId());
+        } else if (scope instanceof IRClosure) {
             IRScope ancestorScope = scope.getNearestTopLocalVariableScope();
             String name;
             if (ancestorScope instanceof IRScriptBody) {
@@ -294,30 +308,31 @@ public class JavaNameMangler {
             } else {
                 name = ancestorScope.getId();
             }
-            return "RUBY$block$" + mangleMethodNameInternal(name);
+            base = RUBY_MARKER + DELIMITER + BLOCK_MARKER + DELIMITER + mangleMethodNameInternal(name);
+        } else if (scope instanceof IRMetaClassBody) {
+            base = RUBY_MARKER + DELIMITER + METACLASS_MARKER;
+        } else if (scope instanceof IRClassBody) {
+            base = RUBY_MARKER + DELIMITER + CLASS_MARKER + DELIMITER + mangleMethodNameInternal(scope.getId());
+        } else if (scope instanceof IRModuleBody) {
+            base = RUBY_MARKER + DELIMITER + MODULE_MARKER + DELIMITER + mangleMethodNameInternal(scope.getId());
+        } else if (scope instanceof IRScriptBody) {
+            base = RUBY_MARKER + DELIMITER + SCRIPT_MARKER;
+        } else {
+            throw new IllegalStateException("unknown scope type for backtrace encoding: " + scope.getClass());
         }
-        if (scope instanceof IRMetaClassBody) {
-            return "RUBY$metaclass";
-        }
-        if (scope instanceof IRClassBody) {
-            return "RUBY$class$" + mangleMethodNameInternal(scope.getId());
-        }
-        if (scope instanceof IRModuleBody) {
-            return "RUBY$module$" + mangleMethodNameInternal(scope.getId());
-        }
-        if (scope instanceof IRScriptBody) {
-            return "RUBY$script";
-        }
-        throw new IllegalStateException("unknown scope type for backtrace encoding: " + scope.getClass());
+
+        // line is insufficient to guarantee a unique name
+//        return base + DELIMITER + '#' + scope.getLine();
+        return base;
     }
 
-    public static final String VARARGS_MARKER = "$__VARARGS__";
+    public static final String VARARGS_MARKER = DELIMITER + "**";
 
     // returns location $ type $ methodName as 3 elements or null if this is an invalid mangled name
     public static List<String> decodeMethodTuple(String methodName) {
-        if (!methodName.startsWith("RUBY$")) return null;
+        if (!methodName.startsWith(RUBY_MARKER + DELIMITER)) return null;
 
-        return StringSupport.split(methodName, '$');
+        return StringSupport.split(methodName, DELIMITER);
     }
 
     public static String decodeMethodName(FrameType type, List<String> mangledTuple) {
@@ -336,12 +351,12 @@ public class JavaNameMangler {
 
     public static FrameType decodeFrameTypeFromMangledName(String type) {
         switch (type) {
-            case "script":    return FrameType.ROOT;
-            case "metaclass": return FrameType.METACLASS;
-            case "method":    return FrameType.METHOD;
-            case "block":     return FrameType.BLOCK;
-            case "class":     return FrameType.MODULE;
-            case "module":    return FrameType.CLASS;
+            case SCRIPT_MARKER:    return FrameType.ROOT;
+            case METACLASS_MARKER: return FrameType.METACLASS;
+            case METHOD_MARKER:    return FrameType.METHOD;
+            case BLOCK_MARKER:     return FrameType.BLOCK;
+            case CLASS_MARKER:     return FrameType.MODULE;
+            case MODULE_MARKER:    return FrameType.CLASS;
         }
         throw new IllegalStateException("unknown encoded method type '" + type);
 

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -97,6 +97,7 @@ public class Options {
     public static final Option<Boolean> JIT_BACKGROUND = bool(JIT, "jit.background", JIT_THRESHOLD.load() != 0, "Run the JIT compiler in a background thread. Off if jit.threshold=0.");
     public static final Option<Boolean> JIT_KERNEL = bool(JIT, "jit.kernel", false, "Run the JIT compiler while the pure-Ruby kernel is booting.");
     public static final Option<ClassLoaderMode> JIT_LOADER_MODE = enumeration(JIT, "jit.loader.mode", ClassLoaderMode.class, ClassLoaderMode.UNIQUE, "Set JIT class loader to use. UNIQUE class loader per class; SHARED loader for all classes");
+    public static final Option<Boolean> JIT_DEBUG = bool(JIT, "jit.debug", false, "Emit extra JIT information for debugging in JVM.");
 
     public static final Option<String> IR_DEBUG_IGV          = string(IR, "ir.debug.igv", (String) null, "Specify file:line of scope to jump to IGV");
     public static final Option<Boolean> IR_DEBUG_IGV_STDOUT = bool(IR, "ir.debug.igv.stdout", false, "Save IGV generated XML to stdout");
@@ -409,9 +410,6 @@ public class Options {
 
     @Deprecated
     public static final Option<Boolean> JIT_DUMPING = bool(JIT, "jit.dumping", false, "Enable stdout dumping of JITed bytecode.");
-
-    @Deprecated
-    public static final Option<Boolean> JIT_DEBUG = bool(JIT, "jit.debug", false, "Log loading of JITed bytecode.");
 
     @Deprecated
     public static final Option<String>  IR_INLINE_COMPILER_PASSES = string(IR, "ir.inline_passes", "Specify comma delimeted list of passes to run after inlining a method.");

--- a/core/src/main/java/org/jruby/util/collections/IntHashMap.java
+++ b/core/src/main/java/org/jruby/util/collections/IntHashMap.java
@@ -2,10 +2,12 @@ package org.jruby.util.collections;
 
 import java.util.AbstractCollection;
 import java.util.AbstractSet;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
 public class IntHashMap<V> {
 
@@ -408,6 +410,15 @@ public class IntHashMap<V> {
             }
         }
         return newMap;
+    }
+
+    public void forEach(BiConsumer<Integer, ? super V> action) {
+        for (Entry<V> entry : table) {
+            while (entry != null) {
+                action.accept(entry.getKey(), entry.value);
+                entry = entry.next;
+            }
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/spec/compiler/general_spec.rb
+++ b/spec/compiler/general_spec.rb
@@ -96,7 +96,8 @@ module JITSpecUtils
 
     compiler = new_visitor(runtime)
     compiled = compiler.compile(method, org.jruby.util.OneShotClassLoader.new(runtime.getJRubyClassLoader()))
-    scriptMethod = compiled.getMethod("RUBY$script",
+    scriptMethod = compiled.getMethod(
+        org.jruby.util.JavaNameMangler::SCRIPT_METHOD_NAME,
         org.jruby.runtime.ThreadContext.java_class,
         org.jruby.parser.StaticScope.java_class,
         org.jruby.runtime.builtin.IRubyObject.java_class,


### PR DESCRIPTION
This PR will encompass several improvements to JRuby's representation of code and objects, in order to make JVM tooling more useful.

Among the ideas explored here:

* Cleaner representation of methods and class for stack traces and profiling.
* Always-on class reification to show real class names in JVM heap inspection tools.
* Better JIT configuration to allow JVM debugging tools to step through Ruby code and set breakpoints and such.
  * This may include some changes to force larger scopes to JIT so they can be debugged, even if this means the JVM cannot native JIT them.
* Enhancements for JVM debuggers to better see into dynamic scopes, Ruby objects with instance variables, and core Ruby types with complicated internals.