### PR TITLE
Decode ByteList properly for toString

### DIFF
--- a/core/src/main/java/org/jruby/util/ByteList.java
+++ b/core/src/main/java/org/jruby/util/ByteList.java
@@ -1163,7 +1163,9 @@ public class ByteList implements Comparable, CharSequence, Serializable {
     public String toString() {
         String decoded = this.stringValue;
         if (decoded == null) {
-            this.stringValue = decoded = decode(bytes, begin, realSize, ISO_LATIN_1);
+            Charset charset = this.encoding.getCharset();
+            if (charset == null) charset = ISO_LATIN_1;
+            this.stringValue = decoded = decode(bytes, begin, realSize, charset);
         }
         return decoded;
     }


### PR DESCRIPTION
This previously decoded the bytelist always as an ISO-8859-1 string, which would obviously break for other encodings and any multibyte characters. This change uses the ByteList's Encoding's actual Charset to decode the string.

Fixes #909.

See https://github.com/jruby/jruby/pull/8301 for original PR closed by 9.5-dev deletion.