### PR TITLE
Deprecate defineOrGetClassUnder

### DIFF
--- a/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
+++ b/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
@@ -100,9 +100,9 @@ public class RubyZlib {
         var GZipFileError = GzipFile.defineClassUnder(context, "Error", ZlibError, errorAllocator);
         var fileErrorAllocator = ZlibError.getAllocator();
         GZipFileError.addReadAttribute(context, "input");
-        GzipFile.defineOrGetClassUnder("CRCError", GZipFileError, fileErrorAllocator);
-        GzipFile.defineOrGetClassUnder("NoFooter", GZipFileError, fileErrorAllocator);
-        GzipFile.defineOrGetClassUnder("LengthError", GZipFileError, fileErrorAllocator);
+        GzipFile.defineClassUnder("CRCError", GZipFileError, fileErrorAllocator);
+        GzipFile.defineClassUnder("NoFooter", GZipFileError, fileErrorAllocator);
+        GzipFile.defineClassUnder("LengthError", GZipFileError, fileErrorAllocator);
 
         Zlib.defineClassUnder(context, "GzipReader", GzipFile, JZlibRubyGzipReader::new).
                 include(context, enumerableModule(context)).

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -29,7 +29,6 @@ import org.jruby.RubyRegexp;
 import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.jruby.api.Create;
-import org.jruby.common.IRubyWarnings;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.Unrescuable;
 import org.jruby.ext.coverage.CoverageData;
@@ -1780,7 +1779,7 @@ public class IRRuntimeHelpers {
             sc = (RubyClass) superClass;
         }
 
-        RubyModule newRubyClass = ((RubyModule)container).defineOrGetClassUnder(id, sc, scope.getFile(), context.getLine() + 1);
+        RubyModule newRubyClass = ((RubyModule)container).defineClassUnder(context, id, sc, null, scope.getFile(), context.getLine() + 1);
 
         scope.setModule(newRubyClass);
 


### PR DESCRIPTION
Most of these were already dead.  Also made the IR consuming one become defineClassUnder like the native extension equivalent of this method.