### PR TITLE
Make hash() always call to hash(ThreadContext) and deprecate

### DIFF
--- a/core/src/main/java/org/jruby/RubyArithmeticSequence.java
+++ b/core/src/main/java/org/jruby/RubyArithmeticSequence.java
@@ -328,11 +328,6 @@ public class RubyArithmeticSequence extends RubyObject {
         return context.tru;
     }
 
-    @Override
-    public RubyFixnum hash() {
-        return hash(metaClass.runtime.getCurrentContext());
-    }
-
     @JRubyMethod(name = "hash")
     public RubyFixnum hash(ThreadContext context) {
         IRubyObject v = safeHash(context, excludeEnd);

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -878,11 +878,6 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return false;
     }
 
-    @Override
-    public RubyFixnum hash() {
-        return hash(metaClass.runtime.getCurrentContext());
-    }
-
     /** rb_ary_hash
      *
      */

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -73,6 +73,7 @@ import static org.jruby.api.Create.*;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.ir.runtime.IRRuntimeHelpers.dupIfKeywordRestAtCallsite;
+import static org.jruby.ir.runtime.IRRuntimeHelpers.getCurrentClassBase;
 import static org.jruby.runtime.Helpers.invokeChecked;
 import static org.jruby.runtime.ThreadContext.*;
 import static org.jruby.runtime.Visibility.*;
@@ -2096,15 +2097,30 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         return context.runtime.newBoolean(result.isTrue());
     }
 
-    /** rb_obj_id
-     *
+    /**
      * Will return the hash code of this object. In comparison to MRI,
      * this method will use the Java identity hash code instead of
      * using rb_obj_id, since the usage of id in JRuby will incur the
      * cost of some. ObjectSpace maintenance.
+     * @deprecated Use {@link RubyBasicObject#hash(ThreadContext)} instead.
      */
