### PR TITLE
Always check for thread events after lock acquisition

### DIFF
--- a/core/src/main/java/org/jruby/ext/thread/Mutex.java
+++ b/core/src/main/java/org/jruby/ext/thread/Mutex.java
@@ -105,13 +105,16 @@ public class Mutex extends RubyObject implements DataType {
             for (;;) {
                 try {
                     context.getThread().lockInterruptibly(lock);
-                    return this;
+                    break;
                 } catch (InterruptedException ex) {
                     /// ignore, check thread events and try again!
                     context.pollThreadEvents();
                 }
             }
         }
+
+        // always check for thread interrupts after acquiring lock
+        thread.pollThreadEvents(context);
 
         return this;
     }


### PR DESCRIPTION
Upon acquiring a lock, we should always check for interrupts that may have occurred while sleeping or acquiring the lock. This avoids proceeding with a critical section of code while there are interrupts pending.

Fixes jruby/jruby#8403