### PR TITLE
Update net-ftp to JRuby-compatible 0.3.7

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -126,7 +126,7 @@ bundled_gems = [
     # ['debug', '1.4.0'],
     ['matrix', '0.4.2'],
     ['minitest', '5.15.0'],
-    ['net-ftp', '0.1.3'],
+    ['net-ftp', '0.3.7'],
     ['net-imap', '0.2.3'],
     ['net-pop', '0.1.1'],
     ['net-smtp', '0.3.1'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -931,7 +931,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>net-ftp</artifactId>
-      <version>0.1.3</version>
+      <version>0.3.7</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1148,7 +1148,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/yaml-0.2.0*</include>
           <include>specifications/matrix-0.4.2*</include>
           <include>specifications/minitest-5.15.0*</include>
-          <include>specifications/net-ftp-0.1.3*</include>
+          <include>specifications/net-ftp-0.3.7*</include>
           <include>specifications/net-imap-0.2.3*</include>
           <include>specifications/net-pop-0.1.1*</include>
           <include>specifications/net-smtp-0.3.1*</include>
@@ -1227,7 +1227,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/yaml-0.2.0*/**/*</include>
           <include>gems/matrix-0.4.2*/**/*</include>
           <include>gems/minitest-5.15.0*/**/*</include>
-          <include>gems/net-ftp-0.1.3*/**/*</include>
+          <include>gems/net-ftp-0.3.7*/**/*</include>
           <include>gems/net-imap-0.2.3*/**/*</include>
           <include>gems/net-pop-0.1.1*/**/*</include>
           <include>gems/net-smtp-0.3.1*/**/*</include>
@@ -1306,7 +1306,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/yaml-0.2.0*</include>
           <include>cache/matrix-0.4.2*</include>
           <include>cache/minitest-5.15.0*</include>
-          <include>cache/net-ftp-0.1.3*</include>
+          <include>cache/net-ftp-0.3.7*</include>
           <include>cache/net-imap-0.2.3*</include>
           <include>cache/net-pop-0.1.1*</include>
           <include>cache/net-smtp-0.3.1*</include>

--- a/spec/ruby/library/net-ftp/shared/puttextfile.rb
+++ b/spec/ruby/library/net-ftp/shared/puttextfile.rb
@@ -34,8 +34,16 @@ describe :net_ftp_puttextfile, shared: true do
     remote_lines.should == local_lines.gsub("\n", "\r\n")
   end
 
-  it "returns nil" do
-    @ftp.send(@method, @local_fixture_file, "text").should be_nil
+  guard -> { Net::FTP::VERSION < '0.3.6' } do
+    it "returns nil" do
+      @ftp.send(@method, @local_fixture_file, "text").should be_nil
+    end
+  end
+
+  guard -> { Net::FTP::VERSION >= '0.3.6' } do
+    it "returns the response" do
+      @ftp.send(@method, @local_fixture_file, "text").should == @ftp.last_response
+    end
   end
 
   describe "when passed a block" do


### PR DESCRIPTION
Previous versions were missing our patch to disable OpenSSL session caching.

See ruby/net-ftp#38