### PR TITLE
Restore extension building for default gems

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -252,18 +252,6 @@ project 'JRuby Lib Setup' do
       File.join(global_bin, "jruby#{RbConfig::CONFIG['EXEEXT']}")
     end
 
-    # Disable extension build for gems (none of ours require a build)
-    class Gem::Ext::Builder
-      def build_extensions
-        return if @spec.extensions.empty?
-
-        say "Skipping native extensions."
-
-        FileUtils.mkdir_p File.dirname(@spec.gem_build_complete_path)
-        FileUtils.touch @spec.gem_build_complete_path
-      end
-    end
-
     ctx.project.artifacts.select do |a|
       a.group_id == 'rubygems' || a.group_id == 'org.jruby.gems'
     end.each do |a|


### PR DESCRIPTION
In #8415 I disabled extension building due to some environment issues on some Linux machines. This PR is a WIP to restore that building once we figure out the problem launching the extconf subprocess from a Maven build.

Reverts jruby/jruby#8415