### PR TITLE
Proc spreading changed in 3.2 with kwrest

### DIFF
--- a/core/src/main/java/org/jruby/runtime/Signature.java
+++ b/core/src/main/java/org/jruby/runtime/Signature.java
@@ -137,7 +137,7 @@ public class Signature {
         boolean hasOptionalKeywords = kwargs - requiredKwargs > 0;
         boolean optionalFromRest = rest() != Rest.NONE && rest != Rest.ANON;
 
-        if (opt() > 0 || optionalFromRest || (hasOptionalKeywords || restKwargs()) && oneForKeywords == 0) {
+        if (opt() > 0 || optionalFromRest || ((hasOptionalKeywords || restKwargs()) && oneForKeywords == 0 && fixedValue == 0)) {
             return -1 * (fixedValue + 1);
         }
 


### PR DESCRIPTION
Fix two specs to make a single arity spec for lambda to fail