### PR TITLE
to_s with TC. new dupString api

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -819,13 +819,9 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     /** rb_ary_to_s
      *
      */
+    @Override
     public RubyString to_s(ThreadContext context) {
         return inspect(context);
-    }
-
-    @Override
-    public IRubyObject to_s() {
-        return to_s(metaClass.runtime.getCurrentContext());
     }
 
     public boolean includes(ThreadContext context, IRubyObject item) {

--- a/core/src/main/java/org/jruby/RubyBignum.java
+++ b/core/src/main/java/org/jruby/RubyBignum.java
@@ -369,16 +369,17 @@ public class RubyBignum extends RubyInteger {
      *
      */
     public IRubyObject to_s(IRubyObject[] args) {
+        var context = getRuntime().getCurrentContext();
         return switch (args.length) {
-            case 0 -> to_s();
+            case 0 -> to_s(context);
             case 1 -> to_s(args[0]);
-            default -> throw argumentError(getRuntime().getCurrentContext(), args.length, 1);
+            default -> throw argumentError(context, args.length, 1);
         };
     }
 
     @Override
-    public RubyString to_s() {
-        return RubyString.newUSASCIIString(getRuntime(), value.toString(10));
+    public RubyString to_s(ThreadContext context) {
+        return RubyString.newUSASCIIString(context.runtime, value.toString(10));
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyClassPathVariable.java
+++ b/core/src/main/java/org/jruby/RubyClassPathVariable.java
@@ -122,8 +122,7 @@ public class RubyClassPathVariable extends RubyObject {
 
     @Override
     @JRubyMethod
-    public IRubyObject to_s() {
-        final ThreadContext context = getRuntime().getCurrentContext();
+    public IRubyObject to_s(ThreadContext context) {
         return callMethod(context, "to_a").callMethod(context, "to_s");
     }
 

--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -915,9 +915,8 @@ public class RubyDir extends RubyObject implements Closeable {
 
     @JRubyMethod(name = "empty?", meta = true)
     public static IRubyObject empty_p(ThreadContext context, IRubyObject recv, IRubyObject arg) {
-        Ruby runtime = context.runtime;
-        RubyString path = StringSupport.checkEmbeddedNulls(runtime, RubyFile.get_path(context, arg));
-        RubyFileStat fileStat = runtime.newFileStat(path.asJavaString(), false);
+        RubyString path = StringSupport.checkEmbeddedNulls(context.runtime, RubyFile.get_path(context, arg));
+        RubyFileStat fileStat = context.runtime.newFileStat(path.asJavaString(), false);
         boolean isDirectory = fileStat.directory_p(context).isTrue();
         return asBoolean(context, isDirectory && entries(context, recv, arg).getLength() <= 2);
     }

--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -461,7 +461,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         ByteList str = new ByteList((path == null ? 4 : path.length()) + 8);
 
         str.append('#').append('<');
-        str.append(getMetaClass().getRealClass().to_s().getByteList());
+        str.append(getMetaClass().getRealClass().to_s(context).getByteList());
         str.append(':').append(path == null ? RubyNil.nilBytes : RubyEncoding.encodeUTF8(path));
         if (!openFile.isOpen()) str.append(CLOSED_MESSAGE);
         str.append('>');

--- a/core/src/main/java/org/jruby/RubyFixnum.java
+++ b/core/src/main/java/org/jruby/RubyFixnum.java
@@ -398,15 +398,16 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
      *
      */
     public RubyString to_s(IRubyObject[] args) {
+        var context = getRuntime().getCurrentContext();
         return switch (args.length) {
-            case 0 -> to_s();
+            case 0 -> to_s(context);
             case 1 -> to_s(args[0]);
-            default -> throw argumentError(getRuntime().getCurrentContext(), args.length, 1);
+            default -> throw argumentError(context, args.length, 1);
         };
     }
 
     @Override
-    public RubyString to_s() {
+    public RubyString to_s(ThreadContext context) {
         return longToString(value, 10);
     }
 

--- a/core/src/main/java/org/jruby/RubyFloat.java
+++ b/core/src/main/java/org/jruby/RubyFloat.java
@@ -64,6 +64,7 @@ import org.jruby.util.Sprintf;
 
 import static org.jruby.api.Convert.*;
 import static org.jruby.api.Create.newArray;
+import static org.jruby.api.Create.newString;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.util.Numeric.f_abs;
@@ -258,14 +259,11 @@ public class RubyFloat extends RubyNumeric implements Appendable {
      */
     @JRubyMethod(name = {"to_s", "inspect"})
     @Override
-    public IRubyObject to_s() {
-        final Ruby runtime = metaClass.runtime;
+    public IRubyObject to_s(ThreadContext context) {
         if (Double.isInfinite(value)) {
-            return RubyString.newStringShared(runtime, value < 0 ? NEGATIVE_INFINITY_TO_S_BYTELIST : POSITIVE_INFINITY_TO_S_BYTELIST);
+            return RubyString.newStringShared(context.runtime, value < 0 ? NEGATIVE_INFINITY_TO_S_BYTELIST : POSITIVE_INFINITY_TO_S_BYTELIST);
         }
-        if (Double.isNaN(value)) {
-            return RubyString.newStringShared(runtime, NAN_TO_S_BYTELIST);
-        }
+        if (Double.isNaN(value)) return RubyString.newStringShared(context.runtime, NAN_TO_S_BYTELIST);
 
         ByteList buf = new ByteList();
         // Under 1.9, use full-precision float formatting (JRUBY-4846).
@@ -290,7 +288,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
 
         buf.setEncoding(USASCIIEncoding.INSTANCE);
 
-        return runtime.newString(buf);
+        return newString(context, buf);
     }
 
     public static final ByteList POSITIVE_INFINITY_TO_S_BYTELIST = new ByteList(ByteList.plain("Infinity"), USASCIIEncoding.INSTANCE, false);
@@ -1289,7 +1287,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
 
     @Override
     public void appendIntoString(RubyString target) {
-        target.catWithCodeRange((RubyString) to_s());
+        target.catWithCodeRange((RubyString) to_s(getRuntime().getCurrentContext()));
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -621,14 +621,10 @@ public class RubyGlobal {
             return pair;
         }
 
+        @Override
         @JRubyMethod(name = "to_s")
         public RubyString to_s(ThreadContext context) {
             return RubyString.newStringShared(context.runtime, ENV);
-        }
-
-        @Override
-        public IRubyObject to_s() {
-            return RubyString.newStringShared(getRuntime(), ENV);
         }
 
         @Deprecated
@@ -794,18 +790,12 @@ public class RubyGlobal {
         // MRI: env_name_new
         // TODO: mri 3.1 does not use env_name_new
         protected static IRubyObject newName(ThreadContext context, IRubyObject key, IRubyObject valueArg) {
-            if (valueArg.isNil()) return context.nil;
-
-            RubyString value = (RubyString) valueArg;
-
-            return newString(context, value);
+            return valueArg.isNil() ? context.nil : newString(context, (RubyString) valueArg);
         }
 
         protected static IRubyObject newString(ThreadContext context, RubyString value, Encoding encoding) {
-            IRubyObject result = newExternalStringWithEncoding(context.runtime, value.strDup(context.runtime).getByteList().shallowDup(), encoding);
-
+            IRubyObject result = newExternalStringWithEncoding(context.runtime, value.getByteList().dup(), encoding);
             result.setFrozen(true);
-
             return result;
         }
 

--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -791,7 +791,7 @@ public abstract class RubyInteger extends RubyNumeric {
 
     @Override
     @JRubyMethod(name = {"to_s", "inspect"})
-    public abstract RubyString to_s();
+    public abstract RubyString to_s(ThreadContext context);
 
     @JRubyMethod(name = "to_s")
     public abstract RubyString to_s(IRubyObject x);

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -688,8 +688,8 @@ public class RubyModule extends RubyObject {
     public RubyString rubyBaseName() {
         String baseName = getBaseName();
 
-        final Ruby runtime = metaClass.runtime;
-        return baseName == null ? null : runtime.newSymbol(baseName).to_s(runtime);
+        var context = metaClass.runtime.getCurrentContext();
+        return baseName == null ? null : (RubyString) asSymbol(context, baseName).to_s(context);
     }
 
     private RubyString calculateAnonymousRubyName() {
@@ -2827,12 +2827,10 @@ public class RubyModule extends RubyObject {
      *
      */
     @JRubyMethod(name = "to_s", alias = "inspect")
-    @Override
-    public RubyString to_s() {
-        Ruby runtime = getRuntime();
+    public RubyString to_s(ThreadContext context) {
         if (isSingleton()) {
             IRubyObject attached = ((MetaClass) this).getAttached();
-            RubyString buffer = runtime.newString("#<Class:");
+            RubyString buffer = newString(context, "#<Class:");
 
             if (attached instanceof RubyModule) {
                 buffer.catWithCodeRange(attached.inspect().convertToString());
@@ -2845,9 +2843,8 @@ public class RubyModule extends RubyObject {
         }
 
         RubyModule refinedClass = this.refinedClass;
-
         if (refinedClass != null) {
-            RubyString buffer = runtime.newString("#<refinement:");
+            RubyString buffer = newString(context, "#<refinement:");
 
             buffer.catWithCodeRange(refinedClass.inspect().convertToString());
             buffer.cat('@', buffer.getEncoding());
@@ -2857,7 +2854,7 @@ public class RubyModule extends RubyObject {
             return buffer;
         }
 
-        return rubyName().strDup(runtime);
+        return dupString(context, rubyName());
     }
 
     /** rb_mod_eqq
@@ -2899,7 +2896,7 @@ public class RubyModule extends RubyObject {
     @JRubyMethod(name = "freeze")
     @Override
     public final IRubyObject freeze(ThreadContext context) {
-        to_s();
+        to_s(context);
         return super.freeze(context);
     }
 

--- a/core/src/main/java/org/jruby/RubyProc.java
+++ b/core/src/main/java/org/jruby/RubyProc.java
@@ -237,12 +237,11 @@ public class RubyProc extends RubyObject implements DataType {
 
     @Override
     @JRubyMethod(name = "to_s", alias = "inspect")
-    public IRubyObject to_s() {
-        Ruby runtime = getRuntime();
-        RubyString string = runtime.newString("#<");
+    public IRubyObject to_s(ThreadContext context) {
+        RubyString string = newString(context, "#<");
         string.setEncoding(RubyString.ASCII);
 
-        string.append(types(runtime, type()));
+        string.append(types(context.runtime, type()));
         string.catStringUnsafe(":0x" + Integer.toString(System.identityHashCode(block), 16));
 
         boolean isSymbolProc = block.getBody() instanceof RubySymbol.SymbolProcBody;

--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -366,11 +366,6 @@ public class RubyProcess {
         }
 
         @JRubyMethod
-        public IRubyObject to_s(ThreadContext context) {
-            return to_s(context.runtime);
-        }
-
-        @JRubyMethod
         public IRubyObject inspect(ThreadContext context) {
             return inspect(context.runtime);
         }
@@ -403,13 +398,10 @@ public class RubyProcess {
             return runtime.newFixnum(status);
         }
 
-        public IRubyObject to_s(Ruby runtime) {
-            return runtime.newString(pst_message("", pid, status));
-        }
-
         @Override
-        public IRubyObject to_s() {
-            return to_s(getRuntime());
+        @JRubyMethod
+        public IRubyObject to_s(ThreadContext context) {
+            return newString(context, pst_message("", pid, status));
         }
 
         boolean unitialized() {

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -363,7 +363,7 @@ public class RubyRange extends RubyObject {
 
     @JRubyMethod(name = "inspect")
     public RubyString inspect(final ThreadContext context) {
-        RubyString i1 = isBeginless && !isEndless ? RubyString.newEmptyString(context.runtime) : inspectValue(context, begin).strDup(context.runtime);
+        RubyString i1 = isBeginless && !isEndless ? RubyString.newEmptyString(context.runtime) : dupString(context, inspectValue(context, begin));
         RubyString i2 = isEndless && !isBeginless ? RubyString.newEmptyString(context.runtime) : inspectValue(context, end);
         i1.cat(DOTDOTDOT, 0, isExclusive ? 3 : 2);
         i1.append(i2);
@@ -371,10 +371,6 @@ public class RubyRange extends RubyObject {
     }
 
     @Override
-    public IRubyObject to_s() {
-        return to_s(getRuntime());
-    }
-
     @JRubyMethod(name = "to_s")
     public IRubyObject to_s(final ThreadContext context) {
         return to_s(context.runtime);

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -1325,25 +1325,14 @@ public class RubyRational extends RubyNumeric {
         return num.hashCode() ^ den.hashCode();
     }
 
-    @Override
-    public IRubyObject to_s() {
-        return to_s(getRuntime());
-    }
-
     /** nurat_to_s
      * 
      */
+    @Override
     @JRubyMethod(name = "to_s")
     public RubyString to_s(ThreadContext context) {
-        return to_s(context.runtime);
-    }
-
-    private RubyString to_s(final Ruby runtime) {
-        RubyString str = RubyString.newString(runtime, new ByteList(10), USASCIIEncoding.INSTANCE);
-        str.append(num.to_s());
-        str.cat((byte)'/');
-        str.append(den.to_s());
-        return str;
+        RubyString str = newString(context, new ByteList(10), USASCIIEncoding.INSTANCE);
+        return str.append(num.to_s(context)).cat((byte)'/').append(den.to_s(context));
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -89,6 +89,7 @@ import java.util.Arrays;
 import java.util.Locale;
 import java.util.function.Function;
 
+import static org.jcodings.Config.CASE_FOLD;
 import static org.jruby.ObjectFlags.CHILLED_F;
 import static org.jruby.RubyComparable.invcmp;
 import static org.jruby.RubyEnumerator.SizeFn;
@@ -863,7 +864,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return strDup(runtime, metaClass.getRealClass());
     }
 
-    final RubyString strDup(Ruby runtime, RubyClass clazz) {
+    public final RubyString strDup(Ruby runtime, RubyClass clazz) {
         shareLevel = SHARE_LEVEL_BYTELIST;
         RubyString dup = new RubyString(runtime, clazz, value);
         dup.shareLevel = SHARE_LEVEL_BYTELIST;
@@ -1265,12 +1266,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     @SuppressWarnings("ReferenceEquality")
     @JRubyMethod(name = {"to_s", "to_str"})
     @Override
-    public IRubyObject to_s() {
-        final Ruby runtime = metaClass.runtime;
-        if (metaClass.getRealClass() != runtime.getString()) {
-            return strDup(runtime, runtime.getString());
-        }
-        return this;
+    public IRubyObject to_s(ThreadContext context) {
+        return metaClass.getRealClass() != context.runtime.getString() ? dupString(context, this) : this;
     }
 
     @Override
@@ -1358,10 +1355,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         if (longLen < 0) throw argumentError(context, "negative argument");
         if (size() == 0) return (RubyString) dup();
 
-        int len = checkInt(context, longLen);
-
         // we limit to int because ByteBuffer can only allocate int sizes
-        len = Helpers.multiplyBufferLength(context.runtime, value.getRealSize(), len);
+        int len = Helpers.multiplyBufferLength(context, value.getRealSize(), checkInt(context, longLen));
 
         ByteList bytes = new ByteList(len);
         if (len > 0) {
@@ -1374,7 +1369,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
             }
             System.arraycopy(bytes.getUnsafeBytes(), 0, bytes.getUnsafeBytes(), n, len - n);
         }
-        return newString(context.runtime, bytes);
+        return Create.newString(context, bytes);
     }
 
     @JRubyMethod(name = "%")
@@ -1394,7 +1389,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         // or continue hardcoding US?
         Sprintf.sprintf1_9(out, Locale.US, value, tmp);
 
-        return newString(context.runtime, out);
+        return Create.newString(context, out);
     }
 
     @JRubyMethod
@@ -1660,7 +1655,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @JRubyMethod(name = "reverse")
     public IRubyObject reverse(ThreadContext context) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.reverse_bang(context);
         return str;
     }
@@ -1789,9 +1784,9 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         if (enc == null) return context.nil;
 
         int flags = Config.CASE_FOLD;
-        RubyString down = strDup(context.runtime);
+        RubyString down = dupString(context, this);
         down.downcase_bang(context, flags);
-        RubyString otherDown = otherStr.strDup(context.runtime);
+        RubyString otherDown = dupString(context, otherStr);
         otherDown.downcase_bang(context, flags);
         return asBoolean(context, down.equals(otherDown));
     }
@@ -1928,9 +1923,9 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         IntHolder flagsP = new IntHolder();
         flagsP.value = flags;
         if ((flags & Config.CASE_ASCII_ONLY) != 0) {
-            StringSupport.asciiOnlyCaseMap(context.runtime, value, flagsP, enc);
+            StringSupport.asciiOnlyCaseMap(context, value, flagsP);
         } else {
-            value = StringSupport.caseMap(context.runtime, value, flagsP, enc);
+            value = StringSupport.caseMap(context, value, flagsP, enc);
         }
         return flagsP.value;
     }
@@ -1940,21 +1935,21 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      */
     @JRubyMethod(name = "upcase")
     public RubyString upcase(ThreadContext context) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.upcase_bang(context);
         return str;
     }
 
     @JRubyMethod(name = "upcase")
     public RubyString upcase(ThreadContext context, IRubyObject arg) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.upcase_bang(context, arg);
         return str;
     }
 
     @JRubyMethod(name = "upcase")
     public RubyString upcase(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.upcase_bang(context, arg0, arg1);
         return str;
     }
@@ -2003,21 +1998,21 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      */
     @JRubyMethod(name = "downcase")
     public RubyString downcase(ThreadContext context) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.downcase_bang(context);
         return str;
     }
 
     @JRubyMethod(name = "downcase")
     public RubyString downcase(ThreadContext context, IRubyObject arg) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.downcase_bang(context, arg);
         return str;
     }
 
     @JRubyMethod(name = "downcase")
     public RubyString downcase(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.downcase_bang(context, arg0, arg1);
         return str;
     }
@@ -2066,21 +2061,21 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      */
     @JRubyMethod(name = "swapcase")
     public RubyString swapcase(ThreadContext context) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.swapcase_bang(context);
         return str;
     }
 
     @JRubyMethod(name = "swapcase")
     public RubyString swapcase(ThreadContext context, IRubyObject arg) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.swapcase_bang(context, arg);
         return str;
     }
 
     @JRubyMethod(name = "swapcase")
     public RubyString swapcase(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.swapcase_bang(context, arg0, arg1);
         return str;
     }
@@ -2116,21 +2111,21 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      */
     @JRubyMethod(name = "capitalize")
     public RubyString capitalize(ThreadContext context) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.capitalize_bang(context);
         return str;
     }
 
     @JRubyMethod(name = "capitalize")
     public RubyString capitalize(ThreadContext context, IRubyObject arg) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.capitalize_bang(context, arg);
         return str;
     }
 
     @JRubyMethod(name = "capitalize")
     public RubyString capitalize(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.capitalize_bang(context, arg0, arg1);
         return str;
     }
@@ -2750,7 +2745,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         }
         if (other instanceof RubyFloat flote) {
             modifyCheck();
-            return catWithCodeRange((RubyString) flote.to_s());
+            return catWithCodeRange((RubyString) flote.to_s(context));
         }
         if (other instanceof RubySymbol) throw typeError(context, "can't convert Symbol into String");
 
@@ -2867,7 +2862,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     @JRubyMethod(name = "crypt")
     public RubyString crypt(ThreadContext context, IRubyObject other) {
         Encoding ascii8bit = context.runtime.getEncodingService().getAscii8bitEncoding();
-        RubyString otherStr = other.convertToString().strDup(context.runtime);
+        RubyString otherStr = dupString(context, other.convertToString());
         otherStr.modify();
         otherStr.associateEncoding(ascii8bit);
         ByteList otherBL = otherStr.getByteList();
@@ -2898,14 +2893,14 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @JRubyMethod(name = "sub", writes = BACKREF)
     public IRubyObject sub(ThreadContext context, IRubyObject arg0, Block block) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.sub_bang(context, arg0, block);
         return str;
     }
 
     @JRubyMethod(name = "sub", writes = BACKREF)
     public IRubyObject sub(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Block block) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.sub_bang(context, arg0, arg1, block);
         return str;
     }
@@ -3226,11 +3221,11 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
             // set backref for user
             if (useBackref) context.clearBackRef();
 
-            return bang ? context.nil : strDup(context.runtime, context.runtime.getString()); /* bang: true, no match, no substitution */
+            return bang ? context.nil : dupString(context, this); /* bang: true, no match, no substitution */
         }
 
         int offset = 0; int cp = spBeg; //int n = 0;
-        RubyString dest = newString(context.runtime, new ByteList(spLen + 30));
+        RubyString dest = Create.newString(context, new ByteList(spLen + 30));
         final Encoding str_enc = value.getEncoding();
         dest.setEncoding(str_enc);
         dest.setCodeRange(str_enc.isAsciiCompatible() ? CR_7BIT : CR_VALID);
@@ -3253,7 +3248,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
                     // set backref for user
                     if (useBackref) context.setBackRef(match);
 
-                    val = objAsString(context, block.yield(context, pattern.strDup(context.runtime)));
+                    val = objAsString(context, block.yield(context, dupString(context, pattern)));
                 }
                 modifyCheck(spBytes, spLen, str_enc);
                 if (bang) frozenCheck();
@@ -3315,7 +3310,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
             // set backref for user
             if (useBackref) context.clearBackRef();
 
-            return bang ? context.nil : strDup(context.runtime, context.runtime.getString()); /* bang: true, no match, no substitution */
+            return bang ? context.nil : dupString(context, this); /* bang: true, no match, no substitution */
         }
 
         int offset = 0; int cp = spBeg; //int n = 0;
@@ -3801,7 +3796,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         } else if (arg instanceof RubyRegexp regexp) {
             return subpat(context, regexp);
         } else if (arg instanceof RubyString str) {
-            return StringSupport.index(this, str, 0, this.checkEncoding(str)) != -1 ? str.strDup(context.runtime, context.runtime.getString()) : context.nil;
+            return StringSupport.index(this, str, 0, this.checkEncoding(str)) != -1 ? dupString(context, str) : context.nil;
         } else if (arg instanceof RubyRange range) {
             int[] begLen = range.begLenInt(context, strLength(), 0);
             return begLen == null ? context.nil : substrEnc(context, begLen[0], begLen[1]);
@@ -4303,7 +4298,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         StringSites sites = sites(context);
         CallSite succ = sites.succ;
         IRubyObject afterEnd = succ.call(context, end, end);
-        RubyString current = strDup(context.runtime);
+        RubyString current = dupString(context, this);
 
         while (!current.op_equal(context, afterEnd).isTrue()) {
             IRubyObject next = null;
@@ -4323,7 +4318,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         CallSite succ = sites.succ;
 
         boolean isAscii = scanForCodeRange() == CR_7BIT;
-        RubyString current = strDup(context.runtime);
+        RubyString current = dupString(context, this);
 
         if (isAscii && ASCII.isDigit(value.getUnsafeBytes()[value.getBegin()])) {
             IRubyObject b = stringToInum(10);
@@ -4561,7 +4556,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     // MRI: rb_str_split_m, overall structure
     private RubyArray splitCommon(ThreadContext context, IRubyObject pat, int lim) {
         // limit of 1 is the whole value.
-        if (lim == 1) return value.isEmpty() ? newArray(context) : newArray(context, strDup(context.runtime, context.runtime.getString()));
+        if (lim == 1) return value.isEmpty() ? newArray(context) : newArray(context, dupString(context, this));
 
         boolean limit = lim > 0; // We have an explicit number of values we want to split into.
         RubyArray<?> result;
@@ -5156,18 +5151,14 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     public IRubyObject delete_prefix(ThreadContext context, IRubyObject prefix) {
         int prefixlen = deletedPrefixLength(prefix);
 
-        if (prefixlen <= 0) return strDup(context.runtime, context.runtime.getString());
-
-        return makeSharedString(context.runtime, prefixlen, size() - prefixlen);
+        return prefixlen <= 0 ? dupString(context, this) : makeSharedString(context.runtime, prefixlen, size() - prefixlen);
     }
 
     @JRubyMethod(name = "delete_suffix")
     public IRubyObject delete_suffix(ThreadContext context, IRubyObject suffix) {
         int suffixlen = deletedSuffixLength(suffix);
 
-        if (suffixlen <= 0) return strDup(context.runtime, context.runtime.getString());
-
-        return makeSharedString(context.runtime, 0, size() - suffixlen);
+        return suffixlen <= 0 ? dupString(context, this) : makeSharedString(context.runtime, 0, size() - suffixlen);
     }
 
     @JRubyMethod(name = "delete_prefix!")
@@ -5296,7 +5287,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     private RubyString justifyCommon(ThreadContext context, ByteList pad, int padCharLen, boolean padSinglebyte,
                                      Encoding enc, int width, int jflag) {
         int len = StringSupport.strLengthFromRubyString(this, enc);
-        if (width < 0 || len >= width) return strDup(context.runtime);
+        if (width < 0 || len >= width) return dupString(context, this);
         int n = width - len;
 
         int llen = (jflag == 'l') ? 0 : ((jflag == 'r') ? n : n / 2);
@@ -5490,10 +5481,9 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     }
 
     private RubyArray partitionMismatch(ThreadContext context) {
-        var runtime = context.runtime;
         final Encoding enc = getEncoding();
-        return RubyArray.newArrayMayCopy(runtime, this.strDup(runtime, runtime.getString()),
-                newEmptyString(runtime, enc), newEmptyString(runtime, enc));
+        return RubyArray.newArrayMayCopy(context.runtime, dupString(context, this),
+                newEmptyString(context.runtime, enc), newEmptyString(context.runtime, enc));
     }
 
     @JRubyMethod(name = "rpartition", writes = BACKREF)
@@ -5521,7 +5511,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     private IRubyObject rpartitionMismatch(ThreadContext context) {
         final Encoding enc = getEncoding();
         return newArrayNoCopy(context, newEmptyString(context.runtime, enc),
-                newEmptyString(context.runtime, enc), this.strDup(context.runtime, context.runtime.getString()));
+                newEmptyString(context.runtime, enc), dupString(context, this));
     }
 
     /** rb_str_chop / rb_str_chop_bang
@@ -5580,14 +5570,14 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      */
     @JRubyMethod(name = "chomp")
     public RubyString chomp(ThreadContext context) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.chomp_bang(context);
         return str;
     }
 
     @JRubyMethod(name = "chomp")
     public RubyString chomp(ThreadContext context, IRubyObject arg0) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.chomp_bang(context, arg0);
         return str;
     }
@@ -5695,7 +5685,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      */
     @JRubyMethod(name = "lstrip")
     public IRubyObject lstrip(ThreadContext context) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.lstrip_bang(context);
         return str;
     }
@@ -5752,7 +5742,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      */
     @JRubyMethod(name = "rstrip")
     public IRubyObject rstrip(ThreadContext context) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.rstrip_bang(context);
         return str;
     }
@@ -5815,7 +5805,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      */
     @JRubyMethod(name = "strip")
     public IRubyObject strip(ThreadContext context) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.strip_bang(context);
         return str;
     }
@@ -5899,14 +5889,14 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @JRubyMethod(name = "delete")
     public IRubyObject delete(ThreadContext context, IRubyObject arg) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.delete_bang(context, arg);
         return str;
     }
 
     @JRubyMethod(name = "delete", required = 1, rest = true, checkArity = false)
     public IRubyObject delete(ThreadContext context, IRubyObject[] args) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.delete_bang(context, args);
         return str;
     }
