### PR TITLE
Return the value of the block for IO.popen

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -4555,10 +4555,12 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
             io.setupPopen(runtime, modes, process);
 
             if (block.isGiven()) {
+                IRubyObject returnedBlock = ensureYieldClose(context, io, block);
                 // RubyStatus uses real native status now, so we unshift Java's shifted exit status
                 context.setLastExitStatus(RubyProcess.RubyStatus.newProcessStatus(runtime, process.waitFor() << 8, ShellLauncher.getPidFromProcess(process)));
+                return returnedBlock;
             }
-            return ensureYieldClose(context, io, block);
+            return io;
         } catch (IOException e) {
             throw runtime.newIOErrorFromException(e);
         } catch (InterruptedException e) {

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -4555,12 +4555,10 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
             io.setupPopen(runtime, modes, process);
 
             if (block.isGiven()) {
-                ensureYieldClose(context, io, block);
-
                 // RubyStatus uses real native status now, so we unshift Java's shifted exit status
                 context.setLastExitStatus(RubyProcess.RubyStatus.newProcessStatus(runtime, process.waitFor() << 8, ShellLauncher.getPidFromProcess(process)));
             }
-            return io;
+            return ensureYieldClose(context, io, block);
         } catch (IOException e) {
             throw runtime.newIOErrorFromException(e);
         } catch (InterruptedException e) {

--- a/spec/tags/ruby/core/io/popen_tags.txt
+++ b/spec/tags/ruby/core/io/popen_tags.txt
@@ -5,7 +5,6 @@ fails:IO.popen with a leading Array argument accepts an IO mode argument followi
 fails:IO.popen with a leading ENV Hash accepts a single String command with a trailing Hash of Process.exec options, and an IO mode
 fails:IO.popen with a leading ENV Hash accepts an Array command with a separate trailing Hash of Process.exec options, and an IO mode
 windows:IO.popen reads a read-only pipe
-windows:IO.popen with a block returns the value of the block
 windows:IO.popen with a leading ENV Hash accepts a single String command
 windows:IO.popen with a leading ENV Hash accepts a single String command, and an IO mode
 windows:IO.popen with a leading ENV Hash accepts a single String command with a trailing Hash of Process.exec options


### PR DESCRIPTION
fixes #8278

Returns the value of the block for IO.popen and remove the test tag.