### PR TITLE
Avoid re-polling while reporting a Thread#raise

### DIFF
--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -311,6 +311,8 @@ public class RubyGlobal {
             runtime.defineGlobalConstant("STDIN", stdin);
             runtime.defineGlobalConstant("STDOUT", stdout);
             runtime.defineGlobalConstant("STDERR", stderr);
+
+            runtime.setOriginalStderr(stderr);
         } else {
             ((RubyIO) runtime.getObject().getConstant("STDIN")).getOpenFile().setFD(stdin.getOpenFile().fd());
             ((RubyIO) runtime.getObject().getConstant("STDOUT")).getOpenFile().setFD(stdout.getOpenFile().fd());

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -34,13 +34,17 @@
 package org.jruby;
 
 import java.io.IOException;
+import java.io.Writer;
 import java.lang.management.ManagementFactory;
 import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channel;
+import java.nio.channels.Channels;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Queue;
@@ -275,7 +279,6 @@ public class RubyThread extends RubyObject implements ExecutionContext {
                         ((RubyFixnum) err).getLongValue() == 2)) {
                     toKill();
                 } else {
-                    afterBlockingCall();
                     if (getStatus() == Status.SLEEP) {
                         exitSleep();
                     }
@@ -2071,7 +2074,9 @@ public class RubyThread extends RubyObject implements ExecutionContext {
     protected void printReportExceptionWarning() {
         Ruby runtime = getRuntime();
         String name = threadImpl.getReportName();
-        runtime.getErrorStream().println("warning: thread \"" + name + "\" terminated with exception (report_on_exception is true):");
+        String warning = "warning: thread \"" + name + "\" terminated with exception (report_on_exception is true):";
+
+        runtime.printErrorString(warning);
     }
 
     /**

--- a/spec/tags/ruby/core/thread/report_on_exception_tags.txt
+++ b/spec/tags/ruby/core/thread/report_on_exception_tags.txt
@@ -1,2 +1,1 @@
 fails:Thread#report_on_exception= when set to true prints a backtrace on $stderr in the regular backtrace order
-fails:Thread#report_on_exception= when set to true prints the backtrace even if the thread was killed just after Thread#raise


### PR DESCRIPTION
Avoid polling during propagation and report of a `Thread#raise` exception. If we dispatch dynamically to the configured stderr, we may hit additional polls that trigger new interrupts, wiping out the raise interrupt currently being handled.

Fixes #8479