@@ -5954,21 +5944,21 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @JRubyMethod(name = "squeeze")
     public IRubyObject squeeze(ThreadContext context) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.squeeze_bang(context);
         return str;
     }
 
     @JRubyMethod(name = "squeeze")
     public IRubyObject squeeze(ThreadContext context, IRubyObject arg) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.squeeze_bang(context, arg);
         return str;
     }
 
     @JRubyMethod(name = "squeeze", required = 1, rest = true, checkArity = false)
     public IRubyObject squeeze(ThreadContext context, IRubyObject[] args) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.squeeze_bang(context, args);
         return str;
     }
@@ -6058,7 +6048,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      */
     @JRubyMethod(name = "tr")
     public IRubyObject tr(ThreadContext context, IRubyObject src, IRubyObject repl) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.trTrans(context, src, repl, false);
         return str;
     }
@@ -6103,7 +6093,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      */
     @JRubyMethod(name = "tr_s")
     public IRubyObject tr_s(ThreadContext context, IRubyObject src, IRubyObject repl) {
-        RubyString str = strDup(context.runtime, context.runtime.getString());
+        RubyString str = dupString(context, this);
         str.trTrans(context, src, repl, true);
         return str;
     }
@@ -6660,7 +6650,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     @JRubyMethod
     public IRubyObject b(ThreadContext context) {
         Encoding encoding = ASCIIEncoding.INSTANCE;
-        RubyString dup = strDup(context.runtime);
+        RubyString dup = dupString(context, this);
         dup.clearCodeRange();
         dup.setEncoding(encoding);
         return dup;
@@ -6676,7 +6666,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     @JRubyMethod
     public IRubyObject scrub(ThreadContext context, IRubyObject repl, Block block) {
         IRubyObject newStr = strScrub(context, repl, block);
-        if (newStr.isNil()) return strDup(context.runtime, context.runtime.getString());
+        if (newStr.isNil()) return dupString(context, this);
         return newStr;
     }
 

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -191,9 +191,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
     @Override
     public final String toString() {
         String decoded = decodedString;
-        if (decoded == null) {
-            decodedString = decoded = RubyEncoding.decodeRaw(getBytes());
-        }
+        if (decoded == null) decodedString = decoded = RubyEncoding.decodeRaw(getBytes());
         return decoded;
     }
 
@@ -489,13 +487,9 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
     }
 
     @Override
