### PR TITLE
We were ignoring switching from a valid CR to broken one

### DIFF
--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -93,7 +93,6 @@ import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
 import static org.jruby.RubyNumeric.checkInt;
 import static org.jruby.anno.FrameField.BACKREF;
 import static org.jruby.runtime.Visibility.PRIVATE;
-import static org.jruby.util.Numeric.checkInteger;
 import static org.jruby.util.StringSupport.CR_7BIT;
 import static org.jruby.util.StringSupport.CR_BROKEN;
 import static org.jruby.util.StringSupport.CR_MASK;

--- a/core/src/main/java/org/jruby/util/StringSupport.java
+++ b/core/src/main/java/org/jruby/util/StringSupport.java
@@ -1822,7 +1822,7 @@ public final class StringSupport {
         replaceInternal(beg, len, source, repl);
         associateEncoding(source, enc);
         int cr = CodeRangeSupport.codeRangeAnd(source.getCodeRange(), repl.getCodeRange());
-        if (cr != CR_BROKEN) source.setCodeRange(cr);
+        if (cr != source.getCodeRange()) source.setCodeRange(cr);
     }
 
     // MRI: rb_str_update, first half


### PR DESCRIPTION
This should fix #8316

We were ignoring switching from a valid CR to broken one.  Why explicitly ignoring this?