### PR TITLE
Rewrite Marshal.dump logic for efficiency

### DIFF
--- a/bench/bench_marshal_dump.rb
+++ b/bench/bench_marshal_dump.rb
@@ -1,0 +1,68 @@
+require 'benchmark/ips'
+
+ARRAY_OF_FIXNUMS = [1,2,3,4,5,6,7,8,9,10]
+ARRAY_OF_BIG_FIXNUMS = [1<<30,1<<30,1<<30,1<<30,1<<30,1<<30,1<<30,1<<30,1<<30,1<<30]
+ARRAY_OF_FLOATS = [1.1111111111,2.2222222222,3.3333333333,4.4444444444,5.5555555555,6.6666666666,7.7777777777,8.8888888888,9.9999999999,10.111111111]
+ARRAY_OF_STRINGS = ARRAY_OF_FLOATS.map(&:to_s)
+ARRAY_OF_ARRAYS = ARRAY_OF_FIXNUMS.map {[it]}
+ARRAY_OF_HASHES = ARRAY_OF_FIXNUMS.map {{it => it}}
+
+class Foo
+  def initialize(val)
+    @val = val
+  end
+end
+
+ARRAY_OF_OBJECTS = ARRAY_OF_FIXNUMS.map {Foo.new(it)}
+ARRAY_OF_TIMES = 10.times.map {Time.now}
+
+Benchmark.ips do |bm|
+  bm.report("array of fixnums") do |i|
+    while i > 0
+      i-=1
+      Marshal.dump(ARRAY_OF_FIXNUMS)
+    end
+  end
+  bm.report("array of big fixnums") do |i|
+    while i > 0
+      i-=1
+      Marshal.dump(ARRAY_OF_BIG_FIXNUMS)
+    end
+  end
+  bm.report("array of floats") do |i|
+    while i > 0
+      i-=1
+      Marshal.dump(ARRAY_OF_FLOATS)
+    end
+  end
+  bm.report("array of strings") do |i|
+    while i > 0
+      i-=1
+      Marshal.dump(ARRAY_OF_STRINGS)
+    end
+  end
+  bm.report("array of arrays") do |i|
+    while i > 0
+      i-=1
+      Marshal.dump(ARRAY_OF_ARRAYS)
+    end
+  end
+  bm.report("array of hashes") do |i|
+    while i > 0
+      i-=1
+      Marshal.dump(ARRAY_OF_HASHES)
+    end
+  end
+  bm.report("array of objects") do |i|
+    while i > 0
+      i-=1
+      Marshal.dump(ARRAY_OF_OBJECTS)
+    end
+  end
+  bm.report("array of times") do |i|
+    while i > 0
+      i-=1
+      Marshal.dump(ARRAY_OF_TIMES)
+    end
+  end
+end

