### PR TITLE
Use same logic as IR for kwarg handling in IO#write

### DIFF
--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -73,6 +73,7 @@ import org.jruby.exceptions.EOFError;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.ext.fcntl.FcntlLibrary;
 import org.jruby.internal.runtime.ThreadedRunnable;
+import org.jruby.ir.runtime.IRRuntimeHelpers;
 import org.jruby.platform.Platform;
 import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
@@ -4292,21 +4293,24 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
     // MRI: io_s_write
     public static IRubyObject ioStaticWrite(ThreadContext context, IRubyObject recv, IRubyObject[] argv, boolean binary) {
-        boolean keywords = hasKeywords(ThreadContext.resetCallInfo(context));
+        IRubyObject keywords = IRRuntimeHelpers.receiveKeywords(context, argv, false, true, false);
         final Ruby runtime = context.runtime;
         IRubyObject string, offset, opt;
         string = offset = opt = context.nil;
 
         switch (argv.length) {
             case 4:
-                if (!keywords) throw runtime.newArgumentError(argv.length, 2, 3);
-                opt = argv[3].convertToHash();
+                if (!(keywords instanceof RubyHash)) throw runtime.newArgumentError(argv.length, 2, 3);
+                opt = keywords;
                 offset = argv[2];
                 string = argv[1];
                 break;
             case 3:
-                opt = TypeConverter.checkHashType(runtime, argv[2]);
-                if (opt.isNil()) offset = argv[2];
+                if (keywords instanceof RubyHash) {
+                    opt = keywords;
+                } else {
+                    offset = argv[2];
+                }
                 string = argv[1];
                 break;
             case 2:

--- a/core/src/main/java/org/jruby/RubyIO.java
+++ b/core/src/main/java/org/jruby/RubyIO.java
@@ -4229,7 +4229,7 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
     // Enebo: annotation processing forced me to do pangea method here...
     @JRubyMethod(name = "read", meta = true, required = 1, optional = 3, checkArity = false, keywords = true)
     public static IRubyObject read(ThreadContext context, IRubyObject recv, IRubyObject[] args, Block unusedBlock) {
-        boolean keywords = hasKeywords(ThreadContext.resetCallInfo(context));
+        IRubyObject keywords = IRRuntimeHelpers.receiveKeywords(context, args, false, true, false);
         int argc = Arity.checkArgumentCount(context, args, 1, 4);
 
         Ruby runtime = context.runtime;
@@ -4239,20 +4239,20 @@ public class RubyIO extends RubyObject implements IOEncodable, Closeable, Flusha
 
         { // rb_scan_args logic, basically
             if (argc > 3) {
-                if (!keywords) throw runtime.newArgumentError(args.length, 1, 4);
-                options = (RubyHash) args[3];
+                if (!(keywords instanceof RubyHash)) throw runtime.newArgumentError(args.length, 1, 4);
+                options = args[3];
                 offset = args[2];
                 length = args[1];
             } else if (argc > 2) {
-                if (args[2] instanceof RubyHash) {
-                    options = (RubyHash) args[2];
+                if (keywords instanceof RubyHash) {
+                    options = keywords;
                 } else {
                     offset = args[2];
                 }
                 length = args[1];
             } else if (argc > 1) {
-                if (args[1] instanceof RubyHash) {
-                    options = (RubyHash) args[1];
+                if (keywords instanceof RubyHash) {
+                    options = keywords;
                 } else {
                     length = args[1];
                 }


### PR DESCRIPTION
When passing kwargs from a ruby2_keywords method to a core "real keywords" method, we lose the keywordiness of the incoming hash and raise an argument error for the arity mismatch. By using the same logic as IR here, we properly handle the incoming r2k hash.

This same patch could be applied generally to all core methods that accept keywords, but given the rarity of r2k to core "real keywords" methods we have chosen to only do targeted fixes. This reduces the potential impact (versus a new, more general solution) and the required work (9.4.10 is eagerly awaited). We will explore more reliable, general improvements to core method kwarg handling in JRuby 10.

Fixes #8398.