### PR TITLE
Remove dependency on jakarta.annotation-api

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -76,8 +76,6 @@ project 'JRuby Base' do
 
   jar 'com.headius:backport9:1.13'
 
-  jar 'jakarta.annotation:jakarta.annotation-api:2.0.0', scope: 'provided'
-
   jar 'org.crac:crac:1.5.0'
 
   plugin_management do

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -233,12 +233,6 @@ DO NOT MODIFY - GENERATED CODE
       <version>1.13</version>
     </dependency>
     <dependency>
-      <groupId>jakarta.annotation</groupId>
-      <artifactId>jakarta.annotation-api</artifactId>
-      <version>2.0.0</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.crac</groupId>
       <artifactId>crac</artifactId>
       <version>1.5.0</version>

--- a/core/src/main/java/org/jruby/anno/AnnotationBinder.java
+++ b/core/src/main/java/org/jruby/anno/AnnotationBinder.java
@@ -133,9 +133,7 @@ public class AnnotationBinder extends AbstractProcessor {
             out.println("import org.jruby.runtime.MethodIndex;");
             out.println("import java.util.Arrays;");
             out.println("import java.util.List;");
-            out.println("import jakarta.annotation.Generated;");
             out.println("");
-            out.println("@Generated(\"org.jruby.anno.AnnotationBinder\")");
             out.println("@SuppressWarnings(\"deprecation\")");
             out.println("public class " + qualifiedName + POPULATOR_SUFFIX + " extends TypePopulator {");
             out.println("    public void populate(RubyModule cls, Class clazz) {");

--- a/core/src/main/java/org/jruby/anno/IndyBinder.java
+++ b/core/src/main/java/org/jruby/anno/IndyBinder.java
@@ -39,7 +39,6 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.Method;
 
-import jakarta.annotation.Generated;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
@@ -129,8 +128,6 @@ public class IndyBinder extends AbstractProcessor {
             }
 
             ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
-
-            cw.visitAnnotation(p(Generated.class), true);
 
             cw.visit(Opcodes.V1_8, ACC_PUBLIC, ("org.jruby.gen." + qualifiedName + POPULATOR_SUFFIX).replace('.', '/'), null, "org/jruby/anno/TypePopulator", null);
 

--- a/maven/jruby-complete/pom.rb
+++ b/maven/jruby-complete/pom.rb
@@ -54,7 +54,7 @@ project 'JRuby Complete' do
             'Bundle-Description' => 'JRuby ${project.version} OSGi bundle',
             'Bundle-SymbolicName' => 'org.jruby.jruby',
             # the artifactId exclusion needs to match the jruby-core from above
-            'Embed-Dependency' => '*;type=jar;scope=provided;inline=true;artifactId=!jnr-ffi|jitescript|jakarta.annotation-api',
+            'Embed-Dependency' => '*;type=jar;scope=provided;inline=true;artifactId=!jnr-ffi|jitescript',
             'Embed-Transitive' => true
           } ) do
     # TODO fix DSL

