### PR TITLE
Make Time load its Ruby-impl side

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -46,6 +46,7 @@ import org.jruby.anno.TypePopulator;
 import org.jruby.api.Create;
 import org.jruby.compiler.Constantizable;
 import org.jruby.compiler.NotCompilableException;
+import org.jruby.exceptions.LoadError;
 import org.jruby.exceptions.LocalJumpError;
 import org.jruby.exceptions.SystemExit;
 import org.jruby.ext.jruby.JRubyUtilLibrary;
@@ -556,7 +557,9 @@ public final class Ruby implements Constantizable {
         }
 
         // FIXME: How should this be loaded as it is not really stdlib but depends on stdlib to be loaded.
-        getLoadService().require("time");
+        try {
+            getLoadService().require("time");
+        } catch (LoadError e) {} // work-around failed classpath only test (which must be omitting stdlib somehow)
     }
 
     private void initProfiling() {

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -554,6 +554,9 @@ public final class Ruby implements Constantizable {
                 getLoadService().require("subspawn/replace-builtin");
             }
         }
+
+        // FIXME: How should this be loaded as it is not really stdlib but depends on stdlib to be loaded.
+        getLoadService().require("time");
     }
 
     private void initProfiling() {

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -219,12 +219,10 @@ public class RubyModule extends RubyObject {
 
     @JRubyMethod
     public IRubyObject autoload(ThreadContext context, IRubyObject symbol, IRubyObject file) {
-        final RubyString fileString = StringSupport.checkEmbeddedNulls(context.runtime, RubyFile.get_path(context, file));
-
+        final RubyString fileString = RubyFile.get_path(context, file);
         if (fileString.isEmpty()) throw argumentError(context, "empty file name");
 
         final String symbolStr = symbol.asJavaString();
-
         if (!IdUtil.isValidConstantName(symbolStr)) {
             throw context.runtime.newNameError("autoload must be constant name", symbolStr);
         }

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -86,7 +86,6 @@ import org.jruby.runtime.backtrace.FrameType;
 import org.jruby.runtime.backtrace.RubyStackTraceElement;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
-import org.jruby.util.StringSupport;
 import org.jruby.util.io.BlockingIO;
 import org.jruby.util.io.ChannelFD;
 import org.jruby.util.io.OpenFile;
@@ -94,6 +93,7 @@ import org.jruby.util.log.Logger;
 import org.jruby.util.log.LoggerFactory;
 import org.jruby.common.IRubyWarnings.ID;
 
+import static org.jruby.api.Check.checkEmbeddedNulls;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Create.newString;
@@ -926,7 +926,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     @JRubyMethod(name = "name=")
     public IRubyObject setName(ThreadContext context, IRubyObject name) {
         if (!name.isNil()) {
-            RubyString nameStr = StringSupport.checkEmbeddedNulls(context.runtime, name);
+            RubyString nameStr = checkEmbeddedNulls(context, name);
             Encoding enc = nameStr.getEncoding();
             if (!enc.isAsciiCompatible()) throw argumentError(context, "ASCII incompatible encoding (" + enc + ")");
 

--- a/core/src/main/java/org/jruby/api/Check.java
+++ b/core/src/main/java/org/jruby/api/Check.java
@@ -1,0 +1,31 @@
+package org.jruby.api;
+
+import org.jruby.RubyString;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import static org.jruby.api.Error.argumentError;
+import static org.jruby.util.StringSupport.strNullCheck;
+
+public class Check {
+    /**
+     * Check to see if the supplied object (which is convertable to a string) contains any
+     * null (\0) bytes.  It will throw an ArgumentError if so and a TypeError is obj is not
+     * a string{able}.
+     *
+     * @param context the current thread context
+     * @param obj object to be made into a string and checked for NULLs
+     * @return the converted str (or original if no conversion happened).
+     */
+    public static RubyString checkEmbeddedNulls(ThreadContext context, IRubyObject obj) {
+        // FIXME: make into a record
+        Object[] checked = strNullCheck(obj);
+
+        if (checked[0] == null) {
+            throw argumentError(context, (boolean)checked[1] ?
+                "string contains null char" : "string contains null byte");
+        }
+
+        return (RubyString) checked[0];
+    }
+}

--- a/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
+++ b/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
@@ -47,6 +47,7 @@ import static jnr.constants.platform.ProtocolFamily.PF_INET6;
 import static jnr.constants.platform.ProtocolFamily.PF_UNIX;
 import static jnr.constants.platform.ProtocolFamily.PF_UNSPEC;
 import static jnr.constants.platform.Sock.*;
+import static org.jruby.api.Check.checkEmbeddedNulls;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Create.newArray;
@@ -383,7 +384,7 @@ public class Addrinfo extends RubyObject {
 
     @JRubyMethod(meta = true)
     public static IRubyObject ip(ThreadContext context, IRubyObject recv, IRubyObject arg) {
-        String host = StringSupport.checkEmbeddedNulls(context.runtime, arg.convertToString()).toString();
+        String host = checkEmbeddedNulls(context, arg.convertToString()).toString();
         try {
             boolean specifiedV6 = host.indexOf(':') != -1;
             InetAddress addy = SocketUtils.getRubyInetAddress(host);

--- a/core/src/main/java/org/jruby/ext/socket/RubyUNIXServer.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUNIXServer.java
@@ -66,7 +66,7 @@ public class RubyUNIXServer extends RubyUNIXSocket {
 
     @JRubyMethod(visibility = Visibility.PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject path) {
-        init_unixsock(context.runtime, path, true);
+        init_unixsock(context, path, true);
 
         return this;
     }

--- a/core/src/main/java/org/jruby/runtime/load/LoadService.java
+++ b/core/src/main/java/org/jruby/runtime/load/LoadService.java
@@ -301,25 +301,17 @@ public class LoadService {
     public static class LoadPathMethods {
         @JRubyMethod
         public static IRubyObject resolve_feature_path(ThreadContext context, IRubyObject self, IRubyObject pathArg) {
-            RubyString path = StringSupport.checkEmbeddedNulls(context.runtime, RubyFile.get_path(context, pathArg));
-            String file = path.toString();
+            RubyString path = RubyFile.get_path(context, pathArg);
             LibrarySearcher.FoundLibrary[] libraryHolder = {null};
-            char extension = context.runtime.getLoadService().searchForRequire(file, libraryHolder);
+            char extension = context.runtime.getLoadService().searchForRequire(path.toString(), libraryHolder);
 
             if (extension == 0) return context.nil;
 
-            RubySymbol ext;
-            switch (extension) {
-                case 'r':
-                    ext = Convert.asSymbol(context, "rb");
-                    break;
-                case 's':
-                    ext = Convert.asSymbol(context, "so"); // FIXME: should this be so or jar?
-                    break;
-                default:
-                    ext = Convert.asSymbol(context, "unknown");
-                    break;
-            }
+            RubySymbol ext = switch (extension) {
+                case 'r' -> Convert.asSymbol(context, "rb");
+                case 's' -> Convert.asSymbol(context, "so"); // FIXME: should this be so or jar?
+                default -> Convert.asSymbol(context, "unknown");
+            };
 
             RubyString name;
             if (libraryHolder[0] == null) {

--- a/core/src/main/java/org/jruby/util/StringSupport.java
+++ b/core/src/main/java/org/jruby/util/StringSupport.java
@@ -924,6 +924,7 @@ public final class StringSupport {
     }
 
     // MRI: StringValueCStr, rb_string_value_cstr without trailing null addition
+    @Deprecated(since = "10.0", forRemoval = true)
     public static RubyString checkEmbeddedNulls(Ruby runtime, IRubyObject ptr) {
         Object[] checked = strNullCheck(ptr);
 


### PR DESCRIPTION
This one is confusing.  We have some Ruby impl but time.rb depends
on date.rb which is a stdlib loaded thing.  So we need to load it
after enough of JRuby it bootstrapped but we want this loaded
ultimately the same time as the Java impl of Time.  I just
put it at the end of Ruby#init but this is probably not right?