### PR TITLE
Unbound#== for aliases to be considered equal.

### DIFF
--- a/core/src/main/java/org/jruby/RubyMethod.java
+++ b/core/src/main/java/org/jruby/RubyMethod.java
@@ -183,7 +183,7 @@ public class RubyMethod extends AbstractRubyMethod {
         }
 
         RubyMethod otherMethod = (RubyMethod)other;
-        return receiver == otherMethod.receiver && originModule == otherMethod.originModule &&
+        return receiver == otherMethod.receiver &&
             ( isSerialMatch(otherMethod.method) || isMethodMissingMatch(otherMethod.getMethod().getRealMethod()) );
     }
 

--- a/spec/tags/ruby/core/unboundmethod/equal_value_tags.txt
+++ b/spec/tags/ruby/core/unboundmethod/equal_value_tags.txt
@@ -1,3 +1,0 @@
-fails:UnboundMethod#== considers methods through aliasing equal
-fails:UnboundMethod#== considers methods through visibility change equal
-fails:UnboundMethod#== considers methods through aliasing and visibility change equal


### PR DESCRIPTION
Unbound#== for aliases to be considered equal.