### PR TITLE
re-implement the option to lazy bind Java:: constants

### DIFF
--- a/core/src/main/java/org/jruby/java/proxies/JavaInterfaceTemplate.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaInterfaceTemplate.java
@@ -306,9 +306,12 @@ public class JavaInterfaceTemplate {
 
     private static IRubyObject newInterfaceProxy(final IRubyObject self) {
         final RubyClass current = self.getMetaClass();
+        final Ruby runtime = current.getRuntime();
         // construct the new interface impl and set it into the object
         Object impl = Java.newInterfaceImpl(self, Java.getInterfacesFromRubyClass(current));
-        IRubyObject implWrapper = Java.getInstance(self.getRuntime(), impl);
+        RubyClass proxyClass = (RubyClass) Java.getProxyClass(runtime, impl.getClass(), false);
+        // we do not want the (InterfaceImpl) proxy-class in this case to be set on the Ruby side
+        IRubyObject implWrapper = Java.getInstanceInternal(runtime, impl, proxyClass, false);
         JavaUtilities.set_java_object(self, self, implWrapper); // self.dataWrapStruct(newObject);
         return implWrapper;
     }

--- a/core/src/main/java/org/jruby/java/proxies/JavaInterfaceTemplate.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaInterfaceTemplate.java
@@ -309,7 +309,7 @@ public class JavaInterfaceTemplate {
         final Ruby runtime = current.getRuntime();
         // construct the new interface impl and set it into the object
         Object impl = Java.newInterfaceImpl(self, Java.getInterfacesFromRubyClass(current));
-        RubyClass proxyClass = (RubyClass) Java.getProxyClass(runtime, impl.getClass(), false);
+        RubyClass proxyClass = (RubyClass) Java.getProxyClass(runtime, impl.getClass());
         // we do not want the (InterfaceImpl) proxy-class in this case to be set on the Ruby side
         IRubyObject implWrapper = Java.getInstanceInternal(runtime, impl, proxyClass, false);
         JavaUtilities.set_java_object(self, self, implWrapper); // self.dataWrapStruct(newObject);

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -297,13 +297,17 @@ public class Java implements Library {
     public static IRubyObject getInstance(Ruby runtime, Object rawJavaObject, boolean forceCache) {
         if (rawJavaObject != null) {
             RubyClass proxyClass = (RubyClass) getProxyClass(runtime, rawJavaObject.getClass());
-
-            if (OBJECT_PROXY_CACHE || forceCache || proxyClass.getCacheProxy()) {
-                return runtime.getJavaSupport().getObjectProxyCache().getOrCreate(rawJavaObject, proxyClass);
-            }
-            return allocateProxy(rawJavaObject, proxyClass);
+            return getInstanceInternal(runtime, rawJavaObject, proxyClass, forceCache);
         }
         return runtime.getNil();
+    }
+
+    public static IRubyObject getInstanceInternal(Ruby runtime, Object rawJavaObject,
+                                                  RubyClass proxyClass, boolean forceCache) {
+        if (OBJECT_PROXY_CACHE || forceCache || proxyClass.getCacheProxy()) {
+            return runtime.getJavaSupport().getObjectProxyCache().getOrCreate(rawJavaObject, proxyClass);
+        }
+        return allocateProxy(rawJavaObject, proxyClass);
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -515,7 +515,7 @@ public class Java implements Library {
             } else {
                 proxy.getMetaClass().defineAnnotatedMethods(OldStyleExtensionInherited.class);
             }
-            setProxyConstantInJavaPackage(proxy, clazz);
+            setProxyConstantInJavaPackage(proxy, clazz, true);
         }
         else {
             createProxyClass(runtime, proxy, clazz, superClass, false);
@@ -840,13 +840,17 @@ public class Java implements Library {
         return null;
     }
 
+    static void setProxyConstantInJavaPackage(final RubyModule proxyClass, final Class<?> clazz) {
+        setProxyConstantInJavaPackage(proxyClass, clazz, Options.JI_EAGER_CONSTANTS.load());
+    }
+
     // package scheme 2: separate module for each full package name, constructed
     // from the camel-cased package segments: Java::JavaLang::Object,
-    static void setProxyConstantInJavaPackage(final RubyModule proxyClass, final Class<?> clazz) {
+    private static void setProxyConstantInJavaPackage(final RubyModule proxyClass, final Class<?> clazz, final boolean eagerSet) {
         assert clazz == proxyClass.dataGetStruct() :
             "not a Java proxy wrapper: " + proxyClass.dataGetStruct() + " expected: " + clazz;
 
-        if (!Modifier.isPublic(clazz.getModifiers())) return;
+        if (!eagerSet || !Modifier.isPublic(clazz.getModifiers())) return;
 
         final String fullName = clazz.getName();
 

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -256,7 +256,7 @@ public class Java implements Library {
         return proxyClass;
     }
 
-    private static void setProxyClass(final Ruby runtime, final RubyModule target, final String constName, final RubyModule proxyClass, final boolean validateConstant) {
+    static void setProxyClass(final Ruby runtime, final RubyModule target, final String constName, final RubyModule proxyClass, final boolean validateConstant) {
         if (constantNotSetOrDifferent(target, constName, proxyClass)) {
             synchronized (target) { // synchronize to prevent "already initialized constant" warnings with multiple threads
                 if (constantNotSetOrDifferent(target, constName, proxyClass)) {

--- a/core/src/main/java/org/jruby/javasupport/JavaPackage.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaPackage.java
@@ -189,7 +189,7 @@ public class JavaPackage extends RubyModule {
 
     RubyModule relativeJavaProxyClass(final Ruby runtime, final IRubyObject name) {
         final String fullName = packageRelativeName( name.toString() ).toString();
-        return Java.getProxyClass(runtime, Java.getJavaClass(runtime, fullName), true);
+        return Java.getProxyClass(runtime, Java.getJavaClass(runtime, fullName));
     }
 
     @JRubyMethod(name = "respond_to?")

--- a/core/src/main/java/org/jruby/javasupport/JavaSupport.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupport.java
@@ -50,7 +50,6 @@ import org.jruby.util.collections.ClassValue;
 import org.jruby.util.collections.ClassValueCalculator;
 
 import java.lang.reflect.Member;
-import java.lang.reflect.Modifier;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -370,16 +369,8 @@ public abstract class JavaSupport {
         return null;
     }
 
-    RubyModule getProxyClassFromCache(Class clazz, boolean setConstant) {
-        RubyModule proxy = proxyClassCache.get(clazz);
-
-        if (setConstant) {
-            if ( Modifier.isPublic(clazz.getModifiers()) ) {
-                Java.addToJavaPackageModule(runtime, clazz, proxy);
-            }
-        }
-
-        return proxy;
+    RubyModule getProxyClassFromCache(Class clazz) {
+        return proxyClassCache.get(clazz);
     }
 
 }

--- a/core/src/test/java/org/jruby/javasupport/TestJava.java
+++ b/core/src/test/java/org/jruby/javasupport/TestJava.java
@@ -24,7 +24,7 @@ public class TestJava extends junit.framework.TestCase {
     public void testProxyCreation() {
         final Ruby runtime = Ruby.newInstance();
         try {
-            Java.getProxyClass(runtime, B.class, false);
+            Java.getProxyClass(runtime, B.class);
             assert(true);
         }
         catch (AssertionError ae) {
@@ -177,14 +177,12 @@ public class TestJava extends junit.framework.TestCase {
 
         final Ruby runtime = Ruby.newInstance(config);
 
-        final Object klass = Java.getProxyClass(runtime, java.lang.System.class, true); // Java::JavaLang::System
+        final Object klass = Java.getProxyClass(runtime, java.lang.System.class); // Java::JavaLang::System
 
         final RubyModule dummySystemProxy = RubyModule.newModule(runtime); // replace Java::JavaLang::System with smt different
         Java.setProxyClass(runtime, runtime.getClassFromPath("Java::JavaLang"), "System", dummySystemProxy, true);
 
         assertSame(klass, Java.getProxyClass(runtime, java.lang.System.class));
-        assertSame(klass, Java.getProxyClass(runtime, java.lang.System.class, true));
-        assertSame(klass, Java.getProxyClass(runtime, java.lang.System.class, false));
 
         // asserting here that the Java.setProxyConstantInJavaPackage path only executes once and not repeatedly
         assertSame(dummySystemProxy, runtime.getClassFromPath("Java::JavaLang::System"));

--- a/core/src/test/java/org/jruby/javasupport/TestJava.java
+++ b/core/src/test/java/org/jruby/javasupport/TestJava.java
@@ -1,5 +1,8 @@
 package org.jruby.javasupport;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
 import java.lang.reflect.Method;
 import java.text.SimpleDateFormat;
 
@@ -21,7 +24,7 @@ public class TestJava extends junit.framework.TestCase {
     public void testProxyCreation() {
         final Ruby runtime = Ruby.newInstance();
         try {
-            Java.getProxyClass(runtime, B.class);
+            Java.getProxyClass(runtime, B.class, false);
             assert(true);
         }
         catch (AssertionError ae) {
@@ -136,5 +139,54 @@ public class TestJava extends junit.framework.TestCase {
 
         assertNotNull(runtime.evalScriptlet("FormatImpl.new")); // used to cause an infinite loop
         assertTrue(runtime.evalScriptlet("FormatImpl.new").toJava(Object.class) instanceof SimpleDateFormat);
+    }
+
+    @Test
+    public void testDuckTypeInterfaceImplGeneratesNoWarning() {
+        final String script =
+            "class Consumer1\n" +
+            "  def self.accept(arg); puts self end\n" +
+            "end\n" +
+            "class Consumer2 < Consumer1; end\n" +
+            "class Consumer3 < Consumer1; end\n" ;
+
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        RubyInstanceConfig config = new RubyInstanceConfig();
+        config.setOutput(new PrintStream(output));
+        config.setError(new PrintStream(output));
+
+        final Ruby runtime = Ruby.newInstance(config);
+        runtime.evalScriptlet(script);
+
+        runtime.evalScriptlet(
+            "coll = java.util.Collections.singleton(42)\n" +
+            "coll.forEach(Consumer1); coll.forEach(Consumer2); coll.forEach(Consumer3)"
+        );
+
+        assertEquals("Consumer1\nConsumer2\nConsumer3\n", output.toString()); // no "warning: already initialized constant ..."
+    }
+
+    @Test
+    public void testGetProxyClass() {
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        RubyInstanceConfig config = new RubyInstanceConfig();
+        config.setOutput(new PrintStream(output));
+        config.setError(new PrintStream(output)); // ignore warnings - we'll be replacing an internal Java proxy constant
+
+        final Ruby runtime = Ruby.newInstance(config);
+
+        final Object klass = Java.getProxyClass(runtime, java.lang.System.class, true); // Java::JavaLang::System
+
+        final RubyModule dummySystemProxy = RubyModule.newModule(runtime); // replace Java::JavaLang::System with smt different
+        Java.setProxyClass(runtime, runtime.getClassFromPath("Java::JavaLang"), "System", dummySystemProxy, true);
+
+        assertSame(klass, Java.getProxyClass(runtime, java.lang.System.class));
+        assertSame(klass, Java.getProxyClass(runtime, java.lang.System.class, true));
+        assertSame(klass, Java.getProxyClass(runtime, java.lang.System.class, false));
+
+        // asserting here that the Java.setProxyConstantInJavaPackage path only executes once and not repeatedly
+        assertSame(dummySystemProxy, runtime.getClassFromPath("Java::JavaLang::System"));
     }
 }


### PR DESCRIPTION
this is a second attempt at resolving (https://github.com/jruby/jruby/issues/8349) the slight regression introduced at https://github.com/jruby/jruby/commit/31f1ed6f7458acc42a545a032424580f5b22d746

the commit is reverted and the `-Xji.eager.constants` feature is re-implemented more conservatively (without effecting all `getProxyClass` callers).

also rename and cleaned up the method setting the actual proxy class constant, the tests are a bit futile but should prevent doing a similar `getProxyClass` refactoring, which would have undesired side effects.

