### PR TITLE
Always set parent and name even if not eager

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -4995,7 +4995,7 @@ public class RubyModule extends RubyObject {
         return value;
     }
 
-    private void setParentForModule(final String name, final IRubyObject value) {
+    public void setParentForModule(final String name, final IRubyObject value) {
         // if adding a module under a constant name, set that module's basename to the constant name
         if ( value instanceof RubyModule ) {
             RubyModule module = (RubyModule) value;

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -850,7 +850,7 @@ public class Java implements Library {
         assert clazz == proxyClass.dataGetStruct() :
             "not a Java proxy wrapper: " + proxyClass.dataGetStruct() + " expected: " + clazz;
 
-        if (!eagerSet || !Modifier.isPublic(clazz.getModifiers())) return;
+        if (!Modifier.isPublic(clazz.getModifiers())) return;
 
         final String fullName = clazz.getName();
 
@@ -872,8 +872,13 @@ public class Java implements Library {
 
         if ( parentModule != null && // TODO a Java Ruby class should not validate (as well)
             ( IdUtil.isConstant(className) || parentModule instanceof JavaPackage ) ) {
-            // setConstant without validation since Java class name might be lower-case
-            setProxyClass(runtime, parentModule, className, proxyClass, false);
+            if (eagerSet) {
+                // setConstant without validation since Java class name might be lower-case
+                setProxyClass(runtime, parentModule, className, proxyClass, false);
+            } else {
+                // just set parent and name
+                parentModule.setParentForModule(className, proxyClass);
+            }
         }
     }
 


### PR DESCRIPTION
Setting a constant has the side effect of also setting the name when a class has none. By making JI constants lazy, we also skip the constant set, so the class remains anonymous.

$ jruby -Xji.eager.constants=false -e 'p java.lang.Runnable.name' nil

This patch restores parent module and name-setting to the last phase of Java proxy class initialization, so that the proxy class gets its real name.