### PR TITLE
Fix pattern JIT Hash match and SyntaxError

### DIFF
--- a/core/src/main/java/org/jruby/compiler/JITCompiler.java
+++ b/core/src/main/java/org/jruby/compiler/JITCompiler.java
@@ -34,6 +34,7 @@ import org.jruby.Ruby;
 import org.jruby.RubyEncoding;
 import org.jruby.RubyInstanceConfig;
 import org.jruby.RubyModule;
+import org.jruby.exceptions.RaiseException;
 import org.jruby.internal.runtime.methods.CompiledIRMethod;
 import org.jruby.internal.runtime.methods.MixedModeIRMethod;
 import org.jruby.ir.IRScope;
@@ -227,6 +228,8 @@ public class JITCompiler implements JITCompilerMBean {
                 // just run directly
                 task.run();
             }
+        } catch (RaiseException e) {
+            throw e;
         } catch (Exception e) {
             throw new NotCompilableException(e);
         }

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
@@ -2072,7 +2072,7 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
                 cond_ne(deconstruct_cache_end, deconstructed, nil(), () -> {
                     call(deconstructed, obj, "deconstruct");
                     label("array_check_end", arrayCheck -> {
-                        addInstr(new EQQInstr(scope, result, getManager().getArrayClass(), deconstructed, false, false));
+                        addInstr(new EQQInstr(scope, result, getManager().getArrayClass(), deconstructed, false, true, false));
                         cond(arrayCheck, result, tru(), () -> type_error("deconstruct must return Array"));
                     });
                 })
@@ -2120,7 +2120,7 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
 
     private void buildPatternConstant(Label testEnd, Variable result, U constant, Operand obj, boolean isSinglePattern, Variable errorString) {
         Operand expression = build(constant);
-        addInstr(new EQQInstr(scope, result, expression, obj, false, true));
+        addInstr(new EQQInstr(scope, result, expression, obj, false, true, true));
         if (isSinglePattern) {
             buildPatternSetEQQError(errorString, result, obj, expression, obj);
         }
@@ -2149,7 +2149,7 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
 
                 call(deconstructed, obj, "deconstruct");
                 label("array_check_end", arrayCheck -> {
-                    addInstr(new EQQInstr(scope, result, getManager().getArrayClass(), deconstructed, false, false));
+                    addInstr(new EQQInstr(scope, result, getManager().getArrayClass(), deconstructed, false, true, false));
                     cond(arrayCheck, result, tru(), () -> type_error("deconstruct must return Array"));
                 });
             });
@@ -2249,7 +2249,7 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
                 Variable inspect = temp();
                 label("key_check_error", (key_check_end)-> {
                     // if errorString is a literal symbol then this is for key pattern error.  Normally it is a string or nil
-                    Variable whichError = addResultInstr(new EQQInstr(scope, temp(), getManager().getSymbolClass(), errorString, false, false));
+                    Variable whichError = addResultInstr(new EQQInstr(scope, temp(), getManager().getSymbolClass(), errorString, false, true, false));
                     addInstr(createBranch(whichError, tru(), key_check_end));
                     if_else(errorString, nil(),
                             () -> call(inspect, value, "inspect"),
@@ -2317,7 +2317,7 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
         Variable d = deconstructHashPatternKeys(testEnd, errorString, constant, assocsKeys, rest, result, obj, isSinglePattern);
 
         label("hash_check_end", endHashCheck -> {
-            addInstr(new EQQInstr(scope, result, getManager().getHashClass(), d, false, true));
+            addInstr(new EQQInstr(scope, result, getManager().getHashClass(), d, false, true, true));
             cond(endHashCheck, result, tru(), () -> type_error("deconstruct_keys must return Hash"));
         });
 
@@ -2777,7 +2777,7 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
                 expression = buildWithOrder(node, containsVariableAssignment(node));
             }
 
-            addInstr(new EQQInstr(scope, eqqResult, expression, testValue, needsSplat, scope.maybeUsingRefinements()));
+            addInstr(new EQQInstr(scope, eqqResult, expression, testValue, needsSplat, false, scope.maybeUsingRefinements()));
             addInstr(createBranch(eqqResult, tru(), bodyLabel));
         }
     }

--- a/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
@@ -997,7 +997,7 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
             Operand expression = build(exprNodes);
             boolean needsSplat = exprNodes instanceof ArgsPushNode || exprNodes instanceof SplatNode || exprNodes instanceof ArgsCatNode;
 
-            addInstr(new EQQInstr(scope, result, expression, value, needsSplat, scope.maybeUsingRefinements()));
+            addInstr(new EQQInstr(scope, result, expression, value, needsSplat, true, scope.maybeUsingRefinements()));
             if (isSinglePattern) {
                 buildPatternSetEQQError(errorString, result, original, expression, value);
             }
