### PR TITLE
Last boostrapping classes/modules decoupled from non-boot

### DIFF
--- a/core/src/main/java/org/jruby/MetaClass.java
+++ b/core/src/main/java/org/jruby/MetaClass.java
@@ -50,14 +50,31 @@ public final class MetaClass extends RubyClass {
      */
     MetaClass(Ruby runtime, RubyClass superClass, RubyBasicObject attached) {
         super(runtime, superClass, false);
-        this.attached = attached;
-        // use same ClassIndex as metaclass, since we're technically still of that type
-        classIndex(superClass.getClassIndex());
-        superClass.addSubclass(this);
+        metaClassInit(superClass, attached);
 
         if (LOG_SINGLETONS || LOG_SINGLETONS_VERBOSE) {
             logSingleton(runtime, superClass, attached);
         }
+    }
+
+    /**
+     * This is an internal API only used by Ruby constructor before ThreadContext exists.  This is for bootstrapping
+     * only.
+     * @param runtime
+     * @param superClass
+     * @param Class
+     * @param attached
+     */
+    MetaClass(Ruby runtime, RubyClass superClass, RubyClass Class, RubyBasicObject attached) {
+        super(runtime, superClass, Class);
+        metaClassInit(superClass, attached);
+    }
+
+    private void metaClassInit(RubyClass superClass, RubyBasicObject attached) {
+        this.attached = attached;
+        // use same ClassIndex as metaclass, since we're technically still of that type
+        classIndex(superClass.getClassIndex());
+        superClass.addSubclass(this);
     }
 
     private static void logSingleton(Ruby runtime, RubyClass superClass, RubyBasicObject attached) {

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -501,6 +501,23 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     }
 
     /**
+     * This will create a new metaclass.  This is only used during bootstrapping before
+     * the initial ThreadContext is defined.  Normal needs of making a metaclass should use
+     * {@link RubyBasicObject#makeMetaClass(RubyClass)}
+     * @param superClass
+     * @param Class
+     * @return
+     */
+    public RubyClass makeMetaClassBootstrap(RubyClass superClass, RubyClass Class) {
+        MetaClass klass = new MetaClass(getRuntime(), superClass, Class, this); // rb_class_boot
+        setMetaClass(klass);
+
+        klass.setMetaClass(superClass.getRealClass().metaClass);
+
+        return klass;
+    }
+
+    /**
      * Makes it possible to change the metaclass of an object. In
      * practice, this is a simple version of Smalltalks Become, except
      * that it doesn't work when we're dealing with subclasses. In

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -120,7 +120,7 @@ public class RubyClass extends RubyModule {
     private static final Logger LOG = LoggerFactory.getLogger(RubyClass.class);
     private static final double SUBCLASSES_CLEAN_FACTOR = 0.25;
 
-    public static void createClassClass(Ruby runtime, RubyClass Class) {
+    public static void finishClassClass(Ruby runtime, RubyClass Class) {
         Class.reifiedClass(RubyClass.class).
                 kindOf(new RubyModule.JavaClassKindOf(RubyClass.class)).
                 classIndex(ClassIndex.CLASS);
@@ -429,6 +429,25 @@ public class RubyClass extends RubyModule {
         }
 
         superClass(superClass); // this is the only case it might be null here (in MetaClass construction)
+    }
+
+    /**
+     *  This is an internal API only used by Ruby constructor before ThreadContext exists.
+     * @param runtime
+     * @param superClass
+     * @param Class
+     */
+    protected RubyClass(Ruby runtime, RubyClass superClass, RubyClass Class) {
+        super(runtime, Class, false);
+
+        this.runtime = runtime;
+        if ((this.realClass = superClass.realClass) != null) {
+            this.variableTableManager = realClass.variableTableManager;
+        } else {
+            this.variableTableManager = new VariableTableManager(this);
+        }
+
+        superClass(superClass);
     }
 
     /** used by CLASS_ALLOCATOR (any Class' class will be a Class!)

--- a/core/src/main/java/org/jruby/RubyConverter.java
+++ b/core/src/main/java/org/jruby/RubyConverter.java
@@ -61,7 +61,6 @@ import static org.jcodings.transcode.EConvResult.*;
 import static org.jruby.api.Convert.*;
 import static org.jruby.api.Create.newArray;
 import static org.jruby.api.Create.newString;
-import static org.jruby.api.Define.defineClassUnder;
 import static org.jruby.api.Error.*;
 import static org.jruby.runtime.Visibility.PRIVATE;
 
@@ -121,7 +120,7 @@ public class RubyConverter extends RubyObject {
     }
 
     public static RubyClass createConverterClass(ThreadContext context, RubyClass Object, RubyClass Encoding) {
-        return defineClassUnder(context, "Converter", Object, RubyConverter::new, Encoding).
+        return Encoding.defineClassUnder(context, "Converter", Object, RubyConverter::new).
                 reifiedClass(RubyConverter.class).
                 kindOf(new RubyModule.JavaClassKindOf(RubyConverter.class)).
                 classIndex(ClassIndex.CONVERTER).

--- a/core/src/main/java/org/jruby/RubyObject.java
+++ b/core/src/main/java/org/jruby/RubyObject.java
@@ -43,7 +43,6 @@ package org.jruby;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.util.List;
 import java.util.Set;
 import java.util.function.BiConsumer;
 
@@ -65,7 +64,6 @@ import static org.jruby.runtime.invokedynamic.MethodNames.EQL;
 import static org.jruby.runtime.invokedynamic.MethodNames.OP_EQUAL;
 import static org.jruby.runtime.invokedynamic.MethodNames.HASH;
 
-import org.jruby.specialized.RubyObjectSpecializer;
 import org.jruby.util.cli.Options;
 
 /**
@@ -140,7 +138,7 @@ public class RubyObject extends RubyBasicObject {
      * argument because of the Object class' central part in runtime
      * initialization.
      */
-    public static void createObjectClass(RubyClass Object) {
+    public static void finishObjectClass(RubyClass Object) {
         Object.reifiedClass(RubyObject.class).classIndex(ClassIndex.OBJECT);
     }
 

--- a/core/src/main/java/org/jruby/api/Define.java
+++ b/core/src/main/java/org/jruby/api/Define.java
@@ -14,7 +14,10 @@ import static org.jruby.api.Access.objectClass;
 public class Define {
     /**
      * Define a new class under the Object namespace. Roughly equivalent to
-     * rb_define_class in MRI.
+     * rb_define_class in MRI.  This is a convenience method as you could use
+     * {@link RubyModule#defineClassUnder(ThreadContext, String, RubyClass, ObjectAllocator)} on
+     * a reference to Object but this is such a common thing that it is its own method.
+     * Note: If a class already exists for this name it returns it or errors if it is not a Class at all.
      *
      * @param context the current thread context
      * @param name The name for the new class
@@ -24,41 +27,20 @@ public class Define {
      * @return The new class
      */
     public static RubyClass defineClass(ThreadContext context, String name, RubyClass superClass, ObjectAllocator allocator) {
-        return defineClassUnder(context, name, superClass, allocator, objectClass(context));
-    }
-
-    /**
-     * Define a new class with the given name under the given module or class
-     * namespace. Roughly equivalent to rb_define_class_under in MRI.
-     *
-     * If the name specified is already bound, its value will be returned if:
-     * * It is a class
-     * * No new superclass is being defined
-     *
-     * @param context the current thread context
-     * @param name The name for the new class
-     * @param superClass The super class for the new class
-     * @param allocator An ObjectAllocator instance that can construct
-     * instances of the new class.
-     * @param parent The namespace under which to define the new class
-     * @return The new class
-     */
-    public static RubyClass defineClassUnder(ThreadContext context, String name, RubyClass superClass,
-                                             ObjectAllocator allocator, RubyModule parent) {
-        return context.runtime.defineClassUnder(name, superClass, allocator, parent, null);
+        return objectClass(context).defineClassUnder(context, name, superClass, allocator);
     }
 
     /**
      * Define a new module under the Object namespace. Roughly equivalent to
      * rb_define_module in MRI.  Note: If a module already exists for this name
-     * it returns it.
+     * it returns it or errors if it is not a Module at all.
      *
      * @param name The name of the new module
      * @return The new module or existing one if it has already been defined.
      */
     @Extension
     public static RubyModule defineModule(ThreadContext context, String name) {
-        return context.runtime.defineModuleUnder(name, objectClass(context));
+        return context.runtime.defineModuleUnder(context, name, objectClass(context));
     }
 
 

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -63,7 +63,6 @@ import static org.jruby.api.Access.*;
 import static org.jruby.api.Convert.*;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineClass;
-import static org.jruby.api.Define.defineClassUnder;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.ext.date.DateUtils.*;
@@ -121,7 +120,7 @@ public class RubyDate extends RubyObject {
                 defineConstant(context, "VERSION", newString(context, "3.2.2"));
 
         var ArgumentError = argumentErrorClass(context);
-        RubyClass dateError = defineClassUnder(context, "Error", ArgumentError, ArgumentError.getAllocator(), Date);
+        RubyClass dateError = Date.defineClassUnder(context, "Error", ArgumentError, ArgumentError.getAllocator());
         context.runtime.setDateError(dateError);
 
         return (RubyClass) Date;


### PR DESCRIPTION
At this point all classes and modules not happening before first threadcontext can now depend on TC being available. This will lead to a lot more lower classes using TC rather than the classes runtime field.