### PR TITLE
Fixes #8355: wallpaper crash in heredoc eof error

### DIFF
--- a/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
@@ -493,12 +493,16 @@ public class RubyLexer extends LexingCommon {
 
             message += (addNewline ? "\n" : "") + pre + shortLine + post;
             addNewline = !message.endsWith("\n");
-            String highlightLine = new String(new char[pb + (pre.length() == 3 ? -4 : 0)]);
-            highlightLine = highlightLine.replace("\0", " ") + "^";
-            if (end_column - start_column > 1) {
-                String underscore = new String(new char[end_column - start_column - 1]);
-                underscore = underscore.replace("\0", "~");
-                highlightLine += underscore;
+            int highlightSize = pb + (pre.length() == 3 ? -4 : 0);
+            String highlightLine = "";
+            if (highlightSize > 0) {
+                highlightLine = new String(new char[pb + (pre.length() == 3 ? -4 : 0)]);
+                highlightLine = highlightLine.replace("\0", " ") + "^";
+                if (end_column - start_column > 1) {
+                    String underscore = new String(new char[end_column - start_column - 1]);
+                    underscore = underscore.replace("\0", "~");
+                    highlightLine += underscore;
+                }
             }
 
             message += (addNewline ? "\n" : "") + highlightLine;

--- a/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
+++ b/core/src/main/java/org/jruby/lexer/yacc/RubyLexer.java
@@ -495,8 +495,8 @@ public class RubyLexer extends LexingCommon {
             addNewline = !message.endsWith("\n");
             int highlightSize = pb + (pre.length() == 3 ? -4 : 0);
             String highlightLine = "";
-            if (highlightSize > 0) {
-                highlightLine = new String(new char[pb + (pre.length() == 3 ? -4 : 0)]);
+            if (highlightSize >= 0) {
+                highlightLine = new String(new char[highlightSize]);
                 highlightLine = highlightLine.replace("\0", " ") + "^";
                 if (end_column - start_column > 1) {
                     String underscore = new String(new char[end_column - start_column - 1]);


### PR DESCRIPTION
This fix prevents the crash but the last source line output it gives does not match Ruby 3.1.  It does give the proper error message so this should not be confusing.

The reason for not fixing this is this output method is already not quite right in a couple of ways and the Prism parser is the future of our parsing.  Fixing the crash does give the important error line saying what is wrong so anyone who hits this will know what is wrong.