### PR TITLE
Revert "re-implement the option to lazy bind Java:: constants"

### DIFF
--- a/core/src/main/java/org/jruby/java/proxies/JavaInterfaceTemplate.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaInterfaceTemplate.java
@@ -306,12 +306,9 @@ public class JavaInterfaceTemplate {
 
     private static IRubyObject newInterfaceProxy(final IRubyObject self) {
         final RubyClass current = self.getMetaClass();
-        final Ruby runtime = current.getRuntime();
         // construct the new interface impl and set it into the object
         Object impl = Java.newInterfaceImpl(self, Java.getInterfacesFromRubyClass(current));
-        RubyClass proxyClass = (RubyClass) Java.getProxyClass(runtime, impl.getClass());
-        // we do not want the (InterfaceImpl) proxy-class in this case to be set on the Ruby side
-        IRubyObject implWrapper = Java.getInstanceInternal(runtime, impl, proxyClass, false);
+        IRubyObject implWrapper = Java.getInstance(self.getRuntime(), impl);
         JavaUtilities.set_java_object(self, self, implWrapper); // self.dataWrapStruct(newObject);
         return implWrapper;
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaPackage.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaPackage.java
@@ -189,7 +189,7 @@ public class JavaPackage extends RubyModule {
 
     RubyModule relativeJavaProxyClass(final Ruby runtime, final IRubyObject name) {
         final String fullName = packageRelativeName( name.toString() ).toString();
-        return Java.getProxyClass(runtime, Java.getJavaClass(runtime, fullName));
+        return Java.getProxyClass(runtime, Java.getJavaClass(runtime, fullName), true);
     }
 
     @JRubyMethod(name = "respond_to?")

--- a/core/src/main/java/org/jruby/javasupport/JavaSupport.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupport.java
@@ -50,6 +50,7 @@ import org.jruby.util.collections.ClassValue;
 import org.jruby.util.collections.ClassValueCalculator;
 
 import java.lang.reflect.Member;
+import java.lang.reflect.Modifier;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -369,8 +370,16 @@ public abstract class JavaSupport {
         return null;
     }
 
-    RubyModule getProxyClassFromCache(Class clazz) {
-        return proxyClassCache.get(clazz);
+    RubyModule getProxyClassFromCache(Class clazz, boolean setConstant) {
+        RubyModule proxy = proxyClassCache.get(clazz);
+
+        if (setConstant) {
+            if ( Modifier.isPublic(clazz.getModifiers()) ) {
+                Java.addToJavaPackageModule(runtime, clazz, proxy);
+            }
+        }
+
+        return proxy;
     }
 
 }

--- a/core/src/test/java/org/jruby/javasupport/TestJava.java
+++ b/core/src/test/java/org/jruby/javasupport/TestJava.java
@@ -1,8 +1,5 @@
 package org.jruby.javasupport;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.io.PrintWriter;
 import java.lang.reflect.Method;
 import java.text.SimpleDateFormat;
 
@@ -139,52 +136,5 @@ public class TestJava extends junit.framework.TestCase {
 
         assertNotNull(runtime.evalScriptlet("FormatImpl.new")); // used to cause an infinite loop
         assertTrue(runtime.evalScriptlet("FormatImpl.new").toJava(Object.class) instanceof SimpleDateFormat);
-    }
-
-    @Test
-    public void testDuckTypeInterfaceImplGeneratesNoWarning() {
-        final String script =
-            "class Consumer1\n" +
-            "  def self.accept(arg); puts self end\n" +
-            "end\n" +
-            "class Consumer2 < Consumer1; end\n" +
-            "class Consumer3 < Consumer1; end\n" ;
-
-        final ByteArrayOutputStream output = new ByteArrayOutputStream();
-
-        RubyInstanceConfig config = new RubyInstanceConfig();
-        config.setOutput(new PrintStream(output));
-        config.setError(new PrintStream(output));
-
-        final Ruby runtime = Ruby.newInstance(config);
-        runtime.evalScriptlet(script);
-
-        runtime.evalScriptlet(
-            "coll = java.util.Collections.singleton(42)\n" +
-            "coll.forEach(Consumer1); coll.forEach(Consumer2); coll.forEach(Consumer3)"
-        );
-
-        assertEquals("Consumer1\nConsumer2\nConsumer3\n", output.toString()); // no "warning: already initialized constant ..."
-    }
-
-    @Test
-    public void testGetProxyClass() {
-        final ByteArrayOutputStream output = new ByteArrayOutputStream();
-
-        RubyInstanceConfig config = new RubyInstanceConfig();
-        config.setOutput(new PrintStream(output));
-        config.setError(new PrintStream(output)); // ignore warnings - we'll be replacing an internal Java proxy constant
-
-        final Ruby runtime = Ruby.newInstance(config);
-
-        final Object klass = Java.getProxyClass(runtime, java.lang.System.class); // Java::JavaLang::System
-
-        final RubyModule dummySystemProxy = RubyModule.newModule(runtime); // replace Java::JavaLang::System with smt different
-        Java.setProxyClass(runtime, runtime.getClassFromPath("Java::JavaLang"), "System", dummySystemProxy, true);
-
-        assertSame(klass, Java.getProxyClass(runtime, java.lang.System.class));
-
-        // asserting here that the Java.setProxyConstantInJavaPackage path only executes once and not repeatedly
-        assertSame(dummySystemProxy, runtime.getClassFromPath("Java::JavaLang::System"));
     }
 }


### PR DESCRIPTION
Reverts jruby/jruby#8368

This did not fix the `already initialized constant` issue fully (introduced by #8208) and led to several additional problems described in #8399. We are reverting this and #8208 all the way back and will attempt to fix #8156 a different way.