-    public IRubyObject to_s() {
-        return to_s(metaClass.runtime);
-    }
-
     @JRubyMethod(name = "to_s")
     public IRubyObject to_s(ThreadContext context) {
-        return to_s(context.runtime);
+        return RubyString.newStringShared(context.runtime, getBytes());
     }
 
     final RubyString to_s(Ruby runtime) {
@@ -513,8 +507,9 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
       return rubyString;
     }
 
+    @Deprecated(since = "9.4-", forRemoval = true)
     public IRubyObject id2name() {
-        return to_s(metaClass.runtime);
+        return to_s(getCurrentContext());
     }
 
     @JRubyMethod
@@ -524,7 +519,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
 
     @Override
     public RubyString asString() {
-        return to_s(metaClass.runtime);
+        return (RubyString) to_s(metaClass.runtime.getCurrentContext());
     }
 
     @JRubyMethod(name = "===")
@@ -672,9 +667,9 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
     @JRubyMethod(name = "start_with?")
     public IRubyObject start_with_p(ThreadContext context, IRubyObject arg) {
         if (arg instanceof RubyRegexp) {
-            return ((RubyRegexp) arg).startsWith(context, to_s(context.runtime)) ? context.tru : context.fals;
+            return ((RubyRegexp) arg).startsWith(context, (RubyString) to_s(context)) ? context.tru : context.fals;
         }
-        return to_s(context.runtime).startsWith(arg.convertToString()) ? context.tru : context.fals;
+        return ((RubyString) to_s(context)).startsWith(arg.convertToString()) ? context.tru : context.fals;
     }
 
     @JRubyMethod(name = "start_with?", rest = true)
