### PR TITLE
We should always have a valid staticScope

### DIFF
--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1659,26 +1659,15 @@ public class IRRuntimeHelpers {
 
     @JIT
     public static IRubyObject searchConst(ThreadContext context, StaticScope staticScope, String constName, boolean noPrivateConsts) {
-<<<<<<< Updated upstream
-        RubyModule object = objectClass(context);
-        IRubyObject constant = staticScope == null ? object.getConstant(constName) : staticScope.getConstantInner(constName);
-=======
-        IRubyObject constant = staticScope.getScopedConstant(context, constName);
->>>>>>> Stashed changes
+        IRubyObject constant = staticScope.getConstantInner(constName);
 
         // Inheritance lookup
         RubyModule module = null;
         if (constant == null) {
-<<<<<<< Updated upstream
-            // SSS FIXME: Is this null check case correct?
-            module = staticScope == null ? object : staticScope.getModule();
-            constant = noPrivateConsts ? module.getConstantFromNoConstMissing(constName, false) : module.getConstantNoConstMissing(constName);
-=======
             module = staticScope.getModule();
             constant = noPrivateConsts ?
                     module.getConstantFromNoConstMissing(constName, false) :
-                    module.getConstantNoConstMissing(context, constName);
->>>>>>> Stashed changes
+                    module.getConstantNoConstMissing(constName);
         }
 
         // Call const_missing or cache

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1659,15 +1659,26 @@ public class IRRuntimeHelpers {
 
     @JIT
     public static IRubyObject searchConst(ThreadContext context, StaticScope staticScope, String constName, boolean noPrivateConsts) {
+<<<<<<< Updated upstream
         RubyModule object = objectClass(context);
         IRubyObject constant = staticScope == null ? object.getConstant(constName) : staticScope.getConstantInner(constName);
+=======
+        IRubyObject constant = staticScope.getScopedConstant(context, constName);
+>>>>>>> Stashed changes
 
         // Inheritance lookup
         RubyModule module = null;
         if (constant == null) {
+<<<<<<< Updated upstream
             // SSS FIXME: Is this null check case correct?
             module = staticScope == null ? object : staticScope.getModule();
             constant = noPrivateConsts ? module.getConstantFromNoConstMissing(constName, false) : module.getConstantNoConstMissing(constName);
+=======
+            module = staticScope.getModule();
+            constant = noPrivateConsts ?
+                    module.getConstantFromNoConstMissing(constName, false) :
+                    module.getConstantNoConstMissing(context, constName);
+>>>>>>> Stashed changes
         }
 
         // Call const_missing or cache

--- a/core/src/main/java/org/jruby/ir/targets/indy/ConstantLookupSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/ConstantLookupSite.java
@@ -80,31 +80,17 @@ public class ConstantLookupSite extends MutableCallSite {
 
     public IRubyObject searchConst(ThreadContext context, StaticScope staticScope) {
         // Lexical lookup
-<<<<<<< Updated upstream
-        RubyModule object = objectClass(context);
-
         // get switchpoint before value
         SwitchPoint switchPoint = getSwitchPointForConstant(context.runtime);
-        IRubyObject constant = (staticScope == null) ? object.getConstant(name) : staticScope.getConstantInner(name);
-=======
-        // get switchpoint before value
-        SwitchPoint switchPoint = getSwitchPointForConstant(context.runtime);
-        IRubyObject constant = staticScope.getScopedConstant(context, name);
->>>>>>> Stashed changes
+        IRubyObject constant = staticScope.getConstantInner(name);
 
         // Inheritance lookup
         RubyModule module = null;
         if (constant == null) {
-<<<<<<< Updated upstream
-            // SSS FIXME: Is this null check case correct?
-            module = staticScope == null ? object : staticScope.getModule();
-            constant = publicOnly ? module.getConstantFromNoConstMissing(name, false) : module.getConstantNoConstMissing(name);
-=======
             module = staticScope.getModule();
             constant = publicOnly ?
                     module.getConstantFromNoConstMissing(name, false) :
-                    module.getConstantNoConstMissing(context, name);
->>>>>>> Stashed changes
+                    module.getConstantNoConstMissing(name);
         }
 
         // Call const_missing or cache

--- a/core/src/main/java/org/jruby/ir/targets/indy/ConstantLookupSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/indy/ConstantLookupSite.java
@@ -80,18 +80,31 @@ public class ConstantLookupSite extends MutableCallSite {
 
     public IRubyObject searchConst(ThreadContext context, StaticScope staticScope) {
         // Lexical lookup
+<<<<<<< Updated upstream
         RubyModule object = objectClass(context);
 
         // get switchpoint before value
         SwitchPoint switchPoint = getSwitchPointForConstant(context.runtime);
         IRubyObject constant = (staticScope == null) ? object.getConstant(name) : staticScope.getConstantInner(name);
+=======
+        // get switchpoint before value
+        SwitchPoint switchPoint = getSwitchPointForConstant(context.runtime);
+        IRubyObject constant = staticScope.getScopedConstant(context, name);
+>>>>>>> Stashed changes
 
         // Inheritance lookup
         RubyModule module = null;
         if (constant == null) {
+<<<<<<< Updated upstream
             // SSS FIXME: Is this null check case correct?
             module = staticScope == null ? object : staticScope.getModule();
             constant = publicOnly ? module.getConstantFromNoConstMissing(name, false) : module.getConstantNoConstMissing(name);
+=======
+            module = staticScope.getModule();
+            constant = publicOnly ?
+                    module.getConstantFromNoConstMissing(name, false) :
+                    module.getConstantNoConstMissing(context, name);
+>>>>>>> Stashed changes
         }
 
         // Call const_missing or cache

--- a/core/src/main/java/org/jruby/ir/targets/simple/ConstantLookupSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/simple/ConstantLookupSite.java
@@ -26,25 +26,15 @@ public class ConstantLookupSite {
     private IRubyObject cacheSearchConst(ThreadContext context, StaticScope staticScope, boolean publicOnly) {
         // Lexical lookup
         String id = this.id;
-<<<<<<< Updated upstream
-        IRubyObject constant = (staticScope == null) ? object.getConstant(id) : staticScope.getConstantInner(id);
-=======
-        IRubyObject constant = staticScope.getScopedConstant(context, id);
->>>>>>> Stashed changes
+        IRubyObject constant = staticScope.getConstantInner(id);
 
         // Inheritance lookup
         RubyModule module = null;
         if (constant == null) {
-<<<<<<< Updated upstream
-            // SSS FIXME: Is this null check case correct?
-            module = staticScope == null ? object : staticScope.getModule();
-            constant = publicOnly ? module.getConstantFromNoConstMissing(id, false) : module.getConstantNoConstMissing(id);
-=======
             module = staticScope.getModule();
             constant = publicOnly ?
                     module.getConstantFromNoConstMissing(id, false) :
-                    module.getConstantNoConstMissing(context, id);
->>>>>>> Stashed changes
+                    module.getConstantNoConstMissing(id);
         }
 
         // Call const_missing or cache

--- a/core/src/main/java/org/jruby/ir/targets/simple/ConstantLookupSite.java
+++ b/core/src/main/java/org/jruby/ir/targets/simple/ConstantLookupSite.java
@@ -25,16 +25,26 @@ public class ConstantLookupSite {
 
     private IRubyObject cacheSearchConst(ThreadContext context, StaticScope staticScope, boolean publicOnly) {
         // Lexical lookup
-        RubyModule object = objectClass(context);
         String id = this.id;
+<<<<<<< Updated upstream
         IRubyObject constant = (staticScope == null) ? object.getConstant(id) : staticScope.getConstantInner(id);
+=======
+        IRubyObject constant = staticScope.getScopedConstant(context, id);
+>>>>>>> Stashed changes
 
         // Inheritance lookup
         RubyModule module = null;
         if (constant == null) {
+<<<<<<< Updated upstream
             // SSS FIXME: Is this null check case correct?
             module = staticScope == null ? object : staticScope.getModule();
             constant = publicOnly ? module.getConstantFromNoConstMissing(id, false) : module.getConstantNoConstMissing(id);
+=======
+            module = staticScope.getModule();
+            constant = publicOnly ?
+                    module.getConstantFromNoConstMissing(id, false) :
+                    module.getConstantNoConstMissing(context, id);
+>>>>>>> Stashed changes
         }
 
         // Call const_missing or cache


### PR DESCRIPTION
Some old guarded code with a comment made me think we don't need this check as we should always have a staticScope.