### PR TITLE
Backport no-inspect NameError logic

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -389,7 +389,9 @@ public final class Ruby implements Constantizable {
         // Initialize all the core classes
         comparableModule = RubyComparable.createComparable(this);
         enumerableModule = RubyEnumerable.createEnumerableModule(this);
+
         stringClass = RubyString.createStringClass(this);
+        emptyFrozenString = freezeAndDedupString(RubyString.newEmptyString(this));
 
         falseString = newString(FALSE_BYTES);
         falseString.setFrozen(true);
@@ -3529,6 +3531,10 @@ public final class Ruby implements Constantizable {
         return emptyFrozenArray;
     }
 
+    public RubyString getEmptyFrozenString() {
+        return emptyFrozenString;
+    }
+
     public RubyBoolean newBoolean(boolean value) {
         return value ? trueObject : falseObject;
     }
@@ -5880,6 +5886,7 @@ public final class Ruby implements Constantizable {
     }
 
     private final RubyArray emptyFrozenArray;
+    private final RubyString emptyFrozenString;
 
     /**
      * A map from Ruby string data to a pre-frozen global version of that string.

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -165,7 +165,7 @@ public class Options {
     public static final Option<Boolean> REGEXP_INTERRUPTIBLE = bool(MISCELLANEOUS, "regexp.interruptible", true, "Allow regexp operations to be interruptible from Ruby.");
     public static final Option<Integer> JAR_CACHE_EXPIRATION = integer(MISCELLANEOUS, "jar.cache.expiration", 750, "The time (ms) between checks if a JAR file containing resources has been updated.");
     public static final Option<String> WINDOWS_FILESYSTEM_ENCODING = string(MISCELLANEOUS, "windows.filesystem.encoding", "UTF-8", "The encoding to use for filesystem names and paths on Windows.");
-    public static final Option<Boolean> INSPECT_NAME_ERROR_OBJECT = bool(MISCELLANEOUS, "inspect.nameError.object", true, "Inspect the target object for display in NameError messages.");
+    public static final Option<Boolean> NAME_ERROR_INSPECT_OBJECT = bool(MISCELLANEOUS, "nameError.inspect.object", true, "Inspect the target object for display in NameError messages.");
 
     public static final Option<Boolean> DEBUG_LOADSERVICE = bool(DEBUG, "debug.loadService", false, "Log require/load file searches.");
     public static final Option<Boolean> DEBUG_LOADSERVICE_TIMING = bool(DEBUG, "debug.loadService.timing", false, "Log require/load parse+evaluate times.");

--- a/core/src/main/java/org/jruby/util/cli/Options.java
+++ b/core/src/main/java/org/jruby/util/cli/Options.java
@@ -165,6 +165,7 @@ public class Options {
     public static final Option<Boolean> REGEXP_INTERRUPTIBLE = bool(MISCELLANEOUS, "regexp.interruptible", true, "Allow regexp operations to be interruptible from Ruby.");
     public static final Option<Integer> JAR_CACHE_EXPIRATION = integer(MISCELLANEOUS, "jar.cache.expiration", 750, "The time (ms) between checks if a JAR file containing resources has been updated.");
     public static final Option<String> WINDOWS_FILESYSTEM_ENCODING = string(MISCELLANEOUS, "windows.filesystem.encoding", "UTF-8", "The encoding to use for filesystem names and paths on Windows.");
+    public static final Option<Boolean> INSPECT_NAME_ERROR_OBJECT = bool(MISCELLANEOUS, "inspect.nameError.object", true, "Inspect the target object for display in NameError messages.");
 
     public static final Option<Boolean> DEBUG_LOADSERVICE = bool(DEBUG, "debug.loadService", false, "Log require/load file searches.");
     public static final Option<Boolean> DEBUG_LOADSERVICE_TIMING = bool(DEBUG, "debug.loadService.timing", false, "Log require/load parse+evaluate times.");


### PR DESCRIPTION
This is a backport of the no-inspect NameError logic added to JRuby 10 in #8533, guarded by an option for users on JRuby 9.4.

On 9.4, the inspect logic is enabled by default, but can be disabled by with the option `-XnameError.inspect.object=false`. Because the object inspect is a specified behavior of Ruby 3.1, we can't disable it by default, but this allows users to opt out of the behavior.

JRuby 10 will ignore this logic and avoid inspecting the object attached to the NameError. The option will have no effect.

Using the example from #8384 with this new option:

```
$ jruby -w -J-Xmx250M -XnameError.inspect.object=false blah.rb
generating large obj
done
NameError: undefined local variable or method `nameerror' for an instance of Test
   error at blah.rb:9
  <main> at blah.rb:16
```

Interestingly, I discovered that the original code does not OOM on Java 21, because it never seems to call the expected inspect method. I will open an issue to investigate that.