### PR TITLE
Warn api

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -433,7 +433,7 @@ public final class Ruby implements Constantizable {
         encodingService.defineEncodings();
         encodingService.defineAliases();
 
-        initDefaultEncodings();
+        initDefaultEncodings(context);
 
         complexClass = profile.allowClass("Complex") ? RubyComplex.createComplexClass(context, numericClass) : null;
         rationalClass = profile.allowClass("Rational") ? RubyRational.createRationalClass(context, numericClass) : null;
@@ -643,7 +643,7 @@ public final class Ruby implements Constantizable {
         return jrubyClassLoader;
     }
 
-    private void initDefaultEncodings() {
+    private void initDefaultEncodings(ThreadContext context) {
         // External should always have a value, but Encoding.external_encoding{,=} will lazily setup
         String encoding = this.config.getExternalEncoding();
         if (encoding != null && !encoding.isEmpty()) {
@@ -658,7 +658,7 @@ public final class Ruby implements Constantizable {
 
         // Filesystem should always have a value
         if (Platform.IS_WINDOWS) {
-            setDefaultFilesystemEncoding(encodingService.getWindowsFilesystemEncoding(this));
+            setDefaultFilesystemEncoding(encodingService.getWindowsFilesystemEncoding(context));
         } else {
             setDefaultFilesystemEncoding(getDefaultExternalEncoding());
         }
@@ -6008,7 +6008,7 @@ public final class Ruby implements Constantizable {
 
     @Deprecated
     public synchronized void addEventHook(EventHook hook) {
-        traceEvents.addEventHook(hook);
+        traceEvents.addEventHook(getCurrentContext(), hook);
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -351,7 +351,6 @@ public final class Ruby implements Constantizable {
         RubyObject.createObjectClass(objectClass);
         RubyModule.createModuleClass(moduleClass);
         RubyClass.createClassClass(this, classClass);
-        RubyModule.createRefinementClass(refinementClass);
 
         // set constants now that they're initialized
         basicObjectClass.setConstant("BasicObject", basicObjectClass);
@@ -394,6 +393,8 @@ public final class Ruby implements Constantizable {
         final ThreadContext context = getCurrentContext();
 
         RubyNil.createNilClass(context, nilClass);
+
+        RubyModule.createRefinementClass(context, refinementClass);
 
         RubyBasicObject.createBasicObjectClass(context, basicObjectClass);
         TopSelfFactory.createTopSelf(context, topSelf, objectClass, false);

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -225,6 +225,7 @@ import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Create.newEmptyString;
 import static org.jruby.api.Create.newFrozenString;
 import static org.jruby.api.Error.*;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.internal.runtime.GlobalVariable.Scope.GLOBAL;
 import static org.jruby.parser.ParserType.*;
 import static org.jruby.util.RubyStringBuilder.str;
@@ -1490,7 +1491,7 @@ public final class Ruby implements Constantizable {
         if (superClass == null) {
             IRubyObject className = parentIsObject ? ids(this, id) :
                     parent.toRubyString(getCurrentContext()).append(newString("::")).append(ids(this, id));
-            warnings.warn(ID.NO_SUPER_CLASS, str(this, "no super class for '", className, "', Object assumed"));
+            warn(getCurrentContext(), str(this, "no super class for '", className, "', Object assumed"));
 
             superClass = objectClass;
         }

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -370,7 +370,7 @@ public final class Ruby implements Constantizable {
         initKernelGsub(kernel);
 
         // Object is ready, create top self
-        topSelf = TopSelfFactory.createTopSelf(this,objectClass, false);
+        topSelf = new RubyObject(this, objectClass);
 
         // Pre-create all the core classes potentially referenced during startup
         nilClass = RubyNil.createNilClass(this, objectClass);
@@ -392,6 +392,8 @@ public final class Ruby implements Constantizable {
 
         // Get the main threadcontext (gets constructed for us)
         final ThreadContext context = getCurrentContext();
+
+        TopSelfFactory.createTopSelf(context, topSelf, objectClass, false);
 
         // includeModule uses TC.
         objectClass.includeModule(kernelModule);
@@ -3115,8 +3117,9 @@ public final class Ruby implements Constantizable {
      * @param wrap Whether to use a new "self" for toplevel
      */
     public void loadExtension(String extName, BasicLibraryService extension, boolean wrap) {
-        IRubyObject self = wrap ? TopSelfFactory.createTopSelf(this, objectClass, true) : getTopSelf();
         ThreadContext context = getCurrentContext();
+        var topSelf = new RubyObject(this, objectClass);
+        IRubyObject self = wrap ? TopSelfFactory.createTopSelf(context, topSelf, objectClass, true) : getTopSelf();
 
         try {
             context.preExtensionLoad(self);

--- a/core/src/main/java/org/jruby/RubyArgsFile.java
+++ b/core/src/main/java/org/jruby/RubyArgsFile.java
@@ -557,15 +557,6 @@ public class RubyArgsFile extends RubyObject {
         return recv;
     }
 
-    @JRubyMethod
-    public static IRubyObject codepoints(ThreadContext context, IRubyObject recv, Block block) {
-        warn(context, "ARGF#codepoints is deprecated; use #each_codepoint instead");
-
-        if (!block.isGiven()) return RubyEnumerator.enumeratorize(context.runtime, recv, "each_line");
-
-        return each_codepoint(context, recv, block);
-    }
-
     /** Invoke a block for each line.
      *
      */

--- a/core/src/main/java/org/jruby/RubyArgsFile.java
+++ b/core/src/main/java/org/jruby/RubyArgsFile.java
@@ -584,7 +584,7 @@ public class RubyArgsFile extends RubyObject {
 
         return recv;
     }
-    
+
     @JRubyMethod(name = "each", optional = 1, checkArity = false)
     public static IRubyObject each(final ThreadContext context, IRubyObject recv, IRubyObject[] args, final Block block) {
         return block.isGiven() ? each_line(context, recv, args, block) : enumeratorize(context.runtime, recv, "each", args);

--- a/core/src/main/java/org/jruby/RubyArgsFile.java
+++ b/core/src/main/java/org/jruby/RubyArgsFile.java
@@ -75,6 +75,7 @@ import static org.jruby.api.Create.newEmptyString;
 import static org.jruby.api.Create.newString;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.argumentError;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.runtime.ThreadContext.CALL_KEYWORD;
 import static org.jruby.runtime.ThreadContext.resetCallInfo;
 import static org.jruby.runtime.Visibility.PRIVATE;
@@ -558,7 +559,7 @@ public class RubyArgsFile extends RubyObject {
 
     @JRubyMethod
     public static IRubyObject codepoints(ThreadContext context, IRubyObject recv, Block block) {
-        context.runtime.getWarnings().warn("ARGF#codepoints is deprecated; use #each_codepoint instead");
+        warn(context, "ARGF#codepoints is deprecated; use #each_codepoint instead");
 
         if (!block.isGiven()) return RubyEnumerator.enumeratorize(context.runtime, recv, "each_line");
 

--- a/core/src/main/java/org/jruby/RubyArgsFile.java
+++ b/core/src/main/java/org/jruby/RubyArgsFile.java
@@ -584,14 +584,7 @@ public class RubyArgsFile extends RubyObject {
 
         return recv;
     }
-
-    @Deprecated // TODO "warning: ARGF#lines is deprecated; use #each_line instead"
-    @JRubyMethod(optional = 1, checkArity = false)
-    public static IRubyObject lines(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
-        if (!block.isGiven()) return RubyEnumerator.enumeratorize(context.runtime, recv, "each_line");
-        return each_line(context, recv, args, block);
-    }
-
+    
     @JRubyMethod(name = "each", optional = 1, checkArity = false)
     public static IRubyObject each(final ThreadContext context, IRubyObject recv, IRubyObject[] args, final Block block) {
         return block.isGiven() ? each_line(context, recv, args, block) : enumeratorize(context.runtime, recv, "each", args);

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -2826,33 +2826,6 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return context.nil;
     }
 
-    @Deprecated
-    public IRubyObject indexes(IRubyObject[] args) {
-        return indexes(getRuntime().getCurrentContext(), args);
-    }
-
-    /** rb_ary_indexes
-     *
-     */
-    @JRubyMethod(name = {"indexes", "indices"}, required = 1, rest = true, checkArity = false)
-    public IRubyObject indexes(ThreadContext context, IRubyObject[] args) {
-        int argc = Arity.checkArgumentCount(context, args, 1, -1);
-
-        Ruby runtime = context.runtime;
-        runtime.getWarnings().warn(ID.DEPRECATED_METHOD, "Array#indexes is deprecated; use Array#values_at");
-
-        if (argc == 1) return newArray(runtime, args[0]);
-
-        RubyArray ary = newBlankArrayInternal(runtime, argc);
-
-        for (int i = 0; i < argc; i++) {
-            ary.storeInternal(context, i, aref(context, args[i]));
-        }
-        ary.realLength = argc;
-
-        return ary;
-    }
-
     /**
      * @return ""
      * @deprecated Use {@link RubyArray#reverse_bang(ThreadContext)} instead.

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -103,6 +103,7 @@ import static org.jruby.api.Create.newHash;
 import static org.jruby.api.Create.newSmallHash;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.*;
+import static org.jruby.api.Warn.warningDeprecated;
 import static org.jruby.runtime.Helpers.*;
 import static org.jruby.runtime.Visibility.PRIVATE;
 import static org.jruby.util.Inspector.*;
@@ -2352,7 +2353,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     private IRubyObject getDefaultSeparator(ThreadContext context) {
         IRubyObject sep = globalVariables(context).get("$,");
 
-        if (!sep.isNil()) context.runtime.getWarnings().warnDeprecated("$, is set to non-nil value");
+        if (!sep.isNil()) warningDeprecated(context, "$, is set to non-nil value");
 
         return sep;
     }

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -2347,7 +2347,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     @JRubyMethod(name = "join")
     public IRubyObject join(ThreadContext context) {
-        return join(context, getDefaultSeparator(context));
+        return join(context, context.nil);
     }
 
     private IRubyObject getDefaultSeparator(ThreadContext context) {

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -103,7 +103,9 @@ import static org.jruby.api.Create.newHash;
 import static org.jruby.api.Create.newSmallHash;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.*;
-import static org.jruby.api.Warn.warningDeprecated;
+import static org.jruby.api.Warn.warn;
+import static org.jruby.api.Warn.warnDeprecated;
+import static org.jruby.api.Warn.warning;
 import static org.jruby.runtime.Helpers.*;
 import static org.jruby.runtime.Visibility.PRIVATE;
 import static org.jruby.util.Inspector.*;
@@ -707,9 +709,8 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         modifyCheck(context);
         unpack(context);
         realLength = 0;
-        if (block.isGiven() && context.runtime.isVerbose()) {
-            context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
-        }
+        if (block.isGiven()) warning(context, "given block not used");
+
         return this;
     }
 
@@ -752,9 +753,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         }
 
         if (block.isGiven()) {
-            if (arg1 != null) {
-                context.runtime.getWarnings().warn(ID.BLOCK_BEATS_DEFAULT_VALUE, "block supersedes default value argument");
-            }
+            if (arg1 != null) warn(context, "block supersedes default value argument");
 
             if (block.getSignature() == Signature.NO_ARGUMENTS) {
                 IRubyObject nil = context.nil;
@@ -1071,9 +1070,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     */
    @JRubyMethod
    public IRubyObject fetch(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Block block) {
-       if (block.isGiven()) {
-           context.runtime.getWarnings().warn(ID.BLOCK_BEATS_DEFAULT_VALUE, "block supersedes default value argument");
-       }
+       if (block.isGiven()) warn(context, "block supersedes default value argument");
 
        long index = numericToLong(context, arg0);
 
@@ -2353,7 +2350,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     private IRubyObject getDefaultSeparator(ThreadContext context) {
         IRubyObject sep = globalVariables(context).get("$,");
 
-        if (!sep.isNil()) warningDeprecated(context, "$, is set to non-nil value");
+        if (!sep.isNil()) warnDeprecated(context, "$, is set to non-nil value");
 
         return sep;
     }
@@ -2701,7 +2698,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     @JRubyMethod(name = {"index", "find_index"})
     public IRubyObject index(ThreadContext context, IRubyObject obj, Block unused) {
-        if (unused.isGiven()) context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
+        if (unused.isGiven()) warn(context, "given block not used");
         return index(context, obj);
     }
 
@@ -2806,7 +2803,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     @JRubyMethod
     public IRubyObject rindex(ThreadContext context, IRubyObject obj, Block unused) {
-        if (unused.isGiven()) context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
+        if (unused.isGiven()) warn(context, "given block not used");
         return rindex(context, obj);
     }
 
@@ -3632,7 +3629,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     @JRubyMethod(name = "count")
     public IRubyObject count(ThreadContext context, IRubyObject obj, Block block) {
-        if (block.isGiven()) context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
+        if (block.isGiven()) warn(context, "given block not used");
 
         int n = 0;
         for (int i = 0; i < realLength; i++) {
@@ -4985,10 +4982,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         if (!self_each.isBuiltin(this)) return RubyEnumerable.all_pCommon(context, self_each, this, arg, block);
         boolean patternGiven = arg != null;
 
-        if (block.isGiven() && patternGiven) {
-            context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
-        }
-
+        if (block.isGiven() && patternGiven) warn(context, "given block not used");
         if (!block.isGiven() || patternGiven) return all_pBlockless(context, arg);
 
         for (int i = 0; i < realLength; i++) {
@@ -5028,9 +5022,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         if (!self_each.isBuiltin(this)) return RubyEnumerable.any_pCommon(context, self_each, this, arg, block);
         boolean patternGiven = arg != null;
 
-        if (block.isGiven() && patternGiven) {
-            context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
-        }
+        if (block.isGiven() && patternGiven) warn(context, "given block not used");
 
         if (!block.isGiven() || patternGiven) return any_pBlockless(context, arg);
 
@@ -5070,10 +5062,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         if (!self_each.isBuiltin(this)) return RubyEnumerable.none_pCommon(context, self_each, this, arg, block);
         boolean patternGiven = arg != null;
 
-        if (block.isGiven() && patternGiven) {
-            context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
-        }
-
+        if (block.isGiven() && patternGiven) warn(context, "given block not used");
         if (!block.isGiven() || patternGiven) return none_pBlockless(context, arg);
 
         for (int i = 0; i < realLength; i++) {
@@ -5112,10 +5101,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         if (!self_each.isBuiltin(this)) return RubyEnumerable.one_pCommon(context, self_each, this, arg, block);
         boolean patternGiven = arg != null;
 
-        if (block.isGiven() && patternGiven) {
-            context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
-        }
-
+        if (block.isGiven() && patternGiven) warn(context, "given block not used");
         if (!block.isGiven() || patternGiven) return one_pBlockless(context, arg);
 
         boolean found = false;

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -2135,17 +2135,6 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         return getMetaClass().getRealClass();
     }
 
-    /** rb_obj_type
-     *
-     * The deprecated version of type, that emits a deprecation
-     * warning.
-     */
-    @Deprecated
-    public RubyClass type_deprecated() {
-        getRuntime().getWarnings().warn(ID.DEPRECATED_METHOD, "Object#type is deprecated; use Object#class");
-        return type();
-    }
-
     /** rb_obj_display
      *
      *  call-seq:

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -54,7 +54,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import org.jruby.anno.JRubyMethod;
-import org.jruby.common.IRubyWarnings.ID;
 import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.Helpers;
@@ -76,7 +75,6 @@ import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.api.Warn.warn;
 import static org.jruby.ir.runtime.IRRuntimeHelpers.dupIfKeywordRestAtCallsite;
-import static org.jruby.ir.runtime.IRRuntimeHelpers.getCurrentClassBase;
 import static org.jruby.runtime.Helpers.invokeChecked;
 import static org.jruby.runtime.ThreadContext.*;
 import static org.jruby.runtime.Visibility.*;
@@ -207,8 +205,9 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      * Will create the Ruby class BasicObject in the runtime specified. This method needs to take the
      * actual class as an argument because of the Object class' central part in runtime initialization.
      */
-    public static void createBasicObjectClass(ThreadContext context, RubyClass BasicObject) {
-        BasicObject.classIndex(ClassIndex.OBJECT).defineMethods(context, RubyBasicObject.class);
+    public static void finishBasicObjectClass(ThreadContext context, RubyClass BasicObject) {
+        BasicObject.classIndex(ClassIndex.OBJECT).
+                defineMethods(context, RubyBasicObject.class);
         recacheBuiltinMethods(context, BasicObject);
     }
 

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -74,6 +74,7 @@ import static org.jruby.api.Convert.*;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.ir.runtime.IRRuntimeHelpers.dupIfKeywordRestAtCallsite;
 import static org.jruby.ir.runtime.IRRuntimeHelpers.getCurrentClassBase;
 import static org.jruby.runtime.Helpers.invokeChecked;
@@ -2507,7 +2508,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      *  The default to_a method is deprecated.
      */
     public RubyArray to_a(ThreadContext context) {
-        context.runtime.getWarnings().warn(ID.DEPRECATED_METHOD, "default 'to_a' will be obsolete");
+        warn(context, "default 'to_a' will be obsolete");
         return newArray(context,this);
     }
 

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -204,22 +204,18 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     public static final ObjectAllocator BASICOBJECT_ALLOCATOR = RubyBasicObject::new;
 
     /**
-     * Will create the Ruby class Object in the runtime
-     * specified. This method needs to take the actual class as an
-     * argument because of the Object class' central part in runtime
-     * initialization.
+     * Will create the Ruby class BasicObject in the runtime specified. This method needs to take the
+     * actual class as an argument because of the Object class' central part in runtime initialization.
      */
-    public static void createBasicObjectClass(Ruby runtime, RubyClass Object) {
-        Object.classIndex(ClassIndex.OBJECT).defineAnnotatedMethodsIndividually(RubyBasicObject.class);
-        recacheBuiltinMethods(runtime);
+    public static void createBasicObjectClass(ThreadContext context, RubyClass BasicObject) {
+        BasicObject.classIndex(ClassIndex.OBJECT).defineMethods(context, RubyBasicObject.class);
+        recacheBuiltinMethods(context, BasicObject);
     }
 
-    static void recacheBuiltinMethods(Ruby runtime) {
-        RubyModule objectClass = runtime.getBasicObject();
-
+    static void recacheBuiltinMethods(ThreadContext context, RubyClass BasicObject) {
         // Since method_missing is marked module we actually define two builtin versions
-        runtime.setDefaultMethodMissing(objectClass.searchMethod("method_missing"),
-                objectClass.metaClass.searchMethod("method_missing"));
+        context.runtime.setDefaultMethodMissing(BasicObject.searchMethod("method_missing"),
+                BasicObject.metaClass.searchMethod("method_missing"));
     }
 
     @JRubyMethod(name = "initialize", visibility = PRIVATE)

--- a/core/src/main/java/org/jruby/RubyBignum.java
+++ b/core/src/main/java/org/jruby/RubyBignum.java
@@ -58,6 +58,7 @@ import static org.jruby.api.Create.newArray;
 import static org.jruby.api.Create.newEmptyArray;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
+import static org.jruby.api.Warn.warn;
 
 /**
  *
@@ -731,14 +732,14 @@ public class RubyBignum extends RubyInteger {
         if (other < 0) {
             IRubyObject x = op_pow(context, -other);
             if (x instanceof RubyInteger) {
-                return RubyRational.newRationalRaw(runtime, RubyFixnum.one(runtime), x);
+                return RubyRational.newRationalRaw(runtime, asFixnum(context, 1), x);
             } else {
                 return dbl2num(runtime, 1.0 / num2dbl(context,x));
             }
         }
         final int xbits = value.bitLength();
         if ((xbits > BIGLEN_LIMIT) || (xbits * other > BIGLEN_LIMIT)) {
-            runtime.getWarnings().warn("in a**b, b may be too big");
+            warn(context, "in a**b, b may be too big");
             return pow(runtime, (double) other);
         }
         else {

--- a/core/src/main/java/org/jruby/RubyBignum.java
+++ b/core/src/main/java/org/jruby/RubyBignum.java
@@ -228,7 +228,7 @@ public class RubyBignum extends RubyInteger {
         BigInteger big = val.value;
         double dbl = convertToDouble(big);
         if (dbl == Double.NEGATIVE_INFINITY || dbl == Double.POSITIVE_INFINITY) {
-            val.getRuntime().getWarnings().warn(ID.BIGNUM_FROM_FLOAT_RANGE, "Bignum out of Float range");
+            warn(val.getRuntime().getCurrentContext(), "Bignum out of Float range");
     }
         return dbl;
     }
@@ -697,60 +697,49 @@ public class RubyBignum extends RubyInteger {
     @Override
     @JRubyMethod(name = {"**", "power"})
     public IRubyObject op_pow(ThreadContext context, IRubyObject other) {
-        Ruby runtime = context.runtime;
-        if (other == zero(runtime)) return RubyFixnum.one(runtime);
+        if (other == asFixnum(context, 0)) return asFixnum(context, 1);
         final double d;
-        if (other instanceof RubyFloat) {
-            d = ((RubyFloat) other).value;
-            if (compareTo(zero(runtime)) == -1 && d != Math.round(d)) {
+        if (other instanceof RubyFloat flote) {
+            d = flote.value;
+            if (compareTo(asFixnum(context, 0)) == -1 && d != Math.round(d)) {
                 RubyComplex complex = RubyComplex.newComplexRaw(context.runtime, this);
                 return sites(context).op_exp.call(context, complex, complex, other);
             }
-        } else if (other instanceof RubyBignum) {
-            d = ((RubyBignum) other).getDoubleValue();
-            context.runtime.getWarnings().warn(ID.MAY_BE_TOO_BIG, "in a**b, b may be too big");
-        } else if (other instanceof RubyFixnum) {
-            return op_pow(context, ((RubyFixnum) other).value);
+        } else if (other instanceof RubyBignum bignum) {
+            d = bignum.getDoubleValue();
+            warn(context, "in a**b, b may be too big");
+        } else if (other instanceof RubyFixnum fixnum) {
+            return op_pow(context, fixnum.value);
         } else {
             return coerceBin(context, sites(context).op_exp, other);
         }
-        return pow(runtime, d);
+        return pow(context, d);
     }
 
-    private RubyNumeric pow(final Ruby runtime, final double d) {
+    private RubyNumeric pow(ThreadContext context, final double d) {
         double pow = Math.pow(big2dbl(this), d);
-        if (Double.isInfinite(pow)) {
-            return RubyFloat.newFloat(runtime, pow);
-        }
-        return RubyNumeric.dbl2ival(runtime, pow);
+        return Double.isInfinite(pow) ?
+                asFloat(context, pow) :
+                RubyNumeric.dbl2ival(context.runtime, pow);
     }
 
     private static final int BIGLEN_LIMIT = 32 * 1024 * 1024;
 
     public final IRubyObject op_pow(final ThreadContext context, final long other) {
-        Ruby runtime = context.runtime;
         if (other < 0) {
             IRubyObject x = op_pow(context, -other);
             if (x instanceof RubyInteger) {
-                return RubyRational.newRationalRaw(runtime, asFixnum(context, 1), x);
+                return RubyRational.newRationalRaw(context.runtime, asFixnum(context, 1), x);
             } else {
-                return dbl2num(runtime, 1.0 / num2dbl(context,x));
+                return dbl2num(context.runtime, 1.0 / num2dbl(context,x));
             }
         }
         final int xbits = value.bitLength();
         if ((xbits > BIGLEN_LIMIT) || (xbits * other > BIGLEN_LIMIT)) {
             warn(context, "in a**b, b may be too big");
-            return pow(runtime, (double) other);
-        }
-        else {
-            return newBignum(runtime, value.pow((int) other));
-        }
-    }
-
-    private void warnIfPowExponentTooBig(final ThreadContext context, final long other) {
-        // MRI issuses warning here on (RBIGNUM(x)->len * SIZEOF_BDIGITS * yy > 1024*1024)
-        if ( ((value.bitLength() + 7) / 8) * 4 * Math.abs((double) other) > 1024 * 1024 ) {
-            context.runtime.getWarnings().warn(ID.MAY_BE_TOO_BIG, "in a**b, b may be too big");
+            return pow(context, (double) other);
+        } else {
+            return newBignum(context.runtime, value.pow((int) other));
         }
     }
 

--- a/core/src/main/java/org/jruby/RubyBoolean.java
+++ b/core/src/main/java/org/jruby/RubyBoolean.java
@@ -109,16 +109,14 @@ public class RubyBoolean extends RubyObject implements Constantizable, Appendabl
     public static void finishFalseClass(ThreadContext context, RubyClass False) {
         False.reifiedClass(RubyBoolean.class).
                 classIndex(ClassIndex.FALSE).
-                defineMethods(context, False.class).
-                defineMethods(context, RubyBoolean.class).
+                defineMethods(context, False.class, RubyBoolean.class).
                 tap(c -> c.getMetaClass().undefMethods(context, "new"));
     }
     
     public static void finishTrueClass(ThreadContext context, RubyClass True) {
         True.reifiedClass(RubyBoolean.class).
                 classIndex(ClassIndex.TRUE).
-                defineMethods(context, True.class).
-                defineMethods(context, RubyBoolean.class).
+                defineMethods(context, True.class, RubyBoolean.class).
                 tap(c -> c.getMetaClass().undefMethods(context, "new"));
     }
 

--- a/core/src/main/java/org/jruby/RubyBoolean.java
+++ b/core/src/main/java/org/jruby/RubyBoolean.java
@@ -45,7 +45,6 @@ import org.jruby.runtime.opto.OptoFactory;
 import org.jruby.util.ByteList;
 
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.runtime.ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR;
 
 /**
  *
@@ -107,27 +106,20 @@ public class RubyBoolean extends RubyObject implements Constantizable, Appendabl
         return constant;
     }
 
-    public static RubyClass createFalseClass(Ruby runtime, RubyClass Object) {
-        RubyClass False = runtime.defineClass("FalseClass", Object, NOT_ALLOCATABLE_ALLOCATOR).
-                reifiedClass(RubyBoolean.class).
-                classIndex(ClassIndex.FALSE);
-        False.defineAnnotatedMethodsIndividually(False.class);
-        False.defineAnnotatedMethodsIndividually(RubyBoolean.class);
-        False.getMetaClass().undefineMethod("new");
-
-        return False;
+    public static void finishFalseClass(ThreadContext context, RubyClass False) {
+        False.reifiedClass(RubyBoolean.class).
+                classIndex(ClassIndex.FALSE).
+                defineMethods(context, False.class).
+                defineMethods(context, RubyBoolean.class).
+                tap(c -> c.getMetaClass().undefMethods(context, "new"));
     }
     
-    public static RubyClass createTrueClass(Ruby runtime, RubyClass Object) {
-        RubyClass True = runtime.defineClass("TrueClass", Object, NOT_ALLOCATABLE_ALLOCATOR).
-                reifiedClass(RubyBoolean.class).
-                classIndex(ClassIndex.TRUE);
-
-        True.defineAnnotatedMethodsIndividually(True.class);
-        True.defineAnnotatedMethodsIndividually(RubyBoolean.class);
-        True.getMetaClass().undefineMethod("new");
-
-        return True;
+    public static void finishTrueClass(ThreadContext context, RubyClass True) {
+        True.reifiedClass(RubyBoolean.class).
+                classIndex(ClassIndex.TRUE).
+                defineMethods(context, True.class).
+                defineMethods(context, RubyBoolean.class).
+                tap(c -> c.getMetaClass().undefMethods(context, "new"));
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -123,15 +123,14 @@ public class RubyClass extends RubyModule {
     public static void createClassClass(Ruby runtime, RubyClass Class) {
         Class.reifiedClass(RubyClass.class).
                 kindOf(new RubyModule.JavaClassKindOf(RubyClass.class)).
-                classIndex(ClassIndex.CLASS).
-                defineAnnotatedMethodsIndividually(RubyClass.class);
-        Class.undefineMethod("module_function");
-        Class.undefineMethod("append_features");
-        Class.undefineMethod("prepend_features");
-        Class.undefineMethod("extend_object");
-        Class.undefineMethod("refine");
+                classIndex(ClassIndex.CLASS);
+    }
 
-        runtime.setBaseNewMethod(Class.searchMethod("new"));
+    public static void finishCreateClassClass(ThreadContext context, RubyClass Class) {
+        Class.defineMethods(context, RubyClass.class).
+                undefMethods(context, "module_function", "append_features", "prepend_features", "extend_object", "refine");
+
+        context.runtime.setBaseNewMethod(Class.searchMethod("new"));
     }
 
     public static final ObjectAllocator CLASS_ALLOCATOR = (runtime, klass) -> {

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -33,9 +33,11 @@ package org.jruby;
 
 import static org.jruby.api.Access.basicObjectClass;
 import static org.jruby.api.Access.classClass;
+import static org.jruby.api.Access.instanceConfig;
 import static org.jruby.api.Access.objectClass;
 import static org.jruby.api.Convert.asSymbol;
 import static org.jruby.api.Error.*;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.runtime.Visibility.PRIVATE;
 import static org.jruby.runtime.Visibility.PUBLIC;
 import static org.jruby.util.CodegenUtils.ci;
@@ -881,7 +883,7 @@ public class RubyClass extends RubyModule {
         return method != null && method.isBuiltin();
     }
 
-    private void dumpReifiedClass(String dumpDir, String javaPath, byte[] classBytes) {
+    private void dumpReifiedClass(ThreadContext context, String dumpDir, String javaPath, byte[] classBytes) {
         if (dumpDir != null) {
             if (dumpDir.length() == 0) dumpDir = ".";
 
@@ -893,9 +895,8 @@ public class RubyClass extends RubyModule {
                 classStream.write(classBytes);
             }
             catch (IOException io) {
-                runtime.getWarnings().warn("unable to dump class file: " + io.getMessage());
-            }
-            finally {
+                warn(context, "unable to dump class file: " + io.getMessage());
+            } finally {
                 if (classStream != null) {
                     try { classStream.close(); }
                     catch (IOException ignored) { /* no-op */ }
@@ -1529,15 +1530,15 @@ public class RubyClass extends RubyModule {
      * @param classDumpDir Directory to save reified java class
      */
     public synchronized void reify(String classDumpDir, boolean useChildLoader) {
+        var context = runtime.getCurrentContext();
         boolean[] java_box = { false };
         // re-check reifiable in case another reify call has jumped in ahead of us
         if (!isReifiable(java_box)) return;
         final boolean concreteExt = java_box[0];
 
         final Class<?> parentReified = superClass.getRealClass().reifiedClass();
-        if (parentReified == null) {
-            throw typeError(getClassRuntime().getCurrentContext(), getName() + "'s parent class is not yet reified");
-        }
+        if (parentReified == null) throw typeError(context, getName() + "'s parent class is not yet reified");
+
 
         ClassDefiningClassLoader classLoader; // usually parent's class-loader
         if (parentReified.getClassLoader() instanceof OneShotClassLoader) {
@@ -1545,12 +1546,12 @@ public class RubyClass extends RubyModule {
         } else {
             if (useChildLoader) {
                 MultiClassLoader parentLoader = new MultiClassLoader(runtime.getJRubyClassLoader());
-                for(Loader cLoader : runtime.getInstanceConfig().getExtraLoaders()) {
+                for(Loader cLoader : instanceConfig(context).getExtraLoaders()) {
                     parentLoader.addClassLoader(cLoader.getClassLoader());
                 }
                 classLoader = new OneShotClassLoader(parentLoader);
             } else {
-                classLoader = runtime.getJRubyClassLoader();
+                classLoader = context.runtime.getJRubyClassLoader();
             }
         }
 
@@ -1582,7 +1583,7 @@ public class RubyClass extends RubyModule {
         // Attempt to load the name we plan to use; skip reification if it exists already (see #1229).
         try {
             Class result = classLoader.defineClass(javaName, classBytes);
-            dumpReifiedClass(classDumpDir, javaPath, classBytes);
+            dumpReifiedClass(context, classDumpDir, javaPath, classBytes);
 
             //Trigger initilization
             @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -77,6 +77,7 @@ import static org.jruby.api.Create.newString;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.runtimeError;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.util.RubyStringBuilder.str;
 import static org.jruby.util.io.EncodingUtils.newExternalStringWithEncoding;
 
@@ -457,7 +458,7 @@ public class RubyDir extends RubyObject implements Closeable {
         }
 
         if(!block.isGiven() && runtime.getChdirThread() != null) {
-            context.runtime.getWarnings().warn("conflicting chdir during another chdir block");
+            warn(context, "conflicting chdir during another chdir block");
         }
 
         IRubyObject result;

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -1677,7 +1677,7 @@ public class RubyEnumerable {
     public static IRubyObject all_pCommon(ThreadContext localContext, CallSite each, IRubyObject self, IRubyObject pattern, final Block block) {
         final boolean patternGiven = pattern != null;
 
-        if (block.isGiven() && patternGiven) warn(context, "given block not used");
+        if (block.isGiven() && patternGiven) warn(localContext, "given block not used");
 
         try {
             if (block.isGiven() && !patternGiven) {

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -78,6 +78,7 @@ import static org.jruby.api.Convert.numericToLong;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineModule;
 import static org.jruby.api.Error.*;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.runtime.Helpers.arrayOf;
 import static org.jruby.runtime.Helpers.invokedynamic;
 import static org.jruby.runtime.builtin.IRubyObject.NULL_ARRAY;
@@ -164,7 +165,7 @@ public class RubyEnumerable {
     public static IRubyObject count(ThreadContext context, IRubyObject self, final IRubyObject methodArg, final Block block) {
         final SingleInt result = new SingleInt();
 
-        if (block.isGiven()) context.runtime.getWarnings().warn(ID.BLOCK_UNUSED , "given block not used");
+        if (block.isGiven()) warn(context, "given block not used");
 
         each(context, eachSite(context), self, new JavaInternalBlockBody(context.runtime, context, "Enumerable#count", Signature.ONE_REQUIRED) {
             public IRubyObject yield(ThreadContext context1, IRubyObject[] args) {
@@ -673,12 +674,11 @@ public class RubyEnumerable {
 
     @JRubyMethod(name = "find_index")
     public static IRubyObject find_index(ThreadContext context, IRubyObject self, final IRubyObject cond, final Block block) {
-        final Ruby runtime = context.runtime;
+        if (block.isGiven()) warn(context, "given block not used");
 
-        if (block.isGiven()) runtime.getWarnings().warn(ID.BLOCK_UNUSED , "given block not used");
-        if (self instanceof RubyArray) return ((RubyArray) self).find_index(context, cond);
-
-        return find_indexCommon(context, eachSite(context), self, cond);
+        return self instanceof RubyArray ary ?
+                ary.find_index(context, cond) :
+                find_indexCommon(context, eachSite(context), self, cond);
     }
 
     public static IRubyObject find_indexCommon(ThreadContext context, IRubyObject self, final Block block, Signature callbackArity) {
@@ -1060,9 +1060,7 @@ public class RubyEnumerable {
 
     @JRubyMethod(name = {"inject", "reduce"})
     public static IRubyObject inject(ThreadContext context, IRubyObject self, IRubyObject init, IRubyObject method, final Block block) {
-        final Ruby runtime = context.runtime;
-
-        if (block.isGiven()) runtime.getWarnings().warn(ID.BLOCK_UNUSED , "given block not used");
+        if (block.isGiven()) warn(context, "given block not used");
 
         final String methodId = method.asJavaString();
         final SingleObject<IRubyObject> result = new SingleObject<>(init);
@@ -1545,9 +1543,7 @@ public class RubyEnumerable {
         final ThreadContext localContext = context;
         final boolean patternGiven = pattern != null;
 
-        if (block.isGiven() && patternGiven) {
-            context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
-        }
+        if (block.isGiven() && patternGiven) warn(context, "given block not used");
 
         try {
             if (block.isGiven() && !patternGiven) {
@@ -1600,9 +1596,7 @@ public class RubyEnumerable {
         final SingleBoolean result = new SingleBoolean(false);
         final boolean patternGiven = pattern != null;
 
-        if (block.isGiven() && patternGiven) {
-            context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
-        }
+        if (block.isGiven() && patternGiven) warn(context, "given block not used");
 
         try {
             if (block.isGiven() && !patternGiven) {
@@ -1683,9 +1677,7 @@ public class RubyEnumerable {
     public static IRubyObject all_pCommon(ThreadContext localContext, CallSite each, IRubyObject self, IRubyObject pattern, final Block block) {
         final boolean patternGiven = pattern != null;
 
-        if (block.isGiven() && patternGiven) {
-            localContext.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
-        }
+        if (block.isGiven() && patternGiven) warn(context, "given block not used");
 
         try {
             if (block.isGiven() && !patternGiven) {
@@ -1774,7 +1766,7 @@ public class RubyEnumerable {
         final boolean patternGiven = pattern != null;
 
         if (block.isGiven() && patternGiven) {
-            localContext.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
+            warn(localContext, "given block not used");
         }
 
         try {

--- a/core/src/main/java/org/jruby/RubyGenerator.java
+++ b/core/src/main/java/org/jruby/RubyGenerator.java
@@ -41,6 +41,7 @@ import org.jruby.util.ArraySupport;
 
 import static org.jruby.api.Convert.castAsProc;
 import static org.jruby.api.Error.typeError;
+import static org.jruby.api.Warn.warn;
 
 @JRubyClass(name = "Enumerator::Generator")
 public class RubyGenerator extends RubyObject {
@@ -62,7 +63,7 @@ public class RubyGenerator extends RubyObject {
         } else {
             proc = Convert.castAsProc(context, args[0]);
 
-            if (block.isGiven()) context.runtime.getWarnings().warn(IRubyWarnings.ID.BLOCK_UNUSED, "given block not used");
+            if (block.isGiven()) warn(context, "given block not used");
         }
 
         return this;

--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -40,13 +40,11 @@ package org.jruby;
 
 import jnr.enxio.channels.NativeDeviceChannel;
 import jnr.posix.POSIX;
-
 import org.jcodings.Encoding;
 import org.jcodings.specific.USASCIIEncoding;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.api.Create;
 import org.jruby.ast.util.ArgsUtil;
-import org.jruby.common.IRubyWarnings.ID;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.internal.runtime.GlobalVariables;
 import org.jruby.internal.runtime.ValueAccessor;
@@ -72,22 +70,6 @@ import org.jruby.util.io.FilenoUtil;
 import org.jruby.util.io.OpenFile;
 import org.jruby.util.io.STDIO;
 
-import static org.jruby.api.Access.argsFile;
-import static org.jruby.api.Access.enumerableModule;
-import static org.jruby.api.Access.exceptionClass;
-import static org.jruby.api.Access.globalVariables;
-import static org.jruby.api.Access.instanceConfig;
-import static org.jruby.api.Access.objectClass;
-import static org.jruby.api.Convert.asBoolean;
-import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Create.*;
-import static org.jruby.api.Error.argumentError;
-import static org.jruby.api.Error.typeError;
-import static org.jruby.api.Warn.warningDeprecated;
-import static org.jruby.internal.runtime.GlobalVariable.Scope.*;
-import static org.jruby.util.RubyStringBuilder.str;
-import static org.jruby.util.io.EncodingUtils.newExternalStringWithEncoding;
-
 import java.io.FileDescriptor;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -102,6 +84,28 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static org.jruby.api.Access.argsFile;
+import static org.jruby.api.Access.enumerableModule;
+import static org.jruby.api.Access.exceptionClass;
+import static org.jruby.api.Access.globalVariables;
+import static org.jruby.api.Access.instanceConfig;
+import static org.jruby.api.Access.objectClass;
+import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Create.newArray;
+import static org.jruby.api.Create.newFrozenString;
+import static org.jruby.api.Create.newRawArray;
+import static org.jruby.api.Create.newString;
+import static org.jruby.api.Error.argumentError;
+import static org.jruby.api.Error.typeError;
+import static org.jruby.api.Warn.warnDeprecated;
+import static org.jruby.api.Warn.warningDeprecated;
+import static org.jruby.internal.runtime.GlobalVariable.Scope.FRAME;
+import static org.jruby.internal.runtime.GlobalVariable.Scope.GLOBAL;
+import static org.jruby.internal.runtime.GlobalVariable.Scope.THREAD;
+import static org.jruby.util.RubyStringBuilder.str;
+import static org.jruby.util.io.EncodingUtils.newExternalStringWithEncoding;
 
 /** This class initializes global variables and constants.
  *
@@ -439,7 +443,7 @@ public class RubyGlobal {
     }
 
     private static void warnDeprecatedGlobal(ThreadContext context, final String name) {
-        warningDeprecated(context, "'" + name + "' is deprecated");
+        warnDeprecated(context, "'" + name + "' is deprecated");
     }
 
     /**
@@ -854,13 +858,13 @@ public class RubyGlobal {
 
         @Override
         public IRubyObject set(IRubyObject value) {
-            warningDeprecated(runtime.getCurrentContext(), "warning: variable " + name + " is no longer effective; ignored");
+            warnDeprecated(runtime.getCurrentContext(), "warning: variable " + name + " is no longer effective; ignored");
             return value;
         }
 
         @Override
         public IRubyObject get() {
-            warningDeprecated(runtime.getCurrentContext(), "warning: variable " + name + " is no longer effective");
+            warnDeprecated(runtime.getCurrentContext(), "warning: variable " + name + " is no longer effective");
             return value;
         }
     }

--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -83,6 +83,7 @@ import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
+import static org.jruby.api.Warn.warningDeprecated;
 import static org.jruby.internal.runtime.GlobalVariable.Scope.*;
 import static org.jruby.util.RubyStringBuilder.str;
 import static org.jruby.util.io.EncodingUtils.newExternalStringWithEncoding;
@@ -437,8 +438,8 @@ public class RubyGlobal {
         return env;
     }
 
-    private static void warnDeprecatedGlobal(final Ruby runtime, final String name) {
-        runtime.getWarnings().warnDeprecated(ID.MISCELLANEOUS, "'" + name + "' is deprecated");
+    private static void warnDeprecatedGlobal(ThreadContext context, final String name) {
+        warningDeprecated(context, "'" + name + "' is deprecated");
     }
 
     /**
@@ -556,13 +557,6 @@ public class RubyGlobal {
             EnvStringValidation.ensureValidEnvString(context, expected, "value");
             
             return super.has_value_p(context, expected.convertToString());
-        }
-
-        @JRubyMethod(name = "index")
-        public IRubyObject index(ThreadContext context, IRubyObject expected) {
-            context.runtime.getWarnings().warn(ID.DEPRECATED_METHOD, "ENV#index is deprecated; use ENV#key");
-
-            return key(context, expected);
         }
 
         @JRubyMethod(name = "keys")
@@ -1042,7 +1036,7 @@ public class RubyGlobal {
         public IRubyObject set(IRubyObject value) {
             IRubyObject result = super.set(value);
 
-            if (!value.isNil()) warnDeprecatedGlobal(runtime, name);
+            if (!value.isNil()) warnDeprecatedGlobal(runtime.getCurrentContext(), name);
 
             return result;
         }
@@ -1057,7 +1051,7 @@ public class RubyGlobal {
         public IRubyObject set(IRubyObject value) {
             IRubyObject result = super.set(value);
 
-            if (!result.isNil()) warnDeprecatedGlobal(runtime, name);
+            if (!result.isNil()) warnDeprecatedGlobal(runtime.getCurrentContext(), name);
 
             return result;
         }

--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -854,13 +854,13 @@ public class RubyGlobal {
 
         @Override
         public IRubyObject set(IRubyObject value) {
-            runtime.getWarnings().warnDeprecated(ID.INEFFECTIVE_GLOBAL, "warning: variable " + name + " is no longer effective; ignored");
+            warningDeprecated(runtime.getCurrentContext(), "warning: variable " + name + " is no longer effective; ignored");
             return value;
         }
 
         @Override
         public IRubyObject get() {
-            runtime.getWarnings().warnDeprecated(ID.INEFFECTIVE_GLOBAL, "warning: variable " + name + " is no longer effective");
+            warningDeprecated(runtime.getCurrentContext(), "warning: variable " + name + " is no longer effective");
             return value;
         }
     }

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -88,6 +88,7 @@ import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Create.newArray;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.*;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.runtime.ThreadContext.hasKeywords;
 import static org.jruby.runtime.ThreadContext.resetCallInfo;
 import static org.jruby.runtime.Visibility.PRIVATE;
@@ -2331,14 +2332,9 @@ public class RubyHash extends RubyObject implements Map {
     }
 
     @JRubyMethod(name = "any?")
-    public IRubyObject any_p(ThreadContext context, IRubyObject arg0, Block block) {
-        IRubyObject pattern = arg0;
-
+    public IRubyObject any_p(ThreadContext context, IRubyObject pattern, Block block) {
         if (isEmpty()) return context.fals;
-
-        if (block.isGiven()) {
-            context.runtime.getWarnings().warn("given block not used");
-        }
+        if (block.isGiven()) warn(context, "given block not used");
 
         return any_p_p(context, pattern);
     }

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -1445,17 +1445,12 @@ public class RubyHash extends RubyObject implements Map {
 
     @JRubyMethod
     public IRubyObject fetch(ThreadContext context, IRubyObject key, IRubyObject _default, Block block) {
-        Ruby runtime = context.runtime;
-        boolean blockGiven = block.isGiven();
-
-        if (blockGiven) {
-            runtime.getWarnings().warn(ID.BLOCK_BEATS_DEFAULT_VALUE, "block supersedes default value argument");
-        }
+        if (block.isGiven()) warn(context, "block supersedes default value argument");
 
         IRubyObject value = internalGet(key);
 
         if (value == null) {
-            if (blockGiven) return block.yield(context, key);
+            if (block.isGiven()) return block.yield(context, key);
 
             return _default;
         }

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -3819,12 +3819,6 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         }
     }
 
-    @JRubyMethod(name = "lines")
-    public IRubyObject lines(final ThreadContext context, Block block) {
-        warn(context, "IO#lines is deprecated; use #each_line instead");
-        return each_line(context, block);
-    }
-
     @JRubyMethod(name = "readlines")
     public RubyArray readlines(ThreadContext context) {
         return Getline.getlineCall(context, GETLINE_ARY, this, getReadEncoding(context));

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -117,6 +117,7 @@ import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.*;
 import static org.jruby.api.Warn.warn;
+import static org.jruby.api.Warn.warnDeprecated;
 import static org.jruby.api.Warn.warningDeprecated;
 import static org.jruby.runtime.ThreadContext.*;
 import static org.jruby.runtime.Visibility.*;
@@ -1859,7 +1860,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         IRubyObject outputFS = globalVariables(context).get("$,");
 
         boolean fieldSeparatorNotNil = !outputFS.isNil();
-        if (fieldSeparatorNotNil) warningDeprecated(context, "$, is set to non-nil value");
+        if (fieldSeparatorNotNil) warnDeprecated(context, "$, is set to non-nil value");
 
         for (int i=0; i<argc; i++) {
             if (fieldSeparatorNotNil && i > 0) write(context, out, outputFS);
@@ -1893,7 +1894,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     public static IRubyObject print2(ThreadContext context, IRubyObject out, IRubyObject arg0, IRubyObject arg1) {
         IRubyObject outputFS = globalVariables(context).get("$,");
         boolean fieldSeparatorNotNil = !outputFS.isNil();
-        if (fieldSeparatorNotNil) warningDeprecated(context, "$, is set to non-nil value");
+        if (fieldSeparatorNotNil) warnDeprecated(context, "$, is set to non-nil value");
 
         write(context, out, arg0);
         if (fieldSeparatorNotNil) write(context, out, outputFS);
@@ -1907,7 +1908,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     public static IRubyObject print3(ThreadContext context, IRubyObject out, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
         IRubyObject outputFS = globalVariables(context).get("$,");
         boolean fieldSeparatorNotNil = !outputFS.isNil();
-        if (fieldSeparatorNotNil) warningDeprecated(context, "$, is set to non-nil value");
+        if (fieldSeparatorNotNil) warnDeprecated(context, "$, is set to non-nil value");
 
         write(context, out, arg0);
         if (fieldSeparatorNotNil) write(context, out, outputFS);
@@ -2920,7 +2921,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         if (write.retrieveCache(maybeIO.getMetaClass()).method.getSignature().isOneArgument()) {
             Ruby runtime = context.runtime;
             if (runtime.isVerbose() && maybeIO != globalVariables(context).get("$stderr")) {
-                warnWrite(runtime, maybeIO);
+                warnWrite(context, maybeIO);
             }
             write.call(context, maybeIO, maybeIO, arg0);
             write.call(context, maybeIO, maybeIO, arg1);
@@ -2929,7 +2930,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return write.call(context, maybeIO, maybeIO, arg0, arg1);
     }
 
-    private static void warnWrite(final Ruby runtime, IRubyObject maybeIO) {
+    private static void warnWrite(ThreadContext context, IRubyObject maybeIO) {
         IRubyObject klass = maybeIO.getMetaClass();
         char sep;
         if (((RubyClass) klass).isSingleton()) {
@@ -2938,7 +2939,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         } else {
             sep = '#';
         }
-        runtime.getWarnings().warningDeprecated(klass.toString() + sep + "write is outdated interface which accepts just one argument");
+        warningDeprecated(context, klass.toString() + sep + "write is outdated interface which accepts just one argument");
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -3622,12 +3622,6 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return each_charInternal(context, block);
     }
 
-    @JRubyMethod(name = "chars")
-    public IRubyObject chars(ThreadContext context, Block block) {
-        warn(context, "IO#chars is deprecated; use #each_char instead");
-        return each_charInternal(context, block);
-    }
-
     @JRubyMethod
     public IRubyObject codepoints(ThreadContext context, Block block) {
         warn(context, "IO#codepoints is deprecated; use #each_codepoint instead");

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -3591,13 +3591,6 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         return block.isGiven() ? each_byteInternal(context, block) : enumeratorize(context.runtime, this, "each_byte");
     }
 
-    // rb_io_bytes
-    @JRubyMethod(name = "bytes")
-    public IRubyObject bytes(ThreadContext context, Block block) {
-        warn(context, "IO#bytes is deprecated; use #each_byte instead");
-        return each_byte(context, block);
-    }
-
     // rb_io_each_char
     public IRubyObject each_charInternal(ThreadContext context, Block block) {
         Ruby runtime = context.runtime;

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -3623,12 +3623,6 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     }
 
     @JRubyMethod
-    public IRubyObject codepoints(ThreadContext context, Block block) {
-        warn(context, "IO#codepoints is deprecated; use #each_codepoint instead");
-        return eachCodePointCommon(context, block, "each_codepoint");
-    }
-
-    @JRubyMethod
     public IRubyObject each_codepoint(ThreadContext context, Block block) {
         return eachCodePointCommon(context, block, "each_codepoint");
     }

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -116,6 +116,7 @@ import static org.jruby.api.Convert.*;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.*;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.runtime.ThreadContext.*;
 import static org.jruby.runtime.Visibility.*;
 import static org.jruby.util.RubyStringBuilder.str;
@@ -1381,7 +1382,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
             str = str.convertToString().newFrozen();
 
-            if (fptr.wbuf.len != 0) context.runtime.getWarnings().warn("syswrite for buffered IO");
+            if (fptr.wbuf.len != 0) warn(context, "syswrite for buffered IO");
 
             ByteList strByteList = ((RubyString) str).getByteList();
             n = OpenFile.writeInternal(context, fptr, strByteList.unsafeBytes(), strByteList.begin(), strByteList.getRealSize());
@@ -2021,7 +2022,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
                 throw context.runtime.newIOError("sysseek for buffered IO");
             }
             if (fptr.isWritable() && fptr.wbuf.len != 0) {
-                context.runtime.getWarnings().warn("sysseek for buffered IO");
+                warn(context, "sysseek for buffered IO");
             }
             fptr.errno(null);
             pos = fptr.posix.lseek(fptr.fd(), pos, whence);
@@ -3593,7 +3594,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     // rb_io_bytes
     @JRubyMethod(name = "bytes")
     public IRubyObject bytes(ThreadContext context, Block block) {
-        context.runtime.getWarnings().warn("IO#bytes is deprecated; use #each_byte instead");
+        warn(context, "IO#bytes is deprecated; use #each_byte instead");
         return each_byte(context, block);
     }
 
@@ -3630,13 +3631,13 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     @JRubyMethod(name = "chars")
     public IRubyObject chars(ThreadContext context, Block block) {
-        context.runtime.getWarnings().warn("IO#chars is deprecated; use #each_char instead");
+        warn(context, "IO#chars is deprecated; use #each_char instead");
         return each_charInternal(context, block);
     }
 
     @JRubyMethod
     public IRubyObject codepoints(ThreadContext context, Block block) {
-        context.runtime.getWarnings().warn("IO#codepoints is deprecated; use #each_codepoint instead");
+        warn(context, "IO#codepoints is deprecated; use #each_codepoint instead");
         return eachCodePointCommon(context, block, "each_codepoint");
     }
 
@@ -3839,7 +3840,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     @JRubyMethod(name = "lines")
     public IRubyObject lines(final ThreadContext context, Block block) {
-        context.runtime.getWarnings().warn("IO#lines is deprecated; use #each_line instead");
+        warn(context, "IO#lines is deprecated; use #each_line instead");
         return each_line(context, block);
     }
 
@@ -4217,7 +4218,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         if ((filename instanceof RubyString name) && name.isEmpty()) throw context.runtime.newErrnoENOENTError();
 
         if ((recv == ioClass(context)) && (cmd = PopenExecutor.checkPipeCommand(context, filename)) != context.nil) {
-            context.runtime.getWarnings().warn("IO process creation with a leading '|' is deprecated and will be removed in Ruby 4.0; use IO.popen instead");
+            warn(context, "IO process creation with a leading '|' is deprecated and will be removed in Ruby 4.0; use IO.popen instead");
             if (PopenExecutor.nativePopenAvailable(context.runtime)) {
                 return (RubyIO) PopenExecutor.pipeOpen(context, cmd, OpenFile.ioOflagsModestr(context, oflags), fmode, convconfig);
             } else {
@@ -5327,9 +5328,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     static void checkUnsupportedOptions(ThreadContext context, RubyHash opts, String[] unsupported, String error) {
         for (String key : unsupported) {
-            if (opts.fastARef(asSymbol(context, key)) != null) {
-                context.runtime.getWarnings().warn(error + ": " + key);
-            }
+            if (opts.fastARef(asSymbol(context, key)) != null) warn(context, error + ": " + key);
         }
     }
 

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1855,19 +1855,14 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
                 return print3(context, out, args[0], args[1], args[2]);
         }
 
-        Ruby runtime = context.runtime;
-        int i;
         int argc = args.length;
         IRubyObject outputFS = globalVariables(context).get("$,");
 
         boolean fieldSeparatorNotNil = !outputFS.isNil();
-        if (fieldSeparatorNotNil) {
-            runtime.getWarnings().warnDeprecated("$, is set to non-nil value");
-        }
-        for (i=0; i<argc; i++) {
-            if (fieldSeparatorNotNil && i>0) {
-                write(context, out, outputFS);
-            }
+        if (fieldSeparatorNotNil) warningDeprecated(context, "$, is set to non-nil value");
+
+        for (int i=0; i<argc; i++) {
+            if (fieldSeparatorNotNil && i > 0) write(context, out, outputFS);
             write(context, out, args[i]);
         }
 
@@ -1896,11 +1891,9 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     }
 
     public static IRubyObject print2(ThreadContext context, IRubyObject out, IRubyObject arg0, IRubyObject arg1) {
-        Ruby runtime = context.runtime;
-
         IRubyObject outputFS = globalVariables(context).get("$,");
         boolean fieldSeparatorNotNil = !outputFS.isNil();
-        if (fieldSeparatorNotNil) runtime.getWarnings().warnDeprecated("$, is set to non-nil value");
+        if (fieldSeparatorNotNil) warningDeprecated(context, "$, is set to non-nil value");
 
         write(context, out, arg0);
         if (fieldSeparatorNotNil) write(context, out, outputFS);
@@ -1912,11 +1905,9 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     }
 
     public static IRubyObject print3(ThreadContext context, IRubyObject out, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
-        Ruby runtime = context.runtime;
-
         IRubyObject outputFS = globalVariables(context).get("$,");
         boolean fieldSeparatorNotNil = !outputFS.isNil();
-        if (fieldSeparatorNotNil) runtime.getWarnings().warnDeprecated("$, is set to non-nil value");
+        if (fieldSeparatorNotNil) warningDeprecated(context, "$, is set to non-nil value");
 
         write(context, out, arg0);
         if (fieldSeparatorNotNil) write(context, out, outputFS);

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -117,6 +117,7 @@ import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.*;
 import static org.jruby.api.Warn.warn;
+import static org.jruby.api.Warn.warningDeprecated;
 import static org.jruby.runtime.ThreadContext.*;
 import static org.jruby.runtime.Visibility.*;
 import static org.jruby.util.RubyStringBuilder.str;
@@ -885,8 +886,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         if (block.isGiven()) {
             IRubyObject className = types(context.runtime, klass);
 
-            context.runtime.getWarnings().warn(ID.BLOCK_NOT_ACCEPTED,
-                    str(context.runtime, className, "::new() does not take block; use ", className, "::open() instead"));
+            warn(context, str(context.runtime, className, "::new() does not take block; use ", className, "::open() instead"));
         }
 
         return klass.newInstance(context, args, block);
@@ -4193,7 +4193,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         if ((filename instanceof RubyString name) && name.isEmpty()) throw context.runtime.newErrnoENOENTError();
 
         if ((recv == ioClass(context)) && (cmd = PopenExecutor.checkPipeCommand(context, filename)) != context.nil) {
-            warn(context, "IO process creation with a leading '|' is deprecated and will be removed in Ruby 4.0; use IO.popen instead");
+            warningDeprecated(context, "IO process creation with a leading '|' is deprecated and will be removed in Ruby 4.0; use IO.popen instead");
             if (PopenExecutor.nativePopenAvailable(context.runtime)) {
                 return (RubyIO) PopenExecutor.pipeOpen(context, cmd, OpenFile.ioOflagsModestr(context, oflags), fmode, convconfig);
             } else {

--- a/core/src/main/java/org/jruby/RubyIOBuffer.java
+++ b/core/src/main/java/org/jruby/RubyIOBuffer.java
@@ -29,6 +29,7 @@ import static org.jruby.api.Convert.*;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
+import static org.jruby.api.Warn.warnExperimental;
 
 public class RubyIOBuffer extends RubyObject {
 
@@ -345,8 +346,7 @@ public class RubyIOBuffer extends RubyObject {
 
         warned = true;
 
-        RubyStackTraceElement trace = context.getSingleBacktrace(1);
-        context.runtime.getWarnings().warnExperimental(trace.getFileName(), trace.getLineNumber(), "IO::Buffer is experimental and both the Ruby and native interface may change in the future!");
+        warnExperimental(context, "IO::Buffer is experimental and both the Ruby and native interface may change in the future!");
     }
 
     private static ByteBuffer newBufferBase(Ruby runtime, int size, int flags) {

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -307,13 +307,6 @@ public class RubyKernel {
         return RubyIO.open(context, fileClass(context), args, block);
     }
 
-    @JRubyMethod(module = true, visibility = PRIVATE)
-    public static IRubyObject getc(ThreadContext context, IRubyObject recv) {
-        context.runtime.getWarnings().warn(ID.DEPRECATED_METHOD, "getc is obsolete; use STDIN.getc instead");
-        IRubyObject defin = globalVariables(context).get("$stdin");
-        return sites(context).getc.call(context, defin, defin);
-    }
-
     // MRI: rb_f_gets
     @JRubyMethod(optional = 1, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject gets(ThreadContext context, IRubyObject recv, IRubyObject[] args) {

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -159,17 +159,17 @@ public class RubyKernel {
     }
 
     public static RubyModule finishKernelModule(ThreadContext context, RubyModule Kernel, RubyInstanceConfig config) {
-        var runtime = context.runtime;
-        Kernel.defineAnnotatedMethodsIndividually(RubyKernel.class);
+        Kernel.defineMethods(context, RubyKernel.class);
         Kernel.setFlag(RubyModule.NEEDSIMPL_F, false); //Kernel is the only normal Module that doesn't need an implementor
 
+        var runtime = context.runtime;
         runtime.setPrivateMethodMissing(new MethodMissingMethod(Kernel, PRIVATE, CallType.NORMAL));
         runtime.setProtectedMethodMissing(new MethodMissingMethod(Kernel, PROTECTED, CallType.NORMAL));
         runtime.setVariableMethodMissing(new MethodMissingMethod(Kernel, PUBLIC, CallType.VARIABLE));
         runtime.setSuperMethodMissing(new MethodMissingMethod(Kernel, PUBLIC, CallType.SUPER));
         runtime.setNormalMethodMissing(new MethodMissingMethod(Kernel, PUBLIC, CallType.NORMAL));
 
-        if (config.isAssumeLoop()) Kernel.defineAnnotatedMethodsIndividually(LoopMethods.class);
+        if (config.isAssumeLoop()) Kernel.defineMethods(context, LoopMethods.class);
 
         if (config.getKernelGsubDefined()) {
             MethodIndex.addMethodReadFields("gsub", FrameField.LASTLINE, FrameField.BACKREF);
@@ -187,7 +187,6 @@ public class RubyKernel {
         }
 
         recacheBuiltinMethods(runtime, Kernel);
-
 
         return Kernel;
     }

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -5248,7 +5248,7 @@ public class RubyModule extends RubyObject {
                 if (warn && notAutoload) {
                     var context = getRuntime().getCurrentContext();
                     warn(context, "already initialized constant " +
-                            this.equals(objectClass(context)) ? name : (this + "::" + name));
+                            (this.equals(objectClass(context)) ? name : (this + "::" + name)));
                 }
 
                 storeConstant(name, value, hidden, file, line);

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1296,6 +1296,7 @@ public class RubyModule extends RubyObject {
         invalidateConstantCacheForModuleInclusion(module);
     }
 
+    @Deprecated(since = "10.0")
     public void defineAnnotatedMethod(Class clazz, String name) {
         // FIXME: This is probably not very efficient, since it loads all methods for each call
         boolean foundMethod = false;

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -153,6 +153,7 @@ import static org.jruby.api.Convert.*;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Error.*;
 import static org.jruby.api.Warn.warn;
+import static org.jruby.api.Warn.warningDeprecated;
 import static org.jruby.runtime.Visibility.MODULE_FUNCTION;
 import static org.jruby.runtime.Visibility.PRIVATE;
 import static org.jruby.runtime.Visibility.PROTECTED;
@@ -3277,7 +3278,7 @@ public class RubyModule extends RubyObject {
     @JRubyMethod(name = "attr", rest = true, reads = VISIBILITY)
     public IRubyObject attr(ThreadContext context, IRubyObject[] args) {
         if (args.length == 2 && (args[1] == context.tru || args[1] == context.fals)) {
-            context.runtime.getWarnings().warnDeprecated(ID.OBSOLETE_ARGUMENT, "optional boolean argument is obsoleted");
+            warningDeprecated(context, "optional boolean argument is obsoleted");
             boolean writeable = args[1].isTrue();
             RubySymbol sym = TypeConverter.checkID(args[0]);
             addAccessor(context, sym, getCurrentVisibilityForDefineMethod(context), args[0].isTrue(), writeable);
@@ -5693,9 +5694,8 @@ public class RubyModule extends RubyObject {
             return null;
         }
         if (entry.deprecated) {
-            final Ruby runtime = getRuntime();
             String parent = "Object".equals(getName()) ? "" : getName();
-            runtime.getWarnings().warnDeprecated(ID.CONSTANT_DEPRECATED, "constant " + parent + "::" + name + " is deprecated");
+            warningDeprecated(getRuntime().getCurrentContext(), "constant " + parent + "::" + name + " is deprecated");
         }
 
         return entry;

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -194,9 +194,11 @@ public class RubyModule extends RubyObject {
         Module.reifiedClass(RubyModule.class).
                 kindOf(new RubyModule.JavaClassKindOf(RubyModule.class)).
                 classIndex(ClassIndex.MODULE);
+    }
 
-        Module.defineAnnotatedMethodsIndividually(RubyModule.class);
-        Module.defineAnnotatedMethodsIndividually(ModuleKernelMethods.class);
+    public static void finishCreateModuleClass(ThreadContext context, RubyClass Module) {
+        Module.defineMethods(context, RubyModule.class);
+        Module.defineMethods(context, ModuleKernelMethods.class);
     }
 
     public void checkValidBindTargetFrom(ThreadContext context, RubyModule originModule, boolean fromBind) throws RaiseException {
@@ -6327,7 +6329,7 @@ public class RubyModule extends RubyObject {
         this.refinements = refinements;
     }
 
-    public static void createRefinementClass(ThreadContext context, RubyClass Refinement) {
+    public static void finishRefinementClass(ThreadContext context, RubyClass Refinement) {
         Refinement.reifiedClass(RubyModule.class).
                 classIndex(ClassIndex.REFINEMENT).
                 defineMethods(context, RefinementMethods.class).

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -6327,14 +6327,11 @@ public class RubyModule extends RubyObject {
         this.refinements = refinements;
     }
 
-    public static void createRefinementClass(RubyClass Refinement) {
+    public static void createRefinementClass(ThreadContext context, RubyClass Refinement) {
         Refinement.reifiedClass(RubyModule.class).
                 classIndex(ClassIndex.REFINEMENT).
-                defineAnnotatedMethodsIndividually(RefinementMethods.class);
-
-        Refinement.undefineMethod("append_features");
-        Refinement.undefineMethod("prepend_features");
-        Refinement.undefineMethod("extend_object");
+                defineMethods(context, RefinementMethods.class).
+                undefMethods(context, "append_features", "prepend_features", "extend_object");
     }
 
     public static class RefinementMethods {

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1330,7 +1330,7 @@ public class RubyModule extends RubyObject {
         return defineAnnotatedConstant(getCurrentContext(), field);
     }
 
-    public final boolean defineAnnotatedConstant(ThreadContext context, Field field) {
+    private boolean defineAnnotatedConstant(ThreadContext context, Field field) {
         JRubyConstant jrubyConstant = field.getAnnotation(JRubyConstant.class);
         if (jrubyConstant == null) return false;
 
@@ -1364,7 +1364,7 @@ public class RubyModule extends RubyObject {
      * @deprecated Use {@link RubyModule#defineMethods(ThreadContext, Class[])} instead.
      */
     @Extension
-    @Deprecated(since = "1.0")
+    @Deprecated(since = "10.0")
     public void defineAnnotatedMethods(Class clazz) {
         defineAnnotatedMethodsIndividually(clazz);
     }
@@ -1459,12 +1459,7 @@ public class RubyModule extends RubyObject {
         return new TypePopulator.ReflectiveTypePopulator(type);
     }
 
-    /**
-     * An internal API only used before the first ThreadContext is defined.  For example,
-     * BasicObject, Boolean,  needs this when getting defined.
-     * Use {@link org.jruby.RubyModule#defineMethods(ThreadContext, Class[])} instead.
-     * @param clazz to generate JRuby methods from
-     */
+    @Deprecated(since = "10.0")
     public final void defineAnnotatedMethodsIndividually(Class clazz) {
         getRuntime().POPULATORS.get(clazz).populate(this, clazz);
     }

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -152,6 +152,7 @@ import static org.jruby.api.Access.objectClass;
 import static org.jruby.api.Convert.*;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Error.*;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.runtime.Visibility.MODULE_FUNCTION;
 import static org.jruby.runtime.Visibility.PRIVATE;
 import static org.jruby.runtime.Visibility.PROTECTED;
@@ -6333,7 +6334,7 @@ public class RubyModule extends RubyObject {
                 RubyModule module = castAsModule(context, _module);
 
                 if (module.getSuperClass() != null) {
-                    context.runtime.getWarnings().warn(module.getName() + " has ancestors, but Refinement#import_methods doesn't import their methods");
+                    warn(context, module.getName() + " has ancestors, but Refinement#import_methods doesn't import their methods");
                 }
             }
 

--- a/core/src/main/java/org/jruby/RubyNil.java
+++ b/core/src/main/java/org/jruby/RubyNil.java
@@ -76,7 +76,7 @@ public class RubyNil extends RubyObject implements Constantizable {
         constant = OptoFactory.newConstantWrapper(IRubyObject.class, this);
     }
     
-    public static void createNilClass(ThreadContext context, RubyClass Nil) {
+    public static void finishNilClass(ThreadContext context, RubyClass Nil) {
         Nil.reifiedClass(RubyNil.class).
                 classIndex(ClassIndex.NIL).
                 defineMethods(context, RubyNil.class).

--- a/core/src/main/java/org/jruby/RubyNil.java
+++ b/core/src/main/java/org/jruby/RubyNil.java
@@ -76,15 +76,11 @@ public class RubyNil extends RubyObject implements Constantizable {
         constant = OptoFactory.newConstantWrapper(IRubyObject.class, this);
     }
     
-    public static RubyClass createNilClass(Ruby runtime, RubyClass Object) {
-        RubyClass NilClass = runtime.defineClass("NilClass", Object, NOT_ALLOCATABLE_ALLOCATOR).
-                reifiedClass(RubyNil.class).
-                classIndex(ClassIndex.NIL);
-
-        NilClass.defineAnnotatedMethodsIndividually(RubyNil.class);
-        NilClass.getMetaClass().undefineMethod("new");
-
-        return NilClass;
+    public static void createNilClass(ThreadContext context, RubyClass Nil) {
+        Nil.reifiedClass(RubyNil.class).
+                classIndex(ClassIndex.NIL).
+                defineMethods(context, RubyNil.class).
+                tap(c -> c.getMetaClass().undefMethods(context, "new"));
     }
     
     @Override

--- a/core/src/main/java/org/jruby/RubyProc.java
+++ b/core/src/main/java/org/jruby/RubyProc.java
@@ -61,6 +61,7 @@ import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.argumentError;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.runtime.ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR;
 import static org.jruby.runtime.ThreadContext.resetCallInfo;
 import static org.jruby.util.RubyStringBuilder.types;
@@ -259,7 +260,7 @@ public class RubyProc extends RubyObject implements DataType {
         checkFrozen();
 
         if (fromMethod) {
-            context.runtime.getWarnings().warn(IRubyWarnings.ID.MISCELLANEOUS, "Skipping set of ruby2_keywords flag for proc (proc created from method)");
+            warn(context, "Skipping set of ruby2_keywords flag for proc (proc created from method)");
             return this;
         }
 
@@ -269,11 +270,11 @@ public class RubyProc extends RubyObject implements DataType {
             if (signature.hasRest() && !signature.hasKwargs()) {
                 ((IRBlockBody) body).getScope().setRuby2Keywords();
             } else {
-                context.runtime.getWarnings().warn(IRubyWarnings.ID.MISCELLANEOUS, "Skipping set of ruby2_keywords flag for proc (proc accepts keywords or proc does not accept argument splat)");
+                warn(context, "Skipping set of ruby2_keywords flag for proc (proc accepts keywords or proc does not accept argument splat)");
             }
 
         } else {
-            context.runtime.getWarnings().warn(IRubyWarnings.ID.MISCELLANEOUS, "Skipping set of ruby2_keywords flag for proc (proc not defined in Ruby)");
+            warn(context, "Skipping set of ruby2_keywords flag for proc (proc not defined in Ruby)");
         }
         return this;
     }

--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -59,6 +59,7 @@ import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineModule;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.rangeError;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.runtime.Helpers.throwException;
 import static org.jruby.runtime.Visibility.*;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -738,7 +739,7 @@ public class RubyProcess {
         var posix = context.runtime.getPosix();
 
         if (!posix.isNative()) {
-            context.runtime.getWarnings().warn("Process#setrlimit not supported on this platform");
+            warn(context, "Process#setrlimit not supported on this platform");
             return context.nil;
         }
 
@@ -1512,7 +1513,7 @@ public class RubyProcess {
         }
 
         if (!context.runtime.getPosix().isNative()) {
-            context.runtime.getWarnings().warn("Process#getrlimit not supported on this platform");
+            warn(context, "Process#getrlimit not supported on this platform");
             RubyFixnum max = asFixnum(context, Long.MAX_VALUE);
             return newArray(context, max, max);
         }

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -1249,7 +1249,7 @@ public class RubyRational extends RubyNumeric {
         long e = ne - de;
 
         if (e > 1023 || e < -1022) {
-            context.runtime.getWarnings().warn(IRubyWarnings.ID.FLOAT_OUT_OF_RANGE, "out of Float range");
+            warn(context, "out of Float range");
             return e > 0 ? Double.MAX_VALUE : 0;
         }
 
@@ -1259,9 +1259,7 @@ public class RubyRational extends RubyNumeric {
 
         f = ldexp(f, e);
 
-        if (Double.isInfinite(f) || Double.isNaN(f)) {
-            context.runtime.getWarnings().warn(IRubyWarnings.ID.FLOAT_OUT_OF_RANGE, "out of Float range");
-        }
+        if (Double.isInfinite(f) || Double.isNaN(f)) warn(context, "out of Float range");
 
         return f;
     }

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -57,6 +57,7 @@ import static org.jruby.api.Create.newArray;
 import static org.jruby.api.Create.newString;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.*;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.ast.util.ArgsUtil.hasExceptionOption;
 import static org.jruby.runtime.Helpers.invokedynamic;
 import static org.jruby.runtime.invokedynamic.MethodNames.HASH;
@@ -851,7 +852,7 @@ public class RubyRational extends RubyNumeric {
             }
             return newInstance(context, getMetaClass(), num, den);
         } else if (other instanceof RubyBignum) {
-            context.runtime.getWarnings().warn("in a**b, b may be too big");
+            warn(context, "in a**b, b may be too big");
             return ((RubyFloat) to_f(context)).op_pow(context, other);
         } else if (other instanceof RubyFloat || other instanceof RubyRational) {
             return f_expt(context, r_to_f(context, this), other);

--- a/core/src/main/java/org/jruby/RubyRegexp.java
+++ b/core/src/main/java/org/jruby/RubyRegexp.java
@@ -84,6 +84,7 @@ import static org.jruby.api.Convert.*;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.*;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.runtime.ThreadContext.resetCallInfo;
 import static org.jruby.util.RubyStringBuilder.str;
 import static org.jruby.util.StringSupport.CR_7BIT;
@@ -1610,7 +1611,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         RubyString string;
         int opts = 0;
         if (args[0] instanceof RubyRegexp) {
-            if (length > 1) context.runtime.getWarnings().warn("flags ignored");
+            if (length > 1) warn(context, "flags ignored");
             string = null;
         } else {
             if (length > 1) opts = objectAsJoniOptions(args[1]);

--- a/core/src/main/java/org/jruby/RubyRegexp.java
+++ b/core/src/main/java/org/jruby/RubyRegexp.java
@@ -85,6 +85,7 @@ import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.*;
 import static org.jruby.api.Warn.warn;
+import static org.jruby.api.Warn.warning;
 import static org.jruby.runtime.ThreadContext.resetCallInfo;
 import static org.jruby.util.RubyStringBuilder.str;
 import static org.jruby.util.StringSupport.CR_7BIT;
@@ -369,8 +370,9 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
 
     // MRI: rb_reg_new_str
     public static RubyRegexp newRegexpFromStr(Ruby runtime, RubyString s, int options) {
+        var context = runtime.getCurrentContext();
         RubyRegexp re = (RubyRegexp)runtime.getRegexp().allocate();
-        re.regexpInitializeString(s, RegexpOptions.fromJoniOptions(options), null);
+        re.regexpInitializeString(context, s, RegexpOptions.fromJoniOptions(options), null);
         return re;
     }
 
@@ -416,7 +418,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
             enc = patternEnc;
         }
         if (warn && isEncodingNone() && enc != ASCIIEncoding.INSTANCE && cr != StringSupport.CR_7BIT) {
-            context.runtime.getWarnings().warn(ID.REGEXP_MATCH_AGAINST_STRING, "historical binary regexp match /.../n against " + enc + " string");
+            warn(context, "historical binary regexp match /.../n against " + enc + " string");
         }
         return enc;
     }
@@ -900,7 +902,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         return regexpInitialize(regexp.str, regexp.str.getEncoding(), regexp.getOptions(), regexp.timeout);
     }
 
-    private static int objectAsJoniOptions(IRubyObject arg) {
+    private static int objectAsJoniOptions(ThreadContext context, IRubyObject arg) {
         Ruby runtime = arg.getRuntime();
         if (arg instanceof RubyFixnum) return fix2int(arg);
         if (arg instanceof RubyString) return RegexpOptions.fromByteList(runtime, ((RubyString) arg).getByteList()).toJoniOptions();
@@ -911,40 +913,48 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         }
         if (arg.isNil()) return 0;
 
-        runtime.getWarnings().warning(str(runtime, "expected true or false as ignorecase: ", arg));
+        warning(context, str(runtime, "expected true or false as ignorecase: ", arg));
 
         return RE_OPTION_IGNORECASE;
     }
 
-    @JRubyMethod(name = "initialize", visibility = Visibility.PRIVATE)
+    @Deprecated(since = "10.0")
     public IRubyObject initialize_m(IRubyObject arg) {
+        return initialize_m(getCurrentContext(), arg);
+    }
+
+    @JRubyMethod(name = "initialize", visibility = Visibility.PRIVATE)
+    public IRubyObject initialize_m(ThreadContext context, IRubyObject arg) {
         return arg instanceof RubyRegexp regexp ?
                 initializeByRegexp(regexp, null) :
-                regexpInitializeString(arg.convertToString(), new RegexpOptions(), null);
+                regexpInitializeString(context, arg.convertToString(), new RegexpOptions(), null);
+    }
+
+    @Deprecated(since = "10.0")
+    public IRubyObject initialize_m(IRubyObject arg0, IRubyObject arg1) {
+        return initialize_m(getCurrentContext(), arg0, arg1);
     }
 
     @JRubyMethod(name = "initialize", visibility = Visibility.PRIVATE, keywords = true)
-    public IRubyObject initialize_m(IRubyObject arg0, IRubyObject arg1) {
-        ThreadContext context = getRuntime().getCurrentContext();
+    public IRubyObject initialize_m(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
         boolean keywords = (resetCallInfo(context) & ThreadContext.CALL_KEYWORD) != 0;
-
 
         IRubyObject timeout;
         RegexpOptions regexpOptions;
         if (keywords) {
             regexpOptions = new RegexpOptions();
             timeout = timeoutFromArg(context, arg1);
-            if (arg0 instanceof RubyRegexp) return initializeByRegexp((RubyRegexp) arg0, timeout);
+            if (arg0 instanceof RubyRegexp regexp) return initializeByRegexp(regexp, timeout);
         } else {
             if (arg0 instanceof RubyRegexp && Options.PARSER_WARN_FLAGS_IGNORED.load()) {
-                metaClass.runtime.getWarnings().warn(ID.REGEXP_IGNORED_FLAGS, "flags ignored");
+                warn(context, "flags ignored");
                 return initializeByRegexp((RubyRegexp)arg0, null);
             }
-            regexpOptions = RegexpOptions.fromJoniOptions(objectAsJoniOptions(arg1));
+            regexpOptions = RegexpOptions.fromJoniOptions(objectAsJoniOptions(context, arg1));
             timeout = null;
         }
 
-        return regexpInitializeString(arg0.convertToString(), regexpOptions, timeout);
+        return regexpInitializeString(context, arg0.convertToString(), regexpOptions, timeout);
     }
 
     /**
@@ -964,14 +974,14 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         boolean keywords = (resetCallInfo(context) & ThreadContext.CALL_KEYWORD) != 0;
 
         if (arg0 instanceof RubyRegexp && Options.PARSER_WARN_FLAGS_IGNORED.load()) {
-            context.runtime.getWarnings().warn(ID.REGEXP_IGNORED_FLAGS, "flags ignored");
+            warn(context, "flags ignored");
             return initializeByRegexp((RubyRegexp)arg0, timeoutFromArg(context, arg2));
         }
 
-        RegexpOptions newOptions = RegexpOptions.fromJoniOptions(objectAsJoniOptions(arg1));
+        RegexpOptions newOptions = RegexpOptions.fromJoniOptions(objectAsJoniOptions(context, arg1));
         if (!keywords) throw argumentError(context, 3, 1, 2);
 
-        return regexpInitializeString(arg0.convertToString(), newOptions, timeoutFromArg(context, arg2));
+        return regexpInitializeString(context, arg0.convertToString(), newOptions, timeoutFromArg(context, arg2));
     }
 
     private IRubyObject timeoutFromArg(ThreadContext context, IRubyObject arg) {
@@ -987,7 +997,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
     }
 
     // rb_reg_initialize_str
-    private RubyRegexp regexpInitializeString(RubyString str, RegexpOptions options, IRubyObject timeout) {
+    private RubyRegexp regexpInitializeString(ThreadContext context, RubyString str, RegexpOptions options, IRubyObject timeout) {
         if (isLiteral()) throw metaClass.runtime.newFrozenError(this);
         ByteList bytes = str.getByteList();
         Encoding enc = bytes.getEncoding();
@@ -1614,7 +1624,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
             if (length > 1) warn(context, "flags ignored");
             string = null;
         } else {
-            if (length > 1) opts = objectAsJoniOptions(args[1]);
+            if (length > 1) opts = objectAsJoniOptions(context, args[1]);
             string = args[0].convertToString();
         }
 

--- a/core/src/main/java/org/jruby/RubyRegexp.java
+++ b/core/src/main/java/org/jruby/RubyRegexp.java
@@ -218,7 +218,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
                 defineConstant(context, "FIXEDENCODING", asFixnum(context, RE_FIXED)).
                 defineConstant(context, "NOENCODING", asFixnum(context, RE_NONE)).
                 defineMethods(context, RubyRegexp.class).
-                tap(c -> c.getSingletonClass().defineAlias("compile", "new"));
+                tap(c -> c.getSingletonClass().defineAlias(context, "compile", "new"));
 
         context.runtime.setRubyTimeout(context.nil);
 

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -6330,7 +6330,6 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
         if (block.isGiven()) {
             if (wantarray) {
-                context.runtime.getWarnings().warning(ID.BLOCK_DEPRECATED, "passing a block to String#" + name + " is deprecated");
                 wantarray = false;
             }
         } else if (!wantarray) {
@@ -6381,7 +6380,6 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
         if (block.isGiven()) {
             if (wantarray) {
-                context.runtime.getWarnings().warning(ID.BLOCK_DEPRECATED, "passing a block to String#" + name + " is deprecated");
                 wantarray = false;
             }
         } else if (!wantarray) {
@@ -6417,7 +6415,6 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     private IRubyObject enumerateBytes(ThreadContext context, String name, Block block, boolean wantarray) {
         if (block.isGiven()) {
             if (wantarray) {
-                context.runtime.getWarnings().warning(ID.BLOCK_DEPRECATED, "passing a block to String#" + name + " is deprecated");
                 wantarray = false;
             }
         } else if (!wantarray) {
@@ -6478,7 +6475,6 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
         if (block.isGiven()) {
             if (wantarray) {
-                context.runtime.getWarnings().warning(ID.BLOCK_DEPRECATED, "passing a block to String#" + name + " is deprecated");
                 wantarray = false;
             }
         } else if (!wantarray) {

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -102,6 +102,7 @@ import static org.jruby.api.Convert.*;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.*;
+import static org.jruby.api.Warn.warningDeprecated;
 import static org.jruby.runtime.Visibility.PRIVATE;
 import static org.jruby.util.RubyStringBuilder.*;
 import static org.jruby.util.StringSupport.*;
@@ -4669,7 +4670,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
             if (splitPattern.isNil()) return context.nil;
 
-            context.runtime.getWarnings().warnDeprecated(ID.MISCELLANEOUS, "$; is set to non-nil value");
+            warningDeprecated(context, "$; is set to non-nil value");
 
             pattern = splitPattern;
         }

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -65,6 +65,7 @@ import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.indexError;
 import static org.jruby.api.Error.typeError;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.runtime.Helpers.invokedynamic;
 import static org.jruby.runtime.ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR;
 import static org.jruby.runtime.ThreadContext.hasKeywords;
@@ -460,7 +461,7 @@ public class RubyStruct extends RubyObject {
 
     private void checkForKeywords(ThreadContext context, boolean keywordInit) {
         if (hasKeywords(ThreadContext.resetCallInfo(context)) && !keywordInit) {
-            context.runtime.getWarnings().warn("Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).");
+            warn(context, "Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).");
         }
     }
 

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -110,6 +110,7 @@ import static org.jruby.api.Create.newString;
 import static org.jruby.api.Convert.asSymbol;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.*;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.runtime.ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR;
 import static org.jruby.runtime.Visibility.*;
 import static org.jruby.util.RubyStringBuilder.str;
@@ -2529,7 +2530,7 @@ public class RubyThread extends RubyObject implements ExecutionContext {
                 lock.unlock();
             } catch (IllegalMonitorStateException imse) {
                 // don't allow a bad lock to prevent others from unlocking
-                getRuntime().getWarnings().warn("BUG: attempted to unlock a non-acquired lock " + lock + " in thread " + toString());
+                warn(getRuntime().getCurrentContext(), "BUG: attempted to unlock a non-acquired lock " + lock + " in thread " + toString());
             }
         }
     }

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -1096,16 +1096,12 @@ public class RubyThread extends RubyObject implements ExecutionContext {
 
     @JRubyMethod
     public IRubyObject fetch(ThreadContext context, IRubyObject key, IRubyObject _default, Block block) {
-        final boolean blockGiven = block.isGiven();
-
-        if (blockGiven) {
-            context.runtime.getWarnings().warn(ID.BLOCK_BEATS_DEFAULT_VALUE, "block supersedes default value argument");
-        }
+        if (block.isGiven()) warn(context, "block supersedes default value argument");
 
         IRubyObject value = op_aref(context, key);
 
         if (value == context.nil) {
-            if (blockGiven) return block.yield(context, key);
+            if (block.isGiven()) return block.yield(context, key);
             return _default;
         }
 

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -2247,7 +2247,7 @@ public class RubyTime extends RubyObject {
         if (time instanceof RubyTime) {
             return ((RubyTime) time).getDateTime().withZoneRetainFields(DateTimeZone.UTC).getMillis();
         } else if (time instanceof RubyStruct) {
-            t = ((RubyStruct) time).aref(asSymbol(context, "to_i")).convertToInteger().getLongValue();
+            t = ((RubyStruct) time).aref(context, asSymbol(context, "to_i")).convertToInteger().getLongValue();
         } else {
             t =  time.callMethod(context, "to_i").convertToInteger().getLongValue();
         }

--- a/core/src/main/java/org/jruby/TopSelfFactory.java
+++ b/core/src/main/java/org/jruby/TopSelfFactory.java
@@ -58,10 +58,10 @@ public final class TopSelfFactory {
     public static IRubyObject createTopSelf(final Ruby runtime) {
         var Object = objectClass(runtime.getCurrentContext());
         var topSelf = new RubyObject(runtime, Object);
-        return createTopSelf(runtime.getCurrentContext(), topSelf, Object, false);
+        return finishTopSelf(runtime.getCurrentContext(), topSelf, Object, false);
     }
     
-    public static IRubyObject createTopSelf(ThreadContext context, IRubyObject topSelf, RubyClass Object, final boolean wrapper) {
+    public static IRubyObject finishTopSelf(ThreadContext context, IRubyObject topSelf, RubyClass Object, final boolean wrapper) {
         final RubyClass singletonClass = topSelf.getSingletonClass();
 
         singletonClass.addMethod("to_s", new JavaMethod.JavaMethodZero(singletonClass, Visibility.PUBLIC, "to_s") {

--- a/core/src/main/java/org/jruby/TopSelfFactory.java
+++ b/core/src/main/java/org/jruby/TopSelfFactory.java
@@ -56,12 +56,12 @@ public final class TopSelfFactory {
 
     @Deprecated(since = "10.0", forRemoval = true)
     public static IRubyObject createTopSelf(final Ruby runtime) {
-        return createTopSelf(runtime, objectClass(runtime.getCurrentContext()), false);
+        var Object = objectClass(runtime.getCurrentContext());
+        var topSelf = new RubyObject(runtime, Object);
+        return createTopSelf(runtime.getCurrentContext(), topSelf, Object, false);
     }
     
-    public static IRubyObject createTopSelf(final Ruby runtime, RubyClass Object, final boolean wrapper) {
-        IRubyObject topSelf = new RubyObject(runtime, Object);
-
+    public static IRubyObject createTopSelf(ThreadContext context, IRubyObject topSelf, RubyClass Object, final boolean wrapper) {
         final RubyClass singletonClass = topSelf.getSingletonClass();
 
         singletonClass.addMethod("to_s", new JavaMethod.JavaMethodZero(singletonClass, Visibility.PUBLIC, "to_s") {
@@ -70,7 +70,7 @@ public final class TopSelfFactory {
                 return newString(context, "main");
             }
         });
-        singletonClass.defineAlias("inspect", "to_s");
+        singletonClass.defineAlias(context, "inspect", "to_s");
         
         // The following three methods must be defined fast, since they expect to modify the current frame
         // (i.e. they expect no frame will be allocated for them). JRUBY-1185.

--- a/core/src/main/java/org/jruby/anno/TypePopulator.java
+++ b/core/src/main/java/org/jruby/anno/TypePopulator.java
@@ -111,19 +111,20 @@ public abstract class TypePopulator {
             AnnotationHelper.populateMethodIndex(clumper.writeGroups, MethodIndex::addMethodWriteFieldsPacked);
 
             final Ruby runtime = target.getRuntime();
+            var context = runtime.getCurrentContext();
             final MethodFactory methodFactory = MethodFactory.createFactory(runtime.getJRubyClassLoader());
 
             for (Map.Entry<String, List<JavaMethodDescriptor>> entry : clumper.getStaticAnnotatedMethods().entrySet()) {
                 final String name = entry.getKey();
                 final List<JavaMethodDescriptor> methods = entry.getValue();
-                target.defineAnnotatedMethod(name, methods, methodFactory);
+                target.defineAnnotatedMethod(context, name, methods, methodFactory);
                 addBoundMethodsUnlessOmitted(runtime, name, methods);
             }
 
             for (Map.Entry<String, List<JavaMethodDescriptor>> entry : clumper.getAnnotatedMethods().entrySet()) {
                 final String name = entry.getKey();
                 final List<JavaMethodDescriptor> methods = entry.getValue();
-                target.defineAnnotatedMethod(name, methods, methodFactory);
+                target.defineAnnotatedMethod(context, name, methods, methodFactory);
                 addBoundMethodsUnlessOmitted(runtime, name, methods);
             }
         }

--- a/core/src/main/java/org/jruby/api/Access.java
+++ b/core/src/main/java/org/jruby/api/Access.java
@@ -6,6 +6,7 @@ import org.jruby.RubyModule;
 import org.jruby.internal.runtime.GlobalVariables;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.encoding.EncodingService;
 import org.jruby.runtime.load.LoadService;
 
 public class Access {
@@ -70,6 +71,15 @@ public class Access {
      */
     public static RubyClass dirClass(ThreadContext context) {
         return context.runtime.getDir();
+    }
+
+    /**
+     * Retrieve the encoding service object
+     * @param context the current thread context
+     * @return the object
+     */
+    public static EncodingService encodingService(ThreadContext context) {
+        return context.runtime.getEncodingService();
     }
 
     /**

--- a/core/src/main/java/org/jruby/api/Access.java
+++ b/core/src/main/java/org/jruby/api/Access.java
@@ -145,6 +145,16 @@ public class Access {
         return context.runtime.getHash();
     }
 
+
+    /**
+     * Retrieve the instance of the class Integer
+     * @param context the current thread context
+     * @return the Class
+     */
+    public static RubyClass integerClass(ThreadContext context) {
+        return context.runtime.getInteger();
+    }
+
     /**
      * Retrieve our runtimes instance config which holds many configurable options
      * which are set up from command-line properties or Java system properties.

--- a/core/src/main/java/org/jruby/api/Warn.java
+++ b/core/src/main/java/org/jruby/api/Warn.java
@@ -1,0 +1,9 @@
+package org.jruby.api;
+
+import org.jruby.runtime.ThreadContext;
+
+public class Warn {
+    public static void warn(ThreadContext context, String message) {
+        context.runtime.getWarnings().warn(message);
+    }
+}

--- a/core/src/main/java/org/jruby/api/Warn.java
+++ b/core/src/main/java/org/jruby/api/Warn.java
@@ -7,7 +7,36 @@ public class Warn {
         context.runtime.getWarnings().warn(message);
     }
 
+    /**
+     * Produce a warning id deprecated is set (e.g. Warning[:deprecated] = true)
+     * @param context the current context
+     * @param message to be displayed as a warning
+     */
+    public static void warnDeprecated(ThreadContext context, String message) {
+        context.runtime.getWarnings().warnDeprecated(message);
+    }
+
+    public static void warning(ThreadContext context, String message) {
+        context.runtime.getWarnings().warning(message);
+    }
+
+    /**
+     * Produce a warning if deprecated is set (e.g. Warning[:deprecated] = true) and in verbose mode.
+     *
+     * @param context the current context
+     * @param message to be displayed as a warning
+     */
     public static void warningDeprecated(ThreadContext context, String message) {
         context.runtime.getWarnings().warningDeprecated(message);
     }
+
+    /**
+     * Produce a warning id deprecated is set (e.g. Warning[:deprecated] = true)
+     * @param context the current context
+     * @param message to be displayed as a warning
+     */
+    public static void warnExperimental(ThreadContext context, String message) {
+        context.runtime.getWarnings().warnExperimental(message);
+    }
+
 }

--- a/core/src/main/java/org/jruby/api/Warn.java
+++ b/core/src/main/java/org/jruby/api/Warn.java
@@ -6,4 +6,8 @@ public class Warn {
     public static void warn(ThreadContext context, String message) {
         context.runtime.getWarnings().warn(message);
     }
+
+    public static void warningDeprecated(ThreadContext context, String message) {
+        context.runtime.getWarnings().warningDeprecated(message);
+    }
 }

--- a/core/src/main/java/org/jruby/common/RubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/RubyWarnings.java
@@ -184,6 +184,7 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
         doWarn(ID.MISCELLANEOUS, filename, LINE_NUMBER_NON_WARNING, message);
     }
 
+    @Deprecated
     public void warnExperimental(String filename, int line, String message) {
         if (runtime.getWarningCategories().contains(Category.EXPERIMENTAL)) warn(ID.MISCELLANEOUS, filename, line, message);
     }
@@ -193,9 +194,12 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
         if (runtime.getWarningCategories().contains(Category.DEPRECATED)) warn(id, message);
     }
 
-    @Deprecated(since = "10.0")
     public void warnDeprecated(String message) {
         if (runtime.getWarningCategories().contains(Category.DEPRECATED)) warn(message);
+    }
+
+    public void warnExperimental(String message) {
+        if (runtime.getWarningCategories().contains(Category.EXPERIMENTAL)) warn(message);
     }
 
     @Deprecated(since = "10.0")

--- a/core/src/main/java/org/jruby/common/RubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/RubyWarnings.java
@@ -239,9 +239,8 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
     }
 
     public void warningDeprecated(ID id, String message) {
-        if (!isVerbose()) return;
-
-        if (runtime.getWarningCategories().contains(Category.DEPRECATED)) warn(id, message);
+        if (!isVerbose() && !runtime.getWarningCategories().contains(Category.DEPRECATED)) return;
+        warn(id, message);
     }
 
     /**

--- a/core/src/main/java/org/jruby/common/RubyWarnings.java
+++ b/core/src/main/java/org/jruby/common/RubyWarnings.java
@@ -188,18 +188,22 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
         if (runtime.getWarningCategories().contains(Category.EXPERIMENTAL)) warn(ID.MISCELLANEOUS, filename, line, message);
     }
 
+    @Deprecated(since = "10.0")
     public void warnDeprecated(ID id, String message) {
         if (runtime.getWarningCategories().contains(Category.DEPRECATED)) warn(id, message);
     }
 
+    @Deprecated(since = "10.0")
     public void warnDeprecated(String message) {
         if (runtime.getWarningCategories().contains(Category.DEPRECATED)) warn(message);
     }
 
+    @Deprecated(since = "10.0")
     public void warnDeprecatedAlternate(String name, String alternate) {
         if (runtime.getWarningCategories().contains(Category.DEPRECATED)) warn(ID.DEPRECATED_METHOD, name + " is deprecated; use " + alternate + " instead");
     }
 
+    @Deprecated(since = "10.0")
     public void warnDeprecatedForRemoval(String name, String version) {
         if (runtime.getWarningCategories().contains(Category.DEPRECATED)) warn(ID.MISCELLANEOUS, name + " is deprecated and will be removed in Ruby " + version);
     }
@@ -237,7 +241,7 @@ public class RubyWarnings implements IRubyWarnings, WarnCallback {
     public void warningDeprecated(ID id, String message) {
         if (!isVerbose()) return;
 
-        warnDeprecated(id, message);
+        if (runtime.getWarningCategories().contains(Category.DEPRECATED)) warn(id, message);
     }
 
     /**

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -981,7 +981,7 @@ public class RubyBigDecimal extends RubyNumeric {
             return this;
         }
 
-        throw typeError(getRuntime().getCurrentContext(), "wrong argument class");
+        throw typeError(context, "wrong argument class");
     }
 
     @JRubyMethod(name = {"%", "modulo"})
@@ -1781,7 +1781,7 @@ public class RubyBigDecimal extends RubyNumeric {
 
     @Deprecated
     public IRubyObject finite_p() {
-        return finite_p(getRuntime().getCurrentContext());
+        return finite_p(getCurrentContext());
     }
 
     private RubyBigDecimal floorNaNInfinityCheck(ThreadContext context) {
@@ -2165,7 +2165,7 @@ public class RubyBigDecimal extends RubyNumeric {
 
     @Deprecated(since = "10.0", forRemoval = true)
     public final IRubyObject to_int() {
-        return to_int(getRuntime().getCurrentContext());
+        return to_int(getCurrentContext());
     }
 
     @Override
@@ -2415,7 +2415,7 @@ public class RubyBigDecimal extends RubyNumeric {
 
     @Deprecated
     public IRubyObject zero_p() {
-        return zero_p(getRuntime().getCurrentContext());
+        return zero_p(getCurrentContext());
     }
 
     @Override
@@ -2534,12 +2534,6 @@ public class RubyBigDecimal extends RubyNumeric {
             return ((RubyBignum) x).getBigIntegerValue().testBit(0) == false; // 0-th bit -> 0
         }
         return false;
-    }
-
-    @Deprecated
-    public static IRubyObject ver(ThreadContext context, IRubyObject recv) {
-        context.runtime.getWarnings().warn(IRubyWarnings.ID.DEPRECATED_METHOD, "BigDecimal.ver is deprecated; use BigDecimal::VERSION instead");
-        return RubyString.newStringShared(context.runtime, VERSION);
     }
 
     @Deprecated // no longer used

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -1893,7 +1893,7 @@ public class RubyBigDecimal extends RubyNumeric {
     @Deprecated
     @JRubyMethod
     public IRubyObject precs(ThreadContext context) {
-        context.runtime.getWarnings().warn(IRubyWarnings.ID.DEPRECATED_METHOD, "BigDecimal#precs is deprecated and will be removed in the future; use BigDecimal#precision instead.");
+        context.runtime.getWarnings().warningDeprecated("BigDecimal#precs is deprecated and will be removed in the future; use BigDecimal#precision instead.");
         return newArray(context,
                 asFixnum(context, getSignificantDigits().length()),
                 asFixnum(context, ((getAllDigits().length() / 4) + 1) * 4));

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -769,27 +769,6 @@ public class RubyBigDecimal extends RubyNumeric {
         return false;
     }
 
-    @Deprecated // no to be used in user-lang
-    @JRubyMethod(name = "new", meta = true)
-    public static IRubyObject new_(ThreadContext context, IRubyObject recv, IRubyObject arg) {
-        context.runtime.getWarnings().warn(IRubyWarnings.ID.DEPRECATED_METHOD, "BigDecimal.new is deprecated; use BigDecimal() method instead.");
-        return BigDecimalKernelMethods.newBigDecimal(context, recv, arg);
-    }
-
-    @Deprecated // no to be used in user-lang
-    @JRubyMethod(name = "new", meta = true)
-    public static IRubyObject new_(ThreadContext context, IRubyObject recv, IRubyObject arg, IRubyObject mathArg) {
-        context.runtime.getWarnings().warn(IRubyWarnings.ID.DEPRECATED_METHOD, "BigDecimal.new is deprecated; use BigDecimal() method instead.");
-        return BigDecimalKernelMethods.newBigDecimal(context, recv, arg, mathArg);
-    }
-
-    @Deprecated // no to be used in user-lang
-    @JRubyMethod(name = "new", meta = true)
-    public static IRubyObject new_(ThreadContext context, IRubyObject recv, IRubyObject arg, IRubyObject mathArg, IRubyObject opts) {
-        context.runtime.getWarnings().warn(IRubyWarnings.ID.DEPRECATED_METHOD, "BigDecimal.new is deprecated; use BigDecimal() method instead.");
-        return BigDecimalKernelMethods.newBigDecimal(context, recv, arg, mathArg, opts);
-    }
-
     private static IRubyObject handleMissingPrecision(ThreadContext context, String name, boolean strict, boolean exception) {
         if (!strict) return getZero(context, 1);
         if (!exception) return context.nil;

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -64,6 +64,7 @@ import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
+import static org.jruby.api.Warn.warningDeprecated;
 import static org.jruby.runtime.ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR;
 
 /**
@@ -1893,7 +1894,7 @@ public class RubyBigDecimal extends RubyNumeric {
     @Deprecated
     @JRubyMethod
     public IRubyObject precs(ThreadContext context) {
-        context.runtime.getWarnings().warningDeprecated("BigDecimal#precs is deprecated and will be removed in the future; use BigDecimal#precision instead.");
+        warningDeprecated(context, "BigDecimal#precs is deprecated and will be removed in the future; use BigDecimal#precision instead.");
         return newArray(context,
                 asFixnum(context, getSignificantDigits().length()),
                 asFixnum(context, ((getAllDigits().length() / 4) + 1) * 4));

--- a/core/src/main/java/org/jruby/ext/coverage/CoverageModule.java
+++ b/core/src/main/java/org/jruby/ext/coverage/CoverageModule.java
@@ -47,6 +47,7 @@ import static org.jruby.api.Convert.*;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Error.runtimeError;
 import static org.jruby.api.Error.typeError;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.ext.coverage.CoverageData.CoverageDataState.*;
 import static org.jruby.ext.coverage.CoverageData.EVAL;
 import static org.jruby.ext.coverage.CoverageData.LINES;
@@ -78,11 +79,11 @@ public class CoverageModule {
                     mode |= EVAL;
                 }
                 if (ArgsUtil.extractKeywordArg(context, "branches", keywords).isTrue()) {
-                    context.runtime.getWarnings().warn("branch coverage is not supported");
+                    warn(context, "branch coverage is not supported");
                     mode |= CoverageData.BRANCHES;
                 }
                 if (ArgsUtil.extractKeywordArg(context, "methods", keywords).isTrue()) {
-                    context.runtime.getWarnings().warn("method coverage is not supported");
+                    warn(context, "method coverage is not supported");
                     mode |= CoverageData.METHODS;
                 }
                 if (ArgsUtil.extractKeywordArg(context, "oneshot_lines", keywords).isTrue()) {
@@ -158,7 +159,7 @@ public class CoverageModule {
 
         IRubyObject result = peek_result(context, self);
         if (stop && !clear) {
-            context.runtime.getWarnings().warn("stop implies clear");
+            warn(context, "stop implies clear");
             clear = true;
         }
 

--- a/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
+++ b/core/src/main/java/org/jruby/ext/fiber/ThreadFiber.java
@@ -41,6 +41,7 @@ import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.castAsHash;
 import static org.jruby.api.Create.newHash;
 import static org.jruby.api.Error.*;
+import static org.jruby.api.Warn.warnExperimental;
 
 public class ThreadFiber extends RubyObject implements ExecutionContext {
 
@@ -774,6 +775,7 @@ public class ThreadFiber extends RubyObject implements ExecutionContext {
 
     @JRubyMethod(name = "storage=")
     public IRubyObject storage_set(ThreadContext context, IRubyObject hash) {
+        warnExperimental(context, "Fiber#storage= is experimental and may be removed in the future!");
         checkSameFiber(context);
 
         setStorage(context, hash);

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
@@ -54,6 +54,7 @@ import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineModule;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Warn.warn;
+import static org.jruby.api.Warn.warningDeprecated;
 import static org.jruby.util.URLUtil.getPath;
 
 /**
@@ -437,7 +438,7 @@ public class JRubyUtilLibrary implements Library {
     @JRubyMethod(module = true)
     @Deprecated(since = "9.4-", forRemoval = true)
     public static RubyArray internal_libraries(ThreadContext context, IRubyObject self) {
-        warn(context, "JRuby::Util.internal_libraries is deprecated");
+        warningDeprecated(context, "JRuby::Util.internal_libraries is deprecated");
         return newEmptyArray(context);
     }
 }

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
@@ -53,6 +53,7 @@ import static org.jruby.api.Convert.*;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineModule;
 import static org.jruby.api.Error.argumentError;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.util.URLUtil.getPath;
 
 /**
@@ -84,20 +85,24 @@ public class JRubyUtilLibrary implements Library {
         return asBoolean(context, context.runtime.isObjectSpaceEnabled());
     }
 
-    @Deprecated
+    @Deprecated(since = "9.4-")
     public static IRubyObject getObjectSpaceEnabled(IRubyObject recv) {
         return getObjectSpaceEnabled(recv.getRuntime().getCurrentContext(), recv);
     }
 
-    @JRubyMethod(name = { "objectspace=", "object_space=" }, module = true)
+    @Deprecated(since = "10.0")
     public static IRubyObject setObjectSpaceEnabled(IRubyObject recv, IRubyObject arg) {
-        final Ruby runtime = recv.getRuntime();
+        return setObjectSpaceEnabled(recv.getRuntime().getCurrentContext(), recv, arg);
+    }
+
+    @JRubyMethod(name = { "objectspace=", "object_space=" }, module = true)
+    public static IRubyObject setObjectSpaceEnabled(ThreadContext context, IRubyObject recv, IRubyObject arg) {
         boolean enabled = arg.isTrue();
         if (enabled) {
-            runtime.getWarnings().warn("ObjectSpace impacts performance. See https://github.com/jruby/jruby/wiki/PerformanceTuning#dont-enable-objectspace");
+            warn(context, "ObjectSpace impacts performance. See https://github.com/jruby/jruby/wiki/PerformanceTuning#dont-enable-objectspace");
         }
-        runtime.setObjectSpaceEnabled(enabled);
-        return runtime.newBoolean(enabled);
+        context.runtime.setObjectSpaceEnabled(enabled);
+        return enabled ? context.tru : context.fals;
     }
 
     @JRubyMethod(meta = true, name = "native_posix?")
@@ -432,7 +437,7 @@ public class JRubyUtilLibrary implements Library {
     @JRubyMethod(module = true)
     @Deprecated(since = "9.4-", forRemoval = true)
     public static RubyArray internal_libraries(ThreadContext context, IRubyObject self) {
-        context.runtime.getWarnings().warn("JRuby::Util.internal_libraries is deprecated");
+        warn(context, "JRuby::Util.internal_libraries is deprecated");
         return newEmptyArray(context);
     }
 }

--- a/core/src/main/java/org/jruby/ext/set/RubySet.java
+++ b/core/src/main/java/org/jruby/ext/set/RubySet.java
@@ -59,6 +59,7 @@ import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Create.newArray;
 import static org.jruby.api.Error.argumentError;
+import static org.jruby.api.Warn.warning;
 
 /**
  * Native implementation of Ruby's Set (set.rb replacement).
@@ -203,9 +204,8 @@ public class RubySet extends RubyObject implements Set {
      */
     @JRubyMethod(visibility = Visibility.PRIVATE) // def initialize(enum = nil, &block)
     public IRubyObject initialize(ThreadContext context, Block block) {
-        if ( block.isGiven() && context.runtime.isVerbose() ) {
-            context.runtime.getWarnings().warning(IRubyWarnings.ID.BLOCK_UNUSED, "given block not used");
-        }
+        if (block.isGiven() && context.runtime.isVerbose()) warning(context, "given block not used");
+
         allocHash(context);
         return this;
     }

--- a/core/src/main/java/org/jruby/ext/tracepoint/TracePoint.java
+++ b/core/src/main/java/org/jruby/ext/tracepoint/TracePoint.java
@@ -264,7 +264,7 @@ public class TracePoint extends RubyObject {
         enabled = toggle;
         
         if (toggle) {
-            context.traceEvents.addEventHook(hook);
+            context.traceEvents.addEventHook(context, hook);
         } else {
             context.traceEvents.removeEventHook(hook);
         }

--- a/core/src/main/java/org/jruby/ext/zlib/ZStream.java
+++ b/core/src/main/java/org/jruby/ext/zlib/ZStream.java
@@ -40,6 +40,7 @@ import org.jruby.runtime.ThreadContext;
 
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.runtime.Visibility.PRIVATE;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -211,7 +212,7 @@ public abstract class ZStream extends RubyObject {
         }
         if ((wbits & 0xf) != 0xf) {
             // windowBits < 15 for reducing memory is meaningless on Java platform. 
-            context.runtime.getWarnings().warn("windowBits < 15 is ignored on this platform");
+            warn(context, "windowBits < 15 is ignored on this platform");
             // continue
         }
         if (forInflate && wbits > JZlib.MAX_WBITS + 32) {

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1098,15 +1098,14 @@ public class IRRuntimeHelpers {
     }
 
     public static RubyModule getModuleFromScope(ThreadContext context, StaticScope scope, IRubyObject arg) {
-        Ruby runtime = context.runtime;
         RubyModule rubyClass = scope.getModule();
 
         // SSS FIXME: Copied from ASTInterpreter.getClassVariableBase and adapted
-        while (scope != null && (rubyClass.isSingleton() || rubyClass == runtime.getDummy())) {
+        while (scope != null && (rubyClass.isSingleton() || rubyClass == context.runtime.getDummy())) {
             scope = scope.getPreviousCRefScope();
             rubyClass = scope.getModule();
             if (scope.getPreviousCRefScope() == null) {
-                runtime.getWarnings().warn(IRubyWarnings.ID.CVAR_FROM_TOPLEVEL_SINGLETON_METHOD, "class variable access from toplevel singleton method");
+                warn(context, "class variable access from toplevel singleton method");
             }
         }
 

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -101,6 +101,7 @@ import static org.jruby.api.Convert.*;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.ir.operands.UndefinedValue.UNDEFINED;
 import static org.jruby.runtime.Block.Type.LAMBDA;
 import static org.jruby.runtime.ThreadContext.*;
@@ -2517,7 +2518,7 @@ public class IRRuntimeHelpers {
 
     public static void warnSetConstInRefinement(ThreadContext context, IRubyObject self) {
         if (self instanceof RubyModule && ((RubyModule) self).isRefinement()) {
-            context.runtime.getWarnings().warn("not defined at the refinement, but at the outer class/module");
+            warn(context, "not defined at the refinement, but at the outer class/module");
         }
     }
 

--- a/core/src/main/java/org/jruby/java/dispatch/CallableSelector.java
+++ b/core/src/main/java/org/jruby/java/dispatch/CallableSelector.java
@@ -25,6 +25,9 @@ import org.jruby.javasupport.ParameterTypes;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.cli.Options;
 import org.jruby.util.collections.IntHashMap;
+
+import static org.jruby.api.Error.runtimeError;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.util.CodegenUtils.getBoxType;
 import static org.jruby.util.CodegenUtils.prettyParams;
 import static org.jruby.javasupport.Java.getFunctionalInterfaceMethod;
@@ -281,14 +284,16 @@ public class CallableSelector {
                 method = mostSpecific;
 
                 if ( ambiguous ) {
+                    var context = runtime.getCurrentContext();
+
                     if (Options.JI_AMBIGUOUS_CALLS_DEBUG.load()) {
-                        runtime.newRuntimeError(
+                        runtimeError(context,
                                 "multiple Java methods found, dumping backtrace and choosing "
                                         + ((Member) ((JavaCallable) method).accessibleObject()).getName()
                                         + prettyParams(msTypes)
                         ).printStackTrace(runtime.getErr());
                     } else {
-                        runtime.getWarnings().warn(
+                        warn(context,
                                 "multiple Java methods found, use -X" + Options.JI_AMBIGUOUS_CALLS_DEBUG.propertyName() + " for backtrace. Choosing "
                                         + ((Member) ((JavaCallable) method).accessibleObject()).getName()
                                         + prettyParams(msTypes));

--- a/core/src/main/java/org/jruby/javasupport/JavaMethod.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaMethod.java
@@ -57,6 +57,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import static org.jruby.RubyModule.undefinedMethodMessage;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.util.CodegenUtils.getBoxType;
 import static org.jruby.util.CodegenUtils.prettyParams;
 import static org.jruby.util.RubyStringBuilder.ids;
@@ -94,7 +95,7 @@ public class JavaMethod extends JavaCallable {
             } catch (SecurityException se) {
                 // we shouldn't get here if JavaClass.CAN_SET_ACCESSIBLE is doing
                 // what it should, so we warn.
-               runtime.getWarnings().warn("failed to setAccessible: " + method + ", exception follows: " + se.getMessage());
+               warn(runtime.getCurrentContext(), "failed to setAccessible: " + method + ", exception follows: " + se.getMessage());
             }
         }
 

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -94,8 +94,8 @@ public abstract class JavaLang {
         });
         JavaExtensions.put(runtime, java.lang.CharSequence.class, proxy -> proxy.defineMethods(context, CharSequence.class));
         JavaExtensions.put(runtime, java.lang.String.class, proxy -> proxy.defineMethods(context, String.class));
-        JavaExtensions.put(runtime, java.lang.Enum.class, proxy -> proxy.defineAlias("inspect", "to_s"));
-        JavaExtensions.put(runtime, java.lang.Boolean.class, proxy -> proxy.defineAlias("inspect", "to_s"));
+        JavaExtensions.put(runtime, java.lang.Enum.class, proxy -> proxy.defineAlias(context, "inspect", "to_s"));
+        JavaExtensions.put(runtime, java.lang.Boolean.class, proxy -> proxy.defineAlias(context, "inspect", "to_s"));
         JavaExtensions.put(runtime, java.lang.Thread.class, proxy -> proxy.addMethod("inspect", new InspectThread(proxy)));
     }
 
@@ -460,14 +460,11 @@ public abstract class JavaLang {
     public static class Class {
 
         static RubyClass define(ThreadContext context, final RubyModule proxy, RubyModule Comparable) {
-            proxy.include(context, Comparable).
-                    defineMethods(context, Class.class);
-            // JavaClass facade (compatibility) :
-            proxy.defineAlias("resource", "get_resource");
-            proxy.defineAlias("declared_field", "get_declared_field");
-            proxy.defineAlias("field", "get_field");
-
-            return (RubyClass) proxy;
+            return proxy.include(context, Comparable).
+                    defineMethods(context, Class.class).
+                    defineAlias(context, "resource", "get_resource").
+                    defineAlias(context, "declared_field", "get_declared_field").
+                    defineAlias(context, "field", "get_field");
         }
 
         @JRubyMethod(name = "ruby_class")

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyReflectionObject.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyReflectionObject.java
@@ -52,7 +52,7 @@ public class JavaProxyReflectionObject extends RubyObject {
 
     protected static void registerRubyMethods(ThreadContext context, RubyClass klass) {
         klass.defineMethods(context, JavaProxyReflectionObject.class);
-        klass.getMetaClass().defineAlias("__j_allocate", "allocate");
+        klass.getMetaClass().defineAlias(context, "__j_allocate", "allocate");
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/parser/RubyParserBase.java
+++ b/core/src/main/java/org/jruby/parser/RubyParserBase.java
@@ -2058,10 +2058,6 @@ public abstract class RubyParserBase {
         return new HashPatternNode(line, restArg, keywordArgs == null ? new HashNode(line) : keywordArgs);
     }
 
-    public void warn_experimental(int line, String message) {
-        ((RubyWarnings) getWarnings()).warnExperimental(lexer.getFile(), line, message);
-    }
-
     public Node rescued_expr(int line, Node arg, Node rescue) {
         return new RescueNode(line, arg,
                 new RescueBodyNode(line, null, remove_begin(rescue), null), null);

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -94,6 +94,7 @@ import static org.jruby.api.Convert.asSymbol;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.runtime.ThreadContext.CALL_KEYWORD_EMPTY;
 import static org.jruby.runtime.Visibility.*;
 import static org.jruby.runtime.invokedynamic.MethodNames.EQL;
@@ -2206,11 +2207,11 @@ public class Helpers {
         switch(symbol.idString()) {
             case "__id__":
             case "__send__":
-                context.runtime.getWarnings().warn(ID.REDEFINING_DANGEROUS, str(context.runtime, "redefining '", ids(context.runtime, symbol), "' may cause serious problem"));
+                warn(context, str(context.runtime, "redefining '", ids(context.runtime, symbol), "' may cause serious problem"));
                 break;
             case "initialize":
                 if (clazz == objectClass(context)) {
-                    context.runtime.getWarnings().warn(ID.REDEFINING_DANGEROUS, "redefining Object#initialize may cause infinite loop");
+                    warn(context, "redefining Object#initialize may cause infinite loop");
                 }
             case "initialize_copy":
             case "initialize_dup":

--- a/core/src/main/java/org/jruby/runtime/TraceEventManager.java
+++ b/core/src/main/java/org/jruby/runtime/TraceEventManager.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Create.*;
+import static org.jruby.api.Warn.warn;
 
 public class TraceEventManager {
     private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
@@ -66,10 +67,15 @@ public class TraceEventManager {
                     RubyEvent.RETURN
             );
 
+    @Deprecated(since = "10.0")
     public synchronized void addEventHook(EventHook hook) {
+        addEventHook(runtime.getCurrentContext(), hook);
+    }
+
+    public synchronized void addEventHook(ThreadContext context, EventHook hook) {
         if (!RubyInstanceConfig.FULL_TRACE_ENABLED && hook.needsDebug()) {
             // without full tracing, many events will not fire
-            runtime.getWarnings().warn("tracing (e.g. set_trace_func) will not capture all events without --debug flag");
+            warn(context, "tracing (e.g. set_trace_func) will not capture all events without --debug flag");
         }
 
         EventHook[] hooks = eventHooks;
@@ -147,7 +153,7 @@ public class TraceEventManager {
         if (traceFunction == null) return;
 
         hook.setTraceFunc(traceFunction);
-        addEventHook(hook);
+        addEventHook(runtime.getCurrentContext(), hook);
     }
 
     /**

--- a/core/src/main/java/org/jruby/runtime/load/LoadService.java
+++ b/core/src/main/java/org/jruby/runtime/load/LoadService.java
@@ -80,6 +80,7 @@ import static org.jruby.api.Access.loadService;
 import static org.jruby.api.Access.objectClass;
 import static org.jruby.api.Convert.asSymbol;
 import static org.jruby.api.Create.*;
+import static org.jruby.api.Warn.warn;
 import static org.jruby.util.URLUtil.getPath;
 
 /**
@@ -525,10 +526,11 @@ public class LoadService {
     }
 
     protected void warnCircularRequire(String requireName) {
+        var context = runtime.getCurrentContext();
         StringBuilder sb = new StringBuilder("loading in progress, circular require considered harmful - " + requireName);
 
-        runtime.getCurrentContext().renderCurrentBacktrace(sb);
-        runtime.getWarnings().warn(sb.toString());
+        context.renderCurrentBacktrace(sb);
+        warn(context, sb.toString());
     }
 
     private RequireState smartLoadInternal(String file, boolean circularRequireWarning) {

--- a/core/src/main/java/org/jruby/util/StringSupport.java
+++ b/core/src/main/java/org/jruby/util/StringSupport.java
@@ -74,6 +74,7 @@ import static org.jruby.api.Create.newArray;
 import static org.jruby.api.Create.newString;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.indexError;
+import static org.jruby.api.Warn.warn;
 
 public final class StringSupport {
     public static final int CR_7BIT_F    = ObjectFlags.CR_7BIT_F;
@@ -2222,7 +2223,7 @@ public final class StringSupport {
             if (wantarray) {
                 // this code should be live in 3.0
                 if (false) { // #if STRING_ENUMERATORS_WANTARRAY
-                    context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
+                    warn(context, "given block not used");
                 } else {
                     wantarray = false;
                 }

--- a/core/src/main/java/org/jruby/util/StringSupport.java
+++ b/core/src/main/java/org/jruby/util/StringSupport.java
@@ -2224,7 +2224,6 @@ public final class StringSupport {
                 if (false) { // #if STRING_ENUMERATORS_WANTARRAY
                     context.runtime.getWarnings().warn(ID.BLOCK_UNUSED, "given block not used");
                 } else {
-                    context.runtime.getWarnings().warning(ID.BLOCK_DEPRECATED, "passing a block to String#lines is deprecated");
                     wantarray = false;
                 }
             }

--- a/core/src/main/java/org/jruby/util/io/SelectorFactory.java
+++ b/core/src/main/java/org/jruby/util/io/SelectorFactory.java
@@ -36,6 +36,8 @@ import java.net.BindException;
 
 import org.jruby.Ruby;
 
+import static org.jruby.api.Warn.warn;
+
 /**
  * @author <a href="mailto:ola.bini@gmail.com">Ola Bini</a>
  */
@@ -54,9 +56,7 @@ public class SelectorFactory {
                    e.getCause() instanceof BindException &&
                    retryCount < RETRY_MAX) {
                     retryCount++;
-                    if(runtime != null) {
-                        runtime.getWarnings().warn("try number " + retryCount + " to get a selector");
-                    }
+                    if (runtime != null) warn(runtime.getCurrentContext(), "try number " + retryCount + " to get a selector");
                 } else {
                     throw e;
                 }

--- a/core/src/test/java/org/jruby/runtime/EventHookTest.java
+++ b/core/src/test/java/org/jruby/runtime/EventHookTest.java
@@ -22,7 +22,7 @@ public final class EventHookTest extends TestCase {
         config.processArguments(new String[]{"--debug"});
         Ruby rt = JavaEmbedUtils.initialize(Collections.<String>emptyList(), config);
         NativeTracer tracer = new NativeTracer();
-        rt.getTraceEvents().addEventHook(tracer);
+        rt.getTraceEvents().addEventHook(rt.getCurrentContext(), tracer);
         RubyRuntimeAdapter evaler = JavaEmbedUtils.newRuntimeAdapter();
         evaler.eval(rt, "sleep 0.01\nsleep 0.01\nsleep 0.01");
         assertEquals("expected tracing", Arrays.asList(1,1,1,2,2,2,3,3,3), tracer.lines);


### PR DESCRIPTION
Warn API made:  warn and warnDeprecated so far.

I also audited our existing warnings and removed methods which no longer exists in 3.4.  This could possible be an incompatibility for an native extension if they called these methods but we need to cull them and not existing is a pretty good justification (note: we can always readd them.  I made them each an individual commit in case this happens).