### PR TITLE
Properly fall back if can't setAccessible

### DIFF
--- a/core/src/main/java/org/jruby/util/io/SeekableByteChannelImpl.java
+++ b/core/src/main/java/org/jruby/util/io/SeekableByteChannelImpl.java
@@ -149,15 +149,17 @@ final class SeekableByteChannelImpl extends AbstractInterruptibleChannel
     private static Field accessibleField(final String name) {
         try {
             Field field = ByteArrayInputStream.class.getDeclaredField(name);
-            Java.trySetAccessible(field);
-            return field;
+            if (Java.trySetAccessible(field)) {
+                return field;
+            }
         }
         catch (NoSuchFieldException ex) {
-            return null; // should never happen
+            // should never happen
         }
         catch (SecurityException ex) {
-            return null;
         }
+
+        return null;
     }
 
 }


### PR DESCRIPTION
Changes in e8dbe9c26 broke this fallback by silencing errors from the old setAccessible (as part of becoming more module-friendly). This patch checks if the setAccessible was successful and returns null for any fields that could not be made accessible. This in turn allows the USABLE fallback to properly reflect actual usability.