### PR TITLE
Use set -u to avoid accessing uninitialized variables

### DIFF
--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -u
 # shellcheck disable=1007
 # -----------------------------------------------------------------------------
 # jruby.bash - Start Script for the JRuby interpreter
@@ -11,7 +12,7 @@ elif command -v typeset >/dev/null; then
     # ksh93 and older have typeset but not local, and expand aliases at parse
     # time so require re-sourcing the script
     alias local=typeset
-    if [ -z "$KSH_VERSION" ] || (eval : '"${.sh.version}"' >/dev/null 2>&1); then
+    if [ -z "${KSH_VERSION-}" ] || (eval : '"${.sh.version}"' >/dev/null 2>&1); then
         # shellcheck source=/dev/null
         . "$0"
         exit
@@ -145,11 +146,11 @@ VERIFY_JRUBY=false
 print_environment_log=false
 regenerate_jsa_file=false
 
-if [ -z "$JRUBY_OPTS" ]; then
+if [ -z "${JRUBY_OPTS-}" ]; then
     JRUBY_OPTS=""
 fi
 
-if [ -z "$JAVA_STACK" ]; then
+if [ -z "${JAVA_STACK-}" ]; then
     JAVA_STACK=-Xss2048k
 fi
 
@@ -172,7 +173,7 @@ readonly cr='
 '
 environment_log="JRuby Environment$cr================="
 add_log() {
-    environment_log="${environment_log}${cr}${*}"
+    environment_log="${environment_log}${cr}${*-}"
 }
 
 # Logic to process "arguments files" on both Java 8 and Java 9+
@@ -318,9 +319,9 @@ resolve() {
 # ----- Determine JRUBY_HOME based on this executable's path ------------------
 
 # get the absolute path of the executable
-if [ "$BASH" ]; then
+if [ "${BASH-}" ]; then
     # shellcheck disable=2128,3028
-    script_src="$BASH_SOURCE"
+    script_src="${BASH_SOURCE-}"
 else
     script_src="$0"
 fi
@@ -362,13 +363,13 @@ add_log
 add_log "Environment:"
 add_log "  JRUBY_HOME: $JRUBY_HOME"
 add_log "  JRUBY_OPTS: $JRUBY_OPTS"
-add_log "  JAVA_OPTS: $JAVA_OPTS"
+add_log "  JAVA_OPTS: ${JAVA_OPTS-}"
 
 # ----- Discover JVM and prep environment to run it ---------------------------
 
 # Determine where the java command is and ensure we have a good JAVA_HOME
-if [ -z "$JAVACMD" ]; then
-    if [ -z "$JAVA_HOME" ]; then
+if [ -z "${JAVACMD-}" ]; then
+    if [ -z "${JAVA_HOME-}" ]; then
         readonly java_home_command="/usr/libexec/java_home"
         if [ -r "$java_home_command" ] \
             && [ -x "$java_home_command" ] \
@@ -447,7 +448,7 @@ process_java_opts "$pwd_jruby_java_opts_file"
 
 # Capture some Java options to be passed separately
 JAVA_OPTS_TEMP=""
-for opt in $JAVA_OPTS; do
+for opt in ${JAVA_OPTS-}; do
     case $opt in
         -Xmx*) JAVA_MEM="$opt" ;;
         -Xss*) JAVA_STACK="$opt" ;;
@@ -467,7 +468,7 @@ for j in "$JRUBY_HOME"/lib/jruby.jar "$JRUBY_HOME"/lib/jruby-complete.jar; do
     if [ ! -e "$j" ]; then
         continue
     fi
-    if [ "$JRUBY_CP" ]; then
+    if [ "${JRUBY_CP-}" ]; then
         JRUBY_CP="$JRUBY_CP$CP_DELIMITER$j"
     else
         JRUBY_CP="$j"
@@ -484,7 +485,7 @@ fi
 
 # ----- Add additional jars from lib to classpath -----------------------------
 
-if [ "$JRUBY_PARENT_CLASSPATH" ]; then
+if [ "${JRUBY_PARENT_CLASSPATH-}" ]; then
     # Use same classpath propagated from parent jruby
     CP="$JRUBY_PARENT_CLASSPATH"
 else
@@ -500,7 +501,7 @@ else
         fi
     done
 
-    if [ "$CP" ] && $cygwin; then
+    if [ "${CP-}" ] && $cygwin; then
         CP="$(cygpath -p -w "$CP")"
     fi
 fi
@@ -536,7 +537,11 @@ do
             exit
             ;;
         -J-classpath|-J-cp)
-            CP="$CP$CP_DELIMITER$2"
+            if [ -z "${CP-}" ]; then
+                CP="$2"
+            else
+              CP="$CP$CP_DELIMITER$2"
+            fi
             CLASSPATH=""
             shift
             ;;
@@ -628,7 +633,7 @@ do
 done
 
 # Force JDK to use specified java.security.egd rand source
-if [ -n "$JAVA_SECURITY_EGD" ]; then
+if [ -n "${JAVA_SECURITY_EGD-}" ]; then
     append java_args "-Djava.security.egd=$JAVA_SECURITY_EGD"
 fi
 
@@ -643,11 +648,11 @@ if $regenerate_jsa_file; then
     esac
 fi
 
-JAVA_OPTS="$JAVA_OPTS $JAVA_MEM $JAVA_STACK"
+JAVA_OPTS="$JAVA_OPTS ${JAVA_MEM-} ${JAVA_STACK-}"
 
 JFFI_OPTS="-Djffi.boot.library.path=$JRUBY_HOME/lib/jni"
 
-CLASSPATH="${CP}${CP_DELIMITER}${CLASSPATH}"
+CLASSPATH="${CP-}${CP_DELIMITER}${CLASSPATH-}"
 
 # ----- Tweak console environment for cygwin ----------------------------------
 
@@ -687,7 +692,7 @@ if $use_modules; then
     process_java_opts "$jruby_module_opts_file"
 
     # Allow overriding default JSA file location
-    if [ -z "$JRUBY_JSA" ]; then
+    if [ -z "${JRUBY_JSA-}" ]; then
         JRUBY_JSA="$jruby_jsa_file"
     fi
 

--- a/bin/jruby.sh
+++ b/bin/jruby.sh
@@ -340,7 +340,11 @@ readonly jruby_module_opts_file="$JRUBY_HOME/bin/.jruby.module_opts"
 
 # Cascading .java_opts files for localized JVM flags
 readonly installed_jruby_java_opts_file="$JRUBY_HOME/bin/.jruby.java_opts"
-readonly home_jruby_java_opts_file="$HOME/.jruby.java_opts"
+if [ -z "${HOME-}" ]; then
+    readonly home_jruby_java_opts_file=""
+else
+    readonly home_jruby_java_opts_file="$HOME/.jruby.java_opts"
+fi
 readonly pwd_jruby_java_opts_file="$PWD/.jruby.java_opts"
 
 # Options from .dev_mode.java_opts for "--dev" mode, to reduce JRuby startup time


### PR DESCRIPTION
A previous version of this script was incorrectly assuming that an uninitialized variable would be initialized to a "false" value, but uninitialized variables typically evaluate to a blank string which is considered true. As a result of this, no-argument calls behaved improperly, breaking the ability to pipe code into the jruby command.

This commit enables `set -u` for the JRuby launcher script, to trigger an error whenever an uninitialized variable is accessed. Variables we expect to possibly be uninitialized (such as various JAVA variables used to override the location of the java command) have been modified to use the `${variable-}` format that does not trigger an error.