### PR TITLE
Root specialized object classloader at JRuby classloader

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -166,6 +166,16 @@ project 'JRuby Base' do
                                       '${project.build.outputDirectory}' ],
                      'executable' =>  'java',
                      'classpathScope' =>  'compile' )
+
+      execute_goals( 'exec',
+                     :id => 'specialized-object-generator',
+                     'arguments' => [ '-Djruby.bytecode.version=${base.java.version}',
+                                      '-classpath',
+                                      xml( '<classpath/>' ),
+                                      'org.jruby.specialized.RubyObjectSpecializer',
+                                      '${project.build.outputDirectory}' ],
+                     'executable' =>  'java',
+                     'classpathScope' =>  'compile' )
     end
   end
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -417,6 +417,24 @@ DO NOT MODIFY - GENERATED CODE
               <classpathScope>compile</classpathScope>
             </configuration>
           </execution>
+          <execution>
+            <id>specialized-object-generator</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <arguments>
+                <argument>-Djruby.bytecode.version=${base.java.version}</argument>
+                <argument>-classpath</argument>
+                <classpath />
+                <argument>org.jruby.specialized.RubyObjectSpecializer</argument>
+                <argument>${project.build.outputDirectory}</argument>
+              </arguments>
+              <executable>java</executable>
+              <classpathScope>compile</classpathScope>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -69,6 +69,7 @@ import org.jruby.runtime.JavaSites;
 import org.jruby.runtime.MethodIndex;
 import org.jruby.runtime.TraceEventManager;
 import org.jruby.runtime.invokedynamic.InvokeDynamicSupport;
+import org.jruby.specialized.RubyObjectSpecializer;
 import org.jruby.util.JavaNameMangler;
 import org.jruby.util.MRIRecursionGuard;
 import org.jruby.util.StringSupport;
