### PR TITLE
fix --jdb -sourcepath command

### DIFF
--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -138,6 +138,7 @@ readonly cygwin
 
 use_exec=true
 java_opts_from_files=""
+jdb=false
 
 NO_BOOTCLASSPATH=false
 VERIFY_JRUBY=false
@@ -153,6 +154,7 @@ fi
 
 java_args=""
 ruby_args=""
+jdb_args=""
 
 # Force OpenJDK-based JVMs to use /dev/urandom for random number generation
 # See https://github.com/jruby/jruby/issues/4685 among others.
@@ -562,6 +564,7 @@ do
         --headless) append java_args -Djava.awt.headless=true ;;
         # Run under JDB
         --jdb)
+            jdb=true
             if [ -z "$JAVA_HOME" ]; then
                 JAVACMD='jdb'
             else
@@ -572,7 +575,7 @@ do
                 fi
             fi
             JDB_SOURCEPATH="${JRUBY_HOME}/core/src/main/java:${JRUBY_HOME}/lib/ruby/stdlib:."
-            append java_args -sourcepath "$JDB_SOURCEPATH"
+            append jdb_args -sourcepath "$JDB_SOURCEPATH"
             append ruby_args -X+C
             ;;
         --client|--server|--noclient)
@@ -691,6 +694,10 @@ prepend java_args $JAVA_OPTS "$JFFI_OPTS"
 
 # Include all options from files at the beginning of the Java command line
 preextend java_args java_opts_from_files
+
+if $jdb; then
+    preextend java_args jdb_args
+fi
 
 prepend java_args "$JAVACMD"
 


### PR DESCRIPTION
Currently the `-sourcepath` command is not being passed correctly to jdb, causing an error when running. This PR separates jdb_args and prepends them to java args just before prepending JAVACMD to ensure the sourcepath command is recognised.

## Before

```
$ jruby --version
jruby 9.4.10.0-SNAPSHOT (3.1.4) 2024-11-29 ffffffffff Java HotSpot(TM) 64-Bit Server VM 23.0.1+11-39 on 23.0.1+11-39 +jit [arm64-darwin]
$ jruby --jdb foo.rb
Initializing jdb ...
> run
run @/Users/dani/projects/mine/jruby/bin/.jruby.java_opts @/Users/dani/projects/mine/jruby/bin/.jruby.module_opts -Xss2048k -Djffi.boot.library.path=/Users/dani/projects/mine/jruby/lib/jni -sourcepath /Users/dani/projects/mine/jruby/core/src/main/java:/Users/dani/projects/mine/jruby/lib/ruby/stdlib:. -Djava.security.egd=file:/dev/urandom --module-path /Users/dani/projects/mine/jruby/lib/jruby.jar -classpath : -Djruby.home=/Users/dani/projects/mine/jruby -Djruby.lib=/Users/dani/projects/mine/jruby/lib -Djruby.script=jruby -Djruby.shell=/bin/sh org.jruby.Main -X+C foo.rb
VM start exception: VM initialization failed for: /Library/Java/JavaVirtualMachines/jdk-23.jdk/Contents/Home/bin/java -Xrunjdwp:transport=dt_socket,address=localhost:50157,suspend=y,includevirtualthreads=n @/Users/dani/projects/mine/jruby/bin/.jruby.java_opts @/Users/dani/projects/mine/jruby/bin/.jruby.module_opts -Xss2048k -Djffi.boot.library.path=/Users/dani/projects/mine/jruby/lib/jni -sourcepath /Users/dani/projects/mine/jruby/core/src/main/java:/Users/dani/projects/mine/jruby/lib/ruby/stdlib:. -Djava.security.egd=file:/dev/urandom --module-path /Users/dani/projects/mine/jruby/lib/jruby.jar -classpath : -Djruby.home=/Users/dani/projects/mine/jruby -Djruby.lib=/Users/dani/projects/mine/jruby/lib -Djruby.script=jruby -Djruby.shell=/bin/sh org.jruby.Main -X+C foo.rb

Unrecognized option: -sourcepath
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.

Fatal error:
Target VM failed to initialize.
```

## After

```
$ jruby --version
jruby 9.4.10.0-SNAPSHOT (3.1.4) 2024-11-29 ffffffffff Java HotSpot(TM) 64-Bit Server VM 23.0.1+11-39 on 23.0.1+11-39 +jit [arm64-darwin]
$ jruby --jdb foo.rb
Initializing jdb ...
> run
run @/Users/dani/projects/mine/jruby/bin/.jruby.java_opts @/Users/dani/projects/mine/jruby/bin/.jruby.module_opts -Xss2048k -Djffi.boot.library.path=/Users/dani/projects/mine/jruby/lib/jni -Djava.security.egd=file:/dev/urandom --module-path /Users/dani/projects/mine/jruby/lib/jruby.jar -classpath : -Djruby.home=/Users/dani/projects/mine/jruby -Djruby.lib=/Users/dani/projects/mine/jruby/lib -Djruby.script=jruby -Djruby.shell=/bin/sh org.jruby.Main -X+C foo.rb
Set uncaught java.lang.Throwable
Set deferred uncaught java.lang.Throwable
>
VM Started: Foo!

The application exited
```