@@ -1249,7 +1249,7 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
                 expression = ((MutableString) expression).frozenString;
             }
 
-            addInstr(new EQQInstr(scope, eqqResult, expression, value, false, scope.maybeUsingRefinements()));
+            addInstr(new EQQInstr(scope, eqqResult, expression, value, false, false, scope.maybeUsingRefinements()));
             addInstr(createBranch(eqqResult, tru(), bodyLabel));
 
             // SSS FIXME: This doesn't preserve original order of when clauses.  We could consider

--- a/core/src/main/java/org/jruby/ir/instructions/EQQInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/EQQInstr.java
@@ -24,24 +24,27 @@ public class EQQInstr extends CallInstr implements FixedArityInstr {
     // This is a splatted value and eqq should compare each element in the array vs
     // treating the array as a single value.
     private final boolean splattedValue;
+    private final boolean pattern;
 
     // clone constructor
-    protected EQQInstr(IRScope scope, Variable result, Operand v1, Operand v2, boolean splattedValue, boolean isPotentiallyRefined, CallSite callSite,
+    protected EQQInstr(IRScope scope, Variable result, Operand v1, Operand v2, boolean splattedValue, boolean pattern, boolean isPotentiallyRefined, CallSite callSite,
                        long callSiteID) {
         super(scope, Operation.EQQ, CallType.FUNCTIONAL, result, scope.getManager().getRuntime().newSymbol("==="),
                 v1, new Operand[] { v2 }, NullBlock.INSTANCE, 0, isPotentiallyRefined, callSite, callSiteID);
 
         this.splattedValue = splattedValue;
+        this.pattern = pattern;
     }
 
     // normal constructor
-    public EQQInstr(IRScope scope, Variable result, Operand v1, Operand v2, boolean splattedValue, boolean isPotentiallyRefined) {
+    public EQQInstr(IRScope scope, Variable result, Operand v1, Operand v2, boolean splattedValue, boolean pattern, boolean isPotentiallyRefined) {
         super(scope, Operation.EQQ, CallType.FUNCTIONAL, result, scope.getManager().getRuntime().newSymbol("==="), v1,
                 new Operand[] { v2 }, NullBlock.INSTANCE, 0, isPotentiallyRefined);
 
         assert result != null: "EQQInstr result is null";
 
         this.splattedValue = splattedValue;
+        this.pattern = pattern;
     }
 
     @Override
@@ -53,10 +56,14 @@ public class EQQInstr extends CallInstr implements FixedArityInstr {
         return splattedValue;
     }
 
+    public boolean isPattern() {
+        return pattern;
+    }
+
     @Override
     public Instr clone(CloneInfo ii) {
         return new EQQInstr(ii.getScope(), ii.getRenamedVariable(result), getReceiver().cloneForInlining(ii),
-                getArg1().cloneForInlining(ii), isSplattedValue(), isPotentiallyRefined(), getCallSite(), getCallSiteId());
+                getArg1().cloneForInlining(ii), isSplattedValue(), isPattern(), isPotentiallyRefined(), getCallSite(), getCallSiteId());
     }
 
     @Override
@@ -64,6 +71,7 @@ public class EQQInstr extends CallInstr implements FixedArityInstr {
         super.encode(e);
 
         e.encode(splattedValue);
+        e.encode(pattern);
     }
 
     public static EQQInstr decode(IRReaderDecoder d) {
@@ -81,7 +89,7 @@ public class EQQInstr extends CallInstr implements FixedArityInstr {
         Variable result = d.decodeVariable();
         if (RubyInstanceConfig.IR_READING_DEBUG) System.out.println("decoding call, result:  " + result);
 
-        return new EQQInstr(d.getCurrentScope(), result, receiver, arg1, d.decodeBoolean(), d.getCurrentScope().maybeUsingRefinements());
+        return new EQQInstr(d.getCurrentScope(), result, receiver, arg1, d.decodeBoolean(), d.decodeBoolean(), d.getCurrentScope().maybeUsingRefinements());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -1597,7 +1597,7 @@ public class JVMVisitor extends IRVisitor {
     private boolean canOmitStoreLoad(EQQInstr eqq, Instr nextInstr) {
         assert nextInstr != null: "Somehow EQQ is the last instr in the scope...";
 
-        return nextInstr instanceof BTrueInstr && eqq.getResult().equals(((BTrueInstr) nextInstr).getArg1());
+        return !eqq.isPattern() && nextInstr instanceof BTrueInstr && eqq.getResult().equals(((BTrueInstr) nextInstr).getArg1());
     }
 
     @Override


### PR DESCRIPTION
This fixes two issues:

* #8283 
* `SyntaxError` raised lazily by IR building can happen during JIT at threshold=0 and the wrapping of it in NotCompileableException broke an expectation in the ruby specs.