### PR TITLE
Don't clear the ThreadGroup when Thread terminates

### DIFF
--- a/core/src/main/java/org/jruby/RubyThreadGroup.java
+++ b/core/src/main/java/org/jruby/RubyThreadGroup.java
@@ -120,7 +120,6 @@ public class RubyThreadGroup extends RubyObject {
     
     public void remove(RubyThread rubyThread) {
         synchronized (rubyThread) {
-            rubyThread.setThreadGroup(null);
             rubyThreadList.remove(rubyThread);
         }
     }


### PR DESCRIPTION
CRuby does not clear the ThreadGroup set in the Thread when the thread terminates. We do, which leads to some unpredictability in specs that check the group against a very short-lived thread. This patch removes the call to clear the thread's group.