### PR TITLE
Do not call File.realpath on our path

### DIFF
--- a/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
+++ b/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
@@ -340,7 +340,7 @@ public class RubyPathname extends RubyObject {
         }
 
         args[2] = RubyHash.newSmallHash(runtime);
-        ((RubyHash) args[2]).fastASetSmall(runtime.newSymbol("base"), context.runtime.getFile().callMethod(context, "realpath", getPath()));
+        ((RubyHash) args[2]).fastASetSmall(runtime.newSymbol("base"), getPath());
 
         JavaSites.PathnameSites sites = sites(context);
         CallSite glob = sites.glob;


### PR DESCRIPTION
File.realpath requires the path to exist on the filesystem, breaking this logic for cases where Pathname is used to glob possibly non-existant file paths.

Fixes #8358