### PR TITLE
Additional teardown to aid GC and release resources

### DIFF
--- a/core/src/main/java/org/jruby/Ruby.java
+++ b/core/src/main/java/org/jruby/Ruby.java
@@ -3402,6 +3402,18 @@ public final class Ruby implements Constantizable {
         threadService.teardown();
         threadService = new ThreadService(this);
 
+        // Release classloader resources
+        releaseClassLoader();
+
+        // Tear down LoadService
+        loadService.tearDown();
+
+        // Clear runtime tables to aid GC
+        boundMethods.clear();
+        allModules.clear();
+        constantNameInvalidators.clear();
+        symbolTable.clear();
+        javaSupport = loadJavaSupport();
     }
 
     private int userTeardown(ThreadContext context) {
@@ -3454,7 +3466,6 @@ public final class Ruby implements Constantizable {
     public void releaseClassLoader() {
         if (jrubyClassLoader != null) {
             jrubyClassLoader.close();
-            //jrubyClassLoader = null;
         }
     }
 
@@ -5625,7 +5636,7 @@ public final class Ruby implements Constantizable {
     private PrintStream err;
 
     // Java support
-    private final JavaSupport javaSupport;
+    private JavaSupport javaSupport;
     private final JRubyClassLoader jrubyClassLoader;
 
     // Object Specializer

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -996,8 +996,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
         public SymbolTable(Ruby runtime) {
             this.runtime = runtime;
             this.loadFactor = DEFAULT_LOAD_FACTOR;
-            this.threshold = (int)(DEFAULT_INITIAL_CAPACITY * DEFAULT_LOAD_FACTOR);
-            this.symbolTable = new SymbolEntry[DEFAULT_INITIAL_CAPACITY];
+            reset();
         }
 
         // note all fields are final -- rehash creates new entries when necessary.
@@ -1335,6 +1334,15 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
 
         public int size() {
             return size;
+        }
+
+        public void clear() {
+            reset();
+        }
+
+        private void reset() {
+            this.threshold = (int)(DEFAULT_INITIAL_CAPACITY * DEFAULT_LOAD_FACTOR);
+            this.symbolTable = new SymbolEntry[DEFAULT_INITIAL_CAPACITY];
         }
 
         private SymbolEntry[] rehash() {

--- a/core/src/main/java/org/jruby/embed/ScriptingContainer.java
+++ b/core/src/main/java/org/jruby/embed/ScriptingContainer.java
@@ -1844,7 +1844,6 @@ public class ScriptingContainer implements EmbedRubyInstanceConfigAdapter {
         LocalContextProvider provider = getProvider();
         if (provider.isRuntimeInitialized()) {
             provider.getRuntime().tearDown(false);
-            provider.getRuntime().releaseClassLoader();
         }
         provider.terminate();
     }

--- a/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
+++ b/core/src/main/java/org/jruby/runtime/load/LibrarySearcher.java
@@ -808,6 +808,12 @@ public class LibrarySearcher {
         return false;
     }
 
+    // Clear caches and release resources
+    public void tearDown() {
+        loadedFeaturesIndex.clear();
+        loadedFeaturesSnapshot.clear();
+    }
+
     enum Suffix {
         RUBY(".rb", ResourceLibrary::new),
         CLASS(".class", ClassResourceLibrary::new),

--- a/core/src/main/java/org/jruby/runtime/load/LoadService.java
+++ b/core/src/main/java/org/jruby/runtime/load/LoadService.java
@@ -1009,4 +1009,9 @@ public class LoadService {
 
         return filename;
     }
+
+    public void tearDown() {
+        loadedFeatures.clear();
+        librarySearcher.tearDown();
+    }
 }


### PR DESCRIPTION
Most of this would happen as part of GC clearing the runtime, but these changes help reduce that load and get the large collections and data structures releasable earlier.

Fixes jruby/jruby#8343