### PR TITLE
Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{sh,bash}]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
I finally got tired of accidentally indenting the launcher with tabs 😅

This PR adds an [EditorConfig](https://editorconfig.org) file for standardized code style settings across editors. It comes included recent versions of Vim/Neovim, and IntelliJ since about 2014. Not sure what the desired style settings would be for `*.rb` or `*.java` but I can add those if desired.