### PR TITLE
Provide concrete-only traversal for Class#subclasses

### DIFF
--- a/bench/bench_subclasses.rb
+++ b/bench/bench_subclasses.rb
@@ -1,5 +1,10 @@
 require 'benchmark/ips'
 
+Custom = Class.new(Object)
+# create these once and hold references
+SINGLETON_COUNT = 1000
+many_singletons = SINGLETON_COUNT.times.map { c = Custom.new; class << c; end; c }
+
 Benchmark.ips do |bm|
   [1, 5, 10, 50].each do |count|
     bm.report("#{count} thread Numeric.subclasses") do
@@ -19,6 +24,17 @@ Benchmark.ips do |bm|
           i = 10_000 / count
           while i > 0
             Object.subclasses
+            i-=1
+          end
+        }
+      }.each(&:join)
+    end
+    bm.report("#{count} thread Custom.subclasses with #{SINGLETON_COUNT} singletons") do
+      count.times.map {
+        Thread.new {
+          i = 10_000 / count
+          while i > 0
+            Custom.subclasses
             i-=1
           end
         }

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -1106,7 +1106,7 @@ public class RubyClass extends RubyModule {
         int clearedCount = 0;
         while (subclassNode != null) {
             RubyClass klass = subclassNode.ref.get();
-            subclassNode = subclassNode.next;
+            subclassNode = subclassNode.nextConcrete;
 
             if (klass == null) {
                 clearedCount++;
@@ -1153,7 +1153,7 @@ public class RubyClass extends RubyModule {
             RubyClass klass = ref.get();
             subclassNode = subclassNode.next;
             if (klass == null) continue;
-            newTop = new SubclassNode(ref, newTop);
+            newTop = new SubclassNode(klass, ref, newTop);
         }
         return newTop;
     }
@@ -1161,14 +1161,17 @@ public class RubyClass extends RubyModule {
     // TODO: make into a Record
     static class SubclassNode {
         final SubclassNode next;
+        final SubclassNode nextConcrete;
+        final boolean concrete;
         final WeakReference<RubyClass> ref;
         SubclassNode(RubyClass klass, SubclassNode next) {
-            ref = new WeakReference<>(klass);
-            this.next = next;
+            this(klass, new WeakReference<>(klass), next);
         }
-        SubclassNode(WeakReference<RubyClass> ref, SubclassNode next) {
+        SubclassNode(RubyClass klass, WeakReference<RubyClass> ref, SubclassNode next) {
             this.ref = ref;
             this.next = next;
+            this.nextConcrete = next == null ? null : next.concrete ? next : next.nextConcrete;
+            this.concrete = !klass.isSingleton();
         }
     }
 


### PR DESCRIPTION
For classes with many singletons, the Class#subclasses walk will cost significantly more than is warranted for the few concrete classes it will return. This can be eliminated by tracking whether each entry is concrete and adding a separate traversal link to the next concrete class in the chain.

Performance of such a case is significantly better:

Before:
```
1 thread Numeric.subclasses
                          1.315k (± 4.6%) i/s -      6.612k in   5.040800s
1 thread Object.subclasses
                         56.282 (± 3.6%) i/s -    285.000 in   5.074688s
1 thread Custom.subclasses with 1000 singletons
                          5.588 (± 0.0%) i/s -     28.000 in   5.021174s
```

After:
```
1 thread Numeric.subclasses
                          2.402k (± 3.4%) i/s -     11.990k in   4.998757s
1 thread Object.subclasses
                        189.977 (± 6.8%) i/s -    954.000 in   5.068134s
1 thread Custom.subclasses with many singletons
                          3.439k (± 1.0%) i/s -     17.334k in   5.040639s
```
