### PR TITLE
Remove rogue exit(0) that shuts down JVM

### DIFF
--- a/core/src/main/java/org/jruby/Main.java
+++ b/core/src/main/java/org/jruby/Main.java
@@ -199,8 +199,6 @@ public class Main {
             if (status.isExit()) {
                 System.exit(status.getStatus());
             }
-
-            System.exit(0);
         }
         catch (RaiseException ex) {
             System.exit( handleRaiseException(ex) );


### PR DESCRIPTION
For normal JRuby use, we let the main script finish and Main.main exits. If non-daemon threads remain running, they will keep the JVM alive. However a change for CRaC support accidentally introduced a hard exit(0) that is always encountered, even if the script did not request a hard exit using `exit` or similar Ruby calls.

This patch removes the hard exit(0) so that "casual" exit from the main script does not force the JVM to shut down. The runtime will still be torn down as usual, but non-daemon threads can keep the JVM alive after JRuby itself has exited.

Fixes #8416