### PR TITLE
Clear callInfo in Enumerable Java-based blocks

### DIFF
--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -2220,6 +2220,7 @@ public class RubyEnumerable {
         }
 
         public IRubyObject call(ThreadContext context, IRubyObject[] args, Block block) {
+            ThreadContext.resetCallInfo(context);
             InternalVariables variables = enumerator.getInternalVariables();
             final IRubyObject enumerable = (IRubyObject) variables.getInternalVariable("chunk_enumerable");
             final RubyProc categorize = (RubyProc) variables.getInternalVariable("chunk_categorize");

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -2302,12 +2302,14 @@ public class RubyEnumerable {
         }
 
         public IRubyObject call(ThreadContext context, IRubyObject[] args, Block block) {
+            ThreadContext.resetCallInfo(context);
             result.append(packEnumValues(context, args));
             return context.nil;
         }
 
         @Override
         public IRubyObject call(ThreadContext context, IRubyObject arg, Block block) {
+            ThreadContext.resetCallInfo(context);
             result.append(arg);
             return context.nil;
         }

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -2344,6 +2344,7 @@ public class RubyEnumerable {
         }
 
         public IRubyObject call(ThreadContext context, IRubyObject[] largs, Block blk) {
+            ThreadContext.resetCallInfo(context);
             final Ruby runtime = context.runtime;
             final boolean blockGiven = block.isGiven();
 
@@ -2386,6 +2387,7 @@ public class RubyEnumerable {
         }
 
         public IRubyObject call(ThreadContext context, IRubyObject[] largs, Block blk) {
+            ThreadContext.resetCallInfo(context);
             IRubyObject value;
             if (largs.length == 0) {
                 value = context.nil;

--- a/spec/jruby/core/enumerable/tally_call_info_spec.rb
+++ b/spec/jruby/core/enumerable/tally_call_info_spec.rb
@@ -1,0 +1,20 @@
+# Enumerable#tally had a Java-based block that did not clear callInfo, potentially leaving CALL_KEYWORD_EMPTY bit stuck
+# for a subsequent call.
+#
+# jruby/jruby#8382
+
+class TallyEnumWithEmptyKwargs
+  include Enumerable
+  def each(&block)
+    block.call(**{})
+  end
+end
+
+def kwarg_method_after_tally(kw:); end
+
+describe "Enumerable#to_a" do
+  it "should clear callInfo when invoking its internal block" do
+    TallyEnumWithEmptyKwargs.new.to_a
+    kwarg_method_after_tally(kw: 1)
+  end
+end

--- a/spec/jruby/core/enumerable/to_a_call_info_spec.rb
+++ b/spec/jruby/core/enumerable/to_a_call_info_spec.rb
@@ -1,0 +1,20 @@
+# Enumerable#to_a had a Java-based block that did not clear callInfo, potentially leaving CALL_KEYWORD_EMPTY bit stuck
+# for a subsequent call.
+#
+# jruby/jruby#8382
+
+class ToAEnumWithEmptyKwargs
+  include Enumerable
+  def each(&block)
+    block.call(**{})
+  end
+end
+
+def kwarg_method_after_to_a(kw:); end
+
+describe "Enumerable#to_a" do
+  it "should clear callInfo when invoking its internal block" do
+    ToAEnumWithEmptyKwargs.new.to_a
+    kwarg_method_after_to_a(kw: 1)
+  end
+end

--- a/spec/jruby/core/enumerable/to_h_call_info_spec.rb
+++ b/spec/jruby/core/enumerable/to_h_call_info_spec.rb
@@ -1,0 +1,20 @@
+# Enumerable#to_h had a Java-based block that did not clear callInfo, potentially leaving CALL_KEYWORD_EMPTY bit stuck
+# for a subsequent call.
+#
+# jruby/jruby#8382
+
+class ToHEnumWithEmptyKwargs
+  include Enumerable
+  def each(&block)
+    block.call(1, 2, **{})
+  end
+end
+
+def kwarg_method_after_to_h(kw:); end
+
+describe "Enumerable#to_h" do
+  it "should clear callInfo when invoking its internal block" do
+    ToHEnumWithEmptyKwargs.new.to_a
+    kwarg_method_after_to_h(kw: 1)
+  end
+end


### PR DESCRIPTION
Enumerable#to_a does not take keywords but also was not handling any incoming callInfo bits. As a result an incoming CALL_KEYWORD_EMPTY bit can get stuck and propagte through to the next call. This does not process any kwargs because it is effectively a block with signature like |a, *b| but whether it should do more than clearing callInfo is unknown.

Fixes jruby/jruby#8382