### PR TITLE
ffi: skip mac specs that do not work on mac

### DIFF
--- a/spec/ffi/function_spec.rb
+++ b/spec/ffi/function_spec.rb
@@ -39,11 +39,13 @@ describe FFI::Function do
   end
 
   it 'can be used as callback from C passing to it a block' do
+    skip 'this does not work on Apple Silicon' if FFI::Platform.mac? && FFI::Platform::ARCH == 'aarch64'
     function_add = FFI::Function.new(:int, [:int, :int]) { |a, b| a + b }
     expect(LibTest.testFunctionAdd(10, 10, function_add)).to eq(20)
   end
 
   it 'can be used as callback from C passing to it a Proc object' do
+    skip 'this does not work on Apple Silicon' if FFI::Platform.mac? && FFI::Platform::ARCH == 'aarch64'
     function_add = FFI::Function.new(:int, [:int, :int], Proc.new { |a, b| a + b })
     expect(LibTest.testFunctionAdd(10, 10, function_add)).to eq(20)
   end

--- a/spec/ffi/library_spec.rb
+++ b/spec/ffi/library_spec.rb
@@ -88,7 +88,7 @@ describe "Library" do
       }.to raise_error(LoadError)
     end
 
-    it "interprets INPUT() in loader scripts", unless: FFI::Platform.windows? do
+    it "interprets INPUT() in loader scripts", if: FFI::Platform::IS_GNU && !FFI::Platform.windows? && !FFI::Platform.mac? do
       path = File.dirname(TestLibrary::PATH)
       file = File.basename(TestLibrary::PATH)
       script = File.join(path, "ldscript.so")


### PR DESCRIPTION
Function specs skipped due to to https://github.com/jruby/jruby/issues/6995 causing segfaults and preventing the full specs to run.

Library spec is skipped as per https://github.com/ffi/ffi/blame/c128cede750242fe19945af8bd6c797728489ad5/spec/ffi/library_spec.rb#L105