+    @Deprecated(since = "10.0")
     public RubyFixnum hash() {
-        return getRuntime().newFixnum(super.hashCode());
+        return hash(getCurrentContext());
+    }
+
+    /**
+     * Will return the hash code of this object. In comparison to MRI,
+     * this method will use the Java identity hash code instead of
+     * using rb_obj_id, since the usage of id in JRuby will incur the
+     * cost of some. ObjectSpace maintenance.
+     *
+     * @param context the current thread context
+     * @return the hash value
+     */
+    // MRI: rb_obj_id
+    public RubyFixnum hash(ThreadContext context) {
+        return asFixnum(context, super.hashCode());
     }
 
     /** rb_obj_class

--- a/core/src/main/java/org/jruby/RubyBignum.java
+++ b/core/src/main/java/org/jruby/RubyBignum.java
@@ -1149,13 +1149,9 @@ public class RubyBignum extends RubyInteger {
         return op_equal(metaClass.runtime.getCurrentContext(), other);
     }
 
-    /** rb_big_hash
-     *
-     */
-    @Override
-    public RubyFixnum hash() {
-        Ruby runtime = metaClass.runtime;
-        return RubyFixnum.newFixnum(runtime, bigHash(runtime, value));
+    // MRI: rb_big_hash
+    public RubyFixnum hash(ThreadContext context) {
+        return asFixnum(context, bigHash(context.runtime, value));
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyComplex.java
+++ b/core/src/main/java/org/jruby/RubyComplex.java
@@ -976,12 +976,11 @@ public class RubyComplex extends RubyNumeric {
      * 
      */
     @JRubyMethod(name = "hash")
-    public IRubyObject hash(ThreadContext context) {
-        Ruby runtime = context.runtime;
+    public RubyFixnum hash(ThreadContext context) {
         long realHash = RubyNumeric.fix2long(invokedynamic(context, real, HASH));
         long imageHash = RubyNumeric.fix2long(invokedynamic(context, image, HASH));
         byte [] bytes = ByteBuffer.allocate(16).putLong(realHash).putLong(imageHash).array();
-        return RubyFixnum.newFixnum(runtime, Helpers.multAndMix(runtime.getHashSeedK0(), Arrays.hashCode(bytes)));
+        return asFixnum(context, Helpers.multAndMix(context.runtime.getHashSeedK0(), Arrays.hashCode(bytes)));
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyFixnum.java
+++ b/core/src/main/java/org/jruby/RubyFixnum.java
@@ -267,10 +267,8 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
         return -CACHE_OFFSET <= -1 ? runtime.fixnumCache[CACHE_OFFSET - 1] : new RubyFixnum(runtime, -1);
     }
 
-    @Override
-    public RubyFixnum hash() {
-        Ruby runtime = metaClass.runtime;
-        return newFixnum(runtime, fixHash(runtime, value));
+    public RubyFixnum hash(ThreadContext context) {
+        return asFixnum(context, fixHash(context.runtime, value));
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyFloat.java
+++ b/core/src/main/java/org/jruby/RubyFloat.java
@@ -665,15 +665,12 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         return Double.doubleToLongBits(val1) == Double.doubleToLongBits(val2);
     }
 
-    /** flo_hash
-     *
-     */
+    // MRI: flo_hash
     @JRubyMethod(name = "hash")
-    @Override
-    public RubyFixnum hash() {
-        Ruby runtime = metaClass.runtime;
-        return RubyFixnum.newFixnum(runtime, floatHash(runtime, value));
+    public RubyFixnum hash(ThreadContext context) {
+        return asFixnum(context, floatHash(context.runtime, value));
     }
+
 
     @Override
     public final int hashCode() {

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1379,14 +1379,7 @@ public class RubyHash extends RubyObject implements Map {
         return otherHash.op_le(context, this);
     }
 
-    /** rb_hash_hash
-     *
-     */
-    @Override
-    public RubyFixnum hash() {
-        return hash(metaClass.runtime.getCurrentContext());
-    }
-
+    // MRI: rb_hash_hash
     @JRubyMethod(name = "hash")
     public RubyFixnum hash(ThreadContext context) {
         final int size = size();

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -2191,8 +2191,8 @@ public class RubyKernel {
     }
 
     @JRubyMethod
-    public static RubyFixnum hash(IRubyObject self) {
-        return ((RubyBasicObject)self).hash();
+    public static RubyFixnum hash(ThreadContext context, IRubyObject self) {
+        return ((RubyBasicObject) self).hash(context);
     }
 
     @JRubyMethod(name = "class")

--- a/core/src/main/java/org/jruby/RubyMatchData.java
+++ b/core/src/main/java/org/jruby/RubyMatchData.java
@@ -844,9 +844,8 @@ public class RubyMatchData extends RubyObject {
     }
 
     @JRubyMethod
-    @Override
-    public RubyFixnum hash() {
-        return asFixnum(getRuntime().getCurrentContext(), hashCode());
+    public RubyFixnum hash(ThreadContext context) {
+        return asFixnum(context, hashCode());
     }
 
     @JRubyMethod(keywords = true, optional = 1)

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2816,9 +2816,8 @@ public class RubyModule extends RubyObject {
     }
 
     @JRubyMethod(name = "hash")
-    @Override
-    public RubyFixnum hash() {
-        return asFixnum(getRuntime().getCurrentContext(), id);
+    public RubyFixnum hash(ThreadContext context) {
+        return asFixnum(context, id);
     }
 
     /** rb_mod_to_s

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -323,11 +323,6 @@ public class RubyRange extends RubyObject {
         return context.nil;
     }
 
-    @Override
-    public RubyFixnum hash() {
-        return hash(metaClass.runtime.getCurrentContext());
-    }
-
     @JRubyMethod(name = "hash")
     public RubyFixnum hash(ThreadContext context) {
         int exclusiveBit = isExclusive ? 1 : 0;

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -1316,8 +1316,10 @@ public class RubyRational extends RubyNumeric {
      * 
      */
     @JRubyMethod(name = "hash")
-    public IRubyObject hash(ThreadContext context) {
-        return f_xor(context, (RubyInteger) invokedynamic(context, num, HASH), (RubyInteger) invokedynamic(context, den, HASH));
+    public RubyFixnum hash(ThreadContext context) {
+        return (RubyFixnum) f_xor(context,
+                (RubyInteger) invokedynamic(context, num, HASH),
+                (RubyInteger) invokedynamic(context, den, HASH));
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyRegexp.java
+++ b/core/src/main/java/org/jruby/RubyRegexp.java
@@ -1047,8 +1047,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
     }
 
     @JRubyMethod
-    @Override
-    public RubyFixnum hash() {
+    public RubyFixnum hash(ThreadContext context) {
         check();
         int hash = pattern.getOptions();
         int len = str.getRealSize();
@@ -1057,7 +1056,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         while (len-- > 0) {
             hash = hash * 33 + bytes[p++];
         }
-        return RubyFixnum.newFixnum(getRuntime(), hash + (hash >> 5));
+        return asFixnum(context, hash + (hash >> 5));
     }
 
     @JRubyMethod(name = {"==", "eql?"})

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1386,10 +1386,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     }
 
     @JRubyMethod
-    @Override
-    public RubyFixnum hash() {
-        Ruby runtime = getRuntime();
-        return asFixnum(runtime.getCurrentContext(), strHashCode(runtime));
+    public RubyFixnum hash(ThreadContext context) {
+        return asFixnum(context, strHashCode(context.runtime));
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -534,12 +534,6 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
         return asBoolean(context, this == other);
     }
 
-    @Deprecated
-    @Override
-    public RubyFixnum hash() {
-        return hash(getCurrentContext());
-    }
-
     @JRubyMethod
     public RubyFixnum hash(ThreadContext context) {
         return asFixnum(context, hashCode());

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -1332,9 +1332,8 @@ public class RubyTime extends RubyObject {
     }
 
     @JRubyMethod
-    @Override
-    public RubyFixnum hash() {
-        return asFixnum(getRuntime().getCurrentContext(), hashCode());
+    public RubyFixnum hash(ThreadContext context) {
+        return asFixnum(context, hashCode());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -966,10 +966,9 @@ public class RubyBigDecimal extends RubyNumeric {
         return absStripTrailingZeros;
     }
 
-    @Override
     @JRubyMethod
-    public RubyFixnum hash() {
-        return RubyFixnum.newFixnum(getRuntime(), absStripTrailingZeros().hashCode() * value.signum());
+    public RubyFixnum hash(ThreadContext context) {
+        return asFixnum(context, absStripTrailingZeros().hashCode() * value.signum());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -883,16 +883,7 @@ public class RubyDate extends RubyObject {
 
     @JRubyMethod
     public RubyFixnum hash(ThreadContext context) {
-        return hashImpl(context.runtime);
-    }
-
-    private RubyFixnum hashImpl(final Ruby runtime) {
-        return new RubyFixnum(runtime, this.dt.getMillis());
-    }
-
-    @Override
-    public RubyFixnum hash() {
-        return hashImpl(getRuntime());
+        return asFixnum(context, dt.getMillis());
     }
 
     @JRubyMethod // Get the date as a Julian Day Number.

--- a/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
+++ b/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
@@ -237,7 +237,7 @@ public class RubyPathname extends RubyObject {
 
     @JRubyMethod(name = "hash")
     public RubyFixnum hash(ThreadContext context) {
-        return getPath().hash();
+        return getPath().hash(context);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -888,17 +888,13 @@ public class RubySet extends RubyObject implements Set {
         return false;
     }
 
-    @Override
     @JRubyMethod
-    public RubyFixnum hash() { // @hash.hash
+    public RubyFixnum hash(ThreadContext context) { // @hash.hash
         RubyHash hash = this.hash;
 
-        if (hash == null) {
-            // Emulate set.rb for jruby/jruby#8393
-            return ((RubyBasicObject) getRuntime().getNil()).hash();
-        }
-
-        return hash.hash();
+        return hash == null ?
+                ((RubyBasicObject) context.nil).hash(context) :  // Emulate set.rb for jruby/jruby#8393
+                hash.hash(context);
     }
 
     @JRubyMethod(name = "classify")

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -702,10 +702,9 @@ public final class ArrayJavaProxy extends JavaProxy {
         return Arrays.equals((Object[]) thisArray, (Object[]) thatArray);
     }
 
-    @Override
     @JRubyMethod
-    public RubyFixnum hash() {
-        return RubyFixnum.newFixnum(getRuntime(), hashCode());
+    public RubyFixnum hash(ThreadContext context) {
+        return asFixnum(context, hashCode());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/MapJavaProxy.java
@@ -541,7 +541,7 @@ public final class MapJavaProxy extends ConcreteJavaProxy {
      */
     @JRubyMethod(name = "hash")
     public RubyFixnum hash(ThreadContext context) {
-        return getOrCreateRubyHashMap(context.runtime).hash();
+        return getOrCreateRubyHashMap(context.runtime).hash(context);
     }
 
     /** rb_hash_fetch

--- a/core/src/main/java/org/jruby/javasupport/JavaObject.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaObject.java
@@ -57,6 +57,7 @@ import org.jruby.util.ByteList;
 import org.jruby.util.JRubyObjectInputStream;
 
 import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.javasupport.JavaUtil.unwrapJava;
 
@@ -168,9 +169,8 @@ public class JavaObject extends RubyObject {
     }
 
     @JRubyMethod
-    @Override
-    public RubyFixnum hash() {
-        return RubyFixnum.newFixnum(getRuntime(), hashCode());
+    public RubyFixnum hash(ThreadContext context) {
+        return asFixnum(context, hashCode());
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/javasupport/JavaProxyMethods.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaProxyMethods.java
@@ -131,7 +131,7 @@ public class JavaProxyMethods {
 
         // NOTE: only JavaProxy includes JavaProxyMethods these are only here for 'manual' JavaObject wrapping
         return recv.dataGetStruct() instanceof IRubyObject dataStruct ?
-                ((RubyBasicObject) dataStruct).hash() : ((RubyBasicObject) recv).hash();
+                ((RubyBasicObject) dataStruct).hash(context) : ((RubyBasicObject) recv).hash(context);
     }
     
     @JRubyMethod(name = "synchronized")

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyReflectionObject.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyReflectionObject.java
@@ -41,6 +41,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Error.typeError;
 
 public class JavaProxyReflectionObject extends RubyObject {
@@ -97,10 +98,9 @@ public class JavaProxyReflectionObject extends RubyObject {
         return this == other;
     }
 
-    @Override
     @JRubyMethod
-    public RubyFixnum hash() {
-        return RubyFixnum.newFixnum(getRuntime(), hashCode());
+    public RubyFixnum hash(ThreadContext context) {
+        return asFixnum(context, hashCode());
     }
 
     @Override

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -3048,18 +3048,15 @@ public class Helpers {
 
     // MRI: rb_hash
     public static RubyFixnum safeHash(final ThreadContext context, IRubyObject obj) {
-        Ruby runtime = context.runtime;
-        IRubyObject hval = context.safeRecurse(sites(context).recursive_hash, runtime, obj, "hash", true);
+        var hval = context.safeRecurse(sites(context).recursive_hash, context.runtime, obj, "hash", true);
 
-        while (!(hval instanceof RubyFixnum)) {
-            if (hval instanceof RubyBignum) {
-                // This is different from MRI because we don't have rb_integer_pack
-                return ((RubyBignum) hval).hash();
-            }
+        while (!(hval instanceof RubyFixnum fixnum)) {
+            // This is different from MRI because we don't have rb_integer_pack
+            if (hval instanceof RubyBignum bignum) return bignum.hash(context);
             hval = hval.convertToInteger();
         }
 
-        return (RubyFixnum) hval;
+        return fixnum;
     }
 
     // MRI: mult_and_mix, roughly since we have no uint64 type


### PR DESCRIPTION
Audited and made sure no more hash() calls but if something still does it his RubyBasicObject#hash() which calls the ThreadContext version.