### PR TITLE
Fix memory leak in Concurrent/ThreadSafeLocalContextProvider, using a Thread for JRuby 9

### DIFF
--- a/core/src/main/java/org/jruby/embed/internal/ThreadLocalContext.java
+++ b/core/src/main/java/org/jruby/embed/internal/ThreadLocalContext.java
@@ -1,0 +1,115 @@
+/**
+ * **** BEGIN LICENSE BLOCK *****
+ * Version: EPL 2.0/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Eclipse Public
+ * License Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ * Copyright (C) 2011 Yoko Harada <yokolet@gmail.com>
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either of the GNU General Public License Version 2 or later (the "GPL"),
+ * or the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the EPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the EPL, the GPL or the LGPL.
+ * **** END LICENSE BLOCK *****
+ */
+package org.jruby.embed.internal;
+
+import java.lang.ref.Cleaner;
+import java.lang.ref.Cleaner.Cleanable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * Utility class that wraps a {@link ThreadLocal} holding a {@link LocalContext}
+ * for each thread. Uses the {@link Cleaner} API to remove this
+ * {@code LocalContext} once either the corresponding {@code Thread} has
+ * terminated, or the {@code ThreadLocalContext} instance itself becomes GC'd.
+ */
+class ThreadLocalContext {
+	private final ConcurrentHashMap<LocalContextCleaningAction, Object> contextRefs = new ConcurrentHashMap<>();
+	private final Cleaner cleaner = Cleaner.create();
+	private final Supplier<LocalContext> localContextFactory;
+
+	public ThreadLocalContext(final Supplier<LocalContext> localContextFactory) {
+		this.localContextFactory = localContextFactory;
+	}
+
+	private volatile ThreadLocal<AtomicReference<LocalContextCleaningAction>> contextHolder = new ThreadLocal<AtomicReference<LocalContextCleaningAction>>() {
+		@Override
+		protected AtomicReference<LocalContextCleaningAction> initialValue() {
+			final LocalContextCleaningAction ctx = new LocalContextCleaningAction(contextRefs,
+					localContextFactory.get());
+			final AtomicReference<LocalContextCleaningAction> ref = new AtomicReference<>(ctx);
+			// register cleaner to run as soon as the *reference* to it gets GC'd. that
+			// happens when either the Thread terminates, or the ThreadLocal itself gets
+			// GC'd (i.e. when this class gets GC'd because terminate() was never called).
+			// see ThreadLocal JavaDoc: ref will stay reachable "as long as the thread is
+			// alive and the ThreadLocal instance is accessible"
+			final Cleanable cleanable = cleaner.register(ref, ctx);
+			if (contextHolder == null)
+				// boundary case if we're already terminating: clean up immediately, because
+				// there is no more cleanup thread to do that later
+				// the returned context will be null, but that's to be expected when operating
+				// on an object that has been terminated
+				cleanable.clean();
+			return ref;
+		}
+	};
+
+	public LocalContext get() {
+		return contextHolder.get().get().get();
+	}
+
+	public void terminate() {
+		contextHolder = null;
+		for (final LocalContextCleaningAction ref : contextRefs.keySet())
+			ref.run();
+	}
+
+	/*
+	 * Runnable that actually performs the cleanup for per-thread LocalContext
+	 * instances. MUST be static because these are registered with a Cleaner, so
+	 * everything that is GC-reachable from them will stay reachable until the
+	 * cleaning action has been run.
+	 */
+	private static class LocalContextCleaningAction extends AtomicReference<LocalContext> implements Runnable {
+		private static final long serialVersionUID = 1L;
+
+		private final ConcurrentHashMap<LocalContextCleaningAction, Object> contextRefs;
+
+		private LocalContextCleaningAction(final ConcurrentHashMap<LocalContextCleaningAction, Object> contextRefs,
+				final LocalContext context) {
+			super(context);
+			this.contextRefs = contextRefs;
+			contextRefs.put(this, this);
+		}
+
+		@Override
+		public void run() {
+			// terminate() vs. clean() relies on this being safe to run multiple times, and
+			// possibly concurrently
+			// both AtomicReference.getAndSet() and ConcurrentHashMap.remove() are fully
+			// thread safe, so the current implementation is fine
+			final LocalContext lc = getAndSet(null);
+			if (lc != null)
+				lc.remove();
+			contextRefs.remove(this);
+		}
+	}
+}

--- a/core/src/main/java/org/jruby/embed/internal/ThreadLocalContext.java
+++ b/core/src/main/java/org/jruby/embed/internal/ThreadLocalContext.java
@@ -29,8 +29,9 @@
  */
 package org.jruby.embed.internal;
 
