### PR TITLE
Pass getsockopt length as an in/out reference

### DIFF
--- a/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
@@ -460,7 +460,7 @@ public class RubyBasicSocket extends RubyIO {
                             int ret = SOCKOPT.getsockopt(fd.realFileno, intLevel, intOpt, buf, len);
 
                             if (ret != 0) {
-                                throw runtime.newErrnoEINVALError(SOCKOPT.strerror(ret));
+                                throw runtime.newErrnoFromLastPOSIXErrno();
                             }
                             flipBuffer(buf);
                             ByteList bytes = new ByteList(buf.array(), buf.position(), len.getValue());
@@ -535,7 +535,7 @@ public class RubyBasicSocket extends RubyIO {
                             int ret = SOCKOPT.setsockopt(fd.realFileno, intLevel, intOpt, buf, buf.remaining());
 
                             if (ret != 0) {
-                                throw runtime.newErrnoEINVALError(SOCKOPT.strerror(ret));
+                                throw runtime.newErrnoFromLastPOSIXErrno();
                             }
                         }
 
@@ -574,7 +574,6 @@ public class RubyBasicSocket extends RubyIO {
         int getsockopt(int s, int level, int optname, @Out ByteBuffer optval, @Out IntByReference optlen);
         int setsockopt(int s, int level, int optname, @In ByteBuffer optval, int optlen);
         int setsockopt(int s, int level, int optname, @In Timeval optval, int optlen);
-        String strerror(int error);
     }
 
     static final LibC SOCKOPT;

--- a/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
@@ -571,7 +571,7 @@ public class RubyBasicSocket extends RubyIO {
         int F_SETFL = jnr.constants.platform.Fcntl.F_SETFL.intValue();
         int O_NONBLOCK = jnr.constants.platform.OpenFlags.O_NONBLOCK.intValue();
 
-        int getsockopt(int s, int level, int optname, @Out ByteBuffer optval, @Out IntByReference optlen);
+        int getsockopt(int s, int level, int optname, @Out ByteBuffer optval, IntByReference optlen);
         int setsockopt(int s, int level, int optname, @In ByteBuffer optval, int optlen);
         int setsockopt(int s, int level, int optname, @In Timeval optval, int optlen);
     }


### PR DESCRIPTION
Fixes intermittent EINVAL errors calling getsockopt by making the length a proper in/out pointer reference.

The error handling here is also improved, since strerror(-1) is not valid, and the error may not be EINVAL.

Fixes #8339.