--- a/bench/bench_marshal_load.rb
+++ b/bench/bench_marshal_load.rb
@@ -1,0 +1,70 @@
+require 'benchmark/ips'
+
+ARRAY_OF_FIXNUMS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+ARRAY_OF_FIXNUMS_DUMPED = Marshal.dump(ARRAY_OF_FIXNUMS)
+ARRAY_OF_BIG_FIXNUMS_DUMPED = Marshal.dump([1<<30,1<<30,1<<30,1<<30,1<<30,1<<30,1<<30,1<<30,1<<30,1<<30])
+ARRAY_OF_FLOATS = [1.1111111111, 2.2222222222, 3.3333333333, 4.4444444444, 5.5555555555, 6.6666666666, 7.7777777777, 8.8888888888, 9.9999999999, 10.111111111]
+ARRAY_OF_FLOATS_DUMPED = Marshal.dump(ARRAY_OF_FLOATS)
+ARRAY_OF_STRINGS_DUMPED = Marshal.dump(ARRAY_OF_FLOATS.map(&:to_s))
+ARRAY_OF_ARRAYS_DUMPED = Marshal.dump(ARRAY_OF_FIXNUMS.map {[it]})
+ARRAY_OF_HASHES_DUMPED = Marshal.dump(ARRAY_OF_FIXNUMS.map {{it => it}})
+
+class Foo
+  def initialize(val)
+    @val = val
+  end
+end
+
+ARRAY_OF_OBJECTS_DUMPED = Marshal.dump(ARRAY_OF_FIXNUMS.map {Foo.new(it)})
+ARRAY_OF_TIMES_DUMPED = Marshal.dump(10.times.map {Time.now})
+
+Benchmark.ips do |bm|
+  bm.report("array of fixnums") do |i|
+    while i > 0
+      i-=1
+      Marshal.load(ARRAY_OF_FIXNUMS_DUMPED)
+    end
+  end
+  bm.report("array of big fixnums") do |i|
+    while i > 0
+      i-=1
+      Marshal.load(ARRAY_OF_BIG_FIXNUMS_DUMPED)
+    end
+  end
+  bm.report("array of floats") do |i|
+    while i > 0
+      i-=1
+      Marshal.load(ARRAY_OF_FLOATS_DUMPED)
+    end
+  end
+  bm.report("array of strings") do |i|
+    while i > 0
+      i-=1
+      Marshal.load(ARRAY_OF_STRINGS_DUMPED)
+    end
+  end
+  bm.report("array of arrays") do |i|
+    while i > 0
+      i-=1
+      Marshal.load(ARRAY_OF_ARRAYS_DUMPED)
+    end
+  end
+  bm.report("array of hashes") do |i|
+    while i > 0
+      i-=1
+      Marshal.load(ARRAY_OF_HASHES_DUMPED)
+    end
+  end
+  bm.report("array of objects") do |i|
+    while i > 0
+      i-=1
+      Marshal.load(ARRAY_OF_OBJECTS_DUMPED)
+    end
+  end
+  bm.report("array of times") do |i|
+    while i > 0
+      i-=1
+      Marshal.dump(ARRAY_OF_TIMES_DUMPED)
+    end
+  end
+end

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -393,6 +393,7 @@ public final class Ruby implements Constantizable {
         encodingService = new EncodingService(this);
 
         symbolClass = RubySymbol.createSymbolClass(this);
+        symbolTable = new RubySymbol.SymbolTable(this);
 
         threadGroupClass = profile.allowClass("ThreadGroup") ? RubyThreadGroup.createThreadGroupClass(this) : null;
         threadClass = profile.allowClass("Thread") ? RubyThread.createThreadClass(this) : null;
@@ -5349,7 +5350,7 @@ public final class Ruby implements Constantizable {
 
     private final ObjectSpace objectSpace = new ObjectSpace();
 
-    private final RubySymbol.SymbolTable symbolTable = new RubySymbol.SymbolTable(this);
+    private final RubySymbol.SymbolTable symbolTable;
 
     private boolean abortOnException = false; // Thread.abort_on_exception
     private boolean reportOnException = true; // Thread.report_on_exception

--- a/core/src/main/java/org/jruby/RubyBignum.java
+++ b/core/src/main/java/org/jruby/RubyBignum.java
@@ -48,6 +48,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.callsite.CachingCallSite;
 import org.jruby.runtime.marshal.MarshalStream;
+import org.jruby.runtime.marshal.NewMarshal;
 import org.jruby.runtime.marshal.UnmarshalStream;
 
 import static org.jruby.RubyFixnum.zero;
@@ -1243,6 +1244,32 @@ public class RubyBignum extends RubyInteger {
         if (oddLengthNonzeroStart) {
             // Pad with a 0
             output.write(0);
+        }
+    }
+
+    public static void marshalTo(RubyBignum bignum, NewMarshal output, ThreadContext context, NewMarshal.RubyOutputStream out) {
+        output.registerLinkTarget(bignum);
+
+        out.write(bignum.value.signum() >= 0 ? '+' : '-');
+
+        BigInteger absValue = bignum.value.abs();
+
+        byte[] digits = absValue.toByteArray();
+
+        boolean oddLengthNonzeroStart = (digits.length % 2 != 0 && digits[0] != 0);
+        int shortLength = digits.length / 2;
+        if (oddLengthNonzeroStart) {
+            shortLength++;
+        }
+        output.writeInt(out, shortLength);
+
+        for (int i = 1; i <= shortLength * 2 && i <= digits.length; i++) {
+            out.write(digits[digits.length - i]);
+        }
+
+        if (oddLengthNonzeroStart) {
+            // Pad with a 0
+            out.write(0);
         }
     }
 

--- a/core/src/main/java/org/jruby/RubyBignum.java
+++ b/core/src/main/java/org/jruby/RubyBignum.java
@@ -1247,7 +1247,7 @@ public class RubyBignum extends RubyInteger {
         }
     }
 
-    public static void marshalTo(RubyBignum bignum, NewMarshal output, ThreadContext context, NewMarshal.RubyOutputStream out) {
+    public static void marshalTo(RubyBignum bignum, NewMarshal output, NewMarshal.RubyOutputStream out) {
         output.registerLinkTarget(bignum);
 
         out.write(bignum.value.signum() >= 0 ? '+' : '-');

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -1277,7 +1277,7 @@ public class RubyClass extends RubyModule {
         output.writeString(MarshalStream.getPathFromClass(clazz));
     }
 
-    public static void marshalTo(RubyClass clazz, NewMarshal output, ThreadContext context, NewMarshal.RubyOutputStream out) {
+    public static void marshalTo(RubyClass clazz, NewMarshal output, NewMarshal.RubyOutputStream out) {
         output.registerLinkTarget(clazz);
         output.writeString(out, MarshalStream.getPathFromClass(clazz));
     }

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -1301,7 +1301,7 @@ public class RubyClass extends RubyModule {
             IRubyObject object = (IRubyObject) obj;
 
             marshalStream.registerLinkTarget(object);
-            marshalStream.dumpVariables(context, out, object.getMarshalVariableList());
+            marshalStream.dumpVariables(context, out, object);
         }
 
         @Override

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -84,6 +84,7 @@ import org.jruby.runtime.ivars.VariableAccessor;
 import org.jruby.runtime.ivars.VariableAccessorField;
 import org.jruby.runtime.ivars.VariableTableManager;
 import org.jruby.runtime.marshal.MarshalStream;
+import org.jruby.runtime.marshal.NewMarshal;
 import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.runtime.opto.Invalidator;
 import org.jruby.util.ArraySupport;
@@ -1263,6 +1264,10 @@ public class RubyClass extends RubyModule {
         getMarshal().marshalTo(runtime, obj, this, marshalStream);
     }
 
+    public final void marshal(Object obj, NewMarshal marshalStream, ThreadContext context, NewMarshal.RubyOutputStream out) {
+        getMarshal().marshalTo(obj, this, marshalStream, context, out);
+    }
+
     public final Object unmarshal(UnmarshalStream unmarshalStream) throws IOException {
         return getMarshal().unmarshalFrom(runtime, this, unmarshalStream);
     }
@@ -1270,6 +1275,11 @@ public class RubyClass extends RubyModule {
     public static void marshalTo(RubyClass clazz, MarshalStream output) throws java.io.IOException {
         output.registerLinkTarget(clazz);
         output.writeString(MarshalStream.getPathFromClass(clazz));
+    }
+
+    public static void marshalTo(RubyClass clazz, NewMarshal output, ThreadContext context, NewMarshal.RubyOutputStream out) {
+        output.registerLinkTarget(clazz);
+        output.writeString(out, MarshalStream.getPathFromClass(clazz));
     }
 
     public static RubyClass unmarshalFrom(UnmarshalStream input) throws java.io.IOException {
@@ -1284,6 +1294,14 @@ public class RubyClass extends RubyModule {
 
             marshalStream.registerLinkTarget(object);
             marshalStream.dumpVariables(object.getMarshalVariableList());
+        }
+
+        @Override
+        public void marshalTo(Object obj, RubyClass type, NewMarshal marshalStream, ThreadContext context, NewMarshal.RubyOutputStream out) {
+            IRubyObject object = (IRubyObject) obj;
+
+            marshalStream.registerLinkTarget(object);
+            marshalStream.dumpVariables(context, out, object.getMarshalVariableList());
         }
 
         @Override
@@ -2535,7 +2553,28 @@ public class RubyClass extends RubyModule {
                     } else {
                         stream.writeDirectly(object);
                     }
+            }
+        }
+
+        public void dump(NewMarshal stream, ThreadContext context, NewMarshal.RubyOutputStream out, IRubyObject object) {
+            switch (type) {
+                case DEFAULT:
+                    stream.writeDirectly(context, out, object);
                     return;
+                case NEW_USER:
+                    stream.userNewMarshal(context, out, object, entry);
+                    return;
+                case OLD_USER:
+                    stream.userMarshal(context, out, object, entry);
+                    return;
+                case DEFAULT_SLOW:
+                    if (object.respondsTo("marshal_dump")) {
+                        stream.userNewMarshal(context, out, object);
+                    } else if (object.respondsTo("_dump")) {
+                        stream.userMarshal(context, out, object);
+                    } else {
+                        stream.writeDirectly(context, out, object);
+                    }
             }
         }
 
@@ -2599,6 +2638,38 @@ public class RubyClass extends RubyModule {
         }
 
         tuple.dump(stream, target);
+    }
+
+    public void smartDump(NewMarshal stream, ThreadContext context, NewMarshal.RubyOutputStream out, IRubyObject target) {
+        MarshalTuple tuple;
+        if ((tuple = cachedDumpMarshal).generation == generation) {
+        } else {
+            // recache
+            CacheEntry entry = searchWithCache("respond_to?");
+            DynamicMethod method = entry.method;
+            if (!method.equals(runtime.getRespondToMethod()) && !method.isUndefined()) {
+
+                // custom respond_to?, always do slow default marshaling
+                tuple = (cachedDumpMarshal = new MarshalTuple(null, MarshalType.DEFAULT_SLOW, generation));
+
+            } else if (!(entry = searchWithCache("marshal_dump")).method.isUndefined()) {
+
+                // object really has 'marshal_dump', cache "new" user marshaling
+                tuple = (cachedDumpMarshal = new MarshalTuple(entry, MarshalType.NEW_USER, generation));
+
+            } else if (!(entry = searchWithCache("_dump")).method.isUndefined()) {
+
+                // object really has '_dump', cache "old" user marshaling
+                tuple = (cachedDumpMarshal = new MarshalTuple(entry, MarshalType.OLD_USER, generation));
+
+            } else {
+
+                // no respond_to?, marshal_dump, or _dump, so cache default marshaling
+                tuple = (cachedDumpMarshal = new MarshalTuple(null, MarshalType.DEFAULT, generation));
+            }
+        }
+
+        tuple.dump(stream, context, out, target);
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyComplex.java
+++ b/core/src/main/java/org/jruby/RubyComplex.java
@@ -41,6 +41,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.marshal.MarshalStream;
+import org.jruby.runtime.marshal.NewMarshal;
 import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.util.ByteList;
 import org.jruby.util.Numeric;
@@ -1106,6 +1107,11 @@ public class RubyComplex extends RubyNumeric {
     private static final ObjectMarshal COMPLEX_MARSHAL = new ObjectMarshal() {
         @Override
         public void marshalTo(Ruby runtime, Object obj, RubyClass type, MarshalStream marshalStream) {
+            //do nothing
+        }
+
+        @Override
+        public void marshalTo(Object obj, RubyClass type, NewMarshal marshalStream, ThreadContext context, NewMarshal.RubyOutputStream out) {
             //do nothing
         }
 

--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -193,10 +193,10 @@ public class RubyException extends RubyObject {
         public void marshalTo(RubyException exc, RubyClass type,
                               NewMarshal marshalStream, ThreadContext context, NewMarshal.RubyOutputStream out) {
             marshalStream.registerLinkTarget(exc);
-            List<Variable<Object>> attrs = exc.getMarshalVariableList();
-            attrs.add(new VariableEntry<>("mesg", exc.getMessage()));
-            attrs.add(new VariableEntry<>("bt", exc.getBacktrace()));
-            marshalStream.dumpVariables(context, out, attrs);
+            marshalStream.dumpVariables(context, out, exc, 2, (marshal, c, o, v, receiver) -> {
+                receiver.receive(marshal, c, o, "mesg", v.getMessage());
+                receiver.receive(marshal, c, o, "bt", v.getBacktrace());
+            });
         }
 
         @Override

--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -51,6 +51,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.builtin.Variable;
 import org.jruby.runtime.component.VariableEntry;
 import org.jruby.runtime.marshal.MarshalStream;
+import org.jruby.runtime.marshal.NewMarshal;
 import org.jruby.runtime.marshal.UnmarshalStream;
 
 import java.io.IOException;
@@ -186,6 +187,16 @@ public class RubyException extends RubyObject {
             attrs.add(new VariableEntry<>("mesg", exc.getMessage()));
             attrs.add(new VariableEntry<>("bt", exc.getBacktrace()));
             marshalStream.dumpVariables(attrs);
+        }
+
+        @Override
+        public void marshalTo(RubyException exc, RubyClass type,
+                              NewMarshal marshalStream, ThreadContext context, NewMarshal.RubyOutputStream out) {
+            marshalStream.registerLinkTarget(exc);
+            List<Variable<Object>> attrs = exc.getMarshalVariableList();
+            attrs.add(new VariableEntry<>("mesg", exc.getMessage()));
+            attrs.add(new VariableEntry<>("bt", exc.getBacktrace()));
+            marshalStream.dumpVariables(context, out, attrs);
         }
 
         @Override

--- a/core/src/main/java/org/jruby/RubyFloat.java
+++ b/core/src/main/java/org/jruby/RubyFloat.java
@@ -55,6 +55,7 @@ import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.marshal.MarshalStream;
+import org.jruby.runtime.marshal.NewMarshal;
 import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.util.ByteList;
 import org.jruby.util.ConvertDouble;
@@ -1213,6 +1214,11 @@ public class RubyFloat extends RubyNumeric implements Appendable {
     public static void marshalTo(RubyFloat aFloat, MarshalStream output) throws java.io.IOException {
         output.registerLinkTarget(aFloat);
         output.writeString(aFloat.marshalDump());
+    }
+
+    public static void marshalTo(RubyFloat aFloat, NewMarshal output, ThreadContext context, NewMarshal.RubyOutputStream out) {
+        output.registerLinkTarget(aFloat);
+        output.writeString(out, aFloat.marshalDump());
     }
 
     public static RubyFloat unmarshalFrom(UnmarshalStream input) throws java.io.IOException {

--- a/core/src/main/java/org/jruby/RubyFloat.java
+++ b/core/src/main/java/org/jruby/RubyFloat.java
@@ -1216,7 +1216,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         output.writeString(aFloat.marshalDump());
     }
 
-    public static void marshalTo(RubyFloat aFloat, NewMarshal output, ThreadContext context, NewMarshal.RubyOutputStream out) {
+    public static void marshalTo(RubyFloat aFloat, NewMarshal output, NewMarshal.RubyOutputStream out) {
         output.registerLinkTarget(aFloat);
         output.writeString(out, aFloat.marshalDump());
     }

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -2484,7 +2484,13 @@ public class RubyHash extends RubyObject implements Map {
         int hashSize = hash.size();
         output.writeInt(out, hashSize);
         try {
-            hash.visitLimited(hash.getRuntime().getCurrentContext(), MarshalDumpVisitor, hashSize, output);
+            hash.visitLimited(hash.getRuntime().getCurrentContext(), new VisitorWithState<NewMarshal>() {
+                @Override
+                public void visit(ThreadContext context, RubyHash self, IRubyObject key, IRubyObject value, int index, NewMarshal state) {
+                    state.dumpObject(context, out, key);
+                    state.dumpObject(context, out, value);
+                }
+            }, hashSize, output);
         } catch (VisitorIOException e) {
             out.handle((IOException) e.getCause());
         }

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -58,6 +58,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.callsite.CachingCallSite;
 import org.jruby.runtime.marshal.MarshalStream;
+import org.jruby.runtime.marshal.NewMarshal;
 import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.util.ByteList;
 import org.jruby.util.RecursiveComparator;
@@ -2476,6 +2477,19 @@ public class RubyHash extends RubyObject implements Map {
         }
 
         if (hash.ifNone != UNDEF) output.dumpObject(hash.ifNone);
+    }
+
+    public static void marshalTo(final RubyHash hash, final NewMarshal output, ThreadContext context, NewMarshal.RubyOutputStream out) {
+        output.registerLinkTarget(hash);
+        int hashSize = hash.size();
+        output.writeInt(out, hashSize);
+        try {
+            hash.visitLimited(hash.getRuntime().getCurrentContext(), MarshalDumpVisitor, hashSize, output);
+        } catch (VisitorIOException e) {
+            out.handle((IOException) e.getCause());
+        }
+
+        if (hash.ifNone != UNDEF) output.dumpObject(context, out, hash.ifNone);
     }
 
     private static final VisitorWithState<MarshalStream> MarshalDumpVisitor = new VisitorWithState<MarshalStream>() {

--- a/core/src/main/java/org/jruby/RubyMarshal.java
+++ b/core/src/main/java/org/jruby/RubyMarshal.java
@@ -41,11 +41,9 @@ import java.io.OutputStream;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyModule;
 
-import org.jruby.api.Error;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.runtime.*;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.runtime.marshal.MarshalStream;
 import org.jruby.runtime.marshal.NewMarshal;
 import org.jruby.runtime.marshal.UnmarshalStream;
 

--- a/core/src/main/java/org/jruby/RubyMarshal.java
+++ b/core/src/main/java/org/jruby/RubyMarshal.java
@@ -168,7 +168,7 @@ public class RubyMarshal {
 
     private static void dumpToStream(ThreadContext context, IRubyObject object, OutputStream rawOutput, int depthLimit) {
         NewMarshal output = new NewMarshal(depthLimit);
-        NewMarshal.RubyOutputStream out = new NewMarshal.RubyOutputStream(rawOutput, ioe -> {throw context.runtime.newIOErrorFromException(ioe);});
+        NewMarshal.RubyOutputStream out = new NewMarshal.RubyOutputStream(rawOutput, context);
 
         output.start(out);
         output.dumpObject(context, out, object);

--- a/core/src/main/java/org/jruby/RubyMarshal.java
+++ b/core/src/main/java/org/jruby/RubyMarshal.java
@@ -34,7 +34,6 @@
 package org.jruby;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -53,6 +52,7 @@ import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.util.ByteList;
 import org.jruby.util.IOInputStream;
 import org.jruby.util.IOOutputStream;
+import org.jruby.util.io.TransparentByteArrayOutputStream;
 
 import static org.jruby.api.Error.typeError;
 
@@ -103,9 +103,9 @@ public class RubyMarshal {
             return io;
         }
 
-        ByteArrayOutputStream stringOutput = new ByteArrayOutputStream();
+        TransparentByteArrayOutputStream stringOutput = new TransparentByteArrayOutputStream();
         dumpToStream(context, objectToDump, stringOutput, depthLimit);
-        RubyString result = RubyString.newString(runtime, new ByteList(stringOutput.toByteArray(), false));
+        RubyString result = RubyString.newString(runtime, new ByteList(stringOutput.getRawBytes(), 0, stringOutput.size(), false));
 
         return result;
     }

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -113,6 +113,7 @@ import org.jruby.runtime.builtin.Variable;
 import org.jruby.runtime.callsite.CacheEntry;
 import org.jruby.runtime.load.LoadService;
 import org.jruby.runtime.marshal.MarshalStream;
+import org.jruby.runtime.marshal.NewMarshal;
 import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.runtime.opto.Invalidator;
 import org.jruby.runtime.opto.OptoFactory;
@@ -3735,6 +3736,11 @@ public class RubyModule extends RubyObject {
     public static void marshalTo(RubyModule module, MarshalStream output) throws java.io.IOException {
         output.registerLinkTarget(module);
         output.writeString(MarshalStream.getPathFromClass(module));
+    }
+
+    public static void marshalTo(RubyModule module, NewMarshal output, ThreadContext context, NewMarshal.RubyOutputStream out) {
+        output.registerLinkTarget(module);
+        output.writeString(out, MarshalStream.getPathFromClass(module));
     }
 
     public static RubyModule unmarshalFrom(UnmarshalStream input) throws java.io.IOException {

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -654,8 +654,7 @@ public class RubyModule extends RubyObject {
      * @return The generated class name
      */
     public String getName() {
-        if (cachedName != null) return cachedName;
-        return calculateName();
+        return cachedName != null ? cachedName : calculateName();
     }
 
     /**
@@ -668,6 +667,24 @@ public class RubyModule extends RubyObject {
      */
     public RubyString rubyName() {
         return cachedRubyName != null ? cachedRubyName : calculateRubyName();
+    }
+
+    /**
+     * Generate a fully-qualified class name or a #-style name as a Symbol. If any element of the path is anonymous,
+     * returns null.
+     *
+     * @return a properly encoded non-anonymous class path as a Symbol, or null.
+     */
+    public RubySymbol symbolName() {
+        IRubyObject symbolName = cachedSymbolName;
+
+        if (symbolName == null) {
+            cachedSymbolName = symbolName = calculateSymbolName();
+        }
+
+        if (symbolName == UNDEF) return null;
+
+        return (RubySymbol) symbolName;
     }
 
     public RubyString rubyBaseName() {
@@ -691,16 +708,18 @@ public class RubyModule extends RubyObject {
 
         if (getBaseName() == null) return calculateAnonymousRubyName(); // no name...anonymous!
 
+        Ruby runtime = getRuntime();
+
         if (usingTemporaryName()) { // temporary name
-            cachedRubyName = getRuntime().newSymbol(baseName).toRubyString(getRuntime().getCurrentContext());
+            cachedRubyName = runtime.newSymbol(baseName).toRubyString(getRuntime().getCurrentContext());
             return cachedRubyName;
         }
-
-        Ruby runtime = getRuntime();
+        
         RubyClass objectClass = runtime.getObject();
-        List<RubyString> parents = new ArrayList<>();
-        for (RubyModule p = getParent(); p != null && p != objectClass; p = p.getParent()) {
-            if (p == this) break;  // Break out of cyclic namespaces like C::A = C2; C2::A = C (jruby/jruby#2314)
+        List<RubyString> parents = new ArrayList<>(5);
+        for (RubyModule p = getParent();
+             p != null && p != objectClass && p != this; // Break out of cyclic namespaces like C::A = C2; C2::A = C (jruby/jruby#2314)
+             p = p.getParent()) {
 
             RubyString name = p.rubyBaseName();
 
@@ -717,21 +736,60 @@ public class RubyModule extends RubyObject {
             parents.add(name);
         }
 
-        Collections.reverse(parents);
+        RubyString fullName = buildPathString(runtime, parents);
 
+        if (cache) cachedRubyName = fullName;
+
+        return fullName;
+    }
+
+    /**
+     * Calculate the module's name path as a Symbol. If any element in the path is anonymous, this will return null.
+     *
+     * Used primarily by Marshal.dump for class names.
+     *
+     * @return a non-anonymous class path as a Symbol, or null
+     */
+    private IRubyObject calculateSymbolName() {
+        if (getBaseName() == null) return UNDEF;
+
+        Ruby runtime = getRuntime();
+
+        if (usingTemporaryName()) { // temporary name
+            return runtime.newSymbol(baseName);
+        }
+
+        RubyClass objectClass = runtime.getObject();
+        List<RubyString> parents = new ArrayList<>(5);
+        for (RubyModule p = getParent();
+             p != null && p != objectClass && p != this; // Break out of cyclic namespaces like C::A = C2; C2::A = C (jruby/jruby#2314)
+             p = p.getParent()) {
+
+            RubyString name = p.rubyBaseName();
+
+            if (name == null) {
+                return UNDEF;
+            }
+
+            parents.add(name);
+        }
+
+        RubyString fullName = buildPathString(runtime, parents);
+
+        return fullName.intern();
+    }
+
+    private RubyString buildPathString(Ruby runtime, List<RubyString> parents) {
         RubyString colons = runtime.newString("::");
         RubyString fullName = runtime.newString();       // newString creates empty ByteList which ends up as
         fullName.setEncoding(USASCIIEncoding.INSTANCE);  // ASCII-8BIT.  8BIT is unfriendly to string concats.
-        for (RubyString parent:  parents) {
-            RubyString rubyString = fullName.catWithCodeRange(parent);
+        for (int i = parents.size() - 1; i >= 0; i--) {
+            RubyString rubyString = fullName.catWithCodeRange(parents.get(i));
             rubyString.catWithCodeRange(colons);
         }
         fullName.catWithCodeRange(rubyBaseName());
 
         fullName.setFrozen(true);
-
-        if (cache) cachedRubyName = fullName;
-
         return fullName;
     }
 
@@ -5779,6 +5837,7 @@ public class RubyModule extends RubyObject {
      */
     private transient String cachedName;
     private transient RubyString cachedRubyName;
+    private transient IRubyObject cachedSymbolName;
 
     @SuppressWarnings("unchecked")
     private volatile Map<String, ConstantEntry> constants = Collections.EMPTY_MAP;

--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -61,6 +61,7 @@ import org.jruby.runtime.component.VariableEntry;
 import org.jruby.runtime.invokedynamic.MethodNames;
 import org.jruby.runtime.marshal.CoreObjectType;
 import org.jruby.runtime.marshal.MarshalStream;
+import org.jruby.runtime.marshal.NewMarshal;
 import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.util.ShellLauncher;
 import org.jruby.exceptions.RaiseException;
@@ -174,6 +175,21 @@ public class RubyProcess {
             attrs.add(new VariableEntry("pid", runtime.newFixnum(status.pid)));
 
             marshalStream.dumpVariables(attrs);
+        }
+
+        @Override
+        public void marshalTo(Object obj, RubyClass type,
+                              NewMarshal marshalStream, ThreadContext context, NewMarshal.RubyOutputStream out) {
+            RubyStatus status = (RubyStatus) obj;
+
+            marshalStream.registerLinkTarget(status);
+            List<Variable<Object>> attrs = status.getMarshalVariableList();
+
+            Ruby runtime = context.runtime;
+            attrs.add(new VariableEntry("status", runtime.newFixnum(status.status)));
+            attrs.add(new VariableEntry("pid", runtime.newFixnum(status.pid)));
+
+            marshalStream.dumpVariables(context, out, attrs);
         }
 
         @Override

--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -183,13 +183,13 @@ public class RubyProcess {
             RubyStatus status = (RubyStatus) obj;
 
             marshalStream.registerLinkTarget(status);
-            List<Variable<Object>> attrs = status.getMarshalVariableList();
 
-            Ruby runtime = context.runtime;
-            attrs.add(new VariableEntry("status", runtime.newFixnum(status.status)));
-            attrs.add(new VariableEntry("pid", runtime.newFixnum(status.pid)));
-
-            marshalStream.dumpVariables(context, out, attrs);
+            marshalStream.dumpVariables(context, out, status, 3, (marshal, c, o, v, receiver) -> {
+                Ruby runtime = c.runtime;
+                // TODO: marshal these values directly
+                receiver.receive(marshal, c, o, "status", runtime.newFixnum(v.status));
+                receiver.receive(marshal, c, o, "pid", runtime.newFixnum(v.pid));
+            });
         }
 
         @Override

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -73,6 +73,7 @@ import org.jruby.runtime.callsite.RespondToCallSite;
 import org.jruby.runtime.component.VariableEntry;
 import org.jruby.runtime.invokedynamic.MethodNames;
 import org.jruby.runtime.marshal.MarshalStream;
+import org.jruby.runtime.marshal.NewMarshal;
 import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.util.Numeric;
 import org.jruby.util.TypeConverter;
@@ -1301,6 +1302,21 @@ public class RubyRange extends RubyObject {
             attrs.add(new VariableEntry<Object>("end", range.end));
 
             marshalStream.dumpVariables(attrs);
+        }
+
+        @Override
+        public void marshalTo(Object obj, RubyClass type,
+                              NewMarshal marshalStream, ThreadContext context, NewMarshal.RubyOutputStream out) {
+            RubyRange range = (RubyRange) obj;
+
+            marshalStream.registerLinkTarget(range);
+            List<Variable<Object>> attrs = range.getMarshalVariableList();
+
+            attrs.add(new VariableEntry<Object>("excl", range.isExclusive ? context.tru : context.fals));
+            attrs.add(new VariableEntry<Object>("begin", range.begin));
+            attrs.add(new VariableEntry<Object>("end", range.end));
+
+            marshalStream.dumpVariables(context, out, attrs);
         }
 
         @Override

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -1310,13 +1310,12 @@ public class RubyRange extends RubyObject {
             RubyRange range = (RubyRange) obj;
 
             marshalStream.registerLinkTarget(range);
-            List<Variable<Object>> attrs = range.getMarshalVariableList();
 
-            attrs.add(new VariableEntry<Object>("excl", range.isExclusive ? context.tru : context.fals));
-            attrs.add(new VariableEntry<Object>("begin", range.begin));
-            attrs.add(new VariableEntry<Object>("end", range.end));
-
-            marshalStream.dumpVariables(context, out, attrs);
+            marshalStream.dumpVariables(context, out, range, 3, (marshal, c, o, v, receiver) -> {
+                receiver.receive(marshal, c, o, "excl", v.isExclusive ? c.tru : c.fals);
+                receiver.receive(marshal, c, o, "begin", v.begin);
+                receiver.receive(marshal, c, o, "end", v.end);
+            });
         }
 
         @Override

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -46,6 +46,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.marshal.MarshalStream;
+import org.jruby.runtime.marshal.NewMarshal;
 import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.util.ByteList;
 import org.jruby.util.Numeric;
@@ -1466,6 +1467,10 @@ public class RubyRational extends RubyNumeric {
         @Override
         public void marshalTo(Ruby runtime, Object obj, RubyClass type, MarshalStream marshalStream) {
             throw typeError(runtime.getCurrentContext(), "marshal_dump should be used instead for Rational");
+        }
+        @Override
+        public void marshalTo(Object obj, RubyClass type, NewMarshal marshalStream, ThreadContext context, NewMarshal.RubyOutputStream out) {
+            throw typeError(context, "marshal_dump should be used instead for Rational");
         }
 
         @Override

--- a/core/src/main/java/org/jruby/RubyRegexp.java
+++ b/core/src/main/java/org/jruby/RubyRegexp.java
@@ -66,6 +66,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.encoding.EncodingCapable;
 import org.jruby.runtime.encoding.MarshalEncoding;
 import org.jruby.runtime.marshal.MarshalStream;
+import org.jruby.runtime.marshal.NewMarshal;
 import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.util.ByteList;
 import org.jruby.util.KCode;
@@ -1871,6 +1872,17 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         if (regexp.getOptions().isFixed()) options |= RE_FIXED;
 
         output.writeByte(options);
+    }
+
+    public static void marshalTo(RubyRegexp regexp, NewMarshal output, NewMarshal.RubyOutputStream out) {
+        output.registerLinkTarget(regexp);
+        output.writeString(out, regexp.str);
+
+        int options = regexp.pattern.getOptions() & EMBEDDABLE;
+
+        if (regexp.getOptions().isFixed()) options |= RE_FIXED;
+
+        output.writeByte(out, options);
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -54,6 +54,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.marshal.MarshalStream;
+import org.jruby.runtime.marshal.NewMarshal;
 import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.util.ByteList;
 import org.jruby.util.RecursiveComparator;
@@ -895,6 +896,20 @@ public class RubyStruct extends RubyObject {
             RubySymbol name = (RubySymbol) member.eltInternal(i);
             output.dumpObject(name);
             output.dumpObject(struct.values[i]);
+        }
+    }
+
+    public static void marshalTo(RubyStruct struct, NewMarshal output, ThreadContext context, NewMarshal.RubyOutputStream out) {
+        output.registerLinkTarget(struct);
+        output.dumpDefaultObjectHeader(context, out, 'S', struct.getMetaClass());
+
+        RubyArray member = __member__(struct.classOf());
+        output.writeInt(out, member.size());
+
+        for (int i = 0; i < member.size(); i++) {
+            RubySymbol name = (RubySymbol) member.eltInternal(i);
+            output.dumpObject(context, out, name);
+            output.dumpObject(context, out, struct.values[i]);
         }
     }
 

--- a/core/src/main/java/org/jruby/RubySystemCallError.java
+++ b/core/src/main/java/org/jruby/RubySystemCallError.java
@@ -156,12 +156,11 @@ public class RubySystemCallError extends RubyStandardError {
             RubySystemCallError exc = (RubySystemCallError) obj;
             marshalStream.registerLinkTarget(exc);
 
-            List<Variable<Object>> attrs = exc.getMarshalVariableList();
-            attrs.add(new VariableEntry<Object>(
-                    "mesg", exc.message == null ? context.nil : exc.message));
-            attrs.add(new VariableEntry<Object>("errno", exc.errno));
-            attrs.add(new VariableEntry<Object>("bt", exc.getBacktrace()));
-            marshalStream.dumpVariables(context, out, attrs);
+            marshalStream.dumpVariables(context, out, exc, 3, (marshal, c, o, v, receiver) -> {
+                receiver.receive(marshal, c, o, "mesg", v.message == null ? c.nil : v.message);
+                receiver.receive(marshal, c, o, "errno", v.errno);
+                receiver.receive(marshal, c, o, "bt", v.getBacktrace());
+            });
         }
 
         @Override

--- a/core/src/main/java/org/jruby/RubySystemCallError.java
+++ b/core/src/main/java/org/jruby/RubySystemCallError.java
@@ -14,10 +14,13 @@ import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ObjectMarshal;
 import static org.jruby.runtime.Visibility.*;
+
+import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.builtin.Variable;
 import org.jruby.runtime.component.VariableEntry;
 import org.jruby.runtime.marshal.MarshalStream;
+import org.jruby.runtime.marshal.NewMarshal;
 import org.jruby.runtime.marshal.UnmarshalStream;
 
 import jnr.constants.platform.Errno;
@@ -138,13 +141,27 @@ public class RubySystemCallError extends RubyStandardError {
                               MarshalStream marshalStream) throws IOException {
             RubySystemCallError exc = (RubySystemCallError) obj;
             marshalStream.registerLinkTarget(exc);
-            
+
             List<Variable<Object>> attrs = exc.getMarshalVariableList();
             attrs.add(new VariableEntry<Object>(
                     "mesg", exc.message == null ? runtime.getNil() : exc.message));
             attrs.add(new VariableEntry<Object>("errno", exc.errno));
             attrs.add(new VariableEntry<Object>("bt", exc.getBacktrace()));
             marshalStream.dumpVariables(attrs);
+        }
+
+        @Override
+        public void marshalTo(Object obj, RubyClass type,
+                              NewMarshal marshalStream, ThreadContext context, NewMarshal.RubyOutputStream out) {
+            RubySystemCallError exc = (RubySystemCallError) obj;
+            marshalStream.registerLinkTarget(exc);
+
+            List<Variable<Object>> attrs = exc.getMarshalVariableList();
+            attrs.add(new VariableEntry<Object>(
+                    "mesg", exc.message == null ? context.nil : exc.message));
+            attrs.add(new VariableEntry<Object>("errno", exc.errno));
+            attrs.add(new VariableEntry<Object>("bt", exc.getBacktrace()));
+            marshalStream.dumpVariables(context, out, attrs);
         }
 
         @Override

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -38,6 +38,7 @@ import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.*;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.marshal.MarshalStream;
+import org.jruby.runtime.marshal.NewMarshal;
 import org.jruby.runtime.marshal.UnmarshalStream;
 import org.jruby.util.ArraySupport;
 
@@ -84,6 +85,10 @@ public class RubySet extends RubyObject implements Set {
 
         public void marshalTo(Ruby runtime, Object obj, RubyClass type, MarshalStream marshalStream) throws IOException {
             defaultMarshal.marshalTo(runtime, obj, type, marshalStream);
+        }
+
+        public void marshalTo(Object obj, RubyClass type, NewMarshal marshalStream, ThreadContext context, NewMarshal.RubyOutputStream out) {
+            defaultMarshal.marshalTo(obj, type, marshalStream, context, out);
         }
 
         public Object unmarshalFrom(Ruby runtime, RubyClass type, UnmarshalStream unmarshalStream) throws IOException {

--- a/core/src/main/java/org/jruby/runtime/ObjectMarshal.java
+++ b/core/src/main/java/org/jruby/runtime/ObjectMarshal.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.runtime.marshal.MarshalStream;
+import org.jruby.runtime.marshal.NewMarshal;
 import org.jruby.runtime.marshal.UnmarshalStream;
 
 import static org.jruby.api.Error.typeError;
@@ -41,9 +42,13 @@ import static org.jruby.api.Error.typeError;
  * @author headius
  */
 public interface ObjectMarshal<T> {
-    public static final ObjectMarshal NOT_MARSHALABLE_MARSHAL = new ObjectMarshal() {
+    ObjectMarshal NOT_MARSHALABLE_MARSHAL = new ObjectMarshal() {
         public void marshalTo(Ruby runtime, Object obj, RubyClass type, MarshalStream marshalStream) {
             throw typeError(runtime.getCurrentContext(), "no marshal_dump is defined for class " + type.getName());
+        }
+
+        public void marshalTo(Object obj, RubyClass type, NewMarshal marshalStream, ThreadContext context, NewMarshal.RubyOutputStream out) {
+            throw typeError(context, "no marshal_dump is defined for class " + type.getName());
         }
 
         public Object unmarshalFrom(Ruby runtime, RubyClass type, UnmarshalStream unmarshalStream) {
@@ -52,5 +57,6 @@ public interface ObjectMarshal<T> {
     };
     
     void marshalTo(Ruby runtime, T obj, RubyClass type, MarshalStream marshalStream) throws IOException;
+    void marshalTo(T obj, RubyClass type, NewMarshal marshalStream, ThreadContext context, NewMarshal.RubyOutputStream out);
     T unmarshalFrom(Ruby runtime, RubyClass type, UnmarshalStream unmarshalStream) throws IOException;
 }

--- a/core/src/main/java/org/jruby/runtime/builtin/IRubyObject.java
+++ b/core/src/main/java/org/jruby/runtime/builtin/IRubyObject.java
@@ -47,6 +47,7 @@ import org.jruby.RubyString;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.JavaSites;
 import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.marshal.NewMarshal;
 
 /**
  * Object is the parent class of all classes in Ruby. Its methods are
@@ -374,6 +375,10 @@ public interface IRubyObject {
      */
     default List<Variable<Object>> getMarshalVariableList() {
         return getVariableList();
+    }
+
+    default void marshalLiveVariables(NewMarshal stream, ThreadContext context, NewMarshal.RubyOutputStream out) {
+
     }
 
     //

--- a/core/src/main/java/org/jruby/runtime/marshal/MarshalCache.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/MarshalCache.java
@@ -40,10 +40,11 @@ import org.jruby.RubySymbol;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
+import org.jruby.util.collections.HashMapInt;
 
 public class MarshalCache {
-    private final Map<IRubyObject, Integer> linkCache = new IdentityHashMap();
-    private final Map<ByteList, Integer> symbolCache = new HashMap();
+    private final HashMapInt linkCache = new HashMapInt<>(true);
+    private final HashMapInt symbolCache = new HashMapInt<ByteList>();
 
     public boolean isRegistered(IRubyObject value) {
         assert !(value instanceof RubySymbol) : "Use isSymbolRegistered for symbol links";
@@ -90,7 +91,7 @@ public class MarshalCache {
     }
 
     private int registeredIndex(IRubyObject value) {
-        return linkCache.get(value).intValue();
+        return linkCache.get(value);
     }
 
     private int registeredSymbolIndex(ByteList sym) {

--- a/core/src/main/java/org/jruby/runtime/marshal/MarshalCache.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/MarshalCache.java
@@ -72,11 +72,11 @@ public class MarshalCache {
         output.writeInt(registeredIndex(value));
     }
 
-    public void writeLink(NewMarshal output, ThreadContext context, NewMarshal.RubyOutputStream out, IRubyObject value) {
+    public void writeLink(NewMarshal output, NewMarshal.RubyOutputStream out, IRubyObject value) {
         assert !(value instanceof RubySymbol) : "Use writeSymbolLink for symbols";
 
         out.write('@');
-        out.write(registeredIndex(value));
+        output.writeInt(out, registeredIndex(value));
     }
 
     public void writeSymbolLink(MarshalStream output, ByteList sym) throws IOException {
@@ -84,7 +84,7 @@ public class MarshalCache {
         output.writeInt(registeredSymbolIndex(sym));
     }
 
-    public void writeSymbolLink(NewMarshal output, ThreadContext context, NewMarshal.RubyOutputStream out, ByteList sym) {
+    public void writeSymbolLink(NewMarshal output, NewMarshal.RubyOutputStream out, ByteList sym) {
         out.write(';');
         output.writeInt(out, registeredSymbolIndex(sym));
     }

--- a/core/src/main/java/org/jruby/runtime/marshal/MarshalCache.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/MarshalCache.java
@@ -37,6 +37,7 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 
 import org.jruby.RubySymbol;
+import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 
@@ -71,9 +72,21 @@ public class MarshalCache {
         output.writeInt(registeredIndex(value));
     }
 
+    public void writeLink(NewMarshal output, ThreadContext context, NewMarshal.RubyOutputStream out, IRubyObject value) {
+        assert !(value instanceof RubySymbol) : "Use writeSymbolLink for symbols";
+
+        out.write('@');
+        out.write(registeredIndex(value));
+    }
+
     public void writeSymbolLink(MarshalStream output, ByteList sym) throws IOException {
         output.write(';');
         output.writeInt(registeredSymbolIndex(sym));
+    }
+
+    public void writeSymbolLink(NewMarshal output, ThreadContext context, NewMarshal.RubyOutputStream out, ByteList sym) {
+        out.write(';');
+        output.writeInt(out, registeredSymbolIndex(sym));
     }
 
     private int registeredIndex(IRubyObject value) {

--- a/core/src/main/java/org/jruby/runtime/marshal/MarshalCommon.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/MarshalCommon.java
@@ -27,7 +27,7 @@ public class MarshalCommon {
     static final char TYPE_IVAR	= 'I';
     static final char TYPE_LINK	= '@';
 
-    static final String SYMBOL_ENCODING_SPECIAL = "E";
-    static final String SYMBOL_ENCODING = "encoding";
+    public static final String SYMBOL_ENCODING_SPECIAL = "E";
+    public static final String SYMBOL_ENCODING = "encoding";
     static final String RUBY2_KEYWORDS_FLAG = "K";
 }

--- a/core/src/main/java/org/jruby/runtime/marshal/NewMarshal.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/NewMarshal.java
@@ -71,8 +71,6 @@ import java.util.function.BiConsumer;
 import static org.jruby.RubyBasicObject.getMetaClass;
 import static org.jruby.api.Convert.castToString;
 import static org.jruby.api.Error.typeError;
-import static org.jruby.runtime.marshal.MarshalCommon.SYMBOL_ENCODING;
-import static org.jruby.runtime.marshal.MarshalCommon.SYMBOL_ENCODING_SPECIAL;
 import static org.jruby.runtime.marshal.MarshalCommon.TYPE_IVAR;
 import static org.jruby.runtime.marshal.MarshalCommon.TYPE_UCLASS;
 import static org.jruby.runtime.marshal.MarshalCommon.TYPE_USERDEF;

--- a/core/src/main/java/org/jruby/runtime/marshal/NewMarshal.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/NewMarshal.java
@@ -602,7 +602,7 @@ public class NewMarshal {
     public void dumpDefaultObjectHeader(ThreadContext context, RubyOutputStream out, char tp, RubyClass type) {
         dumpExtended(context, out, type);
         out.write(tp);
-        writeAndRegisterSymbol(out, RubySymbol.newSymbol(context.runtime, getPathFromClass(context, type.getRealClass())));
+        writeAndRegisterSymbol(out, getPathFromClass(context, type.getRealClass()));
     }
 
     public void writeString(RubyOutputStream out, String value) {

--- a/core/src/main/java/org/jruby/runtime/marshal/NewMarshal.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/NewMarshal.java
@@ -1,0 +1,595 @@
+/*
+ ***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2002-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2004 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004 Charles O Nutter <headius@headius.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2006 Ola Bini <ola.bini@ki.se>
+ * Copyright (C) 2007 William N Dortch <bill.dortch@gmail.com>
+ * 
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby.runtime.marshal;
+
+import org.jcodings.Encoding;
+import org.jcodings.specific.USASCIIEncoding;
+import org.jcodings.specific.UTF8Encoding;
+import org.jruby.Ruby;
+import org.jruby.RubyArray;
+import org.jruby.RubyBasicObject;
+import org.jruby.RubyBignum;
+import org.jruby.RubyBoolean;
+import org.jruby.RubyClass;
+import org.jruby.RubyFixnum;
+import org.jruby.RubyFloat;
+import org.jruby.RubyHash;
+import org.jruby.RubyModule;
+import org.jruby.RubyRegexp;
+import org.jruby.RubyString;
+import org.jruby.RubyStruct;
+import org.jruby.RubySymbol;
+import org.jruby.internal.runtime.methods.DynamicMethod;
+import org.jruby.runtime.ClassIndex;
+import org.jruby.runtime.Constants;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.builtin.Variable;
+import org.jruby.runtime.callsite.CacheEntry;
+import org.jruby.runtime.encoding.MarshalEncoding;
+import org.jruby.util.ByteList;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static org.jruby.RubyBasicObject.getMetaClass;
+import static org.jruby.api.Convert.castToString;
+import static org.jruby.api.Error.typeError;
+import static org.jruby.runtime.marshal.MarshalCommon.SYMBOL_ENCODING;
+import static org.jruby.runtime.marshal.MarshalCommon.SYMBOL_ENCODING_SPECIAL;
+import static org.jruby.runtime.marshal.MarshalCommon.TYPE_IVAR;
+import static org.jruby.runtime.marshal.MarshalCommon.TYPE_UCLASS;
+import static org.jruby.runtime.marshal.MarshalCommon.TYPE_USERDEF;
+import static org.jruby.runtime.marshal.MarshalCommon.TYPE_USRMARSHAL;
+import static org.jruby.util.RubyStringBuilder.str;
+import static org.jruby.util.RubyStringBuilder.types;
+
+/**
+ * Marshals objects into Ruby's binary marshal format.
+ *
+ * @author Anders
+ */
+public class NewMarshal {
+    private final MarshalCache cache;
+    private final int depthLimit;
+    private int depth = 0;
+
+    public NewMarshal(int depthLimit) {
+        this.cache = new MarshalCache();
+        this.depthLimit = depthLimit >= 0 ? depthLimit : Integer.MAX_VALUE;
+    }
+
+    public static class RubyOutputStream extends OutputStream {
+        private final OutputStream wrap;
+        private final Consumer<IOException> handler;
+
+        public RubyOutputStream(OutputStream wrap, Consumer<IOException> handler) {
+            this.wrap = wrap;
+            this.handler = handler;
+        }
+
+        public void write(int b) {
+            try {
+                wrap.write(b);
+            } catch (IOException ioe) {
+                handle(ioe);
+            }
+        }
+
+        public void write(byte[] b, int off, int len) {
+            try {
+                wrap.write(b, off, len);
+            } catch (IOException ioe) {
+                handle(ioe);
+            }
+        }
+
+        public void write(byte[] b) {
+            try {
+                wrap.write(b);
+            } catch (IOException ioe) {
+                handle(ioe);
+            }
+        }
+
+        public void handle(IOException ioe) {
+            handler.accept(ioe);
+        }
+    }
+
+    public void start(RubyOutputStream out) {
+        out.write(Constants.MARSHAL_MAJOR);
+        out.write(Constants.MARSHAL_MINOR);
+    }
+
+    public void dumpObject(ThreadContext context, RubyOutputStream out, IRubyObject value) {
+        depth++;
+        
+        if (depth > depthLimit) throw context.runtime.newArgumentError("exceed depth limit");
+
+        writeAndRegister(context, out, value);
+
+        depth--;
+    }
+
+    public void registerLinkTarget(IRubyObject newObject) {
+        if (shouldBeRegistered(newObject)) {
+            cache.register(newObject);
+        }
+    }
+
+    public void registerSymbol(ByteList sym) {
+        cache.registerSymbol(sym);
+    }
+
+    static boolean shouldBeRegistered(IRubyObject value) {
+        if (value.isNil()) {
+            return false;
+        } else if (value instanceof RubyBoolean) {
+            return false;
+        } else if (value instanceof RubyFixnum) {
+            return ! isMarshalFixnum((RubyFixnum)value);
+        }
+        return true;
+    }
+
+    private static boolean isMarshalFixnum(RubyFixnum fixnum) {
+        return fixnum.getLongValue() <= RubyFixnum.MAX_MARSHAL_FIXNUM && fixnum.getLongValue() >= RubyFixnum.MIN_MARSHAL_FIXNUM;
+    }
+
+    private void writeAndRegisterSymbol(ThreadContext context, RubyOutputStream out, ByteList sym) {
+        if (cache.isSymbolRegistered(sym)) {
+            cache.writeSymbolLink(this, context, out, sym);
+        } else {
+            registerSymbol(sym);
+            dumpSymbol(out, sym);
+        }
+    }
+
+    private void writeAndRegister(ThreadContext context, RubyOutputStream out, IRubyObject value) {
+        if (!(value instanceof RubySymbol) && cache.isRegistered(value)) {
+            cache.writeLink(this, context, out, value);
+        } else {
+            value.getMetaClass().smartDump(this, context, out, value);
+        }
+    }
+
+    private List<Variable<Object>> getVariables(ThreadContext context, RubyOutputStream out, IRubyObject value) {
+        List<Variable<Object>> variables = null;
+        if (value instanceof CoreObjectType) {
+            ClassIndex nativeClassIndex = ((CoreObjectType)value).getNativeClassIndex();
+            
+            if (nativeClassIndex != ClassIndex.OBJECT && nativeClassIndex != ClassIndex.BASICOBJECT) {
+                if (shouldMarshalEncoding(value) || (
+                        !value.isImmediate()
+                        && value.hasVariables()
+                        && nativeClassIndex != ClassIndex.CLASS
+                        && nativeClassIndex != ClassIndex.MODULE
+                        )) {
+                    // object has instance vars and isn't a class, get a snapshot to be marshalled
+                    // and output the ivar header here
+
+                    variables = value.getMarshalVariableList();
+
+                    // check if any of those variables were actually set
+                    if (variables.size() > 0 || shouldMarshalEncoding(value)) {
+                        // write `I' instance var signet if class is NOT a direct subclass of Object
+                        out.write(TYPE_IVAR);
+                    } else {
+                        // no variables, no encoding
+                        variables = null;
+                    }
+                }
+                final RubyClass meta = getMetaClass(value);
+                RubyClass type = meta;
+                switch(nativeClassIndex) {
+                case STRING:
+                case REGEXP:
+                case ARRAY:
+                case HASH:
+                    type = dumpExtended(context, out, meta);
+                    break;
+                }
+
+                if (nativeClassIndex != meta.getClassIndex() &&
+                        nativeClassIndex != ClassIndex.STRUCT &&
+                        nativeClassIndex != ClassIndex.FIXNUM &&
+                        nativeClassIndex != ClassIndex.BIGNUM) {
+                    // object is a custom class that extended one of the native types other than Object
+                    writeUserClass(context, out, value, type);
+                }
+            }
+        }
+        return variables;
+    }
+
+    private static boolean shouldMarshalEncoding(IRubyObject value) {
+        if (!(value instanceof MarshalEncoding)) return false;
+        return ((MarshalEncoding) value).shouldMarshalEncoding();
+    }
+
+    public void writeDirectly(ThreadContext context, RubyOutputStream out, IRubyObject value) {
+        List<Variable<Object>> variables = getVariables(context, out, value);
+        writeObjectData(context, out, value);
+        if (variables != null) {
+            dumpVariablesWithEncoding(context, out, variables, value);
+        }
+    }
+
+    public static String getPathFromClass(RubyModule clazz) {
+        RubyString path = clazz.rubyName();
+        
+        if (path.charAt(0) == '#') {
+            Ruby runtime = clazz.getRuntime();
+            String type = clazz.isClass() ? "class" : "module";
+            throw typeError(runtime.getCurrentContext(), str(runtime, "can't dump anonymous " + type + " ", types(runtime, clazz)));
+        }
+        
+        RubyModule real = clazz.isModule() ? clazz : ((RubyClass)clazz).getRealClass();
+        Ruby runtime = clazz.getRuntime();
+
+        // FIXME: This is weird why we do this.  rubyName should produce something which can be referred so what example
+        // will this fail on?  If there is a failing case then passing asJavaString may be broken since it will not be
+        // a properly encoded string.  If this is an issue we should make a clazz.IdPath where all segments are returned
+        // by their id names.
+        if (runtime.getClassFromPath(path.asJavaString()) != real) {
+            throw typeError(runtime.getCurrentContext(), str(runtime, types(runtime, clazz), " can't be referred"));
+        }
+        return path.asJavaString();
+    }
+    
+    private void writeObjectData(ThreadContext context, RubyOutputStream out, IRubyObject value) {
+        // switch on the object's *native type*. This allows use-defined
+        // classes that have extended core native types to piggyback on their
+        // marshalling logic.
+        if (value instanceof CoreObjectType) {
+            if (value instanceof DataType) {
+                Ruby runtime = value.getRuntime();
+
+                throw typeError(runtime.getCurrentContext(), str(runtime, "no _dump_data is defined for class ", types(runtime, getMetaClass(value))));
+            }
+            ClassIndex nativeClassIndex = ((CoreObjectType)value).getNativeClassIndex();
+
+            switch (nativeClassIndex) {
+            case ARRAY:
+                out.write('[');
+                RubyArray.marshalTo((RubyArray)value, this, context, out);
+                return;
+            case FALSE:
+                out.write('F');
+                return;
+            case FIXNUM:
+                RubyFixnum fixnum = (RubyFixnum)value;
+
+                if (isMarshalFixnum(fixnum)) {
+                    out.write('i');
+                    writeInt(out, (int) fixnum.getLongValue());
+                    return;
+                }
+                // FIXME: inefficient; constructing a bignum just for dumping?
+                value = RubyBignum.newBignum(value.getRuntime(), fixnum.getLongValue());
+
+                // fall through
+            case BIGNUM:
+                out.write('l');
+                RubyBignum.marshalTo((RubyBignum)value, this, context, out);
+                return;
+            case CLASS:
+                if (((RubyClass)value).isSingleton()) throw typeError(context,"singleton class can't be dumped");
+                out.write('c');
+                RubyClass.marshalTo((RubyClass)value, this, context, out);
+                return;
+            case FLOAT:
+                out.write('f');
+                RubyFloat.marshalTo((RubyFloat)value, this, context, out);
+                return;
+            case HASH: {
+                RubyHash hash = (RubyHash)value;
+
+                if(hash.getIfNone() == RubyBasicObject.UNDEF){
+                    out.write('{');
+                } else if (hash.hasDefaultProc()) {
+                    throw typeError(context, "can't dump hash with default proc");
+                } else {
+                    out.write('}');
+                }
+
+                RubyHash.marshalTo(hash, this, context, out);
+                return;
+            }
+            case MODULE:
+                out.write('m');
+                RubyModule.marshalTo((RubyModule)value, this, context, out);
+                return;
+            case NIL:
+                out.write('0');
+                return;
+            case OBJECT:
+            case BASICOBJECT:
+                final RubyClass type = getMetaClass(value);
+                dumpDefaultObjectHeader(context, out, type);
+                type.getRealClass().marshal(value, this, context, out);
+                return;
+            case REGEXP:
+                out.write('/');
+                RubyRegexp.marshalTo((RubyRegexp)value, this, out);
+                return;
+            case STRING:
+                registerLinkTarget(value);
+                out.write('"');
+                writeString(out, value.convertToString().getByteList());
+                return;
+            case STRUCT:
+                RubyStruct.marshalTo((RubyStruct)value, this, context, out);
+                return;
+            case SYMBOL:
+                writeAndRegisterSymbol(context, out, ((RubySymbol) value).getBytes());
+                return;
+            case TRUE:
+                out.write('T');
+                return;
+            default:
+                throw typeError(context, str(context.runtime, "can't dump ", types(context.runtime, value.getMetaClass())));
+            }
+        } else {
+            dumpDefaultObjectHeader(context, out, value.getMetaClass());
+            value.getMetaClass().getRealClass().marshal(value, this, context, out);
+        }
+    }
+
+    public void userNewMarshal(ThreadContext context, RubyOutputStream out, IRubyObject value, CacheEntry entry) {
+        userNewCommon(context, out, value, entry);
+    }
+
+    public void userNewMarshal(ThreadContext context, RubyOutputStream out, IRubyObject value) {
+        userNewCommon(context, out, value, null);
+    }
+
+    private void userNewCommon(ThreadContext context, RubyOutputStream out, IRubyObject value, CacheEntry entry) {
+        registerLinkTarget(value);
+        out.write(TYPE_USRMARSHAL);
+        final RubyClass klass = getMetaClass(value);
+        final Ruby runtime = context.runtime;
+        writeAndRegisterSymbol(context, out, RubySymbol.newSymbol(runtime, klass.getRealClass().getName()).getBytes());
+
+        IRubyObject marshaled;
+        if (entry != null) {
+            marshaled = entry.method.call(runtime.getCurrentContext(), value, entry.sourceModule, "marshal_dump");
+        } else {
+            marshaled = value.callMethod(runtime.getCurrentContext(), "marshal_dump");
+        }
+        if (marshaled.getMetaClass() == klass) {
+            throw runtime.newRuntimeError("marshal_dump returned same class instance");
+        }
+        dumpObject(context, out, marshaled);
+    }
+
+    public void userMarshal(ThreadContext context, RubyOutputStream out, IRubyObject value, CacheEntry entry) {
+        userCommon(context, out, value, entry);
+    }
+
+    public void userMarshal(ThreadContext context, RubyOutputStream out, IRubyObject value) {
+        userCommon(context, out, value, null);
+    }
+
+    private void userCommon(ThreadContext context, RubyOutputStream out, IRubyObject value, CacheEntry entry) {
+        Ruby runtime = context.runtime;
+        RubyFixnum depthLimitFixnum = runtime.newFixnum(depthLimit);
+        final RubyClass klass = getMetaClass(value);
+        IRubyObject dumpResult;
+        if (entry != null) {
+            dumpResult = entry.method.call(context, value, entry.sourceModule, "_dump", depthLimitFixnum);
+        } else {
+            dumpResult = value.callMethod(context, "_dump", depthLimitFixnum);
+        }
+        
+        RubyString marshaled = castToString(context, dumpResult);
+
+        List<Variable<Object>> variables = null;
+        if (marshaled.hasVariables()) {
+            variables = marshaled.getMarshalVariableList();
+            if (variables.size() > 0) {
+                out.write(TYPE_IVAR);
+            } else {
+                variables = null;
+            }
+        }
+
+        out.write(TYPE_USERDEF);
+
+        writeAndRegisterSymbol(context, out, RubySymbol.newSymbol(runtime, klass.getRealClass().getName()).getBytes());
+
+        writeString(out, marshaled.getByteList());
+
+        if (variables != null) {
+            dumpVariables(context, out, variables);
+        }
+
+        registerLinkTarget(value);
+    }
+    
+    public void writeUserClass(ThreadContext context, RubyOutputStream out, IRubyObject obj, RubyClass type) {
+        out.write(TYPE_UCLASS);
+        
+        // w_unique
+        if (type.getName().charAt(0) == '#') {
+            Ruby runtime = obj.getRuntime();
+
+            throw typeError(runtime.getCurrentContext(), str(runtime, "can't dump anonymous class ", types(runtime, type)));
+        }
+        
+        // w_symbol
+        writeAndRegisterSymbol(context, out, RubySymbol.newSymbol(context.runtime, type.getName()).getBytes());
+    }
+    
+    public void dumpVariablesWithEncoding(ThreadContext context, RubyOutputStream out, List<Variable<Object>> vars, IRubyObject obj) {
+        if (shouldMarshalEncoding(obj)) {
+            writeInt(out, vars.size() + 1); // vars preceded by encoding
+            writeEncoding(context, out, ((MarshalEncoding)obj).getMarshalEncoding());
+        } else {
+            writeInt(out, vars.size());
+        }
+        
+        dumpVariablesShared(context, out, vars);
+    }
+
+    public void dumpVariables(ThreadContext context, RubyOutputStream out, List<Variable<Object>> vars) {
+        writeInt(out, vars.size());
+        dumpVariablesShared(context, out, vars);
+    }
+
+    private void dumpVariablesShared(ThreadContext context, RubyOutputStream out, List<Variable<Object>> vars) {
+        for (Variable<Object> var : vars) {
+            if (var.getValue() instanceof IRubyObject) {
+                writeAndRegisterSymbol(context, out, RubySymbol.newSymbol(context.runtime, var.getName()).getBytes());
+                dumpObject(context, out, (IRubyObject)var.getValue());
+            }
+        }
+    }
+
+    public void writeEncoding(ThreadContext context, RubyOutputStream out, Encoding encoding) {
+        Ruby runtime = context.runtime;
+        if (encoding == null || encoding == USASCIIEncoding.INSTANCE) {
+            writeAndRegisterSymbol(context, out, RubySymbol.newSymbol(runtime, SYMBOL_ENCODING_SPECIAL).getBytes());
+            writeObjectData(context, out, runtime.getFalse());
+        } else if (encoding == UTF8Encoding.INSTANCE) {
+            writeAndRegisterSymbol(context, out, RubySymbol.newSymbol(runtime, SYMBOL_ENCODING_SPECIAL).getBytes());
+            writeObjectData(context, out, runtime.getTrue());
+        } else {
+            writeAndRegisterSymbol(context, out, RubySymbol.newSymbol(runtime, SYMBOL_ENCODING).getBytes());
+            RubyString encodingString = new RubyString(runtime, runtime.getString(), encoding.getName());
+            writeObjectData(context, out, encodingString);
+        }
+    }
+    
+    private boolean hasSingletonMethods(RubyClass type) {
+        for(DynamicMethod method : type.getMethods().values()) {
+            // We do not want to capture cached methods
+            if(method.isImplementedBy(type)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** w_extended
+     * 
+     */
+    private RubyClass dumpExtended(ThreadContext context, RubyOutputStream out, RubyClass type) {
+        if(type.isSingleton()) {
+            if (hasSingletonMethods(type) || type.hasVariables()) { // any ivars, since we don't have __attached__ ivar now
+                throw typeError(type.getRuntime().getCurrentContext(), "singleton can't be dumped");
+            }
+            type = type.getSuperClass();
+        }
+        while(type.isIncluded()) {
+            out.write('e');
+            writeAndRegisterSymbol(context, out, RubySymbol.newSymbol(context.runtime, type.getOrigin().getName()).getBytes());
+            type = type.getSuperClass();
+        }
+        return type;
+    }
+
+    public void dumpDefaultObjectHeader(ThreadContext context, RubyOutputStream out, RubyClass type) {
+        dumpDefaultObjectHeader(context, out, 'o',type);
+    }
+
+    public void dumpDefaultObjectHeader(ThreadContext context, RubyOutputStream out, char tp, RubyClass type) {
+        dumpExtended(context, out, type);
+        out.write(tp);
+        writeAndRegisterSymbol(context, out, RubySymbol.newSymbol(context.runtime, getPathFromClass(type.getRealClass())).getBytes());
+    }
+
+    public void writeString(RubyOutputStream out, String value) {
+        writeInt(out, value.length());
+        // FIXME: should preserve unicode?
+        out.write(RubyString.stringToBytes(value));
+    }
+
+    public void writeString(RubyOutputStream out, ByteList value) {
+        int len = value.length();
+        writeInt(out, len);
+        out.write(value.getUnsafeBytes(), value.begin(), len);
+    }
+
+    public void dumpSymbol(RubyOutputStream out, ByteList value) {
+        out.write(':');
+        int len = value.length();
+        writeInt(out, len);
+        out.write(value.getUnsafeBytes(), value.begin(), len);
+    }
+
+    public void writeInt(RubyOutputStream out, int value) {
+        if (value == 0) {
+            out.write(0);
+        } else if (0 < value && value < 123) {
+            out.write(value + 5);
+        } else if (-124 < value && value < 0) {
+            out.write((value - 5) & 0xff);
+        } else {
+            byte[] buf = new byte[4];
+            int i = 0;
+            for (; i < buf.length; i++) {
+                buf[i] = (byte) (value & 0xff);
+
+                value = value >> 8;
+                if (value == 0 || value == -1) {
+                    break;
+                }
+            }
+            int len = i + 1;
+            out.write(value < 0 ? -len : len);
+            out.write(buf, 0, i + 1);
+        }
+    }
+
+    public void writeByte(RubyOutputStream out, int value) {
+        out.write(value);
+    }
+
+    @Deprecated
+    public boolean isTainted() {
+        return false;
+    }
+
+    @Deprecated
+    public boolean isUntrusted() {
+        return false;
+    }
+}

--- a/core/src/main/java/org/jruby/runtime/marshal/NewMarshal.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/NewMarshal.java
@@ -66,7 +66,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.Map;
-import java.util.function.Consumer;
 
 import static org.jruby.RubyBasicObject.getMetaClass;
 import static org.jruby.api.Convert.castToString;
@@ -97,11 +96,11 @@ public class NewMarshal {
 
     public static class RubyOutputStream extends OutputStream {
         private final OutputStream wrap;
-        private final Consumer<IOException> handler;
+        private final ThreadContext context;
 
-        public RubyOutputStream(OutputStream wrap, Consumer<IOException> handler) {
+        public RubyOutputStream(OutputStream wrap, ThreadContext context) {
             this.wrap = wrap;
-            this.handler = handler;
+            this.context = context;
         }
 
         public void write(int b) {
@@ -129,7 +128,7 @@ public class NewMarshal {
         }
 
         public void handle(IOException ioe) {
-            handler.accept(ioe);
+            throw context.runtime.newIOErrorFromException(ioe);
         }
     }
 

--- a/core/src/main/java/org/jruby/runtime/marshal/NewMarshal.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/NewMarshal.java
@@ -557,13 +557,13 @@ public class NewMarshal {
     public void writeEncoding(ThreadContext context, RubyOutputStream out, Encoding encoding) {
         Ruby runtime = context.runtime;
         if (encoding == null || encoding == USASCIIEncoding.INSTANCE) {
-            writeAndRegisterSymbol(out, RubySymbol.newSymbol(runtime, SYMBOL_ENCODING_SPECIAL));
+            writeAndRegisterSymbol(out, runtime.getSymbolTable().getEncodingSymbolE());
             writeObjectData(context, out, runtime.getFalse());
         } else if (encoding == UTF8Encoding.INSTANCE) {
-            writeAndRegisterSymbol(out, RubySymbol.newSymbol(runtime, SYMBOL_ENCODING_SPECIAL));
+            writeAndRegisterSymbol(out, runtime.getSymbolTable().getEncodingSymbolE());
             writeObjectData(context, out, runtime.getTrue());
         } else {
-            writeAndRegisterSymbol(out, RubySymbol.newSymbol(runtime, SYMBOL_ENCODING));
+            writeAndRegisterSymbol(out, runtime.getSymbolTable().getEncodingSymbol());
             RubyString encodingString = new RubyString(runtime, runtime.getString(), encoding.getName());
             writeObjectData(context, out, encodingString);
         }

--- a/core/src/main/java/org/jruby/runtime/marshal/NewMarshal.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/NewMarshal.java
@@ -278,14 +278,16 @@ public class NewMarshal {
         }
     }
 
-    public static String getPathFromClass(ThreadContext context, RubyModule clazz) {
+    public static RubySymbol getPathFromClass(ThreadContext context, RubyModule clazz) {
         Ruby runtime = context.runtime;
-        RubyString path = clazz.rubyName();
+        RubySymbol pathSym = clazz.symbolName();
 
-        if (path.charAt(0) == '#') {
+        if (pathSym == null) {
             String type = clazz.isClass() ? "class" : "module";
             throw typeError(context, str(runtime, "can't dump anonymous " + type + " ", types(runtime, clazz)));
         }
+
+        String path = pathSym.idString();
         
         RubyModule real = clazz.isModule() ? clazz : ((RubyClass)clazz).getRealClass();
 
@@ -293,10 +295,10 @@ public class NewMarshal {
         // will this fail on?  If there is a failing case then passing asJavaString may be broken since it will not be
         // a properly encoded string.  If this is an issue we should make a clazz.IdPath where all segments are returned
         // by their id names.
-        if (runtime.getClassFromPath(path.asJavaString()) != real) {
+        if (runtime.getClassFromPath(path) != real) {
             throw typeError(context, str(runtime, types(runtime, clazz), " can't be referred"));
         }
-        return path.asJavaString();
+        return pathSym;
     }
     
     private void writeObjectData(ThreadContext context, RubyOutputStream out, IRubyObject value) {

--- a/core/src/main/java/org/jruby/runtime/marshal/NewMarshal.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/NewMarshal.java
@@ -344,16 +344,16 @@ public class NewMarshal {
                 // fall through
             case BIGNUM:
                 out.write('l');
-                RubyBignum.marshalTo((RubyBignum)value, this, context, out);
+                RubyBignum.marshalTo((RubyBignum)value, this, out);
                 return;
             case CLASS:
                 if (((RubyClass)value).isSingleton()) throw typeError(context,"singleton class can't be dumped");
                 out.write('c');
-                RubyClass.marshalTo((RubyClass)value, this, context, out);
+                RubyClass.marshalTo((RubyClass)value, this, out);
                 return;
             case FLOAT:
                 out.write('f');
-                RubyFloat.marshalTo((RubyFloat)value, this, context, out);
+                RubyFloat.marshalTo((RubyFloat)value, this, out);
                 return;
             case HASH: {
                 RubyHash hash = (RubyHash)value;

--- a/core/src/main/java/org/jruby/runtime/marshal/NewMarshalCache.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/NewMarshalCache.java
@@ -31,20 +31,16 @@
 
 package org.jruby.runtime.marshal;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.IdentityHashMap;
-import java.util.Map;
-
 import org.jruby.RubySymbol;
-import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 import org.jruby.util.collections.HashMapInt;
 
-public class MarshalCache {
-    private final HashMapInt linkCache = new HashMapInt<>(true);
-    private final HashMapInt symbolCache = new HashMapInt<ByteList>();
+import java.io.IOException;
+
+public class NewMarshalCache {
+    private final HashMapInt<IRubyObject> linkCache = new HashMapInt<>(true);
+    private final HashMapInt<RubySymbol> symbolCache = new HashMapInt<>(true);
 
     public boolean isRegistered(IRubyObject value) {
         assert !(value instanceof RubySymbol) : "Use isSymbolRegistered for symbol links";
@@ -52,7 +48,7 @@ public class MarshalCache {
         return linkCache.containsKey(value);
     }
 
-    public boolean isSymbolRegistered(ByteList sym) {
+    public boolean isSymbolRegistered(RubySymbol sym) {
         return symbolCache.containsKey(sym);
     }
 
@@ -62,27 +58,27 @@ public class MarshalCache {
         linkCache.put(value, Integer.valueOf(linkCache.size()));
     }
 
-    public void registerSymbol(ByteList sym) {
+    public void registerSymbol(RubySymbol sym) {
         symbolCache.put(sym, symbolCache.size());
     }
 
-    public void writeLink(MarshalStream output, IRubyObject value) throws IOException {
+    public void writeLink(NewMarshal output, NewMarshal.RubyOutputStream out, IRubyObject value) {
         assert !(value instanceof RubySymbol) : "Use writeSymbolLink for symbols";
 
-        output.write('@');
-        output.writeInt(registeredIndex(value));
+        out.write('@');
+        output.writeInt(out, registeredIndex(value));
     }
 
-    public void writeSymbolLink(MarshalStream output, ByteList sym) throws IOException {
-        output.write(';');
-        output.writeInt(registeredSymbolIndex(sym));
+    public void writeSymbolLink(NewMarshal output, NewMarshal.RubyOutputStream out, RubySymbol sym) {
+        out.write(';');
+        output.writeInt(out, registeredSymbolIndex(sym));
     }
 
     private int registeredIndex(IRubyObject value) {
         return linkCache.get(value);
     }
 
-    private int registeredSymbolIndex(ByteList sym) {
+    private int registeredSymbolIndex(RubySymbol sym) {
         return symbolCache.get(sym);
     }
 }

--- a/core/src/main/java/org/jruby/util/collections/HashMapInt.java
+++ b/core/src/main/java/org/jruby/util/collections/HashMapInt.java
@@ -1,0 +1,462 @@
+package org.jruby.util.collections;
+
+import java.util.AbstractCollection;
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+public class HashMapInt<V> {
+
+    private Entry<V>[] table;
+    private int count;
+
+    transient volatile Set<V> keySet = null;
+	transient volatile Collection<Integer> values = null;
+
+    private int threshold;
+
+    private final float loadFactor;
+    private final boolean identity;
+
+    public static class Entry<V> {
+        final int hash;
+        final V key;
+        int value;
+        Entry<V> next;
+
+        protected Entry(int hash, V key, int value, Entry<V> next) {
+            this.hash = hash;
+            this.key = key;
+            this.value = value;
+            this.next = next;
+        }
+
+        public V getKey() {
+            return key;
+        }
+
+        public int getValue() {
+            return value;
+        }
+    }
+
+    public HashMapInt() {
+        this(20, 0.75f, false);
+    }
+
+    public HashMapInt(boolean identity) {
+        this(20, 0.75f, identity);
+    }
+
+    public HashMapInt(int initialCapacity, boolean identity) {
+        this(initialCapacity, 0.75f, identity);
+    }
+
+    @SuppressWarnings("unchecked")
+    public HashMapInt(int initialCapacity, float loadFactor, boolean identity) {
+        super();
+        if (initialCapacity < 0) {
+            throw new IllegalArgumentException("Illegal Capacity: " + initialCapacity);
+        }
+        if (loadFactor <= 0) {
+            throw new IllegalArgumentException("Illegal Load: " + loadFactor);
+        }
+        if (initialCapacity == 0) initialCapacity = 1;
+
+        this.loadFactor = loadFactor;
+        this.identity = identity;
+        this.threshold = (int) (initialCapacity * loadFactor);
+        this.table = new Entry[initialCapacity];
+    }
+
+    public int size() {
+        return count;
+    }
+
+    public boolean isEmpty() {
+        return count == 0;
+    }
+
+    public boolean contains(int value) {
+        Entry<V> tab[] = table;
+        for (int i = tab.length; i-- > 0;) {
+            for (Entry<V> e = tab[i]; e != null; e = e.next) {
+                if (e.value == value) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public boolean containsValue(int value) {
+        return contains(value);
+    }
+
+    public boolean containsKey(Object key) {
+        Entry<V>[] tab = table;
+        int hash = getHash(key);
+        int index = (hash & 0x7FFFFFFF) % tab.length;
+        for (Entry<V> e = tab[index]; e != null; e = e.next) {
+            if (e.hash == hash && e.key.equals(key)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public int get(V key) {
+        Entry<V>[] tab = table;
+        int hash = getHash(key);
+        int index = (hash & 0x7FFFFFFF) % tab.length;
+        for (Entry<V> e = tab[index]; e != null; e = e.next) {
+            if (e.hash == hash && keyMatches(key, e)) {
+                return e.value;
+            }
+        }
+        return -1;
+    }
+
+    private <V> int getHash(V key) {
+        return identity ? System.identityHashCode(key) : key.hashCode();
+    }
+
+    private <V> boolean keyMatches(V key, Entry<V> e) {
+        return identity ? e.key == key : e.key.equals(key);
+    }
+
+    protected void rehash() {
+        int oldCapacity = table.length;
+        Entry<V>[] oldMap = table;
+
+        int newCapacity = oldCapacity * 2 + 1;
+        @SuppressWarnings("unchecked")
+        Entry<V>[] newMap = new Entry[newCapacity];
+
+        threshold = (int) (newCapacity * loadFactor);
+        table = newMap;
+
+        for (int i = oldCapacity; i-- > 0;) {
+            for (Entry<V> old = oldMap[i]; old != null;) {
+                Entry<V> e = old;
+                old = old.next;
+
+                int index = (e.hash & 0x7FFFFFFF) % newCapacity;
+                e.next = newMap[index];
+                newMap[index] = e;
+            }
+        }
+    }
+
+	Entry<V> getEntry(V key)	{
+        Entry<V>[] tab = table;
+        int hash = getHash(key);
+        int index = (hash & 0x7FFFFFFF) % tab.length;
+        for(Entry<V> e = tab[index]; e != null; e = e.next) {
+            if (e.hash == hash && keyMatches(key, e)) {
+                return e;
+            }
+        }
+        return null;
+	}
+
+    public int put(V key, int value) {
+        // Makes sure the key is not already in the hashtable.
+        Entry<V>[] tab = table;
+        int hash = getHash(key);
+        int index = (hash & 0x7FFFFFFF) % tab.length;
+        for (Entry<V> e = tab[index]; e != null; e = e.next) {
+            if (e.hash == hash && keyMatches(key, e)) {
+                int old = e.value;
+                e.value = value;
+                return old;
+            }
+        }
+
+        if (count >= threshold) {
+            // Rehash the table if the threshold is exceeded
+            rehash();
+
+            tab = table;
+            index = (hash & 0x7FFFFFFF) % tab.length;
+        }
+
+        // Creates the new entry.
+        Entry<V> e = new Entry<V>(hash, key, value, tab[index]);
+        tab[index] = e;
+        count++;
+        return -1;
+    }
+
+    public int remove(V key) {
+        Entry<V>[] tab = table;
+        int hash = getHash(key);
+        int index = (hash & 0x7FFFFFFF) % tab.length;
+        for (Entry<V> e = tab[index], prev = null; e != null; prev = e, e = e.next) {
+            if (e.hash == hash && keyMatches(key, e)) {
+                if (prev != null) {
+                    prev.next = e.next;
+                } else {
+                    tab[index] = e.next;
+                }
+                count--;
+                return e.value;
+            }
+        }
+        return -1;
+    }
+
+    public synchronized void clear() {
+        Entry<V>[] tab = table;
+        for (int index = tab.length; --index >= 0;) {
+            tab[index] = null;
+        }
+        count = 0;
+    }
+
+    private abstract class HashIterator<T> implements Iterator<T> {
+		Entry<V> next; // next entry to return
+		int index; // current slot
+
+		HashIterator() {
+			Entry<V>[] t = table;
+			int i = t.length;
+			Entry<V> n = null;
+			if(count != 0) { // advance to first entry
+				while (i > 0 && (n = t[--i]) == null) {
+				}
+			}
+			next = n;
+			index = i;
+		}
+
+		public boolean hasNext() {
+			return next != null;
+		}
+
+		Entry<V> nextEntry() {
+			Entry<V> e = next;
+			if(e == null) {
+				throw new NoSuchElementException();
+			}
+			Entry<V> n = e.next;
+			Entry<V>[] t = table;
+			int i = index;
+			while(n == null && i > 0) {
+				n = t[--i];
+			}
+			index = i;
+			next = n;
+			return e;
+		}
+
+		public void remove() {
+            throw new UnsupportedOperationException();
+		}
+
+	}
+
+	private class ValueIterator extends HashIterator<Integer> {
+		public Integer next() {
+			return nextEntry().value;
+		}
+	}
+
+	private class KeyIterator extends HashIterator<V> {
+		public V next() {
+			return nextEntry().key;
+		}
+	}
+
+	private class EntryIterator extends HashIterator<Entry<V>> {
+		public Entry<V> next() {
+			return nextEntry();
+		}
+	}
+
+    Iterator<V> newKeyIterator() {
+		return new KeyIterator();
+	}
+
+	Iterator<Integer> newValueIterator() {
+		return new ValueIterator();
+	}
+
+	Iterator<Entry<V>> newEntryIterator() {
+		return new EntryIterator();
+	}
+
+	private transient Set<Entry<V>> entrySet = null;
+
+	public Set<V> keySet() {
+		Set<V> ks = keySet;
+		return (ks != null ? ks : (keySet = new KeySet()));
+	}
+
+	private class KeySet extends AbstractSet<V> {
+
+		public Iterator<V> iterator() {
+			return newKeyIterator();
+		}
+
+		public int size() {
+			return HashMapInt.this.count;
+		}
+
+        @Override
+		public boolean contains(Object o) {
+			if(o instanceof Number) {
+				return containsKey(((Number)o).intValue());
+			}
+			return false;
+		}
+
+        @Override
+		public boolean remove(Object o) {
+            throw new UnsupportedOperationException();
+		}
+
+        @Override
+		public void clear() {
+			HashMapInt.this.clear();
+		}
+	}
+
+	public Collection<Integer> values() {
+		Collection<Integer> vs = values;
+		return (vs != null ? vs : (values = new Values()));
+	}
+
+	private class Values extends AbstractCollection<Integer> {
+
+		public Iterator<Integer> iterator() {
+			return newValueIterator();
+		}
+
+		public int size() {
+			return HashMapInt.this.count;
+		}
+
+        @Override
+		public boolean contains(Object o) {
+			return containsValue((Integer) o);
+		}
+
+        @Override
+		public void clear()	{
+			HashMapInt.this.clear();
+		}
+	}
+
+	public Set<Entry<V>> entrySet() {
+		Set<Entry<V>> es = entrySet;
+		return (es != null ? es : (entrySet = new EntrySet()));
+	}
+
+	private class EntrySet extends AbstractSet<Entry<V>> {
+
+		public Iterator<Entry<V>> iterator() {
+			return newEntryIterator();
+		}
+
+        @Override
+		public boolean contains(Object o) {
+			if (!(o instanceof Entry)) {
+				return false;
+			}
+			@SuppressWarnings("unchecked")
+            Entry<V> e = (Entry<V>) o;
+			Entry<V> candidate = getEntry(e.key);
+			return candidate != null && candidate.equals(e);
+		}
+
+        @Override
+		public boolean remove(Object o)	{
+            throw new UnsupportedOperationException();
+		}
+
+		public int size() {
+			return HashMapInt.this.count;
+		}
+
+        @Override
+		public void clear() {
+			HashMapInt.this.clear();
+		}
+	}
+
+	@Override
+    public String toString() {
+	    Iterator<Entry<V>> i = entrySet().iterator();
+	    if (! i.hasNext()) return "{}";
+
+	    StringBuilder sb = new StringBuilder();
+	    sb.append('{');
+	    for (;;) {
+	        Entry<V> e = i.next();
+            V key = e.getKey();
+            sb.append(key == this ? "(this IntHashMap)" : key);
+	        sb.append('=');
+	        sb.append(e.getValue());
+	        if (! i.hasNext()) return sb.append('}').toString();
+	        sb.append(", ");
+	    }
+    }
+
+    @Override
+    public Object clone() {
+        HashMapInt<V> newMap = new HashMapInt<>(table.length, loadFactor, identity);
+        for (int i = 0; i < table.length; i++) {
+            Entry<V> entry = table[i];
+            while (entry != null) {
+                newMap.put(entry.getKey(), entry.getValue());
+                entry = entry.next;
+            }
+        }
+        return newMap;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <U> HashMapInt<U> nullMap() { return NullMap.INSTANCE; }
+
+    private static final class NullMap<U> extends HashMapInt<U> {
+
+        static final NullMap INSTANCE = new NullMap();
+
+        private NullMap() { super(0, true); }
+
+        @Override
+        public boolean contains(int value) {
+            return false;
+        }
+
+        @Override
+        public boolean containsKey(Object key) {
+            return false;
+        }
+
+        @Override
+        public int get(Object key) {
+            return -1;
+        }
+
+        @Override
+        public int put(Object key, int value) {
+            return -1;
+        }
+
+        @Override
+        public int remove(Object key) {
+            return -1;
+        }
+
+        @Override
+        protected void rehash() {
+            // NO-OP
+        }
+
+    }
+
+}

--- a/core/src/main/java/org/jruby/util/io/TransparentByteArrayOutputStream.java
+++ b/core/src/main/java/org/jruby/util/io/TransparentByteArrayOutputStream.java
@@ -1,0 +1,12 @@
+package org.jruby.util.io;
+
+import java.io.ByteArrayOutputStream;
+
+/**
+ * A ByteArrayOutputStream that provides access to the contained byte[] buffer.
+ */
+public class TransparentByteArrayOutputStream extends ByteArrayOutputStream {
+    public byte[] getRawBytes() {
+        return buf;
+    }
+}


### PR DESCRIPTION
The Marshal.dump logic we have predates nearly all improvements we have made over time, including:

* Efficient instance variable storage
* Passing ThreadContext on the stack
* Caching dynamic method calls from Java

This PR refactors and overhauls MarshalStream for efficiency and reduced object allocation.