### PR TITLE
getSingletonClass() replaced with singleonClass(context)

### DIFF
--- a/core/src/main/java/org/jruby/MetaClass.java
+++ b/core/src/main/java/org/jruby/MetaClass.java
@@ -100,11 +100,13 @@ public final class MetaClass extends RubyClass {
 
     private RubyClass getSuperSingletonMetaClass() {
         if (attached instanceof RubyClass att) {
-            RubyClass superClass = att.getSuperClass();
+            RubyClass superClass = att.superClass();
             if (superClass != null) superClass = superClass.getRealClass();
             // #<Class:BasicObject>'s singleton class == Class.singleton_class
-            if (superClass == null) return runtime.getClassClass().getSingletonClass();
-            return superClass.getMetaClass().getSingletonClass();
+            // Context should be safe here as we never make a metaclass from a metaclass before first TC is made.
+            var context = getRuntime().getCurrentContext();
+            if (superClass == null) return runtime.getClassClass().singletonClass(context);
+            return superClass.getMetaClass().singletonClass(context);
         }
 
         return getSuperClass().getRealClass().getMetaClass(); // NOTE: is this correct?

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -29,6 +29,7 @@
 package org.jruby;
 
 import org.jcodings.Encoding;
+import org.jruby.api.JRubyAPI;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.ir.interpreter.Interpreter;
 import org.jruby.java.proxies.JavaProxy;
@@ -461,23 +462,21 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         return ((RubyBasicObject) arg).metaClass;
     }
 
-    /** rb_singleton_class
-     *
-     * Note: this method is specialized for RubyFixnum, RubySymbol,
-     * RubyNil and RubyBoolean
-     *
-     * Will either return the existing singleton class for this
-     * object, or create a new one and return that.
-     */
     @Override
     public RubyClass getSingletonClass() {
-        RubyClass klass = metaClass.toSingletonClass(this);
-
-        if (isFrozen()) klass.setFrozen(true);
-
-        return klass;
+        return singletonClass(getCurrentContext());
     }
 
+    /**
+     * Will either return the existing singleton class for this object, or create a new one and return that.
+     * For a few types a singleton class is not possible so it will throw an error.
+     *
+     * @param context the current thread context
+     * @return the singleton of this type
+     */
+
+    // MRI: rb_singleton_class
+    @JRubyAPI
     public RubyClass singletonClass(ThreadContext context) {
         RubyClass klass = metaClass.toSingletonClass(this);
 

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -477,6 +477,14 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         return klass;
     }
 
+    public RubyClass singletonClass(ThreadContext context) {
+        RubyClass klass = metaClass.toSingletonClass(this);
+
+        if (isFrozen()) klass.setFrozen(true);
+
+        return klass;
+    }
+
     /** rb_make_metaclass
      *
      * Will create a new meta class, insert this in the chain of
@@ -2597,13 +2605,8 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
             throw context.runtime.newLocalJumpErrorNoBlock();
         }
 
-        RubyModule klazz;
-        if (isImmediate()) {
-            // Ruby uses Qnil here, we use "dummy" because we need a class
-            klazz = context.runtime.getDummy();
-        } else {
-            klazz = getSingletonClass();
-        }
+        RubyModule klazz = isImmediate() ?  // MRI uses Qnil here, we use "dummy" because we need a class
+                context.runtime.getDummy() : singletonClass(context);
 
         return yieldUnder(context, klazz, args, block, EvalType.INSTANCE_EVAL);
     }

--- a/core/src/main/java/org/jruby/RubyBignum.java
+++ b/core/src/main/java/org/jruby/RubyBignum.java
@@ -158,8 +158,14 @@ public class RubyBignum extends RubyInteger {
 
     @Override
     public RubyClass getSingletonClass() {
-        throw typeError(getRuntime().getCurrentContext(), "can't define singleton");
+        return singletonClass(getRuntime().getCurrentContext());
     }
+
+    @Override
+    public RubyClass singletonClass(ThreadContext context) {
+        throw typeError(context, "can't define singleton");
+    }
+
 
     /** Getter for property value.
      * @return Value of property value.

--- a/core/src/main/java/org/jruby/RubyBignum.java
+++ b/core/src/main/java/org/jruby/RubyBignum.java
@@ -157,11 +157,6 @@ public class RubyBignum extends RubyInteger {
     }
 
     @Override
-    public RubyClass getSingletonClass() {
-        return singletonClass(getRuntime().getCurrentContext());
-    }
-
-    @Override
     public RubyClass singletonClass(ThreadContext context) {
         throw typeError(context, "can't define singleton");
     }

--- a/core/src/main/java/org/jruby/RubyBinding.java
+++ b/core/src/main/java/org/jruby/RubyBinding.java
@@ -75,7 +75,7 @@ public class RubyBinding extends RubyObject {
                 reifiedClass(RubyBinding.class).
                 classIndex(ClassIndex.BINDING).
                 defineMethods(context, RubyBinding.class).
-                tap(c -> c.getSingletonClass().undefMethods(context, "new"));
+                tap(c -> c.singletonClass(context).undefMethods(context, "new"));
     }
 
     public Binding getBinding() {

--- a/core/src/main/java/org/jruby/RubyBoolean.java
+++ b/core/src/main/java/org/jruby/RubyBoolean.java
@@ -93,6 +93,10 @@ public class RubyBoolean extends RubyObject implements Constantizable, Appendabl
         return metaClass;
     }
 
+    public RubyClass singletonClass(ThreadContext context) {
+        return metaClass;
+    }
+
     @Override
     public Class<?> getJavaClass() {
         return boolean.class;

--- a/core/src/main/java/org/jruby/RubyBoolean.java
+++ b/core/src/main/java/org/jruby/RubyBoolean.java
@@ -88,11 +88,6 @@ public class RubyBoolean extends RubyObject implements Constantizable, Appendabl
         return true;
     }
 
-    @Override
-    public RubyClass getSingletonClass() {
-        return metaClass;
-    }
-
     public RubyClass singletonClass(ThreadContext context) {
         return metaClass;
     }

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -2216,8 +2216,8 @@ public class RubyClass extends RubyModule {
 
             // now create proxy class
             m.getstatic(javaPath, RUBY_FIELD, ci(Ruby.class));
-            m.getstatic(javaPath, RUBY_CLASS_FIELD, ci(RubyClass.class));
             m.invokevirtual("org/jruby/Ruby", "getCurrentContext", "()Lorg/jruby/runtime/ThreadContext;");
+            m.getstatic(javaPath, RUBY_CLASS_FIELD, ci(RubyClass.class));
             m.ldc(org.objectweb.asm.Type.getType("L" + javaPath + ";"));
             // if (simpleAlloc) // if simple, don't init, if complex, do init
             // m.iconst_0(); // false (as int)

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -536,7 +536,7 @@ public class RubyClass extends RubyModule {
     }
 
     /**
-     * @see #getSingletonClass()
+     * @see #singletonClass(ThreadContext)
      */
     RubyClass toSingletonClass(RubyBasicObject target) {
         // replaced after makeMetaClass with MetaClass's toSingletonClass
@@ -2217,6 +2217,7 @@ public class RubyClass extends RubyModule {
             // now create proxy class
             m.getstatic(javaPath, RUBY_FIELD, ci(Ruby.class));
             m.getstatic(javaPath, RUBY_CLASS_FIELD, ci(RubyClass.class));
+            m.invokevirtual("org/jruby/Ruby", "getCurrentContext", "()Lorg/jruby/runtime/ThreadContext;");
             m.ldc(org.objectweb.asm.Type.getType("L" + javaPath + ";"));
             // if (simpleAlloc) // if simple, don't init, if complex, do init
             // m.iconst_0(); // false (as int)
@@ -2224,7 +2225,7 @@ public class RubyClass extends RubyModule {
             m.iconst_1(); // true (as int)
 
             m.invokestatic(p(JavaProxyClass.class), "setProxyClassReified",
-                    sig(JavaProxyClass.class, Ruby.class, RubyClass.class, Class.class, boolean.class));
+                    sig(JavaProxyClass.class, ThreadContext.class, RubyClass.class, Class.class, boolean.class));
             m.dup();
             m.putstatic(javaPath, RUBY_PROXY_CLASS_FIELD, ci(JavaProxyClass.class));
 

--- a/core/src/main/java/org/jruby/RubyComplex.java
+++ b/core/src/main/java/org/jruby/RubyComplex.java
@@ -79,7 +79,7 @@ public class RubyComplex extends RubyNumeric {
                 defineMethods(context, RubyComplex.class).
                 undefMethods(context, "<", "<=", ">", ">=", "between?", "clamp", "%", "div", "divmod", "floor", "ceil",
                         "modulo", "remainder", "round", "step", "truncate", "positive?", "negative?").
-                tap(c -> c.getSingletonClass().undefMethods(context, "allocate", "new")).
+                tap(c -> c.singletonClass(context).undefMethods(context, "allocate", "new")).
                 tap(c -> c.defineConstant("I", RubyComplex.convert(context, c, asFixnum(context, 0), asFixnum(context, 1))));
     }
 

--- a/core/src/main/java/org/jruby/RubyContinuation.java
+++ b/core/src/main/java/org/jruby/RubyContinuation.java
@@ -62,7 +62,7 @@ public class RubyContinuation extends RubyObject {
         return defineClass(context, "Continuation", objectClass, objectClass.getAllocator()).
                 reifiedClass(RubyContinuation.class).
                 classIndex(ClassIndex.CONTINUATION).
-                tap(c -> c.getSingletonClass().undefMethods(context, "new"));
+                tap(c -> c.singletonClass(context).undefMethods(context, "new"));
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/RubyEncoding.java
+++ b/core/src/main/java/org/jruby/RubyEncoding.java
@@ -79,7 +79,7 @@ public class RubyEncoding extends RubyObject implements Constantizable {
                 kindOf(new RubyModule.JavaClassKindOf(RubyEncoding.class)).
                 classIndex(ClassIndex.ENCODING).
                 defineMethods(context, RubyEncoding.class).
-                tap(c -> c.getSingletonClass().undefMethods(context, "allocate"));
+                tap(c -> c.singletonClass(context).undefMethods(context, "allocate"));
     }
 
     private Encoding encoding;

--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -121,7 +121,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
                 defineConstant(context, "PATH_SEPARATOR", pathSeparator);
 
         // For JRUBY-5276, physically define FileTest methods on File's singleton
-        File.getSingletonClass().defineMethods(context, RubyFileTest.FileTestFileMethods.class);
+        File.singletonClass(context).defineMethods(context, RubyFileTest.FileTestFileMethods.class);
 
         var FileConstants = File.defineModuleUnder(context, "Constants").
                 defineConstant(context, "RDONLY", asFixnum(context, OpenFlags.O_RDONLY.intValue())).
@@ -205,7 +205,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         if (!Platform.IS_BSD) {
             // lchmod appears to be mostly a BSD-ism, not supported on Linux.
             // See https://github.com/jruby/jruby/issues/5547
-            File.getSingletonClass().searchMethod("lchmod").setNotImplemented(true);
+            File.singletonClass(context).searchMethod("lchmod").setNotImplemented(true);
         }
 
         return File;

--- a/core/src/main/java/org/jruby/RubyFixnum.java
+++ b/core/src/main/java/org/jruby/RubyFixnum.java
@@ -180,9 +180,12 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
     	return true;
     }
 
-    @Override
     public RubyClass getSingletonClass() {
-        throw typeError(getRuntime().getCurrentContext(), "can't define singleton");
+        return singletonClass(getRuntime().getCurrentContext());
+    }
+
+    public RubyClass singletonClass(ThreadContext context) {
+        throw typeError(context, "can't define singleton");
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyFixnum.java
+++ b/core/src/main/java/org/jruby/RubyFixnum.java
@@ -180,10 +180,6 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
     	return true;
     }
 
-    public RubyClass getSingletonClass() {
-        return singletonClass(getRuntime().getCurrentContext());
-    }
-
     public RubyClass singletonClass(ThreadContext context) {
         throw typeError(context, "can't define singleton");
     }

--- a/core/src/main/java/org/jruby/RubyFloat.java
+++ b/core/src/main/java/org/jruby/RubyFloat.java
@@ -147,11 +147,6 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         this.flags |= FROZEN_F;
     }
 
-    @Override
-    public RubyClass getSingletonClass() {
-        return singletonClass(getRuntime().getCurrentContext());
-    }
-
     public RubyClass singletonClass(ThreadContext context) {
         throw typeError(context, "can't define singleton");
     }

--- a/core/src/main/java/org/jruby/RubyFloat.java
+++ b/core/src/main/java/org/jruby/RubyFloat.java
@@ -104,7 +104,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
                 kindOf(new RubyModule.JavaClassKindOf(RubyFloat.class)).
                 classIndex(ClassIndex.FLOAT).
                 defineMethods(context, RubyFloat.class).
-                tap(c -> c.getSingletonClass().undefMethods(context, "new")).
+                tap(c -> c.singletonClass(context).undefMethods(context, "new")).
                 defineConstant(context, "ROUNDS", asFixnum(context, ROUNDS)).
                 defineConstant(context, "RADIX", asFixnum(context, RADIX)).
                 defineConstant(context, "MANT_DIG", asFixnum(context, MANT_DIG)).
@@ -149,7 +149,11 @@ public class RubyFloat extends RubyNumeric implements Appendable {
 
     @Override
     public RubyClass getSingletonClass() {
-        throw typeError(getRuntime().getCurrentContext(), "can't define singleton");
+        return singletonClass(getRuntime().getCurrentContext());
+    }
+
+    public RubyClass singletonClass(ThreadContext context) {
+        throw typeError(context, "can't define singleton");
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -430,7 +430,7 @@ public class RubyGlobal {
             runtime, environmentVariableMap, context.nil,
             instanceConfig.isNativeEnabled() && instanceConfig.isUpdateNativeENVEnabled()
         );
-        env.getSingletonClass().defineMethods(context, CaseInsensitiveStringOnlyRubyHash.class);
+        env.singletonClass(context).defineMethods(context, CaseInsensitiveStringOnlyRubyHash.class);
         runtime.defineGlobalConstant("ENV", env);
 
         // Define System.getProperties() in ENV_JAVA

--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -85,7 +85,7 @@ public abstract class RubyInteger extends RubyNumeric {
                 kindOf(new RubyModule.JavaClassKindOf(RubyInteger.class)).
                 classIndex(ClassIndex.INTEGER).
                 defineMethods(context, RubyInteger.class).
-                tap(c-> c.getSingletonClass().undefMethods(context, "new"));
+                tap(c-> c.singletonClass(context).undefMethods(context, "new"));
     }
 
     public RubyInteger(Ruby runtime, RubyClass rubyClass) {

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -1595,7 +1595,7 @@ public class RubyKernel {
     public static IRubyObject define_singleton_method(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         int argc = Arity.checkArgumentCount(context, args, 1, 2);
 
-        RubyClass singleton_class = recv.getSingletonClass();
+        RubyClass singleton_class = recv.singletonClass(context);
         if (argc > 1) {
             IRubyObject arg1 = args[1];
             if (context.runtime.getUnboundMethod().isInstance(arg1)) {
@@ -2104,9 +2104,14 @@ public class RubyKernel {
         return newString(context, RubyFile.dirname(context, path.asJavaString()));
     }
 
-    @JRubyMethod(module = true)
+    @Deprecated(since = "10.0")
     public static IRubyObject singleton_class(IRubyObject recv) {
-        return recv.getSingletonClass();
+        return singleton_class(recv.getRuntime().getCurrentContext(), recv);
+    }
+
+    @JRubyMethod(module = true)
+    public static IRubyObject singleton_class(ThreadContext context, IRubyObject recv) {
+        return recv.singletonClass(context);
     }
 
     @JRubyMethod(rest = true, keywords = true, reads = SCOPE)

--- a/core/src/main/java/org/jruby/RubyMatchData.java
+++ b/core/src/main/java/org/jruby/RubyMatchData.java
@@ -87,7 +87,7 @@ public class RubyMatchData extends RubyObject {
                 kindOf(new RubyModule.JavaClassKindOf(RubyMatchData.class)).
                 classIndex(ClassIndex.MATCHDATA).
                 defineMethods(context, RubyMatchData.class).
-                tap(c -> c.getSingletonClass().undefMethods(context, "new", "allocate"));
+                tap(c -> c.singletonClass(context).undefMethods(context, "new", "allocate"));
     }
 
     public RubyMatchData(Ruby runtime) {

--- a/core/src/main/java/org/jruby/RubyNil.java
+++ b/core/src/main/java/org/jruby/RubyNil.java
@@ -93,11 +93,6 @@ public class RubyNil extends RubyObject implements Constantizable {
         return true;
     }
 
-    @Override
-    public RubyClass getSingletonClass() {
-        return metaClass;
-    }
-
     public RubyClass singletonClass(ThreadContext context) {
         return metaClass;
     }

--- a/core/src/main/java/org/jruby/RubyNil.java
+++ b/core/src/main/java/org/jruby/RubyNil.java
@@ -97,7 +97,11 @@ public class RubyNil extends RubyObject implements Constantizable {
     public RubyClass getSingletonClass() {
         return metaClass;
     }
-    
+
+    public RubyClass singletonClass(ThreadContext context) {
+        return metaClass;
+    }
+
     @Override
     public Class<?> getJavaClass() {
         return void.class;
@@ -154,7 +158,7 @@ public class RubyNil extends RubyObject implements Constantizable {
     /** nil_inspect
      *
      */
-    @Override
+    @JRubyMethod
     public IRubyObject inspect(ThreadContext context) {
         return RubyNil.inspect(metaClass.runtime);
     }

--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -114,9 +114,10 @@ public class RubyProcess {
         context.runtime.setProcSys(Process.defineModuleUnder(context, "Sys").defineMethods(context, Sys.class));
 
         if (Platform.IS_WINDOWS) {
+            var singleton = ProcessStatus.singletonClass(context);
             // mark rlimit methods as not implemented and skip defining the constants (GH-6491)
-            Process.getSingletonClass().retrieveMethod("getrlimit").setNotImplemented(true);
-            Process.getSingletonClass().retrieveMethod("setrlimit").setNotImplemented(true);
+            singleton.retrieveMethod("getrlimit").setNotImplemented(true);
+            singleton.retrieveMethod("setrlimit").setNotImplemented(true);
         } else {
             Process.defineConstantsFrom(context, jnr.constants.platform.RLIM.class);
             for (RLIMIT r : RLIMIT.values()) {

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -77,7 +77,7 @@ public class RubyRational extends RubyNumeric {
                 kindOf(new RubyModule.JavaClassKindOf(RubyRational.class)).
                 classIndex(ClassIndex.RATIONAL).
                 defineMethods(context, RubyRational.class).
-                tap(c -> c.getSingletonClass().undefMethods(context, "allocate", "new"));
+                tap(c -> c.singletonClass(context).undefMethods(context, "allocate", "new"));
     }
 
     private RubyRational(Ruby runtime, RubyClass clazz, RubyInteger num, RubyInteger den) {

--- a/core/src/main/java/org/jruby/RubyRegexp.java
+++ b/core/src/main/java/org/jruby/RubyRegexp.java
@@ -218,7 +218,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
                 defineConstant(context, "FIXEDENCODING", asFixnum(context, RE_FIXED)).
                 defineConstant(context, "NOENCODING", asFixnum(context, RE_NONE)).
                 defineMethods(context, RubyRegexp.class).
-                tap(c -> c.getSingletonClass().defineAlias(context, "compile", "new"));
+                tap(c -> c.singletonClass(context).defineAlias(context, "compile", "new"));
 
         context.runtime.setRubyTimeout(context.nil);
 

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1269,6 +1269,11 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return str.checkStringType();
     }
 
+    @Deprecated(since = "10.0")
+    public RubyString to_s() {
+        return (RubyString) to_s(getCurrentContext());
+    }
+
     @SuppressWarnings("ReferenceEquality")
     @JRubyMethod(name = {"to_s", "to_str"})
     @Override
@@ -4970,13 +4975,17 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @Override
     public RubyClass getSingletonClass() {
+        return singletonClass(getRuntime().getCurrentContext());
+    }
+
+    public RubyClass singletonClass(ThreadContext context) {
         if (isChilled()) {
             mutateChilledString();
         } else if (isFrozen()) {
-            throw typeError(getRuntime().getCurrentContext(), "can't define singleton");
+            throw typeError(context, "can't define singleton");
         }
 
-        return super.getSingletonClass();
+        return super.singletonClass(context);
     }
 
     // MRI: get_pat_quoted (scan error checking portion)

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -4973,11 +4973,6 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return pat; // String
     }
 
-    @Override
-    public RubyClass getSingletonClass() {
-        return singletonClass(getRuntime().getCurrentContext());
-    }
-
     public RubyClass singletonClass(ThreadContext context) {
         if (isChilled()) {
             mutateChilledString();

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -294,11 +294,12 @@ public class RubyStruct extends RubyObject {
         }
 
         // set reified class to RubyStruct, for Java subclasses to use
-        newStruct.reifiedClass(RubyStruct.class).classIndex(ClassIndex.STRUCT);
+        newStruct.reifiedClass(RubyStruct.class).
+                classIndex(ClassIndex.STRUCT);
         newStruct.setInternalVariable(SIZE_VAR, member.length(context));
         newStruct.setInternalVariable(MEMBER_VAR, member);
         newStruct.setInternalVariable(KEYWORD_INIT_VAR, keywordInitValue);
-        newStruct.getSingletonClass().defineMethods(context, StructMethods.class);
+        newStruct.singletonClass(context).defineMethods(context, StructMethods.class);
 
         // define access methods.
         for (int i = (name == null && !nilName) ? 0 : 1; i < argc; i++) {

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -305,11 +305,6 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
     	return true;
     }
 
-    @Override
-    public RubyClass getSingletonClass() {
-        return singletonClass(getRuntime().getCurrentContext());
-    }
-
     public RubyClass singletonClass(ThreadContext context) {
         throw typeError(context, "can't define singleton");
     }

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -307,7 +307,11 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
 
     @Override
     public RubyClass getSingletonClass() {
-        throw typeError(getRuntime().getCurrentContext(), "can't define singleton");
+        return singletonClass(getRuntime().getCurrentContext());
+    }
+
+    public RubyClass singletonClass(ThreadContext context) {
+        throw typeError(context, "can't define singleton");
     }
 
     public static RubySymbol getSymbolLong(Ruby runtime, long id) {

--- a/core/src/main/java/org/jruby/RubyUnboundMethod.java
+++ b/core/src/main/java/org/jruby/RubyUnboundMethod.java
@@ -83,7 +83,7 @@ public class RubyUnboundMethod extends AbstractRubyMethod {
                 reifiedClass(RubyUnboundMethod.class).
                 classIndex(ClassIndex.UNBOUNDMETHOD).
                 defineMethods(context, AbstractRubyMethod.class, RubyUnboundMethod.class).
-                tap(c -> c.getSingletonClass().undefMethods(context, "new"));
+                tap(c -> c.singletonClass(context).undefMethods(context, "new"));
     }
 
     @Override

--- a/core/src/main/java/org/jruby/TopSelfFactory.java
+++ b/core/src/main/java/org/jruby/TopSelfFactory.java
@@ -62,7 +62,7 @@ public final class TopSelfFactory {
     }
     
     public static IRubyObject finishTopSelf(ThreadContext context, IRubyObject topSelf, RubyClass Object, final boolean wrapper) {
-        final RubyClass singletonClass = topSelf.getSingletonClass();
+        final RubyClass singletonClass = topSelf.singletonClass(context);
 
         singletonClass.addMethod("to_s", new JavaMethod.JavaMethodZero(singletonClass, Visibility.PUBLIC, "to_s") {
             @Override

--- a/core/src/main/java/org/jruby/anno/AnnotationBinder.java
+++ b/core/src/main/java/org/jruby/anno/AnnotationBinder.java
@@ -131,6 +131,7 @@ public class AnnotationBinder extends AbstractProcessor {
             out.println("import org.jruby.runtime.Arity;");
             out.println("import org.jruby.runtime.Visibility;");
             out.println("import org.jruby.runtime.MethodIndex;");
+            out.println("import org.jruby.runtime.ThreadContext;");
             out.println("import java.util.Arrays;");
             out.println("import java.util.List;");
             out.println("import jakarta.annotation.Generated;");
@@ -161,8 +162,11 @@ public class AnnotationBinder extends AbstractProcessor {
 
             out.println("        JavaMethod javaMethod;");
             out.println("        DynamicMethod moduleMethod, aliasedMethod;");
-            if (hasMeta || hasModule) out.println("        RubyClass singletonClass = cls.getSingletonClass();");
-            out.println("        Ruby runtime = cls.getRuntime();");
+            out.println("        ThreadContext context = cls.getRuntime().getCurrentContext();");
+            out.println("        Ruby runtime = context.runtime;");
+            if (hasMeta || hasModule) {
+                out.println("        RubyClass singletonClass = cls.singletonClass(context);");
+            }
             out.println("        boolean core = runtime.isBootingCore();");
 
             Map<CharSequence, List<ExecutableElement>> annotatedMethods = new LinkedHashMap<>();
@@ -501,7 +505,7 @@ public class AnnotationBinder extends AbstractProcessor {
         } else {
             defineMethodOnClass("javaMethod", "cls", names, aliases, md);
             if (module) {
-                out.println("        moduleMethod = populateModuleMethod(cls, javaMethod);");
+                out.println("        moduleMethod = populateModuleMethod(cls, singletonClass, javaMethod);");
                 defineMethodOnClass("moduleMethod", "singletonClass", names, aliases, md);
             }
         }

--- a/core/src/main/java/org/jruby/anno/TypePopulator.java
+++ b/core/src/main/java/org/jruby/anno/TypePopulator.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.jruby.Ruby;
+import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.internal.runtime.methods.JavaMethod;
@@ -66,10 +67,16 @@ public abstract class TypePopulator {
         javaMethod.setNotImplemented(notImplemented);
         javaMethod.setNativeCall(nativeTarget, nativeName, nativeReturn, nativeArguments, isStatic, false);
     }
-    
+
+    // Still needed for older generated populators.
+    @Deprecated(since = "10.0")
     public static DynamicMethod populateModuleMethod(RubyModule cls, DynamicMethod javaMethod) {
+        return populateModuleMethod(cls, cls.singletonClass(cls.getRuntime().getCurrentContext()), javaMethod);
+    }
+
+    public static DynamicMethod populateModuleMethod(RubyModule cls, RubyClass singletonClass, DynamicMethod javaMethod) {
         DynamicMethod moduleMethod = javaMethod.dup();
-        moduleMethod.setImplementationClass(cls.getSingletonClass());
+        moduleMethod.setImplementationClass(singletonClass);
         moduleMethod.setVisibility(Visibility.PUBLIC);
         return moduleMethod;
     }

--- a/core/src/main/java/org/jruby/ext/ffi/AbstractInvoker.java
+++ b/core/src/main/java/org/jruby/ext/ffi/AbstractInvoker.java
@@ -76,12 +76,13 @@ public abstract class AbstractInvoker extends Pointer {
      */
     @JRubyMethod(name="attach")
     public IRubyObject attach(ThreadContext context, IRubyObject obj, IRubyObject methodName) {
+
+        var singleton = obj.singletonClass(context);
+        DynamicMethod m = createDynamicMethod(singleton);
         
-        DynamicMethod m = createDynamicMethod(obj.getSingletonClass());
-        obj.getSingletonClass().addMethod(methodName.asJavaString(), m);
-        if (obj instanceof RubyModule) {
-            ((RubyModule) obj).addMethod(methodName.asJavaString(), m);
-        }
+        singleton.addMethod(methodName.asJavaString(), m);
+        if (obj instanceof RubyModule mod) mod.addMethod(methodName.asJavaString(), m);
+
         getRuntime().getFFI().registerAttachedMethod(m, this);
         
         return this;

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/Function.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/Function.java
@@ -50,8 +50,9 @@ public final class Function extends org.jruby.ext.ffi.AbstractInvoker {
         
         this.enums = enums;
         this.saveError = saveError;
+        var singleton = singletonClass(getRuntime().getCurrentContext());
         // Wire up Function#call(*args) to use the super-fast native invokers
-        getSingletonClass().addMethod("call", createDynamicMethod(getSingletonClass()));
+        singleton.addMethod("call", createDynamicMethod(singleton));
     }
 
     Function(Ruby runtime, RubyClass klass, MemoryIO address,
@@ -64,8 +65,9 @@ public final class Function extends org.jruby.ext.ffi.AbstractInvoker {
                 functionInfo.jffiReturnType, functionInfo.jffiParameterTypes, functionInfo.convention);
         this.enums = enums;
         this.saveError = true;
+        var singleton = singletonClass(getRuntime().getCurrentContext());
         // Wire up Function#call(*args) to use the super-fast native invokers
-        getSingletonClass().addMethod("call", createDynamicMethod(getSingletonClass()));
+        singleton.addMethod("call", createDynamicMethod(singleton));
     }
     
     @JRubyMethod(name = { "new" }, meta = true, required = 2, optional = 2, checkArity = false)

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/JFFIInvoker.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/JFFIInvoker.java
@@ -57,8 +57,9 @@ public class JFFIInvoker extends org.jruby.ext.ffi.AbstractInvoker {
         this.returnType = returnType;
         this.convention = convention;
         this.enums = enums;
+        var singleton = singletonClass(getRuntime().getCurrentContext());
         // Wire up Function#call(*args) to use the super-fast native invokers
-        getSingletonClass().addMethod("call", createDynamicMethod(getSingletonClass()));
+        singleton.addMethod("call", createDynamicMethod(singleton));
     }
     
     @JRubyMethod(name = { "new" }, meta = true, required = 4)

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyLibrary.java
@@ -88,7 +88,7 @@ public class JRubyLibrary implements Library {
              .defineMethods(context, JRubyExecutionContextLocal.class);
 
         JRuby.defineModuleUnder(context, "CONFIG").
-                tap(m -> m.getSingletonClass().defineMethods(context, JRubyConfig.class));
+                tap(m -> m.singletonClass(context).defineMethods(context, JRubyConfig.class));
     }
 
     /**
@@ -327,7 +327,7 @@ public class JRubyLibrary implements Library {
 
         final var subclasses = newArray(context);
 
-        RubyClass singletonClass = klass.getSingletonClass();
+        RubyClass singletonClass = klass.singletonClass(context);
         RubyObjectSpace.each_objectInternal(context, recv, new IRubyObject[] { singletonClass },
                 new Block(new JavaInternalBlockBody(context.runtime, Signature.ONE_ARGUMENT) {
 

--- a/core/src/main/java/org/jruby/ir/instructions/DefineMetaClassInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/DefineMetaClassInstr.java
@@ -68,11 +68,9 @@ public class DefineMetaClassInstr extends OneOperandResultBaseInstr implements F
 
     @Override
     public Object interpret(ThreadContext context, StaticScope currScope, DynamicScope currDynScope, IRubyObject self, Object[] temp) {
-        Ruby runtime = context.runtime;
-
         IRubyObject obj = (IRubyObject) getObject().retrieve(context, self, currScope, currDynScope, temp);
 
-        return IRRuntimeHelpers.newInterpretedMetaClass(runtime, metaClassBody, obj);
+        return IRRuntimeHelpers.newInterpretedMetaClass(context, metaClassBody, obj);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/operands/UndefinedValue.java
+++ b/core/src/main/java/org/jruby/ir/operands/UndefinedValue.java
@@ -114,6 +114,8 @@ public class UndefinedValue extends Operand implements IRubyObject {
     @Override
     public RubyClass getSingletonClass() { throw undefinedOperation(); }
 
+    public RubyClass singletonClass(ThreadContext context) { throw undefinedOperation(); }
+
     @Override
     public RubyClass getType() { throw undefinedOperation(); }
 

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1206,7 +1206,7 @@ public class IRRuntimeHelpers {
                 //   end
                 // -------------
                 case MODULE_EVAL  : return self instanceof RubyModule ? (RubyModule) self : self.getMetaClass();
-                case INSTANCE_EVAL: return self.getSingletonClass();
+                case INSTANCE_EVAL: return self.singletonClass(context);
                 case BINDING_EVAL : ds = ds.getParentScope(); break;
                 case NONE:
                     if (scopeType == null || scopeType.isClosureType()) {
@@ -1854,7 +1854,7 @@ public class IRRuntimeHelpers {
 
         // if (obj.isFrozen()) throw context.runtime.newFrozenError("object");
 
-        return obj.getSingletonClass();
+        return obj.singletonClass(context);
     }
 
     @Interp

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1709,8 +1709,8 @@ public class IRRuntimeHelpers {
      * Construct a new DynamicMethod to wrap the given IRModuleBody and singletonizable object. Used by interpreter.
      */
     @Interp
-    public static DynamicMethod newInterpretedMetaClass(Ruby runtime, IRScope metaClassBody, IRubyObject obj) {
-        RubyClass singletonClass = newMetaClassFromIR(runtime, metaClassBody.getStaticScope(), obj, metaClassBody.maybeUsingRefinements());
+    public static DynamicMethod newInterpretedMetaClass(ThreadContext context, IRScope metaClassBody, IRubyObject obj) {
+        RubyClass singletonClass = newMetaClassFromIR(context, metaClassBody.getStaticScope(), obj, metaClassBody.maybeUsingRefinements());
 
         return new InterpretedIRBodyMethod(metaClassBody, singletonClass);
     }
@@ -1720,18 +1720,18 @@ public class IRRuntimeHelpers {
      */
     @JIT
     public static DynamicMethod newCompiledMetaClass(ThreadContext context, MethodHandle handle, StaticScope scope, IRubyObject obj, int line, boolean refinements, boolean dynscopeEliminated) {
-        RubyClass singletonClass = newMetaClassFromIR(context.runtime, scope, obj, refinements);
+        RubyClass singletonClass = newMetaClassFromIR(context, scope, obj, refinements);
 
         return new CompiledIRNoProtocolMethod(handle, scope, scope.getFile(), line,
                 singletonClass, !dynscopeEliminated);
     }
 
-    private static RubyClass newMetaClassFromIR(Ruby runtime, StaticScope scope, IRubyObject obj, boolean refinements) {
-        RubyClass singletonClass = Helpers.getSingletonClass(runtime, obj);
+    private static RubyClass newMetaClassFromIR(ThreadContext context, StaticScope scope, IRubyObject obj, boolean refinements) {
+        RubyClass singletonClass = obj.singletonClass(context);
 
         scope.setModule(singletonClass);
 
-        if (refinements) scope.captureParentRefinements(runtime.getCurrentContext());
+        if (refinements) scope.captureParentRefinements(context);
 
         return singletonClass;
     }

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -44,7 +44,7 @@ public final class ArrayJavaProxy extends JavaProxy {
         return defineClass(context, "ArrayJavaProxy", JavaProxy, NOT_ALLOCATABLE_ALLOCATOR).
                 defineMethods(context, ArrayJavaProxy.class).
                 include(context, Enumerable).
-                tap(c -> c.singletonClass(context).addMethod("new", new ArrayNewMethod(c.getSingletonClass(), Visibility.PUBLIC)));
+                tap(c -> c.singletonClass(context).addMethod("new", new ArrayNewMethod(c.singletonClass(context), Visibility.PUBLIC)));
     }
 
     public static ArrayJavaProxy newArray(final Ruby runtime, final Class<?> elementType, final int... dimensions) {

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -44,7 +44,7 @@ public final class ArrayJavaProxy extends JavaProxy {
         return defineClass(context, "ArrayJavaProxy", JavaProxy, NOT_ALLOCATABLE_ALLOCATOR).
                 defineMethods(context, ArrayJavaProxy.class).
                 include(context, Enumerable).
-                tap(c -> c.getSingletonClass().addMethod("new", new ArrayNewMethod(c.getSingletonClass(), Visibility.PUBLIC)));
+                tap(c -> c.singletonClass(context).addMethod("new", new ArrayNewMethod(c.getSingletonClass(), Visibility.PUBLIC)));
     }
 
     public static ArrayJavaProxy newArray(final Ruby runtime, final Class<?> elementType, final int... dimensions) {

--- a/core/src/main/java/org/jruby/java/proxies/ConcreteJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ConcreteJavaProxy.java
@@ -426,12 +426,17 @@ public class ConcreteJavaProxy extends JavaProxy {
         if (getObject() == null) setObject(self);
     }
 
+    @Deprecated(since = "10.0")
     protected static void initialize(final RubyClass concreteJavaProxy) {
+        initialize(concreteJavaProxy.getRuntime().getCurrentContext(), concreteJavaProxy);
+    }
+
+    protected static void initialize(ThreadContext context, final RubyClass concreteJavaProxy) {
         concreteJavaProxy.addMethod("initialize", new InitializeMethod(concreteJavaProxy));
         // We define a custom "new" method to ensure that __jcreate! is getting called,
         // so that if the user doesn't call super in their subclasses, the object will
         // still get set up properly. See JRUBY-4704.
-        RubyClass singleton = concreteJavaProxy.getSingletonClass();
+        RubyClass singleton = concreteJavaProxy.singletonClass(context);
         singleton.addMethod("new", new NewMethod(singleton));
     }
 

--- a/core/src/main/java/org/jruby/java/proxies/JavaInterfaceTemplate.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaInterfaceTemplate.java
@@ -70,7 +70,7 @@ public class JavaInterfaceTemplate {
     public static RubyModule createJavaInterfaceTemplateModule(ThreadContext context) {
         return defineModule(context, "JavaInterfaceTemplate").
                 defineMethods(context, JavaProxy.ClassMethods.class).
-                tap(m -> m.getSingletonClass().defineMethods(context, JavaInterfaceTemplate.class));
+                tap(m -> m.singletonClass(context).defineMethods(context, JavaInterfaceTemplate.class));
     }
 
     @JRubyMethod
@@ -174,7 +174,7 @@ public class JavaInterfaceTemplate {
             // First we make modifications to the class, to adapt it to being
             // both a Ruby class and a proxy for a Java type
 
-            RubyClass singleton = clazz.getSingletonClass();
+            RubyClass singleton = clazz.singletonClass(context);
 
             // list of interfaces we implement
             singleton.addReadAttribute(context, "java_interfaces");
@@ -214,7 +214,7 @@ public class JavaInterfaceTemplate {
 
         // Now we add an "implement" and "implement_all" methods to the class
         if ( ! clazz.isMethodBound("implement", false) ) {
-            final RubyClass singleton = clazz.getSingletonClass();
+            final RubyClass singleton = clazz.singletonClass(context);
 
             // implement is called to force this class to create stubs for all methods in the given interface,
             // so they'll show up in the list of methods and be invocable without passing through method_missing
@@ -325,7 +325,7 @@ public class JavaInterfaceTemplate {
         // well
         synchronized (module) {
             if ( initInterfaceModules(self, module) ) { // true - initialized
-                final RubyClass singleton = module.getSingletonClass();
+                final RubyClass singleton = module.singletonClass(context);
                 singleton.addMethod("append_features", new AppendFeatures(singleton));
             }
             else {
@@ -354,7 +354,7 @@ public class JavaInterfaceTemplate {
 
     @JRubyMethod
     public static IRubyObject extended(ThreadContext context, IRubyObject self, IRubyObject object) {
-        RubyClass singleton = object.getSingletonClass();
+        RubyClass singleton = object.singletonClass(context);
         singleton.include(context, self);
         return singleton;
     }

--- a/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
@@ -576,10 +576,6 @@ public class JavaProxy extends RubyObject {
         super.setVariable(index, value);
     }
 
-    public RubyClass getSingletonClass() {
-        return singletonClass(getRuntime().getCurrentContext());
-    }
-
     /** rb_singleton_class
      *
      * Note: this method is specialized for RubyFixnum, RubySymbol,

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -1000,7 +1000,7 @@ public class Java implements Library {
         }
 
         // saves class in singletonized parent, so we don't come back here :
-        if ( cacheMethod ) bindJavaPackageOrClassMethod(parentPackage, name, result);
+        if ( cacheMethod )  bindJavaPackageOrClassMethod(context, parentPackage, name, result);
 
         return result;
     }
@@ -1148,17 +1148,17 @@ public class Java implements Library {
     private static boolean bindJavaPackageOrClassMethod(ThreadContext context, final String name,
         final RubyModule packageOrClass) {
         final RubyModule javaPackage = context.runtime.getJavaSupport().getJavaModule();
-        return bindJavaPackageOrClassMethod(javaPackage, name, packageOrClass);
+        return bindJavaPackageOrClassMethod(context, javaPackage, name, packageOrClass);
     }
 
-    private static boolean bindJavaPackageOrClassMethod(final RubyModule parentPackage,
+    private static boolean bindJavaPackageOrClassMethod(ThreadContext context, final RubyModule parentPackage,
         final String name, final RubyModule packageOrClass) {
 
         if ( parentPackage.getMetaClass().isMethodBound(name, false) ) {
             return false;
         }
 
-        final RubyClass singleton = parentPackage.getSingletonClass();
+        final RubyClass singleton = parentPackage.singletonClass(context);
         singleton.addMethod(name.intern(), new JavaAccessor(singleton, packageOrClass, parentPackage, name));
         return true;
     }

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -614,7 +614,7 @@ public class Java implements Library {
         // Subclasses of Java classes can safely use ivars, so we set this to silence warnings
         subclass.setCacheProxy(true);
 
-        final RubyClass subclassSingleton = subclass.getSingletonClass();
+        final RubyClass subclassSingleton = subclass.singletonClass(context);
         subclassSingleton.addReadAttribute(context, "java_proxy_class");
         subclassSingleton.addMethod("java_interfaces", new JavaMethodZero(subclassSingleton, PUBLIC, "java_interfaces") {
             @Override

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -506,7 +506,7 @@ public class Java implements Library {
         for (int i = extended.length; --i >= 0; ) {
             proxy.include(context, getInterfaceModule(context, extended[i]));
         }
-        Initializer.setupProxyModule(context.runtime, javaClass, proxy);
+        Initializer.setupProxyModule(context, javaClass, proxy);
         addToJavaPackageModule(proxy);
     }
 
@@ -572,7 +572,7 @@ public class Java implements Library {
 
         if ( invokeInherited ) proxyClass.inherit(superClass);
 
-        Initializer.setupProxyClass(context.runtime, javaClass, proxyClass);
+        Initializer.setupProxyClass(context, javaClass, proxyClass);
 
         return proxyClass;
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtil.java
@@ -243,7 +243,7 @@ public class JavaUtil {
         if ( rubyObject instanceof RubyProc ) {
             // Proc implementing an interface, pull in the catch-all code that lets the proc get invoked
             // no matter what method is called on the interface
-            final RubyClass singletonClass = rubyObject.getSingletonClass();
+            final RubyClass singletonClass = rubyObject.singletonClass(context);
 
             if (procClass == procClass(context)) {
                 // We reattach the singleton class to the Proc class object to prevent the method cache in the interface

--- a/core/src/main/java/org/jruby/javasupport/binding/ClassInitializer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/ClassInitializer.java
@@ -16,11 +16,12 @@ final class ClassInitializer extends Initializer {
 
     @Override
     public RubyClass initialize(final RubyModule proxy) {
+        var context = proxy.getRuntime().getCurrentContext();
         final RubyClass proxyClass = (RubyClass) proxy;
 
         // flag the class as a Java class proxy.
         proxy.setJavaProxy(true);
-        proxy.getSingletonClass().setJavaProxy(true);
+        proxy.singletonClass(context).setJavaProxy(true);
 
         // set parent to either package module or outer class
         final RubyModule parent;

--- a/core/src/main/java/org/jruby/javasupport/binding/InstanceFieldGetterInstaller.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/InstanceFieldGetterInstaller.java
@@ -2,6 +2,7 @@ package org.jruby.javasupport.binding;
 
 import org.jruby.RubyModule;
 import org.jruby.java.invokers.InstanceFieldGetter;
+import org.jruby.runtime.ThreadContext;
 
 import java.lang.reflect.Field;
 
@@ -14,7 +15,7 @@ public class InstanceFieldGetterInstaller extends FieldInstaller {
         super(name, INSTANCE_FIELD, field);
     }
 
-    @Override void install(final RubyModule proxy) {
+    @Override void install(ThreadContext context, final RubyModule proxy) {
         if (isAccessible()) {
             proxy.addMethod(name, new InstanceFieldGetter(name, proxy, field));
         }

--- a/core/src/main/java/org/jruby/javasupport/binding/InstanceFieldSetterInstaller.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/InstanceFieldSetterInstaller.java
@@ -2,6 +2,7 @@ package org.jruby.javasupport.binding;
 
 import org.jruby.RubyModule;
 import org.jruby.java.invokers.InstanceFieldSetter;
+import org.jruby.runtime.ThreadContext;
 
 import java.lang.reflect.Field;
 
@@ -14,7 +15,7 @@ public class InstanceFieldSetterInstaller extends FieldInstaller {
         super(name, INSTANCE_FIELD, field);
     }
 
-    @Override void install(final RubyModule proxy) {
+    @Override void install(ThreadContext context, final RubyModule proxy) {
         if (isAccessible()) {
             proxy.addMethod(name, new InstanceFieldSetter(name, proxy, field));
         }

--- a/core/src/main/java/org/jruby/javasupport/binding/InstanceMethodInvokerInstaller.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/InstanceMethodInvokerInstaller.java
@@ -2,6 +2,7 @@ package org.jruby.javasupport.binding;
 
 import org.jruby.RubyModule;
 import org.jruby.java.invokers.InstanceMethodInvoker;
+import org.jruby.runtime.ThreadContext;
 
 import java.lang.reflect.Method;
 
@@ -12,7 +13,7 @@ public class InstanceMethodInvokerInstaller extends MethodInstaller {
 
     public InstanceMethodInvokerInstaller(String name) { super(name, INSTANCE_METHOD); }
 
-    @Override void install(final RubyModule proxy) {
+    @Override void install(ThreadContext context, final RubyModule proxy) {
         if ( hasLocalMethod() ) {
             defineMethods(proxy, new InstanceMethodInvoker(proxy, () -> methods.toArray(new Method[methods.size()]), name));
         }

--- a/core/src/main/java/org/jruby/javasupport/binding/NamedInstaller.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/NamedInstaller.java
@@ -1,6 +1,7 @@
 package org.jruby.javasupport.binding;
 
 import org.jruby.RubyModule;
+import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 
 /**
@@ -22,7 +23,7 @@ public abstract class NamedInstaller {
         this.type = type;
     }
 
-    abstract void install(RubyModule proxy);
+    abstract void install(ThreadContext context, RubyModule proxy);
 
     // small hack to save a cast later on
     boolean hasLocalMethod() { return true; }

--- a/core/src/main/java/org/jruby/javasupport/binding/SingletonMethodInvokerInstaller.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/SingletonMethodInvokerInstaller.java
@@ -3,6 +3,7 @@ package org.jruby.javasupport.binding;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.java.invokers.SingletonMethodInvoker;
+import org.jruby.runtime.ThreadContext;
 
 import java.lang.reflect.Method;
 
@@ -18,10 +19,10 @@ public class SingletonMethodInvokerInstaller extends StaticMethodInvokerInstalle
         this.singleton = singleton;
     }
 
-    @Override void install(final RubyModule proxy) {
+    @Override void install(ThreadContext context, final RubyModule proxy) {
         // we don't check haveLocalMethod() here because it's not local and we know
         // that we always want to go ahead and install it
-        final RubyClass singletonClass = proxy.getSingletonClass();
+        final RubyClass singletonClass = proxy.singletonClass(context);
         defineMethods(singletonClass, new SingletonMethodInvoker(this.singleton, singletonClass, () -> methods.toArray(new Method[methods.size()]), name), false);
     }
 }

--- a/core/src/main/java/org/jruby/javasupport/binding/StaticFieldGetterInstaller.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/StaticFieldGetterInstaller.java
@@ -2,6 +2,7 @@ package org.jruby.javasupport.binding;
 
 import org.jruby.RubyModule;
 import org.jruby.java.invokers.StaticFieldGetter;
+import org.jruby.runtime.ThreadContext;
 
 import java.lang.reflect.Field;
 
@@ -13,9 +14,9 @@ public class StaticFieldGetterInstaller extends FieldInstaller {
         super(name, STATIC_FIELD, field);
     }
 
-    @Override void install(final RubyModule proxy) {
+    @Override void install(ThreadContext context, final RubyModule proxy) {
         if (isAccessible()) {
-            proxy.getSingletonClass().addMethod(name, new StaticFieldGetter(name, proxy, field));
+            proxy.singletonClass(context).addMethod(name, new StaticFieldGetter(name, proxy, field));
         }
     }
 }

--- a/core/src/main/java/org/jruby/javasupport/binding/StaticFieldSetterInstaller.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/StaticFieldSetterInstaller.java
@@ -2,6 +2,7 @@ package org.jruby.javasupport.binding;
 
 import org.jruby.RubyModule;
 import org.jruby.java.invokers.StaticFieldSetter;
+import org.jruby.runtime.ThreadContext;
 
 import java.lang.reflect.Field;
 
@@ -14,9 +15,9 @@ public class StaticFieldSetterInstaller extends FieldInstaller {
         super(name, STATIC_FIELD, field);
     }
 
-    @Override void install(final RubyModule proxy) {
+    @Override void install(ThreadContext context, final RubyModule proxy) {
         if (isAccessible()) {
-            proxy.getSingletonClass().addMethod(name, new StaticFieldSetter(name, proxy, field));
+            proxy.singletonClass(context).addMethod(name, new StaticFieldSetter(name, proxy, field));
         }
     }
 }

--- a/core/src/main/java/org/jruby/javasupport/binding/StaticMethodInvokerInstaller.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/StaticMethodInvokerInstaller.java
@@ -3,6 +3,7 @@ package org.jruby.javasupport.binding;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.java.invokers.StaticMethodInvoker;
+import org.jruby.runtime.ThreadContext;
 
 import java.lang.reflect.Method;
 
@@ -13,9 +14,9 @@ public class StaticMethodInvokerInstaller extends MethodInstaller {
 
     public StaticMethodInvokerInstaller(String name) { super(name, STATIC_METHOD); }
 
-    @Override void install(final RubyModule proxy) {
+    @Override void install(ThreadContext context, final RubyModule proxy) {
         if ( hasLocalMethod() ) {
-            final RubyClass singletonClass = proxy.getSingletonClass();
+            final RubyClass singletonClass = proxy.singletonClass(context);
             defineMethods(singletonClass, new StaticMethodInvoker(singletonClass, () -> methods.toArray(new Method[methods.size()]), name), false);
         }
     }

--- a/core/src/main/java/org/jruby/javasupport/ext/Module.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/Module.java
@@ -174,7 +174,7 @@ public class Module {
             includedPackages = new IncludedPackages();
             target.setInternalVariable("includedPackages", includedPackages);
             ConstMissingMethod method = new ConstMissingMethod(target, includedPackages); // def self.const_missing(constant) :
-            Helpers.addInstanceMethod(target.getSingletonClass(), asSymbol(context, "const_missing"), method, PUBLIC, context);
+            Helpers.addInstanceMethod(target.singletonClass(context), asSymbol(context, "const_missing"), method, PUBLIC, context);
         }
         return includedPackages;
     }

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyClass.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyClass.java
@@ -521,15 +521,15 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
     }
     
     // Note: called from <clinit> of reified classes
-    public static JavaProxyClass setProxyClassReified(final Ruby runtime, final RubyClass clazz,
+    public static JavaProxyClass setProxyClassReified(ThreadContext context, final RubyClass clazz,
             final Class<? extends ReifiedJavaProxy> reified, final boolean allocator) {
-        JavaProxyClass proxyClass = new JavaProxyClass(runtime, reified);
+        JavaProxyClass proxyClass = new JavaProxyClass(context.runtime, reified);
         clazz.setInstanceVariable("@java_proxy_class", proxyClass);
 
-        RubyClass singleton = clazz.getSingletonClass();
+        RubyClass singleton = clazz.singletonClass(context);
 
         singleton.setInstanceVariable("@java_proxy_class", proxyClass);
-        singleton.setInstanceVariable("@java_class", Java.wrapJavaObject(runtime, reified));
+        singleton.setInstanceVariable("@java_class", Java.wrapJavaObject(context.runtime, reified));
 
         if (allocator) {
             DynamicMethod oldNewMethod = singleton.searchMethod("new");
@@ -538,7 +538,7 @@ public class JavaProxyClass extends JavaProxyReflectionObject {
                 singleton.addMethod("new", new NewMethodReified(clazz, reified));
             }
             // Install initialize
-            StaticJCreateMethod.tryInstall(runtime, clazz, proxyClass, reified, defaultNew);
+            StaticJCreateMethod.tryInstall(context.runtime, clazz, proxyClass, reified, defaultNew);
         }
         return proxyClass;
     }

--- a/core/src/main/java/org/jruby/runtime/builtin/IRubyObject.java
+++ b/core/src/main/java/org/jruby/runtime/builtin/IRubyObject.java
@@ -139,8 +139,12 @@ public interface IRubyObject {
      * Retrieve <code>self.singleton_class</code>.
      * @return the Ruby singleton class
      */
-    @JRubyAPI
     RubyClass getSingletonClass();
+
+    @JRubyAPI
+    default RubyClass singletonClass(ThreadContext context) {
+        return getSingletonClass();
+    }
     
     /**
      * RubyMethod getType.

--- a/core/src/main/java/org/jruby/runtime/marshal/UnmarshalStream.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/UnmarshalStream.java
@@ -428,7 +428,7 @@ public class UnmarshalStream extends InputStream {
                 throw argumentError(context, str(runtime, "prepended class ", path, " differs from class ", cls));
             }
 
-            cls = obj.getSingletonClass();
+            cls = obj.singletonClass(context);
 
             for (RubyModule mod: extendedModules) {
                 cls.prependModule(mod);

--- a/core/src/test/java/org/jruby/test/TestMethodFactories.java
+++ b/core/src/test/java/org/jruby/test/TestMethodFactories.java
@@ -122,12 +122,12 @@ public class TestMethodFactories extends Base {
     public void testModuleMethodOwner() {
         RubyModule mod = defineModule(context, "GH3463Module").defineMethods(context, GH3463Module.class);
 
-        DynamicMethod method = mod.getSingletonClass().searchMethod("a_module_method");
+        DynamicMethod method = mod.singletonClass(context).searchMethod("a_module_method");
 
-        assertEquals(mod.getSingletonClass(), method.getImplementationClass());
+        assertEquals(mod.singletonClass(context), method.getImplementationClass());
 
         RubyMethod rubyMethod = (RubyMethod)mod.method(asSymbol(context, "a_module_method"));
 
-        assertEquals(mod.getSingletonClass(), rubyMethod.owner(context));
+        assertEquals(mod.singletonClass(context), rubyMethod.owner(context));
     }
 }

--- a/lib/ruby/stdlib/jruby/synchronized.rb
+++ b/lib/ruby/stdlib/jruby/synchronized.rb
@@ -15,7 +15,7 @@ module JRuby
     
     def self.extend_object(obj)
       obj_r = JRuby.reference0(obj)
-      singleton_class = obj_r.singleton_class
+      singleton_class = obj_r.singleton_class(obj_r.runtime.current_context)
       JRuby.reference(singleton_class).become_synchronized
       
       super


### PR DESCRIPTION
getSingletonClass() replaced with singleonClass(context)

Since singleton class may need to make a singleton it needs context handy.  Also the few types incapable of
singleton classes needs to raise an error.