### PR TITLE
parser passes block node vs only single last value to when

### DIFF
--- a/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
+++ b/core/src/main/java/org/jruby/ir/builder/IRBuilderAST.java
@@ -1101,7 +1101,9 @@ public class IRBuilderAST extends IRBuilder<Node, DefNode, WhenNode, RescueBodyN
         Variable eqqResult = temp();
         Node exprNodes = whenNode.getExpressionNodes();
 
-        if (exprNodes instanceof ListNode && !(exprNodes instanceof DNode) && !(exprNodes instanceof ArrayNode) && !(exprNodes instanceof ZArrayNode)) {
+        if (exprNodes instanceof BlockNode list) {
+            buildWhenValue(eqqResult, testValue, bodyLabel, list.getLast(), seenLiterals, origLocs, false);
+        } else if (exprNodes instanceof ListNode && !(exprNodes instanceof DNode) && !(exprNodes instanceof ArrayNode) && !(exprNodes instanceof ZArrayNode)) {
             buildWhenValues(eqqResult, ((ListNode) exprNodes).children(), testValue, bodyLabel, seenLiterals, origLocs);
         } else if (exprNodes instanceof ArgsPushNode || exprNodes instanceof SplatNode || exprNodes instanceof ArgsCatNode) {
             buildWhenSplatValues(eqqResult, exprNodes, testValue, bodyLabel, seenLiterals, origLocs);


### PR DESCRIPTION
parser passes block node vs only single last value to when

```ruby
p    case 'a'
    when ('a'; 'b')
      :wrong_called
    when ('b'; 'a')
      :called
    end
```