### PR TITLE
Race fixes for AOT mode in 9.3

### DIFF
--- a/core/src/main/java/org/jruby/ir/interpreter/FullInterpreterContext.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/FullInterpreterContext.java
@@ -132,7 +132,7 @@ public class FullInterpreterContext extends InterpreterContext {
         Instr[] linearizedInstrArray = newInstrs.toArray(new Instr[newInstrs.size()]);
 
         BasicBlock[] basicBlocks = getLinearizedBBList();
-        rescueIPCs = new int[2 * basicBlocks.length];
+        int[] rescueIPCs = new int[2 * basicBlocks.length];
 
         // Pass 2: Use ipc info from previous to mark all linearized instrs rpc
         ipc = 0;
@@ -154,7 +154,8 @@ public class FullInterpreterContext extends InterpreterContext {
             }
         }
 
-        instructions = linearizedInstrArray;
+        this.rescueIPCs = rescueIPCs;
+        this.instructions = linearizedInstrArray;
 
         // System.out.println("SCOPE: " + getScope().getId());
         // System.out.println("INSTRS: " + cfg.toStringInstrs());

--- a/core/src/main/java/org/jruby/ir/interpreter/InterpreterContext.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/InterpreterContext.java
@@ -30,12 +30,12 @@ public class InterpreterContext {
 
     // startup interp will mark this at construction and not change but full interpreter will write it
     // much later after running compiler passes.  JIT will not use this field at all.
-    protected Instr[] instructions;
+    protected volatile Instr[] instructions;
 
     // Contains pairs of values.  The first value is number of instrs in this range + number of instrs before
     // this range.  The second number is the rescuePC.  getRescuePC(ipc) will walk this list and first odd value
     // less than this value will be the rpc.
-    protected int[] rescueIPCs = null;
+    protected volatile int[] rescueIPCs = null;
 
     // Cached computed fields
     protected boolean hasExplicitCallProtocol; // Only can be true in Full+
@@ -93,7 +93,7 @@ public class InterpreterContext {
         return instructions == null ? NO_INSTRUCTIONS : instructions;
     }
 
-    private void setInstructions(final List<Instr> instructions) {
+    private synchronized void setInstructions(final List<Instr> instructions) {
         this.instructions = instructions != null ? prepareBuildInstructions(instructions) : null;
     }
 
@@ -108,7 +108,7 @@ public class InterpreterContext {
         }
 
         Deque<Integer> markers = new ArrayDeque<>(8);
-        rescueIPCs = new int[length];
+        int[] rescueIPCs = new int[length];
         int rpc = -1;
 
         for (int ipc = 0; ipc < length; ipc++) {
@@ -124,6 +124,8 @@ public class InterpreterContext {
 
             rescueIPCs[ipc] = rpc;
         }
+
+        this.rescueIPCs = rescueIPCs;
 
         return linearizedInstrArray;
     }


### PR DESCRIPTION
There's potential for races while setting up the interpreter contexts after AOT deserialization or during some other phase transitions in the interpreter and JIT. This PR attempts to lock down those changes and avoid races.