### PR TITLE
Handle encoding checks as in strTranscode

### DIFF
--- a/core/src/main/java/org/jruby/util/io/EncodingUtils.java
+++ b/core/src/main/java/org/jruby/util/io/EncodingUtils.java
@@ -934,7 +934,22 @@ public class EncodingUtils {
         return strTranscode1(context, to, (RubyString) str, ecflags, ecopt, EncodingUtils::encodedDup);
     }
 
-    // rb_str_encode
+    /**
+     * A version of rbStrEncode that works directly with bytes.
+     *
+     * MRI: rb_str_encode but consuming only a byte array range and producing a ByteList.
+     *
+     * @param context
+     * @param bytes
+     * @param start
+     * @param length
+     * @param encoding
+     * @param cr
+     * @param to
+     * @param ecflags
+     * @param ecopt
+     * @return
+     */
     public static ByteList rbByteEncode(ThreadContext context, byte[] bytes, int start, int length, Encoding encoding, int cr, Encoding to, int ecflags, IRubyObject ecopt) {
         byte[] sname, dname;
 
@@ -942,10 +957,8 @@ public class EncodingUtils {
         dname = to.getName();
 
         if (noDecorators(ecflags)) {
-            if (encoding.isAsciiCompatible() && to.isAsciiCompatible()) {
-                if (cr == StringSupport.CR_7BIT) {
-                    return null;
-                }
+            if (is7BitCompat(cr, encoding, to)) {
+                return null;
             } else if (encodingEqual(sname, dname)) {
                 return null;
             }
@@ -1104,6 +1117,12 @@ public class EncodingUtils {
         return senc != null && denc != null
                 && senc.isAsciiCompatible() && denc.isAsciiCompatible()
                 && str.scanForCodeRange() == StringSupport.CR_7BIT;
+    }
+
+    private static boolean is7BitCompat(int cr, Encoding denc, Encoding senc) {
+        return senc != null && denc != null
+                && senc.isAsciiCompatible() && denc.isAsciiCompatible()
+                && cr == StringSupport.CR_7BIT;
     }
 
     private static RubyString strTranscodeScrub(ThreadContext context, IRubyObject forceEncoding, RubyString str, int ecflags, IRubyObject ecopts, TranscodeResult result, boolean explicitlyInvalidReplace, Encoding denc, Encoding senc) {

--- a/spec/java_integration/utilities/io_spec.rb
+++ b/spec/java_integration/utilities/io_spec.rb
@@ -1,5 +1,7 @@
 require File.dirname(__FILE__) + "/../spec_helper"
 require 'jruby'
+require 'stringio'
+require 'tmpdir'
 
 describe "The JRuby module" do
   it "should give access to a Java reference with the reference method" do
@@ -16,5 +18,22 @@ describe "The JRuby module" do
     
     io = JRuby.dereference(io_ref)
     expect(io.class).to eq(IO)
+  end
+end
+
+describe "IOOutputStream" do
+  # https://github.com/jruby/jruby/issues/8686
+  it "allows source and destination encoding to be the same" do
+    filename = File.join(Dir.tmpdir, "iooutputstream_write")
+    io = File.open(filename, "w+:UTF-8")
+    ioos = org.jruby.util.IOOutputStream.new(io, org.jcodings.specific.UTF8Encoding::INSTANCE)
+    bytes = "…".to_java_bytes
+    ioos.write(bytes, 0, bytes.length)
+    ioos.flush
+    io.flush
+
+    File.read(filename).should == "…"
+  ensure
+    io.close rescue nil
   end
 end


### PR DESCRIPTION
Logic in strTranscode evolved over the years to allow same-encoding requests to be no-ops. Those changes were never applied to rbByteEncode, resulting in same-encoding requests triggering errors when the transcoding subsystem saw nothing would be done. This complicated efforts to solve jruby/jruby#8682 by passing an encoding to the IOOutputStream constructor (ruby/json#759 and ruby/json#760).

This patch allows using IOOutputStream and the byte[] IO API it calls with an externally-encoded IO by passing in an expected encoding for incoming bytes. All bytes will be treated as being encoded properly, and if the source and destination encoding is the same, rbByteEncode will return null to indicate no-op.

Note that this misses some functionality of strTranscode in that it does not scrub the string for same-encoding requests.

Partially addresses ruby/json#760.

Fixes jruby/jruby#8686.