### PR TITLE
Update Ruby 3.4 gems from release

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -17,26 +17,26 @@ end
 default_gems = [
     # treat RGs update special:
     # - we do not want bin/update_rubygems or bin/gem overrides
-    ['rubygems-update', '3.5.23', { bin: false, require_paths: ['lib'] }],
+    ['rubygems-update', '3.6.2', { bin: false, require_paths: ['lib'] }],
     ['benchmark', '0.4.0'],
-    ['bundler', '2.5.23'],
+    ['bundler', '2.6.2'],
     ['cgi', '0.4.1'],
     # Currently using a stub gem for JRuby until we can incorporate our code.
     # https://github.com/ruby/date/issues/48
     ['date', '3.4.1'],
     ['delegate', '0.4.0'],
     ['did_you_mean', '2.0.0'],
-    ['digest', '3.1.1'],
+    ['digest', '3.2.0'],
     ['english', '0.8.0'],
     # Ongoing discussion about the -java gem, since it just omits the ext: https://github.com/ruby/erb/issues/52
     ['erb', '4.0.4'],
     ['error_highlight', '0.7.0'],
     # https://github.com/ruby/etc/issues/19
-    # ['etc', '1.4.4'],
+    # ['etc', '1.4.5'],
     # https://github.com/ruby/fcntl/issues/9
     # ['fcntl', '1.2.0'],
     ['ffi', '1.17.0'],
-    ['fiddle', '1.1.5'],
+    ['fiddle', '1.1.6'],
     ['fileutils', '1.7.3'],
     ['find', '0.2.0'],
     ['forwardable', '1.3.3'],
@@ -45,19 +45,19 @@ default_gems = [
     # ['io-nonblock', '0.3.1'],
     ['io-wait', '0.3.1'],
     ['ipaddr', '1.2.7'],
-    ['irb', '1.14.1'],
+    ['irb', '1.14.3'],
     ['jar-dependencies', '0.4.1'],
     ['jruby-readline', '1.3.7'],
     ['jruby-openssl', '0.15.3'],
-    ['json', '2.9.0'],
-    ['logger', '1.6.2'],
+    ['json', '2.9.1'],
+    ['logger', '1.6.4'],
     ['net-http', '0.6.0'],
     ['net-protocol', '0.2.2'],
     ['open-uri', '0.5.0'],
     ['open3', '0.2.1'],
     # https://github.com/ruby/openssl/issues/20#issuecomment-1022872855
     # ['openssl', '3.2.0'],
-    ['optparse', '0.5.0'],
+    ['optparse', '0.6.0'],
     ['ostruct', '0.6.1'],
     # https://github.com/ruby/pathname/issues/17
     # ['pathname', '0.4.0'],
@@ -66,25 +66,18 @@ default_gems = [
     ['pstore', '0.1.4'],
     ['psych', '5.2.3'],
     ['rake-ant', '1.0.6'],
-    ['rdoc', '6.8.1'],
-    # Ext removed from CRuby in 3.3, equivalent for us would be to remove jruby-readline but unknown implications.
-    # The gem below just attempts to load the extension, and failing that loads reline. Our current readline.rb in
-    # jruby-readline does largely the same, but it finds the extension and does not load reline.
-    # https://github.com/ruby/readline/issues/5
-    # ['readline', '0.0.4'],
-    # Will be solved with readline
-    # ['readline-ext', '0.2.0'],
-    ['reline', '0.5.12'],
+    ['rdoc', '6.10.0'],
+    ['reline', '0.6.0'],
     # https://github.com/ruby/resolv/issues/19
-    # ['resolv', '0.5.0'],
+    # ['resolv', '0.6.0'],
     ['ruby2_keywords', '0.0.5'],
-    ['securerandom', '0.4.0'],
+    ['securerandom', '0.4.1'],
     # https://github.com/ruby/set/issues/21
     # ['set', '1.1.1'],
-    ['shellwords', '0.2.1'],
+    ['shellwords', '0.2.2'],
     ['singleton', '0.3.0'],
     ['stringio', '3.1.2'],
-    ['strscan', '3.1.0'],
+    ['strscan', '3.1.2'],
     ['subspawn', '0.1.1'], # has 3 transitive deps:
       ['subspawn-posix', '0.1.1'],
       ['ffi-binary-libfixposix', '0.5.1.1'],
@@ -92,9 +85,9 @@ default_gems = [
     ['syntax_suggest', '2.0.2'],
     ['tempfile', '0.3.1'],
     ['time', '0.4.1'],
-    ['timeout', '0.4.2'],
+    ['timeout', '0.4.3'],
     # https://github.com/ruby/tmpdir/issues/13
-    # ['tmpdir', '0.3.0'],
+    # ['tmpdir', '0.3.1'],
     ['tsort', '0.2.0'],
     ['un', '0.3.0'],
     ['uri', '1.0.2'],
@@ -103,44 +96,53 @@ default_gems = [
     # ['win32ole', '1.9.0'],
     ['yaml', '0.4.0'],
     # https://github.com/ruby/zlib/issues/38
-    # ['zlib', '3.2.0'],
+    # ['zlib', '3.2.1'],
 ]
 
 bundled_gems = [
     ['abbrev', '0.1.2'],
     ['base64', '0.2.0'],
     # Extension still lives in JRuby. See https://github.com/ruby/bigdecimal/issues/268
-    ['bigdecimal', '3.1.8'],
-    ['csv', '3.3.0'],
+    ['bigdecimal', '3.1.9'],
+    ['csv', '3.3.2'],
     # Newer versions require deep control over CRuby internals, needs work to support JRuby.
-    # ['debug', '1.9.2'],
+    # ['debug', '1.10.0'],
     ['debug', '0.2.1'],
     ['drb', '2.2.1'],
     ['getoptlong', '0.2.1'],
     ['matrix', '0.4.2'],
-    ['minitest', '5.25.1'],
-    ['mutex_m', '0.2.0'],
+    ['minitest', '5.25.4'],
+    ['mutex_m', '0.3.0'],
     ['net-ftp', '0.3.8'],
-    ['net-imap', '0.4.17'],
+    ['net-imap', '0.5.4'],
     ['net-pop', '0.1.2'],
     ['net-smtp', '0.5.0'],
     ['nkf', '0.2.0'],
     ['observer', '0.1.2'],
     ['power_assert', '2.0.4'],
-    ['prime', '0.1.2'],
+    ['prime', '0.1.3'],
     ['racc', '1.8.1'],
     ['rake', '${rake.version}'],
     # Depends on many CRuby internals
-    # ['rbs', '3.4.4'],
+    # ['rbs', '3.8.0'],
+    # Ext removed from CRuby in 3.3, equivalent for us would be to remove jruby-readline but unknown implications.
+    # The gem below just attempts to load the extension, and failing that loads reline. Our current readline.rb in
+    # jruby-readline does largely the same, but it finds the extension and does not load reline.
+    # https://github.com/ruby/readline/issues/5
+    # ['readline', '0.0.4'],
+    # Will be solved with readline
+    # ['readline-ext', '0.2.0'],
+    # Depends on prism gem with native ext
+    # ['repl_type_completer', '0.1.1'],
     ['resolv-replace', '0.1.1'],
     ['rexml', '3.3.9'],
     ['rinda', '0.2.0'],
     ['rss', '0.3.1'],
     # https://github.com/ruby/syslog/issues/1
-    # ['syslog', '0.1.2'],
+    # ['syslog', '0.2.0'],
     ['test-unit', '3.6.2'],
     # Depends on many CRuby internals
-    # ['typeprof', '0.21.11'],
+    # ['typeprof', '0.30.1'],
 ]
 
 project 'JRuby Lib Setup' do

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -34,7 +34,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>rubygems-update</artifactId>
-      <version>3.5.23</version>
+      <version>3.6.2</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -60,7 +60,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>bundler</artifactId>
-      <version>2.5.23</version>
+      <version>2.6.2</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -125,7 +125,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>digest</artifactId>
-      <version>3.1.1</version>
+      <version>3.2.0</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -190,7 +190,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>fiddle</artifactId>
-      <version>1.1.5</version>
+      <version>1.1.6</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -281,7 +281,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>irb</artifactId>
-      <version>1.14.1</version>
+      <version>1.14.3</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -333,7 +333,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>json</artifactId>
-      <version>2.9.0</version>
+      <version>2.9.1</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -346,7 +346,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>logger</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.4</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -411,7 +411,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>optparse</artifactId>
-      <version>0.5.0</version>
+      <version>0.6.0</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -502,7 +502,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>rdoc</artifactId>
-      <version>6.8.1</version>
+      <version>6.10.0</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -515,7 +515,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>reline</artifactId>
-      <version>0.5.12</version>
+      <version>0.6.0</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -541,7 +541,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>securerandom</artifactId>
-      <version>0.4.0</version>
+      <version>0.4.1</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -554,7 +554,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>shellwords</artifactId>
-      <version>0.2.1</version>
+      <version>0.2.2</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -593,7 +593,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>strscan</artifactId>
-      <version>3.1.0</version>
+      <version>3.1.2</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -697,7 +697,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>timeout</artifactId>
-      <version>0.4.2</version>
+      <version>0.4.3</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -801,7 +801,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>bigdecimal</artifactId>
-      <version>3.1.8</version>
+      <version>3.1.9</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -814,7 +814,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>csv</artifactId>
-      <version>3.3.0</version>
+      <version>3.3.2</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -879,7 +879,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>minitest</artifactId>
-      <version>5.25.1</version>
+      <version>5.25.4</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -892,7 +892,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>mutex_m</artifactId>
-      <version>0.2.0</version>
+      <version>0.3.0</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -918,7 +918,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>net-imap</artifactId>
-      <version>0.4.17</version>
+      <version>0.5.4</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -996,7 +996,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>prime</artifactId>
-      <version>0.1.2</version>
+      <version>0.1.3</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1118,50 +1118,50 @@ DO NOT MODIFY - GENERATED CODE
         <directory>${gem.home}</directory>
         <includes>
           <include>specifications/default/*</include>
-          <include>specifications/rubygems-update-3.5.23*</include>
+          <include>specifications/rubygems-update-3.6.2*</include>
           <include>specifications/benchmark-0.4.0*</include>
-          <include>specifications/bundler-2.5.23*</include>
+          <include>specifications/bundler-2.6.2*</include>
           <include>specifications/cgi-0.4.1*</include>
           <include>specifications/date-3.4.1*</include>
           <include>specifications/delegate-0.4.0*</include>
           <include>specifications/did_you_mean-2.0.0*</include>
-          <include>specifications/digest-3.1.1*</include>
+          <include>specifications/digest-3.2.0*</include>
           <include>specifications/english-0.8.0*</include>
           <include>specifications/erb-4.0.4*</include>
           <include>specifications/error_highlight-0.7.0*</include>
           <include>specifications/ffi-1.17.0*</include>
-          <include>specifications/fiddle-1.1.5*</include>
+          <include>specifications/fiddle-1.1.6*</include>
           <include>specifications/fileutils-1.7.3*</include>
           <include>specifications/find-0.2.0*</include>
           <include>specifications/forwardable-1.3.3*</include>
           <include>specifications/io-console-0.8.0*</include>
           <include>specifications/io-wait-0.3.1*</include>
           <include>specifications/ipaddr-1.2.7*</include>
-          <include>specifications/irb-1.14.1*</include>
+          <include>specifications/irb-1.14.3*</include>
           <include>specifications/jar-dependencies-0.4.1*</include>
           <include>specifications/jruby-readline-1.3.7*</include>
           <include>specifications/jruby-openssl-0.15.3*</include>
-          <include>specifications/json-2.9.0*</include>
-          <include>specifications/logger-1.6.2*</include>
+          <include>specifications/json-2.9.1*</include>
+          <include>specifications/logger-1.6.4*</include>
           <include>specifications/net-http-0.6.0*</include>
           <include>specifications/net-protocol-0.2.2*</include>
           <include>specifications/open-uri-0.5.0*</include>
           <include>specifications/open3-0.2.1*</include>
-          <include>specifications/optparse-0.5.0*</include>
+          <include>specifications/optparse-0.6.0*</include>
           <include>specifications/ostruct-0.6.1*</include>
           <include>specifications/pp-0.6.2*</include>
           <include>specifications/prettyprint-0.2.0*</include>
           <include>specifications/pstore-0.1.4*</include>
           <include>specifications/psych-5.2.3*</include>
           <include>specifications/rake-ant-1.0.6*</include>
-          <include>specifications/rdoc-6.8.1*</include>
-          <include>specifications/reline-0.5.12*</include>
+          <include>specifications/rdoc-6.10.0*</include>
+          <include>specifications/reline-0.6.0*</include>
           <include>specifications/ruby2_keywords-0.0.5*</include>
-          <include>specifications/securerandom-0.4.0*</include>
-          <include>specifications/shellwords-0.2.1*</include>
+          <include>specifications/securerandom-0.4.1*</include>
+          <include>specifications/shellwords-0.2.2*</include>
           <include>specifications/singleton-0.3.0*</include>
           <include>specifications/stringio-3.1.2*</include>
-          <include>specifications/strscan-3.1.0*</include>
+          <include>specifications/strscan-3.1.2*</include>
           <include>specifications/subspawn-0.1.1*</include>
           <include>specifications/subspawn-posix-0.1.1*</include>
           <include>specifications/ffi-binary-libfixposix-0.5.1.1*</include>
@@ -1169,7 +1169,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/syntax_suggest-2.0.2*</include>
           <include>specifications/tempfile-0.3.1*</include>
           <include>specifications/time-0.4.1*</include>
-          <include>specifications/timeout-0.4.2*</include>
+          <include>specifications/timeout-0.4.3*</include>
           <include>specifications/tsort-0.2.0*</include>
           <include>specifications/un-0.3.0*</include>
           <include>specifications/uri-1.0.2*</include>
@@ -1177,22 +1177,22 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/yaml-0.4.0*</include>
           <include>specifications/abbrev-0.1.2*</include>
           <include>specifications/base64-0.2.0*</include>
-          <include>specifications/bigdecimal-3.1.8*</include>
-          <include>specifications/csv-3.3.0*</include>
+          <include>specifications/bigdecimal-3.1.9*</include>
+          <include>specifications/csv-3.3.2*</include>
           <include>specifications/debug-0.2.1*</include>
           <include>specifications/drb-2.2.1*</include>
           <include>specifications/getoptlong-0.2.1*</include>
           <include>specifications/matrix-0.4.2*</include>
-          <include>specifications/minitest-5.25.1*</include>
-          <include>specifications/mutex_m-0.2.0*</include>
+          <include>specifications/minitest-5.25.4*</include>
+          <include>specifications/mutex_m-0.3.0*</include>
           <include>specifications/net-ftp-0.3.8*</include>
-          <include>specifications/net-imap-0.4.17*</include>
+          <include>specifications/net-imap-0.5.4*</include>
           <include>specifications/net-pop-0.1.2*</include>
           <include>specifications/net-smtp-0.5.0*</include>
           <include>specifications/nkf-0.2.0*</include>
           <include>specifications/observer-0.1.2*</include>
           <include>specifications/power_assert-2.0.4*</include>
-          <include>specifications/prime-0.1.2*</include>
+          <include>specifications/prime-0.1.3*</include>
           <include>specifications/racc-1.8.1*</include>
           <include>specifications/rake-${rake.version}*</include>
           <include>specifications/resolv-replace-0.1.1*</include>
@@ -1200,50 +1200,50 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/rinda-0.2.0*</include>
           <include>specifications/rss-0.3.1*</include>
           <include>specifications/test-unit-3.6.2*</include>
-          <include>gems/rubygems-update-3.5.23*/**/*</include>
+          <include>gems/rubygems-update-3.6.2*/**/*</include>
           <include>gems/benchmark-0.4.0*/**/*</include>
-          <include>gems/bundler-2.5.23*/**/*</include>
+          <include>gems/bundler-2.6.2*/**/*</include>
           <include>gems/cgi-0.4.1*/**/*</include>
           <include>gems/date-3.4.1*/**/*</include>
           <include>gems/delegate-0.4.0*/**/*</include>
           <include>gems/did_you_mean-2.0.0*/**/*</include>
-          <include>gems/digest-3.1.1*/**/*</include>
+          <include>gems/digest-3.2.0*/**/*</include>
           <include>gems/english-0.8.0*/**/*</include>
           <include>gems/erb-4.0.4*/**/*</include>
           <include>gems/error_highlight-0.7.0*/**/*</include>
           <include>gems/ffi-1.17.0*/**/*</include>
-          <include>gems/fiddle-1.1.5*/**/*</include>
+          <include>gems/fiddle-1.1.6*/**/*</include>
           <include>gems/fileutils-1.7.3*/**/*</include>
           <include>gems/find-0.2.0*/**/*</include>
           <include>gems/forwardable-1.3.3*/**/*</include>
           <include>gems/io-console-0.8.0*/**/*</include>
           <include>gems/io-wait-0.3.1*/**/*</include>
           <include>gems/ipaddr-1.2.7*/**/*</include>
-          <include>gems/irb-1.14.1*/**/*</include>
+          <include>gems/irb-1.14.3*/**/*</include>
           <include>gems/jar-dependencies-0.4.1*/**/*</include>
           <include>gems/jruby-readline-1.3.7*/**/*</include>
           <include>gems/jruby-openssl-0.15.3*/**/*</include>
-          <include>gems/json-2.9.0*/**/*</include>
-          <include>gems/logger-1.6.2*/**/*</include>
+          <include>gems/json-2.9.1*/**/*</include>
+          <include>gems/logger-1.6.4*/**/*</include>
           <include>gems/net-http-0.6.0*/**/*</include>
           <include>gems/net-protocol-0.2.2*/**/*</include>
           <include>gems/open-uri-0.5.0*/**/*</include>
           <include>gems/open3-0.2.1*/**/*</include>
-          <include>gems/optparse-0.5.0*/**/*</include>
+          <include>gems/optparse-0.6.0*/**/*</include>
           <include>gems/ostruct-0.6.1*/**/*</include>
           <include>gems/pp-0.6.2*/**/*</include>
           <include>gems/prettyprint-0.2.0*/**/*</include>
           <include>gems/pstore-0.1.4*/**/*</include>
           <include>gems/psych-5.2.3*/**/*</include>
           <include>gems/rake-ant-1.0.6*/**/*</include>
-          <include>gems/rdoc-6.8.1*/**/*</include>
-          <include>gems/reline-0.5.12*/**/*</include>
+          <include>gems/rdoc-6.10.0*/**/*</include>
+          <include>gems/reline-0.6.0*/**/*</include>
           <include>gems/ruby2_keywords-0.0.5*/**/*</include>
-          <include>gems/securerandom-0.4.0*/**/*</include>
-          <include>gems/shellwords-0.2.1*/**/*</include>
+          <include>gems/securerandom-0.4.1*/**/*</include>
+          <include>gems/shellwords-0.2.2*/**/*</include>
           <include>gems/singleton-0.3.0*/**/*</include>
           <include>gems/stringio-3.1.2*/**/*</include>
-          <include>gems/strscan-3.1.0*/**/*</include>
+          <include>gems/strscan-3.1.2*/**/*</include>
           <include>gems/subspawn-0.1.1*/**/*</include>
           <include>gems/subspawn-posix-0.1.1*/**/*</include>
           <include>gems/ffi-binary-libfixposix-0.5.1.1*/**/*</include>
@@ -1251,7 +1251,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/syntax_suggest-2.0.2*/**/*</include>
           <include>gems/tempfile-0.3.1*/**/*</include>
           <include>gems/time-0.4.1*/**/*</include>
-          <include>gems/timeout-0.4.2*/**/*</include>
+          <include>gems/timeout-0.4.3*/**/*</include>
           <include>gems/tsort-0.2.0*/**/*</include>
           <include>gems/un-0.3.0*/**/*</include>
           <include>gems/uri-1.0.2*/**/*</include>
@@ -1259,22 +1259,22 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/yaml-0.4.0*/**/*</include>
           <include>gems/abbrev-0.1.2*/**/*</include>
           <include>gems/base64-0.2.0*/**/*</include>
-          <include>gems/bigdecimal-3.1.8*/**/*</include>
-          <include>gems/csv-3.3.0*/**/*</include>
+          <include>gems/bigdecimal-3.1.9*/**/*</include>
+          <include>gems/csv-3.3.2*/**/*</include>
           <include>gems/debug-0.2.1*/**/*</include>
           <include>gems/drb-2.2.1*/**/*</include>
           <include>gems/getoptlong-0.2.1*/**/*</include>
           <include>gems/matrix-0.4.2*/**/*</include>
-          <include>gems/minitest-5.25.1*/**/*</include>
-          <include>gems/mutex_m-0.2.0*/**/*</include>
+          <include>gems/minitest-5.25.4*/**/*</include>
+          <include>gems/mutex_m-0.3.0*/**/*</include>
           <include>gems/net-ftp-0.3.8*/**/*</include>
-          <include>gems/net-imap-0.4.17*/**/*</include>
+          <include>gems/net-imap-0.5.4*/**/*</include>
           <include>gems/net-pop-0.1.2*/**/*</include>
           <include>gems/net-smtp-0.5.0*/**/*</include>
           <include>gems/nkf-0.2.0*/**/*</include>
           <include>gems/observer-0.1.2*/**/*</include>
           <include>gems/power_assert-2.0.4*/**/*</include>
-          <include>gems/prime-0.1.2*/**/*</include>
+          <include>gems/prime-0.1.3*/**/*</include>
           <include>gems/racc-1.8.1*/**/*</include>
           <include>gems/rake-${rake.version}*/**/*</include>
           <include>gems/resolv-replace-0.1.1*/**/*</include>
@@ -1282,50 +1282,50 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/rinda-0.2.0*/**/*</include>
           <include>gems/rss-0.3.1*/**/*</include>
           <include>gems/test-unit-3.6.2*/**/*</include>
-          <include>cache/rubygems-update-3.5.23*</include>
+          <include>cache/rubygems-update-3.6.2*</include>
           <include>cache/benchmark-0.4.0*</include>
-          <include>cache/bundler-2.5.23*</include>
+          <include>cache/bundler-2.6.2*</include>
           <include>cache/cgi-0.4.1*</include>
           <include>cache/date-3.4.1*</include>
           <include>cache/delegate-0.4.0*</include>
           <include>cache/did_you_mean-2.0.0*</include>
-          <include>cache/digest-3.1.1*</include>
+          <include>cache/digest-3.2.0*</include>
           <include>cache/english-0.8.0*</include>
           <include>cache/erb-4.0.4*</include>
           <include>cache/error_highlight-0.7.0*</include>
           <include>cache/ffi-1.17.0*</include>
-          <include>cache/fiddle-1.1.5*</include>
+          <include>cache/fiddle-1.1.6*</include>
           <include>cache/fileutils-1.7.3*</include>
           <include>cache/find-0.2.0*</include>
           <include>cache/forwardable-1.3.3*</include>
           <include>cache/io-console-0.8.0*</include>
           <include>cache/io-wait-0.3.1*</include>
           <include>cache/ipaddr-1.2.7*</include>
-          <include>cache/irb-1.14.1*</include>
+          <include>cache/irb-1.14.3*</include>
           <include>cache/jar-dependencies-0.4.1*</include>
           <include>cache/jruby-readline-1.3.7*</include>
           <include>cache/jruby-openssl-0.15.3*</include>
-          <include>cache/json-2.9.0*</include>
-          <include>cache/logger-1.6.2*</include>
+          <include>cache/json-2.9.1*</include>
+          <include>cache/logger-1.6.4*</include>
           <include>cache/net-http-0.6.0*</include>
           <include>cache/net-protocol-0.2.2*</include>
           <include>cache/open-uri-0.5.0*</include>
           <include>cache/open3-0.2.1*</include>
-          <include>cache/optparse-0.5.0*</include>
+          <include>cache/optparse-0.6.0*</include>
           <include>cache/ostruct-0.6.1*</include>
           <include>cache/pp-0.6.2*</include>
           <include>cache/prettyprint-0.2.0*</include>
           <include>cache/pstore-0.1.4*</include>
           <include>cache/psych-5.2.3*</include>
           <include>cache/rake-ant-1.0.6*</include>
-          <include>cache/rdoc-6.8.1*</include>
-          <include>cache/reline-0.5.12*</include>
+          <include>cache/rdoc-6.10.0*</include>
+          <include>cache/reline-0.6.0*</include>
           <include>cache/ruby2_keywords-0.0.5*</include>
-          <include>cache/securerandom-0.4.0*</include>
-          <include>cache/shellwords-0.2.1*</include>
+          <include>cache/securerandom-0.4.1*</include>
+          <include>cache/shellwords-0.2.2*</include>
           <include>cache/singleton-0.3.0*</include>
           <include>cache/stringio-3.1.2*</include>
-          <include>cache/strscan-3.1.0*</include>
+          <include>cache/strscan-3.1.2*</include>
           <include>cache/subspawn-0.1.1*</include>
           <include>cache/subspawn-posix-0.1.1*</include>
           <include>cache/ffi-binary-libfixposix-0.5.1.1*</include>
@@ -1333,7 +1333,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/syntax_suggest-2.0.2*</include>
           <include>cache/tempfile-0.3.1*</include>
           <include>cache/time-0.4.1*</include>
-          <include>cache/timeout-0.4.2*</include>
+          <include>cache/timeout-0.4.3*</include>
           <include>cache/tsort-0.2.0*</include>
           <include>cache/un-0.3.0*</include>
           <include>cache/uri-1.0.2*</include>
@@ -1341,22 +1341,22 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/yaml-0.4.0*</include>
           <include>cache/abbrev-0.1.2*</include>
           <include>cache/base64-0.2.0*</include>
-          <include>cache/bigdecimal-3.1.8*</include>
-          <include>cache/csv-3.3.0*</include>
+          <include>cache/bigdecimal-3.1.9*</include>
+          <include>cache/csv-3.3.2*</include>
           <include>cache/debug-0.2.1*</include>
           <include>cache/drb-2.2.1*</include>
           <include>cache/getoptlong-0.2.1*</include>
           <include>cache/matrix-0.4.2*</include>
-          <include>cache/minitest-5.25.1*</include>
-          <include>cache/mutex_m-0.2.0*</include>
+          <include>cache/minitest-5.25.4*</include>
+          <include>cache/mutex_m-0.3.0*</include>
           <include>cache/net-ftp-0.3.8*</include>
-          <include>cache/net-imap-0.4.17*</include>
+          <include>cache/net-imap-0.5.4*</include>
           <include>cache/net-pop-0.1.2*</include>
           <include>cache/net-smtp-0.5.0*</include>
           <include>cache/nkf-0.2.0*</include>
           <include>cache/observer-0.1.2*</include>
           <include>cache/power_assert-2.0.4*</include>
-          <include>cache/prime-0.1.2*</include>
+          <include>cache/prime-0.1.3*</include>
           <include>cache/racc-1.8.1*</include>
           <include>cache/rake-${rake.version}*</include>
           <include>cache/resolv-replace-0.1.1*</include>


### PR DESCRIPTION
This updates all gems we ship with the versions from Ruby 3.4.0.

There is an outstanding issue with the digest 3.2.0 gem not being released yet: https://github.com/ruby/digest/issues/83