### PR TITLE
Update rubygems to 3.6.3 and bundler to 2.6.3

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -17,13 +17,13 @@ end
 default_gems = [
     # treat RGs update special:
     # - we do not want bin/update_rubygems or bin/gem overrides
-    ['rubygems-update', '3.3.26', { bin: false, require_paths: ['lib'] }],
+    ['rubygems-update', '3.6.3', { bin: false, require_paths: ['lib'] }],
     ['abbrev', '0.1.0'],
     ['base64', '0.1.1'],
     ['benchmark', '0.2.0'],
     # Extension still lives in JRuby. See https://github.com/ruby/bigdecimal/issues/268
     ['bigdecimal', '3.1.4'],
-    ['bundler', '2.3.26'],
+    ['bundler', '2.6.3'],
     ['cgi', '0.3.6'],
     ['csv', '3.2.5'],
     # Currently using a stub gem for JRuby until we can incorporate our code.

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -34,7 +34,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>rubygems-update</artifactId>
-      <version>3.3.26</version>
+      <version>3.6.3</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -99,7 +99,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>bundler</artifactId>
-      <version>2.3.26</version>
+      <version>2.6.3</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1092,12 +1092,12 @@ DO NOT MODIFY - GENERATED CODE
         <directory>${gem.home}</directory>
         <includes>
           <include>specifications/default/*</include>
-          <include>specifications/rubygems-update-3.3.26*</include>
+          <include>specifications/rubygems-update-3.6.3*</include>
           <include>specifications/abbrev-0.1.0*</include>
           <include>specifications/base64-0.1.1*</include>
           <include>specifications/benchmark-0.2.0*</include>
           <include>specifications/bigdecimal-3.1.4*</include>
-          <include>specifications/bundler-2.3.26*</include>
+          <include>specifications/bundler-2.6.3*</include>
           <include>specifications/cgi-0.3.6*</include>
           <include>specifications/csv-3.2.5*</include>
           <include>specifications/date-3.3.3*</include>
@@ -1172,12 +1172,12 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/rexml-3.3.9*</include>
           <include>specifications/rss-0.2.9*</include>
           <include>specifications/test-unit-3.5.3*</include>
-          <include>gems/rubygems-update-3.3.26*/**/*</include>
+          <include>gems/rubygems-update-3.6.3*/**/*</include>
           <include>gems/abbrev-0.1.0*/**/*</include>
           <include>gems/base64-0.1.1*/**/*</include>
           <include>gems/benchmark-0.2.0*/**/*</include>
           <include>gems/bigdecimal-3.1.4*/**/*</include>
-          <include>gems/bundler-2.3.26*/**/*</include>
+          <include>gems/bundler-2.6.3*/**/*</include>
           <include>gems/cgi-0.3.6*/**/*</include>
           <include>gems/csv-3.2.5*/**/*</include>
           <include>gems/date-3.3.3*/**/*</include>
@@ -1252,12 +1252,12 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/rexml-3.3.9*/**/*</include>
           <include>gems/rss-0.2.9*/**/*</include>
           <include>gems/test-unit-3.5.3*/**/*</include>
-          <include>cache/rubygems-update-3.3.26*</include>
+          <include>cache/rubygems-update-3.6.3*</include>
           <include>cache/abbrev-0.1.0*</include>
           <include>cache/base64-0.1.1*</include>
           <include>cache/benchmark-0.2.0*</include>
           <include>cache/bigdecimal-3.1.4*</include>
-          <include>cache/bundler-2.3.26*</include>
+          <include>cache/bundler-2.6.3*</include>
           <include>cache/cgi-0.3.6*</include>
           <include>cache/csv-3.2.5*</include>
           <include>cache/date-3.3.3*</include>


### PR DESCRIPTION
At some point between RubyGems 3.3.26 and now, a Bundler release went out that is incompatible with that version. We have not updated either for JRuby 9.4 releases recently, so this gets them current.

Fixes jruby/jruby#8590