### PR TITLE
Force a Thread's block to optimize eagerly

### DIFF
--- a/core/src/main/java/org/jruby/RubyThread.java
+++ b/core/src/main/java/org/jruby/RubyThread.java
@@ -67,6 +67,7 @@ import org.joni.Matcher;
 import org.jruby.anno.JRubyClass;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.api.Create;
+import org.jruby.compiler.Compilable;
 import org.jruby.exceptions.MainExitException;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.exceptions.ThreadKill;
@@ -658,6 +659,12 @@ public class RubyThread extends RubyObject implements ExecutionContext {
         if (threadImpl != ThreadLike.DUMMY) throw context.runtime.newThreadError("already initialized thread");
 
         BlockBody body = block.getBody();
+
+        // Force top-level body for thread to compile, since it may be executed only once and never get to JIT
+        if (body instanceof Compilable compilable) {
+            compilable.forceBuild(context);
+        }
+
         startThread(context, new RubyRunnable(this, context, args, block, callInfo), body.getFile(), body.getLine());
 
         return context.nil;

--- a/core/src/main/java/org/jruby/compiler/Compilable.java
+++ b/core/src/main/java/org/jruby/compiler/Compilable.java
@@ -22,6 +22,30 @@ public interface Compilable<T> {
     default void completeBuild(ThreadContext context, T buildResult) {
         completeBuild(buildResult);
     }
+
+    /**
+     * Force this Compilable to finish its build process.
+     *
+     * Override this and {@link #isBuildComplete()} for implementations that have a build process.
+     *
+     * @param context the current thread context
+     * @return true if the forced build completed; false otherwise
+     */
+    default boolean forceBuild(ThreadContext context) {
+        return false;
+    }
+
+    /**
+     * Indicates whether this Compilable has completed its build process.
+     *
+     * Override this and {@link #forceBuild(ThreadContext)} for implementations that have a build process.
+     *
+     * @return true if the build has completed; false otherwise.
+     */
+    default boolean isBuildComplete() {
+        return true;
+    }
+
     IRScope getIRScope();
     InterpreterContext ensureInstrsReady();
 

--- a/core/src/main/java/org/jruby/compiler/JITCompiler.java
+++ b/core/src/main/java/org/jruby/compiler/JITCompiler.java
@@ -204,7 +204,7 @@ public class JITCompiler implements JITCompilerMBean {
         return new FullBuildTask(this, method);
     }
 
-    public void buildThresholdReached(ThreadContext context, final Compilable method) {
+    public void buildThresholdReached(ThreadContext context, final Compilable method, boolean force) {
         final RubyInstanceConfig config = instanceConfig(context);
 
         final Runnable task = getTaskFor(context, method);
@@ -217,7 +217,7 @@ public class JITCompiler implements JITCompilerMBean {
         }
 
         try {
-            if (config.getJitBackground() && config.getJitThreshold() > 0) {
+            if (!force && config.getJitBackground() && config.getJitThreshold() > 0) {
                 try {
                     executor.submit(task);
                 } catch (RejectedExecutionException ree) {

--- a/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/InterpretedIRMethod.java
@@ -260,7 +260,7 @@ public class InterpretedIRMethod extends AbstractIRMethod implements Compilable<
     // executor pool it may take a while
     // and replace interpreterContext asynchronously.
     private void promoteToFullBuild(ThreadContext context) {
-        tryJit(context, this);
+        tryJit(context, this, false);
     }
 
     @Deprecated

--- a/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
+++ b/core/src/main/java/org/jruby/internal/runtime/methods/MixedModeIRMethod.java
@@ -105,7 +105,7 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
 
         // try jit before checking actualMethod, so we use jitted version immediately if
         // it's ready
-        if (callCount >= 0) tryJit(context, this);
+        if (callCount >= 0) tryJit(context, this, false);
 
         DynamicMethod jittedMethod = actualMethod;
         if (jittedMethod != null) {
@@ -141,7 +141,7 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
 
         // try jit before checking actualMethod, so we use jitted version immediately if
         // it's ready
-        if (callCount >= 0) tryJit(context, this);
+        if (callCount >= 0) tryJit(context, this, false);
 
         DynamicMethod jittedMethod = actualMethod;
         if (jittedMethod != null) {
@@ -178,7 +178,7 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
 
         // try jit before checking actualMethod, so we use jitted version immediately if
         // it's ready
-        if (callCount >= 0) tryJit(context, this);
+        if (callCount >= 0) tryJit(context, this, false);
 
         DynamicMethod jittedMethod = actualMethod;
         if (jittedMethod != null) {
@@ -215,7 +215,7 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
 
         // try jit before checking actualMethod, so we use jitted version immediately if
         // it's ready
-        if (callCount >= 0) tryJit(context, this);
+        if (callCount >= 0) tryJit(context, this, false);
 
         DynamicMethod jittedMethod = actualMethod;
         if (jittedMethod != null) {
@@ -252,7 +252,7 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
 
         // try jit before checking actualMethod, so we use jitted version immediately if
         // it's ready
-        if (callCount >= 0) tryJit(context, this);
+        if (callCount >= 0) tryJit(context, this, false);
 
         DynamicMethod jittedMethod = actualMethod;
         if (jittedMethod != null) {
@@ -358,6 +358,14 @@ public class MixedModeIRMethod extends AbstractIRMethod implements Compilable<Dy
         x.actualMethod = actualMethod;
 
         return x;
+    }
+
+    @Override
+    public boolean forceBuild(ThreadContext context) {
+        build(context, this, true);
+
+        // Force = true should trigger jit to run synchronously, so we'll be optimistic
+        return true;
     }
 
 }


### PR DESCRIPTION
The block of code passed to Thread.new is frequently only executed once during a program's runtime, and in such cases there's often heavy lifting performed within the block such as an IO or Queue loop. Because we do not support any form of on-stack replacement, these blocks may never fully optimize and will remain in whatever execution mode JRuby starts them in (usually the slowest "startup" interpreter).

This patch adds logic from Thread.new into the block body to force completion of builds steps that would optimize the body. This is akin to the behavior of the command-line target script, which we also eagerly compile due to the great number of single-script utilities and benchmarks in the Ruby ecosystem.

This patch also plumbs that force-ability through the other "buildable" execution units: methods and block-based methods like define_method. This may become useful in the future to have more direct control over when a target block or method optimizes.