### PR TITLE
Make identity hashing aware of JavaProxy

### DIFF
--- a/core/src/main/java/org/jruby/RubyHash.java
+++ b/core/src/main/java/org/jruby/RubyHash.java
@@ -46,6 +46,7 @@ import org.jruby.anno.JRubyMethod;
 import org.jruby.common.IRubyWarnings.ID;
 import org.jruby.exceptions.RaiseException;
 import org.jruby.ir.runtime.IRBreakJump;
+import org.jruby.java.proxies.JavaProxy;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
@@ -532,8 +533,16 @@ public class RubyHash extends RubyObject implements Map {
     private static final boolean MRI_HASH = true;
     private static final boolean MRI_HASH_RESIZE = true;
 
-    protected final int hashValue(final IRubyObject key) {
-        final int h = isComparedByIdentity() ? System.identityHashCode(key) : key.hashCode();
+    protected final int hashValue(Object key) {
+        final int h;
+        if (isComparedByIdentity()) {
+            if (key instanceof JavaProxy) {
+                key = ((JavaProxy) key).getObject();
+            }
+            h = System.identityHashCode(key);
+        } else {
+            h = key.hashCode();
+        }
         return MRI_HASH ? MRIHashValue(h) : JavaSoftHashValue(h);
     }
 
@@ -633,8 +642,26 @@ public class RubyHash extends RubyObject implements Map {
     }
 
     private boolean internalKeyExist(int entryHash, IRubyObject entryKey, int hash, IRubyObject key) {
-        return (entryHash == hash
-                && (entryKey == key || (!isComparedByIdentity() && key.eql(entryKey))));
+        if (entryHash == hash)
+            if (entryKey == key) {
+                // same key
+                return true;
+            } else {
+                if (isComparedByIdentity()) {
+                    // identity hash
+                    if (entryKey instanceof JavaProxy && key instanceof JavaProxy) {
+                        if (((JavaProxy) entryKey).getObject() == ((JavaProxy) key).getObject()) {
+                            // wrapped Java objects are identical
+                            return true;
+                        }
+                    }
+                } else if (key.eql(entryKey)) {
+                    // non identity but keys are ===
+                    return true;
+                }
+            }
+
+        return false;
     }
 
     // delete implementation


### PR DESCRIPTION
This change makes compare_by_identity Hash instances know about our JavaProxy wrapper type and treat as identical two wrappers that contain the same object. This will add overhead to all identity hashes in order to type check the incoming keys:

* It must know to calculate the identity hash based on the contained object and not the wrapper (affects all identity Hash).
* It must also try to unwrap proxies and compare contents when traversing existing entries (only affects identity Hash when a key does not already exist).

This fixes the identity Hash portion of jruby/jruby#8612.