### PR TITLE
Properly check for Module's superclass

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -6034,7 +6034,7 @@ public class RubyModule extends RubyObject {
 
                 RubyModule module = (RubyModule) _module;
 
-                if (module.getSuperClass() != runtime.getObject()) {
+                if (module.getSuperClass() != null) {
                     runtime.getWarnings().warn(module.getName() + " has ancestors, but Refinement#import_methods doesn't import their methods");
                 }
             }


### PR DESCRIPTION
It should be null unless something has been included.

Fixes #8275