### PR TITLE
Improvements to instance variable shaping

### DIFF
--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -471,6 +471,10 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         return ((RubyBasicObject) arg).metaClass;
     }
 
+    public VariableTableManager getShape() {
+        return metaClass.getVariableTableManager();
+    }
+
     /** rb_singleton_class
      *
      * Note: this method is specialized for RubyFixnum, RubySymbol,
@@ -1072,7 +1076,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      * object is frozen.
      */
     protected long getObjectId() {
-        return metaClass.getRealClass().getVariableTableManager().getObjectId(this);
+        return getShape().getObjectId(this);
     }
 
     /** rb_obj_inspect
@@ -1150,7 +1154,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         final ThreadContext context = runtime.getCurrentContext();
 
         boolean first = true;
-        for (Map.Entry<String, VariableAccessor> entry : metaClass.getVariableTableManager().getVariableAccessorsForRead().entrySet()) {
+        for (Map.Entry<String, VariableAccessor> entry : getShape().getVariableAccessorsForRead().entrySet()) {
             Object value = entry.getValue().get(this);
             if (!(value instanceof IRubyObject)) continue;
             RubySymbol symbol = runtime.newSymbol(entry.getKey());
@@ -1331,15 +1335,15 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     public void setVariable(int index, Object value) {
         ensureInstanceVariablesSettable();
         if (index < 0) return;
-        metaClass.getVariableTableManager().setVariableInternal(this, index, value);
+        getShape().setVariableInternal(this, index, value);
     }
 
     public final Object getFFIHandle() {
-        return metaClass.getVariableTableManager().getFFIHandle(this);
+        return getShape().getFFIHandle(this);
     }
 
     public final void setFFIHandle(Object value) {
-        metaClass.getVariableTableManager().setFFIHandle(this, value);
+        getShape().setFFIHandle(this, value);
     }
 
     //
@@ -1353,7 +1357,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      */
     @Override
     public boolean hasVariables() {
-        return metaClass.getVariableTableManager().hasVariables(this);
+        return getShape().hasVariables(this);
     }
 
     /**
@@ -1363,7 +1367,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      * @return true if there are set instance variables, false otherwise
      */
     protected boolean hasInstanceVariables() {
-        return metaClass.getVariableTableManager().hasInstanceVariables(this);
+        return getShape().hasInstanceVariables(this);
     }
 
     /**
@@ -1440,7 +1444,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      * table, and returning the removed value.
      */
     protected Object variableTableRemove(String name) {
-        return metaClass.getVariableTableManager().clearVariable(this, name);
+        return getShape().clearVariable(this, name);
     }
 
     /**
@@ -1511,7 +1515,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      */
     @Override
     public void syncVariables(IRubyObject other) {
-        metaClass.getVariableTableManager().syncVariables(this, other);
+        getShape().syncVariables(this, other);
     }
 
     //
@@ -2922,7 +2926,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         oos.defaultWriteObject();
         oos.writeUTF(metaClass.getName());
 
