### PR TITLE
Allow nanosecond precision for Kernel#sleep

### DIFF
--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -48,6 +48,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import jnr.constants.platform.Errno;
 import jnr.posix.POSIX;
@@ -837,27 +838,30 @@ public class RubyKernel {
 
     @JRubyMethod(module = true, visibility = PRIVATE)
     public static IRubyObject sleep(ThreadContext context, IRubyObject recv, IRubyObject timeout) {
-        long milliseconds = (long) (RubyTime.convertTimeInterval(context, timeout) * 1000);
+        long nanoseconds = (long) (RubyTime.convertTimeInterval(context, timeout) * 1_000_000_000);
         // Explicit zero in MRI returns immediately
-        if (milliseconds == 0) return RubyFixnum.zero(context.runtime);
+        if (nanoseconds == 0) return RubyFixnum.zero(context.runtime);
 
-        return sleepCommon(context, milliseconds);
+        return sleepCommon(context, nanoseconds);
     }
 
-    private static RubyFixnum sleepCommon(ThreadContext context, long milliseconds) {
-        final long startTime = System.currentTimeMillis();
+    private static RubyFixnum sleepCommon(ThreadContext context, long nanoseconds) {
+        long milliseconds = TimeUnit.NANOSECONDS.toMillis(nanoseconds);
+        long remainingNanos = nanoseconds - TimeUnit.MILLISECONDS.toNanos(milliseconds);
+
+        final long startTime = System.nanoTime();
         final RubyThread rubyThread = context.getThread();
 
         boolean interrupted = false;
         try {
             // Spurious wakeup-loop
             do {
-                long loopStartTime = System.currentTimeMillis();
+                long loopStartTime = System.nanoTime();
 
-                if (!rubyThread.sleep(milliseconds)) break;
+                if (!rubyThread.sleep(milliseconds, remainingNanos)) break;
 
-                milliseconds -= (System.currentTimeMillis() - loopStartTime);
-            } while (milliseconds > 0);
+                nanoseconds -= (System.nanoTime() - loopStartTime);
+            } while (nanoseconds > 0);
         } catch (InterruptedException ie) {
             // ignore; sleep gets interrupted
             interrupted = true;
@@ -867,7 +871,7 @@ public class RubyKernel {
             }
         }
 
-        return context.runtime.newFixnum(Math.round((System.currentTimeMillis() - startTime) / 1000.0));
+        return context.runtime.newFixnum(Math.round((System.nanoTime() - startTime) / 1_000_000_000.0));
     }
 
     // FIXME: Add at_exit and finalizers to exit, then make exit_bang not call those.

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -846,9 +846,6 @@ public class RubyKernel {
     }
 
     private static RubyFixnum sleepCommon(ThreadContext context, long nanoseconds) {
-        long milliseconds = TimeUnit.NANOSECONDS.toMillis(nanoseconds);
-        long remainingNanos = nanoseconds - TimeUnit.MILLISECONDS.toNanos(milliseconds);
-
         final long startTime = System.nanoTime();
         final RubyThread rubyThread = context.getThread();
 
@@ -857,6 +854,8 @@ public class RubyKernel {
             // Spurious wakeup-loop
             do {
                 long loopStartTime = System.nanoTime();
+                long milliseconds = TimeUnit.NANOSECONDS.toMillis(nanoseconds);
+                long remainingNanos = nanoseconds - TimeUnit.MILLISECONDS.toNanos(milliseconds);
 
                 if (!rubyThread.sleep(milliseconds, remainingNanos)) break;
 

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -1591,7 +1591,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         sleepTask.nanoseconds = nanoseconds + TimeUnit.MILLISECONDS.toNanos(milliseconds);
         try {
             long timeSlept = executeTaskBlocking(getContext(), null, sleepTask);
-            if (nanoseconds == 0 || timeSlept >= nanoseconds) {
+            if (sleepTask.nanoseconds == 0 || timeSlept >= sleepTask.nanoseconds) {
                 // sleep was unbounded or we slept long enough
                 return true;
             } else {

--- a/spec/ruby/core/thread/wakeup_spec.rb
+++ b/spec/ruby/core/thread/wakeup_spec.rb
@@ -4,4 +4,16 @@ require_relative 'shared/wakeup'
 
 describe "Thread#wakeup" do
   it_behaves_like :thread_wakeup, :wakeup
+
+  it "sleeps with nanosecond precision" do
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    100.times do
+      sleep(0.0001)
+    end
+    end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    actual_duration = end_time - start_time
+    assert_true(actual_duration > 0.01) # 100 * 0.0001 => 0.01
+    assert_true(actual_duration < 0.03)
+  end
 end

--- a/spec/ruby/core/thread/wakeup_spec.rb
+++ b/spec/ruby/core/thread/wakeup_spec.rb
@@ -13,7 +13,7 @@ describe "Thread#wakeup" do
     end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
     actual_duration = end_time - start_time
-    assert_true(actual_duration > 0.01) # 100 * 0.0001 => 0.01
-    assert_true(actual_duration < 0.03)
+    (actual_duration > 0.01).should == true # 100 * 0.0001 => 0.01
+    (actual_duration < 0.03).should == true
   end
 end

--- a/test/jruby/test_kernel.rb
+++ b/test/jruby/test_kernel.rb
@@ -369,6 +369,18 @@ class TestKernel < Test::Unit::TestCase
     assert_raises(ArgumentError) { sleep(SecDuration19.new(-0.01)) }
   end
 
+  def test_nanosecond_precision_sleep
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    100.times do
+      sleep(0.0001)
+    end
+    end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    actual_duration = end_time - start_time
+    assert_true(actual_duration > 0.01) # 100 * 0.0001 => 0.01
+    assert_true(actual_duration < 0.03)
+  end
+
   def test_sprintf
     assert_equal 'Hello', Kernel.sprintf('Hello')
   end

--- a/test/jruby/test_kernel.rb
+++ b/test/jruby/test_kernel.rb
@@ -369,18 +369,6 @@ class TestKernel < Test::Unit::TestCase
     assert_raises(ArgumentError) { sleep(SecDuration19.new(-0.01)) }
   end
 
-  def test_nanosecond_precision_sleep
-    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    100.times do
-      sleep(0.0001)
-    end
-    end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-
-    actual_duration = end_time - start_time
-    assert_true(actual_duration > 0.01) # 100 * 0.0001 => 0.01
-    assert_true(actual_duration < 0.03)
-  end
-
   def test_sprintf
     assert_equal 'Hello', Kernel.sprintf('Hello')
   end


### PR DESCRIPTION
* Previously sleep would only convert into milliseconds, so something like 0.0001 would get rounded to 0. 0 was a no-op in RubyKernel#sleep.

* Now it works in nanoseconds internally. RubyThread#sleep has also been expanded to have an overloaded signature which takes both milliseconds and nanoseconds. This supports existing calls expecting milliseconds only, while supporting nanosecond precision for sleep.