### PR TITLE
Fix arity specs for blocks in language

### DIFF
--- a/core/src/main/java/org/jruby/RubyProc.java
+++ b/core/src/main/java/org/jruby/RubyProc.java
@@ -392,11 +392,11 @@ public class RubyProc extends RubyObject implements DataType {
     public RubyFixnum arity(ThreadContext context) {
         Signature signature = block.getSignature();
 
-        if (block.type == Block.Type.LAMBDA) return asFixnum(context, signature.arityValue());
+        int min = signature.min();
+        int max = signature.max();
+        boolean test = isLambda() ? min == max : max != -1; // specific value or unlimited
 
-        // FIXME: Consider min/max like MRI here instead of required + kwarg count.
-        return asFixnum(context, signature.hasRest() ?
-                signature.arityValue() : signature.required() + signature.getRequiredKeywordForArityCount());
+        return asFixnum(context, test ? min : -min-1);
     }
 
     @JRubyMethod(name = "to_proc")

--- a/core/src/main/java/org/jruby/runtime/Signature.java
+++ b/core/src/main/java/org/jruby/runtime/Signature.java
@@ -83,6 +83,27 @@ public class Signature {
     public int keyRest() { return keyRest; }
 
     /**
+     * The minimum number of parameters supplied which can fulfill a call to this signature.  This
+     * method is for calculating the public-facing arity value.
+     *
+     * @return the minimum amount of params expected.
+     */
+    public int min() {
+        return required() + (requiredKwargs > 0 ? 1 : 0);
+    }
+
+    /**
+     * The maximum number of parameters supplied which can fulfill a call to this signature.  This
+     * method is for calculating the public-facing arity value.
+     *
+     * @return the minimum amount of params expected.
+     */
+    public int max() {
+        return rest != Rest.NONE && rest != Rest.ANON ?
+                -1 : required() + opt() + (kwargs() > 0 || restKwargs() ? 1 : 0);
+    }
+
+    /**
      * Total number of keyword argument parameters.
      * @return the number of kwarg parameters
      */

--- a/core/src/main/java/org/jruby/runtime/Signature.java
+++ b/core/src/main/java/org/jruby/runtime/Signature.java
@@ -146,7 +146,7 @@ public class Signature {
         boolean hasOptionalKeywords = kwargs - requiredKwargs > 0;
         boolean optionalFromRest = rest() != Rest.NONE && rest != Rest.ANON;
 
-        if (opt() > 0 || optionalFromRest || (hasOptionalKeywords || restKwargs()) && oneForKeywords == 0) {
+        if (opt() > 0 || optionalFromRest || fixedValue == 0 && (hasOptionalKeywords || restKwargs())) {
             return -1 * (fixedValue + 1);
         }
 


### PR DESCRIPTION
The basic problem was we were not matching MRI in returning 1 for `|a, **k|` and instead returning -2.  There was some other issue which occurred where a weird signature is not being marked as rest and messing up arity for Proc#arity.  I plan on taking a stab at it in next commit but this fix is more important than that so this will land even if I cannot figure that out.