### PR TITLE
Revert "Only set up Java:: constants when accessed directly"

### DIFF
--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -431,14 +431,9 @@ public class Java implements Library {
 
     @SuppressWarnings("deprecation")
     public static RubyModule getProxyClass(final Ruby runtime, final Class<?> clazz) {
-        return getProxyClass(runtime, clazz, Options.JI_EAGER_CONSTANTS.load());
-    }
-
-    @SuppressWarnings("deprecation")
-    public static RubyModule getProxyClass(final Ruby runtime, final Class<?> clazz, boolean setConstant) {
         RubyModule proxy = runtime.getJavaSupport().getUnfinishedProxy(clazz);
         if (proxy != null) return proxy;
-        return runtime.getJavaSupport().getProxyClassFromCache(clazz, setConstant);
+        return runtime.getJavaSupport().getProxyClassFromCache(clazz);
     }
 
     // expected to handle Java proxy (Ruby) sub-classes as well
@@ -495,6 +490,7 @@ public class Java implements Library {
             proxy.includeModule(extModule);
         }
         Initializer.setupProxyModule(runtime, javaClass, proxy);
+        addToJavaPackageModule(proxy);
     }
 
     private static void generateClassProxy(Ruby runtime, Class<?> clazz, RubyClass proxy, RubyClass superClass) {
@@ -516,6 +512,7 @@ public class Java implements Library {
             } else {
                 proxy.getMetaClass().defineAnnotatedMethods(OldStyleExtensionInherited.class);
             }
+            addToJavaPackageModule(proxy);
         }
         else {
             createProxyClass(runtime, proxy, clazz, superClass, false);
@@ -523,6 +520,9 @@ public class Java implements Library {
             final Class<?>[] interfaces = clazz.getInterfaces();
             for ( int i = interfaces.length; --i >= 0; ) {
                 proxy.includeModule(getInterfaceModule(runtime, interfaces[i]));
+            }
+            if ( Modifier.isPublic(clazz.getModifiers()) ) {
+                addToJavaPackageModule(proxy);
             }
         }
 
@@ -841,7 +841,9 @@ public class Java implements Library {
 
     // package scheme 2: separate module for each full package name, constructed
     // from the camel-cased package segments: Java::JavaLang::Object,
-    static void addToJavaPackageModule(Ruby runtime, Class<?> clazz, RubyModule proxyClass) {
+    private static void addToJavaPackageModule(RubyModule proxyClass) {
+        final Ruby runtime = proxyClass.getRuntime();
+        final Class<?> clazz = (Class<?>)proxyClass.dataGetStruct();
         final String fullName;
         if ( ( fullName = clazz.getName() ) == null ) return;
 
@@ -1088,7 +1090,7 @@ public class Java implements Library {
         } catch (ClassNotFoundException ex) { // used to catch NoClassDefFoundError for whatever reason
             return null;
         }
-        return getProxyClass(runtime, clazz, true);
+        return getProxyClass(runtime, clazz);
     }
 
     private static int mapMajorMinorClassVersionToJavaVersion(String msg, final int offset) {

--- a/core/src/main/java/org/jruby/javasupport/JavaPackage.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaPackage.java
@@ -189,7 +189,7 @@ public class JavaPackage extends RubyModule {
 
     RubyModule relativeJavaProxyClass(final Ruby runtime, final IRubyObject name) {
         final String fullName = packageRelativeName( name.toString() ).toString();
-        return Java.getProxyClass(runtime, Java.getJavaClass(runtime, fullName), true);
+        return Java.getProxyClass(runtime, Java.getJavaClass(runtime, fullName));
     }
 
     @JRubyMethod(name = "respond_to?")

--- a/core/src/main/java/org/jruby/javasupport/JavaSupport.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaSupport.java
@@ -50,7 +50,6 @@ import org.jruby.util.collections.ClassValue;
 import org.jruby.util.collections.ClassValueCalculator;
 
 import java.lang.reflect.Member;
-import java.lang.reflect.Modifier;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -370,16 +369,8 @@ public abstract class JavaSupport {
         return null;
     }
 
-    RubyModule getProxyClassFromCache(Class clazz, boolean setConstant) {
-        RubyModule proxy = proxyClassCache.get(clazz);
-
-        if (setConstant) {
-            if ( Modifier.isPublic(clazz.getModifiers()) ) {
-                Java.addToJavaPackageModule(runtime, clazz, proxy);
-            }
-        }
-
-        return proxy;
+    RubyModule getProxyClassFromCache(Class clazz) {
+        return proxyClassCache.get(clazz);
     }
 
 }

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -198,7 +198,6 @@ public class Options {
     public static final Option<Boolean> JI_LOAD_LAZY = bool(JAVA_INTEGRATION, "ji.load.lazy", true, "Load Java support (class extensions) lazily on demand or ahead of time.");
     public static final Option<Boolean> JI_CLOSE_CLASSLOADER = bool(JAVA_INTEGRATION, "ji.close.classloader", false, "Close the JRubyClassLoader used by each runtime");
     public static final Option<String> JI_NESTED_JAR_TMPDIR = string(JAVA_INTEGRATION, "ji.nested.jar.tmpdir", "Use specified dir as a base for unpacking nested jar files.");
-    public static final Option<Boolean> JI_EAGER_CONSTANTS = bool(JAVA_INTEGRATION, "ji.eager.constants", true, "Eagerly bind Java:: constants for newly-encountered classes");
 
     public static final Option<Integer> PROFILE_MAX_METHODS = integer(PROFILING, "profile.max.methods", 100000, "Maximum number of methods to consider for profiling.");
 


### PR DESCRIPTION
Reverts jruby/jruby#8208

This change was a bit half-baked and led to the "already initialized constant" issue. A subsequent attempt in #8368 failed to fix that issue and led to several additional problems described in https://github.com/jruby/jruby/issues/8399. We are reverting #8368 and this PR and will attempt to fix https://github.com/jruby/jruby/issues/8156 a different way.