-        metaClass.getVariableTableManager().serializeVariables(this, oos);
+        getShape().serializeVariables(this, oos);
     }
 
     /**
@@ -2948,7 +2952,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         ois.defaultReadObject();
         metaClass = (RubyClass)ruby.getClassFromPath(ois.readUTF());
 
-        metaClass.getVariableTableManager().deserializeVariables(this, ois);
+        getShape().deserializeVariables(this, ois);
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -52,9 +52,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
@@ -6031,15 +6033,28 @@ public class RubyModule extends RubyObject {
     }
 
     public Set<String> discoverInstanceVariables() {
-        HashSet<String> set = new HashSet();
-        RubyModule cls = this;
-        while (cls != null) {
-            Map<String, DynamicMethod> methods = cls.getOrigin().getMethodLocation().getMethods();
+        // preserve insertion order, so parent variables always precede child variables
+        return discoverInstanceVariablesInner(new LinkedHashSet<>());
+    }
 
-            methods.forEach((name, method) -> set.addAll(method.getInstanceVariableNames()));
-
-            cls = cls.getSuperClass();
+    protected Set<String> discoverInstanceVariablesInner(Set<String> set) {
+        // recurse to superclasses so they get first go at the table layout
+        RubyClass superClass = getSuperClass();
+        if (superClass != null) {
+            superClass.discoverInstanceVariablesInner(set);
         }
+
+        Map<String, DynamicMethod> methods = getOrigin().getMethodLocation().getMethods();
+
+        // gather vars for this class and sort alphabetically
+        TreeSet<String> sorted = new TreeSet<>();
+        for (Map.Entry<String, DynamicMethod> entry : methods.entrySet()) {
+            sorted.addAll(entry.getValue().getInstanceVariableNames());
+        }
+
+        // add all new vars from this class to the set
+        set.addAll(sorted);
+
         return set;
     }
 

--- a/core/src/main/java/org/jruby/RubyObjectShaped.java
+++ b/core/src/main/java/org/jruby/RubyObjectShaped.java
@@ -1,0 +1,58 @@
+/*
+ ***** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2001 Chad Fowler <chadfowler@chadfowler.com>
+ * Copyright (C) 2001 Alan Moore <alan_moore@gmx.net>
+ * Copyright (C) 2001-2002 Benoit Cerrina <b.cerrina@wanadoo.fr>
+ * Copyright (C) 2001-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+ * Copyright (C) 2002-2004 Anders Bengtsson <ndrsbngtssn@yahoo.se>
+ * Copyright (C) 2004-2006 Thomas E Enebo <enebo@acm.org>
+ * Copyright (C) 2004-2005 Charles O Nutter <headius@headius.com>
+ * Copyright (C) 2004 Stefan Matthias Aust <sma@3plus4.de>
+ * Copyright (C) 2006 Ola Bini <ola.bini@ki.se>
+ * Copyright (C) 2006 Miguel Covarrubias <mlcovarrubias@gmail.com>
+ * Copyright (C) 2007 MenTaLguY <mental@rydia.net>
+ * Copyright (C) 2007 William N Dortch <bill.dortch@gmail.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ ***** END LICENSE BLOCK *****/
+
+package org.jruby;
+
+import org.jruby.runtime.ivars.VariableTableManager;
+
+public abstract class RubyObjectShaped extends RubyObject {
+    public RubyObjectShaped(Ruby runtime, RubyClass metaClass) {
+        super(runtime, metaClass);
+
+        variableTableManager = metaClass.getVariableTableManager();
+    }
+
+    @Override
+    public VariableTableManager getShape() {
+        return variableTableManager;
+    }
+
+    private final VariableTableManager variableTableManager;
+}

--- a/core/src/main/java/org/jruby/specialized/RubyObjectSpecializer.java
+++ b/core/src/main/java/org/jruby/specialized/RubyObjectSpecializer.java
@@ -32,6 +32,7 @@ import me.qmx.jitescript.JiteClass;
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyObject;
+import org.jruby.RubyObjectShaped;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -157,7 +158,7 @@ public class RubyObjectSpecializer {
 
     private static Class generateInternal(int size, final String clsPath) {
         // ensure only one thread will attempt to generate and define the new class
-        final String baseName = p(RubyObject.class);
+        final String baseName = p(RubyObjectShaped.class);
 
         final JiteClass jiteClass = new JiteClass(clsPath, baseName, new String[0]) {{
             for (int i = 0; i < size; i++) {


### PR DESCRIPTION
This PR will incorporate a few improvements to how we "right-size" user-defined objects to pack instance variables.

Better parent-driven layout of fields, so they can be shared across subclasses.
Persistent shapes for stale objects; after we realize it needs to grow, existing objects can continue living with the smaller shape.
Improved caching to avoid polymorphic thrashing when the fields are laid out the same.
Analysis of implementation and exploration of other improvements.
Stretch goals might include playing with field-doubling to store numeric values without wrappers, but the primary goal is to do a better job of choosing the right shape or evolving into the right shape over time.

See https://github.com/jruby/jruby/pull/7516.