### PR TITLE
Warn when creating a new ivar table on JavaProxy wrapper

### DIFF
--- a/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
+++ b/core/src/main/java/org/jruby/java/proxies/JavaProxy.java
@@ -565,14 +565,18 @@ public class JavaProxy extends RubyObject {
 
     @Override
     public Object getVariable(int index) {
-        confirmCachedProxy(NONPERSISTENT_IVAR_MESSAGE);
+        checkVariablesOnProxy();
         return super.getVariable(index);
     }
 
     @Override
     public void setVariable(int index, Object value) {
-        confirmCachedProxy(NONPERSISTENT_IVAR_MESSAGE);
+        checkVariablesOnProxy();
         super.setVariable(index, value);
+    }
+
+    public void checkVariablesOnProxy() {
+        confirmCachedProxy(NONPERSISTENT_IVAR_MESSAGE);
     }
 
     /** rb_singleton_class

--- a/core/src/main/java/org/jruby/runtime/ivars/AtomicVariableTable.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/AtomicVariableTable.java
@@ -2,6 +2,7 @@ package org.jruby.runtime.ivars;
 
 import org.jruby.RubyBasicObject;
 import org.jruby.RubyClass;
+import org.jruby.java.proxies.JavaProxy;
 import org.jruby.util.ArraySupport;
 import org.jruby.util.unsafe.UnsafeHolder;
 
@@ -60,6 +61,11 @@ public class AtomicVariableTable {
 
         if (currentTable != null) {
             ArraySupport.copy(currentTable, 0, newTable, 0, currentTable.length);
+        } else {
+            // on first table create, run additional warning checks
+            if (self instanceof JavaProxy) {
+                ((JavaProxy) self).checkVariablesOnProxy();
+            }
         }
 
         newTable[index] = value;

--- a/core/src/main/java/org/jruby/runtime/ivars/AtomicVariableTable.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/AtomicVariableTable.java
@@ -1,0 +1,94 @@
+package org.jruby.runtime.ivars;
+
+import org.jruby.RubyBasicObject;
+import org.jruby.RubyClass;
+import org.jruby.util.ArraySupport;
+import org.jruby.util.unsafe.UnsafeHolder;
+
+/**
+ * Shared operations for working atomically with a Ruby object's variable table.
+ */
+public class AtomicVariableTable {
+
+    /**
+     * Set the given variable index into the specified object using atomic semantics. The "real" class
+     * and index are pass in to provide functional access.
+     *
+     * @param self the object into which to set the variable
+     * @param realClass the "real" class for the object
+     * @param fullFence if a full memory fence should be forced after updating the variable's value
+     * @param index the index of the variable
+     * @param value the variable's value
+     */
+    public static void setVariableAtomic(RubyBasicObject self, RubyClass realClass, boolean fullFence, int index, Object value) {
+        while (true) {
+            int currentStamp = self.varTableStamp;
+            // spin-wait if odd
+            if((currentStamp & 0x01) != 0)
+                continue;
+
+            Object[] currentTable = (Object[]) UnsafeHolder.U.getObjectVolatile(self, RubyBasicObject.VAR_TABLE_OFFSET);
+
+            if (currentTable == null || index >= currentTable.length) {
+                if (!createTableAtomic(self, currentStamp, realClass, currentTable, index, value)) continue;
+            } else {
+                if (!updateTableAtomic(self, currentStamp, fullFence, currentTable, index, value)) continue;
+            }
+
+            break;
+        }
+    }
+
+    /**
+     * Create or expand a variable table for the given object, using atomic operations to ensure visibility.
+     *
+     * @param self the object into which to set the variable
+     * @param currentStamp the current variable table stamp
+     * @param realClass the "real" class for the object
+     * @param currentTable the current table
+     * @param index the index of the variable
+     * @param value the variable's value
+     * @return whether the update was successful, for CAS retrying
+     */
+    private static boolean createTableAtomic(RubyBasicObject self, int currentStamp, RubyClass realClass, Object[] currentTable, int index, Object value) {
+        // try to acquire exclusive access to the varTable field
+        if (!UnsafeHolder.U.compareAndSwapInt(self, RubyBasicObject.STAMP_OFFSET, currentStamp, ++currentStamp)) {
+            return false;
+        }
+
+        Object[] newTable = new Object[realClass.getVariableTableSizeWithExtras()];
+
+        if (currentTable != null) {
+            ArraySupport.copy(currentTable, 0, newTable, 0, currentTable.length);
+        }
+
+        newTable[index] = value;
+
+        UnsafeHolder.U.putOrderedObject(self, RubyBasicObject.VAR_TABLE_OFFSET, newTable);
+
+        // release exclusive access
+        self.varTableStamp = currentStamp + 1;
+
+        return true;
+    }
+
+    /**
+     * Update the given variable table for the given object, using atomic operations to ensure visibility.
+     *
+     * @param self the object into which to set the variable
+     * @param currentStamp the current variable table stamp
+     * @param fullFence if a full memory fence should be forced after updating the variable's value
+     * @param currentTable the current table
+     * @param index the index of the variable
+     * @param value the variable's value
+     * @return whether the update was successful, for CAS retrying
+     */
+    private static boolean updateTableAtomic(RubyBasicObject self, int currentStamp, boolean fullFence, Object[] currentTable, int index, Object value) {
+        // shared access to varTable field.
+        currentTable[index] = value;
+        if (fullFence) UnsafeHolder.U.fullFence();
+
+        // validate stamp. redo on concurrent modification
+        return self.varTableStamp == currentStamp;
+    }
+}

--- a/core/src/main/java/org/jruby/runtime/ivars/StampedVariableAccessor.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/StampedVariableAccessor.java
@@ -59,7 +59,7 @@ public class StampedVariableAccessor extends VariableAccessor {
      */
     public void set(Object object, Object value) {
         ((RubyBasicObject)object).ensureInstanceVariablesSettable();
-        setVariable((RubyBasicObject)object, realClass, index, value);
+        AtomicVariableTable.setVariableAtomic((RubyBasicObject)object, realClass, true, index, value);
     }
     
     /**
@@ -74,88 +74,6 @@ public class StampedVariableAccessor extends VariableAccessor {
      */
     public static void setVariableChecked(RubyBasicObject self, RubyClass realClass, int index, Object value) {
         self.ensureInstanceVariablesSettable();
-        setVariable(self, realClass, index, value);
-    }
-    
-    /**
-     * Set the given variable index into the specified object. The "real" class
-     * and index are pass in to provide functional access.
-     * 
-     * @param self the object into which to set the variable
-     * @param realClass the "real" class for the object
-     * @param index the index of the variable
-     * @param value the variable's value
-     */
-    public static void setVariable(RubyBasicObject self, RubyClass realClass, int index, Object value) {
-        while (true) {
-            int currentStamp = self.varTableStamp;
-            // spin-wait if odd
-            if((currentStamp & 0x01) != 0)
-               continue;
-            
-            Object[] currentTable = (Object[]) UnsafeHolder.U.getObjectVolatile(self, RubyBasicObject.VAR_TABLE_OFFSET);
-            
-            if (currentTable == null || index >= currentTable.length) {
-                if (!createTableUnsafe(self, currentStamp, realClass, currentTable, index, value)) continue;
-            } else {
-                if (!updateTableUnsafe(self, currentStamp, currentTable, index, value)) continue;
-            }
-            
-            break;
-        }
-    }
-
-    /**
-     * Create or exapand a table for the given object, using Unsafe CAS and
-     * ordering operations to ensure visibility.
-     * 
-     * @param self the object into which to set the variable
-     * @param currentStamp the current variable table stamp
-     * @param realClass the "real" class for the object
-     * @param currentTable the current table
-     * @param index the index of the variable
-     * @param value the variable's value
-     * @return whether the update was successful, for CAS retrying
-     */
-    private static boolean createTableUnsafe(RubyBasicObject self, int currentStamp, RubyClass realClass, Object[] currentTable, int index, Object value) {
-        // try to acquire exclusive access to the varTable field
-        if (!UnsafeHolder.U.compareAndSwapInt(self, RubyBasicObject.STAMP_OFFSET, currentStamp, ++currentStamp)) {
-            return false;
-        }
-        
-        Object[] newTable = new Object[realClass.getVariableTableSizeWithExtras()];
-        
-        if (currentTable != null) {
-            ArraySupport.copy(currentTable, 0, newTable, 0, currentTable.length);
-        }
-        
-        newTable[index] = value;
-        
-        UnsafeHolder.U.putOrderedObject(self, RubyBasicObject.VAR_TABLE_OFFSET, newTable);
-        
-        // release exclusive access
-        self.varTableStamp = currentStamp + 1;
-        
-        return true;
-    }
-
-    /**
-     * Update the given table table for the given object, using Unsafe fence or
-     * volatile operations to ensure visibility.
-     * 
-     * @param self the object into which to set the variable
-     * @param currentStamp the current variable table stamp
-     * @param currentTable the current table
-     * @param index the index of the variable
-     * @param value the variable's value
-     * @return whether the update was successful, for CAS retrying
-     */
-    private static boolean updateTableUnsafe(RubyBasicObject self, int currentStamp, Object[] currentTable, int index, Object value) {
-        // shared access to varTable field.
-        currentTable[index] = value;
-        UnsafeHolder.U.fullFence();
-
-        // validate stamp. redo on concurrent modification
-        return self.varTableStamp == currentStamp;
+        AtomicVariableTable.setVariableAtomic(self, realClass, true, index, value);
     }
 }

--- a/core/src/main/java/org/jruby/runtime/ivars/SynchronizedVariableAccessor.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/SynchronizedVariableAccessor.java
@@ -29,6 +29,7 @@ package org.jruby.runtime.ivars;
 
 import org.jruby.RubyBasicObject;
 import org.jruby.RubyClass;
+import org.jruby.java.proxies.JavaProxy;
 import org.jruby.util.ArraySupport;
 
 /**
@@ -102,6 +103,10 @@ public class SynchronizedVariableAccessor extends VariableAccessor {
     private static Object[] ensureTable(RubyBasicObject self, RubyClass realClass, int index) {
         Object[] currentTable = self.varTable;
         if (currentTable == null) {
+            // on first table create, run additional warning checks
+            if (self instanceof JavaProxy) {
+                ((JavaProxy) self).checkVariablesOnProxy();
+            }
             return createTable(self, realClass);
         }
         if (currentTable.length <= index) {

--- a/core/src/main/java/org/jruby/runtime/ivars/VariableTableManager.java
+++ b/core/src/main/java/org/jruby/runtime/ivars/VariableTableManager.java
@@ -155,7 +155,7 @@ public class VariableTableManager {
         if(UnsafeHolder.U == null) {
             SynchronizedVariableAccessor.setVariable(self,realClass,index,value);
         } else {
-            StampedVariableAccessor.setVariable(self,realClass,index,value);
+            AtomicVariableTable.setVariableAtomic(self,realClass,true,index,value);
         }
     }
 
@@ -171,7 +171,7 @@ public class VariableTableManager {
         if(UnsafeHolder.U == null) {
             SynchronizedVariableAccessor.setVariable(self,realClass,index,value);
         } else {
-            StampedVariableAccessor.setVariable(self,realClass,index,value);
+            AtomicVariableTable.setVariableAtomic(self,realClass,true,index,value);
         }
     }
 

--- a/spec/java_integration/object/ivars_spec.rb
+++ b/spec/java_integration/object/ivars_spec.rb
@@ -31,3 +31,14 @@ describe "A class which has been set persistent" do
   end
 end
 
+describe "A class which has not been set persistent" do
+  it "warns when the first instance variable is set" do
+    warns = with_warn_captured {
+      java.lang.Object.new.instance_variable_set :@foo, 1
+    }
+    warns.first.first.should =~ /instance vars on non-persistent Java type/
+
+    java.lang.Object.__persistent__ = false
+  end
+end
+

--- a/spec/java_integration/object/singleton_spec.rb
+++ b/spec/java_integration/object/singleton_spec.rb
@@ -29,3 +29,14 @@ describe "A singleton method added to a Java object from Ruby" do
     expect(CachedInJava.last_instance.answer).to eq(42)
   end
 end
+
+describe "A class which has not been set persistent" do
+  it "warns when turned into a singleton object" do
+    warns = with_warn_captured {
+      class << java.lang.Object.new; end
+    }
+    warns.first.first.should =~ /singleton on non-persistent Java type/
+
+    java.lang.Object.__persistent__ = false
+  end
+end

--- a/spec/java_integration/spec_helper.rb
+++ b/spec/java_integration/spec_helper.rb
@@ -81,3 +81,22 @@ def with_stderr_captured
   end
 end
 
+def with_warn_captured
+  warns = []
+  oldwarn = nil
+
+  Warning.singleton_class.class_eval do
+    oldwarn = instance_method(:warn)
+    define_method :warn do |message, category: nil|
+      warns << [message, category]
+    end
+  end
+
+  yield
+
+  Warning.singleton_class.class_eval do
+    define_method :warn, oldwarn
+  end
+
+  warns
+end


### PR DESCRIPTION
This warning was lost when we optimized variable updates to skip RubyBasicObject's `setVariable` as reported in https://github.com/jruby/jruby/issues/8611. The changes here restore the warning:

* Move common logic for initializing the variable table to the VariableAccessor superclass.
* Ensure all places where a new variable table is created check for JavaProxy and warn appropriately.

Note that field-based variable access does not have this same proxy check because JavaProxy will never use field-based variables.