### PR TITLE
Update stringio to 3.1.5

### DIFF
--- a/lib/pom.rb
+++ b/lib/pom.rb
@@ -97,7 +97,7 @@ default_gems = [
     # ['set', '1.0.2'],
     ['shellwords', '0.1.0'],
     ['singleton', '0.1.1'],
-    ['stringio', '3.1.2'],
+    ['stringio', '3.1.5'],
     ['strscan', '3.1.0'],
     ['subspawn', '0.1.1'], # has 3 transitive deps:
       ['subspawn-posix', '0.1.1'],

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -749,7 +749,7 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>stringio</artifactId>
-      <version>3.1.2</version>
+      <version>3.1.5</version>
       <type>gem</type>
       <scope>provided</scope>
       <exclusions>
@@ -1147,7 +1147,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>specifications/securerandom-0.2.0*</include>
           <include>specifications/shellwords-0.1.0*</include>
           <include>specifications/singleton-0.1.1*</include>
-          <include>specifications/stringio-3.1.2*</include>
+          <include>specifications/stringio-3.1.5*</include>
           <include>specifications/strscan-3.1.0*</include>
           <include>specifications/subspawn-0.1.1*</include>
           <include>specifications/subspawn-posix-0.1.1*</include>
@@ -1227,7 +1227,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>gems/securerandom-0.2.0*/**/*</include>
           <include>gems/shellwords-0.1.0*/**/*</include>
           <include>gems/singleton-0.1.1*/**/*</include>
-          <include>gems/stringio-3.1.2*/**/*</include>
+          <include>gems/stringio-3.1.5*/**/*</include>
           <include>gems/strscan-3.1.0*/**/*</include>
           <include>gems/subspawn-0.1.1*/**/*</include>
           <include>gems/subspawn-posix-0.1.1*/**/*</include>
@@ -1307,7 +1307,7 @@ DO NOT MODIFY - GENERATED CODE
           <include>cache/securerandom-0.2.0*</include>
           <include>cache/shellwords-0.1.0*</include>
           <include>cache/singleton-0.1.1*</include>
-          <include>cache/stringio-3.1.2*</include>
+          <include>cache/stringio-3.1.5*</include>
           <include>cache/strscan-3.1.0*</include>
           <include>cache/subspawn-0.1.1*</include>
           <include>cache/subspawn-posix-0.1.1*</include>

--- a/spec/tags/ruby/library/stringio/each_line_tags.txt
+++ b/spec/tags/ruby/library/stringio/each_line_tags.txt
@@ -1,2 +1,0 @@
-fails:An exception occurred during: stringio_each_separator
-fails(https://github.com/ruby/stringio/pull/61):StringIO#each_line when passed a separator yields each paragraph with all separation characters when passed an empty String as separator

--- a/spec/tags/ruby/library/stringio/each_tags.txt
+++ b/spec/tags/ruby/library/stringio/each_tags.txt
@@ -1,1 +1,0 @@
-fails(https://github.com/ruby/stringio/pull/61):StringIO#each when passed a separator yields each paragraph with all separation characters when passed an empty String as separator

--- a/spec/tags/ruby/library/stringio/initialize_tags.txt
+++ b/spec/tags/ruby/library/stringio/initialize_tags.txt
@@ -1,5 +1,0 @@
-fails:StringIO#initialize when passed keyword arguments accepts a mode argument set to nil with a valid :mode option
-fails:StringIO#initialize when passed keyword arguments accepts a mode argument with a :mode option set to nil
-fails:StringIO#initialize when passed keyword arguments sets binmode from :binmode option
-fails:StringIO#initialize when passed keyword arguments does not set binmode from false :binmode
-fails:StringIO#initialize when passed keyword arguments sets the mode based on the passed :mode option

--- a/spec/tags/ruby/library/stringio/reopen_tags.txt
+++ b/spec/tags/ruby/library/stringio/reopen_tags.txt
@@ -1,7 +1,0 @@
-fails:StringIO#reopen when passed [Object, Integer] reopens self with the passed Object in the passed mode
-fails:StringIO#reopen when passed [Object, Integer] raises a FrozenError when trying to reopen self with a frozen String in truncate-mode
-fails:StringIO#reopen when passed [Object, Integer] does not raise IOError when passed a frozen String in read-mode
-fails:StringIO#reopen when passed [Object, Object] reopens self with the passed Object in the passed mode
-fails:StringIO#reopen when passed [Object, Object] tries to convert the passed mode Object to an Integer using #to_str
-fails:StringIO#reopen when passed [Object, Object] does not raise IOError if a frozen string is passed in read mode
-fails:StringIO#reopen reopens a stream when given a String argument

--- a/spec/tags/ruby/library/stringio/set_encoding_by_bom_tags.txt
+++ b/spec/tags/ruby/library/stringio/set_encoding_by_bom_tags.txt
@@ -1,1 +1,0 @@
-fails(waiting on release of ruby/stringio#101):StringIO#set_encoding_by_bom raises FrozenError when io is frozen

--- a/test/mri/excludes/TestStringIO.rb
+++ b/test/mri/excludes/TestStringIO.rb
@@ -1,6 +1,0 @@
-exclude :test_each, "needs investigation"
-exclude :test_gets_chomp, "needs investigation"
-exclude :test_gets_chomp_eol, "needs investigation"
-exclude :test_overflow, "unusual subprocess test trying to overflow some value"
-exclude :test_read_nonblock_no_exceptions, "temporary until StringIO ext does manual arity-checking (ruby/stringio#48)"
-exclude :test_write_integer_overflow, "JVM does not support > 32bit signed array offsets, so our StringIO cannot either"

--- a/test/mri/stringio/test_ractor.rb
+++ b/test/mri/stringio/test_ractor.rb
@@ -11,7 +11,7 @@ class TestStringIOInRactor < Test::Unit::TestCase
       require "stringio"
       $VERBOSE = nil
       r = Ractor.new do
-        io = StringIO.new("")
+        io = StringIO.new(+"")
         io.puts "abc"
         io.truncate(0)
         io.puts "def"

--- a/test/mri/stringio/test_stringio.rb
+++ b/test/mri/stringio/test_stringio.rb
@@ -14,14 +14,37 @@ class TestStringIO < Test::Unit::TestCase
 
   include TestEOF::Seek
 
+  def test_do_not_mutate_shared_buffers
+    # Ensure we have two strings that are not embedded but have the same shared
+    # string reference.
+    #
+    # In this case, we must use eval because we need two strings literals that
+    # are long enough they cannot be embedded, but also contain the same bytes.
+
+    a = eval(("x" * 1024).dump)
+    b = eval(("x" * 1024).dump)
+
+    s = StringIO.new(b)
+    s.getc
+    s.ungetc '#'
+
+    # We mutated b, so a should not be mutated
+    assert_equal("x", a[0])
+  end
+
+  def test_version
+    assert_kind_of(String, StringIO::VERSION)
+  end
+
   def test_initialize
     assert_kind_of StringIO, StringIO.new
     assert_kind_of StringIO, StringIO.new('str')
     assert_kind_of StringIO, StringIO.new('str', 'r+')
+    assert_kind_of StringIO, StringIO.new(nil)
     assert_raise(ArgumentError) { StringIO.new('', 'x') }
     assert_raise(ArgumentError) { StringIO.new('', 'rx') }
     assert_raise(ArgumentError) { StringIO.new('', 'rbt') }
-    assert_raise(TypeError) { StringIO.new(nil) }
+    assert_raise(TypeError) { StringIO.new(Object) }
 
     o = Object.new
     def o.to_str
@@ -36,14 +59,21 @@ class TestStringIO < Test::Unit::TestCase
     assert_kind_of StringIO, StringIO.new(o)
   end
 
+  def test_null
+    io = StringIO.new(nil)
+    assert_nil io.gets
+    io.puts "abc"
+    assert_nil io.string
+  end
+
   def test_truncate
     io = StringIO.new("")
     io.puts "abc"
-    io.truncate(0)
+    assert_equal(0, io.truncate(0))
     io.puts "def"
     assert_equal("\0\0\0\0def\n", io.string, "[ruby-dev:24190]")
     assert_raise(Errno::EINVAL) { io.truncate(-1) }
-    io.truncate(10)
+    assert_equal(0, io.truncate(10))
     assert_equal("\0\0\0\0def\n\0\0", io.string)
   end
 
@@ -84,6 +114,14 @@ class TestStringIO < Test::Unit::TestCase
     assert_string("", Encoding::UTF_8, StringIO.new("foo").gets(0))
   end
 
+  def test_gets_utf_16
+    stringio = StringIO.new("line1\nline2\nline3\n".encode("utf-16le"))
+    assert_equal("line1\n".encode("utf-16le"), stringio.gets)
+    assert_equal("line2\n".encode("utf-16le"), stringio.gets)
+    assert_equal("line3\n".encode("utf-16le"), stringio.gets)
+    assert_nil(stringio.gets)
+  end
+
   def test_gets_chomp
     assert_equal(nil, StringIO.new("").gets(chomp: true))
     assert_equal("", StringIO.new("\n").gets(chomp: true))
@@ -92,13 +130,15 @@ class TestStringIO < Test::Unit::TestCase
     assert_equal("a", StringIO.new("a").gets(chomp: true))
     assert_equal("a", StringIO.new("a\nb").gets(chomp: true))
     assert_equal("abc", StringIO.new("abc\n\ndef\n").gets(chomp: true))
-    assert_equal("abc\n\ndef", StringIO.new("abc\n\ndef\n").gets(nil, chomp: true))
-    assert_equal("abc\n", StringIO.new("abc\n\ndef\n").gets("", chomp: true))
+    assert_equal("abc\n\ndef\n", StringIO.new("abc\n\ndef\n").gets(nil, chomp: true))
+    assert_equal("abc", StringIO.new("abc\n\ndef\n").gets("", chomp: true))
     stringio = StringIO.new("abc\n\ndef\n")
-    assert_equal("abc\n", stringio.gets("", chomp: true))
-    assert_equal("def", stringio.gets("", chomp: true))
+    assert_equal("abc", stringio.gets("", chomp: true))
+    assert_equal("def\n", stringio.gets("", chomp: true))
 
     assert_string("", Encoding::UTF_8, StringIO.new("\n").gets(chomp: true))
+
+    assert_equal("", StringIO.new("ab").gets("ab", chomp: true))
   end
 
   def test_gets_chomp_eol
@@ -109,11 +149,11 @@ class TestStringIO < Test::Unit::TestCase
     assert_equal("a", StringIO.new("a").gets(chomp: true))
     assert_equal("a", StringIO.new("a\r\nb").gets(chomp: true))
     assert_equal("abc", StringIO.new("abc\r\n\r\ndef\r\n").gets(chomp: true))
-    assert_equal("abc\r\n\r\ndef", StringIO.new("abc\r\n\r\ndef\r\n").gets(nil, chomp: true))
-    assert_equal("abc\r\n", StringIO.new("abc\r\n\r\ndef\r\n").gets("", chomp: true))
+    assert_equal("abc\r\n\r\ndef\r\n", StringIO.new("abc\r\n\r\ndef\r\n").gets(nil, chomp: true))
+    assert_equal("abc", StringIO.new("abc\r\n\r\ndef\r\n").gets("", chomp: true))
     stringio = StringIO.new("abc\r\n\r\ndef\r\n")
-    assert_equal("abc\r\n", stringio.gets("", chomp: true))
-    assert_equal("def", stringio.gets("", chomp: true))
+    assert_equal("abc", stringio.gets("", chomp: true))
+    assert_equal("def\r\n", stringio.gets("", chomp: true))
   end
 
   def test_readlines
@@ -223,7 +263,7 @@ class TestStringIO < Test::Unit::TestCase
 
   def test_write_integer_overflow
     f = StringIO.new
-    f.pos = RbConfig::LIMITS["LONG_MAX"]
+    f.pos = StringIO::MAX_LENGTH
     assert_raise(ArgumentError) {
       f.write("pos + len overflows")
     }
@@ -256,6 +296,12 @@ class TestStringIO < Test::Unit::TestCase
       f.set_encoding(Encoding::ASCII_8BIT)
     }
     assert_equal("foo\x83".b, f.gets)
+
+    f = StringIO.new()
+    f.set_encoding("ISO-8859-16:ISO-8859-1")
+    assert_equal(Encoding::ISO_8859_16, f.external_encoding)
+    assert_equal(Encoding::ISO_8859_16, f.string.encoding)
+    assert_nil(f.internal_encoding)
   end
 
   def test_mode_error
@@ -437,6 +483,11 @@ class TestStringIO < Test::Unit::TestCase
     f.close unless f.closed?
   end
 
+  def test_seek_frozen_string
+    f = StringIO.new(-"1234")
+    assert_equal(0, f.seek(1))
+  end
+
   def test_each_byte
     f = StringIO.new("1234")
     a = []
@@ -584,20 +635,30 @@ class TestStringIO < Test::Unit::TestCase
     end
   end
 
+  def test_each_string_sep
+    f = StringIO.new('a||b||c')
+    assert_equal(["a||", "b||", "c"], f.each("||").to_a)
+    f.rewind
+    assert_equal(["a", "b", "c"], f.each("||", chomp: true).to_a)
+  end
+
   def test_each
     f = StringIO.new("foo\nbar\nbaz\n")
     assert_equal(["foo\n", "bar\n", "baz\n"], f.each.to_a)
     f.rewind
     assert_equal(["foo", "bar", "baz"], f.each(chomp: true).to_a)
-    f = StringIO.new("foo\nbar\n\nbaz\n")
-    assert_equal(["foo\nbar\n\n", "baz\n"], f.each("").to_a)
+    f = StringIO.new("foo\nbar\n\n\nbaz\n")
+    assert_equal(["foo\nbar\n\n\n", "baz\n"], f.each("").to_a)
     f.rewind
-    assert_equal(["foo\nbar\n", "baz"], f.each("", chomp: true).to_a)
+    assert_equal(["foo\nbar", "baz\n"], f.each("", chomp: true).to_a)
 
-    f = StringIO.new("foo\r\nbar\r\n\r\nbaz\r\n")
-    assert_equal(["foo\r\nbar\r\n\r\n", "baz\r\n"], f.each("").to_a)
+    f = StringIO.new("foo\r\nbar\r\n\r\n\r\nbaz\r\n")
+    assert_equal(["foo\r\nbar\r\n\r\n\r\n", "baz\r\n"], f.each("").to_a)
     f.rewind
-    assert_equal(["foo\r\nbar\r\n", "baz"], f.each("", chomp: true).to_a)
+    assert_equal(["foo\r\nbar", "baz\r\n"], f.each("", chomp: true).to_a)
+
+    f = StringIO.new("abc\n\ndef\n")
+    assert_equal(["ab", "c\n", "\nd", "ef", "\n"], f.each(nil, 2, chomp: true).to_a)
   end
 
   def test_putc
@@ -662,6 +723,18 @@ class TestStringIO < Test::Unit::TestCase
     s.force_encoding(Encoding::US_ASCII)
     assert_same(s, f.read(nil, s))
     assert_string("", Encoding::UTF_8, s, bug13806)
+
+    bug20418 = '[Bug #20418] ™€®'.b
+    f = StringIO.new(bug20418)
+    s = ""
+    assert_equal(Encoding::UTF_8, s.encoding, bug20418)
+    f.read(4, s)
+    assert_equal(Encoding::UTF_8, s.encoding, bug20418)
+
+    f.rewind
+    s = ""
+    f.read(nil, s)
+    assert_equal(Encoding::ASCII_8BIT, s.encoding, bug20418)
   end
 
   def test_readpartial
@@ -673,8 +746,8 @@ class TestStringIO < Test::Unit::TestCase
     assert_equal("\u3042\u3044".force_encoding(Encoding::ASCII_8BIT), f.readpartial(f.size))
     f.rewind
     # not empty buffer
-    s = '0123456789'
-    assert_equal("\u3042\u3044".force_encoding(Encoding::ASCII_8BIT), f.readpartial(f.size, s))
+    s = '0123456789'.b
+    assert_equal("\u3042\u3044".b, f.readpartial(f.size, s))
   end
 
   def test_read_nonblock
@@ -698,8 +771,8 @@ class TestStringIO < Test::Unit::TestCase
     assert_equal("\u3042\u3044".force_encoding(Encoding::ASCII_8BIT), f.read_nonblock(f.size))
     f.rewind
     # not empty buffer
-    s = '0123456789'
-    assert_equal("\u3042\u3044".force_encoding(Encoding::ASCII_8BIT), f.read_nonblock(f.size, s))
+    s = '0123456789'.b
+    assert_equal("\u3042\u3044".b, f.read_nonblock(f.size, s))
   end
 
   def test_sysread
@@ -709,6 +782,32 @@ class TestStringIO < Test::Unit::TestCase
     assert_raise(EOFError) { f.sysread(1) }
     f.rewind
     assert_equal Encoding::ASCII_8BIT, f.sysread(3).encoding
+  end
+
+  def test_pread
+    f = StringIO.new("pread")
+    f.read
+
+    assert_equal "pre".b, f.pread(3, 0)
+    assert_equal "read".b, f.pread(4, 1)
+    assert_equal Encoding::ASCII_8BIT, f.pread(4, 1).encoding
+
+    buf = "".b
+    f.pread(3, 0, buf)
+    assert_equal "pre".b, buf
+    f.pread(4, 1, buf)
+    assert_equal "read".b, buf
+
+    assert_raise(EOFError) { f.pread(1, 5) }
+    assert_raise(ArgumentError) { f.pread(-1, 0) }
+    assert_raise(Errno::EINVAL) { f.pread(3, -1) }
+
+    assert_equal "".b, StringIO.new("").pread(0, 0)
+    assert_equal "".b, StringIO.new("").pread(0, -10)
+
+    buf = "stale".b
+    assert_equal "stale".b, StringIO.new("").pread(0, 0, buf)
+    assert_equal "stale".b, buf
   end
 
   def test_size
@@ -757,6 +856,26 @@ class TestStringIO < Test::Unit::TestCase
     assert_equal("b""\0""a", s.string)
   end
 
+  def test_ungetc_fill
+    count = 100
+    s = StringIO.new
+    s.print 'a' * count
+    s.ungetc('b' * (count * 5))
+    assert_equal((count * 5), s.string.size)
+    assert_match(/\Ab+\z/, s.string)
+  end
+
+  def test_ungetc_same_string
+    s = StringIO.new("abc" * 30)
+    s.ungetc(s.string)
+    assert_match(/\A(?:abc){60}\z/, s.string)
+
+    s = StringIO.new("abc" * 30)
+    s.pos = 70 # ("abc".size * 30 - 70).divmod(3) == [6, 2]
+    s.ungetc(s.string)
+    assert_match(/\A(?:abc){30}bc(?:abc){6}\z/, s.string)
+  end
+
   def test_ungetbyte_pos
     b = '\\b00010001 \\B00010001 \\b1 \\B1 \\b000100011'
     s = StringIO.new( b )
@@ -780,6 +899,26 @@ class TestStringIO < Test::Unit::TestCase
     s.pos = 0
     s.ungetbyte("b".ord)
     assert_equal("b""\0""a", s.string)
+  end
+
+  def test_ungetbyte_fill
+    count = 100
+    s = StringIO.new
+    s.print 'a' * count
+    s.ungetbyte('b' * (count * 5))
+    assert_equal((count * 5), s.string.size)
+    assert_match(/\Ab+\z/, s.string)
+  end
+
+  def test_ungetbyte_same_string
+    s = StringIO.new("abc" * 30)
+    s.ungetc(s.string)
+    assert_match(/\A(?:abc){60}\z/, s.string)
+
+    s = StringIO.new("abc" * 30)
+    s.pos = 70 # ("abc".size * 30 - 70).divmod(3) == [6, 2]
+    s.ungetbyte(s.string)
+    assert_match(/\A(?:abc){30}bc(?:abc){6}\z/, s.string)
   end
 
   def test_frozen
@@ -825,18 +964,18 @@ class TestStringIO < Test::Unit::TestCase
   end
 
   def test_overflow
-    omit if RbConfig::SIZEOF["void*"] > RbConfig::SIZEOF["long"]
-    limit = RbConfig::LIMITS["INTPTR_MAX"] - 0x10
+    intptr_max = RbConfig::LIMITS["INTPTR_MAX"]
+    return if intptr_max > StringIO::MAX_LENGTH
+    limit = intptr_max - 0x10
     assert_separately(%w[-rstringio], "#{<<-"begin;"}\n#{<<-"end;"}")
     begin;
       limit = #{limit}
       ary = []
-      while true
+      begin
         x = "a"*0x100000
         break if [x].pack("p").unpack("i!")[0] < 0
         ary << x
-        omit if ary.size > 100
-      end
+      end while ary.size <= 100
       s = StringIO.new(x)
       s.gets("xxx", limit)
       assert_equal(0x100000, s.pos)
@@ -879,6 +1018,44 @@ class TestStringIO < Test::Unit::TestCase
     Encoding.default_internal = default_internal
     $VERBOSE = verbose
   end
+
+  def test_coderange_after_overwrite
+    s = StringIO.new("".b)
+
+    s.write("a=b&c=d")
+    s.rewind
+    assert_predicate(s.string, :ascii_only?)
+    s.write "\u{431 43e 433 443 441}"
+    assert_not_predicate(s.string, :ascii_only?)
+
+    s = StringIO.new("\u{3042}")
+    s.rewind
+    assert_not_predicate(s.string, :ascii_only?)
+    s.write('aaaa')
+    assert_predicate(s.string, :ascii_only?)
+  end
+
+  require "objspace"
+  if ObjectSpace.respond_to?(:dump) && ObjectSpace.dump(eval(%{"test"})).include?('"chilled":true') # Ruby 3.4+ chilled strings
+    def test_chilled_string
+      chilled_string = eval(%{""})
+      io = StringIO.new(chilled_string)
+      assert_warning(/literal string will be frozen/) { io << "test" }
+      assert_equal("test", io.string)
+      assert_same(chilled_string, io.string)
+    end
+
+    def test_chilled_string_string_set
+      io = StringIO.new
+      chilled_string = eval(%{""})
+      io.string = chilled_string
+      assert_warning(/literal string will be frozen/) { io << "test" }
+      assert_equal("test", io.string)
+      assert_same(chilled_string, io.string)
+    end
+  end
+
+  private
 
   def assert_string(content, encoding, str, mesg = nil)
     assert_equal([content, encoding], [str, str.encoding], mesg)


### PR DESCRIPTION
This updates stringio to 3.1.5 which includes all the fixes from https://github.com/ruby/stringio/pull/116 and the regression https://github.com/ruby/stringio/issues/119 fixed by https://github.com/ruby/stringio/pull/121. All CRuby tests and ruby/spec specs for stringio are now green.

Tests are from v3.1.5 of the ruby/stringio repo.