### PR TITLE
Check if tmpStream is null to avoid a NullPointerException.

### DIFF
--- a/core/src/main/java/org/jruby/util/io/ChannelHelper.java
+++ b/core/src/main/java/org/jruby/util/io/ChannelHelper.java
@@ -142,7 +142,7 @@ public abstract class ChannelHelper {
                                     : null;
 
                     // try to unwrap as a Drip stream
-                    if (!(tmpStream instanceof FilterOutputStream)) {
+                    if (tmpStream != null && !(tmpStream instanceof FilterOutputStream)) {
                         // try to get stream out of drip stream
                         OutputStream dripStream = unwrapDripStream(tmpStream);
 


### PR DESCRIPTION
In JDK versions higher than 9, tmpStream always returns null. Reducing the use of exceptions can decrease resource consumption.