### PR TITLE
Fixes to get stringio tests and specs green

### DIFF
--- a/core/src/main/java/org/jruby/RubyEncoding.java
+++ b/core/src/main/java/org/jruby/RubyEncoding.java
@@ -53,6 +53,7 @@ import org.jruby.runtime.encoding.EncodingCapable;
 import org.jruby.runtime.encoding.EncodingService;
 import org.jruby.runtime.opto.OptoFactory;
 import org.jruby.util.ByteList;
+import org.jruby.util.CodeRangeable;
 import org.jruby.util.StringSupport;
 import org.jruby.util.io.EncodingUtils;
 
@@ -471,6 +472,13 @@ public class RubyEncoding extends RubyObject implements Constantizable {
         }
 
         return coder;
+    }
+
+    public static Encoding checkEncoding(ThreadContext context, Encoding encoding, CodeRangeable other) {
+        Encoding enc = StringSupport.areCompatible(encoding, other);
+        if (enc == null) throw context.runtime.newEncodingCompatibilityError("incompatible character encodings: " +
+                encoding + " and " + other.getByteList().getEncoding());
+        return enc;
     }
 
     @JRubyMethod(name = "list", meta = true)

--- a/core/src/main/java/org/jruby/RubyString.java
+++ b/core/src/main/java/org/jruby/RubyString.java
@@ -864,7 +864,7 @@ public class RubyString extends RubyObject implements CharSequence, EncodingCapa
         return dup;
     }
 
-    /* rb_str_subseq */
+    /* MRI: rb_str_subseq */
     public final RubyString makeSharedString(Ruby runtime, int index, int len) {
         return makeShared(runtime, runtime.getString(), value, index, len);
     }

--- a/core/src/main/java/org/jruby/util/StringSupport.java
+++ b/core/src/main/java/org/jruby/util/StringSupport.java
@@ -1946,6 +1946,15 @@ public final class StringSupport {
         str2.scanForCodeRange();
         return encCompatibleLatter(str1, str2, enc1, enc2);
     }
+
+    public static Encoding areCompatible(Encoding enc1, CodeRangeable str2) {
+        Encoding enc2 = str2.getByteList().getEncoding();
+
+        if (enc1 == enc2) return enc1;
+
+        str2.scanForCodeRange();
+        return encCompatibleLatter(null, str2, enc1, enc2);
+    }
     
     private static Encoding encCompatibleLatter(CodeRangeable str1, CodeRangeable str2, Encoding enc1, Encoding enc2) {
         boolean isstr1, isstr2;
@@ -1972,9 +1981,9 @@ public final class StringSupport {
 
         if (!isstr1) {
             CodeRangeable tmp = str1;
-            Encoding enc0 = enc1;
             str1 = str2;
             str2 = tmp;
+            Encoding enc0 = enc1;
             enc1 = enc2;
             enc2 = enc0;
             boolean tmp2 = isstr1;

--- a/core/src/main/java/org/jruby/util/io/ModeFlags.java
+++ b/core/src/main/java/org/jruby/util/io/ModeFlags.java
@@ -508,6 +508,9 @@ public class ModeFlags implements Cloneable {
         if ((flags & APPEND) != 0) {
             fmodeFlags |= OpenFile.APPEND;
         }
+        if ((flags & TRUNC) != 0) {
+            fmodeFlags |= OpenFile.TRUNC;
+        }
         if ((flags & CREAT) != 0) {
             fmodeFlags |= OpenFile.CREATE;
         }


### PR DESCRIPTION
After working on getting the CRuby stringio tests green in ruby/stringio#116 I turned my attention to stringio specs. These fixes are intended to get the specs green as well.