### PR TITLE
[ji] do not expose InterfaceImpl classes in Ruby land

### DIFF
--- a/core/src/main/java/org/jruby/java/codegen/RealClassGenerator.java
+++ b/core/src/main/java/org/jruby/java/codegen/RealClassGenerator.java
@@ -194,7 +194,7 @@ public abstract class RealClassGenerator {
                 String pathName = name.replace('.', '/');
 
                 // construct the class, implementing all supertypes
-                cw.visit(V_BC, ACC_PUBLIC | ACC_SUPER, pathName, null, p(Object.class), superTypeNames);
+                cw.visit(V_BC, ACC_PUBLIC | ACC_SUPER | ACC_SYNTHETIC, pathName, null, p(Object.class), superTypeNames);
                 cw.visitSource(pathName + ".gen", null);
 
                 // fields needed for dispatch and such

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -521,7 +521,9 @@ public class Java implements Library {
             for ( int i = interfaces.length; --i >= 0; ) {
                 proxy.includeModule(getInterfaceModule(runtime, interfaces[i]));
             }
-            if ( Modifier.isPublic(clazz.getModifiers()) ) {
+            // we don't want to expose any synthetic classes into Ruby constants,
+            // JRuby generated classes such as interface impls (org.jruby.gen.InterfaceImpl) are marked synthetic
+            if (Modifier.isPublic(clazz.getModifiers()) && !clazz.isSynthetic()) {
                 addToJavaPackageModule(proxy);
             }
         }

--- a/test/jruby/test_higher_javasupport.rb
+++ b/test/jruby/test_higher_javasupport.rb
@@ -1737,6 +1737,29 @@ CLASSDEF
     end
   end
 
+  def test_no_warnings_on_interface_impls_being_set_as_constants
+    runner_base = Class.new do
+      class << self
+        def run; self != self end
+      end
+    end
+
+    runner_impl1 = Class.new(runner_base)
+    runner_impl2 = Class.new(runner_base)
+    runner_impl3 = Class.new(runner_base)
+
+    output = with_stderr_captured do
+      threads = []
+      threads << java.lang.Thread.new(runner_impl1)
+      threads << java.lang.Thread.new(runner_impl2)
+      threads << java.lang.Thread.new(runner_impl3)
+      threads.each(&:start)
+      threads.each(&:join)
+    end
+    # expect no warning: already initialized constant org.jruby.gen::InterfaceImpl1353309827
+    refute output.index('already initialized constant'), output
+  end
+
   def test_no_warnings_on_concurrent_package_const_initialization
     output = with_stderr_captured do
       threads = (0..10).map do # smt not yet initialized :


### PR DESCRIPTION
Yet another attempt at resolving https://github.com/jruby/jruby/issues/8349, for good.

Since the reverts done in JRuby 9.4.9.0 still generate the warnings.

Seems like there's more (related) stuff that changed (since 9.4.6.0) given the checks, changed in this PR, [were there](https://github.com/jruby/jruby/blob/9.4.6.0/core/src/main/java/org/jruby/javasupport/Java.java#L507-L509) but did not cause warnings :shrug:. 

Instead of chasing around I took an approach of marking `InterfaceImpl` generated classes synthetic and excluded those from being set in Ruby land...