### PR TITLE
New asFixnum, asBoolean, asString in Convert

### DIFF
--- a/core/src/main/java/org/jruby/AbstractRubyMethod.java
+++ b/core/src/main/java/org/jruby/AbstractRubyMethod.java
@@ -35,6 +35,7 @@ package org.jruby;
 
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.api.Convert;
 import org.jruby.internal.runtime.methods.AliasMethod;
 import org.jruby.internal.runtime.methods.DelegatingDynamicMethod;
 import org.jruby.internal.runtime.methods.DynamicMethod;
@@ -48,6 +49,9 @@ import org.jruby.runtime.backtrace.TraceType;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.callsite.CacheEntry;
 import org.jruby.runtime.marshal.DataType;
+
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 
 /**
  * @see RubyMethod
@@ -76,13 +80,18 @@ public abstract class AbstractRubyMethod extends RubyObject implements DataType 
      * @return the number of arguments of a method.
      */
     @JRubyMethod(name = "arity")
+    public RubyFixnum arity(ThreadContext context) {
+        return asFixnum(context, method.getSignature().arityValue());
+    }
+
+    @Deprecated
     public RubyFixnum arity() {
-        return getRuntime().newFixnum(method.getSignature().arityValue());
+        return arity(getCurrentContext());
     }
 
     @JRubyMethod(name = "eql?")
     public IRubyObject op_eql(ThreadContext context, IRubyObject other) {
-        return RubyBoolean.newBoolean(context,  equals(other) );
+        return asBoolean(context,  equals(other) );
     }
 
     @Override
