### PR TITLE
Fixes #8577. kwargs checking: Use bits instead of index

### DIFF
--- a/core/src/main/java/org/jruby/ir/persistence/IRReader.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRReader.java
@@ -15,6 +15,7 @@ import org.jruby.parser.StaticScopeFactory;
 import org.jruby.runtime.Signature;
 
 import java.io.IOException;
+import java.util.BitSet;
 import java.util.EnumSet;
 
 import org.jruby.util.ByteList;
@@ -123,10 +124,15 @@ public class IRReader implements IRPersistenceValues {
         StaticScope.Type type = decoder.decodeStaticScopeType();
         if (RubyInstanceConfig.IR_READING_DEBUG) System.out.println("decodeStaticScope: type = " + type);
         String[] ids = decoder.decodeStringArray();
-        int firstKeywordIndex = decoder.decodeInt();
-        if (RubyInstanceConfig.IR_READING_DEBUG) System.out.println("decodeStaticScope: keyword index = " + firstKeywordIndex);
+        byte[] keywordIndices = decoder.decodeByteArray();
+        if (RubyInstanceConfig.IR_READING_DEBUG) System.out.println("decodeStaticScope: keyword indices count = " + keywordIndices.length);
 
-        StaticScope scope = StaticScopeFactory.newStaticScope(parentScope, type, decoder.getFilename(), ids, firstKeywordIndex);
+        StaticScope scope = StaticScopeFactory.newStaticScope(parentScope, type, decoder.getFilename(), ids, -1);
+
+        // We encode as empty list to not deal with null check here
+        if (keywordIndices.length > 0) {
+            scope.setKeywordIndices(BitSet.valueOf(keywordIndices));
+        }
 
         Signature signature = decoder.decodeSignature();
         scope.setSignature(signature);

--- a/core/src/main/java/org/jruby/ir/persistence/IRWriter.java
+++ b/core/src/main/java/org/jruby/ir/persistence/IRWriter.java
@@ -9,6 +9,7 @@ import org.jruby.ir.interpreter.InterpreterContext;
 import org.jruby.parser.StaticScope;
 
 import java.io.IOException;
+import java.util.BitSet;
 
 /**
  * Write IR data out to persistent store.  IRReader is capable of re-reading this
@@ -95,7 +96,7 @@ public class IRWriter {
         // This naively looks like a bug because these represent id's and not properly encoded names BUT all of those
         // symbols for these ids will be created when IRScope loads the LocalVariable versions of these...so this is ok.
         file.encode(staticScope.getVariables());
-        file.encode(staticScope.getFirstKeywordIndex());
+        file.encode(staticScope.getKeywordIndices().toByteArray());
         file.encode(staticScope.getSignature());
     }
 

--- a/core/src/main/java/org/jruby/runtime/Helpers.java
+++ b/core/src/main/java/org/jruby/runtime/Helpers.java
@@ -23,6 +23,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.NotDirectoryException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -2137,7 +2138,7 @@ public class Helpers {
                 Integer.toString(scope.getType().ordinal()) + ';'
                 + scope.getFile() + ';'
                 + Arrays.stream(scope.getVariables()).collect(Collectors.joining(",")) + ';'
-                + scope.getFirstKeywordIndex() + ';' +
+                + scope.getKeywordIndices().stream().mapToObj((b) -> "" + b) + ';' +
                 + (signature == null ? Signature.NO_ARGUMENTS.encode() : signature.encode()) + ';'
                 + scope.getIRScope().getScopeType().ordinal() + ';'
                 + (instanceVariableNames.size() > 0
@@ -2154,13 +2155,20 @@ public class Helpers {
         String file = bits[1];
 
         String[] varNames = bits[2].split(",");
-        int kwIndex = Integer.parseInt(bits[3]);
         Signature signature = Signature.decode(Long.parseLong(bits[4]));
         IRScopeType scopeType = IRScopeType.fromOrdinal(Integer.parseInt(bits[5]));
         String encodedIvars = bits[6];
         Collection<String> ivarNames = encodedIvars.equals("NONE") ? Collections.EMPTY_LIST : Arrays.asList(encodedIvars.split(","));
 
-        StaticScope scope = StaticScopeFactory.newStaticScope(enclosingScope, type, file, varNames, kwIndex);
+        StaticScope scope = StaticScopeFactory.newStaticScope(enclosingScope, type, file, varNames, -1);
+
+        if (bits[3].length() > 0) {
+            BitSet keywordIndices = new BitSet();
+            for (int i = 0; i < bits[3].length(); i++) {
+                keywordIndices.set(i);
+            }
+            scope.setKeywordIndices(keywordIndices);
+        }
 
         scope.setSignature(signature);
         scope.setScopeType(scopeType);


### PR DESCRIPTION
Keyword index of first keyword encountered in parameter lists is problematic because other variables during parsing can still be encountered (see #8577 for an example).

This fix is a shorter-term fix where we maintain a bitlist to indicate which parameters are keywords.  This removes the need for all keywords to be definedcd  at the end of the scope.

The longer term fix is to fully describe the parameters which can be introspected by the callsite.  This goes way beyond this fix as it outlines how we can easily map known keyword values to keyword parameters in the method and eliminate storing the keywords in a hash (in this case we can pass them as positional parameters).  This is a larger work item and is too much for us in the short term.