### PR TITLE
Avoid loading jar-dependencies to install gem hook

### DIFF
--- a/lib/ruby/stdlib/rubygems/defaults/jruby.rb
+++ b/lib/ruby/stdlib/rubygems/defaults/jruby.rb
@@ -101,7 +101,13 @@ begin
 rescue LoadError
 end
 
-begin
-  require 'jar_install_post_install_hook'
-rescue LoadError
+if defined?(JRUBY_VERSION) && Gem.post_install_hooks.empty?
+  Gem.post_install do |gem_installer|
+    unless (ENV['JARS_SKIP'] || ENV_JAVA['jars.skip']) == 'true'
+      require 'jars/installer'
+      jars = Jars::Installer.new(gem_installer.spec)
+      jars.ruby_maven_install_options = gem_installer.options || {}
+      jars.vendor_jars
+    end
+  end
 end


### PR DESCRIPTION
By requiring a file from jar-dependencies here, we end up activating whatever the default jar-dependencies gem is for the current JRuby runtime. Later on, when the hook is running or gems that use jars simply try to activate a newer jar-dependencies, we get the dreaded version conflict described in
mkristian/jar-dependencies#86, preventing activation of all libraries.

The change here moves the body of the hook into the JRuby defaults.rb for RubyGems rather than loading any files from jar-dependencies itself. This appears to fix issues like those seen in the jruby-9.4.9.0 builds at ruby/rdoc#1229 (bundle exec failing to run due to the version conflict) and may fix other reports.

This PR does not yet fix issues using a newer jar-dependencies on an older JRuby, unfortunately, but it will fix at least part of the problem for JRuby releases 9.4.10.0 and higher.