### PR TITLE
Use warning instead of warning when adding attr as module_function

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2281,7 +2281,7 @@ public class RubyModule extends RubyObject {
         final Ruby runtime = context.runtime;
 
         if (visibility == MODULE_FUNCTION) {
-            runtime.getWarnings().warn(ID.ACCESSOR_MODULE_FUNCTION, "attribute accessor as module_function");
+            runtime.getWarnings().warning(ID.ACCESSOR_MODULE_FUNCTION, "attribute accessor as module_function");
             visibility = PRIVATE;
         }
 


### PR DESCRIPTION
This warning is only supposed to show in verbose mode. Changing from `warn` to `warning` fixes this.