### PR TITLE
Remove upfront fillNill in Array

### DIFF
--- a/core/src/main/java/org/jruby/RubyArray.java
+++ b/core/src/main/java/org/jruby/RubyArray.java
@@ -947,20 +947,24 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
         assert index >= 0;
 
         if (index >= realLength) {
-            int valuesLength = values.length - begin;
-            if (index >= valuesLength) {
-                if (index - realLength >= 1) { // fill null values unassigned up to alloc'd capacity
-                    fillNil(values, begin + realLength, values.length, getRuntime());
-                }
-                storeRealloc(context, index, valuesLength);
-            } else if (index - realLength >= 1) {
-                int baseIndex = begin + realLength;
-                fillNil(values, baseIndex, baseIndex + (index - realLength), getRuntime());
-            }
+            resizeAndFillBackingArray(context, index);
             realLength = index + 1;
         }
 
         safeArraySet(context, values, begin + index, value);
+    }
+
+    private void resizeAndFillBackingArray(ThreadContext context, int index) {
+        int valuesLength = values.length - begin;
+        if (index >= valuesLength) {
+            if (index - realLength >= 1) { // fill null values unassigned up to alloc'd capacity
+                fillNil(values, begin + realLength, values.length, getRuntime());
+            }
+            storeRealloc(context, index, valuesLength);
+        } else if (index - realLength >= 1) {
+            int baseIndex = begin + realLength;
+            fillNil(values, baseIndex, baseIndex + (index - realLength), getRuntime());
+        }
     }
 
     private void storeRealloc(ThreadContext context, final int index, final int valuesLength) {
@@ -2644,8 +2648,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
         int end = (int)(beg + len);
         if (end > realLength) {
-            int valuesLength = values.length - begin;
-            if (end >= valuesLength) realloc(context, end, valuesLength);
+            resizeAndFillBackingArray(context, end);
             realLength = end;
         }
 
@@ -2670,8 +2673,7 @@ public class RubyArray<T extends IRubyObject> extends RubyObject implements List
 
         int end = (int)(beg + len);
         if (end > realLength) {
-            int valuesLength = values.length - begin;
-            if (end >= valuesLength) realloc(context, end, valuesLength);
+            resizeAndFillBackingArray(context, end);
             realLength = end;
         }
 

--- a/core/src/main/java/org/jruby/specialized/RubyArraySpecialized.java
+++ b/core/src/main/java/org/jruby/specialized/RubyArraySpecialized.java
@@ -60,13 +60,11 @@ public abstract class RubyArraySpecialized extends RubyArray {
     protected final void unpack(ThreadContext context) {
         if (!packed()) return;
 
-        // CON: I believe most of the time we'll unpack because we need to grow, so give a bit of extra room.
-        //      For example, <<, unshift, and push will all just add one to front or back.
+        // We give some room to grow based on notion that if we grow once we will likely grow more.
         IRubyObject[] values = new IRubyObject[realLength + 2];
-        Helpers.fillNil(context, values);
-        copyInto(context, values, 1);
+        copyInto(context, values, 0);
         this.values = values;
-        this.begin = 1;
+        this.begin = 0;
 
         finishUnpack(context.nil);
     }


### PR DESCRIPTION
fillNil does a bunch of extra nil sets up to the capacity of the array whether those values ever end up getting used.

The rationale for this fix is anything >realSize should get nil'd only after we change realSize.  For appends this never happens.  The case where it does happen is in aset.  In this case we nil fill between oldRealSize and one less than new realSize.

From a performance analysis all arrays initially benefit from not pre- filling nil up to capacity (which is 16 by default).  For arrays which are doing arbitrary asets past the end of the array it could end up doing more fills but asets like this are pretty uncommon.  Most of the time I do not even think it would be doing more fills for this either.

Additionally I removed the unshift for one extra element for shaped arrays.  The logic here is if you are unshifting once you likely are unshifting more than once so this buys very little.  I may be doing a followup here to make unshift/prepend better at allocating space as it only does it in a very limited case (an empty array and only for 16 prepends).