@@ -692,12 +687,12 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
 
     @JRubyMethod(name = "end_with?")
     public IRubyObject end_with_p(ThreadContext context, IRubyObject arg) {
-        return to_s(context.runtime).endWith(arg) ? context.tru : context.fals;
+        return ((RubyString) to_s(context)).endWith(arg) ? context.tru : context.fals;
     }
 
     @JRubyMethod(name = "end_with?", rest = true)
     public IRubyObject end_with_p(ThreadContext context, IRubyObject[]args) {
-        RubyString str = to_s(context.runtime);
+        RubyString str = (RubyString) to_s(context);
         for (int i = 0; i < args.length; i++) {
             if (str.endWith(args[i])) return context.tru;
         }

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -901,8 +901,7 @@ public class RubyTime extends RubyObject {
     @JRubyMethod(name = "eql?")
     @Override
     public IRubyObject eql_p(IRubyObject other) {
-        if (other instanceof RubyTime) {
-            RubyTime otherTime = (RubyTime)other;
+        if (other instanceof RubyTime otherTime) {
             return (nsec == otherTime.nsec && getTimeInMillis() == otherTime.getTimeInMillis()) ? getRuntime().getTrue() : getRuntime().getFalse();
         }
         return getRuntime().getFalse();
@@ -910,23 +909,17 @@ public class RubyTime extends RubyObject {
 
     @JRubyMethod(name = {"asctime", "ctime"})
     public RubyString asctime() {
-        DateTimeFormatter simpleDateFormat;
+        DateTimeFormatter simpleDateFormat = dt.getDayOfMonth() < 10 ? ONE_DAY_CTIME_FORMATTER : TWO_DAY_CTIME_FORMATTER;
 
-        if (dt.getDayOfMonth() < 10) {
-            simpleDateFormat = ONE_DAY_CTIME_FORMATTER;
-        } else {
-            simpleDateFormat = TWO_DAY_CTIME_FORMATTER;
-        }
-        String result = simpleDateFormat.print(dt);
-        return RubyString.newString(getRuntime(), result, USASCIIEncoding.INSTANCE);
+        return RubyString.newString(getRuntime(), simpleDateFormat.print(dt), USASCIIEncoding.INSTANCE);
     }
 
     @Override
     @JRubyMethod
-    public IRubyObject to_s() {
+    public IRubyObject to_s(ThreadContext context) {
         DateTimeFormatter simpleDateFormat = isUTC() ? TO_S_UTC_FORMATTER : TO_S_FORMATTER;
 
-        return RubyString.newString(getRuntime(), simpleDateFormat.print(getInspectDateTime()), USASCIIEncoding.INSTANCE);
+        return newString(context, simpleDateFormat.print(getInspectDateTime()), USASCIIEncoding.INSTANCE);
     }
 
     @JRubyMethod
@@ -966,7 +959,7 @@ public class RubyTime extends RubyObject {
 
     @Override
     public String toString() {
-        return to_s().asJavaString();
+        return to_s(getRuntime().getCurrentContext()).asJavaString();
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/api/Create.java
+++ b/core/src/main/java/org/jruby/api/Create.java
@@ -98,6 +98,7 @@ public class Create {
     /**
      * Create a new array which is intended to be empty for its entire lifetime.
      * It can still grow but the intention is you think it won't grow (or cannot).
+     * If you want a default-size array then use {@link Create#newArray(ThreadContext)}.
      *
      * @param context the current thread context
      * @return the new array
@@ -152,4 +153,14 @@ public class Create {
         return RubyString.newString(context.runtime, string);
     }
 
+    /**
+     * Duplicate the given string and return a String (original subclass of String is not preserved).
+     *
+     * @param context the current thread context
+     * @param string the string to be duplicated
+     * @return the new string
+     */
+    public static RubyString dupString(ThreadContext context, RubyString string) {
+        return string.strDup(context.runtime, context.runtime.getString());
+    }
 }

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -1834,7 +1834,7 @@ public class RubyBigDecimal extends RubyNumeric {
 
     @JRubyMethod
     public IRubyObject inspect(ThreadContext context) {
-        return toStringImpl(context.runtime, null);
+        return toStringImpl(context, null);
     }
 
     @JRubyMethod(name = "nan?")
@@ -2330,43 +2330,37 @@ public class RubyBigDecimal extends RubyNumeric {
         return build;
     }
 
-    @Override
-    public IRubyObject to_s() {
-        return toStringImpl(getRuntime(), null);
-    }
 
+    @Override
     @JRubyMethod
     public RubyString to_s(ThreadContext context) {
-        return toStringImpl(context.runtime, null);
+        return toStringImpl(context, null);
     }
 
     @JRubyMethod
     public RubyString to_s(ThreadContext context, IRubyObject arg) {
-        return toStringImpl(context.runtime, arg == context.nil ? null : arg.toString());
+        return toStringImpl(context, arg == context.nil ? null : arg.toString());
     }
 
-    private RubyString toStringImpl(final Ruby runtime, String arg) {
-        if ( isNaN() ) return RubyString.newUSASCIIString(runtime, "NaN");
+    private RubyString toStringImpl(ThreadContext context, String arg) {
+        if ( isNaN() ) return RubyString.newUSASCIIString(context.runtime, "NaN");
         if ( isInfinity() ) {
             if ( arg != null && infinitySign >= 0) {
-                if ( formatHasLeadingSpace(arg) ) return RubyString.newUSASCIIString(runtime, " Infinity");
-                if ( formatHasLeadingPlus(arg) ) return RubyString.newUSASCIIString(runtime, "+Infinity");
+                if ( formatHasLeadingSpace(arg) ) return RubyString.newUSASCIIString(context.runtime, " Infinity");
+                if ( formatHasLeadingPlus(arg) ) return RubyString.newUSASCIIString(context.runtime, "+Infinity");
             }
-            return RubyString.newUSASCIIString(runtime, infinityString(infinitySign));
+            return RubyString.newUSASCIIString(context.runtime, infinityString(infinitySign));
         }
-        if ( isZero() ) {
-            if ( zeroSign < 0 ) {
-                return RubyString.newUSASCIIString(runtime, "-0.0");
-            } else {
-                if ( arg != null && formatHasLeadingSpace(arg) ) return RubyString.newUSASCIIString(runtime, " 0.0");
-                if ( arg != null && formatHasLeadingPlus(arg) ) return RubyString.newUSASCIIString(runtime, "+0.0");
-                return RubyString.newUSASCIIString(runtime, "0.0");
-            }
+        if (isZero()) {
+            if (zeroSign < 0) return RubyString.newUSASCIIString(context.runtime, "-0.0");
+            if (arg != null && formatHasLeadingSpace(arg)) return RubyString.newUSASCIIString(context.runtime, " 0.0");
+            if (arg != null && formatHasLeadingPlus(arg)) return RubyString.newUSASCIIString(context.runtime, "+0.0");
+            return RubyString.newUSASCIIString(context.runtime, "0.0");
         }
 
         boolean asEngineering = arg == null || ! formatHasFloatingPointNotation(arg);
 
-        return RubyString.newUSASCIIString(runtime, ( asEngineering ? engineeringValue(arg) : floatingPointValue(arg) ).toString());
+        return RubyString.newUSASCIIString(context.runtime, ( asEngineering ? engineeringValue(arg) : floatingPointValue(arg) ).toString());
     }
 
     @Override
@@ -2380,7 +2374,7 @@ public class RubyBigDecimal extends RubyNumeric {
 
     @Deprecated
     public IRubyObject to_s(IRubyObject[] args) {
-        return toStringImpl(getRuntime(), args.length == 0 ? null : (args[0].isNil() ? null : args[0].toString()));
+        return toStringImpl(getCurrentContext(), args.length == 0 ? null : (args[0].isNil() ? null : args[0].toString()));
     }
 
     // Note: #fix has only no-arg form, but truncate allows optional parameter.

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -1576,7 +1576,7 @@ public class RubyDate extends RubyObject {
         long ns = (dt.getMillisOfSecond() * 1_000_000) + (subMillisNum * 1_000_000) / subMillisDen;
         ByteList str = new ByteList(54); // e.g. #<Date: 2018-01-15 ((2458134j,0s,0n),+0s,2299161j)>
         str.append('#').append('<');
-        str.append(((RubyString) getMetaClass().to_s()).getByteList());
+        str.append(((RubyString) getMetaClass().to_s(context)).getByteList());
         str.append(':').append(' ');
         str.append(to_s(context).getByteList()); // to_s
         str.append(' ').append('(').append('(');
@@ -1608,10 +1608,6 @@ public class RubyDate extends RubyObject {
     static { TO_S_FORMAT.setEncoding(USASCIIEncoding.INSTANCE); }
 
     @Override
-    public final IRubyObject to_s() {
-        return to_s(getRuntime().getCurrentContext());
-    }
-
     @JRubyMethod
     public RubyString to_s(ThreadContext context) { // format('%.4d-%02d-%02d', year, mon, mday)
         return format(context, TO_S_FORMAT, year(context), mon(context), mday(context));

--- a/core/src/main/java/org/jruby/ir/operands/ChilledString.java
+++ b/core/src/main/java/org/jruby/ir/operands/ChilledString.java
@@ -8,6 +8,8 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 
+import static org.jruby.api.Create.dupString;
+
 public class ChilledString extends MutableString implements Stringable, StringLiteral {
     /**
      * Used by persistence and by .freeze optimization
@@ -32,7 +34,7 @@ public class ChilledString extends MutableString implements Stringable, StringLi
 
     @Override
     public Object retrieve(ThreadContext context, IRubyObject self, StaticScope currScope, DynamicScope currDynScope, Object[] temp) {
-        return frozenString.retrieve(context, self, currScope, currDynScope, temp).strDup(context.runtime).chill();
+        return dupString(context, frozenString.retrieve(context, self, currScope, currDynScope, temp)).chill();
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/operands/MutableString.java
+++ b/core/src/main/java/org/jruby/ir/operands/MutableString.java
@@ -13,6 +13,8 @@ import org.jruby.util.ByteList;
 
 import java.util.List;
 
+import static org.jruby.api.Create.dupString;
+
 /**
  * Represents a literal string value.
  *
@@ -78,7 +80,7 @@ public class MutableString extends Operand implements Stringable, StringLiteral 
 
     @Override
     public Object retrieve(ThreadContext context, IRubyObject self, StaticScope currScope, DynamicScope currDynScope, Object[] temp) {
-        return frozenString.retrieve(context, self, currScope, currDynScope, temp).strDup(context.runtime);
+        return dupString(context, frozenString.retrieve(context, self, currScope, currDynScope, temp));
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/targets/indy/ArrayDerefInvokeSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/ArrayDerefInvokeSite.java
@@ -23,6 +23,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.SwitchPoint;
 
+import static org.jruby.api.Create.dupString;
 import static org.jruby.util.CodegenUtils.p;
 import static org.jruby.util.CodegenUtils.sig;
 
@@ -73,7 +74,7 @@ public class ArrayDerefInvokeSite extends NormalInvokeSite {
             // slow path follows normal invoke logic with a strDup for the key
 
             // strdup for this call
-            args[0] = ((RubyString) args[0]).strDup(context.runtime);
+            args[0] = dupString(context, (RubyString) args[0]);
 
             if (methodMissing(entry, caller)) {
                 return callMethodMissing(entry, callType, context, self, selfClass, methodName, args, block);
@@ -120,7 +121,7 @@ public class ArrayDerefInvokeSite extends NormalInvokeSite {
         CacheEntry entry = cache;
 
         // strdup for all calls
-        arg0 = ((RubyString) arg0).strDup(context.runtime);
+        arg0 = dupString(context, (RubyString) arg0);
 
         if (entry.typeOk(selfClass)) {
             return entry.method.call(context, self, entry.sourceModule, name, arg0, block);

--- a/core/src/main/java/org/jruby/javasupport/JavaObject.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaObject.java
@@ -175,12 +175,19 @@ public class JavaObject extends RubyObject {
 
     @JRubyMethod
     @Override
-    public IRubyObject to_s() {
-        return to_s(getRuntime(), dataGetStruct());
+    public IRubyObject to_s(ThreadContext context) {
+        return JavaProxyMethods.to_s(context, dataGetStruct());
     }
 
+    /**
+     * @param runtime
+     * @param dataStruct
+     * @return ""
+     * @deprecated Use {@link
+     */
+    @Deprecated(since = "10.0", forRemoval = true)
     public static IRubyObject to_s(Ruby runtime, Object dataStruct) {
-        return JavaProxyMethods.to_s(runtime, dataStruct);
+        return JavaProxyMethods.to_s(runtime.getCurrentContext(), dataStruct);
     }
 
     @JRubyMethod(name = {"==", "eql?"})

--- a/core/src/main/java/org/jruby/javasupport/JavaPackage.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaPackage.java
@@ -108,7 +108,7 @@ public class JavaPackage extends RubyModule {
     }
 
     @Override
-    public RubyString to_s() { return package_name(); }
+    public RubyString to_s(ThreadContext context) { return package_name(); }
 
     @Override
     @JRubyMethod

--- a/core/src/main/java/org/jruby/javasupport/JavaProxyMethods.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaProxyMethods.java
@@ -99,24 +99,25 @@ public class JavaProxyMethods {
 
     @JRubyMethod
     public static IRubyObject to_s(ThreadContext context, IRubyObject recv) {
-        if (recv instanceof JavaProxy) {
-            return to_s(context.runtime, ((JavaProxy) recv).getObject());
-        }
-        // NOTE: only JavaProxy includes JavaProxyMethods
-        // these is only here for 'manual' JavaObject wrapping :
-        if (recv.dataGetStruct() instanceof IRubyObject) {
-            return ((RubyBasicObject) recv.dataGetStruct()).to_s();
-        }
-        return ((RubyBasicObject) recv).to_s();
+        if (recv instanceof JavaProxy) return to_s(context, ((JavaProxy) recv).getObject());
+
+        // NOTE: only JavaProxy includes JavaProxyMethods these is only here for 'manual' JavaObject wrapping :
+        var data = recv.dataGetStruct();
+        return data instanceof IRubyObject ?
+            ((RubyBasicObject) data).to_s(context) : ((RubyBasicObject) recv).to_s(context);
     }
 
-    static IRubyObject to_s(Ruby runtime, Object javaObject) {
+    static IRubyObject to_s(ThreadContext context, Object javaObject) {
         if (javaObject != null) {
             final String stringValue = javaObject.toString();
-            if ( stringValue == null ) return runtime.getNil();
-            return RubyString.newUnicodeString(runtime, stringValue);
+            return stringValue == null ? context.nil : RubyString.newUnicodeString(context.runtime, stringValue);
         }
-        return RubyString.newEmptyString(runtime);
+        return RubyString.newEmptyString(context.runtime);
+    }
+
+    @Deprecated(since = "10.0", forRemoval = true)
+    static IRubyObject to_s(Ruby runtime, Object javaObject) {
+        return to_s(runtime.getCurrentContext(), javaObject);
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyReflectionObject.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyReflectionObject.java
@@ -110,8 +110,8 @@ public class JavaProxyReflectionObject extends RubyObject {
 
     @Override
     @JRubyMethod
-    public IRubyObject to_s() {
-        return getRuntime().newString(toString());
+    public IRubyObject to_s(ThreadContext context) {
+        return context.runtime.newString(toString());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -504,15 +504,28 @@ public class Helpers {
     }
 
     /**
-     * Calculate a buffer length based on a base size and a multiplier. If the resulting size exceeds MAX_ARRAY_SIZE,
-     * an {@link ArgumentError} will be thrown, similar to when asking the JVM to allocate a too-large array.
-     *
-     * @param base the base size
-     * @param multiplier the multiplier
-     * @return the multiplied size, if valid
-     * @throws ArgumentError if the requested length is greated than the max array size
+     * @param runtime
+     * @param base
+     * @param multiplier
+     * @return ""
+     * @deprecated Use {@link Helpers#multiplyBufferLength(ThreadContext, int, int)} instead.
      */
+    @Deprecated(since = "10.0", forRemoval = true)
     public static int multiplyBufferLength(Ruby runtime, int base, int multiplier) {
+        return multiplyBufferLength(runtime.getCurrentContext(), base, multiplier);
+    }
+
+        /**
+         * Calculate a buffer length based on a base size and a multiplier. If the resulting size exceeds MAX_ARRAY_SIZE,
+         * an {@link ArgumentError} will be thrown, similar to when asking the JVM to allocate a too-large array.
+         *
+         * @param context the thread context
+         * @param base the base size
+         * @param multiplier the multiplier
+         * @return the multiplied size, if valid
+         * @throws ArgumentError if the requested length is greated than the max array size
+         */
+    public static int multiplyBufferLength(ThreadContext context, int base, int multiplier) {
         try {
             int newSize = Math.multiplyExact(base, multiplier);
             if (newSize <= MAX_ARRAY_SIZE) return newSize;
@@ -521,7 +534,7 @@ public class Helpers {
             // fall through to error below
         }
 
-        throw argumentError(runtime.getCurrentContext(), "argument too big");
+        throw argumentError(context, "argument too big");
     }
 
     /**

--- a/core/src/main/java/org/jruby/util/Sprintf.java
+++ b/core/src/main/java/org/jruby/util/Sprintf.java
@@ -987,7 +987,7 @@ public class Sprintf {
                             zero = precision;
                         }
 
-                        RubyString val = num.to_s();
+                        RubyString val = num.to_s(context);
                         int len = val.length() + zero;
                         if (precision >= len) len = precision + 1; // integer part 0
                         if (sign != 0 || (flags & FLAG_SPACE) != 0) ++len;

--- a/core/src/main/java/org/jruby/util/StringSupport.java
+++ b/core/src/main/java/org/jruby/util/StringSupport.java
@@ -2964,7 +2964,20 @@ public final class StringSupport {
 
     private static final int CASE_MAPPING_ADDITIONAL_LENGTH = 20;
 
+    /**
+     * @param runtime
+     * @param src
+     * @param flags
+     * @param enc
+     * @return ""
+     * @deprecated Use {@link StringSupport#caseMap(ThreadContext, ByteList, IntHolder, Encoding)} instead.
+     */
+    @Deprecated(since = "10.0", forRemoval = true)
     public static ByteList caseMap(Ruby runtime, ByteList src, IntHolder flags, Encoding enc) {
+        return caseMap(runtime.getCurrentContext(), src, flags, enc);
+    }
+
+    public static ByteList caseMap(ThreadContext context, ByteList src, IntHolder flags, Encoding enc) {
         IntHolder pp = new IntHolder();
         pp.value = src.getBegin();
         int end = src.getRealSize() + pp.value;
@@ -2978,7 +2991,7 @@ public final class StringSupport {
             buffer.next = new MappingBuffer((end - pp.value) * ++buffers + CASE_MAPPING_ADDITIONAL_LENGTH);
             buffer = buffer.next;
             int len = enc.caseMap(flags, bytes, pp, end, buffer.bytes, 0, buffer.bytes.length);
-            if (len < 0) throw argumentError(runtime.getCurrentContext(), "input string invalid");
+            if (len < 0) throw argumentError(context, "input string invalid");
             buffer.used = len;
             tgtLen += len;
         }
@@ -3001,7 +3014,19 @@ public final class StringSupport {
         return tgt;
     }
 
+    /**
+     * @param runtime
+     * @param value
+     * @param flags
+     * @param enc
+     * @deprecated Use {@link StringSupport#asciiOnlyCaseMap(ThreadContext, ByteList, IntHolder)} instead.
+     */
+    @Deprecated(since = "10.0", forRemoval = true)
     public static void asciiOnlyCaseMap(Ruby runtime, ByteList value, IntHolder flags, Encoding enc) {
+        asciiOnlyCaseMap(runtime.getCurrentContext(), value, flags);
+    }
+
+    public static void asciiOnlyCaseMap(ThreadContext context, ByteList value, IntHolder flags) {
         if (value.getRealSize() == 0) return;
         int s = value.getBegin();
         int end = s + value.getRealSize();
@@ -3010,7 +3035,7 @@ public final class StringSupport {
         IntHolder pp = new IntHolder();
         pp.value = s;
         int len = ASCIIEncoding.INSTANCE.caseMap(flags, bytes, pp, end, bytes, s, end);
-        if (len < 0) throw argumentError(runtime.getCurrentContext(), "input string invalid");
+        if (len < 0) throw argumentError(context, "input string invalid");
     }
 
     public static int encCoderangeClean(int cr) {


### PR DESCRIPTION
make to_s use TC.  Deprecated version in RubyBasicObject calls to new one.

new dupString api.  Audited all strDup to deliineate duping with same metaclass and ones which should become formal Strings.