### PR TITLE
Include class with method name in backtrace

### DIFF
--- a/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
@@ -118,7 +118,7 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
     private IRubyObject INTERPRET_METHOD(ThreadContext context, InterpreterContext ic, RubyModule implClass,
             IRubyObject self, String name, IRubyObject[] args, Block block) {
         try {
-            ThreadContext.pushBacktrace(context, name, ic.getFileName(), ic.getLine());
+            ThreadContext.pushBacktrace(context, implClass, name, ic.getFileName(), ic.getLine());
 
             if (ic.hasExplicitCallProtocol()) {
                 return ic.getEngine().interpret(context, null, self, ic, implClass, name, args, block);
@@ -154,7 +154,7 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
     private IRubyObject INTERPRET_METHOD(ThreadContext context, InterpreterContext ic, RubyModule implClass,
             IRubyObject self, String name, Block block) {
         try {
-            ThreadContext.pushBacktrace(context, name, ic.getFileName(), ic.getLine());
+            ThreadContext.pushBacktrace(context, implClass, name, ic.getFileName(), ic.getLine());
 
             if (ic.hasExplicitCallProtocol()) {
                 return ic.getEngine().interpret(context, null, self, ic, implClass, name, block);
@@ -191,7 +191,7 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
     private IRubyObject INTERPRET_METHOD(ThreadContext context, InterpreterContext ic, RubyModule implClass,
             IRubyObject self, String name, IRubyObject arg1, Block block) {
         try {
-            ThreadContext.pushBacktrace(context, name, ic.getFileName(), ic.getLine());
+            ThreadContext.pushBacktrace(context, implClass, name, ic.getFileName(), ic.getLine());
 
             if (ic.hasExplicitCallProtocol()) {
                 return ic.getEngine().interpret(context, null, self, ic, implClass, name, arg1, block);
@@ -228,7 +228,7 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
     private IRubyObject INTERPRET_METHOD(ThreadContext context, InterpreterContext ic, RubyModule implClass,
             IRubyObject self, String name, IRubyObject arg1, IRubyObject arg2, Block block) {
         try {
-            ThreadContext.pushBacktrace(context, name, ic.getFileName(), ic.getLine());
+            ThreadContext.pushBacktrace(context, implClass, name, ic.getFileName(), ic.getLine());
 
             if (ic.hasExplicitCallProtocol()) {
                 return ic.getEngine().interpret(context, null, self, ic, implClass, name, arg1, arg2, block);
@@ -265,7 +265,7 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
     private IRubyObject INTERPRET_METHOD(ThreadContext context, InterpreterContext ic, RubyModule implClass,
             IRubyObject self, String name, IRubyObject arg1, IRubyObject arg2, IRubyObject arg3, Block block) {
         try {
-            ThreadContext.pushBacktrace(context, name, ic.getFileName(), ic.getLine());
+            ThreadContext.pushBacktrace(context, implClass, name, ic.getFileName(), ic.getLine());
 
             if (ic.hasExplicitCallProtocol()) {
                 return ic.getEngine().interpret(context, null, self, ic, implClass, name, arg1, arg2, arg3, block);

--- a/core/src/main/java/org/jruby/runtime/ThreadContext.java
+++ b/core/src/main/java/org/jruby/runtime/ThreadContext.java
@@ -714,6 +714,20 @@ public final class ThreadContext {
         }
     }
 
+    public static void pushBacktrace(ThreadContext context, RubyModule klass, String method, String file, int line) {
+        if (klass.isSingleton()) {
+            pushBacktrace(context, method, file, line);
+            return;
+        }
+
+        int index = ++context.backtraceIndex;
+        BacktraceElement[] stack = context.backtrace;
+        BacktraceElement.update(stack[index], klass.getRealModule().getName(context), Helpers.getSuperNameFromCompositeName(method), file, line);
+        if (index + 1 == stack.length) {
+            ThreadContext.expandBacktraceStack(context);
+        }
+    }
+
     public static void popBacktrace(ThreadContext context) {
         context.backtraceIndex--;
     }

--- a/core/src/main/java/org/jruby/runtime/backtrace/BacktraceData.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/BacktraceData.java
@@ -201,7 +201,10 @@ public class BacktraceData implements Serializable {
                 // mask internal file paths
                 filename = TraceType.maskInternalFiles(filename);
 
-                RubyStackTraceElement rubyElement = new RubyStackTraceElement("RUBY", newName, filename, rubyFrame.line + 1, false, frameType);
+                // use class name if given
+                String klass = rubyFrame.klass;
+
+                RubyStackTraceElement rubyElement = new RubyStackTraceElement(klass == null ? "RUBY" : klass, newName, filename, rubyFrame.line + 1, false, frameType);
 
                 // dup if masking native and previous frame was native
                 if (maskNative && dupFrame) {

--- a/core/src/main/java/org/jruby/runtime/backtrace/BacktraceElement.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/BacktraceElement.java
@@ -1,5 +1,7 @@
 package org.jruby.runtime.backtrace;
 
+import org.jruby.RubyModule;
+
 public final class BacktraceElement implements Cloneable {
 
     public static final BacktraceElement[] EMPTY_ARRAY = new BacktraceElement[0];
@@ -15,7 +17,12 @@ public final class BacktraceElement implements Cloneable {
 
     @Override
     public String toString() {
-        return method + " at " + filename + ':' + line;
+        return (klass == null ? "" : klass + "#")
+                + method
+                + " at "
+                + filename
+                + ':'
+                + line;
     }
 
     @Override
@@ -24,6 +31,13 @@ public final class BacktraceElement implements Cloneable {
     }
 
     public static void update(BacktraceElement backtrace, String method, String file, int line) {
+        backtrace.method = method;
+        backtrace.filename = file;
+        backtrace.line = line;
+    }
+
+    public static void update(BacktraceElement backtrace, String klass, String method, String file, int line) {
+        backtrace.klass = klass;
         backtrace.method = method;
         backtrace.filename = file;
         backtrace.line = line;
@@ -52,6 +66,16 @@ public final class BacktraceElement implements Cloneable {
     public void setMethod(String method) {
         this.method = method;
     }
+
+    public String getModule() {
+        return klass;
+    }
+
+    public void setModule(String klass) {
+        this.klass = klass;
+    }
+
+    public String klass;
     public String method;
     public String filename;
     public int line;

--- a/core/src/main/java/org/jruby/runtime/backtrace/RubyStackTraceElement.java
+++ b/core/src/main/java/org/jruby/runtime/backtrace/RubyStackTraceElement.java
@@ -93,6 +93,10 @@ public class RubyStackTraceElement implements java.io.Serializable {
         line.cat(ConvertBytes.longToByteListCached(element.getLineNumber()));
         line.cat(CommonByteLists.BACKTRACE_IN);
         if (element.getFrameType() == FrameType.BLOCK) line.catString("block in ");
+        if (element.className != null && !element.className.equals("RUBY")) {
+            line.catString(element.className);
+            line.cat('#');
+        }
         line.cat(methodSym.getBytes());
         line.cat('\'');
 


### PR DESCRIPTION
Ruby 3.3 or 3.4 now displays the method's class when printing a backtrace, if it is not a singleton class or otherwise unprintable. This PR will add the same feature to JRuby.