### PR TITLE
Symbol type calculation tweaks

### DIFF
--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -114,7 +114,7 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
     private volatile RubyString rubyString;
     private static final AtomicReferenceFieldUpdater<RubySymbol, RubyString> RUBY_STRING_UPDATER = AtomicReferenceFieldUpdater.newUpdater(RubySymbol.class, RubyString.class, "rubyString");
     private transient Object constant;
-    private SymbolNameType type;
+    private final SymbolNameType type;
 
     /**
      *
@@ -1010,7 +1010,9 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
     @Override
     public void setEncoding(Encoding e) {
         getBytes().setEncoding(e);
-        type = IdUtil.determineSymbolNameType(getRuntime(), getBytes());
+        if (this.type != IdUtil.determineSymbolNameType(getRuntime(), getBytes())) {
+            // this should warn or raise or something; symbol types should not change (nor should encoding)
+        };
     }
 
     public static final class SymbolTable {

--- a/core/src/main/java/org/jruby/RubySymbol.java
+++ b/core/src/main/java/org/jruby/RubySymbol.java
@@ -284,24 +284,31 @@ public class RubySymbol extends RubyObject implements MarshalEncoding, EncodingC
     }
 
     /**
-     * Is the string this constant represents a valid constant identifier name.
+     * Is the string this symbol represents a valid constant identifier name.
      */
     public boolean validConstantName() {
         return type == SymbolNameType.CONST;
     }
 
     /**
-     * Is the string this constant represents a valid constant identifier name.
+     * Is the string this symbol represents a valid constant identifier name.
      */
     public boolean validInstanceVariableName() {
         return type == SymbolNameType.INSTANCE;
     }
 
     /**
-     * Is the string this constant represents a valid constant identifier name.
+     * Is the string this symbol represents a valid constant identifier name.
      */
     public boolean validClassVariableName() {
         return type == SymbolNameType.CLASS;
+    }
+
+    /**
+     * Is the string this symbol represents a valid attribute setter name.
+     */
+    public boolean validAttrsetName() {
+        return type == SymbolNameType.ATTRSET;
     }
 
 

--- a/core/src/main/java/org/jruby/util/IdUtil.java
+++ b/core/src/main/java/org/jruby/util/IdUtil.java
@@ -321,10 +321,10 @@ public final class IdUtil {
 
                     type = SymbolNameType.JUNK;
                     m++;
-                    if (m + 1 < e || (m < e && data.get(m) != '=')) break;
+                    if (m + 1 < e || m >= e || data.get(m) != '=') break;
                     // fall through
                 case '=':
-                    return SymbolNameType.OTHER;
+                    return SymbolNameType.ATTRSET;
             }
         }
 


### PR DESCRIPTION
Depends on #8677.

* Align logic for calculating ATTRSET more closely with the C code.
* Make type immutable and do not update it for encoding changes.

The second item here is a strange one; I'm not sure it should be possible to `setEncoding` on a `RubySymbol` (it should not be mutable and should not change type) but I don't think I want to make it an error or warning.