### PR TITLE
Fix issues relating to freezing dynamic strings

### DIFF
--- a/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
+++ b/core/src/main/java/org/jruby/ir/targets/JVMVisitor.java
@@ -1191,14 +1191,7 @@ public class JVMVisitor extends IRVisitor {
             }
         }
         if (compoundstring.isFrozen()) {
-            if (runtime.getInstanceConfig().isDebuggingFrozenStringLiteral()) {
-                jvmMethod().loadContext();
-                jvmAdapter().ldc(compoundstring.getFile());
-                jvmAdapter().ldc(compoundstring.getLine());
-                jvmMethod().invokeIRHelper("freezeLiteralString", sig(RubyString.class, RubyString.class, ThreadContext.class, String.class, int.class));
-            } else {
-                jvmMethod().invokeIRHelper("freezeLiteralString", sig(RubyString.class, RubyString.class));
-            }
+            jvmMethod().invokeIRHelper("freezeLiteralString", sig(RubyString.class, RubyString.class));
         }
         jvmStoreLocal(compoundstring.getResult());
     }

--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -1415,7 +1415,6 @@ public abstract class RubyParserBase {
                 DStrNode newDStr = new DStrNode(head.getLine(), ((DStrNode) tail).getEncoding());
                 newDStr.add(head);
                 newDStr.addAll(tail);
-                if (frozenStringLiterals) newDStr.setFrozen(true);
                 return newDStr;
             } 
 


### PR DESCRIPTION
* Don't freeze dynamic strings when concatenating two sequential string literals. (jruby/jruby#8380)
* For the sole remaining frozen DStr case, only freeze and do not create a debug frozen string.

Fixes jruby/jruby#8380