### PR TITLE
Extra "" around singleton in {Name|No}MethodError

### DIFF
--- a/core/src/main/java/org/jruby/RubyNameError.java
+++ b/core/src/main/java/org/jruby/RubyNameError.java
@@ -150,17 +150,20 @@ public class RubyNameError extends RubyStandardError {
                     if (klass.isSingleton()) {
                         separator = newString(context, "");
                         if (object == runtime.getTopSelf()) {
-                            classTmp = newString(context, "main");
+                            className = newString(context, "main");
                         } else {
-                            classTmp = object.anyToString();
+                            className = (RubyString) object.anyToString();
                         }
                     } else {
                         separator = newString(context, "an instance of ");
                         classTmp = klass.getRealClass();
+                        className = getNameOrInspect(context, classTmp);
                     }
+                } else {
+                    className = getNameOrInspect(context, classTmp);
                 }
 
-                className = getNameOrInspect(context, classTmp);
+
             }
 
             RubyArray arr = RubyArray.newArray(runtime, this.name, description, separator, className);


### PR DESCRIPTION
This was weirdly hard to see in reading MRI's logic where it adds a break to jump past reinspecting the String it makes only for singletons (other cases still are module/classes to be inspected).  This fixes a single spec failure in ruby/language.