### PR TITLE
Update jar-dependencies to 0.5.3

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -56,7 +56,7 @@ default_gems = [
     ['io-wait', '0.3.0'],
     ['ipaddr', '1.2.4'],
     ['irb', '1.4.2'],
-    ['jar-dependencies', '0.4.1'],
+    ['jar-dependencies', '0.5.3'],
     ['jruby-readline', '1.3.7'],
     ['jruby-openssl', '0.15.3'],
     ['json', '2.7.1'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -385,7 +385,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>jar-dependencies</artifactId>
-      <version>0.4.1</version>
+      <version>0.5.3</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1119,7 +1119,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/io-wait-0.3.0*</include>
           <include>specifications/ipaddr-1.2.4*</include>
           <include>specifications/irb-1.4.2*</include>
-          <include>specifications/jar-dependencies-0.4.1*</include>
+          <include>specifications/jar-dependencies-0.5.3*</include>
           <include>specifications/jruby-readline-1.3.7*</include>
           <include>specifications/jruby-openssl-0.15.3*</include>
           <include>specifications/json-2.7.1*</include>
@@ -1199,7 +1199,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/io-wait-0.3.0*/**/*</include>
           <include>gems/ipaddr-1.2.4*/**/*</include>
           <include>gems/irb-1.4.2*/**/*</include>
-          <include>gems/jar-dependencies-0.4.1*/**/*</include>
+          <include>gems/jar-dependencies-0.5.3*/**/*</include>
           <include>gems/jruby-readline-1.3.7*/**/*</include>
           <include>gems/jruby-openssl-0.15.3*/**/*</include>
           <include>gems/json-2.7.1*/**/*</include>
@@ -1279,7 +1279,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/io-wait-0.3.0*</include>
           <include>cache/ipaddr-1.2.4*</include>
           <include>cache/irb-1.4.2*</include>
-          <include>cache/jar-dependencies-0.4.1*</include>
+          <include>cache/jar-dependencies-0.5.3*</include>
           <include>cache/jruby-readline-1.3.7*</include>
           <include>cache/jruby-openssl-0.15.3*</include>
           <include>cache/json-2.7.1*</include>


### PR DESCRIPTION
In 9.4.10.0 we fixed the behavior of jar-dependencies to avoid activation until after other gems had booted, allowing jar-deps to be updated independently. That allowed us to release updates to jar-deps for users to install and use, but we could not release before having an upgradable version of JRuby.

This commit updates JRuby to jar-deps 0.5.3 for our 9.4.11.0 release, which should finally end issues with the older jar-deps and the older ruby-maven and ruby-maven-libs it was bound to.

See jruby/jruby#8593 for an example of continuing issues due to those older library versions being shipped in 9.4.10.0.