### PR TITLE
Fixes #8325. Try and convince Ruby that our Java v4 address is really v6

### DIFF
--- a/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
+++ b/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
@@ -499,20 +499,24 @@ public class SocketUtils {
         }
     }
 
-    private static final String ipv4MappedAddressPrefix = "::ffff:";
+    public static final String IP_V4_MAPPED_ADDRESS_PREFIX = "::ffff:";
     private static final String ipv6LocalHost = "::1";
+
+    public static boolean isIPV4MappedAddressPrefix(String address) {
+        return address.startsWith(IP_V4_MAPPED_ADDRESS_PREFIX);
+    }
 
     public static IRubyObject getaddress(ThreadContext context, IRubyObject hostname) {
         try {
             String hostnameString = hostname.convertToString().toString();
             InetAddress address = InetAddress.getByName(hostnameString);
 
-            if (hostnameString.startsWith(ipv4MappedAddressPrefix)) {
+            if (isIPV4MappedAddressPrefix(hostnameString)) {
                 // See https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/net/Inet6Address.html#special-ipv6-address-heading
                 // IPv4 mapped IPv6 addresses will always return an Inet4Address. When given an IPv6 address to
                 // IPSocket.getaddress, ruby will return the IPv6 address. This is not the case in Java.
                 return RubyString.newInternalFromJavaExternal(
-                        context.runtime, ipv4MappedAddressPrefix + address.getHostAddress());
+                        context.runtime, IP_V4_MAPPED_ADDRESS_PREFIX + address.getHostAddress());
             } else if (hostnameString.equals(ipv6LocalHost)) {
                 // Ruby will return "::1" for the local host IPv6 address.
                 // Java will return the full IPv6 address of 0:0:0:0:0:0:0:1.


### PR DESCRIPTION
Fixes #8325

Makes new accept this address without raising and also marks it with our internal hack variable `looksLikeV4ButIsV6`.  by setting this variable we get other behavior like `ipv6?` will now return true.

I also updated inspect to re-add the ipv6 prefix which I think is ok?  If there is another magic prefix then this will inspect differently but I doubt this is very important from a semantic perspective.
