### PR TITLE
Rest args dup keyword hash

### DIFF
--- a/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
+++ b/core/src/main/java/org/jruby/ir/runtime/IRRuntimeHelpers.java
@@ -866,6 +866,12 @@ public class IRRuntimeHelpers {
             }
         }
 
+        // FIXME: This is a bit gross.  a real kwarg callsite if passed to a non-kwarg method but it
+        // has a rest arg will dup the original kwarg (presumably so you cannot modify the original
+        // kwarg hash).  This should be handled during  recv_rest_arg but we no longer have the info so
+        // it happening here.
+        if (hasRestArgs && callKeyword && !ruby2_keywords_method) args[args.length - 1] = hash.dup(context);
+
         // All other situations no-op
         return UNDEFINED;
     }


### PR DESCRIPTION
This fix is ugly but in recv_keyword we will notice that it is not really a keyword but an element of a rest arg.  In that case we will dup the kwarg into a normal hash argument.

The ugly part is this is handled while processing kwargs but if I went to figure out how this worked I would think the logic would be in recv_rest_arg.  Unfortunately, we no longer have the info available by that point (and honestly it would be painful to propagate to a later instruction).