### PR TITLE
Inspect wrong object when symbol/string wanted in error

### DIFF
--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -1566,7 +1566,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
         if (object instanceof RubySymbol || object instanceof RubyString) return object;
 
         IRubyObject tmp = TypeConverter.checkStringType(context, sites(context).to_str_checked, object);
-        if (tmp.isNil()) throw typeError(context, str(context.runtime, "", object, " is not a symbol nor a string"));
+        if (tmp.isNil()) throw typeError(context, object.inspect().toString() + " is not a symbol nor a string");
 
         return tmp;
     }


### PR DESCRIPTION
So many paths hit prepareID I am hoping everything will change to this error string when an expected a symbol/string and it isn't one.