### PR TITLE
No backtick in errors

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -1476,7 +1476,7 @@ public final class Ruby implements Constantizable {
         if (superClass == null) {
             IRubyObject className = parentIsObject ? ids(this, id) :
                     parent.toRubyString(getCurrentContext()).append(newString("::")).append(ids(this, id));
-            warnings.warn(ID.NO_SUPER_CLASS, str(this, "no super class for `", className, "', Object assumed"));
+            warnings.warn(ID.NO_SUPER_CLASS, str(this, "no super class for '", className, "', Object assumed"));
 
             superClass = objectClass;
         }

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -2405,7 +2405,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
                 return newMethod;
             }
         }
-        throw getRuntime().newNameError(str(getRuntime(), "undefined method `", symbol,  "' for `", inspect(), "'"), symbol);
+        throw getRuntime().newNameError(str(getRuntime(), "undefined method '", symbol,  "' for '", inspect(), "'"), symbol);
     }
 
     /** rb_obj_method
@@ -2850,7 +2850,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     protected String validateInstanceVariable(String name) {
         if (IdUtil.isValidInstanceVariableName(name)) return name;
 
-        throw getRuntime().newNameError("`%1$s' is not allowable as an instance variable name", this, name);
+        throw getRuntime().newNameError("'%1$s' is not allowable as an instance variable name", this, name);
     }
 
     @Deprecated
@@ -2861,7 +2861,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     protected String validateInstanceVariable(IRubyObject name) {
         return RubySymbol.retrieveIDSymbol(name, (sym, newSym) -> {
             if (!sym.validInstanceVariableName()) {
-                throw getRuntime().newNameError("`%1$s' is not allowable as an instance variable name", this, name);
+                throw getRuntime().newNameError("'%1$s' is not allowable as an instance variable name", this, name);
             }
         }).idString();
     }

--- a/core/src/main/java/org/jruby/RubyBinding.java
+++ b/core/src/main/java/org/jruby/RubyBinding.java
@@ -158,7 +158,7 @@ public class RubyBinding extends RubyObject {
         DynamicScope evalScope = binding.getEvalScope(context.runtime);
         int slot = evalScope.getStaticScope().isDefined(id);
 
-        if (slot == -1) throw context.runtime.newNameError(str(context.runtime, "local variable `", symbol, "' not defined for " + inspect()), symbol);
+        if (slot == -1) throw context.runtime.newNameError(str(context.runtime, "local variable '", symbol, "' not defined for " + inspect()), symbol);
 
         return evalScope.getValueOrNil(slot & 0xffff, slot >> 16, context.nil);
     }
@@ -182,7 +182,7 @@ public class RubyBinding extends RubyObject {
         String id = RubySymbol.checkID(obj);
 
         if (!RubyLexer.isIdentifierChar(id.charAt(0))) {
-            throw context.runtime.newNameError(str(context.runtime, "wrong local variable name `", obj, "' for ", this), id);
+            throw context.runtime.newNameError(str(context.runtime, "wrong local variable name '", obj, "' for ", this), id);
         }
 
         return id;

--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -419,7 +419,7 @@ public class RubyGlobal {
     }
 
     private static void warnDeprecatedGlobal(final Ruby runtime, final String name) {
-        runtime.getWarnings().warnDeprecated(ID.MISCELLANEOUS, "`" + name + "' is deprecated");
+        runtime.getWarnings().warnDeprecated(ID.MISCELLANEOUS, "'" + name + "' is deprecated");
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -240,16 +240,16 @@ public class RubyKernel {
 
     private static String getMethodMissingFormat(Visibility visibility, CallType callType) {
 
-        String format = "undefined method `%s' for %s%s%s";
+        String format = "undefined method '%s' for %s%s%s";
 
         if (visibility == PRIVATE) {
-            format = "private method `%s' called for %s%s%s";
+            format = "private method '%s' called for %s%s%s";
         } else if (visibility == PROTECTED) {
-            format = "protected method `%s' called for %s%s%s";
+            format = "protected method '%s' called for %s%s%s";
         } else if (callType == CallType.VARIABLE) {
-            format = "undefined local variable or method `%s' for %s%s%s";
+            format = "undefined local variable or method '%s' for %s%s%s";
         } else if (callType == CallType.SUPER) {
-            format = "super: no superclass method `%s' for %s%s%s";
+            format = "super: no superclass method '%s' for %s%s%s";
         }
 
         return format;
@@ -1153,7 +1153,7 @@ public class RubyKernel {
         RubyStackTraceElement[] elements = rEx.getBacktraceElements();
         RubyStackTraceElement firstElement = elements.length > 0 ? elements[0] :
                 new RubyStackTraceElement("", "", "(empty)", 0, false);
-        String msg = String.format("Exception `%s' at %s:%s - %s\n",
+        String msg = String.format("Exception '%s' at %s:%s - %s\n",
                 rEx.getMetaClass(),
                 firstElement.getFileName(), firstElement.getLineNumber(),
                 TypeConverter.convertToType(rEx, runtime.getString(), "to_s"));

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -404,7 +404,7 @@ public class RubyKernel {
             IRubyObject exObj = ArgsUtil.extractKeywordArg(context,  opts, "exception");
 
             if (exObj != context.tru && exObj != context.fals) {
-                throw context.runtime.newArgumentError("`" + rubyClass.getName() + "': expected true or false as exception: " + exObj);
+                throw context.runtime.newArgumentError("'" + rubyClass.getName() + "': expected true or false as exception: " + exObj);
             }
             exception = exObj.isTrue();
         }

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1531,7 +1531,7 @@ public class RubyModule extends RubyObject {
         }
 
         // FIXME: Since we found no method we probably do not have symbol entry...do not want to pollute symbol table here.
-        throw runtime.newNameError(str(runtime, "undefined method '" + name + "' for" + s0 + " `", c, "'"), name);
+        throw runtime.newNameError(str(runtime, "undefined method '" + name + "' for" + s0 + " '", c, "'"), name);
     }
 
     @JRubyMethod(name = "include?")
@@ -1653,7 +1653,7 @@ public class RubyModule extends RubyObject {
 
     private static void warnMethodRemoval(final ThreadContext context, final String id) {
         context.runtime.getWarnings().warn(ID.UNDEFINING_BAD,
-                str(context.runtime, "removing `", ids(context.runtime, id), "' may cause serious problems"));
+                str(context.runtime, "removing '", ids(context.runtime, id), "' may cause serious problems"));
     }
 
     /**
@@ -2454,7 +2454,7 @@ public class RubyModule extends RubyObject {
     }
 
     public static String undefinedMethodMessage(Ruby runtime, IRubyObject name, IRubyObject modName, boolean isModule) {
-        return str(runtime, "undefined method `", name, "' for " + (isModule ? "module" : "class") + " `", modName, "'");
+        return str(runtime, "undefined method '", name, "' for " + (isModule ? "module" : "class") + " '", modName, "'");
     }
 
     /**
@@ -5406,21 +5406,21 @@ public class RubyModule extends RubyObject {
         if (IdUtil.isValidClassVariableName(name)) {
             return name;
         }
-        throw getRuntime().newNameError("`%1$s' is not allowed as a class variable name", this, name);
+        throw getRuntime().newNameError("'%1$s' is not allowed as a class variable name", this, name);
     }
 
     protected final String validateClassVariable(IRubyObject nameObj, String name) {
         if (IdUtil.isValidClassVariableName(name)) {
             return name;
         }
-        throw getRuntime().newNameError("`%1$s' is not allowed as a class variable name", this, nameObj);
+        throw getRuntime().newNameError("'%1$s' is not allowed as a class variable name", this, nameObj);
     }
 
     protected String validateClassVariable(Ruby runtime, IRubyObject object) {
         RubySymbol name = TypeConverter.checkID(object);
 
         if (!name.validClassVariableName()) {
-            throw getRuntime().newNameError(str(runtime, "`", ids(runtime, name), "' is not allowed as a class variable name"), this, object);
+            throw getRuntime().newNameError(str(runtime, "'", ids(runtime, name), "' is not allowed as a class variable name"), this, object);
         }
 
         return name.idString();

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1488,7 +1488,7 @@ public class RubyModule extends RubyObject {
 
         testFrozen("module");
         if (name.equals("__send__") || name.equals("object_id") || name.equals("initialize")) {
-            runtime.getWarnings().warn(ID.UNDEFINING_BAD, "undefining `"+ name +"' may cause serious problems");
+            runtime.getWarnings().warn(ID.UNDEFINING_BAD, "undefining '"+ name +"' may cause serious problems");
         }
 
         if (name.equals("method_missing")) {
@@ -1531,7 +1531,7 @@ public class RubyModule extends RubyObject {
         }
 
         // FIXME: Since we found no method we probably do not have symbol entry...do not want to pollute symbol table here.
-        throw runtime.newNameError(str(runtime, "undefined method `" + name + "' for" + s0 + " `", c, "'"), name);
+        throw runtime.newNameError(str(runtime, "undefined method '" + name + "' for" + s0 + " `", c, "'"), name);
     }
 
     @JRubyMethod(name = "include?")
@@ -2540,10 +2540,10 @@ public class RubyModule extends RubyObject {
                             entry.sourceModule,
                             entry.token);
                 } else {
-                    throw getRuntime().newNameError("undefined method `" + methodName + "' for class `" + getName() + '\'', methodName);
+                    throw getRuntime().newNameError("undefined method '" + methodName + "' for class '" + getName() + '\'', methodName);
                 }
             } else {
-                throw getRuntime().newNameError("undefined method `" + methodName + "' for class `" + getName() + '\'', methodName);
+                throw getRuntime().newNameError("undefined method '" + methodName + "' for class '" + getName() + '\'', methodName);
             }
         }
 
@@ -4608,7 +4608,7 @@ public class RubyModule extends RubyObject {
         if (!isRefinement()) {
             String methodName = nameIsTarget ? "target" : "refined_class";
             String errMsg = RubyStringBuilder.str(context.runtime,
-                    "undefined method `"+ methodName +"' for ", rubyBaseName(),
+                    "undefined method '"+ methodName +"' for ", rubyBaseName(),
                     ":", getMetaClass());
             throw context.runtime.newNoMethodError(errMsg, this, "target", context.runtime.newEmptyArray());
         }

--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -1552,7 +1552,7 @@ public class RubyProcess {
         String signalName = value.startsWith("SIG") ? value.substring(3) : value;
         int signalValue = (int) RubySignal.signm2signo(signalName);
 
-        if (signalValue == 0) throw runtime.newArgumentError("unsupported name `" + signalName + "'");
+        if (signalValue == 0) throw runtime.newArgumentError("unsupported name '" + signalName + "'");
 
         return negative ? -signalValue : signalValue;
     }

--- a/core/src/main/java/org/jruby/ext/ripper/RubyLexer.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RubyLexer.java
@@ -1570,7 +1570,7 @@ public class RubyLexer extends LexingCommon {
             try {
                 Integer.parseInt(refAsString.substring(1).intern());
             } catch (NumberFormatException e) {
-                warn("`" + refAsString + "' is too big for a number variable, always nil");
+                warn("'" + refAsString + "' is too big for a number variable, always nil");
             }
 
             identValue = createTokenString().intern();
@@ -1675,7 +1675,7 @@ public class RubyLexer extends LexingCommon {
     private int identifier(int c, boolean commandState) {
         if (!isIdentifierChar(c)) {
             String badChar = "\\" + Integer.toOctalString(c & 0xff);
-            compile_error("Invalid char `" + badChar + "' ('" + (char) c + "') in expression");
+            compile_error("Invalid char '" + badChar + "' ('" + (char) c + "') in expression");
         }
         // FIXME: on_kw: will return BOM as part of the ident string "\xfeffclass" on MRI and Yard also seems
         // to need this to properly parse.  So I record where token should really start so I can extract as

--- a/core/src/main/java/org/jruby/ext/ripper/RubyLexer.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RubyLexer.java
@@ -460,7 +460,7 @@ public class RubyLexer extends LexingCommon {
     @Override
     protected void setCompileOptionFlag(String name, ByteList value) {
         if (tokenSeen) {
-            warning("`%s' is ignored after any tokens", name);
+            warning("'%s' is ignored after any tokens", name);
             return;
         }
     }

--- a/core/src/main/java/org/jruby/ext/socket/RubyServerSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyServerSocket.java
@@ -132,7 +132,7 @@ public class RubyServerSocket extends RubySocket {
                 channel = ServerSocketChannel.open();
             }
             else {
-                throw runtime.newArgumentError("unsupported server socket type `" + soType + "'");
+                throw runtime.newArgumentError("unsupported server socket type '" + soType + "'");
             }
 
             return newChannelFD(runtime, channel);

--- a/core/src/main/java/org/jruby/ext/socket/RubySocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubySocket.java
@@ -451,14 +451,14 @@ public class RubySocket extends RubyBasicSocket {
                         channel = SocketChannel.open();
                     }
                     else {
-                        throw runtime.newArgumentError("unsupported protocol family `" + soProtocolFamily + "'");
+                        throw runtime.newArgumentError("unsupported protocol family '" + soProtocolFamily + "'");
                     }
                     break;
                 case SOCK_DGRAM:
                     channel = DatagramChannel.open();
                     break;
                 default:
-                    throw runtime.newArgumentError("unsupported socket type `" + soType + "'");
+                    throw runtime.newArgumentError("unsupported socket type '" + soType + "'");
             }
 
             return newChannelFD(runtime, channel);
@@ -677,7 +677,7 @@ public class RubySocket extends RubyBasicSocket {
                 return Sockaddr.addressFromSockaddr_in(context, arg);
 
             default:
-                throw context.runtime.newArgumentError("unsupported protocol family `" + soProtocolFamily + "'");
+                throw context.runtime.newArgumentError("unsupported protocol family '" + soProtocolFamily + "'");
         }
     }
 

--- a/core/src/main/java/org/jruby/internal/runtime/GlobalVariables.java
+++ b/core/src/main/java/org/jruby/internal/runtime/GlobalVariables.java
@@ -110,7 +110,7 @@ public class GlobalVariables {
         if (variable != null) return variable.getAccessor().getValue();
 
         if (runtime.isVerbose()) {
-            runtime.getWarnings().warning(ID.GLOBAL_NOT_INITIALIZED, "global variable `" + name + "' not initialized");
+            runtime.getWarnings().warning(ID.GLOBAL_NOT_INITIALIZED, "global variable '" + name + "' not initialized");
         }
         return runtime.getNil();
     }

--- a/core/src/main/java/org/jruby/internal/runtime/UndefinedAccessor.java
+++ b/core/src/main/java/org/jruby/internal/runtime/UndefinedAccessor.java
@@ -61,7 +61,7 @@ public class UndefinedAccessor implements IAccessor {
      */
     public IRubyObject getValue() {
         if (runtime.isVerbose()) {
-            runtime.getWarnings().warning(ID.ACCESSOR_NOT_INITIALIZED, "global variable `" + name + "' not initialized");
+            runtime.getWarnings().warning(ID.ACCESSOR_NOT_INITIALIZED, "global variable '" + name + "' not initialized");
         }
         return runtime.getNil();
     }

