### PR TITLE
Skip extension builds for default gems

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -252,6 +252,18 @@ project 'JRuby Lib Setup' do
       File.join(global_bin, "jruby#{RbConfig::CONFIG['EXEEXT']}")
     end
 
+    # Disable extension build for gems (none of ours require a build)
+    class Gem::Ext::Builder
+      def build_extensions
+        return if @spec.extensions.empty?
+
+        say "Skipping native extensions."
+
+        FileUtils.mkdir_p File.dirname(@spec.gem_build_complete_path)
+        FileUtils.touch @spec.gem_build_complete_path
+      end
+    end
+
     ctx.project.artifacts.select do |a|
       a.group_id == 'rubygems' || a.group_id == 'org.jruby.gems'
     end.each do |a|


### PR DESCRIPTION
Seems to be issues launching these subprocesses via Maven. While we investigate that, temporarily disable extension building for default gems.

The problem manifests during the default gem install of the fiddle gem, which generates a dummy Makefile on JRuby because it uses the FFI version instead. The launch of extconf.rb exhibits problems in various environments:

* In CI, it ends up running with the system default Java rather than the one configured in JAVA_HOME.
* On local Linux environments, it fails to launch due to a "bad file descriptor: /bin/sh" error.

It seems that the subprocess launch is losing environment in some broken way.