### PR TITLE
Treat Set's internal Hash as nil when uninitialized

### DIFF
--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -924,6 +924,13 @@ public class RubySet extends RubyObject implements Set {
     @Override
     @JRubyMethod
     public RubyFixnum hash() { // @hash.hash
+        RubyHash hash = this.hash;
+
+        if (hash == null) {
+            // Emulate set.rb for jruby/jruby#8393
+            return ((RubyBasicObject) getRuntime().getNil()).hash();
+        }
+
         return hash.hash();
     }
 

--- a/spec/ruby/library/set/hash_spec.rb
+++ b/spec/ruby/library/set/hash_spec.rb
@@ -10,4 +10,9 @@ describe "Set#hash" do
     Set[].hash.should_not == Set[1, 2, 3].hash
     Set[1, 2, 3].hash.should_not == Set[:a, "b", ?c].hash
   end
+
+  # see https://github.com/jruby/jruby/issues/8393
+  it "is equal to nil.hash for an uninitialized Set" do
+    Set.allocate.hash.should == nil.hash
+  end
 end


### PR DESCRIPTION
set.rb is implemented in pure Ruby, so its @hash instance var will
start out as nil. If you attempt to #hash an uninitialized Set,
the resulting hashcode is that of nil, rather than raising an
exception as seen in https://github.com/jruby/jruby/issues/8393.

This fix emulates the nil hash. No other uses of the uninitialized
Set are fixed here, so it's still largely unusable until it has
been initialized.

See also https://github.com/jruby/jruby/issues/8352.

Fixes https://github.com/jruby/jruby/issues/8393.