### PR TITLE
Check for empty string from ENV.op_aref

### DIFF
--- a/core/src/main/java/org/jruby/util/ShellLauncher.java
+++ b/core/src/main/java/org/jruby/util/ShellLauncher.java
@@ -433,7 +433,7 @@ public class ShellLauncher {
             pathObject = env.op_aref(runtime.getCurrentContext(), RubyString.newString(runtime, PATH_ENV));
         }
 
-        if (pathObject == null) {
+        if (pathObject.isNil() || pathObject.convertToString().size() == 0) {
             pathNodes = DEFAULT_PATH; // ASSUME: not modified by callee
         }
 


### PR DESCRIPTION
ENV.op_aref can only return nil or a string (no methods that are bound to Ruby should ever return null) so check both of those conditions to determine fallback on default PATH.

Fixes #8289