### PR TITLE
Change singleton_method to look at extend/prepend

### DIFF
--- a/core/src/main/java/org/jruby/RubyModule.java
+++ b/core/src/main/java/org/jruby/RubyModule.java
@@ -2086,7 +2086,7 @@ public class RubyModule extends RubyObject {
         return generationObject;
     }
 
-    private final Map<String, CacheEntry> getCachedMethods() {
+    protected final Map<String, CacheEntry> getCachedMethods() {
         return this.cachedMethods;
     }
 


### PR DESCRIPTION
Change singleton_method to look at extend/prepend

Object#singleton_method now returns methods in modules prepended to or included in the receiver's singleton class. [[Bug #20620](https://bugs.ruby-lang.org/issues/20620)]

o = Object.new
o.extend(Module.new{def a = 1})
o.singleton_method(:a).call #=> 1