### PR TITLE
Hash#inspect: no arrow for symbol keys.  add spacing to match C Ruby

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -928,8 +928,14 @@ public class RubyHash extends RubyObject implements Map {
 
             if (index > 0) bytes.append((byte) ',').append((byte) ' ');
 
-            str.catWithCodeRange(keyStr);
-            bytes.append((byte) '=').append((byte) '>');
+            boolean keyIsSymbol = key instanceof RubySymbol;
+
+            str.catWithCodeRange(keyIsSymbol ? (RubyString) keyStr.substr(context.runtime, 1, keyStr.length() - 1) : keyStr);
+            if (keyIsSymbol) {
+                bytes.append(':').append(' ');
+            } else {
+                bytes.append(' ').append('=').append('>').append(' ');
+            }
             str.catWithCodeRange(valStr);
         }
     };

--- a/core/src/test/java/org/jruby/test/TestRubyHash.java
+++ b/core/src/test/java/org/jruby/test/TestRubyHash.java
@@ -100,7 +100,7 @@ public class TestRubyHash extends Base {
         result = eval("p $h.to_a");
         assertEquals("[[\"foo\", \"bar\"]]", result);
         result = eval("p $h.to_hash");
-        assertEquals("{\"foo\"=>\"bar\"}", result);
+        assertEquals("{\"foo\" => \"bar\"}", result);
     }
 
     /**
@@ -120,13 +120,13 @@ public class TestRubyHash extends Base {
         assertEquals("[\"foo\", \"bar\"]", eval("$h.each {|pair| p pair}"));
         assertEquals("{\"foo\" => \"bar\"}", eval("p $h.each {|pair| }"));
         assertTrue(eval("$h.each_pair {|pair| p pair}").indexOf("[\"foo\", \"bar\"]") != -1);
-        assertTrue(eval("p $h.each_pair {|pair| }").indexOf("{\"foo\"=>\"bar\"}") != -1);
+        assertTrue(eval("p $h.each_pair {|pair| }").indexOf("{\"foo\" => \"bar\"}") != -1);
 
         assertEquals("\"foo\"", eval("$h.each_key {|k| p k}"));
-        assertEquals("{\"foo\"=>\"bar\"}", eval("p $h.each_key {|k| }"));
+        assertEquals("{\"foo\" => \"bar\"}", eval("p $h.each_key {|k| }"));
 
         assertEquals("\"bar\"", eval("$h.each_value {|v| p v}"));
-        assertEquals("{\"foo\"=>\"bar\"}", eval("p $h.each_value {|v| }"));
+        assertEquals("{\"foo\" => \"bar\"}", eval("p $h.each_value {|v| }"));
     }
 
     /**
@@ -140,20 +140,20 @@ public class TestRubyHash extends Base {
         assertEquals("100", eval("$delete_h.delete(100) {|x| p x }"));
 
         eval("$delete_h = {1=>2,3=>4,5=>6}");
-        assertEquals("{1=>2}", eval("p $delete_h.delete_if {|k,v| k >= 3}"));
-        assertEquals("{1=>2}", eval("p $delete_h"));
+        assertEquals("{1 => 2}", eval("p $delete_h.delete_if {|k,v| k >= 3}"));
+        assertEquals("{1 => 2}", eval("p $delete_h"));
 
         eval("$delete_h.clear");
         assertEquals("{}", eval("p $delete_h"));
 
         eval("$delete_h = {1=>2,3=>4,5=>6}");
-        assertEquals("{1=>2}", eval("p $delete_h.reject {|k,v| k >= 3}"));
+        assertEquals("{1 => 2}", eval("p $delete_h.reject {|k,v| k >= 3}"));
         assertEquals("3", eval("p $delete_h.size"));
 
         eval("$delete_h = {1=>2,3=>4,5=>6}");
         eval("p $delete_h");
 
-        assertEquals("{1=>2}", eval("p $delete_h.reject! {|k,v| k >= 3}"));
+        assertEquals("{1 => 2}", eval("p $delete_h.reject! {|k,v| k >= 3}"));
         assertEquals("1", eval("p $delete_h.size"));
         assertEquals("nil", eval("p $delete_h.reject! {|k,v| false}"));
     }

--- a/core/src/test/java/org/jruby/test/TestRubyHash.java
+++ b/core/src/test/java/org/jruby/test/TestRubyHash.java
@@ -59,7 +59,7 @@ public class TestRubyHash extends Base {
      */
     public void testConstructors() throws Exception {
         result = eval("hash = Hash['b', 200]; p hash");
-        assertEquals("{\"b\"=>200}", result);
+        assertEquals("{\"b\" => 200}", result);
         result = eval("hash = Hash.new(); p hash['test']");
         assertEquals("nil", result);
         result = eval("hash = Hash.new('default'); p hash['test']");
@@ -96,7 +96,7 @@ public class TestRubyHash extends Base {
      */
     public void testConversions() throws Exception {
         result = eval("p $h.to_s");
-        assertEquals("\"{\\\"foo\\\"=>\\\"bar\\\"}\"", result);
+        assertEquals("\"{\\\"foo\\\" => \\\"bar\\\"}\"", result);
         result = eval("p $h.to_a");
         assertEquals("[[\"foo\", \"bar\"]]", result);
         result = eval("p $h.to_hash");
@@ -118,7 +118,7 @@ public class TestRubyHash extends Base {
      */
     public void testIterating() throws Exception {
         assertEquals("[\"foo\", \"bar\"]", eval("$h.each {|pair| p pair}"));
-        assertEquals("{\"foo\"=>\"bar\"}", eval("p $h.each {|pair| }"));
+        assertEquals("{\"foo\" => \"bar\"}", eval("p $h.each {|pair| }"));
         assertTrue(eval("$h.each_pair {|pair| p pair}").indexOf("[\"foo\", \"bar\"]") != -1);
         assertTrue(eval("p $h.each_pair {|pair| }").indexOf("{\"foo\"=>\"bar\"}") != -1);
 
@@ -135,7 +135,7 @@ public class TestRubyHash extends Base {
     public void testDeleting() throws Exception {
         eval("$delete_h = {1=>2,3=>4}");
         assertEquals("2", eval("p $delete_h.delete(1)"));
-        assertEquals("{3=>4}", eval("p $delete_h"));
+        assertEquals("{3 => 4}", eval("p $delete_h"));
         assertEquals("nil", eval("p $delete_h.delete(100)"));
         assertEquals("100", eval("$delete_h.delete(100) {|x| p x }"));
 

--- a/spec/java_integration/types/map_spec.rb
+++ b/spec/java_integration/types/map_spec.rb
@@ -185,9 +185,9 @@ describe "a java.util.Map instance" do
     h.clear
     h.put(1, 100); h.put(2, 200); h.put(3, 300)
     test_equal({1=>100, 2=>200}, h.reject { |k, v| k > 2 })
-    expect( h.inspect ).to include "{1=>100, 2=>200, 3=>300}"
+    expect( h.inspect ).to include "{1 => 100, 2 => 200, 3 => 300}"
     test_equal({1=>100, 2=>200}, h.reject! { |k, v| k > 2 })
-    expect( h.inspect ).to include "{1=>100, 2=>200}"
+    expect( h.inspect ).to include "{1 => 100, 2 => 200}"
 
     test_equal({"c"=>300, "d"=>400, "e"=>500}, h.ruby_replace({"c"=>300, "d"=>400, "e"=>500}))
     test_equal(Java::JavaUtil::LinkedHashMap, h.class)

--- a/spec/java_integration/types/map_spec.rb
+++ b/spec/java_integration/types/map_spec.rb
@@ -176,10 +176,10 @@ describe "a java.util.Map instance" do
     h2.put("b", 254); h2.put("c", 300)
     test_equal({"a"=>100, "b"=>254, "c"=>300}, h1.ruby_merge(h2))
     test_equal({"a"=>100, "b"=>454, "c"=>300}, h1.ruby_merge(h2) { |k, o, n| o+n })
-    expect( h1.inspect ).to include "{\"a\"=>100, \"b\"=>200}"
+    expect( h1.inspect ).to include "{\"a\" => 100, \"b\" => 200}"
 
     h1.merge!(h2) { |k, o, n| o }
-    test_equal('#<Java::JavaUtil::LinkedHashMap: {"a"=>100, "b"=>200, "c"=>300}>', h1.inspect)
+    test_equal('#<Java::JavaUtil::LinkedHashMap: {"a" => 100, "b" => 200, "c" => 300}>', h1.inspect)
     test_equal(Java::JavaUtil::LinkedHashMap, h1.class)
 
     h.clear
@@ -218,7 +218,7 @@ describe "a java.util.Map instance" do
 
     h2 = {"b"=>254, "c"=>300}
     test_equal({"a"=>100, "b"=>200, "c"=>300}, h.update(h2) { |k, o, n| o })
-    expect( h.inspect ).to include "{\"a\"=>100, \"b\"=>200, \"c\"=>300}"
+    expect( h.inspect ).to include "{\"a\" => 100, \"b\" => 200, \"c\" => 300}"
     test_equal(Java::JavaUtil::LinkedHashMap, h.class)
     test_equal([100, 200], h.values_at("a", "b"))
     test_equal([100, 200, nil], h.values_at("a", "b", "z"))


### PR DESCRIPTION
Hash#inspect: no arrow for symbol keys.  add spacing to match C Ruby