### PR TITLE
Properly set up binding for compiled JSR-223 scripts

### DIFF
--- a/core/src/main/java/org/jruby/embed/jsr223/JRubyCompiledScript.java
+++ b/core/src/main/java/org/jruby/embed/jsr223/JRubyCompiledScript.java
@@ -57,7 +57,11 @@ public class JRubyCompiledScript extends CompiledScript {
         this.container = container;
         this.engine = engine;
         Utils.preEval(container, engine.getContext());
-        unit = container.parse(script);
+        try {
+            unit = container.parse(script);
+        } finally {
+            Utils.postEval(container, engine.getContext());
+        }
     }
 
     JRubyCompiledScript(ScriptingContainer container, JRubyEngine engine, Reader reader) throws RaiseException {
@@ -65,7 +69,11 @@ public class JRubyCompiledScript extends CompiledScript {
         this.engine = engine;
         String filename = System.getProperty(ScriptEngine.FILENAME);
         Utils.preEval(container, engine.getContext());
-        unit = container.parse(reader, filename, Utils.getLineNumber(engine.getContext()));
+        try {
+            unit = container.parse(reader, filename, Utils.getLineNumber(engine.getContext()));
+        } finally {
+            Utils.postEval(container, engine.getContext());
+        }
     }
 
     @Override


### PR DESCRIPTION
The `preEval` calls are run later in `doEval` immediately before executing. Doing it here appears to have caused some issue in either the parse or the set-up of the scoping used by the parsed result (see jruby/jruby#8346). Removing these pre-parse `preEval` calls fixes the issue.

Fixes jruby/jruby#8346.

Edit: It turns out the `preEval` is actually necessary for the parse to pick up values properly, so instead we do a full `preEval` and `postEval` around the parse and again around the eval.