### PR TITLE
Ensure non-null reference when replacing

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -4895,7 +4895,9 @@ public final class Ruby implements Constantizable {
             // ref is there but vacated, try to replace it until we have a result
             while (true) {
                 wrapper.string = string;
-                dedupedRef = dedupMap.computeIfPresent(wrapper, (key, old) -> old.get() == null ? weakref : old);
+
+                // re-get reference if it is non-null and populated, or replace with new reference
+                dedupedRef = dedupMap.compute(wrapper, (key, old) -> old == null || old.get() == null ? weakref : old);
 
                 // return result if not vacated
                 unduped = dedupedRef.get();


### PR DESCRIPTION
If we found a vacated reference above, it could be removed from the ConcurrentWeakHashMap by the time we get to this point, resulting in a null return value from computeIfPresent. This new logic uses compute instead, either replacing the null or vacated reference with a new one or leaving in place any populated reference added in parallel somewhere else.

Fixes #8359