### PR TITLE
[feat] support clearing of thread local state

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -940,9 +940,18 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         return RubyString.newString(runtime, rubyName);
     }
 
+    /**
+     * Returns the current Ruby thread.
+     * @param runtime
+     * @return current ruby thread
+     */
+    public static RubyThread current(final Ruby runtime) {
+        return runtime.getCurrentContext().getThread();
+    }
+
     @JRubyMethod(meta = true)
     public static RubyThread current(IRubyObject recv) {
-        return recv.getRuntime().getCurrentContext().getThread();
+        return current(recv.getRuntime());
     }
 
     @JRubyMethod(meta = true)
@@ -1027,6 +1036,30 @@ public class RubyThread extends RubyObject implements ExecutionContext {
             }
         }
         return locals;
+    }
+
+    /**
+     * Clear the fiber local variable storage for this thread.
+     * Meant for Java consumers when reusing threads (e.g. during thread pooling).
+     * @see #clearThreadLocals()
+     */
+    public void clearFiberLocals() {
+        final Map<IRubyObject, IRubyObject> locals = getFiberLocals();
+        synchronized (locals) {
+            locals.clear();
+        }
+    }
+
+    /**
+     * Clear the thread local variable storage for this thread.
+     * Meant for Java consumers when reusing threads (e.g. during thread pooling).
+     * @see #clearFiberLocals()
+     */
+    public void clearThreadLocals() {
+        final Map<IRubyObject, IRubyObject> locals = getThreadLocals();
+        synchronized (locals) {
+            locals.clear();
+        }
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -940,18 +940,9 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         return RubyString.newString(runtime, rubyName);
     }
 
-    /**
-     * Returns the current Ruby thread.
-     * @param runtime
-     * @return current ruby thread
-     */
-    public static RubyThread current(final Ruby runtime) {
-        return runtime.getCurrentContext().getThread();
-    }
-
     @JRubyMethod(meta = true)
     public static RubyThread current(IRubyObject recv) {
-        return current(recv.getRuntime());
+        return recv.getRuntime().getCurrentContext().getThread();
     }
 
     @JRubyMethod(meta = true)

--- a/core/src/test/java/org/jruby/test/TestRubyThread.java
+++ b/core/src/test/java/org/jruby/test/TestRubyThread.java
@@ -1,7 +1,11 @@
 package org.jruby.test;
 
 import org.jruby.RubyThread;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class TestRubyThread extends Base {
@@ -50,4 +54,50 @@ public class TestRubyThread extends Base {
         assertSame(runtime.getNil(), thread.status(runtime.getCurrentContext()));
     }
 
+    public void testClearLocals() throws InterruptedException {
+        final CountDownLatch latch1 = new CountDownLatch(1);
+        final AtomicReference<RubyThread> otherThread = new AtomicReference<>();
+        final CountDownLatch latch2 = new CountDownLatch(1);
+
+        Thread thread = new Thread(() -> {
+            runtime.evalScriptlet("Thread.current[:foo] = :bar");
+            runtime.evalScriptlet("Thread.current.thread_variable_set('local', 42)");
+            otherThread.set(RubyThread.current(runtime.getThread()));
+
+            runtime.evalScriptlet("sleep(0.1)");
+            latch1.countDown();
+
+            runtime.evalScriptlet("sleep(0.1)");
+            try {
+                latch2.await(3, TimeUnit.SECONDS);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        thread.start();
+        latch1.await(3, TimeUnit.SECONDS);
+
+        final ThreadContext context = runtime.getCurrentContext();
+        IRubyObject local;
+
+        local = otherThread.get().op_aref(context, runtime.newSymbol("foo"));
+        assertEquals("bar", local.toString());
+
+        otherThread.get().clearFiberLocals();
+
+        local = otherThread.get().op_aref(context, runtime.newSymbol("foo"));
+        assertSame(runtime.getNil(), local);
+        assertEquals(0, otherThread.get().keys().size());
+
+        local = otherThread.get().thread_variable_p(context, runtime.newString("local"));
+        assertSame(runtime.getTrue(), local);
+
+        otherThread.get().clearThreadLocals();
+
+        local = otherThread.get().thread_variable_p(context, runtime.newString("local"));
+        assertSame(runtime.getFalse(), local);
+
+        latch2.countDown();
+    }
 }


### PR DESCRIPTION
this is to support cases where e.g. a Java thread pool is running Ruby code.

if the ruby code uses any fiber/thread local state e.g. `Thread.current[:foo] = :bar` than there isn't an easy way to cleanup accumulated state in RubyThread's locals (and due the way foreign Java threads are adopted the state will stick around for when the Java thread is re-cycled).