### PR TITLE
Fixes #8344.  Kwargs past must error if not kwarg params

### DIFF
--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -1253,7 +1253,10 @@ public abstract class RubyParserBase {
         //  it.  Prism is replacing this parser so this felt like a lot less work.
         int length = identifierValue.length();
         if (length > 0 && identifierValue.get(length - 1) == ':') {
-            identifierValue.setRealSize(length - 1);
+            // $: is the one exception where it is a valid name
+            if (length != 2 || identifierValue.get(0) != '$') {
+                identifierValue.setRealSize(length - 1);
+            }
         }
 
         // FIXME: We walk this during identifier construction so we should calculate CR without having to walk twice.

--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -1248,6 +1248,14 @@ public abstract class RubyParserBase {
     }
 
     public RubySymbol symbolID(ByteList identifierValue) {
+        // FIXME: parser is sending some keyword args as 'a:' instead of 'a' and since this is illegal we are
+        //  working around it here.  Long term fix is to audit and figure out where this is happening and correct
+        //  it.  Prism is replacing this parser so this felt like a lot less work.
+        int length = identifierValue.length();
+        if (length > 0 && identifierValue.get(length - 1) == ':') {
+            identifierValue.setRealSize(length - 1);
+        }
+
         // FIXME: We walk this during identifier construction so we should calculate CR without having to walk twice.
         if (RubyString.scanForCodeRange(identifierValue) == StringSupport.CR_BROKEN) {
             Ruby runtime = getRuntime();

--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -1248,17 +1248,6 @@ public abstract class RubyParserBase {
     }
 
     public RubySymbol symbolID(ByteList identifierValue) {
-        // FIXME: parser is sending some keyword args as 'a:' instead of 'a' and since this is illegal we are
-        //  working around it here.  Long term fix is to audit and figure out where this is happening and correct
-        //  it.  Prism is replacing this parser so this felt like a lot less work.
-        int length = identifierValue.length();
-        if (length > 0 && identifierValue.get(length - 1) == ':') {
-            // $: is the one exception where it is a valid name
-            if (length != 2 || identifierValue.get(0) != '$') {
-                identifierValue.setRealSize(length - 1);
-            }
-        }
-
         // FIXME: We walk this during identifier construction so we should calculate CR without having to walk twice.
         if (RubyString.scanForCodeRange(identifierValue) == StringSupport.CR_BROKEN) {
             Ruby runtime = getRuntime();
@@ -1675,6 +1664,11 @@ public abstract class RubyParserBase {
     }
 
     public ArgumentNode arg_var(ByteList byteName) {
+        // FIXME: parser is sending some keyword args as 'a:' instead of 'a' and since this is illegal we are
+        //  working around it here.  Long term fix is to audit and figure out where this is happening and correct
+        //  it.  Prism is replacing this parser so this felt like a lot less work.
+        int length = byteName.length();
+        if (length > 0 && byteName.get(length - 1) == ':') byteName.setRealSize(length - 1);
         RubySymbol name = symbolID(byteName);
         numparam_name(byteName);
 

--- a/core/src/main/java/org/jruby/parser/StaticScope.java
+++ b/core/src/main/java/org/jruby/parser/StaticScope.java
@@ -410,7 +410,8 @@ public class StaticScope implements Serializable, Cloneable {
         if (name.equals("_")) return true;
         int slot = exists(name);
 
-        return slot >= 0 && firstKeywordIndex != -1 && slot >= firstKeywordIndex;
+        return slot >= 0 && firstKeywordIndex != -1 &&
+                slot >= firstKeywordIndex  && slot < firstKeywordIndex + signature.kwargs();
     }
 
     /**

--- a/core/src/main/java/org/jruby/runtime/Signature.java
+++ b/core/src/main/java/org/jruby/runtime/Signature.java
@@ -82,6 +82,14 @@ public class Signature {
     public int keyRest() { return keyRest; }
 
     /**
+     * Total number of keyword argument parameters.
+     * @return the number of kwarg parameters
+     */
+    public int kwargs() {
+        return kwargs;
+    }
+
+    /**
      * Are there an exact (fixed) number of parameters to this signature?
      */
     public boolean isFixed() {

--- a/spec/regression/language/keywords_spec.rb
+++ b/spec/regression/language/keywords_spec.rb
@@ -1,0 +1,26 @@
+require 'rspec'
+
+class KeywordsMethods
+  class << self
+    def foo(a: 1)
+      b = a
+    end
+
+    def foo1(a:)
+      b = a
+    end
+
+    def foo2(a: 1, c:)
+      b = a
+    end
+  end
+end
+
+describe 'Keywords' do
+  # https://github.com/jruby/jruby/issues/8344
+  it 'will reject parameters passed which happen to be lvars in method' do
+    expect { KeywordsMethods.foo(b: "a") }.to raise_error(ArgumentError)
+    expect { KeywordsMethods.foo1(b: "a") }.to raise_error(ArgumentError)
+    expect { KeywordsMethods.foo2(b: "a", c: 2) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/regression/language/keywords_spec.rb
+++ b/spec/regression/language/keywords_spec.rb
@@ -13,6 +13,11 @@ class KeywordsMethods
     def foo2(a: 1, c:)
       b = a
     end
+
+    def foo3(a: 60, b: 60, c: 10, d: nil)
+      true
+    end
+
   end
 end
 
@@ -22,5 +27,6 @@ describe 'Keywords' do
     expect { KeywordsMethods.foo(b: "a") }.to raise_error(ArgumentError)
     expect { KeywordsMethods.foo1(b: "a") }.to raise_error(ArgumentError)
     expect { KeywordsMethods.foo2(b: "a", c: 2) }.to raise_error(ArgumentError)
+    expect(KeywordsMethods.foo3(a: 1, b: 2, c: 3, d: 4)).to eq(true)
   end
 end


### PR DESCRIPTION
index indicating start of keywords has no ending index so all local variables appeared to be keyword parameters.  This lead to not raising when a local variable happened to be passed as a keyword argument.