@@ -114,11 +123,10 @@ public abstract class AbstractRubyMethod extends RubyObject implements DataType 
 
     @JRubyMethod(name = "source_location")
     public IRubyObject source_location(ThreadContext context) {
-        Ruby runtime = context.runtime;
-
         String filename = getFilename();
+
         if (filename != null) {
-            return runtime.newArray(runtime.newString(filename), runtime.newFixnum(getLine()));
+            return context.runtime.newArray(Convert.asString(context, filename), asFixnum(context, getLine()));
         }
 
         return context.nil;

--- a/core/src/main/java/org/jruby/BasicObjectStub.java
+++ b/core/src/main/java/org/jruby/BasicObjectStub.java
@@ -41,6 +41,7 @@ import org.jruby.runtime.builtin.InternalVariables;
 import org.jruby.runtime.builtin.RubyJavaObject;
 import org.jruby.runtime.builtin.Variable;
 
+import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.runtime.invokedynamic.MethodNames.INSPECT;
 import static org.jruby.runtime.Helpers.invokedynamic;
@@ -303,11 +304,11 @@ public final class BasicObjectStub {
     }
 
     public static IRubyObject op_equal(IRubyObject self, ThreadContext context, IRubyObject other) {
-        return RubyBoolean.newBoolean(context, self == other);
+        return asBoolean(context, self == other);
     }
 
     public static IRubyObject op_eqq(IRubyObject self, ThreadContext context, IRubyObject other) {
-        return RubyBoolean.newBoolean(context, self == other);
+        return asBoolean(context, self == other);
     }
 
     public static boolean eql(IRubyObject self, IRubyObject other) {

--- a/core/src/main/java/org/jruby/FiberScheduler.java
+++ b/core/src/main/java/org/jruby/FiberScheduler.java
@@ -8,6 +8,8 @@ import org.jruby.util.io.OpenFile;
 
 import java.nio.ByteBuffer;
 
+import static org.jruby.api.Convert.asFixnum;
+
 public class FiberScheduler {
     // MRI: rb_fiber_scheduler_kernel_sleep
     public static IRubyObject kernelSleep(ThreadContext context, IRubyObject scheduler, IRubyObject timeout) {
@@ -21,7 +23,7 @@ public class FiberScheduler {
 
     // MRI: rb_fiber_scheduler_process_wait
     public static IRubyObject processWait(ThreadContext context, IRubyObject scheduler, long pid, int flags) {
-        return Helpers.invokeChecked(context, scheduler, "process_wait", context.runtime.newFixnum(pid), context.runtime.newFixnum(flags));
+        return Helpers.invokeChecked(context, scheduler, "process_wait", asFixnum(context, pid), asFixnum(context, flags));
     }
 
     // MRI: rb_fiber_scheduler_block
@@ -41,12 +43,12 @@ public class FiberScheduler {
 
     // MRI: rb_fiber_scheduler_io_wait_readable
     public static IRubyObject ioWaitReadable(ThreadContext context, IRubyObject scheduler, IRubyObject io) {
-        return ioWait(context, scheduler, io, context.runtime.newFixnum(OpenFile.READABLE), context.nil);
+        return ioWait(context, scheduler, io, asFixnum(context, OpenFile.READABLE), context.nil);
     }
 
     // MRI: rb_fiber_scheduler_io_wait_writable
     public static IRubyObject ioWaitWritable(ThreadContext context, IRubyObject scheduler, IRubyObject io) {
-        return ioWait(context, scheduler, io, context.runtime.newFixnum(OpenFile.WRITABLE), context.nil);
+        return ioWait(context, scheduler, io, asFixnum(context, OpenFile.WRITABLE), context.nil);
     }
 
     // MRI: rb_fiber_scheduler_io_select
@@ -62,7 +64,7 @@ public class FiberScheduler {
     // MRI: rb_fiber_scheduler_io_read
     public static IRubyObject ioRead(ThreadContext context, IRubyObject scheduler, IRubyObject io, IRubyObject buffer, int length, int offset) {
         Ruby runtime = context.runtime;
-        return Helpers.invokeChecked(context, scheduler, "io_read", io, buffer, runtime.newFixnum(length), runtime.newFixnum(offset));
+        return Helpers.invokeChecked(context, scheduler, "io_read", io, buffer, asFixnum(context, length), asFixnum(context, offset));
     }
 
     public static IRubyObject ioRead(ThreadContext context, IRubyObject scheduler, IRubyObject io, IRubyObject buffer, RubyInteger length, RubyInteger offset) {
@@ -71,7 +73,7 @@ public class FiberScheduler {
 
     // MRI: rb_fiber_scheduler_io_pread
     public static IRubyObject ioPRead(ThreadContext context, IRubyObject scheduler, IRubyObject io, IRubyObject buffer, int from, int length, int offset) {
-        return Helpers.invokeChecked(context, scheduler, "io_pread", io, buffer, context.runtime.newFixnum(from), context.runtime.newFixnum(length), context.runtime.newFixnum(offset));
+        return Helpers.invokeChecked(context, scheduler, "io_pread", io, buffer, asFixnum(context, from), asFixnum(context, length), asFixnum(context, offset));
     }
 
     public static IRubyObject ioPRead(ThreadContext context, IRubyObject scheduler, IRubyObject io, IRubyObject buffer, RubyInteger from, RubyInteger length, RubyInteger offset) {
@@ -80,8 +82,7 @@ public class FiberScheduler {
 
     // MRI: rb_fiber_scheduler_io_write
     public static IRubyObject ioWrite(ThreadContext context, IRubyObject scheduler, IRubyObject io, IRubyObject buffer, int length, int offset) {
-        Ruby runtime = context.runtime;
-        return Helpers.invokeChecked(context, scheduler, "io_write", io, buffer, runtime.newFixnum(length), runtime.newFixnum(offset));
+        return Helpers.invokeChecked(context, scheduler, "io_write", io, buffer, asFixnum(context, length), asFixnum(context, offset));
     }
 
     public static IRubyObject ioWrite(ThreadContext context, IRubyObject scheduler, IRubyObject io, IRubyObject buffer, RubyInteger length, RubyInteger offset) {
@@ -90,7 +91,7 @@ public class FiberScheduler {
 
     // MRI: rb_fiber_scheduler_io_pwrite
     public static IRubyObject ioPWrite(ThreadContext context, IRubyObject scheduler, IRubyObject io, IRubyObject buffer, int from, int length, int offset) {
-        return Helpers.invokeChecked(context, scheduler, "io_pwrite", io, buffer, context.runtime.newFixnum(from), context.runtime.newFixnum(length), context.runtime.newFixnum(offset));
+        return Helpers.invokeChecked(context, scheduler, "io_pwrite", io, buffer, asFixnum(context, from), asFixnum(context, length), asFixnum(context, offset));
     }
 
     public static IRubyObject ioPWrite(ThreadContext context, IRubyObject scheduler, IRubyObject io, IRubyObject buffer, RubyInteger from, RubyInteger length, RubyInteger offset) {

--- a/core/src/main/java/org/jruby/RubyArgsFile.java
+++ b/core/src/main/java/org/jruby/RubyArgsFile.java
@@ -43,7 +43,7 @@ import static org.jruby.RubyArgsFile.Next.NextFile;
 import static org.jruby.RubyArgsFile.Next.Stream;
 import static org.jruby.RubyEnumerator.enumeratorize;
 import static org.jruby.anno.FrameField.LASTLINE;
-import static org.jruby.api.Convert.numericToLong;
+import static org.jruby.api.Convert.*;
 import static org.jruby.runtime.ThreadContext.CALL_KEYWORD;
 import static org.jruby.runtime.ThreadContext.resetCallInfo;
 import static org.jruby.runtime.Visibility.PRIVATE;
@@ -652,7 +652,7 @@ public class RubyArgsFile extends RubyObject {
 
         data.next_argv(context);
 
-        return RubyBoolean.newBoolean(context, isClosed(context, data.currentFile));
+        return asBoolean(context, isClosed(context, data.currentFile));
     }
 
     private static boolean isClosed(ThreadContext context, IRubyObject currentFile) {
@@ -678,7 +678,7 @@ public class RubyArgsFile extends RubyObject {
 
     @JRubyMethod(name = "lineno")
     public static IRubyObject lineno(ThreadContext context, IRubyObject recv) {
-        return context.runtime.newFixnum(context.runtime.getCurrentLine());
+        return asFixnum(context, context.runtime.getCurrentLine());
     }
 
     @JRubyMethod(name = "lineno=")
@@ -698,7 +698,7 @@ public class RubyArgsFile extends RubyObject {
         RubyIO currentFile = getCurrentDataFile(context, "no stream to rewind");
 
         RubyFixnum retVal = currentFile.rewind(context);
-        currentFile.lineno_set(context, context.runtime.newFixnum(0));
+        currentFile.lineno_set(context, asFixnum(context, 0));
 
         return retVal;
     }
@@ -860,8 +860,6 @@ public class RubyArgsFile extends RubyObject {
     @JRubyMethod(name = "read", optional = 2, checkArity = false)
     public static IRubyObject read(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         int argc = Arity.checkArgumentCount(context, args, 0, 2);
-
-        Ruby runtime = context.runtime;
         ArgsFileData data = ArgsFileData.getArgsFileData(context.runtime);
         IRubyObject tmp, str, length;
             long len = 0;
@@ -906,7 +904,7 @@ public class RubyArgsFile extends RubyObject {
             } else if (argc >= 1) {
                 final int strLen = ((RubyString) str).getByteList().length();
                 if (strLen < len) {
-                    args[0] = runtime.newFixnum(len - strLen);
+                    args[0] = asFixnum(context, len - strLen);
                     continue;
                 }
             }

--- a/core/src/main/java/org/jruby/RubyArithmeticSequence.java
+++ b/core/src/main/java/org/jruby/RubyArithmeticSequence.java
@@ -51,6 +51,7 @@ import static org.jruby.RubyNumeric.dbl2num;
 import static org.jruby.RubyNumeric.int2fix;
 import static org.jruby.RubyNumeric.num2dbl;
 
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.numericToLong;
 import static org.jruby.runtime.Helpers.hashEnd;
 import static org.jruby.runtime.Helpers.hashStart;
@@ -349,12 +350,8 @@ public class RubyArithmeticSequence extends RubyObject {
 
     @JRubyMethod(name = "hash")
     public RubyFixnum hash(ThreadContext context) {
-        Ruby runtime = context.runtime;
-
-        IRubyObject v;
-
-        v = safeHash(context, excludeEnd);
-        long hash = hashStart(runtime, v.convertToInteger().getLongValue());
+        IRubyObject v = safeHash(context, excludeEnd);
+        long hash = hashStart(context.runtime, v.convertToInteger().getLongValue());
 
         v = safeHash(context, begin);
         hash = murmurCombine(hash, v.convertToInteger().getLongValue());
@@ -366,7 +363,7 @@ public class RubyArithmeticSequence extends RubyObject {
         hash = murmurCombine(hash, v.convertToInteger().getLongValue());
         hash = hashEnd(hash);
 
-        return runtime.newFixnum(hash);
+        return asFixnum(context, hash);
     }
 
     @Override
@@ -627,12 +624,11 @@ public class RubyArithmeticSequence extends RubyObject {
 
     @JRubyMethod(name = "with_index")
     public IRubyObject with_index(ThreadContext context, IRubyObject arg, final Block block) {
-        final Ruby runtime = context.runtime;
         final int index = arg.isNil() ? 0 : RubyNumeric.num2int(arg);
         if ( ! block.isGiven() ) {
             return arg.isNil() ?
-                enumeratorizeWithSize(context, this, "with_index", RubyArithmeticSequence::size) :
-                    enumeratorizeWithSize(context, this, "with_index", new IRubyObject[]{runtime.newFixnum(index)}, RubyArithmeticSequence::size);
+                    enumeratorizeWithSize(context, this, "with_index", RubyArithmeticSequence::size) :
+                    enumeratorizeWithSize(context, this, "with_index", new IRubyObject[]{asFixnum(context, index)}, RubyArithmeticSequence::size);
         }
 
         return RubyEnumerable.callEach(context, fiberSites(context).each, this, new RubyEnumerable.EachWithIndex(block, index));

--- a/core/src/main/java/org/jruby/RubyBignum.java
+++ b/core/src/main/java/org/jruby/RubyBignum.java
@@ -52,7 +52,7 @@ import org.jruby.runtime.marshal.NewMarshal;
 import org.jruby.runtime.marshal.UnmarshalStream;
 
 import static org.jruby.RubyFixnum.zero;
-import static org.jruby.api.Convert.numericToLong;
+import static org.jruby.api.Convert.*;
 import static org.jruby.api.Error.typeError;
 
 /**
@@ -798,7 +798,7 @@ public class RubyBignum extends RubyInteger {
 
     @Override
     public IRubyObject bit_length(ThreadContext context) {
-        return context.runtime.newFixnum(value.bitLength());
+        return asFixnum(context, value.bitLength());
     }
 
     /** rb_big_xor
@@ -1132,18 +1132,18 @@ public class RubyBignum extends RubyInteger {
     @Override
     public IRubyObject op_equal(ThreadContext context, IRubyObject other) {
         final BigInteger otherValue;
-        if (other instanceof RubyFixnum) {
-            otherValue = fix2big((RubyFixnum) other);
-        } else if (other instanceof RubyBignum) {
-            otherValue = ((RubyBignum) other).value;
-        } else if (other instanceof RubyFloat) {
-            double a = ((RubyFloat) other).value;
+        if (other instanceof RubyFixnum fixnum) {
+            otherValue = fix2big(fixnum);
+        } else if (other instanceof RubyBignum bignum) {
+            otherValue = bignum.value;
+        } else if (other instanceof RubyFloat flote) {
+            double a = flote.value;
             if (Double.isNaN(a)) return context.fals;
-            return RubyBoolean.newBoolean(context, a == big2dbl(this));
+            return asBoolean(context, a == big2dbl(this));
         } else {
             return other.op_eqq(context, this);
         }
-        return RubyBoolean.newBoolean(context, value.compareTo(otherValue) == 0);
+        return asBoolean(context, value.compareTo(otherValue) == 0);
     }
 
     /** rb_big_eql
@@ -1204,12 +1204,12 @@ public class RubyBignum extends RubyInteger {
      */
     @Override
     public IRubyObject size(ThreadContext context) {
-        return context.runtime.newFixnum((value.bitLength() + 7) / 8);
+        return asFixnum(context, (value.bitLength() + 7) / 8);
     }
 
     @Override
     public IRubyObject zero_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, isZero());
+        return asBoolean(context, isZero());
     }
 
     @Override
@@ -1347,7 +1347,7 @@ public class RubyBignum extends RubyInteger {
     public IRubyObject isNegative(ThreadContext context) {
         CachingCallSite op_lt_site = sites(context).basic_op_lt;
         if (op_lt_site.isBuiltin(metaClass)) {
-            return RubyBoolean.newBoolean(context, value.signum() < 0);
+            return asBoolean(context, value.signum() < 0);
         }
         return op_lt_site.call(context, this, this, zero(context.runtime));
     }
@@ -1356,7 +1356,7 @@ public class RubyBignum extends RubyInteger {
     public IRubyObject isPositive(ThreadContext context) {
         CachingCallSite op_gt_site = sites(context).basic_op_gt;
         if (op_gt_site.isBuiltin(metaClass)) {
-            return RubyBoolean.newBoolean(context, value.signum() > 0);
+            return asBoolean(context, value.signum() > 0);
         }
         return op_gt_site.call(context, this, this, zero(context.runtime));
     }

--- a/core/src/main/java/org/jruby/RubyBinding.java
+++ b/core/src/main/java/org/jruby/RubyBinding.java
@@ -36,6 +36,7 @@ package org.jruby;
 
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.api.Convert;
 import org.jruby.ext.ripper.RubyLexer;
 import org.jruby.runtime.Arity;
 import org.jruby.runtime.Binding;
@@ -47,6 +48,8 @@ import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.TypeConverter;
 
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.util.RubyStringBuilder.str;
 
 /**
@@ -146,7 +149,7 @@ public class RubyBinding extends RubyObject {
     @JRubyMethod(name = "local_variable_defined?")
     public IRubyObject local_variable_defined_p(ThreadContext context, IRubyObject symbol) {
         String id = checkLocalId(context, symbol);
-        return RubyBoolean.newBoolean(context, binding.getEvalScope(context.runtime).getStaticScope().isDefined(id) != -1);
+        return asBoolean(context, binding.getEvalScope(context.runtime).getStaticScope().isDefined(id) != -1);
     }
 
     @JRubyMethod
@@ -198,9 +201,8 @@ public class RubyBinding extends RubyObject {
 
     @JRubyMethod
     public IRubyObject source_location(ThreadContext context) {
-        Ruby runtime = context.runtime;
-        IRubyObject filename = runtime.newString(binding.getFile()).freeze(context);
-        RubyFixnum line = runtime.newFixnum(binding.getLine() + 1); /* zero-based */
-        return runtime.newArray(filename, line);
+        IRubyObject filename = Convert.asString(context, binding.getFile()).freeze(context);
+        RubyFixnum line = asFixnum(context, binding.getLine() + 1); /* zero-based */
+        return context.runtime.newArray(filename, line);
     }
 }

--- a/core/src/main/java/org/jruby/RubyBoolean.java
+++ b/core/src/main/java/org/jruby/RubyBoolean.java
@@ -45,6 +45,8 @@ import org.jruby.runtime.marshal.MarshalStream;
 import org.jruby.runtime.opto.OptoFactory;
 import org.jruby.util.ByteList;
 
+import static org.jruby.api.Convert.asFixnum;
+
 /**
  *
  * @author  jpetersen
@@ -132,11 +134,13 @@ public class RubyBoolean extends RubyObject implements Constantizable, Appendabl
 
         return trueClass;
     }
-    
+
+    @Deprecated
     public static RubyBoolean newBoolean(Ruby runtime, boolean value) {
         return value ? runtime.getTrue() : runtime.getFalse();
     }
 
+    @Deprecated
     public static RubyBoolean newBoolean(ThreadContext context, boolean value) {
         return value ? context.tru : context.fals;
     }
@@ -234,7 +238,7 @@ public class RubyBoolean extends RubyObject implements Constantizable, Appendabl
     
     @JRubyMethod(name = "hash")
     public RubyFixnum hash(ThreadContext context) {
-        return context.runtime.newFixnum(hashCode());
+        return asFixnum(context, hashCode());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyChain.java
+++ b/core/src/main/java/org/jruby/RubyChain.java
@@ -42,6 +42,7 @@ import org.jruby.util.ByteList;
 
 import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
 import static org.jruby.RubyEnumerator.SizeFn;
+import static org.jruby.api.Convert.asFixnum;
 
 /**
  * Implements Enumerator::Chain
@@ -200,12 +201,11 @@ public class RubyChain extends RubyObject {
 
     @JRubyMethod(name = "with_index")
     public IRubyObject with_index(ThreadContext context, IRubyObject arg, final Block block) {
-        final Ruby runtime = context.runtime;
         final int index = arg.isNil() ? 0 : RubyNumeric.num2int(arg);
         if ( ! block.isGiven() ) {
             return arg.isNil() ?
                 enumeratorizeWithSize(context, this, "with_index", RubyChain::size) :
-                    enumeratorizeWithSize(context, this, "with_index", new IRubyObject[]{runtime.newFixnum(index)}, RubyChain::size);
+                    enumeratorizeWithSize(context, this, "with_index", new IRubyObject[]{asFixnum(context, index)}, RubyChain::size);
         }
 
         return RubyEnumerable.callEach(context, fiberSites(context).each, this, new RubyEnumerable.EachWithIndex(block, index));

--- a/core/src/main/java/org/jruby/RubyClassPathVariable.java
+++ b/core/src/main/java/org/jruby/RubyClassPathVariable.java
@@ -38,6 +38,8 @@ import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import static org.jruby.api.Convert.asFixnum;
+
 /**
  * @author <a href="mailto:ola.bini@ki.se">Ola Bini</a>
  */
@@ -99,8 +101,11 @@ public class RubyClassPathVariable extends RubyObject {
     }
 
     @JRubyMethod(name = {"size", "length"})
+    public IRubyObject size(ThreadContext context) {
+        return asFixnum(context, context.runtime.getJRubyClassLoader().getURLs().length);
+    }
     public IRubyObject size() {
-        return getRuntime().newFixnum(getRuntime().getJRubyClassLoader().getURLs().length);
+        return size(getCurrentContext());
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/RubyComplex.java
+++ b/core/src/main/java/org/jruby/RubyComplex.java
@@ -52,6 +52,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.function.BiFunction;
 
+import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.runtime.Helpers.invokedynamic;
 import static org.jruby.runtime.invokedynamic.MethodNames.HASH;
@@ -833,18 +834,12 @@ public class RubyComplex extends RubyNumeric {
     @JRubyMethod(name = "==")
     @Override
     public IRubyObject op_equal(ThreadContext context, IRubyObject other) {
-        if (other instanceof RubyComplex) {
-            RubyComplex otherComplex = (RubyComplex) other;
-            boolean test = f_equal(context, real, otherComplex.real).isTrue() &&
-                    f_equal(context, image, otherComplex.image).isTrue();
-
-            return RubyBoolean.newBoolean(context, test);
+        if (other instanceof RubyComplex comp) {
+            return asBoolean(context, f_equal(context, real, comp.real).isTrue() && f_equal(context, image, comp.image).isTrue());
         }
 
-        if (other instanceof RubyNumeric && f_real_p(context, (RubyNumeric) other)) {
-            boolean test = f_equal(context, real, other).isTrue() && f_zero_p(context, image);
-
-            return RubyBoolean.newBoolean(context, test);
+        if (other instanceof RubyNumeric num && f_real_p(context, num)) {
+            return asBoolean(context, f_equal(context, real, num).isTrue() && f_zero_p(context, image));
         }
         
         return f_equal(context, other, this);
@@ -1006,7 +1001,7 @@ public class RubyComplex extends RubyNumeric {
     @JRubyMethod(name = "eql?")
     @Override
     public IRubyObject eql_p(ThreadContext context, IRubyObject other) {
-        return RubyBoolean.newBoolean(context, equals(context, other));
+        return asBoolean(context, equals(context, other));
     }
 
     private boolean equals(ThreadContext context, Object other) {

--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -66,6 +66,8 @@ import org.jruby.ast.util.ArgsUtil;
 import static org.jruby.RubyEnumerator.enumeratorize;
 import static org.jruby.RubyFile.filePathConvert;
 import static org.jruby.RubyString.UTF8;
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.util.RubyStringBuilder.str;
 import static org.jruby.util.io.EncodingUtils.newExternalStringWithEncoding;
 
@@ -471,7 +473,7 @@ public class RubyDir extends RubyObject implements Closeable {
             }
         } else {
             runtime.setCurrentDirectory(adjustedPath);
-            result = runtime.newFixnum(0);
+            result = asFixnum(context, 0);
         }
 
         return result;
@@ -838,9 +840,14 @@ public class RubyDir extends RubyObject implements Closeable {
      * Returns the current position in the directory.
      */
     @JRubyMethod(name = {"tell", "pos"})
-    public RubyInteger tell() {
+    public RubyInteger tell(ThreadContext context) {
         checkDir();
-        return getRuntime().newFixnum(pos);
+        return asFixnum(context, pos);
+    }
+
+    @Deprecated
+    public RubyInteger tell() {
+        return tell(getCurrentContext());
     }
 
     /**
@@ -906,7 +913,7 @@ public class RubyDir extends RubyObject implements Closeable {
         RubyString path = StringSupport.checkEmbeddedNulls(runtime, RubyFile.get_path(context, arg));
         RubyFileStat fileStat = runtime.newFileStat(path.asJavaString(), false);
         boolean isDirectory = fileStat.directory_p().isTrue();
-        return runtime.newBoolean(isDirectory && entries(context, recv, arg).getLength() <= 2);
+        return asBoolean(context, isDirectory && entries(context, recv, arg).getLength() <= 2);
     }
 
     @JRubyMethod(name = "exist?", meta = true)
@@ -921,7 +928,7 @@ public class RubyDir extends RubyObject implements Closeable {
         } catch (Exception e) {
             // Restore $!
             runtime.getGlobalVariables().set("$!", exception);
-            return runtime.newBoolean(false);
+            return context.fals;
         }
     }
 

--- a/core/src/main/java/org/jruby/RubyEncoding.java
+++ b/core/src/main/java/org/jruby/RubyEncoding.java
@@ -58,6 +58,7 @@ import org.jruby.util.io.EncodingUtils;
 
 import static com.headius.backport9.buffer.Buffers.clearBuffer;
 import static com.headius.backport9.buffer.Buffers.flipBuffer;
+import static org.jruby.api.Convert.asBoolean;
 
 @JRubyClass(name="Encoding")
 public class RubyEncoding extends RubyObject implements Constantizable {
@@ -566,7 +567,7 @@ public class RubyEncoding extends RubyObject implements Constantizable {
 
     @JRubyMethod(name = "ascii_compatible?")
     public IRubyObject asciiCompatible_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, getEncoding().isAsciiCompatible());
+        return asBoolean(context, getEncoding().isAsciiCompatible());
     }
 
     @JRubyMethod(name = {"to_s", "name"})
@@ -618,7 +619,7 @@ public class RubyEncoding extends RubyObject implements Constantizable {
 
     @JRubyMethod(name = "dummy?")
     public IRubyObject dummy_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, isDummy);
+        return asBoolean(context, isDummy);
     }
 
     @JRubyMethod(name = "compatible?", meta = true)

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -67,6 +67,7 @@ import static org.jruby.RubyEnumerator.SizeFn;
 import static org.jruby.RubyEnumerator.enumeratorize;
 import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
 import static org.jruby.RubyObject.equalInternal;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.numericToLong;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.runtime.Helpers.arrayOf;
@@ -1152,12 +1153,12 @@ public class RubyEnumerable {
         }
 
         public IRubyObject call(ThreadContext context, IRubyObject[] iargs, Block block) {
-            return this.block.call(context, packEnumValues(context, iargs), context.runtime.newFixnum(index++));
+            return this.block.call(context, packEnumValues(context, iargs), asFixnum(context, index++));
         }
 
         @Override
         public IRubyObject call(ThreadContext context, IRubyObject iarg, Block block) {
-            return this.block.call(context, iarg, context.runtime.newFixnum(index++));
+            return this.block.call(context, iarg, asFixnum(context, index++));
         }
     }
 

--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -45,6 +45,7 @@ import org.jruby.util.ByteList;
 import java.util.Spliterator;
 import java.util.stream.Stream;
 
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.numericToLong;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.runtime.Helpers.arrayOf;
@@ -471,12 +472,11 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
     }
 
     private IRubyObject with_index_common(ThreadContext context, final Block block, final String rubyMethodName, IRubyObject arg) {
-        final Ruby runtime = context.runtime;
         final int index = arg.isNil() ? 0 : RubyNumeric.num2int(arg);
         if ( ! block.isGiven() ) {
             return arg.isNil() ?
                     enumeratorizeWithSize(context, this, rubyMethodName, RubyEnumerator::size) :
-                        enumeratorizeWithSize(context, this, rubyMethodName, new IRubyObject[]{runtime.newFixnum(index)}, RubyEnumerator::size);
+                        enumeratorizeWithSize(context, this, rubyMethodName, new IRubyObject[]{asFixnum(context, index)}, RubyEnumerator::size);
         }
 
         return RubyEnumerable.callEach(context, sites(context).each, this, new RubyEnumerable.EachWithIndex(block, index));

--- a/core/src/main/java/org/jruby/RubyException.java
+++ b/core/src/main/java/org/jruby/RubyException.java
@@ -58,6 +58,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.util.List;
 
+import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.runtime.Visibility.PRIVATE;
 import static org.jruby.util.RubyStringBuilder.str;
@@ -383,11 +384,10 @@ public class RubyException extends RubyObject {
     public RubyBoolean op_equal(ThreadContext context, IRubyObject other) {
         if (this == other) return context.tru;
 
-        boolean equal = context.runtime.getException().isInstance(other) &&
+        return asBoolean(context, context.runtime.getException().isInstance(other) &&
                 getMetaClass().getRealClass() == other.getMetaClass().getRealClass() &&
                 callMethod(context, "message").equals(other.callMethod(context, "message")) &&
-                callMethod(context, "backtrace").equals(other.callMethod(context, "backtrace"));
-        return RubyBoolean.newBoolean(context, equal);
+                callMethod(context, "backtrace").equals(other.callMethod(context, "backtrace")));
     }
 
     @JRubyMethod(name = "cause")

--- a/core/src/main/java/org/jruby/RubyFileTest.java
+++ b/core/src/main/java/org/jruby/RubyFileTest.java
@@ -33,6 +33,8 @@ package org.jruby;
 
 import static org.jruby.RubyFile.get_path;
 import static org.jruby.RubyFile.fileResource;
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 
 import java.io.File;
 import java.io.IOException;
@@ -62,24 +64,35 @@ public class RubyFileTest {
     }
 
     @JRubyMethod(name = "blockdev?", module = true)
-    public static IRubyObject blockdev_p(IRubyObject recv, IRubyObject filename) {
-        FileStat stat = fileResource(filename).stat();
+    public static IRubyObject blockdev_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+        FileStat stat = fileResource(context, filename).stat();
 
-        return recv.getRuntime().newBoolean(stat != null && stat.isBlockDev());
+        return asBoolean(context, stat != null && stat.isBlockDev());
+    }
+
+    @Deprecated
+    public static IRubyObject blockdev_p(IRubyObject recv, IRubyObject filename) {
+        return blockdev_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
     @JRubyMethod(name = "chardev?", module = true)
-    public static IRubyObject chardev_p(IRubyObject recv, IRubyObject filename) {
-        FileStat stat = fileResource(filename).stat();
+    public static IRubyObject chardev_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+        FileStat stat = fileResource(context, filename).stat();
 
-        return recv.getRuntime().newBoolean(stat != null && stat.isCharDev());
+        return asBoolean(context, stat != null && stat.isCharDev());
+    }
+
+    @Deprecated
+    public static IRubyObject chardev_p(IRubyObject recv, IRubyObject filename) {
+        return chardev_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
     @Deprecated
     public static IRubyObject directory_p(IRubyObject recv, IRubyObject filename) {
-        return directory_p(recv.getRuntime().getCurrentContext(), recv, filename);
+        return directory_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
+    @Deprecated
     public static IRubyObject directory_p(Ruby ruby, IRubyObject filename) {
         return directory_p(ruby.getCurrentContext(), filename);
     }
@@ -94,35 +107,43 @@ public class RubyFileTest {
             filename = TypeConverter.convertToType(filename, context.runtime.getIO(), "to_io");
         }
 
-        return RubyBoolean.newBoolean(context, fileResource(context, filename).isDirectory());
+        return asBoolean(context, fileResource(context, filename).isDirectory());
     }
 
     @JRubyMethod(name = "executable?", module = true)
+    public static IRubyObject executable_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+        return asBoolean(context, fileResource(context, filename).canExecute());
+    }
+
+    @Deprecated
     public static IRubyObject executable_p(IRubyObject recv, IRubyObject filename) {
-        return recv.getRuntime().newBoolean(fileResource(filename).canExecute());
+        return executable_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
     @JRubyMethod(name = "executable_real?", module = true)
-    public static IRubyObject executable_real_p(IRubyObject recv, IRubyObject filename) {
-        if (recv.getRuntime().getPosix().isNative()) {
-            FileStat stat = fileResource(filename).stat();
-
-            return recv.getRuntime().newBoolean(stat != null && stat.isExecutableReal());
-        }
-        else {
-            return executable_p(recv, filename);
+    public static IRubyObject executable_real_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+        if (context.runtime.getPosix().isNative()) {
+            FileStat stat = fileResource(context, filename).stat();
+            return asBoolean(context, stat != null && stat.isExecutableReal());
+        } else {
+            return executable_p(context, recv, filename);
         }
     }
 
     @Deprecated
+    public static IRubyObject executable_real_p(IRubyObject recv, IRubyObject filename) {
+        return executable_real_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
+    }
+
+    @Deprecated
     public static IRubyObject exist_p(IRubyObject recv, IRubyObject filename) {
-        return exist_p(recv.getRuntime().getCurrentContext(), recv, filename);
+        return exist_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
     @JRubyMethod(name = "exist?", module = true)
     public static IRubyObject exist_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
         // We get_path here to prevent doing it both existsOnClasspath and fileResource (Only call to_path once).
-        return RubyBoolean.newBoolean(context, exist(context, get_path(context, filename)));
+        return asBoolean(context, exist(context, get_path(context, filename)));
     }
 
     static boolean exist(ThreadContext context, RubyString path) {
@@ -135,38 +156,39 @@ public class RubyFileTest {
 
     @Deprecated
     public static RubyBoolean file_p(IRubyObject recv, IRubyObject filename) {
-        return file_p(recv.getRuntime().getCurrentContext(), recv, filename);
+        return file_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
     @JRubyMethod(name = "file?", module = true)
     public static RubyBoolean file_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
-        return RubyBoolean.newBoolean(context, fileResource(filename).isFile());
+        return asBoolean(context, fileResource(context, filename).isFile());
     }
 
     @JRubyMethod(name = "grpowned?", module = true)
-    public static IRubyObject grpowned_p(IRubyObject recv, IRubyObject filename) {
-        Ruby runtime = recv.getRuntime();
-        FileStat stat = fileResource(filename).stat();
+    public static IRubyObject grpowned_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+        FileStat stat = fileResource(context, filename).stat();
 
         // JRUBY-4446, grpowned? always returns false on Windows
-        if (Platform.IS_WINDOWS) return runtime.getFalse();
-        
-        return runtime.newBoolean(stat != null && stat.isGroupOwned());
+        if (Platform.IS_WINDOWS) return context.fals;
+
+        return asBoolean(context, stat != null && stat.isGroupOwned());
+    }
+
+    public static IRubyObject grpowned_p(IRubyObject recv, IRubyObject filename) {
+        return grpowned_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
     @JRubyMethod(name = "identical?", module = true)
     public static IRubyObject identical_p(ThreadContext context, IRubyObject recv, IRubyObject filename1, IRubyObject filename2) {
-        Ruby runtime = context.runtime;
-
-        FileResource file1 = fileResource(filename1);
-        FileResource file2 = fileResource(filename2);
+        FileResource file1 = fileResource(context, filename1);
+        FileResource file2 = fileResource(context, filename2);
 
         // Try posix first
-        if (!Platform.IS_WINDOWS && runtime.getPosix().isNative()) {
+        if (!Platform.IS_WINDOWS && context.runtime.getPosix().isNative()) {
             FileStat stat1 = file1.stat();
             FileStat stat2 = file2.stat();
 
-            return runtime.newBoolean(stat1 != null && stat2 != null && stat1.isIdentical(stat2));
+            return asBoolean(context, stat1 != null && stat2 != null && stat1.isIdentical(stat2));
         }
 
         // fallback to NIO2 to support more platforms
@@ -174,7 +196,7 @@ public class RubyFileTest {
             try {
                 Path canon1 = new File(file1.absolutePath()).getCanonicalFile().toPath();
                 Path canon2 = new File(file2.absolutePath()).getCanonicalFile().toPath();
-                return runtime.newBoolean(Files.isSameFile(canon1, canon2));
+                return asBoolean(context, Files.isSameFile(canon1, canon2));
             } catch (IOException canonicalizationError) {
                 // fall through
             }
@@ -184,22 +206,32 @@ public class RubyFileTest {
     }
 
     @JRubyMethod(name = "owned?", module = true)
-    public static IRubyObject owned_p(IRubyObject recv, IRubyObject filename) {
-        FileStat stat = fileResource(filename).stat();
+    public static IRubyObject owned_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+        FileStat stat = fileResource(context, filename).stat();
 
-        return recv.getRuntime().newBoolean(stat != null && stat.isOwned());
+        return asBoolean(context, stat != null && stat.isOwned());
+    }
+
+    @Deprecated
+    public static IRubyObject owned_p(IRubyObject recv, IRubyObject filename) {
+        return owned_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
     @JRubyMethod(name = "pipe?", module = true)
-    public static IRubyObject pipe_p(IRubyObject recv, IRubyObject filename) {
-        FileStat stat = fileResource(filename).stat();
+    public static IRubyObject pipe_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+        FileStat stat = fileResource(context, filename).stat();
 
-        return recv.getRuntime().newBoolean(stat != null && stat.isNamedPipe());
+        return asBoolean(context, stat != null && stat.isNamedPipe());
+    }
+
+    @Deprecated
+    public static IRubyObject pipe_p(IRubyObject recv, IRubyObject filename) {
+        return pipe_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
     @Deprecated
     public static IRubyObject readable_p(IRubyObject recv, IRubyObject filename) {
-        return readable_p(recv.getRuntime().getCurrentContext(), recv, filename);
+        return readable_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
     // We use file test since it is faster than a stat; also euid == uid in Java always
@@ -210,32 +242,48 @@ public class RubyFileTest {
             filename = get_path(context, filename);
         }
 
-        return runtime.newBoolean(fileResource(filename).canRead());
+        return asBoolean(context, fileResource(context, filename).canRead());
     }
 
     // Not exposed by filetest, but so similar in nature that it is stored here
-    public static IRubyObject rowned_p(IRubyObject recv, IRubyObject filename) {
-        FileStat stat = fileResource(filename).stat();
+    public static IRubyObject rowned_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+        FileStat stat = fileResource(context, filename).stat();
 
-        return recv.getRuntime().newBoolean(stat != null && stat.isROwned());
+        return asBoolean(context, stat != null && stat.isROwned());
+    }
+
+    @Deprecated
+    public static IRubyObject rowned_p(IRubyObject recv, IRubyObject filename) {
+        return rowned_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
     @JRubyMethod(name = "setgid?", module = true)
-    public static IRubyObject setgid_p(IRubyObject recv, IRubyObject filename) {
-        FileStat stat = fileResource(filename).stat();
+    public static IRubyObject setgid_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+        FileStat stat = fileResource(context, filename).stat();
 
-        return recv.getRuntime().newBoolean(stat != null && stat.isSetgid());
+        return asBoolean(context, stat != null && stat.isSetgid());
+    }
+
+    @Deprecated
+    public static IRubyObject setgid_p(IRubyObject recv, IRubyObject filename) {
+        return setgid_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
     @JRubyMethod(name = "setuid?", module = true)
-    public static IRubyObject setuid_p(IRubyObject recv, IRubyObject filename) {
-        FileStat stat = fileResource(filename).stat();
+    public static IRubyObject setuid_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+        FileStat stat = fileResource(context, filename).stat();
 
-        return recv.getRuntime().newBoolean(stat != null && stat.isSetuid());
+        return asBoolean(context, stat != null && stat.isSetuid());
     }
 
+    @Deprecated
+    public static IRubyObject setuid_p(IRubyObject recv, IRubyObject filename) {
+        return setuid_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
+    }
+
+    @Deprecated
     public static IRubyObject size(IRubyObject recv, IRubyObject filename) {
-        return size(recv.getRuntime().getCurrentContext(), recv, filename);
+        return size(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
     @JRubyMethod(name = "size", module = true)
@@ -244,62 +292,81 @@ public class RubyFileTest {
              filename = TypeConverter.convertToType(filename, context.runtime.getIO(), "to_io");
         }
 
-        FileStat stat = fileResource(filename).stat();
+        FileStat stat = fileResource(context, filename).stat();
 
-        if (stat == null) noFileError(filename);
+        if (stat == null) noFileError(context, filename);
 
-        return context.runtime.newFixnum(stat.st_size());
+        return asFixnum(context, stat.st_size());
     }
 
     @Deprecated
     public static IRubyObject size_p(IRubyObject recv, IRubyObject filename) {
-        return size_p(recv.getRuntime().getCurrentContext(), recv, filename);
+        return size_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
     
     @JRubyMethod(name = "size?", module = true)
     public static IRubyObject size_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
-        Ruby runtime = context.runtime;
         if (!(filename instanceof RubyFile) && filename.respondsTo("to_io")) {
-            filename = TypeConverter.convertToType(filename, runtime.getIO(), "to_io");
+            filename = TypeConverter.convertToType(filename, context.runtime.getIO(), "to_io");
         }
 
-        FileStat stat = fileResource(filename).stat();
+        FileStat stat = fileResource(context, filename).stat();
 
-        if (stat == null) return runtime.getNil();
+        if (stat == null) return context.nil;
 
         long length = stat.st_size();
-        return length > 0 ? runtime.newFixnum(length) : runtime.getNil();
+        return length > 0 ? asFixnum(context, length) : context.nil;
     }
 
     @JRubyMethod(name = "socket?", module = true)
-    public static IRubyObject socket_p(IRubyObject recv, IRubyObject filename) {
-        FileStat stat = fileResource(filename).stat();
+    public static IRubyObject socket_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+        FileStat stat = fileResource(context, filename).stat();
 
-        return recv.getRuntime().newBoolean(stat != null && stat.isSocket());
+        return asBoolean(context, stat != null && stat.isSocket());
+    }
+
+    @Deprecated
+    public static IRubyObject socket_p(IRubyObject recv, IRubyObject filename) {
+        return socket_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
     @JRubyMethod(name = "sticky?", module = true)
-    public static IRubyObject sticky_p(IRubyObject recv, IRubyObject filename) {
-        FileStat stat = fileResource(filename).stat();
+    public static IRubyObject sticky_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+        FileStat stat = fileResource(context, filename).stat();
 
-        return recv.getRuntime().newBoolean(stat != null && stat.isSticky());
+        return asBoolean(context, stat != null && stat.isSticky());
+    }
+
+    @Deprecated
+    public static IRubyObject sticky_p(IRubyObject recv, IRubyObject filename) {
+        return sticky_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
     @JRubyMethod(name = "symlink?", module = true)
+    public static RubyBoolean symlink_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+        return asBoolean(context, fileResource(context, filename).isSymLink());        
+    }
+    
+    @Deprecated
     public static RubyBoolean symlink_p(IRubyObject recv, IRubyObject filename) {
-        return recv.getRuntime().newBoolean(fileResource(filename).isSymLink());
+        return symlink_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
     // We do both writable and writable_real through the same method because
     // in our java process effective and real userid will always be the same.
     @JRubyMethod(name = {"writable?", "writable_real?"}, module = true)
+    public static RubyBoolean writable_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+        return asBoolean(context, fileResource(context, filename).canWrite());        
+    }
+    
+    @Deprecated
     public static RubyBoolean writable_p(IRubyObject recv, IRubyObject filename) {
-        return filename.getRuntime().newBoolean(fileResource(filename).canWrite());
+        return writable_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
     @Deprecated
     public static RubyBoolean zero_p(IRubyObject recv, IRubyObject filename) {
-        return zero_p(recv.getRuntime().getCurrentContext(), recv, filename);
+        return zero_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
     }
 
     @JRubyMethod(name = {"empty?", "zero?"}, module = true)
@@ -308,15 +375,15 @@ public class RubyFileTest {
 
         // FIXME: Ultimately we should return a valid stat() from this but without massive NUL coverage
         // this is less risky.
-        if (resource.isNull()) return RubyBoolean.newBoolean(context, true);
+        if (resource.isNull()) return asBoolean(context, true);
 
         FileStat stat = resource.stat();
 
         if (stat == null) return context.fals;
         // MRI behavior, enforced by RubySpecs.
-        if (stat.isDirectory()) return RubyBoolean.newBoolean(context, Platform.IS_WINDOWS);
+        if (stat.isDirectory()) return asBoolean(context, Platform.IS_WINDOWS);
 
-        return RubyBoolean.newBoolean(context, stat.st_size() == 0L);
+        return asBoolean(context, stat.st_size() == 0L);
     }
 
     @JRubyMethod(name = "world_readable?", module = true)
@@ -344,13 +411,23 @@ public class RubyFileTest {
      */
     public static class FileTestFileMethods {
         @JRubyMethod(name = "blockdev?")
+        public static IRubyObject blockdev_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+            return RubyFileTest.blockdev_p(context, recv, filename);
+        }
+        
+        @Deprecated
         public static IRubyObject blockdev_p(IRubyObject recv, IRubyObject filename) {
-            return RubyFileTest.blockdev_p(recv, filename);
+            return blockdev_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
 
         @JRubyMethod(name = "chardev?")
+        public static IRubyObject chardev_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+            return RubyFileTest.chardev_p(context, recv, filename);            
+        }
+        
+        @Deprecated
         public static IRubyObject chardev_p(IRubyObject recv, IRubyObject filename) {
-            return RubyFileTest.chardev_p(recv, filename);
+            return chardev_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
 
         @JRubyMethod(name = "directory?")
@@ -359,13 +436,23 @@ public class RubyFileTest {
         }
 
         @JRubyMethod(name = "executable?")
+        public static IRubyObject executable_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+            return RubyFileTest.executable_p(context, recv, filename);            
+        }
+        
+        @Deprecated
         public static IRubyObject executable_p(IRubyObject recv, IRubyObject filename) {
-            return RubyFileTest.executable_p(recv, filename);
+            return executable_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
 
         @JRubyMethod(name = "executable_real?")
+        public static IRubyObject executable_real_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+            return RubyFileTest.executable_real_p(context, recv, filename);            
+        }
+        
+        @Deprecated
         public static IRubyObject executable_real_p(IRubyObject recv, IRubyObject filename) {
-            return RubyFileTest.executable_real_p(recv, filename);
+            return executable_real_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
 
         @JRubyMethod(name = {"exist?"})
@@ -379,8 +466,13 @@ public class RubyFileTest {
         }
 
         @JRubyMethod(name = "grpowned?")
+        public static IRubyObject grpowned_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+            return RubyFileTest.grpowned_p(context, recv, filename);            
+        }
+        
+        @Deprecated
         public static IRubyObject grpowned_p(IRubyObject recv, IRubyObject filename) {
-            return RubyFileTest.grpowned_p(recv, filename);
+            return grpowned_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
 
         @JRubyMethod(name = "identical?")
@@ -389,13 +481,23 @@ public class RubyFileTest {
         }
 
         @JRubyMethod(name = "owned?")
+        public static IRubyObject owned_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+            return RubyFileTest.owned_p(context, recv, filename);
+        }
+        
+        @Deprecated
         public static IRubyObject owned_p(IRubyObject recv, IRubyObject filename) {
-            return RubyFileTest.owned_p(recv, filename);
+            return owned_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
 
         @JRubyMethod(name = "pipe?")
+        public static IRubyObject pipe_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+            return RubyFileTest.pipe_p(context, recv, filename);
+        }
+        
+        @Deprecated
         public static IRubyObject pipe_p(IRubyObject recv, IRubyObject filename) {
-            return RubyFileTest.pipe_p(recv, filename);
+            return pipe_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
 
         @JRubyMethod(name = {"readable?", "readable_real?"})
@@ -404,13 +506,22 @@ public class RubyFileTest {
         }
 
         @JRubyMethod(name = "setgid?")
+        public static IRubyObject setgid_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+            return RubyFileTest.setgid_p(context, recv, filename);
+        }
+        
         public static IRubyObject setgid_p(IRubyObject recv, IRubyObject filename) {
-            return RubyFileTest.setgid_p(recv, filename);
+            return setgid_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
 
         @JRubyMethod(name = "setuid?")
+        public static IRubyObject setuid_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+            return RubyFileTest.setuid_p(context, recv, filename);            
+        }
+        
+        @Deprecated
         public static IRubyObject setuid_p(IRubyObject recv, IRubyObject filename) {
-            return RubyFileTest.setuid_p(recv, filename);
+            return setuid_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
 
         @JRubyMethod(name = "size")
@@ -424,23 +535,43 @@ public class RubyFileTest {
         }
 
         @JRubyMethod(name = "socket?")
+        public static IRubyObject socket_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+            return RubyFileTest.socket_p(context, recv, filename);            
+        }
+        
+        @Deprecated
         public static IRubyObject socket_p(IRubyObject recv, IRubyObject filename) {
-            return RubyFileTest.socket_p(recv, filename);
+            return socket_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
 
         @JRubyMethod(name = "sticky?")
+        public static IRubyObject sticky_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+            return RubyFileTest.sticky_p(context, recv, filename);
+        }
+
+        @Deprecated
         public static IRubyObject sticky_p(IRubyObject recv, IRubyObject filename) {
-            return RubyFileTest.sticky_p(recv, filename);
+            return sticky_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
 
         @JRubyMethod(name = "symlink?")
+        public static RubyBoolean symlink_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+            return RubyFileTest.symlink_p(context, recv, filename);            
+        }
+        
+        @Deprecated
         public static RubyBoolean symlink_p(IRubyObject recv, IRubyObject filename) {
-            return RubyFileTest.symlink_p(recv, filename);
+            return symlink_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
 
         @JRubyMethod(name = {"writable?", "writable_real?"})
+        public static RubyBoolean writable_p(ThreadContext context, IRubyObject recv, IRubyObject filename) {
+            return RubyFileTest.writable_p(context, recv, filename);
+        }
+        
+        @Deprecated
         public static RubyBoolean writable_p(IRubyObject recv, IRubyObject filename) {
-            return RubyFileTest.writable_p(recv, filename);
+            return writable_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename);
         }
 
         @JRubyMethod(name = {"empty?", "zero?"})
@@ -460,7 +591,7 @@ public class RubyFileTest {
 
         @Deprecated
         public static IRubyObject identical_p(IRubyObject recv, IRubyObject filename1, IRubyObject filename2) {
-            return RubyFileTest.identical_p(recv, filename1, filename2);
+            return RubyFileTest.identical_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename1, filename2);
         }
     }
 
@@ -505,13 +636,12 @@ public class RubyFileTest {
         return false;
     }
 
-    private static void noFileError(IRubyObject filename) {
-        throw filename.getRuntime().newErrnoENOENTError("No such file or directory - " +
-                filename.convertToString());
+    private static void noFileError(ThreadContext context, IRubyObject filename) {
+        throw context.runtime.newErrnoENOENTError("No such file or directory - " + filename.convertToString());
     }
 
     @Deprecated
     public static IRubyObject identical_p(IRubyObject recv, IRubyObject filename1, IRubyObject filename2) {
-        return identical_p(recv.getRuntime().getCurrentContext(), recv, filename1, filename2);
+        return identical_p(((RubyBasicObject) recv).getCurrentContext(), recv, filename1, filename2);
     }
 }

--- a/core/src/main/java/org/jruby/RubyFloat.java
+++ b/core/src/main/java/org/jruby/RubyFloat.java
@@ -62,6 +62,7 @@ import org.jruby.util.ConvertDouble;
 import org.jruby.util.Numeric;
 import org.jruby.util.Sprintf;
 
+import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.util.Numeric.f_abs;
 import static org.jruby.util.Numeric.f_add;
@@ -208,13 +209,13 @@ public class RubyFloat extends RubyNumeric implements Appendable {
     @Override
     @JRubyMethod(name = "negative?")
     public IRubyObject isNegative(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, isNegative());
+        return asBoolean(context, isNegative());
     }
 
     @Override
     @JRubyMethod(name = "positive?")
     public IRubyObject isPositive(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, isPositive());
+        return asBoolean(context, isPositive());
     }
 
     @Override
@@ -496,7 +497,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         switch (other.getMetaClass().getClassIndex()) {
         case INTEGER:
         case FLOAT:
-            return RubyBoolean.newBoolean(context, value == ((RubyNumeric) other).getDoubleValue());
+            return asBoolean(context, value == ((RubyNumeric) other).getDoubleValue());
         default:
             // Numeric.equal
             return super.op_num_equal(context, other);
@@ -507,14 +508,14 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         if (Double.isNaN(value)) {
             return context.fals;
         }
-        return RubyBoolean.newBoolean(context, value == other);
+        return asBoolean(context, value == other);
     }
 
     public IRubyObject op_not_equal(ThreadContext context, double other) {
         if (Double.isNaN(value)) {
             return context.tru;
         }
-        return RubyBoolean.newBoolean(context, value != other);
+        return asBoolean(context, value != other);
     }
 
     public boolean fastEqual(RubyFloat other) {
@@ -581,14 +582,14 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         case INTEGER:
         case FLOAT:
             double b = ((RubyNumeric) other).getDoubleValue();
-            return RubyBoolean.newBoolean(context, !Double.isNaN(b) && value > b);
+            return asBoolean(context, !Double.isNaN(b) && value > b);
         default:
             return coerceRelOp(context, sites(context).op_gt, other);
         }
     }
 
     public IRubyObject op_gt(ThreadContext context, double other) {
-        return RubyBoolean.newBoolean(context, !Double.isNaN(other) && value > other);
+        return asBoolean(context, !Double.isNaN(other) && value > other);
     }
 
     /** flo_ge
@@ -600,14 +601,14 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         case INTEGER:
         case FLOAT:
             double b = ((RubyNumeric) other).getDoubleValue();
-            return RubyBoolean.newBoolean(context, !Double.isNaN(b) && value >= b);
+            return asBoolean(context, !Double.isNaN(b) && value >= b);
         default:
             return coerceRelOp(context, sites(context).op_ge, other);
         }
     }
 
     public IRubyObject op_ge(ThreadContext context, double other) {
-        return RubyBoolean.newBoolean(context, !Double.isNaN(other) && value >= other);
+        return asBoolean(context, !Double.isNaN(other) && value >= other);
     }
 
     /** flo_lt
@@ -619,14 +620,14 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         case INTEGER:
         case FLOAT:
             double b = ((RubyNumeric) other).getDoubleValue();
-            return RubyBoolean.newBoolean(context, !Double.isNaN(b) && value < b);
+            return asBoolean(context, !Double.isNaN(b) && value < b);
         default:
             return coerceRelOp(context, sites(context).op_lt, other);
 		}
     }
 
     public IRubyObject op_lt(ThreadContext context, double other) {
-        return RubyBoolean.newBoolean(context, !Double.isNaN(other) && value < other);
+        return asBoolean(context, !Double.isNaN(other) && value < other);
     }
 
     /** flo_le
@@ -638,14 +639,14 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         case INTEGER:
         case FLOAT:
             double b = ((RubyNumeric) other).getDoubleValue();
-            return RubyBoolean.newBoolean(context, !Double.isNaN(b) && value <= b);
+            return asBoolean(context, !Double.isNaN(b) && value <= b);
         default:
             return coerceRelOp(context, sites(context).op_le, other);
 		}
 	}
 
     public IRubyObject op_le(ThreadContext context, double other) {
-        return RubyBoolean.newBoolean(context, !Double.isNaN(other) && value <= other);
+        return asBoolean(context, !Double.isNaN(other) && value <= other);
 	}
 
     /** flo_eql
@@ -733,7 +734,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
     @JRubyMethod(name = "zero?")
     @Override
     public IRubyObject zero_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, value == 0.0);
+        return asBoolean(context, value == 0.0);
     }
 
     @Override
@@ -1166,8 +1167,13 @@ public class RubyFloat extends RubyNumeric implements Appendable {
      *
      */
     @JRubyMethod(name = "nan?")
+    public IRubyObject nan_p(ThreadContext context) {
+        return asBoolean(context, isNaN());
+    }
+
+    @Deprecated
     public IRubyObject nan_p() {
-        return RubyBoolean.newBoolean(metaClass.runtime, isNaN());
+        return nan_p(getRuntime().getCurrentContext());
     }
 
     public boolean isNaN() {
@@ -1290,7 +1296,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
     public IRubyObject equal_p(ThreadContext context, IRubyObject obj) {
         // if flonum, simlulate identity
         if (flonumable(value)) {
-            return RubyBoolean.newBoolean(context, this == obj || eql(obj));
+            return asBoolean(context, this == obj || eql(obj));
         } else {
             return super.equal_p(context, obj);
         }

--- a/core/src/main/java/org/jruby/RubyGC.java
+++ b/core/src/main/java/org/jruby/RubyGC.java
@@ -38,6 +38,9 @@ import org.jruby.anno.JRubyModule;
 import org.jruby.common.IRubyWarnings.ID;
 import org.jruby.runtime.Arity;
 import org.jruby.runtime.ThreadContext;
+
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.runtime.Visibility.*;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -84,7 +87,7 @@ public class RubyGC {
     public static IRubyObject measure_total_time(ThreadContext context, IRubyObject self) {
         // JVM just keeps track of this so we do not have a toggle here.  If we need to show incremental time
         // from a particular point we will need to record time and do some extra math.
-        return context.runtime.newBoolean(measureTotalTime);
+        return asBoolean(context, measureTotalTime);
     }
 
     @JRubyMethod(module = true, name = "measure_total_time=", visibility = PRIVATE)
@@ -97,7 +100,7 @@ public class RubyGC {
 
     @JRubyMethod(module = true, visibility = PRIVATE)
     public static IRubyObject total_time(ThreadContext context, IRubyObject self) {
-        return context.runtime.newFixnum(getCollectionTime());
+        return asFixnum(context, getCollectionTime());
     }
 
     @JRubyMethod(module = true, visibility = PRIVATE)
@@ -106,7 +109,7 @@ public class RubyGC {
         emptyImplementationWarning(runtime, ID.GC_ENABLE_UNIMPLEMENTED, "GC.enable");
         boolean old = gcDisabled;
         gcDisabled = false;
-        return runtime.newBoolean(old);
+        return asBoolean(context, old);
     }
 
     @JRubyMethod(module = true, visibility = PRIVATE)
@@ -115,27 +118,25 @@ public class RubyGC {
         emptyImplementationWarning(runtime, ID.GC_DISABLE_UNIMPLEMENTED, "GC.disable");
         boolean old = gcDisabled;
         gcDisabled = true;
-        return runtime.newBoolean(old);
+        return asBoolean(context, old);
     }
 
     @JRubyMethod(module = true, visibility = PRIVATE)
     public static IRubyObject stress(ThreadContext context, IRubyObject recv) {
-        return RubyBoolean.newBoolean(context, stress);
+        return asBoolean(context, stress);
     }
 
     @JRubyMethod(name = "stress=", module = true, visibility = PRIVATE)
     public static IRubyObject stress_set(ThreadContext context, IRubyObject recv, IRubyObject arg) {
-        Ruby runtime = context.runtime;
-        emptyImplementationWarning(runtime, ID.GC_STRESS_UNIMPLEMENTED, "GC.stress=");
+        emptyImplementationWarning(context.runtime, ID.GC_STRESS_UNIMPLEMENTED, "GC.stress=");
         stress = arg.isTrue();
-        return runtime.newBoolean(stress);
+        return asBoolean(context, stress);
     }
     
     @JRubyMethod(module = true, visibility = PRIVATE)
     public static IRubyObject count(ThreadContext context, IRubyObject recv) {
         try {
-            int count = getCollectionCount();
-            return context.runtime.newFixnum(count);
+            return asFixnum(context, getCollectionCount());
         } catch (Throwable t) {
             return RubyFixnum.minus_one(context.runtime);
         }
@@ -145,7 +146,7 @@ public class RubyGC {
     public static IRubyObject auto_compact(ThreadContext context, IRubyObject recv) {
         emptyImplementationWarning(context.runtime, ID.GC_ENABLE_UNIMPLEMENTED, "GC.auto_compact");
 
-        return RubyBoolean.newBoolean(context, autoCompact);
+        return asBoolean(context, autoCompact);
     }
 
     @JRubyMethod(name = "auto_compact=", module = true, visibility = PRIVATE)

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -79,6 +79,8 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
 import static org.jruby.RubyEnumerator.SizeFn;
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.runtime.Visibility.PRIVATE;
 import static org.jruby.util.Inspector.*;
@@ -960,7 +962,7 @@ public class RubyHash extends RubyObject implements Map {
      */
     @JRubyMethod(name = {"size", "length"})
     public RubyFixnum rb_size(ThreadContext context) {
-        return context.runtime.newFixnum(size);
+        return asFixnum(context, size);
     }
 
     /**
@@ -1320,7 +1322,7 @@ public class RubyHash extends RubyObject implements Map {
         final RubyHash otherHash = ((RubyBasicObject) other).convertToHash();
         if (size() >= otherHash.size()) return context.fals;
 
-        return RubyBoolean.newBoolean(context, hash_le(otherHash));
+        return asBoolean(context, hash_le(otherHash));
     }
 
     @JRubyMethod(name = "<=")
@@ -1328,7 +1330,7 @@ public class RubyHash extends RubyObject implements Map {
         final RubyHash otherHash = other.convertToHash();
         if (size() > otherHash.size()) return context.fals;
 
-        return RubyBoolean.newBoolean(context, hash_le(otherHash));
+        return asBoolean(context, hash_le(otherHash));
     }
 
     @JRubyMethod(name = ">")
@@ -1365,7 +1367,7 @@ public class RubyHash extends RubyObject implements Map {
             hash = hval[0];
         }
 
-        return context.runtime.newFixnum(hash);
+        return asFixnum(context, hash);
     }
 
     private static final ThreadLocal<ByteBuffer> HASH_16_BYTE = ThreadLocal.withInitial(() -> ByteBuffer.allocate(16));
@@ -1514,7 +1516,7 @@ public class RubyHash extends RubyObject implements Map {
      */
     @JRubyMethod(name = {"has_value?", "value?"})
     public RubyBoolean has_value_p(ThreadContext context, IRubyObject expected) {
-        return RubyBoolean.newBoolean(context, hasValue(context, expected));
+        return asBoolean(context, hasValue(context, expected));
     }
 
     private volatile int iteratorCount;
@@ -2284,7 +2286,7 @@ public class RubyHash extends RubyObject implements Map {
 
     @JRubyMethod(name = "compare_by_identity?")
     public IRubyObject compare_by_identity_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, isComparedByIdentity());
+        return asBoolean(context, isComparedByIdentity());
     }
 
     @JRubyMethod
@@ -2461,7 +2463,7 @@ public class RubyHash extends RubyObject implements Map {
     public static IRubyObject ruby2_keywords_hash_p(ThreadContext context, IRubyObject _self, IRubyObject arg) {
         TypeConverter.checkType(context, arg, context.runtime.getHash());
 
-        return context.runtime.newBoolean(((RubyHash) arg).isRuby2KeywordHash());
+        return asBoolean(context, ((RubyHash) arg).isRuby2KeywordHash());
     }
 
     private static class VisitorIOException extends RuntimeException {
@@ -3016,13 +3018,12 @@ public class RubyHash extends RubyObject implements Map {
 
     @Deprecated
     public RubyFixnum rb_size() {
-        return metaClass.runtime.newFixnum(size());
+        return rb_size(getCurrentContext());
     }
 
     @Deprecated
     public RubyBoolean empty_p() {
-        Ruby runtime = metaClass.runtime;
-        return isEmpty() ? runtime.getTrue() : runtime.getFalse();
+        return asBoolean(getCurrentContext(), isEmpty());
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/RubyIOBuffer.java
+++ b/core/src/main/java/org/jruby/RubyIOBuffer.java
@@ -25,7 +25,8 @@ import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
 import java.util.Arrays;
 
-import static org.jruby.RubyBoolean.newBoolean;
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Error.typeError;
 
 public class RubyIOBuffer extends RubyObject {
@@ -546,12 +547,12 @@ public class RubyIOBuffer extends RubyObject {
 
     @JRubyMethod(name = "size")
     public IRubyObject size(ThreadContext context) {
-        return context.runtime.newFixnum(size);
+        return asFixnum(context, size);
     }
 
     @JRubyMethod(name = "valid?")
     public IRubyObject valid_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, validate());
+        return asBoolean(context, validate());
     }
 
     @JRubyMethod(name = "transfer")
@@ -580,17 +581,17 @@ public class RubyIOBuffer extends RubyObject {
 
     @JRubyMethod(name = "null?")
     public IRubyObject null_p(ThreadContext context) {
-        return newBoolean(context, base == null);
+        return asBoolean(context, base == null);
     }
 
     @JRubyMethod(name = "empty?")
     public IRubyObject empty_p(ThreadContext context) {
-        return newBoolean(context, size == 0);
+        return asBoolean(context, size == 0);
     }
 
     @JRubyMethod(name = "external?")
     public IRubyObject external_p(ThreadContext context) {
-        return newBoolean(context, isExternal());
+        return asBoolean(context, isExternal());
     }
 
     private boolean isExternal() {
@@ -599,7 +600,7 @@ public class RubyIOBuffer extends RubyObject {
 
     @JRubyMethod(name = "internal?")
     public IRubyObject internal_p(ThreadContext context) {
-        return newBoolean(context, isInternal());
+        return asBoolean(context, isInternal());
     }
 
     private boolean isInternal() {
@@ -608,7 +609,7 @@ public class RubyIOBuffer extends RubyObject {
 
     @JRubyMethod(name = "mapped?")
     public IRubyObject mapped_p(ThreadContext context) {
-        return newBoolean(context, isMapped());
+        return asBoolean(context, isMapped());
     }
 
     private boolean isMapped() {
@@ -618,7 +619,7 @@ public class RubyIOBuffer extends RubyObject {
     @JRubyMethod(name = "shared?")
     public IRubyObject shared_p(ThreadContext context) {
         // no support for shared yet
-        return newBoolean(context, false);
+        return asBoolean(context, false);
     }
 
     private boolean isShared() {
@@ -627,7 +628,7 @@ public class RubyIOBuffer extends RubyObject {
 
     @JRubyMethod(name = "locked?")
     public IRubyObject locked_p(ThreadContext context) {
-        return newBoolean(context, isLocked());
+        return asBoolean(context, isLocked());
     }
 
     private boolean isLocked() {
@@ -636,7 +637,7 @@ public class RubyIOBuffer extends RubyObject {
 
     @JRubyMethod(name = "readonly?")
     public IRubyObject readonly_p(ThreadContext context) {
-        return newBoolean(context, isReadonly());
+        return asBoolean(context, isReadonly());
     }
 
     private boolean isReadonly() {
@@ -744,7 +745,7 @@ public class RubyIOBuffer extends RubyObject {
 
     @JRubyMethod(name = "<=>")
     public IRubyObject op_cmp(ThreadContext context, IRubyObject other) {
-        return context.runtime.newFixnum(base.compareTo(((RubyIOBuffer) other).base));
+        return asFixnum(context, base.compareTo(((RubyIOBuffer) other).base));
     }
 
     @JRubyMethod(name = "resize")

--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -129,12 +129,12 @@ public abstract class RubyInteger extends RubyNumeric {
 
     @Override
     public IRubyObject isNegative(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, isNegative());
+        return asBoolean(context, isNegative());
     }
 
     @Override
     public IRubyObject isPositive(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, isPositive());
+        return asBoolean(context, isPositive());
     }
 
     @Override
@@ -989,17 +989,17 @@ public abstract class RubyInteger extends RubyNumeric {
             if (beg.isNil()) {
                 if (!negativeInt(context, end)) {
                     if (!isExclusive) {
-                        end = ((RubyInteger) end).op_plus(context, context.runtime.newFixnum(1));
+                        end = ((RubyInteger) end).op_plus(context, asFixnum(context, 1));
                     }
 
                     RubyInteger mask = generateMask(context, end);
                     if (((RubyInteger) op_and(context, mask)).isZero()) {
-                        return context.runtime.newFixnum(0);
+                        return asFixnum(context, 0);
                     } else {
                         throw context.runtime.newArgumentError("The beginless range for Integer#[] results in infinity");
                     }
                 } else {
-                    return context.runtime.newFixnum(0);
+                    return asFixnum(context, 0);
                 }
             }
             beg = beg.convertToInteger();
@@ -1008,13 +1008,13 @@ public abstract class RubyInteger extends RubyNumeric {
             if (!end.isNil() && cmp < 0) {
                 IRubyObject length = ((RubyInteger) end).op_minus(context, beg);
                 if (!isExclusive) {
-                    length = ((RubyInteger) length).op_plus(context, context.runtime.newFixnum(1));
+                    length = ((RubyInteger) length).op_plus(context, asFixnum(context, 1));
                 }
                 RubyInteger mask = generateMask(context, length);
                 num = (((RubyInteger) num).op_and(context, mask));
                 return num;
             } else if (cmp == 0) {
-                if (isExclusive) return context.runtime.newFixnum(0);
+                if (isExclusive) return asFixnum(context, 0);
                 index = beg;
             } else {
                 return num;
@@ -1043,7 +1043,7 @@ public abstract class RubyInteger extends RubyNumeric {
     }
 
     RubyInteger generateMask(ThreadContext context, IRubyObject length) {
-        RubyFixnum one = context.runtime.newFixnum(1);
+        RubyFixnum one = asFixnum(context, 1);
         return (RubyInteger) ((RubyInteger) one.op_lshift(context, length)).op_minus(context, one);
     }
 

--- a/core/src/main/java/org/jruby/RubyMatchData.java
+++ b/core/src/main/java/org/jruby/RubyMatchData.java
@@ -60,6 +60,7 @@ import org.jruby.util.ByteListHolder;
 import org.jruby.util.RegexpOptions;
 import org.jruby.util.StringSupport;
 
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.util.RubyStringBuilder.str;
 
@@ -381,7 +382,7 @@ public class RubyMatchData extends RubyObject {
 
         int end = regs.getEnd(index);
 
-        return runtime.newArray(runtime.newFixnum(start), runtime.newFixnum(end));
+        return runtime.newArray(asFixnum(context, start), asFixnum(context, end));
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/RubyMethod.java
+++ b/core/src/main/java/org/jruby/RubyMethod.java
@@ -34,6 +34,7 @@ package org.jruby;
 
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyClass;
+import org.jruby.api.Convert;
 import org.jruby.internal.runtime.methods.AliasMethod;
 import org.jruby.internal.runtime.methods.DelegatingDynamicMethod;
 import org.jruby.internal.runtime.methods.DynamicMethod;
@@ -52,6 +53,8 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.callsite.CacheEntry;
 
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.ir.runtime.IRRuntimeHelpers.dupIfKeywordRestAtCallsite;
 
 /** 
@@ -161,7 +164,7 @@ public class RubyMethod extends AbstractRubyMethod {
     @Override
     @JRubyMethod(name = "==")
     public RubyBoolean op_equal(ThreadContext context, IRubyObject other) {
-        return RubyBoolean.newBoolean(context,  equals(other) );
+        return asBoolean(context,  equals(other) );
     }
 
     @Override
@@ -198,7 +201,7 @@ public class RubyMethod extends AbstractRubyMethod {
 
     @JRubyMethod
     public RubyFixnum hash(ThreadContext context) {
-        return context.runtime.newFixnum(hashCodeImpl());
+        return asFixnum(context, hashCodeImpl());
     }
 
     @Override
@@ -273,11 +276,9 @@ public class RubyMethod extends AbstractRubyMethod {
 
     @JRubyMethod
     public IRubyObject source_location(ThreadContext context) {
-        Ruby runtime = context.runtime;
-
         String filename = getFilename();
         if (filename != null) {
-            return runtime.newArray(runtime.newString(filename), runtime.newFixnum(getLine()));
+            return context.runtime.newArray(Convert.asString(context, filename), asFixnum(context, getLine()));
         }
 
         return context.nil;

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1551,7 +1551,7 @@ public class RubyModule extends RubyObject {
 
     @JRubyMethod(name = "singleton_class?")
     public IRubyObject singleton_class_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, isSingleton());
+        return asBoolean(context, isSingleton());
     }
 
     private String frozenType() {
@@ -2887,7 +2887,7 @@ public class RubyModule extends RubyObject {
     @JRubyMethod(name = "===")
     @Override
     public RubyBoolean op_eqq(ThreadContext context, IRubyObject obj) {
-        return RubyBoolean.newBoolean(context, isInstance(obj));
+        return asBoolean(context, isInstance(obj));
     }
 
     /**
@@ -2908,9 +2908,9 @@ public class RubyModule extends RubyObject {
 
         RubyModule otherModule = (RubyModule) other;
         if(otherModule.isIncluded()) {
-            return RubyBoolean.newBoolean(context, otherModule.isSame(this));
+            return asBoolean(context, otherModule.isSame(this));
         } else {
-            return RubyBoolean.newBoolean(context, isSame(otherModule));
+            return asBoolean(context, isSame(otherModule));
         }
     }
 
@@ -2984,16 +2984,21 @@ public class RubyModule extends RubyObject {
     *
     */
     @JRubyMethod(name = "<=>")
-    public IRubyObject op_cmp(IRubyObject obj) {
-        if (this == obj) return getRuntime().newFixnum(0);
-        if (!(obj instanceof RubyModule)) return getRuntime().getNil();
+    public IRubyObject op_cmp(ThreadContext context, IRubyObject obj) {
+        if (this == obj) return asFixnum(context, 0);
+        if (!(obj instanceof RubyModule)) return context.nil;
 
         RubyModule module = (RubyModule) obj;
 
-        if (module.isKindOfModule(this)) return getRuntime().newFixnum(1);
-        if (this.isKindOfModule(module)) return getRuntime().newFixnum(-1);
+        if (module.isKindOfModule(this)) return asFixnum(context, 1);
+        if (this.isKindOfModule(module)) return asFixnum(context, -1);
 
-        return getRuntime().getNil();
+        return context.nil;
+    }
+
+    @Deprecated
+    public IRubyObject op_cmp(IRubyObject obj) {
+        return op_cmp(getCurrentContext(), obj);
     }
 
     public boolean isKindOfModule(RubyModule type) {
@@ -3589,7 +3594,7 @@ public class RubyModule extends RubyObject {
 
     @JRubyMethod(name = "method_defined?")
     public RubyBoolean method_defined_p(ThreadContext context, IRubyObject symbol) {
-        return isMethodBound(TypeConverter.checkID(symbol).idString(), true) ? context.tru : context.fals;
+        return asBoolean(context, isMethodBound(TypeConverter.checkID(symbol).idString(), true));
     }
 
     @JRubyMethod(name = "method_defined?")
@@ -3599,43 +3604,43 @@ public class RubyModule extends RubyObject {
         if (parents) return method_defined_p(context, symbol);
 
         Visibility visibility = checkMethodVisibility(context, symbol, parents);
-        return RubyBoolean.newBoolean(context, visibility != UNDEFINED && visibility != PRIVATE);
+        return asBoolean(context, visibility != UNDEFINED && visibility != PRIVATE);
     }
 
     @JRubyMethod(name = "public_method_defined?")
     public IRubyObject public_method_defined(ThreadContext context, IRubyObject symbol) {
-        return RubyBoolean.newBoolean(context, checkMethodVisibility(context, symbol, true) == PUBLIC);
+        return asBoolean(context, checkMethodVisibility(context, symbol, true) == PUBLIC);
     }
 
     @JRubyMethod(name = "public_method_defined?")
     public IRubyObject public_method_defined(ThreadContext context, IRubyObject symbol, IRubyObject includeSuper) {
         boolean parents = includeSuper.isTrue();
 
-        return RubyBoolean.newBoolean(context, checkMethodVisibility(context, symbol, parents) == PUBLIC);
+        return asBoolean(context, checkMethodVisibility(context, symbol, parents) == PUBLIC);
     }
 
     @JRubyMethod(name = "protected_method_defined?")
     public IRubyObject protected_method_defined(ThreadContext context, IRubyObject symbol) {
-        return RubyBoolean.newBoolean(context, checkMethodVisibility(context, symbol, true) == PROTECTED);
+        return asBoolean(context, checkMethodVisibility(context, symbol, true) == PROTECTED);
     }
 
     @JRubyMethod(name = "protected_method_defined?")
     public IRubyObject protected_method_defined(ThreadContext context, IRubyObject symbol, IRubyObject includeSuper) {
         boolean parents = includeSuper.isTrue();
 
-        return RubyBoolean.newBoolean(context, checkMethodVisibility(context, symbol, parents) == PROTECTED);
+        return asBoolean(context, checkMethodVisibility(context, symbol, parents) == PROTECTED);
     }
 
     @JRubyMethod(name = "private_method_defined?")
     public IRubyObject private_method_defined(ThreadContext context, IRubyObject symbol) {
-        return RubyBoolean.newBoolean(context, checkMethodVisibility(context, symbol, true) == PRIVATE);
+        return asBoolean(context, checkMethodVisibility(context, symbol, true) == PRIVATE);
     }
 
     @JRubyMethod(name = "private_method_defined?")
     public IRubyObject private_method_defined(ThreadContext context, IRubyObject symbol, IRubyObject includeSuper) {
         boolean parents = includeSuper.isTrue();
 
-        return RubyBoolean.newBoolean(context, checkMethodVisibility(context, symbol, parents) == PRIVATE);
+        return asBoolean(context, checkMethodVisibility(context, symbol, parents) == PRIVATE);
     }
 
     private Visibility checkMethodVisibility(ThreadContext context, IRubyObject symbol, boolean parents) {
@@ -4123,13 +4128,12 @@ public class RubyModule extends RubyObject {
      */
     @JRubyMethod(name = "const_defined?")
     public RubyBoolean const_defined_p(ThreadContext context, IRubyObject name) {
-
-        return constDefined(context, name, true) ? context.tru : context.fals;
+        return asBoolean(context, constDefined(context, name, true));
     }
 
     @JRubyMethod(name = "const_defined?")
     public RubyBoolean const_defined_p(ThreadContext context, IRubyObject name, IRubyObject recurse) {
-        return constDefined(context, name, recurse.isTrue()) ? context.tru : context.fals;
+        return asBoolean(context, constDefined(context, name, recurse.isTrue()));
     }
 
     private boolean constDefined(ThreadContext context, IRubyObject name, boolean inherit) {
@@ -4350,7 +4354,7 @@ public class RubyModule extends RubyObject {
             if (location.getFile().equals(BUILTIN_CONSTANT)) {
                 return RubyArray.newEmptyArray(context.runtime);
             }
-            return RubyArray.newArray(context.runtime, runtime.newString(location.getFile()), runtime.newFixnum(location.getLine()));
+            return RubyArray.newArray(context.runtime, runtime.newString(location.getFile()), asFixnum(context, location.getLine()));
         }
 
         return context.nil;

--- a/core/src/main/java/org/jruby/RubyNameError.java
+++ b/core/src/main/java/org/jruby/RubyNameError.java
@@ -44,6 +44,8 @@ import org.jruby.util.ArraySupport;
 import org.jruby.util.ByteList;
 import org.jruby.util.Sprintf;
 
+import static org.jruby.api.Convert.asBoolean;
+
 /**
  * The Java representation of a Ruby NameError.
  *
@@ -280,7 +282,7 @@ public class RubyNameError extends RubyStandardError {
 
     @JRubyMethod(name = "private_call?")
     public IRubyObject private_call_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, isPrivateCall());
+        return asBoolean(context, isPrivateCall());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyNil.java
+++ b/core/src/main/java/org/jruby/RubyNil.java
@@ -45,6 +45,9 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.opto.OptoFactory;
 import org.jruby.util.ByteList;
 
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
+
 /**
  *
  * @author  jpetersen
@@ -189,7 +192,7 @@ public class RubyNil extends RubyObject implements Constantizable {
      */
     @JRubyMethod(name = "|")
     public static RubyBoolean op_or(ThreadContext context, IRubyObject recv, IRubyObject obj) {
-        return RubyBoolean.newBoolean(context, obj.isTrue());
+        return asBoolean(context, obj.isTrue());
     }
     
     /** nil_xor
@@ -197,7 +200,7 @@ public class RubyNil extends RubyObject implements Constantizable {
      */
     @JRubyMethod(name = "^")
     public static RubyBoolean op_xor(ThreadContext context, IRubyObject recv, IRubyObject obj) {
-        return RubyBoolean.newBoolean(context, obj.isTrue());
+        return asBoolean(context, obj.isTrue());
     }
 
     @Override
@@ -213,7 +216,7 @@ public class RubyNil extends RubyObject implements Constantizable {
 
     @JRubyMethod
     public RubyFixnum hash(ThreadContext context) {
-        return context.runtime.newFixnum(hashCode());
+        return asFixnum(context, hashCode());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -60,6 +60,8 @@ import java.math.BigInteger;
 import java.math.RoundingMode;
 
 import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.util.Numeric.f_abs;
 import static org.jruby.util.Numeric.f_arg;
@@ -931,14 +933,14 @@ public class RubyNumeric extends RubyObject {
     */
     @JRubyMethod(name = "real?")
     public IRubyObject real_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, isReal());
+        return asBoolean(context, isReal());
     }
 
     public boolean isReal() { return true; } // only RubyComplex isn't real
 
     @Deprecated
     public IRubyObject scalar_p() {
-        return getRuntime().newBoolean(isReal());
+        return asBoolean(getRuntime().getCurrentContext(), isReal());
     }
 
     /** num_int_p
@@ -1026,7 +1028,7 @@ public class RubyNumeric extends RubyObject {
 
             if (step.isNil()) {
                 step = RubyFixnum.one(context.runtime);
-            } else if (step.op_equal(context, context.runtime.newFixnum(0)).isTrue()) {
+            } else if (step.op_equal(context, asFixnum(context, 0)).isTrue()) {
                 throw context.runtime.newArgumentError("step can't be 0");
             }
 
@@ -1269,15 +1271,13 @@ public class RubyNumeric extends RubyObject {
                 if (excl) {
                     delta--;
                 }
-                if (delta < 0) {
-                    return runtime.newFixnum(0);
-                }
+                if (delta < 0) return asFixnum(context, 0);
 
                 // overflow checking
                 long steps = delta / diff;
                 long stepSize = steps + 1;
                 if (stepSize != Long.MIN_VALUE) {
-                    return new RubyFixnum(runtime, delta / diff + 1);
+                    return asFixnum(context, delta / diff + 1);
                 } else {
                     return RubyBignum.newBignum(runtime, BigInteger.valueOf(steps).add(BigInteger.ONE));
                 }

--- a/core/src/main/java/org/jruby/RubyObject.java
+++ b/core/src/main/java/org/jruby/RubyObject.java
@@ -56,6 +56,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.marshal.DataType;
 
+import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.runtime.Helpers.invokedynamic;
 import static org.jruby.runtime.Helpers.throwException;
@@ -386,7 +387,7 @@ public class RubyObject extends RubyBasicObject {
      */
     @Override
     public IRubyObject op_eqq(ThreadContext context, IRubyObject other) {
-        return RubyBoolean.newBoolean(context, equalInternal(context, this, other));
+        return asBoolean(context, equalInternal(context, this, other));
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyObjectSpace.java
+++ b/core/src/main/java/org/jruby/RubyObjectSpace.java
@@ -49,7 +49,7 @@ import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 
-import static org.jruby.api.Convert.castAsFixnum;
+import static org.jruby.api.Convert.*;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.runtime.Visibility.*;
 import static org.jruby.util.Inspector.inspectPrefix;
@@ -122,16 +122,17 @@ public class RubyObjectSpace {
     @JRubyMethod(name = "_id2ref", module = true, visibility = PRIVATE)
     public static IRubyObject id2ref(IRubyObject recv, IRubyObject id) {
         final Ruby runtime = id.getRuntime();
-        long longId = Convert.castAsFixnum(runtime.getCurrentContext(), id).getLongValue();
+        ThreadContext context = runtime.getCurrentContext();
+        long longId = castAsFixnum(context, id).getLongValue();
         if (longId == 0) {
-            return runtime.getFalse();
+            return context.fals;
         } else if (longId == 20) {
-            return runtime.getTrue();
+            return context.tru;
         } else if (longId == 8) {
-            return runtime.getNil();
+            return context.nil;
         } else if ((longId & 0b01) == 0b01) {
             // fixnum
-            return runtime.newFixnum((longId - 1) / 2);
+            return asFixnum(context, (longId - 1) / 2);
         } else if ((longId & 0b11) == 0b10) {
             // flonum
             double d = 0.0;
@@ -148,7 +149,7 @@ public class RubyObjectSpace {
             if (runtime.isObjectSpaceEnabled()) {
                 IRubyObject object = runtime.getObjectSpace().id2ref(longId);
                 if (object == null) {
-                    return runtime.getNil();
+                    return context.nil;
                 }
                 return object;
             } else {
@@ -185,7 +186,7 @@ public class RubyObjectSpace {
             for (int i = 0; i<count; i++) {
                 block.yield(context, modules.get(i));
             }
-            return runtime.newFixnum(count);
+            return asFixnum(context, count);
         }
         if (rubyClass.getClass() == MetaClass.class) {
             // each_object(Cls.singleton_class) is basically a walk of Cls and all descendants of Cls.
@@ -200,7 +201,7 @@ public class RubyObjectSpace {
                     }
                 }
             }
-            return runtime.newFixnum(count);
+            return asFixnum(context, count);
         }
         if ( ! runtime.isObjectSpaceEnabled() ) {
             throw runtime.newRuntimeError("ObjectSpace is disabled; each_object will only work with Class, pass -X+O to enable");
@@ -210,7 +211,7 @@ public class RubyObjectSpace {
         while ((obj = (IRubyObject) iter.next()) != null) {
             count++; block.yield(context, obj);
         }
-        return runtime.newFixnum(count);
+        return asFixnum(context, count);
     }
 
     @JRubyMethod(name = "each_object", optional = 1, checkArity = false, module = true, visibility = PRIVATE)
@@ -250,18 +251,16 @@ public class RubyObjectSpace {
 
         @JRubyMethod(name = "[]=")
         public IRubyObject op_aref(ThreadContext context, IRubyObject key, IRubyObject value) {
-            Ruby runtime = context.runtime;
-
             Map<IRubyObject, IRubyObject> weakMap = getWeakMapFor(key);
             weakMap.put(key, value);
 
-            return runtime.newFixnum(System.identityHashCode(value));
+            return asFixnum(context, System.identityHashCode(value));
         }
 
         @JRubyMethod(name = "key?")
         public IRubyObject key_p(ThreadContext context, IRubyObject key) {
             Map<IRubyObject, IRubyObject> weakMap = getWeakMapFor(key);
-            return RubyBoolean.newBoolean(context, weakMap.get(key) != null);
+            return asBoolean(context, weakMap.get(key) != null);
         }
 
         @JRubyMethod(name = "keys")
@@ -309,7 +308,7 @@ public class RubyObjectSpace {
 
         @JRubyMethod(name = {"include?", "member?"})
         public IRubyObject member_p(ThreadContext context, IRubyObject key) {
-            return RubyBoolean.newBoolean(context, getWeakMapFor(key).containsKey(key));
+            return asBoolean(context, getWeakMapFor(key).containsKey(key));
         }
 
         @JRubyMethod(name = "delete")
@@ -355,7 +354,7 @@ public class RubyObjectSpace {
         }
 
         public IRubyObject size(ThreadContext context) {
-            return context.runtime.newFixnum(identityMap.size() + valueMap.size());
+            return asFixnum(context, identityMap.size() + valueMap.size());
         }
 
         public IRubyObject inspect(ThreadContext context) {
@@ -420,13 +419,11 @@ public class RubyObjectSpace {
         }
 
         public IRubyObject size(ThreadContext context) {
-            return context.runtime.newFixnum(weakMap.size());
+            return asFixnum(context, weakMap.size());
         }
 
         public IRubyObject inspect(ThreadContext context) {
-            Ruby runtime = context.runtime;
-
-            RubyString part = inspectPrefix(runtime.getCurrentContext(), metaClass.getRealClass(), inspectHashCode());
+            RubyString part = inspectPrefix(context, metaClass.getRealClass(), inspectHashCode());
 
             part.cat(Inspector.SPACE);
             part.cat(Inspector.SIZE_EQUALS);

--- a/core/src/main/java/org/jruby/RubyProc.java
+++ b/core/src/main/java/org/jruby/RubyProc.java
@@ -37,6 +37,7 @@ package org.jruby;
 
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.api.Convert;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.common.IRubyWarnings;
 import org.jruby.ir.runtime.IRRuntimeHelpers;
@@ -56,6 +57,8 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.marshal.DataType;
 
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.util.RubyStringBuilder.types;
 
 /**
@@ -293,7 +296,7 @@ public class RubyProc extends RubyObject implements DataType {
 
         if (type != other.type) return context.fals;
 
-        return context.runtime.newBoolean(getBlock().equals(other.block));
+        return asBoolean(context, getBlock().equals(other.block));
     }
 
     /**
@@ -401,7 +404,7 @@ public class RubyProc extends RubyObject implements DataType {
     public IRubyObject source_location(ThreadContext context) {
         Ruby runtime = context.runtime;
         if (file != null) {
-            return runtime.newArray(runtime.newString(file), runtime.newFixnum(line + 1 /*zero-based*/));
+            return runtime.newArray(runtime.newString(file), asFixnum(context, line + 1 /*zero-based*/));
         }
 
         if (block != null) {
@@ -410,8 +413,8 @@ public class RubyProc extends RubyObject implements DataType {
             // block+binding may exist for a core method, which will have a null filename
             if (binding.getFile() != null) {
                 return runtime.newArray(
-                        runtime.newString(binding.getFile()),
-                        runtime.newFixnum(binding.getLine() + 1 /*zero-based*/));
+                        Convert.asString(context, binding.getFile()),
+                        asFixnum(context, binding.getLine() + 1 /*zero-based*/));
             }
         }
 
@@ -442,7 +445,7 @@ public class RubyProc extends RubyObject implements DataType {
 
     @JRubyMethod(name = "lambda?")
     public IRubyObject lambda_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, isLambda());
+        return asBoolean(context, isLambda());
     }
 
     private boolean isLambda() {

--- a/core/src/main/java/org/jruby/RubyRandom.java
+++ b/core/src/main/java/org/jruby/RubyRandom.java
@@ -33,8 +33,7 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 
-import static org.jruby.api.Convert.castAsBignum;
-import static org.jruby.api.Convert.numericToLong;
+import static org.jruby.api.Convert.*;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.runtime.Visibility.PRIVATE;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -327,7 +326,7 @@ public class RubyRandom extends RubyRandomBase {
         if (!getType().equals(obj.getType())) {
             return context.fals;
         }
-        return RubyBoolean.newBoolean(context, random.equals(((RubyRandom) obj).random));
+        return asBoolean(context, random.equals(((RubyRandom) obj).random));
     }
 
     // c: random_state

--- a/core/src/main/java/org/jruby/RubyRandomBase.java
+++ b/core/src/main/java/org/jruby/RubyRandomBase.java
@@ -13,8 +13,7 @@ import org.jruby.util.TypeConverter;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 
-import static org.jruby.api.Convert.checkToInteger;
-import static org.jruby.api.Convert.numericToLong;
+import static org.jruby.api.Convert.*;
 import static org.jruby.runtime.Visibility.PRIVATE;
 import static org.jruby.util.TypeConverter.toFloat;
 
@@ -523,7 +522,7 @@ public class RubyRandomBase extends RubyObject {
         RubyRandom.RandomType rnd = tryGetRandomType(context, obj);
 
         if (rnd == null) {
-            RubyInteger v = Helpers.invokePublic(context, obj, "rand", context.runtime.newFixnum(limit + 1)).convertToInteger();
+            RubyInteger v = Helpers.invokePublic(context, obj, "rand", asFixnum(context, limit + 1)).convertToInteger();
             long r = numericToLong(context, v);
             if (r < 0) throw context.runtime.newRangeError("random number too small " + r);
             if (r > limit) throw context.runtime.newRangeError("random number too big " + r);

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -52,7 +52,7 @@ import org.jruby.util.ByteList;
 import org.jruby.util.Numeric;
 import org.jruby.util.TypeConverter;
 
-import static org.jruby.api.Convert.checkToInteger;
+import static org.jruby.api.Convert.*;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.ast.util.ArgsUtil.hasExceptionOption;
 import static org.jruby.runtime.Helpers.invokedynamic;
@@ -231,13 +231,13 @@ public class RubyRational extends RubyNumeric {
     }
 
     private static RubyNumeric canonicalizeInternal(ThreadContext context, RubyClass clazz, long num, long den) {
-        if (den == 0)
-            throw context.runtime.newZeroDivisionError();
+        if (den == 0) throw context.runtime.newZeroDivisionError();
+
         if (num == Long.MIN_VALUE && den == Long.MIN_VALUE)
-            canonicalizeInternal(context, clazz, context.runtime.newFixnum(num), context.runtime.newFixnum(den));
+            canonicalizeInternal(context, clazz, asFixnum(context, num), asFixnum(context, den));
         long gcd = i_gcd(num, den);
-        RubyInteger _num = (RubyInteger) context.runtime.newFixnum(num).idiv(context, gcd);
-        RubyInteger _den = (RubyInteger) context.runtime.newFixnum(den).idiv(context, gcd);
+        RubyInteger _num = (RubyInteger) asFixnum(context, num).idiv(context, gcd);
+        RubyInteger _den = (RubyInteger) asFixnum(context, den).idiv(context, gcd);
 
         if (Numeric.CANON && canonicalization && _den.getLongValue() == 1) return _num;
 
@@ -574,7 +574,7 @@ public class RubyRational extends RubyNumeric {
 
     @Override
     public IRubyObject zero_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, isZero());
+        return asBoolean(context, isZero());
     }
 
     @Override
@@ -589,12 +589,12 @@ public class RubyRational extends RubyNumeric {
 
     @Override
     public IRubyObject isNegative(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, signum() < 0);
+        return asBoolean(context, signum() < 0);
     }
 
     @Override
     public IRubyObject isPositive(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, signum() > 0);
+        return asBoolean(context, signum() > 0);
     }
 
     @Override
@@ -969,14 +969,14 @@ public class RubyRational extends RubyNumeric {
     }
 
     public final IRubyObject op_equal(ThreadContext context, RubyInteger other) {
-        if (num.isZero()) return RubyBoolean.newBoolean(context, other.isZero());
+        if (num.isZero()) return asBoolean(context, other.isZero());
         if (!(den instanceof RubyFixnum) || den.getLongValue() != 1) return context.fals;
         return f_equal(context, num, other);
     }
 
     final RubyBoolean op_equal(ThreadContext context, RubyRational other) {
-        if (num.isZero()) return RubyBoolean.newBoolean(context, other.num.isZero());
-        return RubyBoolean.newBoolean(context,
+        if (num.isZero()) return asBoolean(context, other.num.isZero());
+        return asBoolean(context,
                 f_equal(context, num, other.num).isTrue() && f_equal(context, den, other.den).isTrue());
     }
 
@@ -1163,7 +1163,7 @@ public class RubyRational extends RubyNumeric {
 
         final int nsign = ((RubyInteger) n).signum();
 
-        RubyNumeric b = f_expt(context, context.runtime.newFixnum(10), (RubyInteger) n);
+        RubyNumeric b = f_expt(context, asFixnum(context, 10), (RubyInteger) n);
         IRubyObject s = nsign >= 0 ?
                 op_mul(context, (RubyInteger) b) :
                 op_mul(context, b); // (RubyRational) b

--- a/core/src/main/java/org/jruby/RubyRegexp.java
+++ b/core/src/main/java/org/jruby/RubyRegexp.java
@@ -79,7 +79,7 @@ import org.jruby.util.cli.Options;
 import org.jruby.util.io.EncodingUtils;
 import org.jruby.util.collections.WeakValuedMap;
 
-import static org.jruby.api.Convert.castAsHash;
+import static org.jruby.api.Convert.*;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.runtime.ThreadContext.resetCallInfo;
 import static org.jruby.util.RubyStringBuilder.str;
@@ -1041,23 +1041,19 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
     @JRubyMethod(name = {"==", "eql?"})
     @Override
     public IRubyObject op_equal(ThreadContext context, IRubyObject other) {
-        if (this == other) {
-            return context.tru;
-        }
-        if (!(other instanceof RubyRegexp)) {
-            return context.fals;
-        }
+        if (this == other) return context.tru;
+        if (!(other instanceof RubyRegexp)) return context.fals;
+
         RubyRegexp otherRegex = (RubyRegexp) other;
 
         check();
         otherRegex.check();
 
-        return RubyBoolean.newBoolean(context, str.equal(otherRegex.str) && options.equals(otherRegex.options));
+        return asBoolean(context, str.equal(otherRegex.str) && options.equals(otherRegex.options));
     }
 
     @JRubyMethod(name = "~", reads = {LASTLINE}, writes = BACKREF)
     public IRubyObject op_match2(ThreadContext context) {
-        Ruby runtime = context.runtime;
         IRubyObject line = context.getLastLine();
         if (line instanceof RubyString) {
             int start = searchString(context, (RubyString) line, 0, false);
@@ -1065,7 +1061,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
                 // set backref for user
                 context.updateBackref();
 
-                return runtime.newFixnum(start);
+                return asFixnum(context, start);
             }
         }
 
@@ -1374,13 +1370,18 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
     }
 
     @JRubyMethod
+    public IRubyObject options(ThreadContext context) {
+        return asFixnum(context, getOptions().toOptions());
+    }
+
+    @Deprecated
     public IRubyObject options() {
-        return metaClass.runtime.newFixnum(getOptions().toOptions());
+        return options(getCurrentContext());
     }
 
     @JRubyMethod(name = "casefold?")
     public IRubyObject casefold_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, getOptions().isIgnorecase());
+        return asBoolean(context, getOptions().isIgnorecase());
     }
 
     /** rb_reg_source
@@ -1574,7 +1575,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
 
     @JRubyMethod(name = "fixed_encoding?")
     public IRubyObject fixed_encoding_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, options.isFixed());
+        return asBoolean(context, options.isFixed());
     }
 
     private record RegexpArgs(RubyString string, int options, IRubyObject timeout) {}

--- a/core/src/main/java/org/jruby/RubySignal.java
+++ b/core/src/main/java/org/jruby/RubySignal.java
@@ -40,6 +40,8 @@ import org.jruby.util.NoFunctionalitySignalFacade;
 
 import java.util.*;
 
+import static org.jruby.api.Convert.asFixnum;
+
 @JRubyModule(name="Signal")
 public class RubySignal {
 
@@ -143,9 +145,9 @@ public class RubySignal {
             if (names == null) {
                 names = RubyHash.newHash(runtime);
                 for (Map.Entry<String, Integer> sig : RubySignal.list().entrySet()) {
-                    names.op_aset(context, runtime.newDeduplicatedString(sig.getKey()), runtime.newFixnum(sig.getValue()));
+                    names.op_aset(context, runtime.newDeduplicatedString(sig.getKey()), asFixnum(context, sig.getValue()));
                 }
-                names.op_aset(context, runtime.newDeduplicatedString("EXIT"), runtime.newFixnum(0));
+                names.op_aset(context, runtime.newDeduplicatedString("EXIT"), asFixnum(context, 0));
                 recv.getInternalVariables().setInternalVariable("signal_list", names);
             } else {
                 names.dup(context);

--- a/core/src/main/java/org/jruby/RubySignalException.java
+++ b/core/src/main/java/org/jruby/RubySignalException.java
@@ -30,18 +30,17 @@ import static jnr.constants.platform.Signal.NSIG;
 
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.api.Convert;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.SignalException;
 import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 
-import static org.jruby.api.Convert.checkToInteger;
-import static org.jruby.api.Convert.integerAsLong;
+import static org.jruby.api.Convert.*;
 import static org.jruby.runtime.Visibility.PRIVATE;
 
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.util.TypeConverter;
 
 /**
  * The Java representation of a Ruby SignalException.
@@ -69,15 +68,12 @@ public class RubySignalException extends RubyException {
     @JRubyMethod(required = 1, optional = 2, checkArity = false, visibility = PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
-
-        final Ruby runtime = context.runtime;
         int argnum = 1;
-
         IRubyObject sig = checkToInteger(context, args[0]);
 
         if (sig.isNil()) {
             sig = args[0];
-            Arity.checkArgumentCount(runtime, args, 1, argnum);
+            Arity.checkArgumentCount(context.runtime, args, 1, argnum);
         } else {
             argnum = 2;
         }
@@ -85,29 +81,25 @@ public class RubySignalException extends RubyException {
         long _signo;
 
         if (argnum == 2) {
-            _signo = integerAsLong(context, (RubyInteger) sig);
-            if (_signo < 0 || _signo > NSIG.longValue()) {
-                throw runtime.newArgumentError("invalid signal number (" + _signo + ")");
-            }
+            _signo = asLong(context, (RubyInteger) sig);
+            if (_signo < 0 || _signo > NSIG.longValue()) throw context.runtime.newArgumentError("invalid signal number (" + _signo + ")");
 
             if (argc > 1) {
                 sig = args[1];
             } else {
-                sig = runtime.newString(RubySignal.signmWithPrefix(RubySignal.signo2signm(_signo)));
+                sig = Convert.asString(context, RubySignal.signmWithPrefix(RubySignal.signo2signm(_signo)));
             }
         } else {
             String signm = sig.toString();
             _signo = RubySignal.signm2signo(RubySignal.signmWithoutPrefix(signm));
 
-            if (_signo == 0) {
-                throw runtime.newArgumentError("unsupported name " + sig);
-            }
+            if (_signo == 0) throw context.runtime.newArgumentError("unsupported name " + sig);
 
-            sig = runtime.newString(RubySignal.signmWithPrefix(signm));
+            sig = Convert.asString(context, RubySignal.signmWithPrefix(signm));
         }
 
         super.initialize(new IRubyObject[]{sig}, block);
-        this.signo = runtime.newFixnum(_signo);
+        this.signo = asFixnum(context, _signo);
 
         return this;
     }

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -76,6 +76,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.util.RubyStringBuilder.str;
 import static org.jruby.util.RubyStringBuilder.ids;
@@ -524,13 +526,13 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
     @JRubyMethod(name = "===")
     @Override
     public IRubyObject op_eqq(ThreadContext context, IRubyObject other) {
-        return RubyBoolean.newBoolean(context, this == other);
+        return asBoolean(context, this == other);
     }
 
     @JRubyMethod(name = "==")
     @Override
     public IRubyObject op_equal(ThreadContext context, IRubyObject other) {
-        return RubyBoolean.newBoolean(context, this == other);
+        return asBoolean(context, this == other);
     }
 
     @Deprecated
@@ -541,7 +543,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
 
     @JRubyMethod
     public RubyFixnum hash(ThreadContext context) {
-        return context.runtime.newFixnum(hashCode());
+        return asFixnum(context, hashCode());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -47,6 +47,7 @@ import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.tz.FixedDateTimeZone;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.api.Convert;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.TypeError;
@@ -81,8 +82,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.jruby.RubyComparable.invcmp;
-import static org.jruby.api.Convert.checkToInteger;
-import static org.jruby.api.Convert.numericToLong;
+import static org.jruby.api.Convert.*;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.runtime.Helpers.invokedynamic;
 import static org.jruby.runtime.ThreadContext.hasKeywords;
@@ -609,8 +609,13 @@ public class RubyTime extends RubyObject {
     }
 
     @JRubyMethod(name = {"gmt?", "utc?", "gmtime?"})
+    public RubyBoolean gmt(ThreadContext context) {
+        return asBoolean(context, isUTC());
+    }
+
+    @Deprecated
     public RubyBoolean gmt() {
-        return metaClass.runtime.newBoolean(isUTC());
+        return gmt(getRuntime().getCurrentContext());
     }
 
     public boolean isUTC() {
@@ -673,12 +678,8 @@ public class RubyTime extends RubyObject {
     @JRubyMethod(name = "==")
     @Override
     public IRubyObject op_equal(ThreadContext context, IRubyObject other) {
-        if (other instanceof RubyTime) {
-            return RubyBoolean.newBoolean(context, safeCmp(context, this, other) == 0);
-        }
-        if (other == context.nil) {
-            return context.fals;
-        }
+        if (other instanceof RubyTime) return asBoolean(context, safeCmp(context, this, other) == 0);
+        if (other == context.nil) return context.fals;
 
         return RubyComparable.op_equal(context, this, other);
     }
@@ -696,36 +697,28 @@ public class RubyTime extends RubyObject {
 
     @JRubyMethod(name = ">=")
     public IRubyObject op_ge(ThreadContext context, IRubyObject other) {
-        if (other instanceof RubyTime) {
-            return RubyBoolean.newBoolean(context, safeCmp(context, this, other) >= 0);
-        }
+        if (other instanceof RubyTime) return asBoolean(context, safeCmp(context, this, other) >= 0);
 
         return RubyComparable.op_ge(context, this, other);
     }
 
     @JRubyMethod(name = ">")
     public IRubyObject op_gt(ThreadContext context, IRubyObject other) {
-        if (other instanceof RubyTime) {
-            return RubyBoolean.newBoolean(context, safeCmp(context, this, other) > 0);
-        }
+        if (other instanceof RubyTime) return asBoolean(context, safeCmp(context, this, other) > 0);
 
         return RubyComparable.op_gt(context, this, other);
     }
 
     @JRubyMethod(name = "<=")
     public IRubyObject op_le(ThreadContext context, IRubyObject other) {
-        if (other instanceof RubyTime) {
-            return RubyBoolean.newBoolean(context, safeCmp(context, this, other) <= 0);
-        }
+        if (other instanceof RubyTime) return asBoolean(context, safeCmp(context, this, other) <= 0);
 
         return RubyComparable.op_le(context, this, other);
     }
 
     @JRubyMethod(name = "<")
     public IRubyObject op_lt(ThreadContext context, IRubyObject other) {
-        if (other instanceof RubyTime) {
-            return RubyBoolean.newBoolean(context, safeCmp(context, this, other) < 0);
-        }
+        if (other instanceof RubyTime) return asBoolean(context, safeCmp(context, this, other) < 0);
 
         return RubyComparable.op_lt(context, this, other);
     }
@@ -826,7 +819,7 @@ public class RubyTime extends RubyObject {
     @Override
     public IRubyObject op_eqq(ThreadContext context, IRubyObject other) {
         if (other instanceof RubyTime) {
-            return RubyBoolean.newBoolean(context, RubyNumeric.fix2int(invokedynamic(context, this, OP_CMP, other)) == 0);
+            return asBoolean(context, RubyNumeric.fix2int(invokedynamic(context, this, OP_CMP, other)) == 0);
         }
 
         return context.fals;
@@ -835,11 +828,9 @@ public class RubyTime extends RubyObject {
     @JRubyMethod(name = "<=>")
     @Override
     public IRubyObject op_cmp(ThreadContext context, IRubyObject other) {
-        if (other instanceof RubyTime) {
-            return context.runtime.newFixnum(cmp((RubyTime) other));
-        }
-
-        return invcmp(context, sites(context).recursive_cmp, this, other);
+        return other instanceof RubyTime ?
+                asFixnum(context, cmp((RubyTime) other)) :
+                invcmp(context, sites(context).recursive_cmp, this, other);
     }
 
     @JRubyMethod(name = "eql?")
@@ -939,8 +930,13 @@ public class RubyTime extends RubyObject {
     }
 
     @JRubyMethod(name = {"to_i", "tv_sec"})
+    public RubyInteger to_i(ThreadContext context) {
+        return asFixnum(context, Math.floorDiv(getTimeInMillis(), (long) 1000));
+    }
+
+    @Deprecated
     public RubyInteger to_i() {
-        return getRuntime().newFixnum(Math.floorDiv(getTimeInMillis(), (long) 1000));
+        return to_i(getCurrentContext());
     }
 
     /**
@@ -952,8 +948,13 @@ public class RubyTime extends RubyObject {
      * @return the (sec) fractional part of time (in nanos)
      */
     @JRubyMethod(name = {"nsec", "tv_nsec"})
+    public RubyInteger nsec(ThreadContext context) {
+        return asFixnum(context, getNanos());
+    }
+
+    @Deprecated
     public RubyInteger nsec() {
-        return getRuntime().newFixnum(getNanos());
+        return nsec(getCurrentContext());
     }
 
     @JRubyMethod
@@ -967,8 +968,13 @@ public class RubyTime extends RubyObject {
      * @return the (whole) microsecond part of time
      */
     @JRubyMethod(name = {"usec", "tv_usec"})
+    public RubyInteger usec(ThreadContext context) {
+        return asFixnum(context, dt.getMillisOfSecond() * 1000 + getUSec());
+    }
+
+    @Deprecated
     public RubyInteger usec() {
-        return getRuntime().newFixnum(dt.getMillisOfSecond() * 1000 + getUSec());
+        return usec(getCurrentContext());
     }
 
     /**
@@ -1033,78 +1039,115 @@ public class RubyTime extends RubyObject {
     }
 
     @JRubyMethod
+    public RubyInteger sec(ThreadContext context) {
+        return asFixnum(context, dt.getSecondOfMinute());
+    }
+
     public RubyInteger sec() {
-        return getRuntime().newFixnum(dt.getSecondOfMinute());
+        return sec(getCurrentContext());
     }
 
     @JRubyMethod
+    public RubyInteger min(ThreadContext context) {
+        return asFixnum(context, dt.getMinuteOfHour());
+    }
+
+    @Deprecated
     public RubyInteger min() {
-        return getRuntime().newFixnum(dt.getMinuteOfHour());
+        return min(getCurrentContext());
     }
 
     @JRubyMethod
+    public RubyInteger hour(ThreadContext context) {
+        return asFixnum(context, dt.getHourOfDay());
+    }
+
+    @Deprecated
     public RubyInteger hour() {
-        return getRuntime().newFixnum(dt.getHourOfDay());
+        return hour(getCurrentContext());
     }
 
     @JRubyMethod(name = {"mday", "day"})
+    public RubyInteger mday(ThreadContext context) {
+        return asFixnum(context, dt.getDayOfMonth());
+    }
+
+    @Deprecated
     public RubyInteger mday() {
-        return getRuntime().newFixnum(dt.getDayOfMonth());
+        return mday(getCurrentContext());
     }
 
     @JRubyMethod(name = {"month", "mon"})
+    public RubyInteger month(ThreadContext context) {
+        return asFixnum(context, dt.getMonthOfYear());
+    }
+
     public RubyInteger month() {
-        return getRuntime().newFixnum(dt.getMonthOfYear());
+        return month(getCurrentContext());
     }
 
     @JRubyMethod
+    public RubyInteger year(ThreadContext context) {
+        return asFixnum(context, dt.getYear());
+    }
+
+    @Deprecated
     public RubyInteger year() {
-        return getRuntime().newFixnum(dt.getYear());
+        return year(getCurrentContext());
     }
 
     @JRubyMethod
+    public RubyInteger wday(ThreadContext context) {
+        return asFixnum(context, (dt.getDayOfWeek() % 7));
+    }
+
+    @Deprecated
     public RubyInteger wday() {
-        return getRuntime().newFixnum((dt.getDayOfWeek() % 7));
+        return wday(getCurrentContext());
     }
 
     @JRubyMethod
+    public RubyInteger yday(ThreadContext context) {
+        return asFixnum(context, dt.getDayOfYear());
+    }
+
     public RubyInteger yday() {
-        return getRuntime().newFixnum(dt.getDayOfYear());
+        return yday(getCurrentContext());
     }
 
     @JRubyMethod(name = "sunday?")
     public RubyBoolean sunday_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, (dt.getDayOfWeek() % 7) == 0);
+        return asBoolean(context, (dt.getDayOfWeek() % 7) == 0);
     }
 
     @JRubyMethod(name = "monday?")
     public RubyBoolean monday_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, (dt.getDayOfWeek() % 7) == 1);
+        return asBoolean(context, (dt.getDayOfWeek() % 7) == 1);
     }
 
     @JRubyMethod(name = "tuesday?")
     public RubyBoolean tuesday_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, (dt.getDayOfWeek() % 7) == 2);
+        return asBoolean(context, (dt.getDayOfWeek() % 7) == 2);
     }
 
     @JRubyMethod(name = "wednesday?")
     public RubyBoolean wednesday_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, (dt.getDayOfWeek() % 7) == 3);
+        return asBoolean(context, (dt.getDayOfWeek() % 7) == 3);
     }
 
     @JRubyMethod(name = "thursday?")
     public RubyBoolean thursday_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, (dt.getDayOfWeek() % 7) == 4);
+        return asBoolean(context, (dt.getDayOfWeek() % 7) == 4);
     }
 
     @JRubyMethod(name = "friday?")
     public RubyBoolean friday_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, (dt.getDayOfWeek() % 7) == 5);
+        return asBoolean(context, (dt.getDayOfWeek() % 7) == 5);
     }
 
     @JRubyMethod(name = "saturday?")
     public RubyBoolean saturday_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, (dt.getDayOfWeek() % 7) == 6);
+        return asBoolean(context, (dt.getDayOfWeek() % 7) == 6);
     }
 
     @Deprecated
@@ -1121,15 +1164,24 @@ public class RubyTime extends RubyObject {
     }
 
     @JRubyMethod(name = {"gmt_offset", "gmtoff", "utc_offset"})
-    public RubyInteger gmt_offset() {
+    public RubyInteger gmt_offset(ThreadContext context) {
         int offset = dt.getZone().getOffset(dt.getMillis());
 
-        return getRuntime().newFixnum(offset / 1000);
+        return asFixnum(context, offset / 1000);
+    }
+
+    public RubyInteger gmt_offset() {
+        return gmt_offset(getCurrentContext());
     }
 
     @JRubyMethod(name = {"isdst", "dst?"})
+    public RubyBoolean isdst(ThreadContext context) {
+        return asBoolean(context, !dt.getZone().isStandardOffset(dt.getMillis()));
+    }
+
+    @Deprecated
     public RubyBoolean isdst() {
-        return getRuntime().newBoolean(!dt.getZone().isStandardOffset(dt.getMillis()));
+        return isdst(getRuntime().getCurrentContext());
     }
 
     @JRubyMethod
@@ -1213,7 +1265,7 @@ public class RubyTime extends RubyObject {
 
     @JRubyMethod(name = "_dump")
     public RubyString dump(final ThreadContext context) {
-        RubyString str = mdump(context.runtime);
+        RubyString str = mdump(context);
         str.syncVariables(this);
         return str;
     }
@@ -1232,10 +1284,10 @@ public class RubyTime extends RubyObject {
 
     @Deprecated
     public RubyObject mdump() {
-        return mdump(getRuntime());
+        return mdump(getCurrentContext());
     }
 
-    private RubyString mdump(final Ruby runtime) {
+    private RubyString mdump(ThreadContext context) {
         DateTime dateTime = dt.toDateTime(DateTimeZone.UTC);
         byte dumpValue[] = new byte[8];
         long usec = this.nsec / 1000;
@@ -1262,15 +1314,15 @@ public class RubyTime extends RubyObject {
             se >>>= 8;
         }
 
-        RubyString string = RubyString.newString(runtime, new ByteList(dumpValue, false));
+        RubyString string = RubyString.newString(context.runtime, new ByteList(dumpValue, false));
 
         // 1.9 includes more nsecs
         copyInstanceVariablesInto(string);
 
         // nanos in numerator/denominator form
         if (nanosec != 0) {
-            string.setInternalVariable("nano_num", runtime.newFixnum(nanosec));
-            string.setInternalVariable("nano_den", runtime.newFixnum(1));
+            string.setInternalVariable("nano_num", asFixnum(context, nanosec));
+            string.setInternalVariable("nano_den", asFixnum(context, 1));
         }
 
         // submicro for 1.9.1 compat
@@ -1282,17 +1334,17 @@ public class RubyTime extends RubyObject {
         nanosec /= 10;
         submicro[0] |= (byte)((nanosec % 10) << 4);
         if (submicro[1] == 0) len = 1;
-        string.setInternalVariable("submicro", RubyString.newString(runtime, submicro, 0, len));
+        string.setInternalVariable("submicro", RubyString.newString(context.runtime, submicro, 0, len));
 
         // time zone
         final DateTimeZone zone = dt.getZone();
         if (zone != DateTimeZone.UTC) {
             long offset = zone.getOffset(dt.getMillis());
-            string.setInternalVariable("offset", runtime.newFixnum(offset / 1000));
+            string.setInternalVariable("offset", asFixnum(context, offset / 1000));
 
             String zoneName = zone.getShortName(dt.getMillis());
             if (!TIME_OFFSET_PATTERN.matcher(zoneName).matches()) {
-                string.setInternalVariable("zone", runtime.newString(zoneName));
+                string.setInternalVariable("zone", Convert.asString(context, zoneName));
             }
         }
 

--- a/core/src/main/java/org/jruby/RubyUnboundMethod.java
+++ b/core/src/main/java/org/jruby/RubyUnboundMethod.java
@@ -42,6 +42,8 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.callsite.CacheEntry;
 
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.util.RubyStringBuilder.str;
 
 /**
@@ -93,7 +95,7 @@ public class RubyUnboundMethod extends AbstractRubyMethod {
     @Override
     @JRubyMethod(name = "==")
     public RubyBoolean op_equal(ThreadContext context, IRubyObject other) {
-        return RubyBoolean.newBoolean(context,  equals(other) );
+        return asBoolean(context,  equals(other) );
     }
 
     @Override
@@ -109,7 +111,7 @@ public class RubyUnboundMethod extends AbstractRubyMethod {
 
     @JRubyMethod
     public RubyFixnum hash(ThreadContext context) {
-        return context.runtime.newFixnum(hashCode());
+        return asFixnum(context, hashCode());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/api/Convert.java
+++ b/core/src/main/java/org/jruby/api/Convert.java
@@ -2,6 +2,7 @@ package org.jruby.api;
 
 import org.jruby.RubyArray;
 import org.jruby.RubyBignum;
+import org.jruby.RubyBoolean;
 import org.jruby.RubyClass;
 import org.jruby.RubyFile;
 import org.jruby.RubyFixnum;
@@ -31,6 +32,9 @@ import static org.jruby.util.TypeConverter.sites;
  * be that thing.  For example, `integerAsInt` implies the value is already an int and will error if
  * it is not.  `checkToInteger` implies the value might not be an integer and that it may try and convert
  * it to one.
+ *
+ * Methods where the parameter to `As` methods will omit the type from in front of as.  For example,
+ * `longAsInteger` will be `asInteger(context, long)`.
  */
 public class Convert {
     /**
@@ -331,12 +335,52 @@ public class Convert {
     }
 
     /**
+     * Create a Ruby Boolean from a java boolean.
+     * @param context the current thread context
+     * @param value the boolean value
+     * @return the Ruby Boolean
+     */
+    public static RubyBoolean asBoolean(ThreadContext context, boolean value) {
+        return value ? context.tru : context.fals;
+    }
+
+    /**
+     * Create a Ruby Fixnum from a java long.
+     * @param context the current thread context
+     * @param value the long value
+     * @return the Ruby Fixnum
+     */
+    public static RubyFixnum asFixnum(ThreadContext context, long value) {
+        return RubyFixnum.newFixnum(context.runtime, value);
+    }
+
+    /**
+     * Create a Ruby Fixnum from a java int.
+     * @param context the current thread context
+     * @param value the int value
+     * @return the Ruby Fixnum
+     */
+    public static RubyFixnum asFixnum(ThreadContext context, int value) {
+        return RubyFixnum.newFixnum(context.runtime, value);
+    }
+
+    /**
+     * Create a Ruby String from a java String.
+     * @param context the current thread context
+     * @param value the String value
+     * @return the Ruby String
+     */
+    public static RubyString asString(ThreadContext context, String value) {
+        return context.runtime.newString(value);
+    }
+
+    /**
      * Safely convert a Ruby Integer into a java int value.  Raising if the value will not fit.
      * @param context the current thread context
      * @param value the RubyInteger to convert
      * @return the int value
      */
-    public static int integerAsInt(ThreadContext context, RubyInteger value) {
+    public static int asInt(ThreadContext context, RubyInteger value) {
         long num = value.getLongValue();
 
         return checkInt(context, num);
@@ -348,7 +392,7 @@ public class Convert {
      * @param value the RubyInteger to convert
      * @return the int value
      */
-    public static long integerAsLong(ThreadContext context, RubyInteger value) {
+    public static long asLong(ThreadContext context, RubyInteger value) {
         if (value instanceof RubyBignum) {
             return big2long((RubyBignum) value);
         }

--- a/core/src/main/java/org/jruby/common/RubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/RubyWarnings.java
@@ -47,6 +47,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.TypeConverter;
 import org.jruby.util.func.TriFunction;
 
+import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.util.RubyStringBuilder.str;
 
 /**
@@ -258,7 +259,7 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
 
         if (category == null) throw runtime.newArgumentError(str(runtime, "unknown category: ", arg));
 
-        return runtime.newBoolean(runtime.getWarningCategories().contains(category));
+        return asBoolean(context, runtime.getWarningCategories().contains(category));
     }
 
     @JRubyMethod(name = "[]=")

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -59,8 +59,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 
 import static org.jruby.RubyRegexp.*;
-import static org.jruby.api.Convert.castAsArray;
-import static org.jruby.api.Convert.castAsNumeric;
+import static org.jruby.api.Convert.*;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.ext.date.DateUtils.*;
 import static org.jruby.util.Numeric.*;
@@ -278,7 +277,7 @@ public class RubyDate extends RubyObject {
 
     private RubyFixnum DAY_MS(final ThreadContext context) {
         RubyFixnum v = DAY_MS_CACHE;
-        if (v == null) v = DAY_MS_CACHE = context.runtime.newFixnum(DAY_MS);
+        if (v == null) v = DAY_MS_CACHE = asFixnum(context, DAY_MS);
         return v;
     }
 
@@ -827,7 +826,7 @@ public class RubyDate extends RubyObject {
     @Override
     @JRubyMethod(name = "<=>")
     public IRubyObject op_cmp(ThreadContext context, IRubyObject other) {
-        if (other instanceof RubyDate date) return context.runtime.newFixnum(cmp(context, date));
+        if (other instanceof RubyDate date) return asFixnum(context, cmp(context, date));
 
         // other (Numeric) - interpreted as an Astronomical Julian Day Number.
 
@@ -908,12 +907,12 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod(name = "julian?")
     public RubyBoolean julian_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, isJulian());
+        return asBoolean(context, isJulian());
     }
 
     @JRubyMethod(name = "gregorian?")
     public RubyBoolean gregorian_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, ! isJulian());
+        return asBoolean(context, ! isJulian());
     }
 
     public final boolean isJulian() {
@@ -1178,13 +1177,13 @@ public class RubyDate extends RubyObject {
     @JRubyMethod(name = "julian_leap?", meta = true)
     public static IRubyObject julian_leap_p(ThreadContext context, IRubyObject self, IRubyObject year) {
         final RubyInteger y = year.convertToInteger();
-        return RubyBoolean.newBoolean(context, isJulianLeap(y.getLongValue()));
+        return asBoolean(context, isJulianLeap(y.getLongValue()));
     }
 
     @JRubyMethod(name = "gregorian_leap?", alias = "leap?", meta = true)
     public static IRubyObject gregorian_leap_p(ThreadContext context, IRubyObject self, IRubyObject year) {
         final RubyInteger y = year.convertToInteger();
-        return RubyBoolean.newBoolean(context, isGregorianLeap(y.getLongValue()));
+        return asBoolean(context, isGregorianLeap(y.getLongValue()));
     }
 
     // All years divisible by 4 are leap years in the Julian calendar.
@@ -1208,7 +1207,7 @@ public class RubyDate extends RubyObject {
     @JRubyMethod(name = "leap?")
     public IRubyObject leap_p(ThreadContext context) {
         final long year = dt.getYear();
-        return RubyBoolean.newBoolean(context,  isJulian() ? isJulianLeap(year) : isGregorianLeap(year) );
+        return asBoolean(context,  isJulian() ? isJulianLeap(year) : isGregorianLeap(year) );
     }
 
     //
@@ -1467,7 +1466,7 @@ public class RubyDate extends RubyObject {
     }
 
     static RubyRational newRationalConvert(ThreadContext context, IRubyObject num, long den) {
-        return (RubyRational) RubyRational.newRationalConvert(context, num, context.runtime.newFixnum(den));
+        return (RubyRational) RubyRational.newRationalConvert(context, num, asFixnum(context, den));
     }
 
     // def jd_to_ajd(jd, fr, of=0) jd + fr - of - Rational(1, 2) end
@@ -2440,7 +2439,7 @@ public class RubyDate extends RubyObject {
             set_hash(context, hash, "mday", cstr2num(context.runtime, d, bp, ep));
         }
 
-        if (comp != null) set_hash(context, hash, "_comp", RubyBoolean.newBoolean(context, comp));
+        if (comp != null) set_hash(context, hash, "_comp", asBoolean(context, comp));
 
         return hash;
     }

--- a/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
+++ b/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
@@ -37,6 +37,7 @@ import org.jruby.util.SafePropertyAccessor;
 import org.jruby.util.io.OpenFile;
 import java.nio.ByteBuffer;
 
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.numericToLong;
 
 @JRubyModule(name="Etc")
@@ -58,7 +59,7 @@ public class RubyEtc {
                     throw context.runtime.newErrnoFromLastPOSIXErrno();
                 }
             }
-            return context.runtime.newFixnum(ret);
+            return asFixnum(context, ret);
         }
     }
     

--- a/core/src/main/java/org/jruby/ext/ffi/AbstractMemory.java
+++ b/core/src/main/java/org/jruby/ext/ffi/AbstractMemory.java
@@ -49,7 +49,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 
-import static org.jruby.api.Convert.numericToLong;
+import static org.jruby.api.Convert.*;
 import static org.jruby.api.Error.typeError;
 
 /**
@@ -164,7 +164,7 @@ abstract public class AbstractMemory extends MemoryObject {
      */
     @JRubyMethod(name = "hash")
     public RubyFixnum hash(ThreadContext context) {
-        return context.runtime.newFixnum(hashCode());
+        return asFixnum(context, hashCode());
     }
 
     @JRubyMethod(name = "[]")
@@ -196,7 +196,7 @@ abstract public class AbstractMemory extends MemoryObject {
     @JRubyMethod(name = "==")
     @Override
     public IRubyObject op_equal(ThreadContext context, IRubyObject obj) {
-        return RubyBoolean.newBoolean(context, this.equals(obj));
+        return asBoolean(context, this.equals(obj));
     }
     
     /**
@@ -236,7 +236,7 @@ abstract public class AbstractMemory extends MemoryObject {
      */
     @JRubyMethod(name = "type_size")
     public final IRubyObject type_size(ThreadContext context) {
-        return context.runtime.newFixnum(typeSize);
+        return asFixnum(context, typeSize);
     }
 
     /**

--- a/core/src/main/java/org/jruby/ext/ffi/MemoryPointer.java
+++ b/core/src/main/java/org/jruby/ext/ffi/MemoryPointer.java
@@ -12,6 +12,8 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.cli.Options;
 
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.runtime.Visibility.PRIVATE;
 
 @JRubyClass(name = "FFI::MemoryPointer", parent = "FFI::Pointer")
@@ -82,7 +84,7 @@ public class MemoryPointer extends Pointer {
     @JRubyMethod(name = "from_string", meta = true)
     public static IRubyObject from_string(ThreadContext context, IRubyObject klass, IRubyObject s) {
         org.jruby.util.ByteList bl = s.convertToString().getByteList();
-        MemoryPointer ptr = (MemoryPointer) ((RubyClass) klass).newInstance(context, context.runtime.newFixnum(bl.length() + 1), Block.NULL_BLOCK);
+        MemoryPointer ptr = (MemoryPointer) ((RubyClass) klass).newInstance(context, asFixnum(context, bl.length() + 1), Block.NULL_BLOCK);
         ptr.getMemoryIO().putZeroTerminatedByteArray(0, bl.unsafeBytes(), bl.begin(), bl.length());
 
         return ptr;
@@ -114,11 +116,10 @@ public class MemoryPointer extends Pointer {
 
     @JRubyMethod(name = "==")
     public IRubyObject op_equal(ThreadContext context, IRubyObject obj) {
-        return RubyBoolean.newBoolean(context, this == obj
+        return asBoolean(context, this == obj
                 || getAddress() == 0L && obj.isNil()
-                || (obj instanceof MemoryPointer
-                && ((MemoryPointer) obj).getAddress() == getAddress())
-                && ((MemoryPointer) obj).getSize() == getSize());
+                || (obj instanceof MemoryPointer mem && mem.getAddress() == getAddress())
+                && mem.getSize() == getSize());
     }
     
     @JRubyMethod(name = "free")
@@ -137,6 +138,6 @@ public class MemoryPointer extends Pointer {
 
     @JRubyMethod(name = "autorelease?")
     public final IRubyObject autorelease_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, ((AllocatedDirectMemoryIO) getMemoryIO()).isAutoRelease());
+        return asBoolean(context, ((AllocatedDirectMemoryIO) getMemoryIO()).isAutoRelease());
     }
 }

--- a/core/src/main/java/org/jruby/ext/ffi/Platform.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Platform.java
@@ -38,6 +38,8 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.SafePropertyAccessor;
 
+import static org.jruby.api.Convert.asBoolean;
+
 /**
  *
  */
@@ -308,27 +310,27 @@ public class Platform {
 
     @JRubyMethod(name = "windows?", module=true)
     public static IRubyObject windows_p(ThreadContext context, IRubyObject recv) {
-        return RubyBoolean.newBoolean(context, OS == OS.WINDOWS);
+        return asBoolean(context, OS == OS.WINDOWS);
     }
     @JRubyMethod(name = "mac?", module=true)
     public static IRubyObject mac_p(ThreadContext context, IRubyObject recv) {
-        return RubyBoolean.newBoolean(context, OS == OS.DARWIN);
+        return asBoolean(context, OS == OS.DARWIN);
     }
     @JRubyMethod(name = "unix?", module=true)
     public static IRubyObject unix_p(ThreadContext context, IRubyObject recv) {
-        return RubyBoolean.newBoolean(context, Platform.getPlatform().isUnix());
+        return asBoolean(context, Platform.getPlatform().isUnix());
     }
     @JRubyMethod(name = "bsd?", module=true)
     public static IRubyObject bsd_p(ThreadContext context, IRubyObject recv) {
-        return RubyBoolean.newBoolean(context, Platform.getPlatform().isBSD());
+        return asBoolean(context, Platform.getPlatform().isBSD());
     }
     @JRubyMethod(name = "linux?", module=true)
     public static IRubyObject linux_p(ThreadContext context, IRubyObject recv) {
-        return RubyBoolean.newBoolean(context, OS == OS.LINUX);
+        return asBoolean(context, OS == OS.LINUX);
     }
     @JRubyMethod(name = "solaris?", module=true)
     public static IRubyObject solaris_p(ThreadContext context, IRubyObject recv) {
-        return RubyBoolean.newBoolean(context, OS == OS.SOLARIS);
+        return asBoolean(context, OS == OS.SOLARIS);
     }
 
     /**

--- a/core/src/main/java/org/jruby/ext/ffi/Pointer.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Pointer.java
@@ -11,7 +11,7 @@ import org.jruby.runtime.*;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.cli.Options;
 
-import static org.jruby.api.Convert.numericToLong;
+import static org.jruby.api.Convert.*;
 import static org.jruby.runtime.Visibility.*;
 
 /**
@@ -135,7 +135,7 @@ public class Pointer extends AbstractMemory {
      */
     @JRubyMethod(name = "null?")
     public IRubyObject null_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, getMemoryIO().isNull());
+        return asBoolean(context, getMemoryIO().isNull());
     }
 
 
@@ -150,7 +150,7 @@ public class Pointer extends AbstractMemory {
 
     @JRubyMethod(name = { "address", "to_i" })
     public IRubyObject address(ThreadContext context) {
-        return context.runtime.newFixnum(getAddress());
+        return asFixnum(context, getAddress());
     }
 
     /**
@@ -164,7 +164,7 @@ public class Pointer extends AbstractMemory {
 
     @JRubyMethod(name = "==")
     public IRubyObject op_equal(ThreadContext context, IRubyObject obj) {
-        return RubyBoolean.newBoolean(context, this == obj
+        return asBoolean(context, this == obj
                 || getAddress() == 0L && obj.isNil()
                 || (obj instanceof Pointer && ((Pointer) obj).getAddress() == getAddress()));
     }

--- a/core/src/main/java/org/jruby/ext/ffi/Struct.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Struct.java
@@ -11,6 +11,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.cli.Options;
 
+import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.castAsClass;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.runtime.Visibility.*;
@@ -330,7 +331,7 @@ public class Struct extends MemoryObject implements StructLayout.Storage {
 
     @JRubyMethod(name="null?")
     public IRubyObject null_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, getMemory().getMemoryIO().isNull());
+        return asBoolean(context, getMemory().getMemoryIO().isNull());
     }
 
     @JRubyMethod(name = "order")

--- a/core/src/main/java/org/jruby/ext/ffi/StructLayout.java
+++ b/core/src/main/java/org/jruby/ext/ffi/StructLayout.java
@@ -60,6 +60,7 @@ import org.jruby.runtime.callsite.CachingCallSite;
 import org.jruby.runtime.callsite.FunctionalCachingCallSite;
 import org.jruby.util.ByteList;
 
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.castAsArray;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.runtime.Visibility.*;
@@ -726,17 +727,17 @@ public final class StructLayout extends Type {
 
         @JRubyMethod
         public final IRubyObject size(ThreadContext context) {
-            return context.runtime.newFixnum(type.getNativeSize());
+            return asFixnum(context, type.getNativeSize());
         }
 
         @JRubyMethod
         public final IRubyObject alignment(ThreadContext context) {
-            return context.runtime.newFixnum(type.getNativeAlignment());
+            return asFixnum(context, type.getNativeAlignment());
         }
 
         @JRubyMethod
         public final IRubyObject offset(ThreadContext context) {
-            return context.runtime.newFixnum(offset);
+            return asFixnum(context, offset);
         }
 
         @JRubyMethod(name = { "type", "ffi_type" })

--- a/core/src/main/java/org/jruby/ext/ffi/Type.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Type.java
@@ -16,6 +16,8 @@ import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Error.typeError;
 
 /**
@@ -161,7 +163,7 @@ public abstract class Type extends RubyObject {
      */
     @JRubyMethod(name = "size")
     public IRubyObject size(ThreadContext context) {
-        return context.runtime.newFixnum(getNativeSize());
+        return asFixnum(context, getNativeSize());
     }
 
     /**
@@ -172,7 +174,7 @@ public abstract class Type extends RubyObject {
      */
     @JRubyMethod(name = "alignment")
     public IRubyObject alignment(ThreadContext context) {
-        return context.runtime.newFixnum(getNativeAlignment());
+        return asFixnum(context, getNativeAlignment());
     }
 
     @JRubyClass(name = "FFI::Type::Builtin", parent = "FFI::Type")
@@ -219,18 +221,18 @@ public abstract class Type extends RubyObject {
         @Override
         @JRubyMethod(name = "==")
         public IRubyObject op_equal(ThreadContext context, IRubyObject obj) {
-            return RubyBoolean.newBoolean(context, this.equals(obj));
+            return asBoolean(context, this.equals(obj));
         }
 
         @Override
         @JRubyMethod(name = "equal?")
         public IRubyObject equal_p(ThreadContext context, IRubyObject obj) {
-            return RubyBoolean.newBoolean(context, this.equals(obj));
+            return asBoolean(context, this.equals(obj));
         }
         
         @JRubyMethod(name = "eql?")
         public IRubyObject eql_p(ThreadContext context, IRubyObject obj) {
-            return RubyBoolean.newBoolean(context, this.equals(obj));
+            return asBoolean(context, this.equals(obj));
         }
 
     }
@@ -274,7 +276,7 @@ public abstract class Type extends RubyObject {
 
         @JRubyMethod
         public final IRubyObject length(ThreadContext context) {
-            return context.runtime.newFixnum(length);
+            return asFixnum(context, length);
         }
 
         @JRubyMethod

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/Factory.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/Factory.java
@@ -12,6 +12,8 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.platform.Platform;
 import org.jruby.util.WindowsFFI;
 
+import static org.jruby.api.Convert.asFixnum;
+
 public class Factory extends org.jruby.ext.ffi.Factory {
 
     public Factory() {
@@ -117,7 +119,7 @@ public class Factory extends org.jruby.ext.ffi.Factory {
     public static final class LastError {
         @JRubyMethod(name = {  "error" }, module = true)
         public static final IRubyObject error(ThreadContext context, IRubyObject recv) {
-            return context.runtime.newFixnum(com.kenai.jffi.LastError.getInstance().get());
+            return asFixnum(context, com.kenai.jffi.LastError.getInstance().get());
         }
 
         @JRubyMethod(name = {  "error=" }, module = true)

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/Function.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/Function.java
@@ -19,6 +19,7 @@ import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Error.typeError;
 
 @JRubyClass(name="FFI::Function", parent="FFI::Pointer")
@@ -161,7 +162,7 @@ public final class Function extends org.jruby.ext.ffi.AbstractInvoker {
 
     @JRubyMethod(name = { "autorelease?", "autorelease" })
     public final IRubyObject autorelease_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, autorelease);
+        return asBoolean(context, autorelease);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/JITRuntime.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/JITRuntime.java
@@ -10,6 +10,7 @@ import org.jruby.runtime.callsite.CachingCallSite;
 
 import java.math.BigInteger;
 
+import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Error.typeError;
 
 /**
@@ -383,7 +384,7 @@ public final class JITRuntime {
     }
     
     public static IRubyObject newBoolean(ThreadContext context, int value) {
-        return RubyBoolean.newBoolean(context, (value & 0x1) != 0);
+        return asBoolean(context, (value & 0x1) != 0);
     }
 
     public static IRubyObject newBoolean(Ruby runtime, int value) {
@@ -391,7 +392,7 @@ public final class JITRuntime {
     }
     
     public static IRubyObject newBoolean(ThreadContext context, long value) {
-        return RubyBoolean.newBoolean(context, (value & 0x1L) != 0);
+        return asBoolean(context, (value & 0x1L) != 0);
     }
 
     public static IRubyObject newBoolean(Ruby runtime, long value) {

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/NativeClosureProxy.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/NativeClosureProxy.java
@@ -14,6 +14,7 @@ import org.jruby.runtime.callsite.FunctionalCachingCallSite;
 
 import java.lang.ref.WeakReference;
 
+import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Error.typeError;
 
 /**
@@ -268,7 +269,7 @@ final class NativeClosureProxy implements Closure {
                     return getStringParameter(runtime, buffer, index);
 
                 case BOOL:
-                    return runtime.newBoolean(buffer.getByte(index) != 0);
+                    return asBoolean(context, buffer.getByte(index) != 0);
 
                 default:
                     throw typeError(context, "invalid callback parameter type " + type);

--- a/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
+++ b/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 
+import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.castAsHash;
 import static org.jruby.api.Error.typeError;
 
@@ -483,7 +484,7 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
 
     @JRubyMethod(name = "alive?")
     public IRubyObject alive_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, alive());
+        return asBoolean(context, alive());
     }
     
     @JRubyMethod(meta = true)
@@ -642,7 +643,7 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
 
     @JRubyMethod(name = "blocking?")
     public IRubyObject blocking_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, isBlocking());
+        return asBoolean(context, isBlocking());
     }
 
     @JRubyMethod(name = "blocking?", meta = true)

--- a/core/src/main/java/org/jruby/ext/io/nonblock/IONonBlock.java
+++ b/core/src/main/java/org/jruby/ext/io/nonblock/IONonBlock.java
@@ -8,6 +8,8 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.io.OpenFile;
 
+import static org.jruby.api.Convert.asBoolean;
+
 public class IONonBlock {
 
     public static void load(Ruby runtime) {
@@ -16,14 +18,14 @@ public class IONonBlock {
 
     @JRubyMethod(name = "nonblock?")
     public static IRubyObject nonblock_p(ThreadContext context, IRubyObject io) {
-        return context.runtime.newBoolean( !getIO(io).getBlocking() );
+        return asBoolean(context, !getIO(io).getBlocking());
     }
 
     @JRubyMethod(name = "nonblock=")
     public static IRubyObject nonblock_set(ThreadContext context, IRubyObject io, IRubyObject nonblocking) {
         final boolean nonblock = nonblocking.isTrue();
         getIO(io).setBlocking(!nonblock);
-        return context.runtime.newBoolean(nonblock); // NOTE: MRI seems to return io
+        return asBoolean(context, nonblock); // NOTE: MRI seems to return io
     }
 
     @JRubyMethod(name = "nonblock")
@@ -43,7 +45,7 @@ public class IONonBlock {
                 ioObj.setBlocking(oldBlocking);
             }
         }
-        return context.runtime.newBoolean(oldBlocking);
+        return asBoolean(context, oldBlocking);
     }
 
     private static RubyIO getIO(IRubyObject io) {

--- a/core/src/main/java/org/jruby/ext/jruby/CoreExt.java
+++ b/core/src/main/java/org/jruby/ext/jruby/CoreExt.java
@@ -37,6 +37,7 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.castAsString;
 
 /**
@@ -54,7 +55,7 @@ public abstract class CoreExt {
 
         @JRubyMethod
         public static RubyFixnum unseeded_hash(ThreadContext context, IRubyObject recv) {
-            return context.runtime.newFixnum(castAsString(context, recv).unseededStrHashCode(context.runtime));
+            return asFixnum(context, castAsString(context, recv).unseededStrHashCode(context.runtime));
         }
 
         @JRubyMethod(name = "alloc", meta = true)

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyLibrary.java
@@ -52,6 +52,8 @@ import org.jruby.util.ByteList;
 
 import java.io.ByteArrayInputStream;
 
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.parser.ParserType.INLINE;
 
@@ -89,12 +91,12 @@ public class JRubyLibrary implements Library {
     public static class JRubyConfig {
         @JRubyMethod(name = "rubygems_disabled?")
         public static IRubyObject rubygems_disabled_p(ThreadContext context, IRubyObject self) {
-            return RubyBoolean.newBoolean(context, context.runtime.getInstanceConfig().isDisableGems());
+            return asBoolean(context, context.runtime.getInstanceConfig().isDisableGems());
         }
 
         @JRubyMethod(name = "did_you_mean_disabled?")
         public static IRubyObject did_you_mean_disabled_p(ThreadContext context, IRubyObject self) {
-            return RubyBoolean.newBoolean(context, context.runtime.getInstanceConfig().isDisableDidYouMean());
+            return asBoolean(context, context.runtime.getInstanceConfig().isDisableDidYouMean());
         }
     }
 
@@ -169,9 +171,13 @@ public class JRubyLibrary implements Library {
     }
 
     @JRubyMethod(name = "security_restricted?", module = true)
+    public static RubyBoolean is_security_restricted(ThreadContext context, IRubyObject recv) {
+        return asBoolean(context, Ruby.isSecurityRestricted());
+    }
+
+    @Deprecated
     public static RubyBoolean is_security_restricted(IRubyObject recv) {
-        final Ruby runtime = recv.getRuntime();
-        return RubyBoolean.newBoolean(runtime, Ruby.isSecurityRestricted());
+        return is_security_restricted(recv.getRuntime().getCurrentContext(), recv);
     }
 
     // NOTE: its probably too late to set this when jruby library is booted (due the java library) ?
@@ -190,7 +196,7 @@ public class JRubyLibrary implements Library {
      */
     @JRubyMethod(module = true)
     public static IRubyObject identity_hash(ThreadContext context, IRubyObject recv, IRubyObject obj) {
-        return context.runtime.newFixnum(System.identityHashCode(obj));
+        return asFixnum(context, System.identityHashCode(obj));
     }
 
     @JRubyMethod(module = true, name = "parse", alias = "ast_for", required = 1, optional = 3, checkArity = false)

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
@@ -48,6 +48,8 @@ import org.jruby.runtime.load.BasicLibraryService;
 import org.jruby.runtime.load.Library;
 import org.jruby.util.ClasspathLauncher;
 
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.util.URLUtil.getPath;
 
 /**
@@ -74,9 +76,13 @@ public class JRubyUtilLibrary implements Library {
     }
 
     @JRubyMethod(name = { "objectspace", "object_space?" }, alias = { "objectspace?" }, module = true)
+    public static IRubyObject getObjectSpaceEnabled(ThreadContext context, IRubyObject recv) {
+        return asBoolean(context, context.runtime.isObjectSpaceEnabled());
+    }
+
+    @Deprecated
     public static IRubyObject getObjectSpaceEnabled(IRubyObject recv) {
-        final Ruby runtime = recv.getRuntime();
-        return RubyBoolean.newBoolean(runtime, runtime.isObjectSpaceEnabled());
+        return getObjectSpaceEnabled(recv.getRuntime().getCurrentContext(), recv);
     }
 
     @JRubyMethod(name = { "objectspace=", "object_space=" }, module = true)
@@ -92,7 +98,7 @@ public class JRubyUtilLibrary implements Library {
 
     @JRubyMethod(meta = true, name = "native_posix?")
     public static IRubyObject native_posix_p(ThreadContext context, IRubyObject self) {
-        return RubyBoolean.newBoolean(context, context.runtime.getPosix().isNative());
+        return asBoolean(context, context.runtime.getPosix().isNative());
     }
 
     @Deprecated
@@ -409,8 +415,8 @@ public class JRubyUtilLibrary implements Library {
         Ruby runtime = context.runtime;
 
         RubyHash stat = RubyHash.newHash(runtime);
-        stat.op_aset(context, runtime.newSymbol("method_invalidation_count"), runtime.newFixnum(runtime.getCaches().getMethodInvalidationCount()));
-        stat.op_aset(context, runtime.newSymbol("constant_invalidation_count"), runtime.newFixnum(runtime.getCaches().getConstantInvalidationCount()));
+        stat.op_aset(context, runtime.newSymbol("method_invalidation_count"), asFixnum(context, runtime.getCaches().getMethodInvalidationCount()));
+        stat.op_aset(context, runtime.newSymbol("constant_invalidation_count"), asFixnum(context, runtime.getCaches().getConstantInvalidationCount()));
 
         return stat;
     }

--- a/core/src/main/java/org/jruby/ext/monitor/Monitor.java
+++ b/core/src/main/java/org/jruby/ext/monitor/Monitor.java
@@ -13,6 +13,8 @@ import org.jruby.runtime.JavaSites;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import static org.jruby.api.Convert.asBoolean;
+
 @JRubyClass(name = "Monitor")
 public class Monitor extends RubyObject {
     private final Mutex mutex;
@@ -99,7 +101,7 @@ public class Monitor extends RubyObject {
 
     @JRubyMethod(name = "mon_owned?")
     public RubyBoolean mon_owned_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, ownedByCurrentThread(context));
+        return asBoolean(context, ownedByCurrentThread(context));
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
+++ b/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
@@ -30,6 +30,7 @@
 package org.jruby.ext.pathname;
 
 import static org.jruby.anno.FrameField.BACKREF;
+import static org.jruby.api.Convert.asFixnum;
 
 import org.jruby.*;
 import org.jruby.anno.JRubyClass;
@@ -229,11 +230,9 @@ public class RubyPathname extends RubyObject {
     @Override
     @JRubyMethod(name = "<=>")
     public IRubyObject op_cmp(ThreadContext context, IRubyObject other) {
-        if (other instanceof RubyPathname) {
-            return context.runtime.newFixnum(cmp((RubyPathname) other));
-        } else {
-            return context.nil;
-        }
+        return other instanceof RubyPathname path ?
+                asFixnum(context, cmp(path)) :
+                context.nil;
     }
 
     @JRubyMethod(name = "hash")

--- a/core/src/main/java/org/jruby/ext/ripper/RubyRipper.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RubyRipper.java
@@ -47,6 +47,8 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.lexer.LexingCommon.*;
 
 public class RubyRipper extends RubyObject {
@@ -299,7 +301,7 @@ public class RubyRipper extends RubyObject {
             
         if (!parseStarted) return context.nil;
         
-        return context.runtime.newFixnum(parser.getColumn());
+        return asFixnum(context, parser.getColumn());
     }
 
     @JRubyMethod
@@ -309,12 +311,12 @@ public class RubyRipper extends RubyObject {
 
     @JRubyMethod(name = "end_seen?")
     public IRubyObject end_seen_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, parser.isEndSeen());
+        return asBoolean(context, parser.isEndSeen());
     }
 
     @JRubyMethod(name = "error?")
     public IRubyObject error_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, parser.isError());
+        return asBoolean(context, parser.isError());
     }
     @JRubyMethod
     public IRubyObject filename(ThreadContext context) {
@@ -327,14 +329,14 @@ public class RubyRipper extends RubyObject {
         
         if (!parseStarted) return context.nil;
             
-        return context.runtime.newFixnum(parser.getLineno());
+        return asFixnum(context, parser.getLineno());
     }
 
     @JRubyMethod
     public IRubyObject state(ThreadContext context) {
         int state = parser.getState();
 
-        return state == 0 ? context.nil : context.runtime.newFixnum(parser.getState());
+        return state == 0 ? context.nil : asFixnum(context, state);
     }
 
     @JRubyMethod
@@ -358,7 +360,7 @@ public class RubyRipper extends RubyObject {
 
     @JRubyMethod
     public IRubyObject yydebug(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, parser.getYYDebug());
+        return asBoolean(context, parser.getYYDebug());
     }
     
     @JRubyMethod(name = "yydebug=")
@@ -373,7 +375,7 @@ public class RubyRipper extends RubyObject {
         int wid = _width.convertToInteger().getIntValue();
         input.modifyAndClearCodeRange();
         int col = LexingCommon.dedent_string(input.getByteList(), wid);
-        return context.runtime.newFixnum(col);
+        return asFixnum(context, col);
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -50,6 +50,8 @@ import java.util.Iterator;
 import java.util.Set;
 
 import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 
 /**
  * Native implementation of Ruby's Set (set.rb replacement).
@@ -335,12 +337,12 @@ public class RubySet extends RubyObject implements Set {
 
     @JRubyMethod(name = "size", alias = "length")
     public IRubyObject length(ThreadContext context) {
-        return context.runtime.newFixnum( size() );
+        return asFixnum(context, size());
     }
 
     @JRubyMethod(name = "empty?")
     public IRubyObject empty_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context,  isEmpty() );
+        return asBoolean(context, isEmpty());
     }
 
     @JRubyMethod(name = "clear")
@@ -496,7 +498,7 @@ public class RubySet extends RubyObject implements Set {
      */
     @JRubyMethod(name = "include?", alias = { "member?", "===" })
     public RubyBoolean include_p(final ThreadContext context, IRubyObject obj) {
-        return RubyBoolean.newBoolean(context,  containsImpl(obj) );
+        return asBoolean(context,  containsImpl(obj) );
     }
 
     final boolean containsImpl(IRubyObject obj) {
@@ -518,7 +520,7 @@ public class RubySet extends RubyObject implements Set {
                 return this.hash.op_ge(context, ((RubySet) set).hash);
             }
             // size >= set.size && set.all? { |o| include?(o) }
-            return RubyBoolean.newBoolean(context,
+            return asBoolean(context,
                     size() >= ((RubySet) set).size() && allElementsIncluded((RubySet) set)
             );
         }
@@ -533,7 +535,7 @@ public class RubySet extends RubyObject implements Set {
                 return this.hash.op_gt(context, ((RubySet) set).hash);
             }
             // size >= set.size && set.all? { |o| include?(o) }
-            return RubyBoolean.newBoolean(context,
+            return asBoolean(context,
                     size() > ((RubySet) set).size() && allElementsIncluded((RubySet) set)
             );
         }
@@ -547,7 +549,7 @@ public class RubySet extends RubyObject implements Set {
                 return this.hash.op_le(context, ((RubySet) set).hash);
             }
             // size >= set.size && set.all? { |o| include?(o) }
-            return RubyBoolean.newBoolean(context,
+            return asBoolean(context,
                     size() <= ((RubySet) set).size() && allElementsIncluded((RubySet) set)
             );
         }
@@ -561,7 +563,7 @@ public class RubySet extends RubyObject implements Set {
                 return this.hash.op_lt(context, ((RubySet) set).hash);
             }
             // size >= set.size && set.all? { |o| include?(o) }
-            return RubyBoolean.newBoolean(context,
+            return asBoolean(context,
                     size() < ((RubySet) set).size() && allElementsIncluded((RubySet) set)
             );
         }
@@ -574,7 +576,7 @@ public class RubySet extends RubyObject implements Set {
     @JRubyMethod(name = "intersect?")
     public IRubyObject intersect_p(final ThreadContext context, IRubyObject set) {
         if ( set instanceof RubySet ) {
-            return RubyBoolean.newBoolean(context,  intersect((RubySet) set) );
+            return asBoolean(context,  intersect((RubySet) set) );
         }
         throw context.runtime.newArgumentError("value must be a set");
     }
@@ -602,7 +604,7 @@ public class RubySet extends RubyObject implements Set {
     @JRubyMethod(name = "disjoint?")
     public IRubyObject disjoint_p(final ThreadContext context, IRubyObject set) {
         if ( set instanceof RubySet ) {
-            return RubyBoolean.newBoolean(context,  ! intersect((RubySet) set) );
+            return asBoolean(context,  ! intersect((RubySet) set) );
         }
         throw context.runtime.newArgumentError("value must be a set");
     }
@@ -623,7 +625,7 @@ public class RubySet extends RubyObject implements Set {
      * @see SizeFn#size(ThreadContext, IRubyObject, IRubyObject[])
      */
     private static IRubyObject size(ThreadContext context, RubySet recv, IRubyObject[] args) {
-        return context.runtime.newFixnum(recv.size());
+        return asFixnum(context, recv.size());
     }
 
     /**

--- a/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
+++ b/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
@@ -48,6 +48,8 @@ import static jnr.constants.platform.ProtocolFamily.PF_INET6;
 import static jnr.constants.platform.ProtocolFamily.PF_UNIX;
 import static jnr.constants.platform.ProtocolFamily.PF_UNSPEC;
 import static jnr.constants.platform.Sock.*;
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.ext.socket.SocketUtils.sockerr;
 
 public class Addrinfo extends RubyObject {
@@ -434,25 +436,23 @@ public class Addrinfo extends RubyObject {
 
     @JRubyMethod
     public IRubyObject afamily(ThreadContext context) {
-        return context.runtime.newFixnum(getAddressFamily().intValue());
+        return asFixnum(context, getAddressFamily().intValue());
     }
 
     @JRubyMethod
     public IRubyObject pfamily(ThreadContext context) {
-        return context.runtime.newFixnum(pfamily.intValue());
+        return asFixnum(context, pfamily.intValue());
     }
 
     @JRubyMethod
     public IRubyObject socktype(ThreadContext context) {
-      return context.runtime.newFixnum(sock == null ? 0 : sock.intValue());
+      return asFixnum(context, sock == null ? 0 : sock.intValue());
     }
 
     @JRubyMethod
     public IRubyObject protocol(ThreadContext context) {
         // Any unknown protocol will end up null but the one case we see is IPPROTO_RAW is not listed in /etc/protocols
-        int proto = protocol == null ? 255 : protocol.getProto();
-
-        return context.runtime.newFixnum(proto);
+        return asFixnum(context, protocol == null ? 255 : protocol.getProto());
     }
 
     @JRubyMethod
@@ -469,22 +469,22 @@ public class Addrinfo extends RubyObject {
 
     @JRubyMethod(name = "ipv4?")
     public IRubyObject ipv4_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, getAddressFamily() == AF_INET);
+        return asBoolean(context, getAddressFamily() == AF_INET);
     }
 
     @JRubyMethod(name = "ipv6?")
     public IRubyObject ipv6_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, getAddressFamily() == AF_INET6);
+        return asBoolean(context, getAddressFamily() == AF_INET6);
     }
 
     @JRubyMethod(name = "unix?")
     public IRubyObject unix_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, getAddressFamily() == AF_UNIX);
+        return asBoolean(context, getAddressFamily() == AF_UNIX);
     }
 
     @JRubyMethod(name = "ip?")
     public IRubyObject ip_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, getAddressFamily() == AF_INET || getAddressFamily() == AF_INET6);
+        return asBoolean(context, getAddressFamily() == AF_INET || getAddressFamily() == AF_INET6);
     }
 
     @JRubyMethod
@@ -512,29 +512,29 @@ public class Addrinfo extends RubyObject {
         if (getAddressFamily() != AF_INET && getAddressFamily() != AF_INET6) {
             throw sockerr(context.runtime, "need IPv4 or IPv6 address");
         }
-        return context.runtime.newFixnum(((InetSocketAddress) socketAddress).getPort());
+        return asFixnum(context, ((InetSocketAddress) socketAddress).getPort());
     }
 
     @JRubyMethod(name = "ipv4_private?")
     public IRubyObject ipv4_private_p(ThreadContext context) {
         if (getAddressFamily() == AF_INET) {
-            return RubyBoolean.newBoolean(context, getInet4Address().isSiteLocalAddress());
+            return asBoolean(context, getInet4Address().isSiteLocalAddress());
         }
-        return RubyBoolean.newBoolean(context, false);
+        return asBoolean(context, false);
     }
 
     @JRubyMethod(name = "ipv4_loopback?")
     public IRubyObject ipv4_loopback_p(ThreadContext context) {
       if (getAddressFamily() == AF_INET) {
-        return RubyBoolean.newBoolean(context, ((InetSocketAddress) socketAddress).getAddress().isLoopbackAddress());
+        return asBoolean(context, ((InetSocketAddress) socketAddress).getAddress().isLoopbackAddress());
       }
-      return RubyBoolean.newBoolean(context, false);
+      return asBoolean(context, false);
     }
 
     @JRubyMethod(name = "ipv4_multicast?")
     public IRubyObject ipv4_multicast_p(ThreadContext context) {
         if (getAddressFamily() == AF_INET) {
-            return RubyBoolean.newBoolean(context, getInet4Address().isMulticastAddress());
+            return asBoolean(context, getInet4Address().isMulticastAddress());
         }
         return context.fals;
     }
@@ -542,7 +542,7 @@ public class Addrinfo extends RubyObject {
     @JRubyMethod(name = "ipv6_unspecified?")
     public IRubyObject ipv6_unspecified_p(ThreadContext context) {
         if (getAddressFamily() == AF_INET6) {
-            return RubyBoolean.newBoolean(context, ipv6_ip().equals("::"));
+            return asBoolean(context, ipv6_ip().equals("::"));
         }
         return context.fals;
     }
@@ -550,27 +550,27 @@ public class Addrinfo extends RubyObject {
     @JRubyMethod(name = "ipv6_loopback?")
     public IRubyObject ipv6_loopback_p(ThreadContext context) {
       if (getAddressFamily() == AF_INET6) {
-        return RubyBoolean.newBoolean(context, getInetSocketAddress().getAddress().isLoopbackAddress());
+        return asBoolean(context, getInetSocketAddress().getAddress().isLoopbackAddress());
       }
-      return RubyBoolean.newBoolean(context, false);
+      return asBoolean(context, false);
     }
 
     @JRubyMethod(name = "ipv6_multicast?")
     public IRubyObject ipv6_multicast_p(ThreadContext context) {
         if (getAddressFamily() == AF_INET6) {
-            return RubyBoolean.newBoolean(context, getInet6Address().isMulticastAddress());
+            return asBoolean(context, getInet6Address().isMulticastAddress());
         }
         return context.fals;
     }
 
     @JRubyMethod(name = "ipv6_linklocal?")
     public IRubyObject ipv6_linklocal_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, getInetSocketAddress().getAddress().isLinkLocalAddress());
+        return asBoolean(context, getInetSocketAddress().getAddress().isLinkLocalAddress());
     }
 
     @JRubyMethod(name = "ipv6_sitelocal?")
     public IRubyObject ipv6_sitelocal_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, ((InetSocketAddress) socketAddress).getAddress().isSiteLocalAddress());
+        return asBoolean(context, ((InetSocketAddress) socketAddress).getAddress().isSiteLocalAddress());
     }
 
     @JRubyMethod(name = "ipv6_unique_local?")
@@ -583,47 +583,47 @@ public class Addrinfo extends RubyObject {
             return context.fals;
         }
         int firstAddrByte = address.getAddress()[0] & 0xff;
-        return RubyBoolean.newBoolean(context, firstAddrByte == 0xfc || firstAddrByte == 0xfd);
+        return asBoolean(context, firstAddrByte == 0xfc || firstAddrByte == 0xfd);
     }
 
     @JRubyMethod(name = "ipv6_v4mapped?")
     public IRubyObject ipv6_v4mapped_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, looksLikeV4ButIsV6);
+        return asBoolean(context, looksLikeV4ButIsV6);
     }
 
     @JRubyMethod(name = "ipv6_v4compat?")
     public IRubyObject ipv6_v4compat_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, isIPV6() && !looksLikeV4ButIsV6);
+        return asBoolean(context, isIPV6() && !looksLikeV4ButIsV6);
     }
 
     @JRubyMethod(name = "ipv6_mc_nodelocal?")
     public IRubyObject ipv6_mc_nodelocal_p(ThreadContext context) {
         Inet6Address in6 = getInet6Address();
-        return RubyBoolean.newBoolean(context, in6 != null && in6.isMCNodeLocal());
+        return asBoolean(context, in6 != null && in6.isMCNodeLocal());
     }
 
     @JRubyMethod(name = "ipv6_mc_linklocal?")
     public IRubyObject ipv6_mc_linklocal_p(ThreadContext context) {
         Inet6Address in6 = getInet6Address();
-        return RubyBoolean.newBoolean(context, in6 != null && in6.isMCLinkLocal());
+        return asBoolean(context, in6 != null && in6.isMCLinkLocal());
     }
 
     @JRubyMethod(name = "ipv6_mc_sitelocal?")
     public IRubyObject ipv6_mc_sitelocal_p(ThreadContext context) {
         Inet6Address in6 = getInet6Address();
-        return RubyBoolean.newBoolean(context, in6 != null && in6.isMCSiteLocal());
+        return asBoolean(context, in6 != null && in6.isMCSiteLocal());
     }
 
     @JRubyMethod(name = "ipv6_mc_orglocal?")
     public IRubyObject ipv6_mc_orglocal_p(ThreadContext context) {
         Inet6Address in6 = getInet6Address();
-        return RubyBoolean.newBoolean(context, in6 != null && in6.isMCOrgLocal());
+        return asBoolean(context, in6 != null && in6.isMCOrgLocal());
     }
 
     @JRubyMethod(name = "ipv6_mc_global?")
     public IRubyObject ipv6_mc_global_p(ThreadContext context) {
         Inet6Address in6 = getInet6Address();
-        return RubyBoolean.newBoolean(context, in6 != null && in6.isMCGlobal());
+        return asBoolean(context, in6 != null && in6.isMCGlobal());
     }
 
     // FIXME: What is the actual name for ::0.0.0.1

--- a/core/src/main/java/org/jruby/ext/socket/Ifaddr.java
+++ b/core/src/main/java/org/jruby/ext/socket/Ifaddr.java
@@ -17,6 +17,8 @@ import java.net.UnknownHostException;
 
 import jnr.constants.platform.InterfaceInfo;
 
+import static org.jruby.api.Convert.asFixnum;
+
 /**
  *
  * @author Lucas Allan Amorim
@@ -115,12 +117,12 @@ public class Ifaddr extends RubyObject {
 
     @JRubyMethod
     public IRubyObject ifindex(ThreadContext context) {
-        return context.runtime.newFixnum(index);
+        return asFixnum(context, index);
     }
 
     @JRubyMethod
     public IRubyObject flags(ThreadContext context) {
-        return context.runtime.newFixnum(flags);
+        return asFixnum(context, flags);
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/ext/socket/Option.java
+++ b/core/src/main/java/org/jruby/ext/socket/Option.java
@@ -12,19 +12,19 @@ import org.jruby.RubyNumeric;
 import org.jruby.RubyObject;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.api.Convert;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 import org.jruby.util.Pack;
 import org.jruby.util.Sprintf;
-import org.jruby.util.TypeConverter;
 
 import java.nio.ByteBuffer;
 import java.util.Locale;
 
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.checkToInteger;
-import static org.jruby.api.Convert.integerAsInt;
 import static org.jruby.api.Error.typeError;
 
 public class Option extends RubyObject {
@@ -66,17 +66,17 @@ public class Option extends RubyObject {
 
     @JRubyMethod
     public IRubyObject family(ThreadContext context) {
-        return context.runtime.newFixnum(family.longValue());
+        return asFixnum(context, family.longValue());
     }
 
     @JRubyMethod
     public IRubyObject level(ThreadContext context) {
-        return context.runtime.newFixnum(level.longValue());
+        return asFixnum(context, level.longValue());
     }
 
     @JRubyMethod
     public IRubyObject optname(ThreadContext context) {
-        return context.runtime.newFixnum(option.longValue());
+        return asFixnum(context, option.longValue());
     }
 
     @JRubyMethod
@@ -203,7 +203,7 @@ public class Option extends RubyObject {
     public IRubyObject asInt(ThreadContext context) {
         validateDataSize(context, data, 4);
 
-        return context.runtime.newFixnum(unpackInt(data));
+        return asFixnum(context, unpackInt(data));
     }
 
     @JRubyMethod(required = 4, meta = true)
@@ -226,7 +226,7 @@ public class Option extends RubyObject {
     @JRubyMethod(meta = true)
     public static IRubyObject linger(ThreadContext context, IRubyObject self, IRubyObject vonoffArg, IRubyObject vsecs) {
         IRubyObject vonoff = checkToInteger(context, vonoffArg);
-        int coercedVonoff = !vonoff.isNil() ? integerAsInt(context, (RubyInteger) vonoff) : (vonoffArg.isTrue() ? 1 : 0);
+        int coercedVonoff = !vonoff.isNil() ? Convert.asInt(context, (RubyInteger) vonoff) : (vonoffArg.isTrue() ? 1 : 0);
         ByteList data = packLinger(coercedVonoff, vsecs.convertToInteger().getIntValue());
 
         return new Option(context.runtime, ProtocolFamily.PF_UNSPEC, SocketLevel.SOL_SOCKET, SocketOption.SO_LINGER, data);

--- a/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
@@ -52,6 +52,7 @@ import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.api.Convert;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.ext.fcntl.FcntlLibrary;
 import org.jruby.platform.Platform;
@@ -81,6 +82,7 @@ import static jnr.constants.platform.TCP.TCP_KEEPCNT;
 import static jnr.constants.platform.TCP.TCP_KEEPIDLE;
 import static jnr.constants.platform.TCP.TCP_KEEPINTVL;
 import static jnr.constants.platform.TCP.TCP_NODELAY;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.runtime.Helpers.extractExceptionOnlyArg;
 import static org.jruby.runtime.Helpers.throwErrorFromException;
 import static com.headius.backport9.buffer.Buffers.flipBuffer;
@@ -118,7 +120,7 @@ public class RubyBasicSocket extends RubyIO {
 
     @JRubyMethod(name = "do_not_reverse_lookup")
     public IRubyObject do_not_reverse_lookup(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, doNotReverseLookup);
+        return Convert.asBoolean(context, doNotReverseLookup);
     }
 
     @JRubyMethod(name = "do_not_reverse_lookup=")
@@ -129,7 +131,7 @@ public class RubyBasicSocket extends RubyIO {
 
     @JRubyMethod(meta = true)
     public static IRubyObject do_not_reverse_lookup(ThreadContext context, IRubyObject recv) {
-        return RubyBoolean.newBoolean(context, context.runtime.isDoNotReverseLookupEnabled());
+        return Convert.asBoolean(context, context.runtime.isDoNotReverseLookupEnabled());
     }
 
     @JRubyMethod(name = "do_not_reverse_lookup=", meta = true)
@@ -174,7 +176,7 @@ public class RubyBasicSocket extends RubyIO {
             if (channel instanceof DatagramChannel && sockaddr != null) {
                 written = ((DatagramChannel) channel).send(mesgBytes, sockaddr);
 
-                return context.runtime.newFixnum(written);
+                return asFixnum(context, written);
             } else {
                 return syswrite(context, _mesg);
             }

--- a/core/src/main/java/org/jruby/ext/socket/RubyServerSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyServerSocket.java
@@ -51,6 +51,7 @@ import java.nio.channels.SelectableChannel;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Error.typeError;
 
 /**
@@ -74,7 +75,7 @@ public class RubyServerSocket extends RubySocket {
                 IRubyWarnings.ID.LISTEN_SERVER_SOCKET,
                 "pass backlog to #bind instead of #listen (https://github.com/jruby/jruby/wiki/ServerSocket)");
 
-        return context.runtime.newFixnum(0);
+        return asFixnum(context, 0);
     }
 
     @JRubyMethod(notImplemented = true)

--- a/core/src/main/java/org/jruby/ext/socket/RubyUNIXServer.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUNIXServer.java
@@ -46,6 +46,8 @@ import java.net.SocketAddress;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
 
+import static org.jruby.api.Convert.asFixnum;
+
 @JRubyClass(name="UNIXServer", parent="UNIXSocket")
 public class RubyUNIXServer extends RubyUNIXSocket {
     static void createUNIXServer(Ruby runtime) {
@@ -147,13 +149,13 @@ public class RubyUNIXServer extends RubyUNIXSocket {
     @JRubyMethod
     public IRubyObject listen(ThreadContext context, IRubyObject log) {
         // TODO listen backlog
-        return context.runtime.newFixnum(0);
+        return asFixnum(context, 0);
     }
 
     @JRubyMethod
     public IRubyObject sysaccept(ThreadContext context) {
         RubyUNIXSocket socket = (RubyUNIXSocket) accept(context);
-        return context.runtime.newFixnum(((UnixSocketChannel) socket.getChannel()).getFD());
+        return asFixnum(context, ((UnixSocketChannel) socket.getChannel()).getFD());
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/ext/socket/RubyUNIXSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUNIXSocket.java
@@ -67,6 +67,7 @@ import java.nio.ByteOrder;
 import java.nio.channels.Channel;
 
 import static com.headius.backport9.buffer.Buffers.flipBuffer;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Error.typeError;
 
 
@@ -311,7 +312,7 @@ public class RubyUNIXSocket extends RubyBasicSocket {
                 throw context.runtime.newErrnoENOPROTOOPTError();
         }
 
-        return context.runtime.newFixnum(0);
+        return asFixnum(context, 0);
     }
 
     protected static void rb_sys_fail(Ruby runtime, String message) {

--- a/core/src/main/java/org/jruby/ext/thread/Mutex.java
+++ b/core/src/main/java/org/jruby/ext/thread/Mutex.java
@@ -44,6 +44,9 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.marshal.DataType;
 
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
+
 /**
  * The "Mutex" class from the 'thread' library.
  */
@@ -80,7 +83,7 @@ public class Mutex extends RubyObject implements DataType {
 
     @JRubyMethod(name = "locked?")
     public RubyBoolean locked_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, isLocked());
+        return asBoolean(context, isLocked());
     }
 
     public boolean isLocked() {
@@ -89,7 +92,7 @@ public class Mutex extends RubyObject implements DataType {
 
     @JRubyMethod
     public RubyBoolean try_lock(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, tryLock(context));
+        return asBoolean(context, tryLock(context));
     }
 
     public boolean tryLock(ThreadContext context) {
@@ -154,9 +157,8 @@ public class Mutex extends RubyObject implements DataType {
 
     @JRubyMethod
     public IRubyObject sleep(ThreadContext context, IRubyObject timeout) {
-        Ruby runtime = context.runtime;
-
         final long beg = System.currentTimeMillis();
+
         try {
             RubyThread thread = context.getThread();
 
@@ -173,12 +175,12 @@ public class Mutex extends RubyObject implements DataType {
                 }
             }
         } catch (IllegalMonitorStateException imse) {
-            throw runtime.newThreadError("Attempt to unlock a mutex which is not locked");
+            throw context.runtime.newThreadError("Attempt to unlock a mutex which is not locked");
         } catch (InterruptedException ex) {
             context.pollThreadEvents();
         }
 
-        return runtime.newFixnum((System.currentTimeMillis() - beg) / 1000);
+        return asFixnum(context, (System.currentTimeMillis() - beg) / 1000);
     }
 
     @JRubyMethod
@@ -193,7 +195,7 @@ public class Mutex extends RubyObject implements DataType {
 
     @JRubyMethod(name = "owned?")
     public IRubyObject owned_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, lock.isHeldByCurrentThread());
+        return asBoolean(context, lock.isHeldByCurrentThread());
     }
 
     private void checkRelocking(ThreadContext context) {

--- a/core/src/main/java/org/jruby/ext/thread/Queue.java
+++ b/core/src/main/java/org/jruby/ext/thread/Queue.java
@@ -55,6 +55,8 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.marshal.DataType;
 import org.jruby.util.TypeConverter;
 
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Error.typeError;
 
 /*
@@ -342,7 +344,7 @@ public class Queue extends RubyObject implements DataType {
     @JRubyMethod(name = "empty?")
     public RubyBoolean empty_p(ThreadContext context) {
         initializedCheck();
-        return RubyBoolean.newBoolean(context, count.get() == 0);
+        return asBoolean(context, count.get() == 0);
     }
 
     @JRubyMethod(name = {"length", "size"})
@@ -358,7 +360,7 @@ public class Queue extends RubyObject implements DataType {
         try {
             takeLock.lockInterruptibly();
             try {
-                return context.runtime.newFixnum(takeLock.getWaitQueueLength(notEmpty));
+                return asFixnum(context, takeLock.getWaitQueueLength(notEmpty));
             } finally {
                 takeLock.unlock();
             }
@@ -591,7 +593,7 @@ public class Queue extends RubyObject implements DataType {
     @JRubyMethod(name = "closed?")
     public IRubyObject closed_p(ThreadContext context) {
         initializedCheck();
-        return RubyBoolean.newBoolean(context, closed);
+        return asBoolean(context, closed);
     }
 
     public synchronized void shutdown() throws InterruptedException {

--- a/core/src/main/java/org/jruby/ext/thread/SizedQueue.java
+++ b/core/src/main/java/org/jruby/ext/thread/SizedQueue.java
@@ -44,6 +44,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static org.jruby.api.Convert.asFixnum;
+
 /**
  * The "SizedQueue" class from the 'thread' library.
  */
@@ -117,7 +119,7 @@ public class SizedQueue extends Queue {
             try {
                 putLock.lockInterruptibly();
                 try {
-                    return context.runtime.newFixnum(takeLock.getWaitQueueLength(notEmpty) + putLock.getWaitQueueLength(notFull));
+                    return asFixnum(context, takeLock.getWaitQueueLength(notEmpty) + putLock.getWaitQueueLength(notFull));
                 } finally {
                     putLock.unlock();
                 }

--- a/core/src/main/java/org/jruby/ext/tracepoint/TracePoint.java
+++ b/core/src/main/java/org/jruby/ext/tracepoint/TracePoint.java
@@ -13,13 +13,14 @@ import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.EventHook;
 import org.jruby.runtime.JavaSites;
-import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.RubyEvent;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.TypeConverter;
 
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.util.RubyStringBuilder.str;
 
 public class TracePoint extends RubyObject {
@@ -159,7 +160,7 @@ public class TracePoint extends RubyObject {
     
     @JRubyMethod(name = "enabled?")
     public IRubyObject enabled_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, enabled);
+        return asBoolean(context, enabled);
     }
     
     @JRubyMethod
@@ -183,7 +184,7 @@ public class TracePoint extends RubyObject {
     public IRubyObject lineno(ThreadContext context) {
         checkInside(context);
         
-        return context.runtime.newFixnum(line);
+        return asFixnum(context, line);
     }
     
     @JRubyMethod
@@ -260,7 +261,7 @@ public class TracePoint extends RubyObject {
             }
         }
         
-        IRubyObject old = RubyBoolean.newBoolean(context, enabled);
+        IRubyObject old = asBoolean(context, enabled);
         updateEnabled(context, toggle);
         
         return old;

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
@@ -61,6 +61,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.jruby.RubyIO.PARAGRAPH_SEPARATOR;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.castAsString;
 import static org.jruby.runtime.Visibility.PRIVATE;
 
@@ -176,21 +177,24 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
 
     @JRubyMethod
     public IRubyObject rewind(ThreadContext context) {
-        Ruby runtime = context.runtime;
-
         // should invoke seek on realIo...
         realIo.callMethod(context, "seek",
-                new IRubyObject[]{runtime.newFixnum(-internalPosition()), runtime.newFixnum(PosixShim.SEEK_CUR)});
+                new IRubyObject[]{asFixnum(context, -internalPosition()), asFixnum(context, PosixShim.SEEK_CUR)});
 
         // ... and then reinitialize
         initialize(context, realIo);
 
-        return getRuntime().getNil();
+        return context.nil;
     }
 
     @JRubyMethod(name = "lineno")
+    public IRubyObject lineno(ThreadContext context) {
+        return asFixnum(context, line);
+    }
+
+    @Deprecated
     public IRubyObject lineno() {
-        return getRuntime().newFixnum(line);
+        return lineno(getCurrentContext());
     }
 
     @JRubyMethod(name = "readline", writes = FrameField.LASTLINE)

--- a/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
+++ b/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
@@ -54,6 +54,7 @@ import org.jruby.runtime.Arity;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.numericToLong;
 import static org.jruby.runtime.Visibility.*;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -186,8 +187,7 @@ public class RubyZlib {
     }
 
     @JRubyMethod(name = "crc32", optional = 2, checkArity = false, module = true, visibility = PRIVATE)
-    public static IRubyObject crc32(IRubyObject recv, IRubyObject[] args) {
-        ThreadContext context = recv.getRuntime().getCurrentContext();
+    public static IRubyObject crc32(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         args = Arity.scanArgs(context.runtime, args, 0, 2);
         long start = 0;
         ByteList bytes = null;
@@ -206,12 +206,16 @@ public class RubyZlib {
         if (slowPath) {
             result = JZlib.crc32_combine(start, result, bytesLength);
         }
-        return recv.getRuntime().newFixnum(result);
+        return asFixnum(context, result);
+    }
+
+    @Deprecated
+    public static IRubyObject crc32(IRubyObject recv, IRubyObject[] args) {
+        return crc32(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
 
     @JRubyMethod(name = "adler32", optional = 2, checkArity = false, module = true, visibility = PRIVATE)
-    public static IRubyObject adler32(IRubyObject recv, IRubyObject[] args) {
-        ThreadContext context = recv.getRuntime().getCurrentContext();
+    public static IRubyObject adler32(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         args = Arity.scanArgs(context.runtime, args, 0, 2);
         int start = 1;
         ByteList bytes = null;
@@ -226,7 +230,12 @@ public class RubyZlib {
         if (start != 1) {
             result = JZlib.adler32_combine(start, result, bytes.length());
         }
-        return recv.getRuntime().newFixnum(result);
+        return asFixnum(context, result);
+    }
+
+    @Deprecated
+    public static IRubyObject adler32(IRubyObject recv, IRubyObject[] args) {
+        return adler32(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
 
     @JRubyMethod(module = true)
@@ -240,42 +249,48 @@ public class RubyZlib {
     }
 
     @JRubyMethod(name = "crc_table", module = true, visibility = PRIVATE)
-    public static IRubyObject crc_table(IRubyObject recv) {
-        Ruby runtime = recv.getRuntime();
+    public static IRubyObject crc_table(ThreadContext context, IRubyObject recv) {
         int[] table = com.jcraft.jzlib.CRC32.getCRC32Table();
-        RubyArray array = runtime.newArray(table.length);
+        RubyArray array = context.runtime.newArray(table.length);
         for (int i = 0; i < table.length; i++) {
-            array.append(runtime.newFixnum(table[i] & 0xffffffffL));
+            array.append(asFixnum(context, table[i] & 0xffffffffL));
         }
         return array;
     }
 
+    @Deprecated
+    public static IRubyObject crc_table(IRubyObject recv) {
+        return crc_table(((RubyBasicObject) recv).getCurrentContext(), recv);
+    }
+
     @JRubyMethod(name = "crc32_combine", module = true, visibility = PRIVATE)
-    public static IRubyObject crc32_combine(IRubyObject recv,
-                                            IRubyObject arg0,
-                                            IRubyObject arg1,
-                                            IRubyObject arg2) {
-        ThreadContext context = recv.getRuntime().getCurrentContext();
+    public static IRubyObject crc32_combine(ThreadContext context, IRubyObject recv,
+                                            IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
         long crc1 = numericToLong(context, arg0);
         long crc2 = numericToLong(context, arg1);
         long len2 = numericToLong(context, arg2);
 
-        long crc3 = com.jcraft.jzlib.JZlib.crc32_combine(crc1, crc2, len2);
-        return recv.getRuntime().newFixnum(crc3);
+        return asFixnum(context, com.jcraft.jzlib.JZlib.crc32_combine(crc1, crc2, len2));
+    }
+
+    @Deprecated
+    public static IRubyObject crc32_combine(IRubyObject recv, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
+        return crc32_combine(((RubyBasicObject) recv).getCurrentContext(), recv, arg0, arg1, arg2);
     }
 
     @JRubyMethod(name = "adler32_combine", module = true, visibility = PRIVATE)
-    public static IRubyObject adler32_combine(IRubyObject recv,
-                                            IRubyObject arg0,
-                                            IRubyObject arg1,
-                                            IRubyObject arg2) {
-        ThreadContext context = recv.getRuntime().getCurrentContext();
+    public static IRubyObject adler32_combine(ThreadContext context, IRubyObject recv,
+                                              IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
         long adler1 = numericToLong(context, arg0);
         long adler2 = numericToLong(context, arg1);
         long len2 = numericToLong(context, arg2);
 
-        long adler3 = com.jcraft.jzlib.JZlib.adler32_combine(adler1, adler2, len2);
-        return recv.getRuntime().newFixnum(adler3);
+        return asFixnum(context, com.jcraft.jzlib.JZlib.adler32_combine(adler1, adler2, len2));
+    }
+
+    @Deprecated
+    public static IRubyObject adler32_combine(IRubyObject recv, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
+        return adler32_combine(((RubyBasicObject) recv).getCurrentContext(), recv, arg0, arg1, arg2);
     }
 
     static RaiseException newZlibError(Ruby runtime, String message) {

--- a/core/src/main/java/org/jruby/ext/zlib/ZStream.java
+++ b/core/src/main/java/org/jruby/ext/zlib/ZStream.java
@@ -38,6 +38,9 @@ import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
+
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.runtime.Visibility.PRIVATE;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -123,10 +126,15 @@ public abstract class ZStream extends RubyObject {
     }
 
     @JRubyMethod(name = "adler")
-    public IRubyObject adler() {
+    public IRubyObject adler(ThreadContext context) {
         checkClosed();
-        
-        return getRuntime().newFixnum(internalAdler());
+
+        return asFixnum(context, internalAdler());
+    }
+
+    @Deprecated
+    public IRubyObject adler() {
+        return adler(getCurrentContext());
     }
 
     @JRubyMethod(name = "finish")
@@ -158,7 +166,7 @@ public abstract class ZStream extends RubyObject {
     @JRubyMethod(name = "finished?")
     public IRubyObject finished_p(ThreadContext context) {
         checkClosed();
-        return RubyBoolean.newBoolean(context, internalFinished());
+        return asBoolean(context, internalFinished());
     }
 
     @JRubyMethod(name = {"close", "end"})

--- a/core/src/main/java/org/jruby/ir/instructions/AsFixnumInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/AsFixnumInstr.java
@@ -11,6 +11,8 @@ import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import static org.jruby.api.Convert.asFixnum;
+
 public class AsFixnumInstr extends OneOperandResultBaseInstr {
     public AsFixnumInstr(Variable result, Operand operand) {
         super(Operation.AS_FIXNUM, result, operand);
@@ -32,6 +34,6 @@ public class AsFixnumInstr extends OneOperandResultBaseInstr {
 
     @Override
     public Object interpret(ThreadContext context, StaticScope currScope, DynamicScope currDynScope, IRubyObject self, Object[] temp) {
-        return context.runtime.newFixnum((int) getOperand1().retrieve(context, self, currScope, currDynScope, temp));
+        return asFixnum(context, (int) getOperand1().retrieve(context, self, currScope, currDynScope, temp));
     }
 }

--- a/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
@@ -65,6 +65,9 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
+
 /**
  * Base full interpreter.  Subclasses can use utility methods here and override what they want.  This method requires
  * that it has fully built and has had a CFG made, etc...
@@ -502,13 +505,13 @@ public class InterpreterEngine {
             }
 
             case BOX_FIXNUM: {
-                RubyFixnum f = context.runtime.newFixnum(getFixnumArg(fixnums, ((BoxFixnumInstr) instr).getValue()));
+                RubyFixnum f = asFixnum(context, getFixnumArg(fixnums, ((BoxFixnumInstr) instr).getValue()));
                 setResult(temp, currDynScope, ((BoxInstr)instr).getResult(), f);
                 break;
             }
 
             case BOX_BOOLEAN: {
-                RubyBoolean f = RubyBoolean.newBoolean(context, getBooleanArg(booleans, ((BoxBooleanInstr) instr).getValue()));
+                RubyBoolean f = asBoolean(context, getBooleanArg(booleans, ((BoxBooleanInstr) instr).getValue()));
                 setResult(temp, currDynScope, ((BoxInstr)instr).getResult(), f);
                 break;
             }

--- a/core/src/main/java/org/jruby/ir/operands/Boolean.java
+++ b/core/src/main/java/org/jruby/ir/operands/Boolean.java
@@ -6,6 +6,8 @@ import org.jruby.ir.persistence.IRReaderDecoder;
 import org.jruby.ir.persistence.IRWriterEncoder;
 import org.jruby.runtime.ThreadContext;
 
+import static org.jruby.api.Convert.asBoolean;
+
 public class Boolean extends ImmutableLiteral {
     private final boolean truthy;
 
@@ -22,7 +24,7 @@ public class Boolean extends ImmutableLiteral {
 
     @Override
     public Object createCacheObject(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, isTrue());
+        return asBoolean(context, isTrue());
     }
 
     public boolean isTrue()  {

--- a/core/src/main/java/org/jruby/ir/operands/Fixnum.java
+++ b/core/src/main/java/org/jruby/ir/operands/Fixnum.java
@@ -7,6 +7,8 @@ import org.jruby.runtime.ThreadContext;
 
 import java.math.BigInteger;
 
+import static org.jruby.api.Convert.asFixnum;
+
 /*
  * Represents a literal fixnum.
  *
@@ -46,7 +48,7 @@ public class Fixnum extends ImmutableLiteral {
 
     @Override
     public Object createCacheObject(ThreadContext context) {
-        return context.runtime.newFixnum(value);
+        return asFixnum(context, value);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/operands/UnboxedBoolean.java
+++ b/core/src/main/java/org/jruby/ir/operands/UnboxedBoolean.java
@@ -1,10 +1,11 @@
 package org.jruby.ir.operands;
 
-import org.jruby.RubyBoolean;
 import org.jruby.ir.IRVisitor;
 import org.jruby.ir.persistence.IRReaderDecoder;
 import org.jruby.ir.persistence.IRWriterEncoder;
 import org.jruby.runtime.ThreadContext;
+
+import static org.jruby.api.Convert.asBoolean;
 
 public class UnboxedBoolean extends ImmutableLiteral {
     private final boolean truthy;
@@ -25,7 +26,7 @@ public class UnboxedBoolean extends ImmutableLiteral {
 
     @Override
     public Object createCacheObject(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, isTrue());
+        return asBoolean(context, isTrue());
     }
 
     public boolean isTrue()  {

--- a/core/src/main/java/org/jruby/ir/operands/UnboxedFixnum.java
+++ b/core/src/main/java/org/jruby/ir/operands/UnboxedFixnum.java
@@ -3,6 +3,8 @@ package org.jruby.ir.operands;
 import org.jruby.ir.IRVisitor;
 import org.jruby.runtime.ThreadContext;
 
+import static org.jruby.api.Convert.asFixnum;
+
 /*
  * Represents a literal fixnum.
  *
@@ -38,7 +40,7 @@ public class UnboxedFixnum extends ImmutableLiteral {
 
     @Override
     public Object createCacheObject(ThreadContext context) {
-        return context.runtime.newFixnum(value);
+        return asFixnum(context, value);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -89,7 +89,7 @@ import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
 import org.objectweb.asm.Type;
 
-import static org.jruby.api.Convert.castAsModule;
+import static org.jruby.api.Convert.*;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.ir.operands.UndefinedValue.UNDEFINED;
 import static org.jruby.runtime.Block.Type.LAMBDA;
@@ -451,7 +451,7 @@ public class IRRuntimeHelpers {
         boolean ret = IRRuntimeHelpers.isRubyExceptionHandled(context, excType, excObj)
             || IRRuntimeHelpers.isJavaExceptionHandled(context, excType, excObj, false);
 
-        return RubyBoolean.newBoolean(context, ret);
+        return asBoolean(context, ret);
     }
 
     // partially: vm_insnhelper.c - vm_check_match + check_match
@@ -1257,7 +1257,7 @@ public class IRRuntimeHelpers {
     public static RubyBoolean isBlockGiven(ThreadContext context, Object blk) {
         if (blk instanceof RubyProc) blk = ((RubyProc) blk).getBlock();
         if (blk instanceof RubyNil) blk = Block.NULL_BLOCK;
-        return RubyBoolean.newBoolean(context,  ((Block) blk).isGiven() );
+        return asBoolean(context,  ((Block) blk).isGiven() );
     }
 
     @JIT @Interp
@@ -2111,7 +2111,7 @@ public class IRRuntimeHelpers {
     }
 
     public static IRubyObject irNot(ThreadContext context, IRubyObject obj) {
-        return RubyBoolean.newBoolean(context, !(obj.isTrue()));
+        return asBoolean(context, !(obj.isTrue()));
     }
 
     @JIT
@@ -2179,7 +2179,7 @@ public class IRRuntimeHelpers {
             currScope = currScope.getEnclosingScope();
             i++;
         }
-        return context.runtime.newFixnum(i);
+        return asFixnum(context, i);
     }
 
     public static IRubyObject[] toAry(ThreadContext context, IRubyObject[] args) {

--- a/core/src/main/java/org/jruby/ir/targets/indy/FixnumObjectSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/FixnumObjectSite.java
@@ -9,6 +9,7 @@ import java.lang.invoke.CallSite;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.util.CodegenUtils.p;
 import static org.jruby.util.CodegenUtils.sig;
 
@@ -35,6 +36,6 @@ public class FixnumObjectSite extends LazyObjectSite {
     }
 
     public IRubyObject construct(ThreadContext context) {
-        return context.runtime.newFixnum(value);
+        return asFixnum(context, value);
     }
 }

--- a/core/src/main/java/org/jruby/ir/targets/indy/JavaBootstrap.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/JavaBootstrap.java
@@ -275,7 +275,7 @@ public class JavaBootstrap {
     }
 
     public static IRubyObject booleanOrNil(Ruby runtime, Boolean b) {
-        return b == null ? runtime.getNil() : RubyBoolean.newBoolean(runtime, b);
+        return b == null ? runtime.getNil() : runtime.newBoolean(b);
     }
 
     public static IRubyObject stringOrNil(Ruby runtime, CharSequence cs) {

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -18,8 +18,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ConvertBytes;
 import org.jruby.util.RubyStringBuilder;
 
-import static org.jruby.api.Convert.castAsFixnum;
-import static org.jruby.api.Convert.castAsRange;
+import static org.jruby.api.Convert.*;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.javasupport.ext.JavaLang.Character.inspectCharValue;
 import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
@@ -92,12 +91,12 @@ public final class ArrayJavaProxy extends JavaProxy {
 
     @JRubyMethod(name = {"length", "size"})
     public RubyFixnum length(ThreadContext context) {
-        return context.runtime.newFixnum( length() );
+        return asFixnum(context, length());
     }
 
     @JRubyMethod(name = "empty?")
     public RubyBoolean empty_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context,  length() == 0 );
+        return asBoolean(context,  length() == 0 );
     }
 
     @JRubyMethod(name = "[]")
@@ -129,30 +128,30 @@ public final class ArrayJavaProxy extends JavaProxy {
         if ( componentClass.isPrimitive() ) {
             switch (componentClass.getName().charAt(0)) {
                 case 'b':
-                    if (componentClass == byte.class) return RubyBoolean.newBoolean(context,  includes(context, (byte[]) array, obj) );
-                    else /* if (componentClass == boolean.class) */ return RubyBoolean.newBoolean(context,  includes(context, (boolean[]) array, obj) );
+                    if (componentClass == byte.class) return asBoolean(context,  includes(context, (byte[]) array, obj) );
+                    else /* if (componentClass == boolean.class) */ return asBoolean(context,  includes(context, (boolean[]) array, obj) );
                     // break;
                 case 's':
-                    /* if (componentClass == short.class) */ return RubyBoolean.newBoolean(context,  includes(context, (short[]) array, obj) );
+                    /* if (componentClass == short.class) */ return asBoolean(context,  includes(context, (short[]) array, obj) );
                     // break;
                 case 'c':
-                    /* if (componentClass == char.class) */ return RubyBoolean.newBoolean(context,  includes(context, (char[]) array, obj) );
+                    /* if (componentClass == char.class) */ return asBoolean(context,  includes(context, (char[]) array, obj) );
                     // break;
                 case 'i':
-                    /* if (componentClass == int.class) */ return RubyBoolean.newBoolean(context,  includes(context, (int[]) array, obj) );
+                    /* if (componentClass == int.class) */ return asBoolean(context,  includes(context, (int[]) array, obj) );
                     // break;
                 case 'l':
-                    /* if (componentClass == long.class) */ return RubyBoolean.newBoolean(context,  includes(context, (long[]) array, obj) );
+                    /* if (componentClass == long.class) */ return asBoolean(context,  includes(context, (long[]) array, obj) );
                     // break;
                 case 'f':
-                    /* if (componentClass == float.class) */ return RubyBoolean.newBoolean(context,  includes(context, (float[]) array, obj) );
+                    /* if (componentClass == float.class) */ return asBoolean(context,  includes(context, (float[]) array, obj) );
                     // break;
                 case 'd':
-                    /* if (componentClass == double.class) */ return RubyBoolean.newBoolean(context,  includes(context, (double[]) array, obj) );
+                    /* if (componentClass == double.class) */ return asBoolean(context,  includes(context, (double[]) array, obj) );
                     // break;
             }
         }
-        return RubyBoolean.newBoolean(context,  includes(context, (Object[]) array, obj) );
+        return asBoolean(context,  includes(context, (Object[]) array, obj) );
     }
 
     private boolean includes(final ThreadContext context, final Object[] array, final IRubyObject obj) {
@@ -268,9 +267,8 @@ public final class ArrayJavaProxy extends JavaProxy {
     private boolean includes(final ThreadContext context, final boolean[] array, final IRubyObject obj) {
         final int len = array.length;
         if ( len == 0 ) return false;
-        final Ruby runtime = context.runtime;
-        if ( obj instanceof RubyBoolean ) {
-            final boolean objVal = ((RubyBoolean) obj).isTrue();
+        if ( obj instanceof RubyBoolean bool) {
+            final boolean objVal = bool.isTrue();
 
             for ( int i = 0; i < len; i++ ) {
                 if ( objVal == array[i] ) return true;
@@ -278,7 +276,7 @@ public final class ArrayJavaProxy extends JavaProxy {
             return false;
         }
         for ( int i = 0; i < len; i++ ) {
-            IRubyObject value = RubyBoolean.newBoolean(runtime, array[i]);
+            IRubyObject value = asBoolean(context, array[i]);
             if ( equalInternal(context, value, obj) ) return true;
         }
         return false;
@@ -651,7 +649,7 @@ public final class ArrayJavaProxy extends JavaProxy {
     public RubyBoolean op_equal(ThreadContext context, IRubyObject other) {
         if ( other instanceof RubyArray ) {
             // we respond_to? to_ary thus shall handle [1].to_java == [1]
-            return RubyBoolean.newBoolean(context,  equalsRubyArray((RubyArray) other) );
+            return asBoolean(context,  equalsRubyArray((RubyArray) other) );
         }
         return eql_p(context, other);
     }
@@ -680,7 +678,7 @@ public final class ArrayJavaProxy extends JavaProxy {
         else if ( obj.getClass().isArray() ) {
             equals = arraysEquals(getObject(), obj);
         }
-        return RubyBoolean.newBoolean(context, equals);
+        return asBoolean(context, equals);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
@@ -57,6 +57,7 @@ import org.jruby.util.ByteList;
 import org.jruby.util.CodegenUtils;
 import org.jruby.util.JRubyObjectInputStream;
 
+import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.castAsModule;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.runtime.Helpers.arrayOf;
@@ -210,7 +211,7 @@ public class JavaProxy extends RubyObject {
 
     @JRubyMethod(name = "__persistent__", meta = true)
     public static IRubyObject persistent(final ThreadContext context, final IRubyObject clazz) {
-        return RubyBoolean.newBoolean(context, ((RubyClass) clazz).getRealClass().getCacheProxy());
+        return asBoolean(context, ((RubyClass) clazz).getRealClass().getCacheProxy());
     }
 
     @Override
@@ -364,11 +365,7 @@ public class JavaProxy extends RubyObject {
     @Override
     @JRubyMethod(name = "equal?")
     public IRubyObject equal_p(ThreadContext context, IRubyObject other) {
-        if ( other instanceof JavaProxy ) {
-            boolean equal = getObject() == ((JavaProxy) other).getObject();
-            return RubyBoolean.newBoolean(context, equal);
-        }
-        return context.fals;
+        return other instanceof JavaProxy proxy ? asBoolean(context, getObject() == proxy.getObject()) : context.fals;
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
@@ -54,6 +54,8 @@ import java.util.Set;
 import org.jruby.util.RubyStringBuilder;
 import org.jruby.util.TypeConverter;
 
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.util.Inspector.*;
 
 /**
@@ -112,7 +114,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
 
         @Override
         public RubyFixnum rb_size(ThreadContext context) {
-            return context.runtime.newFixnum( mapDelegate().size() );
+            return asFixnum(context, mapDelegate().size());
         }
 
         @Override
@@ -288,7 +290,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
         @Override
         public RubyBoolean compare_by_identity_p(ThreadContext context) {
             // NOTE: obviously little we can do to detect - but at least report Java built-in one :
-            return RubyBoolean.newBoolean(context, mapDelegate() instanceof java.util.IdentityHashMap );
+            return asBoolean(context, mapDelegate() instanceof java.util.IdentityHashMap );
         }
 
         @Override

--- a/core/src/main/java/org/jruby/javasupport/JavaField.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaField.java
@@ -46,6 +46,8 @@ import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asString;
 import static org.jruby.api.Error.typeError;
 
 @Deprecated
@@ -75,22 +77,22 @@ public class JavaField {
 
     @JRubyMethod(name = "public?")
     public RubyBoolean public_p(ThreadContext context) {
-        return context.runtime.newBoolean(Modifier.isPublic(field.getModifiers()));
+        return asBoolean(context, Modifier.isPublic(field.getModifiers()));
     }
 
     @JRubyMethod(name = "static?")
     public RubyBoolean static_p(ThreadContext context) {
-        return context.runtime.newBoolean(Modifier.isStatic(field.getModifiers()));
+        return asBoolean(context, Modifier.isStatic(field.getModifiers()));
     }
 
     @JRubyMethod(name = "enum_constant?")
     public RubyBoolean enum_constant_p(ThreadContext context) {
-        return context.runtime.newBoolean(field.isEnumConstant());
+        return asBoolean(context, field.isEnumConstant());
     }
 
     @JRubyMethod
     public RubyString to_generic_string(ThreadContext context) {
-        return context.runtime.newString(field.toGenericString());
+        return asString(context, field.toGenericString());
     }
 
     @JRubyMethod(name = "type")
@@ -128,7 +130,7 @@ public class JavaField {
 
     @JRubyMethod(name = "final?")
     public RubyBoolean final_p(ThreadContext context) {
-        return context.runtime.newBoolean(Modifier.isFinal(field.getModifiers()));
+        return asBoolean(context, Modifier.isFinal(field.getModifiers()));
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/javasupport/JavaObject.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaObject.java
@@ -56,6 +56,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 import org.jruby.util.JRubyObjectInputStream;
 
+import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.javasupport.JavaUtil.unwrapJava;
 
@@ -192,18 +193,19 @@ public class JavaObject extends RubyObject {
     }
 
     @JRubyMethod(name = "equal?")
-    public IRubyObject same(final IRubyObject other) {
-        final Ruby runtime = getRuntime();
+    public IRubyObject same(ThreadContext context, final IRubyObject other) {
         final Object thisValue = getValue();
         final Object otherValue = unwrapJava(other, NEVER);
 
-        if ( otherValue == NEVER ) { // not a wrapped object
-            return runtime.getFalse();
-        }
+        if (otherValue == NEVER) return context.fals; // not a wrapped object
+        if (!(other instanceof JavaObject)) return context.fals;
 
-        if ( ! (other instanceof JavaObject) ) return runtime.getFalse();
+        return asBoolean(context, thisValue == otherValue);
+    }
 
-        return runtime.newBoolean(thisValue == otherValue);
+    @Deprecated
+    public IRubyObject same(final IRubyObject other) {
+        return same(getCurrentContext(), other);
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/javasupport/JavaPackage.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaPackage.java
@@ -46,6 +46,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ClassProvider;
 import org.jruby.util.TypeConverter;
 
+import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.runtime.Visibility.PRIVATE;
 
 /**
@@ -118,7 +119,7 @@ public class JavaPackage extends RubyModule {
     @JRubyMethod(name = "===")
     public RubyBoolean op_eqq(ThreadContext context, IRubyObject obj) {
         // maybe we could handle java.lang === java.lang.reflect as well ?
-        return RubyBoolean.newBoolean(context, obj == this || isInstance(obj));
+        return asBoolean(context, obj == this || isInstance(obj));
     }
 
     @JRubyMethod(name = "const_missing")
@@ -215,8 +216,8 @@ public class JavaPackage extends RubyModule {
         */
 
         //if ( ! (mname instanceof RubySymbol) ) mname = context.runtime.newSymbol(name);
-        //IRubyObject respond = Helpers.invoke(context, this, "respond_to_missing?", mname, RubyBoolean.newBoolean(context, includePrivate));
-        //return RubyBoolean.newBoolean(context, respond.isTrue());
+        //IRubyObject respond = Helpers.invoke(context, this, "respond_to_missing?", mname, asBoolean(context, includePrivate));
+        //return asBoolean(context, respond.isTrue());
 
         return context.nil; // NOTE: this is wrong - should be true but compatibility first, for now
     }
@@ -244,7 +245,7 @@ public class JavaPackage extends RubyModule {
     }
 
     private RubyBoolean respond_to_missing(final ThreadContext context, IRubyObject mname, final boolean includePrivate) {
-        return RubyBoolean.newBoolean(context, BlankSlateWrapper.handlesMethod(TypeConverter.checkID(mname).idString()) == null);
+        return asBoolean(context, BlankSlateWrapper.handlesMethod(TypeConverter.checkID(mname).idString()) == null);
     }
 
     @JRubyMethod(name = "method_missing")
@@ -283,14 +284,14 @@ public class JavaPackage extends RubyModule {
 
     @JRubyMethod(name = "available?")
     public IRubyObject available_p(ThreadContext context) {
-        return RubyBoolean.newBoolean(context, isAvailable());
+        return asBoolean(context, isAvailable());
     }
 
     @JRubyMethod(name = "sealed?")
     public IRubyObject sealed_p(ThreadContext context) {
         final Package pkg = getPackage();
         if ( pkg == null ) return context.nil;
-        return RubyBoolean.newBoolean(context, pkg.isSealed());
+        return asBoolean(context, pkg.isSealed());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/javasupport/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtil.java
@@ -672,13 +672,13 @@ public class JavaUtil {
     public static final JavaConverter JAVA_BOOLEAN_CONVERTER = new JavaConverter(Boolean.class) {
         public IRubyObject convert(Ruby runtime, Object object) {
             if (object == null) return runtime.getNil();
-            return RubyBoolean.newBoolean(runtime, ((Boolean)object).booleanValue());
+            return runtime.newBoolean(((Boolean)object).booleanValue());
         }
         public IRubyObject get(Ruby runtime, Object array, int i) {
             return convert(runtime, ((Boolean[]) array)[i]);
         }
         public void set(Ruby runtime, Object array, int i, IRubyObject value) {
-            ((Boolean[])array)[i] = (Boolean)value.toJava(Boolean.class);
+            ((Boolean[])array)[i] = value.toJava(Boolean.class);
         }
     };
 
@@ -776,13 +776,13 @@ public class JavaUtil {
     public static final JavaConverter JAVA_BOOLEANPRIM_CONVERTER = new JavaConverter(boolean.class) {
         public IRubyObject convert(Ruby runtime, Object object) {
             if (object == null) return runtime.getNil();
-            return RubyBoolean.newBoolean(runtime, ((Boolean)object).booleanValue());
+            return runtime.newBoolean(((Boolean)object).booleanValue());
         }
         public IRubyObject get(Ruby runtime, Object array, int i) {
-            return RubyBoolean.newBoolean(runtime, ((boolean[])array)[i]);
+            return runtime.newBoolean(((boolean[])array)[i]);
         }
         public void set(Ruby runtime, Object array, int i, IRubyObject value) {
-            ((boolean[])array)[i] = (Boolean)value.toJava(boolean.class);
+            ((boolean[])array)[i] = value.toJava(boolean.class);
         }
     };
 

--- a/core/src/main/java/org/jruby/javasupport/JavaUtilities.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtilities.java
@@ -11,6 +11,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.StringSupport;
 
 import static org.jruby.anno.FrameField.*;
+import static org.jruby.api.Convert.asBoolean;
 
 @JRubyModule(name = "JavaUtilities")
 public class JavaUtilities {
@@ -66,8 +67,7 @@ public class JavaUtilities {
 
     @JRubyMethod(name = "valid_java_identifier?", meta = true)
     public static IRubyObject valid_java_identifier_p(ThreadContext context, IRubyObject recv, IRubyObject name) {
-        final String javaName = name.convertToString().decodeString();
-        return RubyBoolean.newBoolean(context, validJavaIdentifier(javaName));
+        return asBoolean(context, validJavaIdentifier(name.convertToString().decodeString()));
     }
 
     public static boolean validJavaIdentifier(final String javaName) {

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -56,7 +56,8 @@ import java.lang.reflect.Modifier;
 
 import static org.jruby.RubyEnumerator.enumeratorize;
 import static org.jruby.RubyModule.undefinedMethodMessage;
-import static org.jruby.api.Convert.castAsInteger;
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.javasupport.JavaUtil.convertJavaToUsableRubyObject;
 import static org.jruby.javasupport.JavaUtil.isJavaObject;
@@ -128,7 +129,7 @@ public abstract class JavaLang {
             java.util.Iterator iterator = iterable.iterator();
             final boolean twoArguments = block.getSignature().isTwoArguments();
             int i = 0; while ( iterator.hasNext() ) {
-                final RubyInteger index = RubyFixnum.newFixnum(runtime, i++);
+                final RubyInteger index = asFixnum(context, i++);
                 final Object value = iterator.next();
                 final IRubyObject rValue = convertJavaToUsableRubyObject(runtime, value);
 
@@ -156,38 +157,36 @@ public abstract class JavaLang {
 
         @JRubyMethod(name = "count") // @override Enumerable#count
         public static IRubyObject count(final ThreadContext context, final IRubyObject self, final Block block) {
-            final Ruby runtime = context.runtime;
             java.lang.Iterable iterable = unwrapIfJavaObject(self);
-            if ( block.isGiven() ) {
-                return countBlock(context, iterable.iterator(), block);
-            }
+            if (block.isGiven()) return countBlock(context, iterable.iterator(), block);
+
             if ( iterable instanceof java.util.Collection ) {
-                return RubyFixnum.newFixnum(runtime, ((java.util.Collection) iterable).size());
+                return asFixnum(context, ((java.util.Collection) iterable).size());
             }
             int count = 0;
             for( java.util.Iterator it = iterable.iterator(); it.hasNext(); ) { it.next(); count++; }
-            return RubyFixnum.newFixnum(runtime, count);
+            return asFixnum(context, count);
         }
 
         static RubyFixnum countBlock(final ThreadContext context, final java.util.Iterator it, final Block block) {
-            final Ruby runtime = context.runtime;
-            int count = 0; while ( it.hasNext() ) {
-                IRubyObject next = convertJavaToUsableRubyObject( runtime, it.next() );
+            int count = 0;
+            while ( it.hasNext() ) {
+                IRubyObject next = convertJavaToUsableRubyObject(context.runtime, it.next());
                 if ( block.yield( context, next ).isTrue() ) count++;
             }
-            return RubyFixnum.newFixnum(runtime, count);
+            return asFixnum(context, count);
         }
 
         @JRubyMethod(name = "count") // @override Enumerable#count
         public static IRubyObject count(final ThreadContext context, final IRubyObject self, final IRubyObject obj, final Block unused) {
             // unused block due DescriptorInfo not (yet) supporting if a method receives block and an override doesn't
-            final Ruby runtime = context.runtime;
             java.lang.Iterable iterable = unwrapIfJavaObject(self);
-            int count = 0; for ( java.util.Iterator it = iterable.iterator(); it.hasNext(); ) {
-                IRubyObject next = convertJavaToUsableRubyObject( runtime, it.next() );
+            int count = 0;
+            for ( java.util.Iterator it = iterable.iterator(); it.hasNext(); ) {
+                IRubyObject next = convertJavaToUsableRubyObject(context.runtime, it.next() );
                 if ( RubyObject.equalInternal(context, next, obj) ) count++;
             }
-            return RubyFixnum.newFixnum(runtime, count);
+            return asFixnum(context, count);
         }
 
     }
@@ -209,7 +208,7 @@ public abstract class JavaLang {
             final java.lang.Object otherComp = unwrapIfJavaObject(other);
 
             try {
-                return RubyFixnum.newFixnum(context.runtime, comparable.compareTo(otherComp));
+                return asFixnum(context, comparable.compareTo(otherComp));
             } catch (ClassCastException ex) {
                 throw typeError(context, ex.getMessage());
             }
@@ -382,39 +381,37 @@ public abstract class JavaLang {
 
         @JRubyMethod(name = "to_f")
         public static IRubyObject to_f(final ThreadContext context, final IRubyObject self) {
-            java.lang.Number val = (java.lang.Number) self.toJava(java.lang.Number.class);
+            java.lang.Number val = self.toJava(java.lang.Number.class);
             return context.runtime.newFloat(val.doubleValue());
         }
 
         @JRubyMethod(name = "real?")
         public static IRubyObject real_p(final ThreadContext context, final IRubyObject self) {
-            java.lang.Number val = (java.lang.Number) self.toJava(java.lang.Number.class);
-            return RubyBoolean.newBoolean(context, val instanceof Integer || val instanceof Long ||
-                                                    val instanceof Short || val instanceof Byte ||
-                                                    val instanceof Float || val instanceof Double ||
-                                                    val instanceof java.math.BigInteger || val instanceof java.math.BigDecimal);
+            java.lang.Number val = self.toJava(java.lang.Number.class);
+            return asBoolean(context, val instanceof Integer || val instanceof Long || val instanceof Short ||
+                    val instanceof Byte || val instanceof Float || val instanceof Double ||
+                    val instanceof java.math.BigInteger || val instanceof java.math.BigDecimal);
         }
 
         @JRubyMethod(name = { "to_i", "to_int" })
         public static IRubyObject to_i(final ThreadContext context, final IRubyObject self) {
-            java.lang.Number val = (java.lang.Number) self.toJava(java.lang.Number.class);
-            if (val instanceof java.math.BigInteger) { // NOTE: should be moved into its own?
-                return RubyBignum.newBignum(context.runtime, (java.math.BigInteger) val);
+            java.lang.Number val = self.toJava(java.lang.Number.class);
+            if (val instanceof java.math.BigInteger bigint) { // NOTE: should be moved into its own?
+                return RubyBignum.newBignum(context.runtime, bigint);
             }
-            return context.runtime.newFixnum(val.longValue());
+            return asFixnum(context, val.longValue());
         }
 
         @JRubyMethod(name = "integer?")
         public static IRubyObject integer_p(final ThreadContext context, final IRubyObject self) {
-            java.lang.Number val = (java.lang.Number) self.toJava(java.lang.Number.class);
-            return RubyBoolean.newBoolean(context, val instanceof Integer || val instanceof Long ||
-                                                    val instanceof Short || val instanceof Byte ||
-                                                    val instanceof java.math.BigInteger);
+            java.lang.Number val = self.toJava(java.lang.Number.class);
+            return asBoolean(context, val instanceof Integer || val instanceof Long ||
+                    val instanceof Short || val instanceof Byte || val instanceof java.math.BigInteger);
         }
 
         @JRubyMethod(name = "zero?")
         public static IRubyObject zero_p(final ThreadContext context, final IRubyObject self) {
-            return RubyBoolean.newBoolean(context, isZero(self));
+            return asBoolean(context, isZero(self));
         }
 
         private static boolean isZero(final IRubyObject self) {
@@ -456,13 +453,13 @@ public abstract class JavaLang {
         @JRubyMethod(name = "java_identifier_start?", meta = true)
         public static IRubyObject java_identifier_start_p(final ThreadContext context, final IRubyObject self,
                                                           final IRubyObject num) {
-            return RubyBoolean.newBoolean(context,  java.lang.Character.isJavaIdentifierStart(int_char(num)) );
+            return asBoolean(context, java.lang.Character.isJavaIdentifierStart(int_char(num)));
         }
 
         @JRubyMethod(name = "java_identifier_part?", meta = true)
         public static IRubyObject java_identifier_part_p(final ThreadContext context, final IRubyObject self,
                                                          final IRubyObject num) {
-            return RubyBoolean.newBoolean(context,  java.lang.Character.isJavaIdentifierPart(int_char(num)) );
+            return asBoolean(context, java.lang.Character.isJavaIdentifierPart(int_char(num)));
         }
 
         private static int int_char(IRubyObject num) { // str.ord -> Fixnum
@@ -471,13 +468,13 @@ public abstract class JavaLang {
 
         @JRubyMethod(name = "to_i")
         public static IRubyObject to_i(final ThreadContext context, final IRubyObject self) {
-            java.lang.Character c = (java.lang.Character) self.toJava(java.lang.Character.class);
-            return context.runtime.newFixnum(c);
+            java.lang.Character c = self.toJava(java.lang.Character.class);
+            return asFixnum(context, c);
         }
 
         @JRubyMethod(name = "inspect")
         public static IRubyObject inspect(final ThreadContext context, final IRubyObject self) {
-            java.lang.Character c = (java.lang.Character) self.toJava(java.lang.Character.class);
+            java.lang.Character c = self.toJava(java.lang.Character.class);
             return RubyString.newString(context.runtime, inspectCharValue(new java.lang.StringBuilder(3), c));
         }
 
@@ -545,13 +542,13 @@ public abstract class JavaLang {
         @JRubyMethod(name = "annotations?")
         public static IRubyObject annotations_p(final ThreadContext context, final IRubyObject self) {
             final java.lang.Class klass = unwrapJavaObject(self);
-            return RubyBoolean.newBoolean(context, klass.getAnnotations().length > 0);
+            return asBoolean(context, klass.getAnnotations().length > 0);
         }
 
         @JRubyMethod(name = "declared_annotations?")
         public static IRubyObject declared_annotations_p(final ThreadContext context, final IRubyObject self) {
             final java.lang.Class klass = unwrapJavaObject(self);
-            return RubyBoolean.newBoolean(context, klass.getDeclaredAnnotations().length > 0);
+            return asBoolean(context, klass.getDeclaredAnnotations().length > 0);
         }
 
         @JRubyMethod
@@ -596,65 +593,94 @@ public abstract class JavaLang {
 
         @JRubyMethod(name = "<=>") // Ruby Comparable
         public static IRubyObject cmp(final ThreadContext context, final IRubyObject self, final IRubyObject other) {
-            final java.lang.Class that;
-            if ( isJavaObject(other) ) {
-                that = unwrapJavaObject(other);
-            }
-            else {
-                return context.nil;
-            }
-
+            if (!isJavaObject(other)) return context.nil;
+            final java.lang.Class that = unwrapJavaObject(other);
             final java.lang.Class thiz = unwrapJavaObject(self);
 
-            if ( thiz == that ) return context.runtime.newFixnum(0);
-            if ( thiz.isAssignableFrom(that) ) return context.runtime.newFixnum(+1);
-            if ( that.isAssignableFrom(thiz) ) return context.runtime.newFixnum(-1);
+            if (thiz == that) return asFixnum(context, 0);
+            if (thiz.isAssignableFrom(that)) asFixnum(context, +1);
+            if (that.isAssignableFrom(thiz)) asFixnum(context, -1);
 
             return context.nil;
         }
 
         @JRubyMethod(name = "anonymous?")
-        public static IRubyObject anonymous_p(final IRubyObject self) {
+        public static IRubyObject anonymous_p(ThreadContext context, final IRubyObject self) {
             final java.lang.Class klass = unwrapJavaObject(self);
-            return self.getRuntime().newBoolean( klass.isAnonymousClass() );
+            return asBoolean(context, klass.isAnonymousClass());
+        }
+
+        @Deprecated
+        public static IRubyObject anonymous_p(final IRubyObject self) {
+            return anonymous_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         @JRubyMethod(name = "abstract?")
-        public static IRubyObject abstract_p(final IRubyObject self) {
+        public static IRubyObject abstract_p(ThreadContext context, final IRubyObject self) {
             final java.lang.Class klass = unwrapJavaObject(self);
-            return JavaLangReflect.isAbstract( self, klass.getModifiers() );
+            return JavaLangReflect.isAbstract(context, self, klass.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject abstract_p(final IRubyObject self) {
+            return abstract_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         // JavaUtilities::ModifiedShortcuts :
 
         @JRubyMethod(name = "public?")
-        public static IRubyObject public_p(final IRubyObject self) {
+        public static IRubyObject public_p(ThreadContext context, final IRubyObject self) {
             final java.lang.Class klass = unwrapJavaObject(self);
-            return JavaLangReflect.isPublic( self, klass.getModifiers() );
+            return JavaLangReflect.isPublic(context, self, klass.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject public_p(final IRubyObject self) {
+            return public_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         @JRubyMethod(name = "protected?")
-        public static IRubyObject protected_p(final IRubyObject self) {
+        public static IRubyObject protected_p(ThreadContext context, final IRubyObject self) {
             final java.lang.Class klass = unwrapJavaObject(self);
-            return JavaLangReflect.isProtected(self, klass.getModifiers());
+            return JavaLangReflect.isProtected(context, self, klass.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject protected_p(final IRubyObject self) {
+            return protected_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         @JRubyMethod(name = "private?")
-        public static IRubyObject private_p(final IRubyObject self) {
+        public static IRubyObject private_p(ThreadContext context, final IRubyObject self) {
             final java.lang.Class klass = unwrapJavaObject(self);
-            return JavaLangReflect.isPrivate(self, klass.getModifiers());
+            return JavaLangReflect.isPrivate(context, self, klass.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject private_p(final IRubyObject self) {
+            return private_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         @JRubyMethod(name = "final?")
-        public static IRubyObject final_p(final IRubyObject self) {
+        public static IRubyObject final_p(ThreadContext context, final IRubyObject self) {
             final java.lang.Class klass = unwrapJavaObject(self);
-            return JavaLangReflect.isFinal(self, klass.getModifiers());
+            return JavaLangReflect.isFinal(context, self, klass.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject final_p(final IRubyObject self) {
+            return final_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         @JRubyMethod(name = "static?")
-        public static IRubyObject static_p(final IRubyObject self) {
+        public static IRubyObject static_p(ThreadContext context, final IRubyObject self) {
             final java.lang.Class klass = unwrapJavaObject(self);
-            return JavaLangReflect.isStatic(self, klass.getModifiers());
+            return JavaLangReflect.isStatic(context, self, klass.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject static_p(final IRubyObject self) {
+            return static_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         // JavaClass facade (compatibility) :
@@ -942,7 +968,7 @@ public abstract class JavaLang {
             final RubyInteger val = (RubyInteger) self.callMethod(context, "[]", idx);
             int byte_val = val.getIntValue();
             if ( byte_val >= 0 ) return val;
-            return RubyFixnum.newFixnum(context.runtime, byte_val + 256); // byte += 256 if byte < 0
+            return asFixnum(context, byte_val + 256); // byte += 256 if byte < 0
         }
     }
 
@@ -956,7 +982,7 @@ public abstract class JavaLang {
         public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, java.lang.String name, IRubyObject idx, IRubyObject val) {
             int byte_val = ((RubyInteger) val).getIntValue();
             if ( byte_val > 127 ) {
-                val = RubyFixnum.newFixnum(context.runtime, byte_val - 256); // value -= 256 if value > 127
+                val = asFixnum(context, byte_val - 256); // value -= 256 if value > 127
             }
             return self.callMethod(context, "[]=", new IRubyObject[] { idx, val });
         }

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLangReflect.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLangReflect.java
@@ -40,6 +40,7 @@ import org.jruby.util.RubyStringBuilder;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 
+import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.javasupport.JavaUtil.convertArguments;
 import static org.jruby.javasupport.JavaUtil.convertJavaToUsableRubyObject;
 import static org.jruby.util.Inspector.GT;
@@ -120,33 +121,58 @@ public abstract class JavaLangReflect {
         // JavaUtilities::ModifiedShortcuts :
 
         @JRubyMethod(name = "public?")
-        public static IRubyObject public_p(final IRubyObject self) {
+        public static IRubyObject public_p(ThreadContext context, final IRubyObject self) {
             final java.lang.reflect.Constructor thiz = JavaUtil.unwrapJavaObject(self);
-            return isPublic(self, thiz.getModifiers());
+            return isPublic(context, self, thiz.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject public_p(final IRubyObject self) {
+            return public_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         @JRubyMethod(name = "protected?")
-        public static IRubyObject protected_p(final IRubyObject self) {
+        public static IRubyObject protected_p(ThreadContext context, final IRubyObject self) {
             final java.lang.reflect.Constructor thiz = JavaUtil.unwrapJavaObject(self);
-            return isProtected(self, thiz.getModifiers());
+            return isProtected(context, self, thiz.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject protected_p(final IRubyObject self) {
+            return protected_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         @JRubyMethod(name = "private?")
-        public static IRubyObject private_p(final IRubyObject self) {
+        public static IRubyObject private_p(ThreadContext context, final IRubyObject self) {
             final java.lang.reflect.Constructor thiz = JavaUtil.unwrapJavaObject(self);
-            return isPrivate(self, thiz.getModifiers());
+            return isPrivate(context, self, thiz.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject private_p(final IRubyObject self) {
+            return private_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         @JRubyMethod(name = "final?")
-        public static IRubyObject final_p(final IRubyObject self) {
+        public static IRubyObject final_p(ThreadContext context, final IRubyObject self) {
             final java.lang.reflect.Constructor thiz = JavaUtil.unwrapJavaObject(self);
-            return isFinal(self, thiz.getModifiers());
+            return isFinal(context, self, thiz.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject final_p(final IRubyObject self) {
+            return final_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         @JRubyMethod(name = "static?")
-        public static IRubyObject static_p(final IRubyObject self) {
+        public static IRubyObject static_p(ThreadContext context, final IRubyObject self) {
             final java.lang.reflect.Constructor thiz = JavaUtil.unwrapJavaObject(self);
-            return isStatic(self, thiz.getModifiers());
+            return isStatic(context, self, thiz.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject static_p(final IRubyObject self) {
+            return static_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
     }
@@ -209,41 +235,70 @@ public abstract class JavaLangReflect {
         //
 
         @JRubyMethod(name = "abstract?")
-        public static IRubyObject abstract_p(final IRubyObject self) {
+        public static IRubyObject abstract_p(ThreadContext context, final IRubyObject self) {
             final java.lang.reflect.Field thiz = JavaUtil.unwrapJavaObject(self);
-            return isAbstract(self, thiz.getModifiers());
+            return isAbstract(context, self, thiz.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject abstract_p(final IRubyObject self) {
+            return abstract_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         // JavaUtilities::ModifiedShortcuts :
 
         @JRubyMethod(name = "public?")
-        public static IRubyObject public_p(final IRubyObject self) {
+        public static IRubyObject public_p(ThreadContext context, final IRubyObject self) {
             final java.lang.reflect.Method thiz = JavaUtil.unwrapJavaObject(self);
-            return isPublic(self, thiz.getModifiers());
+            return isPublic(context, self, thiz.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject public_p(final IRubyObject self) {
+            return public_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         @JRubyMethod(name = "protected?")
-        public static IRubyObject protected_p(final IRubyObject self) {
+        public static IRubyObject protected_p(ThreadContext context, final IRubyObject self) {
             final java.lang.reflect.Method thiz = JavaUtil.unwrapJavaObject(self);
-            return isProtected(self, thiz.getModifiers());
+            return isProtected(context, self, thiz.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject protected_p(final IRubyObject self) {
+            return protected_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         @JRubyMethod(name = "private?")
-        public static IRubyObject private_p(final IRubyObject self) {
+        public static IRubyObject private_p(ThreadContext context, final IRubyObject self) {
             final java.lang.reflect.Method thiz = JavaUtil.unwrapJavaObject(self);
-            return isPrivate(self, thiz.getModifiers());
+            return isPrivate(context, self, thiz.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject private_p(final IRubyObject self) {
+            return private_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         @JRubyMethod(name = "final?")
-        public static IRubyObject final_p(final IRubyObject self) {
+        public static IRubyObject final_p(ThreadContext context, final IRubyObject self) {
             final java.lang.reflect.Method thiz = JavaUtil.unwrapJavaObject(self);
-            return isFinal(self, thiz.getModifiers());
+            return isFinal(context, self, thiz.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject final_p(final IRubyObject self) {
+            return final_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         @JRubyMethod(name = "static?")
-        public static IRubyObject static_p(final IRubyObject self) {
+        public static IRubyObject static_p(ThreadContext context, final IRubyObject self) {
             final java.lang.reflect.Method thiz = JavaUtil.unwrapJavaObject(self);
-            return isStatic(self, thiz.getModifiers());
+            return isStatic(context, self, thiz.getModifiers());
+        }
+
+        public static IRubyObject static_p(final IRubyObject self) {
+            return static_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
     }
@@ -318,33 +373,59 @@ public abstract class JavaLangReflect {
         // JavaUtilities::ModifiedShortcuts :
 
         @JRubyMethod(name = "public?")
-        public static IRubyObject public_p(final IRubyObject self) {
+        public static IRubyObject public_p(ThreadContext context, final IRubyObject self) {
             final java.lang.reflect.Field thiz = JavaUtil.unwrapJavaObject(self);
-            return isPublic(self, thiz.getModifiers());
+            return isPublic(context, self, thiz.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject public_p(final IRubyObject self) {
+            return public_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         @JRubyMethod(name = "protected?")
-        public static IRubyObject protected_p(final IRubyObject self) {
+        public static IRubyObject protected_p(ThreadContext context, final IRubyObject self) {
             final java.lang.reflect.Field thiz = JavaUtil.unwrapJavaObject(self);
-            return isProtected(self, thiz.getModifiers());
+            return isProtected(context, self, thiz.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject protected_p(final IRubyObject self) {
+            return protected_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         @JRubyMethod(name = "private?")
-        public static IRubyObject private_p(final IRubyObject self) {
+        public static IRubyObject private_p(ThreadContext context, final IRubyObject self) {
             final java.lang.reflect.Field thiz = JavaUtil.unwrapJavaObject(self);
-            return isPrivate(self, thiz.getModifiers());
+            return isPrivate(context, self, thiz.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject private_p(final IRubyObject self) {
+            return private_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         @JRubyMethod(name = "final?")
-        public static IRubyObject final_p(final IRubyObject self) {
+        public static IRubyObject final_p(ThreadContext context, final IRubyObject self) {
             final java.lang.reflect.Field thiz = JavaUtil.unwrapJavaObject(self);
-            return isFinal(self, thiz.getModifiers());
+            return isFinal(context, self, thiz.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject final_p(final IRubyObject self) {
+
+            return final_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         @JRubyMethod(name = "static?")
-        public static IRubyObject static_p(final IRubyObject self) {
+        public static IRubyObject static_p(ThreadContext context, final IRubyObject self) {
             final java.lang.reflect.Field thiz = JavaUtil.unwrapJavaObject(self);
-            return isStatic(self, thiz.getModifiers());
+            return isStatic(context, self, thiz.getModifiers());
+        }
+
+        @Deprecated
+        public static IRubyObject static_p(final IRubyObject self) {
+            return static_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
     }
@@ -360,28 +441,28 @@ public abstract class JavaLangReflect {
         return value.toJava(field.getType());
     }
 
-    static RubyBoolean isAbstract(final IRubyObject self, final int mod) {
-        return self.getRuntime().newBoolean(java.lang.reflect.Modifier.isAbstract(mod));
+    static RubyBoolean isAbstract(ThreadContext context, final IRubyObject self, final int mod) {
+        return asBoolean(context, java.lang.reflect.Modifier.isAbstract(mod));
     }
 
-    static RubyBoolean isPublic(final IRubyObject self, final int mod) {
-        return self.getRuntime().newBoolean(java.lang.reflect.Modifier.isPublic(mod));
+    static RubyBoolean isPublic(ThreadContext context, final IRubyObject self, final int mod) {
+        return asBoolean(context, java.lang.reflect.Modifier.isPublic(mod));
     }
 
-    static RubyBoolean isProtected(final IRubyObject self, final int mod) {
-        return self.getRuntime().newBoolean(java.lang.reflect.Modifier.isProtected(mod));
+    static RubyBoolean isProtected(ThreadContext context, final IRubyObject self, final int mod) {
+        return asBoolean(context, java.lang.reflect.Modifier.isProtected(mod));
     }
 
-    static RubyBoolean isPrivate(final IRubyObject self, final int mod) {
-        return self.getRuntime().newBoolean(java.lang.reflect.Modifier.isPrivate(mod));
+    static RubyBoolean isPrivate(ThreadContext context, final IRubyObject self, final int mod) {
+        return asBoolean(context, java.lang.reflect.Modifier.isPrivate(mod));
     }
 
-    static RubyBoolean isFinal(final IRubyObject self, final int mod) {
-        return self.getRuntime().newBoolean(java.lang.reflect.Modifier.isFinal(mod));
+    static RubyBoolean isFinal(ThreadContext context, final IRubyObject self, final int mod) {
+        return asBoolean(context, java.lang.reflect.Modifier.isFinal(mod));
     }
 
-    static RubyBoolean isStatic(final IRubyObject self, final int mod) {
-        return self.getRuntime().newBoolean(java.lang.reflect.Modifier.isStatic(mod));
+    static RubyBoolean isStatic(ThreadContext context, final IRubyObject self, final int mod) {
+        return asBoolean(context, java.lang.reflect.Modifier.isStatic(mod));
     }
 
 }

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaNio.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaNio.java
@@ -39,6 +39,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.RubyStringBuilder;
 
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.javasupport.JavaUtil.unwrapIfJavaObject;
 import static org.jruby.runtime.Visibility.PUBLIC;
 import static org.jruby.util.Inspector.GT;
@@ -70,7 +71,7 @@ public abstract class JavaNio {
         @JRubyMethod(name = {"length", "size"})
         public static IRubyObject length(final ThreadContext context, final IRubyObject self) {
             java.nio.Buffer obj = self.toJava(java.nio.Buffer.class);
-            return context.runtime.newFixnum(obj.remaining()); // limit - position
+            return asFixnum(context, obj.remaining()); // limit - position
         }
 
     }

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
@@ -45,6 +45,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
 import static org.jruby.RubyEnumerator.enumeratorize;
+import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.javasupport.JavaUtil.convertJavaArrayToRuby;
 import static org.jruby.javasupport.JavaUtil.convertJavaToUsableRubyObject;
 import static org.jruby.javasupport.JavaUtil.inspectObject;
@@ -146,7 +147,7 @@ public abstract class JavaUtil {
         @JRubyMethod(name = { "include?", "member?" }) // @override Enumerable#include?
         public static RubyBoolean include_p(final ThreadContext context, final IRubyObject self, final IRubyObject obj) {
             final java.util.Collection coll = unwrapIfJavaObject(self);
-            return RubyBoolean.newBoolean(context,  coll.contains( obj.toJava(java.lang.Object.class) ) );
+            return asBoolean(context, coll.contains(obj.toJava(java.lang.Object.class)));
         }
 
         // NOTE: first might conflict with some Java types (e.g. java.util.Deque) thus providing a ruby_ alias

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaUtilRegex.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaUtilRegex.java
@@ -35,6 +35,8 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.RubyStringBuilder;
 
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.javasupport.JavaUtil.convertJavaToUsableRubyObject;
 import static org.jruby.javasupport.JavaUtil.unwrapJavaObject;
 import static org.jruby.util.Inspector.*;
@@ -62,7 +64,7 @@ public abstract class JavaUtilRegex {
         @JRubyMethod(name = "=~")
         public static IRubyObject op_match(final ThreadContext context, final IRubyObject self, IRubyObject str) {
             final java.util.regex.Matcher matcher = matcher(self, str);
-            return matcher.find() ? context.runtime.newFixnum(matcher.start()) : context.nil;
+            return matcher.find() ? asFixnum(context, matcher.start()) : context.nil;
         }
 
         @JRubyMethod(name = "match")
@@ -76,14 +78,13 @@ public abstract class JavaUtilRegex {
 
         @JRubyMethod(name = "===")
         public static IRubyObject eqq(final ThreadContext context, final IRubyObject self, IRubyObject str) {
-            return RubyBoolean.newBoolean(context,  matcher(self, str).find() );
+            return asBoolean(context,  matcher(self, str).find() );
         }
 
         @JRubyMethod(name = "casefold?")
         public static IRubyObject casefold_p(final ThreadContext context, final IRubyObject self) {
             final java.util.regex.Pattern regex = unwrapJavaObject(self);
-            boolean i = ( regex.flags() & java.util.regex.Pattern.CASE_INSENSITIVE ) != 0;
-            return RubyBoolean.newBoolean(context, i);
+            return asBoolean(context, (regex.flags() & java.util.regex.Pattern.CASE_INSENSITIVE) != 0);
         }
 
         @JRubyMethod(name = "inspect")
@@ -123,35 +124,34 @@ public abstract class JavaUtilRegex {
         @JRubyMethod
         public static IRubyObject begin(final ThreadContext context, final IRubyObject self, final IRubyObject idx) {
             final java.util.regex.Matcher matcher = unwrapJavaObject(self);
-            if ( idx instanceof RubySymbol ) {
-                return context.runtime.newFixnum( matcher.start(idx.toString()) );
-            }
+            if (idx instanceof RubySymbol) return asFixnum(context, matcher.start(idx.toString()));
+
             final int group = idx.convertToInteger().getIntValue();
-            return context.runtime.newFixnum( matcher.start(group) );
+            return asFixnum(context, matcher.start(group));
         }
 
         @JRubyMethod
         public static IRubyObject end(final ThreadContext context, final IRubyObject self, final IRubyObject idx) {
             final java.util.regex.Matcher matcher = unwrapJavaObject(self);
-            if ( idx instanceof RubySymbol ) {
-                return context.runtime.newFixnum( matcher.end(idx.toString()) );
-            }
+            if (idx instanceof RubySymbol) return asFixnum(context, matcher.end(idx.toString()));
+
             final int group = idx.convertToInteger().getIntValue();
-            return context.runtime.newFixnum(matcher.end(group));
+            return asFixnum(context, matcher.end(group));
         }
 
         @JRubyMethod
         public static IRubyObject offset(final ThreadContext context, final IRubyObject self, final IRubyObject idx) {
             final java.util.regex.Matcher matcher = unwrapJavaObject(self);
-            final IRubyObject beg; final IRubyObject end;
-            if ( idx instanceof RubySymbol ) {
-                beg = context.runtime.newFixnum( matcher.start(idx.toString()) );
-                end = context.runtime.newFixnum( matcher.end(idx.toString()) );
-            }
-            else {
+            final IRubyObject beg;
+            final IRubyObject end;
+
+            if (idx instanceof RubySymbol) {
+                beg = asFixnum(context, matcher.start(idx.toString()));
+                end = asFixnum(context, matcher.end(idx.toString()));
+            } else {
                 final int group = idx.convertToInteger().getIntValue();
-                beg = context.runtime.newFixnum( matcher.start(group) );
-                end = context.runtime.newFixnum( matcher.end(group) );
+                beg = asFixnum(context, matcher.start(group));
+                end = asFixnum(context, matcher.end(group));
             }
             return RubyArray.newArray(context.runtime, beg, end);
         }
@@ -159,7 +159,7 @@ public abstract class JavaUtilRegex {
         @JRubyMethod(name = { "length", "size" })
         public static RubyFixnum size(final ThreadContext context, final IRubyObject self) {
             final java.util.regex.Matcher matcher = unwrapJavaObject(self);
-            return context.runtime.newFixnum(matcher.groupCount() + 1); // the Ruby way!
+            return asFixnum(context, matcher.groupCount() + 1); // the Ruby way!
         }
 
         @JRubyMethod

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyReflectionObject.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyReflectionObject.java
@@ -40,6 +40,7 @@ import org.jruby.javasupport.Java;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Error.typeError;
 
 public class JavaProxyReflectionObject extends RubyObject {
@@ -68,7 +69,7 @@ public class JavaProxyReflectionObject extends RubyObject {
             }
             obj = (IRubyObject) wrappedObj;
         }
-        return RubyBoolean.newBoolean(context,  this.equals(obj) );
+        return asBoolean(context, this.equals(obj));
     }
 
     @Deprecated
@@ -88,7 +89,7 @@ public class JavaProxyReflectionObject extends RubyObject {
             }
             obj = (IRubyObject) wrappedObj;
         }
-        return RubyBoolean.newBoolean(context, this == obj);
+        return asBoolean(context, this == obj);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -81,6 +81,7 @@ import org.jcodings.specific.UTF8Encoding;
 import org.jcodings.unicode.UnicodeEncoding;
 
 import static org.jruby.RubyBasicObject.getMetaClass;
+import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.runtime.ThreadContext.CALL_KEYWORD_EMPTY;
 import static org.jruby.runtime.Visibility.*;
@@ -2394,8 +2395,7 @@ public class Helpers {
      */
     public static RubyBoolean rbEqual(ThreadContext context, IRubyObject a, IRubyObject b) {
         if (a == b) return context.tru;
-        IRubyObject res = sites(context).op_equal.call(context, a, a, b);
-        return RubyBoolean.newBoolean(context, res.isTrue());
+        return asBoolean(context, sites(context).op_equal.call(context, a, a, b).isTrue());
     }
 
     /**
@@ -2408,8 +2408,7 @@ public class Helpers {
      */
     public static RubyBoolean rbEqual(ThreadContext context, IRubyObject a, IRubyObject b, CallSite equal) {
         if (a == b) return context.tru;
-        IRubyObject res = equal.call(context, a, a, b);
-        return RubyBoolean.newBoolean(context, res.isTrue());
+        return asBoolean(context, equal.call(context, a, a, b).isTrue());
     }
 
     /**
@@ -2422,8 +2421,7 @@ public class Helpers {
      */
     public static RubyBoolean rbEql(ThreadContext context, IRubyObject a, IRubyObject b) {
         if (a == b) return context.tru;
-        IRubyObject res = invokedynamic(context, a, EQL, b);
-        return RubyBoolean.newBoolean(context, res.isTrue());
+        return asBoolean(context, invokedynamic(context, a, EQL, b).isTrue());
     }
 
     /**

--- a/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/TraceType.java
@@ -24,6 +24,7 @@ import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
 import org.jruby.util.TypeConverter;
 
+import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.util.RubyStringBuilder.str;
 
 public class TraceType {
@@ -397,7 +398,7 @@ public class TraceType {
         }
 
         if (highlightArg.isNil()) {
-            highlightArg = RubyBoolean.newBoolean(context, autoTTYDetect && RubyException.to_tty_p(context, runtime.getException()).isTrue());
+            highlightArg = asBoolean(context, autoTTYDetect && RubyException.to_tty_p(context, runtime.getException()).isTrue());
         }
 
         return highlightArg;

--- a/core/src/main/java/org/jruby/runtime/callsite/RespondToCallSite.java
+++ b/core/src/main/java/org/jruby/runtime/callsite/RespondToCallSite.java
@@ -10,6 +10,7 @@ import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.util.TypeConverter;
 
 import static org.jruby.RubyBasicObject.getMetaClass;
+import static org.jruby.api.Convert.asBoolean;
 
 public class RespondToCallSite extends MonomorphicCallSite {
     private volatile RespondToTuple respondToTuple = RespondToTuple.NULL_CACHE;
@@ -101,7 +102,7 @@ public class RespondToCallSite extends MonomorphicCallSite {
             if (strName.equals(tuple.name) && !includePrivate == tuple.checkVisibility) return tuple.respondsToBoolean;
         }
         // go through normal call logic, which will hit overridden cacheAndCall
-        return super.call(context, caller, self, getRespondToNameSym(context), RubyBoolean.newBoolean(context, includePrivate)).isTrue();
+        return super.call(context, caller, self, getRespondToNameSym(context), asBoolean(context, includePrivate)).isTrue();
     }
 
     private RubySymbol getRespondToNameSym(ThreadContext context) {
@@ -171,6 +172,6 @@ public class RespondToCallSite extends MonomorphicCallSite {
         CacheEntry respondToLookupResult = klass.searchWithCache(newString);
         boolean respondsTo = Helpers.respondsToMethod(respondToLookupResult.method, checkVisibility);
 
-        return new RespondToTuple(newString, checkVisibility, respondToMethod, respondToLookupResult, RubyBoolean.newBoolean(context, respondsTo));
+        return new RespondToTuple(newString, checkVisibility, respondToMethod, respondToLookupResult, asBoolean(context, respondsTo));
     }
 }

--- a/core/src/main/java/org/jruby/runtime/invokedynamic/MathLinker.java
+++ b/core/src/main/java/org/jruby/runtime/invokedynamic/MathLinker.java
@@ -34,6 +34,7 @@ import java.lang.invoke.SwitchPoint;
 
 import static java.lang.invoke.MethodHandles.*;
 import static java.lang.invoke.MethodType.*;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.util.CodegenUtils.p;
 
 import com.headius.invokebinder.Binder;
@@ -136,7 +137,7 @@ public class MathLinker {
         SwitchPoint switchPoint = (SwitchPoint) classFixnum.getInvalidator().getData();
 
         MethodHandle fallback = Binder.from(site.type())
-                .append(IRubyObject.class, runtime.newFixnum(value))
+                .append(IRubyObject.class, asFixnum(context, value))
                 .invoke(normalSite.dynamicInvoker());
 
         CacheEntry entry = searchWithCache(operator, caller, self.getMetaClass(), site);

--- a/core/src/main/java/org/jruby/util/Numeric.java
+++ b/core/src/main/java/org/jruby/util/Numeric.java
@@ -47,6 +47,7 @@ import org.jruby.runtime.callsite.CachingCallSite;
 
 import java.math.BigInteger;
 
+import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Error.typeError;
 
 public class Numeric {
@@ -430,12 +431,12 @@ public class Numeric {
      * return non-boolean (which unless it is nil it will be isTrue()).
      *
      */
-    public static IRubyObject f_equal(ThreadContext context, IRubyObject x, IRubyObject y) {
-        if (x instanceof RubyFixnum && y instanceof RubyFixnum) {
-            return RubyBoolean.newBoolean(context, ((RubyFixnum) x).getLongValue() == ((RubyFixnum) y).getLongValue());
+    public static IRubyObject f_equal(ThreadContext context, IRubyObject a, IRubyObject b) {
+        if (a instanceof RubyFixnum x && b instanceof RubyFixnum y) {
+            return asBoolean(context, x.getLongValue() == y.getLongValue());
         }
 
-        return sites(context).op_equals.call(context, x, x, y);
+        return sites(context).op_equals.call(context, a, a, b);
     }
 
     public static IRubyObject f_equal(ThreadContext context, RubyInteger x, RubyInteger y) {

--- a/core/src/main/java/org/jruby/util/collections/StringArraySet.java
+++ b/core/src/main/java/org/jruby/util/collections/StringArraySet.java
@@ -39,6 +39,8 @@ import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import static org.jruby.api.Convert.asBoolean;
+
 /**
  * An RubyArray that maintains an O(1) Set for fast include? operations.
  */
@@ -97,7 +99,7 @@ public class StringArraySet extends RubyArray {
 
     @Override
     public final RubyBoolean include_p(ThreadContext context, IRubyObject item) {
-        return RubyBoolean.newBoolean(context, containsString(convertToString(item)));
+        return asBoolean(context, containsString(convertToString(item)));
     }
 
     @Override

--- a/core/src/main/java/org/jruby/util/io/EncodingUtils.java
+++ b/core/src/main/java/org/jruby/util/io/EncodingUtils.java
@@ -58,7 +58,7 @@ import java.util.List;
 
 import static org.jruby.RubyString.*;
 import static org.jruby.api.Convert.checkToInteger;
-import static org.jruby.api.Convert.integerAsInt;
+import static org.jruby.api.Convert.asInt;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.util.StringSupport.CR_UNKNOWN;
 import static org.jruby.util.StringSupport.searchNonAscii;
@@ -210,7 +210,7 @@ public class EncodingUtils {
 
                 if (!intmode.isNil()) {
                     vmode(vmodeAndVperm_p, intmode);
-                    oflags_p[0] = integerAsInt(context, (RubyInteger) intmode);
+                    oflags_p[0] = asInt(context, (RubyInteger) intmode);
                     fmode_p[0] = ModeFlags.getOpenFileFlagsFor(oflags_p[0]);
                 } else {
                     String p = vmode(vmodeAndVperm_p).convertToString().asJavaString();

--- a/core/src/main/java/org/jruby/util/io/OpenFile.java
+++ b/core/src/main/java/org/jruby/util/io/OpenFile.java
@@ -49,6 +49,7 @@ import org.jruby.util.ShellLauncher;
 import org.jruby.util.StringSupport;
 import org.jruby.util.cli.Options;
 
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.util.StringSupport.*;
 
 public class OpenFile implements Finalizable {
@@ -2608,7 +2609,7 @@ public class OpenFile implements Finalizable {
             while (res == EConvResult.DestinationBufferFull) {
                 if (wbuf.len == wbuf.capa) {
                     if (io_fflush(context) < 0)
-                        return noalloc ? context.tru : runtime.newFixnum(posix.getErrno() == null ? 0 : posix.getErrno().longValue());
+                        return noalloc ? context.tru : asFixnum(context, posix.getErrno() == null ? 0 : posix.getErrno().longValue());
                 }
 
                 dsBytes = wbuf.ptr;

--- a/core/src/main/java/org/jruby/util/io/PopenExecutor.java
+++ b/core/src/main/java/org/jruby/util/io/PopenExecutor.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.jruby.RubyString.newString;
+import static org.jruby.api.Convert.asFixnum;
 
 /**
  * Port of MRI's popen+exec logic.
@@ -100,7 +101,7 @@ public class PopenExecutor {
             }
             throw runtime.newErrnoFromErrno(executor.errno, errmsg[0]);
         }
-        return runtime.newFixnum(pid);
+        return asFixnum(context, pid);
     }
 
     // MRI: rb_f_system

--- a/core/src/test/java/org/jruby/test/TestRubyRational.java
+++ b/core/src/test/java/org/jruby/test/TestRubyRational.java
@@ -31,8 +31,10 @@ import org.jruby.Ruby;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
 import org.jruby.RubyRational;
+import org.jruby.runtime.ThreadContext;
 import org.junit.Test;
 
+import static org.jruby.api.Convert.asFixnum;
 import static org.junit.Assert.*;
 
 public class TestRubyRational extends junit.framework.TestCase {
@@ -74,7 +76,8 @@ public class TestRubyRational extends junit.framework.TestCase {
     }
 
     private RubyRational newRational(final long num, final long den) {
-        return (RubyRational) RubyRational.newInstance(runtime.getCurrentContext(), runtime.newFixnum(num), runtime.newFixnum(den));
+        ThreadContext context = runtime.getCurrentContext();
+        return (RubyRational) RubyRational.newInstance(context, asFixnum(context, num), asFixnum(context, den));
     }
 
 }


### PR DESCRIPTION
Note: asString overlaps with a method on IRubyObject so this may be changing its name.

These are the first methods to replace Ruby.newFixnum sorts of methods. Decoupling this is good for reasons:

  1. Ruby is some mega method holder and it has long lost favor as an object vs ThreadContext.
  2. Passing ThreadContext to all JRuby methods (long term goal) means we increasingly do not need Ruby in Ruby objects at all (very long term goal).
  3. Using static methods decouples our implementation from our API

This round did not completely eliminate all uses of the three methods but it converted hundreds of them.  The biggest disruption in this PR is that a lot of @JRubyMethods which did not have ThreadContext now has them.  This meant keeping the old method around but marking it deprecated.  The fact we need to do this is a prime reason why the API initiave will pay off since there will come a time when we do not need to worry about people consuming our methods.  The other side of this is our API will also be exposed properly once we fully modularize (which will mean we long convert people to these methods before we get to point where we cut off access to our other public methods -- which is out impl).