### PR TITLE
Default Windows filesystem encoding to UTF-8

### DIFF
--- a/core/src/main/java/org/jruby/runtime/encoding/EncodingService.java
+++ b/core/src/main/java/org/jruby/runtime/encoding/EncodingService.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 import org.jcodings.specific.USASCIIEncoding;
 import org.jruby.RubyString;
 import org.jruby.util.SafePropertyAccessor;
+import org.jruby.util.cli.Options;
 import org.jruby.util.io.EncodingUtils;
 
 public final class EncodingService {
@@ -430,7 +431,7 @@ public final class EncodingService {
     }
 
     public Encoding getWindowsFilesystemEncoding(Ruby ruby) {
-        String encoding = SafePropertyAccessor.getProperty("file.encoding", "UTF-8");
+        String encoding = Options.WINDOWS_FILESYSTEM_ENCODING.load();
         Encoding filesystemEncoding = loadEncoding(ByteList.create(encoding));
 
         // Use default external if file.encoding does not point at an encoding we recognize

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -164,6 +164,7 @@ public class Options {
     public static final Option<Boolean> PACKED_ARRAYS = bool(MISCELLANEOUS, "packed.arrays", true, "Toggle whether to use \"packed\" arrays for small tuples.");
     public static final Option<Boolean> REGEXP_INTERRUPTIBLE = bool(MISCELLANEOUS, "regexp.interruptible", true, "Allow regexp operations to be interruptible from Ruby.");
     public static final Option<Integer> JAR_CACHE_EXPIRATION = integer(MISCELLANEOUS, "jar.cache.expiration", 750, "The time (ms) between checks if a JAR file containing resources has been updated.");
+    public static final Option<String> WINDOWS_FILESYSTEM_ENCODING = string(MISCELLANEOUS, "windows.filesystem.encoding", "UTF-8", "The encoding to use for filesystem names and paths on Windows.");
 
     public static final Option<Boolean> DEBUG_LOADSERVICE = bool(DEBUG, "debug.loadService", false, "Log require/load file searches.");
     public static final Option<Boolean> DEBUG_LOADSERVICE_TIMING = bool(DEBUG, "debug.loadService.timing", false, "Log require/load parse+evaluate times.");


### PR DESCRIPTION
This change was applied to CRuby in 3.0.

See https://bugs.ruby-lang.org/issues/12654

Fixes #7750