### PR TITLE
Eliminate dynscope for leaf blocks with break/return

### DIFF
--- a/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilder.java
@@ -311,7 +311,7 @@ public abstract class IRBuilder<U, V, W, X, Y, Z> {
     }
 
     private boolean computeNeedsDynamicScopeFlag() {
-        return scope.hasNonLocalReturns() ||
+        return //scope.hasNonLocalReturns() ||
                 scope.canCaptureCallersBinding() ||
                 scope.canReceiveNonlocalReturns() ||
                 flags.contains(BINDING_HAS_ESCAPED);

--- a/core/src/main/java/org/jruby/ir/instructions/BreakInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/BreakInstr.java
@@ -47,7 +47,7 @@ public class BreakInstr extends OneOperandInstr implements FixedArityInstr {
     @Override
     public boolean computeScopeFlags(IRScope scope, EnumSet<IRFlags> flags) {
         scope.setHasBreakInstructions();
-        flags.add(IRFlags.REQUIRES_DYNSCOPE);
+//        flags.add(IRFlags.REQUIRES_DYNSCOPE);
         return true;
     }
 

--- a/core/src/main/java/org/jruby/ir/instructions/CheckForLJEInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/CheckForLJEInstr.java
@@ -74,7 +74,7 @@ public class CheckForLJEInstr extends NoOperandInstr {
     @Override
     public boolean computeScopeFlags(IRScope scope, EnumSet<IRFlags> flags) {
         super.computeScopeFlags(scope, flags);
-        flags.add(IRFlags.REQUIRES_DYNSCOPE);
+        //flags.add(IRFlags.REQUIRES_DYNSCOPE);
         return true;
     }
 }

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -134,7 +134,7 @@ public class IRRuntimeHelpers {
     public static void checkForLJE(ThreadContext context, DynamicScope currentScope, boolean definedWithinMethod, Block block) {
         if (inLambda(block.type)) return; // break/return in lambda is unconditionally a return.
 
-        DynamicScope returnToScope = getContainingReturnToScope(currentScope);
+        DynamicScope returnToScope = getContainingReturnToScope(block.getBinding().getDynamicScope());
 
         if (returnToScope == null || !context.scopeExistsOnCallStack(returnToScope)) {
             throw IRException.RETURN_LocalJumpError.getException(context.runtime);
@@ -163,13 +163,14 @@ public class IRRuntimeHelpers {
     public static IRubyObject initiateNonLocalReturn(DynamicScope currentScope, Block block, IRubyObject returnValue) {
         if (block != null && inLambda(block.type)) throw new IRWrappedLambdaReturnValue(returnValue);
 
-        DynamicScope returnToScope = getContainingLambda(currentScope);
+        DynamicScope parentScope = block.getBinding().getDynamicScope();
+        DynamicScope returnToScope = getContainingLambda(parentScope);
 
-        if (returnToScope == null) returnToScope = getContainingReturnToScope(currentScope);
+        if (returnToScope == null) returnToScope = getContainingReturnToScope(parentScope);
 
         assert returnToScope != null: "accidental return scope";
 
-        throw IRReturnJump.create(currentScope.getStaticScope(), returnToScope, returnValue);
+        throw IRReturnJump.create(block.getBody().getStaticScope(), returnToScope, returnValue);
     }
 
     // Finds static scope of where we want to *return* to.
@@ -217,16 +218,17 @@ public class IRRuntimeHelpers {
         // paths so that ensures are run, frames/scopes are popped from runtime stacks, etc.
         if (inLambda(block.type)) throw new IRWrappedLambdaReturnValue(breakValue, true);
 
-        IRScopeType scopeType = ensureScopeIsClosure(context, dynScope);
+        DynamicScope parentScope = block.getBinding().getDynamicScope();
+//        IRScopeType scopeType = ensureScopeIsClosure(context, parentScope);
 
-        DynamicScope parentScope = dynScope.getParentScope();
+//        DynamicScope parentScope = dynScope.getParentScope();
 
         if (block.isEscaped()) {
             throw Helpers.newLocalJumpErrorForBreak(context.runtime, breakValue);
         }
 
         // Raise a break jump so we can bubble back down the stack to the appropriate place to break from.
-        throw IRBreakJump.create(parentScope, breakValue, scopeType.isEval()); // weirdly evals are impld as closures...yes yes.
+        throw IRBreakJump.create(parentScope, breakValue, false);
     }
 
     // Are we within the scope where we want to return the value we are passing down the stack?


### PR DESCRIPTION
This is a patch to eliminate the need to push a new DynamicScope for leaf blocks that have non-local flow control (break or return) by using the self block's binding's DynamicScope to find the jump target.

9.4 version.