### PR TITLE
Reduce overhead of ObjectSpace#each_object when disabled

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -5764,6 +5764,10 @@ public final class Ruby implements Constantizable {
         objectSpacer.addToObjectSpace(this, useObjectSpace, object);
     }
 
+    public static void addToObjectSpace(Ruby runtime, boolean useObjectSpace, IRubyObject object) {
+        runtime.objectSpacer.addToObjectSpace(runtime, useObjectSpace, object);
+    }
+
     public interface ExitFunction extends ToIntFunction<ThreadContext> {
         default boolean matches(Object o) { return o == this; }
     }

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -5751,17 +5751,11 @@ public final class Ruby implements Constantizable {
         void addToObjectSpace(Ruby runtime, boolean useObjectSpace, IRubyObject object);
     }
 
-    private static final ObjectSpacer DISABLED_OBJECTSPACE = new ObjectSpacer() {
-        @Override
-        public void addToObjectSpace(Ruby runtime, boolean useObjectSpace, IRubyObject object) {
-        }
+    private static final ObjectSpacer DISABLED_OBJECTSPACE = (runtime, useObjectSpace, object) -> {
     };
 
-    private static final ObjectSpacer ENABLED_OBJECTSPACE = new ObjectSpacer() {
-        @Override
-        public void addToObjectSpace(Ruby runtime, boolean useObjectSpace, IRubyObject object) {
-            if (useObjectSpace) runtime.objectSpace.add(object);
-        }
+    private static final ObjectSpacer ENABLED_OBJECTSPACE = (runtime, useObjectSpace, object) -> {
+        if (useObjectSpace) runtime.objectSpace.add(object);
     };
 
     private final ObjectSpacer objectSpacer;

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -241,7 +241,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     public RubyBasicObject(Ruby runtime, RubyClass metaClass) {
         this.metaClass = metaClass;
 
-        runtime.addToObjectSpace(true, this);
+        Ruby.addToObjectSpace(runtime, true, this);
     }
 
     /**

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
@@ -90,6 +90,9 @@ public class JRubyUtilLibrary implements Library {
     @JRubyMethod(name = { "objectspace=", "object_space=" }, module = true)
     public static IRubyObject setObjectSpaceEnabled(IRubyObject recv, IRubyObject arg) {
         final Ruby runtime = recv.getRuntime();
+
+        runtime.getWarnings().warnDeprecated("JRuby::Util.object_space= is deprecated and will be removed in a future version of JRuby. See https://github.com/jruby/jruby/wiki/PerformanceTuning#dont-enable-objectspace");
+
         boolean enabled = arg.isTrue();
         if (enabled) {
             runtime.getWarnings().warn("ObjectSpace impacts performance. See https://github.com/jruby/jruby/wiki/PerformanceTuning#dont-enable-objectspace");


### PR DESCRIPTION
This PR is intended to reduce or eliminate all overhead of the tracking logic for ObjectSpace#each_object when that feature is not enabled.

Initially it will reduce the overhead of the current logic without changing the implementation. Eventually it may use debugging interfaces or a JVM agent to add in the tracking only when requested, avoiding any runtime checks normally.

See https://github.com/jruby/jruby/pull/8279.