### PR TITLE
Eager initialize java_import'ed classes

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/ext/Module.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/Module.java
@@ -113,7 +113,7 @@ public class Module {
             if (className.contains("::")) {
                 throw runtime.newArgumentError("must use Java style name: " + className);
             }
-            javaClass = Java.getJavaClass(runtime, className, false); // raises NameError if not found
+            javaClass = Java.getJavaClass(runtime, className); // raises NameError if not found
         } else if (klass instanceof JavaPackage) {
             throw runtime.newArgumentError("java_import does not work for Java packages (try include_package instead)");
         } else if (klass instanceof RubyModule) {


### PR DESCRIPTION
This was originally done on purpose while working toward the possibility of lazy imports, but it's better for now to just let the class initialize and fail fast if there are linkage errors.

Fixes #8299

Resolves regression discussed in [#799](https://github.com/jruby/jruby/issues/799#issuecomment-2187125505) that prevented consistent error messages for unlinkable classes.