### PR TITLE
add integer pointer memory strategy

### DIFF
--- a/core/src/main/java/org/jruby/ext/ffi/jffi/IntegerPointerParameterStrategy.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/IntegerPointerParameterStrategy.java
@@ -1,0 +1,24 @@
+package org.jruby.ext.ffi.jffi;
+
+import org.jruby.RubyInteger;
+import org.jruby.ext.ffi.MemoryIO;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ *
+ */
+final class IntegerPointerParameterStrategy extends PointerParameterStrategy {
+    IntegerPointerParameterStrategy() {
+        super(true, false);
+    }
+
+    public final MemoryIO getMemoryIO(Object parameter) {
+        return getMemoryIO((RubyInteger) parameter);
+    }
+
+    static MemoryIO getMemoryIO(RubyInteger i) {
+        return NativeMemoryIO.wrap(i.getRuntime(), i.getLongValue());
+    }
+}

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/IntegerPointerParameterStrategy.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/IntegerPointerParameterStrategy.java
@@ -1,10 +1,8 @@
 package org.jruby.ext.ffi.jffi;
 
-import org.jruby.RubyInteger;
+import org.jruby.RubyFixnum;
 import org.jruby.ext.ffi.MemoryIO;
-
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
+import org.jruby.runtime.builtin.IRubyObject;
 
 /**
  *
@@ -15,10 +13,10 @@ final class IntegerPointerParameterStrategy extends PointerParameterStrategy {
     }
 
     public final MemoryIO getMemoryIO(Object parameter) {
-        return getMemoryIO((RubyInteger) parameter);
+        return getMemoryIO((IRubyObject) parameter);
     }
 
-    static MemoryIO getMemoryIO(RubyInteger i) {
-        return NativeMemoryIO.wrap(i.getRuntime(), i.getLongValue());
+    static MemoryIO getMemoryIO(IRubyObject parameter) {
+        return Factory.getInstance().wrapDirectMemory(parameter.getRuntime(), RubyFixnum.num2long(parameter));
     }
 }

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/JITRuntime.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/JITRuntime.java
@@ -428,6 +428,7 @@ public final class JITRuntime {
     private static final PointerParameterStrategy DIRECT_MEMORY_IO = new MemoryIOParameterStrategy(true);
     private static final PointerParameterStrategy HEAP_MEMORY_IO = new MemoryIOParameterStrategy(false);
     private static final PointerParameterStrategy NIL_POINTER_STRATEGY = new NilPointerParameterStrategy();
+    private static final PointerParameterStrategy INTEGER_POINTER_STRATEGY = new IntegerPointerParameterStrategy();
     private static final PointerParameterStrategy HEAP_STRING_POINTER_STRATEGY = new StringParameterStrategy(false, false);
     private static final PointerParameterStrategy TRANSIENT_STRING_PARAMETER_STRATEGY = new StringParameterStrategy(false, true);
     private static final PointerParameterStrategy DIRECT_STRING_PARAMETER_STRATEGY = new StringParameterStrategy(true, true);
@@ -441,6 +442,9 @@ public final class JITRuntime {
 
         } else if (parameter instanceof RubyString) {
             return HEAP_STRING_POINTER_STRATEGY;
+
+        } else if (parameter instanceof RubyInteger) {
+            return INTEGER_POINTER_STRATEGY;
 
         }
         

--- a/spec/ffi/pointer_spec.rb
+++ b/spec/ffi/pointer_spec.rb
@@ -56,12 +56,12 @@ describe "Pointer" do
     expect(PointerTestLib.ptr_ret_int32_t(ptr, 0)).to eq(magic)
   end
 
-  it "Fixnum cannot be used as a Pointer argument" do
-    expect { PointerTestLib.ptr_ret_int32_t(0, 0) }.to raise_error(ArgumentError)
-  end
-
-  it "Bignum cannot be used as a Pointer argument" do
-    expect { PointerTestLib.ptr_ret_int32_t(0xfee1deadbeefcafebabe, 0) }.to raise_error(ArgumentError)
+  it "Integer can be used as a Pointer argument" do
+    memory = FFI::MemoryPointer.new :long_long
+    magic = 0x12345678
+    memory.put_int32(0, magic)
+    adr = memory.address
+    expect(PointerTestLib.ptr_ret_int32_t(adr, 0))
   end
 
   it "String can be used as a Pointer argument" do


### PR DESCRIPTION
Allows implicitly passing integers into FFI functions that take pointers, using the passed in integer as the address.

This mimics the behavior of CRuby.