### PR TITLE
Eliminate fillnil from newArray

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -184,13 +184,11 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         }
 
         IRubyObject[] values = IRubyObject.array(validateBufferLength(runtime, len));
-        Helpers.fillNil(values, 0, len, runtime);
         return new RubyArray(runtime, values, 0, 0);
     }
 
     public static final RubyArray newArrayLight(final Ruby runtime, final int len) {
         IRubyObject[] values = IRubyObject.array(validateBufferLength(runtime, len));
-        Helpers.fillNil(values, 0, len, runtime);
         return new RubyArray(runtime, runtime.getArray(), values, 0, 0, false);
     }
 

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -897,7 +897,14 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
         if (index >= realLength) {
             int valuesLength = values.length - begin;
-            if (index >= valuesLength) storeRealloc(index, valuesLength);
+            if (index >= valuesLength) {
+                storeRealloc(index, valuesLength);
+            } else {
+                unpack();
+                if (index - realLength >= 1) {
+                    fillNil(values, begin + realLength, begin + realLength + index - realLength, getRuntime());
+                }
+            }
             realLength = index + 1;
         }
 

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -899,6 +899,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
             int valuesLength = values.length - begin;
             if (index >= valuesLength) {
                 if (index - realLength >= 1) { // fill null values unassigned up to alloc'd capacity
+                    unpack();
                     fillNil(values, begin + realLength, values.length, getRuntime());
                 }
                 storeRealloc(index, valuesLength);

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -906,7 +906,8 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
             } else {
                 unpack();
                 if (index - realLength >= 1) {
-                    fillNil(values, begin + realLength, begin + realLength + index, getRuntime());
+                    int baseIndex = begin + realLength;
+                    fillNil(values, baseIndex, baseIndex + (index - realLength), getRuntime());
                 }
             }
             realLength = index + 1;

--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -898,11 +898,14 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         if (index >= realLength) {
             int valuesLength = values.length - begin;
             if (index >= valuesLength) {
+                if (index - realLength >= 1) { // fill null values unassigned up to alloc'd capacity
+                    fillNil(values, begin + realLength, values.length, getRuntime());
+                }
                 storeRealloc(index, valuesLength);
             } else {
                 unpack();
                 if (index - realLength >= 1) {
-                    fillNil(values, begin + realLength, begin + realLength + index - realLength, getRuntime());
+                    fillNil(values, begin + realLength, begin + realLength + index, getRuntime());
                 }
             }
             realLength = index + 1;


### PR DESCRIPTION
This is a test but spec:ruby:fast does not break and I suspect it is because any operation which hits > realSize will fill at that point.  Unsafe actions like eltOk always already know realSize.

Concurrent actions perhaps break less because we do this?  We don't really make much in the way of guarantees so?