@@ -342,6 +343,9 @@ public final class Ruby implements Constantizable {
         objectClass.setConstant("Class", classClass);
         objectClass.setConstant("Module", moduleClass);
         objectClass.setConstant("Refinement", refinementClass);
+
+        // specializer for RubyObject subclasses
+        objectSpecializer = new RubyObjectSpecializer(this);
 
         // Initialize Kernel and include into Object
         RubyModule kernel = kernelModule = RubyKernel.createKernelModule(this);
@@ -2617,6 +2621,10 @@ public final class Ruby implements Constantizable {
 
     public JavaSupport getJavaSupport() {
         return javaSupport;
+    }
+
+    public RubyObjectSpecializer getObjectSpecializer() {
+        return objectSpecializer;
     }
 
     public static ClassLoader getClassLoader() {
@@ -5546,6 +5554,9 @@ public final class Ruby implements Constantizable {
     // Java support
     private final JavaSupport javaSupport;
     private final JRubyClassLoader jrubyClassLoader;
+
+    // Object Specializer
+    private final RubyObjectSpecializer objectSpecializer;
 
     // Management/monitoring
     private final BeanManager beanManager;

--- a/core/src/main/java/org/jruby/RubyObject.java
+++ b/core/src/main/java/org/jruby/RubyObject.java
@@ -176,7 +176,7 @@ public class RubyObject extends RubyBasicObject {
                             System.err.println(klass + ";" + foundVariables);
                         }
 
-                        allocator = RubyObjectSpecializer.specializeForVariables(klass, foundVariables);
+                        allocator = runtime.getObjectSpecializer().specializeForVariables(klass, foundVariables);
 
                         // invalidate metaclass so new allocator is picked up for specialized .new
                         klass.metaClass.invalidateCacheDescendants();

--- a/core/src/main/java/org/jruby/specialized/RubyObjectSpecializer.java
+++ b/core/src/main/java/org/jruby/specialized/RubyObjectSpecializer.java
@@ -35,13 +35,14 @@ import org.jruby.RubyObject;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.builtin.IRubyObject;
-import org.jruby.util.ClassDefiningClassLoader;
 import org.jruby.util.cli.Options;
 import org.jruby.util.collections.NonBlockingHashMapLong;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.tree.LabelNode;
 
 import java.lang.invoke.MethodHandles;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Set;
 
 import static org.jruby.util.CodegenUtils.ci;
@@ -54,6 +55,7 @@ import static org.jruby.util.CodegenUtils.sig;
 public class RubyObjectSpecializer {
 
     public static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+    private static final String GENERATED_PACKAGE = "org/jruby/gen/";
 
     private final Ruby runtime;
 
@@ -78,56 +80,20 @@ public class RubyObjectSpecializer {
     }
 
     public ObjectAllocator specializeForVariables(RubyClass klass, Set<String> foundVariables) {
-        int size = foundVariables.size();
+        // clamp to max object width
+        int size = Math.min(foundVariables.size(), Options.REIFY_VARIABLES_MAX.load());
 
-        // clamp to max object width (jruby/jruby#
-        size = Math.min(size, Options.REIFY_VARIABLES_MAX.load());
-
-        ClassAndAllocator cna = null;
-        String className = null;
+        ClassAndAllocator cna;
 
         if (Options.REIFY_VARIABLES_NAME.load()) {
-            className = klass.getName();
-
-            if (className.startsWith("#")) {
-                className = "Anonymous" + Integer.toHexString(System.identityHashCode(klass));
-            } else {
-                className = className.replace("::", "/");
-            }
+            // use Ruby class name for debugging, profiling
+            cna = generateSpecializedRubyObject(uniqueClassName(klass), size, false);
         } else {
-            // Generate class for specified size
+            // Generic class for specified size
             cna = getClassForSize(size);
 
             if (cna == null) {
-                className = "RubyObject" + size;
-            }
-        }
-
-        // if we have a className, proceed to generate
-        if (className != null) {
-            final String clsPath = "org/jruby/gen/" + className;
-
-            synchronized (this) {
-                Class specialized;
-                try {
-                    // try loading class without generating
-                    specialized = runtime.getJRubyClassLoader().loadClass(clsPath.replace('/', '.'));
-                } catch (ClassNotFoundException cnfe) {
-                    // generate specialized class
-                    specialized = generateInternal(size, clsPath);
-                }
-
-                try {
-                    ObjectAllocator allocator = (ObjectAllocator) specialized.getDeclaredClasses()[0].getConstructor().newInstance();
-
-                    cna = new ClassAndAllocator(specialized, allocator);
-
-                    if (!Options.REIFY_VARIABLES_NAME.load()) {
-                        specializedClasses.put(size, cna);
-                    }
-                } catch (Throwable t) {
-                    throw new RuntimeException(t);
-                }
+                cna = generateSpecializedRubyObject(genericClassName(size), size, true);
             }
         }
 
@@ -154,7 +120,78 @@ public class RubyObjectSpecializer {
         return cna.allocator;
     }
 
-    private Class generateInternal(int size, final String clsPath) {
+    private ClassAndAllocator generateSpecializedRubyObject(String className, int size, boolean cache) {
+        ClassAndAllocator cna;
+
+        synchronized (this) {
+            Class specialized;
+            try {
+                // try loading class without generating
+                specialized = runtime.getJRubyClassLoader().loadClass(className.replace('/', '.'));
+            } catch (ClassNotFoundException cnfe) {
+                // generate specialized class
+                specialized = generateInternal(className, size);
+            }
+
+            try {
+                ObjectAllocator allocator = (ObjectAllocator) specialized.getDeclaredClasses()[0].getConstructor().newInstance();
+
+                cna = new ClassAndAllocator(specialized, allocator);
+            } catch (Throwable t) {
+                throw new RuntimeException(t);
+            }
+        }
+
+        if (cache) {
+            specializedClasses.put(size, cna);
+        }
+
+        return cna;
+    }
+
+    private static String genericClassName(int size) {
+        return GENERATED_PACKAGE + "RubyObject" + size;
+    }
+
+    private static String uniqueClassName(RubyClass klass) {
+        String className = klass.getName();
+
+        if (className.startsWith("#")) {
+            className = "Anonymous" + Integer.toHexString(System.identityHashCode(klass));
+        } else {
+            className = className.replace("::", "/");
+        }
+
+        return GENERATED_PACKAGE + className;
+    }
+
+    /**
+     * Emit all generic RubyObject specializations to disk, so they do not need to generate at runtime.
+     */
+    public static void main(String[] args) throws Throwable {
+        String targetPath = args[0];
+
+        Files.createDirectories(Paths.get(targetPath, GENERATED_PACKAGE));
+
+        int maxVars = Options.REIFY_VARIABLES_MAX.load();
+        for (int i = 0; i <= maxVars; i++) {
+            String clsPath = genericClassName(i);
+            JiteClass jcls = generateJiteClass(clsPath, i);
+            Files.write(Paths.get(targetPath, clsPath + ".class"), jcls.toBytes(JDKVersion.V1_8));
+            Files.write(Paths.get(targetPath, clsPath + "Allocator.class"), jcls.getChildClasses().get(0).toBytes(JDKVersion.V1_8));
+        }
+    }
+
+    private Class generateInternal(final String clsPath, int size) {
+        final JiteClass jiteClass = generateJiteClass(clsPath, size);
+
+        Class specializedClass = defineClass(jiteClass);
+        defineClass(jiteClass.getChildClasses().get(0));
+
+        return specializedClass;
+    }
+
+    private static JiteClass generateJiteClass(String clsPath, int size) {
         // ensure only one thread will attempt to generate and define the new class
         final String baseName = p(RubyObject.class);
 
@@ -221,11 +258,7 @@ public class RubyObjectSpecializer {
                 }});
             }});
         }};
-
-        Class specializedClass = defineClass(jiteClass);
-        defineClass(jiteClass.getChildClasses().get(0));
-
-        return specializedClass;
+        return jiteClass;
     }
 
     private static void genGetSwitch(String clsPath, int size, CodeBlock block, int offsetVar) {

--- a/spec/java_integration/interfaces/implementation_spec.rb
+++ b/spec/java_integration/interfaces/implementation_spec.rb
@@ -827,6 +827,25 @@ describe "A Ruby class implementing an interface" do
 
     expect(java_cls.interfaces).to include(java.lang.Runnable.java_class)
   end
+
+
+  describe "that extends a specializable RubyObject" do
+    class C1
+    end
+
+    it "produces a Java class that extends that specialized type" do
+      # construct C1 first to use specialized class
+      c1obj = C1.new
+
+      c2 = Class.new(C1) do
+        include ReturnsInterface
+      end
+
+      c2obj = c2.new
+
+      expect(JRuby.ref(c2obj).getClass.getSuperclass).to eq(JRuby.ref(c1obj).getClass)
+    end
+  end
 end
 
 describe "A class that extends a DelegateClass" do


### PR DESCRIPTION
The classes generated here need to be visible to other classes loaded and generated by JRuby, such as Ruby classes that implement Java interfaces. If the specialized class and a Java interface to implement come from different classloader hierarchies, the JVM classloading subsystem will be unable to resolve the impl class.

The fix here makes the RubyObjectSpecializer per-runtime, so the specialized classes live within the standard JRubyClassLoader hierarchy, visible to other classes loaded and generated by Ruby code at runtime.

An additional fix will pre-generate the first 50 specialized object classes, which will also fix the same issue (they will load into the same classloader as JRuby itself) and avoid re-generating these classes for each runtime instance.

Fixes #8412.