### PR TITLE
Update gem_prelude from Ruby 3.4

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -585,7 +585,9 @@ public final class Ruby implements Constantizable {
 
         // Define blank modules for feature detection in preludes
         if (!this.config.isDisableGems()) Define.defineModule(context, "Gem");
+        if (!this.config.isDisableErrorHighlight()) Define.defineModule(context, "ErrorHighligh");
         if (!this.config.isDisableDidYouMean()) Define.defineModule(context, "DidYouMean");
+        if (!this.config.isDisableSyntaxSuggest()) Define.defineModule(context, "SyntaxSuggest");
 
         // Provide some legacy libraries
         loadService.provide("enumerator.rb");

--- a/core/src/main/java/org/jruby/RubyInstanceConfig.java
+++ b/core/src/main/java/org/jruby/RubyInstanceConfig.java
@@ -1218,6 +1218,20 @@ public class RubyInstanceConfig {
     }
 
     /**
+     * @see Options#CLI_ERROR_HIGHLIGHT_ENABLE
+     */
+    public boolean isDisableErrorHighlight() {
+        return disableErrorHighlight;
+    }
+
+    /**
+     * @see Options#CLI_SYNTAX_SUGGEST_ENABLE
+     */
+    public boolean isDisableSyntaxSuggest() {
+        return disableSyntaxSuggest;
+    }
+
+    /**
      * @see Options#CLI_RUBYOPT_ENABLE
      */
     public void setDisableRUBYOPT(boolean dr) {
@@ -1236,6 +1250,20 @@ public class RubyInstanceConfig {
      */
     public void setDisableDidYouMean(boolean ddym) {
         this.disableDidYouMean = ddym;
+    }
+
+    /**
+     * @see Options#CLI_ERROR_HIGHLIGHT_ENABLE
+     */
+    public void setDisableErrorHighlight(boolean eh) {
+        this.disableErrorHighlight = eh;
+    }
+
+    /**
+     * @see Options#CLI_SYNTAX_SUGGEST_ENABLE
+     */
+    public void setDisableSyntaxSuggest(boolean ss) {
+        this.disableSyntaxSuggest = ss;
     }
 
     /**
@@ -1566,6 +1594,8 @@ public class RubyInstanceConfig {
     private boolean hardExit = false;
     private boolean disableGems = !Options.CLI_RUBYGEMS_ENABLE.load();
     private boolean disableDidYouMean = !Options.CLI_DID_YOU_MEAN_ENABLE.load();
+    private boolean disableErrorHighlight = !Options.CLI_ERROR_HIGHLIGHT_ENABLE.load();
+    private boolean disableSyntaxSuggest = !Options.CLI_SYNTAX_SUGGEST_ENABLE.load();
     private boolean disableRUBYOPT = !Options.CLI_RUBYOPT_ENABLE.load();
     private boolean updateNativeENVEnabled = true;
     private boolean kernelGsubDefined;

--- a/core/src/main/java/org/jruby/ext/rbconfig/RbConfigLibrary.java
+++ b/core/src/main/java/org/jruby/ext/rbconfig/RbConfigLibrary.java
@@ -187,6 +187,10 @@ public class RbConfigLibrary implements Library {
         return getRubyLibDir(runtime);
     }
 
+    public static String getRubyArchDir(Ruby runtime) {
+        return getRubyLibDir(runtime) + '/' + getArchitecture();
+    }
+
     public static String getVendorDir(Ruby runtime) {
         return newFile(getRubyLibDir(runtime), "vendor_ruby").getPath();
     }
@@ -311,6 +315,7 @@ public class RbConfigLibrary implements Library {
         String rubySharedLibDir = getRubySharedLibDir(runtime);
         String rubyLibDir = getRubyLibDir(runtime);
         String archDir = getArchDir(runtime);
+        String rubyArchDir = getRubyArchDir(runtime);
         String vendorDir = getVendorDir(runtime);
         String vendorLibDir = getVendorLibDir(runtime);
         String vendorArchDir = getVendorArchDir(runtime);
@@ -333,6 +338,7 @@ public class RbConfigLibrary implements Library {
         setConfig(context, CONFIG, "sitearchdir",    siteArchDir);
         setConfig(context, CONFIG, "sitearch", "java");
         setConfig(context, CONFIG, "archdir",   archDir);
+        setConfig(context, CONFIG, "rubyarchdir",   rubyArchDir);
         setConfig(context, CONFIG, "topdir",   archDir);
         setConfig(context, CONFIG, "includedir",   includeDir);
         setConfig(context, CONFIG, "rubyhdrdir",   includeDir);

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -229,6 +229,8 @@ public class Options {
     public static final Option<String> CLI_PROFILING_SERVICE = string(CLI, "cli.profiling.service", "Profiling service class to use.");
     public static final Option<Boolean> CLI_RUBYGEMS_ENABLE = bool(CLI, "cli.rubygems.enable", true, "Enable/disable RubyGems.");
     public static final Option<Boolean> CLI_DID_YOU_MEAN_ENABLE = bool(CLI, "cli.did_you_mean.enable", true, "Enable/disable did_you_mean.");
+    public static final Option<Boolean> CLI_ERROR_HIGHLIGHT_ENABLE = bool(CLI, "cli.error_highlight.enable", true, "Enable/disable error_highlight.");
+    public static final Option<Boolean> CLI_SYNTAX_SUGGEST_ENABLE = bool(CLI, "cli.syntax_suggest.enable", true, "Enable/disable syntax_suggest.");
     public static final Option<Boolean> CLI_RUBYOPT_ENABLE = bool(CLI, "cli.rubyopt.enable", true, "Enable/disable RUBYOPT processing at start.");
     public static final Option<Boolean> CLI_STRIP_HEADER = bool(CLI, "cli.strip.header", false, "Strip text before shebang in script. Same as -x.");
     public static final Option<Boolean> CLI_LOAD_GEMFILE = bool(CLI, "cli.load.gemfile", false, "Load a bundler Gemfile in cwd before running. Same as -G.");

--- a/core/src/main/ruby/jruby/kernel/gem_prelude.rb
+++ b/core/src/main/ruby/jruby/kernel/gem_prelude.rb
@@ -1,14 +1,28 @@
-if Object.const_defined?(:Gem)
-  begin
-    require 'rubygems.rb'
-  rescue LoadError # java -jar lib/jruby.jar -e '...'
-    warn 'RubyGems not found; disabling gems' if $VERBOSE
-  else
-    begin
-      gem 'did_you_mean'
-      require 'did_you_mean'
-      Gem.clear_paths
-    rescue LoadError # Gem::LoadError < LoadError
-    end if Object.const_defined?(:DidYouMean)
-  end
-end
+begin
+  require 'rubygems'
+rescue LoadError => e
+  raise unless e.path == 'rubygems'
+
+  warn "`RubyGems' were not loaded."
+else
+  require 'bundled_gems'
+end if defined?(Gem)
+
+begin
+  require 'error_highlight'
+rescue LoadError
+  warn "`error_highlight' was not loaded."
+end if defined?(ErrorHighlight)
+
+begin
+  require 'did_you_mean'
+rescue LoadError
+  warn "`did_you_mean' was not loaded."
+end if defined?(DidYouMean)
+
+begin
+  require 'syntax_suggest/core_ext'
+rescue LoadError
+  warn "`syntax_suggest' was not loaded."
+end if defined?(SyntaxSuggest)
+

--- a/lib/ruby/stdlib/bundled_gems.rb
+++ b/lib/ruby/stdlib/bundled_gems.rb
@@ -1,0 +1,257 @@
+# -*- frozen-string-literal: true -*-
+
+module Gem::BUNDLED_GEMS # :nodoc:
+  SINCE = {
+    "matrix" => "3.1.0",
+    "net-ftp" => "3.1.0",
+    "net-imap" => "3.1.0",
+    "net-pop" => "3.1.0",
+    "net-smtp" => "3.1.0",
+    "prime" => "3.1.0",
+    "racc" => "3.3.0",
+    "abbrev" => "3.4.0",
+    "base64" => "3.4.0",
+    "bigdecimal" => "3.4.0",
+    "csv" => "3.4.0",
+    "drb" => "3.4.0",
+    "getoptlong" => "3.4.0",
+    "mutex_m" => "3.4.0",
+    "nkf" => "3.4.0",
+    "observer" => "3.4.0",
+    "resolv-replace" => "3.4.0",
+    "rinda" => "3.4.0",
+    "syslog" => "3.4.0",
+    "ostruct" => "3.5.0",
+    "pstore" => "3.5.0",
+    "rdoc" => "3.5.0",
+    "win32ole" => "3.5.0",
+    "fiddle" => "3.5.0",
+    "logger" => "3.5.0",
+    "benchmark" => "3.5.0",
+    "irb" => "3.5.0",
+    "reline" => "3.5.0",
+    # "readline" => "3.5.0", # This is wrapper for reline. We don't warn for this.
+  }.freeze
+
+  SINCE_FAST_PATH = SINCE.transform_keys { |g| g.sub(/\A.*\-/, "") }.freeze
+
+  EXACT = {
+    "kconv" => "nkf",
+  }.freeze
+
+  PREFIXED = {
+    "bigdecimal" => true,
+    "csv" => true,
+    "drb" => true,
+    "rinda" => true,
+    "syslog" => true,
+    "fiddle" => true,
+  }.freeze
+
+  WARNED = {}                   # unfrozen
+
+  conf = ::RbConfig::CONFIG
+  if ENV["TEST_BUNDLED_GEMS_FAKE_RBCONFIG"]
+    LIBDIR = (File.expand_path(File.join(__dir__, "..", "lib")) + "/").freeze
+    rubyarchdir = $LOAD_PATH.find{|path| path.include?(".ext/common") }
+    ARCHDIR = (File.expand_path(rubyarchdir) + "/").freeze
+  else
+    LIBDIR = (conf["rubylibdir"] + "/").freeze
+    ARCHDIR = (conf["rubyarchdir"] + "/").freeze
+  end
+  dlext = [conf["DLEXT"], "so"].uniq
+  DLEXT = /\.#{Regexp.union(dlext)}\z/
+  LIBEXT = /\.#{Regexp.union("rb", *dlext)}\z/
+
+  def self.replace_require(specs)
+    return if [::Kernel.singleton_class, ::Kernel].any? {|klass| klass.respond_to?(:no_warning_require) }
+
+    spec_names = specs.to_a.each_with_object({}) {|spec, h| h[spec.name] = true }
+
+    [::Kernel.singleton_class, ::Kernel].each do |kernel_class|
+      kernel_class.send(:alias_method, :no_warning_require, :require)
+      kernel_class.send(:define_method, :require) do |name|
+        if message = ::Gem::BUNDLED_GEMS.warning?(name, specs: spec_names)
+          if ::Gem::BUNDLED_GEMS.uplevel > 0
+            Kernel.warn message, uplevel: ::Gem::BUNDLED_GEMS.uplevel
+          else
+            Kernel.warn message
+          end
+        end
+        kernel_class.send(:no_warning_require, name)
+      end
+      if kernel_class == ::Kernel
+        kernel_class.send(:private, :require)
+      else
+        kernel_class.send(:public, :require)
+      end
+    end
+  end
+
+  def self.uplevel
+    frame_count = 0
+    frames_to_skip = 3
+    uplevel = 0
+    require_found = false
+    Thread.each_caller_location do |cl|
+      frame_count += 1
+      if frames_to_skip >= 1
+        frames_to_skip -= 1
+        next
+      end
+      uplevel += 1
+      if require_found
+        if cl.base_label != "require"
+          return uplevel
+        end
+      else
+        if cl.base_label == "require"
+          require_found = true
+        end
+      end
+      # Don't show script name when bundle exec and call ruby script directly.
+      if cl.path.end_with?("bundle")
+        frame_count = 0
+        break
+      end
+    end
+    require_found ? 1 : frame_count - 1
+  end
+
+  def self.find_gem(path)
+    if !path
+      return
+    elsif path.start_with?(ARCHDIR)
+      n = path.delete_prefix(ARCHDIR).sub(DLEXT, "").chomp(".rb")
+    elsif path.start_with?(LIBDIR)
+      n = path.delete_prefix(LIBDIR).chomp(".rb")
+    else
+      return
+    end
+    (EXACT[n] || !!SINCE[n]) or PREFIXED[n = n[%r[\A[^/]+(?=/)]]] && n
+  end
+
+  def self.warning?(name, specs: nil)
+    # name can be a feature name or a file path with String or Pathname
+    feature = File.path(name)
+
+    # irb already has reline as a dependency on gemspec, so we don't want to warn about it.
+    # We should update this with a more general solution when we have another case.
+    # ex: Gem.loaded_specs[called_gem].dependencies.any? {|d| d.name == feature }
+    return false if feature.start_with?("reline") && caller_locations(2, 1)[0].to_s.include?("irb")
+
+    # The actual checks needed to properly identify the gem being required
+    # are costly (see [Bug #20641]), so we first do a much cheaper check
+    # to exclude the vast majority of candidates.
+    if feature.include?("/")
+      # If requiring $LIBDIR/mutex_m.rb, we check SINCE_FAST_PATH["mutex_m"]
+      # We'll fail to warn requires for files that are not the entry point
+      # of the gem, e.g. require "logger/formatter.rb" won't warn.
+      # But that's acceptable because this warning is best effort,
+      # and in the overwhelming majority of cases logger.rb will end
+      # up required.
+      return unless SINCE_FAST_PATH[File.basename(feature, ".*")]
+    else
+      return unless SINCE_FAST_PATH[feature]
+    end
+
+    # bootsnap expands `require "csv"` to `require "#{LIBDIR}/csv.rb"`,
+    # and `require "syslog"` to `require "#{ARCHDIR}/syslog.so"`.
+    name = feature.delete_prefix(ARCHDIR)
+    name.delete_prefix!(LIBDIR)
+    name.tr!("/", "-")
+    name.sub!(LIBEXT, "")
+    return if specs.include?(name)
+    _t, path = $:.resolve_feature_path(feature)
+    if gem = find_gem(path)
+      return if specs.include?(gem)
+      caller = caller_locations(3, 3)&.find {|c| c&.absolute_path}
+      return if find_gem(caller&.absolute_path)
+    elsif SINCE[name] && !path
+      gem = true
+    else
+      return
+    end
+
+    return if WARNED[name]
+    WARNED[name] = true
+    if gem == true
+      gem = name
+      "#{feature} was loaded from the standard library, but"
+    elsif gem
+      return if WARNED[gem]
+      WARNED[gem] = true
+      "#{feature} is found in #{gem}, which"
+    else
+      return
+    end + build_message(gem)
+  end
+
+  def self.build_message(gem)
+    msg = " #{RUBY_VERSION < SINCE[gem] ? "will no longer be" : "is not"} part of the default gems starting from Ruby #{SINCE[gem]}."
+
+    if defined?(Bundler)
+      msg += "\nYou can add #{gem} to your Gemfile or gemspec to silence this warning."
+
+      # We detect the gem name from caller_locations. First we walk until we find `require`
+      # then take the first frame that's not from `require`.
+      #
+      # Additionally, we need to skip Bootsnap and Zeitwerk if present, these
+      # gems decorate Kernel#require, so they are not really the ones issuing
+      # the require call users should be warned about. Those are upwards.
+      frames_to_skip = 3
+      location = nil
+      require_found = false
+      Thread.each_caller_location do |cl|
+        if frames_to_skip >= 1
+          frames_to_skip -= 1
+          next
+        end
+
+        if require_found
+          if cl.base_label != "require"
+            location = cl.path
+            break
+          end
+        else
+          if cl.base_label == "require"
+            require_found = true
+          end
+        end
+      end
+
+      if location && File.file?(location) && !location.start_with?(Gem::BUNDLED_GEMS::LIBDIR)
+        caller_gem = nil
+        Gem.path.each do |path|
+          if location =~ %r{#{path}/gems/([\w\-\.]+)}
+            caller_gem = $1
+            break
+          end
+        end
+        if caller_gem
+          msg += "\nAlso please contact the author of #{caller_gem} to request adding #{gem} into its gemspec."
+        end
+      end
+    else
+      msg += " Install #{gem} from RubyGems."
+    end
+
+    msg
+  end
+
+  freeze
+end
+
+# for RubyGems without Bundler environment.
+# If loading library is not part of the default gems and the bundled gems, warn it.
+class LoadError
+  def message # :nodoc:
+    return super unless path
+
+    name = path.tr("/", "-")
+    if !defined?(Bundler) && Gem::BUNDLED_GEMS::SINCE[name] && !Gem::BUNDLED_GEMS::WARNED[name]
+      warn name + Gem::BUNDLED_GEMS.build_message(name), uplevel: Gem::BUNDLED_GEMS.uplevel
+    end
+    super
+  end
+end


### PR DESCRIPTION
* New boot libraries: error_highlight and syntax_suggest
* New bundled_gems stdlib that warns for direct requires of libs that have been gemified.
* "New" rubyarchdir value in RbConfig::CONFIG to support the bundled_gems logic. We do not use this dir but it is defined for compatibility.