### PR TITLE
More removal of getRuntime() from non-deprecated code paths

### DIFF
--- a/core/src/main/java/org/jruby/AbstractRubyMethod.java
+++ b/core/src/main/java/org/jruby/AbstractRubyMethod.java
@@ -150,7 +150,7 @@ public abstract class AbstractRubyMethod extends RubyObject implements DataType 
 
     @JRubyMethod(name = "parameters")
     public IRubyObject parameters(ThreadContext context) {
-        return Helpers.methodToParameters(context.runtime, this);
+        return Helpers.methodToParameters(context, this);
     }
 
     protected IRubyObject super_method(ThreadContext context, IRubyObject receiver, RubyModule superClass) {
@@ -240,7 +240,7 @@ public abstract class AbstractRubyMethod extends RubyObject implements DataType 
         }
 
         str.catString("(");
-        ArgumentDescriptor[] descriptors = Helpers.methodToArgumentDescriptors(method);
+        ArgumentDescriptor[] descriptors = Helpers.methodToArgumentDescriptors(context, method);
         if (descriptors.length > 0) {
             RubyString desc = descriptors[0].asParameterName(context);
 

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -868,7 +868,7 @@ public final class Ruby implements Constantizable {
         context.preEvalScriptlet(scope);
 
         try {
-            return interpreter.execute(this, rootNode, getTopSelf());
+            return interpreter.execute(context, rootNode, getTopSelf());
         } finally {
             context.postEvalScriptlet();
         }
@@ -1214,7 +1214,7 @@ public final class Ruby implements Constantizable {
 
     private ScriptAndCode tryCompile(ParseResult result, ClassDefiningClassLoader classLoader) {
         try {
-            return Compiler.getInstance().execute(this, result, classLoader);
+            return Compiler.getInstance().execute(getCurrentContext(), result, classLoader);
         } catch (NotCompilableException | VerifyError e) {
             if (Options.JIT_LOGGING.load()) {
                 if (Options.JIT_LOGGING_VERBOSE.load()) {
@@ -1249,7 +1249,7 @@ public final class Ruby implements Constantizable {
 
     public IRubyObject runInterpreter(ThreadContext context, ParseResult parseResult, IRubyObject self) {
         try {
-            return interpreter.execute(this, parseResult, self);
+            return interpreter.execute(context, parseResult, self);
         } catch (IRReturnJump ex) {
             /* We happen to not push script scope as a dynamic scope or at least we seem to get rid of it.
              * This will capture any return which says it should return to a script scope as the reasonable
@@ -1271,7 +1271,7 @@ public final class Ruby implements Constantizable {
 
     public IRubyObject runInterpreter(ThreadContext context,  Node rootNode, IRubyObject self) {
         assert rootNode != null : "scriptNode is not null";
-        return interpreter.execute(this, (ParseResult) rootNode, self);
+        return interpreter.execute(context, (ParseResult) rootNode, self);
     }
 
     public IRubyObject runInterpreter(Node scriptNode) {

--- a/core/src/main/java/org/jruby/RubyArgsFile.java
+++ b/core/src/main/java/org/jruby/RubyArgsFile.java
@@ -236,7 +236,7 @@ public class RubyArgsFile extends RubyObject {
 
         @Deprecated
         public static ArgsFileData getDataFrom(IRubyObject recv) {
-            return getArgsFileData(recv.getRuntime());
+            return getArgsFileData(((RubyBasicObject) recv).getCurrentContext().runtime);
         }
 
         private void createNewFile(File file) {
@@ -295,7 +295,7 @@ public class RubyArgsFile extends RubyObject {
 
     @Deprecated
     public static void setCurrentLineNumber(IRubyObject recv, int newLineNumber) {
-        recv.getRuntime().setCurrentLine(newLineNumber);
+        ((RubyBasicObject) recv).getCurrentContext().runtime.setCurrentLine(newLineNumber);
     }
 
     @JRubyMethod
@@ -600,13 +600,17 @@ public class RubyArgsFile extends RubyObject {
         return data.currentFile;
     }
 
-    @JRubyMethod(name = "skip")
+    @Deprecated(since = "10.0")
     public static IRubyObject skip(IRubyObject recv) {
-        Ruby runtime = recv.getRuntime();
-        ArgsFileData data = ArgsFileData.getArgsFileData(runtime);
+        return skip(((RubyBasicObject) recv).getCurrentContext(), recv);
+    }
+
+    @JRubyMethod(name = "skip")
+    public static IRubyObject skip(ThreadContext context, IRubyObject recv) {
+        ArgsFileData data = ArgsFileData.getArgsFileData(context.runtime);
 
         if (data.inited && data.next_p == Next.SameFile) {
-            argf_close(runtime.getCurrentContext(), data.currentFile);
+            argf_close(context, data.currentFile);
             data.next_p = NextFile;
         }
 
@@ -905,9 +909,14 @@ public class RubyArgsFile extends RubyObject {
         return globalVariables(context).get("$FILENAME");
     }
 
-    @JRubyMethod(name = "to_s", alias = "inspect")
+    @Deprecated(since = "10.0")
     public static IRubyObject to_s(IRubyObject recv) {
-        return recv.getRuntime().newString("ARGF");
+        return to_s(((RubyBasicObject) recv).getCurrentContext(), recv);
+    }
+
+    @JRubyMethod(name = "to_s", alias = "inspect")
+    public static IRubyObject to_s(ThreadContext context, IRubyObject recv) {
+        return newString(context, "ARGF");
     }
 
     private static RubyIO getCurrentDataFile(ThreadContext context, String errorMessage) {

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -1266,7 +1266,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     @Deprecated
     public IRubyObject insert(IRubyObject[] args) {
-        return insert(getRuntime().getCurrentContext(), args);
+        return insert(getCurrentContext(), args);
     }
 
     @JRubyMethod(name = "insert", required = 1, rest = true, checkArity = false)
@@ -1302,7 +1302,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      */
     @Deprecated(since = "10.0", forRemoval = true)
     public RubyArray transpose() {
-        return transpose(getRuntime().getCurrentContext());
+        return transpose(getCurrentContext());
     }
 
     /** rb_ary_transpose
@@ -1341,7 +1341,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      */
     @Deprecated(since = "10.0", forRemoval = true)
     public IRubyObject values_at(IRubyObject[] args) {
-        return values_at(getRuntime().getCurrentContext(), args);
+        return values_at(getCurrentContext(), args);
     }
 
     /** rb_values_at
@@ -1770,7 +1770,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      */
     @Deprecated(since = "9.4")
     public IRubyObject aref(IRubyObject[] args) {
-        ThreadContext context = getRuntime().getCurrentContext();
+        ThreadContext context = getCurrentContext();
         return switch (args.length) {
             case 1 -> aref(context, args[0]);
             case 2 -> aref(context, args[0], args[1]);
@@ -1783,7 +1783,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     @Deprecated
     public IRubyObject aref(IRubyObject arg0) {
-        return aref(getRuntime().getCurrentContext(), arg0);
+        return aref(getCurrentContext(), arg0);
     }
 
     /** rb_ary_aref
@@ -1816,7 +1816,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     @Deprecated(since = "10.0")
     public IRubyObject aref(IRubyObject arg0, IRubyObject arg1) {
-        return aref(getRuntime().getCurrentContext(), arg0, arg1);
+        return aref(getCurrentContext(), arg0, arg1);
     }
 
     @JRubyMethod(name = {"[]", "slice"})
@@ -1835,7 +1835,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         return switch (args.length) {
             case 2 -> aset(args[0], args[1]);
             case 3 -> aset(args[0], args[1], args[2]);
-            default -> throw argumentError(getRuntime().getCurrentContext(), "wrong number of arguments (" + args.length + " for 2)");
+            default -> throw argumentError(getCurrentContext(), "wrong number of arguments (" + args.length + " for 2)");
         };
     }
 
@@ -3385,7 +3385,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         case 2:
             return slice_bang(args[0], args[1]);
         default:
-            Arity.raiseArgumentError(getRuntime().getCurrentContext(), args.length, 1, 2);
+            Arity.raiseArgumentError(getCurrentContext(), args.length, 1, 2);
             return null; // not reached
         }
     }

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -2300,11 +2300,13 @@ public class RubyClass extends RubyModule {
 
                 for (String sig : sigs) {
                     m.dup();
+                    m.getstatic(javaPath, RUBY_FIELD, ci(Ruby.class));
+                    m.invokevirtual("org/jruby/Ruby", "getCurrentContext", "()Lorg/jruby/runtime/ThreadContext;");
                     m.ldc(name);
                     m.ldc(sig);
                     m.iconst_1();
                     m.invokevirtual(p(JavaProxyClass.class), "initMethod",
-                            sig(void.class, String.class, String.class, boolean.class));
+                            sig(void.class, ThreadContext.class, String.class, String.class, boolean.class));
                 }
             });
             m.pop();

--- a/core/src/main/java/org/jruby/RubyFixnum.java
+++ b/core/src/main/java/org/jruby/RubyFixnum.java
@@ -234,7 +234,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
 
     @Deprecated // not used
     public final RubyFixnum newFixnum(long newValue) {
-        return newFixnum(getRuntime(), newValue);
+        return newFixnum(getCurrentContext().runtime, newValue);
     }
 
     public static RubyFixnum zero(Ruby runtime) {
@@ -440,9 +440,10 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
      */
     @Deprecated
     public IRubyObject to_sym() {
-        RubySymbol symbol = RubySymbol.getSymbolLong(getRuntime(), value);
+        var context = getCurrentContext();
+        RubySymbol symbol = RubySymbol.getSymbolLong(context.runtime, value);
 
-        return symbol != null ? symbol : getRuntime().getNil();
+        return symbol != null ? symbol : context.nil;
     }
 
     /** fix_uminus
@@ -1286,7 +1287,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
 
     @Deprecated // no longer used
     public IRubyObject op_lshift(long width) {
-        return op_lshift(getRuntime().getCurrentContext(), width);
+        return op_lshift(getCurrentContext(), width);
     }
 
     /** fix_rshift
@@ -1294,11 +1295,9 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
      */
     @Override
     public IRubyObject op_rshift(ThreadContext context, IRubyObject other) {
-        if (!(other instanceof RubyFixnum)) {
-            return RubyBignum.newBignum(context.runtime, value).op_rshift(context, other);
-        }
-
-        return op_rshift(context, ((RubyFixnum) other).value);
+        return other instanceof RubyFixnum fix ?
+                op_rshift(context, fix.value) :
+                RubyBignum.newBignum(context.runtime, value).op_rshift(context, other);
     }
 
     @Override
@@ -1317,7 +1316,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
 
     @Deprecated
     public IRubyObject op_rshift(long width) {
-        return op_rshift(getRuntime().getCurrentContext(), width);
+        return op_rshift(getCurrentContext(), width);
     }
 
     /** fix_to_f
@@ -1343,7 +1342,7 @@ public class RubyFixnum extends RubyInteger implements Constantizable, Appendabl
 
     @Deprecated
     public IRubyObject zero_p() {
-        return zero_p(getRuntime().getCurrentContext());
+        return zero_p(getCurrentContext());
     }
 
     /** fix_zero_p

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -3010,12 +3010,12 @@ public class RubyHash extends RubyObject implements Map {
     @Deprecated
     @Override
     public RubyArray to_a() {
-        return to_a(getRuntime().getCurrentContext());
+        return to_a(getCurrentContext());
     }
 
     @Deprecated
     public IRubyObject default_value_set(final IRubyObject defaultValue) {
-        return default_value_set(getRuntime().getCurrentContext(), defaultValue);
+        return default_value_set(getCurrentContext(), defaultValue);
     }
 
     @Deprecated
@@ -3025,7 +3025,7 @@ public class RubyHash extends RubyObject implements Map {
 
     @Deprecated
     public IRubyObject set_default_proc(IRubyObject proc) {
-        return set_default_proc(getRuntime().getCurrentContext(), proc);
+        return set_default_proc(getCurrentContext(), proc);
     }
 
     @Deprecated
@@ -3040,12 +3040,12 @@ public class RubyHash extends RubyObject implements Map {
 
     @Deprecated
     public RubyHash rehash() {
-        return rehash(getRuntime().getCurrentContext());
+        return rehash(getCurrentContext());
     }
 
     @Deprecated
     public RubyHash to_hash() {
-        return to_hash(getRuntime().getCurrentContext());
+        return to_hash(getCurrentContext());
     }
 
     @Deprecated
@@ -3055,7 +3055,7 @@ public class RubyHash extends RubyObject implements Map {
 
     @Deprecated
     public RubyHash rb_clear() {
-        return rb_clear(getRuntime().getCurrentContext());
+        return rb_clear(getCurrentContext());
     }
 
     @Deprecated
@@ -3069,7 +3069,7 @@ public class RubyHash extends RubyObject implements Map {
 
     @Deprecated
     public IRubyObject initialize(IRubyObject[] args, final Block block) {
-        var context = getRuntime().getCurrentContext();
+        var context = getCurrentContext();
         return switch (args.length) {
             case 0 -> initialize(context, block);
             case 1 -> initialize(context, args[0], block);

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1254,7 +1254,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     @Deprecated
     public static IRubyObject sysopen(IRubyObject recv, IRubyObject[] args, Block block) {
-        return sysopen(recv.getRuntime().getCurrentContext(), recv, args, block);
+        return sysopen(((RubyBasicObject) recv).getCurrentContext(), recv, args, block);
     }
 
     // rb_io_s_sysopen
@@ -3030,7 +3030,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     @Deprecated
     public IRubyObject getc() {
-        return getbyte(getRuntime().getCurrentContext());
+        return getbyte(getCurrentContext());
     }
 
     /**
@@ -3568,7 +3568,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     @Deprecated
     public IRubyObject readchar() {
-        return readchar(getRuntime().getCurrentContext());
+        return readchar(getCurrentContext());
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -423,7 +423,7 @@ public class RubyKernel {
 
     @Deprecated(since = "10.0", forRemoval = true)
     public static RubyFloat new_float(IRubyObject recv, IRubyObject object) {
-        return (RubyFloat) new_float(recv.getRuntime().getCurrentContext(), object, true);
+        return (RubyFloat) new_float(((RubyBasicObject) recv).getCurrentContext(), object, true);
     }
 
     private static final ByteList ZEROx = new ByteList(new byte[] { '0','x' }, false);
@@ -893,7 +893,7 @@ public class RubyKernel {
 
     @Deprecated
     public static IRubyObject exit(IRubyObject recv, IRubyObject[] args) {
-        return exit(recv.getRuntime().getCurrentContext(), recv, args);
+        return exit(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
 
     // FIXME: Add at_exit and finalizers to exit, then make exit_bang not call those.
@@ -909,7 +909,7 @@ public class RubyKernel {
 
     @Deprecated
     public static IRubyObject exit_bang(IRubyObject recv, IRubyObject[] args) {
-        return exit_bang(recv.getRuntime().getCurrentContext(), recv, args);
+        return exit_bang(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
 
     @JRubyMethod(name = "exit!", optional = 1, checkArity = false, module = true, visibility = PRIVATE)
@@ -1018,7 +1018,7 @@ public class RubyKernel {
 
     @Deprecated
     public static IRubyObject sprintf(IRubyObject recv, IRubyObject[] args) {
-        return sprintf(recv.getRuntime().getCurrentContext(), recv, args);
+        return sprintf(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
     public static IRubyObject raise(ThreadContext context, IRubyObject self, IRubyObject arg0) {
         // semi extract_raise_opts :
@@ -2108,7 +2108,7 @@ public class RubyKernel {
 
     @Deprecated(since = "10.0")
     public static IRubyObject singleton_class(IRubyObject recv) {
-        return singleton_class(recv.getRuntime().getCurrentContext(), recv);
+        return singleton_class(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
 
     @JRubyMethod(module = true)
@@ -2142,7 +2142,7 @@ public class RubyKernel {
 
     @Deprecated(since = "10.0")
     public static IRubyObject eql_p(IRubyObject self, IRubyObject obj) {
-        return eql_p(self.getRuntime().getCurrentContext(), self, obj);
+        return eql_p(((RubyBasicObject) self).getCurrentContext(), self, obj);
     }
 
     /*
@@ -2174,7 +2174,7 @@ public class RubyKernel {
      */
     @Deprecated(since = "10.0")
     public static IRubyObject initialize_copy(IRubyObject self, IRubyObject original) {
-        return initialize_copy(self.getRuntime().getCurrentContext(), self, original);
+        return initialize_copy(((RubyBasicObject) self).getCurrentContext(), self, original);
     }
 
     @JRubyMethod(name = "initialize_copy", required = 1, visibility = PRIVATE)
@@ -2258,7 +2258,7 @@ public class RubyKernel {
 
     @Deprecated(since = "10.0")
     public static IRubyObject inspect(IRubyObject self) {
-        return inspect(self.getRuntime().getCurrentContext(), self);
+        return inspect(((RubyBasicObject) self).getCurrentContext(), self);
     }
 
     @JRubyMethod(name = "inspect")
@@ -2338,7 +2338,7 @@ public class RubyKernel {
      */
     @Deprecated(since = "10.0", forRemoval = true)
     public static IRubyObject to_s(IRubyObject self) {
-        return to_s(self.getRuntime().getCurrentContext(), self);
+        return to_s(((RubyBasicObject) self).getCurrentContext(), self);
     }
 
     @JRubyMethod(name = "to_s")
@@ -2348,7 +2348,7 @@ public class RubyKernel {
 
     @Deprecated
     public static IRubyObject extend(IRubyObject self, IRubyObject[] args) {
-        return extend(self.getRuntime().getCurrentContext(), self, args);
+        return extend(((RubyBasicObject) self).getCurrentContext(), self, args);
     }
 
     @JRubyMethod(name = "extend", required = 1, rest = true, checkArity = false)
@@ -2517,7 +2517,7 @@ public class RubyKernel {
 
     @Deprecated
     public static IRubyObject require(IRubyObject recv, IRubyObject name, Block block) {
-        return require(recv.getRuntime().getCurrentContext(), recv, name, block);
+        return require(((RubyBasicObject) recv).getCurrentContext(), recv, name, block);
     }
 
     @Deprecated
@@ -2529,7 +2529,7 @@ public class RubyKernel {
 
     @Deprecated
     public static IRubyObject autoload(final IRubyObject recv, IRubyObject symbol, IRubyObject file) {
-        return autoload(recv.getRuntime().getCurrentContext(), recv, symbol, file);
+        return autoload(((RubyBasicObject) recv).getCurrentContext(), recv, symbol, file);
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/RubyMarshal.java
+++ b/core/src/main/java/org/jruby/RubyMarshal.java
@@ -199,7 +199,7 @@ public class RubyMarshal {
 
     @Deprecated
     public static IRubyObject dump(IRubyObject recv, IRubyObject[] args, Block unusedBlock) {
-        return dump(recv.getRuntime().getCurrentContext(), recv, args, unusedBlock);
+        return dump(((RubyBasicObject) recv).getCurrentContext(), recv, args, unusedBlock);
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/RubyMethod.java
+++ b/core/src/main/java/org/jruby/RubyMethod.java
@@ -225,23 +225,17 @@ public class RubyMethod extends AbstractRubyMethod {
      */
     @JRubyMethod
     public IRubyObject to_proc(ThreadContext context) {
-        Ruby runtime = context.runtime;
-
-        MethodBlockBody body;
         Signature signature = method.getSignature();
-        ArgumentDescriptor[] argsDesc;
-        if (method instanceof IRMethodArgs) {
-            argsDesc = ((IRMethodArgs) method).getArgumentDescriptors();
-        } else {
-            argsDesc = Helpers.methodToArgumentDescriptors(method);
-        }
+        ArgumentDescriptor[] argsDesc = method instanceof IRMethodArgs ?
+                ((IRMethodArgs) method).getArgumentDescriptors() :
+                Helpers.methodToArgumentDescriptors(context, method);
 
         int line = getLine(); // getLine adds 1 to 1-index but we need to reset to 0-index internally
-        body = new MethodBlockBody(runtime.getStaticScopeFactory().getDummyScope(), signature, entry, argsDesc,
+        MethodBlockBody body = new MethodBlockBody(context.runtime.getStaticScopeFactory().getDummyScope(), signature, entry, argsDesc,
                 receiver, originModule, originName, getFilename(), line == -1 ? -1 : line - 1);
         Block b = MethodBlockBody.createMethodBlock(body);
 
-        RubyProc proc = RubyProc.newProc(runtime, b, Block.Type.LAMBDA);
+        RubyProc proc = RubyProc.newProc(context.runtime, b, Block.Type.LAMBDA);
         proc.setFromMethod();
         return proc;
     }
@@ -273,7 +267,7 @@ public class RubyMethod extends AbstractRubyMethod {
 
     @JRubyMethod
     public IRubyObject parameters(ThreadContext context) {
-        return Helpers.methodToParameters(context.runtime, this);
+        return Helpers.methodToParameters(context, this);
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -519,26 +519,26 @@ public class RubyModule extends RubyObject {
         if (isSameOrigin(m)) throw argumentError(context, getName(context) + " cyclic prepend detected " + m.getName(context));
     }
 
-    private RubyClass searchProvidersForClass(String name, RubyClass superClazz) {
+    private RubyClass searchProvidersForClass(ThreadContext context, String name, RubyClass superClazz) {
         Set<ClassProvider> classProviders = this.classProviders;
         if (classProviders == Collections.EMPTY_SET) return null;
 
         RubyClass clazz;
         for (ClassProvider classProvider: classProviders) {
-            if ((clazz = classProvider.defineClassUnder(this, name, superClazz)) != null) {
+            if ((clazz = classProvider.defineClassUnder(context, this, name, superClazz)) != null) {
                 return clazz;
             }
         }
         return null;
     }
 
-    private RubyModule searchProvidersForModule(String name) {
+    private RubyModule searchProvidersForModule(ThreadContext context, String name) {
         Set<ClassProvider> classProviders = this.classProviders;
         if (classProviders == Collections.EMPTY_SET) return null;
 
         RubyModule module;
         for (ClassProvider classProvider: classProviders) {
-            if ((module = classProvider.defineModuleUnder(this, name)) != null) {
+            if ((module = classProvider.defineModuleUnder(context, this, name)) != null) {
                 return module;
             }
         }
@@ -2582,7 +2582,7 @@ public class RubyModule extends RubyObject {
                 if (tmp != null) tmp = tmp.getRealClass();
                 if (tmp != superClazz) throw typeError(context, "superclass mismatch for class " + ids(context.runtime, name));
             }
-        } else if ((clazz = searchProvidersForClass(name, superClazz)) != null) {
+        } else if ((clazz = searchProvidersForClass(context, name, superClazz)) != null) {
             // reopen a java class
         } else {
             if (superClazz == null) superClazz = objectClass(context);
@@ -2631,7 +2631,7 @@ public class RubyModule extends RubyObject {
         if (moduleObj != null) {
             if (!moduleObj.isModule()) throw typeError(context, "", moduleObj, " is not a module");
             module = (RubyModule)moduleObj;
-        } else if ((module = searchProvidersForModule(name)) != null) {
+        } else if ((module = searchProvidersForModule(context, name)) != null) {
             // reopen a java module
         } else {
             module = RubyModule.newModule(context, name, this, true, file, line);

--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -1529,7 +1529,8 @@ public class RubyModule extends RubyObject {
 
     @Deprecated(since = "10.0")
     public final void defineAnnotatedMethodsIndividually(Class clazz) {
-        getCurrentContext().runtime.POPULATORS.get(clazz).populate(this, clazz);
+        var context = getCurrentContext();
+        context.runtime.POPULATORS.get(clazz).populate(context, this, clazz);
     }
 
     /**
@@ -1689,7 +1690,7 @@ public class RubyModule extends RubyObject {
         var populators = context.runtime.POPULATORS;
 
         for (var clazz : methodSources) {
-            populators.get(clazz).populate(this, clazz);
+            populators.get(clazz).populate(context, this, clazz);
         }
         return (T) this;
     }

--- a/core/src/main/java/org/jruby/RubyNil.java
+++ b/core/src/main/java/org/jruby/RubyNil.java
@@ -203,7 +203,7 @@ public class RubyNil extends RubyObject implements Constantizable {
 
     @Deprecated
     public IRubyObject nil_p() {
-        return getRuntime().getTrue();
+        return nil_p(getCurrentContext());
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -1653,17 +1653,17 @@ public class RubyNumeric extends RubyObject {
 
     @Deprecated
     public IRubyObject floor() {
-        return floor(getRuntime().getCurrentContext());
+        return floor(getCurrentContext());
     }
 
     @Deprecated
     public IRubyObject ceil() {
-        return ceil(getRuntime().getCurrentContext());
+        return ceil(getCurrentContext());
     }
 
     @Deprecated
     public IRubyObject round() {
-        return round(getRuntime().getCurrentContext());
+        return round(getCurrentContext());
     }
 
     /** num_truncate
@@ -1671,7 +1671,7 @@ public class RubyNumeric extends RubyObject {
      */
     @Deprecated
     public IRubyObject truncate() {
-        return truncate(getRuntime().getCurrentContext());
+        return truncate(getCurrentContext());
     }
 
     private static JavaSites.NumericSites sites(ThreadContext context) {

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -378,7 +378,7 @@ public class RubyNumeric extends RubyObject {
 
     @Deprecated
     public static IRubyObject num2fix(IRubyObject val) {
-        return num2fix(val.getRuntime().getCurrentContext(), val);
+        return num2fix(((RubyBasicObject) val).getCurrentContext(), val);
     }
 
     /** rb_num2fix

--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -264,7 +264,7 @@ public class RubyProcess {
 
         @Deprecated
         public IRubyObject stopped_p() {
-            return stopped_p(getRuntime().getCurrentContext());
+            return stopped_p(getCurrentContext());
         }
 
         @JRubyMethod(name = "signaled?")
@@ -274,7 +274,7 @@ public class RubyProcess {
 
         @Deprecated
         public IRubyObject signaled() {
-            return signaled(getRuntime().getCurrentContext());
+            return signaled(getCurrentContext());
         }
 
         @JRubyMethod(name = "exited?")
@@ -282,8 +282,9 @@ public class RubyProcess {
             return asBoolean(context, PosixShim.WAIT_MACROS.WIFEXITED(status));
         }
 
+        @Deprecated(since = "10.0")
         public IRubyObject exited() {
-            return exited(getRuntime().getCurrentContext());
+            return exited(getCurrentContext());
         }
 
         /**
@@ -373,8 +374,9 @@ public class RubyProcess {
             return asBoolean(context, PosixShim.WAIT_MACROS.WCOREDUMP(status));
         }
 
+        @Deprecated(since = "10.0")
         public IRubyObject coredump_p() {
-            return coredump_p(getRuntime().getCurrentContext());
+            return coredump_p(getCurrentContext());
         }
 
         @JRubyMethod
@@ -438,7 +440,7 @@ public class RubyProcess {
 
         @Deprecated
         public IRubyObject to_i() {
-            return to_i(getRuntime());
+            return to_i(getCurrentContext().runtime);
         }
 
         @Deprecated
@@ -449,7 +451,7 @@ public class RubyProcess {
 
         @Deprecated
         public IRubyObject op_and(IRubyObject arg) {
-            return op_and(getRuntime().getCurrentContext(), arg);
+            return op_and(getCurrentContext(), arg);
         }
     }
 
@@ -467,7 +469,7 @@ public class RubyProcess {
 
         @Deprecated
         public static IRubyObject eid(IRubyObject self) {
-            return euid(self.getRuntime());
+            return euid(((RubyBasicObject) self).getCurrentContext(), null);
         }
         @JRubyMethod(name = "eid", module = true, visibility = PRIVATE)
         public static IRubyObject eid(ThreadContext context, IRubyObject self) {
@@ -476,7 +478,7 @@ public class RubyProcess {
 
         @Deprecated
         public static IRubyObject eid(IRubyObject self, IRubyObject arg) {
-            return eid(self.getRuntime(), arg);
+            return eid(((RubyBasicObject) self).getCurrentContext(), arg);
         }
         @JRubyMethod(name = "eid=", module = true, visibility = PRIVATE)
         public static IRubyObject eid(ThreadContext context, IRubyObject self, IRubyObject arg) {
@@ -513,7 +515,7 @@ public class RubyProcess {
 
         @Deprecated
         public static IRubyObject rid(IRubyObject self) {
-            return rid(self.getRuntime());
+            return rid(((RubyBasicObject) self).getCurrentContext(), self);
         }
         @JRubyMethod(name = "rid", module = true, visibility = PRIVATE)
         public static IRubyObject rid(ThreadContext context, IRubyObject self) {
@@ -572,7 +574,7 @@ public class RubyProcess {
 
         @Deprecated
         public static IRubyObject eid(IRubyObject self) {
-            return eid(self.getRuntime());
+            return eid(((RubyBasicObject) self).getCurrentContext(), self);
         }
         @JRubyMethod(name = "eid", module = true, visibility = PRIVATE)
         public static IRubyObject eid(ThreadContext context, IRubyObject self) {
@@ -584,7 +586,7 @@ public class RubyProcess {
 
         @Deprecated
         public static IRubyObject eid(IRubyObject self, IRubyObject arg) {
-            return eid(self.getRuntime(), arg);
+            return eid(((RubyBasicObject) self).getCurrentContext(), arg);
         }
         @JRubyMethod(name = "eid=", module = true, visibility = PRIVATE)
         public static IRubyObject eid(ThreadContext context, IRubyObject self, IRubyObject arg) {
@@ -620,7 +622,7 @@ public class RubyProcess {
 
         @Deprecated
         public static IRubyObject rid(IRubyObject self) {
-            return rid(self.getRuntime());
+            return rid(((RubyBasicObject) self).getCurrentContext(), self);
         }
         @JRubyMethod(name = "rid", module = true, visibility = PRIVATE)
         public static IRubyObject rid(ThreadContext context, IRubyObject self) {
@@ -669,7 +671,7 @@ public class RubyProcess {
     public static class Sys {
         @Deprecated
         public static IRubyObject getegid(IRubyObject self) {
-            return egid(self.getRuntime().getCurrentContext(), null);
+            return egid(((RubyBasicObject) self).getCurrentContext(), null);
         }
         @JRubyMethod(name = "getegid", module = true, visibility = PRIVATE)
         public static IRubyObject getegid(ThreadContext context, IRubyObject self) {
@@ -687,7 +689,7 @@ public class RubyProcess {
 
         @Deprecated
         public static IRubyObject getgid(IRubyObject self) {
-            return gid(self.getRuntime());
+            return gid(((RubyBasicObject) self).getCurrentContext());
         }
         @JRubyMethod(name = "getgid", module = true, visibility = PRIVATE)
         public static IRubyObject getgid(ThreadContext context, IRubyObject self) {
@@ -696,7 +698,7 @@ public class RubyProcess {
 
         @Deprecated
         public static IRubyObject getuid(IRubyObject self) {
-            return uid(self.getRuntime());
+            return uid(((RubyBasicObject) self).getCurrentContext(), self);
         }
         @JRubyMethod(name = "getuid", module = true, visibility = PRIVATE)
         public static IRubyObject getuid(ThreadContext context, IRubyObject self) {
@@ -705,7 +707,7 @@ public class RubyProcess {
 
         @Deprecated
         public static IRubyObject setegid(IRubyObject recv, IRubyObject arg) {
-            return egid_set(recv.getRuntime().getCurrentContext(), arg);
+            return egid_set(((RubyBasicObject) recv).getCurrentContext(), arg);
         }
         @JRubyMethod(name = "setegid", module = true, visibility = PRIVATE)
         public static IRubyObject setegid(ThreadContext context, IRubyObject recv, IRubyObject arg) {
@@ -714,7 +716,7 @@ public class RubyProcess {
 
         @Deprecated
         public static IRubyObject seteuid(IRubyObject recv, IRubyObject arg) {
-            return euid_set(recv.getRuntime().getCurrentContext(), arg);
+            return euid_set(((RubyBasicObject) recv).getCurrentContext(), arg);
         }
         @JRubyMethod(name = "seteuid", module = true, visibility = PRIVATE)
         public static IRubyObject seteuid(ThreadContext context, IRubyObject recv, IRubyObject arg) {
@@ -723,7 +725,7 @@ public class RubyProcess {
 
         @Deprecated
         public static IRubyObject setgid(IRubyObject recv, IRubyObject arg) {
-            return gid_set(recv.getRuntime(), arg);
+            return gid_set(((RubyBasicObject) recv).getCurrentContext().runtime, arg);
         }
         @JRubyMethod(name = "setgid", module = true, visibility = PRIVATE)
         public static IRubyObject setgid(ThreadContext context, IRubyObject recv, IRubyObject arg) {
@@ -1750,15 +1752,20 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject times(IRubyObject recv, Block unusedBlock) {
-        return times(((RubyBasicObject) recv).getCurrentContext().runtime);
+        return times(((RubyBasicObject) recv).getCurrentContext(), recv, unusedBlock);
     }
     @JRubyMethod(module = true, visibility = PRIVATE)
     public static IRubyObject times(ThreadContext context, IRubyObject recv, Block unusedBlock) {
-        return times(context.runtime);
+        return times(context);
     }
 
+    @Deprecated(since = "10.0")
     public static IRubyObject times(Ruby runtime) {
-        Times tms = runtime.getPosix().times();
+        return times(runtime.getCurrentContext());
+    }
+
+    public static IRubyObject times(ThreadContext context) {
+        Times tms = context.runtime.getPosix().times();
         double utime = 0.0d, stime = 0.0d, cutime = 0.0d, cstime = 0.0d;
         if (tms == null) {
             ThreadMXBean bean = ManagementFactory.getThreadMXBean();
@@ -1773,17 +1780,17 @@ public class RubyProcess {
             cstime = (double)tms.cstime();
         }
 
-        long hz = runtime.getPosix().sysconf(Sysconf._SC_CLK_TCK);
+        long hz = context.runtime.getPosix().sysconf(Sysconf._SC_CLK_TCK);
         if (hz == -1) {
             hz = 60; //https://github.com/ruby/ruby/blob/trunk/process.c#L6616
         }
 
-        return RubyStruct.newStruct(runtime.getTmsStruct(),
+        return newStruct(context, (RubyClass) context.runtime.getTmsStruct(),
                 new IRubyObject[] {
-                        runtime.newFloat(utime / (double) hz),
-                        runtime.newFloat(stime / (double) hz),
-                        runtime.newFloat(cutime / (double) hz),
-                        runtime.newFloat(cstime / (double) hz)
+                        asFloat(context, utime / (double) hz),
+                        asFloat(context, stime / (double) hz),
+                        asFloat(context, cutime / (double) hz),
+                        asFloat(context, cstime / (double) hz)
                 },
                 Block.NULL_BLOCK);
     }

--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -58,6 +58,7 @@ import static org.jruby.api.Convert.*;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineModule;
 import static org.jruby.api.Error.argumentError;
+import static org.jruby.api.Error.notImplementedError;
 import static org.jruby.api.Error.rangeError;
 import static org.jruby.api.Warn.warn;
 import static org.jruby.runtime.Helpers.throwException;
@@ -454,9 +455,14 @@ public class RubyProcess {
 
     @JRubyModule(name="Process::UID")
     public static class UserID {
-        @JRubyMethod(name = "change_privilege", module = true, visibility = PRIVATE)
+        @Deprecated(since = "10.0")
         public static IRubyObject change_privilege(IRubyObject self, IRubyObject arg) {
-            throw self.getRuntime().newNotImplementedError("Process::UID::change_privilege not implemented yet");
+            return change_privilege(((RubyBasicObject) self).getCurrentContext(), self, arg);
+        }
+
+        @JRubyMethod(name = "change_privilege", module = true, visibility = PRIVATE)
+        public static IRubyObject change_privilege(ThreadContext context, IRubyObject self, IRubyObject arg) {
+            throw notImplementedError(context, "Process::UID::change_privilege not implemented yet");
         }
 
         @Deprecated
@@ -480,9 +486,14 @@ public class RubyProcess {
             return euid_set(runtime, arg);
         }
 
-        @JRubyMethod(name = "grant_privilege", module = true, visibility = PRIVATE)
+        @Deprecated(since = "10.0")
         public static IRubyObject grant_privilege(IRubyObject self, IRubyObject arg) {
-            throw self.getRuntime().newNotImplementedError("Process::UID::grant_privilege not implemented yet");
+            return grant_privilege(((RubyBasicObject) self).getCurrentContext(), self, arg);
+        }
+
+        @JRubyMethod(name = "grant_privilege", module = true, visibility = PRIVATE)
+        public static IRubyObject grant_privilege(ThreadContext context, IRubyObject self, IRubyObject arg) {
+            throw notImplementedError(context, "Process::UID::grant_privilege not implemented yet");
         }
 
         @JRubyMethod(name = "re_exchange", module = true, visibility = PRIVATE)
@@ -490,9 +501,14 @@ public class RubyProcess {
             return switch_rb(context, self, Block.NULL_BLOCK);
         }
 
-        @JRubyMethod(name = "re_exchangeable?", module = true, visibility = PRIVATE)
+        @Deprecated(since = "10.0")
         public static IRubyObject re_exchangeable_p(IRubyObject self) {
-            throw self.getRuntime().newNotImplementedError("Process::UID::re_exchangeable? not implemented yet");
+            return re_exchangeable_p(((RubyBasicObject) self).getCurrentContext(), self);
+        }
+
+        @JRubyMethod(name = "re_exchangeable?", module = true, visibility = PRIVATE)
+        public static IRubyObject re_exchangeable_p(ThreadContext context, IRubyObject self) {
+            throw notImplementedError(context, "Process::UID::re_exchangeable? not implemented yet");
         }
 
         @Deprecated
@@ -507,9 +523,14 @@ public class RubyProcess {
             return uid(runtime);
         }
 
-        @JRubyMethod(name = "sid_available?", module = true, visibility = PRIVATE)
+        @Deprecated(since = "10.0")
         public static IRubyObject sid_available_p(IRubyObject self) {
-            throw self.getRuntime().newNotImplementedError("Process::UID::sid_available not implemented yet");
+            return sid_available_p(((RubyBasicObject) self).getCurrentContext(), self);
+        }
+
+        @JRubyMethod(name = "sid_available?", module = true, visibility = PRIVATE)
+        public static IRubyObject sid_available_p(ThreadContext context, IRubyObject self) {
+            throw notImplementedError(context, "Process::UID::sid_available not implemented yet");
         }
 
         @JRubyMethod(name = "switch", module = true, visibility = PRIVATE)
@@ -539,9 +560,14 @@ public class RubyProcess {
 
     @JRubyModule(name="Process::GID")
     public static class GroupID {
-        @JRubyMethod(name = "change_privilege", module = true, visibility = PRIVATE)
+        @Deprecated(since = "10.0")
         public static IRubyObject change_privilege(IRubyObject self, IRubyObject arg) {
-            throw self.getRuntime().newNotImplementedError("Process::GID::change_privilege not implemented yet");
+            return change_privilege(((RubyBasicObject) self).getCurrentContext(), self, arg);
+        }
+
+        @JRubyMethod(name = "change_privilege", module = true, visibility = PRIVATE)
+        public static IRubyObject change_privilege(ThreadContext context, IRubyObject self, IRubyObject arg) {
+            throw notImplementedError(context, "Process::GID::change_privilege not implemented yet");
         }
 
         @Deprecated
@@ -568,9 +594,13 @@ public class RubyProcess {
             return RubyProcess.egid_set(runtime.getCurrentContext(), arg);
         }
 
-        @JRubyMethod(name = "grant_privilege", module = true, visibility = PRIVATE)
         public static IRubyObject grant_privilege(IRubyObject self, IRubyObject arg) {
-            throw self.getRuntime().newNotImplementedError("Process::GID::grant_privilege not implemented yet");
+            return grant_privilege(((RubyBasicObject) self).getCurrentContext(), self, arg);
+        }
+
+        @JRubyMethod(name = "grant_privilege", module = true, visibility = PRIVATE)
+        public static IRubyObject grant_privilege(ThreadContext context, IRubyObject self, IRubyObject arg) {
+            throw notImplementedError(context, "Process::GID::grant_privilege not implemented yet");
         }
 
         @JRubyMethod(name = "re_exchange", module = true, visibility = PRIVATE)
@@ -578,9 +608,14 @@ public class RubyProcess {
             return switch_rb(context, self, Block.NULL_BLOCK);
         }
 
-        @JRubyMethod(name = "re_exchangeable?", module = true, visibility = PRIVATE)
+        @Deprecated(since = "10.0")
         public static IRubyObject re_exchangeable_p(IRubyObject self) {
-            throw self.getRuntime().newNotImplementedError("Process::GID::re_exchangeable? not implemented yet");
+            return re_exchangeable_p(((RubyBasicObject) self).getCurrentContext(), self);
+        }
+
+        @JRubyMethod(name = "re_exchangeable?", module = true, visibility = PRIVATE)
+        public static IRubyObject re_exchangeable_p(ThreadContext context, IRubyObject self) {
+            throw notImplementedError(context, "Process::GID::re_exchangeable? not implemented yet");
         }
 
         @Deprecated
@@ -595,9 +630,14 @@ public class RubyProcess {
             return gid(runtime);
         }
 
-        @JRubyMethod(name = "sid_available?", module = true, visibility = PRIVATE)
+        @Deprecated(since = "10.0")
         public static IRubyObject sid_available_p(IRubyObject self) {
-            throw self.getRuntime().newNotImplementedError("Process::GID::sid_available not implemented yet");
+            return sid_available_p(((RubyBasicObject) self).getCurrentContext(), self);
+        }
+
+        @JRubyMethod(name = "sid_available?", module = true, visibility = PRIVATE)
+        public static IRubyObject sid_available_p(ThreadContext context, IRubyObject self) {
+            throw notImplementedError(context, "Process::GID::sid_available not implemented yet");
         }
 
         @JRubyMethod(name = "switch", module = true, visibility = PRIVATE)
@@ -692,7 +732,7 @@ public class RubyProcess {
 
         @Deprecated
         public static IRubyObject setuid(IRubyObject recv, IRubyObject arg) {
-            return uid_set(recv.getRuntime().getCurrentContext(), null, arg);
+            return uid_set(((RubyBasicObject) recv).getCurrentContext(), null, arg);
         }
         @JRubyMethod(name = "setuid", module = true, visibility = PRIVATE)
         public static IRubyObject setuid(ThreadContext context, IRubyObject recv, IRubyObject arg) {
@@ -705,23 +745,31 @@ public class RubyProcess {
         return RubyKernel.abort(context, recv, args);
     }
 
-    @JRubyMethod(name = "exit!", optional = 1, checkArity = false, module = true, visibility = PRIVATE)
+    @Deprecated(since = "10.0")
     public static IRubyObject exit_bang(IRubyObject recv, IRubyObject[] args) {
-        return RubyKernel.exit_bang(recv.getRuntime().getCurrentContext(), recv, args);
+        return exit_bang(((RubyBasicObject) recv).getCurrentContext(), recv, args);
+    }
+
+    @JRubyMethod(name = "exit!", optional = 1, checkArity = false, module = true, visibility = PRIVATE)
+    public static IRubyObject exit_bang(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        return RubyKernel.exit_bang(context, recv, args);
+    }
+
+    @Deprecated(since = "10.0")
+    public static IRubyObject groups(IRubyObject recv) {
+        return groups(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
 
     @JRubyMethod(name = "groups", module = true, visibility = PRIVATE)
-    public static IRubyObject groups(IRubyObject recv) {
-        final Ruby runtime = recv.getRuntime();
-        long[] groups = runtime.getPosix().getgroups();
-        if (groups == null) { // not-implemented for the given platform (e.g. Windows)
-            throw runtime.newNotImplementedError("groups() function is unimplemented on this machine");
-        }
+    public static IRubyObject groups(ThreadContext context, IRubyObject recv) {
+        long[] groups = context.runtime.getPosix().getgroups();
+        if (groups == null) throw notImplementedError(context, "groups() function is unimplemented on this machine");
+
         IRubyObject[] ary = new IRubyObject[groups.length];
         for(int i = 0; i < groups.length; i++) {
-            ary[i] = RubyFixnum.newFixnum(runtime, groups[i]);
+            ary[i] = asFixnum(context, groups[i]);
         }
-        return RubyArray.newArrayNoCopy(runtime, ary);
+        return RubyArray.newArrayNoCopy(context.runtime, ary);
     }
 
     @JRubyMethod(name = "last_status", module = true, visibility = PRIVATE)
@@ -736,9 +784,7 @@ public class RubyProcess {
 
     @JRubyMethod(name = "setrlimit", module = true, visibility = PRIVATE)
     public static IRubyObject setrlimit(ThreadContext context, IRubyObject recv, IRubyObject resource, IRubyObject rlimCur, IRubyObject rlimMax) {
-        if (Platform.IS_WINDOWS) {
-            throw context.runtime.newNotImplementedError("Process#setrlimit is not implemented on Windows");
-        }
+        if (Platform.IS_WINDOWS) throw notImplementedError(context, "Process#setrlimit is not implemented on Windows");
 
         var posix = context.runtime.getPosix();
 
@@ -984,26 +1030,32 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject getpgrp(IRubyObject recv) {
-        return getpgrp(recv.getRuntime());
+        return getpgrp(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
+
     @JRubyMethod(name = "getpgrp", module = true, visibility = PRIVATE)
     public static IRubyObject getpgrp(ThreadContext context, IRubyObject recv) {
         return asFixnum(context, context.runtime.getPosix().getpgrp());
     }
 
-    @Deprecated
+    @Deprecated(since = "10.0")
     public static IRubyObject getpgrp(Ruby runtime) {
         return asFixnum(runtime.getCurrentContext(), runtime.getPosix().getpgrp());
     }
 
-    @JRubyMethod(name = "groups=", module = true, visibility = PRIVATE)
+    @Deprecated(since = "10.0")
     public static IRubyObject groups_set(IRubyObject recv, IRubyObject arg) {
-        throw recv.getRuntime().newNotImplementedError("Process#groups not yet implemented");
+        return groups_set(((RubyBasicObject) recv).getCurrentContext(), recv, arg);
+    }
+
+    @JRubyMethod(name = "groups=", module = true, visibility = PRIVATE)
+    public static IRubyObject groups_set(ThreadContext context, IRubyObject recv, IRubyObject arg) {
+        throw notImplementedError(context, "Process#groups not yet implemented");
     }
 
     @Deprecated
     public static IRubyObject waitpid(IRubyObject recv, IRubyObject[] args) {
-        return waitpid(recv.getRuntime(), args);
+        return waitpid(((RubyBasicObject) recv).getCurrentContext().runtime, args);
     }
     @JRubyMethod(name = "waitpid", rest = true, module = true, visibility = PRIVATE)
     public static IRubyObject waitpid(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
@@ -1139,7 +1191,7 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject wait(IRubyObject recv, IRubyObject[] args) {
-        return wait(recv.getRuntime(), args);
+        return wait(((RubyBasicObject) recv).getCurrentContext().runtime, args);
     }
     @JRubyMethod(name = "wait", rest = true, module = true, visibility = PRIVATE)
     public static IRubyObject wait(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
@@ -1168,7 +1220,7 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject waitall(IRubyObject recv) {
-        return waitall(recv.getRuntime().getCurrentContext());
+        return waitall(((RubyBasicObject) recv).getCurrentContext());
     }
     @JRubyMethod(name = "waitall", module = true, visibility = PRIVATE)
     public static IRubyObject waitall(ThreadContext context, IRubyObject recv) {
@@ -1203,7 +1255,7 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject setsid(IRubyObject recv) {
-        return setsid(recv.getRuntime());
+        return setsid(((RubyBasicObject) recv).getCurrentContext().runtime);
     }
     @JRubyMethod(name = "setsid", module = true, visibility = PRIVATE)
     public static IRubyObject setsid(ThreadContext context, IRubyObject recv) {
@@ -1217,7 +1269,7 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject setpgrp(IRubyObject recv) {
-        return setpgrp(recv.getRuntime());
+        return setpgrp(((RubyBasicObject) recv).getCurrentContext().runtime);
     }
     @JRubyMethod(name = "setpgrp", module = true, visibility = PRIVATE)
     public static IRubyObject setpgrp(ThreadContext context, IRubyObject recv) {
@@ -1231,7 +1283,7 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject egid_set(IRubyObject recv, IRubyObject arg) {
-        return egid_set(recv.getRuntime().getCurrentContext(), arg);
+        return egid_set(((RubyBasicObject) recv).getCurrentContext(), arg);
     }
     @JRubyMethod(name = "egid=", module = true, visibility = PRIVATE)
     public static IRubyObject egid_set(ThreadContext context, IRubyObject recv, IRubyObject arg) {
@@ -1264,7 +1316,7 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject euid(IRubyObject recv) {
-        return euid(recv.getRuntime());
+        return euid(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
     @JRubyMethod(name = "euid", module = true, visibility = PRIVATE)
     public static IRubyObject euid(ThreadContext context, IRubyObject recv) {
@@ -1278,7 +1330,7 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject uid_set(IRubyObject recv, IRubyObject arg) {
-        return uid_set(recv.getRuntime().getCurrentContext(), null, arg);
+        return uid_set(((RubyBasicObject) recv).getCurrentContext(), null, arg);
     }
     @JRubyMethod(name = "uid=", module = true, visibility = PRIVATE)
     public static IRubyObject uid_set(ThreadContext context, IRubyObject recv, IRubyObject arg) {
@@ -1292,7 +1344,7 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject gid(IRubyObject recv) {
-        return gid(recv.getRuntime().getCurrentContext());
+        return gid(((RubyBasicObject) recv).getCurrentContext());
     }
     @JRubyMethod(name = "gid", module = true, visibility = PRIVATE)
     public static IRubyObject gid(ThreadContext context, IRubyObject recv) {
@@ -1309,14 +1361,19 @@ public class RubyProcess {
         return gid(runtime.getCurrentContext());
     }
 
-    @JRubyMethod(name = "maxgroups", module = true, visibility = PRIVATE)
+    @Deprecated(since = "10.0")
     public static IRubyObject maxgroups(IRubyObject recv) {
-        throw recv.getRuntime().newNotImplementedError("Process#maxgroups not yet implemented");
+        return maxgroups(((RubyBasicObject) recv).getCurrentContext(), recv);
+    }
+
+    @JRubyMethod(name = "maxgroups", module = true, visibility = PRIVATE)
+    public static IRubyObject maxgroups(ThreadContext context, IRubyObject recv) {
+        throw notImplementedError(context, "Process#maxgroups not yet implemented");
     }
 
     @Deprecated
     public static IRubyObject getpriority(IRubyObject recv, IRubyObject arg1, IRubyObject arg2) {
-        return getpriority(recv.getRuntime(), arg1, arg2);
+        return getpriority(((RubyBasicObject) recv).getCurrentContext(), recv, arg1, arg2);
     }
     @JRubyMethod(name = "getpriority", module = true, visibility = PRIVATE)
     public static IRubyObject getpriority(ThreadContext context, IRubyObject recv, IRubyObject arg1, IRubyObject arg2) {
@@ -1334,7 +1391,7 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject uid(IRubyObject recv) {
-        return uid(recv.getRuntime());
+        return uid(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
     @JRubyMethod(name = "uid", module = true, visibility = PRIVATE)
     public static IRubyObject uid(ThreadContext context, IRubyObject recv) {
@@ -1356,19 +1413,29 @@ public class RubyProcess {
         return waitpid2(runtime.getCurrentContext(), runtime.getProcess(), args);
     }
 
-    @JRubyMethod(name = "initgroups", module = true, visibility = PRIVATE)
+    @Deprecated(since = "10.0")
     public static IRubyObject initgroups(IRubyObject recv, IRubyObject arg1, IRubyObject arg2) {
-        throw recv.getRuntime().newNotImplementedError("Process#initgroups not yet implemented");
+        return initgroups(((RubyBasicObject) recv).getCurrentContext(), recv, arg1, arg2);
+    }
+
+    @JRubyMethod(name = "initgroups", module = true, visibility = PRIVATE)
+    public static IRubyObject initgroups(ThreadContext context, IRubyObject recv, IRubyObject arg1, IRubyObject arg2) {
+        throw notImplementedError(context, "Process#initgroups not yet implemented");
+    }
+
+    @Deprecated(since = "10.0")
+    public static IRubyObject maxgroups_set(IRubyObject recv, IRubyObject arg) {
+        return maxgroups_set(((RubyBasicObject) recv).getCurrentContext(), recv, arg);
     }
 
     @JRubyMethod(name = "maxgroups=", module = true, visibility = PRIVATE)
-    public static IRubyObject maxgroups_set(IRubyObject recv, IRubyObject arg) {
-        throw recv.getRuntime().newNotImplementedError("Process#maxgroups_set not yet implemented");
+    public static IRubyObject maxgroups_set(ThreadContext context, IRubyObject recv, IRubyObject arg) {
+        throw notImplementedError(context, "Process#maxgroups_set not yet implemented");
     }
 
     @Deprecated
     public static IRubyObject ppid(IRubyObject recv) {
-        return ppid(recv.getRuntime());
+        return ppid(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
     @JRubyMethod(name = "ppid", module = true, visibility = PRIVATE)
     public static IRubyObject ppid(ThreadContext context, IRubyObject recv) {
@@ -1382,7 +1449,7 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject gid_set(IRubyObject recv, IRubyObject arg) {
-        return gid_set(recv.getRuntime(), arg);
+        return gid_set(((RubyBasicObject) recv).getCurrentContext(), recv, arg);
     }
     @JRubyMethod(name = "gid=", module = true, visibility = PRIVATE)
     public static IRubyObject gid_set(ThreadContext context, IRubyObject recv, IRubyObject arg) {
@@ -1398,7 +1465,7 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject wait2(IRubyObject recv, IRubyObject[] args) {
-        return waitpid2(recv.getRuntime(), args);
+        return waitpid2(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
     @JRubyMethod(name = "wait2", rest = true, module = true, visibility = PRIVATE)
     public static IRubyObject wait2(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
@@ -1407,7 +1474,7 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject euid_set(IRubyObject recv, IRubyObject arg) {
-        return euid_set(recv.getRuntime().getCurrentContext(), arg);
+        return euid_set(((RubyBasicObject) recv).getCurrentContext(), arg);
     }
     @JRubyMethod(name = "euid=", module = true, visibility = PRIVATE)
     public static IRubyObject euid_set(ThreadContext context, IRubyObject recv, IRubyObject arg) {
@@ -1443,7 +1510,7 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject setpriority(IRubyObject recv, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3) {
-        return setpriority(recv.getRuntime(), arg1, arg2, arg3);
+        return setpriority(((RubyBasicObject) recv).getCurrentContext(), recv, arg1, arg2, arg3);
     }
     @JRubyMethod(name = "setpriority", module = true, visibility = PRIVATE)
     public static IRubyObject setpriority(ThreadContext context, IRubyObject recv, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3) {
@@ -1462,7 +1529,7 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject setpgid(IRubyObject recv, IRubyObject arg1, IRubyObject arg2) {
-        return setpgid(recv.getRuntime(), arg1, arg2);
+        return setpgid(((RubyBasicObject) recv).getCurrentContext(), recv, arg1, arg2);
     }
     @JRubyMethod(name = "setpgid", module = true, visibility = PRIVATE)
     public static IRubyObject setpgid(ThreadContext context, IRubyObject recv, IRubyObject arg1, IRubyObject arg2) {
@@ -1478,7 +1545,7 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject getpgid(IRubyObject recv, IRubyObject arg) {
-        return getpgid(recv.getRuntime(), arg);
+        return getpgid(((RubyBasicObject) recv).getCurrentContext(), recv, arg);
     }
     @JRubyMethod(name = "getpgid", module = true, visibility = PRIVATE)
     public static IRubyObject getpgid(ThreadContext context, IRubyObject recv, IRubyObject arg) {
@@ -1493,7 +1560,7 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject getrlimit(IRubyObject recv, IRubyObject arg) {
-        return getrlimit(recv.getRuntime(), arg);
+        return getrlimit(((RubyBasicObject) recv).getCurrentContext(), arg);
     }
     @JRubyMethod(name = "getrlimit", module = true, visibility = PRIVATE)
     public static IRubyObject getrlimit(ThreadContext context, IRubyObject recv, IRubyObject arg) {
@@ -1513,7 +1580,7 @@ public class RubyProcess {
 
     public static IRubyObject getrlimit(ThreadContext context, IRubyObject arg) {
         if (Platform.IS_WINDOWS) {
-            throw context.runtime.newNotImplementedError("Process#getrlimit is not implemented on Windows");
+            throw notImplementedError(context, "Process#getrlimit is not implemented on Windows");
         }
 
         if (!context.runtime.getPosix().isNative()) {
@@ -1529,7 +1596,7 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject egid(IRubyObject recv) {
-        return egid(recv.getRuntime().getCurrentContext(), recv);
+        return egid(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
     @JRubyMethod(name = "egid", module = true, visibility = PRIVATE)
     public static IRubyObject egid(ThreadContext context, IRubyObject recv) {
@@ -1559,7 +1626,7 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject kill(IRubyObject recv, IRubyObject[] args) {
-        return kill(recv.getRuntime(), args);
+        return kill(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
     @JRubyMethod(name = "kill", rest = true, module = true, visibility = PRIVATE)
     public static IRubyObject kill(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
@@ -1637,7 +1704,7 @@ public class RubyProcess {
                         }
                     }
                 } else {
-                    throw context.runtime.newNotImplementedError("this signal not yet implemented in windows");
+                    throw notImplementedError(context, "this signal not yet implemented in windows");
                 }
             }
         } else {
@@ -1683,7 +1750,7 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject times(IRubyObject recv, Block unusedBlock) {
-        return times(recv.getRuntime());
+        return times(((RubyBasicObject) recv).getCurrentContext().runtime);
     }
     @JRubyMethod(module = true, visibility = PRIVATE)
     public static IRubyObject times(ThreadContext context, IRubyObject recv, Block unusedBlock) {
@@ -1823,7 +1890,7 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject pid(IRubyObject recv) {
-        return pid(recv.getRuntime().getCurrentContext());
+        return pid(((RubyBasicObject) recv).getCurrentContext());
     }
     @JRubyMethod(name = "pid", module = true, visibility = PRIVATE)
     public static IRubyObject pid(ThreadContext context, IRubyObject recv) {
@@ -1839,7 +1906,7 @@ public class RubyProcess {
 
     @JRubyMethod(module = true, visibility = PRIVATE, notImplemented = true)
     public static IRubyObject _fork(ThreadContext context, IRubyObject recv, Block block) {
-        throw context.runtime.newNotImplementedError("fork is not available on this platform");
+        throw notImplementedError(context, "fork is not available on this platform");
     }
 
     @Deprecated
@@ -1865,7 +1932,7 @@ public class RubyProcess {
 
     @JRubyMethod(name = "exit", optional = 1, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject exit(IRubyObject recv, IRubyObject[] args) {
-        return RubyKernel.exit(recv.getRuntime().getCurrentContext(), recv, args);
+        return RubyKernel.exit(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
 
     @JRubyMethod(name = "setproctitle", module = true, visibility = PRIVATE)
@@ -1910,6 +1977,6 @@ public class RubyProcess {
 
     @Deprecated
     public static IRubyObject waitpid2(IRubyObject recv, IRubyObject[] args) {
-        return waitpid2(recv.getRuntime(), args);
+        return waitpid2(((RubyBasicObject) recv).getCurrentContext().runtime, args);
     }
 }

--- a/core/src/main/java/org/jruby/RubySignal.java
+++ b/core/src/main/java/org/jruby/RubySignal.java
@@ -159,24 +159,44 @@ public class RubySignal {
         return names;
     }
 
-    @JRubyMethod(meta = true)
+    @Deprecated(since = "10.0")
     public static IRubyObject __jtrap_kernel(final IRubyObject recv, IRubyObject block, IRubyObject sig) {
-        return SIGNAL_FACADE.trap(recv, block, sig);
+        return __jtrap_kernel(((RubyBasicObject) recv).getCurrentContext(), recv, block, sig);
     }
 
     @JRubyMethod(meta = true)
+    public static IRubyObject __jtrap_kernel(ThreadContext context, final IRubyObject recv, IRubyObject block, IRubyObject sig) {
+        return SIGNAL_FACADE.trap(context, recv, block, sig);
+    }
+
+    @Deprecated(since = "10.0")
     public static IRubyObject __jtrap_platform_kernel(final IRubyObject recv, IRubyObject sig) {
-        return SIGNAL_FACADE.restorePlatformDefault(recv, sig);
+        return __jtrap_platform_kernel(((RubyBasicObject) recv).getCurrentContext(), recv, sig);
     }
 
     @JRubyMethod(meta = true)
+    public static IRubyObject __jtrap_platform_kernel(ThreadContext context, final IRubyObject recv, IRubyObject sig) {
+        return SIGNAL_FACADE.restorePlatformDefault(context, recv, sig);
+    }
+
+    @Deprecated(since = "10.0")
     public static IRubyObject __jtrap_osdefault_kernel(final IRubyObject recv, IRubyObject sig) {
-        return SIGNAL_FACADE.restoreOSDefault(recv, sig);
+        return __jtrap_osdefault_kernel(((RubyBasicObject) recv).getCurrentContext(), recv, sig);
     }
 
     @JRubyMethod(meta = true)
+    public static IRubyObject __jtrap_osdefault_kernel(ThreadContext context, final IRubyObject recv, IRubyObject sig) {
+        return SIGNAL_FACADE.restoreOSDefault(context, recv, sig);
+    }
+
+    @Deprecated(since = "10.0")
     public static IRubyObject __jtrap_restore_kernel(final IRubyObject recv, IRubyObject sig) {
-        return SIGNAL_FACADE.ignore(recv, sig);
+        return __jtrap_restore_kernel(((RubyBasicObject) recv).getCurrentContext(), recv, sig);
+    }
+
+    @JRubyMethod(meta = true)
+    public static IRubyObject __jtrap_restore_kernel(ThreadContext context, final IRubyObject recv, IRubyObject sig) {
+        return SIGNAL_FACADE.ignore(context, recv, sig);
     }
 
     @JRubyMethod(meta = true)

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -294,9 +294,11 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return checkEncoding((CodeRangeable) other);
     }
 
+    @Deprecated(since = "10.0")
     final Encoding checkEncoding(EncodingCapable other) {
+        var context = ((RubyBasicObject) other).getCurrentContext();
         Encoding enc = isCompatibleWith(other);
-        if (enc == null) throw getRuntime().newEncodingCompatibilityError("incompatible character encodings: " +
+        if (enc == null) throw context.runtime.newEncodingCompatibilityError("incompatible character encodings: " +
                                 value.getEncoding() + " and " + other.getEncoding());
         return enc;
     }
@@ -4587,37 +4589,48 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      * @param delimiter
      * @return splited entries
      */
+    @Deprecated(since = "10.0")
     public RubyArray split(RubyRegexp delimiter) {
-        return splitCommon(getRuntime().getCurrentContext(), delimiter, 0);
+        return splitCommon(getCurrentContext(), delimiter, 0);
     }
 
-    /**
-     * Split for ext (Java) callers (does not write $~).
-     * @param delimiter
-     * @param limit
-     * @return splited entries
-     */
+    @Deprecated(since = "10.0")
     public RubyArray split(RubyRegexp delimiter, int limit) {
-        return splitCommon(getRuntime().getCurrentContext(), delimiter, limit);
+        return split(getCurrentContext(), delimiter, limit);
     }
 
     /**
      * Split for ext (Java) callers (does not write $~).
-     * @param delimiter
-     * @return splited entries
-     */
-    public RubyArray split(RubyString delimiter) {
-        return splitCommon(getRuntime().getCurrentContext(), delimiter, 0);
-    }
-
-    /**
-     * Split for ext (Java) callers (does not write $~).
+     * @param the thread context
      * @param delimiter
      * @param limit
      * @return splited entries
      */
+    @JRubyAPI
+    public RubyArray split(ThreadContext context, RubyRegexp delimiter, int limit) {
+        return splitCommon(context, delimiter, limit);
+    }
+
+    @Deprecated(since = "10.0")
+    public RubyArray split(RubyString delimiter) {
+        return splitCommon(getCurrentContext(), delimiter, 0);
+    }
+
+    @Deprecated(since = "10.0")
     public RubyArray split(RubyString delimiter, int limit) {
-        return splitCommon(getRuntime().getCurrentContext(), delimiter, limit);
+        return split(getCurrentContext(), delimiter, limit);
+    }
+
+    /**
+     * Split for ext (Java) callers (does not write $~).
+     * @param context the thread context
+     * @param delimiter
+     * @param limit
+     * @return splited entries
+     */
+    @JRubyAPI
+    public RubyArray split(ThreadContext context, RubyString delimiter, int limit) {
+        return splitCommon(context, delimiter, limit);
     }
 
     // MRI: rb_str_split_m, overall structure

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -39,6 +39,7 @@ import java.util.Set;
 
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.api.Create;
 import org.jruby.common.IRubyWarnings.ID;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.internal.runtime.methods.DynamicMethod;
@@ -93,13 +94,17 @@ public class RubyStruct extends RubyObject {
      * @param rubyClass the class
      */
     private RubyStruct(Ruby runtime, RubyClass rubyClass) {
-        super(runtime, rubyClass);
+        this(runtime.getCurrentContext(), rubyClass);
+    }
 
-        int size = RubyNumeric.fix2int(getInternalVariable(runtime.getCurrentContext(), rubyClass, SIZE_VAR));
+    public RubyStruct(ThreadContext context, RubyClass rubyClass) {
+        super(context.runtime, rubyClass);
+
+        int size = RubyNumeric.fix2int(getInternalVariable(context, rubyClass, SIZE_VAR));
 
         values = new IRubyObject[size];
 
-        Helpers.fillNil(values, runtime);
+        Helpers.fillNil(values, context.runtime);
     }
 
     public static RubyClass createStructClass(ThreadContext context, RubyClass Object, RubyModule Enumerable) {
@@ -224,7 +229,7 @@ public class RubyStruct extends RubyObject {
 
     @Deprecated
     public static RubyClass newInstance(IRubyObject recv, IRubyObject[] args, Block block) {
-        return newInstance(recv.getRuntime().getCurrentContext(), recv, args, block);
+        return newInstance(((RubyBasicObject) recv).getCurrentContext(), recv, args, block);
     }
 
     /** Create new Struct class.
@@ -328,58 +333,57 @@ public class RubyStruct extends RubyObject {
     public static class StructMethods {
         @Deprecated(since = "10.0")
         public static IRubyObject newStruct(IRubyObject recv, IRubyObject[] args, Block block) {
-            return newStruct(recv.getRuntime().getCurrentContext(), recv, args, block);
+            return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, args, block);
         }
-
 
         @JRubyMethod(name = {"new", "[]"}, rest = true, keywords = true)
         public static IRubyObject newStruct(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
-            return RubyStruct.newStruct(recv, args, block);
+            return Create.newStruct(context, (RubyClass) recv, args, block);
         }
 
         @Deprecated(since = "10.0")
         public static IRubyObject newStruct(IRubyObject recv, Block block) {
-            return newStruct(recv.getRuntime().getCurrentContext(), recv, block);
+            return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), block);
         }
 
         @JRubyMethod(name = {"new", "[]"}, keywords = true)
         public static IRubyObject newStruct(ThreadContext context, IRubyObject recv, Block block) {
-            return RubyStruct.newStruct(recv, block);
+            return Create.newStruct(context, block);
         }
 
         @Deprecated(since = "10.0")
         public static IRubyObject newStruct(IRubyObject recv, IRubyObject arg0, Block block) {
-            return newStruct(recv.getRuntime().getCurrentContext(), recv, arg0, block);
+            return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), arg0, block);
         }
 
         @JRubyMethod(name = {"new", "[]"}, keywords = true)
         public static IRubyObject newStruct(ThreadContext context, IRubyObject recv, IRubyObject arg0, Block block) {
-            return RubyStruct.newStruct(recv, arg0, block);
+            return Create.newStruct(context, arg0, block);
         }
 
         @Deprecated(since = "10.0")
         public static IRubyObject newStruct(IRubyObject recv, IRubyObject arg0, IRubyObject arg1, Block block) {
-            return newStruct(recv.getRuntime().getCurrentContext(), recv, arg0, arg1, block);
+            return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), arg0, arg1, block);
         }
 
         @JRubyMethod(name = {"new", "[]"}, keywords = true)
         public static IRubyObject newStruct(ThreadContext context, IRubyObject recv, IRubyObject arg0, IRubyObject arg1, Block block) {
-            return RubyStruct.newStruct(recv, arg0, arg1, block);
+            return Create.newStruct(context, arg0, arg1, block);
         }
 
         @Deprecated(since = "10.0")
         public static IRubyObject newStruct(IRubyObject recv, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
-            return newStruct(recv.getRuntime().getCurrentContext(), recv, arg0, arg1, arg2, block);
+            return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), arg0, arg1, arg2, block);
         }
 
         @JRubyMethod(name = {"new", "[]"}, keywords = true)
         public static IRubyObject newStruct(ThreadContext context, IRubyObject recv, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
-            return RubyStruct.newStruct(recv, arg0, arg1, arg2, block);
+            return Create.newStruct(context, arg0, arg1, arg2, block);
         }
 
         @Deprecated(since = "10.0")
         public static IRubyObject members(IRubyObject recv, Block block) {
-            return members(recv.getRuntime().getCurrentContext(), recv);
+            return members(((RubyBasicObject) recv).getCurrentContext(), recv);
         }
 
         @JRubyMethod
@@ -389,7 +393,7 @@ public class RubyStruct extends RubyObject {
 
         @Deprecated(since = "10.0")
         public static IRubyObject inspect(IRubyObject recv) {
-            return inspect(recv.getRuntime().getCurrentContext(), recv);
+            return inspect(((RubyBasicObject) recv).getCurrentContext(), recv);
         }
 
         @JRubyMethod
@@ -402,7 +406,7 @@ public class RubyStruct extends RubyObject {
 
         @Deprecated(since = "10.0")
         public static IRubyObject keyword_init_p(IRubyObject self) {
-            return keyword_init_p(self.getRuntime().getCurrentContext(), self);
+            return keyword_init_p(((RubyBasicObject) self).getCurrentContext(), self);
         }
 
         @JRubyMethod(name = "keyword_init?")
@@ -416,45 +420,60 @@ public class RubyStruct extends RubyObject {
      *
      * MRI: struct_alloc
      *
+     * @deprecated Use {@link org.jruby.api.Create#newStruct(ThreadContext, RubyClass, IRubyObject[], Block)} instead.
      */
+    @Deprecated(since = "10.0")
     public static RubyStruct newStruct(IRubyObject recv, IRubyObject[] args, Block block) {
-        RubyStruct struct = new RubyStruct(recv.getRuntime(), (RubyClass) recv);
-
-        struct.callInit(args, block);
-
-        return struct;
+        return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, args, block);
     }
 
+    /**
+     * @param recv
+     * @param block
+     * @return
+     * @deprecated Use {@link org.jruby.api.Create#newStruct(ThreadContext, Block)} instead.
+     */
+    @Deprecated(since = "10.0")
     public static RubyStruct newStruct(IRubyObject recv, Block block) {
-        RubyStruct struct = new RubyStruct(recv.getRuntime(), (RubyClass) recv);
-
-        struct.callInit(block);
-
-        return struct;
+        return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), block);
     }
 
+    /**
+     * @param recv
+     * @param arg0
+     * @param block
+     * @return
+     * @deprecated Use {@link org.jruby.api.Create#newStruct(ThreadContext, IRubyObject, Block)} instead.
+     */
+    @Deprecated(since = "10.0")
     public static RubyStruct newStruct(IRubyObject recv, IRubyObject arg0, Block block) {
-        RubyStruct struct = new RubyStruct(recv.getRuntime(), (RubyClass) recv);
-
-        struct.callInit(arg0, block);
-
-        return struct;
+        return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), arg0, block);
     }
 
+    /**
+     * @param recv
+     * @param arg0
+     * @param arg1
+     * @param block
+     * @return
+     * @deprecated Use {@link org.jruby.api.Create#newStruct(ThreadContext, IRubyObject, IRubyObject, Block)} instead.
+     */
+    @Deprecated(since = "10.0")
     public static RubyStruct newStruct(IRubyObject recv, IRubyObject arg0, IRubyObject arg1, Block block) {
-        RubyStruct struct = new RubyStruct(recv.getRuntime(), (RubyClass) recv);
-
-        struct.callInit(arg0, arg1, block);
-
-        return struct;
+        return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), arg0, arg1, block);
     }
 
+    /**
+     * @param recv
+     * @param arg0
+     * @param arg1
+     * @param arg2
+     * @param block
+     * @return
+     * @deprecated Use {@link org.jruby.api.Create#newStruct(ThreadContext, IRubyObject, IRubyObject, IRubyObject, Block)} instead.
+     */
     public static RubyStruct newStruct(IRubyObject recv, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
-        RubyStruct struct = new RubyStruct(recv.getRuntime(), (RubyClass) recv);
-
-        struct.callInit(arg0, arg1, arg2, block);
-
-        return struct;
+        return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), arg0, arg1, arg2, block);
     }
 
     private void checkSize(ThreadContext context, int length) {
@@ -571,7 +590,7 @@ public class RubyStruct extends RubyObject {
 
     @Deprecated(since = "9.4-") // NOTE: no longer used ... should it get deleted?
     public static RubyArray members(IRubyObject recv, Block block) {
-        return members(recv.getRuntime().getCurrentContext(), (RubyClass) recv);
+        return members(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv);
     }
 
     private static RubyArray __member__(ThreadContext context, RubyClass clazz) {
@@ -992,7 +1011,7 @@ public class RubyStruct extends RubyObject {
 
         // FIXME: This could all be more efficient, but it's how struct works
         // 1.9 does not appear to call initialize (JRUBY-5875)
-        final RubyStruct result = (RubyStruct) input.entry(new RubyStruct(runtime, rbClass));
+        final RubyStruct result = (RubyStruct) input.entry(new RubyStruct(context, rbClass));
 
         for (int i = 0; i < len; i++) {
             RubySymbol slot = input.symbol();

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -343,42 +343,42 @@ public class RubyStruct extends RubyObject {
 
         @Deprecated(since = "10.0")
         public static IRubyObject newStruct(IRubyObject recv, Block block) {
-            return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), block);
+            return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, block);
         }
 
         @JRubyMethod(name = {"new", "[]"}, keywords = true)
         public static IRubyObject newStruct(ThreadContext context, IRubyObject recv, Block block) {
-            return Create.newStruct(context, block);
+            return Create.newStruct(context, (RubyClass) recv, block);
         }
 
         @Deprecated(since = "10.0")
         public static IRubyObject newStruct(IRubyObject recv, IRubyObject arg0, Block block) {
-            return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), arg0, block);
+            return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, arg0, block);
         }
 
         @JRubyMethod(name = {"new", "[]"}, keywords = true)
         public static IRubyObject newStruct(ThreadContext context, IRubyObject recv, IRubyObject arg0, Block block) {
-            return Create.newStruct(context, arg0, block);
+            return Create.newStruct(context, (RubyClass) recv, arg0, block);
         }
 
         @Deprecated(since = "10.0")
         public static IRubyObject newStruct(IRubyObject recv, IRubyObject arg0, IRubyObject arg1, Block block) {
-            return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), arg0, arg1, block);
+            return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, arg0, arg1, block);
         }
 
         @JRubyMethod(name = {"new", "[]"}, keywords = true)
         public static IRubyObject newStruct(ThreadContext context, IRubyObject recv, IRubyObject arg0, IRubyObject arg1, Block block) {
-            return Create.newStruct(context, arg0, arg1, block);
+            return Create.newStruct(context, (RubyClass) recv, arg0, arg1, block);
         }
 
         @Deprecated(since = "10.0")
         public static IRubyObject newStruct(IRubyObject recv, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
-            return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), arg0, arg1, arg2, block);
+            return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, arg0, arg1, arg2, block);
         }
 
         @JRubyMethod(name = {"new", "[]"}, keywords = true)
         public static IRubyObject newStruct(ThreadContext context, IRubyObject recv, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
-            return Create.newStruct(context, arg0, arg1, arg2, block);
+            return Create.newStruct(context, (RubyClass) recv, arg0, arg1, arg2, block);
         }
 
         @Deprecated(since = "10.0")
@@ -431,11 +431,11 @@ public class RubyStruct extends RubyObject {
      * @param recv
      * @param block
      * @return
-     * @deprecated Use {@link org.jruby.api.Create#newStruct(ThreadContext, Block)} instead.
+     * @deprecated Use {@link org.jruby.api.Create#newStruct(ThreadContext, RubyClass, Block)} instead.
      */
     @Deprecated(since = "10.0")
     public static RubyStruct newStruct(IRubyObject recv, Block block) {
-        return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), block);
+        return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, block);
     }
 
     /**
@@ -443,11 +443,11 @@ public class RubyStruct extends RubyObject {
      * @param arg0
      * @param block
      * @return
-     * @deprecated Use {@link org.jruby.api.Create#newStruct(ThreadContext, IRubyObject, Block)} instead.
+     * @deprecated Use {@link org.jruby.api.Create#newStruct(ThreadContext, RubyClass, IRubyObject, Block)} instead.
      */
     @Deprecated(since = "10.0")
     public static RubyStruct newStruct(IRubyObject recv, IRubyObject arg0, Block block) {
-        return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), arg0, block);
+        return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, arg0, block);
     }
 
     /**
@@ -456,11 +456,11 @@ public class RubyStruct extends RubyObject {
      * @param arg1
      * @param block
      * @return
-     * @deprecated Use {@link org.jruby.api.Create#newStruct(ThreadContext, IRubyObject, IRubyObject, Block)} instead.
+     * @deprecated Use {@link org.jruby.api.Create#newStruct(ThreadContext, RubyClass, IRubyObject, IRubyObject, Block)} instead.
      */
     @Deprecated(since = "10.0")
     public static RubyStruct newStruct(IRubyObject recv, IRubyObject arg0, IRubyObject arg1, Block block) {
-        return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), arg0, arg1, block);
+        return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, arg0, arg1, block);
     }
 
     /**
@@ -470,10 +470,10 @@ public class RubyStruct extends RubyObject {
      * @param arg2
      * @param block
      * @return
-     * @deprecated Use {@link org.jruby.api.Create#newStruct(ThreadContext, IRubyObject, IRubyObject, IRubyObject, Block)} instead.
+     * @deprecated Use {@link org.jruby.api.Create#newStruct(ThreadContext, RubyClass, IRubyObject, IRubyObject, IRubyObject, Block)} instead.
      */
     public static RubyStruct newStruct(IRubyObject recv, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2, Block block) {
-        return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), arg0, arg1, arg2, block);
+        return Create.newStruct(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, arg0, arg1, arg2, block);
     }
 
     private void checkSize(ThreadContext context, int length) {

--- a/core/src/main/java/org/jruby/anno/AnnotationBinder.java
+++ b/core/src/main/java/org/jruby/anno/AnnotationBinder.java
@@ -139,7 +139,12 @@ public class AnnotationBinder extends AbstractProcessor {
             out.println("@Generated(\"org.jruby.anno.AnnotationBinder\")");
             out.println("@SuppressWarnings(\"deprecation\")");
             out.println("public class " + qualifiedName + POPULATOR_SUFFIX + " extends TypePopulator {");
+            out.println("    @Deprecated(since = \"10.0\")");
             out.println("    public void populate(RubyModule cls, Class clazz) {");
+            out.println("        populate(cls.getCurrentContext(), cls, clazz);");
+            out.println("    }");
+            out.println("");
+            out.println("    public void populate(ThreadContext context, RubyModule cls, Class clazz) {");
             if (DEBUG) {
                 out.println("        System.out.println(\"Using pregenerated populator: \" + \"" + qualifiedName + POPULATOR_SUFFIX + "\");");
             }
@@ -162,7 +167,6 @@ public class AnnotationBinder extends AbstractProcessor {
 
             out.println("        JavaMethod javaMethod;");
             out.println("        DynamicMethod moduleMethod, aliasedMethod;");
-            out.println("        ThreadContext context = cls.getRuntime().getCurrentContext();");
             out.println("        Ruby runtime = context.runtime;");
             if (hasMeta || hasModule) {
                 out.println("        RubyClass singletonClass = cls.singletonClass(context);");

--- a/core/src/main/java/org/jruby/anno/TypePopulator.java
+++ b/core/src/main/java/org/jruby/anno/TypePopulator.java
@@ -82,12 +82,17 @@ public abstract class TypePopulator {
     }
 
     public abstract void populate(RubyModule clsmod, Class clazz);
+
+    public void populate(ThreadContext context, RubyModule cls, Class clazz) {
+        // old populated code will naturally call other version and new populated code will override this method.
+        populate(cls, clazz);
+    }
     
     public static final TypePopulator DEFAULT = new DefaultTypePopulator();
     public static class DefaultTypePopulator extends TypePopulator {
         public void populate(RubyModule clsmod, Class clazz) {
             ReflectiveTypePopulator populator = new ReflectiveTypePopulator(clazz);
-            populator.populate(clsmod, clazz);
+            populator.populate(clsmod.getRuntime().getCurrentContext(), clsmod, clazz);
         }
     }
 

--- a/core/src/main/java/org/jruby/api/Create.java
+++ b/core/src/main/java/org/jruby/api/Create.java
@@ -291,8 +291,8 @@ public class Create {
      * @param block
      * @return
      */
-    public static RubyStruct newStruct(ThreadContext context, Block block) {
-        RubyStruct struct = new RubyStruct(context, structClass(context));
+    public static RubyStruct newStruct(ThreadContext context, RubyClass structClass, Block block) {
+        RubyStruct struct = new RubyStruct(context, structClass);
         struct.callInit(block);
         return struct;
     }
@@ -305,8 +305,8 @@ public class Create {
      * @param block
      * @return
      */
-    public static RubyStruct newStruct(ThreadContext context, IRubyObject arg0, Block block) {
-        RubyStruct struct = new RubyStruct(context, structClass(context));
+    public static RubyStruct newStruct(ThreadContext context, RubyClass structClass, IRubyObject arg0, Block block) {
+        RubyStruct struct = new RubyStruct(context, structClass);
         struct.callInit(arg0, block);
         return struct;
     }
@@ -320,8 +320,8 @@ public class Create {
      * @param block
      * @return
      */
-    public static RubyStruct newStruct(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Block block) {
-        RubyStruct struct = new RubyStruct(context, structClass(context));
+    public static RubyStruct newStruct(ThreadContext context, RubyClass structClass, IRubyObject arg0, IRubyObject arg1, Block block) {
+        RubyStruct struct = new RubyStruct(context, structClass);
         struct.callInit(arg0, arg1, block);
         return struct;
     }
@@ -336,9 +336,9 @@ public class Create {
      * @param block
      * @return
      */
-    public static RubyStruct newStruct(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2,
+    public static RubyStruct newStruct(ThreadContext context, RubyClass structClass, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2,
                                        Block block) {
-        RubyStruct struct = new RubyStruct(context, structClass(context));
+        RubyStruct struct = new RubyStruct(context, structClass);
         struct.callInit(arg0, arg1, arg2, block);
         return struct;
     }

--- a/core/src/main/java/org/jruby/api/Create.java
+++ b/core/src/main/java/org/jruby/api/Create.java
@@ -2,6 +2,7 @@ package org.jruby.api;
 
 import org.jcodings.Encoding;
 import org.jruby.*;
+import org.jruby.runtime.Block;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
@@ -11,6 +12,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import static org.jruby.api.Access.stringClass;
+import static org.jruby.api.Access.structClass;
 
 public class Create {
     /**
@@ -281,4 +283,80 @@ public class Create {
     public static RubyRational newRational(ThreadContext context, long num, long den) {
         return RubyRational.newRational(context.runtime, num, den);
     }
+
+    /**
+     * Create a new Struct.
+     *
+     * @param context the current thread context
+     * @param block
+     * @return
+     */
+    public static RubyStruct newStruct(ThreadContext context, Block block) {
+        RubyStruct struct = new RubyStruct(context, structClass(context));
+        struct.callInit(block);
+        return struct;
+    }
+
+    /**
+     * Create a new Struct.
+     *
+     * @param context the current thread context
+     * @param arg0 name of class or first member of struct
+     * @param block
+     * @return
+     */
+    public static RubyStruct newStruct(ThreadContext context, IRubyObject arg0, Block block) {
+        RubyStruct struct = new RubyStruct(context, structClass(context));
+        struct.callInit(arg0, block);
+        return struct;
+    }
+
+    /**
+     * Create a new Struct.
+     *
+     * @param context the current thread context
+     * @param arg0 name of class or first member of struct
+     * @param arg1 a member of struct
+     * @param block
+     * @return
+     */
+    public static RubyStruct newStruct(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Block block) {
+        RubyStruct struct = new RubyStruct(context, structClass(context));
+        struct.callInit(arg0, arg1, block);
+        return struct;
+    }
+
+    /**
+     * Create a new Struct.
+     *
+     * @param context the current thread context
+     * @param arg0 name of class or first member of struct
+     * @param arg1 a member of struct
+     * @param arg2 a member of struct
+     * @param block
+     * @return
+     */
+    public static RubyStruct newStruct(ThreadContext context, IRubyObject arg0, IRubyObject arg1, IRubyObject arg2,
+                                       Block block) {
+        RubyStruct struct = new RubyStruct(context, structClass(context));
+        struct.callInit(arg0, arg1, arg2, block);
+        return struct;
+    }
+
+    /**
+     * Create a new Struct (prefer 0-3 arity versions of this function if you know you arity and it is Struct and
+     * not a subclass of Struct).
+     *
+     * @param context the current thread context
+     * @param structClass expects either a reference to Struct or a subclass of Struct (Passwd for example)
+     * @param args for thr struct
+     * @param block
+     * @return
+     */
+    public static RubyStruct newStruct(ThreadContext context, RubyClass structClass, IRubyObject[] args, Block block) {
+        RubyStruct struct = new RubyStruct(context, structClass);
+        struct.callInit(args, block);
+        return struct;
+    }
+
 }

--- a/core/src/main/java/org/jruby/api/Error.java
+++ b/core/src/main/java/org/jruby/api/Error.java
@@ -79,7 +79,32 @@ public class Error {
     }
 
     /**
-     * Create a runtime error with a simple ASCII String.
+     * Create a name error with a simple ASCII String and the failing name.
+     *
+     * @param context the current thread context
+     * @param message to be displayed in the error
+     * @param name involved in the error
+     * @return the error
+     */
+    public static RaiseException nameError(ThreadContext context, String message, String name) {
+        return context.runtime.newNameError(message, name);
+    }
+
+    /**
+     * Create a name error with a simple ASCII String and the failing name.
+     *
+     * @param context the current thread context
+     * @param message to be displayed in the error
+     * @param name involved in the error
+     * @param throwable the exception which caused this name error
+     * @return the error
+     */
+    public static RaiseException nameError(ThreadContext context, String message, String name, Throwable throwable) {
+        return context.runtime.newNameError(message, name, throwable);
+    }
+
+    /**
+     * Create a range error with a simple ASCII String.
      *
      * @param context the current thread context
      * @param message to be displayed in the error

--- a/core/src/main/java/org/jruby/ast/executable/RuntimeCache.java
+++ b/core/src/main/java/org/jruby/ast/executable/RuntimeCache.java
@@ -117,9 +117,10 @@ public class RuntimeCache {
         return regexps[index];
     }
 
+    @Deprecated(since = "10.0")
     public final RubyRegexp cacheRegexp(int index, RubyString pattern, int options) {
         RubyRegexp regexp = regexps[index];
-        Ruby runtime = pattern.getRuntime();
+        Ruby runtime = pattern.getCurrentContext().runtime;
         if (regexp == null || runtime.getKCode() != regexp.getKCode()) {
             regexp = RubyRegexp.newRegexp(runtime, pattern.getByteList(), RegexpOptions.fromEmbeddedOptions(options));
             regexps[index] = regexp;
@@ -127,6 +128,7 @@ public class RuntimeCache {
         return regexp;
     }
 
+    @Deprecated(since = "10.0")
     public final RubyRegexp cacheRegexp(int index, RubyRegexp regexp) {
         regexps[index] = regexp;
         return regexp;

--- a/core/src/main/java/org/jruby/compiler/BlockJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/BlockJITTask.java
@@ -64,7 +64,7 @@ class BlockJITTask extends JITCompiler.Task {
         if (excludeModuleName != null) {
             body.setCallCount(-1);
             if (jitCompiler.config.isJitLogging()) {
-                JITCompiler.log(body, blockId, "skipping block in " + excludeModuleName);
+                JITCompiler.log(context, body, blockId, "skipping block in " + excludeModuleName);
             }
             return;
         }
@@ -102,18 +102,18 @@ class BlockJITTask extends JITCompiler.Task {
     }
 
     @Override
-    protected void logJitted() {
-        logImpl("block done jitting");
+    protected void logJitted(ThreadContext context) {
+        logImpl(context, "block done jitting");
     }
 
     @Override
-    protected void logFailed(final Throwable ex) {
-        logImpl("could not compile block; passes run: " + body.getIRScope().getExecutedPasses(), ex);
+    protected void logFailed(ThreadContext context, Throwable ex) {
+        logImpl(context, "could not compile block; passes run: " + body.getIRScope().getExecutedPasses(), ex);
     }
 
     @Override
-    protected void logImpl(final String message, Object... reason) {
-        JITCompiler.log(body, blockId, message, reason);
+    protected void logImpl(ThreadContext context, final String message, Object... reason) {
+        JITCompiler.log(context, body, blockId, message, reason);
     }
 
 }

--- a/core/src/main/java/org/jruby/compiler/BlockJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/BlockJITTask.java
@@ -37,6 +37,7 @@ import org.jruby.parser.StaticScope;
 import org.jruby.runtime.ArgumentDescriptor;
 import org.jruby.runtime.CompiledIRBlockBody;
 import org.jruby.runtime.MixedModeIRBlockBody;
+import org.jruby.runtime.ThreadContext;
 
 import static org.jruby.compiler.MethodJITTask.*;
 
@@ -57,7 +58,7 @@ class BlockJITTask extends JITCompiler.Task {
     }
 
     @Override
-    public void exec() throws NoSuchMethodException, IllegalAccessException {
+    public void exec(ThreadContext context) throws NoSuchMethodException, IllegalAccessException {
         // Check if the method has been explicitly excluded
         String excludeModuleName = checkExcludedMethod(jitCompiler.config, className, methodName, body);
         if (excludeModuleName != null) {
@@ -85,7 +86,7 @@ class BlockJITTask extends JITCompiler.Task {
         String jittedName = methodContext.getVariableName();
 
         // blocks only have variable-arity
-        body.completeBuild(runtime.getCurrentContext(),
+        body.completeBuild(context,
                 new CompiledIRBlockBody(
                         JITCompiler.PUBLIC_LOOKUP.findStatic(sourceClass, jittedName, JVMVisitor.CLOSURE_SIGNATURE.type()),
                         scope,

--- a/core/src/main/java/org/jruby/compiler/Compilable.java
+++ b/core/src/main/java/org/jruby/compiler/Compilable.java
@@ -1,6 +1,7 @@
 package org.jruby.compiler;
 
 import org.jruby.MetaClass;
+import org.jruby.RubyBasicObject;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.ir.IRScope;
@@ -14,8 +15,9 @@ import static org.jruby.api.Access.classClass;
  */
 public interface Compilable<T> {
     void setCallCount(int count);
+    @Deprecated(since = "10.0")
     default void completeBuild(T buildResult) {
-        completeBuild(getImplementationClass().getRuntime().getCurrentContext(), buildResult);
+        completeBuild(getImplementationClass().getCurrentContext(), buildResult);
     }
     default void completeBuild(ThreadContext context, T buildResult) {
         completeBuild(buildResult);
@@ -27,9 +29,14 @@ public interface Compilable<T> {
      * Return the owning module/class name.
      * @return method/block owner's name
      */
+    @Deprecated(since = "10.0")
     default String getOwnerName() {
+        return getOwnerName(getImplementationClass().getCurrentContext());
+    }
+
+    default String getOwnerName(ThreadContext context) {
         RubyModule implClass = getImplementationClass();
-        return implClass == null ? null : resolveFullName(implClass);
+        return implClass == null ? null : resolveFullName(context, implClass);
     }
 
     /**
@@ -51,7 +58,7 @@ public interface Compilable<T> {
 
     @Deprecated
     default String getClassName(ThreadContext context) {
-        return getOwnerName();
+        return getOwnerName(context);
     }
 
     /**
@@ -59,9 +66,7 @@ public interface Compilable<T> {
      * @param implementationClass
      * @return class/module name e.g. Foo::Bar::Baz
      */
-    static String resolveFullName(RubyModule implementationClass) {
-        var context = implementationClass.getRuntime().getCurrentContext();
-
+    static String resolveFullName(ThreadContext context, RubyModule implementationClass) {
         if (implementationClass.isSingleton()) {
             MetaClass metaClass = (MetaClass)implementationClass;
             RubyClass realClass = metaClass.getRealClass();

--- a/core/src/main/java/org/jruby/compiler/FullBuildTask.java
+++ b/core/src/main/java/org/jruby/compiler/FullBuildTask.java
@@ -27,22 +27,21 @@ class FullBuildTask implements Runnable {
     public void run() {
         try {
             var scope = method.getIRScope();
+            var context = scope.getManager().getRuntime().getCurrentContext();
             IRScope hardScope = scope.getNearestTopLocalVariableScope();
 
             // define_method may capture something outside itself and we need parents and children to compile
             // to agreement with respect to local variable access (e.g. dynscopes).
             if (hardScope != scope) hardScope.prepareFullBuild();
 
-            method.completeBuild(scope.getManager().getRuntime().getCurrentContext(), scope.prepareFullBuild());
+            method.completeBuild(context, scope.prepareFullBuild());
 
             if (IRRuntimeHelpers.shouldPrintIR(jitCompiler.runtime) && IRRuntimeHelpers.shouldPrintScope(scope)) {
                 ByteArrayOutputStream baos = IRDumper.printIR(scope, true, true);
                 LOG.info("Printing full IR for " + scope.getId() + ":\n" + new String(baos.toByteArray()));
             }
 
-            if (jitCompiler.config.isJitLogging()) {
-                JITCompiler.log(method, method.getName(), "done building");
-            }
+            if (jitCompiler.config.isJitLogging()) JITCompiler.log(context, method, method.getName(), "done building");
         } catch (Throwable t) {
             if (jitCompiler.config.isJitLogging()) {
                 //JITCompiler.log(method, method.getName(), "could not build; passes run: " + method.getIRScope().getExecutedPasses(), t);

--- a/core/src/main/java/org/jruby/compiler/JITCompiler.java
+++ b/core/src/main/java/org/jruby/compiler/JITCompiler.java
@@ -304,14 +304,14 @@ public class JITCompiler implements JITCompilerMBean {
             // See #4739 for a reproduction script that produced various errors without this.
             synchronized (jitCompiler) {
                 try {
-                    exec();
+                    exec(jitCompiler.runtime.getCurrentContext());
                 } catch (Throwable ex) {
                     jitFailed(ex);
                 }
             }
         }
 
-        protected abstract void exec() throws Exception ;
+        protected abstract void exec(ThreadContext context) throws Exception ;
 
         protected String getSourceFile() {
             return null; // unknown by default

--- a/core/src/main/java/org/jruby/compiler/JITCompiler.java
+++ b/core/src/main/java/org/jruby/compiler/JITCompiler.java
@@ -194,11 +194,11 @@ public class JITCompiler implements JITCompilerMBean {
 
     public Runnable getTaskFor(ThreadContext context, Compilable method) {
         if (method instanceof MixedModeIRMethod) {
-            return new MethodJITTask(this, (MixedModeIRMethod) method, method.getOwnerName());
+            return new MethodJITTask(this, (MixedModeIRMethod) method, method.getOwnerName(context));
         } else if (method instanceof MixedModeIRBlockBody) {
-            return new BlockJITTask(this, (MixedModeIRBlockBody) method, method.getOwnerName());
+            return new BlockJITTask(this, (MixedModeIRBlockBody) method, method.getOwnerName(context));
         } else if (method instanceof CompiledIRMethod) {
-            return new MethodCompiledJITTask(this, (CompiledIRMethod) method, method.getOwnerName());
+            return new MethodCompiledJITTask(this, (CompiledIRMethod) method, method.getOwnerName(context));
         }
 
         return new FullBuildTask(this, method);

--- a/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/MethodCompiledJITTask.java
@@ -63,7 +63,7 @@ class MethodCompiledJITTask extends JITCompiler.Task {
         if (excludeModuleName != null) {
             method.setCallCount(-1);
             if (jitCompiler.config.isJitLogging()) {
-                logImpl("skipping (compiled) method in " + excludeModuleName);
+                logImpl(context, "skipping (compiled) method in " + excludeModuleName);
             }
             return;
         }
@@ -99,17 +99,17 @@ class MethodCompiledJITTask extends JITCompiler.Task {
     }
 
     @Override
-    protected void logJitted() {
-        logImpl("(compiled) method done jitting");
+    protected void logJitted(ThreadContext context) {
+        logImpl(context, "(compiled) method done jitting");
     }
 
     @Override
-    protected void logFailed(final Throwable ex) {
-        logImpl("could not re-compile method; passes run: " + method.getIRScope().getExecutedPasses(), ex);
+    protected void logFailed(ThreadContext context, final Throwable ex) {
+        logImpl(context, "could not re-compile method; passes run: " + method.getIRScope().getExecutedPasses(), ex);
     }
 
     @Override
-    protected void logImpl(final String message, Object... reason) {
+    protected void logImpl(ThreadContext context, final String message, Object... reason) {
         JITCompiler.log(method, methodName, message, reason);
     }
 

--- a/core/src/main/java/org/jruby/compiler/MethodJITTask.java
+++ b/core/src/main/java/org/jruby/compiler/MethodJITTask.java
@@ -62,9 +62,7 @@ class MethodJITTask extends JITCompiler.Task {
         String excludeModuleName = checkExcludedMethod(jitCompiler.config, className, methodName, method);
         if (excludeModuleName != null) {
             method.setCallCount(-1);
-            if (jitCompiler.config.isJitLogging()) {
-                logImpl("skipping method in " + excludeModuleName);
-            }
+            if (jitCompiler.config.isJitLogging()) logImpl(context, "skipping method in " + excludeModuleName);
             return;
         }
 
@@ -117,17 +115,17 @@ class MethodJITTask extends JITCompiler.Task {
     }
 
     @Override
-    protected void logJitted() {
-        logImpl("method done jitting");
+    protected void logJitted(ThreadContext context) {
+        logImpl(context, "method done jitting");
     }
 
     @Override
-    protected void logFailed(final Throwable ex) {
-        logImpl("could not compile method; passes run: " + method.getIRScope().getExecutedPasses(), ex);
+    protected void logFailed(ThreadContext context, final Throwable ex) {
+        logImpl(context, "could not compile method; passes run: " + method.getIRScope().getExecutedPasses(), ex);
     }
 
     @Override
-    protected void logImpl(String message, Object... reason) {
+    protected void logImpl(ThreadContext context, String message, Object... reason) {
         JITCompiler.log(method, methodName, message, reason);
     }
 

--- a/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
+++ b/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
@@ -11,6 +11,7 @@ import jnr.constants.platform.Confstr;
 import jnr.constants.platform.Pathconf;
 
 import org.jruby.RubyArray;
+import org.jruby.RubyClass;
 import org.jruby.RubyHash;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyModule;
@@ -144,7 +145,7 @@ public class RubyEtc {
 
         };
         
-        return RubyStruct.newStruct(context.runtime.getPasswdStruct(), args, Block.NULL_BLOCK);
+        return newStruct(context, (RubyClass) context.runtime.getPasswdStruct(), args, Block.NULL_BLOCK);
     }
 
     
@@ -156,7 +157,7 @@ public class RubyEtc {
                 intoStringArray(context, group.getMembers())
         };
         
-        return RubyStruct.newStruct(context.runtime.getGroupStruct(), args, Block.NULL_BLOCK);
+        return newStruct(context, (RubyClass) context.runtime.getGroupStruct(), args, Block.NULL_BLOCK);
     }
 
     private static IRubyObject intoStringArray(ThreadContext context, String[] members) {

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyExecutionContextLocal.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyExecutionContextLocal.java
@@ -75,9 +75,14 @@ public abstract class JRubyExecutionContextLocal extends RubyObject {
         return default_value;
     }
 
-    @JRubyMethod(name = "default_proc")
+    @Deprecated(since = "10.0")
     public IRubyObject getDefaultProc() {
-        return (default_proc != null) ? default_proc : getRuntime().getNil();
+        return getDefaultProc(getCurrentContext());
+    }
+
+    @JRubyMethod(name = "default_proc")
+    public IRubyObject getDefaultProc(ThreadContext context) {
+        return (default_proc != null) ? default_proc : context.nil;
     }
 
     @JRubyMethod(name = "value")

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyObjectInputStream.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyObjectInputStream.java
@@ -43,36 +43,50 @@ public class JRubyObjectInputStream extends RubyObject {
     public JRubyObjectInputStream(Ruby runtime, RubyClass rubyClass) {
 	    super(runtime,rubyClass);
     }
+
+    @Deprecated(since = "10.0")
+    public IRubyObject initialize(IRubyObject wrappedStream) {
+        return initialize(getCurrentContext(), wrappedStream);
+    }
     
     @JRubyMethod(name="initialize",required=1, visibility = Visibility.PRIVATE)
-    public IRubyObject initialize(IRubyObject wrappedStream) {
-        InputStream stream = (InputStream) wrappedStream.toJava(InputStream.class);
+    public IRubyObject initialize(ThreadContext context, IRubyObject wrappedStream) {
+        InputStream stream = wrappedStream.toJava(InputStream.class);
         try {
-            impl = new JRubyObjectInputStreamImpl(getRuntime(), stream);
+            impl = new JRubyObjectInputStreamImpl(context.runtime, stream);
         } catch (IOException ioe) {
-            throw getRuntime().newIOErrorFromException(ioe);
+            throw context.runtime.newIOErrorFromException(ioe);
         }
         return this;
     }
 
+    @Deprecated(since = "10.0")
+    public IRubyObject readObject() {
+        return readObject(getCurrentContext());
+    }
+
     @JRubyMethod(name="read_object", alias="readObject")
-	public IRubyObject readObject() {
+    public IRubyObject readObject(ThreadContext context) {
         try {
-        	return Java.getInstance(getRuntime(), impl.readObject());
+        	return Java.getInstance(context.runtime, impl.readObject());
         } catch (IOException ioe) {
-            throw getRuntime().newIOErrorFromException(ioe);
+            throw context.runtime.newIOErrorFromException(ioe);
         } catch (ClassNotFoundException cnfe) {
-            throw getRuntime().newNameError(cnfe.getLocalizedMessage(), cnfe.getMessage(), cnfe);
+            throw context.runtime.newNameError(cnfe.getLocalizedMessage(), cnfe.getMessage(), cnfe);
         }
     }
 
+    @Deprecated(since = "10.0")
+    public IRubyObject close() {
+        return close(getCurrentContext());
+    }
 
     @JRubyMethod(name="close")
-    public IRubyObject close() {
+    public IRubyObject close(ThreadContext context) {
         try {
             impl.close();
         } catch (IOException ioe) {
-            throw getRuntime().newIOErrorFromException(ioe);
+            throw context.runtime.newIOErrorFromException(ioe);
         }
         return this;
     }

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
@@ -88,12 +88,12 @@ public class JRubyUtilLibrary implements Library {
 
     @Deprecated(since = "9.4-")
     public static IRubyObject getObjectSpaceEnabled(IRubyObject recv) {
-        return getObjectSpaceEnabled(recv.getRuntime().getCurrentContext(), recv);
+        return getObjectSpaceEnabled(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
 
     @Deprecated(since = "10.0")
     public static IRubyObject setObjectSpaceEnabled(IRubyObject recv, IRubyObject arg) {
-        return setObjectSpaceEnabled(recv.getRuntime().getCurrentContext(), recv, arg);
+        return setObjectSpaceEnabled(((RubyBasicObject) recv).getCurrentContext(), recv, arg);
     }
 
     @JRubyMethod(name = { "objectspace=", "object_space=" }, module = true)
@@ -113,7 +113,7 @@ public class JRubyUtilLibrary implements Library {
 
     @Deprecated
     public static IRubyObject getClassLoaderResources(IRubyObject recv, IRubyObject name) {
-        return class_loader_resources(recv.getRuntime().getCurrentContext(), recv, name);
+        return class_loader_resources(((RubyBasicObject) recv).getCurrentContext(), recv, name);
     }
 
     /**

--- a/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
+++ b/core/src/main/java/org/jruby/ext/pathname/RubyPathname.java
@@ -141,10 +141,8 @@ public class RubyPathname extends RubyObject {
 
     public static class PathnameKernelMethods {
         @JRubyMethod(name = "Pathname", module = true, visibility = Visibility.PRIVATE)
-        public static IRubyObject newPathname(IRubyObject recv, IRubyObject path) {
-            if (path instanceof RubyPathname) return path;
-
-            return RubyPathname.newInstance(recv.getRuntime().getCurrentContext(), path);
+        public static IRubyObject newPathname(ThreadContext context, IRubyObject recv, IRubyObject path) {
+            return path instanceof RubyPathname ? path : RubyPathname.newInstance(context, path);
         }
     }
 

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
@@ -31,6 +31,7 @@ import com.jcraft.jzlib.GZIPException;
 import com.jcraft.jzlib.GZIPInputStream;
 import com.jcraft.jzlib.Inflater;
 import org.jruby.Ruby;
+import org.jruby.RubyBasicObject;
 import org.jruby.RubyClass;
 import org.jruby.RubyEnumerator;
 import org.jruby.RubyException;
@@ -79,14 +80,17 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
 
     @JRubyMethod(name = "new", rest = true, meta = true, keywords = true)
     public static IRubyObject newInstance(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
-        JZlibRubyGzipReader result = newInstance(recv, args);
+        JZlibRubyGzipReader result = newInstance(context, (RubyClass) recv, args);
 
         return RubyGzipFile.wrapBlock(context, result, block);
     }
 
+    @Deprecated(since = "10.0")
     public static JZlibRubyGzipReader newInstance(IRubyObject recv, IRubyObject[] args) {
-        var context = recv.getRuntime().getCurrentContext();
-        RubyClass klass = (RubyClass) recv;
+        return newInstance(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, args);
+    }
+
+    public static JZlibRubyGzipReader newInstance(ThreadContext context, RubyClass klass, IRubyObject[] args) {
         JZlibRubyGzipReader result = (JZlibRubyGzipReader) klass.allocate(context);
 
         result.callInit(args, Block.NULL_BLOCK);
@@ -100,7 +104,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
 
         args[0] = Helpers.invoke(context, fileClass(context), "open", args[0], newString(context, "rb"));
 
-        JZlibRubyGzipReader gzio = newInstance(recv, args);
+        JZlibRubyGzipReader gzio = newInstance(context, (RubyClass) recv, args);
 
         return RubyGzipFile.wrapBlock(context, gzio, block);
     }

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
@@ -274,7 +274,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
             result.append(ce);
         }
         
-        fixBrokenTrailingCharacter(result);
+        fixBrokenTrailingCharacter(context, result);
 
         if (stripNewlines) skipNewlines();
 
@@ -285,7 +285,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         line++;
         position += result.length();
 
-        return newStr(context.runtime, result);
+        return newStr(context, result);
     }
 
     private static final int NEWLINE = '\n';
@@ -381,7 +381,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
 
         if (outbuf != null) outbuf.view(val);
 
-        return newStr(context.runtime, val);
+        return newStr(context, val);
     }
 
     private RubyString readAll(ThreadContext context) throws IOException {
@@ -401,10 +401,10 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
             if (limit != -1) rest -= read;
         }
         
-        fixBrokenTrailingCharacter(val);
+        fixBrokenTrailingCharacter(context, val);
         
         this.position += val.length();
-        return newStr(context.runtime, val);
+        return newStr(context, val);
     }
 
 
@@ -681,7 +681,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
     public IRubyObject ungetc(ThreadContext context, IRubyObject c) {
         if (c.isNil()) return c;
         if (c instanceof RubyInteger) {
-            c = EncodingUtils.encUintChr(context, ((RubyInteger) c).getIntValue(), getReadEncoding());
+            c = EncodingUtils.encUintChr(context, ((RubyInteger) c).getIntValue(), getReadEncoding(context));
         } else {
             c = c.convertToString();
         }
@@ -815,9 +815,10 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         return block.isGiven() ? context.nil : buf;
     }
 
-    private void fixBrokenTrailingCharacter(ByteList result) throws IOException {
+    private void fixBrokenTrailingCharacter(ThreadContext context, ByteList result) throws IOException {
         // fix broken trailing character
-        int extraBytes = StringSupport.bytesToFixBrokenTrailingCharacter(result.getUnsafeBytes(), result.getBegin(), result.getRealSize(), getReadEncoding(), result.length());
+        int extraBytes = StringSupport.bytesToFixBrokenTrailingCharacter(result.getUnsafeBytes(), result.getBegin(),
+                result.getRealSize(), getReadEncoding(context), result.length());
 
         for (int i = 0; i < extraBytes; i++) {
             int read = bufferedStream.read();

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
@@ -33,6 +33,7 @@ import com.jcraft.jzlib.GZIPOutputStream;
 import com.jcraft.jzlib.JZlib;
 import org.jcodings.specific.ASCIIEncoding;
 import org.jruby.Ruby;
+import org.jruby.RubyBasicObject;
 import org.jruby.RubyClass;
 import org.jruby.RubyIO;
 import org.jruby.RubyKernel;
@@ -67,14 +68,17 @@ import static org.jruby.runtime.Visibility.PRIVATE;
 public class JZlibRubyGzipWriter extends RubyGzipFile {
     @JRubyMethod(name = "new", rest = true, meta = true, keywords = true)
     public static IRubyObject newInstance(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
-        JZlibRubyGzipWriter result = newInstance(recv, args);
+        JZlibRubyGzipWriter result = newInstance(context, (RubyClass) recv, args);
 
         return RubyGzipFile.wrapBlock(context, result, block);
     }
 
+    @Deprecated(since = "10.0")
     public static JZlibRubyGzipWriter newInstance(IRubyObject recv, IRubyObject[] args) {
-        var context = recv.getRuntime().getCurrentContext();
-        RubyClass klass = (RubyClass) recv;
+        return newInstance(((RubyBasicObject) recv).getCurrentContext(), (RubyClass) recv, args);
+    }
+
+    public static JZlibRubyGzipWriter newInstance(ThreadContext context, RubyClass klass, IRubyObject[] args) {
         JZlibRubyGzipWriter result = (JZlibRubyGzipWriter) klass.allocate(context);
 
         result.callInit(args, Block.NULL_BLOCK);
@@ -87,7 +91,7 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
         Arity.checkArgumentCount(context, args, 1, 4);
         args[0] = Helpers.invoke(context, fileClass(context), "open", args[0], newString(context, "wb"));
         
-        JZlibRubyGzipWriter gzio = newInstance(recv, args);
+        JZlibRubyGzipWriter gzio = newInstance(context, (RubyClass) recv, args);
         
         return RubyGzipFile.wrapBlock(context, gzio, block);
     }

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
@@ -100,8 +100,9 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
         super(runtime, type);
     }
 
+    @Deprecated(since = "10.0")
     public IRubyObject initialize(IRubyObject[] args) {
-        return initialize(getRuntime().getCurrentContext(), args, Block.NULL_BLOCK);
+        return initialize(getCurrentContext(), args, Block.NULL_BLOCK);
     }
 
     @JRubyMethod(name = "initialize", rest = true, visibility = PRIVATE)

--- a/core/src/main/java/org/jruby/ext/zlib/RubyGzipFile.java
+++ b/core/src/main/java/org/jruby/ext/zlib/RubyGzipFile.java
@@ -50,6 +50,7 @@ import org.jruby.util.io.EncodingUtils;
 import org.jruby.util.io.IOEncodable;
 
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Create.newString;
 
 /**
  *
@@ -155,9 +156,14 @@ public class RubyGzipFile extends RubyObject implements IOEncodable {
             ecopts = opts;
         }
     }
-    
+
+    @Deprecated(since = "10.0")
     public Encoding getReadEncoding() {
-        return enc == null ? getRuntime().getDefaultExternalEncoding() : enc;
+        return getReadEncoding(getCurrentContext());
+    }
+
+    public Encoding getReadEncoding(ThreadContext context) {
+        return enc == null ? context.runtime.getDefaultExternalEncoding() : enc;
     }
     
     public Encoding getEnc() {
@@ -172,18 +178,18 @@ public class RubyGzipFile extends RubyObject implements IOEncodable {
         return enc2;
     }
 
-    // c: gzfile_newstr
+    @Deprecated(since = "10.0")
     protected RubyString newStr(Ruby runtime, ByteList value) {
-        if (enc2 == null) {
-            return RubyString.newString(runtime, value, getReadEncoding());
-        }
+        return newStr(runtime.getCurrentContext(), value);
+    }
 
-        if (ec != null && enc2.isDummy()) {
-            value = EncodingUtils.econvStrConvert(runtime.getCurrentContext(), ec, value, 0);
-            return RubyString.newString(runtime, value, getEnc());
-        }
+    // c: gzfile_newstr
+    protected RubyString newStr(ThreadContext context, ByteList value) {
+        if (enc2 == null) return newString(context, value, getReadEncoding(context));
 
-        return EncodingUtils.strConvEncOpts(runtime.getCurrentContext(), RubyString.newString(runtime, value), enc2, enc, ecflags, ecopts);
+        return ec != null && enc2.isDummy() ?
+                newString(context, EncodingUtils.econvStrConvert(context, ec, value, 0), getEnc()) :
+                EncodingUtils.strConvEncOpts(context, newString(context, value), enc2, enc, ecflags, ecopts);
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/ext/zlib/RubyGzipFile.java
+++ b/core/src/main/java/org/jruby/ext/zlib/RubyGzipFile.java
@@ -89,8 +89,8 @@ public class RubyGzipFile extends RubyObject implements IOEncodable {
     @JRubyMethod(meta = true, name = "wrap", required = 1, optional = 1, checkArity = false)
     public static IRubyObject wrap(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block block) {
         RubyGzipFile instance = ((RubyModule) recv).isKindOfModule(Access.getClass(context, "Zlib", "GzipWriter")) ?
-                JZlibRubyGzipWriter.newInstance(recv, args) :
-                JZlibRubyGzipReader.newInstance(recv, args);
+                JZlibRubyGzipWriter.newInstance(context, (RubyClass) recv, args) :
+                JZlibRubyGzipReader.newInstance(context, (RubyClass) recv, args);
 
         return wrapBlock(context, instance, block);
     }

--- a/core/src/main/java/org/jruby/internal/runtime/methods/ProfilingDynamicMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/ProfilingDynamicMethod.java
@@ -167,7 +167,7 @@ public class ProfilingDynamicMethod extends DelegatingDynamicMethod implements I
 
     public ArgumentDescriptor[] getArgumentDescriptors() {
         return delegate instanceof IRMethodArgs ?
-                ((IRMethodArgs) delegate).getArgumentDescriptors() : Helpers.methodToArgumentDescriptors(delegate);
+                ((IRMethodArgs) delegate).getArgumentDescriptors() : Helpers.methodToArgumentDescriptors(delegate.getImplementationClass().getRuntime().getCurrentContext(), delegate);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/Compiler.java
+++ b/core/src/main/java/org/jruby/ir/Compiler.java
@@ -44,7 +44,7 @@ public class Compiler extends IRTranslator<ScriptAndCode, ClassDefiningClassLoad
     }
 
     @Override
-    protected ScriptAndCode execute(final Ruby runtime, final IRScriptBody scope, ClassDefiningClassLoader classLoader) {
+    protected ScriptAndCode execute(ThreadContext context, final IRScriptBody scope, ClassDefiningClassLoader classLoader) {
         JVMVisitor visitor;
         Class compiled;
         byte[] bytecode;
@@ -58,10 +58,10 @@ public class Compiler extends IRTranslator<ScriptAndCode, ClassDefiningClassLoad
 
         try {
             // If we're caching, use AOT-appropriate bytecode
-            visitor = cacheClasses ? JVMVisitor.newForAOT(runtime) : JVMVisitor.newForJIT(runtime);
+            visitor = cacheClasses ? JVMVisitor.newForAOT(context.runtime) : JVMVisitor.newForJIT(context.runtime);
 
-            JVMVisitorMethodContext context = new JVMVisitorMethodContext();
-            bytecode = visitor.compileToBytecode(scope, context);
+            JVMVisitorMethodContext methodContext = new JVMVisitorMethodContext();
+            bytecode = visitor.compileToBytecode(scope, methodContext);
             compiled = visitor.defineScriptFromBytecode(scope, bytecode, classLoader);
         } catch (NotCompilableException nce) {
             throw nce;

--- a/core/src/main/java/org/jruby/ir/IRTranslator.java
+++ b/core/src/main/java/org/jruby/ir/IRTranslator.java
@@ -8,6 +8,7 @@ import org.jruby.ir.interpreter.InterpreterContext;
 import org.jruby.ir.persistence.IRWriter;
 import org.jruby.ir.persistence.IRWriterStream;
 import org.jruby.ir.persistence.util.IRFileExpert;
+import org.jruby.runtime.ThreadContext;
 
 import java.io.IOException;
 
@@ -18,13 +19,13 @@ import java.io.IOException;
  * @param <S> type of specific for translator object
  */
 public abstract class IRTranslator<R, S> {
-    public R execute(Ruby runtime, ParseResult result, S specificObject) {
+    public R execute(ThreadContext context, ParseResult result, S specificObject) {
         IRScriptBody scope;
 
         if (result instanceof IRScriptBody) { // Already have it (likely from read from persistent store).
             scope = (IRScriptBody) result;
         } else {
-            InterpreterContext ic = IRBuilder.buildRoot(runtime.getIRManager(), result);
+            InterpreterContext ic = IRBuilder.buildRoot(context.runtime.getIRManager(), result);
             scope = (IRScriptBody) ic.getScope();
             scope.setScriptDynamicScope(result.getDynamicScope());
 
@@ -38,8 +39,8 @@ public abstract class IRTranslator<R, S> {
             }
         }
 
-        return execute(runtime, scope, specificObject);
+        return execute(context, scope, specificObject);
     }
 
-    protected abstract R execute(Ruby runtime, IRScriptBody producedIrScope, S specificObject);
+    protected abstract R execute(ThreadContext context, IRScriptBody producedIrScope, S specificObject);
 }

--- a/core/src/main/java/org/jruby/ir/interpreter/Interpreter.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/Interpreter.java
@@ -8,8 +8,6 @@ import org.jruby.Ruby;
 import org.jruby.RubyModule;
 import org.jruby.RubyString;
 import org.jruby.ir.IRManager;
-import org.jruby.ir.IRMethod;
-import org.jruby.ir.IRModuleBody;
 import org.jruby.ir.builder.IRBuilder;
 import org.jruby.ir.IREvalScript;
 import org.jruby.ir.IRScope;
@@ -24,7 +22,6 @@ import org.jruby.runtime.Binding;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.DynamicScope;
 import org.jruby.runtime.Frame;
-import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -53,16 +50,15 @@ public class Interpreter extends IRTranslator<IRubyObject, IRubyObject> {
     }
 
     @Override
-    protected IRubyObject execute(Ruby runtime, IRScriptBody irScope, IRubyObject self) {
+    protected IRubyObject execute(ThreadContext context, IRScriptBody irScope, IRubyObject self) {
         InterpreterContext ic = irScope.getInterpreterContext();
 
-        if (IRRuntimeHelpers.shouldPrintIR(runtime) && IRRuntimeHelpers.shouldPrintScope(irScope)) {
+        if (IRRuntimeHelpers.shouldPrintIR(context.runtime) && IRRuntimeHelpers.shouldPrintScope(irScope)) {
             ByteArrayOutputStream baos = IRDumper.printIR(irScope, false);
 
             LOG.info("Printing simple IR for " + irScope.getId() + ":\n" + new String(baos.toByteArray()));
         }
 
-        ThreadContext context = runtime.getCurrentContext();
         String name = ROOT;
 
         if (IRRuntimeHelpers.isDebug()) LOG.info("Executing {}", ic);

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -1396,7 +1396,7 @@ public class IRRuntimeHelpers {
 
         Object[] newArgs = RubyToJavaInvoker.convertArguments(javaMethod, args);
 
-        JavaProxyClass jpc = JavaProxyClass.getProxyClass(context.runtime, definingModule);
+        JavaProxyClass jpc = JavaProxyClass.getProxyClass(context, definingModule);
 
         if (jpc != null) {
             // self is a Java subclass, need to do a bit more logic to dispatch the right method

--- a/core/src/main/java/org/jruby/java/addons/KernelJavaAddons.java
+++ b/core/src/main/java/org/jruby/java/addons/KernelJavaAddons.java
@@ -2,6 +2,7 @@ package org.jruby.java.addons;
 
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
+import org.jruby.RubyBasicObject;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.java.proxies.ArrayJavaProxy;
 import org.jruby.java.util.ArrayUtils;
@@ -16,11 +17,9 @@ public class KernelJavaAddons {
 
     @JRubyMethod
     public static IRubyObject to_java(ThreadContext context, final IRubyObject fromObject) {
-        final Ruby runtime = context.runtime;
-        if ( fromObject instanceof RubyArray ) {
-            return toJavaArray(runtime, Object.class, (RubyArray) fromObject);
-        }
-        return Java.getInstance(runtime, fromObject.toJava(Object.class));
+        return fromObject instanceof RubyArray ary ?
+                toJavaArray(context, Object.class, ary) :
+                Java.getInstance(context.runtime, fromObject.toJava(Object.class));
     }
 
     @JRubyMethod
@@ -29,17 +28,17 @@ public class KernelJavaAddons {
 
         final Class targetType = Java.resolveClassType(context, type);
         if ( fromObject instanceof RubyArray ) {
-            return toJavaArray(context.runtime, targetType, (RubyArray) fromObject);
+            return toJavaArray(context, targetType, (RubyArray) fromObject);
         }
         return Java.getInstance(context.runtime, fromObject.toJava(targetType));
     }
 
-    static ArrayJavaProxy toJavaArray(final Ruby runtime, final Class<?> type, final RubyArray fromArray) {
-        final Object newArray = toJavaArrayInternal(runtime, type, fromArray);
-        return new ArrayJavaProxy(runtime, Java.getProxyClassForObject(runtime, newArray), newArray, JavaUtil.getJavaConverter(type));
+    static ArrayJavaProxy toJavaArray(ThreadContext context, final Class<?> type, final RubyArray fromArray) {
+        final Object newArray = toJavaArrayInternal(context, type, fromArray);
+        return new ArrayJavaProxy(context.runtime, Java.getProxyClassForObject(context.runtime, newArray), newArray, JavaUtil.getJavaConverter(type));
     }
 
-    private static Object toJavaArrayInternal(final Ruby runtime, final Class<?> type, final RubyArray fromArray) {
+    private static Object toJavaArrayInternal(ThreadContext context, final Class<?> type, final RubyArray fromArray) {
         final Object newArray = Array.newInstance(type, fromArray.size());
 
         if (type.isArray()) {
@@ -49,7 +48,7 @@ public class KernelJavaAddons {
                 final IRubyObject element = fromArray.eltInternal(i);
                 final Object nestedArray;
                 if ( element instanceof RubyArray ) { // recurse
-                    nestedArray = toJavaArrayInternal(runtime, nestedType, (RubyArray) element);
+                    nestedArray = toJavaArrayInternal(context, nestedType, (RubyArray) element);
                 }
                 else if ( type.isInstance(element) ) {
                     nestedArray = element;
@@ -57,7 +56,7 @@ public class KernelJavaAddons {
                 else { // still try (nested) toJava conversion :
                     nestedArray = element.toJava(type);
                 }
-                ArrayUtils.setWithExceptionHandlingDirect(runtime, newArray, i, nestedArray);
+                ArrayUtils.setWithExceptionHandlingDirect(context.runtime, newArray, i, nestedArray);
             }
         } else {
             ArrayUtils.copyDataToJavaArrayDirect(fromArray, newArray);
@@ -66,46 +65,74 @@ public class KernelJavaAddons {
         return newArray;
     }
 
-    @JRubyMethod(rest = true)
+    @Deprecated(since = "10.0")
     public static IRubyObject java_signature(IRubyObject recv, IRubyObject[] args) {
-        // empty stub for now
-        return recv.getRuntime().getNil();
+        return java_signature(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
 
     @JRubyMethod(rest = true)
+    public static IRubyObject java_signature(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        return context.nil;
+    }
+
+    @Deprecated(since = "10.0")
     public static IRubyObject java_name(IRubyObject recv, IRubyObject[] args) {
-        // empty stub for now
-        return recv.getRuntime().getNil();
+        return java_name(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
 
     @JRubyMethod(rest = true)
+    public static IRubyObject java_name(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        return context.nil;
+    }
+
+    @Deprecated(since = "10.0")
     public static IRubyObject java_implements(IRubyObject recv, IRubyObject[] args) {
-        // empty stub for now
-        return recv.getRuntime().getNil();
+        return java_implements(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
 
     @JRubyMethod(rest = true)
+    public static IRubyObject java_implements(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        return context.nil;
+    }
+
+    @Deprecated(since = "10.0")
     public static IRubyObject java_annotation(IRubyObject recv, IRubyObject[] args) {
-        // empty stub for now
-        return recv.getRuntime().getNil();
+        return java_annotation(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
 
     @JRubyMethod(rest = true)
+    public static IRubyObject java_annotation(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        return context.nil;
+    }
+
+    @Deprecated(since = "10.0")
     public static IRubyObject java_require(IRubyObject recv, IRubyObject[] args) {
-        // empty stub for now
-        return recv.getRuntime().getNil();
+        return java_require(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
 
     @JRubyMethod(rest = true)
+    public static IRubyObject java_require(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        return context.nil;
+    }
+
+    @Deprecated(since = "10.0")
     public static IRubyObject java_package(IRubyObject recv, IRubyObject[] args) {
-        // empty stub for now
-        return recv.getRuntime().getNil();
+        return java_package(((RubyBasicObject) recv).getCurrentContext(), recv, args);
     }
 
     @JRubyMethod(rest = true)
+    public static IRubyObject java_package(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        return context.nil;
+    }
+
+    @Deprecated(since = "10.0")
     public static IRubyObject java_field(IRubyObject recv, IRubyObject[] args) {
-        // empty stub for now
-        return recv.getRuntime().getNil();
+        return java_field(((RubyBasicObject) recv).getCurrentContext(), recv, args);
+    }
+
+    @JRubyMethod(rest = true)
+    public static IRubyObject java_field(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+        return context.nil;
     }
 
 }

--- a/core/src/main/java/org/jruby/java/addons/StringJavaAddons.java
+++ b/core/src/main/java/org/jruby/java/addons/StringJavaAddons.java
@@ -8,7 +8,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 public class StringJavaAddons {
     @JRubyMethod
     public static IRubyObject to_java_bytes(ThreadContext context, IRubyObject self) {
-        return JavaArrayUtilities.ruby_string_to_bytes(self, self);
+        return JavaArrayUtilities.ruby_string_to_bytes(context, self, self);
     }
     
     @JRubyMethod(meta = true)

--- a/core/src/main/java/org/jruby/java/proxies/ConcreteJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ConcreteJavaProxy.java
@@ -286,7 +286,7 @@ public class ConcreteJavaProxy extends JavaProxy {
             }
 
             if (ctor == null) {
-                ReifiedJavaProxy proxy = JavaUtil.unwrapJava(initialize.call(context, self, clazz, "new", args));
+                ReifiedJavaProxy proxy = JavaUtil.unwrapJava(context, initialize.call(context, self, clazz, "new", args));
                 return proxy.___jruby$rubyObject();
             } else {
 

--- a/core/src/main/java/org/jruby/java/proxies/JavaInterfaceTemplate.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaInterfaceTemplate.java
@@ -253,12 +253,12 @@ public class JavaInterfaceTemplate {
 
         @Override // will be called with zero args
         public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, Block block) {
-            return newInterfaceProxy(self);
+            return newInterfaceProxy(context, self);
         }
 
         @Override
         public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject[] args) {
-            return newInterfaceProxy(self);
+            return newInterfaceProxy(context, self);
         }
 
     }
@@ -301,11 +301,11 @@ public class JavaInterfaceTemplate {
         });
     }
 
-    private static IRubyObject newInterfaceProxy(final IRubyObject self) {
+    private static IRubyObject newInterfaceProxy(ThreadContext context, final IRubyObject self) {
         final RubyClass current = self.getMetaClass();
         // construct the new interface impl and set it into the object
-        Object impl = Java.newInterfaceImpl(self, Java.getInterfacesFromRubyClass(current));
-        IRubyObject implWrapper = Java.getInstance(self.getRuntime(), impl);
+        Object impl = Java.newInterfaceImpl(context, self, Java.getInterfacesFromRubyClass(current));
+        IRubyObject implWrapper = Java.getInstance(context.runtime, impl);
         JavaUtilities.set_java_object(self, self, implWrapper); // self.dataWrapStruct(newObject);
         return implWrapper;
     }
@@ -324,16 +324,13 @@ public class JavaInterfaceTemplate {
         // for this module to call append_features on each of those interfaces as
         // well
         synchronized (module) {
-            if ( initInterfaceModules(self, module) ) { // true - initialized
+            if (initInterfaceModules(context, self, module)) { // true - initialized
                 final RubyClass singleton = module.singletonClass(context);
                 singleton.addMethod(context, "append_features", new AppendFeatures(singleton));
-            }
-            else {
+            } else {
                 // already set up append_features, just add the interface if we haven't already
                 final var interfaceModules = getInterfaceModules(module);
-                if ( ! interfaceModules.includes(context, self) ) {
-                    interfaceModules.append(context, self);
-                }
+                if (!interfaceModules.includes(context, self)) interfaceModules.append(context, self);
             }
         }
     }
@@ -529,9 +526,9 @@ public class JavaInterfaceTemplate {
         return (RubyArray) module.getInstanceVariables().getInstanceVariable("@java_interface_mods");
     }
 
-    private static boolean initInterfaceModules(final IRubyObject self, final IRubyObject module) {
+    private static boolean initInterfaceModules(ThreadContext context, final IRubyObject self, final IRubyObject module) {
         if ( ! module.getInstanceVariables().hasInstanceVariable("@java_interface_mods") ) {
-            final RubyArray interfaceMods = RubyArray.newArray(self.getRuntime(), self);
+            final RubyArray interfaceMods = newArray(context, self);
             module.getInstanceVariables().setInstanceVariable("@java_interface_mods", interfaceMods);
             return true;
         }

--- a/core/src/main/java/org/jruby/java/proxies/JavaInterfaceTemplate.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaInterfaceTemplate.java
@@ -387,7 +387,7 @@ public class JavaInterfaceTemplate {
         final BlockInterfaceImpl ifaceImpl = new BlockInterfaceImpl(implClass, implBlock, methodNames);
         implClass.addMethod(context, "method_missing", ifaceImpl); // def ImplClass.method_missing ...
 
-        final Class<?> ifaceClass = JavaUtil.getJavaClass(((RubyModule) self));
+        final Class<?> ifaceClass = JavaUtil.getJavaClass(context, ((RubyModule) self));
         if ( methodNames == null ) {
             for ( Method method : ifaceClass.getMethods() ) {
                 BlockInterfaceImpl.ConcreteMethod implMethod = ifaceImpl.getConcreteMethod(method.getName());

--- a/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
@@ -188,7 +188,7 @@ public class JavaProxy extends RubyObject {
 
     @JRubyMethod(name = "[]", meta = true, rest = true)
     public static IRubyObject op_aref(ThreadContext context, IRubyObject self, IRubyObject[] args) {
-        final Class<?> type = JavaUtil.getJavaClass((RubyModule) self);
+        final Class<?> type = JavaUtil.getJavaClass(context, (RubyModule) self);
         if ( args.length > 0 ) { // construct new array proxy (ArrayJavaProxy)
             return new ArrayJavaProxyCreator(context, type, args); // e.g. Byte[64]
         }
@@ -198,7 +198,7 @@ public class JavaProxy extends RubyObject {
 
     @JRubyMethod(meta = true)
     public static IRubyObject new_array(ThreadContext context, IRubyObject self, IRubyObject len) {
-        final Class<?> componentType = JavaUtil.getJavaClass((RubyModule) self);
+        final Class<?> componentType = JavaUtil.getJavaClass(context, (RubyModule) self);
         final int length = (int) len.convertToInteger().getLongValue();
         return ArrayJavaProxy.newArray(context.runtime, componentType, length);
     }
@@ -706,7 +706,7 @@ public class JavaProxy extends RubyObject {
             String newNameStr = newName.asJavaString();
             Class<?>[] argTypesClasses = (Class[]) argTypes.convertToArray().toArray(ClassUtils.EMPTY_CLASS_ARRAY);
 
-            final Class<?> clazz = JavaUtil.getJavaClass(proxyClass);
+            final Class<?> clazz = JavaUtil.getJavaClass(context, proxyClass);
             final RubyToJavaInvoker invoker;
             switch (name) {
                 case "<init>" :
@@ -733,7 +733,7 @@ public class JavaProxy extends RubyObject {
 
         private static AbstractRubyMethod getRubyMethod(ThreadContext context, IRubyObject clazz, String name, Class... argTypesClasses) {
             final RubyModule proxyClass = Convert.castAsModule(context, clazz);
-            final Method method = getMethodFromClass(context, JavaUtil.getJavaClass(proxyClass), name, argTypesClasses);
+            final Method method = getMethodFromClass(context, JavaUtil.getJavaClass(context, proxyClass), name, argTypesClasses);
             final String prettyName = name + CodegenUtils.prettyParams(argTypesClasses);
 
             if ( Modifier.isStatic( method.getModifiers() ) ) {
@@ -746,7 +746,7 @@ public class JavaProxy extends RubyObject {
         }
 
         private static Method getMethodFromClass(final ThreadContext context, final IRubyObject klass, final String name, final Class... argTypes) {
-            return getMethodFromClass(context, JavaUtil.getJavaClass((RubyModule) klass), name, argTypes);
+            return getMethodFromClass(context, JavaUtil.getJavaClass(context, (RubyModule) klass), name, argTypes);
         }
 
         private static Method getMethodFromClass(final ThreadContext context, final Class<?> clazz, final String name, final Class... argTypes) {

--- a/core/src/main/java/org/jruby/java/util/ArrayUtils.java
+++ b/core/src/main/java/org/jruby/java/util/ArrayUtils.java
@@ -214,11 +214,11 @@ public class ArrayUtils {
             ThreadContext context, RubyArray rubyArray, int src, org.jruby.javasupport.JavaArray javaArray, int dest, int length) {
         Class targetType = javaArray.getComponentType();
 
-        int destLength = (int)javaArray.length().getLongValue();
+        int destLength = javaArray.getLength();
         int srcLength = rubyArray.getLength();
 
         for (int i = 0; src + i < srcLength && dest + i < destLength && i < length; i++) {
-            javaArray.setWithExceptionHandling(dest + i, rubyArray.entry(src + i).toJava(targetType));
+            javaArray.setWithExceptionHandling(context, dest + i, rubyArray.entry(src + i).toJava(targetType));
         }
     }
 }

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -689,7 +689,7 @@ public class Java implements Library {
             final RubyClass metaClass = self.getMetaClass();
             IRubyObject proxyClass = metaClass.getInstanceVariable("@java_proxy_class");
             if (proxyClass == null || proxyClass.isNil()) { // lazy (proxy) class generation ... on JavaSubClass.new
-                proxyClass = JavaProxyClass.getProxyClass(context.runtime, metaClass);
+                proxyClass = JavaProxyClass.getProxyClass(context, metaClass);
                 metaClass.setInstanceVariable("@java_proxy_class", proxyClass);
             }
             return (JavaProxyClass) proxyClass;
@@ -702,7 +702,7 @@ public class Java implements Library {
 
         @Override
         public final IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject arg0, Block block) {
-            final JavaProxyConstructor[] constructors = getProxyClass(context, self).getConstructors();
+            final JavaProxyConstructor[] constructors = getProxyClass(context, self).getConstructors(context);
 
             final JavaProxyConstructor matching;
             switch (constructors.length) {
@@ -719,7 +719,7 @@ public class Java implements Library {
         @Override
         public final IRubyObject call(final ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject[] args) {
             final int arity = args.length;
-            final JavaProxyConstructor[] constructors = getProxyClass(context, self).getConstructors();
+            final JavaProxyConstructor[] constructors = getProxyClass(context, self).getConstructors(context);
 
             final JavaProxyConstructor matching;
             switch (constructors.length) {

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -220,7 +220,7 @@ public class Java implements Library {
     public static class OldStyleExtensionInherited {
         @Deprecated
         public static IRubyObject inherited(IRubyObject self, IRubyObject subclass) {
-            return inherited(self.getRuntime().getCurrentContext(), self, subclass);
+            return inherited(((RubyBasicObject) self).getCurrentContext(), self, subclass);
         }
 
         @JRubyMethod
@@ -232,7 +232,7 @@ public class Java implements Library {
     public static class NewStyleExtensionInherited {
         @Deprecated
         public static IRubyObject inherited(IRubyObject self, IRubyObject subclass) {
-            return inherited(self.getRuntime().getCurrentContext(), self, subclass);
+            return inherited(((RubyBasicObject) self).getCurrentContext(), self, subclass);
         }
 
         @JRubyMethod
@@ -243,12 +243,8 @@ public class Java implements Library {
     }
 
     @Deprecated(since = "9.4")
-    public static IRubyObject create_proxy_class(
-            IRubyObject self,
-            IRubyObject name,
-            IRubyObject javaClass,
-            IRubyObject mod) {
-        var context = self.getRuntime().getCurrentContext();
+    public static IRubyObject create_proxy_class(IRubyObject self, IRubyObject name, IRubyObject javaClass, IRubyObject mod) {
+        var context = ((RubyBasicObject) self).getCurrentContext();
         RubyModule module = castAsModule(context, mod);
 
         return setProxyClass(context.runtime, module, name.asJavaString(), resolveJavaClassArgument(context, javaClass));
@@ -337,7 +333,7 @@ public class Java implements Library {
 
     @Deprecated(since = "10.0")
     public static RubyModule get_proxy_class(final IRubyObject self, final IRubyObject java_class) {
-        return get_proxy_class(self.getRuntime().getCurrentContext(), self, java_class);
+        return get_proxy_class(((RubyBasicObject) self).getCurrentContext(), self, java_class);
     }
 
     public static RubyModule get_proxy_class(ThreadContext context, IRubyObject self, final IRubyObject java_class) {

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -595,7 +595,7 @@ public class Java implements Library {
 
     @Deprecated
     public static IRubyObject concrete_proxy_inherited(final IRubyObject clazz, final IRubyObject subclazz) {
-        return invokeProxyClassInherited(clazz.getRuntime().getCurrentContext(), clazz, subclazz);
+        return invokeProxyClassInherited(((RubyBasicObject) clazz).getCurrentContext(), clazz, subclazz);
     }
 
     private static IRubyObject invokeProxyClassInherited(final ThreadContext context,
@@ -863,7 +863,7 @@ public class Java implements Library {
         else {
             final int endPackage = fullName.lastIndexOf('.');
             String packageString = endPackage < 0 ? "" : fullName.substring(0, endPackage);
-            parentModule = getJavaPackageModule(context.runtime, packageString);
+            parentModule = getJavaPackageModule(context, packageString);
             className = parentModule == null ? fullName : fullName.substring(endPackage + 1);
         }
 
@@ -875,10 +875,15 @@ public class Java implements Library {
     }
 
     public static RubyModule getJavaPackageModule(final Ruby runtime, final Package pkg) {
-        return getJavaPackageModule(runtime, pkg == null ? "" : pkg.getName());
+        return getJavaPackageModule(runtime.getCurrentContext(), pkg == null ? "" : pkg.getName());
     }
 
+    @Deprecated(since = "10.0")
     public static RubyModule getJavaPackageModule(final Ruby runtime, final String packageString) {
+        return getJavaPackageModule(runtime.getCurrentContext(), packageString);
+    }
+
+    public static RubyModule getJavaPackageModule(ThreadContext context, final String packageString) {
         final String packageName; final int length;
         if ( ( length = packageString.length() ) == 0 ) {
             packageName = "Default";
@@ -894,8 +899,7 @@ public class Java implements Library {
             packageName = name.toString();
         }
 
-        var context = runtime.getCurrentContext();
-        final RubyModule javaModule = runtime.getJavaSupport().getJavaModule(context);
+        final RubyModule javaModule = context.runtime.getJavaSupport().getJavaModule(context);
         final IRubyObject packageModule = javaModule.getConstantAt(context, packageName);
 
         if (packageModule == null) return createPackageModule(context, javaModule, packageName, packageString);
@@ -935,21 +939,23 @@ public class Java implements Library {
         return createPackageModule(context, javaModule, name, packageName);
     }
 
+    @Deprecated(since = "10.0")
     public static RubyModule get_package_module(final IRubyObject self, final IRubyObject name) {
-        return getPackageModule(self.getRuntime().getCurrentContext(), name.asJavaString());
+        return get_package_module(((RubyBasicObject) self).getCurrentContext(), self, name);
     }
 
-    public static IRubyObject get_package_module_dot_format(final IRubyObject self,
+    public static RubyModule get_package_module(ThreadContext context, final IRubyObject self, final IRubyObject name) {
+        return getPackageModule(context, name.asJavaString());
+    }
+
+    public static IRubyObject get_package_module_dot_format(ThreadContext context, final IRubyObject self,
         final IRubyObject dottedName) {
-        final Ruby runtime = self.getRuntime();
-        RubyModule module = getJavaPackageModule(runtime, dottedName.asJavaString());
-        return module == null ? runtime.getNil() : module;
+        RubyModule module = getJavaPackageModule(context, dottedName.asJavaString());
+        return module == null ? context.nil : module;
     }
 
     static RubyModule getProxyOrPackageUnderPackage(final ThreadContext context,
         final RubyModule parentPackage, final String name, final boolean cacheMethod) {
-        final Ruby runtime = context.runtime;
-
         if (name.isEmpty()) throw argumentError(context, "empty class or package name");
 
         final String fullName = JavaPackage.buildPackageName(parentPackage, name).toString();
@@ -963,10 +969,11 @@ public class Java implements Library {
             // fail 99.999% of the time). fortunately, we'll only do this once per
             // package name. (and seriously, folks, look into best practices...)
             RubyModule proxyClass = getProxyClassOrNull(context, fullName);
-            if ( proxyClass != null ) result = proxyClass; /* else not primitive or l-c class */
-            else {
+            if ( proxyClass != null ) {
+                result = proxyClass; /* else not primitive or l-c class */
+            } else {
                 // Haven't found a class, continue on as though it were a package
-                final RubyModule packageModule = getJavaPackageModule(runtime, fullName);
+                final RubyModule packageModule = getJavaPackageModule(context, fullName);
                 // TODO: decompose getJavaPackageModule so we don't parse fullName
                 if ( packageModule == null ) return null;
                 result = packageModule;
@@ -975,25 +982,19 @@ public class Java implements Library {
         else {
             try { // First char is upper case, so assume it's a class name
                 final RubyModule javaClass = getProxyClassOrNull(context, fullName);
-                if ( javaClass != null ) result = javaClass;
-                else {
-                    if ( allowUppercasePackageNames(runtime) ) {
-                        // for those not hip to conventions and best practices,
-                        // we'll try as a package
-                        result = getJavaPackageModule(runtime, fullName);
-                        // NOTE result = getPackageModule(runtime, name);
-                        if ( result == null ) {
-                            throw runtime.newNameError("missing class (or package) name " + fullName, fullName);
-                        }
-                    }
-                    else {
-                        throw runtime.newNameError("missing class name " + fullName, fullName);
-                    }
+                if ( javaClass != null ) {
+                    result = javaClass;
+                } else {
+                    if (!allowUppercasePackageNames(context)) throw nameError(context, "missing class name " + fullName, fullName);
+
+                    // for those not hip to conventions and best practices, we'll try as a package
+                    result = getJavaPackageModule(context, fullName); // NOTE result = getPackageModule(runtime, name);
+                    if (result == null) throw nameError(context, "missing class (or package) name " + fullName, fullName);
                 }
             }
             catch (RuntimeException e) {
                 if ( e instanceof RaiseException ) throw e;
-                throw initCause(runtime.newNameError("missing class or uppercase package name " + fullName + " (" + e + ')', fullName, e), e);
+                throw initCause(nameError(context, "missing class or uppercase package name " + fullName + " (" + e + ')', fullName, e), e);
             }
         }
 
@@ -1003,8 +1004,8 @@ public class Java implements Library {
         return result;
     }
 
-    private static boolean allowUppercasePackageNames(final Ruby runtime) {
-        return runtime.getInstanceConfig().getAllowUppercasePackageNames();
+    private static boolean allowUppercasePackageNames(ThreadContext context) {
+        return instanceConfig(context).getAllowUppercasePackageNames();
     }
 
     private static void checkJavaReservedNames(ThreadContext context, final String name, final boolean allowPrimitives) {
@@ -1346,12 +1347,13 @@ public class Java implements Library {
     @Deprecated
     @JRubyMethod(module = true, visibility = PRIVATE)
     public static IRubyObject java_to_ruby(IRubyObject recv, IRubyObject object, Block unusedBlock) {
+        var context = ((RubyBasicObject) recv).getCurrentContext();
         try {
-            return JavaUtil.java_to_ruby(recv.getRuntime(), object);
+            return JavaUtil.java_to_ruby(context.runtime, object);
         } catch (RuntimeException e) {
-            recv.getRuntime().getJavaSupport().handleNativeException(e, null);
+            context.runtime.getJavaSupport().handleNativeException(e, null);
             // This point is only reached if there was an exception handler installed.
-            return recv.getRuntime().getNil();
+            return context.nil;
         }
     }
 
@@ -1381,7 +1383,7 @@ public class Java implements Library {
     @Deprecated(since = "10.0", forRemoval = true)
     public static IRubyObject new_proxy_instance2(IRubyObject recv, final IRubyObject wrapper,
                                                   final IRubyObject interfaces, Block block) {
-        return new_proxy_instance2(recv.getRuntime().getCurrentContext(), recv, wrapper, interfaces, block);
+        return new_proxy_instance2(((RubyBasicObject) recv).getCurrentContext(), recv, wrapper, interfaces, block);
     }
 
         // TODO: Formalize conversion mechanisms between Java and Ruby
@@ -1400,12 +1402,15 @@ public class Java implements Library {
             unwrapped[i] = klass;
         }
 
-        return getInstance(context.runtime, newInterfaceImpl(wrapper, unwrapped));
+        return getInstance(context.runtime, newInterfaceImpl(context, wrapper, unwrapped));
     }
 
+    @Deprecated(since = "10.0")
     public static Object newInterfaceImpl(final IRubyObject wrapper, Class[] interfaces) {
-        final Ruby runtime = wrapper.getRuntime();
+        return newInterfaceImpl(((RubyBasicObject) wrapper).getCurrentContext(), wrapper, interfaces);
+    }
 
+    public static Object newInterfaceImpl(ThreadContext context, final IRubyObject wrapper, Class[] interfaces) {
         final int length = interfaces.length;
         switch ( length ) {
             case 1 :
@@ -1418,9 +1423,9 @@ public class Java implements Library {
         }
 
         final RubyClass wrapperClass = wrapper.getMetaClass();
-        final boolean isProc = wrapperClass.isSingleton() && wrapperClass.getRealClass() == runtime.getProc();
+        final boolean isProc = wrapperClass.isSingleton() && wrapperClass.getRealClass() == context.runtime.getProc();
 
-        final JRubyClassLoader jrubyClassLoader = runtime.getJRubyClassLoader();
+        final JRubyClassLoader jrubyClassLoader = context.runtime.getJRubyClassLoader();
 
         if ( RubyInstanceConfig.INTERFACES_USE_PROXY ) {
             return newProxyInterfaceImpl(wrapper, interfaces, jrubyClassLoader);
@@ -1432,7 +1437,7 @@ public class Java implements Library {
         // if it's a singleton class and the real class is proc, we're doing closure conversion
         // so just use Proc's hashcode
         if ( isProc ) {
-            interfacesHashCode = 31 * interfacesHashCode + runtime.getProc().hashCode();
+            interfacesHashCode = 31 * interfacesHashCode + context.runtime.getProc().hashCode();
             classLoader = jrubyClassLoader;
         }
         else { // normal new class implementing interfaces
@@ -1445,7 +1450,7 @@ public class Java implements Library {
             proxyImplClass = Class.forName(implClassName, true, jrubyClassLoader);
         }
         catch (ClassNotFoundException ex) {
-            proxyImplClass = RealClassGenerator.createOldStyleImplClass(interfaces, wrapperClass, runtime, implClassName, classLoader);
+            proxyImplClass = RealClassGenerator.createOldStyleImplClass(interfaces, wrapperClass, context.runtime, implClassName, classLoader);
         }
 
         try {
@@ -1453,10 +1458,10 @@ public class Java implements Library {
             return proxyConstructor.newInstance(wrapper);
         }
         catch (InvocationTargetException e) {
-            throw mapGeneratedProxyException(runtime, e);
+            throw mapGeneratedProxyException(context.runtime, e);
         }
         catch (ReflectiveOperationException e) {
-            throw mapGeneratedProxyException(runtime, e);
+            throw mapGeneratedProxyException(context.runtime, e);
         }
     }
 

--- a/core/src/main/java/org/jruby/javasupport/Java.java
+++ b/core/src/main/java/org/jruby/javasupport/Java.java
@@ -372,7 +372,7 @@ public class Java implements Library {
     public static Class<?> resolveClassType(final ThreadContext context, final IRubyObject type) throws TypeError {
         RubyModule proxyClass = Java.resolveType(context.runtime, type);
         if (proxyClass == null) throw typeError(context, "unable to convert to type: " + type);
-        return JavaUtil.getJavaClass(proxyClass);
+        return JavaUtil.getJavaClass(context, proxyClass);
     }
 
     public static RubyModule resolveType(final Ruby runtime, final IRubyObject type) {
@@ -1393,7 +1393,7 @@ public class Java implements Library {
         // Create list of interface names to proxy (and make sure they really are interfaces)
         Class[] unwrapped = new Class[javaClasses.length];
         for (int i = 0; i < javaClasses.length; i++) {
-            final Class<?> klass = JavaUtil.unwrapJava(javaClasses[i]); // TypeError if not a Java wrapper
+            final Class<?> klass = JavaUtil.unwrapJava(context, javaClasses[i]); // TypeError if not a Java wrapper
 
             if (!klass.isInterface()) throw argumentError(context, "Java interface expected, got: " + klass);
 

--- a/core/src/main/java/org/jruby/javasupport/JavaArray.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaArray.java
@@ -34,11 +34,14 @@ package org.jruby.javasupport;
 import java.lang.reflect.Array;
 
 import org.jruby.Ruby;
+import org.jruby.RubyBasicObject;
 import org.jruby.RubyFixnum;
 import org.jruby.api.Convert;
 import org.jruby.java.util.ArrayUtils;
+import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.javasupport.Java.castToJavaObject;
 
 /**
@@ -63,8 +66,9 @@ public class JavaArray extends JavaObject {
         return getValue().getClass().getComponentType();
     }
 
+    @Deprecated(since = "10.0")
     public RubyFixnum length() {
-        return RubyFixnum.newFixnum(getRuntime(), getLength());
+        return asFixnum(getCurrentContext(), getLength());
     }
 
     public int getLength() {
@@ -81,16 +85,18 @@ public class JavaArray extends JavaObject {
         return 17 * getValue().hashCode();
     }
 
+    @Deprecated(since = "10.0")
     public IRubyObject arefDirect(Ruby runtime, int intIndex) {
         return ArrayUtils.arefDirect(runtime, getValue(), javaConverter, intIndex);
     }
 
+    @Deprecated(since = "10.0")
     public IRubyObject aset(IRubyObject indexArg, IRubyObject value) {
-        var context = getRuntime().getCurrentContext();
+        var context = getCurrentContext();
         var index = Convert.castAsInteger(context, indexArg).getIntValue();
         var javaObject = castToJavaObject(context, value).getValue();
 
-        ArrayUtils.setWithExceptionHandlingDirect(getRuntime(), javaObject, index, javaObject);
+        ArrayUtils.setWithExceptionHandlingDirect(context.runtime, javaObject, index, javaObject);
 
         return value;
     }
@@ -99,26 +105,28 @@ public class JavaArray extends JavaObject {
         return ArrayUtils.asetDirect(runtime, getValue(), javaConverter, intIndex, value);
     }
 
-    public void setWithExceptionHandling(int intIndex, Object javaObject) {
-        ArrayUtils.setWithExceptionHandlingDirect(getRuntime(), getValue(), intIndex, javaObject);
+    @Deprecated(since = "10.0")
+    public void setWithExceptionHandling(ThreadContext context, int intIndex, Object javaObject) {
+        ArrayUtils.setWithExceptionHandlingDirect(context.runtime, getValue(), intIndex, javaObject);
     }
 
+    @Deprecated(since = "10.0")
     public IRubyObject afill(IRubyObject beginArg, IRubyObject endArg, IRubyObject value) {
-        var context = getRuntime().getCurrentContext();
+        var context = ((RubyBasicObject) beginArg).getCurrentContext();
         var beginIndex = Convert.castAsInteger(context, beginArg).getIntValue();
         var endIndex = Convert.castAsInteger(context, endArg).getIntValue();
         var javaValue = castToJavaObject(context, value).getValue();
 
-        fillWithExceptionHandling(beginIndex, endIndex, javaValue);
+        fillWithExceptionHandling(context, beginIndex, endIndex, javaValue);
 
         return value;
     }
 
-    public final void fillWithExceptionHandling(int start, int end, Object javaValue) {
-        final Ruby runtime = getRuntime();
+    @Deprecated(since = "10.0")
+    public final void fillWithExceptionHandling(ThreadContext context, int start, int end, Object javaValue) {
         final Object array = getValue();
         for (int i = start; i < end; i++) {
-            ArrayUtils.setWithExceptionHandlingDirect(runtime, array, i, javaValue);
+            ArrayUtils.setWithExceptionHandlingDirect(context.runtime, array, i, javaValue);
         }
     }
 }

--- a/core/src/main/java/org/jruby/javasupport/JavaArrayUtilities.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaArrayUtilities.java
@@ -29,6 +29,7 @@
 package org.jruby.javasupport;
 
 import org.jruby.Ruby;
+import org.jruby.RubyBasicObject;
 import org.jruby.RubyModule;
 import org.jruby.RubyString;
 import org.jruby.anno.JRubyMethod;
@@ -41,6 +42,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.Visibility;
 
 import static org.jruby.api.Convert.castAsString;
+import static org.jruby.api.Create.newString;
 import static org.jruby.api.Define.defineModule;
 import static org.jruby.api.Error.typeError;
 
@@ -64,25 +66,27 @@ public class JavaArrayUtilities {
     public static IRubyObject bytes_to_ruby_string(ThreadContext context, IRubyObject recv, IRubyObject wrappedObject, IRubyObject encoding) {
         byte[] bytes = null;
 
-        if (wrappedObject instanceof JavaProxy) {
-            Object wrapped = ((JavaProxy) wrappedObject).getObject();
+        if (wrappedObject instanceof JavaProxy proxy) {
+            Object wrapped = proxy.getObject();
             if (wrapped instanceof byte[]) bytes = (byte[]) wrapped;
         }
 
         if (bytes == null) throw typeError(context, wrappedObject, "byte[]");
 
-        RubyString string = context.runtime.newString(new ByteList(bytes, true));
+        RubyString string = newString(context, new ByteList(bytes, true));
 
         if (!encoding.isNil()) string.force_encoding(context, encoding);
 
         return string;
     }
 
-    @JRubyMethod(module = true, visibility = Visibility.PRIVATE)
     public static IRubyObject ruby_string_to_bytes(IRubyObject recv, IRubyObject string) {
-        Ruby runtime = recv.getRuntime();
+        return ruby_string_to_bytes(((RubyBasicObject) recv).getCurrentContext(), recv, string);
+    }
 
-        return JavaUtil.convertJavaToUsableRubyObject(runtime, castAsString(runtime.getCurrentContext(), string).getBytes());
+    @JRubyMethod(module = true, visibility = Visibility.PRIVATE)
+    public static IRubyObject ruby_string_to_bytes(ThreadContext context, IRubyObject recv, IRubyObject string) {
+        return JavaUtil.convertJavaToUsableRubyObject(context.runtime, castAsString(context, string).getBytes());
     }
 
     @JRubyMethod(module = true)

--- a/core/src/main/java/org/jruby/javasupport/JavaClass.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaClass.java
@@ -39,6 +39,7 @@ package org.jruby.javasupport;
 
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
+import org.jruby.RubyBasicObject;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.RubyString;
@@ -200,11 +201,12 @@ public class JavaClass extends JavaObject {
     @Deprecated
     @JRubyMethod(name = "for_name", meta = true)
     public static JavaClass for_name(IRubyObject recv, IRubyObject name) {
-        return for_name(recv, name.asJavaString());
+        return forNameVerbose(((RubyBasicObject) recv).getCurrentContext().getRuntime(), name.asJavaString());
     }
 
+    @Deprecated(since = "10.0")
     static JavaClass for_name(IRubyObject recv, String name) {
-        return forNameVerbose(recv.getRuntime(), name);
+        return forNameVerbose(((RubyBasicObject) recv).getCurrentContext().getRuntime(), name);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/javasupport/JavaClass.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaClass.java
@@ -120,7 +120,7 @@ public class JavaClass extends JavaObject {
     }
 
     /**
-     * @see JavaUtil#getJavaClass(RubyModule)
+     * @see JavaUtil#getJavaClass(ThreadContext, RubyModule)
      */
     @Deprecated // no longer used
     public static Class<?> getJavaClass(final ThreadContext context, final RubyModule proxy) {

--- a/core/src/main/java/org/jruby/javasupport/JavaObject.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaObject.java
@@ -58,6 +58,7 @@ import org.jruby.util.JRubyObjectInputStream;
 
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Create.newString;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.javasupport.JavaUtil.unwrapJava;
 
@@ -178,13 +179,19 @@ public class JavaObject extends RubyObject {
         return JavaProxyMethods.to_s(runtime.getCurrentContext(), dataStruct);
     }
 
-    @JRubyMethod(name = {"==", "eql?"})
+    @Deprecated(since = "10.0")
     public IRubyObject op_equal(final IRubyObject other) {
-        return JavaProxyMethods.equals(getRuntime(), getValue(), other);
+        return op_equal(getCurrentContext(), other);
     }
 
+    @JRubyMethod(name = {"==", "eql?"})
+    public IRubyObject op_equal(ThreadContext context, IRubyObject other) {
+        return JavaProxyMethods.equals(context.runtime, getValue(), other);
+    }
+
+    @Deprecated(since = "10.0")
     public static RubyBoolean op_equal(JavaProxy self, IRubyObject other) {
-        return JavaProxyMethods.equals(self.getRuntime(), self.getObject(), other);
+        return JavaProxyMethods.equals(self.getCurrentContext().runtime, self.getObject(), other);
     }
 
     @JRubyMethod(name = "equal?")
@@ -203,29 +210,49 @@ public class JavaObject extends RubyObject {
         return same(getCurrentContext(), other);
     }
 
-    @JRubyMethod
+    @Deprecated(since = "10.0")
     public RubyString java_type() {
-        return getRuntime().newString(getJavaClass().getName());
+        return java_type(getCurrentContext());
     }
 
-    @Deprecated
+    @JRubyMethod
+    public RubyString java_type(ThreadContext context) {
+        return newString(context, getJavaClass().getName());
+    }
+
+    @Deprecated(since = "9.4-")
     public JavaClass java_class() {
-        return JavaClass.get(getRuntime(), getJavaClass());
+        return JavaClass.get(getCurrentContext().runtime, getJavaClass());
     }
 
-    @JRubyMethod
+    @Deprecated(since = "10.0")
     public IRubyObject get_java_class() {
-        return Java.getInstance(getRuntime(), getJavaClass());
+        return get_java_class(getCurrentContext());
     }
 
     @JRubyMethod
+    public IRubyObject get_java_class(ThreadContext context) {
+        return Java.getInstance(context.runtime, getJavaClass());
+    }
+
+    @Deprecated(since = "10.0")
     public RubyFixnum length() {
-        throw typeError(getRuntime().getCurrentContext(), "not a java array");
+        return length(getCurrentContext());
+    }
+
+    @JRubyMethod
+    public RubyFixnum length(ThreadContext context) {
+        throw typeError(context, "not a java array");
+    }
+
+    @Deprecated(since = "10.0")
+    public IRubyObject is_java_proxy() {
+        return is_java_proxy(getCurrentContext());
     }
 
     @JRubyMethod(name = "java_proxy?")
-    public IRubyObject is_java_proxy() {
-        return getRuntime().getTrue();
+    public IRubyObject is_java_proxy(ThreadContext context) {
+        return context.tru;
     }
 
     @JRubyMethod(name = "synchronized")

--- a/core/src/main/java/org/jruby/javasupport/JavaObject.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaObject.java
@@ -108,13 +108,11 @@ public class JavaObject extends RubyObject {
     }
 
     @JRubyMethod(meta = true)
-    public static IRubyObject wrap(final ThreadContext context,
-        final IRubyObject self, final IRubyObject object) {
+    public static IRubyObject wrap(final ThreadContext context, final IRubyObject self, final IRubyObject object) {
         final Object objectValue = unwrapJava(object, NEVER);
 
-        if ( objectValue == NEVER ) return context.nil;
-
-        return wrap(context.runtime, objectValue);
+        return objectValue == NEVER ?
+                context.nil : wrap(context.runtime, objectValue);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/javasupport/JavaProxyMethods.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaProxyMethods.java
@@ -125,7 +125,7 @@ public class JavaProxyMethods {
      */
     @Deprecated(since = "10.0")
     public static IRubyObject inspect(IRubyObject recv) {
-        return inspect(recv.getRuntime().getCurrentContext(), recv);
+        return inspect(((RubyBasicObject) recv).getCurrentContext(), recv);
     }
 
     @JRubyMethod

--- a/core/src/main/java/org/jruby/javasupport/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtil.java
@@ -985,7 +985,7 @@ public class JavaUtil {
 
     private static long processLongConvert(ThreadContext context, Predicate<Long> pred, RubyNumeric numeric, String type) {
         final long value = numeric.getLongValue();
-        if (!pred.test(value)) throw rangeError(context, "too big for " + type + " : " + numeric);
+        if (!pred.test(value)) throw rangeError(context, "too big for " + type + ": " + numeric);
         return value;
     }
 

--- a/core/src/main/java/org/jruby/javasupport/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtil.java
@@ -64,6 +64,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -982,20 +983,20 @@ public class JavaUtil {
         JAVA_CONVERTERS.put(BigInteger.class, JAVA_BIGINTEGER_CONVERTER);
     }
 
-    private static long processLongConvert(ThreadContext context, RubyNumeric numeric, String type) {
+    private static long processLongConvert(ThreadContext context, Predicate<Long> pred, RubyNumeric numeric, String type) {
         final long value = numeric.getLongValue();
-        if (!isLongByteable(value)) throw rangeError(context, "too big for " + type + " : " + numeric);
+        if (!pred.test(value)) throw rangeError(context, "too big for " + type + " : " + numeric);
         return value;
     }
 
     private static final NumericConverter<Byte> NUMERIC_TO_BYTE =
-            (context, numeric, target) -> (byte) processLongConvert(context, numeric, "byte");
+            (context, numeric, target) -> (byte) processLongConvert(context, JavaUtil::isLongByteable, numeric, "byte");
     private static final NumericConverter<Short> NUMERIC_TO_SHORT =
-            (context,numeric, target) -> (short) processLongConvert(context, numeric, "short");
+            (context,numeric, target) -> (short) processLongConvert(context, JavaUtil::isLongShortable, numeric, "short");
     private static final NumericConverter<Character> NUMERIC_TO_CHARACTER =
-            (context, numeric, target) -> (char) processLongConvert(context, numeric, "char");
+            (context, numeric, target) -> (char) processLongConvert(context, JavaUtil::isLongCharable, numeric, "char");
     private static final NumericConverter<Integer> NUMERIC_TO_INTEGER =
-            (context, numeric, target) -> (int) processLongConvert(context, numeric, "int");
+            (context, numeric, target) -> (int) processLongConvert(context, JavaUtil::isLongIntable, numeric, "int");
     private static final NumericConverter<Long> NUMERIC_TO_LONG = (context, numeric, target) -> numeric.getLongValue();
     private static final NumericConverter<Float> NUMERIC_TO_FLOAT = (context, numeric, target) -> {
         final double value = numeric.getDoubleValue();
@@ -1024,6 +1025,7 @@ public class JavaUtil {
     private static boolean isDoubleFloatable(double value) {
         return true;
     }
+
     private static boolean isLongByteable(long value) {
         return value >= Byte.MIN_VALUE && value <= Byte.MAX_VALUE;
     }

--- a/core/src/main/java/org/jruby/javasupport/JavaUtilities.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtilities.java
@@ -32,14 +32,24 @@ public class JavaUtilities {
         return Java.get_interface_module(context, arg0);
     }
 
-    @JRubyMethod(module = true, visibility = Visibility.PRIVATE)
+    @Deprecated(since = "10.0")
     public static IRubyObject get_package_module(IRubyObject recv, IRubyObject arg0) {
-        return Java.get_package_module(recv, arg0);
+        return get_package_module(((RubyBasicObject) recv).getCurrentContext(), recv, arg0);
     }
 
     @JRubyMethod(module = true, visibility = Visibility.PRIVATE)
+    public static IRubyObject get_package_module(ThreadContext context, IRubyObject recv, IRubyObject arg0) {
+        return Java.get_package_module(context, recv, arg0);
+    }
+
+    @Deprecated(since = "10.0")
     public static IRubyObject get_package_module_dot_format(IRubyObject recv, IRubyObject arg0) {
-        return Java.get_package_module_dot_format(recv, arg0);
+        return get_package_module_dot_format(((RubyBasicObject) recv).getCurrentContext(), recv, arg0);
+    }
+
+    @JRubyMethod(module = true, visibility = Visibility.PRIVATE)
+    public static IRubyObject get_package_module_dot_format(ThreadContext context, IRubyObject recv, IRubyObject arg0) {
+        return Java.get_package_module_dot_format(context, recv, arg0);
     }
 
     @Deprecated(since = "10.0")

--- a/core/src/main/java/org/jruby/javasupport/binding/ClassInitializer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/ClassInitializer.java
@@ -4,6 +4,7 @@ import org.jruby.Ruby;
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
 import org.jruby.javasupport.Java;
+import org.jruby.runtime.ThreadContext;
 
 /**
 * Created by headius on 2/26/15.
@@ -15,8 +16,7 @@ final class ClassInitializer extends Initializer {
     }
 
     @Override
-    public RubyClass initialize(final RubyModule proxy) {
-        var context = proxy.getRuntime().getCurrentContext();
+    public RubyClass initialize(ThreadContext context, final RubyModule proxy) {
         final RubyClass proxyClass = (RubyClass) proxy;
 
         // flag the class as a Java class proxy.
@@ -41,7 +41,7 @@ final class ClassInitializer extends Initializer {
 
         final MethodGatherer state = new MethodGatherer(runtime, javaClass.getSuperclass());
 
-        state.initialize(javaClass, proxy);
+        state.initialize(context, javaClass, proxy);
 
         return proxyClass;
     }

--- a/core/src/main/java/org/jruby/javasupport/binding/ConstantField.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/ConstantField.java
@@ -2,6 +2,7 @@ package org.jruby.javasupport.binding;
 
 import org.jruby.RubyModule;
 import org.jruby.javasupport.JavaUtil;
+import org.jruby.runtime.ThreadContext;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -15,13 +16,12 @@ public class ConstantField {
 
     public ConstantField(Field field) { this.field = field; }
 
-    void install(final RubyModule proxy) {
-        var context = proxy.getRuntime().getCurrentContext();
+    void install(ThreadContext context, final RubyModule proxy) {
         final String name = field.getName();
         if (proxy.getConstantAt(context, name) == null) {
             try {
                 final Object value = field.get(null);
-                proxy.setConstant(context, name, JavaUtil.convertJavaToUsableRubyObject(proxy.getRuntime(), value));
+                proxy.setConstant(context, name, JavaUtil.convertJavaToUsableRubyObject(context.runtime, value));
             }
             catch (IllegalAccessException iae) {
                 // if we can't read it, we don't set it

--- a/core/src/main/java/org/jruby/javasupport/binding/Initializer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/Initializer.java
@@ -58,7 +58,7 @@ public abstract class Initializer {
             flagAsJavaProxy(context, proxy); return proxy;
         }
 
-        proxy = new ClassInitializer(context.runtime, javaClass).initialize(proxy);
+        proxy = new ClassInitializer(context.runtime, javaClass).initialize(context, proxy);
         flagAsJavaProxy(context, proxy); return proxy;
     }
 
@@ -88,7 +88,12 @@ public abstract class Initializer {
         proxy.dataWrapStruct(javaClass);
     }
 
-    public abstract RubyModule initialize(RubyModule proxy);
+    public RubyModule initialize(RubyModule proxy) {
+        return initialize(proxy.getCurrentContext(), proxy);
+    }
+
+
+    public abstract RubyModule initialize(ThreadContext context, RubyModule proxy);
 
     @Deprecated
     public static final ClassValue<Method[]> DECLARED_METHODS = MethodGatherer.DECLARED_METHODS;

--- a/core/src/main/java/org/jruby/javasupport/binding/InstanceMethodInvokerInstaller.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/InstanceMethodInvokerInstaller.java
@@ -14,8 +14,8 @@ public class InstanceMethodInvokerInstaller extends MethodInstaller {
     public InstanceMethodInvokerInstaller(String name) { super(name, INSTANCE_METHOD); }
 
     @Override void install(ThreadContext context, final RubyModule proxy) {
-        if ( hasLocalMethod() ) {
-            defineMethods(proxy, new InstanceMethodInvoker(proxy, () -> methods.toArray(new Method[methods.size()]), name));
+        if (hasLocalMethod()) {
+            defineMethods(context, proxy, new InstanceMethodInvoker(proxy, () -> methods.toArray(new Method[methods.size()]), name), true);
         }
     }
 }

--- a/core/src/main/java/org/jruby/javasupport/binding/InterfaceInitializer.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/InterfaceInitializer.java
@@ -2,6 +2,7 @@ package org.jruby.javasupport.binding;
 
 import org.jruby.Ruby;
 import org.jruby.RubyModule;
+import org.jruby.runtime.ThreadContext;
 
 /**
 * Created by headius on 2/26/15.
@@ -13,12 +14,12 @@ final class InterfaceInitializer extends Initializer {
     }
 
     @Override
-    public RubyModule initialize(RubyModule proxy) {
-        final MethodGatherer state = new MethodGatherer(runtime, null);
+    public RubyModule initialize(ThreadContext context, RubyModule proxy) {
+        final MethodGatherer state = new MethodGatherer(context.runtime, null);
 
-        state.initialize(javaClass, proxy);
+        state.initialize(context, javaClass, proxy);
 
-        proxy.getName(runtime.getCurrentContext()); // trigger calculateName()
+        proxy.getName(context); // trigger calculateName()
 
         return proxy;
     }

--- a/core/src/main/java/org/jruby/javasupport/binding/MethodInstaller.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/MethodInstaller.java
@@ -3,6 +3,7 @@ package org.jruby.javasupport.binding;
 import org.jruby.RubyModule;
 import org.jruby.internal.runtime.methods.DynamicMethod;
 import org.jruby.javasupport.JavaUtil;
+import org.jruby.runtime.ThreadContext;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -137,12 +138,17 @@ public abstract class MethodInstaller extends NamedInstaller {
         aliases.remove(alias);
     }
 
+    @Deprecated(since = "10.0")
     final void defineMethods(RubyModule target, DynamicMethod invoker) {
-        defineMethods(target, invoker, true);
+        defineMethods(target.getCurrentContext(), target, invoker, true);
     }
 
+    @Deprecated(since = "10.0")
     protected final void defineMethods(RubyModule target, DynamicMethod invoker, boolean checkDups) {
-        var context = target.getRuntime().getCurrentContext();
+        defineMethods(target.getCurrentContext(), target, invoker, checkDups);
+    }
+
+    protected final void defineMethods(ThreadContext context, RubyModule target, DynamicMethod invoker, boolean checkDups) {
         String oldName = this.name;
         target.addMethod(context, oldName, invoker);
 

--- a/core/src/main/java/org/jruby/javasupport/binding/SingletonMethodInvokerInstaller.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/SingletonMethodInvokerInstaller.java
@@ -23,6 +23,7 @@ public class SingletonMethodInvokerInstaller extends StaticMethodInvokerInstalle
         // we don't check haveLocalMethod() here because it's not local and we know
         // that we always want to go ahead and install it
         final RubyClass singletonClass = proxy.singletonClass(context);
-        defineMethods(singletonClass, new SingletonMethodInvoker(this.singleton, singletonClass, () -> methods.toArray(new Method[methods.size()]), name), false);
+        defineMethods(context, singletonClass,
+                new SingletonMethodInvoker(this.singleton, singletonClass, () -> methods.toArray(new Method[methods.size()]), name), false);
     }
 }

--- a/core/src/main/java/org/jruby/javasupport/binding/StaticMethodInvokerInstaller.java
+++ b/core/src/main/java/org/jruby/javasupport/binding/StaticMethodInvokerInstaller.java
@@ -15,9 +15,10 @@ public class StaticMethodInvokerInstaller extends MethodInstaller {
     public StaticMethodInvokerInstaller(String name) { super(name, STATIC_METHOD); }
 
     @Override void install(ThreadContext context, final RubyModule proxy) {
-        if ( hasLocalMethod() ) {
+        if (hasLocalMethod()) {
             final RubyClass singletonClass = proxy.singletonClass(context);
-            defineMethods(singletonClass, new StaticMethodInvoker(singletonClass, () -> methods.toArray(new Method[methods.size()]), name), false);
+            defineMethods(context, singletonClass,
+                    new StaticMethodInvoker(singletonClass, () -> methods.toArray(new Method[methods.size()]), name), false);
         }
     }
 }

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -234,9 +234,13 @@ public abstract class JavaLang {
             return RubyArray.newArrayMayCopy(runtime, backtrace);
         }
 
-        @JRubyMethod // can not set backtrace for a java.lang.Throwable
         public static IRubyObject set_backtrace(final IRubyObject self, final IRubyObject backtrace) {
-            return self.getRuntime().getNil();
+            return set_backtrace(((RubyBasicObject) self).getCurrentContext(), self, backtrace);
+        }
+
+        @JRubyMethod // can not set backtrace for a java.lang.Throwable
+        public static IRubyObject set_backtrace(ThreadContext context, final IRubyObject self, final IRubyObject backtrace) {
+            return context.nil;
         }
 
         @JRubyMethod

--- a/core/src/main/java/org/jruby/javasupport/ext/Kernel.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/Kernel.java
@@ -70,7 +70,7 @@ public final class Kernel {
     }
 
     private static IRubyObject get_pkg(final ThreadContext context, final String name) {
-        RubyModule module = Java.getJavaPackageModule(context.runtime, name);
+        RubyModule module = Java.getJavaPackageModule(context, name);
         return module == null ? context.nil : module;
     }
 

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyConstructor.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyConstructor.java
@@ -51,6 +51,7 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ArraySupport;
 
+import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Create.newString;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.javasupport.JavaCallable.inspectParameterTypes;
@@ -140,9 +141,14 @@ public class JavaProxyConstructor extends JavaProxyReflectionObject implements P
         return proxyConstructor.newInstance(argsPlus1);
     }
 
-    @JRubyMethod
+    @Deprecated(since = "10.0")
     public RubyFixnum arity() {
-        return RubyFixnum.newFixnum(getRuntime(), getArity());
+        return arity(getCurrentContext());
+    }
+
+    @JRubyMethod
+    public RubyFixnum arity(ThreadContext context) {
+        return asFixnum(context, getArity());
     }
 
     public final int getArity() {
@@ -163,22 +169,27 @@ public class JavaProxyConstructor extends JavaProxyReflectionObject implements P
     @Override
     @JRubyMethod
     public RubyString inspect(ThreadContext context) {
+        return newString(context, toString());
+    }
+
+    @Override
+    public String toString() {
         StringBuilder buf = new StringBuilder();
         buf.append("#<");
         buf.append( getDeclaringClass().nameOnInspection() );
         inspectParameterTypes(buf, this);
         buf.append('>');
-        return newString(context, buf.toString());
+        return buf.toString();
     }
 
-    @Override
-    public String toString() {
-        return inspect(getRuntime().getCurrentContext()).toString();
+    @Deprecated(since = "10.0")
+    public final RubyArray argument_types() {
+        return argument_types(getCurrentContext());
     }
 
     @JRubyMethod
-    public final RubyArray argument_types() {
-        return toClassArray(getRuntime(), getParameterTypes());
+    public final RubyArray argument_types(ThreadContext context) {
+        return toClassArray(context, getParameterTypes());
     }
 
     @JRubyMethod(rest = true)
@@ -245,7 +256,7 @@ public class JavaProxyConstructor extends JavaProxyReflectionObject implements P
 
     @Deprecated
     public IRubyObject new_instance(IRubyObject[] args, Block block) {
-        return new_instance2(getRuntime().getCurrentContext(), args, block);
+        return new_instance2(getCurrentContext(), args, block);
     }
 
     @JRubyMethod(required = 1, optional = 1, checkArity = false)

--- a/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyReflectionObject.java
+++ b/core/src/main/java/org/jruby/javasupport/proxy/JavaProxyReflectionObject.java
@@ -42,6 +42,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Create.newString;
 import static org.jruby.api.Error.typeError;
 
 public class JavaProxyReflectionObject extends RubyObject {
@@ -57,7 +58,7 @@ public class JavaProxyReflectionObject extends RubyObject {
 
     @Deprecated
     public IRubyObject op_equal(IRubyObject other) {
-        return op_eqq(getRuntime().getCurrentContext(), other);
+        return op_eqq(getCurrentContext(), other);
     }
 
     @Override
@@ -75,7 +76,7 @@ public class JavaProxyReflectionObject extends RubyObject {
 
     @Deprecated
     public IRubyObject same(IRubyObject other) {
-        return op_equal(getRuntime().getCurrentContext(), other);
+        return op_equal(getCurrentContext(), other);
     }
 
     @Override
@@ -111,7 +112,7 @@ public class JavaProxyReflectionObject extends RubyObject {
     @Override
     @JRubyMethod
     public IRubyObject to_s(ThreadContext context) {
-        return context.runtime.newString(toString());
+        return newString(context, toString());
     }
 
     @Override
@@ -119,50 +120,80 @@ public class JavaProxyReflectionObject extends RubyObject {
         return getClass().getName();
     }
 
-    @JRubyMethod
+    @Deprecated(since = "10.0")
     public RubyString java_type() {
-        return getRuntime().newString(getJavaClass().getName());
+        return java_type(getCurrentContext());
     }
 
     @JRubyMethod
+    public RubyString java_type(ThreadContext context) {
+        return newString(context, getJavaClass().getName());
+    }
+
+    @Deprecated(since = "10.0")
     public IRubyObject java_class() {
-        return Java.getInstance(getRuntime(), getJavaClass());
+        return java_class(getCurrentContext());
     }
 
     @JRubyMethod
+    public IRubyObject java_class(ThreadContext context) {
+        return Java.getInstance(context.runtime, getJavaClass());
+    }
+
+    @Deprecated(since = "10.0")
     public RubyFixnum length() {
-        throw typeError(getRuntime().getCurrentContext(), "not a java array");
+        return length(getCurrentContext());
+    }
+
+    @JRubyMethod
+    public RubyFixnum length(ThreadContext context) {
+        throw typeError(context, "not a java array");
+    }
+
+    @Deprecated(since = "10.0")
+    public IRubyObject aref(IRubyObject index) {
+        return aref(getCurrentContext(), index);
     }
 
     @JRubyMethod(name = "[]")
-    public IRubyObject aref(IRubyObject index) {
-        throw typeError(getRuntime().getCurrentContext(), "not a java array");
+    public IRubyObject aref(ThreadContext context, IRubyObject index) {
+        throw typeError(context, "not a java array");
+    }
+
+    @Deprecated(since = "10.0")
+    public IRubyObject aset(IRubyObject index, IRubyObject someValue) {
+        return aset(getCurrentContext(), index, someValue);
     }
 
     @JRubyMethod(name = "[]=")
-    public IRubyObject aset(IRubyObject index, IRubyObject someValue) {
-        throw typeError(getRuntime().getCurrentContext(), "not a java array");
+    public IRubyObject aset(ThreadContext context, IRubyObject index, IRubyObject someValue) {
+        throw typeError(context, "not a java array");
+    }
+
+    @Deprecated(since = "10.0")
+    public IRubyObject is_java_proxy() {
+        return is_java_proxy(getCurrentContext());
     }
 
     @JRubyMethod(name = "java_proxy?")
-    public IRubyObject is_java_proxy() {
-        return getRuntime().getFalse();
+    public IRubyObject is_java_proxy(ThreadContext context) {
+        return context.fals;
     }
 
     //
     // utility methods
     //
 
-    final RubyArray toRubyArray(final IRubyObject[] elements) {
-        return RubyArray.newArrayMayCopy(getRuntime(), elements);
+    final RubyArray toRubyArray(ThreadContext context, final IRubyObject[] elements) {
+        return RubyArray.newArrayMayCopy(context.runtime, elements);
     }
 
-    static RubyArray toClassArray(final Ruby runtime, final Class<?>[] classes) {
+    static RubyArray toClassArray(ThreadContext context, final Class<?>[] classes) {
         IRubyObject[] javaClasses = new IRubyObject[classes.length];
         for ( int i = classes.length; --i >= 0; ) {
-            javaClasses[i] = Java.getProxyClass(runtime, classes[i]);
+            javaClasses[i] = Java.getProxyClass(context.runtime, classes[i]);
         }
-        return RubyArray.newArrayMayCopy(runtime, javaClasses);
+        return RubyArray.newArrayMayCopy(context.runtime, javaClasses);
     }
 
 }

--- a/core/src/main/java/org/jruby/runtime/ObjectSpace.java
+++ b/core/src/main/java/org/jruby/runtime/ObjectSpace.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
+import org.jruby.RubyBasicObject;
 import org.jruby.RubyModule;
 import org.jruby.java.proxies.JavaProxy;
 import org.jruby.javasupport.JavaPackage;
@@ -122,7 +123,7 @@ public class ObjectSpace {
 
     @Deprecated
     public void addFinalizer(IRubyObject object, IRubyObject proc) {
-        addFinalizer(object.getRuntime().getCurrentContext(), object, proc);
+        addFinalizer(((RubyBasicObject) object).getCurrentContext(), object, proc);
     }
 
     public IRubyObject addFinalizer(ThreadContext context, IRubyObject object, IRubyObject proc) {

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -1377,9 +1377,7 @@ public final class ThreadContext {
     }
 
     public IRubyObject addThreadTraceFunction(IRubyObject trace_func, boolean useContextHook) {
-        if (!(trace_func instanceof RubyProc)) {
-            throw typeError(trace_func.getRuntime().getCurrentContext(), "trace_func needs to be Proc.");
-        }
+        if (!(trace_func instanceof RubyProc)) throw typeError(this, "trace_func needs to be Proc.");
 
         TraceEventManager.CallTraceFuncHook hook;
 

--- a/core/src/main/java/org/jruby/util/ClassProvider.java
+++ b/core/src/main/java/org/jruby/util/ClassProvider.java
@@ -30,6 +30,7 @@ package org.jruby.util;
 
 import org.jruby.RubyClass;
 import org.jruby.RubyModule;
+import org.jruby.runtime.ThreadContext;
 
 /**
  * @author Bill Dortch
@@ -37,6 +38,19 @@ import org.jruby.RubyModule;
  */
 public interface ClassProvider {
 
-    public RubyClass defineClassUnder(RubyModule module, String name, RubyClass superClazz);
-    public RubyModule defineModuleUnder(RubyModule module, String name);
+    default RubyClass defineClassUnder(RubyModule module, String name, RubyClass superClazz) {
+        return defineClassUnder(module.getCurrentContext(), module, name, superClazz);
+    }
+
+    default RubyClass defineClassUnder(ThreadContext context, RubyModule module, String name, RubyClass superClazz) {
+        throw new RuntimeException("Missing defineClassUnder implementation");
+    }
+
+    @Deprecated(since = "10.0")
+    default RubyModule defineModuleUnder(RubyModule module, String name) {
+        return defineModuleUnder(module.getCurrentContext(), module, name);
+    }
+    default RubyModule defineModuleUnder(ThreadContext context, RubyModule module, String name) {
+        throw new RuntimeException("Missing defineModuleUnder implementation");
+    }
 }

--- a/core/src/main/java/org/jruby/util/NoFunctionalitySignalFacade.java
+++ b/core/src/main/java/org/jruby/util/NoFunctionalitySignalFacade.java
@@ -30,29 +30,30 @@ package org.jruby.util;
 
 import org.jruby.Ruby;
 import org.jruby.runtime.BlockCallback;
+import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 /**
  * @author <a href="mailto:ola.bini@gmail.com">Ola Bini</a>
  */
 public class NoFunctionalitySignalFacade implements SignalFacade {
-    public IRubyObject trap(IRubyObject recv, IRubyObject block, IRubyObject sig) {
-        return recv.getRuntime().getNil();
+    public IRubyObject trap(ThreadContext context, IRubyObject recv, IRubyObject block, IRubyObject sig) {
+        return context.nil;
     }
 
-    public IRubyObject trap(Ruby runtime, BlockCallback block, String sig) {
-        return runtime.getNil();
+    public IRubyObject trap(ThreadContext context, BlockCallback block, String sig) {
+        return context.nil;
     }
 
-    public IRubyObject restorePlatformDefault(IRubyObject recv, IRubyObject sig) {
-        return recv.getRuntime().getNil();
+    public IRubyObject restorePlatformDefault(ThreadContext context, IRubyObject recv, IRubyObject sig) {
+        return context.nil;
     }
 
-    public IRubyObject restoreOSDefault(IRubyObject recv, IRubyObject sig) {
-        return recv.getRuntime().getNil();
+    public IRubyObject restoreOSDefault(ThreadContext context, IRubyObject recv, IRubyObject sig) {
+        return context.nil;
     }
 
-    public IRubyObject ignore(IRubyObject recv, IRubyObject sig) {
-        return recv.getRuntime().getNil();
+    public IRubyObject ignore(ThreadContext context, IRubyObject recv, IRubyObject sig) {
+        return context.nil;
     }
 }// NoFunctionalitySignalFacade

--- a/core/src/main/java/org/jruby/util/SignalFacade.java
+++ b/core/src/main/java/org/jruby/util/SignalFacade.java
@@ -28,26 +28,23 @@
 
 package org.jruby.util;
 
-import org.jruby.Ruby;
 import org.jruby.runtime.BlockCallback;
+import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
-/**
- * @author <a href="mailto:ola.bini@gmail.com">Ola Bini</a>
- */
 public interface SignalFacade {
-    IRubyObject trap(IRubyObject recv, IRubyObject block, IRubyObject sig);
-    IRubyObject trap(Ruby runtime, BlockCallback block, String sig);
+    IRubyObject trap(ThreadContext context, IRubyObject recv, IRubyObject block, IRubyObject sig);
+    IRubyObject trap(ThreadContext context, BlockCallback block, String sig);
     /**
      * Restores the platform (JVM's) default signal handler.
      */
-    IRubyObject restorePlatformDefault(IRubyObject recv, IRubyObject sig);
+    IRubyObject restorePlatformDefault(ThreadContext context, IRubyObject recv, IRubyObject sig);
     /**
      * Restores the OS default signal handler.
      */
-    IRubyObject restoreOSDefault(IRubyObject recv, IRubyObject sig);
+    IRubyObject restoreOSDefault(ThreadContext context, IRubyObject recv, IRubyObject sig);
     /**
      * Ignores this signal.
      */
-    IRubyObject ignore(IRubyObject recv, IRubyObject sig);
+    IRubyObject ignore(ThreadContext context, IRubyObject recv, IRubyObject sig);
 }// SignalFacade

--- a/core/src/test/java/org/jruby/test/TestRubyString.java
+++ b/core/src/test/java/org/jruby/test/TestRubyString.java
@@ -56,7 +56,7 @@ public class TestRubyString extends Base {
 
     public void testSplit() throws RaiseException {
         RubyString str = newString(context, "JRuby is so awesome!");
-        RubyArray res = str.split(newString(context, " "));
+        RubyArray res = str.split(context, newString(context, " "), 0);
         assertEquals(4, res.size());
         assertEquals("JRuby", res.get(0));
         res = str.split(newString(context, " "), 2);
@@ -65,12 +65,12 @@ public class TestRubyString extends Base {
         assertEquals("is so awesome!", res.get(1));
 
         RubyRegexp pat = RubyRegexp.newRegexp(context.runtime, ByteList.create("[ie]s"));
-        res = str.split(pat);
+        res = str.split(context, pat, 0);
         assertEquals(3, res.size());
         assertEquals("JRuby ", res.get(0));
         assertEquals(" so aw", res.get(1));
         assertEquals("ome!", res.get(2));
-        res = str.split(pat, 4);
+        res = str.split(context, pat, 4);
         assertEquals(3, res.size());
     }
 }

--- a/spec/compiler/general_spec.rb
+++ b/spec/compiler/general_spec.rb
@@ -71,6 +71,7 @@ module PersistenceSpecUtils
 
     # interpret with test runtime
     runtime = JRuby.runtime
+    context = runtime.get_current_context
     manager = runtime.getIRManager()
     top_self = runtime.top_self
 
@@ -78,7 +79,7 @@ module PersistenceSpecUtils
     method = org.jruby.ir.persistence.IRReader.load(manager, reader)
 
     interpreter = org.jruby.ir.interpreter.Interpreter.new
-    interpreter.execute(runtime, method, top_self)
+    interpreter.execute(context, method, top_self)
   end
 end
 


### PR DESCRIPTION
More removal of getRuntime() from non-deprecated code paths.

This one also changes method populators to use thread context as well (old method is still there for backwards compat).