### PR TITLE
copy-rename-maven-plugin version

### DIFF
--- a/shaded/pom.rb
+++ b/shaded/pom.rb
@@ -33,7 +33,7 @@ project 'JRuby Core' do
     )
   end
 
-  plugin :'com.coderplus.maven.plugins:copy-rename-maven-plugin' do
+  plugin :'com.coderplus.maven.plugins:copy-rename-maven-plugin', '1.0' do
     execute_goals 'copy',
                   id: 'copy to lib/jruby.jar',
                   phase: 'package',

--- a/shaded/pom.xml
+++ b/shaded/pom.xml
@@ -70,6 +70,7 @@ DO NOT MODIFY - GENERATED CODE
       <plugin>
         <groupId>com.coderplus.maven.plugins</groupId>
         <artifactId>copy-rename-maven-plugin</artifactId>
+        <version>1.0</version>
         <executions>
           <execution>
             <id>copy to lib/jruby.jar</id>


### PR DESCRIPTION
just specify a version to silence the warning

```
[WARNING] Some problems were encountered while building the effective model for org.jruby:jruby-core:jar:10.0.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for com.coderplus.maven.plugins:copy-rename-maven-plugin is missing.
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```