### PR TITLE
More API work: toInt, toInteger, toLong, asLong, asInt

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -218,7 +218,7 @@ import static org.jruby.api.Access.errnoModule;
 import static org.jruby.api.Access.loadService;
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.asSymbol;
-import static org.jruby.api.Convert.numToLong;
+import static org.jruby.api.Convert.toLong;
 import static org.jruby.api.Create.newEmptyString;
 import static org.jruby.api.Create.newFrozenString;
 import static org.jruby.api.Error.*;
@@ -5955,7 +5955,7 @@ public final class Ruby implements Constantizable {
                 RubyException raisedException = exit.getException();
                 // adopt new exit code
                 // see jruby/jruby#5437 and related issues
-                return (int) numToLong(context, raisedException.callMethod(context, "status"));
+                return (int) toLong(context, raisedException.callMethod(context, "status"));
             } catch (RaiseException re) {
                 // display and set error result but do not propagate other errors raised during at_exit
                 Ruby.this.printError(re.getException());

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -218,6 +218,7 @@ import static org.jruby.api.Access.errnoModule;
 import static org.jruby.api.Access.loadService;
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.asSymbol;
+import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Convert.toLong;
 import static org.jruby.api.Create.newEmptyString;
 import static org.jruby.api.Create.newFrozenString;
@@ -449,7 +450,7 @@ public final class Ruby implements Constantizable {
         }
         floatClass = profile.allowClass("Float") ? RubyFloat.createFloatClass(context, numericClass) : null;
         randomClass = RubyRandom.createRandomClass(context, objectClass);
-        setDefaultRandom(newRandom(this, randomClass, randomSeed(this)));
+        setDefaultRandom(newRandom(context, randomClass, randomSeed(this)));
         ioClass = RubyIO.createIOClass(context, objectClass, enumerableModule);
         ioBufferClass = Options.FIBER_SCHEDULER.load() ?
             RubyIOBuffer.createIOBufferClass(context, objectClass, comparableModule, ioClass) : null;
@@ -5955,7 +5956,7 @@ public final class Ruby implements Constantizable {
                 RubyException raisedException = exit.getException();
                 // adopt new exit code
                 // see jruby/jruby#5437 and related issues
-                return (int) toLong(context, raisedException.callMethod(context, "status"));
+                return toInt(context, raisedException.callMethod(context, "status"));
             } catch (RaiseException re) {
                 // display and set error result but do not propagate other errors raised during at_exit
                 Ruby.this.printError(re.getException());

--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -218,6 +218,7 @@ import static org.jruby.api.Access.errnoModule;
 import static org.jruby.api.Access.loadService;
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.asSymbol;
+import static org.jruby.api.Convert.numToLong;
 import static org.jruby.api.Create.newEmptyString;
 import static org.jruby.api.Create.newFrozenString;
 import static org.jruby.api.Error.*;
@@ -3485,7 +3486,7 @@ public final class Ruby implements Constantizable {
 
     @Deprecated(since = "10.0")
     public RubyArray newArray() {
-        return RubyArray.newArray(this);
+        return RubyArray.newArray(this.getCurrentContext());
     }
 
     @Deprecated(since = "10.0")
@@ -3525,7 +3526,7 @@ public final class Ruby implements Constantizable {
 
     @Deprecated(since = "10.0")
     public RubyArray newArray(int size) {
-        return RubyArray.newArray(this, size);
+        return RubyArray.newArray(this.getCurrentContext(), size);
     }
 
     public RubyArray getEmptyFrozenArray() {
@@ -5954,7 +5955,7 @@ public final class Ruby implements Constantizable {
                 RubyException raisedException = exit.getException();
                 // adopt new exit code
                 // see jruby/jruby#5437 and related issues
-                return raisedException.callMethod(context, "status").convertToInteger().getIntValue();
+                return (int) numToLong(context, raisedException.callMethod(context, "status"));
             } catch (RaiseException re) {
                 // display and set error result but do not propagate other errors raised during at_exit
                 Ruby.this.printError(re.getException());

--- a/core/src/main/java/org/jruby/RubyArgsFile.java
+++ b/core/src/main/java/org/jruby/RubyArgsFile.java
@@ -68,14 +68,13 @@ import static org.jruby.api.Access.stringClass;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.asSymbol;
-import static org.jruby.api.Convert.numericToLong;
+import static org.jruby.api.Convert.numToLong;
 import static org.jruby.api.Create.newArray;
 import static org.jruby.api.Create.newEmptyArray;
 import static org.jruby.api.Create.newEmptyString;
 import static org.jruby.api.Create.newString;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.argumentError;
-import static org.jruby.api.Warn.warn;
 import static org.jruby.runtime.ThreadContext.CALL_KEYWORD;
 import static org.jruby.runtime.ThreadContext.resetCallInfo;
 import static org.jruby.runtime.Visibility.PRIVATE;
@@ -864,7 +863,7 @@ public class RubyArgsFile extends RubyObject {
             str = length = nil;
         }
 
-        if (length != nil) len = numericToLong(context, length);
+        if (length != nil) len = numToLong(context, length);
 
         if (str != nil) {
             str = str.convertToString();

--- a/core/src/main/java/org/jruby/RubyArgsFile.java
+++ b/core/src/main/java/org/jruby/RubyArgsFile.java
@@ -68,7 +68,7 @@ import static org.jruby.api.Access.stringClass;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.asSymbol;
-import static org.jruby.api.Convert.numToLong;
+import static org.jruby.api.Convert.toLong;
 import static org.jruby.api.Create.newArray;
 import static org.jruby.api.Create.newEmptyArray;
 import static org.jruby.api.Create.newEmptyString;
@@ -863,7 +863,7 @@ public class RubyArgsFile extends RubyObject {
             str = length = nil;
         }
 
-        if (length != nil) len = numToLong(context, length);
+        if (length != nil) len = toLong(context, length);
 
         if (str != nil) {
             str = str.convertToString();

--- a/core/src/main/java/org/jruby/RubyArithmeticSequence.java
+++ b/core/src/main/java/org/jruby/RubyArithmeticSequence.java
@@ -195,7 +195,7 @@ public class RubyArithmeticSequence extends RubyObject {
         }
 
         /* TODO: the following code should be extracted as arith_seq_take */
-        long n = numToLong(context, num);
+        long n = toLong(context, num);
 
         if (n < 0) throw argumentError(context, "attempt to take negative size");
         if (n == 0) return newEmptyArray(context);
@@ -322,16 +322,16 @@ public class RubyArithmeticSequence extends RubyObject {
     @JRubyMethod(name = "hash")
     public RubyFixnum hash(ThreadContext context) {
         IRubyObject v = safeHash(context, excludeEnd);
-        long hash = hashStart(context.runtime, numToLong(context, v));
+        long hash = hashStart(context.runtime, toLong(context, v));
 
         v = safeHash(context, begin);
-        hash = murmurCombine(hash, numToLong(context, v));
+        hash = murmurCombine(hash, toLong(context, v));
 
         v = safeHash(context, end);
-        hash = murmurCombine(hash, numToLong(context, v));
+        hash = murmurCombine(hash, toLong(context, v));
 
         v = safeHash(context, step);
-        hash = murmurCombine(hash, numToLong(context, v));
+        hash = murmurCombine(hash, toLong(context, v));
         hash = hashEnd(hash);
 
         return asFixnum(context, hash);
@@ -447,11 +447,11 @@ public class RubyArithmeticSequence extends RubyObject {
         if (num == null) return last;
 
         var len = last_is_adjusted ? len_1 : (RubyNumeric) len_1.op_plus(context, asFixnum(context, 1));
-        RubyNumeric nv = !(num instanceof RubyInteger numm) ? numToInteger(context, num) : numm;
+        RubyNumeric nv = !(num instanceof RubyInteger numm) ? toInteger(context, num) : numm;
 
         if (RubyNumeric.numFuncall(context, nv, sites(context).op_gt, len).isTrue()) nv = len;
 
-        long n = numToLong(context, nv);
+        long n = toLong(context, nv);
         if (n < 0) throw argumentError(context, "negative array size");
 
         var ary = newRawArray(context, n);
@@ -490,9 +490,7 @@ public class RubyArithmeticSequence extends RubyObject {
             return dbl2num(runtime, Double.POSITIVE_INFINITY);
         }
 
-        if(!(step instanceof RubyNumeric)) {
-            step = step.convertToInteger();
-        }
+        if (!(step instanceof RubyNumeric)) step = toInteger(context, step);
 
         if (Helpers.rbEqual(context, step, int2fix(runtime, 0)).isTrue()) {
             return dbl2num(runtime, Double.POSITIVE_INFINITY);
@@ -529,7 +527,7 @@ public class RubyArithmeticSequence extends RubyObject {
 
     @JRubyMethod(name = "each_cons")
     public IRubyObject each_cons(ThreadContext context, IRubyObject arg, final Block block) {
-        int size = (int) numToLong(context, arg);
+        int size = (int) toLong(context, arg);
         if (size <= 0) throw argumentError(context, "invalid size");
         return block.isGiven() ? RubyEnumerable.each_consCommon(context, this, size, block) :
                 enumeratorize(context.runtime, this, "each_cons", arg);
@@ -537,7 +535,7 @@ public class RubyArithmeticSequence extends RubyObject {
 
     @JRubyMethod(name = "each_slice")
     public IRubyObject each_slice(ThreadContext context, IRubyObject arg, final Block block) {
-        int size = (int) numToLong(context, arg);
+        int size = (int) toLong(context, arg);
         if (size <= 0) throw argumentError(context, "invalid size");
 
         return block.isGiven() ? RubyEnumerable.each_sliceCommon(context, this, size, block) :

--- a/core/src/main/java/org/jruby/RubyArithmeticSequence.java
+++ b/core/src/main/java/org/jruby/RubyArithmeticSequence.java
@@ -195,7 +195,7 @@ public class RubyArithmeticSequence extends RubyObject {
         }
 
         /* TODO: the following code should be extracted as arith_seq_take */
-        long n = numericToLong(context, num);
+        long n = numToLong(context, num);
 
         if (n < 0) throw argumentError(context, "attempt to take negative size");
         if (n == 0) return newEmptyArray(context);
@@ -322,16 +322,16 @@ public class RubyArithmeticSequence extends RubyObject {
     @JRubyMethod(name = "hash")
     public RubyFixnum hash(ThreadContext context) {
         IRubyObject v = safeHash(context, excludeEnd);
-        long hash = hashStart(context.runtime, v.convertToInteger().getLongValue());
+        long hash = hashStart(context.runtime, numToLong(context, v));
 
         v = safeHash(context, begin);
-        hash = murmurCombine(hash, v.convertToInteger().getLongValue());
+        hash = murmurCombine(hash, numToLong(context, v));
 
         v = safeHash(context, end);
-        hash = murmurCombine(hash, v.convertToInteger().getLongValue());
+        hash = murmurCombine(hash, numToLong(context, v));
 
         v = safeHash(context, step);
-        hash = murmurCombine(hash, v.convertToInteger().getLongValue());
+        hash = murmurCombine(hash, numToLong(context, v));
         hash = hashEnd(hash);
 
         return asFixnum(context, hash);
@@ -453,7 +453,7 @@ public class RubyArithmeticSequence extends RubyObject {
         CallSite op_gt = sites(context).op_gt;
         if (RubyNumeric.numFuncall(context, nv, op_gt, len).isTrue()) nv = len;
 
-        long n = numericToLong(context, nv);
+        long n = numToLong(context, nv);
         if (n < 0) throw argumentError(context, "negative array size");
 
         var ary = newRawArray(context, n);
@@ -531,7 +531,7 @@ public class RubyArithmeticSequence extends RubyObject {
 
     @JRubyMethod(name = "each_cons")
     public IRubyObject each_cons(ThreadContext context, IRubyObject arg, final Block block) {
-        int size = (int) numericToLong(context, arg);
+        int size = (int) numToLong(context, arg);
         if (size <= 0) throw argumentError(context, "invalid size");
         return block.isGiven() ? RubyEnumerable.each_consCommon(context, this, size, block) :
                 enumeratorize(context.runtime, this, "each_cons", arg);
@@ -539,7 +539,7 @@ public class RubyArithmeticSequence extends RubyObject {
 
     @JRubyMethod(name = "each_slice")
     public IRubyObject each_slice(ThreadContext context, IRubyObject arg, final Block block) {
-        int size = (int) numericToLong(context, arg);
+        int size = (int) numToLong(context, arg);
         if (size <= 0) throw argumentError(context, "invalid size");
 
         return block.isGiven() ? RubyEnumerable.each_sliceCommon(context, this, size, block) :

--- a/core/src/main/java/org/jruby/RubyArithmeticSequence.java
+++ b/core/src/main/java/org/jruby/RubyArithmeticSequence.java
@@ -430,37 +430,35 @@ public class RubyArithmeticSequence extends RubyObject {
     // arith_seq_last
     @JRubyMethod
     public IRubyObject last(ThreadContext context, IRubyObject num) {
-        IRubyObject b = begin, e = end, s = step, len_1, len;
-        boolean last_is_adjusted;
+        var b = (RubyNumeric) begin;
+        if (end.isNil()) throw rangeError(context, "cannot get the last element of endless arithmetic sequence");
+        var e = (RubyNumeric) end;
+        IRubyObject s = step;
 
-        if (e.isNil()) throw rangeError(context, "cannot get the last element of endless arithmetic sequence");
-
-        len_1 = ((RubyNumeric)((RubyNumeric)e).op_minus(context, b)).idiv(context, s);
+        var len_1 = (RubyNumeric) ((RubyNumeric) e.op_minus(context, b)).idiv(context, s);
         if (Numeric.f_negative_p(context, len_1)) return num == null ? context.nil : newEmptyArray(context);
 
-        IRubyObject last = ((RubyNumeric)b).op_plus(context, Numeric.f_mul(context, s, len_1));
-        if ((last_is_adjusted = excludeEnd.isTrue()) && Helpers.rbEqual(context, last, e).isTrue()) {
-            last = ((RubyNumeric)last).op_minus(context, s);
+        var last = (RubyNumeric) b.op_plus(context, Numeric.f_mul(context, s, len_1));
+        boolean last_is_adjusted = excludeEnd.isTrue();
+        if (last_is_adjusted && Helpers.rbEqual(context, last, e).isTrue()) {
+            last = (RubyNumeric) last.op_minus(context, s);
         }
 
         if (num == null) return last;
 
-        len = last_is_adjusted ? len_1 : ((RubyNumeric)len_1).op_plus(context, asFixnum(context, 1));
+        var len = last_is_adjusted ? len_1 : (RubyNumeric) len_1.op_plus(context, asFixnum(context, 1));
+        RubyNumeric nv = !(num instanceof RubyInteger numm) ? numToInteger(context, num) : numm;
 
-        IRubyObject nv = num;
-        if (!(nv instanceof RubyInteger)) nv = num.convertToInteger();
-
-        CallSite op_gt = sites(context).op_gt;
-        if (RubyNumeric.numFuncall(context, nv, op_gt, len).isTrue()) nv = len;
+        if (RubyNumeric.numFuncall(context, nv, sites(context).op_gt, len).isTrue()) nv = len;
 
         long n = numToLong(context, nv);
         if (n < 0) throw argumentError(context, "negative array size");
 
         var ary = newRawArray(context, n);
-        b = ((RubyNumeric)last).op_minus(context, Numeric.f_mul(context, s, nv));
+        var i = (RubyNumeric) last.op_minus(context, Numeric.f_mul(context, s, nv));
         while (n > 0) {
-            b = ((RubyNumeric)b).op_plus(context, s);
-            ary.append(context, b);
+            i = (RubyNumeric) i.op_plus(context, s);
+            ary.append(context, i);
             --n;
         }
 

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -748,7 +748,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
             }
         }
 
-        long len = numToLong(context, arg0);
+        long len = toLong(context, arg0);
         if (len < 0) throw argumentError(context, "negative array size");
         int ilen = validateBufferLength(context, len);
 
@@ -1043,7 +1043,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         int arraySize = size();
         var result = Create.newRawArray(context, length);
         for (int i = 0; i < length; i++) {
-            int index = numToInt(context, args[i]);
+            int index = toInt(context, args[i]);
             // FIXME: lookup the bounds part of this in error message??
             if (index >= arraySize) {
                 if (!block.isGiven()) throw context.runtime.newIndexError("index " + index + " outside of array bounds: 0...0");
@@ -1061,7 +1061,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      */
     @JRubyMethod
     public IRubyObject fetch(ThreadContext context, IRubyObject arg0, Block block) {
-        long index = numToLong(context, arg0);
+        long index = toLong(context, arg0);
 
         if (index < 0) index += realLength;
         if (index < 0 || index >= realLength) {
@@ -1079,7 +1079,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
    public IRubyObject fetch(ThreadContext context, IRubyObject arg0, IRubyObject arg1, Block block) {
        if (block.isGiven()) warn(context, "block supersedes default value argument");
 
-       long index = numToLong(context, arg0);
+       long index = toLong(context, arg0);
 
        if (index < 0) index += realLength;
        if (index < 0 || index >= realLength) {
@@ -1236,7 +1236,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     @JRubyMethod(name = "insert")
     public IRubyObject insert(ThreadContext context, IRubyObject arg) {
         modifyCheck(context);
-        numToLong(context, arg);
+        toLong(context, arg);
         return this;
     }
 
@@ -1254,7 +1254,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     @JRubyMethod(name = "insert")
     public IRubyObject insert(ThreadContext context, IRubyObject arg1, IRubyObject arg2) {
         modifyCheck(context);
-        insert(context, numToLong(context, arg1), arg2);
+        insert(context, toLong(context, arg1), arg2);
         return this;
     }
 
@@ -1288,7 +1288,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
         unpack(context);
 
-        long pos = numToLong(context, args[0]);
+        long pos = toLong(context, args[0]);
 
         if (pos == -1) pos = realLength;
         if (pos < 0) pos++;
@@ -1379,7 +1379,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
                 }
                 continue;
             }
-            result.append(context, entry(numToLong(context, arg)));
+            result.append(context, entry(toLong(context, arg)));
         }
 
         return result.finishRawArray(context);
@@ -1406,7 +1406,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         if (step < 0) {
             if (aseqExcl && !aseqEnd.isNil()) {
                 /* Handle exclusion before range reversal */
-                aseqEnd = asFixnum(context, numToLong(context, aseqEnd) + 1);
+                aseqEnd = asFixnum(context, toLong(context, aseqEnd) + 1);
 
                 /* Don't exclude the previous beginning */
                 aseqExcl = false;
@@ -1491,7 +1491,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     }
 
     private Long getStep(ThreadContext context, RubyArithmeticSequence arg0) {
-        return arg0.step(context).isNil() ? null: numToLong(context, arg0.step(context));
+        return arg0.step(context).isNil() ? null: toLong(context, arg0.step(context));
     }
 
     /** rb_ary_subseq
@@ -1818,7 +1818,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
                 return beglen == null ? context.nil : subseq(beglen[0], beglen[1]);
             }
         }
-        return entry(numToLong(context, arg0));
+        return entry(toLong(context, arg0));
     }
 
     @Deprecated(since = "10.0")
@@ -1828,9 +1828,9 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
     @JRubyMethod(name = {"[]", "slice"})
     public IRubyObject aref(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
-        long beg = numToLong(context, arg0);
+        long beg = toLong(context, arg0);
         if (beg < 0) beg += realLength;
-        return subseq(beg, numToLong(context, arg1));
+        return subseq(beg, toLong(context, arg1));
     }
 
     /**
@@ -1890,7 +1890,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
             int beg = checkInt(context, range.begLen0(context, realLength));
             splice(context, beg, checkInt(context, range.begLen1(context, realLength, beg)), arg1);
         } else {
-            store(numToLong(context, arg0), arg1);
+            store(toLong(context, arg0), arg1);
         }
     }
 
@@ -1931,7 +1931,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      */
     @JRubyMethod(name = "at")
     public IRubyObject at(ThreadContext context, IRubyObject pos) {
-        return entry(numToLong(context, pos));
+        return entry(toLong(context, pos));
     }
 
 	/** rb_ary_concat
@@ -2069,7 +2069,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     @JRubyAPI
     @JRubyMethod(name = "first")
     public IRubyObject first(ThreadContext context, IRubyObject arg0) {
-        long n = numToLong(context, arg0);
+        long n = toLong(context, arg0);
         if (n > realLength) {
             n = realLength;
         } else if (n < 0) {
@@ -2128,7 +2128,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      */
     @JRubyMethod(name = "last")
     public IRubyObject last(ThreadContext context, IRubyObject arg0) {
-        long n = numToLong(context, arg0);
+        long n = toLong(context, arg0);
         if (n > realLength) n = realLength;
 
         if (n < 0) throw argumentError(context, "negative array size (or size too big)");
@@ -2634,7 +2634,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         if (arg == null || arg.isNil()) {
             return realLength - beg;
         } else {
-            return numToLong(context, arg);
+            return toLong(context, arg);
         }
         // TODO: In MRI 1.9, an explicit check for negative length is
         // added here. IndexError is raised when length is negative.
@@ -3164,7 +3164,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      */
     @JRubyMethod(name = "delete_at")
     public IRubyObject delete_at(ThreadContext context, IRubyObject obj) {
-        return delete_at((int) numToLong(context, obj));
+        return delete_at((int) toLong(context, obj));
     }
 
     /** rb_ary_reject_bang
@@ -3717,7 +3717,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
         if (!tmp.isNil()) return join(context, tmp);
 
-        long len = numToLong(context, times);
+        long len = toLong(context, times);
         if (len == 0) return RubyArray.newEmptyArray(context.runtime);
         if (len < 0) throw argumentError(context, "negative argument");
         if (Long.MAX_VALUE / len < realLength) throw argumentError(context, "argument too big");
@@ -4284,7 +4284,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      */
     @JRubyMethod(name = "take")
     public IRubyObject take(ThreadContext context, IRubyObject n) {
-        long len = numToLong(context, n);
+        long len = toLong(context, n);
         if (len < 0) throw argumentError(context, "attempt to take negative size");
 
         return subseq(0, len);
@@ -4309,7 +4309,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
      */
     @JRubyMethod(name = "drop")
     public IRubyObject drop(ThreadContext context, IRubyObject n) {
-        long pos = numToLong(context, n);
+        long pos = toLong(context, n);
         if (pos < 0) throw argumentError(context, "attempt to drop negative size");
 
         IRubyObject result = subseq(pos, realLength);
@@ -4348,7 +4348,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         if (arg.isNil()) return cycle(context, block);
         if (!block.isGiven()) return enumeratorizeWithSize(context, this, "cycle", new IRubyObject[] {arg}, RubyArray::cycleSize);
 
-        long times = numToLong(context, arg);
+        long times = toLong(context, arg);
         if (times <= 0) return context.nil;
 
         return cycleCommon(context, times, block);
@@ -4375,7 +4375,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
         if (n == null || n.isNil()) return asFloat(context, RubyFloat.INFINITY);
 
-        long multiple = numToLong(context, n);
+        long multiple = toLong(context, n);
         if (multiple <= 0) return asFixnum(context, 0);
 
         RubyFixnum length = self.length(context);

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -1043,7 +1043,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         int arraySize = size();
         var result = Create.newRawArray(context, length);
         for (int i = 0; i < length; i++) {
-            int index = args[i].convertToInteger().getIntValue();
+            int index = numToInt(context, args[i]);
             // FIXME: lookup the bounds part of this in error message??
             if (index >= arraySize) {
                 if (!block.isGiven()) throw context.runtime.newIndexError("index " + index + " outside of array bounds: 0...0");
@@ -1066,7 +1066,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         if (index < 0) index += realLength;
         if (index < 0 || index >= realLength) {
             if (block.isGiven()) return block.yield(context, arg0);
-            throw context.runtime.newIndexError("index " + index + " out of array");
+            throw indexError(context, "index " + index + " out of array");
         }
 
         return eltOk((int) index);
@@ -1406,7 +1406,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         if (step < 0) {
             if (aseqExcl && !aseqEnd.isNil()) {
                 /* Handle exclusion before range reversal */
-                aseqEnd = asFixnum(context, aseqEnd.convertToInteger().getIntValue() + 1);
+                aseqEnd = asFixnum(context, numToLong(context, aseqEnd) + 1);
 
                 /* Don't exclude the previous beginning */
                 aseqExcl = false;
@@ -1491,7 +1491,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
     }
 
     private Long getStep(ThreadContext context, RubyArithmeticSequence arg0) {
-        return arg0.step(context).isNil() ? null: arg0.step(context).convertToInteger().asLong(context);
+        return arg0.step(context).isNil() ? null: numToLong(context, arg0.step(context));
     }
 
     /** rb_ary_subseq

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -96,6 +96,8 @@ import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.asSymbol;
 import static org.jruby.api.Convert.castAsModule;
+import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.numToLong;
 import static org.jruby.api.Create.newArray;
 import static org.jruby.api.Create.newEmptyArray;
 import static org.jruby.api.Create.newRawArray;
@@ -1239,9 +1241,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         IRubyObject cmp = invokedynamic(context, this, OP_CMP, other);
 
         // if RubyBasicObject#op_cmp is used, the result may be nil (not comparable)
-        if ( ! cmp.isNil() ) {
-            return (int) cmp.convertToInteger().asLong(context);
-        }
+        if (!cmp.isNil()) return numToInt(context, cmp);
 
         /* We used to raise an error if two IRubyObject were not comparable, but
          * in order to support the new ConcurrentHashMapV8 and other libraries
@@ -1920,7 +1920,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         // We just want the TypeError if the argument doesn't convert to a String (JRUBY-386)
         RubyString evalStr = arg0 instanceof RubyString str ? str : arg0.convertToString();
         String file = arg1.convertToString().asJavaString();
-        int line = (int)(arg2.convertToInteger().asLong(context) - 1);
+        int line = numToInt(context, arg2) - 1;
 
         return evalUnder(context, mod, evalStr, file, line, evalType);
     }
@@ -2904,10 +2904,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     }
 
     protected static int nonFixnumHashCode(IRubyObject hashValue) {
-        RubyInteger integer = hashValue.convertToInteger();
-        return integer instanceof RubyBignum ?
-                integer.getBigIntegerValue().intValue() :
-                (int) ((RubyFixnum) integer).getValue();
+        return numToInt(hashValue.getRuntime().getCurrentContext(), hashValue);
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -90,6 +90,7 @@ import static org.jruby.anno.FrameField.VISIBILITY;
 import static org.jruby.api.Access.arrayClass;
 import static org.jruby.api.Access.globalVariables;
 import static org.jruby.api.Access.hashClass;
+import static org.jruby.api.Access.integerClass;
 import static org.jruby.api.Access.stringClass;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
@@ -716,7 +717,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         ThreadContext context = runtime.getCurrentContext();
         BasicObjectSites sites = sites(context);
 
-        IRubyObject result = TypeConverter.convertToType(context, this, runtime.getInteger(), sites.to_int_checked, true);
+        IRubyObject result = TypeConverter.convertToType(context, this, integerClass(context), sites.to_int_checked, true);
 
         if (!(result instanceof RubyInteger)) throw typeError(context, "", this, "#to_int should return Integer");
 
@@ -1233,13 +1234,13 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
      */
     @Override
     public int compareTo(IRubyObject other) {
-        final Ruby runtime = metaClass.runtime;
+        var context = getRuntime().getCurrentContext();
 
-        IRubyObject cmp = invokedynamic(runtime.getCurrentContext(), this, OP_CMP, other);
+        IRubyObject cmp = invokedynamic(context, this, OP_CMP, other);
 
         // if RubyBasicObject#op_cmp is used, the result may be nil (not comparable)
         if ( ! cmp.isNil() ) {
-            return (int) cmp.convertToInteger().getLongValue();
+            return (int) cmp.convertToInteger().asLong(context);
         }
 
         /* We used to raise an error if two IRubyObject were not comparable, but
@@ -1919,7 +1920,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         // We just want the TypeError if the argument doesn't convert to a String (JRUBY-386)
         RubyString evalStr = arg0 instanceof RubyString str ? str : arg0.convertToString();
         String file = arg1.convertToString().asJavaString();
-        int line = (int)(arg2.convertToInteger().getLongValue() - 1);
+        int line = (int)(arg2.convertToInteger().asLong(context) - 1);
 
         return evalUnder(context, mod, evalStr, file, line, evalType);
     }
@@ -2904,10 +2905,9 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
 
     protected static int nonFixnumHashCode(IRubyObject hashValue) {
         RubyInteger integer = hashValue.convertToInteger();
-        if (integer instanceof RubyBignum) {
-            return integer.getBigIntegerValue().intValue();
-        }
-        return (int) integer.getLongValue();
+        return integer instanceof RubyBignum ?
+                integer.getBigIntegerValue().intValue() :
+                (int) ((RubyFixnum) integer).getValue();
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyBasicObject.java
+++ b/core/src/main/java/org/jruby/RubyBasicObject.java
@@ -96,8 +96,7 @@ import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.asSymbol;
 import static org.jruby.api.Convert.castAsModule;
-import static org.jruby.api.Convert.numToInt;
-import static org.jruby.api.Convert.numToLong;
+import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Create.newArray;
 import static org.jruby.api.Create.newEmptyArray;
 import static org.jruby.api.Create.newRawArray;
@@ -1241,7 +1240,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         IRubyObject cmp = invokedynamic(context, this, OP_CMP, other);
 
         // if RubyBasicObject#op_cmp is used, the result may be nil (not comparable)
-        if (!cmp.isNil()) return numToInt(context, cmp);
+        if (!cmp.isNil()) return toInt(context, cmp);
 
         /* We used to raise an error if two IRubyObject were not comparable, but
          * in order to support the new ConcurrentHashMapV8 and other libraries
@@ -1920,7 +1919,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
         // We just want the TypeError if the argument doesn't convert to a String (JRUBY-386)
         RubyString evalStr = arg0 instanceof RubyString str ? str : arg0.convertToString();
         String file = arg1.convertToString().asJavaString();
-        int line = numToInt(context, arg2) - 1;
+        int line = toInt(context, arg2) - 1;
 
         return evalUnder(context, mod, evalStr, file, line, evalType);
     }
@@ -2904,7 +2903,7 @@ public class RubyBasicObject implements Cloneable, IRubyObject, Serializable, Co
     }
 
     protected static int nonFixnumHashCode(IRubyObject hashValue) {
-        return numToInt(hashValue.getRuntime().getCurrentContext(), hashValue);
+        return toInt(hashValue.getRuntime().getCurrentContext(), hashValue);
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyBignum.java
+++ b/core/src/main/java/org/jruby/RubyBignum.java
@@ -291,20 +291,17 @@ public class RubyBignum extends RubyInteger {
      */
     @Override
     public IRubyObject ceil(ThreadContext context, IRubyObject arg){
-        int ndigits = arg.convertToInteger().getIntValue();
+        int ndigits = numToInt(context, arg);
         BigInteger self = value;
-        if (ndigits >= 0){
-            return this;
-        } else {
-            int posdigits = Math.abs(ndigits);
-            BigInteger exp = BigInteger.TEN.pow(posdigits);
-            BigInteger mod = self.mod(exp);
-            BigInteger res = self;
-            if (mod.signum() != 0) {
-                res = self.add( exp.subtract(mod) );// self + (exp - (mod));
-            }
-            return newBignum(context.runtime, res);
-        }
+        if (ndigits >= 0) return this;
+
+        int posdigits = Math.abs(ndigits);
+        BigInteger exp = BigInteger.TEN.pow(posdigits);
+        BigInteger mod = self.mod(exp);
+        BigInteger res = self;
+        if (mod.signum() != 0) res = self.add( exp.subtract(mod) );// self + (exp - (mod));
+
+        return newBignum(context.runtime, res);
     }
 
     /** rb_big_floor
@@ -312,16 +309,14 @@ public class RubyBignum extends RubyInteger {
      */
     @Override
     public IRubyObject floor(ThreadContext context, IRubyObject arg){
-        int ndigits = arg.convertToInteger().getIntValue();
+        int ndigits = numToInt(context, arg);
         BigInteger self = value;
-        if (ndigits >= 0){
-            return this;
-        } else {
-            int posdigits = Math.abs(ndigits);
-            BigInteger exp = BigInteger.TEN.pow(posdigits);
-            BigInteger res = self.subtract(self.mod(exp));
-            return newBignum(context.runtime, res);
-        }
+        if (ndigits >= 0) return this;
+
+        int posdigits = Math.abs(ndigits);
+        BigInteger exp = BigInteger.TEN.pow(posdigits);
+        BigInteger res = self.subtract(self.mod(exp));
+        return newBignum(context.runtime, res);
     }
 
     /** rb_big_truncate
@@ -1068,7 +1063,7 @@ public class RubyBignum extends RubyInteger {
         if (other instanceof RubyBignum bignum) return value.compareTo(bignum.value);
 
         ThreadContext context = getRuntime().getCurrentContext();
-        return (int) coerceCmp(context, sites(context).op_cmp, other).convertToInteger().asLong(context);
+        return numToInt(context, coerceCmp(context, sites(context).op_cmp, other));
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyComplex.java
+++ b/core/src/main/java/org/jruby/RubyComplex.java
@@ -748,7 +748,7 @@ public class RubyComplex extends RubyNumeric {
                     f_mul(context, otherImage, RubyMath.log(context, r)));
             return f_complex_polar(context, getMetaClass(), nr, ntheta);
         } else if (other instanceof RubyFixnum otherFixnum) {
-            long n = otherFixnum.getLongValue();
+            long n = otherFixnum.asLong(context);
             if (n == 0) return newInstance(context, getMetaClass(), asFixnum(context, 1), asFixnum(context, 0));
 
             RubyComplex self = this;

--- a/core/src/main/java/org/jruby/RubyConverter.java
+++ b/core/src/main/java/org/jruby/RubyConverter.java
@@ -236,7 +236,7 @@ public class RubyConverter extends RubyObject {
                 hashArg = 2;
             } else {
                 outputByteOffsetObj = args[2];
-                outputByteoffset = numToInt(context, args[2]);
+                outputByteoffset = toInt(context, args[2]);
             }
         }
         
@@ -245,7 +245,7 @@ public class RubyConverter extends RubyObject {
                 hashArg = 3;
             } else {
                 outputBytesizeObj = args[3];
-                outputBytesize = numToInt(context, args[3]);
+                outputBytesize = toInt(context, args[3]);
             }
         }
         
@@ -255,7 +255,7 @@ public class RubyConverter extends RubyObject {
             if (args[4] instanceof RubyHash) {
                 hashArg = 4;
             } else {
-                flags = numToInt(context, args[4]);
+                flags = toInt(context, args[4]);
             }
         }
         
@@ -549,7 +549,7 @@ public class RubyConverter extends RubyObject {
     public IRubyObject putback(ThreadContext context, IRubyObject[] argv) {
         int argc = Arity.checkArgumentCount(context, argv, 0, 1);
         IRubyObject max = argc == 0 ? context.nil : argv[0];
-        int n = max.isNil() ? ec.putbackable() : Math.min(numToInt(context, max), ec.putbackable());
+        int n = max.isNil() ? ec.putbackable() : Math.min(toInt(context, max), ec.putbackable());
         RubyString str = RubyString.newStringLight(context.runtime, n);
         ByteList strBL = str.getByteList();
 

--- a/core/src/main/java/org/jruby/RubyConverter.java
+++ b/core/src/main/java/org/jruby/RubyConverter.java
@@ -236,7 +236,7 @@ public class RubyConverter extends RubyObject {
                 hashArg = 2;
             } else {
                 outputByteOffsetObj = args[2];
-                outputByteoffset = (int)args[2].convertToInteger().asLong(context);
+                outputByteoffset = numToInt(context, args[2]);
             }
         }
         
@@ -245,7 +245,7 @@ public class RubyConverter extends RubyObject {
                 hashArg = 3;
             } else {
                 outputBytesizeObj = args[3];
-                outputBytesize = (int)args[3].convertToInteger().asLong(context);
+                outputBytesize = numToInt(context, args[3]);
             }
         }
         
@@ -255,7 +255,7 @@ public class RubyConverter extends RubyObject {
             if (args[4] instanceof RubyHash) {
                 hashArg = 4;
             } else {
-                flags = (int)args[4].convertToInteger().asLong(context);
+                flags = numToInt(context, args[4]);
             }
         }
         
@@ -549,9 +549,7 @@ public class RubyConverter extends RubyObject {
     public IRubyObject putback(ThreadContext context, IRubyObject[] argv) {
         int argc = Arity.checkArgumentCount(context, argv, 0, 1);
         IRubyObject max = argc == 0 ? context.nil : argv[0];
-        int n = max.isNil() ?
-                ec.putbackable() :
-                (int) Math.min(max.convertToInteger().asLong(context), ec.putbackable());
+        int n = max.isNil() ? ec.putbackable() : Math.min(numToInt(context, max), ec.putbackable());
         RubyString str = RubyString.newStringLight(context.runtime, n);
         ByteList strBL = str.getByteList();
 

--- a/core/src/main/java/org/jruby/RubyConverter.java
+++ b/core/src/main/java/org/jruby/RubyConverter.java
@@ -236,7 +236,7 @@ public class RubyConverter extends RubyObject {
                 hashArg = 2;
             } else {
                 outputByteOffsetObj = args[2];
-                outputByteoffset = (int)args[2].convertToInteger().getLongValue();
+                outputByteoffset = (int)args[2].convertToInteger().asLong(context);
             }
         }
         
@@ -245,7 +245,7 @@ public class RubyConverter extends RubyObject {
                 hashArg = 3;
             } else {
                 outputBytesizeObj = args[3];
-                outputBytesize = (int)args[3].convertToInteger().getLongValue();
+                outputBytesize = (int)args[3].convertToInteger().asLong(context);
             }
         }
         
@@ -255,7 +255,7 @@ public class RubyConverter extends RubyObject {
             if (args[4] instanceof RubyHash) {
                 hashArg = 4;
             } else {
-                flags = (int)args[4].convertToInteger().getLongValue();
+                flags = (int)args[4].convertToInteger().asLong(context);
             }
         }
         
@@ -546,39 +546,19 @@ public class RubyConverter extends RubyObject {
 
     // econv_putback
     @JRubyMethod(optional = 1, checkArity = false)
-    public IRubyObject putback(ThreadContext context, IRubyObject[] argv)
-    {
+    public IRubyObject putback(ThreadContext context, IRubyObject[] argv) {
         int argc = Arity.checkArgumentCount(context, argv, 0, 1);
+        IRubyObject max = argc == 0 ? context.nil : argv[0];
+        int n = max.isNil() ?
+                ec.putbackable() :
+                (int) Math.min(max.convertToInteger().asLong(context), ec.putbackable());
+        RubyString str = RubyString.newStringLight(context.runtime, n);
+        ByteList strBL = str.getByteList();
 
-        Ruby runtime = context.runtime;
-        int n;
-        int putbackable;
-        IRubyObject str, max;
-
-        if (argc == 0) {
-            max = context.nil;
-        } else {
-            max = argv[0];
-        }
-
-        if (max.isNil()) {
-            n = ec.putbackable();
-        } else {
-            n = (int)max.convertToInteger().getLongValue();
-            putbackable = ec.putbackable();
-            if (putbackable < n) {
-                n = putbackable;
-            }
-        }
-
-        str = RubyString.newStringLight(runtime, n);
-        ByteList strBL = ((RubyString)str).getByteList();
         ec.putback(strBL.getUnsafeBytes(), strBL.getBegin(), n);
         strBL.setRealSize(n);
 
-        if (ec.sourceEncoding != null) {
-            ((RubyString)str).setEncoding(ec.sourceEncoding);
-        }
+        if (ec.sourceEncoding != null) ((RubyString)str).setEncoding(ec.sourceEncoding);
 
         return str;
     }

--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -73,6 +73,7 @@ import static org.jruby.api.Access.objectClass;
 import static org.jruby.api.Check.checkEmbeddedNulls;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Convert.numToInt;
 import static org.jruby.api.Create.newString;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.argumentError;
@@ -713,7 +714,7 @@ public class RubyDir extends RubyObject implements Closeable {
         File newDir = res.unwrap(File.class);
         if (File.separatorChar == '\\') newDir = new File(newDir.getPath());
 
-        int mode = args.length == 2 ? ((int) args[1].convertToInteger().asLong(context)) : 0777;
+        int mode = args.length == 2 ? numToInt(context, args[1]) : 0777;
 
         if (context.runtime.getPosix().mkdir(newDir.getAbsolutePath(), mode) < 0) {
             // FIXME: This is a system error based on errno

--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -73,7 +73,7 @@ import static org.jruby.api.Access.objectClass;
 import static org.jruby.api.Check.checkEmbeddedNulls;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Create.newString;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.argumentError;
@@ -714,7 +714,7 @@ public class RubyDir extends RubyObject implements Closeable {
         File newDir = res.unwrap(File.class);
         if (File.separatorChar == '\\') newDir = new File(newDir.getPath());
 
-        int mode = args.length == 2 ? numToInt(context, args[1]) : 0777;
+        int mode = args.length == 2 ? toInt(context, args[1]) : 0777;
 
         if (context.runtime.getPosix().mkdir(newDir.getAbsolutePath(), mode) < 0) {
             // FIXME: This is a system error based on errno

--- a/core/src/main/java/org/jruby/RubyDir.java
+++ b/core/src/main/java/org/jruby/RubyDir.java
@@ -713,7 +713,7 @@ public class RubyDir extends RubyObject implements Closeable {
         File newDir = res.unwrap(File.class);
         if (File.separatorChar == '\\') newDir = new File(newDir.getPath());
 
-        int mode = args.length == 2 ? ((int) args[1].convertToInteger().getLongValue()) : 0777;
+        int mode = args.length == 2 ? ((int) args[1].convertToInteger().asLong(context)) : 0777;
 
         if (context.runtime.getPosix().mkdir(newDir.getAbsolutePath(), mode) < 0) {
             // FIXME: This is a system error based on errno

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -73,7 +73,7 @@ import static org.jruby.api.Access.hashClass;
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.asFloat;
 import static org.jruby.api.Convert.asSymbol;
-import static org.jruby.api.Convert.numToLong;
+import static org.jruby.api.Convert.toLong;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineModule;
 import static org.jruby.api.Error.*;
@@ -196,7 +196,7 @@ public class RubyEnumerable {
             return enumeratorizeWithSize(context, self, "cycle", new IRubyObject[] { arg }, RubyEnumerable::cycleSize);
         }
 
-        long times = numToLong(context, arg);
+        long times = toLong(context, arg);
         if (times <= 0) return context.nil;
 
         return cycleCommon(context, self, times, block);
@@ -245,7 +245,7 @@ public class RubyEnumerable {
 
         if (args != null && args.length > 0) {
             n = args[0];
-            if (!n.isNil()) mul = numToLong(context, n);
+            if (!n.isNil()) mul = toLong(context, n);
         }
 
         IRubyObject size = size(context, self, args);
@@ -259,7 +259,7 @@ public class RubyEnumerable {
 
     @JRubyMethod(name = "take")
     public static IRubyObject take(ThreadContext context, IRubyObject self, IRubyObject n, Block block) {
-        final long len = numToLong(context, n);
+        final long len = toLong(context, n);
 
         if (len < 0) throw argumentError(context, "attempt to take negative size");
         if (len == 0) return newEmptyArray(context);
@@ -313,7 +313,7 @@ public class RubyEnumerable {
 
     @JRubyMethod(name = "drop")
     public static IRubyObject drop(ThreadContext context, IRubyObject self, IRubyObject n, final Block block) {
-        final long len = numToLong(context, n);
+        final long len = toLong(context, n);
         if (len < 0) throw argumentError(context, "attempt to drop negative size");
 
         final var result = newArray(context);
@@ -391,7 +391,7 @@ public class RubyEnumerable {
 
     @JRubyMethod(name = "first")
     public static IRubyObject first(ThreadContext context, IRubyObject self, final IRubyObject num) {
-        final long firstCount = numToLong(context, num);
+        final long firstCount = toLong(context, num);
         if (firstCount == 0) return newEmptyArray(context);
         if (firstCount < 0) throw argumentError(context, "attempt to take negative size");
 
@@ -1181,7 +1181,7 @@ public class RubyEnumerable {
 
     @JRubyMethod(name = "each_slice")
     public static IRubyObject each_slice(ThreadContext context, IRubyObject self, IRubyObject arg, final Block block) {
-        int size = (int) numToLong(context, arg);
+        int size = (int) toLong(context, arg);
         if (size <= 0) throw argumentError(context, "invalid size");
 
         return block.isGiven() ? each_sliceCommon(context, self, size, block) :
@@ -1233,7 +1233,7 @@ public class RubyEnumerable {
 
     @JRubyMethod(name = "each_cons")
     public static IRubyObject each_cons(ThreadContext context, IRubyObject self, IRubyObject arg, final Block block) {
-        int size = (int) numToLong(context, arg);
+        int size = (int) toLong(context, arg);
         if (size <= 0) throw argumentError(context, "invalid size");
         return block.isGiven() ? each_consCommon(context, self, size, block) : enumeratorizeWithSize(context, self, "each_cons", new IRubyObject[] { arg }, (SizeFn) RubyEnumerable::eachConsSize);
     }

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -240,27 +240,19 @@ public class RubyEnumerable {
      * @see SizeFn#size(ThreadContext, IRubyObject, IRubyObject[])
      */
     private static IRubyObject cycleSize(ThreadContext context, IRubyObject self, IRubyObject[] args) {
-        Ruby runtime = context.runtime;
         long mul = 0;
-        IRubyObject n = runtime.getNil();
+        IRubyObject n = context.nil;
 
         if (args != null && args.length > 0) {
             n = args[0];
-            if (!n.isNil()) mul = n.convertToInteger().asLong(context);
+            if (!n.isNil()) mul = numToLong(context, n);
         }
 
         IRubyObject size = size(context, self, args);
-        if (size == null || size.isNil() || size.equals(RubyFixnum.zero(runtime))) {
-            return size;
-        }
 
-        if (n == null || n.isNil()) {
-            return RubyFloat.newFloat(runtime, RubyFloat.INFINITY);
-        }
-
-        if (mul <= 0) {
-            return RubyFixnum.zero(runtime);
-        }
+        if (size == null || size.isNil() || size.equals(asFixnum(context, 0))) return size;
+        if (n == null || n.isNil()) return asFloat(context, RubyFloat.INFINITY);
+        if (mul <= 0) return asFixnum(context, 0);
 
         return sites(context).cycle_op_mul.call(context, size, size, mul);
     }

--- a/core/src/main/java/org/jruby/RubyEnumerable.java
+++ b/core/src/main/java/org/jruby/RubyEnumerable.java
@@ -73,6 +73,7 @@ import static org.jruby.api.Access.hashClass;
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.asFloat;
 import static org.jruby.api.Convert.asSymbol;
+import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Convert.toLong;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineModule;
@@ -1181,7 +1182,7 @@ public class RubyEnumerable {
 
     @JRubyMethod(name = "each_slice")
     public static IRubyObject each_slice(ThreadContext context, IRubyObject self, IRubyObject arg, final Block block) {
-        int size = (int) toLong(context, arg);
+        int size = toInt(context, arg);
         if (size <= 0) throw argumentError(context, "invalid size");
 
         return block.isGiven() ? each_sliceCommon(context, self, size, block) :
@@ -1233,7 +1234,7 @@ public class RubyEnumerable {
 
     @JRubyMethod(name = "each_cons")
     public static IRubyObject each_cons(ThreadContext context, IRubyObject self, IRubyObject arg, final Block block) {
-        int size = (int) toLong(context, arg);
+        int size = toInt(context, arg);
         if (size <= 0) throw argumentError(context, "invalid size");
         return block.isGiven() ? each_consCommon(context, self, size, block) : enumeratorizeWithSize(context, self, "each_cons", new IRubyObject[] { arg }, (SizeFn) RubyEnumerable::eachConsSize);
     }

--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -419,7 +419,7 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
 
     @JRubyMethod(name = "each_slice")
     public IRubyObject each_slice(ThreadContext context, IRubyObject arg, final Block block) {
-        int size = (int) numToLong(context, arg);
+        int size = (int) toLong(context, arg);
         if (size <= 0) throw argumentError(context, "invalid size");
 
         return block.isGiven() ? RubyEnumerable.each_sliceCommon(context, this, size, block) :
@@ -428,7 +428,7 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
 
     @JRubyMethod(name = "each_cons")
     public IRubyObject each_cons(ThreadContext context, IRubyObject arg, final Block block) {
-        int size = (int) numToLong(context, arg);
+        int size = (int) toLong(context, arg);
         if (size <= 0) throw argumentError(context, "invalid size");
         return block.isGiven() ? RubyEnumerable.each_consCommon(context, this, size, block) :
                 enumeratorize(context.runtime, getType(), this, "each_cons", arg);

--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -419,7 +419,7 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
 
     @JRubyMethod(name = "each_slice")
     public IRubyObject each_slice(ThreadContext context, IRubyObject arg, final Block block) {
-        int size = (int) numericToLong(context, arg);
+        int size = (int) numToLong(context, arg);
         if (size <= 0) throw argumentError(context, "invalid size");
 
         return block.isGiven() ? RubyEnumerable.each_sliceCommon(context, this, size, block) :
@@ -428,7 +428,7 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
 
     @JRubyMethod(name = "each_cons")
     public IRubyObject each_cons(ThreadContext context, IRubyObject arg, final Block block) {
-        int size = (int) numericToLong(context, arg);
+        int size = (int) numToLong(context, arg);
         if (size <= 0) throw argumentError(context, "invalid size");
         return block.isGiven() ? RubyEnumerable.each_consCommon(context, this, size, block) :
                 enumeratorize(context.runtime, getType(), this, "each_cons", arg);
@@ -447,8 +447,9 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
     }
 
     public long size() {
-        final IRubyObject size = size(getRuntime().getCurrentContext());
-        return size instanceof RubyNumeric numeric ? numeric.getLongValue() : -1;
+        var context = getRuntime().getCurrentContext();
+        final IRubyObject size = size(context);
+        return size instanceof RubyNumeric numeric ? numeric.asLong(context) : -1;
     }
 
     /**

--- a/core/src/main/java/org/jruby/RubyEnumerator.java
+++ b/core/src/main/java/org/jruby/RubyEnumerator.java
@@ -419,7 +419,7 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
 
     @JRubyMethod(name = "each_slice")
     public IRubyObject each_slice(ThreadContext context, IRubyObject arg, final Block block) {
-        int size = (int) toLong(context, arg);
+        int size = toInt(context, arg);
         if (size <= 0) throw argumentError(context, "invalid size");
 
         return block.isGiven() ? RubyEnumerable.each_sliceCommon(context, this, size, block) :
@@ -428,7 +428,7 @@ public class RubyEnumerator extends RubyObject implements java.util.Iterator<Obj
 
     @JRubyMethod(name = "each_cons")
     public IRubyObject each_cons(ThreadContext context, IRubyObject arg, final Block block) {
-        int size = (int) toLong(context, arg);
+        int size = toInt(context, arg);
         if (size <= 0) throw argumentError(context, "invalid size");
         return block.isGiven() ? RubyEnumerable.each_consCommon(context, this, size, block) :
                 enumeratorize(context.runtime, getType(), this, "each_cons", arg);

--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -319,7 +319,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
     @JRubyMethod
     public IRubyObject chmod(ThreadContext context, IRubyObject arg) {
         checkClosed(context);
-        int mode = (int) arg.convertToInteger().asLong(context);
+        int mode = numToInt(context, arg);
         final String path = getPath();
         if (!new File(path).exists()) throw context.runtime.newErrnoENOENTError(path);
 
@@ -1118,7 +1118,7 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         int argc = Arity.checkArgumentCount(context, args, 0, 1);
         int oldMask = argc == 0 ?
                 PosixShim.umask(context.runtime.getPosix()) :
-                PosixShim.umask(context.runtime.getPosix(), (int) args[0].convertToInteger().asLong(context));
+                PosixShim.umask(context.runtime.getPosix(), numToInt(context, args[0]));
 
         return asFixnum(context, oldMask);
     }

--- a/core/src/main/java/org/jruby/RubyFile.java
+++ b/core/src/main/java/org/jruby/RubyFile.java
@@ -1568,18 +1568,18 @@ public class RubyFile extends RubyIO implements EncodingCapable {
         long[] timespec = new long[2];
 
         if (value instanceof RubyFloat flote) {
-            timespec[0] = Platform.IS_32_BIT ? RubyNumeric.num2int(value) : toLong(context, value);
+            timespec[0] = Platform.IS_32_BIT ? flote.asInt(context) : flote.asLong(context);
             double fraction = flote.asDouble(context) % 1.0;
             timespec[1] = (long)(fraction * 1e9 + 0.5);
-        } else if (value instanceof RubyNumeric) {
-            timespec[0] = Platform.IS_32_BIT ? RubyNumeric.num2int(value) : toLong(context, value);
+        } else if (value instanceof RubyNumeric numeric) {
+            timespec[0] = Platform.IS_32_BIT ? numeric.asInt(context) : numeric.asLong(context);
             timespec[1] = 0;
         } else {
             RubyTime time = value instanceof RubyTime t ?
                     t : (RubyTime) TypeConverter.convertToType(context, value, timeClass(context), sites(context).to_time_checked, true);
 
-            timespec[0] = Platform.IS_32_BIT ? asInt(context, time.to_i(context)) : toLong(context, time.to_i(context));
-            timespec[1] = Platform.IS_32_BIT ? asInt(context, time.nsec(context)) : toLong(context, time.nsec(context));
+            timespec[0] = Platform.IS_32_BIT ? time.to_i(context).asInt(context) : time.to_i(context).asLong(context);
+            timespec[1] = Platform.IS_32_BIT ? time.nsec(context).asInt(context) : time.nsec(context).asLong(context);
         }
 
         return timespec;

--- a/core/src/main/java/org/jruby/RubyFloat.java
+++ b/core/src/main/java/org/jruby/RubyFloat.java
@@ -177,7 +177,8 @@ public class RubyFloat extends RubyNumeric implements Appendable {
     }
 
     @Override
-    public int getIntValue() {
+    @JRubyAPI
+    public int asInt(ThreadContext context) {
         return (int) value;
     }
 
@@ -490,7 +491,7 @@ public class RubyFloat extends RubyNumeric implements Appendable {
         ThreadContext context = metaClass.runtime.getCurrentContext();
         return switch (other.getMetaClass().getClassIndex()) {
             case INTEGER, FLOAT -> Double.compare(value, ((RubyNumeric) other).asDouble(context));
-            default -> (int) numToLong(context, coerceCmp(context, sites(context).op_cmp, other));
+            default -> (int) toLong(context, coerceCmp(context, sites(context).op_cmp, other));
         };
     }
 

--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -93,7 +93,7 @@ import static org.jruby.api.Access.instanceConfig;
 import static org.jruby.api.Access.objectClass;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Create.newArray;
 import static org.jruby.api.Create.newFrozenString;
 import static org.jruby.api.Create.newRawArray;
@@ -101,7 +101,6 @@ import static org.jruby.api.Create.newString;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.api.Warn.warnDeprecated;
-import static org.jruby.api.Warn.warningDeprecated;
 import static org.jruby.internal.runtime.GlobalVariable.Scope.FRAME;
 import static org.jruby.internal.runtime.GlobalVariable.Scope.GLOBAL;
 import static org.jruby.internal.runtime.GlobalVariable.Scope.THREAD;
@@ -982,7 +981,7 @@ public class RubyGlobal {
 
         @Override
         public IRubyObject set(IRubyObject value) {
-            int line = numToInt(runtime.getCurrentContext(), value);
+            int line = toInt(runtime.getCurrentContext(), value);
             runtime.setCurrentLine(line);
             return value;
         }

--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -981,7 +981,7 @@ public class RubyGlobal {
 
         @Override
         public IRubyObject set(IRubyObject value) {
-            int line = (int)value.convertToInteger().getLongValue();
+            int line = (int)value.convertToInteger().asLong(runtime.getCurrentContext());
             runtime.setCurrentLine(line);
             return value;
         }

--- a/core/src/main/java/org/jruby/RubyGlobal.java
+++ b/core/src/main/java/org/jruby/RubyGlobal.java
@@ -93,6 +93,7 @@ import static org.jruby.api.Access.instanceConfig;
 import static org.jruby.api.Access.objectClass;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Convert.numToInt;
 import static org.jruby.api.Create.newArray;
 import static org.jruby.api.Create.newFrozenString;
 import static org.jruby.api.Create.newRawArray;
@@ -981,7 +982,7 @@ public class RubyGlobal {
 
         @Override
         public IRubyObject set(IRubyObject value) {
-            int line = (int)value.convertToInteger().asLong(runtime.getCurrentContext());
+            int line = numToInt(runtime.getCurrentContext(), value);
             runtime.setCurrentLine(line);
             return value;
         }

--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -819,7 +819,7 @@ public class RubyHash extends RubyObject implements Map {
         if (keywords) {
             IRubyObject[] opts = ArgsUtil.extractKeywordArgs(context, (RubyHash) _default, "capacity");
             // This will allocFirst twice since it already happened before initialize was called.  I think this is ok?
-            if (opts[0] instanceof RubyFixnum fixnum && fixnum.getIntValue() > 0) allocFirst(fixnum.getIntValue());
+            if (opts[0] instanceof RubyFixnum fixnum && fixnum.asInt(context) > 0) allocFirst(fixnum.asInt(context));
 
             if (block.isGiven()) {
                 ifNone = context.runtime.newProc(Block.Type.PROC, block);
@@ -843,7 +843,7 @@ public class RubyHash extends RubyObject implements Map {
         IRubyObject[] opts = ArgsUtil.extractKeywordArgs(context, (RubyHash) hash, "capacity");
 
         // This will allocFirst twice since it already happened before initialize was called.  I think this is ok?
-        if (opts[0] instanceof RubyFixnum fixnum && fixnum.getIntValue() > 0) allocFirst(fixnum.getIntValue());
+        if (opts[0] instanceof RubyFixnum fixnum && fixnum.asInt(context) > 0) allocFirst(fixnum.asInt(context));
 
         modify();
 

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -1279,7 +1279,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
         if (vmode.isNil())
             oflags = OpenFlags.O_RDONLY.intValue();
         else if (!(intmode = checkToInteger(context, vmode)).isNil())
-            oflags = asInt(context, (RubyInteger) intmode);
+            oflags = ((RubyInteger) intmode).asInt(context);
         else {
             vmode = vmode.convertToString();
             oflags = OpenFile.ioModestrOflags(context, vmode.toString());

--- a/core/src/main/java/org/jruby/RubyIOBuffer.java
+++ b/core/src/main/java/org/jruby/RubyIOBuffer.java
@@ -137,7 +137,7 @@ public class RubyIOBuffer extends RubyObject {
 
     @JRubyMethod(meta = true)
     public static IRubyObject string(ThreadContext context, IRubyObject self, IRubyObject _length, Block block) {
-        int size = _length.convertToInteger().getIntValue();
+        int size = numToInt(context, _length);
         if (size < 0) throw argumentError(context, "negative string size (or size too big)");
         RubyString string = RubyString.newString(context.runtime, new byte[size]);
         ByteList bytes = string.getByteList();
@@ -295,26 +295,22 @@ public class RubyIOBuffer extends RubyObject {
 
     @JRubyMethod(name = "initialize")
     public IRubyObject initialize(ThreadContext context, IRubyObject size) {
-        return initialize(context, size.convertToInteger().getIntValue());
+        return initialize(context, numToInt(context, size));
     }
 
     @JRubyMethod(name = "initialize")
     public IRubyObject initialize(ThreadContext context, IRubyObject _size, IRubyObject flags) {
-        IRubyObject nil = context.nil;
+        int size = numToInt(context, _size);
 
-        int size = _size.convertToInteger().getIntValue();
+        initialize(context, new byte[size], size, numToInt(context, flags), context.nil);
 
-        initialize(context, new byte[size], size, flags.convertToInteger().getIntValue(), nil);
-
-        return nil;
+        return context.nil;
     }
 
     public IRubyObject initialize(ThreadContext context, int size) {
-        IRubyObject nil = context.nil;
+        initialize(context, new byte[size], size, flagsForSize(size), context.nil);
 
-        initialize(context, new byte[size], size, flagsForSize(size), nil);
-
-        return nil;
+        return context.nil;
     }
 
     // MRI: io_buffer_initialize
@@ -706,7 +702,7 @@ public class RubyIOBuffer extends RubyObject {
 
     @JRubyMethod(name = "resize")
     public IRubyObject resize(ThreadContext context, IRubyObject size) {
-        resize(context, size.convertToInteger().getIntValue());
+        resize(context, numToInt(context, size));
 
         return this;
     }
@@ -1003,10 +999,6 @@ public class RubyIOBuffer extends RubyObject {
         return asFloat(context, value);
     }
 
-    private static long unwrapLong(ThreadContext context, IRubyObject value) {
-        return value.convertToInteger().asLong(context);
-    }
-
     private static double unwrapDouble(ThreadContext context, IRubyObject value) {
         return value.convertToFloat().asDouble(context);
     }
@@ -1113,7 +1105,7 @@ public class RubyIOBuffer extends RubyObject {
 
         ByteBuffer buffer = getBufferForReading(context);
         DataType dataType = getDataType(_dataType);
-        int offset = _offset.convertToInteger().getIntValue();
+        int offset = numToInt(context, _offset);
 
         return each(context, buffer, dataType, offset, size - offset, block);
     }
@@ -1124,8 +1116,8 @@ public class RubyIOBuffer extends RubyObject {
 
         ByteBuffer buffer = getBufferForReading(context);
         DataType dataType = getDataType(_dataType);
-        int offset = _offset.convertToInteger().getIntValue();
-        int count = _count.convertToInteger().getIntValue();
+        int offset = numToInt(context, _offset);
+        int count = numToInt(context, _count);
 
         return each(context, buffer, dataType, offset, count, block);
     }
@@ -1153,7 +1145,7 @@ public class RubyIOBuffer extends RubyObject {
     public IRubyObject values(ThreadContext context, IRubyObject _dataType, IRubyObject _offset) {
         ByteBuffer buffer = getBufferForReading(context);
         DataType dataType = getDataType(_dataType);
-        int offset = _offset.convertToInteger().getIntValue();
+        int offset = numToInt(context, _offset);
 
         return values(context, buffer, dataType, offset, size - offset);
     }
@@ -1162,8 +1154,8 @@ public class RubyIOBuffer extends RubyObject {
     public IRubyObject values(ThreadContext context, IRubyObject _dataType, IRubyObject _offset, IRubyObject _count) {
         ByteBuffer buffer = getBufferForReading(context);
         DataType dataType = getDataType(_dataType);
-        int offset = _offset.convertToInteger().getIntValue();
-        int count = _count.convertToInteger().getIntValue();
+        int offset = numToInt(context, _offset);
+        int count = numToInt(context, _count);
 
         return values(context, buffer, dataType, offset, count);
     }
@@ -1194,7 +1186,7 @@ public class RubyIOBuffer extends RubyObject {
         if (!block.isGiven()) return RubyEnumerator.enumeratorize(context.runtime, this, "each_byte", Helpers.arrayOf(_offset));
 
         ByteBuffer buffer = getBufferForReading(context);
-        int offset = _offset.convertToInteger().getIntValue();
+        int offset = numToInt(context, _offset);
 
         return eachByte(context, buffer, offset, size - offset, block);
     }
@@ -1204,8 +1196,8 @@ public class RubyIOBuffer extends RubyObject {
         if (!block.isGiven()) return RubyEnumerator.enumeratorize(context.runtime, this, "each_byte", Helpers.arrayOf(_offset, _count));
 
         ByteBuffer buffer = getBufferForReading(context);
-        int offset = _offset.convertToInteger().getIntValue();
-        int count = _count.convertToInteger().getIntValue();
+        int offset = numToInt(context, _offset);
+        int count = numToInt(context, _count);
 
         return eachByte(context, buffer, offset, count, block);
     }
@@ -1226,34 +1218,34 @@ public class RubyIOBuffer extends RubyObject {
 
         switch (dataType) {
             case S8:
-                writeByte(context, buffer, offset, (byte) unwrapLong(context, value));
+                writeByte(context, buffer, offset, (byte) numToLong(context, value));
                 return;
             case U8:
-                writeUnsignedByte(context, buffer, offset, (int) unwrapLong(context, value));
+                writeUnsignedByte(context, buffer, offset, (int) numToLong(context, value));
                 return;
             case u16:
-                writeUnsignedShort(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (int) unwrapLong(context, value));
+                writeUnsignedShort(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (int) numToLong(context, value));
                 return;
             case U16:
-                writeUnsignedShort(context, buffer, offset, ByteOrder.BIG_ENDIAN, (int) unwrapLong(context, value));
+                writeUnsignedShort(context, buffer, offset, ByteOrder.BIG_ENDIAN, (int) numToLong(context, value));
                 return;
             case s16:
-                writeShort(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (short) unwrapLong(context, value));
+                writeShort(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (short) numToLong(context, value));
                 return;
             case S16:
-                writeShort(context, buffer, offset, ByteOrder.BIG_ENDIAN, (short) unwrapLong(context, value));
+                writeShort(context, buffer, offset, ByteOrder.BIG_ENDIAN, (short) numToLong(context, value));
                 return;
             case u32:
-                writeUnsignedInt(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, unwrapLong(context, value));
+                writeUnsignedInt(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, numToLong(context, value));
                 return;
             case U32:
-                writeUnsignedInt(context, buffer, offset, ByteOrder.BIG_ENDIAN, unwrapLong(context, value));
+                writeUnsignedInt(context, buffer, offset, ByteOrder.BIG_ENDIAN, numToLong(context, value));
                 return;
             case s32:
-                writeInt(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (int) unwrapLong(context, value));
+                writeInt(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (int) numToLong(context, value));
                 return;
             case S32:
-                writeInt(context, buffer, offset, ByteOrder.BIG_ENDIAN, (int) unwrapLong(context, value));
+                writeInt(context, buffer, offset, ByteOrder.BIG_ENDIAN, (int) numToLong(context, value));
                 return;
             case u64:
                 writeUnsignedLong(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, unwrapUnsignedLong(value));
@@ -1262,10 +1254,10 @@ public class RubyIOBuffer extends RubyObject {
                 writeUnsignedLong(context, buffer, offset, ByteOrder.BIG_ENDIAN, unwrapUnsignedLong(value));
                 return;
             case s64:
-                writeLong(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, unwrapLong(context, value));
+                writeLong(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, numToLong(context, value));
                 return;
             case S64:
-                writeLong(context, buffer, offset, ByteOrder.BIG_ENDIAN, unwrapLong(context, value));
+                writeLong(context, buffer, offset, ByteOrder.BIG_ENDIAN, numToLong(context, value));
                 return;
             case f32:
                 writeFloat(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (float) unwrapDouble(context, value));

--- a/core/src/main/java/org/jruby/RubyIOBuffer.java
+++ b/core/src/main/java/org/jruby/RubyIOBuffer.java
@@ -12,7 +12,6 @@ import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.Helpers;
 import org.jruby.runtime.ThreadContext;
-import org.jruby.runtime.backtrace.RubyStackTraceElement;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 import org.jruby.util.io.ChannelFD;
@@ -137,7 +136,7 @@ public class RubyIOBuffer extends RubyObject {
 
     @JRubyMethod(meta = true)
     public static IRubyObject string(ThreadContext context, IRubyObject self, IRubyObject _length, Block block) {
-        int size = numToInt(context, _length);
+        int size = toInt(context, _length);
         if (size < 0) throw argumentError(context, "negative string size (or size too big)");
         RubyString string = RubyString.newString(context.runtime, new byte[size]);
         ByteList bytes = string.getByteList();
@@ -295,14 +294,14 @@ public class RubyIOBuffer extends RubyObject {
 
     @JRubyMethod(name = "initialize")
     public IRubyObject initialize(ThreadContext context, IRubyObject size) {
-        return initialize(context, numToInt(context, size));
+        return initialize(context, toInt(context, size));
     }
 
     @JRubyMethod(name = "initialize")
     public IRubyObject initialize(ThreadContext context, IRubyObject _size, IRubyObject flags) {
-        int size = numToInt(context, _size);
+        int size = toInt(context, _size);
 
-        initialize(context, new byte[size], size, numToInt(context, flags), context.nil);
+        initialize(context, new byte[size], size, toInt(context, flags), context.nil);
 
         return context.nil;
     }
@@ -702,7 +701,7 @@ public class RubyIOBuffer extends RubyObject {
 
     @JRubyMethod(name = "resize")
     public IRubyObject resize(ThreadContext context, IRubyObject size) {
-        resize(context, numToInt(context, size));
+        resize(context, toInt(context, size));
 
         return this;
     }
@@ -1105,7 +1104,7 @@ public class RubyIOBuffer extends RubyObject {
 
         ByteBuffer buffer = getBufferForReading(context);
         DataType dataType = getDataType(_dataType);
-        int offset = numToInt(context, _offset);
+        int offset = toInt(context, _offset);
 
         return each(context, buffer, dataType, offset, size - offset, block);
     }
@@ -1116,8 +1115,8 @@ public class RubyIOBuffer extends RubyObject {
 
         ByteBuffer buffer = getBufferForReading(context);
         DataType dataType = getDataType(_dataType);
-        int offset = numToInt(context, _offset);
-        int count = numToInt(context, _count);
+        int offset = toInt(context, _offset);
+        int count = toInt(context, _count);
 
         return each(context, buffer, dataType, offset, count, block);
     }
@@ -1145,7 +1144,7 @@ public class RubyIOBuffer extends RubyObject {
     public IRubyObject values(ThreadContext context, IRubyObject _dataType, IRubyObject _offset) {
         ByteBuffer buffer = getBufferForReading(context);
         DataType dataType = getDataType(_dataType);
-        int offset = numToInt(context, _offset);
+        int offset = toInt(context, _offset);
 
         return values(context, buffer, dataType, offset, size - offset);
     }
@@ -1154,8 +1153,8 @@ public class RubyIOBuffer extends RubyObject {
     public IRubyObject values(ThreadContext context, IRubyObject _dataType, IRubyObject _offset, IRubyObject _count) {
         ByteBuffer buffer = getBufferForReading(context);
         DataType dataType = getDataType(_dataType);
-        int offset = numToInt(context, _offset);
-        int count = numToInt(context, _count);
+        int offset = toInt(context, _offset);
+        int count = toInt(context, _count);
 
         return values(context, buffer, dataType, offset, count);
     }
@@ -1186,7 +1185,7 @@ public class RubyIOBuffer extends RubyObject {
         if (!block.isGiven()) return RubyEnumerator.enumeratorize(context.runtime, this, "each_byte", Helpers.arrayOf(_offset));
 
         ByteBuffer buffer = getBufferForReading(context);
-        int offset = numToInt(context, _offset);
+        int offset = toInt(context, _offset);
 
         return eachByte(context, buffer, offset, size - offset, block);
     }
@@ -1196,8 +1195,8 @@ public class RubyIOBuffer extends RubyObject {
         if (!block.isGiven()) return RubyEnumerator.enumeratorize(context.runtime, this, "each_byte", Helpers.arrayOf(_offset, _count));
 
         ByteBuffer buffer = getBufferForReading(context);
-        int offset = numToInt(context, _offset);
-        int count = numToInt(context, _count);
+        int offset = toInt(context, _offset);
+        int count = toInt(context, _count);
 
         return eachByte(context, buffer, offset, count, block);
     }
@@ -1218,34 +1217,34 @@ public class RubyIOBuffer extends RubyObject {
 
         switch (dataType) {
             case S8:
-                writeByte(context, buffer, offset, (byte) numToLong(context, value));
+                writeByte(context, buffer, offset, (byte) toLong(context, value));
                 return;
             case U8:
-                writeUnsignedByte(context, buffer, offset, (int) numToLong(context, value));
+                writeUnsignedByte(context, buffer, offset, (int) toLong(context, value));
                 return;
             case u16:
-                writeUnsignedShort(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (int) numToLong(context, value));
+                writeUnsignedShort(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (int) toLong(context, value));
                 return;
             case U16:
-                writeUnsignedShort(context, buffer, offset, ByteOrder.BIG_ENDIAN, (int) numToLong(context, value));
+                writeUnsignedShort(context, buffer, offset, ByteOrder.BIG_ENDIAN, (int) toLong(context, value));
                 return;
             case s16:
-                writeShort(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (short) numToLong(context, value));
+                writeShort(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (short) toLong(context, value));
                 return;
             case S16:
-                writeShort(context, buffer, offset, ByteOrder.BIG_ENDIAN, (short) numToLong(context, value));
+                writeShort(context, buffer, offset, ByteOrder.BIG_ENDIAN, (short) toLong(context, value));
                 return;
             case u32:
-                writeUnsignedInt(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, numToLong(context, value));
+                writeUnsignedInt(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, toLong(context, value));
                 return;
             case U32:
-                writeUnsignedInt(context, buffer, offset, ByteOrder.BIG_ENDIAN, numToLong(context, value));
+                writeUnsignedInt(context, buffer, offset, ByteOrder.BIG_ENDIAN, toLong(context, value));
                 return;
             case s32:
-                writeInt(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (int) numToLong(context, value));
+                writeInt(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (int) toLong(context, value));
                 return;
             case S32:
-                writeInt(context, buffer, offset, ByteOrder.BIG_ENDIAN, (int) numToLong(context, value));
+                writeInt(context, buffer, offset, ByteOrder.BIG_ENDIAN, (int) toLong(context, value));
                 return;
             case u64:
                 writeUnsignedLong(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, unwrapUnsignedLong(value));
@@ -1254,10 +1253,10 @@ public class RubyIOBuffer extends RubyObject {
                 writeUnsignedLong(context, buffer, offset, ByteOrder.BIG_ENDIAN, unwrapUnsignedLong(value));
                 return;
             case s64:
-                writeLong(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, numToLong(context, value));
+                writeLong(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, toLong(context, value));
                 return;
             case S64:
-                writeLong(context, buffer, offset, ByteOrder.BIG_ENDIAN, numToLong(context, value));
+                writeLong(context, buffer, offset, ByteOrder.BIG_ENDIAN, toLong(context, value));
                 return;
             case f32:
                 writeFloat(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (float) unwrapDouble(context, value));
@@ -1708,50 +1707,45 @@ public class RubyIOBuffer extends RubyObject {
 
     @JRubyMethod(name = "read")
     public IRubyObject read(ThreadContext context, IRubyObject io, IRubyObject _length) {
-        if (_length.isNil()) {
-            return read(context, io);
-        }
+        if (_length.isNil()) return read(context, io);
 
         IRubyObject scheduler = context.getFiberCurrentThread().getSchedulerCurrent();
-        RubyInteger lengthInteger = _length.convertToInteger();
+        RubyInteger lengthInteger = toInteger(context, _length);
 
         if (!scheduler.isNil()) {
             IRubyObject result = FiberScheduler.ioRead(context, scheduler, io, this, lengthInteger, RubyFixnum.zero(context.runtime));
 
-            if (result != null) {
-                return result;
-            }
+            if (result != null) return result;
         }
 
-        return read(context, io, lengthInteger.getIntValue(), 0);
+        return read(context, io, lengthInteger.asInt(context), 0);
     }
 
     @JRubyMethod(name = "read")
     public IRubyObject read(ThreadContext context, IRubyObject io, IRubyObject _length, IRubyObject _offset) {
         IRubyObject scheduler = context.getFiberCurrentThread().getSchedulerCurrent();
-        RubyInteger offsetInteger = _offset.convertToInteger();
-        int offset = offsetInteger.getIntValue();
+        RubyInteger offset = toInteger(context, _offset);
 
         int length;
         RubyInteger lengthInteger;
         if (_length.isNil()) {
-            length = size - offset;
+            length = size - offset.asInt(context);
             lengthInteger = null;
         } else {
-            lengthInteger = _length.convertToInteger();
-            length = lengthInteger.getIntValue();
+            lengthInteger = toInteger(context, _length);
+            length = lengthInteger.asInt(context);
         }
 
         if (!scheduler.isNil()) {
             if (lengthInteger == null) lengthInteger = asFixnum(context, length);
-            IRubyObject result = FiberScheduler.ioRead(context, scheduler, io, this, lengthInteger, offsetInteger);
+            IRubyObject result = FiberScheduler.ioRead(context, scheduler, io, this, lengthInteger, offset);
 
             if (result != UNDEF) {
                 return result;
             }
         }
 
-        return read(context, io, length, offset);
+        return read(context, io, length, offset.asInt(context));
     }
 
     public IRubyObject read(ThreadContext context, IRubyObject io, int length, int offset) {
@@ -1792,7 +1786,7 @@ public class RubyIOBuffer extends RubyObject {
     @JRubyMethod(name = "pread")
     public IRubyObject pread(ThreadContext context, IRubyObject io, IRubyObject _from) {
         IRubyObject scheduler = context.getFiberCurrentThread().getSchedulerCurrent();
-        RubyInteger fromInteger = _from.convertToInteger();
+        RubyInteger fromInteger = toInteger(context, _from);
         int offset = 0;
         int length = defaultLength(context, offset);
 
@@ -1805,26 +1799,21 @@ public class RubyIOBuffer extends RubyObject {
 
         int from = RubyNumeric.num2int(_from);
 
-
         return pread(context, RubyIO.convertToIO(context, io), from, length, offset);
     }
 
     @JRubyMethod(name = "pread")
     public IRubyObject pread(ThreadContext context, IRubyObject io, IRubyObject _from, IRubyObject _length) {
         IRubyObject scheduler = context.getFiberCurrentThread().getSchedulerCurrent();
-        RubyInteger fromInteger = _from.convertToInteger();
-        RubyInteger lengthInteger = _length.convertToInteger();
+        RubyInteger fromInteger = toInteger(context, _from);
+        RubyInteger lengthInteger = toInteger(context, _length);
 
         if (!scheduler.isNil()) {
-            IRubyObject result = FiberScheduler.ioPRead(context, scheduler, io, this, fromInteger, lengthInteger, RubyFixnum.zero(context.runtime));
-
-            if (result != UNDEF) {
-                return result;
-            }
+            IRubyObject result = FiberScheduler.ioPRead(context, scheduler, io, this, fromInteger, lengthInteger, asFixnum(context, 0));
+            if (result != UNDEF) return result;
         }
 
         int from = RubyNumeric.num2int(fromInteger);
-
         int offset = 0;
         int length = extractLength(context, lengthInteger, offset);
 
@@ -1849,20 +1838,16 @@ public class RubyIOBuffer extends RubyObject {
 
     public IRubyObject pread(ThreadContext context, IRubyObject io, IRubyObject _from, IRubyObject _length, IRubyObject _offset) {
         IRubyObject scheduler = context.getFiberCurrentThread().getSchedulerCurrent();
-        RubyInteger fromInteger = _from.convertToInteger();
-        RubyInteger lengthInteger = _length.convertToInteger();
-        RubyInteger offsetInteger = _offset.convertToInteger();
+        RubyInteger fromInteger = toInteger(context, _from);
+        RubyInteger lengthInteger = toInteger(context, _length);
+        RubyInteger offsetInteger = toInteger(context, _offset);
 
         if (!scheduler.isNil()) {
             IRubyObject result = FiberScheduler.ioPRead(context, scheduler, io, this, fromInteger, lengthInteger, offsetInteger);
-
-            if (result != UNDEF) {
-                return result;
-            }
+            if (result != UNDEF) return result;
         }
 
         int from = RubyNumeric.num2int(fromInteger);
-
         int offset = extractOffset(context, offsetInteger);
         int length = extractLength(context, lengthInteger, offset);
 
@@ -1961,34 +1946,28 @@ public class RubyIOBuffer extends RubyObject {
     @JRubyMethod(name = "write")
     public IRubyObject write(ThreadContext context, IRubyObject io, IRubyObject length) {
         IRubyObject scheduler = context.getFiberCurrentThread().getSchedulerCurrent();
-        RubyInteger lengthInteger = length.convertToInteger();
+        RubyInteger lengthInteger = toInteger(context, length);
 
         if (!scheduler.isNil()) {
             IRubyObject result = FiberScheduler.ioWrite(context, scheduler, io, this, lengthInteger, RubyFixnum.zero(context.runtime));
-
-            if (result != null) {
-                return result;
-            }
+            if (result != null) return result;
         }
 
-        return write(context, io, lengthInteger.getIntValue(), 0);
+        return write(context, io, lengthInteger.asInt(context), 0);
     }
 
     @JRubyMethod(name = "write")
     public IRubyObject write(ThreadContext context, IRubyObject io, IRubyObject length, IRubyObject offset) {
         IRubyObject scheduler = context.getFiberCurrentThread().getSchedulerCurrent();
-        RubyInteger lengthInteger = length.convertToInteger();
-        RubyInteger offsetInteger = offset.convertToInteger();
+        RubyInteger lengthInteger = toInteger(context, length);
+        RubyInteger offsetInteger = toInteger(context, offset);
 
         if (!scheduler.isNil()) {
             IRubyObject result = FiberScheduler.ioWrite(context, scheduler, io, this, lengthInteger, offsetInteger);
-
-            if (result != null) {
-                return result;
-            }
+            if (result != null) return result;
         }
 
-        return write(context, io, lengthInteger.getIntValue(), offsetInteger.getIntValue());
+        return write(context, io, lengthInteger.asInt(context), offsetInteger.asInt(context));
     }
 
     public IRubyObject write(ThreadContext context, IRubyObject io, int length, int offset) {
@@ -2016,14 +1995,13 @@ public class RubyIOBuffer extends RubyObject {
     @JRubyMethod(name = "pwrite")
     public IRubyObject pwrite(ThreadContext context, IRubyObject io, IRubyObject _from) {
         IRubyObject scheduler = context.getFiberCurrentThread().getSchedulerCurrent();
-        RubyInteger fromInteger = _from.convertToInteger();
+        RubyInteger fromInteger = toInteger(context, _from);
         int offset = 0;
         int length = defaultLength(context, offset);
 
         if (!scheduler.isNil()) {
             IRubyObject result = FiberScheduler.ioPWrite(context, scheduler, io, this, fromInteger,
                     asFixnum(context, length), asFixnum(context, 0));
-
             if (result != null) return result;
         }
 
@@ -2035,19 +2013,15 @@ public class RubyIOBuffer extends RubyObject {
     @JRubyMethod(name = "pwrite")
     public IRubyObject pwrite(ThreadContext context, IRubyObject io, IRubyObject _from, IRubyObject _length) {
         IRubyObject scheduler = context.getFiberCurrentThread().getSchedulerCurrent();
-        RubyInteger fromInteger = _from.convertToInteger();
-        RubyInteger lengthInteger = _length.convertToInteger();
+        RubyInteger fromInteger = toInteger(context, _from);
+        RubyInteger lengthInteger = toInteger(context, _length);
 
         if (!scheduler.isNil()) {
             IRubyObject result = FiberScheduler.ioPWrite(context, scheduler, io, this, fromInteger, lengthInteger, RubyFixnum.zero(context.runtime));
-
-            if (result != null) {
-                return result;
-            }
+            if (result != null) return result;
         }
 
         int from = RubyNumeric.num2int(fromInteger);
-
         int offset = 0;
         int length = extractLength(context, lengthInteger, offset);
 
@@ -2072,20 +2046,16 @@ public class RubyIOBuffer extends RubyObject {
 
     public IRubyObject pwrite(ThreadContext context, IRubyObject io, IRubyObject _from, IRubyObject _length, IRubyObject _offset) {
         IRubyObject scheduler = context.getFiberCurrentThread().getSchedulerCurrent();
-        RubyInteger fromInteger = _from.convertToInteger();
-        RubyInteger lengthInteger = _length.convertToInteger();
-        RubyInteger offsetInteger = _offset.convertToInteger();
+        RubyInteger fromInteger = toInteger(context, _from);
+        RubyInteger lengthInteger = toInteger(context, _length);
+        RubyInteger offsetInteger = toInteger(context, _offset);
 
         if (!scheduler.isNil()) {
             IRubyObject result = FiberScheduler.ioPWrite(context, scheduler, io, this, fromInteger, lengthInteger, offsetInteger);
-
-            if (result != null) {
-                return result;
-            }
+            if (result != null) return result;
         }
 
         int from = RubyNumeric.num2int(fromInteger);
-
         int offset = extractOffset(context, offsetInteger);
         int length = extractLength(context, lengthInteger, offset);
 

--- a/core/src/main/java/org/jruby/RubyIOBuffer.java
+++ b/core/src/main/java/org/jruby/RubyIOBuffer.java
@@ -1003,12 +1003,12 @@ public class RubyIOBuffer extends RubyObject {
         return asFloat(context, value);
     }
 
-    private static long unwrapLong(IRubyObject value) {
-        return value.convertToInteger().getLongValue();
+    private static long unwrapLong(ThreadContext context, IRubyObject value) {
+        return value.convertToInteger().asLong(context);
     }
 
-    private static double unwrapDouble(IRubyObject value) {
-        return value.convertToFloat().getDoubleValue();
+    private static double unwrapDouble(ThreadContext context, IRubyObject value) {
+        return value.convertToFloat().asDouble(context);
     }
 
     private static long unwrapUnsignedLong(IRubyObject value) {
@@ -1226,34 +1226,34 @@ public class RubyIOBuffer extends RubyObject {
 
         switch (dataType) {
             case S8:
-                writeByte(context, buffer, offset, (byte) unwrapLong(value));
+                writeByte(context, buffer, offset, (byte) unwrapLong(context, value));
                 return;
             case U8:
-                writeUnsignedByte(context, buffer, offset, (int) unwrapLong(value));
+                writeUnsignedByte(context, buffer, offset, (int) unwrapLong(context, value));
                 return;
             case u16:
-                writeUnsignedShort(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (int) unwrapLong(value));
+                writeUnsignedShort(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (int) unwrapLong(context, value));
                 return;
             case U16:
-                writeUnsignedShort(context, buffer, offset, ByteOrder.BIG_ENDIAN, (int) unwrapLong(value));
+                writeUnsignedShort(context, buffer, offset, ByteOrder.BIG_ENDIAN, (int) unwrapLong(context, value));
                 return;
             case s16:
-                writeShort(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (short) unwrapLong(value));
+                writeShort(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (short) unwrapLong(context, value));
                 return;
             case S16:
-                writeShort(context, buffer, offset, ByteOrder.BIG_ENDIAN, (short) unwrapLong(value));
+                writeShort(context, buffer, offset, ByteOrder.BIG_ENDIAN, (short) unwrapLong(context, value));
                 return;
             case u32:
-                writeUnsignedInt(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, unwrapLong(value));
+                writeUnsignedInt(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, unwrapLong(context, value));
                 return;
             case U32:
-                writeUnsignedInt(context, buffer, offset, ByteOrder.BIG_ENDIAN, unwrapLong(value));
+                writeUnsignedInt(context, buffer, offset, ByteOrder.BIG_ENDIAN, unwrapLong(context, value));
                 return;
             case s32:
-                writeInt(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (int) unwrapLong(value));
+                writeInt(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (int) unwrapLong(context, value));
                 return;
             case S32:
-                writeInt(context, buffer, offset, ByteOrder.BIG_ENDIAN, (int) unwrapLong(value));
+                writeInt(context, buffer, offset, ByteOrder.BIG_ENDIAN, (int) unwrapLong(context, value));
                 return;
             case u64:
                 writeUnsignedLong(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, unwrapUnsignedLong(value));
@@ -1262,22 +1262,22 @@ public class RubyIOBuffer extends RubyObject {
                 writeUnsignedLong(context, buffer, offset, ByteOrder.BIG_ENDIAN, unwrapUnsignedLong(value));
                 return;
             case s64:
-                writeLong(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, unwrapLong(value));
+                writeLong(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, unwrapLong(context, value));
                 return;
             case S64:
-                writeLong(context, buffer, offset, ByteOrder.BIG_ENDIAN, unwrapLong(value));
+                writeLong(context, buffer, offset, ByteOrder.BIG_ENDIAN, unwrapLong(context, value));
                 return;
             case f32:
-                writeFloat(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (float) unwrapDouble(value));
+                writeFloat(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, (float) unwrapDouble(context, value));
                 return;
             case F32:
-                writeFloat(context, buffer, offset, ByteOrder.BIG_ENDIAN, (float) unwrapDouble(value));
+                writeFloat(context, buffer, offset, ByteOrder.BIG_ENDIAN, (float) unwrapDouble(context, value));
                 return;
             case f64:
-                writeDouble(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, unwrapDouble(value));
+                writeDouble(context, buffer, offset, ByteOrder.LITTLE_ENDIAN, unwrapDouble(context, value));
                 return;
             case F64:
-                writeDouble(context, buffer, offset, ByteOrder.BIG_ENDIAN, unwrapDouble(value));
+                writeDouble(context, buffer, offset, ByteOrder.BIG_ENDIAN, unwrapDouble(context, value));
                 return;
         }
 

--- a/core/src/main/java/org/jruby/RubyInteger.java
+++ b/core/src/main/java/org/jruby/RubyInteger.java
@@ -112,7 +112,8 @@ public abstract class RubyInteger extends RubyNumeric {
 
     // conversion
     protected RubyFloat toFloat() {
-        return RubyFloat.newFloat(metaClass.runtime, getDoubleValue());
+        var context = getRuntime().getCurrentContext();
+        return asFloat(context, asDouble(context));
     }
 
     public int signum() { return getBigIntegerValue().signum(); }
@@ -338,7 +339,7 @@ public abstract class RubyInteger extends RubyNumeric {
      */
     protected static IRubyObject timesSize(ThreadContext context, RubyInteger recv, IRubyObject[] args) {
         RubyFixnum zero = RubyFixnum.zero(context.runtime);
-        if ((recv instanceof RubyFixnum && recv.getLongValue() < 0)
+        if ((recv instanceof RubyFixnum && recv.asLong(context) < 0)
                 || sites(context).op_lt.call(context, recv, recv, zero).isTrue()) {
             return zero;
         }
@@ -451,7 +452,8 @@ public abstract class RubyInteger extends RubyNumeric {
         int ret = (int) (uintResult & 0xFFFFFFFF);
         if (ret != 0) {
             throw rangeError(context, this instanceof RubyFixnum ?
-                    getLongValue() + " out of char range" : "bignum out of char range");
+                    asLong(context) + " out of char range" :
+                    "bignum out of char range");
         }
         return uint;
     }
@@ -635,7 +637,7 @@ public abstract class RubyInteger extends RubyNumeric {
     }
 
     protected boolean int_round_zero_p(ThreadContext context, int ndigits) {
-        long bytes = numericToLong(context, sites(context).size.call(context, this, this));
+        long bytes = numToLong(context, sites(context).size.call(context, this, this));
         return (-0.415241 * ndigits - 0.125 > bytes);
     }
 
@@ -695,7 +697,7 @@ public abstract class RubyInteger extends RubyNumeric {
     }
 
     private static long op_mod_two(ThreadContext context, RubyInteger self) {
-        return ((RubyInteger) sites(context).op_mod.call(context, self, self, RubyFixnum.two(context.runtime))).getLongValue();
+        return ((RubyInteger) sites(context).op_mod.call(context, self, self, RubyFixnum.two(context.runtime))).asLong(context);
     }
 
     @JRubyMethod(name = "allbits?")

--- a/core/src/main/java/org/jruby/RubyKernel.java
+++ b/core/src/main/java/org/jruby/RubyKernel.java
@@ -579,9 +579,8 @@ public class RubyKernel {
     }
 
     static RubyFloat new_float(ThreadContext context, RubyInteger num) {
-        return num instanceof RubyBignum ?
-                asFloat(context, RubyBignum.big2dbl((RubyBignum) num)) :
-                asFloat(context, num.getDoubleValue());
+        return asFloat(context, num instanceof RubyBignum big ?
+                RubyBignum.big2dbl(big) : num.asDouble(context));
     }
 
     @JRubyMethod(name = "Hash", required = 1, module = true, visibility = PRIVATE)
@@ -1258,7 +1257,7 @@ public class RubyKernel {
             if (args.length > 3) {
                 // line given, use it and force it into binding
                 // -1 because parser uses zero offsets and other code compensates
-                binding.setLine(((int) args[3].convertToInteger().getLongValue()) - 1);
+                binding.setLine(((int) args[3].convertToInteger().asLong(context)) - 1);
             } else {
                 // filename given, but no line, start from the beginning.
                 binding.setLine(0);
@@ -1759,13 +1758,13 @@ public class RubyKernel {
 
     private static int getTestCommand(ThreadContext context, IRubyObject arg0) {
         int cmd;
-        if (arg0 instanceof RubyFixnum) {
-            cmd = (int)((RubyFixnum) arg0).getLongValue();
+        if (arg0 instanceof RubyFixnum fixnum) {
+            cmd = fixnum.getIntValue();
         } else if (arg0 instanceof RubyString && ((RubyString) arg0).getByteList().length() > 0) {
             // MRI behavior: use first byte of string value if len > 0
             cmd = ((RubyString) arg0).getByteList().charAt(0);
         } else {
-            cmd = (int) arg0.convertToInteger().getLongValue();
+            cmd = (int) arg0.convertToInteger().asLong(context);
         }
 
         // MRI behavior: raise ArgumentError for 'unknown command' before checking number of args

--- a/core/src/main/java/org/jruby/RubyMarshal.java
+++ b/core/src/main/java/org/jruby/RubyMarshal.java
@@ -53,6 +53,7 @@ import org.jruby.util.IOOutputStream;
 import org.jruby.util.io.TransparentByteArrayOutputStream;
 
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Convert.numToInt;
 import static org.jruby.api.Create.newString;
 import static org.jruby.api.Define.defineModule;
 import static org.jruby.api.Error.argumentError;
@@ -100,7 +101,7 @@ public class RubyMarshal {
             throw typeError(context, "Instance of IO needed");
         }
 
-        int depthLimit = limit.convertToInteger().getIntValue();
+        int depthLimit = numToInt(context, limit);
 
         return dumpCommon(context, object, io, depthLimit);
     }

--- a/core/src/main/java/org/jruby/RubyMarshal.java
+++ b/core/src/main/java/org/jruby/RubyMarshal.java
@@ -53,7 +53,7 @@ import org.jruby.util.IOOutputStream;
 import org.jruby.util.io.TransparentByteArrayOutputStream;
 
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Create.newString;
 import static org.jruby.api.Define.defineModule;
 import static org.jruby.api.Error.argumentError;
@@ -87,7 +87,7 @@ public class RubyMarshal {
         if (ioOrLimit instanceof RubyIO || sites(context).respond_to_write.respondsTo(context, ioOrLimit, ioOrLimit)) {
             io = ioOrLimit;
         } else if (ioOrLimit instanceof RubyFixnum fixnum) {
-            depthLimit = fixnum.getIntValue();
+            depthLimit = fixnum.asInt(context);
         } else {
             throw typeError(context, "Instance of IO needed");
         }
@@ -101,7 +101,7 @@ public class RubyMarshal {
             throw typeError(context, "Instance of IO needed");
         }
 
-        int depthLimit = numToInt(context, limit);
+        int depthLimit = toInt(context, limit);
 
         return dumpCommon(context, object, io, depthLimit);
     }

--- a/core/src/main/java/org/jruby/RubyMatchData.java
+++ b/core/src/main/java/org/jruby/RubyMatchData.java
@@ -62,6 +62,7 @@ import java.util.stream.StreamSupport;
 
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.asSymbol;
+import static org.jruby.api.Convert.numToInt;
 import static org.jruby.api.Create.newArray;
 import static org.jruby.api.Create.newEmptyArray;
 import static org.jruby.api.Create.newEmptyString;
@@ -592,7 +593,7 @@ public class RubyMatchData extends RubyObject {
         if (isRange.isNil()) return context.nil;
 
         if (!isRange.isTrue()) {
-            IRubyObject nthMatch = RubyRegexp.nth_match(context, index.convertToInteger().getIntValue(), this);
+            IRubyObject nthMatch = RubyRegexp.nth_match(context, numToInt(context, index), this);
 
             // this should never happen here, but MRI allows any VALUE for result
             // if (result.isNil()) return nthMatch;
@@ -779,9 +780,8 @@ public class RubyMatchData extends RubyObject {
     private int nthToIndex(ThreadContext context, IRubyObject id) {
         int index = namevToBackrefNumber(context, id);
 
-        if (index == -1 && id instanceof RubyInteger) {
-            index = id.convertToInteger().getIntValue();
-        }
+        if (index == -1 && id instanceof RubyInteger) index = numToInt(context, id);
+
         return index;
     }
 

--- a/core/src/main/java/org/jruby/RubyMatchData.java
+++ b/core/src/main/java/org/jruby/RubyMatchData.java
@@ -62,7 +62,7 @@ import java.util.stream.StreamSupport;
 
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.asSymbol;
-import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Create.newArray;
 import static org.jruby.api.Create.newEmptyArray;
 import static org.jruby.api.Create.newEmptyString;
@@ -459,7 +459,7 @@ public class RubyMatchData extends RubyObject {
 
         for (IRubyObject arg : args) {
             if (arg instanceof RubyFixnum fix) {
-                result.append(context, RubyRegexp.nth_match(context, fix.getIntValue(), this));
+                result.append(context, RubyRegexp.nth_match(context, fix.asInt(context), this));
             } else {
                 int num = namevToBackrefNumber(context, arg);
                 if (num >= 0) {
@@ -593,7 +593,7 @@ public class RubyMatchData extends RubyObject {
         if (isRange.isNil()) return context.nil;
 
         if (!isRange.isTrue()) {
-            IRubyObject nthMatch = RubyRegexp.nth_match(context, numToInt(context, index), this);
+            IRubyObject nthMatch = RubyRegexp.nth_match(context, toInt(context, index), this);
 
             // this should never happen here, but MRI allows any VALUE for result
             // if (result.isNil()) return nthMatch;
@@ -780,7 +780,7 @@ public class RubyMatchData extends RubyObject {
     private int nthToIndex(ThreadContext context, IRubyObject id) {
         int index = namevToBackrefNumber(context, id);
 
-        if (index == -1 && id instanceof RubyInteger) index = numToInt(context, id);
+        if (index == -1 && id instanceof RubyInteger) index = toInt(context, id);
 
         return index;
     }

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -38,6 +38,7 @@ package org.jruby;
 import org.jruby.RubyEnumerator.SizeFn;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.api.JRubyAPI;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.javasupport.JavaUtil;
@@ -60,6 +61,8 @@ import java.math.BigInteger;
 import java.math.RoundingMode;
 
 import static org.jruby.RubyEnumerator.enumeratorizeWithSize;
+import static org.jruby.api.Access.floatClass;
+import static org.jruby.api.Access.integerClass;
 import static org.jruby.api.Convert.*;
 import static org.jruby.api.Create.newArray;
 import static org.jruby.api.Define.defineClass;
@@ -138,19 +141,50 @@ public class RubyNumeric extends RubyObject {
     /**
      * Return the value of this numeric as a 64-bit long. If the value does not
      * fit in 64 bits, it will be truncated.
+     * @deprecated Use {@link org.jruby.RubyNumeric#asLong(ThreadContext)} instead.
      */
-    public long getLongValue() { return 0; }
+    @Deprecated(since = "10.0")
+    public long getLongValue() {
+        return asLong(getCurrentContext());
+    }
 
     /**
      * Return the value of this numeric as a 32-bit long. If the value does not
      * fit in 32 bits, it will be truncated.
      */
-    public int getIntValue() { return (int) getLongValue(); }
+    public int getIntValue() { return (int) asLong(getRuntime().getCurrentContext()); }
 
-    public double getDoubleValue() { return getLongValue(); }
+    /**
+     * Return the value of this numeric as a 64-bit long. If the value does not
+     * fit in 64 bits, it will be truncated.
+     */
+    @JRubyAPI
+    public long asLong(ThreadContext context) {
+        return 0;
+    }
+
+    /**
+     * Return a double representation of this numerical value
+     *
+     * @param context the current thread context
+     * @return a double
+     */
+    @JRubyAPI
+    public double asDouble(ThreadContext context) {
+        return asLong(context);
+    }
+
+    /**
+     * @return
+     * @deprecated Use {@link org.jruby.RubyNumeric#asDouble(ThreadContext)} instead.
+     */
+    @Deprecated(since = "10.0")
+    public double getDoubleValue() {
+        return asDouble(getCurrentContext());
+    }
 
     public BigInteger getBigIntegerValue() {
-        return BigInteger.valueOf(getLongValue());
+        return BigInteger.valueOf(asLong(getRuntime().getCurrentContext()));
     }
 
     public static RubyNumeric newNumeric(Ruby runtime) {
@@ -217,13 +251,13 @@ public class RubyNumeric extends RubyObject {
     }
 
     private static long other2long(IRubyObject arg) throws RaiseException {
-        if (arg instanceof RubyFloat) return float2long((RubyFloat) arg);
-        if (arg instanceof RubyBignum) return RubyBignum.big2long((RubyBignum) arg);
+        if (arg instanceof RubyFloat flote) return float2long(flote);
+        if (arg instanceof RubyBignum bignum) return RubyBignum.big2long(bignum);
 
-        Ruby runtime = arg.getRuntime();
-        if (arg.isNil()) throw typeError(runtime.getCurrentContext(), "no implicit conversion from nil to integer");
+        var context = arg.getRuntime().getCurrentContext();
+        if (arg.isNil()) throw typeError(context, "no implicit conversion from nil to integer");
 
-        return ((RubyInteger) TypeConverter.convertToType(arg, runtime.getInteger(), "to_int")).getLongValue();
+        return ((RubyInteger) TypeConverter.convertToType(arg, integerClass(context), "to_int")).asLong(context);
     }
 
     public static long float2long(RubyFloat flt) {
@@ -323,13 +357,13 @@ public class RubyNumeric extends RubyObject {
             case FLOAT:
                 return ((RubyFloat) arg).value;
             case FIXNUM:
-                if (context.sites.Fixnum.to_f.isBuiltin(arg)) return ((RubyFixnum) arg).value;
+                if (context.sites.Fixnum.to_f.isBuiltin(arg)) return ((RubyNumeric) arg).asDouble(context);
                 break;
             case BIGNUM:
-                if (context.sites.Bignum.to_f.isBuiltin(arg)) return ((RubyBignum) arg).getDoubleValue();
+                if (context.sites.Bignum.to_f.isBuiltin(arg)) return ((RubyBignum) arg).asDouble(context);
                 break;
             case RATIONAL:
-                if (context.sites.Rational.to_f.isBuiltin(arg)) return ((RubyRational) arg).getDoubleValue();
+                if (context.sites.Rational.to_f.isBuiltin(arg)) return ((RubyRational) arg).asDouble(context);
                 break;
             case STRING:
                 throw typeError(context, "no implicit conversion to float from string");
@@ -340,7 +374,7 @@ public class RubyNumeric extends RubyObject {
             case FALSE:
                 throw typeError(context, "no implicit conversion to float from false");
         }
-        IRubyObject val = TypeConverter.convertToType(arg, context.runtime.getFloat(), "to_f");
+        IRubyObject val = TypeConverter.convertToType(arg, floatClass(context), "to_f");
         return ((RubyFloat) val).value;
     }
 
@@ -1143,7 +1177,7 @@ public class RubyNumeric extends RubyObject {
             }
         } else {
             // We must avoid integer overflows in "i += step".
-            long end = ((RubyFixnum) to).getLongValue();
+            long end = ((RubyFixnum) to).getValue();
             if (desc) {
                 long tov = Long.MIN_VALUE - diff;
                 if (end > tov) tov = end;
@@ -1423,10 +1457,12 @@ public class RubyNumeric extends RubyObject {
      */
     @JRubyMethod(name = {"arg", "angle", "phase"})
     public IRubyObject arg(ThreadContext context) {
-        final double value = getDoubleValue();
+        final double value = asDouble(context);
         if (Double.isNaN(value)) return this;
+
         return f_negative_p(context, this) || value == 0.0 && 1 / value == Double.NEGATIVE_INFINITY ?
-            context.runtime.getMath().getConstant(context, "PI") : asFixnum(context, 0);
+                context.runtime.getMath().getConstant(context, "PI") :
+                asFixnum(context, 0);
     }
 
     /** numeric_rect

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -152,11 +152,18 @@ public class RubyNumeric extends RubyObject {
      * Return the value of this numeric as a 32-bit long. If the value does not
      * fit in 32 bits, it will be truncated.
      */
-    public int getIntValue() { return (int) asLong(getRuntime().getCurrentContext()); }
+    public int getIntValue() { return asInt(getRuntime().getCurrentContext()); }
 
     /**
-     * Return the value of this numeric as a 64-bit long. If the value does not
-     * fit in 64 bits, it will be truncated.
+     * Returns the value of this numeric and a java int.
+     */
+    @JRubyAPI
+    public int asInt(ThreadContext context) {
+        return (int) asLong(context);
+    }
+
+    /**
+     * Return the value of this numeric as a 64-bit long.
      */
     @JRubyAPI
     public long asLong(ThreadContext context) {
@@ -1253,7 +1260,7 @@ public class RubyNumeric extends RubyObject {
             double n = floatStepSize(from.convertToFloat().value, to.convertToFloat().value, step.convertToFloat().value, excl);
 
             if (Double.isInfinite(n)) return asFloat(context, n);
-            if (posFixable(n)) return asFloat(context, n).convertToInteger();
+            if (posFixable(n)) return toInteger(context, asFloat(context, n));
 
             return RubyBignum.newBignorm(context.runtime, n);
         }

--- a/core/src/main/java/org/jruby/RubyNumeric.java
+++ b/core/src/main/java/org/jruby/RubyNumeric.java
@@ -204,7 +204,7 @@ public class RubyNumeric extends RubyObject {
      */
 
     /** rb_num2int, NUM2INT
-     * if you know it is Integer use {@link org.jruby.api.Convert#asInt(ThreadContext, RubyInteger)}.
+     * if you know it is Integer use {@link org.jruby.api.Convert#toInt(ThreadContext, IRubyObject)}.
      */
     public static int num2int(IRubyObject arg) {
         long num = num2long(arg);

--- a/core/src/main/java/org/jruby/RubyObject.java
+++ b/core/src/main/java/org/jruby/RubyObject.java
@@ -56,7 +56,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.marshal.DataType;
 
 import static org.jruby.api.Convert.asBoolean;
-import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.runtime.Helpers.invokedynamic;
@@ -356,7 +356,7 @@ public class RubyObject extends RubyBasicObject {
         int line;
         if (args.length > 1) {
             file = args[1].convertToString().asJavaString();
-            line = args.length > 2 ? numToInt(context, args[2]) - 1 : 0;
+            line = args.length > 2 ? toInt(context, args[2]) - 1 : 0;
         } else {
             file = "(eval at " + context.getFileAndLine() + ")";
             line = 0;

--- a/core/src/main/java/org/jruby/RubyObject.java
+++ b/core/src/main/java/org/jruby/RubyObject.java
@@ -355,7 +355,7 @@ public class RubyObject extends RubyBasicObject {
         int line;
         if (args.length > 1) {
             file = args[1].convertToString().asJavaString();
-            line = args.length > 2 ? (int)(args[2].convertToInteger().getLongValue() - 1) : 0;
+            line = args.length > 2 ? (int)(args[2].convertToInteger().asLong(context) - 1) : 0;
         } else {
             file = "(eval at " + context.getFileAndLine() + ")";
             line = 0;

--- a/core/src/main/java/org/jruby/RubyObject.java
+++ b/core/src/main/java/org/jruby/RubyObject.java
@@ -56,6 +56,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.runtime.marshal.DataType;
 
 import static org.jruby.api.Convert.asBoolean;
+import static org.jruby.api.Convert.numToInt;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.runtime.Helpers.invokedynamic;
@@ -355,7 +356,7 @@ public class RubyObject extends RubyBasicObject {
         int line;
         if (args.length > 1) {
             file = args[1].convertToString().asJavaString();
-            line = args.length > 2 ? (int)(args[2].convertToInteger().asLong(context) - 1) : 0;
+            line = args.length > 2 ? numToInt(context, args[2]) - 1 : 0;
         } else {
             file = "(eval at " + context.getFileAndLine() + ")";
             line = 0;

--- a/core/src/main/java/org/jruby/RubyObjectSpace.java
+++ b/core/src/main/java/org/jruby/RubyObjectSpace.java
@@ -133,17 +133,12 @@ public class RubyObjectSpace {
 
     @JRubyMethod(name = "_id2ref", module = true, visibility = PRIVATE)
     public static IRubyObject id2ref(ThreadContext context, IRubyObject recv, IRubyObject id) {
-        long longId = castAsFixnum(context, id).getLongValue();
-        if (longId == 0) {
-            return context.fals;
-        } else if (longId == 20) {
-            return context.tru;
-        } else if (longId == 8) {
-            return context.nil;
-        } else if ((longId & 0b01) == 0b01) {
-            // fixnum
-            return asFixnum(context, (longId - 1) / 2);
-        } else if ((longId & 0b11) == 0b10) {
+        long longId = castAsFixnum(context, id).getValue();
+        if (longId == 0) return context.fals;
+        if (longId == 20) return context.tru;
+        if (longId == 8) return context.nil;
+        if ((longId & 0b01) == 0b01) return asFixnum(context, (longId - 1) / 2);  // fixnum
+        if ((longId & 0b11) == 0b10) {
             // flonum
             double d = 0.0;
             if (longId != 0x8000000000000002L) {

--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -115,7 +115,7 @@ public class RubyProcess {
         context.runtime.setProcSys(Process.defineModuleUnder(context, "Sys").defineMethods(context, Sys.class));
 
         if (Platform.IS_WINDOWS) {
-            var singleton = ProcessStatus.singletonClass(context);
+            var singleton = Process.singletonClass(context);
             // mark rlimit methods as not implemented and skip defining the constants (GH-6491)
             singleton.retrieveMethod("getrlimit").setNotImplemented(true);
             singleton.retrieveMethod("setrlimit").setNotImplemented(true);
@@ -194,8 +194,8 @@ public class RubyProcess {
             var pstatus = (RubyFixnum) status.removeInternalVariable("status");
             var pid = (RubyFixnum) status.removeInternalVariable("pid");
 
-            status.status = pstatus.getValue();
-            status.pid = pid.getValue();
+            status.status = pstatus.asLong(context);
+            status.pid = pid.asLong(context);
 
             return status;
         }

--- a/core/src/main/java/org/jruby/RubyProcess.java
+++ b/core/src/main/java/org/jruby/RubyProcess.java
@@ -225,8 +225,8 @@ public class RubyProcess {
         public static IRubyObject wait(ThreadContext context, IRubyObject self, IRubyObject[] args) {
             int argc = Arity.checkArgumentCount(context, args, 0, 2);
 
-            long pid = argc > 0 ? numToInt(context, args[0]) : -1;
-            int flags = argc > 1 ? numToInt(context, args[1]) : 0;
+            long pid = argc > 0 ? toInt(context, args[0]) : -1;
+            int flags = argc > 1 ? toInt(context, args[1]) : 0;
 
             return waitpidStatus(context, pid, flags);
             //checkErrno(runtime, pid, ECHILD);
@@ -234,7 +234,7 @@ public class RubyProcess {
 
         @JRubyMethod(name = "&")
         public IRubyObject op_and(ThreadContext context, IRubyObject arg) {
-            long mask = numToInt(context, arg);
+            long mask = toInt(context, arg);
 
             if (mask < 0) throw argumentError(context, "negative mask value: " + mask);
             if (mask > Integer.MAX_VALUE || mask < Integer.MIN_VALUE) {
@@ -329,7 +329,7 @@ public class RubyProcess {
 
         @JRubyMethod(name = ">>")
         public IRubyObject op_rshift(ThreadContext context, IRubyObject other) {
-            long places = numToInt(context, other);
+            long places = toInt(context, other);
 
             if (places < 0) throw argumentError(context, "negative shift value: " + places);
             if (places > Integer.MAX_VALUE) throw rangeError(context, "shift value out of range: " + places);
@@ -446,7 +446,7 @@ public class RubyProcess {
         @Deprecated
         public IRubyObject op_rshift(Ruby runtime, IRubyObject other) {
             var context = getCurrentContext();
-            long shiftValue = numToLong(context, other);
+            long shiftValue = toLong(context, other);
             return asFixnum(context, status >> shiftValue);
         }
 
@@ -832,7 +832,7 @@ public class RubyProcess {
         /* fall through */
 
             case INTEGER:
-                return numToInt(context, rval);
+                return toInt(context, rval);
         }
 
         if (RLIM.RLIM_INFINITY.defined()) {
@@ -873,7 +873,7 @@ public class RubyProcess {
         /* fall through */
 
             case INTEGER:
-                return numToInt(context, rtype);
+                return toInt(context, rtype);
         }
 
         r = rlimitTypeByHname(name);
@@ -1307,7 +1307,7 @@ public class RubyProcess {
     public static IRubyObject egid_set(ThreadContext context, IRubyObject arg) {
         int gid;
         if (arg instanceof RubyInteger || arg.checkStringType().isNil()) {
-            gid = numToInt(context, arg);
+            gid = toInt(context, arg);
         } else {
             Group group = context.runtime.getPosix().getgrnam(arg.asJavaString());
             if (group == null) throw argumentError(context, "can't find group for " + arg.inspect(context));
@@ -1337,7 +1337,7 @@ public class RubyProcess {
     }
     @JRubyMethod(name = "uid=", module = true, visibility = PRIVATE)
     public static IRubyObject uid_set(ThreadContext context, IRubyObject recv, IRubyObject arg) {
-        checkErrno(context, context.runtime.getPosix().setuid(numToInt(context, arg)));
+        checkErrno(context, context.runtime.getPosix().setuid(toInt(context, arg)));
         return asFixnum(context, 0);
     }
     @Deprecated
@@ -1380,8 +1380,8 @@ public class RubyProcess {
     }
     @JRubyMethod(name = "getpriority", module = true, visibility = PRIVATE)
     public static IRubyObject getpriority(ThreadContext context, IRubyObject recv, IRubyObject arg1, IRubyObject arg2) {
-        int which = numToInt(context, arg1);
-        int who = numToInt(context, arg2);
+        int which = toInt(context, arg1);
+        int who = toInt(context, arg2);
         int result = checkErrno(context, context.runtime.getPosix().getpriority(which, who));
 
         return asFixnum(context, result);
@@ -1456,7 +1456,7 @@ public class RubyProcess {
     }
     @JRubyMethod(name = "gid=", module = true, visibility = PRIVATE)
     public static IRubyObject gid_set(ThreadContext context, IRubyObject recv, IRubyObject arg) {
-        int result = checkErrno(context, context.runtime.getPosix().setgid(numToInt(context, arg)));
+        int result = checkErrno(context, context.runtime.getPosix().setgid(toInt(context, arg)));
 
         return asFixnum(context, result);
 
@@ -1499,7 +1499,7 @@ public class RubyProcess {
     public static IRubyObject euid_set(ThreadContext context, IRubyObject arg) {
         int uid;
         if (arg instanceof RubyInteger || arg.checkStringType().isNil()) {
-            uid = numToInt(context, arg);
+            uid = toInt(context, arg);
         } else {
             Passwd password = context.runtime.getPosix().getpwnam(arg.asJavaString());
             if (password == null) {
@@ -1517,9 +1517,9 @@ public class RubyProcess {
     }
     @JRubyMethod(name = "setpriority", module = true, visibility = PRIVATE)
     public static IRubyObject setpriority(ThreadContext context, IRubyObject recv, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3) {
-        int which = numToInt(context, arg1);
-        int who = numToInt(context, arg2);
-        int prio = numToInt(context, arg3);
+        int which = toInt(context, arg1);
+        int who = toInt(context, arg2);
+        int prio = toInt(context, arg3);
         var posix = context.runtime.getPosix();
         posix.errno(0);
         return asFixnum(context, checkErrno(context, posix.setpriority(which, who, prio)));
@@ -1536,8 +1536,8 @@ public class RubyProcess {
     }
     @JRubyMethod(name = "setpgid", module = true, visibility = PRIVATE)
     public static IRubyObject setpgid(ThreadContext context, IRubyObject recv, IRubyObject arg1, IRubyObject arg2) {
-        int pid = numToInt(context, arg1);
-        int gid = numToInt(context, arg2);
+        int pid = toInt(context, arg1);
+        int gid = toInt(context, arg2);
         return asFixnum(context, checkErrno(context, context.runtime.getPosix().setpgid(pid, gid)));
     }
 
@@ -1552,7 +1552,7 @@ public class RubyProcess {
     }
     @JRubyMethod(name = "getpgid", module = true, visibility = PRIVATE)
     public static IRubyObject getpgid(ThreadContext context, IRubyObject recv, IRubyObject arg) {
-        int pgid = numToInt(context, arg);
+        int pgid = toInt(context, arg);
         return asFixnum(context, checkErrno(context, context.runtime.getPosix().getpgid(pgid)));
 
     }
@@ -1733,7 +1733,7 @@ public class RubyProcess {
 
     @JRubyMethod(name = "detach", module = true, visibility = PRIVATE)
     public static IRubyObject detach(ThreadContext context, IRubyObject recv, IRubyObject arg) {
-        final long pid = numToLong(context, arg);
+        final long pid = toLong(context, arg);
 
         BlockCallback callback = (ctx, args, block) -> {
             // push a dummy frame to avoid AIOOB if an exception fires

--- a/core/src/main/java/org/jruby/RubyRandom.java
+++ b/core/src/main/java/org/jruby/RubyRandom.java
@@ -71,7 +71,7 @@ public class RubyRandom extends RubyRandomBase {
         }
 
         public static Random randomFromFixnum(RubyFixnum seed) {
-            return randomFromLong(numToLong(seed.getRuntime().getCurrentContext(), seed));
+            return randomFromLong(toLong(seed.getRuntime().getCurrentContext(), seed));
         }
 
         public static Random randomFromLong(long seed) {
@@ -272,7 +272,7 @@ public class RubyRandom extends RubyRandomBase {
         if (arg == context.nil) return randFloat(context, random);
         if (arg instanceof RubyRange) return randRandom(context, self, random, arg);
 
-        RubyInteger max = arg.convertToInteger();
+        RubyInteger max = toInteger(context, arg);
         if (max.isZero(context)) return randFloat(context, random);
 
         IRubyObject r = randInt(context, self, random, max, false);
@@ -389,7 +389,7 @@ public class RubyRandom extends RubyRandomBase {
 
     @JRubyMethod(name = "urandom", meta = true)
     public static IRubyObject urandom(ThreadContext context, IRubyObject recv, IRubyObject num) {
-        int n = numToInt(context, num);
+        int n = toInt(context, num);
 
         if (n < 0) throw argumentError(context, "negative string size (or size too big)");
 

--- a/core/src/main/java/org/jruby/RubyRandom.java
+++ b/core/src/main/java/org/jruby/RubyRandom.java
@@ -389,7 +389,7 @@ public class RubyRandom extends RubyRandomBase {
 
     @JRubyMethod(name = "urandom", meta = true)
     public static IRubyObject urandom(ThreadContext context, IRubyObject recv, IRubyObject num) {
-        int n = num.convertToInteger().getIntValue();
+        int n = numToInt(context, num);
 
         if (n < 0) throw argumentError(context, "negative string size (or size too big)");
 

--- a/core/src/main/java/org/jruby/RubyRandom.java
+++ b/core/src/main/java/org/jruby/RubyRandom.java
@@ -71,7 +71,7 @@ public class RubyRandom extends RubyRandomBase {
         }
 
         public static Random randomFromFixnum(RubyFixnum seed) {
-            return randomFromLong(numericToLong(seed.getRuntime().getCurrentContext(), seed));
+            return randomFromLong(numToLong(seed.getRuntime().getCurrentContext(), seed));
         }
 
         public static Random randomFromLong(long seed) {

--- a/core/src/main/java/org/jruby/RubyRandomBase.java
+++ b/core/src/main/java/org/jruby/RubyRandomBase.java
@@ -67,7 +67,7 @@ public class RubyRandomBase extends RubyObject {
 
         checkFrozen();
 
-        random = new RubyRandom.RandomType((argc == 0) ? RubyRandom.randomSeed(context.runtime) : args[0]);
+        random = new RubyRandom.RandomType(context, (argc == 0) ? RubyRandom.randomSeed(context.runtime) : args[0]);
 
         return this;
     }
@@ -475,7 +475,7 @@ public class RubyRandomBase extends RubyObject {
 
         if (rnd == null) {
             RubyInteger v = Helpers.invokePublic(context, obj, "rand", asFixnum(context, limit + 1)).convertToInteger();
-            long r = toLong(context, v);
+            long r = v.asLong(context);
             if (r < 0) throw rangeError(context, "random number too small " + r);
             if (r > limit) throw rangeError(context, "random number too big " + r);
 

--- a/core/src/main/java/org/jruby/RubyRandomBase.java
+++ b/core/src/main/java/org/jruby/RubyRandomBase.java
@@ -311,7 +311,7 @@ public class RubyRandomBase extends RubyObject {
     }
 
     private static double floatValue(ThreadContext context, IRubyObject v) {
-        double value = v.convertToFloat().getDoubleValue();
+        double value = v.convertToFloat().asDouble(context);
         if (!Double.isFinite(value)) domainError(context);
         return value;
     }
@@ -475,7 +475,7 @@ public class RubyRandomBase extends RubyObject {
 
         if (rnd == null) {
             RubyInteger v = Helpers.invokePublic(context, obj, "rand", asFixnum(context, limit + 1)).convertToInteger();
-            long r = numericToLong(context, v);
+            long r = numToLong(context, v);
             if (r < 0) throw rangeError(context, "random number too small " + r);
             if (r > limit) throw rangeError(context, "random number too big " + r);
 

--- a/core/src/main/java/org/jruby/RubyRandomBase.java
+++ b/core/src/main/java/org/jruby/RubyRandomBase.java
@@ -475,7 +475,7 @@ public class RubyRandomBase extends RubyObject {
 
         if (rnd == null) {
             RubyInteger v = Helpers.invokePublic(context, obj, "rand", asFixnum(context, limit + 1)).convertToInteger();
-            long r = numToLong(context, v);
+            long r = toLong(context, v);
             if (r < 0) throw rangeError(context, "random number too small " + r);
             if (r > limit) throw rangeError(context, "random number too big " + r);
 

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -326,9 +326,9 @@ public class RubyRange extends RubyObject {
 
         hash = hashStart(context.runtime, hash);
         IRubyObject v = safeHash(context, begin);
-        hash = murmurCombine(hash, v.convertToInteger().getLongValue());
+        hash = murmurCombine(hash, numToLong(context, v));
         v = safeHash(context, end);
-        hash = murmurCombine(hash, v.convertToInteger().getLongValue());
+        hash = murmurCombine(hash, numToLong(context, v));
         hash = murmurCombine(hash, exclusiveBit << 24);
         hash = hashEnd(hash);
 
@@ -879,8 +879,8 @@ public class RubyRange extends RubyObject {
     }
 
     private void fixnumEndlessStep(ThreadContext context, IRubyObject step, Block block) {
-        long i = begin.convertToInteger().getLongValue();
-        long unit = step.convertToInteger().getLongValue();
+        long i = numToLong(context, begin);
+        long unit = numToInt(context, step);
         // avoid overflow
         while (i <= Long.MAX_VALUE - unit) {
             block.yield(context, asFixnum(context, i));
@@ -1371,8 +1371,8 @@ public class RubyRange extends RubyObject {
         IRubyObject _beg = sites.begin.call(context, range, range);
         IRubyObject _end = sites.end.call(context, range, range);
         boolean excludeEnd = sites.exclude_end.call(context, range, range).isTrue();
-        int beg = _beg.isNil() ? 0 : _beg.convertToInteger().getIntValue();
-        int end = _end.isNil() ? -1 :_end.convertToInteger().getIntValue();
+        int beg = _beg.isNil() ? 0 : numToInt(context, _beg);
+        int end = _end.isNil() ? -1 : numToInt(context, _end);
         int origBeg = beg;
         int origEnd = end;
 

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -325,10 +325,10 @@ public class RubyRange extends RubyObject {
         long hash = exclusiveBit;
 
         hash = hashStart(context.runtime, hash);
-        IRubyObject v = safeHash(context, begin);
-        hash = murmurCombine(hash, toLong(context, v));
+        RubyFixnum v = safeHash(context, begin);
+        hash = murmurCombine(hash, v.asLong(context));
         v = safeHash(context, end);
-        hash = murmurCombine(hash, toLong(context, v));
+        hash = murmurCombine(hash, v.asLong(context));
         hash = murmurCombine(hash, exclusiveBit << 24);
         hash = hashEnd(hash);
 
@@ -425,7 +425,7 @@ public class RubyRange extends RubyObject {
         @Override
         public void doCall(ThreadContext context, IRubyObject arg) {
             if (iter instanceof RubyFixnum iterFixnum) {
-                iter = asFixnum(context, iterFixnum.getLongValue() - 1);
+                iter = asFixnum(context, iterFixnum.getValue() - 1);
             } else if (iter instanceof RubyInteger iterInteger) {
                 iter = iterInteger.op_minus(context, 1);
             } else {
@@ -624,7 +624,7 @@ public class RubyRange extends RubyObject {
 
         if (beg instanceof RubyFixnum && end instanceof RubyFixnum endFixnum) {
             if (excl) {
-                if (endFixnum.getLongValue() == RubyFixnum.MIN) return this;
+                if (endFixnum.getValue() == RubyFixnum.MIN) return this;
 
                 end = endFixnum.op_minus(context, 1);
             }
@@ -820,8 +820,8 @@ public class RubyRange extends RubyObject {
 
         if (begin instanceof RubyFixnum && end.isNil() && step instanceof RubyFixnum) {
             fixnumEndlessStep(context, step, block);
-        } else if (begin instanceof RubyFixnum && end instanceof RubyFixnum && step instanceof RubyFixnum) {
-            fixnumStep(context, ((RubyFixnum) step).getLongValue(), block);
+        } else if (begin instanceof RubyFixnum && end instanceof RubyFixnum && step instanceof RubyFixnum stepf) {
+            fixnumStep(context, stepf.getValue(), block);
         } else if (beginIsNumeric && endIsNumeric && floatStep(context, begin, end, step, isExclusive, isEndless, block)) {
             /* done */
         } else if (!strBegin.isNil() && step instanceof RubyFixnum) {
@@ -880,7 +880,7 @@ public class RubyRange extends RubyObject {
 
     private void fixnumEndlessStep(ThreadContext context, IRubyObject step, Block block) {
         long i = toLong(context, begin);
-        long unit = toInt(context, step);
+        long unit = toLong(context, step);
         // avoid overflow
         while (i <= Long.MAX_VALUE - unit) {
             block.yield(context, asFixnum(context, i));
@@ -1100,7 +1100,7 @@ public class RubyRange extends RubyObject {
             if (!(begin instanceof RubyInteger)) throw typeError(context, "cannot exclude end value with non Integer begin value");
 
             return end instanceof RubyFixnum fixnum ?
-                    asFixnum(context, fixnum.getLongValue() - 1) :
+                    asFixnum(context, fixnum.getValue() - 1) :
                     end.callMethod(context, "-", RubyFixnum.one(context.runtime));
         }
 
@@ -1199,35 +1199,35 @@ public class RubyRange extends RubyObject {
 
     // MRI rb_int_range_last
     private RubyArray intRangeLast(ThreadContext context, IRubyObject arg) {
-        IRubyObject one = asFixnum(context, 1);
-        IRubyObject len1, len, nv, b;
-
-        len1 = ((RubyInteger)end).op_minus(context, begin);
+        RubyFixnum one = asFixnum(context, 1);
+        RubyInteger e = (RubyInteger) end;
+        RubyInteger len;
+        RubyInteger len1 = (RubyInteger) e.op_minus(context, begin);
 
         if (isExclusive) {
-            end = ((RubyInteger)end).op_minus(context, one);
+            e = (RubyInteger) e.op_minus(context, one);
             len = len1;
         } else {
-            len = ((RubyInteger)len1).op_plus(context, one);
+            len = (RubyInteger) len1.op_plus(context, one);
         }
 
-        if (((RubyInteger)len).isZero(context) || Numeric.f_negative_p(context, (RubyInteger)len)) {
+        if (len.isZero(context) || Numeric.f_negative_p(context, len)) {
             return newEmptyArray(context);
         }
 
         long n = toLong(context, arg);
         if (n < 0) throw argumentError(context, "negative array size");
 
-        nv = asFixnum(context, n);
+        RubyInteger nv = asFixnum(context, n);
         if (Numeric.f_gt_p(context, nv, len)) {
              nv = len;
              n = toLong(context, nv);
         }
 
         RubyArray<?> array = newRawArray(context, n);
-        b = ((RubyInteger)end).op_minus(context, nv);
+        RubyInteger b = (RubyInteger) e.op_minus(context, nv);
         while (n > 0) {
-            b = ((RubyInteger)b).op_plus(context, one);
+            b = (RubyInteger) b.op_plus(context, one);
             array.append(context, b);
             n--;
         }
@@ -1446,7 +1446,7 @@ public class RubyRange extends RubyObject {
 
         @JRubyMethod(meta = true)
         public static IRubyObject long_bits_to_double(ThreadContext context, IRubyObject bsearch, IRubyObject fixnum) {
-            return asFloat(context, Double.longBitsToDouble(((RubyFixnum) fixnum).getLongValue()));
+            return asFloat(context, Double.longBitsToDouble(((RubyFixnum) fixnum).asLong(context)));
         }
 
         @JRubyMethod(meta = true)

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -178,7 +178,7 @@ public class RubyRange extends RubyObject {
     }
 
     final boolean checkBegin(ThreadContext context, long length) {
-        long beg = isBeginless ? 0 : numericToLong(context, this.begin);
+        long beg = isBeginless ? 0 : numToLong(context, this.begin);
         if (beg < 0) {
             beg += length;
             if (beg < 0) {
@@ -191,8 +191,8 @@ public class RubyRange extends RubyObject {
     }
 
     final long[] begLen(ThreadContext context, long len, int err) {
-        long beg = isBeginless ? 0 : numericToLong(context, this.begin);
-        long end = isEndless ? -1: numericToLong(context, this.end);
+        long beg = isBeginless ? 0 : numToLong(context, this.begin);
+        long end = isEndless ? -1: numToLong(context, this.end);
 
         if (beg < 0) {
             beg += len;
@@ -220,7 +220,7 @@ public class RubyRange extends RubyObject {
     }
 
     final long begLen0(ThreadContext context, long len) {
-        long beg = isBeginless ? 0 : numericToLong(context, this.begin);
+        long beg = isBeginless ? 0 : numToLong(context, this.begin);
 
         if (beg < 0) {
             beg += len;
@@ -231,7 +231,7 @@ public class RubyRange extends RubyObject {
     }
 
     final long begLen1(ThreadContext context, long len, long beg) {
-        long end = isEndless ? -1 : numericToLong(context, this.end);
+        long end = isEndless ? -1 : numToLong(context, this.end);
 
         if (end < 0) end += len;
         if (!isExclusive || isEndless) end++;
@@ -1215,13 +1215,13 @@ public class RubyRange extends RubyObject {
             return newEmptyArray(context);
         }
 
-        long n = numericToLong(context, arg);
+        long n = numToLong(context, arg);
         if (n < 0) throw argumentError(context, "negative array size");
 
         nv = asFixnum(context, n);
         if (Numeric.f_gt_p(context, nv, len)) {
              nv = len;
-             n = numericToLong(context, nv);
+             n = numToLong(context, nv);
         }
 
         RubyArray<?> array = newRawArray(context, n);
@@ -1441,9 +1441,7 @@ public class RubyRange extends RubyObject {
     public static class BSearch {
         @JRubyMethod(meta = true)
         public static IRubyObject double_to_long_bits(ThreadContext context, IRubyObject bsearch, IRubyObject flote) {
-            return flote instanceof RubyFixnum value ?
-                    asFixnum(context, Double.doubleToLongBits(value.getDoubleValue())) :
-                    asFixnum(context, Double.doubleToLongBits(((RubyFloat) flote).getDoubleValue()));
+            return asFixnum(context, Double.doubleToLongBits(((RubyNumeric) flote).asDouble(context)));
         }
 
         @JRubyMethod(meta = true)
@@ -1453,7 +1451,7 @@ public class RubyRange extends RubyObject {
 
         @JRubyMethod(meta = true)
         public static IRubyObject abs(ThreadContext context, IRubyObject bsearch, IRubyObject flote) {
-            return asFloat(context, Math.abs(((RubyFloat) flote).getDoubleValue()));
+            return asFloat(context, Math.abs(((RubyFloat) flote).asDouble(context)));
         }
     }
 

--- a/core/src/main/java/org/jruby/RubyRange.java
+++ b/core/src/main/java/org/jruby/RubyRange.java
@@ -178,7 +178,7 @@ public class RubyRange extends RubyObject {
     }
 
     final boolean checkBegin(ThreadContext context, long length) {
-        long beg = isBeginless ? 0 : numToLong(context, this.begin);
+        long beg = isBeginless ? 0 : toLong(context, this.begin);
         if (beg < 0) {
             beg += length;
             if (beg < 0) {
@@ -191,8 +191,8 @@ public class RubyRange extends RubyObject {
     }
 
     final long[] begLen(ThreadContext context, long len, int err) {
-        long beg = isBeginless ? 0 : numToLong(context, this.begin);
-        long end = isEndless ? -1: numToLong(context, this.end);
+        long beg = isBeginless ? 0 : toLong(context, this.begin);
+        long end = isEndless ? -1: toLong(context, this.end);
 
         if (beg < 0) {
             beg += len;
@@ -220,7 +220,7 @@ public class RubyRange extends RubyObject {
     }
 
     final long begLen0(ThreadContext context, long len) {
-        long beg = isBeginless ? 0 : numToLong(context, this.begin);
+        long beg = isBeginless ? 0 : toLong(context, this.begin);
 
         if (beg < 0) {
             beg += len;
@@ -231,7 +231,7 @@ public class RubyRange extends RubyObject {
     }
 
     final long begLen1(ThreadContext context, long len, long beg) {
-        long end = isEndless ? -1 : numToLong(context, this.end);
+        long end = isEndless ? -1 : toLong(context, this.end);
 
         if (end < 0) end += len;
         if (!isExclusive || isEndless) end++;
@@ -326,9 +326,9 @@ public class RubyRange extends RubyObject {
 
         hash = hashStart(context.runtime, hash);
         IRubyObject v = safeHash(context, begin);
-        hash = murmurCombine(hash, numToLong(context, v));
+        hash = murmurCombine(hash, toLong(context, v));
         v = safeHash(context, end);
-        hash = murmurCombine(hash, numToLong(context, v));
+        hash = murmurCombine(hash, toLong(context, v));
         hash = murmurCombine(hash, exclusiveBit << 24);
         hash = hashEnd(hash);
 
@@ -879,8 +879,8 @@ public class RubyRange extends RubyObject {
     }
 
     private void fixnumEndlessStep(ThreadContext context, IRubyObject step, Block block) {
-        long i = numToLong(context, begin);
-        long unit = numToInt(context, step);
+        long i = toLong(context, begin);
+        long unit = toInt(context, step);
         // avoid overflow
         while (i <= Long.MAX_VALUE - unit) {
             block.yield(context, asFixnum(context, i));
@@ -1215,13 +1215,13 @@ public class RubyRange extends RubyObject {
             return newEmptyArray(context);
         }
 
-        long n = numToLong(context, arg);
+        long n = toLong(context, arg);
         if (n < 0) throw argumentError(context, "negative array size");
 
         nv = asFixnum(context, n);
         if (Numeric.f_gt_p(context, nv, len)) {
              nv = len;
-             n = numToLong(context, nv);
+             n = toLong(context, nv);
         }
 
         RubyArray<?> array = newRawArray(context, n);
@@ -1371,8 +1371,8 @@ public class RubyRange extends RubyObject {
         IRubyObject _beg = sites.begin.call(context, range, range);
         IRubyObject _end = sites.end.call(context, range, range);
         boolean excludeEnd = sites.exclude_end.call(context, range, range).isTrue();
-        int beg = _beg.isNil() ? 0 : numToInt(context, _beg);
-        int end = _end.isNil() ? -1 : numToInt(context, _end);
+        int beg = _beg.isNil() ? 0 : toInt(context, _beg);
+        int end = _end.isNil() ? -1 : toInt(context, _end);
         int origBeg = beg;
         int origEnd = end;
 

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -34,6 +34,7 @@ import org.jcodings.specific.ASCIIEncoding;
 import org.jcodings.specific.USASCIIEncoding;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
+import org.jruby.api.JRubyAPI;
 import org.jruby.ast.util.ArgsUtil;
 import org.jruby.common.IRubyWarnings;
 import org.jruby.exceptions.RaiseException;
@@ -1071,7 +1072,8 @@ public class RubyRational extends RubyNumeric {
     }
 
     @Override
-    public long getLongValue() {
+    @JRubyAPI
+    public long asLong(ThreadContext context) {
         return convertToInteger().getLongValue();
     }
 
@@ -1209,17 +1211,12 @@ public class RubyRational extends RubyNumeric {
 
     @JRubyMethod(name = "to_f")
     public IRubyObject to_f(ThreadContext context) {
-        return context.runtime.newFloat(getDoubleValue(context));
+        return asFloat(context, asDouble(context));
     }
-    
+
     @Override
-    public double getDoubleValue() {
-        return getDoubleValue(getRuntime().getCurrentContext());
-    }
-
-    private static final long ML = (long)(Math.log(Double.MAX_VALUE) / Math.log(2.0) - 1);
-
-    public double getDoubleValue(ThreadContext context) {
+    @JRubyAPI
+    public double asDouble(ThreadContext context) {
         if (f_zero_p(context, num)) return 0;
 
         RubyInteger myNum = this.num;
@@ -1262,6 +1259,18 @@ public class RubyRational extends RubyNumeric {
         if (Double.isInfinite(f) || Double.isNaN(f)) warn(context, "out of Float range");
 
         return f;
+    }
+
+    private static final long ML = (long)(Math.log(Double.MAX_VALUE) / Math.log(2.0) - 1);
+
+    /**
+     * @param context
+     * @return
+     * @deprecated USe {@link org.jruby.RubyRational#asDouble(ThreadContext)} instead.
+     */
+    @Deprecated(since = "10.0")
+    public double getDoubleValue(ThreadContext context) {
+        return asDouble(context);
     }
 
     /** nurat_to_r

--- a/core/src/main/java/org/jruby/RubyRational.java
+++ b/core/src/main/java/org/jruby/RubyRational.java
@@ -235,7 +235,7 @@ public class RubyRational extends RubyNumeric {
         RubyInteger _num = (RubyInteger) asFixnum(context, num).idiv(context, gcd);
         RubyInteger _den = (RubyInteger) asFixnum(context, den).idiv(context, gcd);
 
-        if (Numeric.CANON && canonicalization && _den.getLongValue() == 1) return _num;
+        if (Numeric.CANON && canonicalization && _den.asLong(context) == 1) return _num;
 
         return newRational(context.runtime, clazz, _num, _den);
     }
@@ -625,12 +625,12 @@ public class RubyRational extends RubyNumeric {
                                         RubyInteger anum, RubyInteger aden, RubyInteger bnum, RubyInteger bden,
                                         final boolean plus) {
         RubyInteger newNum, newDen, g, a, b;
-        if (anum instanceof RubyFixnum && aden instanceof RubyFixnum &&
-            bnum instanceof RubyFixnum && bden instanceof RubyFixnum) {
-            long an = anum.getLongValue();
-            long ad = aden.getLongValue();
-            long bn = bnum.getLongValue();
-            long bd = bden.getLongValue();
+        if (anum instanceof RubyFixnum anumf && aden instanceof RubyFixnum adenf &&
+            bnum instanceof RubyFixnum bnumf && bden instanceof RubyFixnum bdenf) {
+            long an = anumf.getValue();
+            long ad = adenf.getValue();
+            long bn = bnumf.getValue();
+            long bd = bdenf.getValue();
             long ig = i_gcd(ad, bd);
 
             g = asFixnum(context, ig);
@@ -718,12 +718,12 @@ public class RubyRational extends RubyNumeric {
         }
         
         final RubyInteger newNum, newDen;
-        if (anum instanceof RubyFixnum && aden instanceof RubyFixnum &&
-            bnum instanceof RubyFixnum && bden instanceof RubyFixnum) {
-            long an = anum.getLongValue();
-            long ad = aden.getLongValue();
-            long bn = bnum.getLongValue();
-            long bd = bden.getLongValue();
+        if (anum instanceof RubyFixnum anumf && aden instanceof RubyFixnum adenf &&
+            bnum instanceof RubyFixnum bnumf && bden instanceof RubyFixnum bdenf) {
+            long an = anumf.getValue();
+            long ad = adenf.getValue();
+            long bn = bnumf.getValue();
+            long bd = bdenf.getValue();
             long g1 = i_gcd(an, bd);
             long g2 = i_gcd(ad, bn);
             
@@ -938,7 +938,7 @@ public class RubyRational extends RubyNumeric {
 
     public final IRubyObject op_equal(ThreadContext context, RubyInteger other) {
         if (num.isZero(context)) return asBoolean(context, other.isZero(context));
-        if (!(den instanceof RubyFixnum) || den.getLongValue() != 1) return context.fals;
+        if (!(den instanceof RubyFixnum) || den.asLong(context) != 1) return context.fals;
         return f_equal(context, num, other);
     }
 
@@ -1068,7 +1068,7 @@ public class RubyRational extends RubyNumeric {
     @Override
     @JRubyAPI
     public long asLong(ThreadContext context) {
-        return convertToInteger().getLongValue();
+        return convertToInteger().asLong(context);
     }
 
     @Override

--- a/core/src/main/java/org/jruby/RubyRegexp.java
+++ b/core/src/main/java/org/jruby/RubyRegexp.java
@@ -1278,7 +1278,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
         if (timeout != null && timeout.isNil()) return -1; // local override to ignore global timeout.
         if (timeout == null) timeout = context.runtime.getRubyTimeout();
 
-        return timeout.isNil() ? -1 : (long) (timeout.convertToFloat().getDoubleValue() * 1_000_000_000);
+        return timeout.isNil() ? -1 : (long) (timeout.convertToFloat().asDouble(context) * 1_000_000_000);
     }
 
     /**
@@ -1565,7 +1565,7 @@ public class RubyRegexp extends RubyObject implements ReOptions, EncodingCapable
 
         if (pattern.numberOfNames() == 0) return newEmptyArray(context);
 
-        var ary = RubyArray.newBlankArray(context.runtime, pattern.numberOfNames());
+        var ary = RubyArray.newBlankArray(context, pattern.numberOfNames());
         int index = 0;
         for (Iterator<NameEntry> i = pattern.namedBackrefIterator(); i.hasNext();) {
             NameEntry e = i.next();

--- a/core/src/main/java/org/jruby/RubySignal.java
+++ b/core/src/main/java/org/jruby/RubySignal.java
@@ -41,6 +41,7 @@ import org.jruby.util.NoFunctionalitySignalFacade;
 import java.util.*;
 
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Convert.numToInt;
 import static org.jruby.api.Create.newHash;
 import static org.jruby.api.Create.newString;
 import static org.jruby.api.Define.defineModule;
@@ -201,7 +202,7 @@ public class RubySignal {
 
     @JRubyMethod(meta = true)
     public static IRubyObject signame(ThreadContext context, final IRubyObject recv, IRubyObject rubySig) {
-        long sig = rubySig.convertToInteger().getLongValue();
+        long sig = numToInt(context, rubySig);
         String signame = signo2signm(sig);
         if (signame == null) {
             if (sig == 0) return newString(context, "EXIT");

--- a/core/src/main/java/org/jruby/RubySignal.java
+++ b/core/src/main/java/org/jruby/RubySignal.java
@@ -41,7 +41,7 @@ import org.jruby.util.NoFunctionalitySignalFacade;
 import java.util.*;
 
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Create.newHash;
 import static org.jruby.api.Create.newString;
 import static org.jruby.api.Define.defineModule;
@@ -202,7 +202,7 @@ public class RubySignal {
 
     @JRubyMethod(meta = true)
     public static IRubyObject signame(ThreadContext context, final IRubyObject recv, IRubyObject rubySig) {
-        long sig = numToInt(context, rubySig);
+        long sig = toInt(context, rubySig);
         String signame = signo2signm(sig);
         if (signame == null) {
             if (sig == 0) return newString(context, "EXIT");

--- a/core/src/main/java/org/jruby/RubySignalException.java
+++ b/core/src/main/java/org/jruby/RubySignalException.java
@@ -81,7 +81,7 @@ public class RubySignalException extends RubyException {
         long _signo;
 
         if (argnum == 2) {
-            _signo = asLong(context, (RubyInteger) sig);
+            _signo = ((RubyInteger) sig).asLong(context);
             if (_signo < 0 || _signo > NSIG.longValue()) throw argumentError(context, "invalid signal number (" + _signo + ")");
 
             sig = argc > 1 ? args[1] : newString(context, RubySignal.signmWithPrefix(RubySignal.signo2signm(_signo)));

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1302,7 +1302,8 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @Override
     public final int compareTo(IRubyObject other) {
-        return (int) op_cmp(metaClass.runtime.getCurrentContext(), other).convertToInteger().getLongValue();
+        var context = getRuntime().getCurrentContext();
+        return numToInt(context, op_cmp(context, other));
     }
 
     /* rb_str_cmp_m */
@@ -1794,7 +1795,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
             IRubyObject encoding = opts.fastARef(asSymbol(context, "encoding"));
             IRubyObject capacity = opts.fastARef(asSymbol(context, "capacity"));
 
-            if (capacity != null && !capacity.isNil()) modify(capacity.convertToInteger().getIntValue());
+            if (capacity != null && !capacity.isNil()) modify(numToInt(context, capacity));
             if (encoding != null && !encoding.isNil()) {
                 modify();
                 setEncodingAndCodeRange(context.runtime.getEncodingService().getEncodingFromObject(encoding), CR_UNKNOWN);
@@ -4481,7 +4482,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      */
     @JRubyMethod(name = "to_i")
     public IRubyObject to_i(ThreadContext context, IRubyObject arg0) {
-        int base = (int) arg0.convertToInteger().getLongValue();
+        int base = numToInt(context, arg0);
         if (base < 0) throw argumentError(context, "illegal radix " + base);
         return stringToInum(base);
     }
@@ -5574,7 +5575,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         if (arg instanceof RubyRegexp) {
             IRubyObject tmp = rindex(context, arg);
             if (tmp.isNil()) return rpartitionMismatch(context);
-            pos = tmp.convertToInteger().getIntValue();
+            pos = numToInt(context, tmp);
             sep = (RubyString)RubyRegexp.nth_match(context, 0, context.getLocalMatchOrNil());
         } else {
             IRubyObject tmp = arg.checkStringType();
@@ -6686,7 +6687,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         if (options.size() == 1) {
             IRubyObject offsetArg = options.fastARef(asSymbol(context, "offset"));
             if (offsetArg == null) throw argumentError(context, "unknown keyword: " + options.keys().first(context).inspect(context));
-            offset = offsetArg.convertToInteger().getLongValue();
+            offset = numToLong(context, offsetArg);
         }
         // FIXME: keyword arg processing incomplete.  We need a better system.
 

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1389,7 +1389,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     private RubyString multiplyByteList(ThreadContext context, IRubyObject arg) {
         long longLen = toLong(context, arg);
         if (longLen < 0) throw argumentError(context, "negative argument");
-        if (size() == 0) return (RubyString) dup();
+        if (isEmpty()) return (RubyString) dup();
 
         // we limit to int because ByteBuffer can only allocate int sizes
         int len = Helpers.multiplyBufferLength(context, value.getRealSize(), checkInt(context, longLen));
@@ -2797,10 +2797,9 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
             return concatNumeric(context, (int)(fixnum.value & 0xFFFFFFFF));
         }
         if (other instanceof RubyBignum bignum) {
-            if (bignum.getBigIntegerValue().signum() < 0) {
-                throw rangeError(context, "negative string size (or size too big)");
-            }
-            return concatNumeric(context, (int) bignum.getLongValue());
+            if (bignum.signum() < 0) throw rangeError(context, "negative string size (or size too big)");
+
+            return concatNumeric(context, bignum.asInt(context));
         }
         if (other instanceof RubyFloat flote) {
             modifyCheck();

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1303,7 +1303,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     @Override
     public final int compareTo(IRubyObject other) {
         var context = getRuntime().getCurrentContext();
-        return numToInt(context, op_cmp(context, other));
+        return toInt(context, op_cmp(context, other));
     }
 
     /* rb_str_cmp_m */
@@ -1387,7 +1387,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     }
 
     private RubyString multiplyByteList(ThreadContext context, IRubyObject arg) {
-        long longLen = numToLong(context, arg);
+        long longLen = toLong(context, arg);
         if (longLen < 0) throw argumentError(context, "negative argument");
         if (size() == 0) return (RubyString) dup();
 
@@ -1795,7 +1795,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
             IRubyObject encoding = opts.fastARef(asSymbol(context, "encoding"));
             IRubyObject capacity = opts.fastARef(asSymbol(context, "capacity"));
 
-            if (capacity != null && !capacity.isNil()) modify(numToInt(context, capacity));
+            if (capacity != null && !capacity.isNil()) modify(toInt(context, capacity));
             if (encoding != null && !encoding.isNil()) {
                 modify();
                 setEncodingAndCodeRange(context.runtime.getEncodingService().getEncodingFromObject(encoding), CR_UNKNOWN);
@@ -3885,7 +3885,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @JRubyMethod
     public IRubyObject byteslice(ThreadContext context, IRubyObject arg1, IRubyObject arg2) {
-        return byteSubstr(context, numToLong(context, arg1), numToLong(context, arg2));
+        return byteSubstr(context, toLong(context, arg1), toLong(context, arg2));
     }
 
     @JRubyMethod
@@ -4482,7 +4482,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      */
     @JRubyMethod(name = "to_i")
     public IRubyObject to_i(ThreadContext context, IRubyObject arg0) {
-        int base = numToInt(context, arg0);
+        int base = toInt(context, arg0);
         if (base < 0) throw argumentError(context, "illegal radix " + base);
         return stringToInum(base);
     }
@@ -5575,7 +5575,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         if (arg instanceof RubyRegexp) {
             IRubyObject tmp = rindex(context, arg);
             if (tmp.isNil()) return rpartitionMismatch(context);
-            pos = numToInt(context, tmp);
+            pos = toInt(context, tmp);
             sep = (RubyString)RubyRegexp.nth_match(context, 0, context.getLocalMatchOrNil());
         } else {
             IRubyObject tmp = arg.checkStringType();
@@ -5631,14 +5631,11 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     }
 
     private void appendBytes(ThreadContext context, IRubyObject arg) {
-        if (arg instanceof RubyFixnum fix) {
-            cat(fix.getIntValue() & 0xff);
-        } else if (arg instanceof RubyBignum big) {
-            cat(big.getBigIntegerValue().intValue() & 0xff);
-        } else if (arg instanceof RubyString str) {
-            value.append(str.getByteList());
-        } else {
-            throw runtimeError(context, "BUG: append_as_bytes arguments should have been validated");
+        switch (arg) {
+            case RubyFixnum fix -> cat(fix.asInt(context) & 0xff);
+            case RubyBignum big -> cat(big.getBigIntegerValue().intValue() & 0xff);
+            case RubyString str -> value.append(str.getByteList());
+            default -> throw runtimeError(context, "BUG: append_as_bytes arguments should have been validated");
         }
     }
 
@@ -6590,7 +6587,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @JRubyMethod
     public IRubyObject sum(ThreadContext context, IRubyObject arg) {
-        return sumCommon(context, numToLong(context, arg));
+        return sumCommon(context, toLong(context, arg));
     }
 
     public IRubyObject sumCommon(ThreadContext context, long bits) {
@@ -6687,7 +6684,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         if (options.size() == 1) {
             IRubyObject offsetArg = options.fastARef(asSymbol(context, "offset"));
             if (offsetArg == null) throw argumentError(context, "unknown keyword: " + options.keys().first(context).inspect(context));
-            offset = numToLong(context, offsetArg);
+            offset = toLong(context, offsetArg);
         }
         // FIXME: keyword arg processing incomplete.  We need a better system.
 

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -1386,7 +1386,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     }
 
     private RubyString multiplyByteList(ThreadContext context, IRubyObject arg) {
-        long longLen = numericToLong(context, arg);
+        long longLen = numToLong(context, arg);
         if (longLen < 0) throw argumentError(context, "negative argument");
         if (size() == 0) return (RubyString) dup();
 
@@ -3884,7 +3884,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @JRubyMethod
     public IRubyObject byteslice(ThreadContext context, IRubyObject arg1, IRubyObject arg2) {
-        return byteSubstr(context, numericToLong(context, arg1), numericToLong(context, arg2));
+        return byteSubstr(context, numToLong(context, arg1), numToLong(context, arg2));
     }
 
     @JRubyMethod
@@ -6589,7 +6589,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     @JRubyMethod
     public IRubyObject sum(ThreadContext context, IRubyObject arg) {
-        return sumCommon(context, numericToLong(context, arg));
+        return sumCommon(context, numToLong(context, arg));
     }
 
     public IRubyObject sumCommon(ThreadContext context, long bits) {

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -3855,7 +3855,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
     @JRubyMethod(name = {"[]", "slice"}, writes = BACKREF)
     public IRubyObject op_aref(ThreadContext context, IRubyObject arg) {
         if (arg instanceof RubyFixnum fixnum) {
-            return op_aref(context, asInt(context, fixnum));
+            return op_aref(context, fixnum.asInt(context));
         } else if (arg instanceof RubyRegexp regexp) {
             return subpat(context, regexp);
         } else if (arg instanceof RubyString str) {
@@ -4163,7 +4163,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
      */
     @JRubyMethod(name = "[]=", writes = BACKREF)
     public IRubyObject op_aset(ThreadContext context, IRubyObject arg0, IRubyObject arg1) {
-        if (arg0 instanceof RubyFixnum fixnum) return op_aset(context, asInt(context, fixnum), arg1);
+        if (arg0 instanceof RubyFixnum fixnum) return op_aset(context, fixnum.asInt(context), arg1);
         if (arg0 instanceof RubyRegexp regexp) {
             subpatSet(context, regexp, null, arg1);
             return arg1;
@@ -4601,7 +4601,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
 
     /**
      * Split for ext (Java) callers (does not write $~).
-     * @param the thread context
+     * @param context the thread context
      * @param delimiter
      * @param limit
      * @return splited entries

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -174,7 +174,7 @@ public class RubyStruct extends RubyObject {
             IRubyObject hash = context.safeRecurse(
                     (ctx, runtime1, obj, recur) -> recur ? RubyFixnum.zero(runtime1) : invokedynamic(ctx, obj, HASH),
                     context.runtime, values[i], "hash", true);
-            h ^= numToLong(context, hash);
+            h ^= toLong(context, hash);
         }
 
         return asFixnum(context, h);
@@ -517,7 +517,7 @@ public class RubyStruct extends RubyObject {
                         key = asSymbol(context, key.convertToString().getByteList());
                     IRubyObject index = __members__.index(context, key);
                     if (index.isNil()) throw argumentError(context, str(context.runtime, "unknown keywords: ", key));
-                    values[numToInt(context, index)] = entry.getValue();
+                    values[toInt(context, index)] = entry.getValue();
                 });
 
         return context.nil;

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -104,7 +104,7 @@ public class RubyStruct extends RubyObject {
 
         values = new IRubyObject[size];
 
-        Helpers.fillNil(values, context.runtime);
+        Helpers.fillNil(context, values);
     }
 
     public static RubyClass createStructClass(ThreadContext context, RubyClass Object, RubyModule Enumerable) {
@@ -174,7 +174,7 @@ public class RubyStruct extends RubyObject {
             IRubyObject hash = context.safeRecurse(
                     (ctx, runtime1, obj, recur) -> recur ? RubyFixnum.zero(runtime1) : invokedynamic(ctx, obj, HASH),
                     context.runtime, values[i], "hash", true);
-            h ^= numericToLong(context, hash);
+            h ^= numToLong(context, hash);
         }
 
         return asFixnum(context, h);
@@ -500,7 +500,7 @@ public class RubyStruct extends RubyObject {
             return initialize(context, args[0]);
         } else {
             System.arraycopy(args, 0, values, 0, args.length);
-            Helpers.fillNil(values, args.length, values.length, context.runtime);
+            Helpers.fillNil(context, values, args.length, values.length);
         }
 
         return context.nil;
@@ -571,7 +571,7 @@ public class RubyStruct extends RubyObject {
             values[0] = arg0;
         }
 
-        if (provided < values.length) Helpers.fillNil(values, provided, values.length, context.runtime);
+        if (provided < values.length) Helpers.fillNil(context, values, provided, values.length);
 
         return context.nil;
     }
@@ -931,7 +931,7 @@ public class RubyStruct extends RubyObject {
                 }
                 if ( beg + len > j ) {
                     IRubyObject [] tmp = new IRubyObject[beg + len - j];
-                    Helpers.fillNil(tmp, context.runtime);
+                    Helpers.fillNil(context, tmp);
                     result.push(context, tmp);
                 }
                 continue;

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -172,7 +172,7 @@ public class RubyStruct extends RubyObject {
         for (int i = 0; i < values.length; i++) {
             h = (h << 1) | (h < 0 ? 1 : 0);
             IRubyObject hash = context.safeRecurse(
-                    (ctx, runtime1, obj, recur) -> recur ? RubyFixnum.zero(runtime1) : invokedynamic(ctx, obj, HASH),
+                    (ctx, runtime1, obj, recur) -> recur ? asFixnum(ctx, 0) : invokedynamic(ctx, obj, HASH),
                     context.runtime, values[i], "hash", true);
             h ^= toLong(context, hash);
         }

--- a/core/src/main/java/org/jruby/RubyStruct.java
+++ b/core/src/main/java/org/jruby/RubyStruct.java
@@ -517,7 +517,7 @@ public class RubyStruct extends RubyObject {
                         key = asSymbol(context, key.convertToString().getByteList());
                     IRubyObject index = __members__.index(context, key);
                     if (index.isNil()) throw argumentError(context, str(context.runtime, "unknown keywords: ", key));
-                    values[index.convertToInteger().getIntValue()] = entry.getValue();
+                    values[numToInt(context, index)] = entry.getValue();
                 });
 
         return context.nil;

--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -290,21 +290,15 @@ public class RubyThread extends RubyObject implements ExecutionContext {
 
                 if (err == UNDEF) {
                     // no error
-                } else if (err instanceof RubyFixnum fixErr && (fixErr.getLongValue() == 0 ||
-                        fixErr.getLongValue() == 1 ||
-                        fixErr.getLongValue() == 2)) {
+                } else if (err instanceof RubyFixnum fix && (fix.getValue() == 0 || fix.getValue() == 1 || fix.getValue() == 2)) {
                     toKill();
                 } else {
-                    if (getStatus() == Status.SLEEP) {
-                        exitSleep();
-                    }
+                    if (getStatus() == Status.SLEEP) exitSleep();
+
                     // if it's a Ruby exception, force the cause through
-                    IRubyObject[] args;
-                    if (err instanceof RubyException) {
-                        args = Helpers.arrayOf(err, RubyHash.newKwargs(runtime, "cause", ((RubyException) err).cause(context)));
-                    } else {
-                        args = Helpers.arrayOf(err);
-                    }
+                    IRubyObject[] args = err instanceof RubyException exc ?
+                            Helpers.arrayOf(err, RubyHash.newKwargs(runtime, "cause", exc.cause(context))) :
+                            Helpers.arrayOf(err);
                     RubyKernel.raise(context, this, args, Block.NULL_BLOCK);
                 }
             }

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -1564,8 +1564,7 @@ public class RubyTime extends RubyObject {
     private static RubyTime at1(ThreadContext context, IRubyObject recv, IRubyObject arg) {
         final RubyTime time;
 
-        if (arg instanceof RubyTime) {
-            RubyTime other = (RubyTime) arg;
+        if (arg instanceof RubyTime other) {
             time = new RubyTime(context.runtime, (RubyClass) recv, other.dt);
             time.setNSec(other.getNSec());
         } else {
@@ -1577,10 +1576,10 @@ public class RubyTime extends RubyObject {
             // In the case of two arguments, MRI will discard the portion of
             // the first argument after a decimal point (i.e., "floor").
             // However in the case of a single argument, any portion after the decimal point is honored.
-            if (arg instanceof RubyFloat) {
+            if (arg instanceof RubyFloat flote) {
                 // use integral and decimal forms to calculate nanos
-                long seconds = RubyNumeric.float2long((RubyFloat) arg);
-                double dbl = ((RubyFloat) arg).value;
+                long seconds = RubyNumeric.float2long(flote);
+                double dbl = flote.value;
 
                 long nano = (long)((dbl - seconds) * 1000000000);
 
@@ -1590,10 +1589,8 @@ public class RubyTime extends RubyObject {
 
                 millisecs = seconds * 1000 + nano / 1000000;
                 nanosecs = nano % 1000000;
-            } else if (arg instanceof RubyRational) {
+            } else if (arg instanceof RubyRational rational) {
                 // use Rational numerator and denominator to calculate nanos
-                RubyRational rational = (RubyRational) arg;
-
                 BigInteger numerator = rational.getNumerator().getBigIntegerValue();
                 BigInteger denominator = rational.getDenominator().getBigIntegerValue();
 
@@ -1621,7 +1618,8 @@ public class RubyTime extends RubyObject {
         return time;
     }
 
-    private static RubyTime atMulti(ThreadContext context, RubyClass recv, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3, IRubyObject zone) {
+    private static RubyTime atMulti(ThreadContext context, RubyClass recv, IRubyObject arg1, IRubyObject arg2,
+                                    IRubyObject arg3, IRubyObject zone) {
         long millisecs;
         long nanosecs = 0;
 

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -2168,7 +2168,7 @@ public class RubyTime extends RubyObject {
         IRubyObject zoneVar = (IRubyObject) from.getInternalVariables().getInternalVariable("zone");
 
         if (nano_num != null && nano_den != null) {
-            long nanos = nano_num.convertToInteger().getLongValue() / nano_den.convertToInteger().getLongValue();
+            long nanos = numToLong(context, nano_num) / numToLong(context, nano_den);
             time.nsec += nanos;
         }
 
@@ -2176,7 +2176,7 @@ public class RubyTime extends RubyObject {
         if (offsetVar != null && offsetVar.respondsTo("to_int")) {
             final IRubyObject $ex = context.getErrorInfo();
             try {
-                offset = offsetVar.convertToInteger().getIntValue() * 1000;
+                offset = numToInt(context, offsetVar) * 1000;
             }
             catch (TypeError typeError) {
                 context.setErrorInfo($ex); // restore $!
@@ -2243,15 +2243,11 @@ public class RubyTime extends RubyObject {
     }
 
     private static long extractTime(ThreadContext context, IRubyObject time) {
-        long t;
+        if (time instanceof RubyTime tm) return tm.getDateTime().withZoneRetainFields(DateTimeZone.UTC).getMillis();
 
-        if (time instanceof RubyTime) {
-            return ((RubyTime) time).getDateTime().withZoneRetainFields(DateTimeZone.UTC).getMillis();
-        } else if (time instanceof RubyStruct) {
-            t = ((RubyStruct) time).aref(context, asSymbol(context, "to_i")).convertToInteger().getLongValue();
-        } else {
-            t =  time.callMethod(context, "to_i").convertToInteger().getLongValue();
-        }
+        long t = time instanceof RubyStruct ?
+                numToLong(context, ((RubyStruct) time).aref(context, asSymbol(context, "to_i"))) :
+                numToLong(context, time.callMethod(context, "to_i"));
 
         return t * 1000;
     }

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -1605,7 +1605,7 @@ public class RubyTime extends RubyObject {
                 nanosecs = nanos.longValue();
             } else {
                 nanosecs = 0;
-                millisecs = numericToLong(context, arg) * 1000;
+                millisecs = numToLong(context, arg) * 1000;
             }
 
             try {
@@ -1633,7 +1633,7 @@ public class RubyTime extends RubyObject {
             millisecs = (long) (dbl * 1000);
             nanosecs = ((long) (dbl * 1000000000)) % 1000000;
         } else {
-            millisecs = numericToLong(context, arg1) * 1000;
+            millisecs = numToLong(context, arg1) * 1000;
         }
 
         if (!(arg3 instanceof RubySymbol unit)) throw argumentError(context, "unexpected unit " + arg3);
@@ -1650,23 +1650,23 @@ public class RubyTime extends RubyObject {
                 millisecs += (long) (nanos / 1000000);
                 nanosecs += (long) (nanos % 1000000);
             } else if (asSymbol(context, "nanosecond").eql(unit) || asSymbol(context, "nsec").eql(unit)) {
-                nanosecs += numericToLong(context, arg2);
+                nanosecs += numToLong(context, arg2);
             } else {
                 throw argumentError(context, "unexpected unit " + arg3);
             }
         } else {
             if (asSymbol(context, "microsecond").eql(unit) || asSymbol(context, "usec").eql(unit)) {
-                long micros = numericToLong(context, arg2);
+                long micros = numToLong(context, arg2);
                 long nanos = micros * 1000;
                 millisecs += nanos / 1000000;
                 nanosecs += nanos % 1000000;
             } else if (asSymbol(context, "millisecond").eql(unit)) {
-                double millis = numericToLong(context, arg2);
+                double millis = numToLong(context, arg2);
                 double nanos = millis * 1000000;
                 millisecs += nanos / 1000000;
                 nanosecs += nanos % 1000000;
             } else if (asSymbol(context, "nanosecond").eql(unit) || asSymbol(context, "nsec").eql(unit)) {
-                nanosecs += numericToLong(context, arg2);
+                nanosecs += numToLong(context, arg2);
             } else {
                 throw argumentError(context, "unexpected unit " + arg3);
             }
@@ -2087,7 +2087,7 @@ public class RubyTime extends RubyObject {
     // MRI: time.c ~ rb_time_interval 1.9 ... invokes time_timespec(VALUE num, TRUE)
     public static double convertTimeInterval(ThreadContext context, IRubyObject sec) {
         double seconds;
-        if (sec instanceof RubyNumeric num) seconds = num.getDoubleValue();
+        if (sec instanceof RubyNumeric num) seconds = num.asDouble(context);
 
         // NOTE: we can probably do better here, but we're matching MRI behavior
         // this is for converting custom objects such as ActiveSupport::Duration
@@ -2095,8 +2095,8 @@ public class RubyTime extends RubyObject {
             IRubyObject result = sites(context).divmod.call(context, sec, sec, 1);
             if (!(result instanceof RubyArray arr)) throw typeError(context, "unexpected divmod result: into ", result, "");
 
-            seconds = ((RubyNumeric) arr.eltOk(0)).getDoubleValue() + // div
-                    ((RubyNumeric) arr.eltOk(1)).getDoubleValue(); // mod
+            seconds = ((RubyNumeric) arr.eltOk(0)).asDouble(context) + // div
+                    ((RubyNumeric) arr.eltOk(1)).asDouble(context); // mod
         } else {
             boolean raise = true;
             seconds = 0;

--- a/core/src/main/java/org/jruby/RubyTime.java
+++ b/core/src/main/java/org/jruby/RubyTime.java
@@ -1605,7 +1605,7 @@ public class RubyTime extends RubyObject {
                 nanosecs = nanos.longValue();
             } else {
                 nanosecs = 0;
-                millisecs = numToLong(context, arg) * 1000;
+                millisecs = toLong(context, arg) * 1000;
             }
 
             try {
@@ -1633,7 +1633,7 @@ public class RubyTime extends RubyObject {
             millisecs = (long) (dbl * 1000);
             nanosecs = ((long) (dbl * 1000000000)) % 1000000;
         } else {
-            millisecs = numToLong(context, arg1) * 1000;
+            millisecs = toLong(context, arg1) * 1000;
         }
 
         if (!(arg3 instanceof RubySymbol unit)) throw argumentError(context, "unexpected unit " + arg3);
@@ -1650,23 +1650,23 @@ public class RubyTime extends RubyObject {
                 millisecs += (long) (nanos / 1000000);
                 nanosecs += (long) (nanos % 1000000);
             } else if (asSymbol(context, "nanosecond").eql(unit) || asSymbol(context, "nsec").eql(unit)) {
-                nanosecs += numToLong(context, arg2);
+                nanosecs += toLong(context, arg2);
             } else {
                 throw argumentError(context, "unexpected unit " + arg3);
             }
         } else {
             if (asSymbol(context, "microsecond").eql(unit) || asSymbol(context, "usec").eql(unit)) {
-                long micros = numToLong(context, arg2);
+                long micros = toLong(context, arg2);
                 long nanos = micros * 1000;
                 millisecs += nanos / 1000000;
                 nanosecs += nanos % 1000000;
             } else if (asSymbol(context, "millisecond").eql(unit)) {
-                double millis = numToLong(context, arg2);
+                double millis = toLong(context, arg2);
                 double nanos = millis * 1000000;
                 millisecs += nanos / 1000000;
                 nanosecs += nanos % 1000000;
             } else if (asSymbol(context, "nanosecond").eql(unit) || asSymbol(context, "nsec").eql(unit)) {
-                nanosecs += numToLong(context, arg2);
+                nanosecs += toLong(context, arg2);
             } else {
                 throw argumentError(context, "unexpected unit " + arg3);
             }
@@ -2168,7 +2168,7 @@ public class RubyTime extends RubyObject {
         IRubyObject zoneVar = (IRubyObject) from.getInternalVariables().getInternalVariable("zone");
 
         if (nano_num != null && nano_den != null) {
-            long nanos = numToLong(context, nano_num) / numToLong(context, nano_den);
+            long nanos = toLong(context, nano_num) / toLong(context, nano_den);
             time.nsec += nanos;
         }
 
@@ -2176,7 +2176,7 @@ public class RubyTime extends RubyObject {
         if (offsetVar != null && offsetVar.respondsTo("to_int")) {
             final IRubyObject $ex = context.getErrorInfo();
             try {
-                offset = numToInt(context, offsetVar) * 1000;
+                offset = toInt(context, offsetVar) * 1000;
             }
             catch (TypeError typeError) {
                 context.setErrorInfo($ex); // restore $!
@@ -2246,8 +2246,8 @@ public class RubyTime extends RubyObject {
         if (time instanceof RubyTime tm) return tm.getDateTime().withZoneRetainFields(DateTimeZone.UTC).getMillis();
 
         long t = time instanceof RubyStruct ?
-                numToLong(context, ((RubyStruct) time).aref(context, asSymbol(context, "to_i"))) :
-                numToLong(context, time.callMethod(context, "to_i"));
+                toLong(context, ((RubyStruct) time).aref(context, asSymbol(context, "to_i"))) :
+                toLong(context, time.callMethod(context, "to_i"));
 
         return t * 1000;
     }

--- a/core/src/main/java/org/jruby/api/Access.java
+++ b/core/src/main/java/org/jruby/api/Access.java
@@ -302,6 +302,15 @@ public class Access {
     }
 
     /**
+     * Retrieve the instance of the class Random
+     * @param context the current thread context
+     * @return the Class
+     */
+    public static RubyClass randomClass(ThreadContext context) {
+        return context.runtime.getRandomClass();
+    }
+
+    /**
      * Retrieve the instance of the class RuntimeError
      * @param context the current thread context
      * @return the Class

--- a/core/src/main/java/org/jruby/api/Convert.java
+++ b/core/src/main/java/org/jruby/api/Convert.java
@@ -41,7 +41,7 @@ import static org.jruby.util.TypeConverter.sites;
  * Methods where the parameter to `As` methods will omit the type from in front of as.  For example,
  * `longAsInteger` will be `asInteger(context, long)`.  Additionally, naming is terse but in cases where
  * something is ambiguous (asFloat() return a Ruby float but if we need a Java equivalent it will take
- * the extra naming asJavaFloat()).  Luckily for Java primitivesas Ruby types there are not too many
+ * the extra naming asJavaFloat()).  Luckily for Java primitives as Ruby types there are not too many
  * conflicts.
  */
 public class Convert {
@@ -460,7 +460,7 @@ public class Convert {
      * @param arg the RubyNumeric to convert
      * @return the long value
      */
-    public static long numToLong(ThreadContext context, IRubyObject arg) {
+    public static long toLong(ThreadContext context, IRubyObject arg) {
         return num2long(arg);
     }
 
@@ -470,7 +470,7 @@ public class Convert {
      * @param arg the RubyNumeric to convert
      * @return the int value
      */
-    public static int numToInt(ThreadContext context, IRubyObject arg) {
+    public static int toInt(ThreadContext context, IRubyObject arg) {
         return num2int(arg);
     }
 
@@ -480,7 +480,7 @@ public class Convert {
      * @param arg the RubyNumeric to convert
      * @return the int value
      */
-    public static RubyInteger numToInteger(ThreadContext context, IRubyObject arg) {
+    public static RubyInteger toInteger(ThreadContext context, IRubyObject arg) {
         // FIXME: Make proper impl which is amalgam of RubyNumeric num2int and convertToInteger and hen have numTo{Long,Int} use this
         return arg.convertToInteger();
     }

--- a/core/src/main/java/org/jruby/api/Convert.java
+++ b/core/src/main/java/org/jruby/api/Convert.java
@@ -461,7 +461,6 @@ public class Convert {
      * @return the long value
      */
     public static long numToLong(ThreadContext context, IRubyObject arg) {
-        // FIXME: Move this logic out of numeric and into a place which accepts and uses context.
         return num2long(arg);
     }
 
@@ -472,8 +471,18 @@ public class Convert {
      * @return the int value
      */
     public static int numToInt(ThreadContext context, IRubyObject arg) {
-        // FIXME: Move this logic out of numeric and into a place which accepts and uses context.
         return num2int(arg);
+    }
+
+    /**
+     * Safely convert a Ruby Numeric into a java long value.  Raising if the value will not fit.
+     * @param context the current thread context
+     * @param arg the RubyNumeric to convert
+     * @return the int value
+     */
+    public static RubyInteger numToInteger(ThreadContext context, IRubyObject arg) {
+        // FIXME: Make proper impl which is amalgam of RubyNumeric num2int and convertToInteger and hen have numTo{Long,Int} use this
+        return arg.convertToInteger();
     }
 
     /**

--- a/core/src/main/java/org/jruby/api/Convert.java
+++ b/core/src/main/java/org/jruby/api/Convert.java
@@ -23,7 +23,6 @@ import org.jruby.util.ByteList;
 
 import static org.jruby.RubyBignum.big2long;
 import static org.jruby.RubyNumeric.num2long;
-import static org.jruby.api.Create.newString;
 import static org.jruby.api.Error.rangeError;
 import static org.jruby.api.Error.typeError;
 import static org.jruby.util.TypeConverter.convertToTypeWithCheck;
@@ -31,15 +30,18 @@ import static org.jruby.util.TypeConverter.sites;
 
 /**
  * Conversion utilities.
- *
+ * <p>
  * By convention if a method has `As` in it then it implies it is already the thing and it may error
- * if wrong.  If it has `To` in it then it implies it is converting to that thing and it if might not
+ * if wrong.  If it has `To` in it then it implies it is converting to that thing and it might not
  * be that thing.  For example, `integerAsInt` implies the value is already an int and will error if
  * it is not.  `checkToInteger` implies the value might not be an integer and that it may try and convert
  * it to one.
- *
+ * <p>
  * Methods where the parameter to `As` methods will omit the type from in front of as.  For example,
- * `longAsInteger` will be `asInteger(context, long)`.a
+ * `longAsInteger` will be `asInteger(context, long)`.  Additionally, naming is terse but in cases where
+ * something is ambiguous (asFloat() return a Ruby float but if we need a Java equivalent it will take
+ * the extra naming asJavaFloat()).  Luckily for Java primitivesas Ruby types there are not too many
+ * conflicts.
  */
 public class Convert {
     /**
@@ -457,7 +459,7 @@ public class Convert {
      * @param arg the RubyNumeric to convert
      * @return the long value
      */
-    public static long numericToLong(ThreadContext context, IRubyObject arg) {
+    public static long numToLong(ThreadContext context, IRubyObject arg) {
         // FIXME: Move this logic out of numeric and into a place which accepts and uses context.
         return num2long(arg);
     }

--- a/core/src/main/java/org/jruby/api/Convert.java
+++ b/core/src/main/java/org/jruby/api/Convert.java
@@ -22,6 +22,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
 
 import static org.jruby.RubyBignum.big2long;
+import static org.jruby.RubyNumeric.num2int;
 import static org.jruby.RubyNumeric.num2long;
 import static org.jruby.api.Error.rangeError;
 import static org.jruby.api.Error.typeError;
@@ -462,6 +463,17 @@ public class Convert {
     public static long numToLong(ThreadContext context, IRubyObject arg) {
         // FIXME: Move this logic out of numeric and into a place which accepts and uses context.
         return num2long(arg);
+    }
+
+    /**
+     * Safely convert a Ruby Numeric into a java long value.  Raising if the value will not fit.
+     * @param context the current thread context
+     * @param arg the RubyNumeric to convert
+     * @return the int value
+     */
+    public static int numToInt(ThreadContext context, IRubyObject arg) {
+        // FIXME: Move this logic out of numeric and into a place which accepts and uses context.
+        return num2int(arg);
     }
 
     /**

--- a/core/src/main/java/org/jruby/api/Convert.java
+++ b/core/src/main/java/org/jruby/api/Convert.java
@@ -427,32 +427,6 @@ public class Convert {
         return RubyFloat.newFloat(context.runtime, value);
     }
 
-    /**
-     * Safely convert a Ruby Integer into a java int value.  Raising if the value will not fit.
-     * @param context the current thread context
-     * @param value the RubyInteger to convert
-     * @return the int value
-     */
-    public static int asInt(ThreadContext context, RubyInteger value) {
-        long num = value.getLongValue();
-
-        return checkInt(context, num);
-    }
-
-    /**
-     * Safely convert a Ruby Integer into a java int value.  Raising if the value will not fit.
-     * @param context the current thread context
-     * @param value the RubyInteger to convert
-     * @return the int value
-     */
-    public static long asLong(ThreadContext context, RubyInteger value) {
-        if (value instanceof RubyBignum) {
-            return big2long((RubyBignum) value);
-        }
-
-        return value.getLongValue();
-    }
-
     // MRI: rb_num2long and FIX2LONG (numeric.c)
     /**
      * Safely convert a Ruby Numeric into a java long value.  Raising if the value will not fit.

--- a/core/src/main/java/org/jruby/api/Create.java
+++ b/core/src/main/java/org/jruby/api/Create.java
@@ -21,16 +21,16 @@ public class Create {
      * @param context the current thread context
      * @return the new array
      */
-    // mri: rb_ary_new2
+    // mri: rb_ary_new
     public static RubyArray<?> newArray(ThreadContext context) {
-        return RubyArray.newArray(context.runtime);
+        return RubyArray.newArray(context);
     }
 
     // mri: rb_ary_new2
 
     public static RubyArray<?> newArray(ThreadContext context, int length) {
         // FIXME: This should be newBlankArray but things go very wrong in a tough to figure out where sort of way.
-        return RubyArray.newArray(context.runtime, length);
+        return RubyArray.newArray(context, length);
     }
 
     public static <T extends IRubyObject> RubyArray<?> newArray(ThreadContext context, int length,

--- a/core/src/main/java/org/jruby/api/Create.java
+++ b/core/src/main/java/org/jruby/api/Create.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import static org.jruby.api.Access.stringClass;
-import static org.jruby.api.Access.structClass;
 
 public class Create {
     /**
@@ -122,7 +121,7 @@ public class Create {
      * @param <State> a state object for the consumer
      * @param <T> the type of object the Array will hold
      */
-    public static <State, T extends IRubyObject> RubyArray<?> constructArray(ThreadContext context, State state, int length, TriConsumer<ThreadContext, State, RubyArray<T>> populator) {
+    public static <State, T extends IRubyObject> RubyArray<?> newArray(ThreadContext context, State state, int length, TriConsumer<ThreadContext, State, RubyArray<T>> populator) {
         RubyArray rawArray = newRawArray(context, length);
         populator.accept(context, state, rawArray);
         return rawArray.finishRawArray(context);

--- a/core/src/main/java/org/jruby/embed/variable/Argv.java
+++ b/core/src/main/java/org/jruby/embed/variable/Argv.java
@@ -41,6 +41,8 @@ import org.jruby.embed.internal.BiVariableMap;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import static org.jruby.api.Create.newArray;
+
 /**
  *
  * @author yoko
@@ -118,7 +120,7 @@ public class Argv extends AbstractVariable {
     public synchronized void inject() {
         var context = getRuntime().getCurrentContext();
 
-        final var argv = RubyArray.newArray(context.runtime);
+        final var argv = newArray(context);
         if ( javaObject instanceof Collection ) {
             argv.addAll( (Collection) javaObject );
         }

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -374,7 +374,7 @@ public class RubyBigDecimal extends RubyNumeric {
             if (value.isNil()) return c.searchInternalModuleVariable("vpExceptionMode");
             if (!(value instanceof RubyBoolean)) throw argumentError(context, "second argument must be true or false");
 
-            long newExceptionMode = c.searchInternalModuleVariable("vpExceptionMode").convertToInteger().getLongValue();
+            long newExceptionMode = numToLong(context, c.searchInternalModuleVariable("vpExceptionMode"));
 
             boolean enable = value.isTrue();
 
@@ -827,7 +827,7 @@ public class RubyBigDecimal extends RubyNumeric {
             throw typeError(context, "can't convert " + arg.inspect(context) + " into BigDecimal");
         }
 
-        int digits = (int) mathArg.convertToInteger().getLongValue();
+        int digits = numToInt(context, mathArg);
         if (digits < 0) {
             if (!strict) return getZero(context, 1);
             if (!exception) return context.nil;

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -321,7 +321,7 @@ public class RubyBigDecimal extends RubyNumeric {
         IRubyObject old = limit(context, recv);
 
         if (arg == context.nil) return old;
-        if (castAsFixnum(context, arg).getLongValue() < 0) throw argumentError(context, "argument must be positive");
+        if (castAsFixnum(context, arg).getValue() < 0) throw argumentError(context, "argument must be positive");
 
         ((RubyModule) recv).setInternalModuleVariable("vpPrecLimit", arg);
 
@@ -367,7 +367,7 @@ public class RubyBigDecimal extends RubyNumeric {
 
         args = Arity.scanArgs(context, args, 1, 1);
 
-        long mode = castAsFixnum(context, args[0]).getLongValue();
+        long mode = castAsFixnum(context, args[0]).getValue();
         IRubyObject value = args[1];
 
         if ((mode & EXCEPTION_ALL) != 0) {
@@ -414,7 +414,7 @@ public class RubyBigDecimal extends RubyNumeric {
 
     // The Fixnum cast should be fine because these are internal variables and user code cannot change them.
     private static long bigDecimalVar(ThreadContext context, String variableName) {
-        return ((RubyFixnum) Access.getClass(context, "BigDecimal").searchInternalModuleVariable(variableName)).getLongValue();
+        return ((RubyFixnum) Access.getClass(context, "BigDecimal").searchInternalModuleVariable(variableName)).getValue();
     }
 
     private static RoundingMode getRoundingMode(ThreadContext context) {
@@ -453,8 +453,8 @@ public class RubyBigDecimal extends RubyNumeric {
     }
 
     private static BigDecimal toBigDecimal(ThreadContext context, final RubyInteger value) {
-        return value instanceof RubyFixnum ?
-            BigDecimal.valueOf(toLong(context, value)) : new BigDecimal(value.getBigIntegerValue());
+        return value instanceof RubyFixnum fixnum ?
+            BigDecimal.valueOf(fixnum.getValue()) : new BigDecimal(value.getBigIntegerValue());
     }
 
     private static RubyBigDecimal getVpRubyObjectWithPrecInner(ThreadContext context, RubyRational value, RoundingMode mode) {
@@ -513,9 +513,10 @@ public class RubyBigDecimal extends RubyNumeric {
     }
 
     private static RubyBigDecimal newInstance(ThreadContext context, IRubyObject recv, RubyFixnum arg, MathContext mathContext) {
-        final long value = arg.getLongValue();
-        if (value == 0) return getZero(context, 1);
-        return new RubyBigDecimal(context.runtime, (RubyClass) recv, new BigDecimal(value, mathContext));
+        final long value = arg.getValue();
+        return value == 0 ?
+                getZero(context, 1) :
+                new RubyBigDecimal(context.runtime, (RubyClass) recv, new BigDecimal(value, mathContext));
     }
 
     private static RubyBigDecimal newInstance(ThreadContext context, IRubyObject recv, RubyRational arg, MathContext mathContext) {
@@ -2516,10 +2517,9 @@ public class RubyBigDecimal extends RubyNumeric {
     }
 
     private static boolean isEven(final RubyNumeric x) {
-        if (x instanceof RubyFixnum) return (((RubyFixnum) x).getLongValue() & 1) == 0;
-        if (x instanceof RubyBignum) {
-            return ((RubyBignum) x).getBigIntegerValue().testBit(0) == false; // 0-th bit -> 0
-        }
+        if (x instanceof RubyFixnum fix) return (fix.getValue() & 1) == 0;
+        if (x instanceof RubyBignum bignum) return bignum.getBigIntegerValue().testBit(0) == false; // 0-th bit -> 0
+
         return false;
     }
 

--- a/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
+++ b/core/src/main/java/org/jruby/ext/bigdecimal/RubyBigDecimal.java
@@ -374,7 +374,7 @@ public class RubyBigDecimal extends RubyNumeric {
             if (value.isNil()) return c.searchInternalModuleVariable("vpExceptionMode");
             if (!(value instanceof RubyBoolean)) throw argumentError(context, "second argument must be true or false");
 
-            long newExceptionMode = numToLong(context, c.searchInternalModuleVariable("vpExceptionMode"));
+            long newExceptionMode = toLong(context, c.searchInternalModuleVariable("vpExceptionMode"));
 
             boolean enable = value.isTrue();
 
@@ -454,7 +454,7 @@ public class RubyBigDecimal extends RubyNumeric {
 
     private static BigDecimal toBigDecimal(ThreadContext context, final RubyInteger value) {
         return value instanceof RubyFixnum ?
-            BigDecimal.valueOf(numToLong(context, value)) : new BigDecimal(value.getBigIntegerValue());
+            BigDecimal.valueOf(toLong(context, value)) : new BigDecimal(value.getBigIntegerValue());
     }
 
     private static RubyBigDecimal getVpRubyObjectWithPrecInner(ThreadContext context, RubyRational value, RoundingMode mode) {
@@ -827,7 +827,7 @@ public class RubyBigDecimal extends RubyNumeric {
             throw typeError(context, "can't convert " + arg.inspect(context) + " into BigDecimal");
         }
 
-        int digits = numToInt(context, mathArg);
+        int digits = toInt(context, mathArg);
         if (digits < 0) {
             if (!strict) return getZero(context, 1);
             if (!exception) return context.nil;
@@ -1284,7 +1284,7 @@ public class RubyBigDecimal extends RubyNumeric {
     }
 
     private static int getPositiveInt(ThreadContext context, IRubyObject arg) {
-        int value = castAsFixnum(context, arg).getIntValue();
+        int value = castAsFixnum(context, arg).asInt(context);
         if (value < 0) throw argumentError(context, "argument must be positive");
         return value;
     }
@@ -1692,7 +1692,8 @@ public class RubyBigDecimal extends RubyNumeric {
     }
 
     @Override
-    public int getIntValue() {
+    @JRubyAPI
+    public int asInt(ThreadContext context) {
         return value.intValue();
     }
 

--- a/core/src/main/java/org/jruby/ext/coverage/CoverageModule.java
+++ b/core/src/main/java/org/jruby/ext/coverage/CoverageModule.java
@@ -28,7 +28,6 @@ package org.jruby.ext.coverage;
 
 import java.util.Map;
 
-import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyHash;
 import org.jruby.RubyString;
@@ -218,7 +217,7 @@ public class CoverageModule {
             final IntList val = entry.getValue();
             boolean oneshot = (mode & CoverageData.ONESHOT_LINES) != 0;
 
-            var ary = Create.constructArray(context, val, val.size(),
+            var ary = Create.newArray(context, val, val.size(),
                     oneshot ?
                             CoverageModule::convertCoverageOneshot :
                             CoverageModule::convertCoverage

--- a/core/src/main/java/org/jruby/ext/date/DateUtils.java
+++ b/core/src/main/java/org/jruby/ext/date/DateUtils.java
@@ -6,6 +6,8 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.numToLong;
 import static org.jruby.ext.date.RubyDate.*;
 import static org.jruby.util.Numeric.*;
 
@@ -419,7 +421,7 @@ abstract class DateUtils {
         if (!f_zero_p(context, nth[0])) { // f_nonzero_p(*nth)
             t = f_mod(context, t, asFixnum(context, period));
         }
-        return t.convertToInteger().getIntValue() - 4712; /* unshift */
+        return numToInt(context, t) - 4712; /* unshift */
     }
 
     static long guess_style(ThreadContext context, IRubyObject y, double sg) { /* -/+oo or zero */
@@ -432,7 +434,7 @@ abstract class DateUtils {
         } else if (!(y instanceof RubyFixnum)) {
             style = ((RubyNumeric) y).isPositive(context) ? GREGORIAN : JULIAN;
         } else {
-            long iy = y.convertToInteger().getLongValue();
+            long iy = numToLong(context, y);
 
             if (iy < REFORM_BEGIN_YEAR)
                 style = JULIAN; // Double.POSITIVE_INFINITY;

--- a/core/src/main/java/org/jruby/ext/date/DateUtils.java
+++ b/core/src/main/java/org/jruby/ext/date/DateUtils.java
@@ -6,8 +6,8 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.numToInt;
-import static org.jruby.api.Convert.numToLong;
+import static org.jruby.api.Convert.toInt;
+import static org.jruby.api.Convert.toLong;
 import static org.jruby.ext.date.RubyDate.*;
 import static org.jruby.util.Numeric.*;
 
@@ -421,7 +421,7 @@ abstract class DateUtils {
         if (!f_zero_p(context, nth[0])) { // f_nonzero_p(*nth)
             t = f_mod(context, t, asFixnum(context, period));
         }
-        return numToInt(context, t) - 4712; /* unshift */
+        return toInt(context, t) - 4712; /* unshift */
     }
 
     static long guess_style(ThreadContext context, IRubyObject y, double sg) { /* -/+oo or zero */
@@ -434,7 +434,7 @@ abstract class DateUtils {
         } else if (!(y instanceof RubyFixnum)) {
             style = ((RubyNumeric) y).isPositive(context) ? GREGORIAN : JULIAN;
         } else {
-            long iy = numToLong(context, y);
+            long iy = toLong(context, y);
 
             if (iy < REFORM_BEGIN_YEAR)
                 style = JULIAN; // Double.POSITIVE_INFINITY;

--- a/core/src/main/java/org/jruby/ext/date/DateUtils.java
+++ b/core/src/main/java/org/jruby/ext/date/DateUtils.java
@@ -224,7 +224,7 @@ abstract class DateUtils {
                 if (i != -1 && i != 0 && i != 1) return INVALID_OFFSET;
 	            return (int) i * DAY_IN_SECONDS;
             case FLOAT:
-                double d = ((RubyFloat) of).getDoubleValue();
+                double d = ((RubyFloat) of).asDouble(context);
 
                 d = d * DAY_IN_SECONDS;
                 if (d < -DAY_IN_SECONDS || d > DAY_IN_SECONDS) return INVALID_OFFSET;

--- a/core/src/main/java/org/jruby/ext/date/RubyDate.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDate.java
@@ -1263,7 +1263,7 @@ public class RubyDate extends RubyObject {
     static final int SUB_MS_PRECISION = 1_000_000_000;
 
     static RubyNumeric roundToPrecision(ThreadContext context, RubyFloat sub, final long precision) {
-        long s = Math.round(sub.getDoubleValue() * precision);
+        long s = Math.round(sub.asDouble(context) * precision);
         return (RubyNumeric) RubyRational.newRationalCanonicalize(context, s, precision);
     }
 
@@ -1539,11 +1539,12 @@ public class RubyDate extends RubyObject {
 
     // MRI: #define val2sg(vsg,dsg)
     static long val2sg(ThreadContext context, IRubyObject sg) {
-        return getValidStart(context, sg.convertToFloat().getDoubleValue(), ITALY);
+        return getValidStart(context, sg.convertToFloat().asDouble(context), ITALY);
     }
 
+    @Deprecated(since = "10.0")
     static long valid_sg(ThreadContext context, IRubyObject sg) {
-        return getValidStart(context, sg.convertToFloat().getDoubleValue(), 0);
+        return getValidStart(context, sg.convertToFloat().asDouble(context), 0);
     }
 
     // MRI: #define valid_sg(sg)

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -61,6 +61,8 @@ import java.time.*;
 
 import static org.jruby.api.Access.timeClass;
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.numToLong;
 import static org.jruby.api.Define.defineClass;
 
 /**
@@ -186,21 +188,21 @@ public class RubyDateTime extends RubyDate {
         if (argc == 8) sg = val2sg(context, args[7]);
         if (argc >= 7) off = val2off(context, args[6]);
 
-        final int year = (sg > 0) ? getYear(args[0]) : args[0].convertToInteger().getIntValue();
+        final int year = (sg > 0) ? getYear(args[0]) : numToInt(context, args[0]);
         final int month = getMonth(args[1]);
         final long[] rest = new long[] { 0, 1 };
         final int day = (int) getDay(context, args[2], rest);
 
         if (argc >= 4 || rest[0] != 0) {
-            hour = getHour(context, argc >= 4 ? args[3] : RubyFixnum.zero(context.runtime), rest);
+            hour = getHour(context, argc >= 4 ? args[3] : asFixnum(context, 0), rest);
         }
 
         if (argc >= 5 || rest[0] != 0) {
-            minute = getMinute(context, argc >= 5 ? args[4] : RubyFixnum.zero(context.runtime), rest);
+            minute = getMinute(context, argc >= 5 ? args[4] : asFixnum(context, 0), rest);
         }
 
         if (argc >= 6 || rest[0] != 0) {
-            IRubyObject sec = argc >= 6 ? args[5] : RubyFixnum.zero(context.runtime);
+            IRubyObject sec = argc >= 6 ? args[5] : asFixnum(context, 0);
             second = getSecond(context, sec, rest);
             final long r0 = rest[0], r1 = rest[1];
             if (r0 != 0) {
@@ -233,7 +235,7 @@ public class RubyDateTime extends RubyDate {
     }
 
     static long getDay(ThreadContext context, IRubyObject day, final long[] rest) {
-        long d = day.convertToInteger().getLongValue();
+        long d = numToLong(context, day);
 
         if (!(day instanceof RubyInteger) && day instanceof RubyNumeric) { // Rational|Float
             RubyRational rat = ((RubyNumeric) day).convertToRational(context);
@@ -269,7 +271,7 @@ public class RubyDateTime extends RubyDate {
     }
 
     static int getHour(ThreadContext context, IRubyObject hour, final long[] rest) {
-        long h = hour.convertToInteger().getLongValue();
+        long h = numToLong(context, hour);
         long i = 0;
         final long r0 = rest[0], r1 = rest[1];
         if (r0 != 0) {
@@ -283,7 +285,7 @@ public class RubyDateTime extends RubyDate {
     }
 
     static int getMinute(ThreadContext context, IRubyObject val, final long[] rest) {
-        long v = val.convertToInteger().getLongValue();
+        long v = numToLong(context, val);
         long i = 0;
         final long r0 = rest[0], r1 = rest[1];
         if (r0 != 0) {
@@ -321,7 +323,7 @@ public class RubyDateTime extends RubyDate {
         // MRI: s_trunc
         long v;
         if (wholeNum) {
-            v = val.convertToInteger().getLongValue();
+            v = numToLong(context, val);
         } else {
             val = ((RubyNumeric) val).divmod(context, asFixnum(context, 1));
             v = ((RubyInteger) ((RubyArray) val).eltInternal(0)).getLongValue();
@@ -362,7 +364,7 @@ public class RubyDateTime extends RubyDate {
             rest[0] = rat.getNumerator().getLongValue();
             rest[1] = rat.getDenominator().getLongValue();
         } else {
-            rest[0] = res.convertToInteger().getLongValue();
+            rest[0] = numToLong(context, res);
             rest[1] = 1;
         }
     }

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -61,8 +61,8 @@ import java.time.*;
 
 import static org.jruby.api.Access.timeClass;
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.numToInt;
-import static org.jruby.api.Convert.numToLong;
+import static org.jruby.api.Convert.toInt;
+import static org.jruby.api.Convert.toLong;
 import static org.jruby.api.Define.defineClass;
 
 /**
@@ -188,8 +188,8 @@ public class RubyDateTime extends RubyDate {
         if (argc == 8) sg = val2sg(context, args[7]);
         if (argc >= 7) off = val2off(context, args[6]);
 
-        final int year = (sg > 0) ? getYear(args[0]) : numToInt(context, args[0]);
-        final int month = getMonth(args[1]);
+        final int year = (sg > 0) ? getYear(context, args[0]) : toInt(context, args[0]);
+        final int month = getMonth(context, args[1]);
         final long[] rest = new long[] { 0, 1 };
         final int day = (int) getDay(context, args[2], rest);
 
@@ -235,7 +235,7 @@ public class RubyDateTime extends RubyDate {
     }
 
     static long getDay(ThreadContext context, IRubyObject day, final long[] rest) {
-        long d = numToLong(context, day);
+        long d = toLong(context, day);
 
         if (!(day instanceof RubyInteger) && day instanceof RubyNumeric) { // Rational|Float
             RubyRational rat = ((RubyNumeric) day).convertToRational(context);
@@ -271,7 +271,7 @@ public class RubyDateTime extends RubyDate {
     }
 
     static int getHour(ThreadContext context, IRubyObject hour, final long[] rest) {
-        long h = numToLong(context, hour);
+        long h = toLong(context, hour);
         long i = 0;
         final long r0 = rest[0], r1 = rest[1];
         if (r0 != 0) {
@@ -285,7 +285,7 @@ public class RubyDateTime extends RubyDate {
     }
 
     static int getMinute(ThreadContext context, IRubyObject val, final long[] rest) {
-        long v = numToLong(context, val);
+        long v = toLong(context, val);
         long i = 0;
         final long r0 = rest[0], r1 = rest[1];
         if (r0 != 0) {
@@ -323,7 +323,7 @@ public class RubyDateTime extends RubyDate {
         // MRI: s_trunc
         long v;
         if (wholeNum) {
-            v = numToLong(context, val);
+            v = toLong(context, val);
         } else {
             val = ((RubyNumeric) val).divmod(context, asFixnum(context, 1));
             v = ((RubyInteger) ((RubyArray) val).eltInternal(0)).getLongValue();
@@ -364,7 +364,7 @@ public class RubyDateTime extends RubyDate {
             rest[0] = rat.getNumerator().getLongValue();
             rest[1] = rat.getDenominator().getLongValue();
         } else {
-            rest[0] = numToLong(context, res);
+            rest[0] = toLong(context, res);
             rest[1] = 1;
         }
     }

--- a/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
+++ b/core/src/main/java/org/jruby/ext/date/RubyDateTime.java
@@ -242,8 +242,8 @@ public class RubyDateTime extends RubyDate {
             if (rat.getNumerator() instanceof RubyBignum || rat.getDenominator() instanceof RubyBignum) {
                 calcBigIntDayRest(rat, d, rest);
             } else {
-                long num = rat.getNumerator().getLongValue();
-                long den = rat.getDenominator().getLongValue();
+                long num = rat.getNumerator().asLong(context);
+                long den = rat.getDenominator().asLong(context);
                 rest[0] = num - d * den; rest[1] = den;
             }
         }
@@ -301,7 +301,7 @@ public class RubyDateTime extends RubyDate {
     private static boolean isSecondAWholeNumber(ThreadContext context, IRubyObject val) {
         if (val instanceof RubyRational rat) {
             RubyInteger den = rat.getDenominator();
-            return den instanceof RubyFixnum && den.getLongValue() == 1;
+            return den instanceof RubyFixnum denf && denf.getValue() == 1;
         } else if (val instanceof RubyFloat flote) {
             double v = flote.asDouble(context);
             return v == (double) Math.round(v);
@@ -326,7 +326,7 @@ public class RubyDateTime extends RubyDate {
             v = toLong(context, val);
         } else {
             val = ((RubyNumeric) val).divmod(context, asFixnum(context, 1));
-            v = ((RubyInteger) ((RubyArray) val).eltInternal(0)).getLongValue();
+            v = ((RubyInteger) ((RubyArray) val).eltInternal(0)).asLong(context);
             RubyNumeric fr = (RubyNumeric) ((RubyArray) val).eltInternal(1);
             // NOTE: we don't:
             // *fr = f_quo(*fr, INT2FIX(86400));
@@ -345,8 +345,8 @@ public class RubyDateTime extends RubyDate {
     }
 
     private static void addRationalModToRest(ThreadContext context, RubyRational rat, long ival, final long[] rest) {
-        long num = rat.getNumerator().getLongValue();
-        long den = rat.getDenominator().getLongValue();
+        long num = rat.getNumerator().asLong(context);
+        long den = rat.getDenominator().asLong(context);
         num -= ival * den;
         if (num != 0) {
             addFraction(context, rest, RubyRational.newRational(context.runtime, num, den), false);
@@ -356,13 +356,13 @@ public class RubyDateTime extends RubyDate {
     private static void addFraction(ThreadContext context, final long[] rest, RubyNumeric fr, boolean roundFloat) {
         RubyNumeric res = (RubyNumeric) RubyRational.newRational(context.runtime, rest[0], rest[1]).op_plus(context, fr);
         if (res instanceof RubyRational rat) {
-            rest[0] = rat.getNumerator().getLongValue();
-            rest[1] = rat.getDenominator().getLongValue();
+            rest[0] = rat.getNumerator().asLong(context);
+            rest[1] = rat.getDenominator().asLong(context);
         } else if (roundFloat && res instanceof RubyFloat flote) {
             // currently only used for (sub) sec rounding - will need a revision for others
             var rat = roundToPrecision(context, flote, SUB_MS_PRECISION * 1000L).convertToRational(context);
-            rest[0] = rat.getNumerator().getLongValue();
-            rest[1] = rat.getDenominator().getLongValue();
+            rest[0] = rat.getNumerator().asLong(context);
+            rest[1] = rat.getDenominator().asLong(context);
         } else {
             rest[0] = toLong(context, res);
             rest[1] = 1;
@@ -516,7 +516,7 @@ public class RubyDateTime extends RubyDate {
         RubyTime time = new RubyTime(context.runtime, timeClass(context), dt, true);
         if (subMillisNum != 0) {
             RubyNumeric usec = (RubyNumeric) subMillis(context).op_mul(context, asFixnum(context, 1_000_000));
-            time.setNSec(usec.getLongValue());
+            time.setNSec(usec.asLong(context));
         }
         return time;
     }

--- a/core/src/main/java/org/jruby/ext/date/TimeExt.java
+++ b/core/src/main/java/org/jruby/ext/date/TimeExt.java
@@ -71,11 +71,11 @@ public abstract class TimeExt {
         if (time.getNSec() != 0) {
             IRubyObject subMillis = RubyRational.newRationalCanonicalize(context, time.getNSec(), 1_000_000);
             if (subMillis instanceof RubyRational) {
-                subMillisNum = ((RubyRational) subMillis).getNumerator().getLongValue();
-                subMillisDen = ((RubyRational) subMillis).getDenominator().getLongValue();
+                subMillisNum = ((RubyRational) subMillis).getNumerator().asLong(context);
+                subMillisDen = ((RubyRational) subMillis).getDenominator().asLong(context);
             }
             else {
-                subMillisNum = ((RubyInteger) subMillis).getLongValue();
+                subMillisNum = ((RubyInteger) subMillis).asLong(context);
             }
         }
 

--- a/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
+++ b/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
@@ -42,6 +42,7 @@ import static org.jruby.api.Convert.*;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineModule;
 import static org.jruby.api.Error.argumentError;
+import static org.jruby.api.Error.notImplementedError;
 import static org.jruby.api.Error.runtimeError;
 import static org.jruby.api.Warn.warn;
 
@@ -169,9 +170,8 @@ public class RubyEtc {
     
     @JRubyMethod(module = true)
     public static synchronized IRubyObject sysconf(ThreadContext context, IRubyObject recv, IRubyObject arg) {
-        Ruby runtime = context.runtime;
         Sysconf name = Sysconf.valueOf(toLong(context, arg));
-        POSIX posix = runtime.getPosix();
+        POSIX posix = context.runtime.getPosix();
         posix.errno(0);
         long ret = posix.sysconf(name);
 
@@ -181,12 +181,12 @@ public class RubyEtc {
             if (errno == Errno.ENOENT.intValue() || errno == 0) {
                 return context.nil;
             } else if (errno == Errno.EOPNOTSUPP.intValue()) {
-                throw runtime.newNotImplementedError("sysconf() function is unimplemented on this machine");
+                throw notImplementedError(context, "sysconf() function is unimplemented on this machine");
             } else {
-                throw runtime.newErrnoFromLastPOSIXErrno();
+                throw context.runtime.newErrnoFromLastPOSIXErrno();
             }
         }
-        return RubyFixnum.newFixnum(runtime, ret);
+        return asFixnum(context, ret);
     }
     
     @JRubyMethod(module = true)

--- a/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
+++ b/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
@@ -15,7 +15,6 @@ import org.jruby.RubyClass;
 import org.jruby.RubyHash;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.anno.JRubyModule;
-import org.jruby.common.IRubyWarnings.ID;
 import org.jruby.exceptions.RaiseException;
 import jnr.posix.Passwd;
 import jnr.posix.Group;
@@ -51,7 +50,7 @@ public class RubyEtc {
     public static class IOExt {
         @JRubyMethod
         public static synchronized IRubyObject pathconf(ThreadContext context, IRubyObject recv, IRubyObject arg) {
-            Pathconf name = Pathconf.valueOf(numericToLong(context, arg));
+            Pathconf name = Pathconf.valueOf(numToLong(context, arg));
             RubyIO io = (RubyIO) recv;
             OpenFile fptr = io.getOpenFileChecked();
             POSIX posix = context.runtime.getPosix();
@@ -171,7 +170,7 @@ public class RubyEtc {
     @JRubyMethod(module = true)
     public static synchronized IRubyObject sysconf(ThreadContext context, IRubyObject recv, IRubyObject arg) {
         Ruby runtime = context.runtime;
-        Sysconf name = Sysconf.valueOf(numericToLong(context, arg));
+        Sysconf name = Sysconf.valueOf(numToLong(context, arg));
         POSIX posix = runtime.getPosix();
         posix.errno(0);
         long ret = posix.sysconf(name);
@@ -192,7 +191,7 @@ public class RubyEtc {
     
     @JRubyMethod(module = true)
     public static synchronized IRubyObject confstr(ThreadContext context, IRubyObject recv, IRubyObject arg) {
-        Confstr name = Confstr.valueOf(numericToLong(context, arg));
+        Confstr name = Confstr.valueOf(numToLong(context, arg));
         ByteBuffer buf;
 
         POSIX posix = context.runtime.getPosix();

--- a/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
+++ b/core/src/main/java/org/jruby/ext/etc/RubyEtc.java
@@ -50,7 +50,7 @@ public class RubyEtc {
     public static class IOExt {
         @JRubyMethod
         public static synchronized IRubyObject pathconf(ThreadContext context, IRubyObject recv, IRubyObject arg) {
-            Pathconf name = Pathconf.valueOf(numToLong(context, arg));
+            Pathconf name = Pathconf.valueOf(toLong(context, arg));
             RubyIO io = (RubyIO) recv;
             OpenFile fptr = io.getOpenFileChecked();
             POSIX posix = context.runtime.getPosix();
@@ -170,7 +170,7 @@ public class RubyEtc {
     @JRubyMethod(module = true)
     public static synchronized IRubyObject sysconf(ThreadContext context, IRubyObject recv, IRubyObject arg) {
         Ruby runtime = context.runtime;
-        Sysconf name = Sysconf.valueOf(numToLong(context, arg));
+        Sysconf name = Sysconf.valueOf(toLong(context, arg));
         POSIX posix = runtime.getPosix();
         posix.errno(0);
         long ret = posix.sysconf(name);
@@ -191,7 +191,7 @@ public class RubyEtc {
     
     @JRubyMethod(module = true)
     public static synchronized IRubyObject confstr(ThreadContext context, IRubyObject recv, IRubyObject arg) {
-        Confstr name = Confstr.valueOf(numToLong(context, arg));
+        Confstr name = Confstr.valueOf(toLong(context, arg));
         ByteBuffer buf;
 
         POSIX posix = context.runtime.getPosix();

--- a/core/src/main/java/org/jruby/ext/ffi/AbstractMemory.java
+++ b/core/src/main/java/org/jruby/ext/ffi/AbstractMemory.java
@@ -87,7 +87,7 @@ abstract public class AbstractMemory extends MemoryObject {
         DynamicMethod sizeMethod = sizeArg.getMetaClass().searchMethod("size");
         if (sizeMethod.isUndefined()) throw argumentError(context, "Invalid size argument");
 
-        return (int) numericToLong(context, sizeMethod.call(context, sizeArg, sizeArg.getMetaClass(), "size"));
+        return (int) numToLong(context, sizeMethod.call(context, sizeArg, sizeArg.getMetaClass(), "size"));
     }
 
     protected static final RubyArray checkArray(IRubyObject obj) {
@@ -1914,7 +1914,7 @@ abstract public class AbstractMemory extends MemoryObject {
     @JRubyMethod(name = "write_string")
     public IRubyObject write_string(ThreadContext context, IRubyObject strArg, IRubyObject lenArg) {
         ByteList bl = strArg.convertToString().getByteList();
-        getMemoryIO().put(0, bl.getUnsafeBytes(), bl.begin(), Math.min(bl.length(), (int) numericToLong(context, lenArg)));
+        getMemoryIO().put(0, bl.getUnsafeBytes(), bl.begin(), Math.min(bl.length(), (int) numToLong(context, lenArg)));
         return this;
     }
 
@@ -2098,7 +2098,7 @@ abstract public class AbstractMemory extends MemoryObject {
     public final IRubyObject put(ThreadContext context, IRubyObject typeName, IRubyObject offset) {
         Type type = context.runtime.getFFI().getTypeResolver().findType(context.runtime, typeName);
         MemoryOp op = MemoryOp.getMemoryOp(type);
-        if (op != null) return op.get(context, getMemoryIO(), numericToLong(context, offset));
+        if (op != null) return op.get(context, getMemoryIO(), numToLong(context, offset));
 
         throw argumentError(context, "undefined type " + typeName);
     }
@@ -2108,7 +2108,7 @@ abstract public class AbstractMemory extends MemoryObject {
         Type type = context.runtime.getFFI().getTypeResolver().findType(context.runtime, typeName);
         MemoryOp op = MemoryOp.getMemoryOp(type);
         if (op != null) {
-            op.put(context, getMemoryIO(), numericToLong(context, offset), value);
+            op.put(context, getMemoryIO(), numToLong(context, offset), value);
             return context.nil;
         }
 

--- a/core/src/main/java/org/jruby/ext/ffi/AbstractMemory.java
+++ b/core/src/main/java/org/jruby/ext/ffi/AbstractMemory.java
@@ -87,7 +87,7 @@ abstract public class AbstractMemory extends MemoryObject {
         DynamicMethod sizeMethod = sizeArg.getMetaClass().searchMethod("size");
         if (sizeMethod.isUndefined()) throw argumentError(context, "Invalid size argument");
 
-        return (int) numToLong(context, sizeMethod.call(context, sizeArg, sizeArg.getMetaClass(), "size"));
+        return (int) toLong(context, sizeMethod.call(context, sizeArg, sizeArg.getMetaClass(), "size"));
     }
 
     protected static final RubyArray checkArray(IRubyObject obj) {
@@ -1914,7 +1914,7 @@ abstract public class AbstractMemory extends MemoryObject {
     @JRubyMethod(name = "write_string")
     public IRubyObject write_string(ThreadContext context, IRubyObject strArg, IRubyObject lenArg) {
         ByteList bl = strArg.convertToString().getByteList();
-        getMemoryIO().put(0, bl.getUnsafeBytes(), bl.begin(), Math.min(bl.length(), (int) numToLong(context, lenArg)));
+        getMemoryIO().put(0, bl.getUnsafeBytes(), bl.begin(), Math.min(bl.length(), (int) toLong(context, lenArg)));
         return this;
     }
 
@@ -2098,7 +2098,7 @@ abstract public class AbstractMemory extends MemoryObject {
     public final IRubyObject put(ThreadContext context, IRubyObject typeName, IRubyObject offset) {
         Type type = context.runtime.getFFI().getTypeResolver().findType(context.runtime, typeName);
         MemoryOp op = MemoryOp.getMemoryOp(type);
-        if (op != null) return op.get(context, getMemoryIO(), numToLong(context, offset));
+        if (op != null) return op.get(context, getMemoryIO(), toLong(context, offset));
 
         throw argumentError(context, "undefined type " + typeName);
     }
@@ -2108,7 +2108,7 @@ abstract public class AbstractMemory extends MemoryObject {
         Type type = context.runtime.getFFI().getTypeResolver().findType(context.runtime, typeName);
         MemoryOp op = MemoryOp.getMemoryOp(type);
         if (op != null) {
-            op.put(context, getMemoryIO(), numToLong(context, offset), value);
+            op.put(context, getMemoryIO(), toLong(context, offset), value);
             return context.nil;
         }
 

--- a/core/src/main/java/org/jruby/ext/ffi/Pointer.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Pointer.java
@@ -95,7 +95,7 @@ public class Pointer extends AbstractMemory {
     public IRubyObject initialize(ThreadContext context, IRubyObject address) {
         setMemoryIO(address instanceof Pointer
                 ? ((Pointer) address).getMemoryIO()
-                : Factory.getInstance().wrapDirectMemory(context.runtime, numToLong(context, address)));
+                : Factory.getInstance().wrapDirectMemory(context.runtime, toLong(context, address)));
         size = Long.MAX_VALUE;
         typeSize = 1;
 
@@ -106,7 +106,7 @@ public class Pointer extends AbstractMemory {
     public IRubyObject initialize(ThreadContext context, IRubyObject type, IRubyObject address) {
         setMemoryIO(address instanceof Pointer
                 ? ((Pointer) address).getMemoryIO()
-                : Factory.getInstance().wrapDirectMemory(context.runtime, numToLong(context, address)));
+                : Factory.getInstance().wrapDirectMemory(context.runtime, toLong(context, address)));
         size = Long.MAX_VALUE;
         typeSize = calculateTypeSize(context, type);
 

--- a/core/src/main/java/org/jruby/ext/ffi/Pointer.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Pointer.java
@@ -91,7 +91,7 @@ public class Pointer extends AbstractMemory {
         return asFixnum(context, Factory.getInstance().sizeOf(NativeType.POINTER));
     }
 
-    @JRubyMethod(name = { "initialize" }, visibility = PRIVATE)
+    @JRubyMethod(name = "initialize", visibility = PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject address) {
         setMemoryIO(address instanceof Pointer
                 ? ((Pointer) address).getMemoryIO()
@@ -102,7 +102,7 @@ public class Pointer extends AbstractMemory {
         return this;
     }
 
-    @JRubyMethod(name = { "initialize" }, visibility = PRIVATE)
+    @JRubyMethod(name = "initialize", visibility = PRIVATE)
     public IRubyObject initialize(ThreadContext context, IRubyObject type, IRubyObject address) {
         setMemoryIO(address instanceof Pointer
                 ? ((Pointer) address).getMemoryIO()

--- a/core/src/main/java/org/jruby/ext/ffi/Pointer.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Pointer.java
@@ -95,7 +95,7 @@ public class Pointer extends AbstractMemory {
     public IRubyObject initialize(ThreadContext context, IRubyObject address) {
         setMemoryIO(address instanceof Pointer
                 ? ((Pointer) address).getMemoryIO()
-                : Factory.getInstance().wrapDirectMemory(context.runtime, numericToLong(context, address)));
+                : Factory.getInstance().wrapDirectMemory(context.runtime, numToLong(context, address)));
         size = Long.MAX_VALUE;
         typeSize = 1;
 
@@ -106,7 +106,7 @@ public class Pointer extends AbstractMemory {
     public IRubyObject initialize(ThreadContext context, IRubyObject type, IRubyObject address) {
         setMemoryIO(address instanceof Pointer
                 ? ((Pointer) address).getMemoryIO()
-                : Factory.getInstance().wrapDirectMemory(context.runtime, numericToLong(context, address)));
+                : Factory.getInstance().wrapDirectMemory(context.runtime, numToLong(context, address)));
         size = Long.MAX_VALUE;
         typeSize = calculateTypeSize(context, type);
 

--- a/core/src/main/java/org/jruby/ext/ffi/StructLayout.java
+++ b/core/src/main/java/org/jruby/ext/ffi/StructLayout.java
@@ -238,7 +238,7 @@ public final class StructLayout extends Type {
      */
     @JRubyMethod(name = "members")
     public IRubyObject members(ThreadContext context) {
-        return Create.constructArray(context, fieldNames, fieldNames.size(), StructLayout::memberPopulator);
+        return Create.newArray(context, fieldNames, fieldNames.size(), StructLayout::memberPopulator);
     }
 
     private static void memberPopulator(ThreadContext c, List<IRubyObject> f, RubyArray<IRubyObject> a) {
@@ -254,7 +254,7 @@ public final class StructLayout extends Type {
      */
     @JRubyMethod(name = "offsets")
     public IRubyObject offsets(ThreadContext context) {
-        return Create.constructArray(context, this, fieldNames.size(), StructLayout::offsetsPopulator);
+        return Create.newArray(context, this, fieldNames.size(), StructLayout::offsetsPopulator);
     }
 
     private static void offsetsPopulator(ThreadContext c, StructLayout s, RubyArray<IRubyObject> a) {

--- a/core/src/main/java/org/jruby/ext/ffi/Util.java
+++ b/core/src/main/java/org/jruby/ext/ffi/Util.java
@@ -100,15 +100,12 @@ public final class Util {
 
     @Deprecated(since = "10.0")
     public static int intValue(IRubyObject obj, RubyHash enums) {
-        if (obj instanceof RubyInteger) {
-                return (int) ((RubyInteger) obj).getLongValue();
-
-        } else if (obj instanceof RubySymbol) {
+        var context = ((RubyBasicObject) obj).getCurrentContext();
+        if (obj instanceof RubyInteger obji) return obji.asInt(context);
+        if (obj instanceof RubySymbol) {
             IRubyObject value = enums.fastARef(obj);
-            if (value.isNil()) {
-                var context = obj.getRuntime().getCurrentContext();
-                throw argumentError(context, "invalid enum value, " + obj.inspect(context));
-            }
+            if (value.isNil()) throw argumentError(context, "invalid enum value, " + obj.inspect(context));
+
             return (int) longValue(value);
         } else {
             return (int) longValue(obj);

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/Factory.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/Factory.java
@@ -14,6 +14,8 @@ import org.jruby.platform.Platform;
 
 import static org.jruby.api.Access.objectClass;
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.numToLong;
 
 public class Factory extends org.jruby.ext.ffi.Factory {
 
@@ -117,7 +119,7 @@ public class Factory extends org.jruby.ext.ffi.Factory {
 
         @JRubyMethod(name = {  "error=" }, module = true)
         public static final IRubyObject error_set(ThreadContext context, IRubyObject recv, IRubyObject value) {
-            com.kenai.jffi.LastError.getInstance().set((int)value.convertToInteger().getLongValue());
+            com.kenai.jffi.LastError.getInstance().set(numToInt(context, value));
 
             return value;
         }

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/Factory.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/Factory.java
@@ -14,8 +14,7 @@ import org.jruby.platform.Platform;
 
 import static org.jruby.api.Access.objectClass;
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.numToInt;
-import static org.jruby.api.Convert.numToLong;
+import static org.jruby.api.Convert.toInt;
 
 public class Factory extends org.jruby.ext.ffi.Factory {
 
@@ -119,7 +118,7 @@ public class Factory extends org.jruby.ext.ffi.Factory {
 
         @JRubyMethod(name = {  "error=" }, module = true)
         public static final IRubyObject error_set(ThreadContext context, IRubyObject recv, IRubyObject value) {
-            com.kenai.jffi.LastError.getInstance().set(numToInt(context, value));
+            com.kenai.jffi.LastError.getInstance().set(toInt(context, value));
 
             return value;
         }

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/JITRuntime.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/JITRuntime.java
@@ -29,79 +29,79 @@ public final class JITRuntime {
     
     public static int s8Value32(IRubyObject parameter) {
         return (byte) (parameter instanceof RubyFixnum
-                ? ((RubyFixnum) parameter).getLongValue()
+                ? ((RubyFixnum) parameter).getValue()
                 : other2long(parameter));
     }
 
     public static long s8Value64(IRubyObject parameter) {
         return (byte) (parameter instanceof RubyFixnum
-                ? ((RubyFixnum) parameter).getLongValue()
+                ? ((RubyFixnum) parameter).getValue()
                 : other2long(parameter));
     }
 
     public static int u8Value32(IRubyObject parameter) {
         return (int) ((parameter instanceof RubyFixnum
-                ? ((RubyFixnum) parameter).getLongValue()
+                ? ((RubyFixnum) parameter).getValue()
                 : other2long(parameter)) & 0xffL);
     }
 
     public static long u8Value64(IRubyObject parameter) {
         return (parameter instanceof RubyFixnum
-                ? ((RubyFixnum) parameter).getLongValue()
+                ? ((RubyFixnum) parameter).getValue()
                 : other2long(parameter)) & 0xffL;
     }
 
     public static int s16Value32(IRubyObject parameter) {
         return (short) (parameter instanceof RubyFixnum
-                ? ((RubyFixnum) parameter).getLongValue()
+                ? ((RubyFixnum) parameter).getValue()
                 : other2long(parameter));
     }
 
     public static long s16Value64(IRubyObject parameter) {
         return (short) (parameter instanceof RubyFixnum
-                ? ((RubyFixnum) parameter).getLongValue()
+                ? ((RubyFixnum) parameter).getValue()
                 : other2long(parameter));
     }
 
     public static int u16Value32(IRubyObject parameter) {
         return (int) (((parameter instanceof RubyFixnum)
-                ? ((RubyFixnum) parameter).getLongValue()
+                ? ((RubyFixnum) parameter).getValue()
                 : other2long(parameter))  & 0xffffL);
     }
 
     public static long u16Value64(IRubyObject parameter) {
         return ((parameter instanceof RubyFixnum)
-                ? ((RubyFixnum) parameter).getLongValue()
+                ? ((RubyFixnum) parameter).getValue()
                 : other2long(parameter)) & 0xffffL;
     }
 
     public static int s32Value32(IRubyObject parameter) {
         return (int) (parameter instanceof RubyFixnum
-                ? ((RubyFixnum) parameter).getLongValue()
+                ? ((RubyFixnum) parameter).getValue()
                 : other2long(parameter));
     }
 
     public static long s32Value64(IRubyObject parameter) {
         return (int) (parameter instanceof RubyFixnum
-                ? ((RubyFixnum) parameter).getLongValue()
+                ? ((RubyFixnum) parameter).getValue()
                 : other2long(parameter));
     }
 
     public static int u32Value32(IRubyObject parameter) {
         return (int) ((parameter instanceof RubyFixnum
-                ? ((RubyFixnum) parameter).getLongValue()
+                ? ((RubyFixnum) parameter).getValue()
                 : other2long(parameter)) & 0xffffffffL);
     }
 
     public static long u32Value64(IRubyObject parameter) {
         return (parameter instanceof RubyFixnum
-                ? ((RubyFixnum) parameter).getLongValue()
+                ? ((RubyFixnum) parameter).getValue()
                 : other2long(parameter)) & 0xffffffffL;
     }
 
     public static long s64Value64(IRubyObject parameter) {
         return parameter instanceof RubyFixnum
-                ? ((RubyFixnum) parameter).getLongValue()
+                ? ((RubyFixnum) parameter).getValue()
                 : other2long(parameter);
     }
 
@@ -116,7 +116,7 @@ public final class JITRuntime {
 
     public static long u64Value64(IRubyObject parameter) {
         return parameter instanceof RubyFixnum fixnum
-                ? fixnum.getLongValue()
+                ? fixnum.getValue()
                 : other2u64(parameter);
     }
 
@@ -146,10 +146,10 @@ public final class JITRuntime {
         return boolValue(parameter) ? 1L : 0L;
     }
 
-    private static boolean other2bool(IRubyObject parameter) {
-        if (parameter instanceof RubyNumeric numeric) return numeric.getLongValue() != 0;
+    private static boolean other2bool(ThreadContext context, IRubyObject parameter) {
+        if (parameter instanceof RubyNumeric numeric) return numeric.asLong(context) != 0;
 
-        throw typeError(parameter.getRuntime().getCurrentContext(), "cannot convert ", parameter, " to bool");
+        throw typeError(context, "cannot convert ", parameter, " to bool");
     }
 
     public static boolean boolValue(IRubyObject parameter) {
@@ -157,7 +157,7 @@ public final class JITRuntime {
             return parameter.isTrue();
         }
         
-        return other2bool(parameter);
+        return other2bool(parameter.getRuntime().getCurrentContext(), parameter);
     }
     
     public static IRubyObject other2ptr(ThreadContext context, IRubyObject parameter) {

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/JITRuntime.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/JITRuntime.java
@@ -115,36 +115,27 @@ public final class JITRuntime {
     }
 
     public static long u64Value64(IRubyObject parameter) {
-        return parameter instanceof RubyFixnum
-                ? ((RubyFixnum) parameter).getLongValue()
+        return parameter instanceof RubyFixnum fixnum
+                ? fixnum.getLongValue()
                 : other2u64(parameter);
     }
 
     public static int f32Value32(IRubyObject parameter) {
-        if (parameter instanceof RubyFloat) {
-            return Float.floatToRawIntBits((float) ((RubyFloat) parameter).getDoubleValue());
-
-        } else {
-            return (int) other2long(parameter);
-        }
+        return parameter instanceof RubyFloat flote ?
+                Float.floatToRawIntBits((float) flote.getValue()) :
+                (int) other2long(parameter);
     }
 
     public static long f32Value64(IRubyObject parameter) {
-        if (parameter instanceof RubyFloat) {
-            return Float.floatToRawIntBits((float) ((RubyFloat) parameter).getDoubleValue());
-
-        } else {
-            return other2long(parameter);
-        }
+        return parameter instanceof RubyFloat flote ?
+                Float.floatToRawIntBits((float) flote.getValue()) :
+                other2long(parameter);
     }
     
     public static long f64Value64(IRubyObject parameter) {
-        if (parameter instanceof RubyFloat) {
-            return Double.doubleToRawLongBits(((RubyFloat) parameter).getDoubleValue());
-        
-        } else {
-            return other2long(parameter);
-        }
+        return parameter instanceof RubyFloat flote ?
+                Double.doubleToRawLongBits(flote.getValue()) :
+                other2long(parameter);
     }
 
     public static int boolValue32(IRubyObject parameter) {

--- a/core/src/main/java/org/jruby/ext/ffi/jffi/NativeClosureProxy.java
+++ b/core/src/main/java/org/jruby/ext/ffi/jffi/NativeClosureProxy.java
@@ -72,9 +72,9 @@ final class NativeClosureProxy implements Closure {
      * @param value The Ruby object to convert
      * @return a java long value.
      */
-    private static final long longValue(IRubyObject value) {
-        if (value instanceof RubyNumeric) {
-            return ((RubyNumeric) value).getLongValue();
+    private static final long longValue(ThreadContext context, IRubyObject value) {
+        if (value instanceof RubyNumeric num) {
+            return num.asLong(context);
         } else if (value.isNil()) {
             return 0L;
         }
@@ -89,9 +89,9 @@ final class NativeClosureProxy implements Closure {
      * @param value The Ruby object to convert
      * @return a java long value.
      */
-    private static final long addressValue(IRubyObject value) {
-        if (value instanceof RubyNumeric) {
-            return ((RubyNumeric) value).getLongValue();
+    private static final long addressValue(ThreadContext context, IRubyObject value) {
+        if (value instanceof RubyNumeric num) {
+            return num.asLong(context);
         } else if (value instanceof Pointer) {
             return ((Pointer) value).getAddress();
         } else if (value.isNil()) {
@@ -115,18 +115,18 @@ final class NativeClosureProxy implements Closure {
                 case VOID:
                     break;
                 case CHAR, UCHAR:
-                    buffer.setByteReturn((byte) longValue(value)); break;
+                    buffer.setByteReturn((byte) longValue(context, value)); break;
                 case SHORT, USHORT:
-                    buffer.setShortReturn((short) longValue(value)); break;
+                    buffer.setShortReturn((short) longValue(context, value)); break;
                 case INT, UINT:
-                    buffer.setIntReturn((int) longValue(value)); break;
+                    buffer.setIntReturn((int) longValue(context, value)); break;
                 case LONG_LONG:
                     buffer.setLongReturn(Util.int64Value(value)); break;
                 case ULONG_LONG:
                     buffer.setLongReturn(Util.uint64Value(value)); break;
                 case LONG, ULONG:
                     if (LONG_SIZE == 32) {
-                        buffer.setIntReturn((int) longValue(value));
+                        buffer.setIntReturn((int) longValue(context, value));
                     } else {
                         buffer.setLongReturn(Util.int64Value(value));
                     }
@@ -138,7 +138,7 @@ final class NativeClosureProxy implements Closure {
 //                case LONGDOUBLE:
 //                    break; // not implemented
                 case POINTER:
-                    buffer.setAddressReturn(addressValue(value)); break;
+                    buffer.setAddressReturn(addressValue(context, value)); break;
 
                 case BOOL:
                     buffer.setIntReturn(value.isTrue() ? 1 : 0); break;
@@ -147,7 +147,7 @@ final class NativeClosureProxy implements Closure {
         } else if (type instanceof CallbackInfo) {
             if (value instanceof RubyProc || value.respondsTo("call")) {
                 Pointer cb = Factory.getInstance().getCallbackManager().getCallback(context, (CallbackInfo) type, value);
-                buffer.setAddressReturn(addressValue(cb));
+                buffer.setAddressReturn(addressValue(context, cb));
             } else {
                 buffer.setAddressReturn(0L);
                 throw typeError(context, "invalid callback return value, expected Proc or callable object");

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyLibrary.java
@@ -241,7 +241,7 @@ public class JRubyLibrary implements Library {
             case 4 :
                 filename = args[1].convertToString().toString();
                 inlineSource = args[2].isTrue();
-                lineno = numToInt(context, args[3]);
+                lineno = toInt(context, args[3]);
                 break;
             default :
                 throw new AssertionError("unexpected arguments: " + java.util.Arrays.toString(args));

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyLibrary.java
@@ -241,7 +241,7 @@ public class JRubyLibrary implements Library {
             case 4 :
                 filename = args[1].convertToString().toString();
                 inlineSource = args[2].isTrue();
-                lineno = args[3].convertToInteger().getIntValue();
+                lineno = numToInt(context, args[3]);
                 break;
             default :
                 throw new AssertionError("unexpected arguments: " + java.util.Arrays.toString(args));

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
@@ -197,7 +197,7 @@ public class JRubyUtilLibrary implements Library {
     public static IRubyObject set_last_exit_status(ThreadContext context, IRubyObject recv,
                                                    IRubyObject status, IRubyObject pid) {
         RubyProcess.RubyStatus processStatus = RubyProcess.RubyStatus.newProcessStatus(context.runtime,
-                numToLong(context, status), numToLong(context, pid));
+                toLong(context, status), toLong(context, pid));
         context.setLastExitStatus(processStatus);
         return processStatus;
     }
@@ -331,7 +331,7 @@ public class JRubyUtilLibrary implements Library {
     public static IRubyObject wait(ThreadContext context, IRubyObject recv, IRubyObject arg, IRubyObject timeoutMillis) throws InterruptedException {
         Object obj = getSyncObject(arg);
 
-        obj.wait(numToLong(context, timeoutMillis));
+        obj.wait(toLong(context, timeoutMillis));
 
         return arg;
     }
@@ -351,7 +351,7 @@ public class JRubyUtilLibrary implements Library {
      */
     @JRubyMethod(module = true)
     public static IRubyObject wait(ThreadContext context, IRubyObject recv, IRubyObject arg, IRubyObject timeoutMillis, IRubyObject timeoutNanos) throws InterruptedException {
-        getSyncObject(arg).wait(numToLong(context, timeoutMillis), numToInt(context, timeoutNanos));
+        getSyncObject(arg).wait(toLong(context, timeoutMillis), toInt(context, timeoutNanos));
 
         return arg;
     }

--- a/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
+++ b/core/src/main/java/org/jruby/ext/jruby/JRubyUtilLibrary.java
@@ -197,9 +197,7 @@ public class JRubyUtilLibrary implements Library {
     public static IRubyObject set_last_exit_status(ThreadContext context, IRubyObject recv,
                                                    IRubyObject status, IRubyObject pid) {
         RubyProcess.RubyStatus processStatus = RubyProcess.RubyStatus.newProcessStatus(context.runtime,
-                status.convertToInteger().getLongValue(),
-                pid.convertToInteger().getLongValue()
-        );
+                numToLong(context, status), numToLong(context, pid));
         context.setLastExitStatus(processStatus);
         return processStatus;
     }
@@ -333,7 +331,7 @@ public class JRubyUtilLibrary implements Library {
     public static IRubyObject wait(ThreadContext context, IRubyObject recv, IRubyObject arg, IRubyObject timeoutMillis) throws InterruptedException {
         Object obj = getSyncObject(arg);
 
-        obj.wait(timeoutMillis.convertToInteger().getLongValue());
+        obj.wait(numToLong(context, timeoutMillis));
 
         return arg;
     }
@@ -353,11 +351,7 @@ public class JRubyUtilLibrary implements Library {
      */
     @JRubyMethod(module = true)
     public static IRubyObject wait(ThreadContext context, IRubyObject recv, IRubyObject arg, IRubyObject timeoutMillis, IRubyObject timeoutNanos) throws InterruptedException {
-        Object obj = getSyncObject(arg);
-
-        obj.wait(
-                timeoutMillis.convertToInteger().getLongValue(),
-                timeoutNanos.convertToInteger().getIntValue());
+        getSyncObject(arg).wait(numToLong(context, timeoutMillis), numToInt(context, timeoutNanos));
 
         return arg;
     }

--- a/core/src/main/java/org/jruby/ext/ripper/RubyRipper.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RubyRipper.java
@@ -370,7 +370,7 @@ public class RubyRipper extends RubyObject {
     @JRubyMethod(meta = true)
     public static IRubyObject dedent_string(ThreadContext context, IRubyObject self, IRubyObject _input, IRubyObject _width) {
         RubyString input = _input.convertToString();
-        int wid = numToInt(context, _width);
+        int wid = toInt(context, _width);
         input.modifyAndClearCodeRange();
         int col = LexingCommon.dedent_string(input.getByteList(), wid);
         return asFixnum(context, col);
@@ -383,7 +383,7 @@ public class RubyRipper extends RubyObject {
 
     @JRubyMethod(meta = true)
     public static IRubyObject lex_state_name(ThreadContext context, IRubyObject self, IRubyObject lexStateParam) {
-        int lexState = numToInt(context, lexStateParam);
+        int lexState = toInt(context, lexStateParam);
 
         boolean needsSeparator = false;
         RubyString name = null;

--- a/core/src/main/java/org/jruby/ext/ripper/RubyRipper.java
+++ b/core/src/main/java/org/jruby/ext/ripper/RubyRipper.java
@@ -370,7 +370,7 @@ public class RubyRipper extends RubyObject {
     @JRubyMethod(meta = true)
     public static IRubyObject dedent_string(ThreadContext context, IRubyObject self, IRubyObject _input, IRubyObject _width) {
         RubyString input = _input.convertToString();
-        int wid = _width.convertToInteger().getIntValue();
+        int wid = numToInt(context, _width);
         input.modifyAndClearCodeRange();
         int col = LexingCommon.dedent_string(input.getByteList(), wid);
         return asFixnum(context, col);
@@ -383,7 +383,7 @@ public class RubyRipper extends RubyObject {
 
     @JRubyMethod(meta = true)
     public static IRubyObject lex_state_name(ThreadContext context, IRubyObject self, IRubyObject lexStateParam) {
-        int lexState = lexStateParam.convertToInteger().getIntValue();
+        int lexState = numToInt(context, lexStateParam);
 
         boolean needsSeparator = false;
         RubyString name = null;

--- a/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
+++ b/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
@@ -50,7 +50,7 @@ import static jnr.constants.platform.Sock.*;
 import static org.jruby.api.Check.checkEmbeddedNulls;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Create.*;
 import static org.jruby.ext.socket.SocketUtils.IP_V4_MAPPED_ADDRESS_PREFIX;
 import static org.jruby.ext.socket.SocketUtils.sockerr;
@@ -228,8 +228,8 @@ public class Addrinfo extends RubyObject {
                     throw sockerr(runtime, "Address family must be AF_UNIX, AF_INET, AF_INET6, PF_INET or PF_INET6");
                 }
 
-                int proto = protocolArg.isNil() ? 0 : numToInt(context, protocolArg);
-                int socketType = socketTypeArg.isNil() ? 0 : numToInt(context, socketTypeArg);
+                int proto = protocolArg.isNil() ? 0 : toInt(context, protocolArg);
+                int socketType = socketTypeArg.isNil() ? 0 : toInt(context, socketTypeArg);
 
                 if (socketType == 0) {
                     if (proto != 0 && proto != IPPROTO_UDP.intValue()) throw sockerr(runtime, "getaddrinfo: ai_socktype not supported");
@@ -260,7 +260,7 @@ public class Addrinfo extends RubyObject {
                     IRubyObject service = sockaddAry.entry(1).convertToInteger();
                     IRubyObject nodename = sockaddAry.entry(2);
                     String numericnode = sockaddAry.entry(3).convertToString().toString();
-                    int _port = numToInt(context, service);
+                    int _port = toInt(context, service);
 
                     InetAddress inetAddress;
                     boolean ipv4PrefixedString;
@@ -815,7 +815,7 @@ public class Addrinfo extends RubyObject {
                     // IP6 addresses will be 16 bytes wide
                     bytes = bignum.getBigIntegerValue().toByteArray();
                 } else {
-                    long i = numToInt(context, node) & 0xFFFFL;
+                    long i = toInt(context, node) & 0xFFFFL;
 
                     bytes = new byte[]{
                             (byte) ((i >> 24) & 0xFF),
@@ -855,7 +855,7 @@ public class Addrinfo extends RubyObject {
 
     @JRubyMethod
     public IRubyObject getnameinfo(ThreadContext context, IRubyObject flags) {
-        return getnameinfo(context, numToInt(context, flags));
+        return getnameinfo(context, toInt(context, flags));
     }
 
     public IRubyObject getnameinfo(ThreadContext context, int flags) {

--- a/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
+++ b/core/src/main/java/org/jruby/ext/socket/Addrinfo.java
@@ -50,6 +50,7 @@ import static jnr.constants.platform.Sock.*;
 import static org.jruby.api.Check.checkEmbeddedNulls;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Convert.numToInt;
 import static org.jruby.api.Create.*;
 import static org.jruby.ext.socket.SocketUtils.IP_V4_MAPPED_ADDRESS_PREFIX;
 import static org.jruby.ext.socket.SocketUtils.sockerr;
@@ -188,7 +189,7 @@ public class Addrinfo extends RubyObject {
 
     private Addrinfo initializeSimple(ThreadContext context, IRubyObject host, IRubyObject port,
                                       int socketType, int protocolFamily) {
-        InetAddress inetAddress = getRubyInetAddress(host);
+        InetAddress inetAddress = getRubyInetAddress(context, host);
 
         this.socketAddress = new InetSocketAddress(inetAddress, port != null ? SocketUtils.portToInt(context, port) : 0);
         this.pfamily = getInetAddress() instanceof Inet4Address ? PF_INET : PF_INET6;
@@ -227,8 +228,8 @@ public class Addrinfo extends RubyObject {
                     throw sockerr(runtime, "Address family must be AF_UNIX, AF_INET, AF_INET6, PF_INET or PF_INET6");
                 }
 
-                int proto = protocolArg.isNil() ? 0 : protocolArg.convertToInteger().getIntValue();
-                int socketType = socketTypeArg.isNil() ? 0 : socketTypeArg.convertToInteger().getIntValue();
+                int proto = protocolArg.isNil() ? 0 : numToInt(context, protocolArg);
+                int socketType = socketTypeArg.isNil() ? 0 : numToInt(context, socketTypeArg);
 
                 if (socketType == 0) {
                     if (proto != 0 && proto != IPPROTO_UDP.intValue()) throw sockerr(runtime, "getaddrinfo: ai_socktype not supported");
@@ -259,7 +260,7 @@ public class Addrinfo extends RubyObject {
                     IRubyObject service = sockaddAry.entry(1).convertToInteger();
                     IRubyObject nodename = sockaddAry.entry(2);
                     String numericnode = sockaddAry.entry(3).convertToString().toString();
-                    int _port = service.convertToInteger().getIntValue();
+                    int _port = numToInt(context, service);
 
                     InetAddress inetAddress;
                     boolean ipv4PrefixedString;
@@ -806,15 +807,15 @@ public class Addrinfo extends RubyObject {
         return null;
     }
 
-    private static InetAddress getRubyInetAddress(IRubyObject node) {
+    private static InetAddress getRubyInetAddress(ThreadContext context, IRubyObject node) {
         try {
             if (node instanceof RubyInteger) {
                 byte[] bytes;
-                if (node instanceof RubyBignum) {
+                if (node instanceof RubyBignum bignum) {
                     // IP6 addresses will be 16 bytes wide
-                    bytes = ((RubyBignum) node).getBigIntegerValue().toByteArray();
+                    bytes = bignum.getBigIntegerValue().toByteArray();
                 } else {
-                    long i = node.convertToInteger().getIntValue() & 0xFFFFL;
+                    long i = numToInt(context, node) & 0xFFFFL;
 
                     bytes = new byte[]{
                             (byte) ((i >> 24) & 0xFF),
@@ -854,7 +855,7 @@ public class Addrinfo extends RubyObject {
 
     @JRubyMethod
     public IRubyObject getnameinfo(ThreadContext context, IRubyObject flags) {
-        return getnameinfo(context, flags.convertToInteger().getIntValue());
+        return getnameinfo(context, numToInt(context, flags));
     }
 
     public IRubyObject getnameinfo(ThreadContext context, int flags) {

--- a/core/src/main/java/org/jruby/ext/socket/Option.java
+++ b/core/src/main/java/org/jruby/ext/socket/Option.java
@@ -203,7 +203,7 @@ public class Option extends RubyObject {
     @JRubyMethod(meta = true)
     public static IRubyObject linger(ThreadContext context, IRubyObject self, IRubyObject vonoffArg, IRubyObject vsecs) {
         IRubyObject vonoff = checkToInteger(context, vonoffArg);
-        int coercedVonoff = !vonoff.isNil() ? Convert.asInt(context, (RubyInteger) vonoff) : (vonoffArg.isTrue() ? 1 : 0);
+        int coercedVonoff = !vonoff.isNil() ? ((RubyInteger) vonoff).asInt(context) : (vonoffArg.isTrue() ? 1 : 0);
         ByteList data = packLinger(coercedVonoff, toInt(context, vsecs));
 
         return new Option(context.runtime, ProtocolFamily.PF_UNSPEC, SocketLevel.SOL_SOCKET, SocketOption.SO_LINGER, data);

--- a/core/src/main/java/org/jruby/ext/socket/Option.java
+++ b/core/src/main/java/org/jruby/ext/socket/Option.java
@@ -204,7 +204,7 @@ public class Option extends RubyObject {
     public static IRubyObject linger(ThreadContext context, IRubyObject self, IRubyObject vonoffArg, IRubyObject vsecs) {
         IRubyObject vonoff = checkToInteger(context, vonoffArg);
         int coercedVonoff = !vonoff.isNil() ? Convert.asInt(context, (RubyInteger) vonoff) : (vonoffArg.isTrue() ? 1 : 0);
-        ByteList data = packLinger(coercedVonoff, vsecs.convertToInteger().getIntValue());
+        ByteList data = packLinger(coercedVonoff, numToInt(context, vsecs));
 
         return new Option(context.runtime, ProtocolFamily.PF_UNSPEC, SocketLevel.SOL_SOCKET, SocketOption.SO_LINGER, data);
      }

--- a/core/src/main/java/org/jruby/ext/socket/Option.java
+++ b/core/src/main/java/org/jruby/ext/socket/Option.java
@@ -204,7 +204,7 @@ public class Option extends RubyObject {
     public static IRubyObject linger(ThreadContext context, IRubyObject self, IRubyObject vonoffArg, IRubyObject vsecs) {
         IRubyObject vonoff = checkToInteger(context, vonoffArg);
         int coercedVonoff = !vonoff.isNil() ? Convert.asInt(context, (RubyInteger) vonoff) : (vonoffArg.isTrue() ? 1 : 0);
-        ByteList data = packLinger(coercedVonoff, numToInt(context, vsecs));
+        ByteList data = packLinger(coercedVonoff, toInt(context, vsecs));
 
         return new Option(context.runtime, ProtocolFamily.PF_UNSPEC, SocketLevel.SOL_SOCKET, SocketOption.SO_LINGER, data);
      }

--- a/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
@@ -84,6 +84,7 @@ import static jnr.constants.platform.TCP.TCP_KEEPIDLE;
 import static jnr.constants.platform.TCP.TCP_KEEPINTVL;
 import static jnr.constants.platform.TCP.TCP_NODELAY;
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Convert.numToInt;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.argumentError;
@@ -110,7 +111,7 @@ public class RubyBasicSocket extends RubyIO {
     @JRubyMethod(meta = true)
     public static IRubyObject for_fd(ThreadContext context, IRubyObject _klass, IRubyObject _fileno) {
         Ruby runtime = context.runtime;
-        int fileno = (int)_fileno.convertToInteger().getLongValue();
+        int fileno = numToInt(context, _fileno);
         RubyClass klass = (RubyClass)_klass;
 
         ChannelFD fd = runtime.getFilenoUtil().getWrapperFromFileno(fileno);
@@ -432,8 +433,8 @@ public class RubyBasicSocket extends RubyIO {
                 return new Option(context.runtime, ProtocolFamily.PF_INET, level, opt, packedValue);
 
             default:
-                int intLevel = _level.convertToInteger().getIntValue();
-                int intOpt = _opt.convertToInteger().getIntValue();
+                int intLevel = numToInt(context, _level);
+                int intOpt = numToInt(context, _opt);
                 ChannelFD fd = getOpenFile().fd();
                 IPProto proto = IPProto.valueOf(intLevel);
  
@@ -498,11 +499,11 @@ public class RubyBasicSocket extends RubyIO {
                     socketType.setSocketOption(channel, opt, asNumber(context, val));
                 }
 
-                return RubyFixnum.zero(runtime);
+                return asFixnum(context, 0);
 
             default:
-                int intLevel = _level.convertToInteger().getIntValue();
-                int intOpt = _opt.convertToInteger().getIntValue();
+                int intLevel = numToInt(context, _level);
+                int intOpt = numToInt(context, _opt);
                 ChannelFD fd = getOpenFile().fd();
                 IPProto proto = IPProto.valueOf(intLevel);
 
@@ -515,7 +516,7 @@ public class RubyBasicSocket extends RubyIO {
 
                             ByteBuffer buf = ByteBuffer.allocate(4);
                             buf.order(ByteOrder.nativeOrder());
-                            flipBuffer(buf.putInt(val.convertToInteger().getIntValue()));
+                            flipBuffer(buf.putInt(numToInt(context, val)));
                             int ret = SOCKOPT.setsockopt(fd.realFileno, intLevel, intOpt, buf, buf.remaining());
 
                             if (ret != 0) {

--- a/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyBasicSocket.java
@@ -84,7 +84,7 @@ import static jnr.constants.platform.TCP.TCP_KEEPIDLE;
 import static jnr.constants.platform.TCP.TCP_KEEPINTVL;
 import static jnr.constants.platform.TCP.TCP_NODELAY;
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.argumentError;
@@ -111,7 +111,7 @@ public class RubyBasicSocket extends RubyIO {
     @JRubyMethod(meta = true)
     public static IRubyObject for_fd(ThreadContext context, IRubyObject _klass, IRubyObject _fileno) {
         Ruby runtime = context.runtime;
-        int fileno = numToInt(context, _fileno);
+        int fileno = toInt(context, _fileno);
         RubyClass klass = (RubyClass)_klass;
 
         ChannelFD fd = runtime.getFilenoUtil().getWrapperFromFileno(fileno);
@@ -433,8 +433,8 @@ public class RubyBasicSocket extends RubyIO {
                 return new Option(context.runtime, ProtocolFamily.PF_INET, level, opt, packedValue);
 
             default:
-                int intLevel = numToInt(context, _level);
-                int intOpt = numToInt(context, _opt);
+                int intLevel = toInt(context, _level);
+                int intOpt = toInt(context, _opt);
                 ChannelFD fd = getOpenFile().fd();
                 IPProto proto = IPProto.valueOf(intLevel);
  
@@ -502,8 +502,8 @@ public class RubyBasicSocket extends RubyIO {
                 return asFixnum(context, 0);
 
             default:
-                int intLevel = numToInt(context, _level);
-                int intOpt = numToInt(context, _opt);
+                int intLevel = toInt(context, _level);
+                int intOpt = toInt(context, _opt);
                 ChannelFD fd = getOpenFile().fd();
                 IPProto proto = IPProto.valueOf(intLevel);
 
@@ -516,7 +516,7 @@ public class RubyBasicSocket extends RubyIO {
 
                             ByteBuffer buf = ByteBuffer.allocate(4);
                             buf.order(ByteOrder.nativeOrder());
-                            flipBuffer(buf.putInt(numToInt(context, val)));
+                            flipBuffer(buf.putInt(toInt(context, val)));
                             int ret = SOCKOPT.setsockopt(fd.realFileno, intLevel, intOpt, buf, buf.remaining());
 
                             if (ret != 0) {

--- a/core/src/main/java/org/jruby/ext/socket/RubySocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubySocket.java
@@ -142,15 +142,14 @@ public class RubySocket extends RubyBasicSocket {
 
     @JRubyMethod(meta = true)
     public static IRubyObject for_fd(ThreadContext context, IRubyObject socketClass, IRubyObject _fd) {
-        int intFD = Convert.castAsFixnum(context, _fd).getIntValue();
-        Ruby runtime = context.runtime;
-        ChannelFD fd = runtime.getFilenoUtil().getWrapperFromFileno(intFD);
+        int intFD = Convert.castAsFixnum(context, _fd).asInt(context);
+        ChannelFD fd = context.runtime.getFilenoUtil().getWrapperFromFileno(intFD);
 
-        if (fd == null) throw runtime.newErrnoEBADFError();
+        if (fd == null) throw context.runtime.newErrnoEBADFError();
 
         RubySocket socket = (RubySocket)((RubyClass)socketClass).allocate(context);
 
-        socket.initFieldsFromDescriptor(runtime, fd);
+        socket.initFieldsFromDescriptor(context.runtime, fd);
         socket.initSocket(fd);
 
         return socket;

--- a/core/src/main/java/org/jruby/ext/socket/RubyTCPSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyTCPSocket.java
@@ -97,7 +97,7 @@ public class RubyTCPSocket extends RubyIPSocket {
                 if (opts != null) {
                     IRubyObject timeoutObj = ArgsUtil.extractKeywordArg(context, opts, "connect_timeout");
                     if (!timeoutObj.isNil()) {
-                        timeout = (long) (timeoutObj.convertToFloat().getDoubleValue() * 1000);
+                        timeout = (long) (timeoutObj.convertToFloat().asDouble(context) * 1000);
                     }
                 }
 

--- a/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
@@ -77,9 +77,9 @@ import java.nio.channels.UnsupportedAddressTypeException;
 
 import static org.jruby.api.Access.getModule;
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.asInt;
 import static org.jruby.api.Convert.toInt;
-import static org.jruby.api.Create.*;
+import static org.jruby.api.Create.newArray;
+import static org.jruby.api.Create.newString;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.runtime.Helpers.extractExceptionOnlyArg;
 

--- a/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
@@ -77,6 +77,7 @@ import java.nio.channels.UnsupportedAddressTypeException;
 
 import static org.jruby.api.Access.getModule;
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Convert.numToInt;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.runtime.Helpers.extractExceptionOnlyArg;
@@ -379,7 +380,7 @@ public class RubyUDPSocket extends RubyIPSocket {
                     }
 
                 } else {
-                    port = (int) _port.convertToInteger().getLongValue();
+                    port = numToInt(context, _port);
                 }
 
                 addrs = SocketUtils.getRubyInetAddresses(nameStr.toString());

--- a/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
@@ -77,7 +77,7 @@ import java.nio.channels.UnsupportedAddressTypeException;
 
 import static org.jruby.api.Access.getModule;
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.runtime.Helpers.extractExceptionOnlyArg;
@@ -380,7 +380,7 @@ public class RubyUDPSocket extends RubyIPSocket {
                     }
 
                 } else {
-                    port = numToInt(context, _port);
+                    port = toInt(context, _port);
                 }
 
                 addrs = SocketUtils.getRubyInetAddresses(nameStr.toString());

--- a/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUDPSocket.java
@@ -77,6 +77,7 @@ import java.nio.channels.UnsupportedAddressTypeException;
 
 import static org.jruby.api.Access.getModule;
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Convert.asInt;
 import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineClass;
@@ -376,7 +377,7 @@ public class RubyUDPSocket extends RubyIPSocket {
                     if (service != null) {
                         port = service.getPort();
                     } else {
-                        port = (int) _port.convertToInteger("to_i").getLongValue();
+                        port = (int) _port.convertToInteger("to_i").asLong(context);
                     }
 
                 } else {

--- a/core/src/main/java/org/jruby/ext/socket/RubyUNIXSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUNIXSocket.java
@@ -70,6 +70,7 @@ import static com.headius.backport9.buffer.Buffers.flipBuffer;
 import static org.jruby.api.Access.ioClass;
 import static org.jruby.api.Check.checkEmbeddedNulls;
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Convert.numToInt;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.argumentError;
@@ -90,13 +91,12 @@ public class RubyUNIXSocket extends RubyBasicSocket {
 
     @JRubyMethod(meta = true)
     public static IRubyObject for_fd(ThreadContext context, IRubyObject recv, IRubyObject _fileno) {
-        Ruby runtime = context.runtime;
-        int fileno = (int)_fileno.convertToInteger().getLongValue();
+        int fileno = numToInt(context, _fileno);
 
         RubyClass klass = (RubyClass)recv;
         RubyUNIXSocket unixSocket = (RubyUNIXSocket)(Helpers.invoke(context, klass, "allocate"));
         UnixSocketChannel channel = UnixSocketChannel.fromFD(fileno);
-        unixSocket.init_sock(runtime, channel);
+        unixSocket.init_sock(context.runtime, channel);
         return unixSocket;
     }
 

--- a/core/src/main/java/org/jruby/ext/socket/RubyUNIXSocket.java
+++ b/core/src/main/java/org/jruby/ext/socket/RubyUNIXSocket.java
@@ -67,10 +67,11 @@ import java.nio.ByteOrder;
 import java.nio.channels.Channel;
 
 import static com.headius.backport9.buffer.Buffers.flipBuffer;
+import static org.jruby.api.Access.fixnumClass;
 import static org.jruby.api.Access.ioClass;
 import static org.jruby.api.Check.checkEmbeddedNulls;
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.argumentError;
@@ -91,7 +92,7 @@ public class RubyUNIXSocket extends RubyBasicSocket {
 
     @JRubyMethod(meta = true)
     public static IRubyObject for_fd(ThreadContext context, IRubyObject recv, IRubyObject _fileno) {
-        int fileno = numToInt(context, _fileno);
+        int fileno = toInt(context, _fileno);
 
         RubyClass klass = (RubyClass)recv;
         RubyUNIXSocket unixSocket = (RubyUNIXSocket)(Helpers.invoke(context, klass, "allocate"));
@@ -142,8 +143,8 @@ public class RubyUNIXSocket extends RubyBasicSocket {
 
         if (arg.callMethod(context, "kind_of?", ioClass(context)).isTrue()) {
           fd = ((RubyIO) arg).getOpenFileChecked().getFileno();
-        } else if (arg.callMethod(context, "kind_of?", context.runtime.getFixnum()).isTrue()) {
-          fd = ((RubyFixnum) arg).getIntValue();
+        } else if (arg.callMethod(context, "kind_of?", fixnumClass(context)).isTrue()) {
+          fd = ((RubyFixnum) arg).asInt(context);
         } else {
           throw typeError(context, "neither IO nor file descriptor");
         }

--- a/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
+++ b/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
@@ -77,6 +77,7 @@ import static jnr.constants.platform.Sock.SOCK_STREAM;
 import static org.jruby.api.Access.objectClass;
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.asInt;
+import static org.jruby.api.Convert.numToInt;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.ext.socket.Addrinfo.AI_CANONNAME;
@@ -287,7 +288,7 @@ public class SocketUtils {
             port = getservbyname(context, new IRubyObject[]{port});
         }
 
-        int p = port.isNil() ? 0 : (int)port.convertToInteger().getLongValue();
+        int p = port.isNil() ? 0 : numToInt(context, port);
 
         // TODO: implement flags
         int flag = flags.isNil() ? 0 : RubyNumeric.fix2int(flags);

--- a/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
+++ b/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
@@ -77,7 +77,7 @@ import static jnr.constants.platform.Sock.SOCK_STREAM;
 import static org.jruby.api.Access.objectClass;
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.asInt;
-import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.ext.socket.Addrinfo.AI_CANONNAME;
@@ -288,7 +288,7 @@ public class SocketUtils {
             port = getservbyname(context, new IRubyObject[]{port});
         }
 
-        int p = port.isNil() ? 0 : numToInt(context, port);
+        int p = port.isNil() ? 0 : toInt(context, port);
 
         // TODO: implement flags
         int flag = flags.isNil() ? 0 : RubyNumeric.fix2int(flags);

--- a/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
+++ b/core/src/main/java/org/jruby/ext/socket/SocketUtils.java
@@ -76,9 +76,10 @@ import static jnr.constants.platform.Sock.SOCK_DGRAM;
 import static jnr.constants.platform.Sock.SOCK_STREAM;
 import static org.jruby.api.Access.objectClass;
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.asInt;
 import static org.jruby.api.Convert.toInt;
-import static org.jruby.api.Create.*;
+import static org.jruby.api.Create.newArray;
+import static org.jruby.api.Create.newEmptyArray;
+import static org.jruby.api.Create.newString;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.ext.socket.Addrinfo.AI_CANONNAME;
 
@@ -679,7 +680,7 @@ public class SocketUtils {
 
             if (serv != null) return serv.getPort();
 
-            return asInt(context, (RubyInteger) portStr.to_i(context));
+            return ((RubyInteger) portStr.to_i(context)).asInt(context);
         }
         return RubyNumeric.fix2int(port);
     }

--- a/core/src/main/java/org/jruby/ext/thread/Queue.java
+++ b/core/src/main/java/org/jruby/ext/thread/Queue.java
@@ -58,8 +58,7 @@ import org.jruby.util.TypeConverter;
 import static org.jruby.api.Access.arrayClass;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.numToInt;
-import static org.jruby.api.Convert.numToLong;
+import static org.jruby.api.Convert.toLong;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
 
@@ -455,7 +454,7 @@ public class Queue extends RubyObject implements DataType {
         if (_timeout.isNil()) {
             timeoutNS = 0;
         } else if (_timeout instanceof RubyFixnum) {
-            timeoutNS = TimeUnit.NANOSECONDS.convert(numToLong(context, _timeout), TimeUnit.SECONDS);
+            timeoutNS = TimeUnit.NANOSECONDS.convert(toLong(context, _timeout), TimeUnit.SECONDS);
         } else {
             timeoutNS = (long) (RubyNumeric.num2dbl(context, _timeout) * 1_000_000_000);
         }

--- a/core/src/main/java/org/jruby/ext/thread/Queue.java
+++ b/core/src/main/java/org/jruby/ext/thread/Queue.java
@@ -58,6 +58,8 @@ import org.jruby.util.TypeConverter;
 import static org.jruby.api.Access.arrayClass;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.numToLong;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
 
@@ -453,7 +455,7 @@ public class Queue extends RubyObject implements DataType {
         if (_timeout.isNil()) {
             timeoutNS = 0;
         } else if (_timeout instanceof RubyFixnum) {
-            timeoutNS = TimeUnit.NANOSECONDS.convert(_timeout.convertToInteger().getLongValue(), TimeUnit.SECONDS);
+            timeoutNS = TimeUnit.NANOSECONDS.convert(numToLong(context, _timeout), TimeUnit.SECONDS);
         } else {
             timeoutNS = (long) (RubyNumeric.num2dbl(context, _timeout) * 1_000_000_000);
         }

--- a/core/src/main/java/org/jruby/ext/thread/Queue.java
+++ b/core/src/main/java/org/jruby/ext/thread/Queue.java
@@ -449,16 +449,11 @@ public class Queue extends RubyObject implements DataType {
     }
 
     protected static long queueTimeoutToNanos(ThreadContext context, IRubyObject _timeout) {
-        long timeoutNS;
+        if (_timeout.isNil()) return 0;
 
-        if (_timeout.isNil()) {
-            timeoutNS = 0;
-        } else if (_timeout instanceof RubyFixnum) {
-            timeoutNS = TimeUnit.NANOSECONDS.convert(toLong(context, _timeout), TimeUnit.SECONDS);
-        } else {
-            timeoutNS = (long) (RubyNumeric.num2dbl(context, _timeout) * 1_000_000_000);
-        }
-        return timeoutNS;
+        return _timeout instanceof RubyFixnum fixnum ?
+                TimeUnit.NANOSECONDS.convert(fixnum.getValue(), TimeUnit.SECONDS) :
+                (long) (RubyNumeric.num2dbl(context, _timeout) * 1_000_000_000);
     }
 
     @JRubyMethod(name = {"push", "<<", "enq"})

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipReader.java
@@ -65,6 +65,8 @@ import static org.jruby.api.Access.fileClass;
 import static org.jruby.api.Access.globalVariables;
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.castAsString;
+import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.numToLong;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.runtime.Visibility.PRIVATE;
@@ -707,7 +709,7 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
         if (b.isNil()) return b;
 
         try {
-            bufferedStream.unread(b.convertToInteger().getIntValue());
+            bufferedStream.unread(numToInt(context, b));
             position--;
         } catch (IOException ioe) {
             throw context.runtime.newIOErrorFromException(ioe);
@@ -800,14 +802,14 @@ public class JZlibRubyGzipReader extends RubyGzipFile {
                 }
 
                 obj.read(context, IRubyObject.NULL_ARRAY);
-                pos = io.callMethod(context, "pos").convertToInteger().getLongValue();
+                pos = numToLong(context, io.callMethod(context, "pos"));
                 unused = obj.unused();
                 obj.finish(context);
                 if (!unused.isNil()) {
-                    pos -= unused.callMethod(context, "length").convertToInteger().getLongValue();
+                    pos -= numToLong(context, unused.callMethod(context, "length"));
                     io.callMethod(context, "pos=", asFixnum(context, pos));
                 }
-            } while (pos < io.callMethod(context, "size").convertToInteger().getLongValue());
+            } while (pos < numToLong(context, io.callMethod(context, "size")));
         } catch (IOException ioe) {
             throw context.runtime.newIOErrorFromException(ioe);
         }

--- a/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
+++ b/core/src/main/java/org/jruby/ext/zlib/JZlibRubyGzipWriter.java
@@ -386,7 +386,7 @@ public class JZlibRubyGzipWriter extends RubyGzipFile {
             this.mtime = RubyTime.newTime(context.runtime, RubyNumeric.fix2long(arg) * 1000);
         }
         try {
-            io.setModifiedTime(this.mtime.to_i(context).getLongValue());
+            io.setModifiedTime(this.mtime.to_i(context).asLong(context));
         } catch (GZIPException e) {
             throw RubyZlib.newGzipFileError(context, "header is already written");
         }

--- a/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
+++ b/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
@@ -36,7 +36,6 @@ package org.jruby.ext.zlib;
 import java.util.zip.CRC32;
 import java.util.zip.Adler32;
 
-import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyBasicObject;
 import org.jruby.RubyClass;
@@ -57,7 +56,7 @@ import org.jruby.runtime.ThreadContext;
 
 import static org.jruby.api.Access.*;
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.numericToLong;
+import static org.jruby.api.Convert.numToLong;
 import static org.jruby.api.Create.newString;
 import static org.jruby.api.Define.defineModule;
 import static org.jruby.runtime.ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR;
@@ -202,7 +201,7 @@ public class RubyZlib {
         long start = 0;
         ByteList bytes = null;
         if (!args[0].isNil()) bytes = args[0].convertToString().getByteList();
-        if (!args[1].isNil()) start = numericToLong(context, args[1]);
+        if (!args[1].isNil()) start = numToLong(context, args[1]);
         start &= 0xFFFFFFFFL;
 
         final boolean slowPath = start != 0;
@@ -230,7 +229,7 @@ public class RubyZlib {
         int start = 1;
         ByteList bytes = null;
         if (!args[0].isNil()) bytes = args[0].convertToString().getByteList();
-        if (!args[1].isNil()) start = (int) numericToLong(context, args[1]);
+        if (!args[1].isNil()) start = (int) numToLong(context, args[1]);
 
         Adler32 checksum = new Adler32();
         if (bytes != null) {
@@ -287,9 +286,9 @@ public class RubyZlib {
     @JRubyMethod(name = "crc32_combine", module = true, visibility = PRIVATE)
     public static IRubyObject crc32_combine(ThreadContext context, IRubyObject recv,
                                             IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
-        long crc1 = numericToLong(context, arg0);
-        long crc2 = numericToLong(context, arg1);
-        long len2 = numericToLong(context, arg2);
+        long crc1 = numToLong(context, arg0);
+        long crc2 = numToLong(context, arg1);
+        long len2 = numToLong(context, arg2);
 
         return asFixnum(context, com.jcraft.jzlib.JZlib.crc32_combine(crc1, crc2, len2));
     }
@@ -302,9 +301,9 @@ public class RubyZlib {
     @JRubyMethod(name = "adler32_combine", module = true, visibility = PRIVATE)
     public static IRubyObject adler32_combine(ThreadContext context, IRubyObject recv,
                                               IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
-        long adler1 = numericToLong(context, arg0);
-        long adler2 = numericToLong(context, arg1);
-        long len2 = numericToLong(context, arg2);
+        long adler1 = numToLong(context, arg0);
+        long adler2 = numToLong(context, arg1);
+        long len2 = numToLong(context, arg2);
 
         return asFixnum(context, com.jcraft.jzlib.JZlib.adler32_combine(adler1, adler2, len2));
     }

--- a/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
+++ b/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
@@ -56,7 +56,7 @@ import org.jruby.runtime.ThreadContext;
 
 import static org.jruby.api.Access.*;
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.numToLong;
+import static org.jruby.api.Convert.toLong;
 import static org.jruby.api.Create.newString;
 import static org.jruby.api.Define.defineModule;
 import static org.jruby.runtime.ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR;
@@ -201,7 +201,7 @@ public class RubyZlib {
         long start = 0;
         ByteList bytes = null;
         if (!args[0].isNil()) bytes = args[0].convertToString().getByteList();
-        if (!args[1].isNil()) start = numToLong(context, args[1]);
+        if (!args[1].isNil()) start = toLong(context, args[1]);
         start &= 0xFFFFFFFFL;
 
         final boolean slowPath = start != 0;
@@ -229,7 +229,7 @@ public class RubyZlib {
         int start = 1;
         ByteList bytes = null;
         if (!args[0].isNil()) bytes = args[0].convertToString().getByteList();
-        if (!args[1].isNil()) start = (int) numToLong(context, args[1]);
+        if (!args[1].isNil()) start = (int) toLong(context, args[1]);
 
         Adler32 checksum = new Adler32();
         if (bytes != null) {
@@ -286,9 +286,9 @@ public class RubyZlib {
     @JRubyMethod(name = "crc32_combine", module = true, visibility = PRIVATE)
     public static IRubyObject crc32_combine(ThreadContext context, IRubyObject recv,
                                             IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
-        long crc1 = numToLong(context, arg0);
-        long crc2 = numToLong(context, arg1);
-        long len2 = numToLong(context, arg2);
+        long crc1 = toLong(context, arg0);
+        long crc2 = toLong(context, arg1);
+        long len2 = toLong(context, arg2);
 
         return asFixnum(context, com.jcraft.jzlib.JZlib.crc32_combine(crc1, crc2, len2));
     }
@@ -301,9 +301,9 @@ public class RubyZlib {
     @JRubyMethod(name = "adler32_combine", module = true, visibility = PRIVATE)
     public static IRubyObject adler32_combine(ThreadContext context, IRubyObject recv,
                                               IRubyObject arg0, IRubyObject arg1, IRubyObject arg2) {
-        long adler1 = numToLong(context, arg0);
-        long adler2 = numToLong(context, arg1);
-        long len2 = numToLong(context, arg2);
+        long adler1 = toLong(context, arg0);
+        long adler2 = toLong(context, arg1);
+        long len2 = toLong(context, arg2);
 
         return asFixnum(context, com.jcraft.jzlib.JZlib.adler32_combine(adler1, adler2, len2));
     }

--- a/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
+++ b/core/src/main/java/org/jruby/ext/zlib/RubyZlib.java
@@ -198,10 +198,8 @@ public class RubyZlib {
     @JRubyMethod(name = "crc32", optional = 2, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject crc32(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         args = Arity.scanArgs(context, args, 0, 2);
-        long start = 0;
-        ByteList bytes = null;
-        if (!args[0].isNil()) bytes = args[0].convertToString().getByteList();
-        if (!args[1].isNil()) start = toLong(context, args[1]);
+        ByteList bytes = !args[0].isNil() ? args[0].convertToString().getByteList() : null;
+        long start = !args[1].isNil() ? toLong(context, args[1]) : 0;
         start &= 0xFFFFFFFFL;
 
         final boolean slowPath = start != 0;
@@ -226,19 +224,15 @@ public class RubyZlib {
     @JRubyMethod(name = "adler32", optional = 2, checkArity = false, module = true, visibility = PRIVATE)
     public static IRubyObject adler32(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
         args = Arity.scanArgs(context, args, 0, 2);
-        int start = 1;
-        ByteList bytes = null;
-        if (!args[0].isNil()) bytes = args[0].convertToString().getByteList();
-        if (!args[1].isNil()) start = (int) toLong(context, args[1]);
+        ByteList bytes = !args[0].isNil() ? args[0].convertToString().getByteList() : null;
+        int start = !args[1].isNil() ? (int) toLong(context, args[1]) : 1;
 
         Adler32 checksum = new Adler32();
-        if (bytes != null) {
-            checksum.update(bytes.getUnsafeBytes(), bytes.begin(), bytes.length());
-        }
+        if (bytes != null) checksum.update(bytes.getUnsafeBytes(), bytes.begin(), bytes.length());
+
         long result = checksum.getValue();
-        if (start != 1) {
-            result = JZlib.adler32_combine(start, result, bytes.length());
-        }
+        if (start != 1) result = JZlib.adler32_combine(start, result, bytes.length());
+
         return asFixnum(context, result);
     }
 
@@ -271,7 +265,7 @@ public class RubyZlib {
     @JRubyMethod(name = "crc_table", module = true, visibility = PRIVATE)
     public static IRubyObject crc_table(ThreadContext context, IRubyObject recv) {
         int[] table = com.jcraft.jzlib.CRC32.getCRC32Table();
-        return Create.constructArray(context, table, table.length, RubyZlib::crctablePopulator);
+        return Create.newArray(context, table, table.length, RubyZlib::crctablePopulator);
     }
 
     private static void crctablePopulator(ThreadContext c, int[] t, RubyArray<IRubyObject> a) {

--- a/core/src/main/java/org/jruby/ir/instructions/BSwitchInstr.java
+++ b/core/src/main/java/org/jruby/ir/instructions/BSwitchInstr.java
@@ -151,10 +151,10 @@ public class BSwitchInstr extends MultiBranchInstr {
         Object result = operand.retrieve(context, self, currScope, currDynScope, temp);
 
         int value;
-        if (result instanceof RubyFixnum && expectedClass == RubyFixnum.class) {
-            value = ((RubyFixnum) result).getIntValue();
-        } else if (result instanceof RubySymbol && expectedClass == RubySymbol.class) {
-            value = ((RubySymbol) result).getId();
+        if (result instanceof RubyFixnum fixnum && expectedClass == RubyFixnum.class) {
+            value = fixnum.asInt(context);
+        } else if (result instanceof RubySymbol symbol && expectedClass == RubySymbol.class) {
+            value = symbol.getId();
         } else {
             // not an optimizable value, fall back on old case logic
             return rubyCase.getTargetPC();
@@ -162,11 +162,9 @@ public class BSwitchInstr extends MultiBranchInstr {
 
         int index = Arrays.binarySearch(jumps, value);
 
-        if (index < 0) {
-            return elseTarget.getTargetPC();
-        }
-
-        return targets[index].getTargetPC();
+        return index < 0 ?
+                elseTarget.getTargetPC() :
+                targets[index].getTargetPC();
     }
 
     @Override

--- a/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
@@ -528,7 +528,7 @@ public class InterpreterEngine {
             case UNBOX_FIXNUM: {
                 UnboxInstr ui = (UnboxInstr)instr;
                 var val = (RubyNumeric) retrieveOp(ui.getValue(), context, self, currDynScope, currScope, temp);
-                fixnums[((TemporaryLocalVariable)ui.getResult()).offset] = val.getLongValue();
+                fixnums[((TemporaryLocalVariable)ui.getResult()).offset] = val.asLong(context);
                 break;
             }
 

--- a/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
+++ b/core/src/main/java/org/jruby/ir/interpreter/InterpreterEngine.java
@@ -4,6 +4,7 @@ import org.jruby.RubyBoolean;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
 import org.jruby.RubyModule;
+import org.jruby.RubyNumeric;
 import org.jruby.exceptions.Unrescuable;
 import org.jruby.ir.Operation;
 import org.jruby.ir.instructions.ArgReceiver;
@@ -519,23 +520,15 @@ public class InterpreterEngine {
 
             case UNBOX_FLOAT: {
                 UnboxInstr ui = (UnboxInstr)instr;
-                Object val = retrieveOp(ui.getValue(), context, self, currDynScope, currScope, temp);
-                if (val instanceof RubyFloat) {
-                    floats[((TemporaryLocalVariable)ui.getResult()).offset] = ((RubyFloat)val).getValue();
-                } else {
-                    floats[((TemporaryLocalVariable)ui.getResult()).offset] = ((RubyFixnum)val).getDoubleValue();
-                }
+                var val = (RubyNumeric) retrieveOp(ui.getValue(), context, self, currDynScope, currScope, temp);
+                floats[((TemporaryLocalVariable)ui.getResult()).offset] = val.asDouble(context);
                 break;
             }
 
             case UNBOX_FIXNUM: {
                 UnboxInstr ui = (UnboxInstr)instr;
-                Object val = retrieveOp(ui.getValue(), context, self, currDynScope, currScope, temp);
-                if (val instanceof RubyFloat) {
-                    fixnums[((TemporaryLocalVariable)ui.getResult()).offset] = ((RubyFloat)val).getLongValue();
-                } else {
-                    fixnums[((TemporaryLocalVariable)ui.getResult()).offset] = ((RubyFixnum)val).getLongValue();
-                }
+                var val = (RubyNumeric) retrieveOp(ui.getValue(), context, self, currDynScope, currScope, temp);
+                fixnums[((TemporaryLocalVariable)ui.getResult()).offset] = val.getLongValue();
                 break;
             }
 

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -322,12 +322,12 @@ public class IRRuntimeHelpers {
 
     @JIT
     public static double unboxFloat(IRubyObject val) {
-        return val instanceof RubyFloat flote ? flote.getValue() : (double) ((RubyFixnum)val).getLongValue();
+        return val instanceof RubyFloat flote ? flote.getValue() : (double) ((RubyFixnum)val).getValue();
     }
 
     @JIT
     public static long unboxFixnum(IRubyObject val) {
-        return val instanceof RubyFloat flote ? (long) flote.getValue() : ((RubyFixnum)val).getLongValue();
+        return val instanceof RubyFloat flote ? (long) flote.getValue() : ((RubyFixnum)val).getValue();
     }
 
     public static boolean flt(double v1, double v2) {

--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -322,7 +322,7 @@ public class IRRuntimeHelpers {
 
     @JIT
     public static double unboxFloat(IRubyObject val) {
-        return val instanceof RubyFloat flote ? flote.getValue() : ((RubyFixnum)val).getDoubleValue();
+        return val instanceof RubyFloat flote ? flote.getValue() : (double) ((RubyFixnum)val).getLongValue();
     }
 
     @JIT

--- a/core/src/main/java/org/jruby/java/addons/ArrayJavaAddons.java
+++ b/core/src/main/java/org/jruby/java/addons/ArrayJavaAddons.java
@@ -10,7 +10,6 @@ import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.asInt;
 import static org.jruby.api.Create.newEmptyArray;
 import static org.jruby.api.Error.typeError;
 
@@ -100,7 +99,7 @@ public class ArrayJavaAddons {
         assert dims instanceof RubyArray;
         assert index instanceof RubyFixnum;
 
-        return calcDimensions(context, (RubyArray<?>) rubyArray, (RubyArray<?>) dims, asInt(context, (RubyFixnum) index));
+        return calcDimensions(context, (RubyArray<?>) rubyArray, (RubyArray<?>) dims, ((RubyFixnum) index).asInt(context));
     }
 
     private static RubyArray<?> calcDimensions(ThreadContext context,

--- a/core/src/main/java/org/jruby/java/addons/ArrayJavaAddons.java
+++ b/core/src/main/java/org/jruby/java/addons/ArrayJavaAddons.java
@@ -106,20 +106,19 @@ public class ArrayJavaAddons {
     private static RubyArray<?> calcDimensions(ThreadContext context,
         final RubyArray<?> array, final RubyArray dims, final int index) {
 
+        var zero = asFixnum(context, 0);
         while ( dims.size() <= index ) {
-            dims.append(context, RubyFixnum.zero(context.runtime) );
+            dims.append(context, zero);
         }
 
-        final long dim = ((RubyFixnum) dims.eltInternal(index)).getLongValue();
+        final long dim = ((RubyFixnum) dims.eltInternal(index)).getValue();
         if ( array.size() > dim ) {
             dims.eltInternalSet(index, asFixnum(context, array.size()));
         }
 
         for ( int i = 0; i < array.size(); i++ ) {
             final IRubyObject element = array.eltInternal(i);
-            if ( element instanceof RubyArray ) {
-                calcDimensions(context, (RubyArray<?>) element, dims, 1);
-            }
+            if ( element instanceof RubyArray ary) calcDimensions(context, ary, dims, 1);
         }
 
         return dims;

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -309,7 +309,7 @@ public final class ArrayJavaProxy extends JavaProxy {
     @JRubyMethod(name = "first") // Enumerable override
     public IRubyObject first(ThreadContext context, IRubyObject count) {
         final Object array = getObject();
-        int len = count.convertToInteger().getIntValue();
+        int len = numToInt(context, count);
         int size = Array.getLength(array); if ( len > size ) len = size;
 
         final Ruby runtime = context.runtime;

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -162,7 +162,7 @@ public final class ArrayJavaProxy extends JavaProxy {
         final int len = array.length;
         if ( len == 0 ) return false;
         if ( obj instanceof RubyFixnum fix) {
-            final long objVal = fix.getLongValue();
+            final long objVal = fix.getValue();
             if ( objVal < Byte.MIN_VALUE || objVal > Byte.MAX_VALUE ) return false;
 
             for (byte b : array) {
@@ -180,7 +180,7 @@ public final class ArrayJavaProxy extends JavaProxy {
         final int len = array.length;
         if ( len == 0 ) return false;
         if (obj instanceof RubyFixnum fix) {
-            final long objVal = fix.getLongValue();
+            final long objVal = fix.getValue();
             if ( objVal < Short.MIN_VALUE || objVal > Short.MAX_VALUE ) return false;
 
             for (short value : array) {
@@ -198,7 +198,7 @@ public final class ArrayJavaProxy extends JavaProxy {
         final int len = array.length;
         if ( len == 0 ) return false;
         if (obj instanceof RubyFixnum fix) {
-            final long objVal = fix.getLongValue();
+            final long objVal = fix.getValue();
             if ( objVal < Integer.MIN_VALUE || objVal > Integer.MAX_VALUE ) return false;
 
             for (int j : array) {
@@ -216,7 +216,7 @@ public final class ArrayJavaProxy extends JavaProxy {
         final int len = array.length;
         if ( len == 0 ) return false;
         if ( obj instanceof RubyFixnum fix) {
-            final long objVal = fix.getLongValue();
+            final long objVal = fix.getValue();
 
             for (long l : array) {
                 if (objVal == l) return true;
@@ -233,7 +233,7 @@ public final class ArrayJavaProxy extends JavaProxy {
         final int len = array.length;
         if ( len == 0 ) return false;
         if (obj instanceof RubyFixnum fix) {
-            final long objVal = fix.getLongValue();
+            final long objVal = fix.getValue();
             if ( objVal < Character.MIN_VALUE || objVal > Character.MAX_VALUE ) return false;
 
             for (char c : array) {

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -266,9 +266,9 @@ public final class ArrayJavaProxy extends JavaProxy {
 
     private boolean includes(final ThreadContext context, final float[] array, final IRubyObject obj) {
         final int len = array.length;
-        if ( len == 0 ) return false;
-        if ( obj instanceof RubyFloat flote) {
-            final double objVal = flote.getDoubleValue();
+        if (len == 0) return false;
+        if (obj instanceof RubyFloat flote) {
+            final double objVal = flote.asDouble(context);
 
             for (float v : array) {
                 if ((float) objVal == v) return true;
@@ -283,9 +283,9 @@ public final class ArrayJavaProxy extends JavaProxy {
 
     private boolean includes(final ThreadContext context, final double[] array, final IRubyObject obj) {
         final int len = array.length;
-        if ( len == 0 ) return false;
+        if (len == 0) return false;
         if (obj instanceof RubyFloat flote) {
-            final double objVal = flote.getDoubleValue();
+            final double objVal = flote.asDouble(context);
 
             for (double v : array) {
                 if (objVal == v) return true;

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxy.java
@@ -309,7 +309,7 @@ public final class ArrayJavaProxy extends JavaProxy {
     @JRubyMethod(name = "first") // Enumerable override
     public IRubyObject first(ThreadContext context, IRubyObject count) {
         final Object array = getObject();
-        int len = numToInt(context, count);
+        int len = toInt(context, count);
         int size = Array.getLength(array); if ( len > size ) len = size;
 
         final Ruby runtime = context.runtime;
@@ -795,8 +795,8 @@ public final class ArrayJavaProxy extends JavaProxy {
     private IRubyObject arrayRange(final ThreadContext context, final RubyRange range) {
         final Object array = getObject();
         final int arrayLength = Array.getLength( array );
-        int first = castAsFixnum(context, range.first(context), "Only Integer ranges supported").getIntValue();
-        int last = castAsFixnum(context, range.last(context), "Only Integer ranges supported").getIntValue();
+        int first = castAsFixnum(context, range.first(context), "Only Integer ranges supported").asInt(context);
+        int last = castAsFixnum(context, range.last(context), "Only Integer ranges supported").asInt(context);
 
         first = first >= 0 ? first : arrayLength + first;
         if (first < 0 || first >= arrayLength) return context.nil;
@@ -820,8 +820,8 @@ public final class ArrayJavaProxy extends JavaProxy {
         final Object array = getObject();
         final int arrayLength = Array.getLength( array );
 
-        int first = castAsFixnum(context, rFirst, "Only Integer ranges supported").getIntValue();
-        int length = castAsFixnum(context, rLength, "Only Integer ranges supported").getIntValue();
+        int first = castAsFixnum(context, rFirst, "Only Integer ranges supported").asInt(context);
+        int length = castAsFixnum(context, rLength, "Only Integer ranges supported").asInt(context);
 
         if (length > arrayLength) throw context.runtime.newIndexError("length specified is longer than array");
         if (length < 0) return context.nil;

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxyCreator.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxyCreator.java
@@ -8,7 +8,7 @@ import org.jruby.runtime.Arity;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
-import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.runtime.ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR;
 
@@ -69,7 +69,7 @@ public class ArrayJavaProxyCreator extends RubyObject {
             System.arraycopy(dimensions, 0, newDimensions, 0, dlen);
         }
         for ( int i = 0; i < slen; i++ ) {
-            int size = numToInt(context, sizes[i]);
+            int size = toInt(context, sizes[i]);
             newDimensions[ i + dlen ] = size;
         }
         dimensions = newDimensions;

--- a/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxyCreator.java
+++ b/core/src/main/java/org/jruby/java/proxies/ArrayJavaProxyCreator.java
@@ -8,6 +8,7 @@ import org.jruby.runtime.Arity;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
+import static org.jruby.api.Convert.numToInt;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.runtime.ObjectAllocator.NOT_ALLOCATABLE_ALLOCATOR;
 
@@ -39,7 +40,7 @@ public class ArrayJavaProxyCreator extends RubyObject {
     ArrayJavaProxyCreator(final ThreadContext context, Class<?> elementType, final IRubyObject[] sizes) {
         this(context.runtime, elementType);
         assert sizes.length > 0;
-        aggregateDimensions(sizes);
+        aggregateDimensions(context, sizes);
     }
 
     private ArrayJavaProxyCreator(final Ruby runtime, Class<?> elementType) {
@@ -50,7 +51,7 @@ public class ArrayJavaProxyCreator extends RubyObject {
     @JRubyMethod(name = "[]", required = 1, rest = true, checkArity = false)
     public final IRubyObject op_aref(ThreadContext context, IRubyObject[] sizes) {
         Arity.checkArgumentCount(context, sizes, 1, -1);
-        aggregateDimensions(sizes);
+        aggregateDimensions(context, sizes);
         return this;
     }
 
@@ -59,7 +60,7 @@ public class ArrayJavaProxyCreator extends RubyObject {
         return ArrayJavaProxy.newArray(context.runtime, elementType, dimensions);
     }
 
-    private void aggregateDimensions(final IRubyObject[] sizes) {
+    private void aggregateDimensions(ThreadContext context, final IRubyObject[] sizes) {
         final int slen = sizes.length; if ( slen == 0 ) return;
         final int dlen = dimensions.length;
         final int[] newDimensions = new int[ dlen + slen ];
@@ -68,7 +69,7 @@ public class ArrayJavaProxyCreator extends RubyObject {
             System.arraycopy(dimensions, 0, newDimensions, 0, dlen);
         }
         for ( int i = 0; i < slen; i++ ) {
-            int size = (int) sizes[i].convertToInteger().getLongValue();
+            int size = numToInt(context, sizes[i]);
             newDimensions[ i + dlen ] = size;
         }
         dimensions = newDimensions;

--- a/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
@@ -59,7 +59,7 @@ import org.jruby.util.JRubyObjectInputStream;
 
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.castAsModule;
-import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Create.newEmptyArray;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.typeError;
@@ -200,7 +200,7 @@ public class JavaProxy extends RubyObject {
     @JRubyMethod(meta = true)
     public static IRubyObject new_array(ThreadContext context, IRubyObject self, IRubyObject len) {
         final Class<?> componentType = JavaUtil.getJavaClass(context, (RubyModule) self);
-        final int length = numToInt(context, len);
+        final int length = toInt(context, len);
         return ArrayJavaProxy.newArray(context.runtime, componentType, length);
     }
 

--- a/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
@@ -59,6 +59,7 @@ import org.jruby.util.JRubyObjectInputStream;
 
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.castAsModule;
+import static org.jruby.api.Convert.numToInt;
 import static org.jruby.api.Create.newEmptyArray;
 import static org.jruby.api.Define.defineClass;
 import static org.jruby.api.Error.typeError;
@@ -199,7 +200,7 @@ public class JavaProxy extends RubyObject {
     @JRubyMethod(meta = true)
     public static IRubyObject new_array(ThreadContext context, IRubyObject self, IRubyObject len) {
         final Class<?> componentType = JavaUtil.getJavaClass(context, (RubyModule) self);
-        final int length = (int) len.convertToInteger().getLongValue();
+        final int length = numToInt(context, len);
         return ArrayJavaProxy.newArray(context.runtime, componentType, length);
     }
 

--- a/core/src/main/java/org/jruby/javasupport/JavaArray.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaArray.java
@@ -93,7 +93,7 @@ public class JavaArray extends JavaObject {
     @Deprecated(since = "10.0")
     public IRubyObject aset(IRubyObject indexArg, IRubyObject value) {
         var context = getCurrentContext();
-        var index = Convert.castAsInteger(context, indexArg).getIntValue();
+        var index = Convert.castAsInteger(context, indexArg).asInt(context);
         var javaObject = castToJavaObject(context, value).getValue();
 
         ArrayUtils.setWithExceptionHandlingDirect(context.runtime, javaObject, index, javaObject);
@@ -113,8 +113,8 @@ public class JavaArray extends JavaObject {
     @Deprecated(since = "10.0")
     public IRubyObject afill(IRubyObject beginArg, IRubyObject endArg, IRubyObject value) {
         var context = ((RubyBasicObject) beginArg).getCurrentContext();
-        var beginIndex = Convert.castAsInteger(context, beginArg).getIntValue();
-        var endIndex = Convert.castAsInteger(context, endArg).getIntValue();
+        var beginIndex = Convert.castAsInteger(context, beginArg).asInt(context);
+        var endIndex = Convert.castAsInteger(context, endArg).asInt(context);
         var javaValue = castToJavaObject(context, value).getValue();
 
         fillWithExceptionHandling(context, beginIndex, endIndex, javaValue);

--- a/core/src/main/java/org/jruby/javasupport/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/JavaUtil.java
@@ -984,7 +984,7 @@ public class JavaUtil {
     }
 
     private static long processLongConvert(ThreadContext context, Predicate<Long> pred, RubyNumeric numeric, String type) {
-        final long value = numeric.getLongValue();
+        final long value = numeric.asLong(context);
         if (!pred.test(value)) throw rangeError(context, "too big for " + type + ": " + numeric);
         return value;
     }
@@ -997,7 +997,7 @@ public class JavaUtil {
             (context, numeric, target) -> (char) processLongConvert(context, JavaUtil::isLongCharable, numeric, "char");
     private static final NumericConverter<Integer> NUMERIC_TO_INTEGER =
             (context, numeric, target) -> (int) processLongConvert(context, JavaUtil::isLongIntable, numeric, "int");
-    private static final NumericConverter<Long> NUMERIC_TO_LONG = (context, numeric, target) -> numeric.getLongValue();
+    private static final NumericConverter<Long> NUMERIC_TO_LONG = (context, numeric, target) -> numeric.asLong(context);
     private static final NumericConverter<Float> NUMERIC_TO_FLOAT = (context, numeric, target) -> {
         final double value = numeric.asDouble(context);
         // many cases are ok to convert to float; if not one of these, error
@@ -1015,7 +1015,7 @@ public class JavaUtil {
     };
     private static final NumericConverter<Object> NUMERIC_TO_OBJECT = (context, numeric, target) -> {
         // for Object, default to natural wrapper type
-        if (numeric instanceof RubyFixnum) return Long.valueOf(numeric.getLongValue());
+        if (numeric instanceof RubyFixnum fixnum) return Long.valueOf(fixnum.getValue());
         if (numeric instanceof RubyFloat) return Double.valueOf(numeric.asDouble(context));
         if (numeric instanceof RubyBignum) return ((RubyBignum)numeric).getValue();
         if (numeric instanceof RubyBigDecimal) return ((RubyBigDecimal)numeric).getValue();
@@ -1162,15 +1162,11 @@ public class JavaUtil {
             return rubyObject.convertToString().getByteList();
         }
         if (javaClass == BigInteger.class) {
-         	if ( rubyObject instanceof RubyBignum ) {
-         		return ((RubyBignum) rubyObject).getValue();
-         	}
-            if ( rubyObject instanceof RubyNumeric ) {
- 				return BigInteger.valueOf( ((RubyNumeric) rubyObject).getLongValue() );
-         	}
+         	if (rubyObject instanceof RubyBignum bignum) return bignum.getValue();
+            if ( rubyObject instanceof RubyNumeric num) return BigInteger.valueOf(num.asLong(context));
             if ( rubyObject.respondsTo("to_i") ) {
          		RubyNumeric rubyNumeric = ((RubyNumeric) rubyObject.callMethod(context, "to_f"));
- 				return  BigInteger.valueOf( rubyNumeric.getLongValue() );
+ 				return BigInteger.valueOf(rubyNumeric.asLong(context));
          	}
         }
         if (javaClass == BigDecimal.class && !(rubyObject instanceof JavaObject)) {
@@ -1253,7 +1249,7 @@ public class JavaUtil {
     public static final RubyConverter RUBY_BYTE_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             if (rubyObject.respondsTo("to_i")) {
-                return (byte) ((RubyNumeric) rubyObject.callMethod(context, "to_i")).getLongValue();
+                return (byte) ((RubyNumeric) rubyObject.callMethod(context, "to_i")).asLong(context);
             }
             return (byte) 0;
         }
@@ -1263,7 +1259,7 @@ public class JavaUtil {
     public static final RubyConverter RUBY_SHORT_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             if (rubyObject.respondsTo("to_i")) {
-                return (short) ((RubyNumeric) rubyObject.callMethod(context, "to_i")).getLongValue();
+                return (short) ((RubyNumeric) rubyObject.callMethod(context, "to_i")).asLong(context);
             }
             return (short) 0;
         }
@@ -1273,7 +1269,7 @@ public class JavaUtil {
     public static final RubyConverter RUBY_CHAR_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             if (rubyObject.respondsTo("to_i")) {
-                return (char) ((RubyNumeric) rubyObject.callMethod(context, "to_i")).getLongValue();
+                return (char) ((RubyNumeric) rubyObject.callMethod(context, "to_i")).asLong(context);
             }
             return (char) 0;
         }
@@ -1283,7 +1279,7 @@ public class JavaUtil {
     public static final RubyConverter RUBY_INTEGER_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             if (rubyObject.respondsTo("to_i")) {
-                return (int) ((RubyNumeric) rubyObject.callMethod(context, "to_i")).getLongValue();
+                return (int) ((RubyNumeric) rubyObject.callMethod(context, "to_i")).asLong(context);
             }
             return (int) 0;
         }
@@ -1293,7 +1289,7 @@ public class JavaUtil {
     public static final RubyConverter RUBY_LONG_CONVERTER = new RubyConverter() {
         public Object convert(ThreadContext context, IRubyObject rubyObject) {
             if (rubyObject.respondsTo("to_i")) {
-                return ((RubyNumeric) rubyObject.callMethod(context, "to_i")).getLongValue();
+                return ((RubyNumeric) rubyObject.callMethod(context, "to_i")).asLong(context);
             }
             return 0L;
         }
@@ -1512,8 +1508,8 @@ public class JavaUtil {
             javaObject = null;
             break;
         case INTEGER:
-            if (object instanceof RubyFixnum) {
-                javaObject = Long.valueOf(((RubyFixnum) object).getLongValue());
+            if (object instanceof RubyFixnum fix) {
+                javaObject = Long.valueOf(fix.getValue());
             } else {
                 javaObject = ((RubyBignum) object).getValue();
             }

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaLang.java
@@ -794,18 +794,17 @@ public abstract class JavaLang {
         public static IRubyObject new_array(ThreadContext context, IRubyObject self, IRubyObject length) {
             final java.lang.Class klass = unwrapJavaObject(self);
 
-            if (length instanceof RubyInteger) { // one-dimensional array
-                int len = ((RubyInteger) length).getIntValue();
-                return ArrayJavaProxy.newArray(context.runtime, klass, len);
+            if (length instanceof RubyInteger lenint) { // one-dimensional array
+                return ArrayJavaProxy.newArray(context.runtime, klass, lenint.asInt(context));
             }
-            if (length instanceof RubyArray) { // n-dimensional array
-                IRubyObject[] aryLengths = ((RubyArray) length).toJavaArrayMaybeUnsafe();
+            if (length instanceof RubyArray ary) { // n-dimensional array
+                IRubyObject[] aryLengths = ary.toJavaArrayMaybeUnsafe();
                 final int len = aryLengths.length;
                 if (len == 0) throw argumentError(context, "empty dimensions specifier for java array");
 
                 final int[] dimensions = new int[len];
                 for (int i = len; --i >= 0; ) {
-                    dimensions[i] = Convert.castAsInteger(context, aryLengths[i]).getIntValue();
+                    dimensions[i] = Convert.castAsInteger(context, aryLengths[i]).asInt(context);
                 }
                 return ArrayJavaProxy.newArray(context.runtime, klass, dimensions);
             }
@@ -942,7 +941,7 @@ public abstract class JavaLang {
         @Override
         public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, java.lang.String name, IRubyObject idx) {
             final RubyInteger val = (RubyInteger) self.callMethod(context, "[]", idx);
-            int byte_val = val.getIntValue();
+            int byte_val = val.asInt(context);
             if ( byte_val >= 0 ) return val;
             return asFixnum(context, byte_val + 256); // byte += 256 if byte < 0
         }
@@ -956,7 +955,7 @@ public abstract class JavaLang {
 
         @Override
         public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, java.lang.String name, IRubyObject idx, IRubyObject val) {
-            int byte_val = ((RubyInteger) val).getIntValue();
+            int byte_val = ((RubyInteger) val).asInt(context);
             if ( byte_val > 127 ) {
                 val = asFixnum(context, byte_val - 256); // value -= 256 if value > 127
             }

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
@@ -48,7 +48,7 @@ import java.lang.reflect.InvocationTargetException;
 import static org.jruby.RubyEnumerator.enumeratorize;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Create.*;
 import static org.jruby.javasupport.JavaUtil.convertJavaArrayToRuby;
 import static org.jruby.javasupport.JavaUtil.convertJavaToUsableRubyObject;
@@ -166,7 +166,7 @@ public abstract class JavaUtil {
         @JRubyMethod(name = { "first", "ruby_first" }) // re-def Enumerable#first(n)
         public static IRubyObject first(final ThreadContext context, final IRubyObject self, final IRubyObject count) {
             final java.util.Collection<?> coll = unwrapIfJavaObject(self);
-            int len = numToInt(context, count);
+            int len = toInt(context, count);
             int size = coll.size(); if ( len > size ) len = size;
             if ( len == 0 ) return RubyArray.newEmptyArray(context.runtime);
             var objArray = new IRubyObject[len];
@@ -314,8 +314,8 @@ public abstract class JavaUtil {
             final int size = list.size();
 
             if ( idx instanceof RubyRange ) {
-                int first = numToInt(context, idx.callMethod(context, "first"));
-                int last = numToInt(context, idx.callMethod(context, "last"));
+                int first = toInt(context, idx.callMethod(context, "first"));
+                int last = toInt(context, idx.callMethod(context, "last"));
                 if ( last < 0 ) last += size;
                 if ( first < 0 ) first += size;
                 if ( first < 0 || first >= size ) return context.nil;
@@ -325,7 +325,7 @@ public abstract class JavaUtil {
                 return Java.getInstance(context.runtime, list.subList(first, last));
             }
 
-            int i = numToInt(context, idx);
+            int i = toInt(context, idx);
             if ( i < 0 ) i = size + i; // -1 ... size - 1
             if ( i >= size || i < 0 ) return context.nil;
             return convertJavaToUsableRubyObject(context.runtime, list.get(i));
@@ -339,12 +339,12 @@ public abstract class JavaUtil {
 
             final java.util.List list = unwrapIfJavaObject(self);
 
-            int i = numToInt(context, idx.convertToInteger());
+            int i = toInt(context, idx.convertToInteger());
             final int size = list.size();
             if ( i < 0 ) i = size + i; // -1 ... size - 1
             if ( i >= size || i < 0 ) return context.nil;
 
-            int last = numToInt(context, len);
+            int last = toInt(context, len);
             if ( last < 0 ) return context.nil;
             last += i; if ( last > size ) last = size;
 
@@ -359,8 +359,8 @@ public abstract class JavaUtil {
             final int size = list.size();
 
             if ( idx instanceof RubyRange ) {
-                int first = numToInt(context, idx.callMethod(context, "first"));
-                int last = numToInt(context, idx.callMethod(context, "last"));
+                int first = toInt(context, idx.callMethod(context, "first"));
+                int last = toInt(context, idx.callMethod(context, "last"));
                 if ( last < 0 ) last += size;
                 if ( first < 0 ) first += size;
                 if ( ((RubyRange) idx).isExcludeEnd() ) last--;
@@ -372,7 +372,7 @@ public abstract class JavaUtil {
                 return val;
             }
 
-            int i = numToInt(context, idx);
+            int i = toInt(context, idx);
             if ( i < 0 ) i = size + i; // -1 ... size - 1
             if ( i >= size ) {
                 for ( int t = 0; t < i - size; t++ ) list.add(null);
@@ -394,7 +394,7 @@ public abstract class JavaUtil {
         @JRubyMethod(name = { "first", "ruby_first" }) // #first ext like with array: [1, 2, 3].first(2) == [1, 2]
         public static IRubyObject first(final ThreadContext context, final IRubyObject self, final IRubyObject count) {
             final java.util.List list = unwrapIfJavaObject(self);
-            int len = numToInt(context, count);
+            int len = toInt(context, count);
             int size = list.size(); if ( len > size ) len = size;
             return Java.getInstance(context.runtime, list.subList(0, len));
         }
@@ -409,7 +409,7 @@ public abstract class JavaUtil {
         @JRubyMethod(name = { "last", "ruby_last" }) // #last ext like with array: [1, 2, 3].last(2) == [2, 3]
         public static IRubyObject last(final ThreadContext context, final IRubyObject self, final IRubyObject count) {
             final java.util.List list = unwrapIfJavaObject(self);
-            int len = numToInt(context, count);
+            int len = toInt(context, count);
             int size = list.size();
             int start = size - len; if ( start < 0 ) start = 0;
             int end = start + len; if ( end > size ) end = size;

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaUtil.java
@@ -48,6 +48,7 @@ import java.lang.reflect.InvocationTargetException;
 import static org.jruby.RubyEnumerator.enumeratorize;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Convert.numToInt;
 import static org.jruby.api.Create.*;
 import static org.jruby.javasupport.JavaUtil.convertJavaArrayToRuby;
 import static org.jruby.javasupport.JavaUtil.convertJavaToUsableRubyObject;
@@ -165,7 +166,7 @@ public abstract class JavaUtil {
         @JRubyMethod(name = { "first", "ruby_first" }) // re-def Enumerable#first(n)
         public static IRubyObject first(final ThreadContext context, final IRubyObject self, final IRubyObject count) {
             final java.util.Collection<?> coll = unwrapIfJavaObject(self);
-            int len = count.convertToInteger().getIntValue();
+            int len = numToInt(context, count);
             int size = coll.size(); if ( len > size ) len = size;
             if ( len == 0 ) return RubyArray.newEmptyArray(context.runtime);
             var objArray = new IRubyObject[len];
@@ -313,8 +314,8 @@ public abstract class JavaUtil {
             final int size = list.size();
 
             if ( idx instanceof RubyRange ) {
-                int first = idx.callMethod(context, "first").convertToInteger().getIntValue();
-                int last = idx.callMethod(context, "last").convertToInteger().getIntValue();
+                int first = numToInt(context, idx.callMethod(context, "first"));
+                int last = numToInt(context, idx.callMethod(context, "last"));
                 if ( last < 0 ) last += size;
                 if ( first < 0 ) first += size;
                 if ( first < 0 || first >= size ) return context.nil;
@@ -324,7 +325,7 @@ public abstract class JavaUtil {
                 return Java.getInstance(context.runtime, list.subList(first, last));
             }
 
-            int i = idx.convertToInteger().getIntValue();
+            int i = numToInt(context, idx);
             if ( i < 0 ) i = size + i; // -1 ... size - 1
             if ( i >= size || i < 0 ) return context.nil;
             return convertJavaToUsableRubyObject(context.runtime, list.get(i));
@@ -338,12 +339,12 @@ public abstract class JavaUtil {
 
             final java.util.List list = unwrapIfJavaObject(self);
 
-            int i = idx.convertToInteger().getIntValue();
+            int i = numToInt(context, idx.convertToInteger());
             final int size = list.size();
             if ( i < 0 ) i = size + i; // -1 ... size - 1
             if ( i >= size || i < 0 ) return context.nil;
 
-            int last = len.convertToInteger().getIntValue();
+            int last = numToInt(context, len);
             if ( last < 0 ) return context.nil;
             last += i; if ( last > size ) last = size;
 
@@ -358,8 +359,8 @@ public abstract class JavaUtil {
             final int size = list.size();
 
             if ( idx instanceof RubyRange ) {
-                int first = idx.callMethod(context, "first").convertToInteger().getIntValue();
-                int last = idx.callMethod(context, "last").convertToInteger().getIntValue();
+                int first = numToInt(context, idx.callMethod(context, "first"));
+                int last = numToInt(context, idx.callMethod(context, "last"));
                 if ( last < 0 ) last += size;
                 if ( first < 0 ) first += size;
                 if ( ((RubyRange) idx).isExcludeEnd() ) last--;
@@ -371,7 +372,7 @@ public abstract class JavaUtil {
                 return val;
             }
 
-            int i = idx.convertToInteger().getIntValue();
+            int i = numToInt(context, idx);
             if ( i < 0 ) i = size + i; // -1 ... size - 1
             if ( i >= size ) {
                 for ( int t = 0; t < i - size; t++ ) list.add(null);
@@ -393,7 +394,7 @@ public abstract class JavaUtil {
         @JRubyMethod(name = { "first", "ruby_first" }) // #first ext like with array: [1, 2, 3].first(2) == [1, 2]
         public static IRubyObject first(final ThreadContext context, final IRubyObject self, final IRubyObject count) {
             final java.util.List list = unwrapIfJavaObject(self);
-            int len = count.convertToInteger().getIntValue();
+            int len = numToInt(context, count);
             int size = list.size(); if ( len > size ) len = size;
             return Java.getInstance(context.runtime, list.subList(0, len));
         }
@@ -408,7 +409,7 @@ public abstract class JavaUtil {
         @JRubyMethod(name = { "last", "ruby_last" }) // #last ext like with array: [1, 2, 3].last(2) == [2, 3]
         public static IRubyObject last(final ThreadContext context, final IRubyObject self, final IRubyObject count) {
             final java.util.List list = unwrapIfJavaObject(self);
-            int len = count.convertToInteger().getIntValue();
+            int len = numToInt(context, count);
             int size = list.size();
             int start = size - len; if ( start < 0 ) start = 0;
             int end = start + len; if ( end > size ) end = size;

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaUtilRegex.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaUtilRegex.java
@@ -37,7 +37,7 @@ import org.jruby.util.RubyStringBuilder;
 
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.toInt;
 import static org.jruby.api.Create.newArray;
 import static org.jruby.api.Create.newString;
 import static org.jruby.javasupport.JavaUtil.convertJavaToUsableRubyObject;
@@ -118,7 +118,7 @@ public abstract class JavaUtilRegex {
             final java.util.regex.Matcher matcher = unwrapJavaObject(self);
             if (idx instanceof RubySymbol) return asFixnum(context, matcher.start(idx.toString()));
 
-            final int group = numToInt(context, idx);
+            final int group = toInt(context, idx);
             return asFixnum(context, matcher.start(group));
         }
 
@@ -127,7 +127,7 @@ public abstract class JavaUtilRegex {
             final java.util.regex.Matcher matcher = unwrapJavaObject(self);
             if (idx instanceof RubySymbol) return asFixnum(context, matcher.end(idx.toString()));
 
-            final int group = numToInt(context, idx);
+            final int group = toInt(context, idx);
             return asFixnum(context, matcher.end(group));
         }
 
@@ -141,7 +141,7 @@ public abstract class JavaUtilRegex {
                 beg = asFixnum(context, matcher.start(idx.toString()));
                 end = asFixnum(context, matcher.end(idx.toString()));
             } else {
-                final int group = numToInt(context, idx);
+                final int group = toInt(context, idx);
                 beg = asFixnum(context, matcher.start(group));
                 end = asFixnum(context, matcher.end(group));
             }
@@ -207,11 +207,10 @@ public abstract class JavaUtilRegex {
             if ( idx instanceof RubySymbol || idx instanceof RubyString ) {
                 return newString(context, matcher.group(idx.toString()));
             }
-            if ( idx instanceof RubyInteger ) {
-                final int group = ((RubyInteger) idx).getIntValue();
-                return newString(context, matcher.group(group));
-            }
-            return to_a(context, self).aref(context, idx); // Range
+
+            return idx instanceof RubyInteger group ?
+                    newString(context, matcher.group(group.asInt(context))) :
+                    to_a(context, self).aref(context, idx); // Range
         }
 
         @JRubyMethod(name = "[]")

--- a/core/src/main/java/org/jruby/javasupport/ext/JavaUtilRegex.java
+++ b/core/src/main/java/org/jruby/javasupport/ext/JavaUtilRegex.java
@@ -37,6 +37,7 @@ import org.jruby.util.RubyStringBuilder;
 
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Convert.numToInt;
 import static org.jruby.api.Create.newArray;
 import static org.jruby.api.Create.newString;
 import static org.jruby.javasupport.JavaUtil.convertJavaToUsableRubyObject;
@@ -117,7 +118,7 @@ public abstract class JavaUtilRegex {
             final java.util.regex.Matcher matcher = unwrapJavaObject(self);
             if (idx instanceof RubySymbol) return asFixnum(context, matcher.start(idx.toString()));
 
-            final int group = idx.convertToInteger().getIntValue();
+            final int group = numToInt(context, idx);
             return asFixnum(context, matcher.start(group));
         }
 
@@ -126,7 +127,7 @@ public abstract class JavaUtilRegex {
             final java.util.regex.Matcher matcher = unwrapJavaObject(self);
             if (idx instanceof RubySymbol) return asFixnum(context, matcher.end(idx.toString()));
 
-            final int group = idx.convertToInteger().getIntValue();
+            final int group = numToInt(context, idx);
             return asFixnum(context, matcher.end(group));
         }
 
@@ -140,7 +141,7 @@ public abstract class JavaUtilRegex {
                 beg = asFixnum(context, matcher.start(idx.toString()));
                 end = asFixnum(context, matcher.end(idx.toString()));
             } else {
-                final int group = idx.convertToInteger().getIntValue();
+                final int group = numToInt(context, idx);
                 beg = asFixnum(context, matcher.start(group));
                 end = asFixnum(context, matcher.end(group));
             }

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -91,6 +91,7 @@ import static org.jruby.api.Access.moduleClass;
 import static org.jruby.api.Access.objectClass;
 import static org.jruby.api.Convert.asBoolean;
 import static org.jruby.api.Convert.asSymbol;
+import static org.jruby.api.Convert.toInteger;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Define.defineModule;
 import static org.jruby.api.Error.argumentError;
@@ -2011,9 +2012,7 @@ public class Helpers {
     @Deprecated // not used
     public static IRubyObject aValueSplat(IRubyObject value) {
         var context = ((RubyBasicObject) value).getCurrentContext();
-        if (!(value instanceof RubyArray array) || array.length().getLongValue() == 0) {
-            return context.nil;
-        }
+        if (!(value instanceof RubyArray array) || array.length().getValue() == 0) return context.nil;
 
         return array.getLength() == 1 ? array.first(context) : array;
     }
@@ -3081,7 +3080,7 @@ public class Helpers {
         while (!(hval instanceof RubyFixnum fixnum)) {
             // This is different from MRI because we don't have rb_integer_pack
             if (hval instanceof RubyBignum bignum) return bignum.hash(context);
-            hval = hval.convertToInteger();
+            hval = toInteger(context, hval);
         }
 
         return fixnum;

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -548,17 +548,22 @@ public class Helpers {
         throw argumentError(context, "argument too big");
     }
 
+    @Deprecated(since = "10.0")
+    public static int addBufferLength(Ruby runtime, int base, int extra) {
+        return addBufferLength(runtime.getCurrentContext(), base, extra);
+    }
+
     /**
      * Calculate a buffer length based on a base size and a extra size. If the resulting size exceeds MAX_ARRAY_SIZE
      * and the extra size is nonzero, use the MAX_ARRAY_SIZE as the buffer length.
      *
-     * @param runtime the runtime
+     * @param context the current thread context
      * @param base the base size
      * @param extra the extra buffer size
      * @return the combined buffer size, or MAX_ARRAY_SIZE
      * @throws ArgumentError if the original or combined size cannot be accommodated by MAX_ARRAY_SIZE
      */
-    public static int addBufferLength(Ruby runtime, int base, int extra) {
+    public static int addBufferLength(ThreadContext context, int base, int extra) {
         try {
             int newSize = Math.addExact(base, extra);
 
@@ -569,16 +574,21 @@ public class Helpers {
             // fall through to error below
         }
 
-        throw argumentError(runtime.getCurrentContext(), "argument too big");
+        throw argumentError(context, "argument too big");
+    }
+
+    // FIXME: We need to deprecate this one RubyArray no longer needs it
+    public static int validateBufferLength(Ruby runtime, long length) {
+        return validateBufferLength(runtime.getCurrentContext(), length);
     }
 
     /**
      * Check that the buffer length requested is within the valid range of 0 to MAX_ARRAY_SIZE, or raise an argument
      * error.
      */
-    public static int validateBufferLength(Ruby runtime, long length) {
-        if (length < 0) throw argumentError(runtime.getCurrentContext(), "negative argument");
-        if (length > MAX_ARRAY_SIZE) throw argumentError(runtime.getCurrentContext(), "argument too big");
+    public static int validateBufferLength(ThreadContext context, long length) {
+        if (length < 0) throw argumentError(context, "negative argument");
+        if (length > MAX_ARRAY_SIZE) throw argumentError(context, "argument too big");
 
         return (int) length;
     }
@@ -2345,9 +2355,14 @@ public class Helpers {
         return RubyProc.newProc(context.runtime, block, Block.Type.LAMBDA);
     }
 
+    @Deprecated(since = "10.0")
     public static void fillNil(final IRubyObject[] arr, int from, int to, Ruby runtime) {
+        fillNil(runtime.getCurrentContext(), arr, from, to);
+    }
+
+    public static void fillNil(ThreadContext context, final IRubyObject[] arr, int from, int to) {
         if (arr.length == 0) return;
-        IRubyObject nils[] = runtime.getNilPrefilledArray();
+        IRubyObject nils[] = context.runtime.getNilPrefilledArray();
         int i;
 
         // NOTE: seems that Arrays.fill(arr, runtime.getNil()) won't do better ... on Java 8
@@ -2388,8 +2403,13 @@ public class Helpers {
         return arr;
     }
 
+    @Deprecated(since = "10.0")
     public static void fillNil(IRubyObject[] arr, Ruby runtime) {
-        fillNil(arr, 0, arr.length, runtime);
+        fillNil(runtime.getCurrentContext(), arr);
+    }
+
+    public static void fillNil(ThreadContext context, IRubyObject[] arr) {
+        fillNil(context, arr, 0, arr.length);
     }
 
     public static Block getBlock(ThreadContext context, IRubyObject self, Node node) {

--- a/core/src/main/java/org/jruby/runtime/marshal/MarshalStream.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/MarshalStream.java
@@ -128,7 +128,8 @@ public class MarshalStream extends FilterOutputStream {
     }
 
     private static boolean isMarshalFixnum(RubyFixnum fixnum) {
-        return fixnum.getLongValue() <= RubyFixnum.MAX_MARSHAL_FIXNUM && fixnum.getLongValue() >= RubyFixnum.MIN_MARSHAL_FIXNUM;
+        var value = fixnum.getValue();
+        return value <= RubyFixnum.MAX_MARSHAL_FIXNUM && value >= RubyFixnum.MIN_MARSHAL_FIXNUM;
     }
 
     private void writeAndRegisterSymbol(ByteList sym) throws IOException {
@@ -252,11 +253,11 @@ public class MarshalStream extends FilterOutputStream {
 
                 if (isMarshalFixnum(fixnum)) {
                     write('i');
-                    writeInt((int) fixnum.getLongValue());
+                    writeInt((int) fixnum.getValue());
                     return;
                 }
                 // FIXME: inefficient; constructing a bignum just for dumping?
-                value = RubyBignum.newBignum(value.getRuntime(), fixnum.getLongValue());
+                value = RubyBignum.newBignum(value.getRuntime(), fixnum.getValue());
 
                 // fall through
             case BIGNUM:

--- a/core/src/main/java/org/jruby/runtime/marshal/NewMarshal.java
+++ b/core/src/main/java/org/jruby/runtime/marshal/NewMarshal.java
@@ -170,7 +170,8 @@ public class NewMarshal {
     }
 
     private static boolean isMarshalFixnum(RubyFixnum fixnum) {
-        return fixnum.getLongValue() <= RubyFixnum.MAX_MARSHAL_FIXNUM && fixnum.getLongValue() >= RubyFixnum.MIN_MARSHAL_FIXNUM;
+        var value = fixnum.getValue();
+        return value <= RubyFixnum.MAX_MARSHAL_FIXNUM && value >= RubyFixnum.MIN_MARSHAL_FIXNUM;
     }
 
     private void writeAndRegisterSymbol(RubyOutputStream out, RubySymbol sym) {
@@ -332,12 +333,12 @@ public class NewMarshal {
 
                 if (isMarshalFixnum(fixnum)) {
                     out.write('i');
-                    writeInt(out, (int) fixnum.getLongValue());
+                    writeInt(out, (int) fixnum.getValue());
                     return;
                 }
                 // FIXME: inefficient; constructing a bignum just for dumping?
                 runtime = context.runtime;
-                value = RubyBignum.newBignum(runtime, fixnum.getLongValue());
+                value = RubyBignum.newBignum(runtime, fixnum.getValue());
 
                 // fall through
             case BIGNUM:

--- a/core/src/main/java/org/jruby/specialized/RubyArraySpecialized.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArraySpecialized.java
@@ -63,7 +63,7 @@ public abstract class RubyArraySpecialized extends RubyArray {
         // CON: I believe most of the time we'll unpack because we need to grow, so give a bit of extra room.
         //      For example, <<, unshift, and push will all just add one to front or back.
         IRubyObject[] values = new IRubyObject[realLength + 2];
-        Helpers.fillNil(values, context.runtime);
+        Helpers.fillNil(context, values);
         copyInto(context, values, 1);
         this.values = values;
         this.begin = 1;

--- a/core/src/main/java/org/jruby/util/IOChannel.java
+++ b/core/src/main/java/org/jruby/util/IOChannel.java
@@ -47,6 +47,7 @@ import org.jruby.runtime.callsite.FunctionalCachingCallSite;
 import org.jruby.runtime.callsite.RespondToCallSite;
 
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Convert.toInt;
 
 /**
  * Wrap an IO object in a Channel.
@@ -150,14 +151,13 @@ public abstract class IOChannel implements Channel {
             buffer.append(src, remaining);
         }
 
+        var context = runtime.getCurrentContext();
         // call write with new String based on this ByteList
-        IRubyObject written = write.call(runtime.getCurrentContext(), io, io, RubyString.newStringLight(runtime, buffer));
-        int wrote = written.convertToInteger().getIntValue();
+        IRubyObject written = write.call(context, io, io, RubyString.newStringLight(runtime, buffer));
+        int wrote = toInt(context, written);
 
         // set source position to match bytes written
-        if (wrote > 0) {
-            src.position(position + wrote);
-        }
+        if (wrote > 0) src.position(position + wrote);
 
         return wrote;
     }

--- a/core/src/main/java/org/jruby/util/Numeric.java
+++ b/core/src/main/java/org/jruby/util/Numeric.java
@@ -206,11 +206,11 @@ public class Numeric {
     // MRI: safe_mul
     public static IRubyObject safe_mul(ThreadContext context, IRubyObject a, IRubyObject b, boolean az, boolean bz) {
         double v;
-        if (!az && bz && a instanceof RubyFloat aa && !Double.isNaN(v = aa.getDoubleValue())) {
-            a = v < 0.0d ? asFloat(context, -1.0d) : asFloat(context, 1.0d);
+        if (!az && bz && a instanceof RubyFloat aa && !Double.isNaN(v = aa.asDouble(context))) {
+            a = asFloat(context, v < 0.0d ? -1.0d : 1.0d);
         }
-        if (!bz && az && b instanceof RubyFloat bb && !Double.isNaN(v = bb.getDoubleValue())) {
-            b = v < 0.0d ? asFloat(context, -1.0) : asFloat(context, 1.0);
+        if (!bz && az && b instanceof RubyFloat bb && !Double.isNaN(v = bb.asDouble(context))) {
+            b = asFloat(context, v < 0.0d ? -1.0 : 1.0);
         }
         return f_mul(context, a, b);
     }

--- a/core/src/main/java/org/jruby/util/Numeric.java
+++ b/core/src/main/java/org/jruby/util/Numeric.java
@@ -33,7 +33,6 @@ import org.joni.WarnCallback;
 import org.jcodings.specific.ASCIIEncoding;
 import org.jruby.Ruby;
 import org.jruby.RubyBignum;
-import org.jruby.RubyBoolean;
 import org.jruby.RubyComplex;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
@@ -379,7 +378,7 @@ public class Numeric {
     }
 
     public static RubyInteger f_negate(ThreadContext context, RubyInteger x) {
-        return x.negate();
+        return x.negate(context);
     }
 
     /** f_to_f
@@ -655,7 +654,7 @@ public class Numeric {
     }
 
     public static long i_ilog2(ThreadContext context, RubyInteger x) {
-        long q = (numToInt(context, x.size(context)) - 8) * 8 + 1;
+        long q = (toInt(context, x.size(context)) - 8) * 8 + 1;
 
         if (q > 0) {
             x = x.op_rshift(context, q);

--- a/core/src/main/java/org/jruby/util/Numeric.java
+++ b/core/src/main/java/org/jruby/util/Numeric.java
@@ -59,30 +59,28 @@ public class Numeric {
         CachingCallSite op_plus = sites(context).op_plus;
 
         if (op_plus.isBuiltin(x)) {
-            if (x instanceof RubyInteger) {
-                if (fixnumZero(x)) return y;
-                if (fixnumZero(y)) return x;
-                return ((RubyInteger) x).op_plus(context, y);
-            } else if (x instanceof RubyFloat) {
-                if (fixnumZero(y)) return x;
-                return ((RubyFloat) x).op_plus(context, y);
-            } else if (x instanceof RubyRational) {
-                if (fixnumZero(y)) return x;
-                return ((RubyRational) x).op_plus(context, y);
+            if (x instanceof RubyInteger rint) {
+                if (fixnumZero(context, x)) return y;
+                if (fixnumZero(context, y)) return x;
+                return rint.op_plus(context, y);
+            } else if (x instanceof RubyFloat flote) {
+                if (fixnumZero(context, y)) return x;
+                return flote.op_plus(context, y);
+            } else if (x instanceof RubyRational rat) {
+                if (fixnumZero(context, y)) return x;
+                return rat.op_plus(context, y);
             }
         }
 
         return op_plus.call(context, x, x, y);
     }
 
-    private static boolean fixnumZero(IRubyObject y) {
-        return y instanceof RubyFixnum
-                && ((RubyFixnum) y).getLongValue() == 0;
+    private static boolean fixnumZero(ThreadContext context, IRubyObject y) {
+        return y instanceof RubyFixnum fixnum && fixnum.isZero(context);
     }
 
     private static boolean fixnumOne(IRubyObject y) {
-        return y instanceof RubyFixnum
-                && ((RubyFixnum) y).getLongValue() == 1;
+        return y instanceof RubyFixnum fix && fix.getValue() == 1;
     }
 
     public static RubyInteger f_add(ThreadContext context, RubyInteger x, RubyInteger y) {
@@ -100,19 +98,16 @@ public class Numeric {
     }
 
     public static RubyFixnum f_cmp(ThreadContext context, RubyInteger x, RubyInteger y) {
-        final int cmp;
-        if (x instanceof RubyFixnum && y instanceof RubyFixnum) {
-            cmp = Long.compare(((RubyFixnum) x).getLongValue(), ((RubyFixnum) y).getLongValue());
-        }
-        else { // RubyBignum || RubyFixnum
-            cmp = x.getBigIntegerValue().compareTo(y.getBigIntegerValue());
-        }
+        final int cmp = x instanceof RubyFixnum fixx && y instanceof RubyFixnum fixy ?
+                Long.compare(fixx.getValue(), fixy.getValue()) :
+                x.getBigIntegerValue().compareTo(y.getBigIntegerValue());
+
         return asFixnum(context, cmp);
     }
 
     public static RubyFixnum f_cmp(ThreadContext context, RubyInteger x, long y) {
         final int cmp = x instanceof RubyFixnum xx ?
-                Long.compare(xx.getLongValue(), y) :
+                Long.compare(xx.getValue(), y) :
                 x.getBigIntegerValue().compareTo(BigInteger.valueOf(y));
 
         return asFixnum(context, cmp);
@@ -122,7 +117,7 @@ public class Numeric {
      *
      */
     public static IRubyObject f_div(ThreadContext context, IRubyObject x, IRubyObject y) {
-        return y instanceof RubyFixnum yy && yy.getLongValue() == 1 ?
+        return y instanceof RubyFixnum yy && yy.getValue() == 1 ?
                 x : sites(context).op_quo.call(context, x, x, y);
     }
 
@@ -130,34 +125,30 @@ public class Numeric {
      *
      */
     public static boolean f_gt_p(ThreadContext context, IRubyObject x, IRubyObject y) {
-        if (x instanceof RubyFixnum && y instanceof RubyFixnum) {
-            return ((RubyFixnum)x).getLongValue() > ((RubyFixnum)y).getLongValue();
-        }
-        return sites(context).op_gt.call(context, x, x, y).isTrue();
+        return x instanceof RubyFixnum fixx && y instanceof RubyFixnum fixy ?
+                fixx.getValue() > fixy.getValue() :
+                sites(context).op_gt.call(context, x, x, y).isTrue();
     }
 
     public static boolean f_gt_p(ThreadContext context, RubyInteger x, RubyInteger y) {
-        if (x instanceof RubyFixnum && y instanceof RubyFixnum) {
-            return ((RubyFixnum)x).getLongValue() > ((RubyFixnum)y).getLongValue();
-        }
-        return x.getBigIntegerValue().compareTo(y.getBigIntegerValue()) > 0;
+        return x instanceof RubyFixnum fixx && y instanceof RubyFixnum fixy ?
+                fixx.getValue() > fixy.getValue() :
+                x.getBigIntegerValue().compareTo(y.getBigIntegerValue()) > 0;
     }
 
     /** f_lt_p
      *
      */
     public static boolean f_lt_p(ThreadContext context, IRubyObject x, IRubyObject y) {
-        if (x instanceof RubyFixnum && y instanceof RubyFixnum) {
-            return ((RubyFixnum)x).getLongValue() < ((RubyFixnum)y).getLongValue();
-        }
-        return sites(context).op_lt.call(context, x, x, y).isTrue();
+        return x instanceof RubyFixnum fixx && y instanceof RubyFixnum fixy ?
+                fixx.getValue() < fixy.getValue() :
+                sites(context).op_lt.call(context, x, x, y).isTrue();
     }
 
     public static boolean f_lt_p(ThreadContext context, RubyInteger x, RubyInteger y) {
-        if (x instanceof RubyFixnum && y instanceof RubyFixnum) {
-            return ((RubyFixnum)x).getLongValue() < ((RubyFixnum)y).getLongValue();
-        }
-        return x.getBigIntegerValue().compareTo(y.getBigIntegerValue()) < 0;
+        return x instanceof RubyFixnum fixx && y instanceof RubyFixnum fixy ?
+                fixx.getValue() < fixy.getValue() :
+                x.getBigIntegerValue().compareTo(y.getBigIntegerValue()) < 0;
     }
 
     /** f_mod
@@ -175,12 +166,8 @@ public class Numeric {
 
         if (op_times.isBuiltin(x)) {
             if (x instanceof RubyInteger) {
-                if (fixnumZero(y)) {
-                    return y;
-                }
-                if (fixnumZero(x) && y instanceof RubyInteger) {
-                    return x;
-                }
+                if (fixnumZero(context, y)) return y;
+                if (fixnumZero(context, x) && y instanceof RubyInteger) return x;
                 if (fixnumOne(x)) return y;
                 if (fixnumOne(y)) return x;
                 return ((RubyInteger) x).op_mul(context, y);
@@ -220,7 +207,7 @@ public class Numeric {
     public static IRubyObject f_sub(ThreadContext context, IRubyObject x, IRubyObject y) {
         CachingCallSite op_minus = sites(context).op_minus;
 
-        if (op_minus.isBuiltin(x) && fixnumZero(y)) {
+        if (op_minus.isBuiltin(x) && fixnumZero(context, y)) {
             return x;
         }
 
@@ -427,11 +414,9 @@ public class Numeric {
      *
      */
     public static IRubyObject f_equal(ThreadContext context, IRubyObject a, IRubyObject b) {
-        if (a instanceof RubyFixnum x && b instanceof RubyFixnum y) {
-            return asBoolean(context, x.getLongValue() == y.getLongValue());
-        }
-
-        return sites(context).op_equals.call(context, a, a, b);
+        return a instanceof RubyFixnum x && b instanceof RubyFixnum y ?
+                asBoolean(context, x.getValue() == y.getValue()) :
+                sites(context).op_equals.call(context, a, a, b);
     }
 
     public static IRubyObject f_equal(ThreadContext context, RubyInteger x, RubyInteger y) {
@@ -525,25 +510,27 @@ public class Numeric {
      *
      */
     public static boolean f_one_p(ThreadContext context, IRubyObject x) {
-        if (x instanceof RubyFixnum) return ((RubyFixnum) x).getLongValue() == 1;
-        return sites(context).op_equals.call(context, x, x, RubyFixnum.one(context.runtime)).isTrue();
+        return x instanceof RubyFixnum fixx ?
+                fixx.getValue() == 1 :
+                sites(context).op_equals.call(context, x, x, asFixnum(context, 1)).isTrue();
     }
 
    /** f_minus_one_p
     *
     */
     public static boolean f_minus_one_p(ThreadContext context, IRubyObject x) {
-        if (x instanceof RubyFixnum) return ((RubyFixnum) x).getLongValue() == -1;
-        return sites(context).op_equals.call(context, x, x, RubyFixnum.minus_one(context.runtime)).isTrue();
+        return x instanceof RubyFixnum fixx ?
+                fixx.getValue() == -1 :
+                sites(context).op_equals.call(context, x, x, asFixnum(context, -1)).isTrue();
     }
 
    /** f_odd_p
     *
     */
     public static boolean f_odd_p(ThreadContext context, IRubyObject i) {
-        if (i instanceof RubyFixnum) return ((RubyFixnum) i).getLongValue() % 2 != 0;
-        RubyFixnum two = RubyFixnum.two(context.runtime);
-        return (((RubyFixnum) sites(context).op_mod.call(context, i, i, two)).getLongValue() != 0);
+        return i instanceof RubyFixnum fixx ?
+                fixx.getValue() % 2 != 0 :
+                !((RubyFixnum) sites(context).op_mod.call(context, i, i, asFixnum(context, 2))).isZero(context);
     }
 
     /**
@@ -598,7 +585,7 @@ public class Numeric {
      */
     public static IRubyObject f_gcd(ThreadContext context, IRubyObject x, IRubyObject y) {
         if (x instanceof RubyFixnum xx && y instanceof RubyFixnum yy && isLongMinValue(xx)) {
-            return asFixnum(context, i_gcd(xx.getLongValue(), yy.getLongValue()));
+            return asFixnum(context, i_gcd(xx.getValue(), yy.getValue()));
         }
 
         if (f_negative_p(context, x)) x = f_negate(context, x);
@@ -609,7 +596,7 @@ public class Numeric {
 
         for (;;) {
             if (x instanceof RubyFixnum xx && y instanceof RubyFixnum yy && isLongMinValue(xx)) {
-                return asFixnum(context, i_gcd(xx.getLongValue(), yy.getLongValue()));
+                return asFixnum(context, i_gcd(xx.getValue(), yy.getValue()));
             }
             IRubyObject z = x;
             x = f_mod(context, y, x);
@@ -620,7 +607,7 @@ public class Numeric {
     // 'fast' gcd version
     public static RubyInteger f_gcd(ThreadContext context, RubyInteger x, RubyInteger y) {
         if (x instanceof RubyFixnum xx && y instanceof RubyFixnum yy && isLongMinValue(xx)) {
-            return asFixnum(context, i_gcd(xx.getLongValue(), yy.getLongValue()));
+            return asFixnum(context, i_gcd(xx.getValue(), yy.getValue()));
         }
 
         BigInteger gcd = x.getBigIntegerValue().gcd(y.getBigIntegerValue());
@@ -636,7 +623,7 @@ public class Numeric {
      * @return true if it is equal to Long.MAX_VALUE, false otherwise.
      */
     protected static boolean isLongMinValue(RubyFixnum x) {
-        return x.getLongValue() != Long.MIN_VALUE;
+        return x.getValue() != Long.MIN_VALUE;
     }
 
     /** f_lcm
@@ -660,7 +647,7 @@ public class Numeric {
             x = x.op_rshift(context, q);
         }
 
-        long fx = x.getLongValue();
+        long fx = x.asLong(context);
         long r = -1;
 
         while (fx != 0) {
@@ -929,8 +916,8 @@ public class Numeric {
     }
 
     public static boolean f_eqeq_p(ThreadContext context, IRubyObject x, IRubyObject y) {
-        if (x instanceof RubyFixnum xFixnum && y instanceof RubyFixnum yFixnum) {
-            return xFixnum.getLongValue() == yFixnum.getLongValue();
+        if (x instanceof RubyFixnum fixx && y instanceof RubyFixnum fixy) {
+            return fixx.getValue() == fixy.getValue();
         } else if (x instanceof RubyFloat || y instanceof RubyFloat) {
             return RubyNumeric.num2dbl(context, x) == RubyNumeric.num2dbl(context, y);
         }

--- a/core/src/main/java/org/jruby/util/Numeric.java
+++ b/core/src/main/java/org/jruby/util/Numeric.java
@@ -655,7 +655,7 @@ public class Numeric {
     }
 
     public static long i_ilog2(ThreadContext context, RubyInteger x) {
-        long q = (x.size(context).convertToInteger().getLongValue() - 8) * 8 + 1;
+        long q = (numToInt(context, x.size(context)) - 8) * 8 + 1;
 
         if (q > 0) {
             x = x.op_rshift(context, q);

--- a/core/src/main/java/org/jruby/util/Pack.java
+++ b/core/src/main/java/org/jruby/util/Pack.java
@@ -100,11 +100,11 @@ public class Pack {
     }
 
     private static float obj2flt(ThreadContext context, IRubyObject o) {
-        return (float) toFloat(context.runtime, o).getDoubleValue();
+        return (float) toFloat(context.runtime, o).asDouble(context);
     }
 
     private static double obj2dbl(ThreadContext context, IRubyObject o) {
-        return toFloat(context.runtime, o).getDoubleValue();
+        return toFloat(context.runtime, o).asDouble(context);
     }
 
     static {

--- a/core/src/main/java/org/jruby/util/RubyDateFormatter.java
+++ b/core/src/main/java/org/jruby/util/RubyDateFormatter.java
@@ -637,7 +637,7 @@ public class RubyDateFormatter {
         RubyNumeric truncated = (RubyNumeric) sub_millis.numerator(context).
                 convertToInteger().op_mul(context, power);
         truncated = (RubyNumeric) truncated.idiv(context, sub_millis.denominator(context));
-        long decimals = toLong(context, truncated);
+        long decimals = truncated.asLong(context);
         RubyTimeOutputFormatter.formatNumber(buff, decimals, prec, '0');
     }
 

--- a/core/src/main/java/org/jruby/util/RubyDateFormatter.java
+++ b/core/src/main/java/org/jruby/util/RubyDateFormatter.java
@@ -53,8 +53,7 @@ import org.jruby.lexer.StrftimeLexer;
 import org.jruby.runtime.ThreadContext;
 
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.numToInt;
-import static org.jruby.api.Convert.numToLong;
+import static org.jruby.api.Convert.toLong;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.util.CommonByteLists.*;
 import static org.jruby.util.RubyDateFormatter.FieldType.*;
@@ -638,7 +637,7 @@ public class RubyDateFormatter {
         RubyNumeric truncated = (RubyNumeric) sub_millis.numerator(context).
                 convertToInteger().op_mul(context, power);
         truncated = (RubyNumeric) truncated.idiv(context, sub_millis.denominator(context));
-        long decimals = numToLong(context, truncated);
+        long decimals = toLong(context, truncated);
         RubyTimeOutputFormatter.formatNumber(buff, decimals, prec, '0');
     }
 

--- a/core/src/main/java/org/jruby/util/RubyDateFormatter.java
+++ b/core/src/main/java/org/jruby/util/RubyDateFormatter.java
@@ -53,6 +53,8 @@ import org.jruby.lexer.StrftimeLexer;
 import org.jruby.runtime.ThreadContext;
 
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.numToLong;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.util.CommonByteLists.*;
 import static org.jruby.util.RubyDateFormatter.FieldType.*;
@@ -636,7 +638,7 @@ public class RubyDateFormatter {
         RubyNumeric truncated = (RubyNumeric) sub_millis.numerator(context).
                 convertToInteger().op_mul(context, power);
         truncated = (RubyNumeric) truncated.idiv(context, sub_millis.denominator(context));
-        long decimals = truncated.convertToInteger().getLongValue();
+        long decimals = numToLong(context, truncated);
         RubyTimeOutputFormatter.formatNumber(buff, decimals, prec, '0');
     }
 

--- a/core/src/main/java/org/jruby/util/RubyTimeParser.java
+++ b/core/src/main/java/org/jruby/util/RubyTimeParser.java
@@ -38,7 +38,7 @@ public class RubyTimeParser {
         IRubyObject year;
         IRubyObject subsec = context.nil;
         int mon = -1, mday = -1, hour = -1, min = -1, sec = -1;
-        long prec = precision.isNil() ? SIZE_MAX : numToLong(context, precision);
+        long prec = precision.isNil() ? SIZE_MAX : toLong(context, precision);
 
         if (!isEOS() && (isSpace() || Character.isSpaceChar(bytes[end - 1]))) {
             throw argumentError(context, str(context.runtime, "can't parse: ", str));

--- a/core/src/main/java/org/jruby/util/RubyTimeParser.java
+++ b/core/src/main/java/org/jruby/util/RubyTimeParser.java
@@ -38,7 +38,7 @@ public class RubyTimeParser {
         IRubyObject year;
         IRubyObject subsec = context.nil;
         int mon = -1, mday = -1, hour = -1, min = -1, sec = -1;
-        long prec = precision.isNil() ? SIZE_MAX : numericToLong(context, precision);
+        long prec = precision.isNil() ? SIZE_MAX : numToLong(context, precision);
 
         if (!isEOS() && (isSpace() || Character.isSpaceChar(bytes[end - 1]))) {
             throw argumentError(context, str(context.runtime, "can't parse: ", str));

--- a/core/src/main/java/org/jruby/util/RubyTimeParser.java
+++ b/core/src/main/java/org/jruby/util/RubyTimeParser.java
@@ -10,6 +10,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 
 import static org.jruby.api.Convert.*;
 import static org.jruby.api.Convert.asFixnum;
+import static org.jruby.api.Create.newString;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.util.RubyStringBuilder.str;
 
@@ -95,21 +96,21 @@ public class RubyTimeParser {
         int zend = ptr;
         eatSpace();
         if (!isEOS()) {
-            IRubyObject invalid = context.runtime.newString(new ByteList(bytes, ptr, end - ptr, true));
+            IRubyObject invalid = newString(context, new ByteList(bytes, ptr, end - ptr, true));
             throw argumentError(context, str(context.runtime, "can't parse at: ", invalid));
         }
         if (zend > zstr) {
-            zone = context.runtime.newString(new ByteList(bytes, zstr, zend - zstr, true));
+            zone = newString(context, new ByteList(bytes, zstr, zend - zstr, true));
         } else if (hour == -1) {
             throw argumentError(context, "no time information");
         }
         if (!subsec.isNil()) {
             if (ndigits < TIME_SCALE_NUMDIGITS) {
                 int mul = (int) Math.pow(10, TIME_SCALE_NUMDIGITS - ndigits);
-                subsec = asFixnum(context, asLong(context, (RubyInteger) subsec) * mul);
+                subsec = asFixnum(context, ((RubyInteger) subsec).asLong(context) * mul);
             } else if (ndigits > TIME_SCALE_NUMDIGITS) {
                 int mul = (int) Math.pow(10, ndigits - TIME_SCALE_NUMDIGITS);
-                subsec = RubyRational.newRational(context.runtime, asLong(context, (RubyInteger) subsec), mul);
+                subsec = RubyRational.newRational(context.runtime, ((RubyInteger) subsec).asLong(context), mul);
             }
         }
 

--- a/core/src/main/java/org/jruby/util/Sprintf.java
+++ b/core/src/main/java/org/jruby/util/Sprintf.java
@@ -48,7 +48,7 @@ import org.jruby.util.io.EncodingUtils;
 import static org.jruby.api.Access.integerClass;
 import static org.jruby.api.Access.stringClass;
 import static org.jruby.api.Convert.asFixnum;
-import static org.jruby.api.Convert.numToLong;
+import static org.jruby.api.Convert.toLong;
 import static org.jruby.api.Create.newString;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
@@ -606,7 +606,7 @@ public class Sprintf {
                             n = StringSupport.codeLength(bl.getEncoding(), c);
                         }
                     } else {
-                        c = (int) numToLong(context, arg) & 0xFFFFFFFF;
+                        c = (int) toLong(context, arg) & 0xFFFFFFFF;
                         try {
                             n = StringSupport.codeLength(encoding, c);
                         } catch (EncodingException e) {

--- a/core/src/main/java/org/jruby/util/TypeConverter.java
+++ b/core/src/main/java/org/jruby/util/TypeConverter.java
@@ -54,6 +54,7 @@ import org.jruby.runtime.builtin.IRubyObject;
 
 import static org.jruby.api.Access.arrayClass;
 import static org.jruby.api.Access.hashClass;
+import static org.jruby.api.Access.integerClass;
 import static org.jruby.api.Access.stringClass;
 import static org.jruby.api.Create.newArray;
 import static org.jruby.api.Convert.asSymbol;
@@ -422,24 +423,21 @@ public class TypeConverter {
             }
         }
 
-        if (val instanceof RubyFloat) {
-            RubyFloat f = (RubyFloat) val;
-            if (!exception && !Double.isFinite(f.getDoubleValue())) return context.nil;
+        if (val instanceof RubyFloat f) {
+            if (!exception && !Double.isFinite(f.asDouble(context))) return context.nil;
             return RubyNumeric.dbl2ival(context.runtime, f.getValue());
         } else if (val instanceof RubyInteger) {
             return val;
-        } else if (val instanceof RubyString) {
-            return RubyNumeric.str2inum(context.runtime, (RubyString) val, base, true, exception);
+        } else if (val instanceof RubyString str) {
+            return RubyNumeric.str2inum(context.runtime, str, base, true, exception);
         } else if (val.isNil()) {
             if (!exception) return context.nil;
             throw typeError(context, "can't convert nil into Integer");
         }
 
         try {
-            tmp = TypeConverter.convertToType(context, val, runtime.getInteger(), sites(context).to_int_checked, false);
-            if (tmp instanceof RubyInteger) {
-                return tmp;
-            }
+            tmp = TypeConverter.convertToType(context, val, integerClass(context), sites(context).to_int_checked, false);
+            if (tmp instanceof RubyInteger) return tmp;
         } catch (RaiseException re) {
             if (!exception) return context.nil;
             throw re;
@@ -447,7 +445,7 @@ public class TypeConverter {
 
         if (!exception) {
             try {
-                IRubyObject ret = TypeConverter.convertToType(context, val, runtime.getInteger(), sites(context).to_i_checked, false);
+                IRubyObject ret = TypeConverter.convertToType(context, val, integerClass(context), sites(context).to_i_checked, false);
                 if (ret instanceof RubyInteger) return ret;
             } catch (RaiseException re) {
                 if (exception) throw re;

--- a/core/src/main/java/org/jruby/util/io/ChannelFD.java
+++ b/core/src/main/java/org/jruby/util/io/ChannelFD.java
@@ -8,6 +8,7 @@ import jnr.posix.POSIX;
 import org.jruby.RubySystemCallError;
 import org.jruby.exceptions.SystemCallError;
 import org.jruby.platform.Platform;
+import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
 import java.io.Closeable;
@@ -22,6 +23,8 @@ import java.nio.channels.SelectableChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.channels.WritableByteChannel;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.jruby.api.Convert.toInt;
 
 /**
 * Created by headius on 5/24/14.
@@ -182,8 +185,8 @@ public class ChannelFD implements Closeable {
                 // We check for EPERM due to GH-6129, and because it has only been seen on WSL inotify file descriptors
                 // we assume that it means this is not a normal file.
                 IRubyObject errno = ((RubySystemCallError) e.getException()).errno();
-                if (errno.isNil()
-                        || errno.convertToInteger().getIntValue() != Errno.EPERM.intValue()) {
+                var context = errno.getRuntime().getCurrentContext();
+                if (errno.isNil() || toInt(context, errno) != Errno.EPERM.intValue()) {
                     // rethrow anything not EPERM
                     throw e;
                 }

--- a/core/src/main/java/org/jruby/util/io/EncodingUtils.java
+++ b/core/src/main/java/org/jruby/util/io/EncodingUtils.java
@@ -1748,11 +1748,11 @@ public class EncodingUtils {
         if ((io.getOpenFile().getMode() & OpenFile.READABLE) == 0) return null;
         if ((b1 = io.getbyte(context)).isNil()) return null;
 
-        switch ((int)((RubyFixnum)b1).getLongValue()) {
+        switch ((int)((RubyFixnum)b1).getValue()) {
             case 0xEF:
                 if ((b2 = io.getbyte(context)).isNil()) break;
-                if (b2 instanceof RubyFixnum && ((RubyFixnum)b2).getLongValue() == 0xBB && !(b3 = io.getbyte(context)).isNil()) {
-                    if (((RubyFixnum)b3).getLongValue() == 0xBF) {
+                if (b2 instanceof RubyFixnum && ((RubyFixnum)b2).getValue() == 0xBB && !(b3 = io.getbyte(context)).isNil()) {
+                    if (((RubyFixnum)b3).getValue() == 0xBF) {
                         return UTF8Encoding.INSTANCE;
                     }
                     io.ungetbyte(context, b3);
@@ -1761,17 +1761,17 @@ public class EncodingUtils {
                 break;
             case 0xFE:
                 if ((b2 = io.getbyte(context)).isNil()) break;
-                if (b2 instanceof RubyFixnum && ((RubyFixnum)b2).getLongValue() == 0xFF) {
+                if (b2 instanceof RubyFixnum && ((RubyFixnum)b2).getValue() == 0xFF) {
                     return UTF16BEEncoding.INSTANCE;
                 }
                 io.ungetbyte(context, b2);
                 break;
             case 0xFF:
                 if ((b2 = io.getbyte(context)).isNil()) break;
-                if (b2 instanceof RubyFixnum && ((RubyFixnum)b2).getLongValue() == 0xFE) {
+                if (b2 instanceof RubyFixnum && ((RubyFixnum)b2).getValue() == 0xFE) {
                     b3 = io.getbyte(context);
-                    if (b3 instanceof RubyFixnum && ((RubyFixnum)b3).getLongValue() == 0 && !(b4 = io.getbyte(context)).isNil()) {
-                        if (((RubyFixnum)b4).getLongValue() == 0) {
+                    if (b3 instanceof RubyFixnum && ((RubyFixnum)b3).getValue() == 0 && !(b4 = io.getbyte(context)).isNil()) {
+                        if (((RubyFixnum)b4).getValue() == 0) {
                             return UTF32LEEncoding.INSTANCE;
                         }
                         io.ungetbyte(context, b4);
@@ -1785,9 +1785,9 @@ public class EncodingUtils {
                 break;
             case 0:
                 if ((b2 = io.getbyte(context)).isNil()) break;
-                if (b2 instanceof RubyFixnum && ((RubyFixnum)b2).getLongValue() == 0 && !(b3 = io.getbyte(context)).isNil()) {
-                    if (b3 instanceof RubyFixnum && ((RubyFixnum)b3).getLongValue() == 0xFE && !(b4 = io.getbyte(context)).isNil()) {
-                        if (b4 instanceof RubyFixnum && ((RubyFixnum)b4).getLongValue() == 0xFF) {
+                if (b2 instanceof RubyFixnum && ((RubyFixnum)b2).getValue() == 0 && !(b3 = io.getbyte(context)).isNil()) {
+                    if (b3 instanceof RubyFixnum && ((RubyFixnum)b3).getValue() == 0xFE && !(b4 = io.getbyte(context)).isNil()) {
+                        if (b4 instanceof RubyFixnum && ((RubyFixnum)b4).getValue() == 0xFF) {
                             return UTF32BEEncoding.INSTANCE;
                         }
                         io.ungetbyte(context, b4);

--- a/core/src/main/java/org/jruby/util/io/EncodingUtils.java
+++ b/core/src/main/java/org/jruby/util/io/EncodingUtils.java
@@ -328,7 +328,7 @@ public class EncodingUtils {
 
                 IRubyObject extraFlags = hashARef(context, options, "flags");
                 if (!extraFlags.isNil()) {
-                    oflags_p[0] |= numToInt(context, extraFlags);
+                    oflags_p[0] |= toInt(context, extraFlags);
                 }
 
                 ecflags = (fmode_p[0] & OpenFile.READABLE) != 0 ?
@@ -2052,7 +2052,7 @@ public class EncodingUtils {
         if (!flags.isNil()) {
             if (!opt.isNil()) throw argumentError(context, args.length, 3);
 
-            ecflags_p[0] = numToInt(context, flags);
+            ecflags_p[0] = toInt(context, flags);
             ecopts_p[0] = context.nil;
         } else if (!opt.isNil()) {
             ecflags_p[0] = EncodingUtils.econvPrepareOpts(context, opt, ecopts_p);

--- a/core/src/main/java/org/jruby/util/io/EncodingUtils.java
+++ b/core/src/main/java/org/jruby/util/io/EncodingUtils.java
@@ -253,7 +253,7 @@ public class EncodingUtils {
 
                 if (!intmode.isNil()) {
                     vmode(vmodeAndVperm_p, intmode);
-                    oflags_p[0] = asInt(context, (RubyInteger) intmode);
+                    oflags_p[0] = ((RubyInteger) intmode).asInt(context);
                     fmode_p[0] = ModeFlags.getOpenFileFlagsFor(oflags_p[0]);
                 } else {
                     String p = vmode(vmodeAndVperm_p).convertToString().asJavaString();

--- a/core/src/main/java/org/jruby/util/io/EncodingUtils.java
+++ b/core/src/main/java/org/jruby/util/io/EncodingUtils.java
@@ -328,7 +328,7 @@ public class EncodingUtils {
 
                 IRubyObject extraFlags = hashARef(context, options, "flags");
                 if (!extraFlags.isNil()) {
-                    oflags_p[0] |= extraFlags.convertToInteger().getIntValue();
+                    oflags_p[0] |= numToInt(context, extraFlags);
                 }
 
                 ecflags = (fmode_p[0] & OpenFile.READABLE) != 0 ?
@@ -2052,7 +2052,7 @@ public class EncodingUtils {
         if (!flags.isNil()) {
             if (!opt.isNil()) throw argumentError(context, args.length, 3);
 
-            ecflags_p[0] = (int)flags.convertToInteger().getLongValue();
+            ecflags_p[0] = numToInt(context, flags);
             ecopts_p[0] = context.nil;
         } else if (!opt.isNil()) {
             ecflags_p[0] = EncodingUtils.econvPrepareOpts(context, opt, ecopts_p);

--- a/core/src/main/java/org/jruby/util/io/Getline.java
+++ b/core/src/main/java/org/jruby/util/io/Getline.java
@@ -1,7 +1,6 @@
 package org.jruby.util.io;
 
 import org.jcodings.Encoding;
-import org.jruby.Ruby;
 import org.jruby.RubyHash;
 import org.jruby.RubyString;
 import org.jruby.ast.util.ArgsUtil;
@@ -12,8 +11,7 @@ import org.jruby.util.StringSupport;
 import org.jruby.util.TypeConverter;
 
 import static org.jruby.api.Access.globalVariables;
-import static org.jruby.api.Convert.numToInt;
-import static org.jruby.api.Convert.numToLong;
+import static org.jruby.api.Convert.toLong;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
 
@@ -235,7 +233,7 @@ public class Getline {
             }
         }
 
-        limit = lim == nil ? -1 : numToLong(context, lim);
+        limit = lim == nil ? -1 : toLong(context, lim);
 
         return getline.getline(context, self, rs, (int) limit, chomp, block);
     }

--- a/core/src/main/java/org/jruby/util/io/Getline.java
+++ b/core/src/main/java/org/jruby/util/io/Getline.java
@@ -12,6 +12,8 @@ import org.jruby.util.StringSupport;
 import org.jruby.util.TypeConverter;
 
 import static org.jruby.api.Access.globalVariables;
+import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.numToLong;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.typeError;
 
@@ -233,7 +235,7 @@ public class Getline {
             }
         }
 
-        limit = lim == nil ? -1 : lim.convertToInteger().getLongValue();
+        limit = lim == nil ? -1 : numToLong(context, lim);
 
         return getline.getline(context, self, rs, (int) limit, chomp, block);
     }

--- a/core/src/main/java/org/jruby/util/io/PopenExecutor.java
+++ b/core/src/main/java/org/jruby/util/io/PopenExecutor.java
@@ -50,6 +50,8 @@ import static org.jruby.api.Access.objectClass;
 import static org.jruby.api.Check.checkEmbeddedNulls;
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.asSymbol;
+import static org.jruby.api.Convert.numToInt;
+import static org.jruby.api.Convert.numToLong;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.runtimeError;
@@ -1292,7 +1294,7 @@ public class PopenExecutor {
                     } else if (val == context.tru) {
                         pgroup = 0; /* new process group. */
                     } else {
-                        pgroup = val.convertToInteger().getLongValue();
+                        pgroup = numToLong(context, val);
                         if (pgroup < 0) {
                             throw argumentError(context, "negative process group symbol : " + pgroup);
                         }
@@ -1352,7 +1354,7 @@ public class PopenExecutor {
                     eargp.chdir_dir = valTmp.toString();
                 }
                 else if (id.equals("umask")) {
-                    int cmask = val.convertToInteger().getIntValue();
+                    int cmask = numToInt(context, val);
                     if (eargp.umaskGiven) {
                         throw argumentError(context, "umask option specified twice");
                     }
@@ -1384,7 +1386,7 @@ public class PopenExecutor {
 //                    checkUidSwitch();
                     {
 //                        PREPARE_GETPWNAM;
-                        eargp.uid = val.convertToInteger().getIntValue();
+                        eargp.uid = numToInt(context, val);
                         eargp.uidGiven = true;
                     }
 //                    #else
@@ -1398,7 +1400,7 @@ public class PopenExecutor {
 //                    checkGidSwitch();
                     {
 //                        PREPARE_GETGRNAM;
-                        eargp.gid = val.convertToInteger().getIntValue();
+                        eargp.gid = numToInt(context, val);
                         eargp.gidGiven = true;
                     }
 //                    #else
@@ -1490,7 +1492,7 @@ public class PopenExecutor {
                     else if (flags instanceof RubyString)
                         intFlags = OpenFile.ioModestrOflags(context, flags.toString());
                     else
-                        intFlags = flags.convertToInteger().getIntValue();
+                        intFlags = numToInt(context, flags);
                     flags = asFixnum(context, intFlags);
                     perm = ((RubyArray)val).entry(2);
                     perm = perm.isNil() ? asFixnum(context, 0644) : perm.convertToInteger();

--- a/core/src/main/java/org/jruby/util/io/PopenExecutor.java
+++ b/core/src/main/java/org/jruby/util/io/PopenExecutor.java
@@ -22,7 +22,6 @@ import org.jruby.RubyString;
 import org.jruby.RubySymbol;
 import org.jruby.api.API;
 
-import org.jruby.api.Access;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.ext.fcntl.FcntlLibrary;
 import org.jruby.platform.Platform;
@@ -50,8 +49,8 @@ import static org.jruby.api.Access.objectClass;
 import static org.jruby.api.Check.checkEmbeddedNulls;
 import static org.jruby.api.Convert.asFixnum;
 import static org.jruby.api.Convert.asSymbol;
-import static org.jruby.api.Convert.numToInt;
-import static org.jruby.api.Convert.numToLong;
+import static org.jruby.api.Convert.toInt;
+import static org.jruby.api.Convert.toLong;
 import static org.jruby.api.Create.*;
 import static org.jruby.api.Error.argumentError;
 import static org.jruby.api.Error.runtimeError;
@@ -1251,8 +1250,8 @@ public class PopenExecutor {
                 int lastfd = oldfd;
                 IRubyObject val = h.fastARef(asFixnum(context, lastfd));
                 long depth = 0;
-                while (val instanceof RubyFixnum && 0 <= ((RubyFixnum)val).getIntValue()) {
-                    lastfd = RubyNumeric.fix2int(val);
+                while (val instanceof RubyFixnum fixnum && 0 <= fixnum.asInt(context)) {
+                    lastfd = fixnum.asInt(context);
                     val = h.fastARef(val);
                     if (ary.size() < depth) throw argumentError(context, "cyclic child fd redirection from " + oldfd);
                     depth++;
@@ -1294,7 +1293,7 @@ public class PopenExecutor {
                     } else if (val == context.tru) {
                         pgroup = 0; /* new process group. */
                     } else {
-                        pgroup = numToLong(context, val);
+                        pgroup = toLong(context, val);
                         if (pgroup < 0) {
                             throw argumentError(context, "negative process group symbol : " + pgroup);
                         }
@@ -1354,7 +1353,7 @@ public class PopenExecutor {
                     eargp.chdir_dir = valTmp.toString();
                 }
                 else if (id.equals("umask")) {
-                    int cmask = numToInt(context, val);
+                    int cmask = toInt(context, val);
                     if (eargp.umaskGiven) {
                         throw argumentError(context, "umask option specified twice");
                     }
@@ -1386,7 +1385,7 @@ public class PopenExecutor {
 //                    checkUidSwitch();
                     {
 //                        PREPARE_GETPWNAM;
-                        eargp.uid = numToInt(context, val);
+                        eargp.uid = toInt(context, val);
                         eargp.uidGiven = true;
                     }
 //                    #else
@@ -1400,7 +1399,7 @@ public class PopenExecutor {
 //                    checkGidSwitch();
                     {
 //                        PREPARE_GETGRNAM;
-                        eargp.gid = numToInt(context, val);
+                        eargp.gid = toInt(context, val);
                         eargp.gidGiven = true;
                     }
 //                    #else
@@ -1492,7 +1491,7 @@ public class PopenExecutor {
                     else if (flags instanceof RubyString)
                         intFlags = OpenFile.ioModestrOflags(context, flags.toString());
                     else
-                        intFlags = numToInt(context, flags);
+                        intFlags = toInt(context, flags);
                     flags = asFixnum(context, intFlags);
                     perm = ((RubyArray)val).entry(2);
                     perm = perm.isNil() ? asFixnum(context, 0644) : perm.convertToInteger();
@@ -1505,10 +1504,9 @@ public class PopenExecutor {
                 break;
 
             case STRING:
-                path = val;
-                path = RubyFile.get_path(context, path);
+                path = RubyFile.get_path(context, val);
                 if (key instanceof RubyIO) key = checkExecRedirectFd(context, key, true);
-                if (key instanceof RubyFixnum k && (k.getIntValue() == 1 || k.getIntValue() == 2)) {
+                if (key instanceof RubyFixnum k && (k.asInt(context) == 1 || k.asInt(context) == 2)) {
                     flags = asFixnum(context, OpenFlags.O_WRONLY.intValue()|OpenFlags.O_CREAT.intValue()|OpenFlags.O_TRUNC.intValue());
                 } else if (key instanceof RubyArray keyAry) {
                     boolean allOut = true;

--- a/core/src/main/java/org/jruby/util/time/TimeArgs.java
+++ b/core/src/main/java/org/jruby/util/time/TimeArgs.java
@@ -147,14 +147,14 @@ public class TimeArgs {
 
             RubyRational nsec = (RubyRational) rat.op_mul(context, asFixnum(context, 1000));
 
-            long tmpNanos = (long) nsec.getDoubleValue(context);
+            long tmpNanos = (long) nsec.asDouble(context);
 
             millis = tmpNanos / 1_000_000;
             nanos = tmpNanos % 1_000_000;
         } else if (usecObj instanceof RubyFloat flo) {
             if (flo.isNegative(context)) throw argumentError(context, "argument out of range.");
 
-            double micros = flo.getDoubleValue();
+            double micros = flo.asDouble(context);
 
             millis = (long) (micros / 1000);
             nanos = (long) Math.rint((micros * 1000) % 1_000_000);

--- a/core/src/main/java/org/jruby/util/time/TimeArgs.java
+++ b/core/src/main/java/org/jruby/util/time/TimeArgs.java
@@ -128,7 +128,7 @@ public class TimeArgs {
 
                     RubyRational nsec = (RubyRational) rat.op_mul(context, asFixnum(context, 1_000_000_000));
 
-                    long fullNanos = nsec.getLongValue();
+                    long fullNanos = nsec.asLong(context);
                     long fullMillis = fullNanos / 1_000_000;
 
                     nanos = fullNanos - fullMillis * 1_000_000;

--- a/core/src/test/java/org/jruby/test/TestRubyFixnum.java
+++ b/core/src/test/java/org/jruby/test/TestRubyFixnum.java
@@ -15,30 +15,30 @@ public class TestRubyFixnum extends junit.framework.TestCase {
 
         num = RubyFixnum.zero(context.runtime);
         assertEquals(asFixnum(context, 0), num);
-        assertEquals(0, num.getLongValue());
+        assertEquals(0, num.getValue());
     }
 
     public void testMinusOne() {
         RubyFixnum num = RubyFixnum.minus_one(context.runtime);
         assertEquals(asFixnum(context, -1), num);
-        assertEquals(-1, num.getLongValue());
+        assertEquals(-1, num.getValue());
     }
 
     public void testOne() {
         RubyFixnum num = RubyFixnum.one(context.runtime);
         assertEquals(asFixnum(context, 1), num);
-        assertEquals(1, num.getLongValue());
+        assertEquals(1, num.getValue());
     }
 
     public void testTwo() {
         RubyFixnum num = RubyFixnum.two(context.runtime);
         assertEquals(asFixnum(context, 2), num);
-        assertEquals(2, num.getLongValue());
+        assertEquals(2, num.getValue());
     }
 
     public void testFour() {
         RubyFixnum num = RubyFixnum.four(context.runtime);
         assertEquals(asFixnum(context, 4), num);
-        assertEquals(4, num.getLongValue());
+        assertEquals(4, num.getValue());
     }
 }

--- a/core/src/test/java/org/jruby/test/TestRubyRational.java
+++ b/core/src/test/java/org/jruby/test/TestRubyRational.java
@@ -43,9 +43,10 @@ public class TestRubyRational extends junit.framework.TestCase {
 
     @Test // JRUBY-5941
     public void testRationalToDouble() {
+        var context = runtime.getCurrentContext();
         RubyRational rational = RubyRational.newRational(runtime, 1, 1000);
-        double toDouble = rational.getDoubleValue();
-        double expected = ((RubyFloat)rational.to_f(runtime.getCurrentContext())).getDoubleValue();
+        double toDouble = rational.asDouble(context);
+        double expected = ((RubyFloat)rational.to_f(context)).asDouble(context);
         assertEquals(expected, toDouble, 0);
     }
 


### PR DESCRIPTION
More API work: toInt, toInteger, toLong, asLong, asInt

asLong and asInt are on Numeric and accept context (future proofing and fixing an issue where one type needed context).

toInt, toInteger, toLong will try and convert IRubyObject to the ruby or java types in one step.

Note: No work has been put into the implementation of these API methods.  They still call back into older versions.