--- a/core/src/main/java/org/jruby/ir/targets/indy/IndyInvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/IndyInvocationCompiler.java
@@ -36,7 +36,7 @@ public class IndyInvocationCompiler implements InvocationCompiler {
     public void invokeOther(String file, String scopeFieldName, CallBase call, int arity) {
         String id = call.getId();
         if (arity > IRBytecodeAdapter.MAX_ARGUMENTS)
-            throw new NotCompilableException("call to `" + id + "' has more than " + IRBytecodeAdapter.MAX_ARGUMENTS + " arguments");
+            throw new NotCompilableException("call to '" + id + "' has more than " + IRBytecodeAdapter.MAX_ARGUMENTS + " arguments");
         if (call.isPotentiallyRefined()) {
             normalCompiler.invokeOther(file, scopeFieldName, call, arity);
             return;
@@ -119,7 +119,7 @@ public class IndyInvocationCompiler implements InvocationCompiler {
     public void invokeSelf(String file, String scopeFieldName, CallBase call, int arity) {
         String id = call.getId();
         if (arity > IRBytecodeAdapter.MAX_ARGUMENTS)
-            throw new NotCompilableException("call to `" + id + "' has more than " + IRBytecodeAdapter.MAX_ARGUMENTS + " arguments");
+            throw new NotCompilableException("call to '" + id + "' has more than " + IRBytecodeAdapter.MAX_ARGUMENTS + " arguments");
         if (call.isPotentiallyRefined()) {
             normalCompiler.invokeSelf(file, scopeFieldName, call, arity);
             return;

--- a/core/src/main/java/org/jruby/ir/targets/simple/NormalInvocationCompiler.java
+++ b/core/src/main/java/org/jruby/ir/targets/simple/NormalInvocationCompiler.java
@@ -70,7 +70,7 @@ public class NormalInvocationCompiler implements InvocationCompiler {
     public void invoke(String file, int lineNumber, String scopeFieldName, CallBase call, int arity) {
         String id = call.getId();
         if (arity > IRBytecodeAdapter.MAX_ARGUMENTS)
-            throw new NotCompilableException("call to `" + id + "' has more than " + IRBytecodeAdapter.MAX_ARGUMENTS + " arguments");
+            throw new NotCompilableException("call to '" + id + "' has more than " + IRBytecodeAdapter.MAX_ARGUMENTS + " arguments");
 
         MethodType incoming, outgoing;
         String incomingSig, outgoingSig;
@@ -355,7 +355,7 @@ public class NormalInvocationCompiler implements InvocationCompiler {
 
     public void invokeSelf(String file, String scopeFieldName, CallBase call, int arity) {
         if (arity > IRBytecodeAdapter.MAX_ARGUMENTS)
-            throw new NotCompilableException("call to `" + call.getId() + "' has more than " + IRBytecodeAdapter.MAX_ARGUMENTS + " arguments");
+            throw new NotCompilableException("call to '" + call.getId() + "' has more than " + IRBytecodeAdapter.MAX_ARGUMENTS + " arguments");
 
         invoke(file, compiler.getLastLine(), scopeFieldName, call, arity);
     }

--- a/core/src/main/java/org/jruby/java/proxies/JavaInterfaceTemplate.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaInterfaceTemplate.java
@@ -418,7 +418,7 @@ public class JavaInterfaceTemplate {
                     }
                 }
                 // did not continue (main) loop - passed method name not found in interface
-                runtime.getWarnings().warn("`" + name + "' is not a declared method in interface " + ifaceClass.getName());
+                runtime.getWarnings().warn("'" + name + "' is not a declared method in interface " + ifaceClass.getName());
             }
         }
 

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -1330,7 +1330,7 @@ public class Java implements Library {
         final IRubyObject name = args[0];
         if ( args.length > 1 ) {
             final int count = args.length - 1;
-            throw context.runtime.newArgumentError("Java does not have a method `"+ name +"' with " + count + " arguments");
+            throw context.runtime.newArgumentError("Java does not have a method '"+ name +"' with " + count + " arguments");
         }
         return method_missing(context, self, name);
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaPackage.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaPackage.java
@@ -266,7 +266,7 @@ public class JavaPackage extends RubyModule {
         final String method, final int argsLength) {
         String packageName = ((JavaPackage) pkg).packageName;
         return runtime.newArgumentError(
-                "Java package '" + packageName + "' does not have a method `" +
+                "Java package '" + packageName + "' does not have a method '" +
                         method + "' with " + argsLength + (argsLength == 1 ? " argument" : " arguments")
         );
     }

--- a/core/src/main/java/org/jruby/javasupport/ext/Module.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/Module.java
@@ -139,7 +139,7 @@ public class Module {
         try {
             return Java.setProxyClass(runtime, target, constant, javaClass);
         } catch (NameError e) {
-            String message = "cannot import Java class " + javaClass.getName() + " as `" + constant + "' : " + e.getException().getMessage();
+            String message = "cannot import Java class " + javaClass.getName() + " as '" + constant + "' : " + e.getException().getMessage();
             throw (RaiseException) runtime.newNameError(message, constant).initCause(e);
         }
     }
@@ -229,7 +229,7 @@ public class Module {
             try {
                 return Java.setProxyClass(runtime, (RubyModule) self, constName, foundClass);
             } catch (NameError e) {
-                String message = "cannot set Java class " + foundClass.getName() + " as `" + constant + "' : " + e.getException().getMessage();
+                String message = "cannot set Java class " + foundClass.getName() + " as '" + constant + "' : " + e.getException().getMessage();
                 throw runtime.newNameError(message, constant);
             }
         }

--- a/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
@@ -150,7 +150,7 @@ public class RubyLexer extends LexingCommon {
     }
     
     protected void ambiguousOperator(String op, String syn) {
-        warning(ID.AMBIGUOUS_ARGUMENT, "`" + op + "' after local variable or literal is interpreted as binary operator");
+        warning(ID.AMBIGUOUS_ARGUMENT, "'" + op + "' after local variable or literal is interpreted as binary operator");
         warning(ID.AMBIGUOUS_ARGUMENT, "even though it seems like " + syn);
     }
 
@@ -530,7 +530,7 @@ public class RubyLexer extends LexingCommon {
     @Override
     protected void setCompileOptionFlag(String name, ByteList value) {
         if (tokenSeen) {
-            warnings.warn(ID.ACCESSOR_MODULE_FUNCTION, "`" + name + "' is ignored after any tokens");
+            warnings.warn(ID.ACCESSOR_MODULE_FUNCTION, "'" + name + "' is ignored after any tokens");
             return;
         }
 
@@ -855,7 +855,7 @@ public class RubyLexer extends LexingCommon {
             if (c == '/') {
                 warning(ID.AMBIGUOUS_ARGUMENT, "ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator");
             } else {
-                warning(ID.AMBIGUOUS_ARGUMENT, "ambiguous first argument; put parentheses or a space even after `" + (char) c + "' operator");
+                warning(ID.AMBIGUOUS_ARGUMENT, "ambiguous first argument; put parentheses or a space even after '" + (char) c + "' operator");
             }
         }
         return true;
@@ -1488,7 +1488,7 @@ public class RubyLexer extends LexingCommon {
             try {
                 ref = Integer.parseInt(refAsString.substring(1));
             } catch (NumberFormatException e) {
-                warn(ID.AMBIGUOUS_ARGUMENT, "`" + refAsString + "' is too big for a number variable, always nil");
+                warn(ID.AMBIGUOUS_ARGUMENT, "'" + refAsString + "' is too big for a number variable, always nil");
                 ref = 0;
             }
 

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -2196,7 +2196,7 @@ public class Helpers {
         switch(symbol.idString()) {
             case "__id__":
             case "__send__":
-                runtime.getWarnings().warn(ID.REDEFINING_DANGEROUS, str(runtime, "redefining `", ids(runtime, symbol), "' may cause serious problem"));
+                runtime.getWarnings().warn(ID.REDEFINING_DANGEROUS, str(runtime, "redefining '", ids(runtime, symbol), "' may cause serious problem"));
                 break;
             case "initialize":
                 if (clazz == runtime.getObject()) {

--- a/core/src/main/java/org/jruby/runtime/backtrace/RubyStackTraceElement.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/RubyStackTraceElement.java
@@ -98,7 +98,7 @@ public class RubyStackTraceElement implements java.io.Serializable {
 
     @Deprecated
     public final CharSequence mriStyleString() {
-        // return fileName + ':' + lineNumber + ":in `" + methodName + '\'';
+        // return fileName + ':' + lineNumber + ":in '" + methodName + '\'';
         return new StringBuilder(fileName.length() + methodName.length() + 12).
                 append(fileName).append(':').append(lineNumber).
                 append(":in `").append(methodName).append('\'');

--- a/core/src/main/java/org/jruby/runtime/encoding/EncodingService.java
+++ b/core/src/main/java/org/jruby/runtime/encoding/EncodingService.java
@@ -420,7 +420,7 @@ public final class EncodingService {
         try {
             return EncodingUtils.charsetForEncoding(encoding);
         } catch (UnsupportedCharsetException uce) {
-            throw runtime.newEncodingCompatibilityError("no java.nio.charset.Charset found for encoding `" + encoding.toString() + "'");
+            throw runtime.newEncodingCompatibilityError("no java.nio.charset.Charset found for encoding '" + encoding.toString() + "'");
         }
     }
 

--- a/core/src/main/java/org/jruby/runtime/load/ClassExtensionLibrary.java
+++ b/core/src/main/java/org/jruby/runtime/load/ClassExtensionLibrary.java
@@ -98,7 +98,7 @@ public class ClassExtensionLibrary implements Library {
                 continue;
             } catch (UnsupportedClassVersionError ucve) {
                 if (runtime.isDebug()) ucve.printStackTrace();
-                throw runtime.newLoadError("JRuby ext built for wrong Java version in `" + className + "': " + ucve, className);
+                throw runtime.newLoadError("JRuby ext built for wrong Java version in '" + className + "': " + ucve, className);
             }
         }
 

--- a/core/src/main/java/org/jruby/runtime/load/LoadService.java
+++ b/core/src/main/java/org/jruby/runtime/load/LoadService.java
@@ -642,13 +642,13 @@ public class LoadService {
                 service.basicLoad(runtime);
             } else {
                 // invalid type of library, raise error
-                throw runtime.newLoadError("library `" + libraryName + "' is not of type Library or BasicLibraryService", libraryName);
+                throw runtime.newLoadError("library '" + libraryName + "' is not of type Library or BasicLibraryService", libraryName);
             }
         } catch (RaiseException re) {
             throw re;
         } catch (Throwable e) {
             debugLoadException(runtime, e);
-            throw runtime.newLoadError("library `" + libraryName + "' could not be loaded: " + e, libraryName);
+            throw runtime.newLoadError("library '" + libraryName + "' could not be loaded: " + e, libraryName);
         }
     }
 
@@ -779,7 +779,7 @@ public class LoadService {
         String file = resource.getName();
         String location = loadName;
         if (file.endsWith(".so") || file.endsWith(".dll") || file.endsWith(".bundle")) {
-            throw runtime.newLoadError("C extensions are not supported, can't load `" + resource.getName() + "'", resource.getName());
+            throw runtime.newLoadError("C extensions are not supported, can't load '" + resource.getName() + "'", resource.getName());
         } else if (file.endsWith(".jar")) {
             return new JarredScript(resource, baseName);
         } else if (file.endsWith(".class")) {

--- a/core/src/main/java/org/jruby/runtime/marshal/UnmarshalStream.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/UnmarshalStream.java
@@ -329,7 +329,7 @@ public class UnmarshalStream extends InputStream {
 
     public void prohibitIVar(MarshalState state, String label, String name) {
         if (state != null && state.isIvarWaiting()) {
-            throw typeError(runtime.getCurrentContext(), "can't override instance variable of " + label + "`" + name + "'");
+            throw typeError(runtime.getCurrentContext(), "can't override instance variable of " + label + "'" + name + "'");
         }
     }
 

--- a/core/src/main/java/org/jruby/util/IOChannel.java
+++ b/core/src/main/java/org/jruby/util/IOChannel.java
@@ -164,7 +164,7 @@ public abstract class IOChannel implements Channel {
         if(io.respondsTo(readMethod)) {
             return new FunctionalCachingCallSite(readMethod);
         } else {
-            throw new IllegalArgumentException(io.getMetaClass() + "not coercible to " + getClass().getSimpleName() + ": no `" + readMethod + "' method");
+            throw new IllegalArgumentException(io.getMetaClass() + "not coercible to " + getClass().getSimpleName() + ": no '" + readMethod + "' method");
         }
     }
 

--- a/core/src/main/java/org/jruby/util/cli/ArgumentProcessor.java
+++ b/core/src/main/java/org/jruby/util/cli/ArgumentProcessor.java
@@ -475,7 +475,7 @@ public class ArgumentProcessor {
                                 continue;
                             }
 
-                            config.getError().println("warning: unknown argument for --debug: `" + debug + "'");
+                            config.getError().println("warning: unknown argument for --debug: '" + debug + "'");
                         }
                         break FOR;
                     } else if (argument.startsWith("--encoding")) {
@@ -671,7 +671,7 @@ public class ArgumentProcessor {
         BiFunction<ArgumentProcessor, Boolean, Void> feature = FEATURES.get(name);
 
         if (feature == null) {
-            config.getError().println("warning: unknown argument for --" + (enable ? "enable" : "disable") + ": `" + name + "'");
+            config.getError().println("warning: unknown argument for --" + (enable ? "enable" : "disable") + ": '" + name + "'");
         } else {
             feature.apply(this, enable);
         }

--- a/core/src/test/java/org/jruby/embed/jsr223/JRubyCompiledScriptTest.java
+++ b/core/src/test/java/org/jruby/embed/jsr223/JRubyCompiledScriptTest.java
@@ -213,7 +213,7 @@ public class JRubyCompiledScriptTest extends BaseTest {
             fail("script expected to fail but returned: " + result);
         } catch (ScriptException e) {
             assertTrue(Objects.toString(e.getCause()), e.getCause() instanceof org.jruby.exceptions.NameError);
-            assertTrue(e.getCause().getMessage(), e.getCause().getMessage().contains("undefined local variable or method `sample_message'"));
+            assertTrue(e.getCause().getMessage(), e.getCause().getMessage().contains("undefined local variable or method 'sample_message'"));
         }
     }
 

--- a/spec/java_integration/interfaces/java8_methods_spec.rb
+++ b/spec/java_integration/interfaces/java8_methods_spec.rb
@@ -209,7 +209,7 @@ describe "an interface" do
       impl = Java::Java8Interface.impl(:baz) { |*args| "#{args.inspect}-IMPL" }
       expect{ Java::Java8Interface.bar(impl) }.to raise_error(NoMethodError)
     end
-    expect( output.index("`baz' is not a declared method in interface") ).to_not be nil
+    expect( output.index("'baz' is not a declared method in interface") ).to_not be nil
   end
 
   it "does not consider Map vs func-type Consumer ambiguous" do

--- a/spec/java_integration/packages/access_spec.rb
+++ b/spec/java_integration/packages/access_spec.rb
@@ -83,7 +83,7 @@ describe "java package" do
     begin
       javax.script(1)
     rescue ArgumentError => e
-      expect( e.message ).to eql "Java package 'javax' does not have a method `script' with 1 argument"
+      expect( e.message ).to eql "Java package 'javax' does not have a method 'script' with 1 argument"
     else; fail 'error not raised' end
   end
 

--- a/test/jruby/test_kernel.rb
+++ b/test/jruby/test_kernel.rb
@@ -285,25 +285,25 @@ class TestKernel < Test::Unit::TestCase
     # by Exception Class
     $stderr = StringIO.new
     raise StandardError rescue nil
-    tobe = "Exception `StandardError' at #{__FILE__}:#{__LINE__ - 1} - StandardError"
+    tobe = "Exception 'StandardError' at #{__FILE__}:#{__LINE__ - 1} - StandardError"
     assert_equal(tobe, $stderr.string.split("\n")[0])
 
     # by String
     $stderr.reopen
     raise "TEST_ME" rescue nil
-    tobe = "Exception `RuntimeError' at #{__FILE__}:#{__LINE__ - 1} - TEST_ME"
+    tobe = "Exception 'RuntimeError' at #{__FILE__}:#{__LINE__ - 1} - TEST_ME"
     assert_equal(tobe, $stderr.string.split("\n")[0])
 
     # by Exception
     $stderr.reopen
     raise RuntimeError.new("TEST_ME") rescue nil
-    tobe = "Exception `RuntimeError' at #{__FILE__}:#{__LINE__ - 1} - TEST_ME"
+    tobe = "Exception 'RuntimeError' at #{__FILE__}:#{__LINE__ - 1} - TEST_ME"
     assert_equal(tobe, $stderr.string.split("\n")[0])
 
     # by re-raise
     $stderr.reopen
     raise "TEST_ME" rescue raise rescue nil
-    tobe = "Exception `RuntimeError' at #{__FILE__}:#{__LINE__ - 1} - TEST_ME"
+    tobe = "Exception 'RuntimeError' at #{__FILE__}:#{__LINE__ - 1} - TEST_ME"
     traces = $stderr.string.split("\n")
     assert_equal(tobe, traces[0])
     assert_equal(tobe, traces[1])

--- a/test/jruby/test_time.rb
+++ b/test/jruby/test_time.rb
@@ -196,7 +196,7 @@ class TestTimeNilOps < Test::Unit::TestCase
       fail "bleh"
     rescue NoMethodError=>x
       assert x
-      assert_equal "undefined method `*' for #{t.inspect}:Time", x.message
+      assert_equal "undefined method '*' for #{t.inspect}:Time", x.message
     end
   end
 
@@ -207,7 +207,7 @@ class TestTimeNilOps < Test::Unit::TestCase
       fail "bleh"
     rescue NoMethodError=>x
       assert x
-      assert_equal "undefined method `/' for #{t.inspect}:Time", x.message
+      assert_equal "undefined method '/' for #{t.inspect}:Time", x.message
     end
   end
 


### PR DESCRIPTION
CRuby no longer quotes identifiers in error messages like `` `foo'``, instead using a single quote for both quotes like `'foo'`.