-import java.lang.ref.Cleaner;
-import java.lang.ref.Cleaner.Cleanable;
+import java.lang.ref.PhantomReference;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -43,8 +44,8 @@ import java.util.function.Supplier;
  */
 class ThreadLocalContext {
 	private final ConcurrentHashMap<LocalContextCleaningAction, Object> contextRefs = new ConcurrentHashMap<>();
-	private final Cleaner cleaner = Cleaner.create();
 	private final Supplier<LocalContext> localContextFactory;
+	private final Cleaner cleaner = new Cleaner();
 
 	public ThreadLocalContext(final Supplier<LocalContext> localContextFactory) {
 		this.localContextFactory = localContextFactory;
@@ -61,13 +62,13 @@ class ThreadLocalContext {
 			// GC'd (i.e. when this class gets GC'd because terminate() was never called).
 			// see ThreadLocal JavaDoc: ref will stay reachable "as long as the thread is
 			// alive and the ThreadLocal instance is accessible"
-			final Cleanable cleanable = cleaner.register(ref, ctx);
+			ctx.register(ref, cleaner);
 			if (contextHolder == null)
 				// boundary case if we're already terminating: clean up immediately, because
 				// there is no more cleanup thread to do that later
 				// the returned context will be null, but that's to be expected when operating
 				// on an object that has been terminated
-				cleanable.clean();
+				ctx.run();
 			return ref;
 		}
 	};
@@ -77,6 +78,7 @@ class ThreadLocalContext {
 	}
 
 	public void terminate() {
+		cleaner.interrupt();
 		contextHolder = null;
 		for (final LocalContextCleaningAction ref : contextRefs.keySet())
 			ref.run();
@@ -88,10 +90,13 @@ class ThreadLocalContext {
 	 * everything that is GC-reachable from them will stay reachable until the
 	 * cleaning action has been run.
 	 */
-	private static class LocalContextCleaningAction extends AtomicReference<LocalContext> implements Runnable {
+	static class LocalContextCleaningAction extends AtomicReference<LocalContext> implements Runnable {
 		private static final long serialVersionUID = 1L;
 
 		private final ConcurrentHashMap<LocalContextCleaningAction, Object> contextRefs;
+
+		@SuppressWarnings("unused") // only used to make sure the PhantomReference doesn't get GC'd
+		private CleanerReference phantomReference;
 
 		private LocalContextCleaningAction(final ConcurrentHashMap<LocalContextCleaningAction, Object> contextRefs,
 				final LocalContext context) {
@@ -110,6 +115,43 @@ class ThreadLocalContext {
 			if (lc != null)
 				lc.remove();
 			contextRefs.remove(this);
+		}
+
+		private void register(final AtomicReference<LocalContextCleaningAction> ref, final Cleaner cleaner) {
+			phantomReference = new CleanerReference(ref, cleaner.q, this);
+		}
+	}
+
+	private static class CleanerReference extends PhantomReference<AtomicReference<LocalContextCleaningAction>> {
+		private Runnable cleanup;
+
+		public CleanerReference(final AtomicReference<LocalContextCleaningAction> referent,
+				final ReferenceQueue<AtomicReference<LocalContextCleaningAction>> q, final Runnable cleanup) {
+			super(referent, q);
+			this.cleanup = cleanup;
+		}
+	}
+
+	private static class Cleaner extends Thread {
+		private final ReferenceQueue<AtomicReference<LocalContextCleaningAction>> q = new ReferenceQueue<>();
+
+		public Cleaner() {
+			setName("JRuby-ThreadLocalContext-Cleaner-" + getId());
+			setDaemon(true);
+			start();
+		}
+
+		@Override
+		public void run() {
+			while (!interrupted()) {
+				final Reference<?> cleanable;
+				try {
+					cleanable = q.remove();
+				} catch (InterruptedException e) {
+					break;
+				}
+				((CleanerReference) cleanable).cleanup.run();
+			}
 		}
 	}
 }

--- a/core/src/main/java/org/jruby/embed/internal/ThreadSafeLocalContextProvider.java
+++ b/core/src/main/java/org/jruby/embed/internal/ThreadSafeLocalContextProvider.java
@@ -40,33 +40,7 @@ import org.jruby.embed.LocalVariableBehavior;
  * @author Yoko Harada &lt;<a href="mailto:yokolet@gmail.com">yokolet@gmail.com</a>&gt;
  */
 public class ThreadSafeLocalContextProvider extends AbstractLocalContextProvider {
-    private volatile ConcurrentLinkedQueue<AtomicReference<LocalContext>> contextRefs =
-        new ConcurrentLinkedQueue<AtomicReference<LocalContext>>();
-
-    private final ThreadLocal<AtomicReference<LocalContext>> contextHolder =
-            new ThreadLocal<AtomicReference<LocalContext>>() {
-                @Override
-                public AtomicReference<LocalContext> initialValue() {
-                    AtomicReference<LocalContext> contextRef = null;
-
-                    try {
-                        contextRef = new AtomicReference<LocalContext>(getInstance());
-                        contextRefs.add(contextRef);
-                        return contextRef;
-                    } catch (NullPointerException npe) {
-                        if (contextRefs == null) {
-                            // contextRefs became null, we've been terminated
-                            if (contextRef != null) {
-                                contextRef.get().remove();
-                            }
-
-                            return null;
-                        } else {
-                            throw npe;
-                        }
-                    }
-                }
-            };
+    private final ThreadLocalContext contextHolder = new ThreadLocalContext(this::getInstance);
 
     public ThreadSafeLocalContextProvider(LocalVariableBehavior behavior) {
         super(behavior);
@@ -79,40 +53,27 @@ public class ThreadSafeLocalContextProvider extends AbstractLocalContextProvider
 
     @Override
     public Ruby getRuntime() {
-        return contextHolder.get().get().getRuntime();
+        return contextHolder.get().getRuntime();
     }
 
     @Override
     public BiVariableMap getVarMap() {
-        return contextHolder.get().get().getVarMap(this);
+        return contextHolder.get().getVarMap(this);
     }
 
     @Override
     public Map getAttributeMap() {
-        return contextHolder.get().get().getAttributeMap();
+        return contextHolder.get().getAttributeMap();
     }
 
     @Override
     public boolean isRuntimeInitialized() {
-        return contextHolder.get().get().isInitialized();
+        return contextHolder.get().isInitialized();
     }
 
     @Override
     public void terminate() {
-        ConcurrentLinkedQueue<AtomicReference<LocalContext>> terminated = contextRefs;
-        contextRefs = null;
-
-        if (terminated != null) {
-            for (AtomicReference<LocalContext> contextRef : terminated) {
-                contextRef.get().remove();
-                contextRef.lazySet(null);
-            }
-
-            terminated.clear();
-        }
-
-        contextHolder.remove();
-        contextHolder.set(null);
+    	contextHolder.terminate();
     }
 
 }

--- a/core/src/test/java/org/jruby/embed/internal/ThreadLocalContextTest.java
+++ b/core/src/test/java/org/jruby/embed/internal/ThreadLocalContextTest.java
@@ -1,0 +1,247 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.jruby.embed.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.jruby.RubyInstanceConfig;
+import org.jruby.embed.LocalVariableBehavior;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ThreadLocalContextTest {
+	private ThreadLocalContext factory;
+	private Semaphore threadReady;
+	private Semaphore threadCanExit;
+	private AtomicReference<Canary> canary;
+	private AtomicReference<PhantomReference<LocalContext>> ref;
+	private ReferenceQueue<LocalContext> q;
+
+	@Before
+	public void init() {
+		final RubyInstanceConfig config = new RubyInstanceConfig();
+		factory = new ThreadLocalContext(() -> new DummyLocalContext(config));
+		threadReady = new Semaphore(0);
+		threadCanExit = new Semaphore(0);
+		canary = new AtomicReference<>();
+		ref = new AtomicReference<>();
+		q = new ReferenceQueue<>();
+	}
+
+	@After
+	public void terminate() {
+		factory.terminate(); // get rid of cleaner thread
+	}
+
+	/** Simply checks that different threads get different LocalContexts. */
+	@Test
+	public void testContextPerThread() throws InterruptedException {
+		// there is only one LocalContext per thread
+		final LocalContext a = factory.get();
+		assertNotNull(a);
+		assertEquals(a, factory.get());
+
+		final Cage thread = new Cage(() -> {
+			final LocalContext c = factory.get();
+			// this thread also gets only one LocalContext
+			assertNotNull(c);
+			assertEquals(c, factory.get());
+			// ...but it's different from the main thread's context
+			assertNotEquals(a, c);
+		});
+		thread.start();
+		thread.checkAndJoin();
+	}
+
+	/**
+	 * Checks background cleanup when a thread has terminated, but
+	 * {@link ThreadLocalContext#terminate()} hasn't been called yet.
+	 */
+	@Test
+	public void testBackgroundCleanup() throws InterruptedException {
+		Cage thread = new Cage(() -> {
+			createCanary();
+			waitForMainThread();
+		});
+		thread.start();
+
+		try {
+			checkSpuriousTermination();
+
+			// terminate the thread and wait for background cleanup. keep poking the GC to
+			// speed things up
+			// this test can in theory fail spuriously because the GC is free to ignore
+			// System.gc() indefinitely, and also to delay cleaning up the LocalContext.
+			// in practice, the first System.gc() ends up collecting stuff and
+			// LocalContext.remove() gets called.
+			threadCanExit.release();
+			thread.checkAndJoin();
+
+			// at this point, remove() must have been called, but the LocalContext must also
+			// have been garbage-collected. it isn't acceptable for it to stay reachable and
+			// thus leak memory once the thread has terminated.
+			checkCleanup();
+			checkGarbageCollection();
+		} finally {
+			// always get rid of thread. better be safe than sorry
+			thread.interrupt();
+			thread.join();
+		}
+	}
+
+	/**
+	 * Checks eager cleanup when {@link ThreadLocalContext#terminate()} is called
+	 * while there are still threads (potentially) using their LocalContext.
+	 */
+	@Test
+	public void testTerminate() throws InterruptedException {
+		// same procedure as testBackgroundCleanup() but it explicitly calls terminate()
+		// while the thread is still active
+		Cage thread = new Cage(() -> {
+			createCanary();
+			waitForMainThread();
+			// at this point the LocalContext should have become invalid
+			assertFalse("LocalContext not removed", canary.get().isAlive());
+		});
+		thread.start();
+
+		try {
+			checkSpuriousTermination();
+
+			// eagerly terminate the ThreadLocalContext with the thread still alive. this
+			// must cause the LocalContext to be cleaned up immediately. (it doesn't
+			// actually get garbage-collected because it is still referenced by the
+			// ThreadLocal.)
+			factory.terminate();
+			checkCleanup();
+
+			// now release the thread, which then verifies that its LocalContext has become
+			// invalid before terminating. now the thread is gone, the LocalContext also has
+			// to be garbage-collected.
+			threadCanExit.release();
+			thread.checkAndJoin();
+			checkGarbageCollection();
+		} finally {
+			// always get rid of thread. better be safe than sorry
+			thread.interrupt();
+			thread.join();
+		}
+	}
+
+	private void createCanary() {
+		final DummyLocalContext ctx = (DummyLocalContext) factory.get();
+		assertNotNull(ctx);
+		canary.set(ctx.getCanary());
+		ref.set(new PhantomReference<>(ctx, q));
+		threadReady.release();
+	}
+
+	private void waitForMainThread() {
+		try { // wait until we can exit
+			threadCanExit.acquire();
+		} catch (InterruptedException e) {
+			fail("interrupted");
+		}
+	}
+
+	private void checkSpuriousTermination() throws InterruptedException {
+		threadReady.acquire(); // wait for thread to create the reference
+
+		// thread is still running and ThreadLocalContext hasn't been terminated either,
+		// so LocalContext must stick around through GC cycles
+		System.gc();
+		Thread.sleep(100);
+		assertTrue("LocalContext removed prematurely", canary.get().isAlive());
+	}
+
+	private void checkCleanup() throws InterruptedException {
+		// this code keeps trying for 10s: we'd rather have the test take longer than
+		// fail spuriously...
+		for (int i = 0; i < 100 && canary.get().isAlive(); i++) {
+			System.gc();
+			Thread.sleep(100);
+		}
+		assertFalse("LocalContext not removed", canary.get().isAlive());
+	}
+
+	private void checkGarbageCollection() throws InterruptedException {
+		// this code keeps trying for 10s: we'd rather have the test take longer than
+		// fail spuriously...
+		Reference<?> clearedRef = null;
+		for (int i = 0; i < 100 && clearedRef == null; i++) {
+			System.gc();
+			clearedRef = q.remove(100);
+		}
+		assertNotNull("LocalContext not garbage-collected", clearedRef);
+		assertEquals("some other object was garbage-collected?!", ref.get(), clearedRef);
+		assertTrue("reference wasn't cleared?!", ref.get().refersTo(null));
+	}
+
+	private class Cage extends Thread {
+		private AssertionError exception;
+
+		public Cage(final Runnable run) {
+			super(run);
+		}
+
+		@Override
+		public void run() {
+			try {
+				super.run();
+			} catch (final AssertionError e) {
+				exception = e;
+			}
+		}
+
+		private void checkAndJoin() throws InterruptedException {
+			join();
+			if (exception != null)
+				throw exception;
+		}
+	}
+
+	private static class Canary {
+		private volatile boolean alive = true;
+
+		private void kill() {
+			alive = false;
+		}
+
+		public boolean isAlive() {
+			return alive;
+		}
+	}
+
+	private class DummyLocalContext extends LocalContext {
+		private Canary canary;
+
+		public DummyLocalContext(RubyInstanceConfig config) {
+			super(config, LocalVariableBehavior.TRANSIENT, false);
+			this.canary = new Canary();
+		}
+
+		public Canary getCanary() {
+			return canary;
+		}
+
+		@Override
+		public void remove() {
+			canary.kill();
+			super.remove();
+		}
+	}
+}


### PR DESCRIPTION
Uses the Cleaner API to run LocalContext.remove() when a Thread has terminated, but also eagerly calls all LocalContext.remove() on terminate().

This gets rid of the memory leak demonstrated by the test case in #8422 .