### PR TITLE
do not expose Java proxy generated classes in Ruby land

### DIFF
--- a/core/src/main/java/org/jruby/java/proxies/JavaInterfaceTemplate.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaInterfaceTemplate.java
@@ -306,9 +306,12 @@ public class JavaInterfaceTemplate {
 
     private static IRubyObject newInterfaceProxy(final IRubyObject self) {
         final RubyClass current = self.getMetaClass();
+        final Ruby runtime = current.getRuntime();
         // construct the new interface impl and set it into the object
         Object impl = Java.newInterfaceImpl(self, Java.getInterfacesFromRubyClass(current));
-        IRubyObject implWrapper = Java.getInstance(self.getRuntime(), impl);
+        RubyClass proxyClass = (RubyClass) Java.getProxyClass(runtime, impl.getClass(), false);
+        // we do not want the (InterfaceImpl) proxy-class in this case to be set on the Ruby side
+        IRubyObject implWrapper = Java.getInstanceInternal(runtime, impl, proxyClass, false);
         JavaUtilities.set_java_object(self, self, implWrapper); // self.dataWrapStruct(newObject);
         return implWrapper;
     }

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -297,13 +297,17 @@ public class Java implements Library {
     public static IRubyObject getInstance(Ruby runtime, Object rawJavaObject, boolean forceCache) {
         if (rawJavaObject != null) {
             RubyClass proxyClass = (RubyClass) getProxyClass(runtime, rawJavaObject.getClass());
-
-            if (OBJECT_PROXY_CACHE || forceCache || proxyClass.getCacheProxy()) {
-                return runtime.getJavaSupport().getObjectProxyCache().getOrCreate(rawJavaObject, proxyClass);
-            }
-            return allocateProxy(rawJavaObject, proxyClass);
+            return getInstanceInternal(runtime, rawJavaObject, proxyClass, forceCache);
         }
         return runtime.getNil();
+    }
+
+    public static IRubyObject getInstanceInternal(Ruby runtime, Object rawJavaObject,
+                                                  RubyClass proxyClass, boolean forceCache) {
+        if (OBJECT_PROXY_CACHE || forceCache || proxyClass.getCacheProxy()) {
+            return runtime.getJavaSupport().getObjectProxyCache().getOrCreate(rawJavaObject, proxyClass);
+        }
+        return allocateProxy(rawJavaObject, proxyClass);
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -429,16 +429,21 @@ public class Java implements Library {
         return getProxyClass(runtime, javaClass.javaClass());
     }
 
-    @SuppressWarnings("deprecation")
     public static RubyModule getProxyClass(final Ruby runtime, final Class<?> clazz) {
         return getProxyClass(runtime, clazz, Options.JI_EAGER_CONSTANTS.load());
     }
 
-    @SuppressWarnings("deprecation")
-    public static RubyModule getProxyClass(final Ruby runtime, final Class<?> clazz, boolean setConstant) {
-        RubyModule proxy = runtime.getJavaSupport().getUnfinishedProxy(clazz);
+    /**
+     * @param runtime
+     * @param clazz the Java class
+     * @param setConstant is only considered upon actual proxy class initialization
+     * @return Ruby proxy module/class for the Java interface/class
+     */
+    public static RubyModule getProxyClass(final Ruby runtime, final Class<?> clazz, final boolean setConstant) {
+        RubyModule proxy = runtime.getJavaSupport().getUnfinishedProxy(clazz, setConstant);
         if (proxy != null) return proxy;
-        return runtime.getJavaSupport().getProxyClassFromCache(clazz, setConstant);
+
+        return runtime.getJavaSupport().getProxyClassFromCache(clazz);
     }
 
     // expected to handle Java proxy (Ruby) sub-classes as well
@@ -479,7 +484,7 @@ public class Java implements Library {
                 generateClassProxy(runtime, clazz, (RubyClass) proxy, superClass);
             }
         } finally {
-            javaSupport.endProxy(clazz);
+            javaSupport.endProxy(clazz, proxy);
         }
 
         return proxy;

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -256,7 +256,7 @@ public class Java implements Library {
         return proxyClass;
     }
 
-    private static void setProxyClass(final Ruby runtime, final RubyModule target, final String constName, final RubyModule proxyClass, final boolean validateConstant) {
+    static void setProxyClass(final Ruby runtime, final RubyModule target, final String constName, final RubyModule proxyClass, final boolean validateConstant) {
         if (constantNotSetOrDifferent(target, constName, proxyClass)) {
             synchronized (target) { // synchronize to prevent "already initialized constant" warnings with multiple threads
                 if (constantNotSetOrDifferent(target, constName, proxyClass)) {

--- a/core/src/main/java/org/jruby/javasupport/JavaPackage.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaPackage.java
@@ -309,22 +309,20 @@ public class JavaPackage extends RubyModule {
         public RubyClass defineClassUnder(RubyModule pkg, String name, RubyClass superClazz) {
             // shouldn't happen, but if a superclass is specified, it's not ours
             if ( superClazz != null ) return null;
-
-            final String subPackageName = JavaPackage.buildPackageName(pkg, name).toString();
-
-            final Ruby runtime = pkg.getRuntime();
-            Class<?> javaClass = Java.getJavaClass(runtime, subPackageName);
-            return (RubyClass) Java.getProxyClass(runtime, javaClass);
+            return (RubyClass) defineImpl(pkg, name);
         }
 
         public RubyModule defineModuleUnder(RubyModule pkg, String name) {
+            return defineImpl(pkg, name);
+        }
+
+        private RubyModule defineImpl(RubyModule pkg, String name) {
             final String subPackageName = JavaPackage.buildPackageName(pkg, name).toString();
 
             final Ruby runtime = pkg.getRuntime();
             Class<?> javaClass = Java.getJavaClass(runtime, subPackageName);
-            return Java.getInterfaceModule(runtime, javaClass);
+            return Java.getProxyClass(runtime, javaClass);
         }
-
     }
 
     /**


### PR DESCRIPTION
this PR changes some of the bits from: https://github.com/jruby/jruby/commit/31f1ed6f7458acc42a545a032424580f5b22d746

e.g. it effectively makes sure `getProxyClass` (which might be used in user ext) behaves as before - not setting a Java proxy class constant upon every invocation...

fixes #8349 