### PR TITLE
Ensure subclass set prevents concurrent modification

### DIFF
--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -54,7 +54,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import java.util.concurrent.locks.StampedLock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
@@ -1196,7 +1196,7 @@ public class RubyClass extends RubyModule {
     };
 
     static class WeakRubyClassSet extends WeakHashMap<RubyClass, Object> implements RubyClassSet {
-        final StampedLock lock = new StampedLock();
+        final ReentrantLock lock = new ReentrantLock();
 
         public WeakRubyClassSet() {
             super();
@@ -1208,45 +1208,45 @@ public class RubyClass extends RubyModule {
 
         @Override
         public void addClass(RubyClass klass) {
-            StampedLock lock = this.lock;
-            long stamp = lock.writeLock();
+            ReentrantLock lock = this.lock;
+            lock.lock();
             try {
                 super.put(klass, NEVER);
             } finally {
-                lock.unlockWrite(stamp);
+                lock.unlock();
             }
         }
 
         @Override
         public void forEachClass(BiConsumerIgnoresSecond<RubyClass> action) {
-            StampedLock lock = this.lock;
-            long stamp = lock.readLock();
+            ReentrantLock lock = this.lock;
+            lock.lock();
             try {
                 super.forEach(action);
             } finally {
-                lock.unlockRead(stamp);
+                lock.unlock();
             }
         }
 
         @Override
         public void removeClass(RubyClass klass) {
-            StampedLock lock = this.lock;
-            long stamp = lock.writeLock();
+            ReentrantLock lock = this.lock;
+            lock.lock();
             try {
                 super.remove(klass);
             } finally {
-                lock.unlockWrite(stamp);
+                lock.unlock();
             }
         }
 
         @Override
         public boolean isEmptyOfClasses() {
-            StampedLock lock = this.lock;
-            long stamp = lock.readLock();
+            ReentrantLock lock = this.lock;
+            lock.lock();
             try {
                 return super.isEmpty();
             } finally {
-                lock.unlockRead(stamp);
+                lock.unlock();
             }
         }
     }

--- a/core/src/main/java/org/jruby/RubyClass.java
+++ b/core/src/main/java/org/jruby/RubyClass.java
@@ -54,7 +54,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.StampedLock;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -1062,13 +1061,13 @@ public class RubyClass extends RubyModule {
         return new SubclassArray(context.runtime, this.concreteSubclassesEstimate);
     }
 
-    private static class SubclassArray extends RubyArray<RubyClass> implements BiConsumer<RubyClass, Object> {
+    private static class SubclassArray extends RubyArray<RubyClass> implements BiConsumerIgnoresSecond<RubyClass> {
         public SubclassArray(Ruby runtime, int length) {
             super(runtime, length);
         }
 
         @Override
-        public void accept(RubyClass klass, Object o) {
+        public void accept(RubyClass klass) {
             processConcreteSubclass(this, klass);
         }
     }
@@ -1078,11 +1077,11 @@ public class RubyClass extends RubyModule {
     }
 
     void addAllSubclasses(SubclassList mine) {
-        getSubclassesForRead().forEach(mine);
+        getSubclassesForRead().forEachClass(mine);
     }
 
-    private Map<RubyClass, Object> getSubclassesForRead() {
-        Map<RubyClass, Object> result = this.subclasses;
+    private RubyClassSet getSubclassesForRead() {
+        RubyClassSet result = this.subclasses;
 
         if (result != null) {
             return result;
@@ -1101,11 +1100,11 @@ public class RubyClass extends RubyModule {
     }
 
     private void addVisibleSubclasses(SubclassArray subs) {
-        getVisibleSubclassesForRead().forEach(subs);
+        getVisibleSubclassesForRead().forEachClass(subs);
     }
 
-    private Map<RubyClass, Object> getVisibleSubclassesForRead() {
-        Map<RubyClass, Object> visibleSubclasses = VISIBLE_SUBCLASSES_UPDATER.updateAndGet(this, RubyClass::getOrDefaultSubclasses);
+    private RubyClassSet getVisibleSubclassesForRead() {
+        RubyClassSet visibleSubclasses = VISIBLE_SUBCLASSES_UPDATER.updateAndGet(this, RubyClass::getOrDefaultSubclasses);
         return visibleSubclasses;
     }
 
@@ -1135,56 +1134,91 @@ public class RubyClass extends RubyModule {
      * @param subclass The subclass to add
      */
     public void addSubclass(RubyClass subclass) {
-        Map<RubyClass, Object> subclasses = getSubclassesForWrite();
-        subclasses.put(subclass, NEVER);
+        RubyClassSet subclasses = getSubclassesForWrite();
+        subclasses.addClass(subclass);
 
         if (!subclass.isSingleton()) {
-            Map visibleSubclasses = getVisibleSubclassesForWrite();
-            visibleSubclasses.put(subclass, NEVER);
+            RubyClassSet visibleSubclasses = getVisibleSubclassesForWrite();
+            visibleSubclasses.addClass(subclass);
         }
     }
 
-    private Map<RubyClass, Object> getVisibleSubclassesForWrite() {
-        Map<RubyClass, Object> visibleSubclasses = this.visibleSubclasses;
+    private RubyClassSet getVisibleSubclassesForWrite() {
+        RubyClassSet visibleSubclasses = this.visibleSubclasses;
 
-        if (visibleSubclasses != null && visibleSubclasses != Collections.EMPTY_MAP) {
+        if (visibleSubclasses != null && visibleSubclasses != EMPTY_RUBYCLASS_SET) {
             return visibleSubclasses;
         }
 
         return VISIBLE_SUBCLASSES_UPDATER.updateAndGet(this, RubyClass::getOrCreateSubclasses);
     }
 
-    private Map<RubyClass, Object> getSubclassesForWrite() {
-        Map<RubyClass, Object> subclasses = this.subclasses;
+    private RubyClassSet getSubclassesForWrite() {
+        RubyClassSet subclasses = this.subclasses;
 
-        if (subclasses != null && subclasses != Collections.EMPTY_MAP) {
+        if (subclasses != null && subclasses != EMPTY_RUBYCLASS_SET) {
             return subclasses;
         }
 
         return SUBCLASSES_UPDATER.updateAndGet(this, RubyClass::getOrCreateSubclasses);
     }
 
-    private static Map<RubyClass, Object> getOrCreateSubclasses(Map<RubyClass, Object> subclasses) {
-        if (subclasses != null && subclasses != Collections.EMPTY_MAP) return subclasses;
-        return new SubclassesWeakMap<>();
+    private static RubyClassSet getOrCreateSubclasses(RubyClassSet subclasses) {
+        if (subclasses != null && subclasses != EMPTY_RUBYCLASS_SET) return subclasses;
+        return new WeakRubyClassSet();
     }
 
-    private static class SubclassesWeakMap<K, V> extends WeakHashMap<K, V> {
+    interface RubyClassSet {
+        void addClass(RubyClass klass);
+        void forEachClass(BiConsumerIgnoresSecond<RubyClass> action);
+        void removeClass(RubyClass klass);
+        boolean isEmptyOfClasses();
+    }
+
+    interface BiConsumerIgnoresSecond<T> extends BiConsumer<T, Object> {
+        default void accept(T t, Object u) {
+            accept(t);
+        }
+        void accept(T t);
+    }
+
+    static RubyClassSet EMPTY_RUBYCLASS_SET = new RubyClassSet() {
+        public void addClass(RubyClass klass) {
+            throw new UnsupportedOperationException("EMPTY_RUBYCLASS_SET is unmodifiable");
+        }
+        public void forEachClass(BiConsumerIgnoresSecond<RubyClass> action) {}
+        public void removeClass(RubyClass key) {
+            throw new UnsupportedOperationException("EMPTY_RUBYCLASS_SET is unmodifiable");
+        }
+        public boolean isEmptyOfClasses() {
+            return true;
+        }
+    };
+
+    static class WeakRubyClassSet extends WeakHashMap<RubyClass, Object> implements RubyClassSet {
         final StampedLock lock = new StampedLock();
 
+        public WeakRubyClassSet() {
+            super();
+        }
+
+        public WeakRubyClassSet(int size) {
+            super(size);
+        }
+
         @Override
-        public V put(K key, V value) {
+        public void addClass(RubyClass klass) {
             StampedLock lock = this.lock;
             long stamp = lock.writeLock();
             try {
-                return super.put(key, value);
+                super.put(klass, NEVER);
             } finally {
                 lock.unlockWrite(stamp);
             }
         }
 
         @Override
-        public void forEach(BiConsumer<? super K, ? super V> action) {
+        public void forEachClass(BiConsumerIgnoresSecond<RubyClass> action) {
             StampedLock lock = this.lock;
             long stamp = lock.readLock();
             try {
@@ -1193,11 +1227,33 @@ public class RubyClass extends RubyModule {
                 lock.unlockRead(stamp);
             }
         }
+
+        @Override
+        public void removeClass(RubyClass klass) {
+            StampedLock lock = this.lock;
+            long stamp = lock.writeLock();
+            try {
+                super.remove(klass);
+            } finally {
+                lock.unlockWrite(stamp);
+            }
+        }
+
+        @Override
+        public boolean isEmptyOfClasses() {
+            StampedLock lock = this.lock;
+            long stamp = lock.readLock();
+            try {
+                return super.isEmpty();
+            } finally {
+                lock.unlockRead(stamp);
+            }
+        }
     }
 
-    private static Map<RubyClass, Object> getOrDefaultSubclasses(Map<RubyClass, Object> subclasses) {
+    private static RubyClassSet getOrDefaultSubclasses(RubyClassSet subclasses) {
         if (subclasses != null) return subclasses;
-        return Collections.EMPTY_MAP;
+        return EMPTY_RUBYCLASS_SET;
     }
 
     /**
@@ -1206,12 +1262,12 @@ public class RubyClass extends RubyModule {
      * @param subclass The subclass to remove
      */
     public void removeSubclass(RubyClass subclass) {
-        Map subclasses = SUBCLASSES_UPDATER.updateAndGet(this, RubyClass::getOrCreateSubclasses);
-        subclasses.remove(subclass);
+        RubyClassSet subclasses = SUBCLASSES_UPDATER.updateAndGet(this, RubyClass::getOrCreateSubclasses);
+        subclasses.removeClass(subclass);
 
         if (!subclass.isSingleton()) {
-            Map visibleSubclasses = VISIBLE_SUBCLASSES_UPDATER.updateAndGet(this, RubyClass::getOrCreateSubclasses);
-            visibleSubclasses.remove(subclass);
+            RubyClassSet visibleSubclasses = VISIBLE_SUBCLASSES_UPDATER.updateAndGet(this, RubyClass::getOrCreateSubclasses);
+            visibleSubclasses.removeClass(subclass);
         }
     }
 
@@ -1233,7 +1289,7 @@ public class RubyClass extends RubyModule {
     public void becomeSynchronized() {
         super.becomeSynchronized();
 
-        getSubclassesForRead().forEach((k, v) -> k.becomeSynchronized());
+        getSubclassesForRead().forEachClass(RubyClass::becomeSynchronized);
     }
 
     /**
@@ -1252,7 +1308,7 @@ public class RubyClass extends RubyModule {
     public void invalidateCacheDescendants() {
         super.invalidateCacheDescendants();
 
-        getSubclassesForRead().forEach((k, v) -> k.invalidateCacheDescendants());
+        getSubclassesForRead().forEachClass(RubyClass::invalidateCacheDescendants);
     }
 
     void addInvalidatorsAndFlush(InvalidatorList invalidators) {
@@ -1262,7 +1318,7 @@ public class RubyClass extends RubyModule {
         // if we're not at boot time, don't bother fully clearing caches
         if (!runtime.isBootingCore()) cachedMethods.clear();
 
-        getSubclassesForRead().forEach(invalidators);
+        getSubclassesForRead().forEachClass(invalidators);
     }
 
     public final Ruby getClassRuntime() {
@@ -3157,10 +3213,10 @@ public class RubyClass extends RubyModule {
     protected final Ruby runtime;
     private ObjectAllocator allocator; // the default allocator
     protected ObjectMarshal marshal;
-    private volatile Map<RubyClass, Object> subclasses;
-    private volatile Map<RubyClass, Object> visibleSubclasses;
-    private static final AtomicReferenceFieldUpdater<RubyClass, Map> SUBCLASSES_UPDATER = AtomicReferenceFieldUpdater.newUpdater(RubyClass.class, Map.class, "subclasses");
-    private static final AtomicReferenceFieldUpdater<RubyClass, Map> VISIBLE_SUBCLASSES_UPDATER = AtomicReferenceFieldUpdater.newUpdater(RubyClass.class, Map.class, "visibleSubclasses");
+    private volatile RubyClassSet subclasses;
+    private volatile RubyClassSet visibleSubclasses;
+    private static final AtomicReferenceFieldUpdater<RubyClass, RubyClassSet> SUBCLASSES_UPDATER = AtomicReferenceFieldUpdater.newUpdater(RubyClass.class, RubyClassSet.class, "subclasses");
+    private static final AtomicReferenceFieldUpdater<RubyClass, RubyClassSet> VISIBLE_SUBCLASSES_UPDATER = AtomicReferenceFieldUpdater.newUpdater(RubyClass.class, RubyClassSet.class, "visibleSubclasses");
     private int concreteSubclassesEstimate = 4;
     private int allDescendantsEstimate = 4;
     private int allSubclassesEstimate = 4;

--- a/test/jruby.index
+++ b/test/jruby.index
@@ -14,6 +14,7 @@ jruby/test_block
 jruby/test_caller
 jruby/test_case
 jruby/test_class
+jruby/test_class_subclasses
 jruby/test_comparable
 jruby/test_core_arities
 jruby/test_coverage

--- a/test/jruby/test_class_subclasses.rb
+++ b/test/jruby/test_class_subclasses.rb
@@ -1,0 +1,39 @@
+require 'test/unit'
+
+class TestClassSubclasses < Test::Unit::TestCase
+  def test_concurrent_modification
+    c = Class.new
+    c2 = Class.new(c)
+    go = false
+
+    thread_count = 100
+    threads = thread_count.times.map {
+      Thread.new {
+        Thread.pass until go
+        c3 = Class.new(c2)
+        o = c3.new
+        c.class_eval {
+          def foo; end
+        }
+        class << o
+          extend Enumerable
+          prepend Comparable
+        end
+        c.class_eval {
+          def foo; end
+        }
+        c3.class_eval {
+          include Enumerable
+          prepend Comparable
+        }
+        c.class_eval {
+          def foo; end
+        }
+        :success
+      }
+    }
+
+    go = true
+    assert_equal(threads.map(&:value), [:success] * thread_count)
+  end
+end


### PR DESCRIPTION
The new SubclassesWeakMap properly included read/write locking for the `put` and `forEach` methods, but unfortunately the `remove` and `isEmpty` methods were not overridden with locking. This went unnoticed until after the 9.4.11.0 release, leading to jruby/jruby#8602.

This patch makes two modifications to ensure proper locking:

* Instead of working with the full Map interface, and possibly missing other method uses in the future, this narrows the subclasses map interface to a RubyClassSet with only unique methods that we use. This guarantees only these methods can be called, and we can ensure they are implemented properly.
* Add the missing locking to the `remove` method, now named `removeClass`.

Fixes jruby/jruby#8602.