--- a/spec/java_integration/fixtures/EveryTypeAnnotations.java
+++ b/spec/java_integration/fixtures/EveryTypeAnnotations.java
@@ -49,8 +49,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.annotation.Resource;
-
 public class EveryTypeAnnotations {
 	@Retention(RUNTIME)
 	@Target({ TYPE, FIELD, METHOD, PARAMETER, CONSTRUCTOR, LOCAL_VARIABLE, ANNOTATION_TYPE, PACKAGE, TYPE_PARAMETER,
@@ -69,7 +67,14 @@ public class EveryTypeAnnotations {
 		char achar() default 0;
 		RetentionPolicy anenum() default RetentionPolicy.CLASS;
 		Class<?> aClass()  default java.lang.Object.class;
-		Resource[] Darray() default {};
+		StringHolder[] Darray() default {};
+	}
+
+	@Retention(RUNTIME)
+	@Target({ TYPE, FIELD, METHOD, PARAMETER, CONSTRUCTOR, LOCAL_VARIABLE, ANNOTATION_TYPE, PACKAGE, TYPE_PARAMETER,
+			TYPE_USE })
+	public @interface StringHolder {
+		String value() default "";
 	}
 
     public static Map<String, List<Object>> decodeAnnotatedMethods(Class cls) {
@@ -93,7 +98,7 @@ public class EveryTypeAnnotations {
     		char achar = annotation.achar();
     		RetentionPolicy anenum = annotation.anenum();
     		Class<?> aClass = annotation.aClass();
-    		Resource[] Darray = annotation.Darray();
+    		StringHolder[] Darray = annotation.Darray();
     		
     		
     		decoded.put(method.getName(), Arrays.asList(astr, abyte, ashort, anint, along, afloat, adouble, abool, anbool, achar, anenum, aClass, Darray));

--- a/spec/java_integration/reify/annos_spec.rb
+++ b/spec/java_integration/reify/annos_spec.rb
@@ -60,7 +60,7 @@ describe "JRuby annotation processing:" do
         "astr=\"Hello\", abyte=0xde, ashort=0xEF_FF, anint=0xFFff_EeeE, along=0xFFFF_EEEE_0000_9999,"+
         "afloat=3.5, adouble=1024.1024, abool=true, anbool=false, achar='?',"+
         "anenum=java.lang.annotation.RetentionPolicy.RUNTIME, aClass=java.lang.String.java_class,"+
-        "Darray={@jakarta.annotation.Resource(description=\"first\"), @jakarta.annotation.Resource(description=\"second\")})"+
+        "Darray={@java_integration.fixtures.EveryTypeAnnotations.StringHolder(value=\"first\"), @java_integration.fixtures.EveryTypeAnnotations.StringHolder(value=\"second\")})"+
         " void foo()")
       def foo; end
   
@@ -103,7 +103,7 @@ describe "JRuby annotation processing:" do
       arry = output[-1]
       expect(easy_out).to eq(["Hello", -34, -4097,-4370, -18769007044199, 3.5, 1024.1024,true, false,'?'.ord, java.lang.annotation.RetentionPolicy::RUNTIME, java.lang.String.java_class.to_java])
       expect(arry).to_not be_nil
-expect(arry.map  &:description).to eq(%w{first second})
+expect(arry.map  &:value).to eq(%w{first second})
     end
     
     it "has signed base10-set values" do

--- a/spec/java_integration/types/classgen_spec.rb
+++ b/spec/java_integration/types/classgen_spec.rb
@@ -145,7 +145,7 @@ describe "A Ruby subclass of a Java concrete class with custom methods and annot
       "astr=\"Hello\", abyte=0xde, ashort=0xEF_FF, anint=0xFFff_EeeE, along=0xFFFF_EEEE_0000_9999,"+
       "afloat=3.5, adouble=1024.1024, abool=true, anbool=false, achar='?',"+
       "anenum=java.lang.annotation.RetentionPolicy.RUNTIME, aClass=java.lang.String.java_class,"+
-      "Darray={@jakarta.annotation.Resource(description=\"first\"), @jakarta.annotation.Resource(description=\"second\")})"+
+      "Darray={@java_integration.fixtures.EveryTypeAnnotations.StringHolder(value=\"first\"), @java_integration.fixtures.EveryTypeAnnotations.StringHolder(value=\"second\")})"+
       " void foo()")
     def foo; end
 
@@ -158,7 +158,7 @@ describe "A Ruby subclass of a Java concrete class with custom methods and annot
     arry = output[-1]
     expect(easy_out).to eq(["Hello", -34, -4097,-4370, -18769007044199, 3.5, 1024.1024,true, false,'?'.ord, java.lang.annotation.RetentionPolicy::RUNTIME, java.lang.String.java_class.to_java])
     expect(arry).to_not be_nil
-expect(arry.map  &:description).to eq(%w{first second})
+expect(arry.map  &:value).to eq(%w{first second})
   end
 end
 

--- a/test/pom.rb
+++ b/test/pom.rb
@@ -25,7 +25,6 @@ project 'JRuby Integration Tests' do
 
   scope :test do
     jar 'junit:junit:4.11'
-    jar 'jakarta.annotation:jakarta.annotation-api:2.0.0'
     jar 'commons-logging:commons-logging:1.1.3'
     jar 'org.livetribe:livetribe-jsr223:2.0.7'
     jar 'org.jruby:jruby-core', '${project.version}'
@@ -83,13 +82,6 @@ project 'JRuby Integration Tests' do
                                           'overWrite' =>  'false',
                                           'outputDirectory' =>  'target',
                                           'destFileName' =>  'junit.jar' },
-                                        { 'groupId' =>  'jakarta.annotation',
-                                          'artifactId' =>  'jakarta.annotation-api',
-                                          'version' =>  '2.0.0',
-                                          'type' =>  'jar',
-                                          'overWrite' =>  'false',
-                                          'outputDirectory' =>  'target',
-                                          'destFileName' =>  'annotation-api.jar' },
                                         { 'groupId' =>  'com.googlecode.jarjar',
                                           'artifactId' =>  'jarjar',
                                           'version' =>  '1.1',


### PR DESCRIPTION
We only used this for the Generated anno, for generated code, and for the Resource anno in one test. Removed use of Generated and switched use of Resource to use Deprecated (for a test of Java integration with annotations).