### PR TITLE
Speed up incremental builds

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -31,6 +31,18 @@ This will run the default "install" goal (`mvn install`) and will do all of the 
 
 The environment is now suitable for running Ruby applications.
 
+If you have Maven installed in your PATH, you can just use `mvn` instead of `./mvnw`.
+
+Incremental Builds
+------------------
+
+When working on JRuby sources, it is helpful to incrementally rebuild only the `lib/jruby.jar` file rather than also
+re-assembling the standard library. You can add `-Dcore` to the `mvn` command line to speed up incremental builds:
+
+```
+./mvnw -Dcore
+```
+
 Running JRuby
 -------------
 

--- a/pom.rb
+++ b/pom.rb
@@ -160,10 +160,17 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
                    :phase => 'site-deploy' )
   end
 
-  modules [ 'shaded', 'core', 'lib' ]
-
   build do
     default_goal 'install'
+  end
+
+  modules("core", "shaded")
+
+  profile :stdlib do
+    activation do
+      property name: '!core'
+    end
+    modules(["lib"])
   end
 
   profile 'test' do
@@ -302,6 +309,12 @@ project 'JRuby', 'https://github.com/jruby/jruby' do
       jdk '1.8'
     end
     plugin :javadoc, :additionalparam => '-Xdoclint:none'
+  end
+
+  profile 'core' do
+    activation do
+      property name: 'core'
+    end
   end
 
   reporting do

--- a/pom.xml
+++ b/pom.xml
@@ -84,9 +84,8 @@ DO NOT MODIFY - GENERATED CODE
     </mailingList>
   </mailingLists>
   <modules>
-    <module>shaded</module>
     <module>core</module>
-    <module>lib</module>
+    <module>shaded</module>
   </modules>
   <scm>
     <connection>scm:git:git@jruby.org:jruby.git</connection>
@@ -527,6 +526,17 @@ DO NOT MODIFY - GENERATED CODE
   </reporting>
   <profiles>
     <profile>
+      <id>stdlib</id>
+      <activation>
+        <property>
+          <name>!core</name>
+        </property>
+      </activation>
+      <modules>
+        <module>lib</module>
+      </modules>
+    </profile>
+    <profile>
       <id>test</id>
       <modules>
         <module>test</module>
@@ -837,6 +847,14 @@ DO NOT MODIFY - GENERATED CODE
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>core</id>
+      <activation>
+        <property>
+          <name>core</name>
+        </property>
+      </activation>
     </profile>
   </profiles>
 </project>

--- a/shaded/pom.rb
+++ b/shaded/pom.rb
@@ -28,7 +28,8 @@ project 'JRuby Core' do
                    transformers: [ {'@implementation' => 'org.apache.maven.plugins.shade.resource.ManifestResourceTransformer',
                                          mainClass: 'org.jruby.Main',
                                          manifestEntries: {'Automatic-Module-Name' => 'org.jruby.dist'}}],
-                   createSourcesJar: true
+                   createSourcesJar: false,
+                   compress: false
     )
   end
 
@@ -82,7 +83,8 @@ project 'JRuby Core' do
                        filters: [
                            {artifact: 'com.headius:invokebinder', excludes: '**/module-info.class'}
                        ],
-                       createSourcesJar: true
+                       createSourcesJar: true,
+                       compress: true
         )
       end
     end

--- a/shaded/pom.xml
+++ b/shaded/pom.xml
@@ -61,7 +61,8 @@ DO NOT MODIFY - GENERATED CODE
                   </manifestEntries>
                 </transformer>
               </transformers>
-              <createSourcesJar>true</createSourcesJar>
+              <createSourcesJar>false</createSourcesJar>
+              <compress>false</compress>
             </configuration>
           </execution>
         </executions>
@@ -157,6 +158,7 @@ DO NOT MODIFY - GENERATED CODE
                     </filter>
                   </filters>
                   <createSourcesJar>true</createSourcesJar>
+                  <compress>true</compress>
                 </configuration>
               </execution>
             </executions>
@@ -211,6 +213,7 @@ DO NOT MODIFY - GENERATED CODE
                     </filter>
                   </filters>
                   <createSourcesJar>true</createSourcesJar>
+                  <compress>true</compress>
                 </configuration>
               </execution>
             </executions>
@@ -265,6 +268,7 @@ DO NOT MODIFY - GENERATED CODE
                     </filter>
                   </filters>
                   <createSourcesJar>true</createSourcesJar>
+                  <compress>true</compress>
                 </configuration>
               </execution>
             </executions>
@@ -319,6 +323,7 @@ DO NOT MODIFY - GENERATED CODE
                     </filter>
                   </filters>
                   <createSourcesJar>true</createSourcesJar>
+                  <compress>true</compress>
                 </configuration>
               </execution>
             </executions>
@@ -373,6 +378,7 @@ DO NOT MODIFY - GENERATED CODE
                     </filter>
                   </filters>
                   <createSourcesJar>true</createSourcesJar>
+                  <compress>true</compress>
                 </configuration>
               </execution>
             </executions>
@@ -427,6 +433,7 @@ DO NOT MODIFY - GENERATED CODE
                     </filter>
                   </filters>
                   <createSourcesJar>true</createSourcesJar>
+                  <compress>true</compress>
                 </configuration>
               </execution>
             </executions>
@@ -481,6 +488,7 @@ DO NOT MODIFY - GENERATED CODE
                     </filter>
                   </filters>
                   <createSourcesJar>true</createSourcesJar>
+                  <compress>true</compress>
                 </configuration>
               </execution>
             </executions>
@@ -535,6 +543,7 @@ DO NOT MODIFY - GENERATED CODE
                     </filter>
                   </filters>
                   <createSourcesJar>true</createSourcesJar>
+                  <compress>true</compress>
                 </configuration>
               </execution>
             </executions>
@@ -589,6 +598,7 @@ DO NOT MODIFY - GENERATED CODE
                     </filter>
                   </filters>
                   <createSourcesJar>true</createSourcesJar>
+                  <compress>true</compress>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
This is a series of patches to make a fast-as-possible incremental build profile.

## Reducing the build

Currently when doing a default build of JRuby, the three modules "core" (jruby-base, the actual JRuby sources), "shaded" (jruby-core, the combined JRuby and dependencies jar), and "lib" (jruby-stdlib) are always build. The "lib" module is expensive to build because it launches JRuby to conditionally fetch and unpack or install gems to populate the standard library. This can become tedious when iterating on source-only changes to JRuby.

## Making jar builds faster

The core and shaded jar files are always built with full compression, which is unnecessary and slow for local incremental builds. The shaded jar also builds a shaded sources jar which is useless for local development and produces warnings about duplicate files. We can make these jars faster to build and omit unnecessary bits.