### PR TITLE
[deps] bump rexml default gem to 3.3.9

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -135,7 +135,7 @@ bundled_gems = [
     ['rake', '${rake.version}'],
     # Depends on many CRuby internals
     # ['rbs', '2.0.0'],
-    ['rexml', '3.3.4'],
+    ['rexml', '3.3.9'],
     ['rss', '0.2.9'],
     ['test-unit', '3.5.3'],
     # Depends on many CRuby internals

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -1035,7 +1035,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>rexml</artifactId>
-      <version>3.3.4</version>
+      <version>3.3.9</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1169,7 +1169,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/prime-0.1.2*</include>
           <include>specifications/power_assert-2.0.1*</include>
           <include>specifications/rake-${rake.version}*</include>
-          <include>specifications/rexml-3.3.4*</include>
+          <include>specifications/rexml-3.3.9*</include>
           <include>specifications/rss-0.2.9*</include>
           <include>specifications/test-unit-3.5.3*</include>
           <include>gems/rubygems-update-3.3.26*/**/*</include>
@@ -1249,7 +1249,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/prime-0.1.2*/**/*</include>
           <include>gems/power_assert-2.0.1*/**/*</include>
           <include>gems/rake-${rake.version}*/**/*</include>
-          <include>gems/rexml-3.3.4*/**/*</include>
+          <include>gems/rexml-3.3.9*/**/*</include>
           <include>gems/rss-0.2.9*/**/*</include>
           <include>gems/test-unit-3.5.3*/**/*</include>
           <include>cache/rubygems-update-3.3.26*</include>
@@ -1329,7 +1329,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/prime-0.1.2*</include>
           <include>cache/power_assert-2.0.1*</include>
           <include>cache/rake-${rake.version}*</include>
-          <include>cache/rexml-3.3.4*</include>
+          <include>cache/rexml-3.3.9*</include>
           <include>cache/rss-0.2.9*</include>
           <include>cache/test-unit-3.5.3*</include>
         </includes>


### PR DESCRIPTION
due CVE reports (CVE-2024-49761 REXML ReDoS vulnerability)
```
Name: rexml
Version: 3.3.8
CVE: CVE-2024-49761
GHSA: GHSA-2rxp-v6pw-ch6m
Criticality: Unknown
URL: https://github.com/ruby/rexml/security/advisories/GHSA-2rxp-v6pw-ch6m
Title: REXML ReDoS vulnerability
Solution: update to '>= 3.3.9'
```