### PR TITLE
Fix bugs from GzipReader wrapped IO-like test

### DIFF
--- a/core/src/main/java/org/jruby/util/IOInputStream.java
+++ b/core/src/main/java/org/jruby/util/IOInputStream.java
@@ -141,8 +141,15 @@ public class IOInputStream extends InputStream {
         if (readValue.isNil()) return -1;
 
         ByteList str = readValue.convertToString().getByteList();
-        System.arraycopy(str.getUnsafeBytes(), str.getBegin(), b, off, str.getRealSize());
 
-        return str.getRealSize();
+        int readSize = str.realSize();
+
+        if (readSize > len) {
+            throw runtime.newIOError("read call of " + len + " bytes produced a String of length " + readSize);
+        }
+
+        System.arraycopy(str.getUnsafeBytes(), str.getBegin(), b, off, readSize);
+
+        return readSize;
      }
 }

--- a/test/jruby/test_zlib.rb
+++ b/test/jruby/test_zlib.rb
@@ -429,6 +429,7 @@ class TestZlib < Test::Unit::TestCase
 
   def self.create_gzip_stream(string)
     s = StringIO.new
+    s.set_encoding(Encoding::BINARY, Encoding::BINARY)
     Zlib::GzipWriter.wrap(s) { |io|
       io.write("hello")
     }


### PR DESCRIPTION
This includes two fixes for jruby/jruby#8391:

1. Don't blindly copy the resulting string bytes from a `read` call into the given buffer; we may have gotten more bytes than requested from a bad `read` implementation.
2. Fix a test fixture that potentially can produce more bytes than requested from a wrapped GzipReader `read` call.

The fix is targeted at jruby-9.3 in case we need to do any releases of that branch in the future, but the only planned release for now is 9.4.9.0.