### PR TITLE
Eliminate last consumers of Variable logic

### DIFF
--- a/core/src/main/java/org/jruby/BasicObjectStub.java
+++ b/core/src/main/java/org/jruby/BasicObjectStub.java
@@ -30,6 +30,7 @@ package org.jruby;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.Block;
@@ -259,13 +260,16 @@ public final class BasicObjectStub {
      */
     private static StringBuilder inspectObj(IRubyObject self, StringBuilder part) {
         ThreadContext context = getRuntime(self).getCurrentContext();
-        String sep = "";
+        getInstanceVariables(self).forEachInstanceVariable(new BiConsumer<>() {
+            String sep = "";
 
-        for (Variable<IRubyObject> ivar : getInstanceVariables(self).getInstanceVariableList()) {
-            part.append(sep).append(' ').append(ivar.getName()).append('=');
-            part.append(invokedynamic(context, ivar.getValue(), INSPECT));
-            sep = ",";
-        }
+            @Override
+            public void accept(String name, IRubyObject value) {
+                part.append(sep).append(' ').append(name).append('=');
+                part.append(invokedynamic(context, value, INSPECT));
+                sep = ",";
+            }
+        });
         part.append('>');
         return part;
     }

--- a/core/src/main/java/org/jruby/runtime/builtin/InstanceVariables.java
+++ b/core/src/main/java/org/jruby/runtime/builtin/InstanceVariables.java
@@ -7,6 +7,7 @@ package org.jruby.runtime.builtin;
 
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 /**
  * Interface that represents the instance variable aspect of Ruby
@@ -76,7 +77,21 @@ public interface InstanceVariables {
      */
     void copyInstanceVariablesInto(InstanceVariables other);
 
+    /**
+     * Iterate over all instance variable name/value pairs for this object.
+     *
+     * @param accessor a consumer for each variable
+     */
     default void forEachInstanceVariable(BiConsumer<String, IRubyObject> accessor) {
         getInstanceVariableList().forEach((var) -> accessor.accept(var.getName(), var.getValue()));
+    }
+
+    /**
+     * Iterate over all instance variable names for this object.
+     *
+     * @param consumer consumer for the names
+     */
+    default void forEachInstanceVariableName(Consumer<String> consumer) {
+        forEachInstanceVariable((name, value) -> consumer.accept(name));
     }
 }

--- a/core/src/main/java/org/jruby/runtime/builtin/InstanceVariables.java
+++ b/core/src/main/java/org/jruby/runtime/builtin/InstanceVariables.java
@@ -6,6 +6,7 @@
 package org.jruby.runtime.builtin;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 
 /**
  * Interface that represents the instance variable aspect of Ruby
@@ -74,4 +75,8 @@ public interface InstanceVariables {
      * Copies all instance variables from the given object into the receiver
      */
     void copyInstanceVariablesInto(InstanceVariables other);
+
+    default void forEachInstanceVariable(BiConsumer<String, IRubyObject> accessor) {
+        getInstanceVariableList().forEach((var) -> accessor.accept(var.getName(), var.getValue()));
+    }
 }


### PR DESCRIPTION
This PR will replace the remaining uses of the `Variable` collections returned by methods like `InstanceVariables.getInstanceVariableList` so we can start deprecating those interfaces and fix users in the wild.

* `getInstanceVariableList` replaced with `forEachInstanceVariable`, eliminating a transient `Map` of `Variable` objects.
* `getInstanceVariableNameList` replaced with `forEachInstanceVariableName`, eliminating a transient `List<String>`.

Most of these do allocate a stateful Lambda, but I've made efforts to keep that cost to a minimum.