### PR TITLE
Enumerable#inject/reduce should show arg error with no arg or block

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -1074,6 +1074,8 @@ public class RubyEnumerable {
 
     @JRubyMethod(name = {"inject", "reduce"})
     public static IRubyObject inject(ThreadContext context, IRubyObject self, final Block block) {
+        if (!block.isGiven()) throw context.runtime.newArgumentError("wrong number of arguments (given 0, expected 1..2)");
+
         return injectCommon(context, self, null, block);
     }
 

--- a/spec/tags/ruby/core/enumerable/inject_tags.txt
+++ b/spec/tags/ruby/core/enumerable/inject_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#inject raises an ArgumentError when no parameters or block is given

--- a/spec/tags/ruby/core/enumerable/reduce_tags.txt
+++ b/spec/tags/ruby/core/enumerable/reduce_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#reduce raises an ArgumentError when no parameters or block is given


### PR DESCRIPTION
Enumerable#inject/reduce should show arg error with no arg or block