### PR TITLE
Update jcodings to 1.0.62 and joni to 2.2.4

### DIFF
--- a/core/pom.rb
+++ b/core/pom.rb
@@ -51,8 +51,8 @@ project 'JRuby Base' do
   jar 'com.github.jnr:jffi:${jffi.version}'
   jar 'com.github.jnr:jffi:${jffi.version}:native'
 
-  jar 'org.jruby.joni:joni:2.2.3'
-  jar 'org.jruby.jcodings:jcodings:1.0.61'
+  jar 'org.jruby.joni:joni:2.2.4'
+  jar 'org.jruby.jcodings:jcodings:1.0.62'
   jar 'org.jruby:dirgra:0.3'
 
   jar 'com.headius:invokebinder:1.13'

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -149,12 +149,12 @@ DO NOT MODIFY - GENERATED CODE
     <dependency>
       <groupId>org.jruby.joni</groupId>
       <artifactId>joni</artifactId>
-      <version>2.2.3</version>
+      <version>2.2.4</version>
     </dependency>
     <dependency>
       <groupId>org.jruby.jcodings</groupId>
       <artifactId>jcodings</artifactId>
-      <version>1.0.61</version>
+      <version>1.0.62</version>
     </dependency>
     <dependency>
       <groupId>org.jruby</groupId>

--- a/spec/tags/ruby/library/rbconfig/unicode_emoji_version_tags.txt
+++ b/spec/tags/ruby/library/rbconfig/unicode_emoji_version_tags.txt
@@ -1,0 +1,1 @@
+fails(JRuby 9.4 updated Unicode to 15.0):RbConfig::CONFIG['UNICODE_EMOJI_VERSION'] is 13.1

--- a/spec/tags/ruby/library/rbconfig/unicode_version_tags.txt
+++ b/spec/tags/ruby/library/rbconfig/unicode_version_tags.txt
@@ -1,0 +1,1 @@
+fails(JRuby 9.4 updated Unicode to 15.0):RbConfig::CONFIG['UNICODE_VERSION'] is 13.0.0


### PR DESCRIPTION
jcodings 1.0.62:

* update unicode to 15.0 (jruby/jcodings#66)

joni 2.2.4:

* update jcodings to 1.0.62
* fix: char class casefold for certain chars (jruby/joni#85)